### PR TITLE
Mobile praxis cards: delete the invented torn edge and the injected keyframe (#867)

### DIFF
--- a/frontend/src/components/praxisCard/__tests__/noInjectedStylesheets.test.ts
+++ b/frontend/src/components/praxisCard/__tests__/noInjectedStylesheets.test.ts
@@ -1,0 +1,46 @@
+/**
+ * #867 — no praxis-card component may render a `<style>` element.
+ *
+ * A component-injected stylesheet duplicates on every mount, sits outside the
+ * `[data-theme="dark"]` cascade, and bypasses the `prefers-reduced-motion`
+ * guard that every animation in index.css is wrapped in. The specific keyframe
+ * this issue removed (`@keyframes blink`, injected by the Singularity mobile
+ * card) is incidental; the injection is the failure class, so that is what is
+ * pinned here.
+ *
+ * A source scan rather than a render: the offending element is often nested
+ * under a branch no fixture reaches, and this way one assertion covers every
+ * archetype, present and future, without instantiating any of them.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+const PRAXIS_CARD_DIR = fileURLToPath(new URL('..', import.meta.url))
+
+/** Components only — `__tests__` holds this guard, which names `<style>` itself. */
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry: string) => {
+    const path = join(dir, entry)
+    if (statSync(path).isDirectory()) return entry === '__tests__' ? [] : sourceFiles(path)
+    return /\.tsx?$/.test(entry) ? [path] : []
+  })
+}
+
+/** Comments legitimately mention `<style>` (this file's own header does). */
+const stripComments = (source: string) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+
+describe('praxis cards never inject a stylesheet (#867)', () => {
+  it('renders no <style> element anywhere under praxisCard/', () => {
+    const offenders = sourceFiles(PRAXIS_CARD_DIR)
+      .filter((path) => /<style[\s>]/.test(stripComments(readFileSync(path, 'utf8'))))
+      .map((path) => relative(PRAXIS_CARD_DIR, path))
+    expect(offenders).toEqual([])
+  })
+
+  it('scans a non-empty set, so the guard cannot pass by finding nothing', () => {
+    expect(sourceFiles(PRAXIS_CARD_DIR).length).toBeGreaterThan(10)
+  })
+})

--- a/frontend/src/components/praxisCard/mobile/SingularityMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/SingularityMobilePraxisCard.tsx
@@ -3,10 +3,18 @@ import type { PraxisCardOut } from '../../../api/praxis'
 import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 
 /**
- * Singularity MOBILE praxis card (#573) — a terminal readout on a scanline void:
- * bracketed corners, a blinking prompt masthead, mono phosphor. No sigil (the
- * faction carries none). Mirrors the desktop Singularity praxis frame;
- * --faction-singularity-* tokens read identically in both themes (always-dark).
+ * Singularity MOBILE praxis card (#573) — a terminal readout on a scanline
+ * void: a scanline scrim, a masthead trailed by a blinking block cursor, mono
+ * phosphor. No sigil (the faction carries none). Mirrors the desktop
+ * Singularity praxis frame; --faction-singularity-* tokens read identically in
+ * both themes (always-dark).
+ *
+ * The cursor is design-backed — the mobile design names the blinking prompt as
+ * a signature of the treatment — but its blink belongs to `.sg-cursor` in
+ * index.css, not here. This file used to inject its own `<style>` keyframe
+ * (#867): a component-injected stylesheet duplicates on every mount, sits
+ * outside the `[data-theme="dark"]` cascade, and bypasses the reduced-motion
+ * guard that the class already carries. Never write `animation:` inline.
  */
 export default function SingularityMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
   const { t } = useTranslation('praxis')
@@ -53,6 +61,8 @@ export default function SingularityMobilePraxisCard({ praxis }: { praxis: Praxis
         >
           {t('card.masthead.singularity')}
           <span
+            aria-hidden
+            className="sg-cursor"
             style={{
               display: 'inline-block',
               width: 5,
@@ -60,13 +70,11 @@ export default function SingularityMobilePraxisCard({ praxis }: { praxis: Praxis
               marginLeft: 'var(--space-xs)',
               background: 'var(--faction-singularity-card-text)',
               verticalAlign: 'middle',
-              animation: 'blink 1s step-end infinite',
             }}
           />
         </div>
         <MobilePraxisBody praxis={praxis} theme={theme} />
       </div>
-      <style>{'@keyframes blink { 50% { opacity: 0; } }'}</style>
     </div>
   )
 }

--- a/frontend/src/components/praxisCard/mobile/SnideMobilePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/mobile/SnideMobilePraxisCard.tsx
@@ -4,13 +4,16 @@ import { factionCssVar } from '../../../utils/factions'
 import { SnideSigil } from '../../snide/snideAtoms'
 import { MobilePraxisBody, type MobileSlotTheme } from './shared'
 
-const TORN_CLIP =
-  'polygon(0% 0%, 4% 100%, 8% 20%, 12% 90%, 16% 10%, 20% 80%, 24% 0%, 28% 100%, 32% 15%, 36% 85%, 40% 5%, 44% 95%, 48% 20%, 52% 80%, 56% 0%, 60% 100%, 64% 15%, 68% 90%, 72% 5%, 76% 85%, 80% 0%, 84% 100%, 88% 20%, 92% 80%, 96% 10%, 100% 0%)'
-
 /**
- * S.N.I.D.E. MOBILE praxis card (#573) — a dark evidence file with a torn top
- * edge, a strip of tape, and the struck-through circle-S sigil. Mirrors the
- * desktop SNIDE praxis frame; --faction-snide-* tokens, native-dark.
+ * S.N.I.D.E. MOBILE praxis card (#573) — a dark evidence file with a strip of
+ * tape and the struck-through circle-S sigil. Mirrors the desktop SNIDE praxis
+ * frame; --faction-snide-* tokens, native-dark.
+ *
+ * The tape is design-backed and stays: the mobile design draws `.snide-tape`
+ * and calls this card "lifted from the real SNIDETaskCard. Nothing invented."
+ * The torn top edge that used to sit above it was NOT — a 26-point clip-path
+ * with no counterpart in any design — so #867 deleted it here, as #842 had on
+ * desktop. Do not reinstate it.
  */
 export default function SnideMobilePraxisCard({ praxis }: { praxis: PraxisCardOut }) {
   const { t } = useTranslation('praxis')
@@ -34,17 +37,6 @@ export default function SnideMobilePraxisCard({ praxis }: { praxis: PraxisCardOu
         boxShadow: '5px 6px 0 rgba(0,0,0,.5)',
       }}
     >
-      <div
-        style={{
-          position: 'absolute',
-          top: -1,
-          left: 0,
-          right: 0,
-          height: 6,
-          background: 'var(--color-bg-page)',
-          clipPath: TORN_CLIP,
-        }}
-      />
       <div className="snide-tape" style={{ top: -8, left: 20, transform: 'rotate(-8deg)' }} />
       <div
         style={{


### PR DESCRIPTION
Pure deletion. Two mobile praxis cards carried chrome the mobile designs do not draw, and one of them injected its own stylesheet.

Closes #867

## What the designs actually say

The issue's step 1 was "read the mobile designs before deleting". They were read (in the `World Zero Frontend Kit` project, at `mobile-system/factions/WZ Mobile - SNIDE.html` and `WZ Mobile - Singularity.html`, **not** the `*.dc.html` path the issue body cites). **Both design questions came back the opposite way to the issue body's assumption**, and the owner's comment on #867 is the governing scope:

| | Issue body assumed | Design says | Shipped here |
|---|---|---|---|
| SNIDE tape | invention, delete | drawn; "lifted from the real SNIDETaskCard. Nothing invented." | **kept** |
| SNIDE torn edge | invention, delete | zero occurrences of torn / jagged / rip / deckle | **deleted** |
| Singularity cursor | invention, delete | ships `.sg-cursor`; "blinking prompt" is named signature anatomy | **kept** |
| Singularity keyframe | move into `index.css` | already there, gated | **deleted the duplicate; used the class** |

## Changes

**`SnideMobilePraxisCard.tsx`** — deleted the 26-point `clip-path: polygon(...)` module constant and the absolutely-positioned strip that consumed it. `className="snide-tape"` is untouched.

**`SingularityMobilePraxisCard.tsx`** — deleted `<style>{'@keyframes blink { 50% { opacity: 0; } }'}</style>` and the inline `animation: 'blink 1s step-end infinite'`. The cursor now carries `className="sg-cursor"`, which `index.css:1867` already defines as `animation: sg-term-blink 1s steps(1) infinite` **inside a `prefers-reduced-motion: no-preference` guard**. Also `aria-hidden`, matching `SingularityScoreStamp`'s cursor. Its width/height/colour were already correct against the class, so nothing inline had to be kept for the mobile size — no re-added keyframe.

**No `index.css` change.** No new tokens, no new colours.

**Both docstrings** rewritten. Snide's advertised "a torn top edge" as intended; Singularity's described "bracketed corners" the component has never rendered. Each now records *why* the surviving mark survives, so the next pass doesn't delete the tape or the cursor on a second reading of the original issue.

## The test

One assertion, not a suite: **no component under `praxisCard/` may render a `<style>` element**. The specific keyframe is incidental — component-injected stylesheets are the failure class, because they duplicate on every mount, sit outside the `[data-theme="dark"]` cascade, and bypass the reduced-motion guard. It is a source scan rather than a render, so it covers archetypes no fixture instantiates, including ones not written yet. It was confirmed to fail before the fix (it caught its own regex literal on first run, which is why `__tests__/` is excluded from the walk).

## Verified

`vitest` 1258/1258 pass (111 files) · `tsc --noEmit` clean (only the known stale-junction `Cannot find module 'node:fs'` false alarm from PR #675, plus two pre-existing `TS7006`s in files this PR does not touch) · `eslint src/components/praxisCard --max-warnings=0` clean · `vite build` succeeds.

**Visual QA is outstanding** — no screenshot capability and no dev stack in this environment.

## Out of scope, deliberately

`@keyframes wz-blink` (`index.css:1821`) is a third blink implementation, and **seven other components still inject a `<style>` tag** (`FactionCard`, `FactionSelectCard`, `SingularityTaskCard`, `SingularityTaskDetail`, `SingularityHome`, and the four Singularity duel rails / seal confirms, which inject a `CURSOR_CSS` string that redefines `.sg-cursor` on top of the `index.css` one). Consolidating those is a separate issue; the guard here is scoped to `praxisCard/` so it stays green.

## What to eyeball

1. **SNIDE mobile praxis card, top edge** — the tape strip is still there at `top: -8, left: 20`, rotated -8°, and the card's top border is now a clean 1px line with no 6px ragged strip above it. Check the tape does not look orphaned now that the torn strip is gone.
2. **SNIDE mobile card in both themes** — the deleted strip was painted `var(--color-bg-page)`, so if anything was relying on it to mask the card's top border, it will show now.
3. **Singularity mobile praxis card masthead** — the block cursor after `MASTHEAD` should still blink, at 1s steps, and be the same size and phosphor colour as before.
4. **Singularity cursor with `prefers-reduced-motion: reduce`** — it should now stop blinking but **stay drawn** (it is punctuation on the line, not an indicator). Previously it blinked regardless. This is the actual user-visible fix.
5. **Any other Singularity surface on the same screen** — the deleted `@keyframes blink` was global once mounted; confirm nothing else was quietly depending on this card to define it. (`SingularityTaskCard` and `SingularityHome` inject their own copies, so they are self-sufficient.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
