### PR TITLE
fix(admin): source the pending queue from /admin/tasks/pending (#909)

### DIFF
--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -123,8 +123,19 @@ export async function getAccountDetail(id: number): Promise<AccountDetail> {
   return data
 }
 
+/**
+ * Every task, for the admin table. The explicit `limit` and `sort` are load-bearing
+ * (#909): `/tasks` defaults to 50 rows ordered easiest-first, which silently dropped
+ * the hardest tasks — including every proposed metatask — off the admin list.
+ *
+ * ponytail: two requests (this plus `getPendingTasks`) cover an admin table of tens
+ * of rows; when the task table outgrows 500, move status filtering server-side and
+ * paginate.
+ */
 export async function getAllTasks(): Promise<TaskOut[]> {
-  const { data } = await api.get<TaskOut[]>('/tasks', { params: { status: 'all' } })
+  const { data } = await api.get<TaskOut[]>('/tasks', {
+    params: { status: 'all', limit: 500, sort: 'newest' },
+  })
   return data
 }
 

--- a/frontend/src/locales/en/admin.json
+++ b/frontend/src/locales/en/admin.json
@@ -63,6 +63,7 @@
     "levelLabel": "Level req.",
     "meta": "{{points}} pts · lvl {{level}} · {{faction}}",
     "crossFaction": "cross-faction",
+    "proposedBy": "Proposed by {{name}}",
     "status": {
       "active": "active",
       "pending": "pending",

--- a/frontend/src/pages/admin/TasksTab.tsx
+++ b/frontend/src/pages/admin/TasksTab.tsx
@@ -1,7 +1,14 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getAllTasks, updateTaskStatus, adminPatchTask } from "../../api/admin";
+import {
+  getAllTasks,
+  getPendingTasks,
+  updateTaskStatus,
+  adminPatchTask,
+} from "../../api/admin";
 import type { TaskOut } from "../../api/tasks";
+import { mergeAdminTaskRows } from "./adminTaskRows";
+import type { AdminTaskRow } from "./adminTaskRows";
 import { extractError } from "../../utils/errors";
 
 type StatusFilter = "all" | "pending" | "active" | "retired";
@@ -28,7 +35,7 @@ export default function TasksTab() {
       | undefined;
     return known ? t(`tasks.status.${known}`) : status;
   };
-  const [tasks, setTasks] = useState<TaskOut[]>([]);
+  const [tasks, setTasks] = useState<AdminTaskRow[]>([]);
   const [filter, setFilter] = useState<StatusFilter>("all");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -37,10 +44,15 @@ export default function TasksTab() {
   const [editState, setEditState] = useState<EditState | null>(null);
   const [saving, setSaving] = useState(false);
 
+  // Both sources refetch together: approving a pending task changes its status
+  // in one and removes it from the other, so refreshing only one leaves a stale
+  // row (#909).
   const refresh = () => {
     setError(null);
-    getAllTasks()
-      .then(setTasks)
+    Promise.all([getAllTasks(), getPendingTasks()])
+      .then(([allTasks, pendingTasks]) =>
+        setTasks(mergeAdminTaskRows(allTasks, pendingTasks)),
+      )
       .catch((err) => setError(extractError(err, t("tasks.loadError"))))
       .finally(() => setLoading(false));
   };
@@ -247,6 +259,15 @@ export default function TasksTab() {
                           task.primary_faction_slug ?? t("tasks.crossFaction"),
                       })}
                     </p>
+                    {/* Only /admin/tasks/pending carries a proposer, and it is
+                        empty for admin-created rows — render nothing then. */}
+                    {task.status === "pending" && task.created_by_name && (
+                      <p className="font-body text-xs text-muted">
+                        {t("tasks.proposedBy", {
+                          name: task.created_by_name,
+                        })}
+                      </p>
+                    )}
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
                     {(task.status === "pending" ||

--- a/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
+++ b/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
@@ -1,0 +1,80 @@
+/**
+ * #909 — a proposed metatask must reach the admin review queue.
+ *
+ * The regression this guards: `/tasks` returns a capped, easiest-first window,
+ * so a level-6 metatask sorts past it and never appears. The merge is what
+ * restores it, using the uncapped `/admin/tasks/pending` response.
+ */
+import { describe, it, expect } from "vitest";
+import { mergeAdminTaskRows } from "../adminTaskRows";
+import type { TaskOut } from "../../../api/tasks";
+import type { PendingTaskOut } from "../../../api/admin";
+
+function task(overrides: Partial<TaskOut> & { id: number }): TaskOut {
+  return {
+    title: `task ${overrides.id}`,
+    description: null,
+    point_value: 10,
+    level_required: 0,
+    status: "active",
+    task_type: "standard",
+    created_by: 1,
+    primary_faction_slug: null,
+    metatask_faction_slug: null,
+    is_task_vision_eligible: false,
+    created_at: "2026-07-01T00:00:00Z",
+    can_submit_praxis: true,
+    allowed_modes: [],
+    eligible_for_current_user: true,
+    ...overrides,
+  };
+}
+
+/** The 50-row easiest-first window the admin tab used to be limited to. */
+const EASIEST_FIFTY: TaskOut[] = Array.from({ length: 50 }, (_, index) =>
+  task({ id: index + 1, level_required: 0 }),
+);
+
+const PENDING_METATASK: PendingTaskOut = {
+  ...task({
+    id: 909,
+    status: "pending",
+    task_type: "metatask",
+    level_required: 6,
+    title: "Chart the coven's tasks",
+  }),
+  created_by_name: "mollusk",
+};
+
+describe("mergeAdminTaskRows", () => {
+  it("surfaces a pending metatask that sorted past the /tasks window", () => {
+    const merged = mergeAdminTaskRows(EASIEST_FIFTY, [PENDING_METATASK]);
+
+    const metatask = merged.find((row) => row.id === PENDING_METATASK.id);
+    expect(metatask).toBeDefined();
+    expect(metatask?.task_type).toBe("metatask");
+    expect(metatask?.level_required).toBe(6);
+    // The proposer's name is the whole reason the pending endpoint exists.
+    expect(metatask?.created_by_name).toBe("mollusk");
+    // ...and the pending chip's count, computed over the merged set, sees it.
+    expect(merged.filter((row) => row.status === "pending")).toHaveLength(1);
+  });
+
+  it("does not duplicate a task both sources returned, and the pending row wins", () => {
+    const merged = mergeAdminTaskRows(
+      [...EASIEST_FIFTY, task({ id: 909, status: "pending", title: "stale" })],
+      [PENDING_METATASK],
+    );
+
+    expect(merged.filter((row) => row.id === 909)).toHaveLength(1);
+    expect(merged.length).toBe(EASIEST_FIFTY.length + 1);
+    const metatask = merged.find((row) => row.id === 909);
+    expect(metatask?.title).toBe("Chart the coven's tasks");
+    expect(metatask?.created_by_name).toBe("mollusk");
+  });
+
+  it("leaves rows with no pending counterpart untouched", () => {
+    const merged = mergeAdminTaskRows(EASIEST_FIFTY, []);
+    expect(merged).toEqual(EASIEST_FIFTY);
+  });
+});

--- a/frontend/src/pages/admin/adminTaskRows.ts
+++ b/frontend/src/pages/admin/adminTaskRows.ts
@@ -1,0 +1,40 @@
+import type { TaskOut } from "../../api/tasks";
+import type { PendingTaskOut } from "../../api/admin";
+
+/**
+ * One row in the admin Tasks tab. A plain task, optionally carrying the
+ * proposer's display name — only `/admin/tasks/pending` supplies that.
+ */
+export type AdminTaskRow = TaskOut & { created_by_name?: string };
+
+/**
+ * Merge the two sources the admin Tasks tab reads (#909).
+ *
+ * `/tasks?status=all` is capped and ordered server-side, so on its own it can
+ * silently drop rows — historically the 50 easiest, which put every proposed
+ * metatask (level 6 to propose) outside the window. `/admin/tasks/pending` is
+ * uncapped and is the authority on the review queue, so its rows win on an id
+ * conflict: they are the only ones carrying `created_by_name`.
+ *
+ * Pending rows that the `/tasks` response did not contain lead the merged
+ * list — a row the capped source missed is exactly what the review queue
+ * exists to surface. Everything else keeps the order `/tasks` returned it in.
+ */
+export function mergeAdminTaskRows(
+  allTasks: TaskOut[],
+  pendingTasks: PendingTaskOut[],
+): AdminTaskRow[] {
+  const pendingById = new Map<number, PendingTaskOut>(
+    pendingTasks.map((task) => [task.id, task]),
+  );
+  const seen = new Set<number>();
+
+  const merged: AdminTaskRow[] = allTasks.map((task) => {
+    seen.add(task.id);
+    const pending = pendingById.get(task.id);
+    return pending ? { ...task, ...pending } : task;
+  });
+
+  const missing = pendingTasks.filter((task) => !seen.has(task.id));
+  return [...missing, ...merged];
+}


### PR DESCRIPTION
Closes #909

## What was wrong

The admin Tasks tab called `getAllTasks()`, which GETs `/tasks?status=all` with **no `limit` and no `sort`**. The backend defaults to `limit=50` ordered `level_required ASC, point_value DESC` — easiest first. So the tab has always rendered *the 50 easiest tasks*, and then filtered by status client-side over that already-truncated array.

Metatasks require level 6 to propose, so they sort to the very bottom and are the first rows dropped. An admin could not see, let alone approve, a proposed metatask. The counts on all four chips were computed from the same truncated array, so all four were wrong — the missing metatask was just the visible symptom.

`GET /admin/tasks/pending` — uncapped, no level gate, returns the proposer's display name — has existed the whole time and had **zero callers**.

## The fix

- `getAllTasks()` now sends `limit: 500, sort: 'newest'`. `'newest'` is a real value — `SORT_NEWEST = "newest"` in `backend/services/task.py`, which orders `created_at DESC, id DESC`. Required regardless of the pending endpoint, or the active/retired chips stay capped at the 50 easiest.
- Pending rows come from the existing `getPendingTasks()` (`/admin/tasks/pending`), now wired up. It is no longer dead code.
- New pure `mergeAdminTaskRows()` (`frontend/src/pages/admin/adminTaskRows.ts`) merges the two by task id into the single array the tab already renders. The pending row wins on conflict — it is the only source carrying `created_by_name`. Pending rows absent from the `/tasks` response lead the list; everything else keeps `/tasks` order.
- `refresh()` refetches **both** sources via `Promise.all`. Approving a pending task changes its status in one source and removes it from the other, so refreshing one alone left a stale row.
- Pending rows render "Proposed by \<name\>" under the meta line, from a new `tasks.proposedBy` key in `admin.json`. `created_by_name` is `""` for admin-created rows — those render nothing, never a dangling "Proposed by ".
- `ponytail:` comment on `getAllTasks` naming the ceiling and the upgrade path (server-side status filtering + pagination when the table outgrows 500).

Client-side chip filtering and the counts are unchanged — over the merged, uncapped set they are simply now honest for all four chips.

**Not in scope** (per the issue): pagination; server-side status filtering per chip (it fixes *less* — per-chip counts derive from the full list, so fetching one status at a time zeroes the others); the player-facing Tasks page, where pending rows stay hidden from non-admins by design.

## Test

`frontend/src/pages/admin/__tests__/adminTaskRows.test.ts` tests the extracted merge function directly — the harness is `renderToStaticMarkup` only (no jsdom, effects never run), so a self-fetching component is not testable here. The defect case: 50 level-0 tasks standing in for the old window, plus a level-6 pending metatask absent from them; the merged result contains the metatask, carries its proposer, and the pending count is 1. Two supporting cases cover de-duplication (pending row wins) and the no-pending no-op.

## Verification

- `vitest run` — 112 files / 1261 tests pass
- `tsc --noEmit` — clean (only the known `node:fs`/`node:url` stale-junction false alarm from PR #675)
- `eslint src/pages/admin src/api/admin.ts` — clean
- `vite build` — succeeds

**Visual QA is outstanding** — I cannot screenshot (the Browser pane renderer times out) and there is no dev stack in this worktree.

## What to eyeball

Admin → Tasks (`/admin`, Tasks tab):

1. **Pending chip** — propose a metatask from a level-6+ character, then check it appears here. This is the whole bug.
2. **Pending rows** — each shows "Proposed by \<name\>" under the `pts · lvl · faction` line. A pending task with no proposer (admin-created) must show **no** proposer line at all.
3. **All four chip counts** — `pending` / `active` / `retired` should now sum to more than 50 on a seeded DB, and match the row count each chip renders.
4. **Ordering** — the `all` list should now read newest-first, not easiest-first. Previously-invisible high-level tasks should appear.
5. **No duplicates** — a pending task must appear exactly once under both the `pending` and `all` chips.
6. **Approve/retire** — approve a pending task; the row should move to `active` and the pending count drop, with no manual reload and no ghost row left in `pending`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)