### PR TITLE
fix(ua): one ensō — the detailed brush mark on every UA surface

### DIFF
--- a/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
+++ b/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
@@ -41,9 +41,9 @@ describe("FactionAvatar — UA variant (#200)", () => {
     expect(html).toContain("var(--faction-ua-card-font)");
     expect(html).toContain("var(--faction-ua-lift)");
     expect(html).not.toMatch(/var\(--ua-[a-z]/); // the whole legacy family, deleted in #853
-    // The sigil badge is present — the ensō's heavy sweep (#849 retired the
-    // gilt shield, so the 100x120 viewBox marker is gone with it).
-    expect(html).toContain('d="M134 41.2 A68 68 0 1 1 66 158.8"');
+    // The sigil badge is present — the masked brush ensō (#849 retired the
+    // gilt shield; #908 made this the one ensō on every UA surface).
+    expect(html).toContain("/factionMarks/enso.svg");
   });
 
   it("renders the character portrait when avatar_url is present", () => {
@@ -54,7 +54,7 @@ describe("FactionAvatar — UA variant (#200)", () => {
     );
     expect(html).toContain("isolde.png");
     // Still badged with the mark.
-    expect(html).toContain('d="M134 41.2 A68 68 0 1 1 66 158.8"');
+    expect(html).toContain("/factionMarks/enso.svg");
   });
 
   it("falls back to the plain default avatar for an unknown slug", () => {
@@ -63,7 +63,7 @@ describe("FactionAvatar — UA variant (#200)", () => {
     );
     // No UA tokens and no ensō badge on the fallback circle.
     expect(html).not.toMatch(/var\(--ua-[a-z]/); // the whole legacy family, deleted in #853
-    expect(html).not.toContain('d="M134 41.2 A68 68 0 1 1 66 158.8"');
+    expect(html).not.toContain("/factionMarks/enso.svg");
     // Default renders the plain initial circle.
     expect(html).toContain("I");
   });

--- a/frontend/src/components/cards/UaSigil.tsx
+++ b/frontend/src/components/cards/UaSigil.tsx
@@ -1,4 +1,5 @@
 import i18n from "../../i18n";
+import { Enso } from "../factionMarks";
 
 /**
  * Shared UA (University of Asthmatics) identity atoms — the ensō sigil and the
@@ -10,7 +11,7 @@ import i18n from "../../i18n";
  * dark mode, and its mark is the ensō — the hand-drawn circle, made in one
  * breath, left open.
  *
- * Drawn once here and dropped into every UA surface that carries the mark
+ * Assembled once here and dropped into every UA surface that carries the mark
  * (faction hero, task card, avatar badge, edit-praxis masthead) rather than
  * re-drawn per file. All colours via tokens (never hardcode hex — CLAUDE.md),
  * and every token below has both themes, so the mark follows the
@@ -18,49 +19,39 @@ import i18n from "../../i18n";
  */
 
 /**
- * Ensō — UA's sigil (#849, brief §4).
+ * Ensō — UA's sigil (#849, brief §4; consolidated by #908).
  *
- * Two arcs, not one path: a HEAVY sweep (stroke-width 22) that carries most of
- * the circle, then a LIGHT return (10, slightly transparent) that closes toward
- * the start and stops short. The gap sits at the lower left, ~7-8 o'clock, and
- * the whole figure is rotated -7° so it reads as a stroke of the hand rather
- * than as geometry. The taper is done with two stroke-widths instead of a
- * variable-width outline — the cheap approximation, and at sigil sizes
- * (16-150px) it is the one that survives.
+ * ONE ENSŌ. This used to draw its own two-arc approximation — a heavy sweep
+ * plus a light return, rotated -7° — as a stand-in that avoided shipping the
+ * kit's 705 KB brush study site-wide. That left UA with two different circles,
+ * the good one on a single surface. Owner ruling 2026-07-21: "No two ensō's on
+ * purpose." The approximation is deleted; every UA surface now renders the
+ * vendored `enso.svg` — 284 hand-drawn strokes and a turbulence filter — at
+ * every size, from the 13px inline mark to the 420px backdrop.
  *
- * This is deliberately NOT the kit's `enso-detailed.svg`, which is 705 KB across
- * 284 hand-drawn paths. That asset does ship — as the praxis card's total mark,
- * where it is drawn at 118-138px and loaded as a masked file outside the JS
- * bundle (`components/factionMarks/Enso.tsx`, #839). Two ensōs on purpose:
- * different sizes, different consumers, different delivery. Do not consolidate.
+ * Delivery is {@link Enso}'s: a static asset under `public/` painted through a
+ * CSS mask, so the file supplies only the alpha and the ink comes from a token.
+ * The asset stays out of the JS bundle, is cached after first paint, and is
+ * non-blocking — the page renders whether or not the mask has arrived. Colour
+ * is unchanged from the arcs: `--faction-ua-glow`, which carries both themes,
+ * so the mark follows the `[data-theme="dark"]` cascade with no ternary.
  *
  * The ensō is reserved for the SCORE and the FACTION MARK. It is never a
  * container border — a card outlined in an ensō is the mark spent as decoration.
  *
- * The viewBox is square. Callers that pass a non-square width/height (a legacy
- * shield ratio, e.g. 72x86) get the circle centred and letterboxed by the
- * default `preserveAspectRatio`, which is the correct read.
+ * The drawing is square. Callers that pass a non-square width/height (e.g. the
+ * mobile praxis card's 16x19) get the circle centred and letterboxed by
+ * `mask-size: contain` + `mask-position: center`, which is the correct read and
+ * matches what the old `preserveAspectRatio` did.
  */
 export function UaSigil({ width, height }: { width: number; height: number }) {
   return (
-    <svg
-      width={width}
+    <Enso
+      size={width}
       height={height}
-      viewBox="0 0 200 200"
-      fill="none"
-      aria-hidden="true"
-      style={{ display: "block", flexShrink: 0 }}
-    >
-      <g
-        transform="rotate(-7 100 100)"
-        stroke="var(--faction-ua-glow)"
-        strokeLinecap="round"
-        fill="none"
-      >
-        <path d="M134 41.2 A68 68 0 1 1 66 158.8" strokeWidth="22" />
-        <path d="M66 158.8 A68 68 0 0 1 66 41.2" strokeWidth="10" strokeOpacity="0.85" />
-      </g>
-    </svg>
+      color="var(--faction-ua-glow)"
+      style={{ flexShrink: 0 }}
+    />
   );
 }
 

--- a/frontend/src/components/cards/__tests__/factionSigil.test.tsx
+++ b/frontend/src/components/cards/__tests__/factionSigil.test.tsx
@@ -13,26 +13,27 @@ import UaMandala from "../UaMandala";
 describe("FactionSigil dispatcher (#659)", () => {
   it("renders the UA ensō for the ua slug", () => {
     const html = renderToStaticMarkup(<FactionSigil slug="ua" />);
-    // The ensō is two arcs on a square viewBox, not the old 100x120 shield.
-    expect(html).toContain('viewBox="0 0 200 200"');
-    expect(html).toContain('d="M134 41.2 A68 68 0 1 1 66 158.8"');
-    expect(html).toContain('d="M66 158.8 A68 68 0 0 1 66 41.2"');
+    // One ensō (#908): the vendored brush drawing, painted through a CSS mask.
+    // The two-arc approximation on a 200x200 viewBox is gone, and so is the
+    // 100x120 gilt shield it replaced.
+    expect(html).toContain("/factionMarks/enso.svg");
+    expect(html).not.toContain('viewBox="0 0 200 200"');
   });
 
-  it("tapers the ensō by stroke-width and leaves the circle open", () => {
+  it("delivers the mark as a mask, so the asset stays out of the JS bundle", () => {
     const html = renderToStaticMarkup(<FactionSigil slug="ua" />);
-    // The heavy sweep and the light return — the taper is two widths, not a
-    // variable-width outline. Two arcs only means the gap survives.
-    expect(html).toContain('stroke-width="22"');
-    expect(html).toContain('stroke-width="10"');
-    expect(html.match(/<path/g) ?? []).toHaveLength(2);
-    // Hand-drawn, not geometry.
-    expect(html).toContain("rotate(-7 100 100)");
+    // The file supplies the ALPHA only; nothing is inlined and no <path> for
+    // the mark reaches the markup.
+    expect(html).toMatch(/mask-image:url\(\/factionMarks\/enso\.svg\)/);
+    // Letterboxed and centred, so non-square callers do not stretch the circle.
+    expect(html).toContain("mask-size:contain");
+    expect(html).toContain("mask-position:center");
   });
 
   it("draws the ensō in the ornament token so it follows the dark cascade", () => {
     const html = renderToStaticMarkup(<FactionSigil slug="ua" />);
-    expect(html).toContain("var(--faction-ua-glow)");
+    // The mask takes its ink from background-color — i.e. from a token.
+    expect(html).toContain("background-color:var(--faction-ua-glow)");
     // The salon is dead: no gilt shield, no legacy gold, no raw hex.
     expect(html).not.toMatch(/var\(--ua-[a-z]/); // the whole legacy family, deleted in #853
     expect(html).not.toContain("#");

--- a/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
+++ b/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
@@ -34,8 +34,15 @@ import UaComment from '../../comments/voices/UaComment'
 
 const SRC_DIR = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..', '..')
 
-/** The ensō's heavy sweep — the one path that proves the mark is on a surface. */
-const ENSO_SWEEP = 'd="M134 41.2 A68 68 0 1 1 66 158.8"'
+/**
+ * The masked brush asset — the one string that proves the mark is on a surface.
+ *
+ * This used to pin the two-arc approximation's path geometry. #908 deleted that
+ * drawing: there is one ensō now, the vendored `enso.svg`, delivered as a CSS
+ * mask at every size (see `cards/UaSigil.tsx` and `factionMarks/Enso.tsx`).
+ * Same guard, new mechanism — the surfaces still have to render *a* mark.
+ */
+const ENSO_MARK = '/factionMarks/enso.svg'
 
 const TASK: TaskOut = {
   id: 12,
@@ -187,7 +194,7 @@ describe('the ensō is reserved for the score and the faction mark', () => {
       ['feed row', feedRow],
       ['composer', composer],
     ] as const) {
-      expect(render(), `${name} lost the ensō`).toContain(ENSO_SWEEP)
+      expect(render(), `${name} lost the ensō`).toContain(ENSO_MARK)
     }
   })
 

--- a/frontend/src/components/factionMarks/Enso.tsx
+++ b/frontend/src/components/factionMarks/Enso.tsx
@@ -22,22 +22,38 @@ import type { FactionMarkProps } from "./Lotus";
  *
  * Both export the same component shape, so call sites do not care which
  * mechanism is underneath.
+ *
+ * This is UA's ONLY ensō (#908). The two-arc approximation that `UaSigil` used
+ * to draw is gone; `UaSigil` is now a thin wrapper over this component, so the
+ * mark is one drawing delivered one way at every size from 13px to 420px.
  */
 
 /** Where the asset lives under `public/`. */
 const ENSO_ASSET = "url(/factionMarks/enso.svg)";
 
+export interface EnsoProps extends Omit<FactionMarkProps, "lineColor"> {
+  /**
+   * Box height, when the mark must fill a non-square slot. Defaults to
+   * {@link FactionMarkProps.size}, so the ordinary call stays square. The mask
+   * is `contain`/`center`, so a non-square box letterboxes the circle rather
+   * than stretching it — the same read the old inline `<svg>` got from the
+   * default `preserveAspectRatio`.
+   */
+  height?: number;
+}
+
 export default function Enso({
   size = 138,
+  height = size,
   color = "currentColor",
   opacity = 1,
   style,
   className,
-}: Omit<FactionMarkProps, "lineColor">) {
+}: EnsoProps) {
   const maskStyle: CSSProperties = {
     display: "block",
     width: size,
-    height: size,
+    height,
     opacity,
     // The asset is the alpha channel; the colour is a token the theme owns.
     backgroundColor: color,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
@@ -145,8 +145,8 @@ function render(): { html: string; text: string } {
 describe('UA mobile composer — what it draws', () => {
   it('heads the form with the ensō', () => {
     const { html } = render()
-    // The heavy sweep of the two-arc sigil (#849), not the 705 KB textured one.
-    expect(html).toContain('M134 41.2 A68 68 0 1 1 66 158.8')
+    // The one ensō (#908): the vendored brush drawing, painted through a mask.
+    expect(html).toContain('/factionMarks/enso.svg')
     expect(html).toContain('var(--faction-ua-glow)')
   })
 

--- a/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/uaMobileDispatch.test.tsx
@@ -82,8 +82,8 @@ describe('mobile faction-page UA dispatch', () => {
 describe('UA mobile faction page — what it draws', () => {
   it('sets the ensō beside the name as the faction mark', () => {
     const { html } = render(<UaFactionPage state={baseState()} />)
-    // The heavy sweep of the two-arc sigil (#849), not the 705 KB textured one.
-    expect(html).toContain('M134 41.2 A68 68 0 1 1 66 158.8')
+    // The one ensō (#908): the vendored brush drawing, painted through a mask.
+    expect(html).toContain('/factionMarks/enso.svg')
     expect(html).toContain('var(--faction-ua-glow)')
   })
 

--- a/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
@@ -94,8 +94,8 @@ describe('mobile FieldDesk-home UA dispatch', () => {
 describe('UA mobile home — what it draws', () => {
   it('heads the screen with the ensō', () => {
     const { html } = render(<UaHome state={baseState()} />)
-    // The heavy sweep of the two-arc sigil (#849), not the 705 KB textured one.
-    expect(html).toContain('M134 41.2 A68 68 0 1 1 66 158.8')
+    // The one ensō (#908): the vendored brush drawing, painted through a mask.
+    expect(html).toContain('/factionMarks/enso.svg')
     expect(html).toContain('var(--faction-ua-glow)')
   })
 

--- a/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
@@ -99,8 +99,8 @@ describe("mobile task-detail UA dispatch", () => {
 describe("UA mobile task detail — what it draws", () => {
   it("writes the point value inside the ensō", () => {
     const { html, text } = render(<UAMobileTaskDetail state={baseState()} />);
-    // The heavy sweep of the two-arc sigil (#849), not the 705 KB textured one.
-    expect(html).toContain("M134 41.2 A68 68 0 1 1 66 158.8");
+    // The one ensō (#908): the vendored brush drawing, painted through a mask.
+    expect(html).toContain("/factionMarks/enso.svg");
     expect(html).toContain("var(--faction-ua-vermil)");
     expect(text).toContain("42");
   });

--- a/frontend/src/pages/tasks/mobileArchetypes/cards/__tests__/uaMobileTaskCard.test.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/cards/__tests__/uaMobileTaskCard.test.tsx
@@ -40,8 +40,8 @@ const text = html.replace(/<[^>]*>/g, '')
 
 describe('UA mobile task card', () => {
   it('writes the point value inside the ensō', () => {
-    // The heavy sweep of the two-arc sigil (#849) — not the 705 KB textured one.
-    expect(html).toContain('M134 41.2 A68 68 0 1 1 66 158.8')
+    // The one ensō (#908): the vendored brush drawing, painted through a mask.
+    expect(html).toContain('/factionMarks/enso.svg')
     expect(html).toContain('var(--faction-ua-glow)')
     expect(text).toContain('30')
   })


### PR DESCRIPTION
UA had two different ensōs and the good one was on exactly one surface. Now there is one.

`UaSigil` no longer draws its own two-arc approximation. It wraps `factionMarks/Enso` — the vendored 284-stroke brush drawing, delivered as a static `public/factionMarks/enso.svg` painted through a CSS mask. Every UA surface, 13px to 420px, renders the same mark.

Closes #908

## What changed

- **`frontend/src/components/cards/UaSigil.tsx`** — body replaced; the exported signature `UaSigil({ width, height })` is unchanged and **all 16 call sites are untouched**. The "Two ensōs on purpose … Do not consolidate" paragraph is deleted per the owner ruling (2026-07-21), not worked around.
- **`frontend/src/components/factionMarks/Enso.tsx`** — widened with an optional `height` (defaults to `size`, so the existing `UaScoreStamp` call is untouched). One mask implementation, not two. `mask-size: contain` + `mask-position: center` reproduces the old `preserveAspectRatio` letterboxing for the non-square callers.
- **7 test files** — every pin on the deleted arc geometry replaced with an assertion that the surface renders `/factionMarks/enso.svg`, mirroring `factionMarks.test.tsx:27`. The issue named `uaDesktopSkin.test.tsx`; grep found six more (`factionAvatar`, `factionSigil`, and the four `uaDispatch`-family tests). `factionSigil`'s two geometry tests became mask-delivery tests. Nothing was dropped without a replacement.

Colour is unchanged: still `--faction-ua-glow`, still through the `[data-theme="dark"]` cascade. No new tokens, no hex, one element swap (`<svg>` → masked `<span>`) — every call site was already an HTML context, none nested inside an SVG.

## Verified

`tsc --noEmit` clean · `vitest` 1258/1258 pass · `eslint` clean · `vite build` clean. JS bundle unchanged at 1,748.92 kB (the asset is not in it).

## Visual QA is OUTSTANDING — and this is the real risk

**I cannot screenshot; nothing here was seen rendered.** A 284-stroke brush study with a turbulence filter may go muddy or read as a grey smudge exactly where a 2-arc glyph read cleanly. Per the issue that is a *sizing* question for the surface, not a reason to keep a second drawing — but someone has to look.

### What to eyeball, smallest first (the small ones are where it breaks)

| px | surface | file |
|---|---|---|
| **13** | task-detail inline point mark — **highest risk** | `pages/taskDetail/archetypes/UaTaskDetail.tsx:650` |
| **16×19** | mobile praxis card — **the only non-square caller**; confirm the circle letterboxes and is not stretched | `components/praxisCard/mobile/UaMobilePraxisCard.tsx:82` |
| **18** | feed-row corner mark | `components/feed/UaFeedFrame.tsx:45` |
| 34 | mobile composer / faction page / home mastheads | `UaComposer.tsx:99`, `UaFactionPage.tsx:158`, `UaHome.tsx:90` |
| 38 | comment voice avatar | `components/comments/voices/UaComment.tsx:58` |
| 40 | edit-praxis masthead | `pages/editPraxis/archetypes/UaEditPraxis.tsx:149` |
| 52 | mobile task card — **numeral sits inside the ring**; check the brush's inner edge does not collide with the digits | `UaMobileTaskCard.tsx:89` |
| 76 / 96 | mobile task detail, faction hero, faction select card | `UaTaskDetail.tsx:162`, `UaFactionHero.tsx:75`, `FactionSelectCard.tsx:82` |
| variable | avatar badge (`glyph={(s) => …}`), and the `uaAtoms` value-in-ring atom | `UaAvatar.tsx:32`, `uaAtoms.tsx:91` |
| 420 | page backdrop at 0.06 opacity, bled off the upper left | `components/backdrop/UaBackdrop.tsx:47` |

Also worth checking: **dark mode** on any two of the above (the mask takes `background-color` from the token, so it should follow, but it has never been seen at these sizes), and the **first paint** — the mask is non-blocking, so the mark pops in a beat late on a cold cache.

## Left alone deliberately

The arc path data still appears in `.design-sync/BRIEF-ua-identity.md` and `.design-sync/ua-enso.svg` — vendored *design* artefacts, not code. `frontend/` is clean. Deleting design-bundle files is outside this issue's scope; flagging rather than doing it. Also untouched, per the issue: `enso.svg` optimisation, any surface's mark size, and `UaScoreStamp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
