### PR TITLE
WOW redesign 1/6: token block completion + contrast gate

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -107,7 +107,11 @@
      text, so it owes 4.5:1 on card-bg — the design's plum pays it outright
      (5.79:1) where no readable yellow ever could. The gold #c8a02a is the
      chronicle's frame/rule colour, not an ink: it measures 2.24:1 on the cream
-     and never carries text. */
+     and never carries text.
+     THIS TOKEN IS THE KIT'S "whimsy" PLUM. The WoW faction kit's token table
+     names #7A4A9E `whimsy`; it is byte-identical to the value below, which
+     #838 had already landed. #896 asked for a `--faction-wow-whimsy` alias and
+     it was refused: one colour, one name. Read the kit's `whimsy` as this. */
   --faction-wow-card-accent: #7a4a9e; /* chronicle plum — 5.79:1 */
   --faction-coven-card-accent: #ec5f99;
   --faction-snide-card-accent: #b6ff2e; /* toxic acid */
@@ -536,6 +540,14 @@
   /* WOW — cream/gold/plum chronicle frame (the chronicle is WOW's, ADR-0050) */
   --faction-wow-chronicle-bg: var(--faction-wow-card-bg); /* cream parchment */
   --faction-wow-chronicle-gold: #c8a02a; /* frame + rules; theme-invariant */
+  /* The kit's olive-gold eyebrow/label ink — the small caps that head a section
+     ("TASK CARD", "BY ORDER OF"). The kit states #8a6d1f, which measures
+     4.46:1 on --faction-wow-card-bg and so misses AA: that value was picked
+     against the kit's own near-white documentation plate (rgba(251,244,224,.55)
+     over white), not against WOW's cream card. Walked down to the nearest
+     compliant shade of the same 43.5deg hue — 5.32:1 on the cream card and
+     4.74:1 on the parchment panel, so it is legible on both chronicle grounds. */
+  --faction-wow-accent-deep: #7d6118;
   /* The FRAME, split out of the accent (#860 ask 2). ChronicleTheme carried one
      `accent` doing duty as border AND rule AND ink tint, so the card bound
      itself in plum and the design's gold frame never shipped. */
@@ -895,6 +907,7 @@
      the legible choice, so here the accent CAN be the faction colour — for the
      factions whose skin IS their spine hue. WOW's is not (#838): the plum lifts
      instead, which is the flip the chronicle's gold deliberately does not make. */
+  /* The kit's `whimsy · dk`, under the name it already had (see :root). */
   --faction-wow-card-accent: #c79be0; /* chronicle plum, lifted — 7.94:1 */
   --faction-coven-card-accent: #f472b6;
   --faction-snide-card-accent: #b6ff2e;
@@ -1061,6 +1074,11 @@
   --faction-wow-chronicle-bg: var(--faction-wow-card-bg);
   --faction-wow-chronicle-panel: #2a2210; /* the inset parchment plate, darkened */
   --faction-wow-chronicle-shadow: rgba(0, 0, 0, 0.8);
+  /* The eyebrow ink lifts (the kit states light only). Same 43deg olive-gold,
+     raised until it clears both dark chronicle grounds — 8.83:1 on the deep
+     ground, 7.66:1 on the darkened panel. Deliberately short of the "gold
+     bright" below, which the stamp total reserves for its own line. */
+  --faction-wow-accent-deep: #cfb268;
   --faction-wow-stamp-total: #e3b84a; /* the design's dark "gold bright" */
   --faction-wow-stamp-shadow: rgba(0, 0, 0, 0.4);
   /* The plum chip lifts to the design's dark secondary plum, one step below the

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -40,8 +40,10 @@ const BOTH_THEMES: Theme[] = ["light", "dark"];
 /** Every faction that supplies the standard `--faction-{key}-card-*` block (§3). */
 const CARD_KEYS = [
   "ua",
-  // `wow` supplies the §3 block and nothing more (#812) — it has a colour but
-  // no archetype, so it appears here and NOT in ARCHETYPE_PAIRS below.
+  // `wow` supplied the §3 block and nothing more until #896 gated the chronicle
+  // primitives, so it now appears here AND in ARCHETYPE_PAIRS below. The §3
+  // block still covers four of the kit's six stated pairs on its own — see the
+  // WOW comment down there for which.
   "wow",
   "everymen",
   "coven",
@@ -155,6 +157,28 @@ const ARCHETYPE_PAIRS: Pair[] = [
     text: "--faction-ua-vermil",
     floor: AA_LARGE,
   },
+
+  // WOW — the cream/gold/plum chronicle (#838, ADR-0050). The faction kit
+  // states six contrast pairs; FOUR of them are the §3 card block measured in
+  // both themes, so CARD_PAIRS already gates them and repeating them here would
+  // be a second name for one measurement:
+  //   text / card-bg  (both themes) = `wow card body text`
+  //   plum / card-bg  (both themes) = `wow card accent`
+  // What is left are the chronicle's own primitives, which no generator reaches.
+  //
+  // The kit's "on-fill / gold" pair puts ink on the frame gold. Its stated ink
+  // #2a1d02 has no token and does not need one: --faction-wow-on-fill is the
+  // WOW ink, is theme-invariant like the gold it sits on, and measures 7.64:1
+  // where the kit's own value manages 6.68:1 — not the 8.1:1 the kit claims.
+  { what: "wow chronicle gold element, ink", surface: "--faction-wow-chronicle-gold", text: "--faction-wow-on-fill" },
+  // The kit's "gold / card-bg dk" pair. The bright total is a *dark*-theme
+  // value; measuring the token in both themes also gates its light sibling,
+  // which the kit never states.
+  { what: "wow stamp total, on card", surface: "--faction-wow-card-bg", text: "--faction-wow-stamp-total" },
+  // The eyebrow/label ink #896 added. The kit's #8a6d1f fails AA on the cream
+  // card (4.46:1) — it was chosen against the kit's near-white documentation
+  // plate — so index.css ships it walked down the same hue.
+  { what: "wow eyebrow ink, on card", surface: "--faction-wow-card-bg", text: "--faction-wow-accent-deep" },
 
   // Albescent's FACTION tokens are gone (#783) — it renders Default's surfaces,
   // which `default` already covers. What remains is the always-light palette


### PR DESCRIPTION
WOW redesign 1/6. Tokens and the contrast gate, before anything visual is built.

Closes #896

## `--faction-wow-whimsy` was NOT minted, and why

The issue's first bullet is wrong. The plum it asks for **already ships**, under
another name, byte-identical in both themes on `origin/main`:

```
:root                  --faction-wow-card-accent: #7a4a9e;  /* kit: whimsy      */
[data-theme="dark"]    --faction-wow-card-accent: #c79be0;  /* kit: whimsy · dk */
```

So the claim that "#835 asked for this token too but shipped without it" is not
what happened: #838 had already landed the colour, and the owner ruled during
#835 against minting a second name for it. Minting `--faction-wow-whimsy` now
would create exactly the duplicate that ruling forbade.

The kit's own palette strip (`WoW-Task-Card-decree.html`) agrees independently:
`whimsy #7A4A9E -> ALREADY SHIPPED as --faction-wow-card-accent. Do NOT mint a duplicate.`

Instead, both declarations now carry a comment saying **this token is the kit's
"whimsy" plum**, so the next reader of the kit does not re-file this.

## What landed

### `--faction-wow-accent-deep` — genuinely new

The kit's olive-gold eyebrow/label ink (the small caps heading every section:
"TASK CARD", "FEED FRAME", "BY ORDER OF"). `grep -ri 8a6d1f frontend/src`
returned nothing before this PR.

| theme | value | reasoning |
|---|---|---|
| light | `#7d6118` | **not** the kit's `#8A6D1F` — see below |
| dark | `#cfb268` | new; the kit is light-only |

**The kit's light value fails its own gate.** `#8A6D1F` measures **4.46:1** on
`--faction-wow-card-bg` (`#fbf4e0`) — under AA. It is fine in the kit because
the kit paints it on its own documentation plate,
`rgba(251,244,224,.55)` over white, which is near-white and much lighter than
WOW's cream card. Walked down the same 43.5° hue to `#7d6118`: **5.32:1** on the
cream card and **4.74:1** on `--faction-wow-chronicle-panel`, so it is legible on
both light chronicle grounds and a later slice cannot misuse it.

Dark value `#cfb268` is the same hue lifted: **8.83:1** on the deep ground
(`#1b1508`), **7.66:1** on the darkened panel (`#2a2210`). Held deliberately
short of `--faction-wow-stamp-total` dark (`#e3b84a`), which the score stamp
reserves for its total line, and above `--faction-wow-card-muted` (`#b69c64`,
6.85:1) so eyebrow and metadata stay distinguishable.

### Six contrast rows — four were already gated

I measured all six of the kit's stated pairs before adding anything. **Four are
the §3 card block**, which the existing `CARD_PAIRS` generator already measures
in both themes for every faction including `wow`. Re-adding them to
`ARCHETYPE_PAIRS` would be a second name for one measurement:

| kit pair | already covered by |
|---|---|
| text / card-bg | `wow card body text` (light) |
| text / card-bg dk | `wow card body text` (dark) |
| plum / card-bg | `wow card accent` (light) |
| plum / card-bg dk | `wow card accent` (dark) |

The remaining two are chronicle primitives no generator reaches, so they are new
rows — and since the manifest measures every row in **both** themes, they bring
their unstated siblings with them. A third row gates the new eyebrow ink; a new
ink token with no gate would be a hole in exactly the audit this issue exists to
build. Net: **3 rows × 2 themes = 6 new test cases**, all green.

| new row | light | dark |
|---|---|---|
| `wow chronicle gold element, ink` | 7.64:1 | 7.64:1 (both tokens theme-invariant) |
| `wow stamp total, on card` | 5.38:1 | 9.70:1 |
| `wow eyebrow ink, on card` | 5.32:1 | 8.83:1 |

Every row is expressed in token names, never hex — the test resolves vars.

**One substitution, deliberate.** The kit's "on-fill / gold" pair states ink
`#2A1D02`, which is in no token and needs none: `--faction-wow-on-fill` is WOW's
ink, is theme-invariant like the frame gold it sits on, and measures **7.64:1**
against it — AAA, and better than the kit's own value manages.

### Ratios that did not match the stated table

Verified rather than trusted, per the issue. Recomputed WCAG 2.x relative
luminance for all six:

| kit pair | kit states | measured | verdict |
|---|---|---|---|
| on-fill / gold | 8.1:1 AAA | **6.68:1** | **kit is wrong** — that is AA, not AAA. Moot here: the repo's own ink gives 7.64:1 and is genuinely AAA. |
| text / card-bg | 12.4:1 | 14.02:1 | kit understates; passes |
| plum / card-bg | 5.2:1 | 5.79:1 | kit understates; passes |
| gold / card-bg dk | 9.6:1 | 9.70:1 | matches |
| text / card-bg dk | 13.1:1 | 14.72:1 | kit understates; passes |
| plum / card-bg dk | 7.4:1 | 7.94:1 | kit understates; passes |

Plus the token fix already described: the kit's eyebrow ink `#8A6D1F` measures
4.46:1 on the card and **fails AA**, so the token ships walked down.

Nothing was added to `BASELINE` — that list only shrinks.

### Stale comment updated

`CARD_KEYS` carried a comment saying `wow` "supplies the §3 block and nothing
more … so it appears here and NOT in `ARCHETYPE_PAIRS` below". That went stale
the moment these rows landed; it now says which four pairs the §3 block still
covers on its own.

## Untouched, on purpose

`--faction-wow` (`#e0a800` / `#f5c542`, the rainbow spine hue — the kit labelling
`#C8A02A` "primary" does not make it the fill), `--faction-wow-chronicle-gold`
(no rename), `-light` / `-border` / `-on-fill` (`#14110b` stays — it is the ink
on the spine hue), `--faction-wow-body-font`, `votes.json`, `chrome.wow`, the
praxis masthead. `utils/factions.ts` holds only the per-faction spine colour, no
per-token map, so it needed no change. **No component files touched.**

## Verification

- `vitest run` — 111 files, 1264 tests, all green (contrast 134, up 6)
- `tsc --noEmit` — no error in any touched file; the 25 reported are all the
  known stale-junction `node:fs`/`node:url` false alarm (PR #675) and its
  knock-on implicit-`any`s, in test files I did not touch
- `vite build` — clean
- `eslint` — clean on the test file; `index.css` is not in the lint config
- **Visual QA is outstanding** — I cannot screenshot and there is no dev stack.
  Every claim here is a computed ratio, not an eyeball.

## What to eyeball

1. `--faction-wow-accent-deep` light `#7d6118` against the kit's `#8A6D1F` — it
   is 4% darker in lightness at identical hue. Does the eyebrow still read as
   olive-gold rather than brown on the cream card?
2. The same token dark `#cfb268` next to `--faction-wow-card-muted` `#b69c64` on
   `#1b1508` — are eyebrow and metadata distinguishable, or too close?
3. `#cfb268` next to `--faction-wow-stamp-total` `#e3b84a` — the eyebrow should
   sit clearly below the "gold bright" the stamp reserves for its total.
4. Whether dark ink on `--faction-wow-chronicle-gold` is a real surface WOW will
   paint (the kit's quest button and checkbox both do it) — if the gold is only
   ever frame and rule, that row gates a pairing that never renders. Harmless,
   but say so and I will drop it.
5. Confirm the ruling stands: no `--faction-wow-whimsy`, the kit's `whimsy` is
   read as `--faction-wow-card-accent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
