### PR TITLE
WOW redesign 3/6: the copy deck — voice, the Charter, page strings, taunts

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -200,6 +200,10 @@
         "masthead": "The Job Board",
         "charEyebrow": "on file",
         "questsHeading": "jobs in play"
+      },
+      "wow": {
+        "greeting": "Good morrow, Sir {{name}}.",
+        "masthead": "Thy crusade awaits. The noodle sword is where thou left it."
       }
     }
   },

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -14,7 +14,7 @@
     "ua": "We practise art as a daily, deliberate thing. One true mark, then another. The satisfaction is in the making, not the tally.",
     "snide": "Specialists in one-on-one competition. Bonus points for winning duels.",
     "coven": "A soft-lit circle of makers. Full points on every task.",
-    "wow": "Collective-minded. Excel at their own faction's tasks; reduced elsewhere.",
+    "wow": "A gold-clad order of knights sworn to the solemn crusade of inflicting joy upon a dreary world. We wield the noodle sword. We take the ridiculous with total, unsmiling seriousness — that tension is not a bug, it is the entire creed, and the Court will hear no argument. Once per level, a knight may reach one rank above their own to claim a single quest.",
     "ephemerists": "Wanderers who set down fleeting truths before the road moves on. Task Vision — access to select retired tasks.",
     "everymen": "No inner circle, no waiting to be chosen. Reliable hands who do the work in front of them and finish what they start.",
     "singularity": "embrace your digital double",
@@ -536,6 +536,41 @@
         "join": "Join the coven",
         "joined": "welcome home, witch"
       }
+    }
+  },
+  "wow": {
+    "charter": {
+      "heading": "The Charter",
+      "title": "The Charter of Whimsy",
+      "paragraphs": [
+        "Hear ye. We are the Warriors of Whimsy, and we have taken a vow so grave it loops entirely back around to silly: to bring whimsy into a world that keeps insisting on being sensible.",
+        "We march in real armour after imaginary dragons. We hold ceremonies for the frankly ceremonious. We knight houseplants. Our motto, borne on the crest in the honest tongue of Pig Latin, is Imsy-whay or-fay every-oneway — whimsy, for everyone — and we mean it with our whole gleaming breastplates.",
+        "The noodle sword is not a joke to us. It is THE joke, and we carry it with both hands and a straight face. That is the crusade. Enlist, and take the ridiculous seriously alongside us."
+      ]
+    },
+    "tasks": {
+      "heading": "Quests Awaiting a Champion",
+      "empty": "No quests afoot. The realm is, briefly and tragically, sensible."
+    },
+    "praxis": {
+      "heading": "Chronicles of Proof"
+    },
+    "join": {
+      "eligibleTitle": "Enlist in the Crusade",
+      "eligibleBody": "the armour is one-size, the oath is for life"
+    },
+    "spotlight": {
+      "label": "Champion of the Fortnight"
+    },
+    "roster": {
+      "heading": "The Muster Roll"
+    },
+    "mobile": {
+      "eyebrow": "The Field Pavilion",
+      "subtitle": "thy crusade, in the palm of thy gauntlet"
+    },
+    "invitation": {
+      "pitch": "By decree most official (we made the seal ourselves), thou art summoned to the Warriors of Whimsy. Bring a straight face. We shall supply the sword."
     }
   },
   "invitation": {

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -41,7 +41,12 @@
     "points": "{{points}} pts",
     "pointsEarned": "+{{points}} pts",
     "level": "lvl {{level}}",
-    "quotedHeadline": "“{{headline}}”"
+    "quotedHeadline": "“{{headline}}”",
+    "wow": {
+      "questTaken": "{{name}} took up a quest, breastplate agleam.",
+      "praxisSealed": "{{name}} sealed a chronicle of proof.",
+      "levelUp": "{{name}} was elevated a rank by the Court."
+    }
   },
   "dateDivider": {
     "today": "Today",
@@ -175,6 +180,9 @@
       "questMeta": "new quest · {{points}} pts",
       "signup": "sign up",
       "points": "{{points}} pts"
+    },
+    "wow": {
+      "signup": "Take Up the Quest"
     }
   },
   "factionCard": {
@@ -307,6 +315,9 @@
       "members_one": "{{count}} witch ✦",
       "members_other": "{{count}} witches ✦",
       "cta": "peek inside ✦"
+    },
+    "wow": {
+      "tagline": "Whimsy for everyone. — Imsy-whay or-fay every-oneway."
     },
     "snide": {
       "masthead": "Field Dispatch · Nº 0666",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -642,7 +642,7 @@
       "na": "Anyone",
       "ua": "Practise with us — one true mark a day.",
       "coven": "Circle",
-      "wow": "Collective",
+      "wow": "Knights who take the ridiculous with total seriousness.",
       "everymen": "Mobilize",
       "snide": "Mischief",
       "ephemerists": "Record",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -393,6 +393,9 @@
         "re": "re:",
         "witness": "Bear witness"
       }
+    },
+    "wow": {
+      "intro": "Herein lies the sworn account, submitted to the Court for its solemn and giggling judgment."
     }
   },
   "comments": {
@@ -441,6 +444,12 @@
     "albescent": {
       "letterhead": "Albescent — correspondence",
       "edited": "amended"
+    },
+    "wow": {
+      "prompt": "Add thy counsel to the chronicle…",
+      "post": "Proclaim",
+      "react": "Huzzah",
+      "empty": "No counsel yet. Be the first to cry Huzzah."
     }
   },
   "duelCrossLink": {

--- a/frontend/src/locales/en/taunts.json
+++ b/frontend/src/locales/en/taunts.json
@@ -88,5 +88,22 @@
     "praxis_complete": [
       "{{from_name}} executed. {{to_name}} is still in the queue."
     ]
+  },
+  "wow": {
+    "score_overtake": [
+      "Stand aside, {{to_name}} — {{from_name}} advances, noodle sword held high and dignity fully intact.",
+      "By order of the Court, {{from_name}} hath vaulted clean past {{to_name}}. Trumpets were requested. A kazoo was available.",
+      "{{to_name}}, thy lead hath wilted like an un-serenaded fern. {{from_name}} now reigns, gravely and absurdly."
+    ],
+    "level_up": [
+      "Kneel, {{from_name}}. Now rise, {{from_name}} — one rank grander and not one whit less ridiculous.",
+      "The Court elevates {{from_name}}! A fresh pauldron has been glued on. It is mostly straight.",
+      "Huzzah for {{from_name}}, promoted this day for distinguished services to gleeful nonsense."
+    ],
+    "praxis_complete": [
+      "{{from_name}} hath furnished proof. The fern has been formally notified.",
+      "Deed sealed. {{from_name}} adds one more glorious absurdity to the eternal ledger of whimsy.",
+      "The Court reviewed {{from_name}}'s chronicle, wept a single joyful tear, and stamped it GLORIOUS."
+    ]
   }
 }


### PR DESCRIPTION
WOW redesign 3/6 — the copy deck. Locale catalogs only; no component, CSS or
backend files touched.

Closes #898

The kit keys everything as `faction.wow.*`, a namespace that exists nowhere in
this repo. Every string is lifted verbatim (exceptions noted below) and mapped
onto the real catalogs, which split by concern rather than by faction.

## Key inventory

Downstream slices (#899 task card / comment / feed, #900 hero / backdrop /
profile / select card, #901 mobile, #895 duel) consume these.

### `factions.json`
| key | value |
|---|---|
| `descriptions.wow` | **replaced** — kit voice + one mechanics clause (see below) |
| `wow.charter.heading` | `The Charter` (section label) |
| `wow.charter.title` | `The Charter of Whimsy` (document title) |
| `wow.charter.paragraphs` | array of the kit's 3 paragraphs |
| `wow.tasks.heading` | `Quests Awaiting a Champion` |
| `wow.tasks.empty` | `No quests afoot. The realm is, briefly and tragically, sensible.` |
| `wow.praxis.heading` | `Chronicles of Proof` |
| `wow.join.eligibleTitle` | `Enlist in the Crusade` |
| `wow.join.eligibleBody` | `the armour is one-size, the oath is for life` |
| `wow.spotlight.label` | `Champion of the Fortnight` |
| `wow.roster.heading` | `The Muster Roll` |
| `wow.mobile.eyebrow` | `The Field Pavilion` |
| `wow.mobile.subtitle` | `thy crusade, in the palm of thy gauntlet` |
| `wow.invitation.pitch` | the summons-by-decree paragraph |

`names.wow` already read "Warriors of Whimsy" — the kit agrees, so it is
untouched.

### `taunts.json`
`wow.score_overtake`, `wow.level_up`, `wow.praxis_complete` — 3 variants each.

### `praxis.json`
| key | value |
|---|---|
| `detail.wow.intro` | `Herein lies the sworn account…` |
| `comments.wow.prompt` | `Add thy counsel to the chronicle…` |
| `comments.wow.post` | `Proclaim` |
| `comments.wow.react` | `Huzzah` |
| `comments.wow.empty` | `No counsel yet. Be the first to cry Huzzah.` |

`card.masthead.wow` already ships `Chronicle of proof · № {{id}}` — left alone.

### `feed.json`
| key | value |
|---|---|
| `row.wow.questTaken` | `{{name}} took up a quest, breastplate agleam.` |
| `row.wow.praxisSealed` | `{{name}} sealed a chronicle of proof.` |
| `row.wow.levelUp` | `{{name}} was elevated a rank by the Court.` |
| `taskCard.wow.signup` | `Take Up the Quest` |
| `factionSelect.wow.tagline` | `Whimsy for everyone. — Imsy-whay or-fay every-oneway.` |

### `forms.json`
`proposeTask.factionDescriptor.wow` — was `Collective`, now a sentence.
`editPraxis.wow` is **untouched** (#835 owns it).

### `common.json`
`fieldDesk.home.wow.greeting` / `.masthead`.

## The two conflicts

**1. The description dropped the mechanics — and the mechanics it claimed were
wrong.** The old `descriptions.wow` read "Excel at their own faction's tasks;
reduced elsewhere", but `backend/eras/era_1.py` gives WOW
`own_task_modifier=1.0` and `other_task_modifier=1.0`. Checking every faction
in that file, `duel_win_modifier=1.5` / `duel_loss_modifier=0.5` is the Era 1
**baseline** (UA, Coven, Ephemerists, Everymen, Singularity, Albescent and `na`
all carry it; only S.N.I.D.E. differs at 2.0/0.0). WOW's single distinguishing
rule is therefore `level_jump_reach=1`, and that is the clause appended:

> …Once per level, a knight may reach one rank above their own to claim a
> single quest.

**2. The tagline is keyed to the select card.** The brief suggested
`factions.json → wow.tagline`, but every faction's select-card copy actually
lives in `feed.json → factionSelect.<slug>`, and UA's `subtitle` ("A daily
practice of making marks.") already occupies exactly this tagline slot in
`FactionSelectCard.tsx`. So it lands at `feed:factionSelect.wow.tagline`. #900
can point the hero's motto slot at the same key rather than duplicating the
string.

## Judgement calls worth a glance

- **Taunt tokens are swapped relative to the kit.** The kit credits the
  achiever with `{{to_name}}`. `activity_feed._foe_taunt_item` makes `from_name`
  the sender (whose faction picks the branch — i.e. the achiever) and `to_name`
  the recipient, and `catalog.test.ts` enforces exactly that for UA. Every WOW
  line is flipped to match, so the level-up and praxis lines name only
  `{{from_name}}` and the overtake lines read "…{{from_name}} advances" past
  `{{to_name}}`.
- **Two kit strings were split at their em dash** into the title/body slot pair
  the existing archetypes already use: the join line
  (`eligibleTitle`/`eligibleBody`, mirroring `everymen.roll.*`) and the mobile
  line (`eyebrow`/`subtitle` — every other faction's `mobile.eyebrow` is 2–3
  words, e.g. "The Union Hall"). Both halves are verbatim.
- **The propose-task descriptor lost its lead-in.** The kit reads "For the
  Warriors of Whimsy — knights who take the ridiculous with total
  seriousness."; `DefaultProposeTask.tsx` prints the faction-name pill
  immediately before the descriptor, so the lead-in would repeat itself on
  screen. Trimmed to "Knights who take the ridiculous with total
  seriousness.", following UA's sentence-length precedent from #850.
- **The field-desk greeting interpolates `{{name}}`**, not the kit's
  `{{to_name}}` — the field desk is single-character, and `{{name}}` is the
  token `common.json` already uses there ("Step into {{name}}").
- **Nothing invented.** The kit's deck has no praxis-section empty state and no
  section kickers, and none were written. #900/#901 may find
  `factions.wow.praxis.empty` and the `*.kicker` slots missing.
- **Skipped as settled (ADR-0050):** the kit's vote block duplicates
  `votes.json → wow` and `chrome.wow`. Both untouched. The kit's duel seal and
  duel rail voice is left for #895.

## Not fixed here — donor-slug copy artifacts spotted in passing

The WOW → Coven aesthetic handover left Coven wearing WOW's words in several
places. Out of scope for this slice, flagged rather than silently edited:
`feed:factionSelect.coven.name` = "Warriors of Whimsy",
`factions.coven.invitation.pitch` opens "Warriors of Whimsy is World Zero's
coven…", and `feed:taskCard.coven.windowTitle` / `factions.coven.mobile.eyebrow`
= "wow.exe" (though `feed:identity.coven.windowTitle` was already fixed to
"whimsy.exe"). Also `taunts.coven` is written in the old collective-minded WOW
voice.

## Verification

- `tsc --noEmit` — clean (only the known stale-junction `node:fs`/`node:url`
  false alarms from PR #675, which are absent in CI).
- `vitest run` — 111 files, 1258 tests passed, including
  `locales/__tests__/catalog.test.ts` (33).
- `vite build` — built.
- `eslint src/locales` — clean.
- `pytest backend/tests/unit/test_i18n_catalog_coverage.py` — 5 passed (the
  ADR-0031/0038 drift guard).

## What to eyeball

**Visual QA is outstanding — I cannot screenshot and there is no dev stack, so
nothing below was seen rendered.** Most of these keys have no consumer yet
(the WOW faction body, task card, feed row and select card all arrive in
#899/#900/#901), so nothing changes on screen today except the keys that
already have live consumers:

1. **`descriptions.wow`** — now four sentences where it was one. It renders in
   the faction index card, the faction-detail hero and anywhere
   `factionDescription('wow')` is called. It is longer than every other
   faction's blurb; check it does not blow out the card.
2. **`proposeTask.factionDescriptor.wow`** — on Propose a Task, the WOW pennant
   now carries a sentence instead of the single word "Collective". UA is the
   only other sentence; check the two read consistently in the row.
3. **The Charter's second paragraph** contains the Pig Latin motto and an em
   dash pair; confirm the apostrophes and dashes survived the JSON round trip.
4. **Taunt attribution** — the swapped tokens are the highest-risk change here.
   Worth reading `taunts.wow.score_overtake` once with the resolver in mind:
   `from_name` must be the character who pulled ahead.
