### PR TITLE
duel_victor badge: won a duel last era (#823)

### DIFF
--- a/backend/alembic/versions/0008_duel_resolved_era.py
+++ b/backend/alembic/versions/0008_duel_resolved_era.py
@@ -1,0 +1,49 @@
+"""Stamp the closing era on a frozen duel: `duel.resolved_era_id` (#823).
+
+#824 froze the duel *outcome* at era close but left "which era was this duel
+fought in?" to ``resolved_at``. That timestamp cannot answer it: ``apply_era_reset``
+inserts the new ``Era`` row (whose ``started_at`` defaults to the transaction
+clock) *before* stamping ``resolved_at``, so every frozen duel timestamps just
+*after* the incoming era's start and a boundary comparison attributes it to the
+era it did not belong to. This column records the closing era explicitly.
+
+Nullable and never backfilled: no era has ever closed, so no ``resolved`` duel
+exists in any environment.
+
+0001_squashed builds a *fresh* DB straight from the ORM models, so CI and local
+resets already land on this shape. A deployed DB is stamped further down the
+chain and never re-runs it — hence this revision. Idempotent either way.
+
+Revision ID: 0008_duel_resolved_era
+Revises: 0007_duel_frozen_outcome
+Create Date: 2026-07-21
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0008_duel_resolved_era"
+down_revision: Union[str, None] = "0007_duel_frozen_outcome"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE duel ADD COLUMN IF NOT EXISTS resolved_era_id INTEGER")
+
+    # ADD CONSTRAINT has no IF NOT EXISTS in Postgres; guard on the catalog so a
+    # DB already built from the models (constraint present) is a no-op.
+    op.execute(
+        """
+        DO $$ BEGIN
+            ALTER TABLE duel
+                ADD CONSTRAINT duel_resolved_era_id_fkey
+                FOREIGN KEY (resolved_era_id) REFERENCES era (id);
+        EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE duel DROP CONSTRAINT IF EXISTS duel_resolved_era_id_fkey")
+    op.execute("ALTER TABLE duel DROP COLUMN IF EXISTS resolved_era_id")

--- a/backend/badges.py
+++ b/backend/badges.py
@@ -29,6 +29,10 @@ class BadgeContext:
     # strictly ahead on votes right now, or holding a forfeit win. The first
     # per-character (rather than per-account) fact in the context.
     is_duel_winner: bool
+    # True when this character is the frozen winner of a duel resolved at the
+    # close of the *previous* era (#823). The first cross-era fact in the context:
+    # every other one is about the here and now.
+    won_duel_last_era: bool
 
 
 @dataclass(frozen=True)
@@ -53,14 +57,32 @@ def _is_duelist(context: BadgeContext) -> bool:
 
     Provisional by design (ADR-0011): mid-era a duel has no discrete winner, the
     tally floats, and so does this badge. A forfeit win is sticky for as long as
-    the duel stays live. "Won a duel last era" is a separate, frozen fact (#823)
-    and deliberately not this badge.
+    the duel stays live, and a frozen win survives era close (owner ruling on
+    #748), so this reads "won *or* winning" and never lapses. The narrower
+    "won a duel last era" is ``duel_victor`` (#823), a separate badge.
     """
     return context.is_duel_winner
+
+
+def _is_duel_victor(context: BadgeContext) -> bool:
+    """Won a duel *last era* — a finalized result, not a floating one (#823).
+
+    Distinct from ``duelist`` on purpose: that badge is "won or winning" and holds
+    on any live lead, any forfeit, or any frozen win however old. This one holds
+    only for a win frozen at the close of the era immediately before the current
+    one (ADR-0052 — era close is the only moment a duel acquires a winner), so it
+    lapses one era later. A tie or no-contest froze a NULL winner and grants
+    nothing to either side.
+
+    Unobservable until an era actually closes: Era 1 is live and no era has ever
+    closed, so no ``resolved`` duel exists in any environment yet.
+    """
+    return context.won_duel_last_era
 
 
 ALL_BADGES: tuple[Badge, ...] = (
     Badge(key="sock_puppeteer", name="Sock Puppeteer", condition=_is_sock_puppeteer),
     Badge(key="sock_puppet", name="Sock Puppet", condition=_is_sock_puppet),
     Badge(key="duelist", name="Duelist", condition=_is_duelist),
+    Badge(key="duel_victor", name="Duel Victor", condition=_is_duel_victor),
 )

--- a/backend/models/duel.py
+++ b/backend/models/duel.py
@@ -73,6 +73,17 @@ class Duel(CreatedAtMixin, Base):
     resolved_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # The era that was *closing* when this duel resolved — i.e. the era the duel
+    # was fought in, not the one the reset opened (ADR-0052: "a duel that spans an
+    # era boundary resolves in the era that was closing"). NULL until resolution.
+    #
+    # `resolved_at` alone cannot answer "which era was this?" (#823): the reset
+    # inserts the new Era row *before* stamping `resolved_at`, so every frozen
+    # duel timestamps a hair *after* the incoming era's `started_at` and a naive
+    # boundary comparison attributes it to the era it did not belong to.
+    resolved_era_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("era.id"), nullable=True
+    )
     # Snapshot of each side's points_from_votes at the moment of resolution, so a
     # resolved surface can show vote shares without the live tally moving under it.
     challenger_final_points: Mapped[Optional[int]] = mapped_column(nullable=True)

--- a/backend/services/badge.py
+++ b/backend/services/badge.py
@@ -8,6 +8,7 @@ on a list path: :func:`build_badge_contexts` folds the whole page into a fixed
 number of set-based queries and assembles each context in memory (#655). The
 rule is "never *per-character* on list paths", not "never on list paths".
 """
+from dataclasses import dataclass
 from typing import Iterable, Optional
 
 from sqlalchemy import func, or_, select
@@ -18,6 +19,7 @@ from sqlalchemy.orm import aliased
 from badges import ALL_BADGES, BadgeContext
 from models.character import Character
 from models.duel import Duel, DuelStatus
+from models.era import Era
 from models.praxis import Praxis
 from schemas.character import BadgeOut
 from services.duel_outcome import duel_winner
@@ -34,16 +36,44 @@ BADGE_DUEL_STATUSES: tuple[DuelStatus, ...] = (
 )
 
 
-async def _duel_winning_character_ids(
+@dataclass(frozen=True)
+class DuelWinnerFacts:
+    """The two per-character duel facts, read out of one pass over the duels."""
+
+    # Won or winning, live or frozen, however long ago — the `duelist` badge (#748).
+    winners: frozenset[int] = frozenset()
+    # Frozen winner of a duel resolved at the close of the previous era — the
+    # `duel_victor` badge (#823). Always a subset of `winners`.
+    last_era_winners: frozenset[int] = frozenset()
+
+
+async def _previous_era_id(session: AsyncSession) -> Optional[int]:
+    """Id of the era before the current one, or None if none has ever closed.
+
+    ``Era`` rows are append-only, one per reset, so "the era before this one" is
+    the second-highest id. Reading the *table* rather than comparing timestamps is
+    the whole point: a duel's ``resolved_at`` lands microseconds *after* the
+    incoming era's ``started_at`` (the reset inserts the row first), so a boundary
+    comparison would file every frozen duel under the era it did not belong to.
+    """
+    result = await session.execute(
+        select(Era.id).order_by(Era.id.desc()).offset(1).limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _duel_winner_facts(
     character_ids: set[int],
     session: AsyncSession,
-) -> set[int]:
-    """Ids of the given characters that have won or are winning a duel (#748).
+) -> DuelWinnerFacts:
+    """Both duel facts for the given characters, from one pass over their duels.
 
-    Two set-based queries regardless of page size: one for every badge-eligible
+    Three set-based queries regardless of page size: one for every badge-eligible
     duel any of these characters is a side of (joined to the challenger's praxis,
-    which is where the challenger's character id lives), then one
-    :func:`tally_votes` over the *live* sides' praxis ids.
+    which is where the challenger's character id lives), one
+    :func:`tally_votes` over the *live* sides' praxis ids, and one for the previous
+    era's id. The last-era fact (#823) rides the same duel rows rather than
+    querying again — it is a filter on the winners, not a second source.
 
     Frozen and live split the same way :mod:`services.praxis_scoring` splits
     them:
@@ -59,7 +89,7 @@ async def _duel_winning_character_ids(
     score, frozen or live.
     """
     if not character_ids:
-        return set()
+        return DuelWinnerFacts()
 
     challenger_praxis = aliased(Praxis)
     duel_rows = (
@@ -72,6 +102,7 @@ async def _duel_winning_character_ids(
                 Duel.forfeited_by_character_id,
                 Duel.status,
                 Duel.winner_character_id,
+                Duel.resolved_era_id,
             )
             .join(
                 challenger_praxis,
@@ -87,7 +118,11 @@ async def _duel_winning_character_ids(
         )
     ).all()
     if not duel_rows:
-        return set()
+        return DuelWinnerFacts()
+
+    # Unconditional, so the query count does not depend on *which* duels a page
+    # happens to contain (the batch guard compares pages, ADR-0033).
+    previous_era_id = await _previous_era_id(session)
 
     # Only the live duels need a tally: a resolved duel's winner is already
     # frozen on the row, so tallying its sides would be wasted work.
@@ -101,6 +136,7 @@ async def _duel_winning_character_ids(
     tallies = await tally_votes(list(praxis_ids), session)
 
     winners: set[int] = set()
+    last_era_winners: set[int] = set()
     for row in duel_rows:
         if row.status == DuelStatus.resolved:
             # Frozen fact (#824): trust the recorded winner, never the points.
@@ -120,9 +156,23 @@ async def _duel_winning_character_ids(
                 opponent_points=opponent_points,
                 forfeited_by_character_id=row.forfeited_by_character_id,
             )
-        if winner_character_id is not None and winner_character_id in character_ids:
-            winners.add(winner_character_id)
-    return winners
+        if winner_character_id is None or winner_character_id not in character_ids:
+            continue
+        winners.add(winner_character_id)
+        # "Last era" is a property of the *freeze*, not of the win: only a
+        # resolved duel carries a `resolved_era_id`, and only the era immediately
+        # before the current one counts. An older frozen win keeps `duelist` and
+        # loses `duel_victor` — the badge lapses one era after it is earned.
+        if (
+            row.status == DuelStatus.resolved
+            and previous_era_id is not None
+            and row.resolved_era_id == previous_era_id
+        ):
+            last_era_winners.add(winner_character_id)
+    return DuelWinnerFacts(
+        winners=frozenset(winners),
+        last_era_winners=frozenset(last_era_winners),
+    )
 
 
 async def build_badge_contexts(
@@ -140,9 +190,10 @@ async def build_badge_contexts(
     The sibling count is deliberately unfiltered by status: a puppet is a puppet
     whether or not the list path would surface it.
 
-    The duel-winner fact (#748) is per-*character*, so it gets its own
-    set-based pass over the page (:func:`_duel_winning_character_ids`) rather
-    than a query inside the loop.
+    The two duel facts (#748, #823) are per-*character*, so they get their own
+    set-based pass over the page (:func:`_duel_winner_facts`) rather than a query
+    inside the loop — one pass for both, since "won last era" is a filter on the
+    same winners rather than a second source.
     """
     characters = list(characters)
     account_ids = {character.account_id for character in characters}
@@ -170,7 +221,7 @@ async def build_badge_contexts(
         for account_id, character_count, earliest_id in result.all()
     }
 
-    duel_winners = await _duel_winning_character_ids(
+    duel_facts = await _duel_winner_facts(
         {character.id for character in characters}, session
     )
 
@@ -182,7 +233,8 @@ async def build_badge_contexts(
         contexts[character.id] = BadgeContext(
             account_character_count=character_count,
             is_earliest_on_account=character.id == earliest_id,
-            is_duel_winner=character.id in duel_winners,
+            is_duel_winner=character.id in duel_facts.winners,
+            won_duel_last_era=character.id in duel_facts.last_era_winners,
         )
     return contexts
 

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -104,9 +104,26 @@ async def get_or_create_stats(
     return stats
 
 
+async def get_closing_era_id(new_era_row: Era, session: AsyncSession) -> int | None:
+    """The era being closed by the reset that inserted ``new_era_row``.
+
+    The row immediately before it by id — ``Era`` rows are only ever appended, one
+    per reset. Returns None when there is no earlier era (the very first reset),
+    which is also the "nothing has ever closed" state Era 1 is in today.
+    """
+    result = await session.execute(
+        select(Era.id)
+        .where(Era.id < new_era_row.id)
+        .order_by(Era.id.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 async def resolve_duels_at_era_close(
     session: AsyncSession,
     resolved_at: datetime | None = None,
+    closing_era_id: int | None = None,
 ) -> list[Duel]:
     """Freeze every unresolved duel's outcome (ADR-0052). Returns the frozen rows.
 
@@ -118,6 +135,10 @@ async def resolve_duels_at_era_close(
     - a snapshot of both sides' ``points_from_votes``, so a resolved surface can
       show vote shares without the live tally moving under it.
     - ``resolved_at`` and the terminal ``resolved`` status.
+    - ``resolved_era_id`` — the era being closed, so "which era was this duel?"
+      survives as a fact rather than a timestamp comparison (#823). ``resolved_at``
+      cannot answer it: the new ``Era`` row is inserted before this runs, so every
+      frozen duel timestamps *after* the incoming era's ``started_at``.
 
     ``active`` duels (accepted, but never both-submitted) never became votable, so
     they resolve as a **no-contest**: null winner, zero snapshots. ``pending``
@@ -184,6 +205,7 @@ async def resolve_duels_at_era_close(
         duel.challenger_final_points = challenger_points
         duel.opponent_final_points = opponent_points
         duel.resolved_at = resolved_at
+        duel.resolved_era_id = closing_era_id
         duel.status = DuelStatus.resolved
 
     await session.flush()
@@ -203,8 +225,11 @@ async def apply_era_reset(
     (ADR-0011 / ADR-0052).
     """
     # Freeze duels first: the outcome must be computed against the closing era's
-    # tallies, before any stats row for the new era exists.
-    await resolve_duels_at_era_close(session)
+    # tallies, before any stats row for the new era exists. The closing era is the
+    # row before ``new_era_row``, and is stamped on each duel so a later read can
+    # tell "last era" from "this era" without comparing timestamps (#823).
+    closing_era_id = await get_closing_era_id(new_era_row, session)
+    await resolve_duels_at_era_close(session, closing_era_id=closing_era_id)
 
     for character in characters:
         # Find previous stats to carry all_time_score forward

--- a/backend/tests/integration/test_duel_victor_badge.py
+++ b/backend/tests/integration/test_duel_victor_badge.py
@@ -1,0 +1,463 @@
+"""The duel_victor badge — won a duel *last era* (#823, ADR-0033, ADR-0052).
+
+These tests are the entire safety net for this badge. Era 1 is live and **no era
+has ever closed**, so no ``resolved`` duel exists in any environment: the badge
+cannot render anywhere in the running app and cannot be checked by looking at it.
+
+The badge holds only for a character frozen as ``Duel.winner_character_id`` on a
+duel whose ``resolved_era_id`` is the era immediately before the current one.
+That column exists because ``resolved_at`` cannot answer the question: the reset
+inserts the new ``Era`` row *before* stamping ``resolved_at``, so a frozen duel
+timestamps microseconds *after* the incoming era's ``started_at`` and a boundary
+comparison files it under the era it did not belong to. The last test walks the
+real ``apply_era_reset`` to pin that end to end.
+
+Sibling ``duelist`` (#748) is "won *or* winning" and does not lapse; this one is
+the narrow finalized-last-era case, so a last-era winner holds both.
+"""
+from typing import Optional
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.account import Account
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.duel import Duel, DuelStatus
+from models.era import Era
+from models.faction import Faction
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from models.vote import Vote
+from services.badge import build_badge_contexts, list_badges_for_character
+from services.era import apply_era_reset
+
+DUEL_VICTOR_BADGE = {"key": "duel_victor", "name": "Duel Victor"}
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+async def _make_character(
+    session: AsyncSession, era: Era, *, username: str
+) -> Character:
+    account = Account(email=f"{username}@example.com")
+    session.add(account)
+    await session.flush()
+    character = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username,
+        faction_slug="ua",
+    )
+    session.add(character)
+    await session.flush()
+    session.add(
+        CharacterStats(
+            character_id=character.id,
+            era_id=era.id,
+            score=0,
+            all_time_score=0,
+            level=0,
+            votes_spent_this_era=0,
+        )
+    )
+    await session.flush()
+    return character
+
+
+async def _make_task(session: AsyncSession, creator: Character) -> Task:
+    task = Task(
+        title="duel task",
+        description="proof",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=creator.id,
+        primary_faction_slug="ua",
+    )
+    session.add(task)
+    await session.flush()
+    return task
+
+
+async def _make_solo(session: AsyncSession, task: Task, author: Character) -> Praxis:
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=author.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.submitted,
+        title="side",
+        body_text="proof",
+    )
+    session.add(praxis)
+    await session.flush()
+    session.add(PraxisMember(praxis_id=praxis.id, character_id=author.id))
+    await session.flush()
+    return praxis
+
+
+async def _cast_vote(
+    session: AsyncSession, praxis: Praxis, voter: Character, value: int
+) -> None:
+    session.add(
+        Vote(
+            praxis_id=praxis.id,
+            voter_character_id=voter.id,
+            voter_account_id=voter.account_id,
+            value=value,
+        )
+    )
+    await session.flush()
+
+
+async def _next_era(session: AsyncSession, account: Account, *, name: str) -> Era:
+    """Append an Era row — the reset's own insert, without the reset."""
+    era_row = Era(name=name, config_key=CURRENT_ERA.config_key, started_by=account.id)
+    session.add(era_row)
+    await session.commit()
+    await session.refresh(era_row)
+    return era_row
+
+
+async def _make_duel(
+    session: AsyncSession,
+    era: Era,
+    *,
+    label: str,
+    challenger_votes: int = 0,
+    opponent_votes: int = 0,
+    status: DuelStatus = DuelStatus.settled,
+    forfeiter: Optional[str] = None,
+) -> tuple[Duel, Character, Character]:
+    """Two fresh characters + their two solo praxes, linked as one live duel."""
+    challenger = await _make_character(session, era, username=f"{label}ch")
+    opponent = await _make_character(session, era, username=f"{label}op")
+    voter = await _make_character(session, era, username=f"{label}v")
+    task = await _make_task(session, challenger)
+    challenger_praxis = await _make_solo(session, task, challenger)
+    opponent_praxis = await _make_solo(session, task, opponent)
+
+    if challenger_votes:
+        await _cast_vote(session, challenger_praxis, voter, challenger_votes)
+    if opponent_votes:
+        await _cast_vote(session, opponent_praxis, voter, opponent_votes)
+
+    forfeited_by = None
+    if forfeiter == "challenger":
+        forfeited_by = challenger.id
+    elif forfeiter == "opponent":
+        forfeited_by = opponent.id
+
+    duel = Duel(
+        task_id=task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_character_id=opponent.id,
+        opponent_praxis_id=opponent_praxis.id,
+        status=status,
+        forfeited_by_character_id=forfeited_by,
+    )
+    session.add(duel)
+    await session.commit()
+    return duel, challenger, opponent
+
+
+async def _freeze(
+    session: AsyncSession,
+    duel: Duel,
+    *,
+    winner: Optional[Character],
+    resolved_era: Optional[Era],
+) -> None:
+    """Stamp the frozen outcome by hand — what ``apply_era_reset`` writes."""
+    duel.status = DuelStatus.resolved
+    duel.winner_character_id = winner.id if winner else None
+    duel.resolved_era_id = resolved_era.id if resolved_era else None
+    await session.commit()
+
+
+async def _badge_keys(session: AsyncSession, character: Character) -> list[str]:
+    return [badge.key for badge in await list_badges_for_character(character, session)]
+
+
+# ---------------------------------------------------------------------------
+# the badge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_frozen_win_in_the_previous_era_earns_the_badge(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """The whole point: a finalized win in the era that just closed."""
+    duel, challenger, opponent = await _make_duel(
+        db_session, era, label="won", challenger_votes=5, opponent_votes=1
+    )
+    await _freeze(db_session, duel, winner=challenger, resolved_era=era)
+    await _next_era(db_session, account, name="Era 2")
+
+    # `duelist` never lapses, so a last-era victor holds both duel badges.
+    assert await _badge_keys(db_session, challenger) == ["duelist", "duel_victor"]
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_forfeit_winner_on_the_lower_frozen_score_still_earns_it(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """Read `winner_character_id`; never infer the winner from the points.
+
+    The opponent forfeited while ahead 9-1, so the freeze names the challenger on
+    the *lower* score. Comparing tallies would decorate the wrong side.
+    """
+    duel, challenger, opponent = await _make_duel(
+        db_session,
+        era,
+        label="ff",
+        challenger_votes=1,
+        opponent_votes=9,
+        forfeiter="opponent",
+    )
+    await _freeze(db_session, duel, winner=challenger, resolved_era=era)
+    await _next_era(db_session, account, name="Era 2")
+
+    assert "duel_victor" in await _badge_keys(db_session, challenger)
+    assert "duel_victor" not in await _badge_keys(db_session, opponent)
+
+
+@pytest.mark.asyncio
+async def test_frozen_win_in_the_current_era_does_not_earn_it(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """A win stamped with the *live* era is not "last era" — that is `duelist`.
+
+    The reset cannot produce this (it stamps the era it is closing), but nothing
+    in the schema forbids it, and the badge must filter on the era rather than on
+    "is resolved at all" — otherwise it is indistinguishable from `duelist`.
+    """
+    duel, challenger, opponent = await _make_duel(
+        db_session, era, label="cur", challenger_votes=5, opponent_votes=1
+    )
+    current_era = await _next_era(db_session, account, name="Era 2")
+    await _freeze(db_session, duel, winner=challenger, resolved_era=current_era)
+
+    assert await _badge_keys(db_session, challenger) == ["duelist"]
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_a_frozen_win_two_eras_ago_has_lapsed(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """"Last era" is a window, not a permanent record — it closes behind you."""
+    duel, challenger, opponent = await _make_duel(
+        db_session, era, label="old", challenger_votes=5, opponent_votes=1
+    )
+    await _freeze(db_session, duel, winner=challenger, resolved_era=era)
+    await _next_era(db_session, account, name="Era 2")
+    await _next_era(db_session, account, name="Era 3")
+
+    assert await _badge_keys(db_session, challenger) == ["duelist"]
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_null_frozen_winner_grants_nothing_to_either_side(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """A tie or a no-contest froze NULL — nobody won it (ADR-0052)."""
+    duel, challenger, opponent = await _make_duel(
+        db_session, era, label="tie", challenger_votes=3, opponent_votes=3
+    )
+    await _freeze(db_session, duel, winner=None, resolved_era=era)
+    await _next_era(db_session, account, name="Era 2")
+
+    assert await _badge_keys(db_session, challenger) == []
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_a_live_duel_never_earns_it(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """Leading a *settled* duel is provisional (ADR-0011) — `duelist`, not this."""
+    _duel, challenger, opponent = await _make_duel(
+        db_session, era, label="live", challenger_votes=5, opponent_votes=1
+    )
+    await _next_era(db_session, account, name="Era 2")
+
+    assert await _badge_keys(db_session, challenger) == ["duelist"]
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_no_era_has_closed_so_nobody_is_a_victor(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """Today's state: one Era row, so there is no previous era to have won in."""
+    duel, challenger, opponent = await _make_duel(
+        db_session, era, label="era1", challenger_votes=5, opponent_votes=1
+    )
+    await _freeze(db_session, duel, winner=challenger, resolved_era=era)
+
+    assert await _badge_keys(db_session, challenger) == ["duelist"]
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_a_frozen_win_with_no_recorded_era_grants_nothing(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """`resolved_era_id` is nullable; an unstamped freeze must not fall through."""
+    duel, challenger, opponent = await _make_duel(
+        db_session, era, label="unstamped", challenger_votes=5, opponent_votes=1
+    )
+    await _freeze(db_session, duel, winner=challenger, resolved_era=None)
+    await _next_era(db_session, account, name="Era 2")
+
+    assert await _badge_keys(db_session, challenger) == ["duelist"]
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_a_character_with_no_duels_earns_nothing(
+    db_session: AsyncSession, era: Era, account: Account, character: Character,
+    faction_ua: Faction,
+):
+    duel, challenger, _opponent = await _make_duel(
+        db_session, era, label="other", challenger_votes=5, opponent_votes=1
+    )
+    await _freeze(db_session, duel, winner=challenger, resolved_era=era)
+    await _next_era(db_session, account, name="Era 2")
+
+    assert await _badge_keys(db_session, character) == []
+
+
+@pytest.mark.asyncio
+async def test_endpoint_surfaces_the_duel_victor_badge(
+    client, db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    duel, challenger, _opponent = await _make_duel(
+        db_session, era, label="api", challenger_votes=4, opponent_votes=2
+    )
+    await _freeze(db_session, duel, winner=challenger, resolved_era=era)
+    await _next_era(db_session, account, name="Era 2")
+
+    resp = await client.get(f"/characters/{challenger.id}")
+    assert resp.status_code == 200
+    assert DUEL_VICTOR_BADGE in resp.json()["badges"]
+
+
+# ---------------------------------------------------------------------------
+# end to end through the real era close
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_real_era_reset_produces_the_badge(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """The load-bearing test: no hand-stamped fixture anywhere in the chain.
+
+    ``apply_era_reset`` freezes the duel and stamps the *closing* era, and the
+    badge reads it back. A ``resolved_at`` comparison would fail here — the new
+    Era row is inserted first, so the freeze timestamps after the new era began.
+    """
+    duel, challenger, opponent = await _make_duel(
+        db_session, era, label="reset", challenger_votes=6, opponent_votes=2
+    )
+
+    new_era_row = Era(
+        name="Era 2", config_key=CURRENT_ERA.config_key, started_by=account.id
+    )
+    db_session.add(new_era_row)
+    await db_session.flush()
+    await apply_era_reset([challenger, opponent], new_era_row, db_session)
+    await db_session.commit()
+
+    await db_session.refresh(duel)
+    assert duel.status == DuelStatus.resolved
+    assert duel.winner_character_id == challenger.id
+    assert duel.resolved_era_id == era.id
+    # The trap this column exists for: the freeze lands *after* the new era began.
+    assert duel.resolved_at >= new_era_row.started_at
+
+    assert "duel_victor" in await _badge_keys(db_session, challenger)
+    assert "duel_victor" not in await _badge_keys(db_session, opponent)
+
+
+# ---------------------------------------------------------------------------
+# the batch rule
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_last_era_fact_costs_no_extra_query_per_character(
+    db_connection, db_session: AsyncSession, era: Era, account: Account,
+    faction_ua: Faction,
+):
+    """ADR-0033's batch rule, extended to the first cross-era fact.
+
+    A 6-character page costs exactly what a 2-character one does. The era lookup
+    is one query for the whole page, and the last-era filter rides the duel rows
+    the duelist fact already fetched.
+    """
+    one_duel, one_challenger, one_opponent = await _make_duel(
+        db_session, era, label="q1", challenger_votes=5, opponent_votes=1
+    )
+    two_duel, two_challenger, two_opponent = await _make_duel(
+        db_session, era, label="q2", challenger_votes=1, opponent_votes=5
+    )
+    three_duel, three_challenger, three_opponent = await _make_duel(
+        db_session, era, label="q3", challenger_votes=4, opponent_votes=0
+    )
+    await _freeze(db_session, one_duel, winner=one_challenger, resolved_era=era)
+    await _freeze(db_session, two_duel, winner=two_opponent, resolved_era=era)
+    current_era = await _next_era(db_session, account, name="Era 2")
+    # Frozen in the *live* era: present in the same page, must not qualify.
+    await _freeze(db_session, three_duel, winner=three_challenger,
+                  resolved_era=current_era)
+
+    statements: list[str] = []
+
+    @event.listens_for(db_connection.sync_connection, "before_cursor_execute")
+    def record(conn, cursor, statement, parameters, context, executemany):
+        # SAVEPOINT / RELEASE churn from the test harness is not a query.
+        if statement.lstrip().upper().startswith("SELECT"):
+            statements.append(statement)
+
+    try:
+        statements.clear()
+        small = await build_badge_contexts([one_challenger, one_opponent], db_session)
+        small_query_count = len(statements)
+
+        statements.clear()
+        large = await build_badge_contexts(
+            [
+                one_challenger,
+                one_opponent,
+                two_challenger,
+                two_opponent,
+                three_challenger,
+                three_opponent,
+            ],
+            db_session,
+        )
+        large_query_count = len(statements)
+    finally:
+        event.remove(db_connection.sync_connection, "before_cursor_execute", record)
+
+    assert large_query_count == small_query_count
+    assert small_query_count <= 4, statements
+
+    assert small[one_challenger.id].won_duel_last_era is True
+    assert small[one_opponent.id].won_duel_last_era is False
+    assert large[two_opponent.id].won_duel_last_era is True
+    assert large[two_challenger.id].won_duel_last_era is False
+    # Frozen in the current era, so `duelist` only.
+    assert large[three_challenger.id].is_duel_winner is True
+    assert large[three_challenger.id].won_duel_last_era is False

--- a/backend/tests/integration/test_duelist_badge.py
+++ b/backend/tests/integration/test_duelist_badge.py
@@ -433,7 +433,10 @@ async def test_batch_path_is_constant_query_count(
         event.remove(db_connection.sync_connection, "before_cursor_execute", record)
 
     assert large_query_count == small_query_count
-    assert small_query_count <= 3, statements
+    # Four: the account roll-up, the duel rows, the live tally, and the
+    # previous-era lookup #823 added. The guard that matters is the equality
+    # above — this bound only keeps the fixed cost visible.
+    assert small_query_count <= 4, statements
 
     assert small[one_challenger.id].is_duel_winner is True
     assert small[one_opponent.id].is_duel_winner is False

--- a/backend/tests/unit/test_badges.py
+++ b/backend/tests/unit/test_badges.py
@@ -1,7 +1,8 @@
 """Unit tests for the badge registry conditions (ADR-0033, #459, #748).
 
 Covers the seed pair — sock_puppeteer / sock_puppet — across 1-character and
-2-character accounts, the duelist badge, plus registry invariants. (A
+2-character accounts, the two duel badges (duelist #748, duel_victor #823), plus
+registry invariants. (A
 0-character context cannot exist: the context is always built *for* a
 character, so the count includes it.)
 """
@@ -14,11 +15,13 @@ def _context(
     account_character_count: int = 1,
     is_earliest_on_account: bool = True,
     is_duel_winner: bool = False,
+    won_duel_last_era: bool = False,
 ) -> BadgeContext:
     return BadgeContext(
         account_character_count=account_character_count,
         is_earliest_on_account=is_earliest_on_account,
         is_duel_winner=is_duel_winner,
+        won_duel_last_era=won_duel_last_era,
     )
 
 
@@ -61,6 +64,26 @@ def test_duelist_is_independent_of_the_sock_pair() -> None:
         is_duel_winner=True,
     )
     assert _badge_keys(context) == ["sock_puppeteer", "duelist"]
+
+
+def test_last_era_winner_earns_duel_victor() -> None:
+    assert _badge_keys(_context(won_duel_last_era=True)) == ["duel_victor"]
+
+
+def test_duel_victor_is_absent_without_a_frozen_last_era_win() -> None:
+    """A live lead is `duelist`'s business — this badge needs a finalized result."""
+    assert _badge_keys(_context(is_duel_winner=True)) == ["duelist"]
+
+
+def test_a_last_era_winner_normally_holds_both_duel_badges() -> None:
+    """`duelist` is "won or winning" and includes frozen wins (owner ruling, #748).
+
+    So the two duel badges stack rather than replace: the context the service
+    builds sets both flags for a last-era winner. They are separate facts and the
+    registry evaluates them independently — this pins the expected pairing.
+    """
+    context = _context(is_duel_winner=True, won_duel_last_era=True)
+    assert _badge_keys(context) == ["duelist", "duel_victor"]
 
 
 def test_registry_keys_are_unique() -> None:


### PR DESCRIPTION
Adds the `duel_victor` badge — **won a duel last era** — the deferred half of #748.

Part of #823 — this is the BACKEND half. The Fleur-de-Lis badge art in
`frontend/src/components/badges/badgeArt.tsx` lands in a follow-up PR, which carries the `Closes`.
## The mechanism (the interesting part)

`resolved_at` **cannot** tell you which era a duel belonged to, and a boundary comparison against the `Era` table gets it backwards. `apply_era_reset` inserts the new `Era` row *first* (its `started_at` defaults to the transaction clock), *then* stamps `resolved_at = datetime.now()`. So every frozen duel timestamps a hair **after** the incoming era's start, and "the era whose window contains `resolved_at`" is always the era the duel did *not* belong to. The badge would never fire.

So this takes the issue's own option 2: a new nullable `duel.resolved_era_id`, stamped by `resolve_duels_at_era_close` with the era being closed (`get_closing_era_id` = the `Era` row before `new_era_row`). ADR-0052 already says "a duel that spans an era boundary resolves in the era that was closing" — this records that as a fact instead of leaving it to arithmetic.

The badge fact is `BadgeContext.won_duel_last_era`, the **first cross-era fact** in the context: the character is the frozen `winner_character_id` of a duel whose `resolved_era_id` is the era immediately before the current one. It rides the duel rows `_duel_winner_facts` (was `_duel_winning_character_ids`) already fetches — the last-era case is a *filter on the winners*, not a second source — plus **one** page-wide query for the previous era id. No per-character query; the batch guard's page-vs-page equality assertion still holds, its absolute bound moves 3 → 4.

It reads `winner_character_id`, never the points: a forfeit winner can hold the lower frozen score.

`duelist` is untouched. It stays "won *or* winning" and never lapses, so a last-era victor holds **both** badges; `duel_victor` lapses one era after it's earned.

## The honest constraint

**Era 1 is live and no era has ever closed**, so no `resolved` duel exists in any environment. This badge cannot render anywhere in the running app, in dev or in prod, and there is no way to look at it. **The tests are the entire safety net.** (Same trap as #906 — correct and broken look identical here.)

## What to eyeball

- `backend/tests/integration/test_duel_victor_badge.py` — 12 tests. The load-bearing one is `test_the_real_era_reset_produces_the_badge`: no hand-stamped fixture anywhere, it drives the real `apply_era_reset` and asserts `resolved_at >= new_era_row.started_at` to pin the exact inversion that makes a timestamp comparison wrong. Also covered: frozen win in the previous era, forfeit winner on the *lower* score, frozen win in the **current** era (absent — that's `duelist`'s job), a win two eras ago (lapsed), NULL winner / tie / no-contest (absent for both sides), `resolved_era_id IS NULL`, a live duel, "no era has ever closed" (today's state), and a character with no duels.
- `backend/badges.py` — the new registry entry `Badge(key="duel_victor", name="Duel Victor", …)`. Copy lives in the registry, matching `duelist` exactly (badges emit `key` + `name`; there is no i18n catalog for badge names, so there is no frontend copy to add).
- `backend/alembic/versions/0008_duel_resolved_era.py` — round-tripped on a scratch DB (`upgrade head` → `downgrade 0007` → `upgrade head`), and `alembic check` reports no model drift. Nullable, never backfilled: there is nothing to backfill.
- The **frontend art is deliberately not in this PR.** `badgeArtFor()` falls back to `UnknownBadgeArt`, so shipping backend-first is safe. The Fleur-de-Lis SVG from the issue, and the legibility call it asks for (240px design vs ~18px render), are frontend work — see the note below.

## Not done here / for the orchestrator

- **Frontend:** register `duel_victor` in `BADGE_ART` (`frontend/src/components/badges/badgeArt.tsx`) with the crowned fleur-de-lis. The issue's two open questions (does the `DUEL`/`VICTOR` ring legend survive at 18px; does the ten-stop spectrum mush) are both decisions about the art, and none of this backend work depends on the answer.
- **Visual QA: outstanding, and impossible.** Nothing renders until an era closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

