### PR TITLE
Metatask Seals 1/6: seal foundation (dispatch + Default skin + × + add slot)

### DIFF
--- a/frontend/src/components/metaTaskSeal/DefaultSeal.tsx
+++ b/frontend/src/components/metaTaskSeal/DefaultSeal.tsx
@@ -1,0 +1,80 @@
+import { useTranslation } from 'react-i18next'
+
+import { factionName } from '../../utils/factions'
+import type { SealSkinProps } from './types'
+
+/**
+ * The neutral seal skin — a ringed sticker mounted on neutral paper.
+ *
+ * Every metatask whose issuing faction has no bespoke skin registered falls
+ * through to this via {@link MetaTaskSeal}'s dispatch table, so integrations
+ * render end to end before the per-faction skins land (#929/#930/#931). It shows
+ * the uppercase "<FACTION> METATASK" label, the condition and the "+N PTS" bonus,
+ * plus the `×` peel control when `removable`.
+ */
+export default function DefaultSeal({ metatask, removable, onRemove }: SealSkinProps) {
+  const { t } = useTranslation('praxis')
+  const faction = factionName(metatask.metatask_faction_slug)
+
+  return (
+    <div
+      className="relative"
+      style={{
+        background: 'var(--faction-default-card-bg)',
+        color: 'var(--faction-default-card-text)',
+        border: '2px solid var(--faction-default-border)',
+        borderRadius: 12,
+        padding: 'var(--space-md) var(--space-lg)',
+      }}
+    >
+      {removable && (
+        <button
+          type="button"
+          onClick={() => onRemove?.(metatask.id)}
+          aria-label={t('detail.seal.remove')}
+          className="absolute font-body leading-none"
+          style={{
+            top: 'var(--space-sm)',
+            right: 'var(--space-sm)',
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--faction-default-card-muted)',
+            fontSize: 'var(--text-xl)',
+            cursor: 'pointer',
+          }}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      )}
+
+      <span
+        className="eyebrow block"
+        style={{ color: 'var(--faction-default-card-muted)' }}
+      >
+        {t('detail.seal.label', { faction })}
+      </span>
+
+      <span
+        className="font-body block"
+        style={{
+          fontSize: 'var(--text-content)',
+          color: 'var(--faction-default-card-text)',
+          marginTop: 'var(--space-xs)',
+        }}
+      >
+        {metatask.title}
+      </span>
+
+      <span
+        className="font-display block"
+        style={{
+          fontSize: 'var(--text-title)',
+          color: 'var(--faction-default-card-accent)',
+          marginTop: 'var(--space-xs)',
+        }}
+      >
+        {t('detail.seal.bonus', { points: metatask.point_value })}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/metaTaskSeal/MetaTaskSeal.tsx
+++ b/frontend/src/components/metaTaskSeal/MetaTaskSeal.tsx
@@ -1,0 +1,91 @@
+import type { ComponentType } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import type { TaskOut } from '../../api/tasks'
+import { pickVariant } from '../../utils/factionDispatch'
+import DefaultSeal from './DefaultSeal'
+import type { SealSkinProps } from './types'
+
+/**
+ * Central seal-skin registry — the ONE fall-through table the per-faction seal
+ * issues extend (#929/#930/#931). A metatask's `metatask_faction_slug` selects
+ * its skin; anything unregistered renders {@link DefaultSeal}. Adding a faction
+ * skin is one row here — no dispatcher elsewhere changes. Empty for now: every
+ * seal renders the neutral Default until the skins land.
+ */
+const SEAL_SKINS: Record<string, ComponentType<SealSkinProps>> = {}
+
+export interface MetaTaskSealProps {
+  /**
+   * The praxis's applied metatasks (`PraxisOut.applied_metatasks`). One seal is
+   * rendered per entry, stacked in order.
+   */
+  metatasks: TaskOut[]
+  /**
+   * When true, every seal shows its `×` peel control. Read-only surfaces (card,
+   * detail) omit it; the compose surface (#933) passes it.
+   */
+  removable?: boolean
+  /** Fired by a seal's `×` with the metatask's task id (compose surface wires it, #933). */
+  onRemove?: (taskId: number) => void
+  /**
+   * When provided, render the dashed "+ Add a metatask" slot below the stack.
+   * The caller passes this only when the viewer is eligible to seal, so the slot
+   * is absent on read-only surfaces by construction.
+   */
+  onAdd?: () => void
+}
+
+/**
+ * Renders a praxis's applied metatasks as a stack of foreign seals, each
+ * dispatched on its issuing faction, with an optional "+ Add a metatask" empty
+ * slot below. Read-only surfaces pass just `metatasks`; the compose surface
+ * wires `removable`/`onRemove`/`onAdd`.
+ */
+export default function MetaTaskSeal({
+  metatasks,
+  removable,
+  onRemove,
+  onAdd,
+}: MetaTaskSealProps) {
+  const { t } = useTranslation('praxis')
+
+  // Nothing sealed and no way to add one — render nothing.
+  if (metatasks.length === 0 && !onAdd) return null
+
+  return (
+    <div className="flex flex-col" style={{ gap: 'var(--space-sm)' }}>
+      {metatasks.map((metatask) => {
+        const Skin = pickVariant(SEAL_SKINS, metatask.metatask_faction_slug, DefaultSeal)
+        return (
+          <Skin
+            key={metatask.id}
+            metatask={metatask}
+            removable={removable}
+            onRemove={onRemove}
+          />
+        )
+      })}
+
+      {onAdd && (
+        <button
+          type="button"
+          onClick={onAdd}
+          className="font-body"
+          style={{
+            border: '2px dashed var(--faction-default-border)',
+            borderRadius: 12,
+            background: 'transparent',
+            color: 'var(--faction-default-card-muted)',
+            fontSize: 'var(--text-md)',
+            padding: 'var(--space-md) var(--space-lg)',
+            textAlign: 'left',
+            cursor: 'pointer',
+          }}
+        >
+          {t('detail.seal.add')}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/metaTaskSeal/types.ts
+++ b/frontend/src/components/metaTaskSeal/types.ts
@@ -1,0 +1,27 @@
+import type { TaskOut } from '../../api/tasks'
+
+/**
+ * The contract every seal skin receives.
+ *
+ * A seal renders one applied metatask as a foreign STICKER: it keeps the
+ * ISSUING faction's identity (label derived from `metatask.metatask_faction_slug`)
+ * and never adopts the host card's dress. Each seal shows three things — the
+ * issuing-faction label, the condition (`metatask.title`) and the bonus
+ * (`metatask.point_value`, rendered "+N PTS").
+ */
+export interface SealSkinProps {
+  /**
+   * The applied metatask (one entry from `PraxisOut.applied_metatasks`).
+   * `title` is the condition line, `point_value` the bonus, and
+   * `metatask_faction_slug` the issuing faction that selects the skin.
+   */
+  metatask: TaskOut
+  /**
+   * When true, render the `×` peel control at the sticker's upper-right — the
+   * only foreign control on an otherwise read-only seal. Read-only surfaces
+   * (card, detail) omit it; the compose surface (#933) wires it.
+   */
+  removable?: boolean
+  /** Fired by the `×` control with the metatask's task id. */
+  onRemove?: (taskId: number) => void
+}

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -181,6 +181,12 @@
       "applying": "...",
       "readOnlyNote": "Reach level 7 to apply metatasks."
     },
+    "seal": {
+      "label": "{{faction}} Metatask",
+      "bonus": "+{{points}} PTS",
+      "remove": "Remove metatask",
+      "add": "+ Add a metatask"
+    },
     "default": {
       "breadcrumbTasks": "Tasks",
       "breadcrumbPraxis": "Praxis",

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -6,6 +6,7 @@ import VoteUI from '../../../components/vote/VoteUI'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, PraxisScoreBreakdown, MemberByline } from '../shared'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 
 /** Style Guide §12.3 */
 const RAINBOW_COLORS = ['var(--underline-1)', 'var(--underline-2)', 'var(--underline-3)', 'var(--underline-4)', 'var(--underline-5)', 'var(--underline-6)', 'var(--underline-1)', 'var(--underline-2)']
@@ -108,6 +109,15 @@ export default function DefaultPraxisDetail({
           {t('detail.default.points', { points: praxis.task_point_value })}
         </span>
       </div>
+
+      {/* ── Metatask Seals (#928) — read-only stack, below the byline/context,
+          above the media preview. The compose surface (#933) wires the
+          removable/add controls; here they are proven end to end read-only. ── */}
+      {praxis.applied_metatasks.length > 0 && (
+        <div className="mb-5">
+          <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+        </div>
+      )}
 
       {/* ── Media Gallery (§12.5) ── */}
       {praxis.media_items.length > 0 && (


### PR DESCRIPTION
Part of #927 · **Foundation — blocks all other seal issues (#929/#930/#931 skins, #933 compose).**

## What

Introduces the `MetaTaskSeal` component surface under `frontend/src/components/metaTaskSeal/`:

- **`types.ts`** — the shared `SealSkinProps` contract (`metatask: TaskOut`, `removable`, `onRemove`). Each seal reads `title` (condition), `point_value` (bonus) and `metatask_faction_slug` (issuing faction) from the applied metatask.
- **`DefaultSeal.tsx`** — the one neutral skin: a ringed sticker on neutral paper showing the uppercase `<FACTION> METATASK` label, the condition, and the `+N PTS` bonus. It keeps the issuing faction's *label*, not the host card's dress. Renders the `×` peel control at the upper-right only when `removable`.
- **`MetaTaskSeal.tsx`** — dispatch + stack + slot. Renders one seal per applied metatask, stacked, each dispatched on `metatask_faction_slug` through a **single central `SEAL_SKINS` registry** with `DefaultSeal` as the `pickVariant` fallback (the manifest surface the skin issues extend — currently empty, so everything renders Default). Below the stack, a dashed `+ Add a metatask` slot renders only when the caller passes `onAdd` (i.e. the viewer is eligible to seal). Props are `removable`/`onRemove`/`onAdd`; read-only surfaces pass none.

Reference-integrated read-only into `DefaultPraxisDetail.tsx`, below the byline/context strip and above the media preview, so the surface is proven end to end. New user-facing copy lives in `frontend/src/locales/en/praxis.json` under `detail.seal` (ADR-0031). No backend change — `PraxisOut.applied_metatasks` already carries the data.

Per-faction skins land in #929/#930/#931; the removable/add controls get wired by the compose surface in #933.

Closes #928

## Verification

- `tsc --noEmit`: clean for all changed files (the only remaining errors are the known stale-junction `node:fs`/`node:url` false alarm in unrelated `__tests__`, PR #675).
- `eslint` (incl. `no-raw-style-values` + `i18next/no-literal-string`): clean on all changed files.
- `vite build`: green.
- `vitest run src/pages/praxisDetail`: 139 passed (includes the archetype-slot suite that renders `DefaultPraxisDetail`).
- **Visual QA outstanding** — I cannot screenshot (no dev stack / renderer times out).

## What to eyeball

On the **praxis-detail page (Default archetype)** for a praxis that has one or more applied metatasks:

- The seal stack appears **below the byline/task-context block and above the media gallery**.
- **N applied metatasks → N stacked Default seals**, each showing an uppercase `<FACTION> METATASK` label, the condition text, and the `+N PTS` bonus on neutral paper.
- No per-faction styling — every seal is the neutral Default skin (skins arrive in #929/#930/#931).
- The `×` remove control and the `+ Add a metatask` slot are **not** shown here (read-only integration); they get exercised by the compose surface in #933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
