### PR TITLE
fix(praxis): score stamp's votes row goes stale after voting (#912)

### DIFF
--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/votedStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/votedStamp.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * The score stamp's votes row and total track the viewer's own just-cast vote
+ * (#912).
+ *
+ * `useVotedPraxis` merges a vote override into BOTH the total (`score`) and the
+ * votes row (`points_from_votes`) before a card picks its faction skin, so the
+ * stamp's breakdown moves with the footer instead of lagging until the next
+ * fetch. Before #912 only `score` was merged, so the stamp rendered last-fetch
+ * server truth for its votes row while everything beside it showed the override.
+ *
+ * Harness note: the hook reads the override through `useSyncExternalStore`,
+ * whose server snapshot is `null` under `renderToStaticMarkup` (nobody votes
+ * mid-SSR), so rendering the hook directly can never observe an override in this
+ * DOM-less harness. These cases pin the same seam the hook composes instead:
+ * take the store's delta (the shared `deltaFrom` the hook's `useVoteOverride`
+ * also runs), merge it exactly as `useVotedPraxis` does, and assert the stamp.
+ */
+import { describe, it, expect, afterEach } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import '../../../../i18n'
+import type { PraxisCardOut } from '../../../../api/praxis'
+import { recordVote, tallyDelta, __resetVoteOverrides } from '../../../vote/voteOverrides'
+import DefaultScoreStamp from '../DefaultScoreStamp'
+
+const PRAXIS_ID = 7
+
+function praxis(overrides: Record<string, unknown> = {}): PraxisCardOut {
+  return {
+    id: PRAXIS_ID,
+    task_point_value: 12,
+    display_multiplier: 1,
+    metatask_points: 0,
+    points_from_votes: 4,
+    score: 16,
+    voter_count: 3,
+    ...overrides,
+  } as PraxisCardOut
+}
+
+/** The merge `useVotedPraxis` performs — kept byte-for-byte alongside it. */
+function votedPraxis(base: PraxisCardOut): PraxisCardOut {
+  const delta = tallyDelta(base.id)
+  if (!delta) return base
+  return {
+    ...base,
+    score: base.score + delta.score,
+    points_from_votes: base.points_from_votes + delta.score,
+    voter_count: base.voter_count + delta.voters,
+  }
+}
+
+const text = (html: string) => html.replace(/<[^>]*>/g, '')
+const render = (p: PraxisCardOut) =>
+  text(renderToStaticMarkup(<DefaultScoreStamp praxis={p} />))
+
+afterEach(() => __resetVoteOverrides())
+
+describe('score stamp reflects the viewer’s own vote (#912)', () => {
+  it('moves the votes row AND the total when an override is active', () => {
+    // Server truth: 4 vote-points, total 16. The viewer re-votes 2 -> 5 (+3).
+    recordVote(PRAXIS_ID, 5, 2)
+    const html = render(votedPraxis(praxis()))
+
+    // Both the votes row and the total advance by the same +3 the footer shows.
+    expect(html).toContain('+ 7 from votes')
+    expect(html).toContain('19.0')
+    // Base is untouched — a vote cannot move it — and the stale numbers are gone.
+    expect(html).toContain('12')
+    expect(html).not.toContain('+ 4 from votes')
+    expect(html).not.toContain('16.0')
+  })
+
+  it('adds one delta, not two — the same raw star-sum lands on each field', () => {
+    // First vote (no prior): +5 to the votes row and +5 to the total, nothing more.
+    recordVote(PRAXIS_ID, 5, null)
+    const voted = votedPraxis(praxis())
+    const delta = tallyDelta(PRAXIS_ID)!
+    expect(delta.score).toBe(5)
+    expect(voted.points_from_votes).toBe(9)
+    expect(voted.score).toBe(21)
+  })
+
+  it('returns to server truth with no double-count once the override clears', () => {
+    recordVote(PRAXIS_ID, 5, 2)
+    __resetVoteOverrides()
+    // The next fetch has already folded the vote into server truth; the merge
+    // must be a no-op now, not stack another +3 on top.
+    const html = render(votedPraxis(praxis()))
+    expect(html).toContain('+ 4 from votes')
+    expect(html).toContain('16.0')
+    expect(html).not.toContain('+ 7 from votes')
+    expect(html).not.toContain('19.0')
+  })
+})

--- a/frontend/src/components/vote/useVotedPraxis.ts
+++ b/frontend/src/components/vote/useVotedPraxis.ts
@@ -21,6 +21,7 @@ export function useVotedPraxis(praxis: PraxisCardOut): PraxisCardOut {
   return {
     ...praxis,
     score: praxis.score + delta.score,
+    points_from_votes: praxis.points_from_votes + delta.score,
     voter_count: praxis.voter_count + delta.voters,
   }
 }


### PR DESCRIPTION
## Problem

Cast or change a vote on a praxis card: the vote control and the footer score update, but the **score stamp's votes row stayed on last-fetch server truth** until a refetch.

## What actually changed since the issue was written

ADR-0053 (PR #902) renamed the stamp's score fields. The stamp no longer reads `base_points`/`total`; it reads `points_from_votes` (the votes row) and `score` (the total) via `scoreStamp/scoreBreakdown.ts`. `useVotedPraxis` was **already** merging `score`, so the **total already moved live** — the issue's "total goes stale" claim had rotted. The one remaining bug was the **votes row**: `points_from_votes` was never merged.

## Fix

One line in `useVotedPraxis`:

```ts
points_from_votes: praxis.points_from_votes + delta.score,
```

Units match with no conversion: `delta.score` is `mine - (prior ?? 0)` (raw star-sum delta, `voteOverrides.ts`) and `points_from_votes` is `SUM(Vote.value)` — the same raw star sum. `score` was left as-is (already merged); base / multiplier / metatask (`task_point_value`, `display_multiplier`, `metatask_points`) are untouched — a vote cannot move any of them. Both card dispatchers already call this hook before choosing a faction skin, so all nine stamp variants are fixed at once. The docstring already named the score stamp correctly (no `PraxisScoreHero`), so it was left alone.

## Test

`scoreStamp/__tests__/votedStamp.test.tsx` pins the observable contract at the store-delta + stamp seam: an active override moves **both** the votes row and the total by the same delta, base is untouched, and clearing the override returns to server truth with no double-count.

Harness caveat: the hook reads the override through `useSyncExternalStore`, whose `getServerSnapshot` returns `null` under `renderToStaticMarkup` (nobody votes mid-SSR). I verified empirically that rendering the hook directly can never observe an override in this DOM-less harness, so the test drives the same shared `deltaFrom` the hook's `useVoteOverride` runs, merged exactly as `useVotedPraxis` does, rather than through a live hook render.

## Verification

- `tsc --noEmit`: clean for both changed files (the only errors are the known stale-junction `node:fs`/`node:url` false alarms from PR #675, in pre-existing test files I never touched).
- `eslint` (changed files): clean.
- `vite build`: passes.
- `vitest`: 1339 passed (115 files), including the 3 new cases.
- pytest: N/A (frontend only).
- **Visual QA is outstanding** — no dev stack / no screenshots available in this environment.

## What to eyeball

- Vote on a praxis **feed card**: the stamp's `+ N from votes` row and the total both jump instantly, in step with the footer score.
- **Re-vote** (change your stars) before a refetch: both numbers move by the change, no double-count.
- On the next fetch that returns the same praxis, the stamp matches server truth (the override retires cleanly — no stacked delta).
- Confirm across a few faction skins (Everymen, WOW, Coven, UA, S.N.I.D.E., Singularity, unaffiliated) since all nine share the one hook.

Closes #912
