### PR TITLE
feat(filters): Unaffiliated tile on the Tasks/Praxes faction filter (+ keep na tasks listable on a fresh DB)

### DIFF
--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -63,11 +63,20 @@ async def hidden_faction_slugs(session: AsyncSession) -> list[str]:
     Listing visibility is a faction-*status* axis, not a per-character permit,
     so it can't route through :func:`faction_permits`; it lives here so all
     faction-rule knowledge still has one home. Task listings exclude these.
+
+    The unaffiliated sentinel is subtracted from the result: ``na`` is seeded
+    as a ``hidden`` Faction row (``seed.py``), but hidden/deprecated factions
+    are excluded from listings because nobody should act on them, whereas
+    *unaffiliated* is a state every generic / cross-faction task carries and
+    must stay listable. Without this, player-proposed tasks — which default to
+    ``na`` (``services.task.propose_task``) — vanish from the Tasks page on a
+    freshly seeded database. This does not touch ``GET /factions``, which reads
+    ``visible`` rows directly, so ``na`` remains absent from the registry.
     """
     result = await session.execute(
         select(Faction.slug).where(Faction.status != FactionStatus.visible)
     )
-    return [row[0] for row in result.all()]
+    return [row[0] for row in result.all() if row[0] != UNAFFILIATED_FACTION_SLUG]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -438,6 +438,57 @@ async def test_list_tasks_excludes_hidden_faction_tasks(
 
 
 @pytest.mark.asyncio
+async def test_list_tasks_includes_unaffiliated_tasks(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+):
+    """Cross-faction (`na`) tasks stay listable even though `na` is a hidden row.
+
+    The `faction_ua` fixture (pulled in via `character`) seeds `na` with
+    `FactionStatus.hidden`, mirroring a freshly seeded DB. A genuinely hidden
+    faction's task is excluded; the unaffiliated sentinel's task is not —
+    unaffiliated is a state, not a deprecated faction (issue #921).
+    """
+    from sqlalchemy import select
+
+    # A genuinely hidden/deprecated faction — its task must NOT be listed.
+    hidden_result = await db_session.execute(
+        select(Faction).where(Faction.slug == "hiddenfaction")
+    )
+    if hidden_result.scalar_one_or_none() is None:
+        db_session.add(Faction(slug="hiddenfaction", status=FactionStatus.hidden))
+        await db_session.commit()
+
+    unaffiliated_task = Task(
+        title="Cross-Faction Task",
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug=UNAFFILIATED_FACTION_SLUG,
+    )
+    hidden_task = Task(
+        title="Hidden Faction Task",
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="hiddenfaction",
+    )
+    db_session.add_all([unaffiliated_task, hidden_task])
+    await db_session.commit()
+
+    resp = await client.get("/tasks")
+    assert resp.status_code == 200
+    ids = [t["id"] for t in resp.json()]
+    assert unaffiliated_task.id in ids
+    assert hidden_task.id not in ids
+
+
+@pytest.mark.asyncio
 async def test_create_praxis_for_hidden_faction_task_rejected(
     client: AsyncClient,
     db_session: AsyncSession,

--- a/frontend/src/components/ui/FilterFactionTabs.tsx
+++ b/frontend/src/components/ui/FilterFactionTabs.tsx
@@ -1,14 +1,26 @@
+import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import type { FactionOut } from "../../api/factions";
 import {
   factionCssVar,
+  factionFill,
   factionName,
   sortFactionsByRainbowOrder,
+  UNAFFILIATED_FACTION_SLUG,
 } from "../../utils/factions";
 
 /**
  * Faction filter — Diagonal Banner Tabs (Style Guide §5.3).
  * Pennant shape via .pennant-shape class, faction-colored, inactive: desaturated + low opacity.
+ *
+ * After the registry factions comes one extra pennant for the unaffiliated
+ * sentinel (#921): cross-faction is the default kind of proposed task, yet it is
+ * the one slice you couldn't isolate. `na` is a state, not a faction (ADR-0030 /
+ * ADR-0039), so it is deliberately absent from `GET /factions` and from
+ * `FACTION_RAINBOW_ORDER` — this component supplies it explicitly, appended
+ * last, exactly where `sortFactionsByRainbowOrder` sorts unknown slugs. Its fill
+ * is the rainbow spectrum (`factionFill('na', 'bar')`), NOT `factionCssVar('na')`
+ * which resolves to neutral grey.
  */
 
 interface Props {
@@ -17,12 +29,31 @@ interface Props {
   onChange: (slug: string) => void;
 }
 
+// Shared pennant chrome — the fill (and, for `na`, only the fill) varies per
+// pennant; everything else is identical across the row.
+const PENNANT_STYLE: CSSProperties = {
+  color: "var(--color-text-on-accent)",
+  fontFamily: "'Courier Prime', monospace",
+  fontSize: "var(--text-sm)",
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.07em",
+  padding: "var(--space-xs) var(--space-md)",
+  cursor: "pointer",
+  border: "none",
+  borderRadius: 0,
+  textShadow: "0 1px 2px rgba(0,0,0,0.3)",
+  filter: "none",
+  transition: "all 120ms",
+};
+
 export default function FilterFactionTabs({
   factions,
   value,
   onChange,
 }: Props) {
   const { t } = useTranslation('common');
+  const unaffiliatedActive = value === UNAFFILIATED_FACTION_SLUG;
   return (
     <div className="flex gap-1 items-center">
       <span className="eyebrow">{t("filters.faction")}</span>
@@ -34,27 +65,29 @@ export default function FilterFactionTabs({
             onClick={() => onChange(value === faction.slug ? "" : faction.slug)}
             className="pennant-shape"
             style={{
+              ...PENNANT_STYLE,
               background: factionCssVar(faction.slug),
-              color: "var(--color-text-on-accent)",
-              fontFamily: "'Courier Prime', monospace",
-              fontSize: "var(--text-sm)",
-              fontWeight: 700,
-              textTransform: "uppercase",
-              letterSpacing: "0.07em",
-              padding: "var(--space-xs) var(--space-md)",
-              cursor: "pointer",
-              border: "none",
-              borderRadius: 0,
-              textShadow: "0 1px 2px rgba(0,0,0,0.3)",
               opacity: active ? 1 : 0.85,
-              filter: "none",
-              transition: "all 120ms",
             }}
           >
             {factionName(faction.slug)}
           </button>
         );
       })}
+      <button
+        key={UNAFFILIATED_FACTION_SLUG}
+        onClick={() =>
+          onChange(unaffiliatedActive ? "" : UNAFFILIATED_FACTION_SLUG)
+        }
+        className="pennant-shape"
+        style={{
+          ...PENNANT_STYLE,
+          ...factionFill(UNAFFILIATED_FACTION_SLUG, "bar"),
+          opacity: unaffiliatedActive ? 1 : 0.85,
+        }}
+      >
+        {factionName(UNAFFILIATED_FACTION_SLUG)}
+      </button>
     </div>
   );
 }

--- a/frontend/src/pages/proposeTask/useProposeTask.ts
+++ b/frontend/src/pages/proposeTask/useProposeTask.ts
@@ -18,15 +18,13 @@ import { getFactions, type FactionOut } from "../../api/factions";
 import { useAuth } from "../../auth/AuthContext";
 import { extractError } from "../../utils/errors";
 import i18n from "../../i18n";
+// The unaffiliated sentinel now lives in utils/factions.ts (with the other
+// slug/CSS-key knowledge) so a `ui/` component can import it without depending
+// on a page module (#921). Imported for the guards below and re-exported so
+// existing importers of this module keep working.
+import { UNAFFILIATED_FACTION_SLUG } from "../../utils/factions";
 
-/**
- * The unaffiliated sentinel (ADR-0030 / ADR-0039). Mirrors the backend's
- * `UNAFFILIATED_FACTION_SLUG` (`services/faction_service.py`): a task carrying
- * this slug is generic / cross-faction, owned by no faction. Unaffiliated is a
- * state rather than a faction, so it is deliberately absent from the faction
- * registry — the picker offers it as an explicit extra option (#704).
- */
-export const UNAFFILIATED_FACTION_SLUG = "na";
+export { UNAFFILIATED_FACTION_SLUG };
 
 export interface ProposeTaskState {
   // Gating (faction-agnostic guards live in the dispatcher)

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -25,6 +25,19 @@ import i18n from "../i18n";
 // pattern as utils/taunts.ts.
 const tString = i18n.t as unknown as (key: string) => string;
 
+/**
+ * The unaffiliated sentinel (ADR-0030 / ADR-0039). Mirrors the backend's
+ * `UNAFFILIATED_FACTION_SLUG` (`services/faction_service.py`): a task carrying
+ * this slug is generic / cross-faction, owned by no faction. Unaffiliated is a
+ * state rather than a faction, so it is deliberately absent from the faction
+ * registry — surfaces that offer it (the propose-task picker #704, the filter
+ * pennant row #921) do so as an explicit extra option, never via `GET /factions`.
+ *
+ * Lives here, with the other slug/CSS-key knowledge, so both a `ui/` component
+ * and a page module can import it without a page→ui dependency (#921).
+ */
+export const UNAFFILIATED_FACTION_SLUG = "na";
+
 export interface FactionConfig {
   slug: string;
   /** Primary faction color (light mode value — use factionCssVar for theme-aware styles) */


### PR DESCRIPTION
Closes #921

## What this does
Adds an **Unaffiliated** pennant to the desktop faction filter and fixes a fresh-DB bug where cross-faction tasks vanished from the Tasks page. Coupled frontend + backend, one PR.

### Part 1 — the tile (frontend)
`components/ui/FilterFactionTabs.tsx` (rendered by both `Tasks.tsx` and `Praxes.tsx`) appends **one** extra pennant after the registry factions:
- Label `factionName('na')` → "Unaffiliated".
- Fill is the **rainbow spectrum** via `factionFill('na', 'bar')` — deliberately **not** `factionCssVar('na')`, which resolves to the `default` key's neutral grey. `'bar'` is the banner-shaped surface's fill; the white uppercase label sits on it with the same `textShadow` as every sibling pennant.
- Toggle (`value === slug ? "" : slug`) and active/inactive opacity (1 / 0.85) identical to the other pennants.
- `na` is **not** added to `GET /factions` or `FACTION_RAINBOW_ORDER`; it appends last, exactly where `sortFactionsByRainbowOrder` puts unknown slugs.
- `UNAFFILIATED_FACTION_SLUG` moved from `pages/proposeTask/useProposeTask.ts` → `utils/factions.ts` (so a `ui/` component doesn't import a page module), re-exported from its old home so existing importers keep working. No second `"na"` literal.

### Part 2 — the guard (backend)
On a freshly seeded DB, `seed.py` creates `na` as a `hidden` Faction row, and `list_tasks` excludes hidden factions' tasks — so player-proposed cross-faction tasks (which default to `na`) disappeared. Fix: `hidden_faction_slugs()` now subtracts `UNAFFILIATED_FACTION_SLUG` (backend's own constant), with a comment naming the distinction — hidden/deprecated factions stay excluded, unaffiliated is a *state* every generic task carries and must stay listable. `na` is **not** flipped to `visible`; `GET /factions` is unchanged.

## Tests
- New backend integration test `test_list_tasks_includes_unaffiliated_tasks`: a `primary_faction_slug="na"` task **is** returned by `list_tasks` while a genuinely hidden faction's task is **not**. Ran against a dedicated `wz921_test` DB (parallel agents share `worldzero_test`). Full `test_tasks.py` + `test_factions.py` = 76 passed.
- Frontend: `tsc --noEmit` clean (only the known PR-#675 `node:*` stale-junction false alarm remains, in untouched test files), `eslint .` exit 0, `vite build` succeeds, `vitest` 1336 passed.

## Visual QA — OUTSTANDING
I **cannot screenshot** (Browser-pane renderer times out, no dev stack), so the pennant's rendered appearance is unverified by eye. Verified only via tsc/eslint/build/tests.

## What to eyeball
- **Tasks (desktop):** the "Unaffiliated" pennant appears **last** in the filter row and carries the **rainbow spectrum** fill, not neutral grey.
- **Tasks (desktop):** clicking it filters the list to cross-faction items; clicking again clears the filter. Label stays legible on the rainbow.
- **Praxes (desktop):** same pennant, same colour, same toggle (same component).
- Existing faction pennants and the propose-task picker look unchanged; `GET /factions` still omits `na`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)