### PR TITLE
Task/Metatask filter on the tasks browse page (#934)

### DIFF
--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -8,6 +8,14 @@
       "searchLabel": "Search tasks"
     }
   },
+  "browse": {
+    "taskType": "Type",
+    "tasks": "Tasks",
+    "metatasks": "Metatasks"
+  },
+  "metatask": {
+    "eyebrow": "Metatask · {{faction}}"
+  },
   "mobile": {
     "count": "{{count}} shown",
     "allFactions": "All",

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -8,6 +8,8 @@ import { extractError } from '../utils/errors'
 import { useFormFactor } from '../hooks/useFormFactor'
 import { useTasks, type TasksState } from './tasks/useTasks'
 import DefaultTasks from './tasks/mobileArchetypes/DefaultTasks'
+import MetataskRow from './tasks/MetataskRow'
+import type { TaskType } from '../api/tasks'
 
 export default function Tasks() {
   const state = useTasks()
@@ -33,6 +35,8 @@ function DesktopTasks({ state }: { state: TasksState }) {
     factions,
     statusFilters,
     levelFilters,
+    taskType,
+    setTaskType,
     status,
     setStatus,
     faction,
@@ -48,12 +52,15 @@ function DesktopTasks({ state }: { state: TasksState }) {
     displayPointsFor,
   } = state
 
+  const isMetatask = taskType === 'metatask'
+
   return (
     <div className="py-8">
       <PageTitle title="Tasks" eyebrow={`${tasks.length} shown`} />
 
       {/* Filters (Style Guide §5.3) */}
       <div className="flex flex-col gap-2.5 mb-6">
+        <TaskTypeToggle value={taskType} onChange={setTaskType} />
         <FilterStamps options={statusFilters} value={status} onChange={setStatus} />
         <FilterFactionTabs factions={factions} value={faction} onChange={setFaction} />
         <FilterLevelNodes levels={levelFilters} value={level} onChange={setLevel} />
@@ -93,17 +100,27 @@ function DesktopTasks({ state }: { state: TasksState }) {
         <p className="font-body text-muted">{t('listPage.empty')}</p>
       ) : (
         <>
-          {/* Flex-wrap container — NOT a grid. Varied card sizes and rotations are intentional (Style Guide §6). */}
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-lg)', alignItems: 'flex-start' }}>
-            {tasks.map((task) => (
-              <TaskCard
-                key={task.id}
-                task={task}
-                displayPoints={displayPointsFor(task)}
-                onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
-              />
-            ))}
-          </div>
+          {isMetatask ? (
+            /* Metatasks are informational — a clean issuing-faction row list, no
+               sign-up CTA (they're applied to a praxis via the picker). */
+            <div className="flex flex-col gap-3" style={{ maxWidth: 640 }}>
+              {tasks.map((task) => (
+                <MetataskRow key={task.id} task={task} points={displayPointsFor(task)} />
+              ))}
+            </div>
+          ) : (
+            /* Flex-wrap container — NOT a grid. Varied card sizes and rotations are intentional (Style Guide §6). */
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-lg)', alignItems: 'flex-start' }}>
+              {tasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  displayPoints={displayPointsFor(task)}
+                  onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
+                />
+              ))}
+            </div>
+          )}
           {hasMore && (
             <div className="flex justify-center mt-6">
               <button
@@ -127,6 +144,54 @@ function DesktopTasks({ state }: { state: TasksState }) {
           )}
         </>
       )}
+    </div>
+  )
+}
+
+/**
+ * Task / Metatask browse toggle (#934) — rubber-stamp pair, sharing the status
+ * filter's stamp voice. Switching mode resets the growing window (setter side).
+ */
+function TaskTypeToggle({
+  value,
+  onChange,
+}: {
+  value: TaskType
+  onChange: (value: TaskType) => void
+}) {
+  const { t } = useTranslation('tasks')
+  const options: ReadonlyArray<{ key: TaskType; label: string }> = [
+    { key: 'standard', label: t('browse.tasks') },
+    { key: 'metatask', label: t('browse.metatasks') },
+  ]
+  return (
+    <div className="flex gap-1.5 items-center">
+      <span className="eyebrow">{t('browse.taskType')}</span>
+      {options.map((option) => {
+        const active = value === option.key
+        return (
+          <button
+            key={option.key}
+            type="button"
+            onClick={() => onChange(option.key)}
+            className="font-body uppercase"
+            style={{
+              border: `2px solid ${active ? 'var(--color-text-primary)' : 'var(--color-border-strong)'}`,
+              borderRadius: 0,
+              background: active ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
+              color: active ? 'var(--color-bg-page)' : 'var(--color-text-primary)',
+              fontSize: 'var(--text-base)',
+              fontWeight: 700,
+              letterSpacing: '0.1em',
+              padding: 'var(--space-xs) var(--space-sm)',
+              cursor: 'pointer',
+              transition: 'all 120ms',
+            }}
+          >
+            {option.label}
+          </button>
+        )
+      })}
     </div>
   )
 }

--- a/frontend/src/pages/tasks/MetataskRow.tsx
+++ b/frontend/src/pages/tasks/MetataskRow.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next'
+import type { TaskOut } from '../../api/tasks'
+import { factionCssVar, factionName } from '../../utils/factions'
+
+/**
+ * Shared compact metatask row (#934). Metatasks are informational — they're
+ * applied to a praxis through the picker, never signed up for — so this row
+ * carries NO sign-up CTA. It's dressed in the ISSUING faction's tint
+ * (`metatask_faction_slug`), not a primary-faction card archetype: a metatask
+ * belongs to whichever faction set the condition. Rendered verbatim by the
+ * desktop browse grid and every mobile skin while the Task/Metatask toggle sits
+ * in Metatask mode. A drop-in for the richer MetaTaskSeal (#928) once it lands.
+ */
+export default function MetataskRow({ task, points }: { task: TaskOut; points: number }) {
+  const { t } = useTranslation('tasks')
+  const slug = task.metatask_faction_slug
+  const accent = factionCssVar(slug)
+  return (
+    <div
+      className="w-full flex flex-col gap-2 p-4 bg-surface"
+      style={{
+        borderLeft: `4px solid ${accent}`,
+        borderTop: '1px solid var(--color-border)',
+        borderRight: '1px solid var(--color-border)',
+        borderBottom: '1px solid var(--color-border)',
+      }}
+    >
+      <span className="eyebrow inline-flex items-center gap-1.5" style={{ color: accent }}>
+        <i
+          className="inline-block"
+          style={{ width: 8, height: 8, borderRadius: 2, background: accent }}
+        />
+        {t('metatask.eyebrow', { faction: factionName(slug) })}
+      </span>
+
+      <h2 className="font-display italic font-medium text-wz-2xl leading-tight text-ink">
+        {task.title}
+      </h2>
+
+      {task.description && (
+        <p className="card-description font-body text-muted">{task.description}</p>
+      )}
+
+      <div className="flex items-center gap-3">
+        <span className="font-body font-bold text-wz-lg text-ink bg-surface-alt border border-border px-2 py-0.5">
+          {t('mobile.points', { points })}
+        </span>
+        <span className="eyebrow text-tertiary">
+          {t('mobile.level', { level: task.level_required })}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -29,6 +29,8 @@ const CANNED: TasksState = {
   factionConfigs: [],
   levelFilters: [0, 1, 2, 3, 4, 5],
   statusFilters: ['All', 'active'],
+  taskType: 'standard',
+  setTaskType: () => {},
   status: 'All',
   setStatus: () => {},
   faction: '',

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import type { TasksState } from '../useTasks'
 import MobileTaskCard from './mobileTaskCard'
+import MetataskRow from '../MetataskRow'
 import FactionSigilRow from '../../../components/ui/FactionSigilRow'
 import { ChipRow, Chip } from '../../../components/ui/ChipRow'
 
@@ -24,6 +25,8 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
     factions,
     statusFilters,
     levelFilters,
+    taskType,
+    setTaskType,
     status,
     setStatus,
     faction,
@@ -36,6 +39,8 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
     loadMore,
     displayPointsFor,
   } = state
+
+  const isMetatask = taskType === 'metatask'
 
   return (
     <div className="py-4" data-testid="mobile-tasks-browse">
@@ -64,6 +69,16 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
           borderRadius: 6,
         }}
       />
+
+      {/* Task / Metatask mode toggle (#934) */}
+      <ChipRow label={t('browse.taskType')}>
+        <Chip on={taskType === 'standard'} onClick={() => setTaskType('standard')}>
+          {t('browse.tasks')}
+        </Chip>
+        <Chip on={taskType === 'metatask'} onClick={() => setTaskType('metatask')}>
+          {t('browse.metatasks')}
+        </Chip>
+      </ChipRow>
 
       {/* Status chips */}
       <ChipRow label={tc('filters.status')}>
@@ -103,9 +118,13 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
           <p className="font-body text-muted">{t('listPage.empty')}</p>
         ) : (
           <div className="flex flex-col gap-3">
-            {tasks.map((task) => (
-              <MobileTaskCard key={task.id} task={task} points={displayPointsFor(task)} />
-            ))}
+            {tasks.map((task) =>
+              isMetatask ? (
+                <MetataskRow key={task.id} task={task} points={displayPointsFor(task)} />
+              ) : (
+                <MobileTaskCard key={task.id} task={task} points={displayPointsFor(task)} />
+              ),
+            )}
             {hasMore && (
               <button
                 type="button"

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -15,7 +15,7 @@
  */
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { listTasks, type TaskOut } from '../../api/tasks'
+import { listTasks, type TaskOut, type TaskType } from '../../api/tasks'
 import { createPraxis } from '../../api/praxis'
 import { getFactions, type FactionOut } from '../../api/factions'
 import { getGameConfig, type FactionConfigOut } from '../../api/gameConfig'
@@ -54,6 +54,13 @@ export interface TasksState {
   statusFilters: string[]
 
   // Filter state (setters reset the growing window).
+  /**
+   * Browse mode (#934): 'standard' lists ordinary tasks (the default, metatasks
+   * excluded backend-side), 'metatask' lists issuing-faction metatask rows —
+   * informational, never signed up for.
+   */
+  taskType: TaskType
+  setTaskType: (taskType: TaskType) => void
   status: string
   setStatus: (status: string) => void
   faction: string
@@ -83,6 +90,7 @@ export function useTasks(): TasksState {
 
   const [factions, setFactions] = useState<FactionOut[]>([])
   const [factionConfigs, setFactionConfigs] = useState<FactionConfigOut[]>([])
+  const [taskType, setTaskTypeState] = useState<TaskType>('standard')
   const [status, setStatusState] = useState('All')
   const [faction, setFactionState] = useState('')
   const [level, setLevelState] = useState<number | ''>('')
@@ -104,6 +112,9 @@ export function useTasks(): TasksState {
   const { data, loading, error, hasMore, loadMore, resetWindow } = usePagedResource(
     (limit) =>
       listTasks({
+        // 'standard' → omit task_type so the backend applies its default
+        // (metatasks excluded); 'metatask' → list only metatask rows.
+        task_type: taskType === 'metatask' ? 'metatask' : undefined,
         status: status === 'All' ? undefined : status,
         faction: faction || undefined,
         level: level === '' ? undefined : level,
@@ -111,13 +122,14 @@ export function useTasks(): TasksState {
         exclude_character_id: characterId,
         limit,
       }),
-    [status, faction, level, trimmedQuery, characterId],
+    [taskType, status, faction, level, trimmedQuery, characterId],
     PAGE_LIMIT,
   )
   const tasks = data ?? []
 
   // Every filter change resets the window so "load more" can't strand a grown
   // page against a freshly-narrowed result set.
+  const setTaskType = (next: TaskType) => { setTaskTypeState(next); resetWindow() }
   const setStatus = (next: string) => { setStatusState(next); resetWindow() }
   const setFaction = (next: string) => { setFactionState(next); resetWindow() }
   const setLevel = (next: number | '') => { setLevelState(next); resetWindow() }
@@ -157,6 +169,8 @@ export function useTasks(): TasksState {
     levelFilters: LEVEL_FILTERS,
     statusFilters,
 
+    taskType,
+    setTaskType,
     status,
     setStatus,
     faction,


### PR DESCRIPTION
Closes #934

Adds a **Task / Metatask** toggle to the tasks browse page so players can see what metatasks exist without opening the apply picker. Frontend only — the backend already supports `task_type` (returns only metatasks for `task_type=metatask`, excludes them by default otherwise).

## What changed
- **`useTasks.ts`** — new `taskType` filter (default `standard`) exposed on `TasksState` with a `setTaskType` that resets the growing window like the other setters. Threaded into the `listTasks({ task_type })` call and the `usePagedResource` deps. Standard mode omits `task_type` (preserving today's metatasks-excluded default); Metatask mode passes `metatask`.
- **`MetataskRow.tsx`** (new, shared) — compact, informational row dressed in the **issuing faction** (`metatask_faction_slug`) tint: condition title, point value, level. **No sign-up CTA** (metatasks are applied to a praxis via the picker, never signed up for). A drop-in for the richer `MetaTaskSeal` (#928) once it lands. Token-only styling so the `no-raw-style-values` ratchet stays green.
- **Desktop `Tasks.tsx`** — a rubber-stamp `TaskTypeToggle` in the filter row; Metatask mode renders a `MetataskRow` list (no `TaskCard`, no signup) instead of the flex-wrap card grid.
- **Mobile `DefaultTasks.tsx`** — a Task/Metatask chip row reusing the shared `ChipRow`/`Chip`; Metatask mode swaps each `MobileTaskCard` for a `MetataskRow`.
- Faction / level / search filters still apply within each mode; the window resets on toggle.

`api/tasks.ts` already declared `task_type` on `TaskFilters` and forwarded it — no change needed there. `#928`'s `MetaTaskSeal` does not exist on `main`, so it is not imported (not hard-blocked).

## Verification
- `tsc --noEmit`: clean on app + changed files (only pre-existing `node:fs`-cascade false alarms in unrelated test files remain).
- `eslint` on all changed files: **0 errors** (ratchet green).
- `vitest` dispatch + catalog tests: **35 passed**.
- `vite build`: **built OK**.
- **Visual QA is outstanding** — no dev stack / screenshot available in this environment.

## What to eyeball
- Desktop: toggle to **Metatasks** — confirm metatask rows appear with their issuing-faction slug/tint and **no sign-up button**; toggle back to **Tasks** shows standard tasks only (unchanged default).
- Mobile: same toggle in the filter chip row — confirm metatask rows render and no signup CTA.
- Apply a faction / level / search filter in each mode and confirm it still narrows the set; confirm the list window resets when toggling modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)