### PR TITLE
fix(praxis): score stamp's votes row goes stale after voting

### DIFF
--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -10,13 +10,15 @@
  * The dispatch cases pin the other half: the stamp resolves per faction with
  * `Default*` fall-through, like every other surface (ADR-0039).
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
 import '../../../../i18n'
 import type { PraxisCardOut } from '../../../../api/praxis'
 import { pickVariant } from '../../../../utils/factionDispatch'
 import { surfaceMap } from '../../../../factions'
 import { scoreBreakdown, formatMult } from '../scoreBreakdown'
+import { applyVoteDelta } from '../../../vote/useVotedPraxis'
+import { recordVote, tallyDelta, __resetVoteOverrides } from '../../../vote/voteOverrides'
 import DefaultScoreStamp from '../DefaultScoreStamp'
 import EverymenScoreStamp from '../EverymenScoreStamp'
 import EphemeristsScoreStamp from '../EphemeristsScoreStamp'
@@ -96,6 +98,23 @@ describe('scoreBreakdown row selection (ADR-0053)', () => {
   it('formats the multiplier to two decimals', () => {
     expect(formatMult(0.8)).toBe('×0.80')
     expect(formatMult(2)).toBe('×2.00')
+  })
+})
+
+describe('useVotedPraxis merge feeds the stamp breakdown (#912)', () => {
+  beforeEach(() => {
+    __resetVoteOverrides()
+  })
+
+  it('moves both the votes row and the total on an active override, before any refetch', () => {
+    const base = praxis({ id: 1, voter_count: 2, points_from_votes: 4, score: 13.6 })
+    recordVote(1, 5, null)
+    const delta = tallyDelta(1)
+    if (!delta) throw new Error('expected an active override')
+    const voted = applyVoteDelta(base, delta)
+    expect(scoreBreakdown(voted)).toEqual(
+      expect.objectContaining({ votes: 9, total: 18.6 }),
+    )
   })
 })
 

--- a/frontend/src/components/vote/useVotedPraxis.ts
+++ b/frontend/src/components/vote/useVotedPraxis.ts
@@ -1,5 +1,20 @@
 import type { PraxisCardOut } from '../../api/praxis'
-import { useVoteOverride } from './voteOverrides'
+import { useVoteOverride, type VoteDelta } from './voteOverrides'
+
+/**
+ * The arithmetic half of the merge, pulled out so it's testable without the
+ * hook: `useSyncExternalStore`'s server snapshot is always null under
+ * `renderToStaticMarkup` (see voteOverrides.ts), so a component-rendered test
+ * can never observe an active override. `tallyDelta` + this function can.
+ */
+export function applyVoteDelta(praxis: PraxisCardOut, delta: VoteDelta): PraxisCardOut {
+  return {
+    ...praxis,
+    score: praxis.score + delta.score,
+    voter_count: praxis.voter_count + delta.voters,
+    points_from_votes: praxis.points_from_votes + delta.score,
+  }
+}
 
 /**
  * Merge the viewer's own just-cast vote into a praxis (#626).
@@ -18,9 +33,5 @@ import { useVoteOverride } from './voteOverrides'
 export function useVotedPraxis(praxis: PraxisCardOut): PraxisCardOut {
   const delta = useVoteOverride(praxis.id)
   if (!delta) return praxis
-  return {
-    ...praxis,
-    score: praxis.score + delta.score,
-    voter_count: praxis.voter_count + delta.voters,
-  }
+  return applyVoteDelta(praxis, delta)
 }


### PR DESCRIPTION
Closes #912

## Problem

Casting or changing a vote on a praxis card updated the vote control and the footer score, but the score stamp's **votes row** stayed stale until the next fetch.

## Root cause

`useVotedPraxis` already patched `score` and `voter_count` on the vote-override merge (`score` feeds the stamp's `total` via `scoreBreakdown`, so the total was already correct). It never patched `points_from_votes`, which feeds the stamp's votes row specifically — so the total moved but the votes row underneath it didn't.

## Fix

- Add the same vote delta to `points_from_votes` in the merge (`frontend/src/components/vote/useVotedPraxis.ts`).
- Pulled the merge arithmetic into an exported `applyVoteDelta` helper so it's independently testable — `useSyncExternalStore`'s server snapshot is always `null` under `renderToStaticMarkup` (per the existing comment in `voteOverrides.ts`), so a component-rendered test can never observe an active override. `applyVoteDelta` + the existing `tallyDelta` pure-read seam can.
- Added a regression test in `scoreStamp.test.tsx` asserting both the votes row and the total move together on an active override, using the `__resetVoteOverrides()` seam.

## Out of scope (per the issue)

- The praxis detail page — it has its own correct merge and isn't touched.
- `base_points`/`metatask_points`/`display_multiplier` — a vote can't move any of them.

## Test results

- `npx vitest run` — 114 files, 1337 tests passed.
- `npm run typecheck` — clean.
- `npx eslint` on both changed files — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V3tUbp1xb5HWLRhXm3zAKc)_