### PR TITLE
Surface the WOW level-jump allowance in the UI (#816)

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -50,6 +50,12 @@ export interface CurrentUser {
   // FieldDesk locked-dossier gate copy (#270/#274). Never hardcode the gate number.
   second_character_level_required: number
   era_name: string
+  // Faction level-jump allowance (#811). reach = levels above own level this
+  // faction grants (0 = no such ability, so hide the affordance entirely);
+  // available = the allowance is unspent at the character's current level.
+  // Drive UI off these config-backed fields — never a `slug === 'wow'` branch.
+  level_jump_reach: number
+  level_jump_available: boolean
 }
 
 export async function getMe(): Promise<CurrentUser> {

--- a/frontend/src/components/vote/__tests__/albescentVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/albescentVote.test.tsx
@@ -62,6 +62,8 @@ function currentUser(): CurrentUser {
     can_comment: true,
     second_character_level_required: 5,
     era_name: 'Era 3',
+    level_jump_reach: 0,
+    level_jump_available: false,
   }
 }
 

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -570,7 +570,10 @@
       "subtitle": "thy crusade, in the palm of thy gauntlet"
     },
     "invitation": {
-      "pitch": "By decree most official (we made the seal ourselves), thou art summoned to the Warriors of Whimsy. Bring a straight face. We shall supply the sword."
+      "pitch": "By decree most official (we made the seal ourselves), thou art summoned to the Warriors of Whimsy. Bring a straight face. We shall supply the sword.",
+      "perks": [
+        "The Leap of Whimsy — once each rank, a knight may storm a single quest one rung above their station and take it anyway"
+      ]
     }
   },
   "invitation": {

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -29,7 +29,11 @@
     "fetchError": "<0>Try refreshing.</0>",
     "notFound": "Task not found.",
     "pageTitle": "Task",
-    "pageEyebrow": "Tasks · Detail"
+    "pageEyebrow": "Tasks · Detail",
+    "levelJump": {
+      "tag": "Level-jump",
+      "note": "Requires level {{level}}, one rung above you — your faction's once-a-level leap covers it."
+    }
   },
   "propose": {
     "pageTitle": "Propose a Task",

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
@@ -74,6 +74,8 @@ function currentUser(faction_slug: string | null): CurrentUser {
     can_comment: true,
     second_character_level_required: 5,
     era_name: 'Era 3',
+    level_jump_reach: 0,
+    level_jump_available: false,
   }
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -121,6 +121,8 @@ function user(characterId: number): CurrentUser {
     can_comment: true,
     second_character_level_required: 5,
     era_name: "Era 1",
+    level_jump_reach: 0,
+    level_jump_available: false,
   };
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
@@ -158,6 +158,8 @@ function user(): CurrentUser {
     can_comment: true,
     second_character_level_required: 5,
     era_name: 'Era 1',
+    level_jump_reach: 0,
+    level_jump_available: false,
   }
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/mobileStarVote.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/mobileStarVote.test.tsx
@@ -54,6 +54,8 @@ function currentUser(): CurrentUser {
     can_comment: true,
     second_character_level_required: 5,
     era_name: 'Era 3',
+    level_jump_reach: 0,
+    level_jump_available: false,
   }
 }
 

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -92,6 +92,7 @@ function baseState(overrides: Partial<TaskDetailState>): TaskDetailState {
     isInProgress: false,
     inProgressPraxisId: null,
     canSignUp: false,
+    levelJumpSignup: false,
     slotsOpen: 13,
     maxTaskSlots: 17,
     factionMultiplier: 1.0,

--- a/frontend/src/pages/taskDetail/__tests__/levelJump.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/levelJump.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Level-jump affordance (#816) — the three visual states, tested as pure
+ * props-in/value-out (harness note: no DOM, effects never run, so the hook and
+ * self-fetching page aren't testable; the predicate and the presentational
+ * banner are).
+ *
+ * The predicate distinguishes:
+ *   1. Reachable BECAUSE of the allowance  -> true  (distinct level-jump CTA)
+ *   2. Spent                               -> false (CTA gone; reads as locked)
+ *   3. Plain out of reach                  -> false (CTA gone; reads as locked)
+ * driven entirely off level_jump_reach / level_jump_available / task level vs
+ * viewer level — never a slug comparison.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import "../../../i18n"; // initialise i18next with the real catalogs (throws on a missing key)
+import { isLevelJumpSignup } from "../levelJump";
+import { LevelJumpBanner } from "../archetypes/shared";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut } from "../../../api/tasks";
+
+const TASK_ABOVE: TaskOut = {
+  id: 1,
+  title: "Knight a houseplant",
+  description: null,
+  point_value: 20,
+  level_required: 4, // one above a level-3 viewer
+  status: "active",
+  task_type: "standard",
+  created_by: 1,
+  primary_faction_slug: "snide",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+describe("isLevelJumpSignup — the three states", () => {
+  it("state 1: reachable BECAUSE of the allowance -> true", () => {
+    expect(
+      isLevelJumpSignup({
+        canSignUp: true,
+        levelJumpReach: 1,
+        levelJumpAvailable: true,
+        taskLevelRequired: 4,
+        viewerLevel: 3,
+      }),
+    ).toBe(true);
+  });
+
+  it("state 2: spent (allowance unavailable -> backend denies -> canSignUp false) -> false", () => {
+    // Once spent, the backend's can_submit_praxis is false, so canSignUp is
+    // false and the flag never fires — the task reads as locked.
+    expect(
+      isLevelJumpSignup({
+        canSignUp: false,
+        levelJumpReach: 1,
+        levelJumpAvailable: false,
+        taskLevelRequired: 4,
+        viewerLevel: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("state 3: plain out of reach (more than reach above level) -> false", () => {
+    expect(
+      isLevelJumpSignup({
+        canSignUp: false, // backend denies: task is 2 above a reach-1 viewer
+        levelJumpReach: 1,
+        levelJumpAvailable: true,
+        taskLevelRequired: 5,
+        viewerLevel: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("no ability (reach 0) -> false even for a signable above-level task", () => {
+    expect(
+      isLevelJumpSignup({
+        canSignUp: true,
+        levelJumpReach: 0,
+        levelJumpAvailable: false,
+        taskLevelRequired: 4,
+        viewerLevel: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it("ordinary at-or-below-level signup is not a level-jump", () => {
+    expect(
+      isLevelJumpSignup({
+        canSignUp: true,
+        levelJumpReach: 1,
+        levelJumpAvailable: true,
+        taskLevelRequired: 3,
+        viewerLevel: 3,
+      }),
+    ).toBe(false);
+  });
+});
+
+/** Minimal state builder — only the fields the banner reads matter. */
+function state(overrides: Partial<TaskDetailState>): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK_ABOVE,
+    fetchError: null,
+    submissions: [],
+    signups: [],
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: true,
+    levelJumpSignup: false,
+    slotsOpen: 5,
+    maxTaskSlots: 20,
+    factionMultiplier: 1.0,
+    modifiedPoints: 20,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+describe("LevelJumpBanner — markup out", () => {
+  it("renders the level-jump tag + note when levelJumpSignup is true", () => {
+    const html = renderToStaticMarkup(
+      <LevelJumpBanner state={state({ levelJumpSignup: true })} />,
+    );
+    const text = html.replace(/<[^>]*>/g, "");
+    expect(text, "distinct level-jump tag").toContain("Level-jump");
+    // Note quotes the required level so the CTA never reads identical to an
+    // at-or-below-level signup.
+    expect(text, "note quotes the required level").toContain("4");
+  });
+
+  it("renders nothing when levelJumpSignup is false (spent / out of reach reads as locked)", () => {
+    const html = renderToStaticMarkup(
+      <LevelJumpBanner state={state({ levelJumpSignup: false })} />,
+    );
+    expect(html).toBe("");
+  });
+});

--- a/frontend/src/pages/taskDetail/__tests__/mobileArchetypeDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mobileArchetypeDispatch.test.tsx
@@ -66,6 +66,7 @@ function baseState(overrides: Partial<TaskDetailState>): TaskDetailState {
     isInProgress: false,
     inProgressPraxisId: null,
     canSignUp: true,
+    levelJumpSignup: false,
     slotsOpen: 13,
     maxTaskSlots: 17,
     factionMultiplier: 1.0,

--- a/frontend/src/pages/taskDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -79,6 +79,7 @@ function baseState(overrides: Partial<TaskDetailState>): TaskDetailState {
     isInProgress: false,
     inProgressPraxisId: null,
     canSignUp: false,
+    levelJumpSignup: false,
     slotsOpen: 13,
     maxTaskSlots: 17,
     factionMultiplier: 1.0,

--- a/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaDispatch.test.tsx
@@ -53,6 +53,7 @@ function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {
     isInProgress: false,
     inProgressPraxisId: null,
     canSignUp: true,
+    levelJumpSignup: false,
     slotsOpen: 3,
     maxTaskSlots: 8,
     factionMultiplier: 1.0,

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
-import { ErrorBanner, relationOf } from "./shared";
+import { ErrorBanner, LevelJumpBanner, relationOf } from "./shared";
 import type { TaskSignupOut } from "../../../api/tasks";
 import type { PraxisCardOut } from "../../../api/praxis";
 import type { TaskDetailState } from "../useTaskDetail";
@@ -401,6 +401,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
         </div>
 
         {/* ── Signup CTA bar (only when sign-up is possible) ── */}
+        <LevelJumpBanner state={state} />
         {canSignUp && (
           <div>
             <div

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -6,6 +6,7 @@ import FeedBadge from "../../../components/feed/FeedBadge";
 import DefaultSigil from "../../../components/cards/DefaultSigil";
 import { factionCssVar, factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
+import { LevelJumpBanner } from "./shared";
 import type { TaskDetailState } from "../useTaskDetail";
 
 const VISIBLE_SIGNUPS = 4;
@@ -242,6 +243,7 @@ export default function DefaultTaskDetail({
           </div>
 
           {/* ── Signup Block ── */}
+          <LevelJumpBanner state={state} />
           {canSignUp && (
             <div className="sidebar-card mb-5" style={{ padding: "var(--space-lg) var(--space-xl)" }}>
               <button

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -4,7 +4,7 @@ import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
 import { factionName } from "../../../utils/factions";
 import { EphemeristsSigil, Foxing, LapisLastWord } from "../../../components/cards/ephemeristsAtoms";
-import { ErrorBanner, relationOf } from "./shared";
+import { ErrorBanner, LevelJumpBanner, relationOf } from "./shared";
 import type { TaskSignupOut } from "../../../api/tasks";
 import type { TaskDetailState } from "../useTaskDetail";
 
@@ -561,6 +561,7 @@ export default function EphemeristsTaskDetail({
         </section>
 
         {/* ── Signup CTA — only when the viewer may enroll ── */}
+        <LevelJumpBanner state={state} />
         {canSignUp && (
           <section
             style={{

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
-import { ErrorBanner, relationOf } from "./shared";
+import { ErrorBanner, LevelJumpBanner, relationOf } from "./shared";
 import type { TaskSignupOut } from "../../../api/tasks";
 import type { TaskDetailState } from "../useTaskDetail";
 
@@ -412,6 +412,7 @@ export default function EverymenTaskDetail({
           </div>
 
           {/* ── CTA bar / signed-on states ── */}
+          <LevelJumpBanner state={state} />
           {canSignUp && (
             <div
               style={{

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
-import { ErrorBanner, relationOf } from "./shared";
+import { ErrorBanner, LevelJumpBanner, relationOf } from "./shared";
 import type { TaskSignupOut } from "../../../api/tasks";
 import type { TaskDetailState } from "../useTaskDetail";
 
@@ -393,6 +393,7 @@ export default function SingularityTaskDetail({
           </section>
 
           {/* ── CTA bar / signed-up states ── */}
+          <LevelJumpBanner state={state} />
           {canSignUp && (
             <div
               style={{

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -5,7 +5,7 @@ import PraxisCard from "../../../components/PraxisCard";
 import { mediaUrl } from "../../../utils/media";
 import { factionName } from "../../../utils/factions";
 import { SnideSigil } from "../../../components/snide/snideAtoms";
-import { ErrorBanner, relationOf } from "./shared";
+import { ErrorBanner, LevelJumpBanner, relationOf } from "./shared";
 import type { TaskSignupOut } from "../../../api/tasks";
 import type { TaskDetailState } from "../useTaskDetail";
 
@@ -520,6 +520,7 @@ export default function SnideTaskDetail({
         </div>
 
         {/* ── CTA slab (black-ink dispatch bar) ── */}
+        <LevelJumpBanner state={state} />
         <div
           style={{
             display: "flex",

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -12,7 +12,7 @@ import {
   uaShade,
 } from "../../../components/cards/uaAtoms";
 import { mediaUrl } from "../../../utils/media";
-import { ErrorBanner, relationOf } from "./shared";
+import { ErrorBanner, LevelJumpBanner, relationOf } from "./shared";
 import type { TaskSignupOut } from "../../../api/tasks";
 import type { TaskDetailState } from "../useTaskDetail";
 
@@ -407,6 +407,7 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
           </div>
 
           {/* ── Sign-up / signed-on states ── */}
+          <LevelJumpBanner state={state} />
           {canSignUp && (
             <div style={PANEL}>
               <button onClick={handleSignup} style={FILLED_ACTION}>

--- a/frontend/src/pages/taskDetail/archetypes/shared.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/shared.tsx
@@ -5,6 +5,8 @@
  * each other's look. Mirrors editPraxis/archetypes/shared.tsx.
  */
 import type { CSSProperties } from "react";
+import { useTranslation } from "react-i18next";
+import type { TaskDetailState } from "../useTaskDetail";
 
 /** Resolve a signup character's relationship to the viewer (for badges). */
 export function relationOf(
@@ -20,6 +22,53 @@ export function relationOf(
 interface ErrorBannerProps {
   message: string | null;
   style?: CSSProperties;
+}
+
+/**
+ * LevelJumpBanner — the shared level-jump affordance (#816). Rendered at the top
+ * of every archetype's sign-up region so a WOW member (or any future faction
+ * whose config grants a level-jump reach) sees a task they can only claim BECAUSE
+ * of the allowance marked distinctly, never identical to a task at or below their
+ * level. Purely presentational and config-driven: it renders only when
+ * `state.levelJumpSignup` is true (computed in useTaskDetail off
+ * `level_jump_reach`/`level_jump_available` — no slug comparison). When the
+ * allowance is spent or the task is plainly out of reach the CTA doesn't render
+ * at all, so this banner never appears and the task reads as locked.
+ */
+export function LevelJumpBanner({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation("tasks");
+  if (!state.levelJumpSignup || !state.task) return null;
+  return (
+    <div
+      className="font-body"
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        flexWrap: "wrap",
+        gap: "var(--space-sm)",
+        marginBottom: "var(--space-sm)",
+        padding: "var(--space-xs) var(--space-md)",
+        background: "var(--color-bg-surface-alt)",
+        border: "1px solid var(--color-border)",
+        borderRadius: 6,
+      }}
+    >
+      <span
+        className="eyebrow"
+        style={{ color: "var(--color-text-primary)" }}
+      >
+        {t("detail.levelJump.tag")}
+      </span>
+      <span
+        style={{
+          fontSize: "var(--text-sm)",
+          color: "var(--color-text-secondary)",
+        }}
+      >
+        {t("detail.levelJump.note", { level: state.task.level_required })}
+      </span>
+    </div>
+  );
 }
 
 export function ErrorBanner({ message, style }: ErrorBannerProps) {

--- a/frontend/src/pages/taskDetail/levelJump.ts
+++ b/frontend/src/pages/taskDetail/levelJump.ts
@@ -1,0 +1,46 @@
+/**
+ * Level-jump affordance predicate (#811/#816).
+ *
+ * A faction may grant its members a level-jump allowance: once per level they
+ * may sign up for a task a fixed number of levels above their own. WOW is the
+ * only faction that grants it in Era 1, but the whole point of the config field
+ * is that a SECOND faction could gain it without touching this code — so the
+ * predicate never compares a slug. It reads only the config-backed fields the
+ * backend already computed (`level_jump_reach`, `level_jump_available`) plus the
+ * viewer's level and the task's requirement.
+ *
+ * Eligibility itself is NOT recomputed here. `canSignUp` already trusts the
+ * backend's `can_submit_praxis`, which threads the same reach and is false once
+ * the allowance is spent. So a signable task ABOVE the viewer's level can only be
+ * signable because of the allowance — that is exactly what this predicate marks.
+ * When it returns false (allowance spent, or the task is plainly out of reach)
+ * the sign-up CTA does not render at all, so the task reads as locked.
+ */
+export interface LevelJumpSignupParams {
+  /** Whether the backend says this viewer may sign up (trusted, not recomputed). */
+  canSignUp: boolean;
+  /** Levels above own level the viewer's faction grants (0 = no such ability). */
+  levelJumpReach: number;
+  /** Whether the allowance is unspent at the viewer's current level. */
+  levelJumpAvailable: boolean;
+  /** The task's required level. */
+  taskLevelRequired: number | null | undefined;
+  /** The viewer's own level. */
+  viewerLevel: number;
+}
+
+export function isLevelJumpSignup({
+  canSignUp,
+  levelJumpReach,
+  levelJumpAvailable,
+  taskLevelRequired,
+  viewerLevel,
+}: LevelJumpSignupParams): boolean {
+  return (
+    canSignUp &&
+    levelJumpReach > 0 &&
+    levelJumpAvailable &&
+    taskLevelRequired != null &&
+    taskLevelRequired > viewerLevel
+  );
+}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/CovenTaskDetail.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import PraxisCard from '../../../components/PraxisCard'
 import { MobileStickyBar, MobileStickyCaption } from './shared'
+import { LevelJumpBanner } from '../archetypes/shared'
 import type { TaskDetailState } from '../useTaskDetail'
 
 /**
@@ -274,6 +275,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
       {/* Sticky action bar */}
       {canSignUp && (
         <MobileStickyBar>
+          <LevelJumpBanner state={state} />
           {signupError && (
             <div style={{ fontFamily: BODY, fontSize: "var(--text-lg)", color: 'var(--color-danger)', padding: "var(--space-sm) var(--space-md)", background: 'var(--faction-coven-light)', border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 9 }}>
               {signupError}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx
@@ -5,6 +5,7 @@ import LevelGem from "../../../components/ui/LevelGem";
 import DefaultSigil from "../../../components/cards/DefaultSigil";
 import { factionCssVar, factionName } from "../../../utils/factions";
 import { MobileStickyBar, MobileStickyCaption } from "./shared";
+import { LevelJumpBanner } from "../archetypes/shared";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -156,6 +157,7 @@ export default function DefaultTaskDetail({ state }: { state: TaskDetailState })
       {/* Sticky action bar — the mobile CTA pattern; carries the one primary verb. */}
       {canSignUp && (
         <MobileStickyBar>
+          <LevelJumpBanner state={state} />
           {signupError && (
             <div
               className="font-body"

--- a/frontend/src/pages/taskDetail/mobileArchetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/EphemeristsTaskDetail.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import PraxisCard from '../../../components/PraxisCard'
 import { EphemeristsSigil, LapisLastWord } from '../../../components/cards/ephemeristsAtoms'
 import { MobileStickyBar, MobileStickyCaption } from './shared'
+import { LevelJumpBanner } from '../archetypes/shared'
 import type { TaskDetailState } from '../useTaskDetail'
 
 /**
@@ -222,6 +223,7 @@ export default function EphemeristsTaskDetail({ state }: { state: TaskDetailStat
       {/* Sticky action bar */}
       {canSignUp && (
         <MobileStickyBar>
+          <LevelJumpBanner state={state} />
           {signupError && (
             <div style={{ fontFamily: SERIF, fontSize: "var(--text-lg)", color: 'var(--color-danger)', padding: "var(--space-sm) var(--space-md)", background: 'var(--faction-ephemerists-light)', border: `1px solid ${GOLD_DEEP}` }}>
               {signupError}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/EverymenTaskDetail.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
 import { MobileStickyBar, MobileStickyCaption } from "./shared";
+import { LevelJumpBanner } from "../archetypes/shared";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -354,6 +355,7 @@ export default function EverymenTaskDetail({ state }: { state: TaskDetailState }
       {/* Sticky action bar — stamped CTA / signed-on state */}
       {canSignUp && (
         <MobileStickyBar>
+          <LevelJumpBanner state={state} />
           {signupError && (
             <div
               className="font-body"

--- a/frontend/src/pages/taskDetail/mobileArchetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/SingularityTaskDetail.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import PraxisCard from '../../../components/PraxisCard'
 import { MobileStickyBar, MobileStickyCaption } from './shared'
+import { LevelJumpBanner } from '../archetypes/shared'
 import type { TaskDetailState } from '../useTaskDetail'
 
 /**
@@ -222,6 +223,7 @@ export default function SingularityTaskDetail({ state }: { state: TaskDetailStat
       {/* Sticky action bar */}
       {canSignUp && (
         <MobileStickyBar>
+          <LevelJumpBanner state={state} />
           {signupError && (
             <div style={{ fontFamily: FONT, fontSize: "var(--text-lg)", color: 'var(--color-danger)', padding: "var(--space-sm) var(--space-md)", background: signal(10), border: `1px solid ${signal(40)}` }}>
               {signupError}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/SnideTaskDetail.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import PraxisCard from '../../../components/PraxisCard'
 import { MobileStickyBar, MobileStickyCaption } from './shared'
+import { LevelJumpBanner } from '../archetypes/shared'
 import type { TaskDetailState } from '../useTaskDetail'
 
 /**
@@ -233,6 +234,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
       {/* Sticky action bar */}
       {canSignUp && (
         <MobileStickyBar>
+          <LevelJumpBanner state={state} />
           {signupError && (
             <div style={{ fontFamily: TYPE, fontSize: "var(--text-lg)", color: 'var(--color-danger)', padding: "var(--space-sm) var(--space-md)", background: 'var(--faction-snide-light)', border: `1px solid ${LINE}` }}>
               {signupError}

--- a/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/UaTaskDetail.tsx
@@ -6,6 +6,7 @@ import UaMandala from '../../../components/cards/UaMandala'
 import { UaSigil } from '../../../components/cards/UaSigil'
 import { toRoman } from '../../../components/cards/ephemeristsAtoms'
 import { MobileStickyBar, MobileStickyCaption } from './shared'
+import { LevelJumpBanner } from '../archetypes/shared'
 import type { TaskDetailState } from '../useTaskDetail'
 
 /**
@@ -304,6 +305,7 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
       {/* Sticky action bar */}
       {canSignUp && (
         <MobileStickyBar>
+          <LevelJumpBanner state={state} />
           {signupError && (
             /* #848 turned --faction-ua-light opaque, so it can no longer whisper
                behind an error line. A failure is lifted, not tinted: the raised

--- a/frontend/src/pages/taskDetail/mobileArchetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/WowTaskDetail.tsx
@@ -49,6 +49,7 @@ import {
   wowMobilePage,
 } from "../../../components/cards/wowMobile";
 import { MobileStickyBar, MobileStickyCaption } from "./shared";
+import { LevelJumpBanner } from "../archetypes/shared";
 import type { TaskDetailState } from "../useTaskDetail";
 
 export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
@@ -246,6 +247,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
       {/* ── the one primary verb, pinned above the tab bar ── */}
       {canSignUp && (
         <MobileStickyBar>
+          <LevelJumpBanner state={state} />
           <WowCheckerBand height={3} />
           {signupError && (
             <p

--- a/frontend/src/pages/taskDetail/useTaskDetail.ts
+++ b/frontend/src/pages/taskDetail/useTaskDetail.ts
@@ -49,6 +49,15 @@ export interface TaskDetailState {
 
   // Derived gameplay numbers
   canSignUp: boolean;
+  // True when the sign-up CTA is only reachable because of the viewer's faction
+  // level-jump allowance (#811/#816): the task sits above the viewer's level but
+  // within `level_jump_reach`, the allowance is unspent, and the backend already
+  // says they may sign up. Drives a distinct "level-jump" affordance so an
+  // above-level task that IS reachable never looks identical to one that is out
+  // of reach. Config-backed — no `slug === 'wow'` branch (a second faction could
+  // gain the ability). When it goes false (spent, or plainly out of reach) the
+  // CTA simply doesn't render, so an above-level task reads as locked.
+  levelJumpSignup: boolean;
   slotsOpen: number;
   maxTaskSlots: number;
   factionMultiplier: number;
@@ -222,6 +231,20 @@ export function useTaskDetail(idParam: string | undefined): TaskDetailState {
 
   const canSignUp =
     !!user && !mySubmission && !isInProgress && !!task?.can_submit_praxis;
+  // The signable task is a level-jump iff the viewer's faction grants reach, the
+  // allowance is unspent, and the task sits above the viewer's own level. We do
+  // NOT recompute eligibility — canSignUp already trusts the backend's
+  // `can_submit_praxis` (which itself threads the same reach and is false once
+  // the allowance is spent), so a signable above-level task can ONLY be signable
+  // via the allowance.
+  const viewerLevel = user?.character?.level ?? 0;
+  const levelJumpReach = user?.level_jump_reach ?? 0;
+  const levelJumpSignup =
+    canSignUp &&
+    levelJumpReach > 0 &&
+    !!user?.level_jump_available &&
+    !!task &&
+    task.level_required > viewerLevel;
   const slotsOpen = maxTaskSlots - taskSlotCount;
 
   const voteCount = submissions.length;
@@ -253,6 +276,7 @@ export function useTaskDetail(idParam: string | undefined): TaskDetailState {
     inProgressPraxisId,
 
     canSignUp,
+    levelJumpSignup,
     slotsOpen,
     maxTaskSlots,
     factionMultiplier,

--- a/frontend/src/pages/taskDetail/useTaskDetail.ts
+++ b/frontend/src/pages/taskDetail/useTaskDetail.ts
@@ -27,6 +27,7 @@ import { useAuth } from "../../auth/AuthContext";
 import { extractError } from "../../utils/errors";
 import { computeDisplayPoints } from "../../utils/points";
 import { useGameConfig } from "../../hooks/useGameConfig";
+import { isLevelJumpSignup } from "./levelJump";
 
 const DEFAULT_MAX_TASK_SLOTS = 20;
 
@@ -232,19 +233,17 @@ export function useTaskDetail(idParam: string | undefined): TaskDetailState {
   const canSignUp =
     !!user && !mySubmission && !isInProgress && !!task?.can_submit_praxis;
   // The signable task is a level-jump iff the viewer's faction grants reach, the
-  // allowance is unspent, and the task sits above the viewer's own level. We do
-  // NOT recompute eligibility — canSignUp already trusts the backend's
-  // `can_submit_praxis` (which itself threads the same reach and is false once
-  // the allowance is spent), so a signable above-level task can ONLY be signable
-  // via the allowance.
-  const viewerLevel = user?.character?.level ?? 0;
-  const levelJumpReach = user?.level_jump_reach ?? 0;
-  const levelJumpSignup =
-    canSignUp &&
-    levelJumpReach > 0 &&
-    !!user?.level_jump_available &&
-    !!task &&
-    task.level_required > viewerLevel;
+  // allowance is unspent, and the task sits above the viewer's own level. Logic
+  // lives in the pure `isLevelJumpSignup` predicate so it is testable props-in/
+  // value-out. We do NOT recompute eligibility — canSignUp already trusts the
+  // backend's `can_submit_praxis`.
+  const levelJumpSignup = isLevelJumpSignup({
+    canSignUp,
+    levelJumpReach: user?.level_jump_reach ?? 0,
+    levelJumpAvailable: !!user?.level_jump_available,
+    taskLevelRequired: task?.level_required,
+    viewerLevel: user?.character?.level ?? 0,
+  });
   const slotsOpen = maxTaskSlots - taskSlotCount;
 
   const voteCount = submissions.length;


### PR DESCRIPTION
Surfaces the Warriors of Whimsy level-jump allowance (#811 backend) in the UI. Frontend only.

Closes #816

## What changed

**Part 1 — discovery (invite pop-up perk)**
- `factions.json`: added a `perks` line to `wow.invitation` describing the Leap of Whimsy, in WOW's knightly voice. `InvitationLetterPopup` already renders `<slug>.invitation.perks[]` conditionally, so this is copy-only (WOW's invitation block previously had no `perks` array — this adds one).

**Part 2 — member-facing state (task detail signup region)**
- `api/auth.ts`: added `level_jump_reach: number` and `level_jump_available: boolean` to `CurrentUser` (they already arrive top-level from `/auth/me`).
- `levelJump.ts` (new): pure `isLevelJumpSignup` predicate — the three-state logic, driven entirely off `level_jump_reach` / `level_jump_available` / task level vs viewer level. **No `slug === 'wow'` anywhere.** Eligibility is not recomputed: it trusts `canSignUp` (backed by `can_submit_praxis`, which threads the same reach and goes false once spent).
- `useTaskDetail.ts`: exposes `levelJumpSignup` on `TaskDetailState` via the predicate.
- `archetypes/shared.tsx`: new shared `LevelJumpBanner` — a small "Level-jump" tag + note rendered atop the signup region so an allowance-reachable above-level task never looks identical to one at/below level.
- Wired the banner into all **15** task-detail archetypes (7 desktop + 8 mobile) so it appears regardless of which faction's archetype renders the task.
- `tasks.json`: `detail.levelJump.{tag,note}` copy.

The three states (all off the config fields, no slug branch):
1. **Reachable via the allowance** — above level but within reach, unspent, backend says signable → signup CTA + distinct level-jump tag.
2. **Spent** — allowance used → backend denies → CTA doesn't render → reads as locked.
3. **Plain out of reach** — more than `reach` above level → CTA doesn't render → reads as locked.
When `level_jump_reach === 0`, nothing renders (no ability).

## Verification
- `tsc --noEmit`: clean (remaining errors are the known `node:fs`/`node:url` stale-junction false alarm, PR #675, in files not touched here).
- `vite build`: succeeds (790 modules).
- `eslint`: clean on all changed files (no-raw-style-values ratchet + i18n literal rules).
- `vitest`: new `levelJump.test.tsx` (7 tests: predicate three-states + edge cases + banner markup) passes; full `src/pages/taskDetail` suite (87 tests) green; the 5 backfilled `CurrentUser` fixture tests green.
- **Visual QA is outstanding** — I cannot screenshot (no dev stack / Browser pane renderer times out).

## What to eyeball
- The WOW invite pop-up shows the new Leap-of-Whimsy perk line.
- As a WOW member at level N, a level-N+1 task's detail page reads as an available level-jump (distinct "Level-jump" tag above the sign-up CTA), on any faction's archetype (desktop + mobile).
- After spending the allowance this level, that same N+1 task reads as locked (no CTA, no tag).
- A task more than one level above reads as plainly locked; a task at/below level shows the ordinary CTA with no tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
