### PR TITLE
Metatask rules: unlock at L5, per-praxis cap at L7, and faction-open

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -198,10 +198,10 @@ The single game-logic predicate behind the Sign-up affordance: whether a charact
 *claim* a task right now. One boolean, owned by the service layer, exposed as the
 `can_sign_up` flag — the API and frontend read it, they never assemble it. Its
 governing invariant: it is true **iff `create_praxis` would accept**, so the button
-hides exactly when the action would be rejected (level, metatask faction, **active
+hides exactly when the action would be rejected (level, **active
 membership**, task bank, Analog carve-out). See ADR-0008.
 _Avoid_: conflating with `can_submit_praxis` (the narrow dup-authorship rule only) or
-`eligible_for_current_user` (level + metatask faction only) — neither is the whole gate.
+`eligible_for_current_user` (level only) — neither is the whole gate.
 
 **Active membership**:
 A character holding a `PraxisMember` row on a non-deleted praxis for a task whose status
@@ -319,18 +319,20 @@ removed).
 `task_type` + `metatask_faction_slug` and the `TaskType` enum collapses. This reverses migration
 0006 and has **not** landed; treat the standalone-model language elsewhere as aspiration, not
 present reality.
-- **Access** is **one predicate** — `can_access_metatask` = Albescent **or**
-  (`level ≥ era.metatask_apply_level` **and** own faction). Enforced once **at apply**; the
-  "can apply" UI flag mirrors it. Replaces the three drifted gates (the per-metatask
-  `level_required` check is deleted).
+- **Access**: `can_access_metatask` = Albescent (bypasses the level gate) **or**
+  `level ≥ era.metatask_apply_level`. **Faction-open** — a character may apply
+  **any** faction's metatask, not only their own; `metatask_faction_slug` records authorship,
+  not permission. Enforced once **at apply**; the "can apply" UI flag mirrors it (minus the
+  Albescent level bypass).
 - **Praxis-wide**: once applied, **every member** of that praxis banks the bonus — scoring does
   **no** per-member access re-check; `get_meta_task_points` is a dumb sum of attached
   `point_value`s. _Avoid_: per-member metatask gating (rejected — see ADR-0015).
 - **Duel symmetry**: a metatask applies to **both** linked duel praxes (ADR-0011), so neither
   duelist gains a base-point head start. (Today's single-praxis duel already gets this via
   praxis-wide; the two-praxes model needs both-sides attachment — coordinates with #185.)
-- **Propose** (level 6) is a separate gate from **apply** (level 7) — distinct actions, not one
-  rule.
+- **See**, **propose**, and **apply** all gate at **level 5** — distinct actions that share a
+  level. A praxis holds **1** metatask until the applying character reaches **level 7**, which
+  raises the cap to **3** (`metatasks_per_praxis_base`/`_max`/`_max_level`).
 
 **Register row / Praxis Index**:
 The faction's list view of submitted praxes; the praxis **card** lives here (compact, next to

--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -194,6 +194,10 @@ ERA_N = EraConfig(
     collab_auto_submit_days=10,          # pending-publish silence-is-consent window (ADR-0012)
     metatask_apply_level=7,
     flag_level_required=4,
+    # Metatask-per-praxis cap: base until the max-level, then max.
+    metatasks_per_praxis_base=1,
+    metatasks_per_praxis_max=3,
+    metatasks_per_praxis_max_level=7,
     # Comment gates (ADR-0006)
     comment_level_required=2,
     comment_flag_review_threshold=1,

--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -426,21 +426,22 @@ ERA_1_LEVEL_PROFILES = (
     LevelProfile(
         rank_key="voyager",
         unlocks=(
+            LevelUnlock(LevelUnlockKind.ability, "see_metatasks"),
+            LevelUnlock(LevelUnlockKind.ability, "propose_metatask"),
+            LevelUnlock(LevelUnlockKind.ability, "apply_metatasks"),
             LevelUnlock(LevelUnlockKind.sense, "distance_taste"),
         ),
     ),
     LevelProfile(
         rank_key="chronicler",
         unlocks=(
-            LevelUnlock(LevelUnlockKind.ability, "see_metatasks"),
-            LevelUnlock(LevelUnlockKind.ability, "propose_metatask"),
             LevelUnlock(LevelUnlockKind.sense, "place_memory"),
         ),
     ),
     LevelProfile(
         rank_key="luminary",
         unlocks=(
-            LevelUnlock(LevelUnlockKind.ability, "apply_metatasks"),
+            LevelUnlock(LevelUnlockKind.ability, "multiple_metatasks"),
             LevelUnlock(LevelUnlockKind.sense, "three_plans"),
         ),
     ),
@@ -468,16 +469,20 @@ ERA_1 = EraConfig(
     level_thresholds=(0, 10, 70, 170, 330, 610, 1090, 1840, 3040),
     # Capability level gates (see SPEC-game-rules.md "Level privileges")
     level_to_propose_task=3,
-    level_to_propose_metatask=6,
-    level_to_see_metatasks=6,
+    level_to_propose_metatask=5,
+    level_to_see_metatasks=5,
     level_to_see_retired_tasks=2,
     level_to_see_pending_tasks=3,
     # Praxis / moderation / metatask gates
     duel_level_required=2,
     collaboration_level_required=1,
     collab_auto_submit_days=10,
-    metatask_apply_level=7,
+    metatask_apply_level=5,
     flag_level_required=4,
+    # Metatask-per-praxis cap: 1 until L7, then up to 3.
+    metatasks_per_praxis_base=1,
+    metatasks_per_praxis_max=3,
+    metatasks_per_praxis_max_level=7,
     # Comment gates (ADR-0006) — social layer opens at L2 in the vault
     comment_level_required=2,
     comment_flag_review_threshold=1,

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -111,6 +111,15 @@ class EraConfig:
     metatask_apply_level: int             # min level to apply a metatask (non-Albescent)
     flag_level_required: int              # min level to flag a praxis for moderation
 
+    # Metatask-per-praxis cap. A praxis holds at most metatasks_per_praxis_base
+    # metatasks until the applying character reaches metatasks_per_praxis_max_level,
+    # from which point the cap rises to metatasks_per_praxis_max. Level-based only
+    # (no faction bypass). Enforced in services/praxis.py::apply_metatask via
+    # services/meta_task.py::metatask_cap_for_level.
+    metatasks_per_praxis_base: int      # cap below metatasks_per_praxis_max_level
+    metatasks_per_praxis_max: int       # cap once at/above that level
+    metatasks_per_praxis_max_level: int # level that raises the cap
+
     # Comment gates (ADR-0006; enforced in services/comment.py). comment_level_required
     # is surfaced on /auth/me like the other capability gates; the flag threshold is
     # service-only.

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -111,15 +111,6 @@ class EraConfig:
     metatask_apply_level: int             # min level to apply a metatask (non-Albescent)
     flag_level_required: int              # min level to flag a praxis for moderation
 
-    # Metatask-per-praxis cap. A praxis holds at most metatasks_per_praxis_base
-    # metatasks until the applying character reaches metatasks_per_praxis_max_level,
-    # from which point the cap rises to metatasks_per_praxis_max. Level-based only
-    # (no faction bypass). Enforced in services/praxis.py::apply_metatask via
-    # services/meta_task.py::metatask_cap_for_level.
-    metatasks_per_praxis_base: int      # cap below metatasks_per_praxis_max_level
-    metatasks_per_praxis_max: int       # cap once at/above that level
-    metatasks_per_praxis_max_level: int # level that raises the cap
-
     # Comment gates (ADR-0006; enforced in services/comment.py). comment_level_required
     # is surfaced on /auth/me like the other capability gates; the flag threshold is
     # service-only.
@@ -148,6 +139,15 @@ class EraConfig:
     # ADR-0022: completed-task count (per faction) required to earn that faction's invite.
     # Defaulted so existing EraConfig constructions stay valid.
     invitation_task_threshold: int = 2
+
+    # Metatask-per-praxis cap (defaulted so bare EraConfig constructions stay valid).
+    # A praxis holds metatasks_per_praxis_base metatasks until the applying character
+    # reaches metatasks_per_praxis_max_level, from which the cap rises to
+    # metatasks_per_praxis_max. Level-based only; enforced in
+    # services/praxis.py::apply_metatask via services/meta_task.py::metatask_cap_for_level.
+    metatasks_per_praxis_base: int = 1
+    metatasks_per_praxis_max: int = 3
+    metatasks_per_praxis_max_level: int = 7
 
     # Task definitions for this era
     tasks: tuple = ()                # tuple[TaskDef, ...]

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -11,7 +11,7 @@ from models.character_stats import CharacterStats
 from models.faction import Faction, FactionStatus
 from models.faction_defection_history import FactionDefectionHistory
 from models.invitation_letter import InvitationLetter
-from models.task import Task, TaskType
+from models.task import Task
 from services.character import ALBESCENT_FACTION_SLUG, can_start_as_albescent
 from services.era import clear_defection_history_for_era, get_current_era_row, get_or_create_stats
 
@@ -35,26 +35,19 @@ def faction_permits(
     whenever a decision might be changed by the actor's or the task's faction.
     A new faction rule is then a one-function edit that every caller inherits.
 
-    Today the only faction rule concerns metatasks:
-
-    * Standard tasks are faction-open — always permitted.
-    * A metatask requires the character's faction to match
-      ``task.metatask_faction_slug``, **except** Albescent characters, who may
-      act on any faction's metatask.
+    There is currently **no** active faction gate. Standard tasks have always
+    been faction-open, and metatasks are now faction-open too: any
+    character may act on any faction's metatask, regardless of their own
+    faction. ``task.metatask_faction_slug`` now records only which faction
+    authored a metatask — it no longer gates who may apply it. The seam is kept
+    (ADR-0029) so re-introducing a faction rule stays a one-function edit that
+    every caller inherits.
 
     This is the *faction* axis only. Level gates, the task-bank cap, and
     listing visibility (see :func:`hidden_faction_slugs`) are separate axes and
-    live elsewhere. If a future rule needs to vary by action (sign-up vs. vote
-    vs. flag), add an ``action`` parameter here — not a second predicate.
+    live elsewhere.
     """
-    if task.task_type != TaskType.metatask:
-        return True
-    # Albescent's charter lets it act on any faction's metatask.
-    if character.faction_slug == ALBESCENT_FACTION_SLUG:
-        return True
-    if task.metatask_faction_slug is None:
-        return False
-    return character.faction_slug == task.metatask_faction_slug
+    return True
 
 
 async def hidden_faction_slugs(session: AsyncSession) -> list[str]:

--- a/backend/services/meta_task.py
+++ b/backend/services/meta_task.py
@@ -10,8 +10,22 @@ A metatask is a Task row with ``task_type == TaskType.metatask``. Its
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from game_config import EraConfig
 from models.meta_task import PraxisMetaTask
 from models.task import Task, TaskType
+
+
+def metatask_cap_for_level(character_level: int, era: EraConfig) -> int:
+    """Max metatasks one praxis may hold, keyed off the applying character's level.
+
+    Below ``era.metatasks_per_praxis_max_level`` the cap is
+    ``metatasks_per_praxis_base``; at or above it, ``metatasks_per_praxis_max``.
+    Level-based only — no faction bypass (Albescent's apply-gate bypass does not
+    lift the quantity cap).
+    """
+    if character_level >= era.metatasks_per_praxis_max_level:
+        return era.metatasks_per_praxis_max
+    return era.metatasks_per_praxis_base
 
 
 async def get_meta_task_points(

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -45,6 +45,7 @@ from services import collab_consensus
 from services.character_stats import recalculate_character_stats
 from services.praxis_scoring import Contribution, compute_contributions
 from services.faction_service import faction_permits
+from services.meta_task import metatask_cap_for_level
 from services.era import get_current_era_row, get_or_create_stats
 from services.level_jump import available_level_reach, consume_level_jump
 from models.duel import Duel, DuelStatus
@@ -1739,6 +1740,23 @@ async def apply_metatask(
         raise HTTPException(
             status_code=409,
             detail="This metatask is already applied to the praxis.",
+        )
+
+    # Quantity cap: how many metatasks this praxis may hold rises with the
+    # applying character's level (metatasks_per_praxis_max_level).
+    cap = metatask_cap_for_level(stats.level, era)
+    current_count = await session.scalar(
+        select(func.count())
+        .select_from(PraxisMetaTask)
+        .where(PraxisMetaTask.praxis_id == praxis_id)
+    )
+    if current_count >= cap:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"This praxis already holds the maximum of {cap} "
+                f"metatask{'s' if cap != 1 else ''} at your level."
+            ),
         )
 
     session.add(PraxisMetaTask(praxis_id=praxis_id, task_id=task_id))

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -1311,11 +1311,10 @@ def is_task_eligible_for_character(
 ) -> bool:
     """Return True if ``character`` is eligible to act on ``task``.
 
-    For standard tasks the gate is only ``task.level_required``. For metatask
-    rows the character's faction must also permit it — see
-    :func:`services.faction_service.faction_permits` (same faction as the
-    metatask, or Albescent, who may act on any). Anonymous viewers are never
-    eligible.
+    The gate is ``task.level_required`` plus whatever
+    :func:`services.faction_service.faction_permits` enforces — presently
+    nothing, as metatasks are faction-open. Anonymous viewers are
+    never eligible.
 
     Note this mirrors the metatask scoring gate in
     :func:`services.meta_task.get_meta_task_points`
@@ -1658,9 +1657,10 @@ def _check_metatask_eligibility(
     era: EraConfig,
 ) -> Optional[str]:
     """Return a 403 reason string if this character can't apply ``task``, else None."""
-    # Albescent bypasses both the level and faction gates (its charter). The
-    # level gate is a separate axis; the faction decision routes through the
-    # single seam (ADR-0029, #171) — for non-Albescent it reduces to a slug match.
+    # Albescent bypasses the level gate (its charter); everyone else must meet
+    # metatask_apply_level. Metatasks are faction-open, so the seam
+    # `faction_permits` (ADR-0029, #171) currently permits every faction — the
+    # call is retained so a future faction rule is inherited here automatically.
     if character.faction_slug == ALBESCENT_FACTION_SLUG:
         return None
     if character_level < era.metatask_apply_level:
@@ -1669,10 +1669,7 @@ def _check_metatask_eligibility(
             "to apply metatasks."
         )
     if not faction_permits(character, task, era):
-        return (
-            "This metatask belongs to a different faction. "
-            "Only Albescent characters can apply any faction's metatask."
-        )
+        return "This metatask belongs to a different faction."
     return None
 
 
@@ -1689,10 +1686,11 @@ async def apply_metatask(
     - The task must be ``TaskType.metatask`` (else 400).
     - The applying character must be a member of the praxis (else 403).
     - The praxis must be ``in_progress`` (else 422).
-    - Faction gate:
-        * Albescent characters may apply any faction's metatask.
-        * Otherwise the character must be at least ``era.metatask_apply_level``
-          AND their ``faction_slug`` must match ``task.metatask_faction_slug``.
+    - Level gate: at least ``era.metatask_apply_level`` (Albescent bypasses).
+      Metatasks are faction-open — any faction may apply any
+      faction's metatask.
+    - Quantity cap: at most ``metatask_cap_for_level(level, era)`` metatasks on
+      one praxis (else 422).
     """
     praxis = await get_praxis(praxis_id, session)
     task = await session.get(Task, task_id)

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -1465,14 +1465,14 @@ async def test_get_task_metatask_eligibility_meets_level_same_faction(
 
 
 @pytest.mark.asyncio
-async def test_get_task_metatask_eligibility_different_faction(
+async def test_get_task_metatask_eligibility_cross_faction_is_open(
     client: AsyncClient,
     character: Character,
     auth_headers: dict,
     db_session: AsyncSession,
     era,
 ):
-    """Metatask level 5, character level 6, different faction -> eligible_for_current_user=False."""
+    """Metatask level 5, character level 6, different faction -> eligible (metatasks are faction-open)."""
     from models.character_stats import CharacterStats
     from models.faction import Faction, FactionStatus
     from models.task import TaskType
@@ -1518,7 +1518,7 @@ async def test_get_task_metatask_eligibility_different_faction(
 
     resp = await client.get(f"/tasks/{meta_task.id}", headers=auth_headers)
     assert resp.status_code == 200
-    assert resp.json()["eligible_for_current_user"] is False
+    assert resp.json()["eligible_for_current_user"] is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_character_capabilities.py
+++ b/backend/tests/unit/test_character_capabilities.py
@@ -1,8 +1,8 @@
 """Unit tests for services.character_capabilities.compute_capabilities.
 
 Pure function — no DB, no fixtures. Table-driven against the level thresholds
-defined on ``CURRENT_ERA`` (Era 1: propose_task=3, propose_metatask=6,
-see_metatasks=6, see_retired=2, see_pending=3, comment=2).
+defined on ``CURRENT_ERA`` (Era 1: propose_task=3, propose_metatask=5,
+see_metatasks=5, see_retired=2, see_pending=3, comment=2).
 """
 import pytest
 
@@ -16,7 +16,7 @@ from services.character_capabilities import (
 # (level, is_admin) -> expected (can_propose_task, can_propose_metatask,
 #                                can_see_metatasks, can_see_retired_tasks,
 #                                can_see_pending_tasks, can_comment)
-# Era 1 thresholds: 3 / 6 / 6 / 2 / 3 / 2.
+# Era 1 thresholds: 3 / 5 / 5 / 2 / 3 / 2.
 _TABLE = [
     # No character at all -> everything False.
     (None, False, False, False, False, False, False, False),
@@ -28,8 +28,8 @@ _TABLE = [
     # Meets propose_task and see_pending (both threshold 3).
     (3, False, True, False, False, True, True, True),
     (4, False, True, False, False, True, True, True),
-    (5, False, True, False, False, True, True, True),
-    # Meets every flag (propose-metatask + see-metatasks thresholds are both 6).
+    # Meets every flag (propose-metatask + see-metatasks thresholds are both 5).
+    (5, False, True, True, True, True, True, True),
     (6, False, True, True, True, True, True, True),
     (7, False, True, True, True, True, True, True),
     # Admin short-circuit — every flag True regardless of level, even None.

--- a/backend/tests/unit/test_faction_permits.py
+++ b/backend/tests/unit/test_faction_permits.py
@@ -22,10 +22,12 @@ def test_standard_task_is_faction_open() -> None:
     assert faction_permits(_character("na"), task) is True
 
 
-def test_metatask_requires_matching_faction() -> None:
+def test_metatask_is_faction_open() -> None:
+    # Metatasks are faction-open: any character may act on any
+    # faction's metatask, whatever their own faction or the metatask's.
     task = _task(TaskType.metatask, metatask_faction_slug="wow")
     assert faction_permits(_character("wow"), task) is True
-    assert faction_permits(_character("ephemerists"), task) is False
+    assert faction_permits(_character("ephemerists"), task) is True
 
 
 def test_albescent_may_act_on_any_faction_metatask() -> None:
@@ -33,8 +35,7 @@ def test_albescent_may_act_on_any_faction_metatask() -> None:
     assert faction_permits(_character(ALBESCENT_FACTION_SLUG), task) is True
 
 
-def test_metatask_without_a_faction_denies_non_albescent() -> None:
+def test_metatask_without_a_faction_is_still_open() -> None:
     task = _task(TaskType.metatask, metatask_faction_slug=None)
-    assert faction_permits(_character("wow"), task) is False
-    # Albescent's charter still lets it through.
+    assert faction_permits(_character("wow"), task) is True
     assert faction_permits(_character(ALBESCENT_FACTION_SLUG), task) is True

--- a/backend/tests/unit/test_level_profiles.py
+++ b/backend/tests/unit/test_level_profiles.py
@@ -14,6 +14,7 @@ GATE_ATTRS = [
     "level_to_propose_metatask",
     "level_to_see_metatasks",
     "metatask_apply_level",
+    "metatasks_per_praxis_max_level",
     "albescent_level_required",
 ]
 
@@ -48,10 +49,15 @@ def test_grounded_ability_sits_at_its_gate_constants_level(gate_attr):
     assert _ability_keys(gate_level), f"no ability unlock at level {gate_level} for {gate_attr}"
 
 
-def test_level_5_has_no_hard_gate_sense_only():
-    """Level 5 has no EraConfig gate; the spec doc's 'promote level-0 tasks' is
-    aspirational and unimplemented, so the profile is whimsy-only."""
-    kinds = {unlock.kind for unlock in ERA_1.level_profiles[5].unlocks}
+def test_level_5_unlocks_the_metatask_abilities():
+    """The three metatask gates (see / propose / apply) all land at level 5."""
+    assert _ability_keys(5) == {"see_metatasks", "propose_metatask", "apply_metatasks"}
+
+
+def test_level_6_has_no_hard_gate_sense_only():
+    """Level 6 no longer carries a metatask gate (they moved to 5), so its
+    profile is whimsy-only."""
+    kinds = {unlock.kind for unlock in ERA_1.level_profiles[6].unlocks}
     assert kinds == {LevelUnlockKind.sense}
 
 

--- a/backend/tests/unit/test_metatask_cap.py
+++ b/backend/tests/unit/test_metatask_cap.py
@@ -1,0 +1,29 @@
+"""Unit tests for services.meta_task.metatask_cap_for_level.
+
+Pure function — no DB. Era 1: base=1, max=3, max_level=7.
+"""
+import pytest
+
+from game_config import CURRENT_ERA
+from services.meta_task import metatask_cap_for_level
+
+
+@pytest.mark.parametrize(
+    "level,expected",
+    [
+        (0, 1),
+        (5, 1),   # can apply metatasks (apply gate = 5) but still capped at 1
+        (6, 1),
+        (7, 3),   # cap rises at the gate level
+        (8, 3),
+    ],
+)
+def test_cap_rises_at_gate_level(level: int, expected: int) -> None:
+    assert metatask_cap_for_level(level, CURRENT_ERA) == expected
+
+
+def test_cap_gate_matches_era_config() -> None:
+    """Boundary is exactly metatasks_per_praxis_max_level, not one above."""
+    gate = CURRENT_ERA.metatasks_per_praxis_max_level
+    assert metatask_cap_for_level(gate - 1, CURRENT_ERA) == CURRENT_ERA.metatasks_per_praxis_base
+    assert metatask_cap_for_level(gate, CURRENT_ERA) == CURRENT_ERA.metatasks_per_praxis_max

--- a/frontend/src/locales/en/progression.json
+++ b/frontend/src/locales/en/progression.json
@@ -89,6 +89,10 @@
       "name": "Apply your faction's metatasks",
       "desc": "Take on the metatasks your faction has published."
     },
+    "multiple_metatasks": {
+      "name": "Stack multiple metatasks",
+      "desc": "Attach more than one metatask to a single praxis."
+    },
     "three_plans": {
       "name": "Hold three plans at once without confusion",
       "desc": "Your mind now files contingencies the way it once filed excuses."


### PR DESCRIPTION
Three metatask rule changes (Era 1 config + the one service that enforces each). Two commits.

## 1 · Metatasks unlock at level 5 (was 6/6/7)
All three metatask gates move to **L5**: `level_to_see_metatasks`, `level_to_propose_metatask`, `metatask_apply_level`. The level-up pop-up now announces see/propose/apply together at L5 (voyager); L6 (chronicler) becomes sense-only.

## 2 · Per-praxis metatask cap rises at level 7
New rule (there was no cap before — only a no-duplicates check). A praxis holds **1** metatask until the applying character reaches **level 7**, which raises the cap to **3**. Keyed off the applying character's level only (no faction bypass); enforced in `apply_metatask` (422 when full) via a pure `metatask_cap_for_level` helper. New `EraConfig` fields `metatasks_per_praxis_base/max/max_level`. New L7 unlock `multiple_metatasks`.

## 3 · Metatasks are faction-open
Any character may now apply **any** faction's metatask, not only their own. The old own-faction restriction lived entirely in `faction_permits` (the ADR-0029 single seam both call sites route through), so this is a one-function change: it returns `True` for every task. `metatask_faction_slug` now records authorship only. Albescent's level bypass stands. The seam call is retained at both sites so a future faction rule is inherited automatically.

## Docs
`CONTEXT.md` glossary updated: metatask access is now level-only, plus the corrected L5 gate line and the new cap. (No ADR — item 3 reverses a rule set moments earlier in the same session; that's a mind-change, not an architectural decision.)

## Tests
- New `test_metatask_cap.py` (pure unit test of the cap boundary).
- `test_character_capabilities` / `test_level_profiles` updated for the L5 move + new gate.
- `test_faction_permits` + the cross-faction eligibility case in `test_tasks.py` inverted to faction-open.
- 56 backend unit tests pass locally. Integration tests need Postgres + `.env` (not run locally); CI will exercise them.