### PR TITLE
Metatask Seals 3/6: seal skins B (coven, ua, albescent, na) (#930)

### DIFF
--- a/frontend/src/components/metaTaskSeal/DefaultSeal.tsx
+++ b/frontend/src/components/metaTaskSeal/DefaultSeal.tsx
@@ -4,13 +4,15 @@ import { factionName } from '../../utils/factions'
 import type { SealSkinProps } from './types'
 
 /**
- * The neutral seal skin — a ringed sticker mounted on neutral paper.
+ * The neutral seal skin — plain caps, the whole rainbow, no allegiance (#930).
  *
- * Every metatask whose issuing faction has no bespoke skin registered falls
- * through to this via {@link MetaTaskSeal}'s dispatch table, so integrations
- * render end to end before the per-faction skins land (#929/#930/#931). It shows
- * the uppercase "<FACTION> METATASK" label, the condition and the "+N PTS" bonus,
- * plus the `×` peel control when `removable`.
+ * This is the Unaffiliated (`na`) seal AND the shared fallback: every metatask
+ * whose issuing faction has no bespoke skin registered falls through to it via
+ * {@link MetaTaskSeal}'s dispatch table (e.g. `wow` until #931), so integrations
+ * render end to end before the per-faction skins land. It stays a tasteful
+ * neutral card — a full-spectrum rainbow accent strip and an uppercase register
+ * are its only signature — showing the "<FACTION> METATASK" label, the condition
+ * and the "+N PTS" bonus, plus the `×` peel control when `removable`.
  */
 export default function DefaultSeal({ metatask, removable, onRemove }: SealSkinProps) {
   const { t } = useTranslation('praxis')
@@ -25,8 +27,22 @@ export default function DefaultSeal({ metatask, removable, onRemove }: SealSkinP
         border: '2px solid var(--faction-default-border)',
         borderRadius: 12,
         padding: 'var(--space-md) var(--space-lg)',
+        overflow: 'hidden',
       }}
     >
+      {/* the whole rainbow, no allegiance — a full-spectrum accent, top edge */}
+      <span
+        aria-hidden="true"
+        className="absolute"
+        style={{
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 3,
+          background: 'var(--faction-default-rainbow)',
+        }}
+      />
+
       {removable && (
         <button
           type="button"
@@ -59,6 +75,8 @@ export default function DefaultSeal({ metatask, removable, onRemove }: SealSkinP
         style={{
           fontSize: 'var(--text-content)',
           color: 'var(--faction-default-card-text)',
+          textTransform: 'uppercase',
+          letterSpacing: '0.03em',
           marginTop: 'var(--space-xs)',
         }}
       >

--- a/frontend/src/components/metaTaskSeal/__tests__/sealSkinsB.test.tsx
+++ b/frontend/src/components/metaTaskSeal/__tests__/sealSkinsB.test.tsx
@@ -1,10 +1,11 @@
 /**
- * Seal skins A (#929) — snide, singularity, everymen, ephemerists.
+ * Seal skins B (#930) — coven, ua, albescent, and the na/Unaffiliated fallback.
  *
- * Each skin must honor the shared seal contract (condition = title, bonus =
- * point_value) in its own bespoke costume, dispatch off `metatask_faction_slug`
- * instead of falling through to Default, and wire `removable`/`onRemove`
- * exactly like every other skin.
+ * Each bespoke skin must honor the shared seal contract (label = issuing
+ * faction, condition = title, bonus = point_value) in its own costume, dispatch
+ * off `metatask_faction_slug` instead of falling through to Default, and wire
+ * `removable`/`onRemove`. `na` is deliberately unskinned (ADR-0039): it renders
+ * via the tuned DefaultSeal, which is what the last case asserts.
  */
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect, vi } from "vitest";
@@ -12,14 +13,15 @@ import { describe, it, expect, vi } from "vitest";
 import MetaTaskSeal from "../MetaTaskSeal";
 import DefaultSeal from "../DefaultSeal";
 import i18n from "../../../i18n";
+import { factionName } from "../../../utils/factions";
 import type { TaskOut } from "../../../api/tasks";
 
 function metatask(slug: string, overrides: Partial<TaskOut> = {}): TaskOut {
   return {
     id: 42,
-    title: "do it underwater. no cuts.",
+    title: "read it aloud to a stranger",
     description: null,
-    point_value: 50,
+    point_value: 45,
     level_required: 1,
     status: "active",
     task_type: "metatask",
@@ -39,20 +41,19 @@ function markup(element: React.ReactElement): string {
   return renderToStaticMarkup(element);
 }
 
-const SKIN_SLUGS = ["snide", "singularity", "everymen", "ephemerists"];
+const SKIN_SLUGS = ["coven", "ua", "albescent"];
 
-describe("seal skins A content-slot invariant", () => {
+describe("seal skins B content-slot invariant", () => {
   for (const slug of SKIN_SLUGS) {
     const task = metatask(slug);
     const bonus = i18n.t("praxis:detail.seal.bonus", { points: task.point_value });
+    const label = i18n.t("praxis:detail.seal.label", {
+      faction: factionName(slug),
+    });
 
     it(`${slug} renders the condition (title)`, () => {
       const html = markup(<MetaTaskSeal metatasks={[task]} />);
-      // Snide clips the condition into per-word "ransom" chips, so each word
-      // lands in its own element rather than one contiguous text node.
-      for (const word of task.title.split(" ")) {
-        expect(html).toContain(word);
-      }
+      expect(html).toContain(task.title);
     });
 
     it(`${slug} renders the bonus (+point_value PTS)`, () => {
@@ -60,21 +61,19 @@ describe("seal skins A content-slot invariant", () => {
       expect(html).toContain(bonus);
     });
 
+    it(`${slug} renders the issuing-faction label`, () => {
+      const html = markup(<MetaTaskSeal metatasks={[task]} />);
+      expect(html).toContain(label);
+    });
+
     it(`${slug} renders its own skin, not the Default fallthrough`, () => {
       const bespoke = markup(<MetaTaskSeal metatasks={[task]} />);
-      const fallback = markup(
-        <DefaultSeal metatask={task} removable={false} />,
-      );
+      const fallback = markup(<DefaultSeal metatask={task} removable={false} />);
       expect(bespoke).not.toBe(fallback);
     });
 
-    it(`${slug} wires removable + onRemove to the metatask id`, () => {
+    it(`${slug} wires the × control when removable`, () => {
       const onRemove = vi.fn();
-      renderToStaticMarkup(
-        <MetaTaskSeal metatasks={[task]} removable onRemove={onRemove} />,
-      );
-      // Static markup can't fire click handlers, but it must render the ×
-      // control when removable so there's something to click.
       const html = markup(
         <MetaTaskSeal metatasks={[task]} removable onRemove={onRemove} />,
       );
@@ -89,15 +88,25 @@ describe("seal skins A content-slot invariant", () => {
   }
 });
 
-describe("seal skins A — unregistered slug still falls through", () => {
-  it("an unrecognized metatask_faction_slug renders the Default seal", () => {
-    // `wow` has no seal skin yet (lands in #931), so it still falls through to
-    // Default — coven/ua/albescent are skinned as of #930 and no longer would.
-    const task = metatask("wow");
-    // MetaTaskSeal wraps its stack in a flex container, so compare the
-    // dispatched seal's own markup, not the wrapper around it.
+describe("seal skins B — na renders via the tuned DefaultSeal", () => {
+  it("an unaffiliated (na) metatask renders the Default seal", () => {
+    const task = metatask("na");
+    // MetaTaskSeal wraps its stack in a flex container, so compare against the
+    // dispatched seal's own markup rather than the wrapper around it.
     const html = markup(<MetaTaskSeal metatasks={[task]} />);
     const fallback = markup(<DefaultSeal metatask={task} removable={false} />);
     expect(html).toContain(fallback);
+  });
+
+  it("still shows the label, condition and bonus for na", () => {
+    const task = metatask("na");
+    const html = markup(<MetaTaskSeal metatasks={[task]} />);
+    expect(html).toContain(task.title);
+    expect(html).toContain(
+      i18n.t("praxis:detail.seal.bonus", { points: task.point_value }),
+    );
+    expect(html).toContain(
+      i18n.t("praxis:detail.seal.label", { faction: factionName("na") }),
+    );
   });
 });

--- a/frontend/src/components/metaTaskSeal/skins/AlbescentSeal.tsx
+++ b/frontend/src/components/metaTaskSeal/skins/AlbescentSeal.tsx
@@ -1,0 +1,97 @@
+import { useTranslation } from 'react-i18next'
+
+import { factionName } from '../../../utils/factions'
+import type { SealSkinProps } from '../types'
+
+/**
+ * Albescent seal — the pale correspondence register (#930). A seal is a foreign
+ * sticker that keeps its ISSUER's voice, so this is one of the rare moments the
+ * secret society shows its face: near-black ink on a near-white sheet, with a
+ * single soft spectrum strip as its only colour. It reads the always-light
+ * `--albescent-reveal-*` reveal tokens (never a `--faction-albescent-*` theme,
+ * which does not exist by design) so it stays restrained and un-tinted.
+ */
+export default function AlbescentSeal({ metatask, removable, onRemove }: SealSkinProps) {
+  const { t } = useTranslation('praxis')
+  const faction = factionName(metatask.metatask_faction_slug)
+
+  return (
+    <div
+      className="relative"
+      style={{
+        background: 'var(--albescent-reveal-surface)',
+        color: 'var(--albescent-reveal-text)',
+        border: '1px solid var(--albescent-reveal-border)',
+        borderRadius: 4,
+        padding: 'var(--space-md) var(--space-lg)',
+        boxShadow: 'var(--albescent-reveal-shadow)',
+        fontFamily: 'var(--font-faction-serif)',
+        overflow: 'hidden',
+      }}
+    >
+      {removable && (
+        <button
+          type="button"
+          onClick={() => onRemove?.(metatask.id)}
+          aria-label={t('detail.seal.remove')}
+          className="absolute font-body leading-none"
+          style={{
+            top: 'var(--space-sm)',
+            right: 'var(--space-sm)',
+            zIndex: 2,
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--albescent-reveal-text-muted)',
+            fontSize: 'var(--text-xl)',
+            cursor: 'pointer',
+          }}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      )}
+
+      <span
+        className="eyebrow block"
+        style={{ color: 'var(--albescent-reveal-text-muted)' }}
+      >
+        {t('detail.seal.label', { faction })}
+      </span>
+
+      {/* the soft spectrum strip — the one colour on the sheet, kept pale */}
+      <span
+        aria-hidden="true"
+        className="block"
+        style={{
+          height: 2,
+          borderRadius: 2,
+          background: 'var(--faction-default-rainbow)',
+          opacity: 0.35,
+          margin: 'var(--space-xs) 0 var(--space-sm)',
+        }}
+      />
+
+      <span
+        className="block"
+        style={{
+          fontSize: 'var(--text-content)',
+          color: 'var(--albescent-reveal-text)',
+        }}
+      >
+        {metatask.title}
+      </span>
+
+      <span
+        className="block"
+        style={{
+          fontSize: 'var(--text-title)',
+          fontWeight: 600,
+          letterSpacing: '0.02em',
+          color: 'var(--albescent-reveal-ink)',
+          marginTop: 'var(--space-xs)',
+        }}
+      >
+        {t('detail.seal.bonus', { points: metatask.point_value })}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/metaTaskSeal/skins/CovenSeal.tsx
+++ b/frontend/src/components/metaTaskSeal/skins/CovenSeal.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from 'react-i18next'
+
+import { factionName } from '../../../utils/factions'
+import type { SealSkinProps } from '../types'
+
+/**
+ * Cozy Coven seal — a hand-lettered sticker pressed on with a strip of washi
+ * tape. Same three-field contract as every seal (label / condition / bonus) but
+ * in Coven's own voice: Caveat script on blush sticker stock, a pink hairline
+ * edge, and the bonus punched out as a little gummed stamp chip.
+ */
+export default function CovenSeal({ metatask, removable, onRemove }: SealSkinProps) {
+  const { t } = useTranslation('praxis')
+  const faction = factionName(metatask.metatask_faction_slug)
+
+  return (
+    <div
+      className="relative"
+      style={{
+        background: 'var(--faction-coven-sticker-bg)',
+        color: 'var(--faction-coven-sticker-muted)',
+        border: '1px solid var(--faction-coven-sticker-border)',
+        borderRadius: 14,
+        padding: 'var(--space-lg) var(--space-lg) var(--space-md)',
+        boxShadow: '0 3px 10px var(--faction-coven-sticker-shadow)',
+        fontFamily: 'var(--faction-coven-card-font)',
+        transform: 'rotate(-0.6deg)',
+        overflow: 'hidden',
+      }}
+    >
+      {/* washi tape holding the sticker to the host praxis */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          top: -8,
+          left: '50%',
+          width: 72,
+          height: 20,
+          marginLeft: -36,
+          background: 'var(--faction-coven-tape)',
+          transform: 'rotate(-2.5deg)',
+        }}
+      />
+
+      {removable && (
+        <button
+          type="button"
+          onClick={() => onRemove?.(metatask.id)}
+          aria-label={t('detail.seal.remove')}
+          className="absolute font-body leading-none"
+          style={{
+            top: 'var(--space-sm)',
+            right: 'var(--space-sm)',
+            zIndex: 2,
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--faction-coven-sticker-accent)',
+            fontSize: 'var(--text-xl)',
+            cursor: 'pointer',
+          }}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      )}
+
+      <span
+        className="eyebrow block"
+        style={{ color: 'var(--faction-coven-sticker-accent)' }}
+      >
+        {t('detail.seal.label', { faction })}
+      </span>
+
+      <span
+        className="block"
+        style={{
+          fontFamily: 'var(--faction-coven-card-font)',
+          fontSize: 'var(--text-title)',
+          lineHeight: 1.1,
+          color: 'var(--faction-coven-title-text)',
+          marginTop: 'var(--space-xs)',
+        }}
+      >
+        {metatask.title}
+      </span>
+
+      <span
+        className="inline-block font-body"
+        style={{
+          background: 'var(--faction-coven-stamp-chip-bg)',
+          color: 'var(--faction-coven-stamp-chip-text)',
+          fontSize: 'var(--text-lg)',
+          fontWeight: 700,
+          letterSpacing: '0.04em',
+          padding: 'var(--space-xs) var(--space-sm)',
+          borderRadius: 6,
+          marginTop: 'var(--space-sm)',
+          transform: 'rotate(-1.5deg)',
+          boxShadow: '0 1px 3px var(--faction-coven-stamp-shadow)',
+        }}
+      >
+        {t('detail.seal.bonus', { points: metatask.point_value })}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/components/metaTaskSeal/skins/UaSeal.tsx
+++ b/frontend/src/components/metaTaskSeal/skins/UaSeal.tsx
@@ -1,0 +1,111 @@
+import { useTranslation } from 'react-i18next'
+
+import { factionName } from '../../../utils/factions'
+import type { SealSkinProps } from '../types'
+
+/**
+ * UA seal — a wax-lotus note pressed into the host praxis, "a note on
+ * refinement". Same three-field contract as every seal, in UA's gilt-salon
+ * voice: Cormorant small-caps eyebrow on sun-bleached parchment, an EB Garamond
+ * condition, and the bonus struck in vermil display type beside a lotus wax disc.
+ */
+export default function UaSeal({ metatask, removable, onRemove }: SealSkinProps) {
+  const { t } = useTranslation('praxis')
+  const faction = factionName(metatask.metatask_faction_slug)
+
+  return (
+    <div
+      className="relative"
+      style={{
+        background: 'var(--faction-ua-card-parchment)',
+        color: 'var(--faction-ua-card-text)',
+        border: '1px solid var(--faction-ua-card-frame)',
+        borderRadius: 3,
+        padding: 'var(--space-md) var(--space-lg)',
+        fontFamily: 'var(--faction-ua-card-font)',
+        overflow: 'hidden',
+      }}
+    >
+      {/* the lotus wax disc — ornament, never text (--faction-ua-card-lotus) */}
+      <span
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          top: 'var(--space-md)',
+          right: 'var(--space-lg)',
+          width: 26,
+          height: 26,
+          borderRadius: '50%',
+          background: 'var(--faction-ua-card-lotus)',
+          opacity: 'var(--faction-ua-card-lotus-opacity)',
+        }}
+      />
+
+      {removable && (
+        <button
+          type="button"
+          onClick={() => onRemove?.(metatask.id)}
+          aria-label={t('detail.seal.remove')}
+          className="absolute font-body leading-none"
+          style={{
+            top: 'var(--space-sm)',
+            right: 'var(--space-sm)',
+            zIndex: 2,
+            background: 'transparent',
+            border: 'none',
+            color: 'var(--faction-ua-card-accent)',
+            fontSize: 'var(--text-xl)',
+            cursor: 'pointer',
+          }}
+        >
+          <span aria-hidden="true">×</span>
+        </button>
+      )}
+
+      <span
+        className="eyebrow block"
+        style={{
+          fontFamily: 'var(--faction-ua-card-font)',
+          color: 'var(--faction-ua-card-accent)',
+        }}
+      >
+        {t('detail.seal.label', { faction })}
+      </span>
+
+      <span
+        aria-hidden="true"
+        className="block"
+        style={{
+          height: 1,
+          background: 'var(--faction-ua-card-rule)',
+          margin: 'var(--space-xs) 0 var(--space-sm)',
+        }}
+      />
+
+      <span
+        className="block"
+        style={{
+          fontFamily: 'var(--faction-ua-body-font)',
+          fontSize: 'var(--text-content)',
+          color: 'var(--faction-ua-card-text)',
+        }}
+      >
+        {metatask.title}
+      </span>
+
+      <span
+        className="block"
+        style={{
+          fontFamily: 'var(--faction-ua-card-font)',
+          fontSize: 'var(--text-title)',
+          fontWeight: 600,
+          letterSpacing: '0.02em',
+          color: 'var(--faction-ua-card-total)',
+          marginTop: 'var(--space-xs)',
+        }}
+      >
+        {t('detail.seal.bonus', { points: metatask.point_value })}
+      </span>
+    </div>
+  )
+}

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -31,6 +31,7 @@ import { AlbescentSelectCard } from '../components/cards/FactionSelectCard'
 import AlbescentVote from '../components/vote/AlbescentVote'
 import AlbescentPraxisCard from '../components/praxisCard/desktop/AlbescentPraxisCard'
 import AlbescentMobilePraxisCard from '../components/praxisCard/mobile/AlbescentMobilePraxisCard'
+import AlbescentSeal from '../components/metaTaskSeal/skins/AlbescentSeal'
 
 export const ALBESCENT_MANIFEST: FactionManifest = {
   slug: 'albescent',
@@ -65,4 +66,14 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    * (#783): the widget prints plain numerals via `reframeLabel`.
    */
   vote: () => AlbescentVote,
+
+  /**
+   * The seal skin (#930). A seal is a FOREIGN sticker that keeps its ISSUER's
+   * voice on someone else's praxis — so an Albescent-issued metatask is a reveal
+   * moment, not a host surface Albescent has to hide on. It reads the always-
+   * light `--albescent-reveal-*` tokens (the same reveal register as the
+   * invitation letter and sigil), never a `--faction-albescent-*` theme, so the
+   * society shows its pale face only where it is doing the sealing.
+   */
+  metaTaskSeal: () => AlbescentSeal,
 }

--- a/frontend/src/factions/coven.ts
+++ b/frontend/src/factions/coven.ts
@@ -35,6 +35,7 @@ import CovenTaskDetail from '../pages/taskDetail/archetypes/CovenTaskDetail'
 import CovenVote from '../components/vote/CovenVote'
 import CovenPraxisCard from '../components/praxisCard/desktop/CovenPraxisCard'
 import CovenScoreStamp from '../components/praxisCard/scoreStamp/CovenScoreStamp'
+import CovenSeal from '../components/metaTaskSeal/skins/CovenSeal'
 import { CovenSigil } from '../components/cards/CovenSigil'
 import { CovenCard } from '../components/cards/FactionCard'
 import { COVENSelectCard } from '../components/cards/FactionSelectCard'
@@ -47,6 +48,7 @@ export const COVEN_MANIFEST: FactionManifest = {
   taskCard: () => CovenTaskCard,
   praxisCard: () => CovenPraxisCard,
   scoreStamp: () => CovenScoreStamp,
+  metaTaskSeal: () => CovenSeal,
   avatar: () => CovenAvatar,
   backdrop: () => CovenBackdrop,
   sigil: () => CovenSigil,

--- a/frontend/src/factions/ua.ts
+++ b/frontend/src/factions/ua.ts
@@ -27,6 +27,7 @@ import UaMobileTaskDetail from '../pages/taskDetail/mobileArchetypes/UaTaskDetai
 import UaPraxisDetail from '../pages/praxisDetail/archetypes/UaPraxisDetail'
 import UaProfileBody from '../pages/characterProfile/archetypes/UaProfileBody'
 import UaScoreStamp from '../components/praxisCard/scoreStamp/UaScoreStamp'
+import UaSeal from '../components/metaTaskSeal/skins/UaSeal'
 import UaTaskCard from '../components/cards/UaTaskCard'
 import UaTaskDetail from '../pages/taskDetail/archetypes/UaTaskDetail'
 import UaVote from '../components/vote/UaVote'
@@ -43,6 +44,7 @@ export const UA_MANIFEST: FactionManifest = {
   taskCard: () => UaTaskCard,
   praxisCard: () => UaPraxisCard,
   scoreStamp: () => UaScoreStamp,
+  metaTaskSeal: () => UaSeal,
   avatar: () => UaAvatar,
   backdrop: () => UaBackdrop,
   sigil: () => UaSigilAdapter,


### PR DESCRIPTION
Closes #930. Part of the Metatask Seals epic (#927), continuing the skin-A pattern from #929 on the #928 foundation.

## What

Three bespoke issuing-faction seal skins, each a **foreign sticker** that keeps its *issuer's* voice on the host praxis (label / condition / bonus), registered one line each in the faction manifests — plus the `na` (Unaffiliated) seal handled per ADR-0039.

| slug | treatment | tokens |
|---|---|---|
| **coven** | Hand-lettered blush sticker on washi tape, Caveat script; bonus punched out as a gummed stamp chip. ⚠ Donor-slug respected — pink is **coven's**, not wow's. | `--faction-coven-sticker-*`, `--faction-coven-stamp-chip-*`, `--faction-coven-tape`, `--faction-coven-card-font` |
| **ua** | Gilt-salon "note on refinement": sun-bleached parchment, Cormorant small-caps eyebrow, EB Garamond condition, a lotus wax disc, bonus struck in vermil. | `--faction-ua-card-{parchment,frame,rule,lotus,total}`, `--faction-ua-body-font` |
| **albescent** | The pale secret-society register — near-black ink on a near-white sheet, a single soft spectrum strip as its only colour. Reads the always-light `--albescent-reveal-*` reveal tokens (no `--faction-albescent-*` theme exists by design). | `--albescent-reveal-*`, `--font-faction-serif`, `--faction-default-rainbow` |

## `na` / Unaffiliated

Per ADR-0039, `na` deliberately has **no manifest** and falls through to `DefaultSeal`. Rather than create an `na` manifest, `DefaultSeal` is tuned to the #930 `na` spec — "plain caps, the whole rainbow, no allegiance": a full-spectrum rainbow accent strip along the top edge and an uppercase condition register — while staying a tasteful neutral card so it remains the generic fallback for any still-unskinned faction (e.g. `wow`, until #931).

## Notes

- `sealSkinsA`'s "unregistered slug falls through to Default" example switched from `coven` → `wow`, since coven is now skinned (wow is still unskinned until #931). Without this, skin-A would have gone red.
- **No new CSS variables** — all three skins reuse existing tokens, so `index.css` and `utils/factions.ts` are untouched and in sync.
- Some token hints in the original issue were stale against current `index.css` (albescent's `--al-*` family is now `--albescent-reveal-*`; `--faction-ua-gilt` was removed in #853; there is no `--faction-albescent-card-font`). The skins use the tokens that actually exist.

## Files

- New: `frontend/src/components/metaTaskSeal/skins/{Coven,Ua,Albescent}Seal.tsx`
- Edited: `frontend/src/factions/{coven,ua,albescent}.ts` (one-line register + import), `frontend/src/components/metaTaskSeal/DefaultSeal.tsx` (na tuning)
- Tests: new `__tests__/sealSkinsB.test.tsx` (condition/bonus/label + dispatch, plus `na` via Default); `sealSkinsA.test.tsx` fall-through example updated

## Verification

- `npx tsc --noEmit` → exit 0
- `npx eslint` on all touched files → exit 0 (no `no-raw-style-values` violations)
- `npx vitest run src/components/metaTaskSeal` → 41 passed (sealSkinsB 20, sealSkinsA 21)

## Acceptance (per #930)

- ✅ Each of coven / ua / albescent renders its specimen skin (condition = `title`, bonus = `point_value`), light + dark.
- ✅ coven does not leak into or borrow from wow (uses only coven's own tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mHRqw1goSByRq5xFc4thS

---
_Generated by [Claude Code](https://claude.ai/code/session_012mHRqw1goSByRq5xFc4thS)_