### PR TITLE
Add WOW metatask seal skin (#931)

### DIFF
--- a/frontend/src/components/metaTaskSeal/__tests__/sealSkinsA.test.tsx
+++ b/frontend/src/components/metaTaskSeal/__tests__/sealSkinsA.test.tsx
@@ -91,9 +91,11 @@ describe("seal skins A content-slot invariant", () => {
 
 describe("seal skins A — unregistered slug still falls through", () => {
   it("an unrecognized metatask_faction_slug renders the Default seal", () => {
-    // `wow` has no seal skin yet (lands in #931), so it still falls through to
-    // Default — coven/ua/albescent are skinned as of #930 and no longer would.
-    const task = metatask("wow");
+    // Every real faction is skinned now (wow was the last, #931), so this uses a
+    // slug that names no faction at all to pin the Default fallthrough for any
+    // unrecognized issuer. na — a real but deliberately-unskinned faction — is
+    // covered in sealSkinsB.
+    const task = metatask("nonesuch");
     // MetaTaskSeal wraps its stack in a flex container, so compare the
     // dispatched seal's own markup, not the wrapper around it.
     const html = markup(<MetaTaskSeal metatasks={[task]} />);

--- a/frontend/src/components/metaTaskSeal/__tests__/sealSkinsB.test.tsx
+++ b/frontend/src/components/metaTaskSeal/__tests__/sealSkinsB.test.tsx
@@ -1,5 +1,6 @@
 /**
- * Seal skins B (#930) — coven, ua, albescent, and the na/Unaffiliated fallback.
+ * Seal skins B — coven, ua, albescent (#930), wow (#931), and the na/Unaffiliated
+ * fallback.
  *
  * Each bespoke skin must honor the shared seal contract (label = issuing
  * faction, condition = title, bonus = point_value) in its own costume, dispatch
@@ -41,7 +42,7 @@ function markup(element: React.ReactElement): string {
   return renderToStaticMarkup(element);
 }
 
-const SKIN_SLUGS = ["coven", "ua", "albescent"];
+const SKIN_SLUGS = ["coven", "ua", "albescent", "wow"];
 
 describe("seal skins B content-slot invariant", () => {
   for (const slug of SKIN_SLUGS) {

--- a/frontend/src/components/metaTaskSeal/skins/WowSeal.tsx
+++ b/frontend/src/components/metaTaskSeal/skins/WowSeal.tsx
@@ -1,0 +1,132 @@
+import { useTranslation } from 'react-i18next'
+
+import { factionName } from '../../../utils/factions'
+import type { SealSkinProps } from '../types'
+
+/**
+ * Warriors of Whimsy seal — a court writ pressed onto the host praxis and
+ * closed with a wax seal (#931). The kit draws no wow specimen, so this is built
+ * from WOW's own chronicle identity (ADR-0050): cream parchment bound in gold,
+ * written in plum, with the chronicle's woven gold/plum running-head stripe up
+ * top and a plum wax-seal disc ringed in gold at the corner.
+ *
+ * Same three-field contract as every seal (label / condition / bonus) in WOW's
+ * heraldic voice — MedievalSharp illuminates the decree, Lora reads the
+ * condition. Deliberately NOT coven's cozy pink (#927 donor-slug note): the gold
+ * frame and plum ink keep it unmistakably WOW and clearly not the coven sticker.
+ */
+export default function WowSeal({ metatask, removable, onRemove }: SealSkinProps) {
+  const { t } = useTranslation('praxis')
+  const faction = factionName(metatask.metatask_faction_slug)
+
+  return (
+    <div
+      className="relative"
+      style={{
+        background: 'var(--faction-wow-chronicle-bg)',
+        color: 'var(--faction-wow-card-text)',
+        border: '2px solid var(--faction-wow-chronicle-border)',
+        borderRadius: 6,
+        overflow: 'hidden',
+        boxShadow: '0 4px 16px -8px var(--faction-wow-chronicle-shadow)',
+        fontFamily: 'var(--faction-wow-body-font)',
+        transition: 'background 150ms, color 150ms',
+      }}
+    >
+      {/* the chronicle running head — a woven gold/plum stripe, no text */}
+      <div
+        aria-hidden="true"
+        style={{
+          height: 5,
+          background:
+            'repeating-linear-gradient(90deg, var(--faction-wow-chronicle-gold) 0 10px, var(--faction-wow-card-accent) 10px 20px)',
+        }}
+      />
+
+      <div style={{ position: 'relative', padding: 'var(--space-md) var(--space-lg)' }}>
+        {/* the wax seal — plum disc ringed in gold; ornament, never text */}
+        <span
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            top: 'var(--space-md)',
+            right: 'var(--space-lg)',
+            width: 26,
+            height: 26,
+            borderRadius: '50%',
+            background: 'var(--faction-wow-plum-surface)',
+            border: '2px solid var(--faction-wow-chronicle-gold)',
+          }}
+        />
+
+        {removable && (
+          <button
+            type="button"
+            onClick={() => onRemove?.(metatask.id)}
+            aria-label={t('detail.seal.remove')}
+            className="absolute font-body leading-none"
+            style={{
+              top: 'var(--space-sm)',
+              right: 'var(--space-sm)',
+              zIndex: 2,
+              background: 'transparent',
+              border: 'none',
+              color: 'var(--faction-wow-card-accent)',
+              fontSize: 'var(--text-xl)',
+              cursor: 'pointer',
+            }}
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        )}
+
+        <span
+          className="eyebrow block"
+          style={{
+            fontFamily: 'var(--faction-wow-card-font)',
+            letterSpacing: '0.14em',
+            color: 'var(--faction-wow-card-accent)',
+          }}
+        >
+          {t('detail.seal.label', { faction })}
+        </span>
+
+        <span
+          aria-hidden="true"
+          className="block"
+          style={{
+            height: 1,
+            background: 'var(--faction-wow-rule)',
+            margin: 'var(--space-xs) 0 var(--space-sm)',
+          }}
+        />
+
+        <span
+          className="block"
+          style={{
+            fontFamily: 'var(--faction-wow-body-font)',
+            fontStyle: 'italic',
+            fontSize: 'var(--text-content)',
+            lineHeight: 1.3,
+            color: 'var(--faction-wow-card-text)',
+          }}
+        >
+          {metatask.title}
+        </span>
+
+        <span
+          className="block"
+          style={{
+            fontFamily: 'var(--faction-wow-card-font)',
+            fontSize: 'var(--text-title)',
+            letterSpacing: '0.03em',
+            color: 'var(--faction-wow-stamp-total)',
+            marginTop: 'var(--space-xs)',
+          }}
+        >
+          {t('detail.seal.bonus', { points: metatask.point_value })}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
+++ b/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
@@ -60,7 +60,9 @@ function Sentinel() {
  * FIELD PAVILION mobile surfaces (`mobileFieldDesk` and `mobileTaskCard` from
  * the one phone screen the kit drew, plus `mobileTaskDetail`,
  * `mobilePraxisDetail`, `mobileFactionPage` and `mobileProfile` derived from
- * that screen's chrome and the matching desktop archetype).
+ * that screen's chrome and the matching desktop archetype), and #931's
+ * `metaTaskSeal` — WOW's court-writ seal, the last faction seal skin, built from
+ * the chronicle identity since the kit drew no wow specimen.
  *
  * EIGHT SURFACES ARE STILL UNCLAIMED and every one is deliberate, not an
  * oversight. `factionBody` and `factionCard`: the kit drew WOW's faction HERO,
@@ -101,9 +103,10 @@ const WOW_SKINNED: ReadonlySet<FactionSurface> = new Set([
   'mobilePraxisDetail',
   'mobileFactionPage',
   'mobileProfile',
+  'metaTaskSeal',
 ])
 
-describe('wow is partly skinned: twenty-five surfaces claimed, the rest fall back', () => {
+describe('wow is partly skinned: twenty-six surfaces claimed, the rest fall back', () => {
   it('registers a manifest now (#821)', () => {
     expect(FACTION_MANIFESTS.map((manifest) => manifest.slug)).toContain('wow')
   })

--- a/frontend/src/factions/wow.ts
+++ b/frontend/src/factions/wow.ts
@@ -68,6 +68,7 @@ import WowVote from '../components/vote/WowVote'
 import WowMobilePraxisCard from '../components/praxisCard/mobile/WowMobilePraxisCard'
 import WowPraxisCard from '../components/praxisCard/desktop/WowPraxisCard'
 import WowScoreStamp from '../components/praxisCard/scoreStamp/WowScoreStamp'
+import WowSeal from '../components/metaTaskSeal/skins/WowSeal'
 import WowEditPraxis from '../pages/editPraxis/archetypes/WowEditPraxis'
 import WowMobileEditPraxis from '../pages/editPraxis/mobileArchetypes/WowEditPraxis'
 import WowDuelSealConfirm from '../components/duel/WowDuelSealConfirm'
@@ -91,6 +92,7 @@ export const WOW_MANIFEST: FactionManifest = {
   feedFrame: () => WowFeedFrame,
   praxisCard: () => WowPraxisCard,
   scoreStamp: () => WowScoreStamp,
+  metaTaskSeal: () => WowSeal,
   mobilePraxisCard: () => WowMobilePraxisCard,
   vote: () => WowVote,
   editPraxis: () => WowEditPraxis,


### PR DESCRIPTION
## What

The **wow** metatask seal skin — the last faction seal, and the one with **no drawn specimen**. Built from WOW's own chronicle identity (ADR-0050), not borrowed from any other faction's seal.

Closes #931

## Design

A court writ pressed onto the host praxis and closed with a wax seal, in WOW's heraldic voice:
- Cream chronicle parchment (`--faction-wow-chronicle-bg`) bound in a **gold** frame (`--faction-wow-chronicle-border`), written in **plum** ink (`--faction-wow-card-text` / `--faction-wow-card-accent`).
- The chronicle's woven **gold/plum running-head stripe** across the top (the same signature stripe `WowPraxisCard` wears).
- A **plum wax-seal disc ringed in gold** at the corner — ornament, `aria-hidden`, never text.
- MedievalSharp (`--faction-wow-card-font`) illuminates the issuer label and bonus; Lora (`--faction-wow-body-font`) reads the condition. Bonus struck in the gold total mark (`--faction-wow-stamp-total`).

Deliberately **not** Coven's cozy pink (Caveat script on blush stock) — gold-and-plum chronicle vs pink washi sticker keeps the two visibly distinct in light **and** dark (both palettes flip via the `[data-theme="dark"]` cascade; no color values added, all existing `--faction-wow-*` tokens).

Same three-field seal contract as every other skin (issuer label / condition = `title` / bonus = `+N PTS`), with the `×` peel control wired to `onRemove(metatask.id)` when `removable`.

## Files

- `frontend/src/components/metaTaskSeal/skins/WowSeal.tsx` — new skin.
- `frontend/src/factions/wow.ts` — `metaTaskSeal: () => WowSeal` in WOW's own manifest (the only registration edit).
- Tests: added `wow` to the enumerated skin suite in `sealSkinsB.test.tsx`; repointed the now-obsolete "wow falls through to Default" case in `sealSkinsA.test.tsx` to a genuinely-unregistered slug (every real faction is skinned now); added `metaTaskSeal` to `WOW_SKINNED` in `wowRendersDefault.test.tsx` (25 -> 26 claimed; the 8-unclaimed note is now exactly accurate again).

## Checks

- `tsc --noEmit`: clean for all changed files (the repo-wide `node:fs`/`node:url` errors are the known stale-junction false alarm, PR #675, not from this change).
- `eslint`: clean on all changed files (the `no-raw-style-values` ratchet is satisfied).
- `vitest`: seal skin suites + `wowRendersDefault` green (125 tests across the faction + seal dirs).

**Visual QA is outstanding** — no dev stack in the worktree and the Browser pane renderer times out, so I could NOT eyeball the rendered seal. Verified via tests/tsc/eslint only.

## What to eyeball

- A `metatask_faction_slug = "wow"` seal on some host praxis card (e.g. a Coven or UA card) — it must read as WOW: gold frame, plum ink, the gold/plum running-head stripe, wax-seal disc.
- Light **and** dark mode — the parchment/ink flip and the gold stripe + plum disc stay legible in both.
- Confirm it is **clearly not Coven pink** — no blush sticker / washi tape / Caveat script bleeding in.
- The `×` peel control (when `removable`) sits at the upper-right and reads against the parchment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
