### PR TITLE
Metatask seals: read-only stack on all praxis-detail archetypes (desktop + mobile) (#932)

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -23,6 +23,7 @@ import "../../../i18n";
 import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { PraxisOut } from "../../../api/praxis";
+import type { TaskOut } from "../../../api/tasks";
 import type { VoteSummary } from "../../../api/votes";
 
 function render(element: ReactElement): { html: string; text: string } {
@@ -164,6 +165,51 @@ function multiplierState(): PraxisDetailState {
   s.votes = { praxis_id: 1, total_votes: 4, total_score: 14 };
   return s;
 }
+
+// ─── Metatask seal stack (#932) ──────────────────────────────────────────────
+// Every detail archetype renders the read-only applied-metatask seal stack in
+// its below-score / above-media slot when `applied_metatasks` is non-empty, and
+// nothing when it is empty. The seal dispatches on the METATASK's issuing
+// faction (here `snide`), not the host archetype's — a UA-hosted page shows a
+// Snide-issued seal. Its condition line is the metatask title, the anchor below.
+
+const SEAL_METATASK: TaskOut = {
+  id: 501,
+  title: "Composting",
+  description: null,
+  point_value: 60,
+  level_required: 0,
+  status: "active",
+  task_type: "metatask",
+  created_by: 9,
+  primary_faction_slug: null,
+  metatask_faction_slug: "snide",
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  can_submit_praxis: false,
+  allowed_modes: [],
+  eligible_for_current_user: false,
+};
+
+/** Same praxis, now carrying one applied metatask seal. */
+function sealedState(): PraxisDetailState {
+  const s = state();
+  s.praxis = { ...PRAXIS, applied_metatasks: [SEAL_METATASK] };
+  return s;
+}
+
+describe("praxis-read metatask seal stack", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders the applied seal, and nothing when none applied`, () => {
+      expect(render(<Archetype state={sealedState()} />).text, "seal condition line").toContain(
+        "Composting",
+      );
+      expect(render(<Archetype state={state()} />).text, "no seal when empty").not.toContain(
+        "Composting",
+      );
+    });
+  }
+});
 
 describe("praxis-read earned-points breakdown", () => {
   for (const [slug, Archetype] of Object.entries(archetypes)) {

--- a/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -17,6 +17,7 @@ import i18n from '../../../i18n'
 import DefaultMobilePraxisDetail from '../mobileArchetypes/DefaultPraxisDetail'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { PraxisOut } from '../../../api/praxis'
+import type { TaskOut } from '../../../api/tasks'
 import type { VoteSummary } from '../../../api/votes'
 
 function render(element: ReactElement): { html: string; text: string } {
@@ -143,6 +144,50 @@ function multiplierState(): PraxisDetailState {
   s.votes = { praxis_id: 1, total_votes: 4, total_score: 14 }
   return s
 }
+
+// ─── Metatask seal stack (#932) ──────────────────────────────────────────────
+// The mobile twin: each mobile detail archetype renders the read-only
+// applied-metatask seal stack in its below-byline / above-media slot when
+// `applied_metatasks` is non-empty, and nothing when empty. The seal dispatches
+// on the METATASK's issuing faction (here `snide`), not the host archetype's.
+
+const SEAL_METATASK: TaskOut = {
+  id: 501,
+  title: 'Composting',
+  description: null,
+  point_value: 60,
+  level_required: 0,
+  status: 'active',
+  task_type: 'metatask',
+  created_by: 9,
+  primary_faction_slug: null,
+  metatask_faction_slug: 'snide',
+  is_task_vision_eligible: false,
+  created_at: '2026-01-01T00:00:00Z',
+  can_submit_praxis: false,
+  allowed_modes: [],
+  eligible_for_current_user: false,
+}
+
+/** Same praxis, now carrying one applied metatask seal. */
+function sealedState(): PraxisDetailState {
+  const s = state()
+  s.praxis = { ...PRAXIS, applied_metatasks: [SEAL_METATASK] }
+  return s
+}
+
+describe('mobile praxis-read metatask seal stack', () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} renders the applied seal, and nothing when none applied`, () => {
+      expect(render(<Archetype state={sealedState()} />).text, 'seal condition line').toContain(
+        'Composting',
+      )
+      expect(render(<Archetype state={state()} />).text, 'no seal when empty').not.toContain(
+        'Composting',
+      )
+    })
+  }
+})
 
 describe('mobile praxis-read earned-points breakdown', () => {
   for (const [slug, Archetype] of Object.entries(archetypes)) {

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -22,6 +22,7 @@ import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, PraxisScoreBreakdown, MemberByline } from '../shared'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 // ── whimsy.exe token vocabulary (same as CovenTaskDetail) ──────────────────────
@@ -323,6 +324,15 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                 </div>
               </div>
             </div>
+
+            {/* ── Metatask seals (#932) — read-only stack, below the byline/points
+                block, above the evidence. Dispatched on each metatask's issuing
+                faction, not Coven; empty stack renders nothing. ── */}
+            {praxis.applied_metatasks.length > 0 && (
+              <div style={{ marginTop: 'var(--space-lg)' }}>
+                <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+              </div>
+            )}
 
             {/* ── 3 · the account (body text) ── */}
             {praxis.body_text && (

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -18,6 +18,7 @@ import { EphemeristsSigil, EphEyebrow, Foxing, LapisLastWord, toRoman } from '..
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, PraxisScoreBreakdown, MemberByline } from '../shared'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetailState }) {
@@ -213,6 +214,15 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
             </span>
           </div>
         </div>
+
+        {/* ── Metatask seals (#932) — read-only stack, below the byline/points
+            block, above the evidence. Dispatched on each metatask's issuing
+            faction; an empty stack renders nothing. ── */}
+        {praxis.applied_metatasks.length > 0 && (
+          <div style={{ marginBottom: 'var(--space-xl)' }}>
+            <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+          </div>
+        )}
 
         {/* ── The account ── */}
         {praxis.body_text && (

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -23,6 +23,7 @@ import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, PraxisScoreBreakdown, MemberByline } from '../shared'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 const POSTER = 'var(--font-accent)' // Bebas Neue
@@ -194,6 +195,15 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
             </div>
           </div>
         </div>
+
+        {/* ── Metatask seals (#932) — read-only stack, below the byline/points
+            block, above the proof-of-work plates. Each seal keeps its issuing
+            faction's voice, not Everymen's; an empty stack renders nothing. ── */}
+        {praxis.applied_metatasks.length > 0 && (
+          <div style={{ marginTop: 'var(--space-xl)' }}>
+            <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+          </div>
+        )}
 
         {/* ── The report (account body) ── */}
         {praxis.body_text && (

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -23,6 +23,7 @@ import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, PraxisScoreBreakdown, MemberByline } from '../shared'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 // ── Terminal atoms (presentation only — no shared behavior) ──────────────────
@@ -360,6 +361,15 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
               </div>
             </div>
           </div>
+
+          {/* ── Metatask seals (#932) — read-only stack, below the byline/points
+              block, above the artifacts. Dispatched on each metatask's issuing
+              faction, not Singularity's; an empty stack renders nothing. ── */}
+          {praxis.applied_metatasks.length > 0 && (
+            <div style={{ marginTop: 'var(--space-lg)' }}>
+              <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+            </div>
+          )}
 
           {/* ── The account body → PROCESS_LOG ── */}
           {praxis.body_text && (

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -20,6 +20,7 @@ import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, PraxisScoreBreakdown, MemberByline } from '../shared'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
 // Always-dark dossier tokens (scoped to this archetype's container).
@@ -283,6 +284,15 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
             </span>
           </div>
         </div>
+
+        {/* ── Metatask seals (#932) — read-only stack, below the byline/points
+            block, above the evidence. Each seal keeps its issuing faction's
+            voice, not SNIDE's; an empty stack renders nothing. ── */}
+        {praxis.applied_metatasks.length > 0 && (
+          <div style={{ marginBottom: 'var(--space-2xl)' }}>
+            <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+          </div>
+        )}
 
         {/* ── The confession (taped notebook) ── */}
         {praxis.body_text && (

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -31,6 +31,7 @@ import VoteUI from '../../../components/vote/VoteUI'
 import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, MemberByline, praxisBreakdownParts } from '../shared'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import type { PraxisOut } from '../../../api/praxis'
 import type { VoteSummary, VoterDetail } from '../../../api/votes'
@@ -373,6 +374,15 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
             </div>
           </div>
         </div>
+
+        {/* ── Metatask seals (#932) — read-only stack, below the byline/points
+            block, above the evidence plate. Each seal keeps its issuing
+            faction's voice, not UA's; an empty stack renders nothing. ── */}
+        {praxis.applied_metatasks.length > 0 && (
+          <div style={{ marginBottom: 'var(--space-xl)' }}>
+            <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+          </div>
+        )}
 
         {/* ── The account (body) ── */}
         {praxis.body_text && (

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/CovenPraxisDetail.tsx
@@ -26,6 +26,7 @@ import {
   MemberByline,
 } from '../shared'
 import { VoteFactionContext } from '../../../components/vote/VoteShell'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import { MobileStarVote } from './shared'
 
 const PINK = 'var(--faction-coven)'
@@ -150,6 +151,11 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
           </div>
         </div>
       </div>
+
+      {/* Metatask seals (#932) — read-only stack, below the byline, above the
+          media. Each seal keeps its issuing faction's voice; renders nothing
+          when none are applied. */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
 
       {/* praxis.exe window — full media inside */}
       {praxis.media_items.length > 0 && (

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
@@ -26,6 +26,7 @@ import {
   MemberByline,
 } from '../shared'
 import { VoteFactionContext } from '../../../components/vote/VoteShell'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import { MobileStarVote } from './shared'
 
 export default function DefaultPraxisDetail({ state }: { state: PraxisDetailState }) {
@@ -115,6 +116,11 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
           {t('detail.default.points', { points: praxis.task_point_value })}
         </span>
       </Link>
+
+      {/* Metatask seals (#932) — read-only stack, below the task/points context,
+          above the media. Each seal keeps its issuing faction's voice; renders
+          nothing when none are applied. */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
 
       {/* Full media */}
       {praxis.media_items.length > 0 && <MediaGallery media={praxis.media_items} />}

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/EphemeristsPraxisDetail.tsx
@@ -16,6 +16,7 @@ import {
   MemberByline,
 } from '../shared'
 import { VoteFactionContext } from '../../../components/vote/VoteShell'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import { MobileStarVote } from './shared'
 
 /**
@@ -94,6 +95,11 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
         </div>
         <EphemeristsSigil size={20} color={LAPIS} />
       </div>
+
+      {/* Metatask seals (#932) — read-only stack, below the byline, above the
+          evidence. Each seal keeps its issuing faction's voice; renders nothing
+          when none are applied. */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
 
       {/* Evidence plate — full media inside */}
       {praxis.media_items.length > 0 && (

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/EverymenPraxisDetail.tsx
@@ -15,6 +15,7 @@ import {
   MemberByline,
 } from '../shared'
 import { VoteFactionContext } from '../../../components/vote/VoteShell'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import { MobileStarVote } from './shared'
 
 /**
@@ -90,6 +91,11 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
           </div>
         </div>
       </div>
+
+      {/* Metatask seals (#932) — read-only stack, below the byline, above the
+          proof of work. Each seal keeps its issuing faction's voice; renders
+          nothing when none are applied. */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
 
       {/* Proof of work — full media inside */}
       {praxis.media_items.length > 0 && (

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/SingularityPraxisDetail.tsx
@@ -15,6 +15,7 @@ import {
   MemberByline,
 } from '../shared'
 import { VoteFactionContext } from '../../../components/vote/VoteShell'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import { MobileStarVote } from './shared'
 
 /**
@@ -98,6 +99,11 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
           </div>
         </div>
       </div>
+
+      {/* Metatask seals (#932) — read-only stack, below the byline, above the
+          artifacts. Each seal keeps its issuing faction's voice; renders nothing
+          when none are applied. */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
 
       {/* Output artifacts — full media inside */}
       {praxis.media_items.length > 0 && (

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/SnidePraxisDetail.tsx
@@ -15,6 +15,7 @@ import {
   MemberByline,
 } from '../shared'
 import { VoteFactionContext } from '../../../components/vote/VoteShell'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import { MobileStarVote } from './shared'
 
 /**
@@ -97,6 +98,11 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
           </div>
         </div>
       </div>
+
+      {/* Metatask seals (#932) — read-only stack, below the byline, above the
+          evidence. Each seal keeps its issuing faction's voice; renders nothing
+          when none are applied. */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
 
       {/* Evidence plate — full media inside */}
       {praxis.media_items.length > 0 && (

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/UaPraxisDetail.tsx
@@ -15,6 +15,7 @@ import {
   MemberByline,
 } from '../shared'
 import { VoteFactionContext } from '../../../components/vote/VoteShell'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import { MobileStarVote } from './shared'
 
 /**
@@ -106,6 +107,11 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
           </div>
         </div>
       </div>
+
+      {/* Metatask seals (#932) — read-only stack, below the byline, above the
+          exhibited plate. Each seal keeps its issuing faction's voice; renders
+          nothing when none are applied. */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
 
       {/* Exhibited plate — full media inside */}
       {praxis.media_items.length > 0 && (

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/WowPraxisDetail.tsx
@@ -56,6 +56,7 @@ import {
   PraxisVoterBreakdown,
 } from "../shared";
 import { VoteFactionContext } from "../../../components/vote/VoteShell";
+import MetaTaskSeal from "../../../components/metaTaskSeal/MetaTaskSeal";
 import { MobileStarVote } from "./shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 
@@ -168,6 +169,11 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
       </div>
 
       <PraxisOwnerActions state={state} />
+
+      {/* Metatask seals (#932) — read-only stack, below the byline/score block,
+          above the quest reference and evidence. Each seal keeps its issuing
+          faction's voice, not the Court's; renders nothing when none applied. */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
 
       {/* ── re: the quest ── */}
       <div


### PR DESCRIPTION
Part of #927. Advances #932 — wires the read-only metatask **seal stack** into **every praxis-detail archetype**, desktop + mobile. Consumes `<MetaTaskSeal>` (#928); does not touch the seal component or any skin.

> [!IMPORTANT]
> **Not `Closes #932`.** The issue also asks for the seal stack on the **feed praxis card**, but the card payload cannot carry it yet — see "Card surfaces are blocked" below. This PR delivers the **detail** half in full; the card half needs a small backend change first. Leaving the issue open on purpose.

## What changed (detail surfaces — all archetypes)
Each archetype now renders `<MetaTaskSeal metatasks={praxis.applied_metatasks} />` in the Section-A slot — **below the score / byline / points block, above the media preview** — read-only (no `removable`/`onAdd`). The seal dispatches on each metatask's **issuing** faction, so a WOW-hosted page can show a Snide seal. An empty `applied_metatasks` renders nothing (the component returns `null`).

- **Desktop** (`pages/praxisDetail/archetypes/`): Coven, Ephemerists, Everymen, Singularity, Snide, Ua. (Default was already wired in #928.)
- **Mobile** (`pages/praxisDetail/mobileArchetypes/`): Default, Coven, Ephemerists, Everymen, Singularity, Snide, Ua, Wow.
- **Tests**: extended `archetypeSlots.test.tsx` and `mobileArchetypeSlots.test.tsx` with a per-archetype "metatask seal stack" guard — asserts every registered archetype renders an applied seal (a `snide`-issued one on non-snide hosts, proving cross-faction dispatch) and renders nothing when the stack is empty.

Data source is `PraxisOut.applied_metatasks` (already on the detail payload).

## Card surfaces are blocked (needs a backend field first)
The feed card renders from **`PraxisCardOut`**, which carries only `metatask_points` (a summed number) — **not** the per-metatask `TaskOut` rows. The seal must dispatch on each metatask's `metatask_faction_slug`, which lives only in `applied_metatasks`. That field is on `PraxisOut` (detail) but **not** on `PraxisCardOut`, and `build_praxis_card_out` never populates it. So the card cannot render seals without:
1. **Backend**: add `applied_metatasks: List[TaskOut] = []` to `PraxisCardOut` and populate it in `build_praxis_card_out` (bulk `PraxisMetaTask`→`Task` query keyed by praxis id, to avoid an N+1 in the feed).
2. **Frontend follow-up**: add the field to the `PraxisCardOut` TS type and drop `<MetaTaskSeal>` into `praxisCard/desktop/shared.tsx` `PraxisBody` (after the score block, before `PraxisMediaGallery`) and the mobile card equivalents.

The epic's "data is already on the payload" note names only `PraxisOut`, so this gap wasn't scoped as a child issue. Recommend a small backend issue for step 1, then re-dispatch the card wiring.

## Checks
- `tsc --noEmit`: clean for touched files (repo-wide, only the known `node:fs`/`node:url` junction false alarms from the local worktree remain — CI resolves them).
- `eslint`: clean on all changed files.
- `vitest`: `pages/praxisDetail` + `components/metaTaskSeal` — 201 passed.
- **No visual QA** — no dev stack and the Browser pane renderer times out here. Verified structurally via the slot tests only.

## What to eyeball
- A **praxis detail page** with a metatask applied, **desktop** — e.g. a **Coven** or **Ua** page — confirm the seal sits **below the byline/points block and above the media**.
- The same on **mobile** for a couple of factions — e.g. **Snide** and **Wow** — confirm the seal sits below the byline and above the media/vote widgets.
- A cross-faction case: a non-Snide host page showing a **Snide-issued** seal (the seal keeps the issuer's voice, not the host's).
- A detail page with **no** metatask applied — confirm nothing renders in that slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
