### PR TITLE
Metatask seals: read-only stack on the feed praxis card (desktop + mobile)

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -44,6 +44,7 @@ from services.praxis import (
     _build_invite_out,
     _require_member,
     apply_metatask,
+    applied_metatasks_for,
     author_contributions_for,
     build_praxis_card_out,
     build_praxis_out,
@@ -160,6 +161,11 @@ async def list_praxes_route(
     # whole page — not per card. Grouped by author because the breakdown is the
     # AUTHOR's banked points, not the viewer's.
     author_contributions = await author_contributions_for(praxes, session)
+    # Applied metatasks for the seal stack (#932): one page-wide join for every
+    # praxis id — not a per-card query. The card's seal dispatches on each
+    # metatask's issuing faction, so it needs the TaskOut rows, not just the
+    # summed metatask_points the card already carries.
+    applied_metatasks = await applied_metatasks_for(praxes, session)
     return [
         await build_praxis_card_out(
             praxis,
@@ -167,6 +173,7 @@ async def list_praxes_route(
             crowned_ids=crowned,
             viewer_votes=viewer_votes,
             author_contributions=author_contributions,
+            applied_metatasks=applied_metatasks,
         )
         for praxis in praxes
     ]

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -121,6 +121,12 @@ class PraxisCardOut(BaseModel):
     points_from_votes: int = 0
     voter_count: int = 0
     is_top_for_task: bool = False  # Task Crown: top submitted praxis for its task (ADR-0028)
+    # The metatasks pinned to this praxis, as full TaskOut rows (not just the
+    # summed ``metatask_points`` above). The feed card renders a read-only seal
+    # stack that dispatches on each metatask's issuing faction, so it needs the
+    # rows. Populated page-wide in one query by the feed router (no N+1); the
+    # card builder falls back to a single-praxis query for other callers.
+    applied_metatasks: List[TaskOut] = []
     task_faction_slug: Optional[str] = None
     # Full-fidelity fields for bespoke mobile praxis cards (#573).
     body_text: Optional[str] = None

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -329,6 +329,39 @@ async def author_contributions_for(
     return contributions
 
 
+async def applied_metatasks_for(
+    praxes: list[Praxis],
+    session: AsyncSession,
+) -> dict[int, list[TaskOut]]:
+    """Applied metatasks (as ``TaskOut`` rows) for each praxis, in ONE query.
+
+    The feed card's seal stack dispatches on each metatask's issuing faction, so
+    it needs the ``TaskOut`` rows, not just the summed ``metatask_points``. List
+    routes build cards in a per-praxis comprehension, so a per-card metatask
+    query would be an N+1 across the page; this batches every praxis id on the
+    page into a single join and hands the result to
+    :func:`build_praxis_card_out` via ``applied_metatasks``.
+
+    Praxis ids with no applied metatask are simply absent from the returned map
+    (the card builder treats a missing entry as an empty stack).
+    """
+    if not praxes:
+        return {}
+
+    praxis_ids = [p.id for p in praxes]
+    rows = await session.execute(
+        select(PraxisMetaTask.praxis_id, Task)
+        .join(Task, PraxisMetaTask.task_id == Task.id)
+        .where(PraxisMetaTask.praxis_id.in_(praxis_ids))
+    )
+    metatasks_by_praxis: dict[int, list[TaskOut]] = {}
+    for praxis_id, task in rows.all():
+        metatasks_by_praxis.setdefault(praxis_id, []).append(
+            TaskOut.model_validate(task)
+        )
+    return metatasks_by_praxis
+
+
 def _resolve_card_scoring(
     contribution: Optional[Contribution], task_point_value: int, tally_votes_points: int
 ) -> tuple[int, float, int, float]:
@@ -374,6 +407,7 @@ async def build_praxis_card_out(
     crowned_ids: Optional[set[int]] = None,
     viewer_votes: Optional[dict[int, ViewerVote]] = None,
     author_contributions: Optional[dict[int, Contribution]] = None,
+    applied_metatasks: Optional[dict[int, list[TaskOut]]] = None,
 ) -> PraxisCardOut:
     """Lightweight card for list views.
 
@@ -397,6 +431,12 @@ async def build_praxis_card_out(
     list routes precompute it once via :func:`author_contributions_for` so the
     score breakdown is not re-derived per card. When absent, this builder scores
     the single praxis itself (single-card callers).
+
+    ``applied_metatasks`` maps praxis id → the metatasks pinned to it (as
+    ``TaskOut`` rows) for the read-only seal stack; list routes precompute it
+    once via :func:`applied_metatasks_for` so the seal never becomes a per-card
+    query (N+1). When absent, this builder loads the single praxis's metatasks
+    itself (single-card callers). A missing entry means no metatasks applied.
     """
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
@@ -432,6 +472,15 @@ async def build_praxis_card_out(
     if crowned_ids is None:
         crowned_ids = await crowned_praxis_ids([praxis.task_id], session)
 
+    # Applied metatasks for the seal stack. Reuse the precomputed page-wide map
+    # when the list route supplies it; otherwise load this praxis's own.
+    if applied_metatasks is not None:
+        praxis_metatasks = applied_metatasks.get(praxis.id, [])
+    else:
+        praxis_metatasks = (await applied_metatasks_for([praxis], session)).get(
+            praxis.id, []
+        )
+
     return PraxisCardOut(
         id=praxis.id,
         task_id=praxis.task_id,
@@ -456,6 +505,7 @@ async def build_praxis_card_out(
         points_from_votes=points_from_votes,
         voter_count=tally.voter_count,
         is_top_for_task=praxis.id in crowned_ids,
+        applied_metatasks=praxis_metatasks,
         task_faction_slug=praxis.task.primary_faction_slug if praxis.task else None,
         body_text=praxis.body_text,
         created_by_faction_slug=praxis.created_by.faction_slug if praxis.created_by else None,

--- a/backend/tests/integration/test_praxis_card_breakdown.py
+++ b/backend/tests/integration/test_praxis_card_breakdown.py
@@ -31,11 +31,16 @@ from models.character_stats import CharacterStats
 from models.duel import Duel, DuelStatus
 from models.era import Era
 from models.faction import Faction, FactionStatus
+from models.meta_task import PraxisMetaTask
 from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
-from models.task import Task, TaskStatus
+from models.task import Task, TaskStatus, TaskType
 from models.vote import Vote
 from services.character_stats import recalculate_character_stats
-from services.praxis import build_praxis_card_out, build_praxis_out
+from services.praxis import (
+    applied_metatasks_for,
+    build_praxis_card_out,
+    build_praxis_out,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -210,6 +215,42 @@ async def _make_collab(
     )
     await session.flush()
     return praxis
+
+
+async def _make_metatask(
+    session: AsyncSession,
+    creator: Character,
+    *,
+    issuing_faction_slug: str,
+    points: int,
+) -> Task:
+    """A Task with ``task_type == metatask``, issued by ``issuing_faction_slug``.
+
+    The card's seal dispatches on ``metatask_faction_slug``, so the metatask's
+    issuing faction is what the frontend reads — independent of the host card's
+    faction (a WOW card can carry a Snide seal).
+    """
+    task = Task(
+        title=f"{issuing_faction_slug} metatask",
+        description="metatask",
+        point_value=points,
+        level_required=0,
+        status=TaskStatus.active,
+        task_type=TaskType.metatask,
+        created_by=creator.id,
+        primary_faction_slug=issuing_faction_slug,
+        metatask_faction_slug=issuing_faction_slug,
+    )
+    session.add(task)
+    await session.flush()
+    return task
+
+
+async def _apply_metatask(
+    session: AsyncSession, praxis: Praxis, metatask: Task
+) -> None:
+    session.add(PraxisMetaTask(praxis_id=praxis.id, task_id=metatask.id))
+    await session.flush()
 
 
 async def _make_duel(
@@ -472,3 +513,84 @@ async def test_fractional_totals_bank_by_rounding_not_truncation(
     stats = stats_result.scalar_one()
     # 3 × 16.3 = 48.9 → 49, not 48.
     assert stats.score == 49
+
+
+# ---------------------------------------------------------------------------
+# applied metatasks — the card seal stack (#932)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_card_carries_applied_metatask_rows_for_the_seal(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """The card payload carries the pinned metatasks as TaskOut rows.
+
+    The feed seal stack dispatches on each metatask's issuing faction, so the
+    card must surface the rows (not just the summed ``metatask_points``). A WOW
+    praxis carrying a Snide-issued metatask reads a Snide seal — the seal
+    follows the metatask's faction, not the host card's.
+    """
+    await _ensure_faction(db_session, "wow")
+    await _ensure_faction(db_session, "snide")
+    author = await _make_character(
+        db_session, era, faction_slug="wow", username="sealauthor", email="seal@x.com"
+    )
+    task = await _make_task(db_session, author, faction_slug="wow", points=10)
+    praxis = await _make_solo(db_session, task, author)
+    metatask = await _make_metatask(
+        db_session, author, issuing_faction_slug="snide", points=5
+    )
+    await _apply_metatask(db_session, praxis, metatask)
+
+    card = await _load_card(db_session, praxis.id)
+
+    assert len(card.applied_metatasks) == 1
+    seal = card.applied_metatasks[0]
+    assert seal.id == metatask.id
+    # Cross-faction: the seal dispatches on the metatask's issuing faction.
+    assert seal.metatask_faction_slug == "snide"
+    assert seal.task_type == TaskType.metatask.value
+
+
+@pytest.mark.asyncio
+async def test_card_applied_metatasks_is_empty_when_none_applied(
+    db_session: AsyncSession, era: Era, faction_ua: Faction, character: Character
+):
+    """No metatasks pinned → the card carries an empty stack (seal renders nothing)."""
+    task = await _make_task(db_session, character, faction_slug="ua", points=10)
+    praxis = await _make_solo(db_session, task, character)
+
+    card = await _load_card(db_session, praxis.id)
+
+    assert card.applied_metatasks == []
+
+
+@pytest.mark.asyncio
+async def test_applied_metatasks_for_batches_the_page_in_one_map(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """The page-wide helper returns a praxis-id → rows map; bare praxes are absent.
+
+    This is the feed path (no N+1): one join for every praxis id on the page.
+    A praxis with no metatask is simply missing from the map, which the card
+    builder treats as an empty stack.
+    """
+    await _ensure_faction(db_session, "snide")
+    author = await _make_character(
+        db_session, era, faction_slug="ua", username="batchauthor", email="batch@x.com"
+    )
+    task = await _make_task(db_session, author, faction_slug="ua", points=10)
+    sealed = await _make_solo(db_session, task, author)
+    bare = await _make_solo(db_session, task, author)
+    metatask = await _make_metatask(
+        db_session, author, issuing_faction_slug="snide", points=5
+    )
+    await _apply_metatask(db_session, sealed, metatask)
+
+    result = await applied_metatasks_for([sealed, bare], db_session)
+
+    assert set(result.keys()) == {sealed.id}
+    assert [row.id for row in result[sealed.id]] == [metatask.id]
+    # A card builder given this map falls back to [] for the bare praxis.
+    assert result.get(bare.id, []) == []

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -152,6 +152,15 @@ export interface PraxisCardOut {
    * Null/absent when no character on the viewer's account has voted.
    */
   voted_by_name?: string | null
+  /**
+   * The metatasks pinned to this praxis, as full TaskOut rows (not just the
+   * summed `metatask_points` above). The card's read-only seal stack dispatches
+   * on each metatask's issuing faction, so it needs the rows. The backend always
+   * emits it (empty when none); optional so a stale cached payload or an older
+   * caller degrades to no seal rather than crashing the card — matching the
+   * other late-added card fields above.
+   */
+  applied_metatasks?: TaskOut[]
 }
 
 export interface PraxisCreate {

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -11,8 +11,10 @@ import { describe, it, expect } from 'vitest'
 import type { ReactElement } from 'react'
 import '../../../i18n'
 import type { PraxisCardOut } from '../../../api/praxis'
+import type { TaskOut } from '../../../api/tasks'
 import { PraxisByline, PraxisStats, PraxisVoteFooter } from '../shared'
-import { MobileVoteFooter } from '../mobile/shared'
+import { PraxisBody } from '../desktop/shared'
+import { MobilePraxisBody, MobileVoteFooter } from '../mobile/shared'
 
 function praxis(overrides: Partial<PraxisCardOut>): PraxisCardOut {
   return {
@@ -27,8 +29,32 @@ function praxis(overrides: Partial<PraxisCardOut>): PraxisCardOut {
     member_count: 1,
     score: 12.5,
     voter_count: 3,
+    applied_metatasks: [],
     ...overrides,
   } as PraxisCardOut
+}
+
+function metatask(overrides: Partial<TaskOut>): TaskOut {
+  return {
+    id: 99,
+    // A unique single-word title: seal skins may wrap multi-word titles in
+    // per-word tags, so stripping markup would collapse the inter-word spaces.
+    title: 'Sealmark',
+    description: null,
+    point_value: 5,
+    level_required: 7,
+    status: 'active',
+    task_type: 'metatask',
+    created_by: 3,
+    primary_faction_slug: 'snide',
+    metatask_faction_slug: 'snide',
+    is_task_vision_eligible: false,
+    created_at: '2026-01-01T00:00:00Z',
+    can_submit_praxis: false,
+    allowed_modes: [],
+    eligible_for_current_user: false,
+    ...overrides,
+  } as TaskOut
 }
 
 const render = (node: ReactElement) =>
@@ -100,6 +126,50 @@ describe('the meta line (#888)', () => {
     const html = render(<PraxisStats praxis={praxis({})} />)
     expect(html).toContain('var(--text-xl)')
     expect(html).not.toContain('var(--text-xs)')
+  })
+})
+
+describe('the applied-metatask seal stack (#932)', () => {
+  // A WOW card carrying a Snide-issued metatask: the seal follows the metatask's
+  // ISSUING faction, not the host card's. Every seal skin prints the title.
+  const snideSeal = metatask({ metatask_faction_slug: 'snide' })
+
+  it('the desktop body renders a seal below the score when a metatask is applied', () => {
+    const html = render(
+      <PraxisBody
+        praxis={praxis({ created_by_faction_slug: 'wow', applied_metatasks: [snideSeal] })}
+        tint="#000"
+        muted="#555"
+      />,
+    )
+    expect(text(html)).toContain('Sealmark')
+  })
+
+  it('the desktop body renders no seal when nothing is applied', () => {
+    const html = render(
+      <PraxisBody praxis={praxis({ applied_metatasks: [] })} tint="#000" muted="#555" />,
+    )
+    expect(text(html)).not.toContain('Sealmark')
+  })
+
+  it('the mobile body renders a seal below the score when a metatask is applied', () => {
+    const html = render(
+      <MobilePraxisBody
+        praxis={praxis({ created_by_faction_slug: 'wow', applied_metatasks: [snideSeal] })}
+        theme={{ paper: '#fff', ink: '#000', accent: '#333', muted: '#555' }}
+      />,
+    )
+    expect(text(html)).toContain('Sealmark')
+  })
+
+  it('the mobile body renders no seal when nothing is applied', () => {
+    const html = render(
+      <MobilePraxisBody
+        praxis={praxis({ applied_metatasks: [] })}
+        theme={{ paper: '#fff', ink: '#000', accent: '#333', muted: '#555' }}
+      />,
+    )
+    expect(text(html)).not.toContain('Sealmark')
   })
 })
 

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -15,6 +15,7 @@ import {
   type PraxisCardFonts,
 } from "../shared";
 import ScoreStamp from "../scoreStamp/ScoreStamp";
+import MetaTaskSeal from "../../metaTaskSeal/MetaTaskSeal";
 
 /**
  * Bespoke DESKTOP praxis-card shared pieces (#839).
@@ -168,6 +169,12 @@ export function PraxisBody({
          */}
         <ScoreStamp praxis={praxis} showCrown={showCrown} />
       </div>
+      {/*
+       * Read-only applied-metatask seal stack (#932): below the score, above the
+       * media. Each seal dispatches on its metatask's ISSUING faction, not this
+       * card's — a WOW card can carry a Snide seal. Renders nothing when empty.
+       */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks ?? []} />
       <PraxisStats
         praxis={praxis}
         style={{ color: muted, marginTop: "var(--space-sm)" }}

--- a/frontend/src/components/praxisCard/mobile/shared.tsx
+++ b/frontend/src/components/praxisCard/mobile/shared.tsx
@@ -7,6 +7,7 @@ import { relativeTime } from '../../../utils/dates'
 import { mediaUrl } from '../../../utils/media'
 import { rosterNames } from '../shared'
 import ScoreStamp from '../scoreStamp/ScoreStamp'
+import MetaTaskSeal from '../../metaTaskSeal/MetaTaskSeal'
 import { TaskCrown } from '../../cards/TaskCrown'
 import VoteUI from '../../vote/VoteUI'
 
@@ -534,6 +535,12 @@ export function MobilePraxisBody({
        * crown is suppressed here because the mobile body floats its own.
        */}
       <ScoreStamp praxis={praxis} showCrown={false} />
+      {/*
+       * Read-only applied-metatask seal stack (#932): below the score, above the
+       * media. Each seal dispatches on its metatask's ISSUING faction, not this
+       * card's. Stacks single-column; renders nothing when empty.
+       */}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks ?? []} />
       <MobileModeChip praxis={praxis} theme={theme} />
       <MobileRoster praxis={praxis} theme={theme} />
       {/* Every card shows the media slot — a drop target when empty (#821). */}


### PR DESCRIPTION
Closes #932

Completes the acceptance for #932. The detail half shipped in #948; this PR wires the read-only applied-metatask seal stack onto the **feed praxis card** (desktop + mobile, all factions). It required a small additive, backward-compatible backend change because the card payload lacked the per-metatask rows the seal dispatches on.

## Backend (additive, no N+1)
- `schemas/praxis.py`: add `applied_metatasks: List[TaskOut] = []` to `PraxisCardOut` (mirrors `PraxisOut`).
- `services/praxis.py`: new page-wide helper `applied_metatasks_for(praxes, session) -> dict[int, list[TaskOut]]` — ONE join for every praxis id on the page (mirrors `author_contributions_for`). `build_praxis_card_out` takes a new optional `applied_metatasks` param; when absent it falls back to its own single-praxis query, so detail/single-card/test callers are unchanged.
- `routers/praxes.py`: the feed calls `applied_metatasks_for(praxes, session)` once before the per-praxis comprehension and threads the map in — the seal never becomes a per-card query.
- Tests: `test_praxis_card_breakdown.py` gains coverage for the card carrying a cross-faction metatask row, the empty stack, and the batch helper's page map.

## Frontend
- `api/praxis.ts`: add `applied_metatasks?: TaskOut[]` to the TS `PraxisCardOut` (optional to match the other late-added card fields — the backend always emits it; optional degrades a stale payload to no seal rather than crashing).
- Desktop `praxisCard/desktop/shared.tsx` and mobile `praxisCard/mobile/shared.tsx`: drop `<MetaTaskSeal metatasks={praxis.applied_metatasks ?? []} />` into the shared body, below the score stamp and above the media slot. One shared body per platform, so every faction archetype gets the seal from one edit. Read-only (no `removable`/`onRemove`/`onAdd`); the component returns `null` when empty.
- `praxisCard/__tests__/cardChrome.test.tsx`: pins the wiring for both platforms (cross-faction seal when applied; nothing when empty).

The seal dispatches on the **metatask's issuing faction**, not the host card — a WOW card showing a Snide seal is correct.

## Checks (all green locally)
- `tsc --noEmit`: zero real errors (only the known `node:fs/url/path` stale-junction false alarms in unrelated `__tests__` files, per PR #675; CI's fresh install resolves them).
- `eslint`: clean on all touched files.
- `vite build`: succeeds.
- frontend `vitest`: 93/93 in `components/praxisCard`.
- backend `pytest` (dedicated `wz932_test` DB): `test_praxis_card_breakdown.py` + `test_praxis_card_byline.py` = 13 passed; `test_praxes.py` + `test_activity_feed.py` = 87 passed.

**Visual QA outstanding:** I could NOT do visual QA — no dev stack, and the Browser pane renderer times out (screenshots unavailable). Verified structurally via tests/tsc/eslint/build only.

## What to eyeball
- A **feed card with a metatask applied** — desktop and mobile — showing the seal **below the score / above the media**, across a couple of factions (e.g. a WOW card and a UA card).
- A **cross-faction seal**: e.g. a WOW-authored praxis carrying a **Snide** metatask should render the Snide seal skin on the card (the seal follows the metatask's faction, not the card's).
- A **card with no metatask** — the seal area shows **nothing** (no empty frame, no gap artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)