### PR TITLE
Restore spectrum ring on the unaffiliated credential card

### DIFF
--- a/frontend/src/components/CredentialCard.tsx
+++ b/frontend/src/components/CredentialCard.tsx
@@ -143,7 +143,10 @@ export default function CredentialCard({
             borderRadius: '50%',
             padding: 'var(--space-xs)',
             boxSizing: 'border-box',
-            background: 'var(--fc-accent)',
+            // Unaffiliated wears the spectrum ring (all paths open, ADR-0039);
+            // themed factions keep their accent hoop. Conic ramp is the
+            // round-ring geometry — NOT --faction-default-rainbow (a bar ramp).
+            background: skinned ? 'var(--fc-accent)' : 'var(--faction-default-ring)',
             border: 'none',
             cursor: onAvatarClick ? 'pointer' : 'default',
             boxShadow: '0 4px 14px rgba(0,0,0,0.18)',


### PR DESCRIPTION
## What

The unaffiliated player's credential-card portrait ring was rendering as a flat neutral hoop instead of the community rainbow.

## Why

`CredentialCard`'s portrait ring uses `var(--fc-accent)` for its background. For the neutral (unaffiliated / `na` / unknown) skin, `--fc-accent` resolves to `--color-text-primary` — a solid color — so the spectrum ring never appeared. Sibling surfaces (`DefaultProfileBody`, `DefaultAvatar`) already draw the unaffiliated ring with the spectrum tokens.

## Change

One-line branch in the ring background: neutral skin → conic `--faction-default-ring`; themed factions keep `--fc-accent`. Used the conic ring ramp (not `--faction-default-rainbow`, which is the horizontal-bar ramp) per the geometry doctrine in `index.css`.

## Reviewer notes

- `CredentialCard` is shared by the profile header, FieldDesk roster cards, and the character-creation live preview — only the neutral/unaffiliated case changes; every themed faction is byte-for-byte unchanged.
- No visual QA (no dev stack in the worktree); verified against the tokens the neighbouring components already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)