### PR TITLE
Set site favicon to the Rainbow WØ icon (#946)

### DIFF
--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,20 +1,41 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <!--
+    World Zero site icon: the "Rainbow WoZero" mark (design ca218fc4,
+    "Rainbow W0 Icon"). A rounded tile carrying the WO-stroke wordmark
+    glyph in Lora italic, filled with the unaffiliated rainbow spectrum.
+    Primary is the dark tile; the light tile (a design alternate) shows
+    under a dark color scheme so the icon always contrasts the tab bar.
+  -->
+  <defs>
+    <linearGradient id="wzRainbow" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#c1272d" />
+      <stop offset="0.16" stop-color="#ea580c" />
+      <stop offset="0.33" stop-color="#ca8a04" />
+      <stop offset="0.5" stop-color="#16a34a" />
+      <stop offset="0.66" stop-color="#2563eb" />
+      <stop offset="0.83" stop-color="#6d28d9" />
+      <stop offset="1" stop-color="#a21caf" />
+    </linearGradient>
+  </defs>
   <style>
-    /* Ink on transparent for light tab bars; paper on transparent for dark. */
-    .mark { fill: #1a1209; }
-    .zero { fill: #be185d; }
+    .tile { fill: #1a1209; }
+    .tile-edge { fill: none; stroke: none; stroke-width: 1.5; }
     @media (prefers-color-scheme: dark) {
-      .mark { fill: #f0e6d0; }
+      .tile { fill: #f7f4ee; }
+      .tile-edge { stroke: rgba(0, 0, 0, 0.1); }
     }
   </style>
+  <rect class="tile" x="0" y="0" width="64" height="64" rx="14" />
+  <rect class="tile-edge" x="0.75" y="0.75" width="62.5" height="62.5" rx="13.25" />
   <text
-    x="32"
-    y="33"
+    x="32.5"
+    y="44.5"
     text-anchor="middle"
-    dominant-baseline="central"
-    font-family="'Arial Black', 'Helvetica Neue', Helvetica, Arial, sans-serif"
-    font-weight="900"
-    font-size="40"
-    letter-spacing="-3"
-  ><tspan class="mark">W</tspan><tspan class="zero">&#8709;</tspan></text>
+    font-family="Lora, Georgia, 'Times New Roman', serif"
+    font-style="italic"
+    font-weight="700"
+    font-size="34"
+    letter-spacing="0.5"
+    fill="url(#wzRainbow)"
+  >W&#216;</text>
 </svg>


### PR DESCRIPTION
Closes #946.

Replaces the placeholder favicon that merged in #943 with the canonical **"Rainbow W0 Icon"** design.

## Design source

Implements the design from Claude Design (project `ca218fc4`, linked in #946): a rounded tile carrying the **WØ** wordmark glyph in **Lora italic (700)**, filled with the unaffiliated **diagonal rainbow spectrum**:

`#c1272d → #ea580c → #ca8a04 → #16a34a → #2563eb → #6d28d9 → #a21caf` (red → orange → gold → green → blue → violet → magenta).

The design ships two tiles — a **primary dark tile** (`#1a1209`) and a **light-tile alternate** (`#f7f4ee` with a hairline edge). The favicon uses the dark tile by default and swaps to the light tile under `prefers-color-scheme: dark`, so the self-contained tile always contrasts the browser's tab bar.

## Changes

- **`frontend/public/favicon.svg`** — the Rainbow WØ tile as a single theme-aware SVG (gradient-filled glyph). Pixel-sharp at every favicon size (16–64px) with padding built in. `index.html` already carries the `<link rel="icon">` from #943, so this is a one-file swap.

## Notes

- Font caveat: favicons can't pull in Google-hosted Lora at tab-render time, so the glyph falls back to Georgia italic — the same fallback stack the design itself declares (`'Lora', Georgia, serif`). If an exact Lora render is wanted, the WØ can be converted to vector paths in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mHRqw1goSByRq5xFc4thS

---
_Generated by [Claude Code](https://claude.ai/code/session_012mHRqw1goSByRq5xFc4thS)_