### PR TITLE
Collab: standalone Leave button (C2) + holdout sees cast not unsubmit (C3)

### DIFF
--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -306,7 +306,6 @@ test.describe('collaboration UI (clicked buttons)', () => {
   // only way to leave is via the bank-full drop-to-accept modal, so a member
   // who simply wants out has no button.
   test('C2: a member can leave the collab from a standalone control', async ({ browser }) => {
-    test.fail()
     const seed = await seedCollabDraft(browser, 'ui-leave')
     try {
       const page = await seed.bob.ctx.newPage()
@@ -322,7 +321,6 @@ test.describe('collaboration UI (clicked buttons)', () => {
   // detail page should see a CAST control. Today the page falls through to the
   // owner "unsubmit" control, which 422s because the holdout never submitted.
   test('C3: a holdout on a pending collab is not shown the unsubmit control', async ({ browser }) => {
-    test.fail()
     const seed = await seedCollabDraft(browser, 'ui-holdout')
     try {
       // Alice casts (API) → the collab enters `pending`; Bob is the holdout.

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -148,6 +148,7 @@
       "cancelChallengeAria": "cancel challenge",
       "rescindInviteAria": "rescind invite to {{name}}"
     },
+    "leaveAction": "Leave collab",
     "collab": {
       "castStatus": "{{cast}} of {{total}} cast",
       "pillCast": "cast",
@@ -160,7 +161,6 @@
       "castAction": "Cast my part",
       "castFinalAction": "Cast — send it live",
       "pullBackAction": "Pull my part back",
-      "leaveAction": "Leave collab",
       "successHeading": "The proof is woven",
       "successBody": "Every part is cast — your collab is live.",
       "successContinue": "View the praxis"

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -101,6 +101,7 @@
       "upload": "Could not upload {{name}}.",
       "removeMedia": "Could not remove media item.",
       "invite": "Could not invite {{name}}.",
+      "leave": "Could not leave the collab.",
       "rescindInvite": "Could not rescind the invite.",
       "challenge": "Could not challenge {{name}}.",
       "cancelChallenge": "Could not cancel the challenge.",
@@ -113,7 +114,8 @@
       "leaveDuel": "Switching mode will cancel your duel challenge. Continue?",
       "soloDropsCoauthors": "Switching to solo will remove your co-authors — your draft stays. Continue?",
       "duelDropsCoauthors": "Switching to a duel will remove your co-authors — your draft stays. Continue?",
-      "dropTask": "Drop this task? Your draft will be lost."
+      "dropTask": "Drop this task? Your draft will be lost.",
+      "leaveCollab": "Leave this collab? You'll drop out and the others carry on without you."
     },
     "seal": {
       "pickerTitle": "Seal a metatask onto this praxis",
@@ -158,6 +160,7 @@
       "castAction": "Cast my part",
       "castFinalAction": "Cast — send it live",
       "pullBackAction": "Pull my part back",
+      "leaveAction": "Leave collab",
       "successHeading": "The proof is woven",
       "successBody": "Every part is cast — your collab is live.",
       "successContinue": "View the praxis"

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -266,7 +266,7 @@ export function InviteSearch({
             color: "var(--color-text-tertiary)",
           }}
         >
-          {t("editPraxis.collab.leaveAction")}
+          {t("editPraxis.leaveAction")}
         </button>
       )}
     </div>

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -49,6 +49,16 @@ export function InviteSearch({
   const onPick = duelMode ? state.sendChallenge : state.sendInvite;
   // Cast progress drives the roster + hides "invite another" once weaving starts (#591).
   const castCount = praxis.members.filter((m) => m.has_submitted).length;
+  // A non-creator collab member can drop out from here (#958) — a standalone exit
+  // that doesn't require the bank-full drop-to-accept modal. The creator instead
+  // deletes/drops the whole draft (DropButton), so the leave control is hidden for
+  // them; duel mode has no membership to leave.
+  const isCreator = praxis.created_by_id === state.currentCharacterId;
+  const canLeaveCollab =
+    !duelMode &&
+    praxis.type === "collab" &&
+    !isCreator &&
+    praxis.members.some((member) => member.character_id === state.currentCharacterId);
   return (
     <div>
       <div
@@ -240,6 +250,24 @@ export function InviteSearch({
           </div>
         )}
       </div>
+      )}
+      {canLeaveCollab && (
+        <button
+          type="button"
+          onClick={() => void state.leaveCollab()}
+          className="font-body eyebrow hover:underline"
+          style={{
+            display: "block",
+            marginTop: "var(--space-sm)",
+            background: "none",
+            border: "none",
+            padding: 0,
+            cursor: "pointer",
+            color: "var(--color-text-tertiary)",
+          }}
+        >
+          {t("editPraxis.collab.leaveAction")}
+        </button>
       )}
     </div>
   );

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -114,6 +114,7 @@ function baseState(slug: string | null): EditPraxisState {
     submitting: false,
     publish: async () => {},
     pullBack: async () => {},
+    leaveCollab: async () => {},
     collabSuccess: false,
     continueFromCollabSuccess: () => {},
     duelSealOpen: false,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
@@ -115,6 +115,7 @@ function stateWith(publish: () => Promise<void>): EditPraxisState {
     submitting: false,
     publish,
     pullBack: async () => {},
+    leaveCollab: async () => {},
     collabSuccess: false,
     continueFromCollabSuccess: () => {},
     duelSealOpen: false,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
@@ -123,6 +123,7 @@ function baseState(): EditPraxisState {
     submitting: false,
     publish: async () => {},
     pullBack: async () => {},
+    leaveCollab: async () => {},
     collabSuccess: false,
     continueFromCollabSuccess: () => {},
     duelSealOpen: false,

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -17,6 +17,7 @@ import {
   cancelInvite as cancelInviteApi,
   getPraxis,
   inviteToPraxis,
+  leavePraxis,
   removeMetatask,
   submitPraxis,
   unsubmitPraxis,
@@ -126,6 +127,12 @@ export interface EditPraxisState {
   publish: () => Promise<void>;
   /** Pull my own cast back on a pending collab (#591). */
   pullBack: () => Promise<void>;
+  /**
+   * Leave a collab I was invited into — drop my own membership without the
+   * bank-full drop-to-accept modal (#958). Creator can't leave (they delete/drop
+   * the whole draft via `cancel`); the button is hidden for them.
+   */
+  leaveCollab: () => Promise<void>;
   cancel: () => Promise<void>;
 
   /**
@@ -590,6 +597,27 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     }
   }, [idParam, refetch]);
 
+  // Drop my own membership from a collab I was invited into (#958). Distinct from
+  // `cancel` (creator deletes the whole draft) and `pullBack` (retract my cast but
+  // stay a member): leaving removes me entirely, so I'm sent back to the task list.
+  // Backend `leave_praxis` re-checks membership and can complete consensus for
+  // whoever stays; the gate on the button already hides it from the creator.
+  const leaveCollab = useCallback(async () => {
+    if (!praxis) return;
+    const confirmed = window.confirm(
+      i18n.t("forms:editPraxis.confirm.leaveCollab"),
+    );
+    if (!confirmed) return;
+    try {
+      await leavePraxis(praxis.id);
+      await refetch();
+    } catch (err) {
+      setError(extractError(err, i18n.t("forms:editPraxis.errors.leave")));
+      return;
+    }
+    navigate("/tasks");
+  }, [praxis, navigate, refetch]);
+
   // The success screen's only exit: an explicit "it's on the public board" tap.
   // Deliberately not a timer — the player leaves when they've read it (#591).
   const continueFromCollabSuccess = useCallback(() => {
@@ -1039,6 +1067,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     submitting,
     publish,
     pullBack,
+    leaveCollab,
     cancel,
     collabSuccess,
     continueFromCollabSuccess,

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -335,26 +335,33 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   const viewerSubmittedWaiting =
     isCollab && praxis.status === 'in_progress' && viewerMember?.has_submitted === true
 
+  // A collab goes `pending` once a co-author casts (collab_consensus.on_submit,
+  // ADR-0012). A member who has NOT cast is a holdout: the unsubmit branch below
+  // would 422 for them ("already in editing mode", praxis.py) since they have
+  // nothing of their own to pull back. Show them the CAST control instead —
+  // mirroring the composer footer's gate (deriveCollabGate) — so casting is the
+  // one action offered. A member who HAS cast keeps the unsubmit path (#958).
+  const isPendingHoldout =
+    isCollab && praxis.status === 'pending' && viewerMember?.has_submitted !== true
+
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
         <Link to={`/praxes/${praxis.id}/edit`} className="font-body eyebrow hover:underline" style={{ color: 'var(--color-text-tertiary)' }}>
           {t('detail.owner.edit')}
         </Link>
-        {praxis.status === 'in_progress' ? (
-          viewerSubmittedWaiting ? (
-            <span className="eyebrow" style={{ color: 'var(--color-success)', fontWeight: 700 }}>
-              {t('detail.owner.submittedWaiting')}
-            </span>
-          ) : (
-            <button
-              onClick={handleResubmit}
-              disabled={withdrawing}
-              style={{ background: 'var(--color-success)', color: 'var(--color-text-on-accent)', fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', letterSpacing: '0.08em', padding: 'var(--space-xs) var(--space-md)', border: 'none', cursor: 'pointer', borderRadius: 0, opacity: withdrawing ? 0.5 : 1 }}
-            >
-              {withdrawing ? t('detail.owner.submitting') : t('detail.owner.submit')}
-            </button>
-          )
+        {praxis.status === 'in_progress' && viewerSubmittedWaiting ? (
+          <span className="eyebrow" style={{ color: 'var(--color-success)', fontWeight: 700 }}>
+            {t('detail.owner.submittedWaiting')}
+          </span>
+        ) : praxis.status === 'in_progress' || isPendingHoldout ? (
+          <button
+            onClick={handleResubmit}
+            disabled={withdrawing}
+            style={{ background: 'var(--color-success)', color: 'var(--color-text-on-accent)', fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', letterSpacing: '0.08em', padding: 'var(--space-xs) var(--space-md)', border: 'none', cursor: 'pointer', borderRadius: 0, opacity: withdrawing ? 0.5 : 1 }}
+          >
+            {withdrawing ? t('detail.owner.submitting') : t('detail.owner.submit')}
+          </button>
         ) : forfeitsOnUnsubmit && duel ? (
           /* A forfeit is the one irreversible duel beat, so it gets the same
              dispatched dialog the (reversible) seal confirm got in #718 rather


### PR DESCRIPTION
Closes #958

Part of the collab-e2e epic (#953); flips two of #955's red steps green.

## What changed

### C3 — holdout sees cast, not unsubmit (`pages/praxisDetail/shared.tsx`)
When a collab goes `pending` (a co-author cast, `collab_consensus.on_submit`), a member who has **not** cast previously fell through to the `unsubmit` control, which 422s (`praxis.py`, "already in editing mode") because they have nothing of their own to pull back. `PraxisOwnerActions` now shows a holdout the green **cast** control (mirroring the composer footer's gate). A member who HAS cast keeps the unsubmit/waiting path unchanged.

### C2 — standalone "Leave collab" button (composer)
A non-creator collab member can now leave from a standalone control, wired to the existing `leavePraxis` endpoint (`POST /praxes/{id}/leave`). Previously the only exit was the bank-full drop-to-accept modal (`FeedCardCollabInvite.tsx`), stranding joined members. Added:
- `leaveCollab` handler in `useEditPraxis.ts` (confirm → `leavePraxis` → back to `/tasks`).
- A "Leave collab" button in the shared `InviteSearch` (`archetypes/controls.tsx`) — the one collab host every desktop + mobile archetype renders, so all 16 get it from one place. Hidden for the creator (they delete/drop the whole draft via `cancel`) and in duel mode.
- Locale keys (`forms.json`): `editPraxis.collab.leaveAction`, `editPraxis.confirm.leaveCollab`, `editPraxis.errors.leave`.

### e2e
Removed `test.fail()` from the **C2** and **C3** steps only (`e2e/collaboration.spec.ts`). C1 (#959) and C4 (#960) left as `test.fail()`.

## Footprint note (please eyeball)
The brief scoped ownership to `shared.tsx` + `api/praxis.ts`, but **C2's merged acceptance test navigates to `/praxes/:id/edit`** (the composer, `EditPraxis`), not the detail page — so C2 cannot be satisfied from `shared.tsx`. The issue body itself says "on the composer **and/or** detail page", and the composer files are not on the brief's DO-NOT list (which is `CollabRoster.tsx`, `usePendingRequests.ts`, C1/C4 steps — none touched). I implemented C2 on the composer via the minimal single-injection point. Flagging so it can be vetoed. `leavePraxis` already existed; no `api/praxis.ts` change was needed.

## Verification
- `tsc --noEmit`: clean (only the known `node:fs` stale-junction false alarm, PR #675).
- `eslint` on changed files: clean (no `no-raw-style-values` hits).
- `vite build`: succeeds.
- `vitest` editPraxis + praxisDetail suites: 202 passed (updated 3 mobile mock `EditPraxisState` objects for the new `leaveCollab` field).
- e2e is nightly-only / needs a live stack; **not run here**. Visual QA outstanding (the Browser pane renderer times out — no screenshots).

## What to eyeball
- Detail page as a **holdout** on a `pending` collab (a co-author cast, you didn't): you should see the green **cast/submit** button, not "unsubmit".
- Detail page as a member who **already cast** on a `pending` collab: unchanged (unsubmit/waiting).
- Composer (`/praxes/:id/edit`) as a **joined (non-creator) member** of a collab: a "Leave collab" control appears; the **creator** does not see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)