### PR TITLE
Duel dissolve controls: cancel an active duel (D1) + opponent-cancel pending (D2) (#956)

### DIFF
--- a/frontend/e2e/duel.spec.ts
+++ b/frontend/e2e/duel.spec.ts
@@ -24,7 +24,7 @@ import {
  * Happy path (steps buttons exist for today → GREEN, or expose a real bug):
  *   challenge → accept → both seal → settled rail.
  *
- * Red steps (test.fail() — no control exists yet, flipped green by the fix):
+ * Dissolve steps (were red until #956 added the controls, now GREEN):
  *   D1 (dissolve an active duel)          → #956
  *   D2 (opponent withdraws a pending one) → #956
  * D3 (resolved rail) lives in the isolated duel-zzz-resolved.spec.ts because it
@@ -95,15 +95,13 @@ test.describe('duel lifecycle', () => {
     }
   })
 
-  // D1 (RED — #956): after accept, EITHER participant can neutrally cancel the
-  // ACTIVE duel (→ declined, no forfeit penalty). Backend already allows it
-  // (services/duel.py). Today the only cancel control is the composer chip's ×,
-  // rendered for a PENDING challenge only (controls.tsx) — an active duel has no
-  // dissolve button anywhere. Expected to fail until #956 adds one; that fix
-  // should give the control an accessible name matching the pattern below (or
-  // update this locator) and then delete test.fail().
+  // D1 (#956, GREEN): after accept, EITHER participant can neutrally cancel the
+  // ACTIVE duel (→ declined, no forfeit penalty). Backend already allowed it
+  // (services/duel.py); #956 added the composer-chip "dissolve duel" control
+  // (aria-label "dissolve the duel") reachable while the duel is active. Alice's
+  // in_progress praxis redirects /praxes/{id} → the edit composer, where the chip
+  // (and its dissolve button) live.
   test('D1: an active duel can be neutrally dissolved by a participant', async ({ browser }) => {
-    test.fail()
     const seed = await seedChallenge(browser)
     const { alice, bob, alicePraxisId } = seed
     try {
@@ -125,14 +123,12 @@ test.describe('duel lifecycle', () => {
     }
   })
 
-  // D2 (RED — #956): the OPPONENT can cancel/withdraw a still-PENDING challenge,
-  // not only Decline. Today the opponent's feed card offers Accept + Decline only;
-  // cancel is challenger-only (the composer chip ×). Expected to fail until #956
-  // adds a withdraw control to the opponent's challenge card, then delete
-  // test.fail(). Scoped to the challenge card (the Accept button's action row) so
-  // an unrelated "cancel" elsewhere on /updates can't satisfy it.
+  // D2 (#956, GREEN): the OPPONENT can cancel/withdraw a still-PENDING challenge,
+  // not only Decline. #956 added a "Withdraw" button to the opponent's challenge
+  // card action row (FeedCardDuelChallenge), hitting the same /duels/{id}/cancel
+  // endpoint. Scoped to the challenge card (the Accept button's action row) so an
+  // unrelated "cancel" elsewhere on /updates can't satisfy it.
   test('D2: the opponent can withdraw a pending challenge', async ({ browser }) => {
-    test.fail()
     const seed = await seedChallenge(browser)
     const { alice, bob, alicePraxisId } = seed
     try {

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -8,7 +8,7 @@ import { useMyActiveTasks } from "../../hooks/useMyActiveTasks";
 import { useGameConfig } from "../../hooks/useGameConfig";
 import { useAuth } from "../../auth/AuthContext";
 import { deletePraxis, leavePraxis } from "../../api/praxis";
-import { respondToChallenge } from "../../api/duel";
+import { cancelChallenge, respondToChallenge } from "../../api/duel";
 import { factionColor } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import { extractError } from "../../utils/errors";
@@ -53,6 +53,13 @@ export default function FeedCardDuelChallenge({ item }: Props) {
   // the modal instead, so we need our own channel for drop/retry failures.
   const [dropError, setDropError] = useState("");
   const [busy, setBusy] = useState(false);
+  // Withdraw is the OPPONENT's mirror of the challenger's composer-chip × (#956):
+  // either participant may neutrally call off a still-pending challenge, not only
+  // Decline it. Hits the same /duels/{id}/cancel endpoint. Local terminal state
+  // so the card settles to a "withdrawn" note once acted on.
+  const [withdrawn, setWithdrawn] = useState(false);
+  const [withdrawing, setWithdrawing] = useState(false);
+  const [withdrawError, setWithdrawError] = useState("");
 
   const landOnPraxis = (praxisId: number | null) => {
     // Accepting creates the opponent's fresh praxis server-side — land the
@@ -80,6 +87,22 @@ export default function FeedCardDuelChallenge({ item }: Props) {
   };
 
   const handleDecline = () => decline();
+
+  const handleWithdraw = async () => {
+    if (withdrawing) return;
+    setWithdrawing(true);
+    setWithdrawError("");
+    try {
+      await cancelChallenge(duel_id);
+      setWithdrawn(true);
+    } catch (err) {
+      setWithdrawError(
+        extractError(err, i18n.t("feed:duelChallenge.withdrawError")),
+      );
+    } finally {
+      setWithdrawing(false);
+    }
+  };
 
   // Drop the chosen in-progress praxis to free a slot, then retry the accept.
   //   authored solo  → deletePraxis  (removes the praxis)
@@ -220,8 +243,8 @@ export default function FeedCardDuelChallenge({ item }: Props) {
           <span style={{ fontSize: 12 }}>&#x2694;</span>
         </div>
 
-        {/* Accept/Decline buttons */}
-        {isPending && (
+        {/* Accept / Decline / Withdraw buttons */}
+        {isPending && !withdrawn && (
           <div
             style={{
               marginTop: "var(--space-md)",
@@ -234,7 +257,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
           >
             <button
               onClick={handleAccept}
-              disabled={loading || busy}
+              disabled={loading || busy || withdrawing}
               style={{
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: "var(--text-sm)",
@@ -252,7 +275,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
             </button>
             <button
               onClick={handleDecline}
-              disabled={loading || busy}
+              disabled={loading || busy || withdrawing}
               style={{
                 fontFamily: "'Courier Prime', monospace",
                 fontSize: "var(--text-sm)",
@@ -268,6 +291,26 @@ export default function FeedCardDuelChallenge({ item }: Props) {
             >
               {i18n.t("feed:duelChallenge.decline")}
             </button>
+            {/* Either participant can neutrally call off a pending challenge —
+                the opponent's mirror of the challenger's × (#956). */}
+            <button
+              onClick={handleWithdraw}
+              disabled={loading || busy || withdrawing}
+              style={{
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: "var(--text-sm)",
+                fontWeight: 700,
+                textTransform: "uppercase",
+                letterSpacing: "0.1em",
+                background: "transparent",
+                color: "var(--color-text-tertiary)",
+                border: "1px solid var(--color-border)",
+                padding: "var(--space-xs) var(--space-lg)",
+                cursor: loading || busy || withdrawing ? "not-allowed" : "pointer",
+              }}
+            >
+              {i18n.t("feed:duelChallenge.withdraw")}
+            </button>
             {error && !showDropModal && (
               <span
                 className="eyebrow"
@@ -276,6 +319,25 @@ export default function FeedCardDuelChallenge({ item }: Props) {
                 {error}
               </span>
             )}
+            {withdrawError && (
+              <span
+                className="eyebrow"
+                style={{ color: "var(--color-danger)" }}
+              >
+                {withdrawError}
+              </span>
+            )}
+          </div>
+        )}
+
+        {withdrawn && (
+          <div style={{ marginTop: "var(--space-sm)", marginLeft: "var(--space-3xl)" }}>
+            <span
+              className="eyebrow"
+              style={{ color: "var(--color-text-tertiary)" }}
+            >
+              {i18n.t("feed:duelChallenge.withdrawn")}
+            </span>
           </div>
         )}
 

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -72,6 +72,9 @@
     "taskMeta": "{{points}} pts · winner takes the points",
     "accept": "Accept Duel",
     "decline": "Decline",
+    "withdraw": "Withdraw",
+    "withdrawn": "Withdrawn — the duel was called off",
+    "withdrawError": "Could not withdraw the challenge. Try again.",
     "accepted": "Duel Accepted — view duel",
     "declined": "Declined",
     "bankFull": {

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -113,6 +113,7 @@
       "leaveDuel": "Switching mode will cancel your duel challenge. Continue?",
       "soloDropsCoauthors": "Switching to solo will remove your co-authors — your draft stays. Continue?",
       "duelDropsCoauthors": "Switching to a duel will remove your co-authors — your draft stays. Continue?",
+      "dissolveDuel": "Dissolve this duel? It ends for both of you and each side scores as an ordinary praxis — no forfeit penalty.",
       "dropTask": "Drop this task? Your draft will be lost."
     },
     "seal": {
@@ -144,6 +145,8 @@
       "statusPending": "pending",
       "statusSubmitted": "submitted",
       "cancelChallengeAria": "cancel challenge",
+      "dissolveDuelLabel": "Dissolve duel",
+      "dissolveDuelAria": "dissolve the duel",
       "rescindInviteAria": "rescind invite to {{name}}"
     },
     "collab": {

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -78,8 +78,8 @@ export function InviteSearch({
                     ? t("editPraxis.invite.statusAccepted")
                     : t("editPraxis.invite.statusChallenged")}
                 </em>
-                {/* Only a pending challenge can be withdrawn (backend forbids
-                    cancelling an accepted duel). */}
+                {/* A still-pending challenge is withdrawn with the compact × —
+                    nothing is at stake yet. */}
                 {(state.duel == null || state.duel.status === "pending") && (
                   <button
                     type="button"
@@ -96,6 +96,30 @@ export function InviteSearch({
                     }}
                   >
                     ×
+                  </button>
+                )}
+                {/* Once accepted, either participant can still dissolve the duel
+                    neutrally (#956) — the backend recalculates both sides back to
+                    solo scoring, no forfeit. It's a heavier action than the ×, so
+                    it's a labelled button behind a confirm (state.dissolveDuel). */}
+                {state.duel?.status === "active" && (
+                  <button
+                    type="button"
+                    onClick={() => void state.dissolveDuel()}
+                    aria-label={t("editPraxis.invite.dissolveDuelAria")}
+                    style={{
+                      background: "transparent",
+                      border: "1px solid currentColor",
+                      color: "inherit",
+                      cursor: "pointer",
+                      fontFamily: skin.fontFamily,
+                      fontSize: "var(--text-sm)",
+                      lineHeight: 1,
+                      padding: "var(--space-xs) var(--space-sm)",
+                      marginLeft: "var(--space-xs)",
+                    }}
+                  >
+                    {t("editPraxis.invite.dissolveDuelLabel")}
                   </button>
                 )}
               </span>

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -98,6 +98,7 @@ function baseState(slug: string | null): EditPraxisState {
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},
+    dissolveDuel: async () => {},
     metaTasks: [],
     appliedMetatasks: new Set(),
     applyingMetatask: null,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
@@ -99,6 +99,7 @@ function stateWith(publish: () => Promise<void>): EditPraxisState {
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},
+    dissolveDuel: async () => {},
     metaTasks: [],
     appliedMetatasks: new Set(),
     applyingMetatask: null,

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
@@ -107,6 +107,7 @@ function baseState(): EditPraxisState {
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},
+    dissolveDuel: async () => {},
     metaTasks: [],
     appliedMetatasks: new Set(),
     applyingMetatask: null,

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -96,7 +96,15 @@ export interface EditPraxisState {
   // the praxis stays type='solo' and gains a duel_id.
   duel: DuelDetailOut | null;
   sendChallenge: (character: CharacterOut) => Promise<void>;
+  /** Withdraw a still-pending challenge (challenger's composer chip ×). */
   cancelDuel: () => Promise<void>;
+  /**
+   * Dissolve an already-accepted (active) duel (#956). Either participant may do
+   * it; the backend recalculates both sides back to plain-solo scoring with no
+   * forfeit penalty. Asks first (it ends the duel for both) — otherwise the same
+   * neutral cancel as `cancelDuel`.
+   */
+  dissolveDuel: () => Promise<void>;
 
   // Metatasks (seal stack + Section-D picker + Section-E remove, #933)
   metaTasks: TaskOut[];
@@ -661,9 +669,11 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
         return;
       }
 
-      // Only a *pending* challenge can be cancelled (the backend forbids
-      // unilaterally cancelling an accepted duel). Once the opponent has
-      // accepted, the challenger can't switch away.
+      // Mode-switching away from an ACCEPTED duel is blocked here: an active duel
+      // is dissolved through the dedicated "dissolve duel" control (#956), which
+      // asks first, rather than silently as a side effect of picking solo/collab.
+      // (The backend permits cancelling an active duel — services/duel.py — so
+      // this guard is a UI choice, not a backend limitation.)
       if (inDuel && duel && duel.status !== "pending") {
         setError(i18n.t("forms:editPraxis.errors.duelUnderway"));
         return;
@@ -849,6 +859,14 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     }
   }, [praxis]);
 
+  // Dissolve an *active* duel (#956). Same neutral cancel as `cancelDuel`, but
+  // gated behind a confirm because it ends an accepted duel for both sides.
+  const dissolveDuel = useCallback(async () => {
+    if (!praxis?.duel_id) return;
+    if (!window.confirm(i18n.t("forms:editPraxis.confirm.dissolveDuel"))) return;
+    await cancelDuel();
+  }, [praxis?.duel_id, cancelDuel]);
+
   // ---- Metatasks (#933) ----
   // Legacy toggle (apply when absent, remove when present) kept on the state
   // shape; the new compose flow adds through the picker and removes through the
@@ -1019,6 +1037,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     duel,
     sendChallenge,
     cancelDuel,
+    dissolveDuel,
 
     metaTasks,
     appliedMetatasks,


### PR DESCRIPTION
Closes #956

Part of #953. Adds the two missing duel-dissolve controls and flips #954's D1/D2 `test.fail()` steps green.

## D1 — dissolve an active duel
Backend already lets **either participant** neutrally cancel a `pending` **or** `active` duel (`POST /duels/{id}/cancel` → `services/duel.py`), recalculating both sides back to plain-solo scoring with no forfeit penalty. Until now the only cancel control was the composer opponent-chip `×`, gated to `pending`, so after accept the only exit was a *penalizing* forfeit-by-unsubmit.

- Added a **"Dissolve duel"** button to the composer opponent chip (`controls.tsx`), shown while `duel.status === 'active'`.
- Wired to a new `dissolveDuel()` handler in `useEditPraxis` — a `window.confirm`-gated wrapper around the existing neutral `cancelChallenge` (matching the `cancel()`/`changeMode()` confirm precedent). A fully-skinned dispatched dialog (like `DuelSealConfirm`) was considered but deferred to keep the footprint tight; the seal/forfeit dialog carries stakes tiles + roster that a neutral no-penalty dissolve doesn't need.
- Repaired the stale "backend forbids cancelling an accepted duel" comments in `controls.tsx` and `useEditPraxis` (`changeMode`).

## D2 — opponent can withdraw a pending challenge
The pending-cancel `×` lived only on the challenger's composer chip; the opponent could only **Decline** from the feed card. Added a **"Withdraw"** button to the opponent's challenge card action row (`FeedCardDuelChallenge.tsx` — where the existing Decline path lives), hitting the same `cancelChallenge` endpoint and settling the card to a "withdrawn" note.

## Files
- `frontend/src/pages/editPraxis/useEditPraxis.ts` — `dissolveDuel()` + interface field; repaired comment.
- `frontend/src/pages/editPraxis/archetypes/controls.tsx` — active-duel dissolve button; repaired comment.
- `frontend/src/components/feed/FeedCardDuelChallenge.tsx` — opponent Withdraw button + state. (Beyond the literally-listed footprint, but this is the opponent's decline-path location the issue says to mirror and where the D2 test asserts.)
- `frontend/src/locales/en/forms.json`, `feed.json` — new copy keys.
- `frontend/e2e/duel.spec.ts` — removed D1/D2 `test.fail()` markers; refreshed stale header. **D3 (`duel-zzz-resolved.spec.ts`, #957) untouched.**
- Three mobile-archetype dispatch test mocks — added `dissolveDuel` to satisfy the widened `EditPraxisState`.

`api/duel.ts` intentionally unchanged (`cancelChallenge` already existed) to ease #957's rebase.

## Verification
- `tsc --noEmit` clean (baseline `node:*` false-alarm errors in test files unchanged — PR #675).
- `eslint` clean on all changed files (no raw hex/font-size/spacing).
- `vite build` succeeds.
- vitest: affected mobile-dispatch suites + i18n catalog test pass (52 tests).
- **e2e is nightly-only** and outside the linted/typechecked `src` scope, so PR CI does not run the spec. No local dev stack + Browser pane can't screenshot, so visual QA is outstanding.

## What to eyeball
- **As the opponent, on `/updates`:** a pending duel challenge card shows Accept / Decline / **Withdraw**; Withdraw calls off the duel and the card settles to "Withdrawn".
- **As the challenger, in the composer:** a still-pending challenge still withdraws via the compact chip `×`.
- **As either participant, in the composer after accept (active duel):** a **"Dissolve duel"** button appears on the opponent chip; clicking asks for confirmation, then ends the duel for both with no forfeit penalty.