### PR TITLE
Collab: kick control on the roster (C1, #959)

### DIFF
--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -286,7 +286,6 @@ test.describe('collaboration UI (clicked buttons)', () => {
   // CollabRoster renders member pills but ships NO kick affordance, so
   // POST /praxes/{id}/kick/{member_id} is unreachable from the UI.
   test('C1: a member can kick a co-author from the roster pill', async ({ browser }) => {
-    test.fail()
     const seed = await seedCollabDraft(browser, 'ui-kick')
     try {
       const page = await seed.alice.ctx.newPage()

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -310,6 +310,20 @@ export async function cancelInvite(
   await api.delete(`/praxes/${praxisId}/invite/${inviteId}`)
 }
 
+/**
+ * Remove another member from a collab (#959). Any member may kick any other, but
+ * not themselves (that is `leavePraxis`) — mirrors the backend `kick_member`
+ * guard. `memberId` is the target's CHARACTER id. A kick resets the whole group
+ * back to editing (ADR-0013), so the returned praxis reflects the reset state.
+ */
+export async function kickMember(
+  praxisId: number,
+  memberId: number,
+): Promise<PraxisOut> {
+  const { data } = await api.post<PraxisOut>(`/praxes/${praxisId}/kick/${memberId}`)
+  return data
+}
+
 // ---------------------------------------------------------------------------
 // Metatasks — metatasks are Task rows with task_type='metatask' attached
 // to a praxis via POST /praxes/{id}/metatasks.

--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -19,6 +19,7 @@
  * speaks the same states in its own voice and anything it hasn't overridden
  * falls back to the shared `editPraxis.collab.*` block (#591).
  */
+import { useTranslation } from 'react-i18next'
 import type { PraxisMemberOut } from '../../api/praxis'
 import { factionCssVar } from '../../utils/factions'
 import { collabCopy } from './collabCopy'
@@ -54,17 +55,42 @@ export function CollabRoster({
   currentCharacterId,
   factionSlug,
   taskPointValue,
+  onKick,
 }: {
   members: readonly PraxisMemberOut[]
   currentCharacterId: number | null | undefined
   factionSlug: string | null | undefined
   taskPointValue?: number | null
+  /**
+   * Remove another member (#959). Receives the target's CHARACTER id. When
+   * provided, a kick × renders on every OTHER member's pill — but only if the
+   * viewer is themselves a member, mirroring the backend `kick_member` guard
+   * ("any member may kick any other, not self"). The confirm step lives here so
+   * both the composer and the read-only detail block get it for free; the
+   * callback only has to run the API call + refresh.
+   */
+  onKick?: (memberId: number) => void | Promise<void>
 }) {
+  const { t } = useTranslation('forms')
   const gate = deriveCollabGate(members, currentCharacterId)
   if (gate.memberCount < 2) return null // solo/duel render nothing
 
   const accent = factionCssVar(factionSlug, 'card-accent')
   const pct = Math.round((gate.castCount / gate.memberCount) * 100)
+
+  // Mirror the backend: only a member may kick, and never themselves.
+  const viewerIsMember = members.some((m) => m.character_id === currentCharacterId)
+  const canKick = onKick != null && viewerIsMember
+
+  const handleKick = (member: PraxisMemberOut) => {
+    if (!onKick) return
+    // A kick resets everyone's cast (ADR-0013), so confirm before firing.
+    const ok = window.confirm(
+      t('editPraxis.confirm.kickMember', { name: member.character_display_name }),
+    )
+    if (!ok) return
+    void onKick(member.character_id)
+  }
 
   const banner =
     gate.state === 'waiting'
@@ -123,6 +149,29 @@ export function CollabRoster({
               <span className="eyebrow text-[9px]" style={{ color: cast ? accent : 'var(--color-warning)' }}>
                 {cast ? `✓ ${collabCopy(factionSlug, 'pillCast')}` : collabCopy(factionSlug, 'pillWeaving')}
               </span>
+              {/* Kick × — on every OTHER member's pill (never my own), gated to
+                  members (#959). The glyph is an ornament; the button's name is
+                  the aria-label so screen readers and the e2e locator resolve it. */}
+              {canKick && !isMe && (
+                <button
+                  type="button"
+                  onClick={() => handleKick(member)}
+                  aria-label={t('editPraxis.invite.kickMemberAria', {
+                    name: member.character_display_name,
+                  })}
+                  style={{
+                    background: 'transparent',
+                    border: 'none',
+                    color: 'var(--color-text-tertiary)',
+                    cursor: 'pointer',
+                    fontSize: 'var(--text-md)',
+                    lineHeight: 1,
+                    padding: 0,
+                  }}
+                >
+                  ×
+                </button>
+              )}
             </div>
           )
         })}

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -103,6 +103,7 @@
       "invite": "Could not invite {{name}}.",
       "leave": "Could not leave the collab.",
       "rescindInvite": "Could not rescind the invite.",
+      "kick": "Could not remove {{name}} from the collab.",
       "challenge": "Could not challenge {{name}}.",
       "cancelChallenge": "Could not cancel the challenge.",
       "updateMetatask": "Could not update metatask.",
@@ -115,7 +116,8 @@
       "soloDropsCoauthors": "Switching to solo will remove your co-authors — your draft stays. Continue?",
       "duelDropsCoauthors": "Switching to a duel will remove your co-authors — your draft stays. Continue?",
       "dropTask": "Drop this task? Your draft will be lost.",
-      "leaveCollab": "Leave this collab? You'll drop out and the others carry on without you."
+      "leaveCollab": "Leave this collab? You'll drop out and the others carry on without you.",
+      "kickMember": "Remove {{name}} from this collab? It clears everyone's cast and sends the group back to editing."
     },
     "seal": {
       "pickerTitle": "Seal a metatask onto this praxis",
@@ -146,7 +148,8 @@
       "statusPending": "pending",
       "statusSubmitted": "submitted",
       "cancelChallengeAria": "cancel challenge",
-      "rescindInviteAria": "rescind invite to {{name}}"
+      "rescindInviteAria": "rescind invite to {{name}}",
+      "kickMemberAria": "kick {{name}} from the collab"
     },
     "leaveAction": "Leave collab",
     "collab": {

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -118,6 +118,7 @@ export function InviteSearch({
                   currentCharacterId={state.currentCharacterId}
                   factionSlug={praxis.task_faction_slug}
                   taskPointValue={praxis.task_point_value}
+                  onKick={state.kickMember}
                 />
               </div>,
               ...praxis.invites

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -95,6 +95,7 @@ function baseState(slug: string | null): EditPraxisState {
     inviting: false,
     sendInvite: async () => {},
     cancelInvite: async () => {},
+    kickMember: async () => {},
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
@@ -96,6 +96,7 @@ function stateWith(publish: () => Promise<void>): EditPraxisState {
     inviting: false,
     sendInvite: async () => {},
     cancelInvite: async () => {},
+    kickMember: async () => {},
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
@@ -104,6 +104,7 @@ function baseState(): EditPraxisState {
     inviting: false,
     sendInvite: async () => {},
     cancelInvite: async () => {},
+    kickMember: async () => {},
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -17,6 +17,7 @@ import {
   cancelInvite as cancelInviteApi,
   getPraxis,
   inviteToPraxis,
+  kickMember as kickMemberApi,
   leavePraxis,
   removeMetatask,
   submitPraxis,
@@ -92,6 +93,8 @@ export interface EditPraxisState {
   inviting: boolean;
   sendInvite: (character: CharacterOut) => Promise<void>;
   cancelInvite: (inviteId: number) => Promise<void>;
+  /** Remove another member from the collab (#959) — target is a character id. */
+  kickMember: (memberId: number) => Promise<void>;
 
   // Duel challenge (#311) — selecting duel attaches a challenge to this praxis;
   // the praxis stays type='solo' and gains a duel_id.
@@ -828,6 +831,34 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     [praxis],
   );
 
+  // Remove another member from the collab (#959). Any member may kick any other
+  // (mirrors the backend guard); the confirm step lives in CollabRoster, so this
+  // just fires the call and reloads — the kick resets the group to editing, so
+  // the refreshed praxis carries the reset roster + cast state (ADR-0013).
+  const kickMember = useCallback(
+    async (memberId: number) => {
+      if (!praxis) return;
+      setError("");
+      try {
+        const updated = await kickMemberApi(praxis.id, memberId);
+        setPraxis(updated);
+      } catch (err) {
+        const kicked = praxis.members.find(
+          (member) => member.character_id === memberId,
+        );
+        setError(
+          extractError(
+            err,
+            i18n.t("forms:editPraxis.errors.kick", {
+              name: kicked?.character_display_name ?? "",
+            }),
+          ),
+        );
+      }
+    },
+    [praxis],
+  );
+
   // ---- Duel challenge (#311): pick an opponent, cancel a pending challenge ----
   const sendChallenge = useCallback(
     async (character: CharacterOut) => {
@@ -1043,6 +1074,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     inviting,
     sendInvite,
     cancelInvite,
+    kickMember,
 
     duel,
     sendChallenge,

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -112,6 +112,7 @@ function state(): PraxisDetailState {
     handleWithdraw: async () => {},
     handleResubmit: async () => {},
     handleFlag: async () => {},
+    handleKickMember: async () => {},
     metatasks: [],
     metataskLoading: false,
     metataskError: null,

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -163,6 +163,7 @@ function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
     handleWithdraw: async () => {},
     handleResubmit: async () => {},
     handleFlag: async () => {},
+    handleKickMember: async () => {},
     metatasks: [],
     metataskLoading: false,
     metataskError: null,

--- a/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -97,6 +97,7 @@ function state(): PraxisDetailState {
     handleWithdraw: async () => {},
     handleResubmit: async () => {},
     handleFlag: async () => {},
+    handleKickMember: async () => {},
     metatasks: [],
     metataskLoading: false,
     metataskError: null,

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -208,7 +208,7 @@ export function PraxisAdminBar({ state }: { state: PraxisDetailState }) {
  * self-hides on a solo/duel praxis (<2 members).
  */
 export function CollabRosterBlock({ state }: { state: PraxisDetailState }) {
-  const { praxis, user } = state
+  const { praxis, user, handleKickMember } = state
   if (!praxis) return null
   if (praxis.status !== 'in_progress' && praxis.status !== 'pending') return null
   return (
@@ -218,6 +218,9 @@ export function CollabRosterBlock({ state }: { state: PraxisDetailState }) {
         currentCharacterId={user?.character?.id ?? null}
         factionSlug={praxis.task_faction_slug}
         taskPointValue={praxis.task_point_value}
+        // Any member may kick another from the roster (#959). CollabRoster gates
+        // the control to members and hides it on the viewer's own pill.
+        onKick={handleKickMember}
       />
     </div>
   )

--- a/frontend/src/pages/praxisDetail/usePraxisDetail.ts
+++ b/frontend/src/pages/praxisDetail/usePraxisDetail.ts
@@ -18,6 +18,7 @@ import {
   flagPraxis,
   applyMetatask,
   removeMetatask,
+  kickMember,
   type PraxisOut,
 } from "../../api/praxis";
 import { getVotes, getVoters, type VoteSummary, type VoterDetail } from "../../api/votes";
@@ -83,6 +84,8 @@ export interface PraxisDetailState {
   handleWithdraw: () => Promise<void>;
   handleResubmit: () => Promise<void>;
   handleFlag: () => Promise<void>;
+  /** Remove another member from the collab (#959) — target is a character id. */
+  handleKickMember: (memberId: number) => Promise<void>;
 
   // Metatasks
   metatasks: TaskOut[];
@@ -263,6 +266,22 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
     }
   };
 
+  // Kick another member from the roster (#959). Any member may kick any other
+  // (mirrors the backend guard); the confirm step lives in CollabRoster. A kick
+  // resets the group to editing (ADR-0013), so the response carries the fresh
+  // roster/cast state. On failure we re-sync from the server so the roster can't
+  // drift out of step with the backend.
+  const handleKickMember = async (memberId: number) => {
+    if (!praxis) return;
+    try {
+      const updated = await kickMember(praxis.id, memberId);
+      setPraxis(updated);
+    } catch {
+      const resynced = await getPraxis(praxis.id).catch(() => null);
+      if (resynced) setPraxis(resynced);
+    }
+  };
+
   const handleFlag = async () => {
     if (!praxis) return;
     if (flagReason === null) {
@@ -361,5 +380,6 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
     handleWithdraw,
     handleResubmit,
     handleFlag,
+    handleKickMember,
   };
 }


### PR DESCRIPTION
Surfaces the already-built-but-unreachable `POST /praxes/{id}/kick/{member_id}` endpoint with a real UI control.

## What changed
- `api/praxis.ts` — new `kickMember(praxisId, memberId)` (memberId is the target CHARACTER id).
- `components/collab/CollabRoster.tsx` — optional `onKick` prop renders a kick `×` on every OTHER member's pill (never the viewer's own). Gated to members, mirroring the backend guard ("any member may kick any other, not self" — no creator-only restriction). A `window.confirm` lives in the component (it resets everyone's cast, ADR-0013), matching the existing `leaveCollab` confirm pattern.
- Composer: `useEditPraxis.kickMember` + `controls.tsx` pass `onKick`.
- Detail: `usePraxisDetail.handleKickMember` + `shared.tsx` `CollabRosterBlock` pass `onKick`.
- `locales/en/forms.json` — kick confirm / aria-label / error copy. Kept OUT of the voiced `editPraxis.collab` block (added to `confirm`/`invite`/`errors`), so `collabCopy.test.ts` catalog-completeness is untouched.
- `e2e/collaboration.spec.ts` — removed `test.fail()` from the C1 step (`#959`). C4 (`#960`) left failing; C2/C3 untouched.
- Test fixtures constructing `EditPraxisState` / `PraxisDetailState` updated for the two new required fields.

## Verification
- `tsc --noEmit`: clean of this change. The only residual errors are the known `node:fs`/`node:url` stale-junction false alarm (PR #675) and its `TS7006` cascade in two untouched files — both vanish under a real `npm ci` (CI).
- `vitest run`: 1491/1491 pass (100 files).
- `eslint` on changed files: clean (no raw hex/font-size/spacing; kick × uses `var(--text-md)` + tokens).
- `vite build`: succeeds.
- e2e is nightly-only and outside `src`, so PR CI won't exercise the C1 flip.

## Visual QA outstanding
Cannot screenshot in this environment (Browser pane renderer times out) and there's no dev stack, so the rendered control was verified via tests/tsc/eslint/build only.

## What to eyeball
- Composer (`/praxes/{id}/edit`) roster: as a member, each OTHER member's pill shows a kick `×`; your own pill has none. Clicking it prompts a confirm, then removes that member and the group returns to `in_progress` with casts cleared.
- Detail page (`/praxes/{id}`) `CollabRosterBlock` (shown while `in_progress`/`pending`): same kick `×` on other members' pills for a member viewer; a non-member viewer sees none.
- Confirm the kicked member drops from the roster and everyone's cast resets.

Closes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)