### PR TITLE
Collab: surface all pending invites, not just 5 (C4, #960)

### DIFF
--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -340,7 +340,6 @@ test.describe('collaboration UI (clicked buttons)', () => {
   // accept-reachable. The requests inbox (usePendingRequests) caps its fetch at
   // 5, so the sixth-oldest invite silently falls off with no other surface.
   test('C4: the oldest of six pending invites is still reachable', async ({ browser }) => {
-    test.fail()
     const s = pairSeq++
     const inviter = await login(browser, `ci-${RUN}-${s}`, `CI${s}-${RUN}`, 8)
     const bob = await login(browser, `cb-${RUN}-${s}`, `CB${s}-${RUN}`, 0)

--- a/frontend/src/hooks/usePendingRequests.ts
+++ b/frontend/src/hooks/usePendingRequests.ts
@@ -19,7 +19,9 @@ export function usePendingRequests() {
       return
     }
     setLoading(true)
-    getActivityFeed({ filter: 'requests', limit: 5 })
+    // Surface all pending invites/challenges — a "requests" feed is inherently
+    // small (unresolved invites only), so pull the backend's max page (#960).
+    getActivityFeed({ filter: 'requests', limit: 100 })
       .then((response) => setPendingRequests(response.items))
       .catch(() => {})
       .finally(() => setLoading(false))


### PR DESCRIPTION
## What

`usePendingRequests` capped its `requests` activity-feed fetch at `limit: 5`, so with more than 5 pending collab invites / duel challenges the older ones fell off the sidebar inbox with no other surface to accept/decline from — the "invited but can't accept" edge from #953.

Per the grill decision (no new inbox surface), this raises the cap to the backend's page maximum (`le=100` on `/activity-feed`). A `requests` feed is inherently small — it holds only unresolved invites/challenges, not the full activity stream — so 100 reaches every pending request in practice.

Also flips the **C4** e2e step in `collaboration.spec.ts` green (drops its `test.fail()`). C1/C2/C3 were already un-failed by merged fixes; untouched here. The unrelated "credits both collaborators" known-gap `test.fail()` is untouched.

## Files
- `frontend/src/hooks/usePendingRequests.ts` — `limit: 5` → `limit: 100` (+ comment naming the ceiling).
- `frontend/e2e/collaboration.spec.ts` — remove `test.fail()` from the C4 step.

## Verification
- `tsc --noEmit`: clean for touched files (only the known `node:*` stale-junction false alarm from PR #675 in unrelated test files).
- vitest: hook consumers (`MobileLayout.test.tsx`, `fieldDeskDispatch.test.tsx`) — 7/7 pass.
- e2e is nightly-only and lives outside `src`, so PR CI won't exercise the C4 spec edit.
- Visual QA outstanding: no dev stack / Browser pane available in this environment.

## What to eyeball
- Create more than 5 pending collab invites (and/or duel challenges) to a single account.
- Confirm the oldest ones still appear in the sidebar requests inbox and remain acceptable/declinable.

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)