### PR TITLE
fix: stop Default Task Detail leaking Ephemerists teal onto na links

### DIFF
--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -69,7 +69,7 @@ export default function DefaultTaskDetail({
       >
         <Link
           to="/tasks"
-          style={{ color: "var(--faction-ephemerists)", textDecoration: "none" }}
+          style={{ color: "var(--color-text-secondary)", textDecoration: "none" }}
         >
           {t("default.breadcrumb")}
         </Link>
@@ -493,7 +493,7 @@ export default function DefaultTaskDetail({
                         fontWeight: 700,
                         textTransform: "uppercase",
                         letterSpacing: "0.1em",
-                        color: "var(--faction-ephemerists)",
+                        color: "var(--faction-default-card-accent)",
                         textDecoration: "none",
                       }}
                     >

--- a/frontend/src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx
@@ -53,7 +53,7 @@ export default function DefaultTaskDetail({ state }: { state: TaskDetailState })
         className="font-body mb-3"
         style={{ fontSize: "var(--text-base)", letterSpacing: "0.08em", color: "var(--color-text-tertiary)" }}
       >
-        <Link to="/tasks" style={{ color: "var(--faction-ephemerists)", textDecoration: "none" }}>
+        <Link to="/tasks" style={{ color: "var(--color-text-secondary)", textDecoration: "none" }}>
           {t("default.breadcrumb")}
         </Link>
         {" › "}
@@ -144,7 +144,7 @@ export default function DefaultTaskDetail({ state }: { state: TaskDetailState })
               <div style={{ textAlign: "center", marginTop: "var(--space-lg)" }}>
                 <Link
                   to={`/praxes?task_id=${task.id}`}
-                  style={{ fontFamily: "'Courier Prime', monospace", fontSize: "var(--text-md)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em", color: "var(--faction-ephemerists)", textDecoration: "none" }}
+                  style={{ fontFamily: "'Courier Prime', monospace", fontSize: "var(--text-md)", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.1em", color: "var(--faction-default-card-accent)", textDecoration: "none" }}
                 >
                   {t("default.viewAll", { count: submissions.length })}
                 </Link>


### PR DESCRIPTION
Closes #971

## What changed
`DefaultTaskDetail` (the `default`/`na` task-detail archetype) hardcoded `var(--faction-ephemerists)` (teal) on four links, so an unaffiliated task page rendered another faction's colour instead of the neutral na kit (ADR-0039 — same bug family as the old na→ua orange bug).

Fixed 4 instances across desktop + mobile:
- `frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx` — breadcrumb link (L72) → `--color-text-secondary`; "view all" CTA link (L496) → `--faction-default-card-accent`
- `frontend/src/pages/taskDetail/mobileArchetypes/DefaultTaskDetail.tsx` — breadcrumb link (L56) → `--color-text-secondary`; "view all" CTA link (L147) → `--faction-default-card-accent`

Token choices mirror the identical breadcrumb/accent-link pattern already used in `DefaultPraxisDetail.tsx` for the same na kit.

## Test plan
- `npx vitest run src/pages/taskDetail` — 4 files, 75 tests passed
- `npx vitest run` (full frontend suite) — 100 files, 1494 tests passed
- `npx tsc --noEmit` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9nQxuPw98PW8QTBi9waka)_