### PR TITLE
Every praxis type earns metatask points (#882)

### DIFF
--- a/backend/services/praxis_scoring.py
+++ b/backend/services/praxis_scoring.py
@@ -129,14 +129,17 @@ async def compute_contributions(
     if opponent_praxis_ids:
         opp_tallies = await tally_votes(list(opponent_praxis_ids), session)
 
-    # ── meta task points for non-duel solo praxes ───────────────────────────
-    # Collab and duel praxes get 0 metatask points (preserving current behaviour).
-    solo_non_duel_ids = [
-        p.id for p in praxes
-        if p.type == PraxisType.solo and p.id not in duel_by_own_praxis
-    ]
+    # ── meta task points for EVERY praxis (ADR-0051) ─────────────────────────
+    # All praxis types earn metatask points. The bonus rides both multipliers
+    # inside compute_praxis_score's (base + meta) × faction × duel + votes, so a
+    # collab keeps its metatask and a duel side's metatask is multiplied by the
+    # duel outcome — a Snide loss at ×0.0 zeroes the metatask along with the
+    # base, which is intended (the metatask is part of what the duel judged).
+    # This reads the same PraxisMetaTask rows as applied_metatasks_for (the seal
+    # set): the level gate here can zero the points while the seal stays
+    # attached, so metatask_points == 0 beside a non-null seal is legitimate.
     meta_points = await get_meta_task_points_bulk(
-        solo_non_duel_ids, character_level=character_level, session=session
+        praxis_ids, character_level=character_level, session=session
     )
 
     # ── assemble contributions ───────────────────────────────────────────────
@@ -151,7 +154,7 @@ async def compute_contributions(
         task_faction = task.primary_faction_slug or "na"
         own_tally = get_tally(tallies, praxis.id)
         base_points = task.point_value
-        metatask_points = 0
+        metatask_points = meta_points.get(praxis.id, 0)
 
         if praxis.type == PraxisType.collab:
             faction_multiplier = compute_faction_multiplier(
@@ -222,7 +225,6 @@ async def compute_contributions(
                 collaboration_mode=COLLABORATION_MODE_SOLO,
             )
             duel_multiplier = 1.0
-            metatask_points = meta_points.get(praxis.id, 0)
 
         total = compute_praxis_score(
             base_points,

--- a/backend/tests/integration/test_praxis_card_breakdown.py
+++ b/backend/tests/integration/test_praxis_card_breakdown.py
@@ -223,18 +223,20 @@ async def _make_metatask(
     *,
     issuing_faction_slug: str,
     points: int,
+    level_required: int = 0,
 ) -> Task:
     """A Task with ``task_type == metatask``, issued by ``issuing_faction_slug``.
 
     The card's seal dispatches on ``metatask_faction_slug``, so the metatask's
     issuing faction is what the frontend reads — independent of the host card's
-    faction (a WOW card can carry a Snide seal).
+    faction (a WOW card can carry a Snide seal). ``level_required`` gates the
+    metatask's points: an author below it earns 0 while the seal stays attached.
     """
     task = Task(
         title=f"{issuing_faction_slug} metatask",
         description="metatask",
         point_value=points,
-        level_required=0,
+        level_required=level_required,
         status=TaskStatus.active,
         task_type=TaskType.metatask,
         created_by=creator.id,
@@ -594,3 +596,151 @@ async def test_applied_metatasks_for_batches_the_page_in_one_map(
     assert [row.id for row in result[sealed.id]] == [metatask.id]
     # A card builder given this map falls back to [] for the bare praxis.
     assert result.get(bare.id, []) == []
+
+
+# ---------------------------------------------------------------------------
+# every praxis type earns metatask points (#882 / ADR-0051)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_collab_earns_metatask_points(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """A collab praxis carrying a metatask now scores the bonus (#882).
+
+    Before #882 the scoring pass filtered metatask points to solo-non-duel ids,
+    so a sealed collab read ``metatask_points: 0``. The bonus now rides the
+    (base + meta) × faction + votes formula like any other praxis.
+    """
+    author = await _make_character(
+        db_session, era, faction_slug="ua", username="collabmeta", email="cm@x.com"
+    )
+    member = await _make_character(
+        db_session, era, faction_slug="ua", username="collabmetamem", email="cmm@x.com"
+    )
+    task = await _make_task(db_session, author, faction_slug="ua", points=10)
+    praxis = await _make_collab(db_session, task, author, member)
+    metatask = await _make_metatask(
+        db_session, author, issuing_faction_slug="ua", points=5
+    )
+    await _apply_metatask(db_session, praxis, metatask)
+
+    card = await _load_card(db_session, praxis.id)
+
+    assert card.metatask_points == 5
+    # (10 + 5) × 1.0 + 0 = 15.0 — was 10.0 (meta filtered out) before #882.
+    assert card.score == pytest.approx(15.0)
+    assert_invariant(card)
+
+
+@pytest.mark.asyncio
+async def test_duel_side_earns_metatask_points(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """A duel-side praxis carrying a metatask scores the bonus, times the outcome.
+
+    The metatask rides both multipliers: the winning UA side's ×1.5 duel
+    modifier multiplies (base + meta). Before #882 duel sides were filtered out
+    of the metatask pass and read ``metatask_points: 0``.
+    """
+    challenger = await _make_character(
+        db_session, era, faction_slug="ua", username="dmetawin", email="dmw@x.com"
+    )
+    opponent = await _make_character(
+        db_session, era, faction_slug="ua", username="dmetaopp", email="dmo@x.com"
+    )
+    voter = await _make_character(
+        db_session, era, faction_slug="ua", username="dmetavoter", email="dmv@x.com"
+    )
+    task = await _make_task(db_session, challenger, faction_slug="ua", points=10)
+    challenger_praxis = await _make_solo(db_session, task, challenger)
+    opponent_praxis = await _make_solo(db_session, task, opponent)
+    metatask = await _make_metatask(
+        db_session, challenger, issuing_faction_slug="ua", points=5
+    )
+    await _apply_metatask(db_session, challenger_praxis, metatask)
+
+    # Challenger wins (5 > 2).
+    await _cast_vote(db_session, challenger_praxis, voter, 5)
+    await _cast_vote(db_session, opponent_praxis, voter, 2)
+    await _make_duel(db_session, task, challenger_praxis, opponent, opponent_praxis)
+
+    winner_card = await _load_card(db_session, challenger_praxis.id)
+
+    assert winner_card.metatask_points == 5
+    assert winner_card.display_multiplier == pytest.approx(1.5)
+    # (10 + 5) × 1.5 + 5 = 27.5.
+    assert winner_card.score == pytest.approx(27.5)
+    assert_invariant(winner_card)
+
+
+@pytest.mark.asyncio
+async def test_snide_duel_loss_zeroes_the_metatask(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """A losing Snide side's ×0.0 wipes the metatask along with the base (#882).
+
+    The metatask is part of the submission the duel judged, so the loss forfeits
+    it. Votes still survive the wipeout. ``metatask_points`` still reports the
+    level-met bonus (5); the ×0.0 multiplier zeroes it inside the score.
+    """
+    await _ensure_faction(db_session, "snide")
+    challenger = await _make_character(
+        db_session, era, faction_slug="ua", username="smetawin", email="smw@x.com"
+    )
+    loser = await _make_character(
+        db_session, era, faction_slug="snide", username="smetalose", email="sml@x.com"
+    )
+    voter = await _make_character(
+        db_session, era, faction_slug="ua", username="smetavoter", email="smv@x.com"
+    )
+    task = await _make_task(db_session, challenger, faction_slug="ua", points=10)
+    challenger_praxis = await _make_solo(db_session, task, challenger)
+    loser_praxis = await _make_solo(db_session, task, loser)
+    metatask = await _make_metatask(
+        db_session, loser, issuing_faction_slug="snide", points=5
+    )
+    await _apply_metatask(db_session, loser_praxis, metatask)
+
+    await _cast_vote(db_session, challenger_praxis, voter, 5)
+    await _cast_vote(db_session, loser_praxis, voter, 2)
+    await _make_duel(db_session, task, challenger_praxis, loser, loser_praxis)
+
+    loser_card = await _load_card(db_session, loser_praxis.id)
+
+    assert loser_card.metatask_points == 5
+    assert loser_card.display_multiplier == pytest.approx(0.0)
+    # (10 + 5) × 0.0 + 2 = 2.0 — the metatask is forfeit with the base.
+    assert loser_card.score == pytest.approx(2.0)
+    assert_invariant(loser_card)
+
+
+@pytest.mark.asyncio
+async def test_under_level_author_earns_zero_but_keeps_the_seal(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """An author below the metatask's level bar scores +0 but keeps the seal.
+
+    The level gate lives in the same pass as the points, so ``metatask_points``
+    reads 0 while ``applied_metatasks`` still carries the row — a legitimate
+    ``+0`` seal (unchanged by #882).
+    """
+    author = await _make_character(
+        db_session, era, faction_slug="ua", username="underlvl", email="ul@x.com", level=0
+    )
+    task = await _make_task(db_session, author, faction_slug="ua", points=10)
+    praxis = await _make_solo(db_session, task, author)
+    metatask = await _make_metatask(
+        db_session, author, issuing_faction_slug="ua", points=5, level_required=7
+    )
+    await _apply_metatask(db_session, praxis, metatask)
+
+    card = await _load_card(db_session, praxis.id)
+
+    # Points gated to 0 by level, but the seal row stays attached (+0).
+    assert card.metatask_points == 0
+    assert card.score == pytest.approx(10.0)
+    assert len(card.applied_metatasks) == 1
+    assert card.applied_metatasks[0].id == metatask.id
+    assert_invariant(card)

--- a/docs/adr/0053-a-praxis-has-one-number-merit-is-retired.md
+++ b/docs/adr/0053-a-praxis-has-one-number-merit-is-retired.md
@@ -124,3 +124,29 @@ downstream. It now uses `round()`.
 `16.5` each show `49.5` while the profile banks `49`. Which praxis "lost" the
 half point is unanswerable, and answering it is a scoring-semantics decision
 deserving its own ADR. Not decided here.
+
+## Amendment (2026-07-24, #882): every praxis type earns metatask points
+
+This ADR's Consequences claimed a collab card "now reflects... its metatask
+points", but the scoring service did not yet deliver that. `praxis_scoring.py`
+fed only *solo, non-duel* praxis ids to `get_meta_task_points_bulk` — a leftover
+filter, not a ruling — so a sealed collab or duel side scored `metatask_points:
+0` regardless of what the payload was told to report. #882 deletes the filter:
+**all praxis ids** now flow through the metatask pass.
+
+There is **no arithmetic change** to the formula. The metatask already sits
+inside the parenthesis of `score = (base + meta) × faction × duel + votes`, so:
+
+- A **collab** now banks its metatask like any solo praxis.
+- A **duel side's** metatask is multiplied by the duel outcome. A **Snide loss
+  at ×0.0 zeroes the metatask along with the base** — intended: the metatask is
+  part of the submission the duel judged (consistent with ADR-0015's "the duel
+  multiplier is a deliberate faction perk and should keep applying to metatask
+  points"). The reported `metatask_points` still shows the level-met bonus; the
+  ×0.0 multiplier zeroes it inside `score`.
+
+The scored set and the **seal set** (`applied_metatasks_for`, #932) now read the
+same `PraxisMetaTask` rows for every praxis type, so they cannot desync. The
+author-level gate still zeroes points for an under-level author while the seal
+stays attached — `metatask_points: 0` beside a non-null seal is a legitimate
+`+0` state, unchanged here.


### PR DESCRIPTION
Closes #882

## What changed
`backend/services/praxis_scoring.py` gated metatask points to `solo_non_duel_ids` before calling `get_meta_task_points_bulk` — a leftover filter its own comment described as "preserving current behaviour", not a ruling. This deletes the filter and feeds **all** praxis ids through the metatask pass, so collab and duel praxes now bank their metatask bonus.

**No arithmetic change.** The metatask already rides both multipliers inside `compute_praxis_score`'s `(base + meta) × faction × duel + votes`, so a Snide duel loss at ×0.0 correctly zeroes the metatask along with the base — intended, the metatask is part of the submission the duel judged.

**Scored set and seal set stay consistent.** The scoring pass and `applied_metatasks_for` (the #932 seal stack) now read the same `PraxisMetaTask` rows for every praxis type — they cannot desync. The author-level gate still zeroes points for an under-level author while the seal stays attached (`metatask_points: 0` beside a non-null seal is a legitimate `+0`).

## ADR
Amended **ADR-0053** (the true #881 foundation that introduced `metatask_points` / `display_multiplier` on `PraxisOut` + `PraxisCardOut`). Note: the issue/brief referenced "ADR-0051", but that ADR is about duel-acceptance level gates; ADR-0053 is where these payload fields and the `(base + meta) × mult + votes` invariant actually live.

## Tests
Added four cases to `backend/tests/integration/test_praxis_card_breakdown.py`:
- a collab praxis with a metatask now scores it (was 0),
- a duel-side praxis earns it, multiplied by the duel outcome,
- a Snide duel loss zeroes it,
- an under-level author scores +0 but keeps the seal.

Run (dedicated DB `wz882_test`):
```
TEST_DATABASE_URL=postgresql+asyncpg://.../wz882_test pytest \
  tests/integration/test_praxis_card_breakdown.py \
  tests/integration/test_praxis_scoring.py \
  tests/integration/test_character_stats.py
# 21 passed
```
Backend-only; no frontend touched. Visual QA not applicable (no rendering change) — the seal display shipped with the #927 epic.

## What to eyeball
- A **collab** praxis carrying a metatask now shows non-zero `metatask_points` (e.g. `(10 + 5) × 1.0 + 0 = 15`, was `10`).
- A **duel-side** praxis carrying a metatask shows non-zero `metatask_points`, multiplied by the outcome (winner `(10 + 5) × 1.5 + 5 = 27.5`).
- A **Snide duel loss** reports `metatask_points: 5` but `display_multiplier: 0.0`, so `score = (10 + 5) × 0.0 + votes` — the metatask is forfeit with the base.
- An **under-level author** shows `metatask_points: 0` with the seal still attached (`+0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)