### PR TITLE
Fix seed early-return: propagate new era tasks + placeholder metatask to seeded DBs (#905)

### DIFF
--- a/backend/seed.py
+++ b/backend/seed.py
@@ -67,6 +67,149 @@ async def upsert_era_factions(session, era) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Phase 2: Admin bootstrap (idempotent)
+# ---------------------------------------------------------------------------
+
+async def bootstrap_admin(session, era, pixie_acc) -> Character:
+    """Ensure the Pixie admin account + character + admin role + Era row exist.
+
+    Idempotent: when ``pixie_acc`` is already present this returns Pixie's
+    existing character untouched; only a genuinely un-bootstrapped DB creates
+    the account, OAuth link, Era row, admin role and starting CharacterStats.
+    Returns Pixie's character (needed as ``created_by`` for seeded tasks).
+    """
+    if pixie_acc is not None:
+        print("  >Pixie account already exists — skipping account/era/admin setup")
+        return (await session.execute(
+            select(Character).where(Character.account_id == pixie_acc.id).limit(1)
+        )).scalar_one()
+
+    print("  >Pixie account")
+    pixie_acc = Account(email="pixieofhugs@gmail.com")
+    session.add(pixie_acc)
+    await session.flush()
+
+    session.add(OAuthProvider(
+        account_id=pixie_acc.id,
+        provider="google",
+        provider_user_id="google_pixie",
+        access_token="seed_token",
+    ))
+
+    pixie_char = Character(
+        account_id=pixie_acc.id,
+        username="pixie",
+        display_name="Pixie",
+        bio="",
+        faction_slug="ua",
+    )
+    session.add(pixie_char)
+    await session.flush()
+
+    print(f"  >{era.name}")
+    era_row = Era(
+        name=era.name,
+        config_key=era.config_key,
+        started_by=pixie_acc.id,
+    )
+    session.add(era_row)
+    await session.flush()
+
+    print("  >Admin role -> pixie")
+    admin_role = Role(name="admin", description="Full administrative access")
+    session.add(admin_role)
+    await session.flush()
+
+    session.add(AccountRole(
+        account_id=pixie_acc.id,
+        role_id=admin_role.id,
+        granted_by=pixie_acc.id,
+    ))
+
+    session.add(CharacterStats(
+        character_id=pixie_char.id,
+        era_id=era_row.id,
+        score=0,
+        all_time_score=0,
+        level=0,
+        votes_spent_this_era=0,
+    ))
+    await session.flush()
+    return pixie_char
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Tasks (from era config) — idempotent per-task sync
+# ---------------------------------------------------------------------------
+
+async def sync_era_tasks(session, era, created_by_id: int) -> int:
+    """Add every era-config task that is not already in the database.
+
+    Idempotent and — crucially — a genuine *sync*, not an all-or-nothing seed:
+    it upserts per task (keyed on title) so that a task added to the era config
+    after a database was first seeded actually reaches that database on the next
+    seed run. The previous implementation only seeded tasks when the table was
+    empty, so config task additions never propagated to any already-seeded
+    environment (including production). Returns how many rows were added.
+    """
+    existing_titles = set(
+        (await session.execute(select(Task.title))).scalars().all()
+    )
+    added = 0
+    for task_def in era.tasks:
+        if task_def.title in existing_titles:
+            continue
+        session.add(Task(
+            title=task_def.title,
+            description=task_def.description,
+            point_value=task_def.point_value,
+            level_required=task_def.level_required,
+            status=TaskStatus.active,
+            created_by=created_by_id,
+            primary_faction_slug=task_def.faction_slug,
+            is_task_vision_eligible=task_def.is_task_vision_eligible,
+        ))
+        added += 1
+    await session.flush()
+    return added
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Meta Tasks (placeholder) — idempotent
+# ---------------------------------------------------------------------------
+
+async def ensure_placeholder_metatask(session, created_by_id: int) -> bool:
+    """Seed a single placeholder metatask so the UI has something to render.
+
+    A metatask is a Task row with ``task_type=metatask`` (unified in migration
+    0006, SESSION M). Guarded by a count check, so this is safe on a populated
+    database. Returns True if the placeholder was created this run.
+    """
+    metatask_count = (
+        await session.execute(
+            select(func.count())
+            .select_from(Task)
+            .where(Task.task_type == TaskType.metatask)
+        )
+    ).scalar()
+    if metatask_count:
+        return False
+    session.add(Task(
+        title="Upside Down",
+        description="Do this task upside down",
+        point_value=100,
+        level_required=0,
+        status=TaskStatus.active,
+        task_type=TaskType.metatask,
+        created_by=created_by_id,
+        primary_faction_slug="ua",
+        metatask_faction_slug="ua",
+    ))
+    await session.flush()
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Dev-only demo content
 # ---------------------------------------------------------------------------
 
@@ -180,23 +323,20 @@ async def seed(env: str, yes: bool) -> None:
 
         task_count = (await session.execute(select(func.count()).select_from(Task))).scalar()
 
+        # Every phase below is idempotent (upsert / count-guard / per-task sync),
+        # so a fully-seeded DB runs the exact same phases as an empty one — there
+        # is no early-return shortcut. This matters because Phases 3 and 4 add
+        # content that appears in the era config *after* the first seed (new
+        # tasks, the placeholder metatask); an early return skipped them, so
+        # config additions never reached any already-seeded environment,
+        # including production (#905). Phase 1 was already hoisted for the same
+        # reason (#784, Cozy Coven): the Faction table is a thin display mirror
+        # of the era config, safe to top up and needing no migration.
         if pixie_acc and task_count > 0:
-            print("Database already fully seeded (pixie account + tasks exist).")
-            # A faction added to the era config AFTER a database was seeded would
-            # otherwise never get its row: this branch used to return before
-            # Phase 1 ran (#784, Cozy Coven). The Faction table is a thin display
-            # mirror of the era config, so topping it up is always safe and needs
-            # no migration.
-            new_factions = await upsert_era_factions(session, era)
-            if new_factions > 0:
-                await session.commit()
-                print(f"  >Factions ({new_factions} new)")
-            if env == "dev":
-                await seed_dev_demo(session)  # idempotent — tops up demo content
-            await engine.dispose()
-            return
-
-        print("Seeding World Zero...\n")
+            print("Database already fully seeded — running idempotent top-up "
+                  "(factions, admin, task sync, metatask).")
+        else:
+            print("Seeding World Zero...\n")
 
         # ------------------------------------------------------------------
         # Phase 1: Factions (from era config, upsert)
@@ -208,124 +348,26 @@ async def seed(env: str, yes: bool) -> None:
             print("  >Factions already exist — skipping")
 
         # ------------------------------------------------------------------
-        # Phase 2: Admin bootstrap (Pixie account + character + role)
+        # Phase 2: Admin bootstrap (Pixie account + character + era + role)
         # ------------------------------------------------------------------
-        if pixie_acc:
-            print("  >Pixie account already exists — skipping account/era/admin setup")
-            pixie_char_result = await session.execute(
-                select(Character).where(Character.account_id == pixie_acc.id).limit(1)
-            )
-            pixie_char = pixie_char_result.scalar_one()
-        else:
-            print("  >Pixie account")
-            pixie_acc = Account(email="pixieofhugs@gmail.com")
-            session.add(pixie_acc)
-            await session.flush()
-
-            session.add(OAuthProvider(
-                account_id=pixie_acc.id,
-                provider="google",
-                provider_user_id="google_pixie",
-                access_token="seed_token",
-            ))
-
-            pixie_char = Character(
-                account_id=pixie_acc.id,
-                username="pixie",
-                display_name="Pixie",
-                bio="",
-                faction_slug="ua",
-            )
-            session.add(pixie_char)
-            await session.flush()
-
-            # ------------------------------------------------------------------
-            # Era
-            # ------------------------------------------------------------------
-            print(f"  >{era.name}")
-            era_row = Era(
-                name=era.name,
-                config_key=era.config_key,
-                started_by=pixie_acc.id,
-            )
-            session.add(era_row)
-            await session.flush()
-
-            # ------------------------------------------------------------------
-            # Admin role + grant
-            # ------------------------------------------------------------------
-            print("  >Admin role -> pixie")
-            admin_role = Role(name="admin", description="Full administrative access")
-            session.add(admin_role)
-            await session.flush()
-
-            session.add(AccountRole(
-                account_id=pixie_acc.id,
-                role_id=admin_role.id,
-                granted_by=pixie_acc.id,
-            ))
-
-            # ------------------------------------------------------------------
-            # CharacterStats (pixie starts at zero)
-            # ------------------------------------------------------------------
-            session.add(CharacterStats(
-                character_id=pixie_char.id,
-                era_id=era_row.id,
-                score=0,
-                all_time_score=0,
-                level=0,
-                votes_spent_this_era=0,
-            ))
-            await session.flush()
+        pixie_char = await bootstrap_admin(session, era, pixie_acc)
 
         # ------------------------------------------------------------------
-        # Phase 3: Tasks (from era config)
+        # Phase 3: Tasks (from era config) — idempotent per-task sync
         # ------------------------------------------------------------------
-        if task_count == 0:
-            print(f"  >Tasks ({len(era.tasks)})")
-            for task_def in era.tasks:
-                session.add(Task(
-                    title=task_def.title,
-                    description=task_def.description,
-                    point_value=task_def.point_value,
-                    level_required=task_def.level_required,
-                    status=TaskStatus.active,
-                    created_by=pixie_char.id,
-                    primary_faction_slug=task_def.faction_slug,
-                    is_task_vision_eligible=task_def.is_task_vision_eligible,
-                ))
+        new_tasks = await sync_era_tasks(session, era, pixie_char.id)
+        if new_tasks > 0:
+            print(f"  >Tasks ({new_tasks} new)")
         else:
             print(f"  >Tasks already exist ({task_count}) — skipping")
 
         # ------------------------------------------------------------------
-        # Phase 4: Meta Tasks (placeholder)
-        # A metatask is a Task row with task_type=metatask. See SESSION M
-        # migration (0006) for the unification. Seed a single placeholder
-        # metatask so the UI has something to render.
+        # Phase 4: Meta Tasks (placeholder) — idempotent
         # ------------------------------------------------------------------
-        from sqlalchemy import func as sqlfunc
-        metatask_count = (
-            await session.execute(
-                select(sqlfunc.count())
-                .select_from(Task)
-                .where(Task.task_type == TaskType.metatask)
-            )
-        ).scalar()
-        if metatask_count == 0:
+        if await ensure_placeholder_metatask(session, pixie_char.id):
             print("  >Metatasks (1 placeholder)")
-            session.add(Task(
-                title="Upside Down",
-                description="Do this task upside down",
-                point_value=100,
-                level_required=0,
-                status=TaskStatus.active,
-                task_type=TaskType.metatask,
-                created_by=pixie_char.id,
-                primary_faction_slug="ua",
-                metatask_faction_slug="ua",
-            ))
         else:
-            print(f"  >Metatasks already exist ({metatask_count}) — skipping")
+            print("  >Metatasks already exist — skipping")
 
         await session.commit()
 

--- a/backend/tests/integration/test_seed_task_sync.py
+++ b/backend/tests/integration/test_seed_task_sync.py
@@ -1,0 +1,111 @@
+"""The seeder propagates era-config additions to an already-seeded DB (#905).
+
+`backend/seed.py` used to `return` early on any DB that already had the Pixie
+account plus at least one task, skipping Phases 2-4. Two consequences, both
+prod-relevant:
+
+  * a task added to the era config after the first seed never reached the
+    database (Phase 3 was unreachable, and even when reached it was
+    all-or-nothing on an empty table — never a per-task sync), and
+  * the Phase-4 placeholder metatask was only ever created on a from-scratch
+    seed, so `praxis_meta_task` had zero rows everywhere.
+
+These tests exercise the now-idempotent phase helpers directly against a
+populated database — the exact path the seeded-DB case now runs — and assert
+that a newly-added config task lands and the placeholder metatask is created
+(and neither duplicates on re-run).
+"""
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import TaskDef
+from models.character import Character
+from models.era import Era
+from models.faction import Faction
+from models.task import Task, TaskType
+from seed import ensure_placeholder_metatask, sync_era_tasks
+
+
+def _standard_task(title: str, faction_slug: str = "ua") -> TaskDef:
+    return TaskDef(
+        title=title,
+        description="fixture task",
+        faction_slug=faction_slug,
+        level_required=0,
+        point_value=10,
+    )
+
+
+def _era_with_tasks(*tasks: TaskDef) -> SimpleNamespace:
+    """A minimal era stand-in — ``sync_era_tasks`` reads only ``era.tasks``."""
+    return SimpleNamespace(tasks=tuple(tasks))
+
+
+@pytest.mark.asyncio
+async def test_task_sync_propagates_new_era_task_on_seeded_db(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+    faction_ua: Faction,
+):
+    """A task added to the era config after the first seed reaches a seeded DB."""
+    # First seed: the config has a single task.
+    added = await sync_era_tasks(
+        db_session, _era_with_tasks(_standard_task("Alpha Task")), character.id
+    )
+    assert added == 1
+
+    # A new task is added to the era config; re-run the (now idempotent) sync.
+    v2 = _era_with_tasks(_standard_task("Alpha Task"), _standard_task("Beta Task"))
+    added_on_reseed = await sync_era_tasks(db_session, v2, character.id)
+
+    # Only the genuinely-new task is inserted — this is the deployment gap the
+    # old all-or-nothing `if task_count == 0` guard left open.
+    assert added_on_reseed == 1
+
+    titles = set((await db_session.execute(select(Task.title))).scalars().all())
+    assert "Beta Task" in titles
+
+    # And the pre-existing task is not duplicated.
+    alpha_rows = (
+        await db_session.execute(select(Task).where(Task.title == "Alpha Task"))
+    ).scalars().all()
+    assert len(alpha_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_placeholder_metatask_created_on_already_seeded_db(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+    faction_ua: Faction,
+):
+    """The Phase-4 placeholder metatask is created even when tasks already exist."""
+    # Simulate an already-seeded DB: a standard task exists, no metatask does.
+    await sync_era_tasks(
+        db_session, _era_with_tasks(_standard_task("Alpha Task")), character.id
+    )
+
+    created = await ensure_placeholder_metatask(db_session, character.id)
+    assert created is True
+
+    metatasks = (
+        await db_session.execute(
+            select(Task).where(Task.task_type == TaskType.metatask)
+        )
+    ).scalars().all()
+    assert len(metatasks) == 1
+
+    # Idempotent: a second run creates nothing.
+    created_again = await ensure_placeholder_metatask(db_session, character.id)
+    assert created_again is False
+
+    metatasks = (
+        await db_session.execute(
+            select(Task).where(Task.task_type == TaskType.metatask)
+        )
+    ).scalars().all()
+    assert len(metatasks) == 1


### PR DESCRIPTION
## What

`backend/seed.py` had an early return at `if pixie_acc and task_count > 0` that topped up factions (and, in dev, `seed_dev_demo`) then returned before Phases 2-4. On any already-seeded database — including production — this silently skipped:

- **Phase 3 (task sync)** — verified: it never ran on a seeded DB, and even when reached it was all-or-nothing (`if task_count == 0`), never a per-task sync. So **a task added to `eras/era_1.py` after the first seed never reached the database**. That is the real deployment gap.
- **Phase 4 (placeholder metatask)** — only ever created on a from-scratch seed, so `praxis_meta_task` had zero rows everywhere (the symptom that surfaced this in #891).

## Fix (root cause, minimal)

Removed the early-return shortcut and routed the seeded-DB case through the **same** idempotent phases instead of duplicating them. Phases 2-4 are extracted into reusable helpers so both the fresh-seed and seeded-DB paths call one implementation:

- `bootstrap_admin` (Phase 2) — unchanged semantics; returns Pixie's character.
- `sync_era_tasks` (Phase 3) — now a genuine **per-task upsert keyed on title**, so config additions propagate on redeploy without duplicating existing rows. (The old `if task_count == 0` guard was idempotent but not a sync — that is why the gap existed.)
- `ensure_placeholder_metatask` (Phase 4) — unchanged count-guard, now reachable.

The "already seeded" logging intent is preserved (it now announces an idempotent top-up rather than returning).

## Tests

New `backend/tests/integration/test_seed_task_sync.py` proves the gap is closed by exercising the phase helpers against a populated DB (the exact path the seeded case now runs):

- a task added to the era config after the first seed lands on the already-seeded DB, and the pre-existing task is not duplicated;
- the placeholder metatask is created even when tasks already exist, and is idempotent on re-run.

Invocation (dedicated test DB, per parallel-agent isolation):

```
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz905_test \
  pytest tests/integration/test_seed_task_sync.py -v
```

Result: `2 passed`. `tests/integration/test_seed_score_fixtures.py` still green (`4 passed`).

## What to eyeball

- Re-seeding an existing **dev** DB now creates the placeholder metatask AND syncs any newly-added era tasks (previously skipped by the early return).
- **Production** task additions in `eras/era_1.py` will now propagate on the next `python seed.py --env prod` / redeploy, without duplicating existing tasks or re-bootstrapping the admin account.
- No migration involved — tasks and factions are content the seeder owns, not schema.

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)