### PR TITLE
test: fix feedRow coven taunt assertion reddening main (frontend job)

### DIFF
--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -56,7 +56,7 @@ describe('normalizeFeedItem', () => {
 
   it('resolves a taunt from the catalog, quotes it, and drops points', () => {
     // ADR-0031: payload is a structured reference; the catalog owns the words.
-    // wow/score_overtake has 2 variants; taunt_id 9 -> 9 % 2 = 1 -> the second.
+    // coven/score_overtake has 2 variants; taunt_id 9 -> 9 % 2 = 1 -> the second.
     const row = normalizeFeedItem(
       item('foe_taunt', {
         from_character_id: 9,
@@ -68,7 +68,7 @@ describe('normalizeFeedItem', () => {
       }),
     )!
     expect(row.action).toBe('taunts you')
-    expect(row.headline).toBe('Ada rose past Bo. The whole is greater than the parts.')
+    expect(row.headline).toBe('One small spell, quietly cast — and Ada slips ahead of Bo. No hard feelings, only glitter.')
     expect(row.headlineQuoted).toBe(true)
     expect(row.points).toBeNull()
   })


### PR DESCRIPTION
## Why
`main` is red on the `frontend` (vitest) job. `#917` correctly rewrote coven's `score_overtake` taunt out of the inherited WOW donor voice (PR #978), but `frontend/src/components/__tests__/feedRow.test.tsx:71` still pinned the old string `"Ada rose past Bo. The whole is greater than the parts."`. Copy PR #978 didn't update the frozen assertion.

`frontend` is not a required check (only `test`/pytest is), so #978 merged with the vitest job red. This restores it.

## Fix
- Point the assertion at coven's current second `score_overtake` variant (`taunt_id 9 → 9 % 2 = 1`): `"One small spell, quietly cast — and Ada slips ahead of Bo. No hard feelings, only glitter."`
- Fix the stale `wow/score_overtake` comment (the test resolves `coven`).

Confirmed root-cause scope: only this assertion was frozen to the old copy — `mixedStream` (whimsy.exe) and `wowRendersDefault` still pass.

## What to eyeball
Nothing visual — test-only. Green `frontend` job restores main.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>