### PR TITLE
fix(duel): Snide wins ties for the Duelist badge + era freeze, not just the multiplier

### DIFF
--- a/backend/services/badge.py
+++ b/backend/services/badge.py
@@ -23,6 +23,7 @@ from models.era import Era
 from models.praxis import Praxis
 from schemas.character import BadgeOut
 from services.duel_outcome import duel_winner
+from services.scoring import snide_tie_winner_id
 from services.vote_tally import get_tally, tally_votes
 
 # Every duel status that can feed the duelist badge. `resolved` is included
@@ -135,6 +136,23 @@ async def _duel_winner_facts(
     )
     tallies = await tally_votes(list(praxis_ids), session)
 
+    # A live tie needs both sides' factions to resolve the Snide tiebreak (#748):
+    # Snide takes ties, so it must win the badge on a tie exactly as it wins the
+    # multiplier. One set-based query over the live sides, never per-character.
+    faction_by_character: dict[int, str] = {}
+    tie_side_ids = {row.challenger_character_id for row in live_rows}
+    tie_side_ids.update(row.opponent_character_id for row in live_rows)
+    tie_side_ids.discard(None)
+    if tie_side_ids:
+        faction_rows = await session.execute(
+            select(Character.id, Character.faction_slug).where(
+                Character.id.in_(tie_side_ids)
+            )
+        )
+        faction_by_character = {
+            character_id: (slug or "") for character_id, slug in faction_rows.all()
+        }
+
     winners: set[int] = set()
     last_era_winners: set[int] = set()
     for row in duel_rows:
@@ -155,6 +173,12 @@ async def _duel_winner_facts(
                 ).points_from_votes,
                 opponent_points=opponent_points,
                 forfeited_by_character_id=row.forfeited_by_character_id,
+                tie_break_winner_id=snide_tie_winner_id(
+                    faction_by_character.get(row.challenger_character_id, ""),
+                    row.challenger_character_id,
+                    faction_by_character.get(row.opponent_character_id, ""),
+                    row.opponent_character_id,
+                ),
             )
         if winner_character_id is None or winner_character_id not in character_ids:
             continue

--- a/backend/services/duel_outcome.py
+++ b/backend/services/duel_outcome.py
@@ -21,18 +21,26 @@ def duel_winner(
     challenger_points: int,
     opponent_points: int,
     forfeited_by_character_id: Optional[int] = None,
+    tie_break_winner_id: Optional[int] = None,
 ) -> Optional[int]:
     """Return the winning character id, or ``None`` for a tie / no-contest.
 
-    Two branches, in priority order (ADR-0011):
+    Three branches, in priority order (ADR-0011):
 
     1. **Forfeit.** ``forfeited_by_character_id`` set → the *other* side wins by
        default and vote tallies do not decide the outcome.
     2. **Tally.** Otherwise the side with *strictly greater*
-       ``VoteTally.points_from_votes`` wins. Equal points is a tie → ``None``.
+       ``VoteTally.points_from_votes`` wins.
+    3. **Tiebreak.** Equal points returns ``tie_break_winner_id`` — a winner some
+       faction ability grants on a tie (Snide wins ties, #748), pre-resolved from
+       the factions by the caller (:func:`services.scoring.snide_tie_winner_id`)
+       so this rule stays plain-ints-in. ``None`` (the default) is a real tie, and
+       also the correct answer for a no-contest (a duel that never became votable),
+       which callers express by passing equal points.
 
-    ``None`` is also the correct answer for a no-contest (a duel that never
-    became votable), which callers express by passing equal points.
+    Keeping the tiebreak *here* is the point: this is the one rule the badge
+    (#748), the live multiplier, and the era-close freeze (ADR-0052) all share, so
+    a Snide tie must name the same winner in every one of them.
     """
     if forfeited_by_character_id is not None:
         if forfeited_by_character_id == challenger_character_id:
@@ -43,4 +51,4 @@ def duel_winner(
         return challenger_character_id
     if opponent_points > challenger_points:
         return opponent_character_id
-    return None
+    return tie_break_winner_id

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -5,12 +5,14 @@ from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
+from models.character import Character
 from models.character_stats import CharacterStats
 from models.duel import Duel, DuelStatus
 from models.era import Era
 from models.faction_defection_history import FactionDefectionHistory
 from models.praxis import Praxis
 from services.duel_outcome import duel_winner
+from services.scoring import snide_tie_winner_id
 from services.vote_tally import get_tally, tally_votes
 
 ERA_RESET_DEFAULT_FACTION: str = "na"
@@ -172,6 +174,23 @@ async def resolve_duels_at_era_close(
     praxes_by_id: dict[int, Praxis] = {p.id: p for p in praxis_result.scalars()}
     tallies = await tally_votes(praxis_ids, session)
 
+    # Both sides' factions, so a tie freezes to the Snide tiebreak winner rather
+    # than a permanent NULL (#748: Snide wins ties — the one duel_winner rule must
+    # freeze what the live multiplier already shows).
+    character_ids = {duel.opponent_character_id for duel in duels}
+    character_ids.update(
+        praxis.created_by_id
+        for praxis in praxes_by_id.values()
+    )
+    faction_result = await session.execute(
+        select(Character.id, Character.faction_slug).where(
+            Character.id.in_(character_ids)
+        )
+    )
+    faction_by_character: dict[int, str] = {
+        character_id: (slug or "") for character_id, slug in faction_result.all()
+    }
+
     for duel in duels:
         is_contest = duel.status == DuelStatus.settled
         if is_contest:
@@ -189,15 +208,22 @@ async def resolve_duels_at_era_close(
             opponent_points = 0
 
         challenger_praxis = praxes_by_id.get(duel.challenger_praxis_id)
+        challenger_character_id = (
+            challenger_praxis.created_by_id if challenger_praxis else None
+        )
         duel.winner_character_id = (
             duel_winner(
-                challenger_character_id=(
-                    challenger_praxis.created_by_id if challenger_praxis else None
-                ),
+                challenger_character_id=challenger_character_id,
                 opponent_character_id=duel.opponent_character_id,
                 challenger_points=challenger_points,
                 opponent_points=opponent_points,
                 forfeited_by_character_id=duel.forfeited_by_character_id,
+                tie_break_winner_id=snide_tie_winner_id(
+                    faction_by_character.get(challenger_character_id, ""),
+                    challenger_character_id,
+                    faction_by_character.get(duel.opponent_character_id, ""),
+                    duel.opponent_character_id,
+                ),
             )
             if is_contest
             else None

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -103,20 +103,54 @@ def compute_duel_multiplier(
             return 1.5 if is_winner else 0.5
         return faction_config.duel_win_modifier if is_winner else faction_config.duel_loss_modifier
 
-    # Tied case
-    one_is_snide = (character_faction_slug == SNIDE_FACTION_SLUG) != (
-        opponent_faction_slug == SNIDE_FACTION_SLUG
-    )
-    if not one_is_snide:
+    # Tied case: Snide wins ties (one shared predicate, see snide_tie_winner_slug).
+    tie_winner_slug = snide_tie_winner_slug(character_faction_slug, opponent_faction_slug)
+    if tie_winner_slug is None:
         return 1.0
 
-    # One Snide: Snide wins the tie
     faction_config = era.factions.get(character_faction_slug)
     if faction_config is None:
-        return 2.0 if character_faction_slug == SNIDE_FACTION_SLUG else 0.5
-    if character_faction_slug == SNIDE_FACTION_SLUG:
+        return 2.0 if character_faction_slug == tie_winner_slug else 0.5
+    if character_faction_slug == tie_winner_slug:
         return faction_config.duel_win_modifier
     return faction_config.duel_loss_modifier
+
+
+def snide_tie_winner_slug(faction_a: str, faction_b: str) -> Optional[str]:
+    """The faction slug that wins a *tied* duel, or ``None`` for a true tie.
+
+    Snide's ability is that it takes ties — but only when it is the *sole* Snide
+    side. Two Snide sides (or no Snide) is a real tie. This is the one definition
+    of the rule; both the live multiplier above and the winner id below read it.
+    """
+    a_snide = faction_a == SNIDE_FACTION_SLUG
+    b_snide = faction_b == SNIDE_FACTION_SLUG
+    if a_snide and not b_snide:
+        return faction_a
+    if b_snide and not a_snide:
+        return faction_b
+    return None
+
+
+def snide_tie_winner_id(
+    challenger_faction_slug: str,
+    challenger_character_id: Optional[int],
+    opponent_faction_slug: str,
+    opponent_character_id: Optional[int],
+) -> Optional[int]:
+    """Character id that wins a tied duel by the Snide tiebreak, else ``None``.
+
+    Feeds ``duel_winner(..., tie_break_winner_id=...)`` so the single winner rule
+    (the badge, the freeze) agrees with what the multiplier has always done.
+    """
+    winner_slug = snide_tie_winner_slug(challenger_faction_slug, opponent_faction_slug)
+    if winner_slug is None:
+        return None
+    return (
+        challenger_character_id
+        if challenger_faction_slug == winner_slug
+        else opponent_character_id
+    )
 
 
 def compute_praxis_score(

--- a/backend/tests/integration/test_duel_era_resolution.py
+++ b/backend/tests/integration/test_duel_era_resolution.py
@@ -31,7 +31,8 @@ from services.era import apply_era_reset
 
 
 async def _make_character(
-    session: AsyncSession, era: Era, *, username: str, email: str
+    session: AsyncSession, era: Era, *, username: str, email: str,
+    faction_slug: str = "ua",
 ) -> Character:
     account = Account(email=email)
     session.add(account)
@@ -40,7 +41,7 @@ async def _make_character(
         account_id=account.id,
         username=username,
         display_name=username,
-        faction_slug="ua",
+        faction_slug=faction_slug,
     )
     session.add(character)
     await session.flush()
@@ -119,13 +120,17 @@ async def _make_duel(
     challenger_votes: int | None,
     opponent_votes: int | None,
     forfeiter: str | None = None,
+    challenger_faction: str = "ua",
+    opponent_faction: str = "ua",
 ) -> tuple[Duel, Character, Character]:
     """Build a full duel: two characters, two solo praxes, optional votes."""
     challenger = await _make_character(
-        session, era, username=f"{label}_ch", email=f"{label}_ch@x.com"
+        session, era, username=f"{label}_ch", email=f"{label}_ch@x.com",
+        faction_slug=challenger_faction,
     )
     opponent = await _make_character(
-        session, era, username=f"{label}_op", email=f"{label}_op@x.com"
+        session, era, username=f"{label}_op", email=f"{label}_op@x.com",
+        faction_slug=opponent_faction,
     )
     voter = await _make_character(
         session, era, username=f"{label}_v", email=f"{label}_v@x.com"
@@ -268,6 +273,35 @@ async def test_era_reset_freezes_a_mix_of_duels(
     assert incomplete_duel.winner_character_id is None
     assert incomplete_duel.challenger_final_points == 0
     assert incomplete_duel.opponent_final_points == 0
+
+
+@pytest.mark.asyncio
+async def test_era_reset_freezes_the_snide_tie_to_snide(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """A tied duel with a lone Snide side freezes to Snide, not a NULL winner (#748).
+
+    Snide wins ties everywhere the live multiplier applies; the permanent frozen
+    record must agree, or `duel_victor` (#823) would lose a win the site showed.
+    """
+    from models.faction import FactionStatus
+
+    db_session.add(Faction(slug="snide", status=FactionStatus.visible))
+    await db_session.commit()
+
+    duel, challenger, _opponent = await _make_duel(
+        db_session, era, label="snidefreeze", status=DuelStatus.settled,
+        challenger_votes=3, opponent_votes=3,
+        challenger_faction="snide", opponent_faction="ua",
+    )
+
+    await _close_the_era(db_session, account)
+
+    await db_session.refresh(duel)
+    assert duel.status == DuelStatus.resolved
+    assert duel.winner_character_id == challenger.id
+    assert duel.challenger_final_points == 3
+    assert duel.opponent_final_points == 3
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_duelist_badge.py
+++ b/backend/tests/integration/test_duelist_badge.py
@@ -40,7 +40,7 @@ DUELIST_BADGE = {"key": "duelist", "name": "Duelist"}
 
 
 async def _make_character(
-    session: AsyncSession, era: Era, *, username: str
+    session: AsyncSession, era: Era, *, username: str, faction_slug: str = "ua"
 ) -> Character:
     account = Account(email=f"{username}@example.com")
     session.add(account)
@@ -49,7 +49,7 @@ async def _make_character(
         account_id=account.id,
         username=username,
         display_name=username,
-        faction_slug="ua",
+        faction_slug=faction_slug,
     )
     session.add(character)
     await session.flush()
@@ -124,10 +124,16 @@ async def _make_duel(
     status: DuelStatus = DuelStatus.settled,
     forfeiter: Optional[str] = None,
     winner_character_id: Optional[int] = None,
+    challenger_faction: str = "ua",
+    opponent_faction: str = "ua",
 ) -> tuple[Duel, Character, Character]:
     """Two fresh characters + their two solo praxes, linked as one duel."""
-    challenger = await _make_character(session, era, username=f"{label}ch")
-    opponent = await _make_character(session, era, username=f"{label}op")
+    challenger = await _make_character(
+        session, era, username=f"{label}ch", faction_slug=challenger_faction
+    )
+    opponent = await _make_character(
+        session, era, username=f"{label}op", faction_slug=opponent_faction
+    )
     voter = await _make_character(session, era, username=f"{label}v")
     task = await _make_task(session, challenger)
     challenger_praxis = await _make_solo(session, task, challenger)
@@ -188,6 +194,34 @@ async def test_a_tie_is_not_a_win(
         db_session, era, label="tie", challenger_votes=3, opponent_votes=3
     )
     assert await _badge_keys(db_session, challenger) == []
+    assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_snide_wins_the_tie_and_earns_the_badge(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """Snide takes ties (#748): the badge must agree with the 2.0× multiplier.
+
+    A tied duel names no winner by votes, but Snide's ability wins ties, so the
+    Snide side reads as the duel winner everywhere the tiebreak applies — the
+    live multiplier already did this; the badge was the straggler.
+    """
+    from models.faction import FactionStatus
+
+    db_session.add(Faction(slug="snide", status=FactionStatus.visible))
+    await db_session.commit()
+
+    _, challenger, opponent = await _make_duel(
+        db_session,
+        era,
+        label="snidetie",
+        challenger_votes=3,
+        opponent_votes=3,
+        challenger_faction="snide",
+        opponent_faction="ua",
+    )
+    assert await _badge_keys(db_session, challenger) == ["duelist"]
     assert await _badge_keys(db_session, opponent) == []
 
 
@@ -433,10 +467,11 @@ async def test_batch_path_is_constant_query_count(
         event.remove(db_connection.sync_connection, "before_cursor_execute", record)
 
     assert large_query_count == small_query_count
-    # Four: the account roll-up, the duel rows, the live tally, and the
-    # previous-era lookup #823 added. The guard that matters is the equality
-    # above — this bound only keeps the fixed cost visible.
-    assert small_query_count <= 4, statements
+    # Five: the account roll-up, the duel rows, the live tally, the previous-era
+    # lookup (#823), and the live sides' faction lookup (#748 Snide tiebreak). The
+    # guard that matters is the equality above — this bound only keeps the fixed
+    # cost visible.
+    assert small_query_count <= 5, statements
 
     assert small[one_challenger.id].is_duel_winner is True
     assert small[one_opponent.id].is_duel_winner is False

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from game_config import ERA_1
+from services.duel_outcome import duel_winner
 from services.scoring import (
     COLLABORATION_MODE_COLLAB,
     COLLABORATION_MODE_DUEL,
@@ -11,6 +12,8 @@ from services.scoring import (
     compute_praxis_score,
     compute_vote_budget,
     compute_votes_available,
+    snide_tie_winner_id,
+    snide_tie_winner_slug,
 )
 
 
@@ -313,6 +316,61 @@ def test_duel_tie_both_snide():
     # Both Snide → both get 1.0 (not one-is-snide rule)
     result = compute_duel_multiplier("snide", "snide", is_winner=False, is_tied=True, era=ERA_1)
     assert result == 1.0
+
+
+def test_snide_tie_winner_slug_sole_snide_wins():
+    assert snide_tie_winner_slug("snide", "wow") == "snide"
+    assert snide_tie_winner_slug("wow", "snide") == "snide"
+
+
+def test_snide_tie_winner_slug_no_or_both_snide_is_a_real_tie():
+    assert snide_tie_winner_slug("wow", "ua") is None
+    assert snide_tie_winner_slug("snide", "snide") is None
+
+
+def test_snide_tie_winner_id_resolves_to_the_snide_side():
+    # Snide is the challenger → the challenger id wins the tie.
+    assert snide_tie_winner_id("snide", 1, "wow", 2) == 1
+    # Snide is the opponent → the opponent id wins the tie.
+    assert snide_tie_winner_id("wow", 1, "snide", 2) == 2
+    # No Snide → nobody wins the tie.
+    assert snide_tie_winner_id("wow", 1, "ua", 2) is None
+
+
+def test_duel_winner_returns_tiebreak_on_equal_points():
+    # Equal points, no forfeit → the pre-resolved tiebreak winner (Snide's id).
+    assert (
+        duel_winner(
+            challenger_character_id=1,
+            opponent_character_id=2,
+            challenger_points=3,
+            opponent_points=3,
+            tie_break_winner_id=1,
+        )
+        == 1
+    )
+    # A real tie (no tiebreak) is still None.
+    assert (
+        duel_winner(
+            challenger_character_id=1,
+            opponent_character_id=2,
+            challenger_points=3,
+            opponent_points=3,
+        )
+        is None
+    )
+    # Forfeit outranks any tiebreak.
+    assert (
+        duel_winner(
+            challenger_character_id=1,
+            opponent_character_id=2,
+            challenger_points=3,
+            opponent_points=3,
+            forfeited_by_character_id=1,
+            tie_break_winner_id=1,
+        )
+        == 2
+    )
 
 
 def test_duel_faction_multiplier_ignores_duel_mode():


### PR DESCRIPTION
## The bug

A **Snide** character who wins a *tied* duel (Snide's ability is "you win ties") shows 2.0× and reads as the winner on every praxis surface, but gets **no Duelist badge**.

## Root cause

Two different "who won" rules disagreed exactly in the Snide-tie case:

- `compute_duel_multiplier` (scoring.py) — **has** the Snide-wins-ties tiebreaker → 2.0×.
- `duel_winner` (duel_outcome.py) — the "single" winner rule shared by the Duelist badge **and** the era-close freeze — returned `None` on a tie and knew nothing about Snide.

So the badge asked `duel_winner`, got `None`, and the Snide winner wasn't in `winners`. The same latent gap in `apply_era_reset` would freeze `winner_character_id = NULL` **permanently** for a Snide tie, also breaking the future `duel_victor` badge (#823).

The badge is provisional by design (ADR-0011): it floats with the votes mid-era. Leading a tie *now* counts as winning *now* — the win can still slip if the votes move. This fix makes the badge and the freeze agree with what the multiplier already showed.

## The fix (one shared rule)

- Fold the tiebreak into `duel_winner` via a pre-resolved `tie_break_winner_id` (keeps it plain-ints-in — no faction imports, no cycle).
- One shared `snide_tie_winner` predicate in scoring.py; `compute_duel_multiplier` now reads it too, so there's a single definition of "Snide wins ties."
- Wire the Duelist badge and the era freeze to pass it. `praxis_scoring` is already correct via the multiplier and is untouched.

## Tests

268 pass. New: Snide-tie earns the badge, Snide-tie freezes to Snide at era close, plus unit coverage of the pure helpers. The badge batch query-count guard went 4→5 (one constant faction lookup, still page-size-independent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)