### PR TITLE
Comment composer: legible submit ink via on-accent token (#924)

### DIFF
--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -41,6 +41,7 @@ export function DefaultComment(props: CommentProps) {
             onSubmit={onSubmit}
             submitting={submitting}
             accent={factionCssVar(character.faction_slug, 'card-accent')}
+            onAccent={factionCssVar(character.faction_slug, 'on-accent')}
           />
         </div>
       </div>
@@ -49,6 +50,7 @@ export function DefaultComment(props: CommentProps) {
   const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
   const accent = factionCssVar(slug, 'card-accent')
+  const onAccent = factionCssVar(slug, 'on-accent')
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
   return (
     <div style={{ display: 'flex', gap: 'var(--space-md)' }}>
@@ -70,7 +72,7 @@ export function DefaultComment(props: CommentProps) {
         </div>
         <div style={{ marginTop: 'var(--space-xs)', color: 'var(--color-text-primary)', lineHeight: 1.5 }}>
           {owner.editing ? (
-            <CommentEditor owner={owner} accent={accent} />
+            <CommentEditor owner={owner} accent={accent} onAccent={onAccent} />
           ) : (
             <MentionText body={comment.body_text} mentions={comment.mentions} accent={accent} />
           )}

--- a/frontend/src/components/comments/OwnerControls.tsx
+++ b/frontend/src/components/comments/OwnerControls.tsx
@@ -226,11 +226,14 @@ export function OwnerControls({ owner }: { owner: OwnerEdit }) {
 export function CommentEditor({
   owner,
   accent,
+  onAccent,
   bg,
   text,
 }: {
   owner: OwnerEdit
   accent: string
+  /** AA ink for the Save button, painted in `accent` (#924). See ComposerControls. */
+  onAccent: string
   bg?: string
   text?: string
 }) {
@@ -243,6 +246,7 @@ export function CommentEditor({
         onSubmit={owner.save}
         submitting={owner.saving}
         accent={accent}
+        onAccent={onAccent}
         bg={bg}
         text={text}
         maxLength={MAX_COMMENT_BODY}

--- a/frontend/src/components/comments/__tests__/OwnerControls.test.tsx
+++ b/frontend/src/components/comments/__tests__/OwnerControls.test.tsx
@@ -118,7 +118,7 @@ describe('OwnerControls', () => {
 describe('CommentEditor', () => {
   it('seeds the composer with the current body and shows Save', () => {
     const html = renderToStaticMarkup(
-      <CommentEditor owner={makeOwner({ editing: true })} accent="var(--color-accent)" />,
+      <CommentEditor owner={makeOwner({ editing: true })} accent="var(--color-accent)" onAccent="var(--faction-default-on-accent)" />,
     )
     expect(html).toContain('seedlings along the estuary')
     expect(html).toContain('Save')

--- a/frontend/src/components/comments/shared.tsx
+++ b/frontend/src/components/comments/shared.tsx
@@ -104,6 +104,7 @@ export function ComposerControls({
   onSubmit,
   submitting,
   accent,
+  onAccent,
   bg = 'transparent',
   text = 'inherit',
   maxLength,
@@ -116,6 +117,12 @@ export function ComposerControls({
   onSubmit: () => void
   submitting: boolean
   accent: string
+  /**
+   * AA-legible ink for the submit button, which is painted in `accent` (#924).
+   * A voice passes `var(--faction-{slug}-on-accent)` — the ink measured on its
+   * composer accent, which is NOT `-on-fill` (that ink is measured on the fill).
+   */
+  onAccent: string
   bg?: string
   text?: string
   /** Cap the body length (edit mode passes MAX_COMMENT_BODY) + light a live count. */
@@ -205,7 +212,7 @@ export function ComposerControls({
             disabled={disabled}
             style={{
               background: accent,
-              color: '#fff',
+              color: onAccent,
               border: 'none',
               borderRadius: 4,
               padding: 'var(--space-xs) var(--space-lg)',

--- a/frontend/src/components/comments/voices/CovenComment.tsx
+++ b/frontend/src/components/comments/voices/CovenComment.tsx
@@ -43,7 +43,7 @@ export default function CovenComment(props: CommentProps) {
         <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
           <FactionAvatar character={character} size="sm" />
           <div style={{ flex: 1 }}>
-            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-coven-card-accent)" bg="var(--faction-coven-notepad-bg)" text="var(--faction-coven-card-text)" />
+            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-coven-card-accent)" onAccent="var(--faction-coven-on-accent)" bg="var(--faction-coven-notepad-bg)" text="var(--faction-coven-card-text)" />
           </div>
         </div>
       </Window>
@@ -59,7 +59,7 @@ export default function CovenComment(props: CommentProps) {
         <div style={{ flex: 1, minWidth: 0 }}>
           <div style={{ fontFamily: 'var(--faction-coven-card-font)', fontSize: 'var(--text-content)', lineHeight: 1.25, color: 'var(--faction-coven-card-text)' }}>
             {owner.editing ? (
-              <CommentEditor owner={owner} accent="var(--faction-coven-card-accent)" bg="var(--faction-coven-notepad-bg)" text="var(--faction-coven-card-text)" />
+              <CommentEditor owner={owner} accent="var(--faction-coven-card-accent)" onAccent="var(--faction-coven-on-accent)" bg="var(--faction-coven-notepad-bg)" text="var(--faction-coven-card-text)" />
             ) : (
               <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-coven-card-accent)" />
             )}

--- a/frontend/src/components/comments/voices/EphemeristsComment.tsx
+++ b/frontend/src/components/comments/voices/EphemeristsComment.tsx
@@ -36,7 +36,7 @@ export default function EphemeristsComment(props: CommentProps) {
           <div style={{ fontSize: 'var(--text-base)', letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--faction-ephemerists-card-accent)', marginBottom: 'var(--space-sm)' }}>
             {t('comments.ephemerists.prompt')}
           </div>
-          <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-ephemerists-card-accent)" bg="rgba(255,255,255,0.35)" text="var(--faction-ephemerists-card-text)" />
+          <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-ephemerists-card-accent)" onAccent="var(--faction-ephemerists-on-accent)" bg="rgba(255,255,255,0.35)" text="var(--faction-ephemerists-card-text)" />
         </div>
       </div>
     )
@@ -61,7 +61,7 @@ export default function EphemeristsComment(props: CommentProps) {
         </span>
       </div>
       {owner.editing ? (
-        <CommentEditor owner={owner} accent="var(--faction-ephemerists-card-accent)" bg="rgba(255,255,255,0.35)" text="var(--faction-ephemerists-card-text)" />
+        <CommentEditor owner={owner} accent="var(--faction-ephemerists-card-accent)" onAccent="var(--faction-ephemerists-on-accent)" bg="rgba(255,255,255,0.35)" text="var(--faction-ephemerists-card-text)" />
       ) : (
         <div style={{ fontSize: 'var(--text-content)', lineHeight: 1.55 }}>
           <span style={{

--- a/frontend/src/components/comments/voices/EverymenComment.tsx
+++ b/frontend/src/components/comments/voices/EverymenComment.tsx
@@ -41,7 +41,7 @@ export default function EverymenComment(props: CommentProps) {
         <div style={{ padding: 'var(--space-md) var(--space-lg)', display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
           <FactionAvatar character={character} size="sm" />
           <div style={{ flex: 1 }}>
-            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-everymen-card-accent)" bg="rgba(0,0,0,0.03)" text="var(--faction-everymen-card-text)" />
+            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-everymen-card-accent)" onAccent="var(--faction-everymen-on-accent)" bg="rgba(0,0,0,0.03)" text="var(--faction-everymen-card-text)" />
           </div>
         </div>
       </div>
@@ -69,7 +69,7 @@ export default function EverymenComment(props: CommentProps) {
           </div>
           <div style={{ fontSize: 'var(--text-content)', lineHeight: 1.4, marginTop: 'var(--space-xs)' }}>
             {owner.editing ? (
-              <CommentEditor owner={owner} accent="var(--faction-everymen-card-accent)" bg="rgba(0,0,0,0.03)" text="var(--faction-everymen-card-text)" />
+              <CommentEditor owner={owner} accent="var(--faction-everymen-card-accent)" onAccent="var(--faction-everymen-on-accent)" bg="rgba(0,0,0,0.03)" text="var(--faction-everymen-card-text)" />
             ) : (
               <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-everymen-card-accent)" />
             )}

--- a/frontend/src/components/comments/voices/SingularityComment.tsx
+++ b/frontend/src/components/comments/voices/SingularityComment.tsx
@@ -52,7 +52,7 @@ export default function SingularityComment(props: CommentProps) {
               {t('comments.singularity.protocol')}
               <span style={{ display: 'inline-block', width: 5, height: 9, background: 'var(--faction-singularity-card-text)', marginLeft: 'var(--space-xs)', verticalAlign: 'middle', animation: 'blink 1s step-end infinite' }} />
             </div>
-            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-singularity-card-text)" bg="#0a1f12" text="var(--faction-singularity-card-text)" />
+            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-singularity-card-text)" onAccent="var(--faction-singularity-on-accent)" bg="#0a1f12" text="var(--faction-singularity-card-text)" />
           </div>
         </div>
       </div>
@@ -80,7 +80,7 @@ export default function SingularityComment(props: CommentProps) {
           </div>
           <div style={{ fontSize: 'var(--text-content)', lineHeight: 1.55, marginTop: 'var(--space-xs)' }}>
             {owner.editing ? (
-              <CommentEditor owner={owner} accent="var(--faction-singularity-card-text)" bg="#0a1f12" text="var(--faction-singularity-card-text)" />
+              <CommentEditor owner={owner} accent="var(--faction-singularity-card-text)" onAccent="var(--faction-singularity-on-accent)" bg="#0a1f12" text="var(--faction-singularity-card-text)" />
             ) : (
               <>
                 <span style={{ color: 'var(--faction-singularity-card-muted)' }}>&gt; </span>

--- a/frontend/src/components/comments/voices/SnideComment.tsx
+++ b/frontend/src/components/comments/voices/SnideComment.tsx
@@ -81,7 +81,7 @@ export default function SnideComment(props: CommentProps) {
             }}>
               {t('comments.snide.prompt')}
             </div>
-            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-snide-pink)" bg="rgba(255,255,255,0.04)" text="var(--faction-snide-card-text)" />
+            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-snide-pink)" onAccent="var(--faction-snide-on-accent)" bg="rgba(255,255,255,0.04)" text="var(--faction-snide-card-text)" />
           </div>
         </div>
       </div>
@@ -109,7 +109,7 @@ export default function SnideComment(props: CommentProps) {
           </div>
           <div style={{ fontFamily: 'var(--faction-snide-font-cond)', textTransform: 'uppercase', fontSize: 'var(--text-content)', lineHeight: 1.4, letterSpacing: '0.02em' }}>
             {owner.editing ? (
-              <CommentEditor owner={owner} accent="var(--faction-snide-pink)" bg="rgba(255,255,255,0.04)" text="var(--faction-snide-card-text)" />
+              <CommentEditor owner={owner} accent="var(--faction-snide-pink)" onAccent="var(--faction-snide-on-accent)" bg="rgba(255,255,255,0.04)" text="var(--faction-snide-card-text)" />
             ) : (
               <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-snide-acid)" />
             )}

--- a/frontend/src/components/comments/voices/UaComment.tsx
+++ b/frontend/src/components/comments/voices/UaComment.tsx
@@ -75,6 +75,7 @@ export default function UaComment(props: CommentProps) {
             onSubmit={onSubmit}
             submitting={submitting}
             accent="var(--faction-ua-card-accent)"
+            onAccent="var(--faction-ua-on-accent)"
             bg="var(--faction-ua-panel)"
             text="var(--faction-ua-card-text)"
           />
@@ -140,6 +141,7 @@ export default function UaComment(props: CommentProps) {
             <CommentEditor
               owner={owner}
               accent="var(--faction-ua-card-accent)"
+              onAccent="var(--faction-ua-on-accent)"
               bg="var(--faction-ua-panel)"
               text="var(--faction-ua-card-text)"
             />

--- a/frontend/src/components/comments/voices/WowComment.tsx
+++ b/frontend/src/components/comments/voices/WowComment.tsx
@@ -80,6 +80,7 @@ export default function WowComment(props: CommentProps) {
             onSubmit={onSubmit}
             submitting={submitting}
             accent="var(--faction-wow-card-accent)"
+            onAccent="var(--faction-wow-on-accent)"
             bg="var(--faction-wow-chronicle-panel)"
             text="var(--faction-wow-card-text)"
             submitLabel={t('comments.wow.post')}
@@ -144,6 +145,7 @@ export default function WowComment(props: CommentProps) {
             <CommentEditor
               owner={owner}
               accent="var(--faction-wow-card-accent)"
+              onAccent="var(--faction-wow-on-accent)"
               bg="var(--faction-wow-chronicle-panel)"
               text="var(--faction-wow-card-text)"
             />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -63,6 +63,23 @@
   --faction-ephemerists-on-fill: #ffffff; /* #1d6e72 — 5.96:1 */
   --faction-singularity-on-fill: #ffffff; /* #2563eb — 5.17:1 */
 
+  /* ── Text on the comment-composer ACCENT (#924) ── The AA-legible ink for the
+     submit button, which is painted in the voice's card-accent (NOT the fill), so
+     it is a different question from -on-fill: e.g. WOW's accent is plum, not the
+     gold its -on-fill measures. Each voice passes its own `accent` — most send
+     --faction-{key}-card-accent, SNIDE sends --faction-snide-pink, Singularity
+     sends --faction-singularity-card-text, na/Default sends the resolved
+     card-accent. Threaded into ComposerControls as `onAccent`; guarded by the
+     ACCENT_PAIRS block in factionContrast.test.ts. Dark overrides live below. */
+  --faction-ua-on-accent: #fcf7ef; /* #a5400f — 5.89:1 (warm white, matches on-fill) */
+  --faction-everymen-on-accent: #ffffff; /* #c1272d — 5.84:1 */
+  --faction-coven-on-accent: #14110b; /* #ec5f99 — white only 3.15:1; ink 5.98:1 */
+  --faction-snide-on-accent: #14110b; /* #ff2d8b (snide-pink) — white 3.50:1; ink 5.38:1 */
+  --faction-wow-on-accent: #ffffff; /* #7a4a9e plum — ink only 2.96:1; white 6.36:1 */
+  --faction-ephemerists-on-accent: #ffffff; /* #9c3622 rubric — 7.08:1 */
+  --faction-singularity-on-accent: #14110b; /* #4ade80 green — white only 1.74:1; ink 10.81:1 */
+  --faction-default-on-accent: #ffffff; /* #1a1209 — 18.51:1 (na has no on-fill; this is its own) */
+
   /* ── Faction tints (backgrounds, highlights) ── */
   --faction-ua-light: #f2e0cb; /* sand tint — opaque, same stock as -panel */
   --faction-wow-light: rgba(224, 168, 0, 0.12);
@@ -946,6 +963,18 @@
   --faction-everymen-on-fill: #14110b; /* #ef5350 — white only 3.49:1; ink 5.45:1 */
   --faction-ephemerists-on-fill: #14110b; /* #3aa0a4 — white only 3.11:1; ink 6.05:1 */
   --faction-singularity-on-fill: #14110b; /* #60a5fa — white only 2.54:1; ink 7.41:1 */
+
+  /* ── Text on the comment-composer ACCENT (dark, #924) ── The accents brighten in
+     dark, so most flip to ink. Ephemerists is the exception: its dark rubric
+     #c0533a takes WHITE (ink 4.07 fails; warm-white 4.34 fails — pure white only).
+     snide (pink) and singularity (green) have theme-invariant accents and inherit
+     their :root ink through the cascade. */
+  --faction-ua-on-accent: #201a14; /* #f0894a — warm white only 2.35:1; ink 6.87:1 */
+  --faction-everymen-on-accent: #14110b; /* #e2433f — white only 4.11:1; ink 4.58:1 */
+  --faction-coven-on-accent: #14110b; /* #f472b6 — white only 2.65:1; ink 7.11:1 */
+  --faction-wow-on-accent: #14110b; /* #c79be0 plum lifted — white only 2.28:1; ink 8.25:1 */
+  --faction-ephemerists-on-accent: #ffffff; /* #c0533a — ink 4.07 & warm-white 4.34 fail; white 4.63:1 */
+  --faction-default-on-accent: #14110b; /* #f0e6d0 — white only 1.24:1; ink 15.19:1 */
 
   /* ── Faction tints (dark) ── */
   --faction-ua-light: #241e18; /* sand tint, dimmed — same stock as the card */

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -89,6 +89,32 @@ const FILL_PAIRS: Pair[] = FILL_KEYS.map((key) => ({
 }));
 
 /**
+ * #924 — text on each comment voice's COMPOSER ACCENT. The submit button is
+ * painted in the accent the voice passes, NOT the fill, so this is a distinct
+ * question from FILL_PAIRS: WOW's accent is plum (white legible), its fill is
+ * gold (ink legible). The surface here is the exact var each voice hands
+ * `ComposerControls` as `accent` — most send `card-accent`, but SNIDE sends
+ * `--faction-snide-pink` and Singularity sends `--faction-singularity-card-text`,
+ * so the surface column cannot be generated from the key. `default` (na) is
+ * INCLUDED here where FILL_PAIRS omits it: the na composer paints its button in a
+ * solid accent (not the rainbow), so `--faction-default-on-accent` is real text.
+ */
+const ACCENT_PAIRS: Pair[] = [
+  { key: "ua", accent: "--faction-ua-card-accent" },
+  { key: "everymen", accent: "--faction-everymen-card-accent" },
+  { key: "coven", accent: "--faction-coven-card-accent" },
+  { key: "snide", accent: "--faction-snide-pink" },
+  { key: "wow", accent: "--faction-wow-card-accent" },
+  { key: "ephemerists", accent: "--faction-ephemerists-card-accent" },
+  { key: "singularity", accent: "--faction-singularity-card-text" },
+  { key: "default", accent: "--faction-default-card-accent" },
+].map(({ key, accent }) => ({
+  what: `${key} composer accent, on-accent`,
+  surface: accent,
+  text: `--faction-${key}-on-accent`,
+}));
+
+/**
  * Archetype-private primitives. Each entry is a role index.css states in
  * words; nothing here is inferred from how a component happens to use a token.
  */
@@ -265,7 +291,7 @@ const ARCHETYPE_PAIRS: Pair[] = [
   },
 ];
 
-const PAIRS: Pair[] = [...CARD_PAIRS, ...FILL_PAIRS, ...ARCHETYPE_PAIRS];
+const PAIRS: Pair[] = [...CARD_PAIRS, ...FILL_PAIRS, ...ACCENT_PAIRS, ...ARCHETYPE_PAIRS];
 
 /**
  * Part C — the baseline allowlist (the ratchet).


### PR DESCRIPTION
## What

The comment-composer submit button (`shared.tsx` `ComposerControls`) is painted in each voice's **card-accent** but hardcoded `color: '#fff'`. White fails WCAG AA (4.5:1) on several accents. The issue's original "reuse `-on-fill`" plan is wrong — `-on-fill` is ink measured against the *fill* hue, not the accent, so swapping to it regresses WOW-light, Ephemerists-dark, and leaves Singularity-light failing; and there is no `--faction-default-on-fill` for na. The owner approved this rescope in the issue's latest comment.

## Approach

New per-theme `--faction-{slug}-on-accent` token family in `index.css` (7 voices + `--faction-default-on-accent` for na), each the AA-legible ink measured against that voice's **actual composer accent** — most `card-accent`, but SNIDE passes `--faction-snide-pink` and Singularity passes `--faction-singularity-card-text`. Threaded through `ComposerControls` and `CommentEditor` as a new `onAccent` prop (parallel to the existing `accent` plumbing), replacing the `#fff`.

Every ink was re-measured with the repo's own WCAG helper (`utils/contrast.ts`) against the current accent values — the resulting direction matches the prior build agent's table in both themes. Notable non-obvious results the guard now locks in:
- **Ephemerists dark** needs pure `#ffffff` (4.63:1); warm-white `#fcf7ef` (4.34) and ink (4.07) both **fail**.
- **Singularity** and **na** need **ink** (white is 1.74 / 1.24).
- **UA** uses its warm-white `#fcf7ef` (light) / `#201a14` (dark), matching its `-on-fill` hexes.

A new `ACCENT_PAIRS` block in `factionContrast.test.ts` pairs each voice's composer accent ↔ its `on-accent` and asserts ≥4.5:1 in both themes — the permanent regression guard.

## Verification

- `tsc --noEmit`: clean (only the known stale-junction `node:*` false alarms, PR #675).
- `eslint` (`no-raw-style-values`): clean.
- `factionContrast.test.ts`: 162 tests pass, including the new accent↔on-accent block.
- `factionTokensDeclared.test.ts` + full `comments/` suite: pass.
- `vite build`: succeeds.
- **Visual QA is outstanding** — no dev stack and the Browser pane renderer times out, so this was verified by tests/tsc/eslint only.

## What to eyeball

Every faction's comment-composer submit button should read legibly in **both** themes:
- **Light mode:** coven and snide (light-pink accents → dark ink), Singularity (green accent → dark ink), na/Default (near-black accent → white).
- **Dark mode:** Ephemerists (its accent needs white, not ink — the tightest pair at 4.63:1), UA / everymen / coven / wow / na (bright accents → dark ink).
- Sibling `@mention` links and comment body text are unchanged — only the submit/save button ink moved.

Closes #924

🤖 Generated with [Claude Code](https://claude.com/claude-code)