### PR TITLE
Updates badge resolves on accept + panel surfaces "your turn to submit"

### DIFF
--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -80,6 +80,7 @@ FEED_ITEM_TYPE_FRIEND_DEFECTION = "friend_defection"
 FEED_ITEM_TYPE_FOE_COMPLETION = "foe_completion"
 FEED_ITEM_TYPE_COMMENT_MENTION = "comment_mention"
 FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED = "collaborator_submitted"
+FEED_ITEM_TYPE_AWAITING_SUBMISSION = "awaiting_submission"
 
 # --- Filter tabs ------------------------------------------------------------
 FILTER_ALL = "all"
@@ -687,6 +688,63 @@ def _collaborator_submitted_item(row: Any) -> ActivityFeedItemDC:
     )
 
 
+def _awaiting_submission_query(ctx: FeedContext) -> Select:
+    """Collab / duel praxes waiting on the VIEWER's own submission.
+
+    A ``PraxisMember`` for the viewer with ``has_submitted=False`` on a still-open
+    (in_progress / mid-consensus pending) collab or duel praxis — i.e. it's their
+    turn to post. The mirror of ``_collaborator_submitted_query`` (which surfaces
+    *others'* submissions). Solo drafts are excluded: a solo praxis-in-progress is
+    just your own draft, not an awaited action, so it would only be badge noise.
+    Ordered by ``joined_at`` — when the praxis landed in the viewer's court
+    (collab accept / duel accept both create the member row then).
+    """
+    query = (
+        select(
+            PraxisMember.id,
+            PraxisMember.joined_at,
+            PraxisMember.praxis_id,
+            Praxis.type.label("praxis_type"),
+            Task.title.label("task_title"),
+            Task.point_value.label("task_point_value"),
+            Task.primary_faction_slug.label("task_faction_slug"),
+            Task.level_required.label("task_level_required"),
+        )
+        .join(Praxis, PraxisMember.praxis_id == Praxis.id)
+        .join(Task, Praxis.task_id == Task.id)
+        .where(
+            PraxisMember.character_id == ctx.character_id,
+            PraxisMember.has_submitted.is_(False),
+            Praxis.type.in_([PraxisType.collab, PraxisType.duel]),
+            Praxis.status.in_([PraxisStatus.in_progress, PraxisStatus.pending]),
+        )
+    )
+    if ctx.before is not None:
+        query = query.where(PraxisMember.joined_at < ctx.before)
+    return query.order_by(PraxisMember.joined_at.desc()).limit(SUB_QUERY_LIMIT)
+
+
+def _awaiting_submission_item(row: Any) -> ActivityFeedItemDC:
+    # No external actor — it's the viewer's own turn. actor_faction_slug=None so
+    # the card frames to the task's faction (schema context_faction_slug fallback).
+    return ActivityFeedItemDC(
+        type=FEED_ITEM_TYPE_AWAITING_SUBMISSION,
+        timestamp=row.joined_at,
+        actor_display_name=None,
+        actor_faction_slug=None,
+        actor_avatar_url=None,
+        payload={
+            "praxis_member_id": row.id,
+            "praxis_id": row.praxis_id,
+            "praxis_type": row.praxis_type.value,
+            "task_title": row.task_title,
+            "task_point_value": row.task_point_value,
+            "task_faction_slug": row.task_faction_slug,
+            "task_level_required": row.task_level_required,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # The registry — one entry per feed type. Adding a type is one line here.
 # ---------------------------------------------------------------------------
@@ -754,6 +812,16 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_collaborator_submitted_query,
         to_item=_collaborator_submitted_item,
+    ),
+    FeedSource(
+        # "Waiting on you to submit" — collab/duel praxes in the viewer's court.
+        # In FILTER_REQUESTS so it drives the sidebar Pending Requests panel and
+        # the mobile bell badge alongside incoming invites/challenges.
+        item_type=FEED_ITEM_TYPE_AWAITING_SUBMISSION,
+        filters=frozenset({FILTER_ALL, FILTER_YOUR_STUFF, FILTER_REQUESTS}),
+        needs=frozenset(),
+        query=_awaiting_submission_query,
+        to_item=_awaiting_submission_item,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_INVITATION_LETTER,

--- a/backend/tests/integration/test_activity_feed.py
+++ b/backend/tests/integration/test_activity_feed.py
@@ -292,3 +292,57 @@ async def test_activity_feed_shows_collaborator_submitted(
     assert not [
         i for i in own.json()["items"] if i["type"] == "collaborator_submitted"
     ]
+
+
+@pytest.mark.asyncio
+async def test_activity_feed_awaiting_submission_in_requests(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A collab awaiting the viewer's own submission surfaces as an
+    ``awaiting_submission`` request (panel + badge), and clears once they
+    submit (#updates-badge — 'waiting on you to submit')."""
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "Team"},
+        headers=auth_headers2,
+    )
+    praxis_id = create.json()["id"]
+    inv = await client.post(
+        f"/praxes/{praxis_id}/invite",
+        json={"invitee_id": character.id},
+        headers=auth_headers2,
+    )
+    await client.post(
+        f"/praxes/{praxis_id}/invite/{inv.json()['id']}/respond",
+        json={"accept": True},
+        headers=auth_headers,
+    )
+
+    # character joined but hasn't submitted -> it's in their court.
+    requests = (
+        await client.get(
+            "/activity-feed", params={"filter": "requests", "limit": 100},
+            headers=auth_headers,
+        )
+    ).json()
+    awaiting = [i for i in requests["items"] if i["type"] == "awaiting_submission"]
+    assert len(awaiting) == 1, requests["items"]
+    assert awaiting[0]["payload"]["praxis_id"] == praxis_id
+    assert awaiting[0]["payload"]["praxis_type"] == "collab"
+    # Count/badge stays consistent with the fetch (ADR-0036 invariant).
+    assert requests["counts"]["requests"] == len(requests["items"])
+
+    # Once character submits their part, the praxis leaves their requests bucket.
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
+    after = (
+        await client.get(
+            "/activity-feed", params={"filter": "requests", "limit": 100},
+            headers=auth_headers,
+        )
+    ).json()
+    assert not [i for i in after["items"] if i["type"] == "awaiting_submission"]

--- a/frontend/src/api/duel.ts
+++ b/frontend/src/api/duel.ts
@@ -1,4 +1,5 @@
 import api from './axios'
+import { notifyRequestsChanged } from '../utils/requestsBus'
 
 // ---------------------------------------------------------------------------
 // Types — match backend schemas/duel.py exactly (ADR-0011)
@@ -74,6 +75,9 @@ export async function getDuelDetail(duelId: number): Promise<DuelDetailOut> {
 
 export async function respondToChallenge(duelId: number, data: DuelRespondIn): Promise<DuelOut> {
   const { data: result } = await api.post<DuelOut>(`/duels/${duelId}/respond`, data)
+  // The challenge left your requests bucket (accept → now awaiting your
+  // submission; decline → gone). Refresh every feed surface (#updates-badge).
+  notifyRequestsChanged()
   return result
 }
 

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -1,5 +1,6 @@
 import api from './axios'
 import { clearVoteOverrides } from '../components/vote/voteOverrides'
+import { notifyRequestsChanged } from '../utils/requestsBus'
 import type { TaskOut } from './tasks'
 import type { FlagReason } from '../utils/flagReasons'
 
@@ -230,6 +231,7 @@ export async function updatePraxis(id: number, data: PraxisUpdate): Promise<Prax
 
 export async function deletePraxis(id: number): Promise<void> {
   await api.delete(`/praxes/${id}`)
+  notifyRequestsChanged()
 }
 
 /** Flip a praxis between solo and collab in place, preserving id/content/media (#321). */
@@ -247,11 +249,15 @@ export async function changePraxisType(id: number, type: PraxisType): Promise<Pr
 // the caller has submitted, it clears only the caller's part.
 export async function unsubmitPraxis(id: number): Promise<PraxisOut> {
   const { data } = await api.post<PraxisOut>(`/praxes/${id}/unsubmit`)
+  // A collab/duel is awaiting your submission again — refresh the badge.
+  notifyRequestsChanged()
   return data
 }
 
 export async function submitPraxis(id: number): Promise<PraxisOut> {
   const { data } = await api.post<PraxisOut>(`/praxes/${id}/submit`)
+  // Your part landed — this praxis leaves the "awaiting your submission" bucket.
+  notifyRequestsChanged()
   return data
 }
 
@@ -261,6 +267,7 @@ export async function submitPraxis(id: number): Promise<PraxisOut> {
  */
 export async function leavePraxis(id: number): Promise<PraxisOut> {
   const { data } = await api.post<PraxisOut>(`/praxes/${id}/leave`)
+  notifyRequestsChanged()
   return data
 }
 
@@ -299,6 +306,9 @@ export async function respondToInvite(
     `/praxes/${praxisId}/invite/${inviteId}/respond`,
     { accept },
   )
+  // The invite left your requests bucket (accept → now awaiting your
+  // submission; decline → gone). Refresh every feed surface (#updates-badge).
+  notifyRequestsChanged()
   return data
 }
 

--- a/frontend/src/components/feed/normalizeFeedItem.ts
+++ b/frontend/src/components/feed/normalizeFeedItem.ts
@@ -29,6 +29,7 @@ export const FACTION_ROW_TYPES = new Set([
   'friend_defection',
   'global_task',
   'collaborator_submitted',
+  'awaiting_submission',
 ])
 
 export interface FeedRow {
@@ -114,6 +115,29 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.points', { points: p.task_point_value })
             : null,
         level: null,
+        time,
+      }
+    case 'awaiting_submission':
+      // Your turn: a collab/duel praxis waiting on your submission (#updates-
+      // badge). No actor — the action leads and the task title links straight
+      // to the editor. Badged by praxis type so collab/duel read distinctly.
+      return {
+        slug,
+        actor: null,
+        actorHref: null,
+        action: i18n.t('feed:row.action.awaitingSubmission'),
+        badge:
+          p.praxis_type === 'duel'
+            ? { type: 'duel', label: i18n.t('feed:badge.duel') }
+            : { type: 'collab', label: i18n.t('feed:badge.collab') },
+        headline: p.task_title ?? null,
+        headlineHref: p.praxis_id != null ? `/praxes/${p.praxis_id}/edit` : null,
+        headlineQuoted: false,
+        points:
+          p.task_point_value != null
+            ? i18n.t('feed:row.points', { points: p.task_point_value })
+            : null,
+        level: p.task_level_required ?? null,
         time,
       }
     case 'vote_on_mine':

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -215,19 +215,29 @@ export default function Sidebar() {
         <section style={panelStyle}>
           <SectionHeader label={t('sidebar.pendingRequests.heading', { count: pendingRequests.length })} />
           <div className="flex flex-col gap-1.5">
-            {pendingRequests.map((item, index) => (
-              <PendingRequestRow
-                key={`${item.type}-${index}`}
-                item={item}
-                isFirst={index === 0}
-                onResolved={() => {
-                  // An accepted collab/duel becomes an in-progress praxis —
-                  // refresh both panels so the request moves bars (#346).
-                  refetchPendingRequests()
-                  refetchActiveTasks()
-                }}
-              />
-            ))}
+            {pendingRequests.map((item, index) =>
+              // "Waiting on you to submit" — a collab/duel already in your court.
+              // No accept/decline; a single link to the editor (#updates-badge).
+              item.type === 'awaiting_submission' ? (
+                <AwaitingSubmissionRow
+                  key={`${item.type}-${index}`}
+                  item={item}
+                  isFirst={index === 0}
+                />
+              ) : (
+                <PendingRequestRow
+                  key={`${item.type}-${index}`}
+                  item={item}
+                  isFirst={index === 0}
+                  onResolved={() => {
+                    // An accepted collab/duel becomes an in-progress praxis —
+                    // refresh both panels so the request moves bars (#346).
+                    refetchPendingRequests()
+                    refetchActiveTasks()
+                  }}
+                />
+              ),
+            )}
           </div>
         </section>
       )}
@@ -412,6 +422,67 @@ const REQUEST_BUTTON_BASE: CSSProperties = {
   textTransform: 'uppercase',
   letterSpacing: '0.08em',
   padding: 'var(--space-xs) var(--space-sm)',
+}
+
+/**
+ * A "waiting on you to submit" row: a collab/duel praxis already in the
+ * viewer's court (#updates-badge). Unlike PendingRequestRow there's no
+ * accept/decline — just a link into the editor to post your part.
+ */
+function AwaitingSubmissionRow({
+  item,
+  isFirst,
+}: {
+  item: ActivityFeedItem
+  isFirst: boolean
+}) {
+  const { t } = useTranslation('common')
+  const praxisId = item.payload.praxis_id
+  const isDuel = item.payload.praxis_type === 'duel'
+  return (
+    <div
+      className="py-1.5"
+      style={{ borderTop: !isFirst ? '1px dashed var(--color-border)' : undefined }}
+    >
+      <div className="flex items-center gap-2">
+        {/* task-faction dot in place of an actor avatar */}
+        <span
+          className="shrink-0 rounded-full"
+          style={{
+            width: 24,
+            height: 24,
+            background: `linear-gradient(135deg, ${factionCssVar(item.payload.task_faction_slug, 'light')}, ${factionCssVar(item.payload.task_faction_slug)})`,
+          }}
+        />
+        <div className="flex-1 min-w-0">
+          <Link
+            to={`/praxes/${praxisId}/edit`}
+            className="font-body block truncate"
+            style={{ fontSize: 'var(--text-xl)', fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+          >
+            {item.payload.task_title}
+          </Link>
+          <span className="eyebrow block" style={{ color: 'var(--color-text-tertiary)' }}>
+            {isDuel ? t('requests.awaitingSubmissionDuel') : t('requests.awaitingSubmissionCollab')}
+          </span>
+        </div>
+      </div>
+      <div className="flex items-center gap-1.5" style={{ marginTop: 'var(--space-xs)', marginLeft: 'var(--space-2xl)' }}>
+        <Link
+          to={`/praxes/${praxisId}/edit`}
+          style={{
+            ...REQUEST_BUTTON_BASE,
+            background: isDuel ? 'var(--badge-duel)' : 'var(--badge-collab)',
+            color: 'var(--color-text-on-accent)',
+            border: 'none',
+            textDecoration: 'none',
+          }}
+        >
+          {t('actions.submit')}
+        </Link>
+      </div>
+    </div>
+  )
 }
 
 /**

--- a/frontend/src/hooks/usePendingRequests.ts
+++ b/frontend/src/hooks/usePendingRequests.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { getActivityFeed, type ActivityFeedItem } from '../api/activityFeed'
 import { useAuth } from '../auth/AuthContext'
+import { onRequestsChanged } from '../utils/requestsBus'
 
 /**
  * Hook to fetch pending collab invites and duel challenges.
@@ -29,6 +30,9 @@ export function usePendingRequests() {
 
   useEffect(() => {
     refetch()
+    // Respond/submit/leave anywhere in the app invalidates this count (#346):
+    // refetch so the sidebar panel and mobile bell badge resolve immediately.
+    return onRequestsChanged(refetch)
   }, [refetch])
 
   return { pendingRequests, loading, refetch } as const

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -297,6 +297,7 @@
   "actions": {
     "accept": "Accept",
     "decline": "Decline",
+    "submit": "Submit",
     "proposeTask": "Propose a Task"
   },
   "filters": {
@@ -319,7 +320,9 @@
   },
   "requests": {
     "collabInvite": "Collab Invite",
-    "duelChallenge": "Duel Challenge"
+    "duelChallenge": "Duel Challenge",
+    "awaitingSubmissionCollab": "Your turn — submit your collab",
+    "awaitingSubmissionDuel": "Your turn — submit your duel"
   },
   "sidebar": {
     "characterCard": {

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -36,7 +36,8 @@
       "votedOnYourPraxis": "voted on your praxis",
       "tauntsYou": "taunts you",
       "defected": "defected from {{oldFaction}} to {{newFaction}}",
-      "globalTaskActivated": "A new task has been activated"
+      "globalTaskActivated": "A new task has been activated",
+      "awaitingSubmission": "Waiting on your submission"
     },
     "points": "{{points}} pts",
     "pointsEarned": "+{{points}} pts",

--- a/frontend/src/pages/updates/useUpdates.ts
+++ b/frontend/src/pages/updates/useUpdates.ts
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { getActivityFeed, type ActivityFeedItem, type FeedCounts } from '../../api/activityFeed'
 import { extractError } from '../../utils/errors'
+import { onRequestsChanged } from '../../utils/requestsBus'
 
 export type FeedFilter = 'All' | 'Friends' | 'Foes' | 'Your Stuff' | 'Global' | 'Requests'
 
@@ -64,6 +65,9 @@ export function useUpdates(): UpdatesState {
   const [nextCursor, setNextCursor] = useState<string | null>(null)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
+  // Bumped when a request is accepted/declined/submitted anywhere; re-runs the
+  // load effect so the tab counts (esp. Requests) resolve without a reload.
+  const [refreshKey, setRefreshKey] = useState(0)
 
   const fetchFeed = useCallback(async (feedFilter: FeedFilter, cursor?: string) => {
     return getActivityFeed({
@@ -91,7 +95,10 @@ export function useUpdates(): UpdatesState {
       setLoading(false)
     })
     return () => { cancelled = true }
-  }, [filter, fetchFeed])
+  }, [filter, fetchFeed, refreshKey])
+
+  // Refresh the current filter (items + counts) after any accept/decline/submit.
+  useEffect(() => onRequestsChanged(() => setRefreshKey((key) => key + 1)), [])
 
   const loadMore = async () => {
     if (!nextCursor || loadingMore) return

--- a/frontend/src/utils/requestsBus.ts
+++ b/frontend/src/utils/requestsBus.ts
@@ -1,0 +1,28 @@
+// ponytail: a ~12-line pub-sub so an accept/decline/submit anywhere refreshes
+// the requests count, the mobile bell badge, and the sidebar panel — cheaper
+// than threading a refetch callback through every feed card and detail page.
+// The activity-feed counts live in independent hook instances (useUpdates,
+// usePendingRequests) with no shared cache; without this, only the component
+// that made the request would see the change. Upgrade to a query cache
+// (react-query) if the app grows more of these cross-component invalidations.
+
+type Listener = () => void
+
+const listeners = new Set<Listener>()
+
+/**
+ * Fire after any action that changes the current character's pending requests
+ * (accept/decline an invite or challenge, submit/unsubmit, leave/delete a
+ * collab or duel praxis). Every subscribed feed surface refetches.
+ */
+export function notifyRequestsChanged(): void {
+  for (const fn of listeners) fn()
+}
+
+/** Subscribe to request changes; returns an unsubscribe function. */
+export function onRequestsChanged(fn: Listener): () => void {
+  listeners.add(fn)
+  return () => {
+    listeners.delete(fn)
+  }
+}


### PR DESCRIPTION
## What & why

Two related activity-feed bugs reported from QA:

1. **The Updates number never resolved after accepting.** Accepting/declining a duel or collab left the Updates count (desktop tab + mobile bell badge) stuck. Root cause: the feed counts live in *independent* hook instances (`useUpdates`, `usePendingRequests`) with no shared cache, and the feed cards respond by calling the API directly — so nothing told the other surfaces to refetch.

2. **The side panel didn't show "waiting on you to submit."** The `requests` bucket only held incoming invites/challenges. Collab/duel praxes already in *your* court (accepted, not yet submitted) produced no notification anywhere.

## Approach

**Bug 1 — one choke point.** New ~12-line `requestsBus` pub/sub. `notifyRequestsChanged()` fires from the API functions every accept path routes through (`respondToInvite`, `respondToChallenge`) plus the other actions that change the set (`submit`/`unsubmit`/`leave`/`delete`). Both hooks subscribe and refetch. Badge, panel, and the Requests tab now resolve instantly, wherever you act.

**Bug 2 — one feed source.** Added `awaiting_submission` to the ADR-0036 feed registry (`FILTER_ALL`/`YOUR_STUFF`/`REQUESTS`), so it flows to the panel, the mobile badge, and the Updates tab from a single entry: `PraxisMember` rows with `has_submitted=False` on an open collab/duel. Solo drafts excluded (would badge every in-progress draft as noise). Rendered as a slot row in the feed and a "Submit" row in the sidebar Pending Requests panel.

One consequence worth knowing: accepting a collab/duel invite no longer drops the count to zero — the item correctly **moves** from "invite" to "waiting on you to submit," and clears when you actually submit.

## Verification

- New backend integration test: `awaiting_submission` appears in `requests` and clears on submit; count/fetch invariant (ADR-0036) holds. `test_activity_feed.py` 4/4 green.
- eslint clean on all changed files; tsc clean on changed files.
- **Verified live** in the running app: the sidebar panel rendered both a Collab Invite row and a "FLIP THE SYSTEM — Your turn — submit your collab — Submit" row; the mobile layout showed a "2 pending requests" bell badge; clicking **Decline** dropped the panel count 2 → 1 with no reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)