### PR TITLE
fix(feed): give unaffiliated (na) actors the rainbow on fill surfaces (#983)

### DIFF
--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -139,4 +139,17 @@ describe('FeedRowContent', () => {
     expect(html).toContain('Reforest')
     expect(html).toContain('href="/praxes/7"')
   })
+
+  // ADR-0039: an unaffiliated (na) actor's monogram avatar is the rainbow ring,
+  // not the flat grey a scalar factionColor would hand it. Real factions keep
+  // their tinted disc.
+  it('gives an na actor the rainbow-ring avatar, a real faction a tinted disc', () => {
+    const naRow = normalizeFeedItem({ ...item('friend_completion', { character_id: 3, praxis_id: 7, task_title: 'Reforest', task_point_value: 40 }), context_faction_slug: 'na' })!
+    const naHtml = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={naRow} avatarUrl={null} /></MemoryRouter>)
+    expect(naHtml).toContain('--faction-default-ring')
+
+    const covenRow = normalizeFeedItem(item('friend_completion', { character_id: 3, praxis_id: 7, task_title: 'Reforest', task_point_value: 40 }))!
+    const covenHtml = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={covenRow} avatarUrl={null} /></MemoryRouter>)
+    expect(covenHtml).not.toContain('--faction-default-ring')
+  })
 })

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -13,7 +13,7 @@ import {
   leavePraxis,
 } from "../../api/praxis";
 import { extractError } from "../../utils/errors";
-import { factionColor } from "../../utils/factions";
+import { factionColor, factionFill, isKnownFaction } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
 
@@ -33,8 +33,11 @@ export default function FeedCardCollabInvite({ item }: Props) {
     task_level_required,
     inviter_character_id,
   } = item.payload;
-  const taskColor = factionColor(task_faction_slug);
   const actorColor = factionColor(item.actor_faction_slug);
+  // na actors get the spectrum, real factions keep their tinted disc (ADR-0039).
+  const actorAvatarFill = isKnownFaction(item.actor_faction_slug)
+    ? { background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)` }
+    : factionFill(item.actor_faction_slug, "dot");
   const navigate = useNavigate();
 
   const { user } = useAuth();
@@ -118,7 +121,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
                 width: 28,
                 height: 28,
                 borderRadius: "50%",
-                background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+                ...actorAvatarFill,
                 flexShrink: 0,
                 marginTop: "var(--space-xs)",
               }}
@@ -190,7 +193,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
               width: 8,
               height: 8,
               borderRadius: "50%",
-              background: taskColor,
+              ...factionFill(task_faction_slug, "dot"),
               flexShrink: 0,
             }}
           />

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -9,7 +9,7 @@ import { useGameConfig } from "../../hooks/useGameConfig";
 import { useAuth } from "../../auth/AuthContext";
 import { deletePraxis, leavePraxis } from "../../api/praxis";
 import { cancelChallenge, respondToChallenge } from "../../api/duel";
-import { factionColor } from "../../utils/factions";
+import { factionColor, factionFill, isKnownFaction } from "../../utils/factions";
 import { relativeTime } from "../../utils/dates";
 import { extractError } from "../../utils/errors";
 import FeedBadge from "./FeedBadge";
@@ -37,8 +37,11 @@ export default function FeedCardDuelChallenge({ item }: Props) {
     task_faction_slug,
     challenger_character_id,
   } = item.payload;
-  const taskColor = factionColor(task_faction_slug);
   const actorColor = factionColor(item.actor_faction_slug);
+  // na actors get the spectrum, real factions keep their tinted disc (ADR-0039).
+  const actorAvatarFill = isKnownFaction(item.actor_faction_slug)
+    ? { background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)` }
+    : factionFill(item.actor_faction_slug, "dot");
   const navigate = useNavigate();
 
   const { user } = useAuth();
@@ -147,7 +150,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
                 width: 28,
                 height: 28,
                 borderRadius: "50%",
-                background: `linear-gradient(135deg, ${actorColor}, ${actorColor}88)`,
+                ...actorAvatarFill,
                 flexShrink: 0,
                 marginTop: "var(--space-xs)",
               }}
@@ -219,7 +222,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
               width: 8,
               height: 8,
               borderRadius: "50%",
-              background: taskColor,
+              ...factionFill(task_faction_slug, "dot"),
               flexShrink: 0,
             }}
           />

--- a/frontend/src/components/feed/FeedRowContent.tsx
+++ b/frontend/src/components/feed/FeedRowContent.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import i18n from '../../i18n'
-import { factionColor } from '../../utils/factions'
+import { factionColor, isKnownFaction } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import FeedBadge from './FeedBadge'
 import type { FeedRow } from './normalizeFeedItem'
@@ -20,6 +20,7 @@ export default function FeedRowContent({
   avatarUrl: string | null
 }) {
   const accent = factionColor(row.slug)
+  const known = isKnownFaction(row.slug)
   const initial = row.actor?.[0]?.toUpperCase() ?? '·'
 
   const actorNode = row.actor ? (
@@ -50,7 +51,7 @@ export default function FeedRowContent({
                 alt=""
                 style={{ width: 28, height: 28, borderRadius: '50%', objectFit: 'cover', flexShrink: 0, marginTop: 'var(--space-xs)' }}
               />
-            ) : (
+            ) : known ? (
               <div
                 style={{
                   width: 28,
@@ -70,6 +71,42 @@ export default function FeedRowContent({
                 }}
               >
                 {initial}
+              </div>
+            ) : (
+              // Unaffiliated (na): no legible ink sits on the spectrum, so the
+              // rainbow is the ring and the monogram rides a neutral interior
+              // (ADR-0039 §4, the same idiom as CharacterSwitcher's miniRing).
+              <div
+                style={{
+                  width: 28,
+                  height: 28,
+                  borderRadius: '50%',
+                  background: 'var(--faction-default-ring)',
+                  // eslint-disable-next-line local/no-raw-style-values -- ornament: this inset *is* the drawn ring stroke, not spacing
+                  padding: 2,
+                  boxSizing: 'border-box',
+                  flexShrink: 0,
+                  marginTop: 'var(--space-xs)',
+                }}
+              >
+                <span
+                  style={{
+                    display: 'flex',
+                    width: '100%',
+                    height: '100%',
+                    borderRadius: '50%',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    background: 'var(--color-bg-surface-alt)',
+                    color: 'var(--color-text-primary)',
+                    fontFamily: "'Courier Prime', monospace",
+                    // eslint-disable-next-line local/no-raw-style-values -- ornament: monogram glyph sized to the 28px avatar disc
+                    fontSize: 12,
+                    fontWeight: 700,
+                  }}
+                >
+                  {initial}
+                </span>
               </div>
             )}
           </MaybeLink>


### PR DESCRIPTION
Fixes the **fill** half of #983: unaffiliated (`na`) actors in the activity feed rendered flat grey instead of the na rainbow, because all four feed cards took their accent from `factionColor(slug)`, which has no rainbow branch.

## What changed
Routes the feed's **fill** surfaces through the ADR-0039 helpers. Real factions are visually unchanged; only `na` (and `albescent`, which resolves to `default`) changes.

- **`FeedRowContent`** — monogram avatar becomes the rainbow **ring** (paper interior + ink initial), the ADR-0039 §4 idiom, since no ink is legible across the spectrum. Real factions keep their tinted disc.
- **`FeedCardDuelChallenge` / `FeedCardCollabInvite`** — actor avatar disc + task dot go through `factionFill(slug, "dot")` (conic rainbow for na, solid `var()` hue for real factions — which also makes those dots theme-aware).
- **`FeedCardInvitationLetter`** — unchanged; only scalar text colors (grey per ADR-0039 §2), and invitations only come from real factions.

Scalar surfaces (actor-name text `color:`, the frame's grey left border, the headline rule) **intentionally stay grey** — ADR-0039 §2, a gradient is only legal in `background:`.

## Test
`feedRow.test.tsx` gains a guard: an na row renders `--faction-default-ring`; a coven row does not. eslint + tsc + vitest (10/10) verified green.

## Out of scope (stays in #983, `needs-design`)
The **full** na Updates look — gradient `@mentions`, conic unread dots, rainbow tab underline + wordmark rule — is specified in `templates/global/Notifications.dc.html` (World Zero Design System project) and never built. It's a tabbed-Inbox layout vs. the live card-per-event feed, so it needs a design decision + vendoring. See the [#983 comment](https://github.com/pixieofhugs/WorldZeroPlayground/issues/983) — it's the missing **Updates** surface of the na-kit fidelity family (#967–970).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
