### PR TITLE
copy(coven): feed identity windowTitle whimsy.exe -> coven.exe

### DIFF
--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -120,7 +120,7 @@
       "wordmark": "THE EPHEMERISTS"
     },
     "coven": {
-      "windowTitle": "whimsy.exe"
+      "windowTitle": "coven.exe"
     },
     "singularity": {
       "protocol": "singularity protocol"

--- a/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
+++ b/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
@@ -66,7 +66,7 @@ describe('mobile Updates mixed multi-faction stream', () => {
     const { text, html } = render(baseState({ items }))
     // Distinct per-faction frame markers appearing TOGETHER in one render
     // prove a mixed stream, not one uniform tint.
-    expect(text, 'COVEN window chrome').toContain('whimsy.exe')
+    expect(text, 'COVEN window chrome').toContain('coven.exe')
     // UA's frame is dress only now (#851): a 3px orange rule and the ensō, no
     // engraved masthead, so the marker is the token rather than a house line.
     expect(html, 'UA ink-rule frame').toContain('3px solid var(--faction-ua)')


### PR DESCRIPTION
Follow-up from #917 (Coven donor-slug cleanup, landed in #978). #917 de-donored `feed:taskCard.coven.windowTitle` (`wow.exe` -> `coven.exe`) but deliberately left the sibling `identity.coven.windowTitle` out of its table because it is coupled to a vitest assertion. This PR retires that last donor-slug artifact.

## Change
- `frontend/src/locales/en/feed.json` — `identity.coven.windowTitle`: `"whimsy.exe"` -> `"coven.exe"` (matches the already-fixed `taskCard.coven.windowTitle`; keeps Coven's window chrome consistent across all three consuming surfaces).
- `frontend/src/pages/updates/__tests__/mixedStream.test.tsx:69` — the coupled COVEN-window-chrome assertion updated `'whimsy.exe'` -> `'coven.exe'` so the `frontend` vitest job stays green.

Copy + one test assertion only. No component or CSS change. `FactionSelectCard.tsx:131` (`--gestalt-title-text`) is explicitly out of scope — separate tracked styling concern.

## Verification
- `vitest run src/pages/updates/__tests__/mixedStream.test.tsx` — 4/4 pass.
- `eslint` on both changed files — 0 errors (feed.json is JSON, not linted).
- `tsc --version` confirmed 5.9.3 (real binary, not a stub) before trusting the run.
- No `whimsy` remains as user-facing Coven copy; remaining hits are code comments, CSS token names, and WOW's legit "Warriors of Whimsy" faction text — all out of scope.
- Visual QA outstanding: no dev stack / Browser pane in this environment, so the rendered Coven feed window / faction-select title bar was not screenshotted.

## What to eyeball
- The Coven feed window chrome (CovenFeedFrame) and the Coven faction-select window title bar now read `coven.exe`.

Closes #988