### PR TITLE
Mobile composers: Solo · Collab · Duel mode picker (#877)

### DIFF
--- a/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
@@ -30,7 +30,12 @@ import {
 } from "../archetypes/controls";
 import { MetataskSealStack } from "../MetataskSealStack";
 import type { EditPraxisState } from "../useEditPraxis";
-import { MobileStickyBar, SegToggle, type ComposerTab } from "./shared";
+import {
+  DefaultModePicker,
+  MobileStickyBar,
+  SegToggle,
+  type ComposerTab,
+} from "./shared";
 
 const PINK = "var(--faction-coven)";
 const PINK_DEEP = "var(--faction-coven-card-accent)";
@@ -259,6 +264,9 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
 
       {tab === "write" ? (
         <>
+          {/* Mode — Solo · Collab · Duel, above the title (scrolls with content) */}
+          <DefaultModePicker state={state} />
+
           <Window title={t("editPraxis.coven.titleLabel")}>
             <TitleField
               state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
@@ -25,7 +25,12 @@ import {
 } from "../archetypes/controls";
 import { MetataskSealStack } from "../MetataskSealStack";
 import type { EditPraxisState } from "../useEditPraxis";
-import { MobileStickyBar, SegToggle, type ComposerTab } from "./shared";
+import {
+  DefaultModePicker,
+  MobileStickyBar,
+  SegToggle,
+  type ComposerTab,
+} from "./shared";
 
 const ACCENT = "var(--faction-default)";
 const SURFACE = "var(--color-bg-surface)";
@@ -136,6 +141,9 @@ export default function DefaultEditPraxis({
 
       {tab === "write" ? (
         <>
+          {/* Mode — Solo · Collab · Duel, above the title (scrolls with content) */}
+          <DefaultModePicker state={state} />
+
           {/* Title */}
           <label style={{ display: "flex", flexDirection: "column", gap: "var(--space-xs)" }}>
             <span style={eyebrow}>{t("editPraxis.na.titleLabel")}</span>

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
@@ -17,7 +17,12 @@ import {
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
 import type { EditPraxisState } from '../useEditPraxis'
-import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+import {
+  DefaultModePicker,
+  MobileStickyBar,
+  SegToggle,
+  type ComposerTab,
+} from './shared'
 
 /**
  * The Ephemerists MOBILE composer (#527) — "Seal & Enter" on a phone. The same
@@ -121,6 +126,9 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
 
       {tab === 'write' ? (
         <>
+          {/* Mode — Solo · Collab · Duel, above the title (scrolls with content) */}
+          <DefaultModePicker state={state} />
+
           <Leaf title={t('editPraxis.ephemerists.titleLabel')}>
             <TitleField
               state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
@@ -17,7 +17,12 @@ import {
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
 import type { EditPraxisState } from '../useEditPraxis'
-import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+import {
+  DefaultModePicker,
+  MobileStickyBar,
+  SegToggle,
+  type ComposerTab,
+} from './shared'
 
 /**
  * Everymen MOBILE composer (#529) — "Stamp & File" on a phone. The same
@@ -113,6 +118,9 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
 
       {tab === 'write' ? (
         <>
+          {/* Mode — Solo · Collab · Duel, above the title (scrolls with content) */}
+          <DefaultModePicker state={state} />
+
           <Plate title={t('editPraxis.everymen.titleLabel')}>
             <TitleField
               state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
@@ -17,7 +17,12 @@ import {
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
 import type { EditPraxisState } from '../useEditPraxis'
-import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+import {
+  DefaultModePicker,
+  MobileStickyBar,
+  SegToggle,
+  type ComposerTab,
+} from './shared'
 
 /**
  * Singularity MOBILE composer (#526) — "TRANSMIT SIGNAL" on a phone. The same
@@ -114,6 +119,9 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
 
       {tab === 'write' ? (
         <>
+          {/* Mode — Solo · Collab · Duel, above the title (scrolls with content) */}
+          <DefaultModePicker state={state} />
+
           <Panel title={t('editPraxis.singularity.mobile.titleLabel')}>
             <TitleField
               state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
@@ -17,7 +17,12 @@ import {
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
 import type { EditPraxisState } from '../useEditPraxis'
-import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+import {
+  DefaultModePicker,
+  MobileStickyBar,
+  SegToggle,
+  type ComposerTab,
+} from './shared'
 
 /**
  * S.N.I.D.E. MOBILE composer (#530) — "FILE IT & RUN" on a phone. The same
@@ -120,6 +125,9 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
 
       {tab === 'write' ? (
         <>
+          {/* Mode — Solo · Collab · Duel, above the title (scrolls with content) */}
+          <DefaultModePicker state={state} />
+
           <Plate title={t('editPraxis.snide.titleLabel')}>
             <TitleField
               state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
@@ -18,7 +18,12 @@ import {
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
 import type { EditPraxisState } from '../useEditPraxis'
-import { MobileStickyBar, SegToggle, type ComposerTab } from './shared'
+import {
+  DefaultModePicker,
+  MobileStickyBar,
+  SegToggle,
+  type ComposerTab,
+} from './shared'
 
 /**
  * University of Asthmatics MOBILE composer (#525/#852) — sealing a mark, on a
@@ -169,6 +174,9 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
 
       {tab === 'write' ? (
         <>
+          {/* Mode — Solo · Collab · Duel, above the title (scrolls with content) */}
+          <DefaultModePicker state={state} />
+
           <Field label={t('editPraxis.ua.titleLabel')}>
             <TitleField
               state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
@@ -36,7 +36,12 @@ import {
 } from "../archetypes/controls";
 import { MetataskSealStack } from "../MetataskSealStack";
 import type { EditPraxisState } from "../useEditPraxis";
-import { MobileStickyBar, SegToggle, type ComposerTab } from "./shared";
+import {
+  DefaultModePicker,
+  MobileStickyBar,
+  SegToggle,
+  type ComposerTab,
+} from "./shared";
 
 /* The chronicle palette, straight off the post-#838 token block. */
 const GOLD = factionCssVar("wow", "chronicle-gold"); // gilt frame + rules
@@ -276,6 +281,9 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
 
       {tab === "write" ? (
         <>
+          {/* Mode — Solo · Collab · Duel, above the title (scrolls with content) */}
+          <DefaultModePicker state={state} />
+
           <Plate
             title={t("editPraxis.wow.titleLabel")}
             aside={<TitleCounter length={state.title.length} color={MUTED} />}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/modePicker.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/modePicker.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Mobile mode picker (#877) — the Solo · Collab · Duel segmented control that
+ * every mobile composer scrolls at the top, above the title. It renders through
+ * the shared ModePicker, so these tests pin the reused gate/lock behaviour as it
+ * reaches the Default mobile skin: all three segments when the task allows every
+ * mode and the duel chip is visible, the duel segment hidden below the level
+ * gate, and a single collapsed pill once the mode is locked. renderToStaticMarkup
+ * needs no DOM (effects never run), so we feed a fully-formed state.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../../i18n";
+import type { EditPraxisState } from "../../useEditPraxis";
+import type { PraxisOut } from "../../../../api/praxis";
+import type { TaskOut } from "../../../../api/tasks";
+
+const mocks = vi.hoisted(() => ({
+  formFactor: "mobile" as "mobile" | "desktop",
+  state: null as EditPraxisState | null,
+}));
+
+vi.mock("../../../../hooks/useFormFactor", () => ({
+  useFormFactor: () => mocks.formFactor,
+}));
+vi.mock("../../useEditPraxis", () => ({
+  useEditPraxis: () => mocks.state,
+}));
+
+// Imported after the mocks are registered.
+import EditPraxis from "../../../EditPraxis";
+
+function task(allowedModes: string[]): TaskOut {
+  return {
+    id: 7,
+    title: "A Very Human Thing",
+    description: "Do a small honest thing.",
+    point_value: 20,
+    level_required: 1,
+    status: "active",
+    task_type: "standard",
+    created_by: 3,
+    primary_faction_slug: null,
+    metatask_faction_slug: null,
+    is_task_vision_eligible: false,
+    created_at: "2026-01-01T00:00:00Z",
+    can_submit_praxis: true,
+    allowed_modes: allowedModes,
+    eligible_for_current_user: true,
+  };
+}
+
+const praxis = {
+  id: 55,
+  task_id: 7,
+  task_title: "A Very Human Thing",
+  type: "solo",
+  status: "in_progress",
+  title: "I helped a stranger",
+  body_text: "## What I did\n\nCaught the papers.",
+  moderation_status: "visible",
+  duel_id: null,
+  members: [],
+  invites: [],
+  media_items: [],
+} as unknown as PraxisOut;
+
+function baseState(): EditPraxisState {
+  return {
+    loading: false,
+    praxis,
+    task: task(["solo", "collab", "duel"]),
+    error: "",
+    setError: () => {},
+    title: "I helped a stranger",
+    setTitle: () => {},
+    body: "## What I did\n\nCaught the papers.",
+    setBody: () => {},
+    wordCount: 4,
+    media: [],
+    fileError: "",
+    handleFileChange: () => {},
+    removeMedia: async () => {},
+    pendingImage: null,
+    confirmImageEdit: async () => {},
+    cancelImageEdit: () => {},
+    switchingMode: null,
+    changeMode: async () => {},
+    inviteQuery: "",
+    setInviteQuery: () => {},
+    inviteResults: [],
+    inviteOpen: false,
+    setInviteOpen: () => {},
+    inviting: false,
+    sendInvite: async () => {},
+    cancelInvite: async () => {},
+    kickMember: async () => {},
+    duel: null,
+    sendChallenge: async () => {},
+    cancelDuel: async () => {},
+    dissolveDuel: async () => {},
+    metaTasks: [],
+    appliedMetatasks: new Set(),
+    applyingMetatask: null,
+    toggleMetatask: async () => {},
+    appliedMetataskList: [],
+    addMetatask: async () => {},
+    metataskPickerOpen: false,
+    openMetataskPicker: () => {},
+    closeMetataskPicker: () => {},
+    metataskRemovalTarget: null,
+    requestRemoveMetatask: () => {},
+    confirmRemoveMetatask: async () => {},
+    cancelRemoveMetatask: () => {},
+    submitting: false,
+    publish: async () => {},
+    pullBack: async () => {},
+    leaveCollab: async () => {},
+    collabSuccess: false,
+    continueFromCollabSuccess: () => {},
+    duelSealOpen: false,
+    requestDuelSeal: () => {},
+    cancelDuelSeal: () => {},
+    cancel: async () => {},
+    autosaveAt: null,
+    saveStatus: "idle",
+    isPublished: false,
+    controlsLocked: false,
+    modeIsLocked: false,
+    showInviteBox: false,
+    showMetatasks: false,
+    canSealMetatask: false,
+    showSealStack: false,
+    duelMode: false,
+    duelChipVisible: false,
+    currentCharacterId: 3,
+  };
+}
+
+function render(state: EditPraxisState): string {
+  mocks.state = state;
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <EditPraxis />
+    </MemoryRouter>,
+  );
+}
+
+// The na mode labels the shared skin reuses (forms.json editPraxis.na.mode.*).
+const SOLO = "On my own";
+const COLLAB = "With others";
+const DUEL = "Head-to-head";
+
+describe("mobile mode picker (#877)", () => {
+  it("renders all three segments when every mode is allowed and the duel chip is visible", () => {
+    const html = render({ ...baseState(), duelChipVisible: true });
+    expect(html).toContain(SOLO);
+    expect(html).toContain(COLLAB);
+    expect(html).toContain(DUEL);
+  });
+
+  it("hides the duel segment below the level gate (duelChipVisible false)", () => {
+    const html = render({ ...baseState(), duelChipVisible: false });
+    expect(html).toContain(SOLO);
+    expect(html).toContain(COLLAB);
+    expect(html).not.toContain(DUEL);
+  });
+
+  it("collapses to a single active pill once the mode is locked", () => {
+    // Locked solo praxis: the shared ModePicker drops every non-active option, so
+    // the control shows only the active mode — a static pill, not a dead toggle.
+    const html = render({
+      ...baseState(),
+      modeIsLocked: true,
+      duelChipVisible: true,
+    });
+    expect(html).toContain(SOLO);
+    expect(html).not.toContain(COLLAB);
+    expect(html).not.toContain(DUEL);
+  });
+});

--- a/frontend/src/pages/editPraxis/mobileArchetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/shared.tsx
@@ -8,6 +8,9 @@
  */
 import type { CSSProperties, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import type { PraxisType } from "../../../api/praxis";
+import { ModePicker } from "../archetypes/controls";
+import type { EditPraxisState } from "../useEditPraxis";
 
 // The fixed MobileTabBar + its safe-area padding occupy this much at the bottom
 // of the viewport (mirrors MobileLayout's <main> bottom padding). The submit
@@ -41,6 +44,78 @@ export function MobileStickyBar({
     >
       {children}
     </div>
+  );
+}
+
+const MODE_KEYS = ["solo", "collab", "duel"] as const;
+
+/**
+ * Mobile mode picker (#877) — the single-row Solo · Collab · Duel segmented
+ * control that scrolls at the top of every mobile composer. It renders THROUGH
+ * the shared ModePicker (archetypes/controls) so the level gate (#311), the
+ * task's allowed-modes filter, and the lock collapse are reused verbatim — this
+ * skin only paints each segment. The duel segment appears only when
+ * `duelChipVisible`; once `modeIsLocked` (published/moderated) the shared
+ * component hides the non-active options, so this collapses to a single static
+ * pill instead of a dead one-segment toggle. Copy reuses the desktop `na` mode
+ * labels — no new strings. Every faction shares this one Default skin until a
+ * bespoke mobile picker lands.
+ */
+export function DefaultModePicker({ state }: { state: EditPraxisState }) {
+  const { t } = useTranslation("forms");
+  const allowedModes = state.task?.allowed_modes ?? ["solo", "collab", "duel"];
+  const options: { key: PraxisType; label: string }[] = MODE_KEYS.map(
+    (key) => ({ key, label: t(`editPraxis.na.mode.${key}.label`) }),
+  );
+  const locked = state.modeIsLocked;
+  return (
+    <ModePicker
+      state={state}
+      skin={{
+        options,
+        allowedModes,
+        // Locked: shed the segmented chrome so the lone active option reads as a
+        // standalone pill, not a container hugging one button.
+        containerStyle: locked
+          ? { display: "inline-flex" }
+          : {
+              display: "flex",
+              gap: "var(--space-xs)",
+              padding: "var(--space-xs)",
+              background: "var(--color-bg-surface)",
+              border: "1px solid var(--color-border)",
+              borderRadius: 999,
+            },
+        renderOption: (opt, { active, disabled, onSelect }) => (
+          <button
+            key={opt.key}
+            type="button"
+            aria-pressed={active}
+            disabled={disabled && !active}
+            onClick={onSelect}
+            style={{
+              flex: locked ? "0 0 auto" : 1,
+              padding: "var(--space-sm) var(--space-md)",
+              borderRadius: 999,
+              border: "none",
+              fontFamily: "var(--font-body)",
+              fontSize: "var(--text-md)",
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              fontWeight: active ? 700 : 400,
+              background: active ? "var(--faction-default)" : "transparent",
+              color: active
+                ? "var(--color-text-on-accent)"
+                : "var(--color-text-secondary)",
+              cursor: disabled ? "default" : "pointer",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {opt.label}
+          </button>
+        ),
+      }}
+    />
   );
 }
 


### PR DESCRIPTION
## What & why
On a phone you could not choose solo/collab/duel — no mobile composer rendered a mode picker, so every mobile praxis was stuck at whatever mode state defaulted to. Everything downstream of the choice already reacted (`useEditPraxis` exposes `changeMode`, `duelChipVisible`, `modeIsLocked`, `allowedModes`; the invite/challenge box is gated on `state.showInviteBox`). The whole hole was that nothing rendered a control calling `changeMode`.

## Change
- New **`DefaultModePicker`** mobile skin in `mobileArchetypes/shared.tsx`: a single-row **Solo · Collab · Duel** segmented control. It renders **through the shared `ModePicker`** (`archetypes/controls.tsx`), so the level gate (#311), the task's `allowed_modes` filter, and the lock collapse are reused verbatim — the skin only paints each segment via `renderOption`. No gate/lock logic is re-implemented.
- Wired into **all 8 mobile archetypes** (Default, Coven, Ua, Snide, Singularity, Everymen, Ephemerists, Wow), at the **top of the write tab, above the title field** (scrolls with content, not sticky). All 8 share the one Default skin — per-faction bespoke mobile pickers are a later nicety.
- Duel segment appears only when `duelChipVisible` (hidden below level, never shown-disabled). Once `modeIsLocked` the shared component hides non-active options, so the control **collapses to a single static pill** (chrome shed) rather than a dead one-segment toggle.
- Copy reuses the existing `editPraxis.na.mode.*` labels — **no new strings**.

## Verification
- `tsc --noEmit`: clean for all changed files (only the known stale-junction `node:fs`/`node:url` false alarms in unrelated `__tests__`, per PR #675, remain).
- `vite build`: succeeds.
- `eslint`: clean on all changed files.
- `vitest` (`mobileArchetypes/__tests__/`): 22 passed, including a new `modePicker.test.tsx` (all-three-segments, duel hidden below gate, single-pill collapse when locked).
- **Visual QA outstanding**: no dev stack / screenshotting available in this environment.

## What to eyeball
On a phone (narrow viewport / mobile form factor):
- Each faction's composer shows the **Solo · Collab · Duel** segmented control above the title.
- Picking **Collab** or **Duel** reveals the invite/challenge box.
- Once a duel is **accepted** (mode locked) the control collapses to a single locked pill.
- The **Duel** segment is hidden for characters below the level gate.

Closes #877