### PR TITLE
test(factions): cover the mobile factions directory (+ testability split) (#743)

### DIFF
--- a/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
+++ b/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Mobile factions directory (#732 grid + #733 letters, tested #743). Renders the
+ * pure `FactionsDirectoryView` skin directly over controlled rows — the same seam
+ * DefaultPlayers gives the players directory. The live `DefaultFactionsDirectory`
+ * container self-fetches inside a useEffect, and this harness is node +
+ * renderToStaticMarkup (no DOM, effects never fire), so a direct container render
+ * only ever reaches the loading state; feeding the view controlled props is the
+ * only way to assert the four things merge review had to catch by hand.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import type { FactionOut, FactionPageOut, FactionStatusOut, InvitationLetterOut } from '../../../api/factions'
+import FactionsDirectoryView from '../mobileArchetypes/FactionsDirectoryView'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+// An Albescent-hidden six-faction list, deliberately out of rainbow order and
+// carrying `na` — exactly what an unrevealed player gets from GET /factions
+// (ADR-0027 omits Albescent; the view drops `na`). This is the shape that shipped
+// the 7-stripes-over-6-cards regression when the bar was built off the static
+// seven-slug array instead of the rendered rows.
+const FACTIONS: FactionOut[] = [
+  { slug: 'coven' },
+  { slug: 'everymen' },
+  { slug: 'snide' },
+  { slug: 'na' },
+  { slug: 'ua' },
+  { slug: 'ephemerists' },
+  { slug: 'singularity' },
+]
+
+function status(rows: Array<[string, string]>): FactionPageOut {
+  const all_factions: FactionStatusOut[] = rows.map(([slug, status]) => ({ slug, status }))
+  return { current_faction_slug: 'coven', all_factions }
+}
+
+// A viewer who is a Coven member, recruited by S.N.I.D.E., and not invited by
+// Everymen — one of each of the three card states the tiles must distinguish.
+const STATUS = status([
+  ['coven', 'member'],
+  ['snide', 'invited'],
+  ['everymen', 'not_invited'],
+  ['ua', 'not_invited'],
+  ['ephemerists', 'not_invited'],
+  ['singularity', 'not_invited'],
+])
+
+const NO_INVITES: InvitationLetterOut[] = []
+
+function view(overrides: Partial<React.ComponentProps<typeof FactionsDirectoryView>> = {}) {
+  return render(
+    <FactionsDirectoryView
+      factions={FACTIONS}
+      factionPage={STATUS}
+      invitations={NO_INVITES}
+      loading={false}
+      error={null}
+      unaffiliated={false}
+      onVisit={() => {}}
+      {...overrides}
+    />,
+  )
+}
+
+// The stripe bar is one hard-edged span per rendered card. Extract it so the
+// count and the order are read off the legend alone, not the whole page.
+function stripeBar(html: string): string {
+  const start = html.indexOf('data-testid="faction-stripe-bar"')
+  expect(start, 'stripe bar rendered').toBeGreaterThan(-1)
+  return html.slice(start, html.indexOf('</div>', start))
+}
+
+describe('mobile factions directory — stripe/card correspondence (#743)', () => {
+  it('draws exactly one stripe per rendered card, na dropped', () => {
+    const { html } = view()
+    const stripes = (stripeBar(html).match(/<span/g) ?? []).length
+    // One CTA button per FactionSelectCard is the only <button on the page.
+    const cards = (html.match(/<button/g) ?? []).length
+
+    // Six real factions survive (na filtered), Albescent never present. This is
+    // the invariant that broke: a static seven-stripe bar over six cards.
+    expect(stripes, 'six stripes').toBe(6)
+    expect(cards, 'six cards').toBe(6)
+    expect(stripes, 'stripe N == card N').toBe(cards)
+  })
+
+  it('keeps rainbow order, not desktop member-first sort', () => {
+    const { html } = view()
+    const bar = stripeBar(html)
+    // Coven is a member here; a member-first sort would float it to the front.
+    // Rainbow order pins it last (pink) and Everymen first (red).
+    const order = ['everymen', 'ua', 'snide', 'ephemerists', 'singularity', 'coven']
+    const positions = order.map((slug) => bar.indexOf(`--faction-${slug}`))
+    for (const [index, pos] of positions.entries()) {
+      expect(pos, `${order[index]} present in bar`).toBeGreaterThan(-1)
+    }
+    const sorted = [...positions].sort((a, b) => a - b)
+    expect(positions, 'stripes ascend in rainbow order').toEqual(sorted)
+    expect(
+      bar.indexOf('--faction-coven'),
+      'the member faction is not floated to the front',
+    ).toBeGreaterThan(bar.indexOf('--faction-everymen'))
+  })
+})
+
+describe('mobile factions directory — real card state (#743)', () => {
+  it('renders each card in its true member/eligible/locked voice, not a uniform neutral', () => {
+    const { text } = view()
+    // Distinct per-state status copy proves the status prop reaches the tiles.
+    expect(text, 'Coven member line').toContain('You’re one of us now')
+    expect(text, 'S.N.I.D.E. eligible line').toContain('Consider yourself recruited.')
+    expect(text, 'Everymen locked line').toContain('Put in the shift and there’s a place for you.')
+    // The eligible/locked copies must not collapse into one another.
+    expect(text).not.toContain('Active operative — welcome to the mess.')
+  })
+
+  it('falls back to locked when a faction has no status row', () => {
+    const { text } = view({ factionPage: status([]) })
+    // No rows at all → every card locked, none showing an eligible/member voice.
+    expect(text, 'Coven falls back to locked').toContain('Do the tiny brave thing to be invited')
+    expect(text).not.toContain('You’re one of us now')
+    expect(text).not.toContain('Consider yourself recruited.')
+  })
+})
+
+describe('mobile factions directory — invitation letters panel (#743)', () => {
+  it('draws nothing when the invite list is empty', () => {
+    const { text } = view({ invitations: [] })
+    // The panel is header + rows only when a letter exists — an empty feed is silent.
+    expect(text).not.toContain('Recent Invitations')
+    expect(text, 'no INVITE badge without a letter').not.toContain('INVITE')
+  })
+
+  it('renders a row per letter, linking to the faction detail page', () => {
+    const invitations: InvitationLetterOut[] = [
+      { faction_slug: 'snide', delivered_at: '2026-01-01T00:00:00Z' },
+      { faction_slug: 'coven', delivered_at: '2026-01-02T00:00:00Z' },
+    ]
+    const { html, text } = view({ invitations })
+    expect(text, 'panel header appears with a count').toContain('Recent Invitations')
+    expect(html, 'S.N.I.D.E. letter links to its detail page').toContain('href="/factions/snide"')
+    expect(html, 'Coven letter links to its detail page').toContain('href="/factions/coven"')
+  })
+})
+
+describe('mobile factions directory — states (#743)', () => {
+  it('shows the loading line and no cards before data arrives', () => {
+    const { html, text } = view({ loading: true })
+    expect(text, 'loading copy shown').toContain('Loading')
+    expect(html, 'no cards while loading').not.toContain('<button')
+  })
+
+  it('surfaces a load error in place of the card stack', () => {
+    const { html, text } = view({ error: 'Boom', loading: false })
+    expect(text).toContain('Boom')
+    expect(html, 'no cards behind an error').not.toContain('<button')
+  })
+
+  it('shows the unaffiliated banner only to a factionless viewer', () => {
+    expect(view({ unaffiliated: true }).html).toContain('sidebar-card')
+    expect(view({ unaffiliated: false }).html).not.toContain('sidebar-card')
+  })
+})

--- a/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
+++ b/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import { Trans, useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import {
   getFactions,
   getFactionStatus,
@@ -9,44 +9,25 @@ import {
   type FactionPageOut,
   type InvitationLetterOut,
 } from '../../../api/factions'
-import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
-import { relativeTime } from '../../../utils/dates'
-import FactionSelectCard, { type SelectState } from '../../../components/cards/FactionSelectCard'
 import { useAuth } from '../../../auth/AuthContext'
 import { extractError } from '../../../utils/errors'
+import FactionsDirectoryView from './FactionsDirectoryView'
 
 const NA_SLUG = 'na'
 
-const STATUS_MEMBER = 'member'
-const STATUS_INVITED = 'invited'
-const STATUS_NOT_INVITED = 'not_invited'
-const STATUS_CAN_RETURN = 'can_return'
-
 /**
- * Default MOBILE factions-directory skin — the phone twin of the desktop
- * Factions grid. A single-column screen, in render order: a title, the faction
- * stripe bar, any invitation letters the player holds (#733), an "unaffiliated"
- * banner (shown only while the viewer hasn't sworn to a faction), then a
- * vertical stack of the SAME bespoke FactionSelectCard
- * archetypes desktop uses (#732), each visiting its faction's detail page where
- * all membership actions live (#347). Member counts are intentionally dropped —
- * no cheap per-faction count query exists (ADR-0035: real fields only).
+ * Default MOBILE factions-directory container — the thin fetching wrapper behind
+ * the pure `FactionsDirectoryView` skin. Bespoke faction directory skins register
+ * in Factions' `mobileFactionsDirectory` surface.
  *
- * The stripe bar is a legend for the list: one hard-edged span per rendered
- * row, in the same rainbow order, so stripe N == card N. That's why it is NOT
- * `var(--faction-default-rainbow)` (a smooth gradient, no per-faction
- * correspondence) and why the list keeps rainbow order rather than desktop's
- * member-first sort. The stripe count follows the fetched list rather than a
- * static seven — Albescent is hidden until revealed (ADR-0027).
- *
- * Self-fetches the (slug-only) faction list plus the viewer's per-faction
- * status, so the cards render real member/eligible/locked rather than a
- * uniform neutral. Bespoke faction directory skins register in Factions'
- * the `mobileFactionsDirectory` surface.
+ * Self-fetches the (slug-only) faction list plus the viewer's per-faction status
+ * and any invitation letters, then hands them to the view as controlled props so
+ * the cards render real member/eligible/locked rather than a uniform neutral. All
+ * layout lives in the view; this file owns only the fetch, so the surface is
+ * testable over controlled rows (#743) — mirror of DefaultPlayers' container.
  */
 export default function DefaultFactionsDirectory() {
   const { t } = useTranslation('factions')
-  const { t: tc } = useTranslation('common')
   const { user } = useAuth()
   const navigate = useNavigate()
   const character = user?.character ?? null
@@ -70,7 +51,7 @@ export default function DefaultFactionsDirectory() {
     // two, and `get_account_invited_faction_slugs` excludes the same pair while
     // being ACCOUNT-pooled — strictly broader than the character-scoped
     // /factions/invitations. So every slug this feed can return already reports
-    // `invited` in /factions/status. `selectState` stays as-is (#733).
+    // `invited` in /factions/status. The view's selectState stays as-is (#733).
     const load = async () => {
       const factionsData = await getFactions()
       if (cancelled) return
@@ -93,154 +74,15 @@ export default function DefaultFactionsDirectory() {
     }
   }, [t, character?.id])
 
-  // Same invite-gated status → three-state mapping as DesktopFactions.
-  const selectState = (slug: string): SelectState => {
-    const status =
-      factionPage?.all_factions.find((f) => f.slug === slug)?.status ?? STATUS_NOT_INVITED
-    if (status === STATUS_MEMBER) return 'member'
-    if (status === STATUS_INVITED || status === STATUS_CAN_RETURN) return 'eligible'
-    return 'locked'
-  }
-
-  const visible = sortFactionsByRainbowOrder(factions.filter((f) => f.slug !== NA_SLUG))
-
   return (
-    <div className="py-4" data-testid="mobile-factions-directory">
-      <h1
-        className="font-display italic font-medium mb-3"
-        style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)', lineHeight: 1.1 }}
-      >
-        {tc('nav.factions')}
-      </h1>
-
-      {/* Faction legend: one hard-edged stripe per faction, in the same order
-          as the cards below. Deliberately not extracted — single caller.
-
-          Driven off `visible` (the rows actually rendered), NOT the static
-          FACTION_RAINBOW_ORDER: Albescent is a secret society omitted from
-          /factions until the account is revealed to it (ADR-0027, #390,
-          routers/factions.py:53). A hardcoded seven-stripe bar would both
-          break the stripe==row correspondence for unrevealed players and
-          leak Albescent's existence in its own colour. */}
-      {visible.length > 0 && (
-        <div
-          aria-hidden="true"
-          style={{
-            display: 'flex',
-            height: 10,
-            borderRadius: 999,
-            overflow: 'hidden',
-            marginBottom: 'var(--space-xl)',
-          }}
-        >
-          {visible.map((f) => (
-            <span key={f.slug} style={{ flex: 1, background: factionCssVar(f.slug) }} />
-          ))}
-        </div>
-      )}
-
-      {/* Invitation letters. Rendered only when the player actually holds one —
-          an empty list draws NOTHING (no header, no empty state).
-
-          ponytail: NO collapse toggle, unlike desktop's collapsed-by-default
-          panel. Desktop can collapse because its grid is fully visible above
-          the fold and each tile already shows `eligible`; on a phone the cards
-          are a tall vertical stack, so this panel is the only thing that tells
-          an invited player a letter exists without scrolling. A collapsed
-          `▸ Recent Invitations (1)` would defeat the point of the issue, and
-          one or two rows never need collapsing. Rows link to the detail page,
-          which owns Accept/Decline (ADR-0030, #347). */}
-      {invitations.length > 0 && (
-        <div className="mb-4" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
-          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
-            {t('index.recentInvitations', { count: invitations.length })}
-          </span>
-          {invitations.map((inv) => (
-            <Link
-              key={inv.faction_slug}
-              to={`/factions/${inv.faction_slug}`}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 'var(--space-sm)',
-                padding: 'var(--space-md)',
-                textDecoration: 'none',
-                background: `linear-gradient(135deg, ${factionCssVar(inv.faction_slug, 'light')}, transparent)`,
-                borderLeft: `3px solid ${factionCssVar(inv.faction_slug, 'border')}`,
-              }}
-            >
-              <span className="eyebrow">{t('index.inviteBadge')}</span>
-              <span
-                className="font-body"
-                style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)', flex: 1, lineHeight: 1.4 }}
-              >
-                <Trans
-                  t={t}
-                  i18nKey="index.invitedToJoin"
-                  values={{ faction: factionName(inv.faction_slug) }}
-                  components={[
-                    <span key="0" />,
-                    <span key="1" style={{ fontWeight: 700, color: factionCssVar(inv.faction_slug) }} />,
-                  ]}
-                />
-              </span>
-              <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
-                {relativeTime(inv.delivered_at)}
-              </span>
-            </Link>
-          ))}
-        </div>
-      )}
-
-      {unaffiliated && (
-        <section
-          className="sidebar-card mb-4"
-          style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', padding: 'var(--space-md) var(--space-lg)' }}
-        >
-          <span
-            aria-hidden="true"
-            style={{
-              width: 34,
-              height: 34,
-              borderRadius: '50%',
-              flex: 'none',
-              background: 'var(--color-bg-surface-alt)',
-              border: '1px solid var(--color-border)',
-            }}
-          />
-          <div>
-            <div
-              className="font-display italic"
-              style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)' }}
-            >
-              {t('mobile.unaffiliatedTitle')}
-            </div>
-            <p
-              className="font-body"
-              style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)', marginTop: 'var(--space-xs)', lineHeight: 1.4 }}
-            >
-              {t('mobile.unaffiliatedBody')}
-            </p>
-          </div>
-        </section>
-      )}
-
-      {loading ? (
-        <p className="font-body text-muted">{t('index.loading')}</p>
-      ) : error ? (
-        <p className="font-body content-text text-red-600 border-2 border-red-300 px-3 py-2">{error}</p>
-      ) : (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2xl)' }}>
-          {visible.map((f) => (
-            <FactionSelectCard
-              key={f.slug}
-              faction={f.slug}
-              state={selectState(f.slug)}
-              onVisit={() => navigate(`/factions/${f.slug}`)}
-            />
-          ))}
-        </div>
-      )}
-    </div>
+    <FactionsDirectoryView
+      factions={factions}
+      factionPage={factionPage}
+      invitations={invitations}
+      loading={loading}
+      error={error}
+      unaffiliated={unaffiliated}
+      onVisit={(slug) => navigate(`/factions/${slug}`)}
+    />
   )
 }

--- a/frontend/src/pages/factions/mobileArchetypes/FactionsDirectoryView.tsx
+++ b/frontend/src/pages/factions/mobileArchetypes/FactionsDirectoryView.tsx
@@ -1,0 +1,220 @@
+import { Link } from 'react-router-dom'
+import { Trans, useTranslation } from 'react-i18next'
+import type {
+  FactionOut,
+  FactionPageOut,
+  InvitationLetterOut,
+} from '../../../api/factions'
+import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
+import { relativeTime } from '../../../utils/dates'
+import FactionSelectCard, { type SelectState } from '../../../components/cards/FactionSelectCard'
+
+const NA_SLUG = 'na'
+
+const STATUS_MEMBER = 'member'
+const STATUS_INVITED = 'invited'
+const STATUS_NOT_INVITED = 'not_invited'
+const STATUS_CAN_RETURN = 'can_return'
+
+export interface FactionsDirectoryViewProps {
+  /** Slug-only faction list from GET /factions — Albescent absent until revealed. */
+  factions: FactionOut[]
+  /** Per-faction viewer status from GET /factions/status — drives card state. */
+  factionPage: FactionPageOut | null
+  /** Invitation letters the viewer holds — backs the letters PANEL only. */
+  invitations: InvitationLetterOut[]
+  loading: boolean
+  error: string | null
+  /** Whether the viewer has not yet sworn to a faction (shows the banner). */
+  unaffiliated: boolean
+  /** Visit-faction handler — navigates to the faction's detail page. */
+  onVisit: (slug: string) => void
+}
+
+/**
+ * Pure presentational skin for the Default MOBILE factions directory — the phone
+ * twin of the desktop Factions grid. A single-column screen, in render order: a
+ * title, the faction stripe bar, any invitation letters the player holds (#733),
+ * an "unaffiliated" banner (shown only while the viewer hasn't sworn to a
+ * faction), then a vertical stack of the SAME bespoke FactionSelectCard
+ * archetypes desktop uses (#732), each visiting its faction's detail page where
+ * all membership actions live (#347). Member counts are intentionally dropped —
+ * no cheap per-faction count query exists (ADR-0035: real fields only).
+ *
+ * The stripe bar is a legend for the list: one hard-edged span per rendered
+ * row, in the same rainbow order, so stripe N == card N. That's why it is NOT
+ * `var(--faction-default-rainbow)` (a smooth gradient, no per-faction
+ * correspondence) and why the list keeps rainbow order rather than desktop's
+ * member-first sort. The stripe count follows the fetched list rather than a
+ * static seven — Albescent is hidden until revealed (ADR-0027).
+ *
+ * NO fetching and NO effects: the container (`DefaultFactionsDirectory`) fetches
+ * the slug-only faction list plus the viewer's per-faction status and feeds them
+ * here as controlled props, so the cards render real member/eligible/locked
+ * rather than a uniform neutral. This seam is what makes the surface testable
+ * (#743) — mirror of how DefaultPlayers is the pure skin behind its container.
+ */
+export default function FactionsDirectoryView({
+  factions,
+  factionPage,
+  invitations,
+  loading,
+  error,
+  unaffiliated,
+  onVisit,
+}: FactionsDirectoryViewProps) {
+  const { t } = useTranslation('factions')
+  const { t: tc } = useTranslation('common')
+
+  // Same invite-gated status → three-state mapping as DesktopFactions.
+  const selectState = (slug: string): SelectState => {
+    const status =
+      factionPage?.all_factions.find((f) => f.slug === slug)?.status ?? STATUS_NOT_INVITED
+    if (status === STATUS_MEMBER) return 'member'
+    if (status === STATUS_INVITED || status === STATUS_CAN_RETURN) return 'eligible'
+    return 'locked'
+  }
+
+  const visible = sortFactionsByRainbowOrder(factions.filter((f) => f.slug !== NA_SLUG))
+
+  return (
+    <div className="py-4" data-testid="mobile-factions-directory">
+      <h1
+        className="font-display italic font-medium mb-3"
+        style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)', lineHeight: 1.1 }}
+      >
+        {tc('nav.factions')}
+      </h1>
+
+      {/* Faction legend: one hard-edged stripe per faction, in the same order
+          as the cards below. Deliberately not extracted — single caller.
+
+          Driven off `visible` (the rows actually rendered), NOT the static
+          FACTION_RAINBOW_ORDER: Albescent is a secret society omitted from
+          /factions until the account is revealed to it (ADR-0027, #390,
+          routers/factions.py:53). A hardcoded seven-stripe bar would both
+          break the stripe==row correspondence for unrevealed players and
+          leak Albescent's existence in its own colour. */}
+      {visible.length > 0 && (
+        <div
+          aria-hidden="true"
+          data-testid="faction-stripe-bar"
+          style={{
+            display: 'flex',
+            height: 10,
+            borderRadius: 999,
+            overflow: 'hidden',
+            marginBottom: 'var(--space-xl)',
+          }}
+        >
+          {visible.map((f) => (
+            <span key={f.slug} style={{ flex: 1, background: factionCssVar(f.slug) }} />
+          ))}
+        </div>
+      )}
+
+      {/* Invitation letters. Rendered only when the player actually holds one —
+          an empty list draws NOTHING (no header, no empty state).
+
+          ponytail: NO collapse toggle, unlike desktop's collapsed-by-default
+          panel. Desktop can collapse because its grid is fully visible above
+          the fold and each tile already shows `eligible`; on a phone the cards
+          are a tall vertical stack, so this panel is the only thing that tells
+          an invited player a letter exists without scrolling. A collapsed
+          `▸ Recent Invitations (1)` would defeat the point of the issue, and
+          one or two rows never need collapsing. Rows link to the detail page,
+          which owns Accept/Decline (ADR-0030, #347). */}
+      {invitations.length > 0 && (
+        <div className="mb-4" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
+          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+            {t('index.recentInvitations', { count: invitations.length })}
+          </span>
+          {invitations.map((inv) => (
+            <Link
+              key={inv.faction_slug}
+              to={`/factions/${inv.faction_slug}`}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--space-sm)',
+                padding: 'var(--space-md)',
+                textDecoration: 'none',
+                background: `linear-gradient(135deg, ${factionCssVar(inv.faction_slug, 'light')}, transparent)`,
+                borderLeft: `3px solid ${factionCssVar(inv.faction_slug, 'border')}`,
+              }}
+            >
+              <span className="eyebrow">{t('index.inviteBadge')}</span>
+              <span
+                className="font-body"
+                style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)', flex: 1, lineHeight: 1.4 }}
+              >
+                <Trans
+                  t={t}
+                  i18nKey="index.invitedToJoin"
+                  values={{ faction: factionName(inv.faction_slug) }}
+                  components={[
+                    <span key="0" />,
+                    <span key="1" style={{ fontWeight: 700, color: factionCssVar(inv.faction_slug) }} />,
+                  ]}
+                />
+              </span>
+              <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+                {relativeTime(inv.delivered_at)}
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {unaffiliated && (
+        <section
+          className="sidebar-card mb-4"
+          style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', padding: 'var(--space-md) var(--space-lg)' }}
+        >
+          <span
+            aria-hidden="true"
+            style={{
+              width: 34,
+              height: 34,
+              borderRadius: '50%',
+              flex: 'none',
+              background: 'var(--color-bg-surface-alt)',
+              border: '1px solid var(--color-border)',
+            }}
+          />
+          <div>
+            <div
+              className="font-display italic"
+              style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)' }}
+            >
+              {t('mobile.unaffiliatedTitle')}
+            </div>
+            <p
+              className="font-body"
+              style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)', marginTop: 'var(--space-xs)', lineHeight: 1.4 }}
+            >
+              {t('mobile.unaffiliatedBody')}
+            </p>
+          </div>
+        </section>
+      )}
+
+      {loading ? (
+        <p className="font-body text-muted">{t('index.loading')}</p>
+      ) : error ? (
+        <p className="font-body content-text text-red-600 border-2 border-red-300 px-3 py-2">{error}</p>
+      ) : (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2xl)' }}>
+          {visible.map((f) => (
+            <FactionSelectCard
+              key={f.slug}
+              faction={f.slug}
+              state={selectState(f.slug)}
+              onVisit={() => onVisit(f.slug)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Adds the missing test coverage for the mobile factions directory (`DefaultFactionsDirectory`), the surface #735/#737 landed with no tests.

The component was a self-fetching container: it populates `factions` / `factionPage` / `invitations` in a `useEffect` that awaits the API. The test harness is `node` + `renderToStaticMarkup` (no jsdom, effects never fire), so a direct render only ever reaches the loading state — it cannot assert any of the four coverage points. The players directory is testable only because it has a pure prop-driven skin (`DefaultPlayers`); the factions directory needed the same seam.

**The owner approved lifting the issue's original "test file only, no production changes" constraint** — a prior investigation correctly found the component untestable as-is, and the minimal production split below was approved.

## Production split (visual no-op)

- **Extract `FactionsDirectoryView`** — a pure presentational skin taking controlled props `{ factions, factionPage, invitations, loading, error, unaffiliated, onVisit }`. All the JSX (stripe bar, invitation letters panel, unaffiliated banner, `FactionSelectCard` stack) moved here. No fetching, no effects.
- **`DefaultFactionsDirectory` stays the thin wrapper** — keeps the `useEffect` fetch of `/factions` + `/factions/status` + `/factions/invitations` and passes results down. Mirrors how `DefaultPlayers` is the pure skin behind its container.

The only markup change is a `data-testid="faction-stripe-bar"` on the (already `aria-hidden`) legend div, so the test can read the stripe count off the legend alone.

## Test

New `frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx`, modelled on `playersDirectory.test.tsx`, rendering `FactionsDirectoryView` over controlled rows:

- **Stripe count == rendered card count** with an Albescent-hidden six-faction list (the exact 7-stripes-over-6-cards regression fixed in `61eaff0`), with `na` dropped.
- **Cards render real member/eligible/locked state** from the status prop (distinct per-state status copy), plus the locked fallback when a faction has no status row.
- **Invitations panel is silent when empty**, and renders rows linking to `/factions/:slug` when non-empty.
- **Rainbow order preserved** — a member faction (Coven) is not floated to the front.
- Plus loading / error / unaffiliated-banner states.

## Verify

- `tsc --noEmit` clean for the changed files (only the known `node:fs`/`node:url` stale-junction false alarms in unrelated pre-existing test files, PR #675).
- `eslint` clean on all three files.
- `vite build` OK.
- New test: 9 passing, exercising `FactionsDirectoryView` directly (not a hollow loading-state test). Existing `mobileArchetypeSlots.test.tsx` still green (18 passing).

## What to eyeball

Visual QA is outstanding — I cannot screenshot and there is no dev stack. The mobile factions directory must look **identical to before** (visual no-op):

- Same rainbow stripe legend bar (one stripe per rendered card, same order, Albescent absent for unrevealed players).
- Same vertical card stack with live member / eligible / locked state per faction.
- Same invitation letters panel (silent when you hold none; rows linking to the faction detail page when you do).
- Same unaffiliated banner for factionless viewers, same loading / error lines.

Closes #743