### PR TITLE
Move duel actions from the owner controls into the duel rail (#752)

### DIFF
--- a/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
+++ b/frontend/src/components/duel/__tests__/duelSkinSlots.test.tsx
@@ -231,7 +231,7 @@ describe('duel rail skins render every slot', () => {
     ),
   ]
 
-  it.each(skins)('%s passes headline, tally, note and body through', (_name, Skin) => {
+  it.each(skins)('%s passes headline, tally, note, body and actions through', (_name, Skin) => {
     const html = renderToStaticMarkup(
       <Skin
         accent="var(--faction-snide)"
@@ -241,12 +241,17 @@ describe('duel rail skins render every slot', () => {
         tally={<span>SLOT_TALLY</span>}
         note={<span>SLOT_NOTE</span>}
         body={<span>SLOT_BODY</span>}
+        actions={<span>SLOT_ACTIONS</span>}
       />,
     )
     expect(html).toContain('SLOT_HEADLINE')
     expect(html).toContain('SLOT_TALLY')
     expect(html).toContain('SLOT_NOTE')
     expect(html).toContain('SLOT_BODY')
+    // #752: the owner's action row is a seventh slot every skin must place. A
+    // skin that forgot to render it — leaving the submit/pull-back/forfeit
+    // control stranded off-screen — fails here, in every registered face.
+    expect(html).toContain('SLOT_ACTIONS')
   })
 
   /**
@@ -273,6 +278,7 @@ describe('duel rail skins render every slot', () => {
         tally={<span>SLOT_TALLY</span>}
         note={<span>SLOT_NOTE</span>}
         body={<span>SLOT_BODY</span>}
+        actions={<span>SLOT_ACTIONS</span>}
       />,
     )
     const sizes = html.match(/font-size:\s*var\((--text-[a-z]+)\)/g) ?? []
@@ -280,8 +286,8 @@ describe('duel rail skins render every slot', () => {
     expect(offenders).toEqual([])
   })
 
-  // declined / forfeited legitimately arrive with no race left; a skin must not
-  // crash or invent one.
+  // declined / forfeited legitimately arrive with no race left AND no action row
+  // (#752: `actions` is null there too); a skin must not crash or invent either.
   it.each(skins)('%s survives the empty-body states', (_name, Skin) => {
     const html = renderToStaticMarkup(
       <Skin
@@ -292,6 +298,7 @@ describe('duel rail skins render every slot', () => {
         tally={null}
         note={null}
         body={null}
+        actions={null}
       />,
     )
     expect(html).toContain('SLOT_HEADLINE')

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -50,7 +50,7 @@ export default function PraxisDetail() {
     <>
       {/* Duel cross-link is neutral chrome above every archetype (#313); one
           shared faction-tokened widget, per the grilled #310 decision. */}
-      {state.duel && <DuelCrossLink praxis={state.praxis} duel={state.duel} />}
+      {state.duel && <DuelCrossLink praxis={state.praxis} duel={state.duel} state={state} />}
       <Archetype state={state} />
       {/* Comments are neutral chrome below every archetype (ADR-0006); a thread
           renders on a visible praxis only. Mounted at the dispatcher so it covers

--- a/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
@@ -44,6 +44,8 @@ import {
   StakesTiles,
   type DuelSlotTheme,
 } from "../../components/duel/shared";
+import type { PraxisDetailState } from "./usePraxisDetail";
+import { PraxisSubmitControls } from "./shared";
 
 /**
  * The rail is mounted by the dispatcher, above the archetype, so it can't read
@@ -93,6 +95,14 @@ export interface DuelRailSkinProps {
   note: ReactNode | null;
   /** Roster + next-step + stakes. `null` for declined and forfeited, which have no race left. */
   body: ReactNode | null;
+  /**
+   * The owner's submit / pull-back / forfeit control (#752), resolved by the
+   * dispatcher — it lives here so state and the control that changes it share a
+   * surface. `null` when the viewer isn't the owner, and for `declined` /
+   * `forfeited`, which have no cast left to change. A skin renders it; it never
+   * decides WHICH action shows (the control's own branch owns that, upstream).
+   */
+  actions: ReactNode | null;
 }
 
 /** The plain rail: a soft wash with an accent edge, the shape #313 shipped. */
@@ -104,6 +114,7 @@ export function DefaultDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const wrapper: CSSProperties = {
     maxWidth,
@@ -137,6 +148,13 @@ export function DefaultDuelRail({
       )}
       {note}
       {body}
+      {/* The owner's action row (#752): a soft-ruled footer so the control that
+          changes the duel's state sits right under the state itself. */}
+      {actions && (
+        <div style={{ marginTop: "var(--space-md)", paddingTop: "var(--space-sm)", borderTop: `1px solid ${accent}` }}>
+          {actions}
+        </div>
+      )}
     </div>
   );
 }
@@ -182,9 +200,16 @@ function OpponentBadge({ side }: { side: DuelSideOut }) {
 export default function DuelCrossLink({
   praxis,
   duel,
+  state,
 }: {
   praxis: PraxisOut;
   duel: DuelDetailOut;
+  /**
+   * The read-page state, threaded from the archetype dispatcher so the rail can
+   * own the owner's submit/pull-back/forfeit control (#752). Optional: the
+   * lifecycle tests mount the rail without it, in which case `actions` stays null.
+   */
+  state?: PraxisDetailState;
 }) {
   const { t } = useTranslation("praxis");
   const isChallenger = praxis.id === duel.challenger.praxis_id;
@@ -220,6 +245,27 @@ export default function DuelCrossLink({
   const theme: DuelSlotTheme = { accent };
   const forfeited = duel.forfeited_by_character_id != null;
 
+  // The owner's submit / pull-back / forfeit control, relocated here from the
+  // owner controls (#752) so it sits under the state it changes. Built once and
+  // passed to the branches that still have a cast to change; `declined` and
+  // `forfeited` pass `null`. `PraxisSubmitControls` self-hides for non-owners and
+  // never renders on this page for `null`, so the read-page tests (no `state`)
+  // get a null slot. `withdrawError` rides along so it lands beside the control.
+  const actions =
+    state && state.isOwner && state.praxis ? (
+      <div>
+        <PraxisSubmitControls state={state} />
+        {state.withdrawError && (
+          <p
+            className="font-body content-text"
+            style={{ color: "var(--color-danger)", marginTop: "var(--space-sm)" }}
+          >
+            {state.withdrawError}
+          </p>
+        )}
+      </div>
+    ) : null;
+
   // The rail body every live state shares: who has cast, what happens next, and
   // what it's worth. The slots own every branch inside them. `settled` passes
   // nextStep={false} — its own "live" standing line already says the same thing.
@@ -249,6 +295,7 @@ export default function DuelCrossLink({
         tally={null}
         note={null}
         body={null}
+        actions={null}
         headline={
           iForfeited ? (
             <span>{t("duelCrossLink.youForfeited")}</span>
@@ -287,6 +334,7 @@ export default function DuelCrossLink({
           <span>{t("duelCrossLink.pending", { name: foe.display_name })}</span>
         }
         body={body(true)}
+        actions={actions}
       />
     );
   }
@@ -301,6 +349,7 @@ export default function DuelCrossLink({
         tally={null}
         note={null}
         body={null}
+        actions={null}
         headline={
           <span>{t("duelCrossLink.declined", { name: foe.display_name })}</span>
         }
@@ -322,6 +371,7 @@ export default function DuelCrossLink({
           </span>
         }
         body={body(true)}
+        actions={actions}
       />
     );
   }
@@ -381,6 +431,7 @@ export default function DuelCrossLink({
           </div>
         }
         body={null}
+        actions={actions}
       />
     );
   }
@@ -424,6 +475,7 @@ export default function DuelCrossLink({
         </div>
       }
       body={body(false)}
+      actions={actions}
     />
   );
 }

--- a/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Settled-duel forfeit escalation on PraxisOwnerActions (#718).
+ * Settled-duel forfeit escalation on the submit/pull-back/forfeit control (#718).
  *
  * The asymmetry this guards is the whole point of the issue, and it is exactly
  * the kind of thing a "warn on any duel" implementation gets wrong:
@@ -13,6 +13,11 @@
  *
  * The cost figures come from the mocked game config, so a Snide side is told it
  * keeps 0 rather than an invented "half".
+ *
+ * #752 relocated this control from the owner controls into the duel RAIL, so the
+ * duel cases below mount `PraxisSubmitControls` (its new home) directly. The
+ * last two cases pin the relocation itself: the owner controls suppress the
+ * cluster for a duel, and keep it for an ordinary praxis.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
@@ -44,7 +49,7 @@ const CONFIG = {
 
 vi.mock('../../../hooks/useGameConfig', () => ({ useGameConfig: () => CONFIG }))
 
-const { PraxisOwnerActions } = await import('../shared')
+const { PraxisOwnerActions, PraxisSubmitControls } = await import('../shared')
 
 function text(element: ReactElement): string {
   return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>).replace(/<[^>]*>/g, '')
@@ -212,10 +217,10 @@ function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
   } as PraxisDetailState
 }
 
-describe('PraxisOwnerActions forfeit escalation (#718)', () => {
+describe('forfeit escalation (#718)', () => {
   it('settled duel: the confirm warns, names the winner, and quotes the cost', () => {
     const t = text(
-      <PraxisOwnerActions
+      <PraxisSubmitControls
         state={state({ duel: duel('settled', true), showWithdrawConfirm: true })}
       />,
     )
@@ -226,13 +231,13 @@ describe('PraxisOwnerActions forfeit escalation (#718)', () => {
   })
 
   it('settled duel: the quiet unsubmit control takes the forfeit verb', () => {
-    const t = text(<PraxisOwnerActions state={state({ duel: duel('settled', true) })} />)
+    const t = text(<PraxisSubmitControls state={state({ duel: duel('settled', true) })} />)
     expect(t).toMatch(/Forfeit/i)
   })
 
   it('active duel: no warning — the reopen is still free', () => {
     const t = text(
-      <PraxisOwnerActions
+      <PraxisSubmitControls
         state={state({ duel: duel('active', false), showWithdrawConfirm: true })}
       />,
     )
@@ -241,7 +246,34 @@ describe('PraxisOwnerActions forfeit escalation (#718)', () => {
   })
 
   it('no duel at all: the ordinary confirm is untouched', () => {
-    const t = text(<PraxisOwnerActions state={state({ showWithdrawConfirm: true })} />)
+    const t = text(<PraxisSubmitControls state={state({ showWithdrawConfirm: true })} />)
     expect(t).not.toMatch(/FORFEIT/i)
+  })
+})
+
+// #752: the control was relocated into the duel rail, so the owner controls must
+// no longer render it for a duel praxis — otherwise a settled-duel Forfeit would
+// sit in the rail AND an unsubmit in the owner controls, the #646 double control.
+describe('owner controls suppress the duel action cluster (#752)', () => {
+  it('settled duel: the owner controls render no submit/forfeit — the rail owns it', () => {
+    const t = text(
+      <PraxisOwnerActions
+        state={state({ duel: duel('settled', true), showWithdrawConfirm: true })}
+      />,
+    )
+    expect(t).not.toMatch(/FORFEIT/i)
+    expect(t).not.toMatch(/wins by default/i)
+    // the edit link is the only owner control left for a duel praxis.
+    expect(t).toMatch(/Edit/i)
+  })
+
+  it('ordinary praxis: the owner controls still render the cluster inline', () => {
+    // No duel_id, so `hasDuel` is false and the cluster stays in the owner
+    // controls (there is no rail to move it to).
+    const ordinary = { ...praxis(), duel_id: null }
+    const t = text(
+      <PraxisOwnerActions state={state({ praxis: ordinary, showWithdrawConfirm: true })} />,
+    )
+    expect(t).toMatch(/Yes, unsubmit/i)
   })
 })

--- a/frontend/src/pages/praxisDetail/duelRails/CovenDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/CovenDuelRail.tsx
@@ -52,6 +52,7 @@ export default function CovenDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const shell: CSSProperties = {
     maxWidth,
@@ -112,6 +113,12 @@ export default function CovenDuelRail({
             }}
           >
             {body}
+          </div>
+        )}
+        {/* The owner's action row (#752), footed under the window's border rule. */}
+        {actions && (
+          <div style={{ marginTop: 'var(--space-md)', paddingTop: 'var(--space-sm)', borderTop: `1.5px solid ${NOTEPAD_BORDER}` }}>
+            {actions}
           </div>
         )}
         {/* ponytail: `declined` and `forfeited` arrive with body === null, so the

--- a/frontend/src/pages/praxisDetail/duelRails/CovenMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/CovenMobileDuelRail.tsx
@@ -56,6 +56,7 @@ export default function CovenMobileDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   // ponytail: `maxWidth` is intentionally ignored on mobile. The rail is
   // full-bleed inside the phone column, so the desktop archetype-width map has
@@ -126,6 +127,12 @@ export default function CovenMobileDuelRail({
             }}
           >
             {body}
+          </div>
+        )}
+        {/* The owner's action row (#752), footed under the window's border rule. */}
+        {actions && (
+          <div style={{ marginTop: 'var(--space-md)', paddingTop: 'var(--space-sm)', borderTop: `1.5px solid ${NOTEPAD_BORDER}` }}>
+            {actions}
           </div>
         )}
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/EphemeristsDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/EphemeristsDuelRail.tsx
@@ -91,6 +91,7 @@ export default function EphemeristsDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const sheet: CSSProperties = {
     maxWidth,
@@ -213,6 +214,19 @@ export default function EphemeristsDuelRail({
                 {body}
               </div>
             </>
+          )}
+
+          {/* The owner's action row (#752), ruled off with an ochre hairline. */}
+          {actions && (
+            <div
+              style={{
+                marginTop: 'var(--space-md)',
+                paddingTop: 'var(--space-sm)',
+                borderTop: `1px solid color-mix(in srgb, ${OCHRE} 55%, transparent)`,
+              }}
+            >
+              {actions}
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/EphemeristsMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/EphemeristsMobileDuelRail.tsx
@@ -59,6 +59,7 @@ export default function EphemeristsMobileDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const sheet: CSSProperties = {
     margin: 'var(--space-md) 0',
@@ -168,6 +169,19 @@ export default function EphemeristsMobileDuelRail({
                 {body}
               </div>
             </>
+          )}
+
+          {/* The owner's action row (#752), ruled off with an ochre hairline. */}
+          {actions && (
+            <div
+              style={{
+                marginTop: 'var(--space-md)',
+                paddingTop: 'var(--space-sm)',
+                borderTop: `1px solid color-mix(in srgb, ${OCHRE} 55%, transparent)`,
+              }}
+            >
+              {actions}
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/EverymenDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/EverymenDuelRail.tsx
@@ -70,6 +70,7 @@ export default function EverymenDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const shell: CSSProperties = {
     maxWidth,
@@ -160,6 +161,13 @@ export default function EverymenDuelRail({
             }}
           >
             {body}
+          </div>
+        )}
+
+        {/* The owner's action row (#752), filed under a heavy ink rule. */}
+        {actions && (
+          <div style={{ marginTop: 'var(--space-md)', paddingTop: 'var(--space-sm)', borderTop: `2px solid ${INK}` }}>
+            {actions}
           </div>
         )}
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/EverymenMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/EverymenMobileDuelRail.tsx
@@ -31,6 +31,7 @@ export default function EverymenMobileDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   // ponytail: `maxWidth` is intentionally ignored. The rail is full-bleed inside
   // the phone column, so the desktop archetype-width map has nothing to line up
@@ -128,6 +129,13 @@ export default function EverymenMobileDuelRail({
             }}
           >
             {body}
+          </div>
+        )}
+
+        {/* The owner's action row (#752), filed under a heavy ink rule. */}
+        {actions && (
+          <div style={{ marginTop: 'var(--space-md)', paddingTop: 'var(--space-sm)', borderTop: `2px solid ${INK}` }}>
+            {actions}
           </div>
         )}
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/SingularityDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/SingularityDuelRail.tsx
@@ -81,6 +81,7 @@ export default function SingularityDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const shell: CSSProperties = {
     maxWidth,
@@ -148,6 +149,13 @@ export default function SingularityDuelRail({
             is the correct empty state — the duel is over — so no bespoke
             "connection closed" ornament is drawn for it. */}
       </div>
+      )}
+
+      {/* The owner's action row (#752), on its own hairline-ruled prompt block. */}
+      {actions && (
+        <div style={{ padding: 'var(--space-md) var(--space-lg)', borderTop: `1px solid ${HAIRLINE}` }}>
+          {actions}
+        </div>
       )}
 
       <style>{CURSOR_CSS}</style>

--- a/frontend/src/pages/praxisDetail/duelRails/SingularityMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/SingularityMobileDuelRail.tsx
@@ -58,6 +58,7 @@ export default function SingularityMobileDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const shell: CSSProperties = {
     margin: 'var(--space-md) 0',
@@ -122,6 +123,13 @@ export default function SingularityMobileDuelRail({
               {body}
             </div>
           )}
+        </div>
+      )}
+
+      {/* The owner's action row (#752), on its own hairline-ruled block. */}
+      {actions && (
+        <div style={{ padding: 'var(--space-md)', borderTop: `1px solid ${HAIRLINE}` }}>
+          {actions}
         </div>
       )}
 

--- a/frontend/src/pages/praxisDetail/duelRails/SnideDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/SnideDuelRail.tsx
@@ -71,6 +71,7 @@ export default function SnideDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const shell: CSSProperties = {
     ...HALFTONE,
@@ -154,6 +155,12 @@ export default function SnideDuelRail({
             }}
           >
             {body}
+          </div>
+        )}
+        {/* The owner's action row (#752), footed under a dashed acid rule. */}
+        {actions && (
+          <div style={{ marginTop: 'var(--space-md)', paddingTop: 'var(--space-sm)', borderTop: `2px dashed ${ACID}` }}>
+            {actions}
           </div>
         )}
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/SnideMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/SnideMobileDuelRail.tsx
@@ -26,6 +26,7 @@ export default function SnideMobileDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   // ponytail: `maxWidth` is intentionally ignored on mobile. The rail is
   // full-bleed inside the phone column, so the desktop archetype-width map has
@@ -106,6 +107,12 @@ export default function SnideMobileDuelRail({
             }}
           >
             {body}
+          </div>
+        )}
+        {/* The owner's action row (#752), footed under a dashed acid rule. */}
+        {actions && (
+          <div style={{ marginTop: 'var(--space-md)', paddingTop: 'var(--space-sm)', borderTop: `2px dashed ${ACID}` }}>
+            {actions}
           </div>
         )}
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/WowDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/WowDuelRail.tsx
@@ -72,6 +72,7 @@ export default function WowDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const shell: CSSProperties = {
     maxWidth,
@@ -173,6 +174,20 @@ export default function WowDuelRail({
             }}
           >
             {body}
+          </div>
+        )}
+
+        {/* ── the owner's action row (#752), footed on a champion-gold rule so
+              the control that changes the duel sits under its state ── */}
+        {actions && (
+          <div
+            style={{
+              marginTop: 'var(--space-md)',
+              paddingTop: 'var(--space-sm)',
+              borderTop: `1px solid ${CHAMPION}`,
+            }}
+          >
+            {actions}
           </div>
         )}
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/WowMobileDuelRail.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/WowMobileDuelRail.tsx
@@ -43,6 +43,7 @@ export default function WowMobileDuelRail({
   tally,
   note,
   body,
+  actions,
 }: DuelRailSkinProps) {
   const shell: CSSProperties = {
     margin: 'var(--space-md) 0',
@@ -136,6 +137,19 @@ export default function WowMobileDuelRail({
             }}
           >
             {body}
+          </div>
+        )}
+
+        {/* the owner's action row (#752), footed on a champion-gold rule */}
+        {actions && (
+          <div
+            style={{
+              marginTop: 'var(--space-md)',
+              paddingTop: 'var(--space-sm)',
+              borderTop: `1px solid ${CHAMPION}`,
+            }}
+          >
+            {actions}
           </div>
         )}
       </div>

--- a/frontend/src/pages/praxisDetail/duelRails/__tests__/wowDuelRail.test.tsx
+++ b/frontend/src/pages/praxisDetail/duelRails/__tests__/wowDuelRail.test.tsx
@@ -154,6 +154,7 @@ describe('WOW duel rail: the opponent colour is a ring and a bar, never a text g
         tally={<span>SLOT_TALLY</span>}
         note={<span>SLOT_NOTE</span>}
         body={<span>SLOT_BODY</span>}
+        actions={null}
       />,
     )
 

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -314,7 +314,43 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
 
 export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
-  const { praxis, isOwner, user, duel, withdrawing, showWithdrawConfirm, setShowWithdrawConfirm, withdrawError, handleWithdraw, handleResubmit } = state
+  const { praxis, isOwner, withdrawError } = state
+  if (!praxis || !isOwner) return null
+
+  // A duel praxis surfaces its submit / pull-back / forfeit control in the duel
+  // RAIL now (#752), where the state that control changes already reads — one
+  // place, and never two rows of the same destructive control (the #646 bug).
+  // So the owner controls drop the cluster (and its error) for a duel and keep
+  // only the edit link; the rail renders `PraxisSubmitControls` instead. An
+  // ordinary praxis has no rail, so it keeps the cluster inline exactly as before.
+  const hasDuel = praxis.duel_id != null
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
+        <Link to={`/praxes/${praxis.id}/edit`} className="font-body eyebrow hover:underline" style={{ color: 'var(--color-text-tertiary)' }}>
+          {t('detail.owner.edit')}
+        </Link>
+        {!hasDuel && <PraxisSubmitControls state={state} />}
+      </div>
+      {!hasDuel && withdrawError && <p className="font-body content-text mb-3" style={{ color: 'var(--color-danger)' }}>{withdrawError}</p>}
+    </div>
+  )
+}
+
+/**
+ * The submit / pull-back / forfeit control for a praxis you own — the one
+ * mutation seam that changes its cast state (and, for a duel side, the duel's).
+ * Extracted from PraxisOwnerActions (#752) so the duel RAIL can render it beside
+ * the state it changes; an ordinary praxis keeps it inline in the owner controls.
+ * It is rendered in exactly ONE surface per praxis, never both, so the #646
+ * double-destructive-control bug cannot recur. Every branch below is unchanged
+ * from the owner controls — this is a relocation, not a rewrite. `withdrawError`
+ * is rendered by the caller, next to wherever this control lands.
+ */
+export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const { praxis, isOwner, user, duel, withdrawing, showWithdrawConfirm, setShowWithdrawConfirm, handleWithdraw, handleResubmit } = state
   if (!praxis || !isOwner) return null
 
   // A SETTLED duel side's quiet unsubmit is a permanent forfeit (ADR-0011
@@ -322,8 +358,6 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   // existing two-step confirm rather than adding a control (#718). During
   // `active` it stays exactly as-is: until the opponent casts, pulling back is a
   // free neutral reopen with no penalty, and warning about one would be a lie.
-  // Fixed at this choke point deliberately: PraxisOwnerActions is the only path
-  // to unsubmit on the detail page, so it catches anyone who never read the rail.
   const forfeitsOnUnsubmit = duel?.status === 'settled' && duel.forfeited_by_character_id == null
 
   // On a collab that hasn't gone live yet, a member who has already submitted
@@ -347,66 +381,56 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   const isPendingHoldout =
     isCollab && praxis.status === 'pending' && viewerMember?.has_submitted !== true
 
-  return (
-    <div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
-        <Link to={`/praxes/${praxis.id}/edit`} className="font-body eyebrow hover:underline" style={{ color: 'var(--color-text-tertiary)' }}>
-          {t('detail.owner.edit')}
-        </Link>
-        {praxis.status === 'in_progress' && viewerSubmittedWaiting ? (
-          <span className="eyebrow" style={{ color: 'var(--color-success)', fontWeight: 700 }}>
-            {t('detail.owner.submittedWaiting')}
-          </span>
-        ) : praxis.status === 'in_progress' || isPendingHoldout ? (
-          <button
-            onClick={handleResubmit}
-            disabled={withdrawing}
-            style={{ background: 'var(--color-success)', color: 'var(--color-text-on-accent)', fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', letterSpacing: '0.08em', padding: 'var(--space-xs) var(--space-md)', border: 'none', cursor: 'pointer', borderRadius: 0, opacity: withdrawing ? 0.5 : 1 }}
-          >
-            {withdrawing ? t('detail.owner.submitting') : t('detail.owner.submit')}
-          </button>
-        ) : forfeitsOnUnsubmit && duel ? (
-          /* A forfeit is the one irreversible duel beat, so it gets the same
-             dispatched dialog the (reversible) seal confirm got in #718 rather
-             than an inline text expand (#751). The trigger stays put and the
-             dialog mounts over it as a fixed overlay. Skinned by the TASK's
-             faction, matching the composer's own dispatch. */
-          <>
-            <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-danger)' }}>
-              {t('duelForfeit.action')}
-            </button>
-            {showWithdrawConfirm && (
-              <DuelSealConfirm
-                mode="forfeit"
-                taskFactionSlug={praxis.task_faction_slug}
-                duel={duel}
-                viewerCharacterId={viewerCharacterId}
-                taskPointValue={praxis.task_point_value}
-                onConfirm={handleWithdraw}
-                onCancel={() => setShowWithdrawConfirm(false)}
-                busy={withdrawing}
-              />
-            )}
-          </>
-        ) : !showWithdrawConfirm ? (
-          <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}>
-            {t('detail.owner.unsubmit')}
-          </button>
-        ) : (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', flexWrap: 'wrap' }}>
-            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t('detail.owner.confirmPrompt')}</span>
-            <button
-              onClick={handleWithdraw}
-              disabled={withdrawing}
-              style={{ background: 'rgba(220,38,38,0.1)', border: '1.5px solid var(--color-danger)', color: 'var(--color-danger)', fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', padding: 'var(--space-xs) var(--space-md)', cursor: 'pointer', borderRadius: 0 }}
-            >
-              {withdrawing ? t('detail.owner.submitting') : t('detail.owner.confirmUnsubmit')}
-            </button>
-            <button onClick={() => setShowWithdrawConfirm(false)} className="btn-outline" style={{ fontSize: 'var(--text-sm)', padding: 'var(--space-xs) var(--space-md)' }}>{t('detail.owner.cancel')}</button>
-          </div>
-        )}
-      </div>
-      {withdrawError && <p className="font-body content-text mb-3" style={{ color: 'var(--color-danger)' }}>{withdrawError}</p>}
+  return praxis.status === 'in_progress' && viewerSubmittedWaiting ? (
+    <span className="eyebrow" style={{ color: 'var(--color-success)', fontWeight: 700 }}>
+      {t('detail.owner.submittedWaiting')}
+    </span>
+  ) : praxis.status === 'in_progress' || isPendingHoldout ? (
+    <button
+      onClick={handleResubmit}
+      disabled={withdrawing}
+      style={{ background: 'var(--color-success)', color: 'var(--color-text-on-accent)', fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', letterSpacing: '0.08em', padding: 'var(--space-xs) var(--space-md)', border: 'none', cursor: 'pointer', borderRadius: 0, opacity: withdrawing ? 0.5 : 1 }}
+    >
+      {withdrawing ? t('detail.owner.submitting') : t('detail.owner.submit')}
+    </button>
+  ) : forfeitsOnUnsubmit && duel ? (
+    /* A forfeit is the one irreversible duel beat, so it gets the same
+       dispatched dialog the (reversible) seal confirm got in #718 rather
+       than an inline text expand (#751). The trigger stays put and the
+       dialog mounts over it as a fixed overlay. Skinned by the TASK's
+       faction, matching the composer's own dispatch. */
+    <>
+      <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-danger)' }}>
+        {t('duelForfeit.action')}
+      </button>
+      {showWithdrawConfirm && (
+        <DuelSealConfirm
+          mode="forfeit"
+          taskFactionSlug={praxis.task_faction_slug}
+          duel={duel}
+          viewerCharacterId={viewerCharacterId}
+          taskPointValue={praxis.task_point_value}
+          onConfirm={handleWithdraw}
+          onCancel={() => setShowWithdrawConfirm(false)}
+          busy={withdrawing}
+        />
+      )}
+    </>
+  ) : !showWithdrawConfirm ? (
+    <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}>
+      {t('detail.owner.unsubmit')}
+    </button>
+  ) : (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', flexWrap: 'wrap' }}>
+      <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t('detail.owner.confirmPrompt')}</span>
+      <button
+        onClick={handleWithdraw}
+        disabled={withdrawing}
+        style={{ background: 'rgba(220,38,38,0.1)', border: '1.5px solid var(--color-danger)', color: 'var(--color-danger)', fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', padding: 'var(--space-xs) var(--space-md)', cursor: 'pointer', borderRadius: 0 }}
+      >
+        {withdrawing ? t('detail.owner.submitting') : t('detail.owner.confirmUnsubmit')}
+      </button>
+      <button onClick={() => setShowWithdrawConfirm(false)} className="btn-outline" style={{ fontSize: 'var(--text-sm)', padding: 'var(--space-xs) var(--space-md)' }}>{t('detail.owner.cancel')}</button>
     </div>
   )
 }


### PR DESCRIPTION
Moves the per-state duel action row — **Submit entry** / **Pull back** / **Forfeit** / the *"scored as an ordinary praxis"* note — out of the owner controls and into the duel **rail footer**, so the duel state and the control that changes it read in one place.

## What changed
- **Seventh slot.** `DuelRailSkinProps` gains `actions: ReactNode | null`. The `DuelCrossLink` dispatcher resolves it per `DuelStatus` alongside `headline` / `body` and hands the skin a rendered node — `null` for `declined` and `forfeited` (no cast left to change), and `null` for any non-owner.
- **No duplicate.** The submit / pull-back / forfeit cluster was extracted from `PraxisOwnerActions` into a new exported `PraxisSubmitControls`. The owner controls suppress it (and its error) when `praxis.duel_id != null` — the rail owns it now — so the same destructive control never appears twice (the #646 bug). An ordinary praxis has no rail and keeps the cluster inline, unchanged.
- **Each skin renders `actions`** in a ruled footer under `body`: all 12 faction rails (desktop + mobile) plus `DefaultDuelRail`.
- **Copy reused, not invented:** `duelForfeit.action`, `detail.owner.unsubmit`, and the existing submit labels from `praxis.json`.
- **State channel:** `PraxisDetail.tsx` now threads `state` into `DuelCrossLink` (the rail and the owner controls are mounted by different dispatchers). `state` is optional on the rail, so the lifecycle tests that mount it without state get a null `actions` slot.

## Tests
- `duelSkinSlots.test.tsx` extended: asserts the `actions` slot reaches the DOM in every registered rail skin (the `SLOT_ACTIONS` sentinel), and updated the Label-tier and empty-body cases for the new required prop.
- `duelForfeitWarning.test.tsx` retargeted at `PraxisSubmitControls` (the control's new home) and gained a suppression guard: the owner controls render no submit/forfeit for a duel praxis, and still render the cluster for an ordinary one.
- `wowDuelRail.test.tsx` updated for the new required prop.
- `tsc --noEmit` clean, `eslint src` clean, `vite build` OK, full vitest suite green (1512 passed).

## Judgment call to note
The issue names `null` for `declined` and `forfeited`. `resolved` (ADR-0052, added after the issue) is treated like `settled`/`active` here — it still passes `actions`, preserving the pre-existing owner-control behavior for a frozen duel rather than silently removing the control. Easy to flip to `null` if the reviewer prefers "no race left" to cover `resolved` too.

## What to eyeball
No dev stack / screenshots available (verified via tests + tsc + eslint + build only), so visual QA is outstanding. Open a duel praxis **you own** in each state and confirm the action row now lives in the RAIL, with no second submit/unsubmit control down in the owner controls:
- **open / pending** — the challenge is out, unanswered → **Pull back** in the rail footer.
- **active (unsubmitted)** — your side not cast → **Submit entry** in the rail footer.
- **active (your side submitted)** — → **Pull back** in the rail footer.
- **settled / accepted** (both cast) — → **Forfeit** in the rail footer, with the forfeit dialog.
- **declined / no-duel** — the *"scored as an ordinary praxis"* note in the rail; no action control.
- Check every faction duel rail (Coven, Ephemerists, Everymen, Singularity, Snide, WOW, and the Default) plus **mobile**.
- Confirm the owner controls below the archetype show only the **Edit** link for a duel praxis.

Closes #752