### PR TITLE
Unaffiliated selection scalars show the spectrum via a new factionFill `frame` shape (#794)

### DIFF
--- a/frontend/src/components/ui/ChipRow.tsx
+++ b/frontend/src/components/ui/ChipRow.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import { factionFill } from '../../utils/factions'
 
 /**
  * Touch-native filter idiom shared by the mobile browse pages — a labelled,
@@ -31,6 +32,14 @@ export function ChipRow({ label, children }: { label: string; children: ReactNod
  * variant is deliberately not reused — it would fight a faction sigil's own
  * colours — so selection reads as the ring plus full opacity, matching the
  * desktop faction pennants (STYLE §7: inactive 0.85, active 1, no desaturate).
+ *
+ * `unaffiliated` (#794) is set by the caller for the na/Unaffiliated glyph chip,
+ * where `tint` would resolve to neutral grey. Its identity is the spectrum
+ * (ADR-0039), which has no single scalar, so a selected na chip trades the
+ * grey ring+glow for a rainbow `frame` border; the glow is dropped because a
+ * single-colour box-shadow cannot carry the spectrum, so the frame alone
+ * carries selection. The caller passes `!isKnownFaction(slug)` (a VALUE test,
+ * not key presence, #749) — so every non-na chip stays pixel-identical.
  */
 export function Chip({
   on,
@@ -38,6 +47,7 @@ export function Chip({
   tint,
   ariaLabel,
   iconOnly,
+  unaffiliated,
   children,
 }: {
   on: boolean
@@ -45,11 +55,16 @@ export function Chip({
   tint?: string
   ariaLabel?: string
   iconOnly?: boolean
+  unaffiliated?: boolean
   children: ReactNode
 }) {
   // ponytail: one style object with a handful of ternaries rather than two chip
   // components — the two variants share every box property but the fill.
   const ring = tint ?? 'var(--color-text-primary)'
+  // Selected na glyph chip: the spectrum arrives as a border ring, replacing
+  // the grey ring/glow. `frameStyle` overrides background/border/boxSizing.
+  const useFrame = Boolean(iconOnly && on && unaffiliated)
+  const frameStyle = useFrame ? factionFill(null, 'frame') : undefined
 
   return (
     <button
@@ -73,8 +88,9 @@ export function Chip({
           iconOnly ? (on ? ring : 'var(--color-border-strong)') : on ? 'transparent' : 'var(--color-border-strong)'
         }`,
         // Ring is a box-shadow, not a thicker border, so selecting a chip does
-        // not reflow the row by a pixel.
-        boxShadow: iconOnly && on ? `0 0 0 2px ${ring}, 0 0 8px ${ring}` : undefined,
+        // not reflow the row by a pixel. na's frame carries its own selection,
+        // so the coloured glow is dropped there (a solid glow can't be spectral).
+        boxShadow: iconOnly && on && !useFrame ? `0 0 0 2px ${ring}, 0 0 8px ${ring}` : undefined,
         opacity: iconOnly && !on ? 0.85 : undefined,
         borderRadius: 999,
         padding: iconOnly ? 'var(--space-xs)' : 'var(--space-sm) var(--space-md)',
@@ -82,6 +98,9 @@ export function Chip({
         minWidth: iconOnly ? 36 : undefined,
         whiteSpace: 'nowrap',
         cursor: 'pointer',
+        // Spread last so the rainbow frame's background/border/boxSizing win
+        // over the scalar ring above. Empty for every non-na chip.
+        ...frameStyle,
       }}
     >
       {tint && !iconOnly && (

--- a/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
+++ b/frontend/src/pages/players/mobileArchetypes/DefaultPlayers.tsx
@@ -233,18 +233,19 @@ function Roster({ players, myCharId }: { players: RankedPlayer[]; myCharId: numb
           {t('leaderboard.mobile.allFactions')}
         </Chip>
         {factionChips.map(({ slug }) => {
-          // Scalar-only, so no isKnownFaction branch: Chip spends `tint` on a
-          // border colour and a box-shadow ring, and a gradient is invalid in
-          // both. The unaffiliated selection ring stays neutral by necessity —
-          // the spectrum arrives on this chip through the FactionSigil glyph
-          // below, which draws --faction-default-ring. factionCssVar already
-          // maps `na` to --faction-default; see the isKnownFaction docblock in
-          // utils/factions for why that is the design, not a fallback (#754).
+          // Chip spends `tint` on a border colour and a box-shadow ring, and a
+          // gradient is invalid in both — so for a real faction the ring is its
+          // solid hue. `na` has no scalar hue (ADR-0039): factionCssVar maps it
+          // to grey, so instead the chip flags itself `unaffiliated` and Chip
+          // swaps the grey ring for a rainbow `frame` border (#794). The value
+          // test (not key presence) is the isKnownFaction docblock's rule (#749).
+          const unaffiliated = !isKnownFaction(slug)
           const ring = factionCssVar(slug)
           return (
             <Chip
               key={slug}
               iconOnly
+              unaffiliated={unaffiliated}
               // The visible name is gone, so the label is the only name left.
               ariaLabel={factionName(slug === UNAFFILIATED ? null : slug)}
               on={faction === slug}

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -164,6 +164,11 @@ export default function DefaultProposeTask({
 
   const color = factionCssVar(factionSlug);
   const fname = factionName(factionSlug);
+  // The form opens on unaffiliated, whose accent (`color`) resolves to neutral
+  // grey. A real faction paints its solid hue; `na` gets the spectrum as a
+  // border `frame` / fill instead of falling back to grey (ADR-0039, #794).
+  // Only the scalar ACCENTS switch — `color:` text stays neutral ink (#649).
+  const selectedKnown = isKnownFaction(factionSlug);
 
   // Unaffiliated leads the picker: it is the default, and it is a state rather
   // than a faction, so it is an extra option here rather than a registry entry
@@ -311,7 +316,11 @@ export default function DefaultProposeTask({
             <div
               className="sidebar-card"
               style={{
-                borderLeft: `4px solid ${color}`,
+                // A real faction accents its left edge; `na` is framed in the
+                // spectrum (a gradient can't be a scalar border-colour).
+                ...(selectedKnown
+                  ? { borderLeft: `4px solid ${color}` }
+                  : factionFill(factionSlug, "frame")),
                 padding: "var(--space-lg) var(--space-xl)",
                 marginBottom: "var(--space-lg)",
               }}
@@ -577,8 +586,14 @@ export default function DefaultProposeTask({
             {title && (
               <div
                 style={{
-                  background: factionCssVar(factionSlug, "light"),
-                  border: `1.5px solid ${factionCssVar(factionSlug, "border")}`,
+                  // Known factions tint the strip in their light/border pair;
+                  // `na` gets the rainbow as a frame around a neutral interior.
+                  ...(selectedKnown
+                    ? {
+                        background: factionCssVar(factionSlug, "light"),
+                        border: `1.5px solid ${factionCssVar(factionSlug, "border")}`,
+                      }
+                    : factionFill(factionSlug, "frame")),
                   borderRadius: 8,
                   padding: "var(--space-md) var(--space-lg)",
                   marginBottom: "var(--space-lg)",
@@ -666,15 +681,19 @@ export default function DefaultProposeTask({
                 type="submit"
                 disabled={submitting}
                 style={{
-                  background: color,
-                  color: "var(--color-text-on-accent)",
+                  // A real faction fills the CTA with its solid hue + on-accent
+                  // ink. `na` has no legible single ink across the spectrum, so
+                  // it takes the `pill` — rainbow frame, neutral paper, dark ink
+                  // — instead of a grey block (ADR-0039, #649).
+                  ...(selectedKnown
+                    ? { background: color, color: "var(--color-text-on-accent)", border: "none" }
+                    : factionFill(factionSlug, "pill")),
                   fontFamily: "'Courier Prime', monospace",
                   fontSize: "var(--text-lg)",
                   fontWeight: 700,
                   textTransform: "uppercase",
                   letterSpacing: "0.15em",
                   padding: "var(--space-md) var(--space-xl)",
-                  border: "none",
                   cursor: submitting ? "wait" : "pointer",
                   position: "relative",
                   opacity: submitting ? 0.6 : 1,

--- a/frontend/src/utils/__tests__/factionAlbescentHidesInPlainSight.test.ts
+++ b/frontend/src/utils/__tests__/factionAlbescentHidesInPlainSight.test.ts
@@ -42,7 +42,7 @@ const SUFFIXES = [
   "on-fill",
 ];
 
-const SHAPES: FactionFillShape[] = ["bar", "dot", "pill"];
+const SHAPES: FactionFillShape[] = ["bar", "dot", "pill", "frame"];
 
 describe("Albescent is indistinguishable from unaffiliated", () => {
   it("resolves every CSS variable to exactly what `na` resolves to", () => {

--- a/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
+++ b/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
@@ -119,6 +119,63 @@ describe("factionFill (#636 / ADR-0039)", () => {
       color: "var(--faction-coven-on-fill)",
     });
   });
+
+  // ── frame: the rainbow as a scalar border ring (#794) ──
+
+  it("gives na a rainbow border ring with a neutral interior for a frame", () => {
+    const fill = factionFill("na", "frame");
+    expect(fill.border).toBe("2px solid transparent");
+    expect(fill.boxSizing).toBe("border-box");
+    expect(fill.background).toContain("border-box");
+    expect(fill.background).toContain("--faction-default-rainbow");
+  });
+
+  it("drops the pill's forced ink for a frame, so the caller owns its text", () => {
+    // The one thing that distinguishes frame from pill: no `color` key. A grey
+    // surface reaching for a rainbow *ring* keeps its own text colour (neutral
+    // ink is correct for real single-ink text, #649) — it is only the scalar
+    // accent that was falling back to grey.
+    expect(factionFill("na", "frame").color).toBeUndefined();
+    expect(factionFill("na", "pill").color).toBe(
+      "var(--faction-default-card-text)",
+    );
+  });
+
+  it("unregistered / null slugs frame like na (default), not ua", () => {
+    expect(factionFill("not_a_faction", "frame")).toEqual(
+      factionFill("na", "frame"),
+    );
+    expect(factionFill(null, "frame")).toEqual(factionFill("na", "frame"));
+  });
+
+  it("degrades a real faction's frame to a plain solid border", () => {
+    expect(factionFill("everymen", "frame")).toEqual({
+      border: "2px solid var(--faction-everymen)",
+    });
+    expect(factionFill("coven", "frame")).toEqual({
+      border: "2px solid var(--faction-coven)",
+    });
+  });
+
+  it("keeps bar / dot / pill byte-identical after adding frame", () => {
+    // Guards the refactor: the new shape must not perturb the existing three.
+    expect(factionFill("na", "bar")).toEqual({
+      background: "var(--faction-default-rainbow)",
+    });
+    expect(factionFill("na", "dot")).toEqual({
+      background: "var(--faction-default-ring)",
+    });
+    expect(factionFill("na", "pill")).toEqual({
+      background:
+        "linear-gradient(var(--faction-default-card-bg), var(--faction-default-card-bg)) padding-box, var(--faction-default-rainbow) border-box",
+      border: "2px solid transparent",
+      color: "var(--faction-default-card-text)",
+      boxSizing: "border-box",
+    });
+    expect(factionFill("snide", "bar")).toEqual({
+      background: "var(--faction-snide)",
+    });
+  });
 });
 
 describe("FACTION_RAINBOW_ORDER does not leak Albescent (#783, ADR-0027)", () => {

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -149,8 +149,12 @@ export function factionCssVar(
  * Surface geometry a faction FILL can occupy. Determines how `na`'s spectrum is
  * rendered — the wrong shape compiles fine but looks bad (a 7-stop linear on a
  * 10px dot reads as mud), so the call site picks it. See ADR-0039.
+ *
+ * `"frame"` is the border-only case (#794): a rainbow *ring* for a surface that
+ * needs a scalar accent (a selection ring, a card edge) rather than a fill, so
+ * na stops falling back to grey there too.
  */
-export type FactionFillShape = "bar" | "dot" | "pill";
+export type FactionFillShape = "bar" | "dot" | "pill" | "frame";
 
 /**
  * A faction FILL as a style object to spread onto the filled element.
@@ -165,10 +169,26 @@ export type FactionFillShape = "bar" | "dot" | "pill";
  *   - `"pill"` → the rainbow as a *frame* (border-box) around a neutral paper
  *                interior with ink text — no single ink is legible across the
  *                spectrum, so the label never sits on it.
+ *   - `"frame"` → the rainbow as a border ring only (the pill's border-box
+ *                treatment MINUS the forced ink), for a scalar accent (a
+ *                selection ring, a card edge) that would otherwise degrade to
+ *                grey. The interior is filled with the neutral card paper rather
+ *                than left see-through ON PURPOSE: a rounded gradient border with
+ *                a genuinely transparent centre is not expressible as a single
+ *                spreadable `background` — a transparent padding-box reveals the
+ *                border-box gradient straight through the middle. The pill fills
+ *                opaque paper for exactly this reason; `frame` keeps that fill but
+ *                drops the ink so the caller owns its own text colour (#794).
+ *
+ * The scalar (`border/ring`) contexts that used to reach for `factionCssVar` and
+ * land on grey now ask for `"frame"` instead. A real faction's `"frame"` is a
+ * plain solid `var(--faction-{key})` border, so `factionCssVar` + `"frame"` agree
+ * for known factions and only `na`/unregistered slugs change.
  *
  * Prefer this over `factionCssVar(slug)` for any `background:` that renders a
- * dynamic slug (one that can be `na` at runtime). Scalar contexts (`color:`,
- * borders) keep using `factionCssVar` and stay neutral grey for `na`.
+ * dynamic slug (one that can be `na` at runtime). Genuine single-ink TEXT
+ * (`color:`) keeps using `factionCssVar` and stays neutral grey for `na` — no
+ * single stop is legible across seven (#649), so that is correct, not a fallback.
  */
 export function factionFill(
   slug: string | null | undefined,
@@ -192,6 +212,22 @@ export function factionFill(
       background: `var(--faction-${key})`,
       color: `var(--faction-${key}-on-fill)`,
     };
+  }
+
+  if (shape === "frame") {
+    if (isDefault) {
+      // The pill's rainbow border-box over an opaque neutral interior, minus the
+      // forced ink (see the docblock on why the interior can't be see-through).
+      return {
+        background:
+          "linear-gradient(var(--faction-default-card-bg), var(--faction-default-card-bg)) padding-box, var(--faction-default-rainbow) border-box",
+        border: "2px solid transparent",
+        boxSizing: "border-box",
+      };
+    }
+    // A real faction degrades to a plain solid border, exactly as the other
+    // shapes degrade to a solid background — the caller keeps its own interior.
+    return { border: `2px solid var(--faction-${key})` };
   }
 
   if (isDefault) {


### PR DESCRIPTION
## What

`na`'s identity is the rainbow (ADR-0039), but the spectrum only had *fill* forms (`bar`/`dot`) and a *filled-pill* form. Any surface that needed a **scalar** accent — a selection ring, a card edge — reached for `factionCssVar(slug)`, which resolves `na` to neutral grey. This adds the missing **border** form and repaints the two surfaces that were shipping grey.

### 1. The primitive — `factionFill(slug, 'frame')`
- **default / na** → the rainbow as a border ring: `--faction-default-rainbow` on `border-box`, `2px solid transparent` border, `boxSizing: border-box`. It is the `pill`'s border-box treatment **minus the forced ink**, so the caller owns its own text colour.
- **real faction** → a plain `2px solid var(--faction-{key})` border (mirrors how the other shapes degrade to a solid), so the caller keeps its interior.
- `bar` / `dot` / `pill` are left byte-identical (new branch only; verified on disk).
- Unit checks added mirroring the existing `factionFill` tests; the Albescent-equality suite's `SHAPES` now includes `frame`, so Albescent inherits it automatically (no special-case — it hides by looking unaffiliated).

### 2a. Players filter chip (mobile `DefaultPlayers` → shared `Chip`)
The glyph was already spectral (`FactionSigil slug={null}`); only the selected **ring** was grey. `Chip` gains an `unaffiliated` flag (the caller's `!isKnownFaction(slug)` **value** test, #749). A selected `na` chip now takes the rainbow `frame` and **drops the coloured glow** (a single-colour box-shadow can't be spectral; the frame carries selection). Every non-na chip is pixel-identical — the frame style is empty and spread last.

### 2b. Propose-Task form accent (`DefaultProposeTask`)
The form opens on unaffiliated, so its whole accent went grey. Repainted **for na only**: the form card is framed in the rainbow, the preview strip takes the `frame`, and the submit CTA takes the `pill` (rainbow frame + neutral paper + dark ink — no single ink is legible across seven, #649). Body/heading `color:` **text stays neutral ink**, per doctrine. Real factions unchanged.

## One deliberate deviation from the brief
The brief specified the frame's interior as *literally transparent* ("caller keeps its own background"). A rounded gradient border with a genuinely see-through centre is **not expressible as a single spreadable `background`**: a transparent `padding-box` layer reveals the `border-box` gradient straight through the middle (you'd get a rainbow-**filled** box, not a frame), and the `mask`-composite alternative masks the element's own children away — fatal for the chip's sigil. The `pill` fills opaque paper for exactly this reason. So `frame` keeps an **opaque neutral interior** (`--faction-default-card-bg`) and only drops the ink. Both consumers need a neutral interior anyway (a see-through one would show rainbow behind the sigil / form). Flagging for the record — happy to revisit if a bespoke wrapper is preferred somewhere.

## Verification
- `tsc --noEmit`: clean in scope (the repo-wide `node:fs`/`node:url` errors are the known stale-junction false alarm, PR #675, in unrelated test files).
- `eslint` on all four changed files: clean (`no-raw-style-values` green — colours only via tokens).
- `vite build`: OK.
- `vitest`: full suite **1515 passed / 100 files**; new `frame` unit checks pass.
- Grepped built output that `bar`/`dot`/`pill` are unchanged.

**Visual QA is outstanding** — there is no dev stack here and the browser pane can't screenshot, so the rendering below has not been eyeballed.

## What to eyeball
As an **unaffiliated (na)** character:
- **Players page filter chip**, when selected → a **rainbow frame** border, **no grey ring** and **no coloured glow**.
- **Propose-Task form** → the **left border / card**, the **preview strip**, and the **submit button** show the spectrum; **body text stays neutral ink**.

Then confirm the negatives:
- A **real faction's** chip and propose-task form are **pixel-unchanged**.
- An **Albescent-revealed** viewer sees the **same** rainbow treatment as na on these surfaces (it routes through `default`; no albescent branch was added).

Closes #794