### PR TITLE
na comment fidelity: spectrum hairline + rainbow @mentions (#970)

### DIFF
--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -12,7 +12,7 @@ import { useAuth } from '../../auth/AuthContext'
 import FactionAvatar from '../avatar/FactionAvatar'
 import { pickVariant } from '../../utils/factionDispatch'
 import { surfaceMap } from '../../factions'
-import { factionCssVar } from '../../utils/factions'
+import { factionCssVar, factionFill } from '../../utils/factions'
 import { formatCommentTime } from '../../utils/commentTime'
 import {
   type CommentProps,
@@ -21,14 +21,19 @@ import {
   MentionText,
 } from './shared'
 import { CommentEditor, OwnerControls, useOwnerEdit } from './OwnerControls'
-import { CommentFlagControl } from './FlagControl'
+import { CommentFlagControl, canFlagComment } from './FlagControl'
 
 /**
  * Neutral fallback voice — invariant slots themed only by the faction CSS vars +
- * FactionAvatar + the timestamp dialect. Any unregistered faction renders this.
+ * FactionAvatar + the timestamp dialect. Any unregistered faction renders this,
+ * which is also the na / Unaffiliated identity (ADR-0039): so the row wears the
+ * spectrum-band na tells — a rainbow hairline across the bubble top and
+ * gradient-clipped @mentions (#970), reached via factionFill/`--faction-default-rainbow`
+ * (NOT factionCssVar, which is neutral grey for na).
  */
 export function DefaultComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
+  const { user } = useAuth()
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props
     return (
@@ -52,29 +57,70 @@ export function DefaultComment(props: CommentProps) {
   const accent = factionCssVar(slug, 'card-accent')
   const onAccent = factionCssVar(slug, 'on-accent')
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
+  // A quiet control row lives at the bubble foot (design intent) — but only when
+  // there is something to show: the author's edit/withdraw or a flag affordance.
+  // Hidden while editing, since the inline editor owns Save/Cancel then.
+  const showControls =
+    !owner.editing && (owner.isOwner || canFlagComment(comment, user?.character?.id))
   return (
-    <div style={{ display: 'flex', gap: 'var(--space-md)' }}>
+    <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
       <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)', flexWrap: 'wrap' }}>
-          <Link
-            to={`/characters/${comment.author.id}`}
-            style={{ fontWeight: 600, color: accent, textDecoration: 'none' }}
-          >
-            {comment.author.display_name}
-          </Link>
-          <span style={{ fontSize: 'var(--text-md)', color: 'var(--color-text-tertiary)' }}>
-            {formatCommentTime(slug, comment.created_at)}
-            {comment.is_edited ? ` · ${t('comments.edited')}` : ''}
-          </span>
-          <OwnerControls owner={owner} />
-          <CommentFlagControl comment={comment} />
-        </div>
-        <div style={{ marginTop: 'var(--space-xs)', color: 'var(--color-text-primary)', lineHeight: 1.5 }}>
-          {owner.editing ? (
-            <CommentEditor owner={owner} accent={accent} onAccent={onAccent} />
-          ) : (
-            <MentionText body={comment.body_text} mentions={comment.mentions} accent={accent} />
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          background: factionCssVar(slug, 'card-bg'),
+          border: `1px solid ${factionCssVar(slug, 'border')}`,
+          borderRadius: 8,
+          overflow: 'hidden',
+          boxShadow: '0 4px 14px -10px rgba(0,0,0,0.4)',
+        }}
+      >
+        {/* spectrum hairline — the na tell; a rainbow for default/na, a solid
+            hue would never appear here because only default slugs reach this
+            voice. Reached via factionFill (rainbow), not factionCssVar (grey). */}
+        <div style={{ height: 3, ...factionFill(slug, 'bar') }} />
+        <div style={{ padding: 'var(--space-md) var(--space-lg)' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)', flexWrap: 'wrap' }}>
+            <Link
+              to={`/characters/${comment.author.id}`}
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontStyle: 'italic',
+                fontWeight: 700,
+                color: factionCssVar(slug, 'card-text'),
+                textDecoration: 'none',
+              }}
+            >
+              {comment.author.display_name}
+            </Link>
+            <span style={{ fontSize: 'var(--text-md)', color: factionCssVar(slug, 'card-muted') }}>
+              {formatCommentTime(slug, comment.created_at)}
+              {comment.is_edited ? ` · ${t('comments.edited')}` : ''}
+            </span>
+          </div>
+          <div style={{ marginTop: 'var(--space-xs)', color: factionCssVar(slug, 'card-text'), lineHeight: 1.5 }}>
+            {owner.editing ? (
+              <CommentEditor owner={owner} accent={accent} onAccent={onAccent} />
+            ) : (
+              <MentionText body={comment.body_text} mentions={comment.mentions} accent={accent} rainbow />
+            )}
+          </div>
+          {showControls && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                flexWrap: 'wrap',
+                gap: 'var(--space-md)',
+                marginTop: 'var(--space-sm)',
+                paddingTop: 'var(--space-sm)',
+                borderTop: `1px solid ${factionCssVar(slug, 'border')}`,
+              }}
+            >
+              <OwnerControls owner={owner} />
+              <CommentFlagControl comment={comment} />
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/components/comments/shared.tsx
+++ b/frontend/src/components/comments/shared.tsx
@@ -63,10 +63,19 @@ export function MentionText({
   body,
   mentions,
   accent,
+  rainbow = false,
 }: {
   body: string
   mentions: CommentMention[]
   accent?: string
+  /**
+   * Opt-in na / Unaffiliated tell (#970): render resolved @mentions as
+   * gradient-clipped spectrum text via the shared `.rainbow-ink` class
+   * (`--faction-default-rainbow`), instead of the flat `accent` ink. Only the
+   * Default (na) voice passes this; every other voice omits it and renders
+   * byte-identically.
+   */
+  rainbow?: boolean
 }) {
   if (mentions.length === 0) return <>{body}</>
   const byHandle = new Map(mentions.map((m) => [m.username.toLowerCase(), m]))
@@ -81,7 +90,14 @@ export function MentionText({
               <Link
                 key={index}
                 to={`/characters/${mention.character_id}`}
-                style={{ color: accent ?? 'inherit', fontWeight: 600, textDecoration: 'none' }}
+                className={rainbow ? 'rainbow-ink' : undefined}
+                // rainbow: omit inline `color` so `.rainbow-ink`'s transparent
+                // fill can reveal the gradient clip; a flat color would win.
+                style={{
+                  ...(rainbow ? null : { color: accent ?? 'inherit' }),
+                  fontWeight: rainbow ? 700 : 600,
+                  textDecoration: 'none',
+                }}
               >
                 {part}
               </Link>


### PR DESCRIPTION
Design-fidelity pass on the Default (`na` / Unaffiliated) **comment voice**, porting from the vendored source (`Default Comment Edit.dc.html`, design project `1eb2665a`). The shipped `DefaultComment` was token-clean but reached colour through `factionCssVar` (neutral grey for `na`), so it was missing the spectrum-band na tells.

## What changed
- **Spectrum hairline** — a 3px rainbow bar across the top of the na comment bubble, reached via `factionFill(slug, 'bar')` → `--faction-default-rainbow` (**not** `factionCssVar`, which is grey for `na`).
- **Rainbow @mentions** — resolved `@handles` now render as gradient-clipped bold text via the existing shared `.rainbow-ink` class (`--faction-default-rainbow`). Added an opt-in `rainbow` prop to the shared `MentionText`; **only the Default voice passes it**, so every other faction voice renders byte-identically.
- **Bubble skin** — wrapped the row in the card bubble the hairline sits on (`--faction-default-card-bg` / `-border` / radius), author name in the display italic, and relocated the shared edit/withdraw + flag affordances into the quiet foot control row the design draws (divider above, muted, not faction-loud; hidden while editing or when there is nothing to show).
- The **avatar ring** already renders the rainbow-padded spectrum ring for `na` via `FactionAvatar` (`DefaultAvatar`), so it is unchanged.

Behaviour is untouched: edit/withdraw runs through the shared `OwnerControls` / `useOwnerEdit` — no per-voice fork. `DefaultComment` is also the fallback for `albescent` / unknown slugs, all of which resolve to the same `--faction-default-*` identity by design (ADR-0039), so they correctly inherit the na tells; the seven real factions each own their voice and are untouched.

## Files
- `frontend/src/components/comments/CommentThread.tsx` — `DefaultComment` row bubble + hairline + rainbow mentions + foot control row.
- `frontend/src/components/comments/shared.tsx` — opt-in `rainbow` prop on `MentionText`.

## Verification
- `tsc --noEmit`: clean for source (the only errors are the known `node:fs`/`node:url` stale-junction false alarm in `__tests__`, PR #675 — pre-existing, none in touched files).
- `eslint` on both files: clean.
- `vite build`: OK.
- `vitest`: full suite **1513 passed**; comments suite 23 passed.
- Grepped: `rainbow` is passed to `MentionText` only from `DefaultComment`; the seven faction voices call it unchanged.
- **Visual QA is outstanding** — no dev stack / screenshotting available in this environment; `background-clip:text` fails invisibly if a gradient token ever resolves empty, and gradient contrast can't be machine-measured (axe punts on gradients).

## Deviations
- **Padding/gap snapped to the `--space-*` scale** (design 12/15/13px → `--space-md`/`--space-lg`) per the token house rule (no raw spacing).
- **Body/author font-size not hardcoded** to the design's 11.5/16px — left on the inherited content tier per the content-text floor (#623/#627); author name takes the display italic + weight, size inherits.
- **"You" / "Unaffiliated" pill not ported.** The component does not currently render a faction/ownership pill and it has no i18n home; it is net-new content rather than a re-skin of something already rendered, so it is deferred (the task scoped these secondary tells to "where they map to what the component already renders").

## What to eyeball
- An na / Unaffiliated comment shows the 3px spectrum hairline at the top of the bubble and rainbow gradient-clipped `@mentions` (both light and dark themes — the clip fails invisibly, so this needs human eyes).
- A real-faction comment voice (e.g. Everymen, Coven) is visually unchanged — no hairline, flat accent-coloured mentions.
- Edit / withdraw still work identically across every faction (shared control machinery, only the na skin moved the affordances to the foot row).

Closes #970