### PR TITLE
na kit fidelity: rebuild Default Profile to the redesign (#969)

### DIFF
--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -255,7 +255,13 @@ export default function DefaultProfileBody({
   )
 
   return (
-    <div className="py-8">
+    <div className="py-8" style={{ position: 'relative' }}>
+      {/* Full-page spectrum wash — the na "all paths open" backdrop. The
+          `.na-backdrop` rule (raw radial-gradient rgba + a [data-theme="dark"]
+          brighten) lives in index.css and is owned by frontend-style; port it
+          from the vendored default.css. Inert until that class lands. */}
+      <div className="na-backdrop" aria-hidden />
+      <div style={{ position: 'relative', zIndex: 1 }}>
       {/* ── ① Identity + progression — spectrum band, credential pinned ── */}
       <div
         style={{
@@ -527,6 +533,7 @@ export default function DefaultProfileBody({
       ) : (
         mainColumn
       )}
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
+++ b/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
@@ -1,186 +1,375 @@
+import type { CSSProperties } from 'react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type { BadgeOut } from '../../../api/auth'
 import { badgeArtFor } from '../../../components/badges/badgeArt'
+import CredentialCard from '../../../components/CredentialCard'
 import PraxisCard from '../../../components/PraxisCard'
 import TaskCard from '../../../components/TaskCard'
-import { factionCssVar, factionName } from '../../../utils/factions'
+import { factionFill, factionName, isKnownFaction } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import type { ProfileBodyProps } from '../FactionProfileBody'
 
 type Segment = 'praxis' | 'tasks'
 
+const EYEBROW: CSSProperties = {
+  fontFamily: 'var(--font-body)',
+  fontSize: 'var(--text-base)',
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  color: 'var(--color-text-tertiary)',
+}
+
 /**
- * Default MOBILE public-profile skin (#517) — a phone-native reflow of the
- * desktop CharacterProfile that CONSUMES the same #459 player-profile contract
- * (identity, badges, friend/foe, dropped role/about): a centred credential
- * header, a real-fields stats row, badges (hidden when empty), the friend/foe
- * control, and a segmented Praxis / Tasks toggle over the existing PraxisCard /
- * TaskCard components stacked single-column. Presentation only — renders no
- * field the contract doesn't expose. Every faction falls through here until it
- * registers a bespoke mobile profile skin.
+ * Default MOBILE public-profile skin (#517, redrawn for #969) — a phone-native
+ * reflow of the na "all paths open" spectrum kit that CONSUMES the same #459
+ * player-profile contract (identity, progression, badges, friend/foe, praxis).
+ *
+ * The na fidelity fix: the identity band, avatar hoop, progression bar and
+ * section dot all reach the spectrum through `factionFill(slug, …)` /
+ * CredentialCard, never `factionCssVar('na')` — which resolves grey (ADR-0039,
+ * #749). This file is ALSO the mobile fallback for every faction except WOW
+ * (only WOW registers `mobileProfile`), so those seams stay per-faction: a
+ * themed slug gets its solid hue, `na`/albescent get the rainbow. Copy branches
+ * on `isKnownFaction` too — "faction pending" is unaffiliated-only.
+ *
+ * Presentation only — renders no field the contract doesn't expose.
  */
 export default function DefaultProfile({
   character,
   submissions,
   proposedTasks,
+  progression,
   identityActions,
 }: ProfileBodyProps) {
   const { t } = useTranslation('common')
   const [segment, setSegment] = useState<Segment>('praxis')
   const badges = character.badges ?? []
-  const color = factionCssVar(character.faction_slug)
+  const isUnaffiliated = !isKnownFaction(character.faction_slug)
+  const joined = new Date(character.created_at).toLocaleDateString(undefined, {
+    month: 'short',
+    year: 'numeric',
+  })
+
+  // ⑤ FDL laurel target: highest earned points (PraxisCardOut.score is the
+  // task base + vote sum); first entry wins a tie.
+  const topScore = submissions.reduce((max, praxis) => Math.max(max, praxis.score ?? 0), 0)
+  const laurelId = submissions.find((praxis) => (praxis.score ?? 0) === topScore)?.id ?? null
+
+  // ① progression numbers (null until game config supplies thresholds).
+  const pointsIntoLevel = progression
+    ? Math.max(character.score - progression.currentThreshold, 0)
+    : 0
+  const levelSpan = progression
+    ? Math.max(progression.nextThreshold - progression.currentThreshold, 0)
+    : 0
+  const ringDegrees = progression
+    ? Math.round(Math.min(Math.max(progression.progressPercent, 0), 100) * 3.6)
+    : 0
 
   return (
-    <div className="py-4" data-testid="mobile-profile">
-      {/* ── ① Identity — centred credential header ── */}
-      <div style={{ textAlign: 'center', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-        {character.avatar_url ? (
-          <img
-            src={mediaUrl(character.avatar_url)}
-            alt={character.display_name}
-            style={{
-              width: 84,
-              height: 84,
-              borderRadius: '50%',
-              objectFit: 'cover',
-              border: `2px solid ${factionCssVar(character.faction_slug, 'border')}`,
-            }}
-          />
-        ) : (
-          <span
-            aria-hidden
-            style={{
-              width: 84,
-              height: 84,
-              borderRadius: '50%',
-              background: `linear-gradient(135deg, ${factionCssVar(character.faction_slug, 'light')}, ${color})`,
-              border: `2px solid ${factionCssVar(character.faction_slug, 'border')}`,
-            }}
-          />
-        )}
-        <h1
-          className="font-display italic font-medium"
-          style={{ fontSize: 'var(--text-heading)', marginTop: 'var(--space-md)', color: 'var(--color-text-primary)', overflowWrap: 'anywhere' }}
+    <div className="py-4" data-testid="mobile-profile" style={{ position: 'relative' }}>
+      {/* Full-page spectrum wash — the na "all paths open" backdrop. The
+          `.na-backdrop` rule (raw radial-gradient rgba + a [data-theme="dark"]
+          brighten) lives in index.css and is owned by frontend-style; port it
+          from the vendored default.css. Inert until that class lands. */}
+      <div className="na-backdrop" aria-hidden />
+      <div style={{ position: 'relative', zIndex: 1 }}>
+        {/* ── ① Identity — spectrum band, centred credential ── */}
+        <div
+          style={{
+            position: 'relative',
+            overflow: 'hidden',
+            borderRadius: 16,
+            padding: 'var(--space-xs)',
+            ...factionFill(character.faction_slug, 'bar'),
+            boxShadow: '0 20px 50px -26px rgba(0,0,0,0.4)',
+          }}
         >
-          {character.display_name}
-        </h1>
-        <div className="eyebrow" style={{ marginTop: 'var(--space-xs)', display: 'inline-flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
-          <i style={{ width: 8, height: 8, borderRadius: 2, background: color, flex: 'none' }} />
-          {t('leaderboard.mobile.factionLevel', {
-            faction: factionName(character.faction_slug),
-            level: character.level,
-          })}
-        </div>
-
-        {/* friend/foe — kept feature (#459), faction-skinned, folded under identity */}
-        {identityActions && <div style={{ marginTop: 'var(--space-lg)', maxWidth: 220, width: '100%' }}>{identityActions}</div>}
-      </div>
-
-      {/* ── Stats row — real fields only ── */}
-      <div
-        style={{
-          display: 'flex',
-          margin: 'var(--space-lg) 0',
-          border: '1px solid var(--color-border)',
-          borderRadius: 12,
-          background: 'var(--color-bg-surface-alt)',
-          overflow: 'hidden',
-        }}
-      >
-        <Stat label={t('profile.mobile.stats.points')} value={character.score} />
-        <Stat label={t('profile.mobile.stats.praxis')} value={submissions.length} divider />
-        <Stat label={t('profile.mobile.stats.tasks')} value={proposedTasks.length} divider />
-      </div>
-
-      {/* ── ③ Badges — hidden entirely when empty ── */}
-      {badges.length > 0 && (
-        <div style={{ marginBottom: 'var(--space-lg)' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', marginBottom: 'var(--space-sm)' }}>
-            <h2 className="font-display italic" style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)' }}>
-              {t('profile.badgesHeading')}
-            </h2>
-            <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--color-text-tertiary)' }}>
-              {t('profile.badgesEarned', { count: badges.length })}
-            </span>
-          </div>
           <div
             style={{
-              border: '1px solid var(--color-border)',
               borderRadius: 12,
-              background: 'var(--color-bg-surface-alt)',
-              padding: 'var(--space-xs) var(--space-lg)',
+              background: isUnaffiliated ? 'var(--faction-default-card-bg)' : 'var(--color-bg-surface-alt)',
+              padding: 'var(--space-lg)',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 'var(--space-md)',
             }}
           >
-            {badges.map((badge, index) => (
-              <BadgeRow key={badge.key} badge={badge} last={index === badges.length - 1} />
-            ))}
+            {/* eyebrow: spectrum-ring dot + Player · Unaffiliated */}
+            <span
+              style={{
+                ...EYEBROW,
+                color: isUnaffiliated ? 'var(--faction-default-card-muted)' : 'var(--color-text-tertiary)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 'var(--space-sm)',
+              }}
+            >
+              <span
+                aria-hidden
+                style={{
+                  width: 18,
+                  height: 18,
+                  borderRadius: '50%',
+                  flex: 'none',
+                  ...factionFill(character.faction_slug, 'dot'),
+                  WebkitMask: 'radial-gradient(circle, transparent 38%, #000 40%)',
+                  mask: 'radial-gradient(circle, transparent 38%, #000 40%)',
+                }}
+              />
+              {t('profile.playerFaction', {
+                faction: isUnaffiliated ? t('profile.unaffiliated') : factionName(character.faction_slug),
+              })}
+            </span>
+
+            {/* identity header — the shared credential card (its Unaffiliated
+                state wears the spectrum ring; themed slugs keep their accent) */}
+            <CredentialCard
+              displayName={character.display_name}
+              handle={character.username}
+              bio={character.bio}
+              factionSlug={character.faction_slug}
+              level={character.level}
+              score={character.score}
+              avatarUrl={character.avatar_url ? mediaUrl(character.avatar_url) : null}
+            />
+
+            {/* subtitle: faction-pending (na only) + handle / joined */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 'var(--space-sm)',
+                flexWrap: 'wrap',
+                justifyContent: 'center',
+              }}
+            >
+              {isUnaffiliated && (
+                <>
+                  <span
+                    className="font-display italic"
+                    style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}
+                  >
+                    {t('profile.unaffiliatedPending')}
+                  </span>
+                  <span
+                    aria-hidden
+                    style={{ width: 4, height: 4, borderRadius: '50%', background: 'var(--color-text-tertiary)' }}
+                  />
+                </>
+              )}
+              <span className="font-body" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-tertiary)' }}>
+                {t('profile.handleJoined', { username: character.username, joined })}
+              </span>
+            </div>
+
+            {/* progression panel — level ring + points-into-level bar */}
+            {progression && (
+              <div
+                style={{
+                  width: '100%',
+                  border: '1px solid var(--color-border-strong)',
+                  borderRadius: 12,
+                  padding: 'var(--space-lg)',
+                  background: 'var(--color-bg-surface-alt)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--space-lg)',
+                }}
+              >
+                <div
+                  style={{
+                    flexShrink: 0,
+                    width: 60,
+                    height: 60,
+                    borderRadius: '50%',
+                    background: `conic-gradient(var(--color-text-primary) ${ringDegrees}deg, var(--color-border) 0)`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <span
+                    style={{
+                      width: 46,
+                      height: 46,
+                      borderRadius: '50%',
+                      background: 'var(--color-bg-surface-alt)',
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      lineHeight: 1,
+                    }}
+                  >
+                    <span style={{ ...EYEBROW, fontSize: 'var(--text-xs)', letterSpacing: '0.1em' }}>{t('profile.lvl')}</span>
+                    <span
+                      className="font-display italic"
+                      style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)' }}
+                    >
+                      {character.level}
+                    </span>
+                  </span>
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      alignItems: 'baseline',
+                      marginBottom: 'var(--space-sm)',
+                    }}
+                  >
+                    <span className="font-body" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}>
+                      {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
+                    </span>
+                    <span style={{ ...EYEBROW, fontSize: 'var(--text-sm)', letterSpacing: '0.08em' }}>
+                      {t('profile.nextLevel', { level: progression.nextLevel })}
+                    </span>
+                  </div>
+                  <div style={{ height: 10, borderRadius: 20, background: 'var(--color-border)', overflow: 'hidden' }}>
+                    <div
+                      style={{
+                        height: '100%',
+                        borderRadius: 20,
+                        width: `${progression.progressPercent}%`,
+                        ...factionFill(character.faction_slug, 'bar'),
+                        transition: 'width 300ms',
+                      }}
+                    />
+                  </div>
+                  <div
+                    className="font-body"
+                    style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-tertiary)', marginTop: 'var(--space-xs)' }}
+                  >
+                    {t('profile.ptsToNext', { score: character.score, threshold: progression.nextThreshold })}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* friend/foe — kept feature (#459), folded under identity */}
+            {identityActions && (
+              <div style={{ marginTop: 'var(--space-xs)', maxWidth: 220, width: '100%' }}>{identityActions}</div>
+            )}
           </div>
         </div>
-      )}
 
-      {/* ── Segmented Praxis / Tasks toggle ── */}
-      <div
-        style={{
-          display: 'flex',
-          gap: 'var(--space-xs)',
-          padding: 'var(--space-xs)',
-          borderRadius: 999,
-          background: 'var(--color-bg-surface-alt)',
-          border: '1px solid var(--color-border)',
-          marginBottom: 'var(--space-lg)',
-        }}
-      >
-        <SegTab on={segment === 'praxis'} onClick={() => setSegment('praxis')}>
-          {t('profile.mobile.tabPraxis')}
-        </SegTab>
-        <SegTab on={segment === 'tasks'} onClick={() => setSegment('tasks')}>
-          {t('profile.mobile.tabTasks')}
-        </SegTab>
-      </div>
+        {/* ── ③ Badges — hidden entirely when empty ── */}
+        {badges.length > 0 && (
+          <div style={{ marginTop: 'var(--space-lg)', marginBottom: 'var(--space-lg)' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', marginBottom: 'var(--space-sm)' }}>
+              <h2 className="font-display italic" style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)' }}>
+                {t('profile.badgesHeading')}
+              </h2>
+              <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--color-text-tertiary)' }}>
+                {t('profile.badgesEarned', { count: badges.length })}
+              </span>
+            </div>
+            <div
+              style={{
+                border: '1px solid var(--color-border)',
+                borderRadius: 12,
+                background: 'var(--color-bg-surface-alt)',
+                padding: 'var(--space-xs) var(--space-lg)',
+              }}
+            >
+              {badges.map((badge, index) => (
+                <BadgeRow key={badge.key} badge={badge} last={index === badges.length - 1} />
+              ))}
+            </div>
+          </div>
+        )}
 
-      {/* ── Content — reuse the existing cards, stacked single-column ── */}
-      {segment === 'praxis' ? (
-        submissions.length === 0 ? (
-          <p className="font-body text-muted">{t('profile.praxisEmptyTitle')}</p>
+        {/* ── Segmented Praxis / Tasks toggle ── */}
+        <div
+          style={{
+            display: 'flex',
+            gap: 'var(--space-xs)',
+            padding: 'var(--space-xs)',
+            borderRadius: 999,
+            background: 'var(--color-bg-surface-alt)',
+            border: '1px solid var(--color-border)',
+            marginTop: 'var(--space-lg)',
+            marginBottom: 'var(--space-lg)',
+          }}
+        >
+          <SegTab on={segment === 'praxis'} onClick={() => setSegment('praxis')}>
+            {t('profile.mobile.tabPraxis')}
+          </SegTab>
+          <SegTab on={segment === 'tasks'} onClick={() => setSegment('tasks')}>
+            {t('profile.mobile.tabTasks')}
+          </SegTab>
+        </div>
+
+        {/* ── Content — reuse the existing cards, stacked single-column ── */}
+        {segment === 'praxis' ? (
+          submissions.length === 0 ? (
+            <p className="font-body text-muted">{t('profile.praxisEmptyTitle')}</p>
+          ) : (
+            <div className="flex flex-col gap-4 items-stretch">
+              {submissions.map((praxis) => (
+                <div key={praxis.id} style={{ position: 'relative' }}>
+                  {praxis.id === laurelId && <FdlLaurel />}
+                  <PraxisCard praxis={praxis} />
+                </div>
+              ))}
+            </div>
+          )
+        ) : proposedTasks.length === 0 ? (
+          <p className="font-body text-muted">{t('profile.proposedTasksEmpty')}</p>
         ) : (
           <div className="flex flex-col gap-4 items-stretch">
-            {submissions.map((praxis) => (
-              <PraxisCard key={praxis.id} praxis={praxis} />
+            {proposedTasks.map((task) => (
+              <TaskCard key={task.id} task={task} displayPoints={task.point_value} />
             ))}
           </div>
-        )
-      ) : proposedTasks.length === 0 ? (
-        <p className="font-body text-muted">{t('profile.proposedTasksEmpty')}</p>
-      ) : (
-        <div className="flex flex-col gap-4 items-stretch">
-          {proposedTasks.map((task) => (
-            <TaskCard key={task.id} task={task} displayPoints={task.point_value} />
-          ))}
-        </div>
-      )}
+        )}
+      </div>
     </div>
   )
 }
 
-function Stat({ label, value, divider }: { label: string; value: number; divider?: boolean }) {
+/** The FDL laurel stamped on the character's top praxis. Spectrum ring, ink glyph. */
+function FdlLaurel() {
   return (
-    <div
+    <span
+      title="Top praxis"
       style={{
-        flex: 1,
-        textAlign: 'center',
-        padding: 'var(--space-md) var(--space-sm)',
-        borderLeft: divider ? '1px solid var(--color-border)' : undefined,
+        position: 'absolute',
+        top: -11,
+        right: 14,
+        zIndex: 20,
+        width: 44,
+        height: 44,
+        filter: 'drop-shadow(0 4px 8px rgba(0,0,0,0.25))',
       }}
     >
-      <div className="font-display italic" style={{ fontSize: 'var(--text-title)', fontWeight: 700, color: 'var(--color-text-primary)' }}>
-        {value}
-      </div>
-      <div className="eyebrow" style={{ color: 'var(--color-text-tertiary)', marginTop: 'var(--space-xs)' }}>
-        {label}
-      </div>
-    </div>
+      <span style={{ position: 'absolute', inset: 0, borderRadius: '50%', background: 'var(--faction-default-ring)' }} />
+      <span
+        style={{
+          position: 'absolute',
+          inset: 4,
+          borderRadius: '50%',
+          background: 'var(--color-bg-surface-alt)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'var(--color-text-primary)',
+        }}
+      >
+        <svg width={18} height={22} viewBox="0 0 40 48" fill="currentColor" aria-hidden>
+          <path d="M20 1 C16 10 16 17 20 24 C24 17 24 10 20 1 Z" />
+          <path d="M20 22 C14 15 8 15 6 21 C4.6 25 8 29 13.5 27.6 C10.5 25 12.5 21 20 22 Z" />
+          <path d="M20 22 C26 15 32 15 34 21 C35.4 25 32 29 26.5 27.6 C29.5 25 27.5 21 20 22 Z" />
+          <rect x="11" y="26" width="18" height="4.5" rx="2.2" />
+          <path d="M20 30 C17.5 37 16 41 20 47 C24 41 22.5 37 20 30 Z" />
+        </svg>
+      </span>
+    </span>
   )
 }
 
@@ -240,7 +429,7 @@ function SegTab({ on, onClick, children }: { on: boolean; onClick: () => void; c
       onClick={onClick}
       style={{
         flex: 1,
-        fontFamily: "'Courier Prime', monospace",
+        fontFamily: 'var(--font-body)',
         fontSize: 'var(--text-lg)',
         fontWeight: on ? 700 : 400,
         letterSpacing: '0.08em',

--- a/frontend/src/pages/characterProfile/mobileArchetypes/__tests__/defaultProfile.test.tsx
+++ b/frontend/src/pages/characterProfile/mobileArchetypes/__tests__/defaultProfile.test.tsx
@@ -4,8 +4,8 @@
  * with the data + form-factor hooks mocked (phone → the Default mobile skin,
  * desktop → the existing faction-dispatched body). The content test renders the
  * Default mobile skin directly to pin the reused #459 contract fields: identity,
- * the real-fields stats row, badges, friend/foe, and the segmented Praxis/Tasks
- * toggle over the shared PraxisCard/TaskCard.
+ * the progression panel (#969, replacing the old stats row), badges, friend/foe,
+ * and the segmented Praxis/Tasks toggle over the shared PraxisCard/TaskCard.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
@@ -150,14 +150,22 @@ describe('Default mobile profile content slots', () => {
     character: character(),
     submissions: [praxis()],
     proposedTasks: [task()],
-    progression: null,
+    progression: {
+      nextLevel: 8,
+      currentThreshold: 1500,
+      nextThreshold: 2000,
+      progressPercent: 76,
+    },
     identityActions: <div>Friend</div>,
   }
 
-  it('renders identity, stats, badges and friend/foe from the #459 contract', () => {
+  it('renders identity, progression, badges and friend/foe from the #459 contract', () => {
     const { text } = html(<DefaultProfile {...props} />)
-    expect(text, 'name').toContain('Reza')
-    expect(text, 'stats row').toContain('Points')
+    expect(text, 'name (credential)').toContain('Reza')
+    // #969: the mobile stats row was replaced by the redesign's progression
+    // panel (level ring + points-into-level bar toward level+1).
+    expect(text, 'progression next-level label').toContain('next · lvl 8')
+    expect(text, 'progression points-into-level').toContain('380 / 500 pts this level')
     expect(text, 'badge').toContain('Sock Puppet')
     expect(text, 'friend/foe control').toContain('Friend')
   })


### PR DESCRIPTION
Rebuilds the unaffiliated/na public **Player Profile** — desktop `DefaultProfileBody.tsx` + mobile `DefaultProfile.tsx` — against the vendored redesign (`Default Profile.dc.html` / `default.css`, design project `1eb2665a`). Ported from the source files, token-only, rainbow as accent.

## What changed

**Mobile (`DefaultProfile.tsx`) — the real fidelity fix.** The old mobile skin themed identity via `factionCssVar(faction_slug)`, which resolves **grey** for `na` (ADR-0039/#749) — the na-identity bug. Rebuilt to the spectrum kit:
- Identity band, avatar hoop, progression bar and the section dot now reach the spectrum through `factionFill(slug, 'bar'/'dot')` and the shared `CredentialCard` (its Unaffiliated state wears the spectrum ring). No `factionCssVar('na')` on any na surface.
- Adds the redesign's **progression panel** (level ring + points-into-level bar toward level+1), wired to the real `progression` prop.
- Uses the shared `CredentialCard` for the identity header (was a hand-rolled avatar).
- FDL laurel on the top praxis (parity with desktop).
- **Dual-role preserved:** only WOW registers a `mobileProfile`, so this file is the mobile fallback for the other six themed factions + `na`/albescent. Those seams stay per-faction — `factionFill` hands a themed slug its solid hue and only `na`/albescent get the rainbow; the "faction pending" copy is gated on `isKnownFaction`.

**Both surfaces.** Render the `.na-backdrop` full-page spectrum-wash hook element (the design's new backdrop). See Deviations — the CSS rule is a frontend-style follow-up.

**Test.** Updated `defaultProfile.test.tsx` to pin the new progression panel in place of the removed stats row (11 profile tests pass).

## Verify
- `tsc --noEmit`: clean for the changed files (the only errors are the known `node:fs`/`node:url` stale-junction false alarm, PR #675, all in pre-existing `__tests__`).
- `eslint` (incl. `no-raw-style-values`): clean.
- `vite build`: OK.
- `vitest run src/pages/characterProfile`: 11/11 pass.
- Rainbow reaches the bundle via the token: `--faction-default-rainbow` present in built JS; `na-backdrop` hook present.
- Other factions' profile archetypes untouched (diff = the 3 files only).
- **Visual QA is outstanding** — no dev stack, and the Browser pane cannot screenshot.

## New API endpoints consumed
None.

## Deviations
- **Design:** full-page `.na-backdrop` spectrum wash (radial-gradient rgba stops + a `[data-theme="dark"]` brighten). **Shipped:** the markup hook `<div className="na-backdrop">` + a `position:relative;z-index:1` content wrapper; the `.na-backdrop` **CSS rule is deferred to frontend-style** (raw rgba + dark override belong in `index.css`, which frontend-feature must not edit). **Rule:** colours live only in `index.css` / frontend-style owns `*.css`. Port from the vendored `default.css`. Inert until that rule lands.
- **Design:** right-rail **featured "Proudest badge"** card with a `note` and an `earnedAt` date; mobile **stats row** (Points/Praxis/Tasks). **Shipped:** neither. `BadgeOut` exposes only `{ key, name }` — there is no proudest-selection flag, no per-badge note, and no earned-at timestamp, so a featured card would fabricate data/semantics on a public profile. Badges render as the flat spectrum-medallion rail (real names only); the mobile stats row is replaced by the redesign's progression panel. **Rule:** don't fabricate contract fields (design-fidelity: sample content is placeholder).
- **Design:** ② **About** section. **Shipped:** none. There is no long-form about field in the contract (only `bio`, already shown in the credential); the design gates About on `hasAbout`, which is always false — so hiding it matches the design's own empty-state. **Rule:** render only contract fields.
- **Mobile-only affordances kept** (not in the desktop design, retained as the phone-native reflow): the segmented **Praxis/Tasks** toggle and the proposed-tasks tab (kept feature #419).

## What to eyeball (visual QA outstanding)
An **unaffiliated (na)** character's public profile, **desktop and mobile**:
- Spectrum-band identity header (rainbow frame around the credential card).
- Progression **ring + bar in rainbow**; level ring fills by percent.
- Badges rail — spectrum-medallion rows (hidden when the player has none).
- Recent praxis with the FDL laurel on the top entry.
- **Neutral — no recruitment nudge.**
- Spectrum **brightens in dark mode** (via the `[data-theme="dark"]` cascade + the deferred `.na-backdrop` dark rule).
- Also sanity-check a **themed** faction that falls through to the mobile Default (e.g. Ephemerists): it keeps its solid hue and its faction name, not the rainbow / "faction pending".

Closes #969