### PR TITLE
Empty the grandfathered orphan-token allowlist (#890)

### DIFF
--- a/frontend/src/components/cards/FactionCard.tsx
+++ b/frontend/src/components/cards/FactionCard.tsx
@@ -773,7 +773,7 @@ export function DefaultFactionCard(props: FactionCardProps) {
         <div
           style={{
             width: "100%",
-            background: "var(--color-bg-card)",
+            background: "var(--color-bg-surface)",
             border: `2px solid ${factionCssVar(props.faction.slug, "border")}`,
             padding: "var(--space-md) var(--space-lg)",
             fontFamily: "var(--font-body)",

--- a/frontend/src/components/comments/__tests__/OwnerControls.test.tsx
+++ b/frontend/src/components/comments/__tests__/OwnerControls.test.tsx
@@ -118,7 +118,7 @@ describe('OwnerControls', () => {
 describe('CommentEditor', () => {
   it('seeds the composer with the current body and shows Save', () => {
     const html = renderToStaticMarkup(
-      <CommentEditor owner={makeOwner({ editing: true })} accent="var(--color-accent)" onAccent="var(--faction-default-on-accent)" />,
+      <CommentEditor owner={makeOwner({ editing: true })} accent="var(--color-accent-primary)" onAccent="var(--faction-default-on-accent)" />,
     )
     expect(html).toContain('seedlings along the estuary')
     expect(html).toContain('Save')

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -736,6 +736,7 @@
   --everymen-ink: #221a12;
   --everymen-red: #c1272d;
   --everymen-red-deep: #8d1c20;
+  --everymen-red-light: rgba(193, 39, 45, 0.08); /* low-alpha red wash — error-banner field */
   --everymen-paper: #ece1c6;
   --everymen-paper-deep: #ddceac;
   --everymen-paper-text: #221a12;
@@ -1245,6 +1246,7 @@
   --everymen-ink: #0d0907;
   --everymen-red: #e2433f;
   --everymen-red-deep: #b32a28;
+  --everymen-red-light: rgba(226, 67, 63, 0.08); /* low-alpha red wash — error-banner field */
   --everymen-paper: #221a16;
   --everymen-paper-deep: #17110d;
   --everymen-paper-text: #f3e7ce;

--- a/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
@@ -57,7 +57,7 @@ export default function DefaultFactionBody({
                 style={{
                   border: `1px solid ${accent}`,
                   padding: "var(--space-sm) var(--space-md)",
-                  background: "var(--color-bg-card)",
+                  background: "var(--color-bg-surface)",
                 }}
               >
                 <CharacterBadge character={m} size="sm" />

--- a/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
@@ -123,7 +123,7 @@ export function DefaultDuelRail({
     borderLeft: `3px solid ${accent}`,
     background: soft,
     fontFamily: "var(--font-body)",
-    color: "var(--color-text)",
+    color: "var(--color-text-primary)",
   };
   return (
     // .content-text, not a wrapper `fontSize` (#769). This wrapper used to set

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -200,7 +200,7 @@ export default function DefaultPraxisDetail({
               <div style={{ marginBottom: canEdit ? "var(--space-md)" : 0 }}>
                 <span className="eyebrow" style={{ display: "block", marginBottom: 'var(--space-sm)' }}>{t('detail.metatasks.applied')}</span>
                 {state.praxis.applied_metatasks.map((metatask) => (
-                  <div key={metatask.id} className="flex items-center gap-2 mb-1" style={{ padding: "var(--space-xs) var(--space-sm)", background: "var(--color-surface-soft)", fontSize: 'var(--text-md)' }}>
+                  <div key={metatask.id} className="flex items-center gap-2 mb-1" style={{ padding: "var(--space-xs) var(--space-sm)", background: "var(--color-bg-surface-alt)", fontSize: 'var(--text-md)' }}>
                     <span className="flex-1 font-body">{metatask.title}</span>
                     <span className="eyebrow">{t('detail.metatasks.appliedPoints', { points: metatask.point_value })}</span>
                     {canEdit && (
@@ -236,13 +236,13 @@ export default function DefaultPraxisDetail({
                   </p>
                 ) : (
                   available.map((metatask) => (
-                    <div key={metatask.id} className="flex items-center gap-2 mb-1" style={{ padding: "var(--space-xs) var(--space-sm)", background: "var(--color-surface-soft)", fontSize: 'var(--text-md)' }}>
+                    <div key={metatask.id} className="flex items-center gap-2 mb-1" style={{ padding: "var(--space-xs) var(--space-sm)", background: "var(--color-bg-surface-alt)", fontSize: 'var(--text-md)' }}>
                       <span className="flex-1 font-body">{metatask.title}</span>
                       <span className="eyebrow">{t('detail.metatasks.appliedPoints', { points: metatask.point_value })}</span>
                       <button
                         onClick={() => void state.handleApplyMetatask(metatask.id)}
                         disabled={state.applyingMetataskId === metatask.id}
-                        style={{ background: "none", border: "1px solid var(--color-accent)", color: "var(--color-accent)", fontSize: 'var(--text-xs)', padding: "var(--space-xs) var(--space-sm)", cursor: "pointer", opacity: state.applyingMetataskId === metatask.id ? 0.5 : 1 }}
+                        style={{ background: "none", border: "1px solid var(--color-accent-primary)", color: "var(--color-accent-primary)", fontSize: 'var(--text-xs)', padding: "var(--space-xs) var(--space-sm)", cursor: "pointer", opacity: state.applyingMetataskId === metatask.id ? 0.5 : 1 }}
                       >
                         {state.applyingMetataskId === metatask.id ? t('detail.metatasks.applying') : t('detail.metatasks.apply')}
                       </button>

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/shared.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/shared.tsx
@@ -44,7 +44,7 @@ export function MobileStarVote({
   currentValue,
   points,
   totalVotes,
-  accent = 'var(--color-accent)',
+  accent = 'var(--color-accent-primary)',
   accentFont = 'var(--font-display)',
 }: {
   praxisId: number

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -256,7 +256,7 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
             display: 'flex',
             alignItems: 'center',
             gap: 'var(--space-md)',
-            background: 'var(--color-bg-card)',
+            background: 'var(--color-bg-surface)',
           }}
         >
           <TaskCrown size={34} ringInset={3} />

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -466,7 +466,7 @@ export default function EverymenTaskDetail({
                 message={signupError}
                 style={{
                   flexBasis: "100%",
-                  background: "var(--everymen-red-light, rgba(193,39,45,0.08))",
+                  background: "var(--everymen-red-light)",
                   border: `1px solid ${RED}`,
                   color: RED_DEEP,
                 }}
@@ -574,7 +574,7 @@ export default function EverymenTaskDetail({
                 message={signupError}
                 style={{
                   flexBasis: "100%",
-                  background: "var(--everymen-red-light, rgba(193,39,45,0.08))",
+                  background: "var(--everymen-red-light)",
                   border: `1px solid ${RED}`,
                   color: RED_DEEP,
                 }}

--- a/frontend/src/utils/__tests__/factionTokensDeclared.test.ts
+++ b/frontend/src/utils/__tests__/factionTokensDeclared.test.ts
@@ -52,24 +52,6 @@ const REFERENCE = /var\(\s*(--[A-Za-z0-9_-]+)\s*[,)]/g;
 
 const COMMENT = /\/\*[\s\S]*?\*\//g;
 
-/**
- * Pre-existing orphans, grandfathered when the guard widened past `--faction-*`
- * (#879). Modelled on the `no-raw-style-values` ratchet: this list may SHRINK,
- * never grow. Do not add a name here to quiet a failure — declare the token in
- * `index.css` (or point the reference at the token that was meant). The
- * "no dead entries" test below makes the ratchet self-enforcing.
- *
- * Each of these needs a design call about which declared token was intended,
- * which is why #879 did not fix them inline. Tracked in #890.
- */
-const GRANDFATHERED = new Set([
-  "--color-accent", // near-miss of --color-accent-primary
-  "--color-bg-card", // no such token
-  "--color-surface-soft", // no such token
-  "--color-text", // near-miss of --color-text-primary
-  "--everymen-red-light", // has a literal fallback, so it renders
-]);
-
 function collectSourceFiles(directory: string): string[] {
   return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
     const path = join(directory, entry.name);
@@ -142,18 +124,10 @@ describe("CSS custom properties are declared before use (#806, #879)", () => {
   });
 
   it("has no var(--…) reference pointing at an undeclared custom property", () => {
-    const unexpected = orphans
-      .filter((name) => !GRANDFATHERED.has(name))
-      .flatMap((name) =>
-        (referenced.get(name) ?? []).map((path) => `${name} in ${path}`),
-      );
+    const unexpected = orphans.flatMap((name) =>
+      (referenced.get(name) ?? []).map((path) => `${name} in ${path}`),
+    );
 
     expect(unexpected).toEqual([]);
-  });
-
-  it("keeps the grandfathered allowlist a ratchet (no dead entries)", () => {
-    const fixed = [...GRANDFATHERED].filter((name) => !orphans.includes(name));
-
-    expect(fixed).toEqual([]);
   });
 });


### PR DESCRIPTION
Spun out of #879. Empties the grandfathered orphan-token allowlist in `factionTokensDeclared.test.ts` by repointing each dangling `var(--…)` at the declared token it was meant to be. `GRANDFATHERED` and the "no dead entries" ratchet test are deleted; the guard now passes with zero allowlist.

Each repoint is a **same-intent** substitution — the closest correct declared token — not a restyle.

## Token mapping (orphan → declared, per file)

| Orphan | Declared token chosen | File(s) |
|---|---|---|
| `--color-accent` | `--color-accent-primary` (declared near-miss) | `pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx`, `pages/praxisDetail/mobileArchetypes/shared.tsx`, `components/comments/__tests__/OwnerControls.test.tsx` (fixture) |
| `--color-text` | `--color-text-primary` (declared near-miss) | `pages/praxisDetail/DuelCrossLink.tsx` |
| `--color-bg-card` | `--color-bg-surface` (standard frosted card/panel surface, §7) | `components/cards/FactionCard.tsx`, `pages/factionDetail/archetypes/DefaultFactionBody.tsx`, `pages/praxisDetail/shared.tsx` |
| `--color-surface-soft` | `--color-bg-surface-alt` (soft inset list-row surface, kept distinct from the card surface) | `pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx` |
| `--everymen-red-light` | **declared** as a new Everymen palette tint in both theme blocks of `index.css` (light `rgba(193,39,45,0.08)` = the old literal fallback; dark `rgba(226,67,63,0.08)`, parallel to dark `--everymen-red`); raw rgba fallback dropped | `pages/taskDetail/archetypes/EverymenTaskDetail.tsx` (×2) |

Design notes:
- `--color-bg-card` and `--color-surface-soft` were two distinct names, so they map to two distinct declared surfaces (`--color-bg-surface` for cards/banners, `--color-bg-surface-alt` for the soft metatask rows) — preserving the original intent rather than collapsing them.
- The Everymen error-banner wash was the one raw-colour breach (a literal `rgba(...)` fallback outside `index.css`). Rather than borrow `--everymen-stamp-field` (a stamp-ornament token), a proper `--everymen-red-light` palette tint is declared — theme-aware, and it makes the token name that code already used real.
- `TaskCrown.tsx` was listed against `--color-bg-card` in the issue but references only declared `--fdl-*` tokens; no change needed there.

## What to eyeball (visual QA outstanding — see below)

These surfaces must look **unchanged** (same-intent repoints, not restyles), in both light and dark:
- Praxis detail — desktop (metatask apply/available rows + apply button) and mobile (star-vote accent default)
- Faction card (`DefaultFactionCard` background)
- Task Crown banner (`praxisDetail/shared.tsx`)
- Default faction body (member chips)
- Duel cross-link (wrapper text colour)
- Everymen task detail (signup + in-progress error banners)

## Verification
- `tsc --noEmit` clean (only the known `node:fs`/`node:url` stale-junction false alarm, PR #675)
- `eslint` clean on all edited files (incl. `no-raw-style-values`)
- `vite build` OK
- Full vitest green: 102 files / 1530 tests, incl. the now-allowlist-free `factionTokensDeclared` guard (3 tests)
- Grepped `frontend/src`: none of the 5 orphan names remain as undeclared references

**Visual QA is outstanding** — no dev stack available and the Browser pane renderer times out, so rendering was not eyeballed. Verified via tests/tsc/eslint/build only.

Closes #890