### PR TITLE
na kit fidelity: rebuild Default Praxis Detail to the redesign

### DIFF
--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -196,7 +196,23 @@
       "pointsFromVotes": "Points earned from votes",
       "pts": "pts",
       "submitted": "Submitted {{date}}",
-      "flagged": "flagged"
+      "flagged": "flagged",
+      "praxisEyebrow": "A praxis · unaffiliated · counts for everyone",
+      "basePts": "base pts",
+      "filedRe": "Re: {{task}} · filed {{date}}",
+      "evidence": "Evidence",
+      "plate": "Plate I",
+      "theAccount": "The account",
+      "castHeading": "Cast your vote",
+      "castPrompt": "How much did this move you?",
+      "ledgerAwarded": "pts awarded by votes",
+      "ledgerBacked_one": "person backed it",
+      "ledgerBacked_other": "people backed it",
+      "ledgerBackedBy": "Backed by",
+      "ledgerBackers_one": "{{count}} backer",
+      "ledgerBackers_other": "{{count}} backers",
+      "ledgerTotal": "+{{points}} pts",
+      "ledgerEmpty": "No votes yet — be the first to back it."
     },
     "ua": {
       "status": {

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -1,268 +1,345 @@
+/**
+ * Default (Unaffiliated / na) praxis-read archetype — the spectrum-band editorial
+ * kit (CONTEXT.md "Default archetype"; ADR-0039/0046/0048). Rebuilt to the na
+ * redesign (project 1eb2665a, `Default Praxis Detail.dc.html`): "one filed praxis
+ * in full" — a rainbow-bordered praxis SHEET (ring eyebrow, big italic finding,
+ * author row with a rainbow-ring avatar + base pts, a rainbow-bordered EVIDENCE
+ * plate with a "Plate I" caption, a ruled "The account" prose block) beside a
+ * sticky rail: the ADR-0005 vote panel (the live na spectrum widget via VoteUI)
+ * and a points/backers LEDGER. NO AVERAGE anywhere (ADR-0005/0014) — the ledger
+ * shows points awarded, how many people backed it, and each backer's own rung.
+ *
+ * This is also VoteUI/archetype fallback for themed-but-unskinned factions (wow,
+ * albescent): the chrome wears the na spectrum, while VoteUI still dispatches the
+ * vote widget on the praxis's own task faction, so a wow praxis votes in its own
+ * voice (ADR-0039).
+ *
+ * Tokens only: --faction-default-* (rainbow via --faction-default-rainbow /
+ * -ring) + --color-*. The full-page wash is the shared `.na-backdrop` hook (its
+ * rule is owned by the na-kit / Task Detail #967; this surface only mounts the
+ * hook). Invariant behavior slots (admin bar, banners, owner actions, flag) come
+ * from the shared module.
+ */
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import MediaGallery from '../../../components/MediaGallery'
-import { formatTimestamp } from '../../../utils/dates'
-import VoteUI from '../../../components/vote/VoteUI'
-import type { PraxisDetailState } from '../usePraxisDetail'
-import { PraxisAdminBar, PraxisStatusBanners, PraxisOwnerActions, PraxisFlagBlock, PraxisVoterBreakdown, PraxisScoreBreakdown, MemberByline } from '../shared'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import VoteUI from '../../../components/vote/VoteUI'
+import { formatTimestamp } from '../../../utils/dates'
+import {
+  PraxisAdminBar,
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisFlagBlock,
+  MemberByline,
+  praxisBreakdownParts,
+} from '../shared'
 import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import type { PraxisOut } from '../../../api/praxis'
+import type { VoteSummary, VoterDetail } from '../../../api/votes'
 
-/** Style Guide §12.3 */
-const RAINBOW_COLORS = ['var(--underline-1)', 'var(--underline-2)', 'var(--underline-3)', 'var(--underline-4)', 'var(--underline-5)', 'var(--underline-6)', 'var(--underline-1)', 'var(--underline-2)']
+function initials(name: string): string {
+  return (
+    name
+      .trim()
+      .split(/\s+/)
+      .map((word) => word[0])
+      .slice(0, 2)
+      .join('')
+      .toUpperCase() || '·'
+  )
+}
 
 /**
- * Default praxis-detail archetype — the original universal layout, now consuming
- * the shared {@link PraxisDetailState}. Any faction without a bespoke archetype
- * falls through to this, so it must stay visually identical to the pre-refactor
- * page.
+ * The points / backers LEDGER (the design's dark "take" panel).
+ *
+ * DEVIATION (named per docs/agents/design-fidelity.md): the design draws this as
+ * an ALWAYS-dark receipt (#17161d/#f0e6d0/#8b8272). CLAUDE.md forbids hardcoded
+ * hex and there is no always-dark `--color-*` token to map onto, so it uses the
+ * `--faction-default-card-*` family — which matches the design's palette exactly
+ * in dark mode and becomes the light na card in light mode (theme-aware, not
+ * always-dark). Rainbow accents stay `--faction-default-rainbow`.
+ *
+ * Every number here is honest live data (ADR-0005): `points_from_votes` awarded,
+ * `total_votes` backers, and each backer's own rung as a rainbow bar (value / 5).
+ * NO AVERAGE. The design's per-backer "+N points" is NOT available from the API
+ * (there is no per-voter point breakdown — a vote is a single 1-5 rung), so the
+ * bar shows the rung and no fabricated per-backer points figure is invented.
  */
-export default function DefaultPraxisDetail({
-  state,
+function TheLedger({
+  praxis,
+  votes,
+  voters,
 }: {
-  state: PraxisDetailState
+  praxis: PraxisOut
+  votes: VoteSummary | null
+  voters: VoterDetail[]
 }) {
   const { t } = useTranslation('praxis')
-  const { praxis } = state
+  // The single earned-points breakdown (#641, ADR-0053): the payload's own
+  // terms, `{base} × {mult} + {votes}`, the `× {mult}` term omitted at ×1.0.
+  const { base, votePoints, isPlain, multiplierLabel } = praxisBreakdownParts(praxis)
+  const backerCount = votes?.total_votes ?? voters.length
+
+  return (
+    <div
+      style={{
+        position: 'relative',
+        overflow: 'hidden',
+        borderRadius: 12,
+        background: 'var(--faction-default-card-bg)',
+        color: 'var(--faction-default-card-text)',
+        border: '1px solid var(--faction-default-border)',
+        boxShadow: '0 14px 32px -18px var(--color-overlay-medium)',
+        padding: 'var(--space-lg) var(--space-lg) var(--space-xl)',
+      }}
+    >
+      {/* rainbow header rule */}
+      <div style={{ height: 4, borderRadius: 3, background: 'var(--faction-default-rainbow)', marginBottom: 'var(--space-lg)' }} />
+
+      {/* pts awarded · people backed it */}
+      <div style={{ display: 'flex', marginBottom: 'var(--space-lg)' }}>
+        <div style={{ flex: 1, paddingRight: 'var(--space-md)' }}>
+          <div style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--faction-default-card-text)' }}>
+            {`+${praxis.points_from_votes}`}
+          </div>
+          <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-sm)' }}>
+            {t('detail.default.ledgerAwarded')}
+          </div>
+        </div>
+        <div style={{ flex: 1, paddingLeft: 'var(--space-md)', borderLeft: '1px solid var(--faction-default-border)' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', fontFamily: 'var(--font-accent)', fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--faction-default-card-text)' }}>
+            <span aria-hidden style={{ fontSize: 'var(--text-title)', color: 'var(--faction-default-card-muted)' }}>&#10003;</span>
+            {backerCount}
+          </div>
+          <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-sm)' }}>
+            {t('detail.default.ledgerBacked', { count: backerCount })}
+          </div>
+        </div>
+      </div>
+
+      {/* earned-points breakdown (#641, ADR-0053): base × mult + votes */}
+      <div style={{ borderTop: '1px dashed var(--faction-default-border)', paddingTop: 'var(--space-md)', marginBottom: voters.length ? 'var(--space-lg)' : 0 }}>
+        <span style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-title)', color: 'var(--faction-default-card-text)', whiteSpace: 'nowrap' }}>
+          {base}
+          {!isPlain && (
+            <>
+              <span aria-hidden style={{ opacity: 0.55, margin: '0 var(--space-xs)' }}>&#215;</span>
+              {multiplierLabel}
+            </>
+          )}
+          <span aria-hidden style={{ opacity: 0.55, margin: '0 var(--space-xs)' }}>+</span>
+          {votePoints}
+        </span>
+        <span className="eyebrow" style={{ display: 'block', marginTop: 'var(--space-xs)', color: 'var(--faction-default-card-muted)' }}>
+          {isPlain ? t('detail.default.pointsFromVotes') : t('detail.score.ptsMultVotes')}
+        </span>
+      </div>
+
+      {/* Backed by — each backer + the rung they gave (value / 5) */}
+      {voters.length > 0 ? (
+        <>
+          <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginBottom: 'var(--space-md)' }}>
+            {t('detail.default.ledgerBackedBy')}
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-md)' }}>
+            {voters.map((voter) => (
+              <div key={voter.character_id} style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)' }}>
+                <Link to={`/characters/${voter.character_id}`} style={{ textDecoration: 'none', flexShrink: 0 }}>
+                  <span
+                    style={{
+                      width: 26,
+                      height: 26,
+                      borderRadius: '50%',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      background: 'var(--faction-default-card-muted)',
+                      color: 'var(--faction-default-card-bg)',
+                      fontFamily: 'var(--font-accent)',
+                      fontSize: 'var(--text-sm)',
+                    }}
+                  >
+                    {initials(voter.display_name)}
+                  </span>
+                </Link>
+                <Link
+                  to={`/characters/${voter.character_id}`}
+                  style={{ width: 92, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontFamily: 'var(--font-display)', fontStyle: 'italic', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)', textDecoration: 'none' }}
+                >
+                  {voter.display_name}
+                </Link>
+                <div style={{ flex: 1, height: 9, borderRadius: 5, background: 'var(--faction-default-border)', position: 'relative', overflow: 'hidden' }}>
+                  <div style={{ position: 'absolute', inset: 0, width: `${(voter.value / 5) * 100}%`, background: 'var(--faction-default-rainbow)' }} />
+                </div>
+                <span style={{ width: 24, textAlign: 'right', fontFamily: 'var(--font-accent)', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)' }}>
+                  {voter.value}
+                </span>
+              </div>
+            ))}
+          </div>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', borderTop: '1px solid var(--faction-default-border)', marginTop: 'var(--space-md)', paddingTop: 'var(--space-md)' }}>
+            <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
+              {t('detail.default.ledgerBackers', { count: voters.length })}
+            </span>
+            <span style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-title)', color: 'var(--faction-default-card-text)' }}>
+              {t('detail.default.ledgerTotal', { points: praxis.points_from_votes })}
+            </span>
+          </div>
+        </>
+      ) : (
+        <p className="font-body" style={{ fontSize: 'var(--text-base)', color: 'var(--faction-default-card-muted)', margin: 0 }}>
+          {t('detail.default.ledgerEmpty')}
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default function DefaultPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const { praxis, votes, voters } = state
 
   // Guarded non-null by the dispatcher.
   if (!praxis) return null
 
+  const authorInitial = initials(praxis.created_by_display_name)
+
   return (
-    <div className="py-8 max-w-2xl">
-      {/* ── Breadcrumb (§12.1) ── */}
-      <nav className="font-body mb-4" style={{ fontSize: 'var(--text-sm)', letterSpacing: '0.1em', color: 'var(--color-text-tertiary)' }}>
-        <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>{t('detail.default.breadcrumbTasks')}</Link>
-        {' › '}
-        <Link to={`/tasks/${praxis.task_id}`} style={{ color: 'var(--color-text-secondary)', textDecoration: 'none' }}>
-          {praxis.task_title}
-        </Link>
-        {' › '}
-        <span style={{ color: 'var(--color-text-primary)' }}>{t('detail.default.breadcrumbPraxis')}</span>
-      </nav>
+    <div style={{ position: 'relative' }}>
+      {/* Full-page spectrum wash. The `.na-backdrop` rule ships with the na kit
+          / Task Detail (#967); mounting the hook here is harmless until it lands. */}
+      <div className="na-backdrop" />
 
-      <PraxisStatusBanners state={state} />
-      <PraxisAdminBar state={state} />
+      <div className="py-8" style={{ position: 'relative', zIndex: 1, maxWidth: 1080, marginInline: 'auto' }}>
+        {/* ── Breadcrumb: Tasks / {task} / Praxis ── */}
+        <nav className="font-body mb-4" style={{ fontSize: 'var(--text-sm)', letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)' }}>
+          <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>{t('detail.default.breadcrumbTasks')}</Link>
+          {' / '}
+          <Link to={`/tasks/${praxis.task_id}`} style={{ color: 'inherit', textDecoration: 'none' }}>
+            {praxis.task_title}
+          </Link>
+          {' / '}
+          <span style={{ color: 'var(--color-text-primary)' }}>{t('detail.default.breadcrumbPraxis')}</span>
+        </nav>
 
-      {/* ── Byline Block (§12.2) ── */}
-      <div
-        className="sidebar-card flex items-center gap-3 mb-4"
-        style={{ padding: 'var(--space-md) var(--space-lg)' }}
-      >
-        <Link to={`/characters/${praxis.created_by_id}`}>
-          <div
-            className="rounded-full shrink-0"
-            style={{
-              width: 42,
-              height: 42,
-              background: 'var(--faction-default-rainbow)',
-            }}
-          />
-        </Link>
-        <div className="flex-1 min-w-0">
-          <MemberByline
-            praxis={praxis}
-            linkClassName="font-display italic"
-            linkStyle={{ fontSize: 'var(--text-xl)', color: 'var(--faction-default-card-accent)', textDecoration: 'none' }}
-          />
-          <span className="eyebrow">{formatTimestamp(praxis.created_at)}</span>
-        </div>
-      </div>
+        {/* ── Behavior slots (invariant) ── */}
+        <PraxisStatusBanners state={state} />
+        <PraxisAdminBar state={state} />
 
-      {/* ── Praxis Title (§12.3) ── */}
-      <h1
-        className="font-display italic font-medium"
-        style={{ fontSize: 'var(--text-heading)', color: 'var(--color-text-primary)', lineHeight: 1.2, marginBottom: 'var(--space-xs)' }}
-      >
-        {praxis.title}
-      </h1>
-      {/* Rainbow underline bar — 8 equal segments */}
-      <div style={{ display: 'flex', height: 4, marginBottom: 'var(--space-lg)' }}>
-        {RAINBOW_COLORS.map((color, index) => (
-          <div key={index} style={{ flex: 1, background: color }} />
-        ))}
-      </div>
+        {/* ── Layout: sheet / rail ── */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 340px', gap: 'var(--space-2xl)', alignItems: 'start' }}>
 
-      <PraxisOwnerActions state={state} />
+          {/* ── THE PRAXIS SHEET — rainbow-bordered card ── */}
+          <div style={{ borderRadius: 16, padding: 6, background: 'var(--faction-default-rainbow)', boxShadow: '0 18px 44px -26px var(--color-overlay-strong)' }}>
+            <div style={{ borderRadius: 11, background: 'var(--faction-default-card-bg)', color: 'var(--faction-default-card-text)', padding: 'var(--space-2xl)' }}>
 
-      {/* ── Task Context Strip (§12.4) ── */}
-      <div
-        className="sidebar-card mb-5"
-        style={{
-          borderLeft: '4px solid var(--faction-default-card-accent)',
-          borderRadius: '0 8px 8px 0',
-          padding: 'var(--space-sm) var(--space-lg)',
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--space-sm)',
-        }}
-      >
-        <span className="eyebrow">{t('detail.default.completingTask')}</span>
-        <Link
-          to={`/tasks/${praxis.task_id}`}
-          className="font-body"
-          style={{ fontSize: 'var(--text-lg)', fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
-        >
-          {praxis.task_title}
-        </Link>
-        <span className="font-body" style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-tertiary)', marginLeft: 'auto' }}>
-          {t('detail.default.points', { points: praxis.task_point_value })}
-        </span>
-      </div>
+              {/* Eyebrow: ring dot + counts-for-everyone */}
+              <div className="flex items-center" style={{ gap: 'var(--space-sm)', marginBottom: 'var(--space-lg)' }}>
+                <span aria-hidden style={{ width: 26, height: 26, borderRadius: '50%', flex: 'none', background: 'var(--faction-default-ring)', WebkitMask: 'radial-gradient(circle, transparent 38%, black 40%)', mask: 'radial-gradient(circle, transparent 38%, black 40%)' }} />
+                <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>{t('detail.default.praxisEyebrow')}</span>
+              </div>
 
-      {/* ── Metatask Seals (#928) — read-only stack, below the byline/context,
-          above the media preview. The compose surface (#933) wires the
-          removable/add controls; here they are proven end to end read-only. ── */}
-      {praxis.applied_metatasks.length > 0 && (
-        <div className="mb-5">
-          <MetaTaskSeal metatasks={praxis.applied_metatasks} />
-        </div>
-      )}
+              {/* Finding title */}
+              <h1
+                className="font-display italic"
+                style={{ fontWeight: 700, fontSize: 'var(--text-display)', lineHeight: 1.06, margin: '0 0 var(--space-lg)', color: 'var(--faction-default-card-text)', overflowWrap: 'anywhere' }}
+              >
+                {praxis.title}
+              </h1>
 
-      {/* ── Media Gallery (§12.5) ── */}
-      {praxis.media_items.length > 0 && (
-        <div className="mb-5">
-          <MediaGallery media={praxis.media_items} />
-        </div>
-      )}
+              {/* Owner actions (invariant) */}
+              <PraxisOwnerActions state={state} />
 
-      {/* ── Body Text (§12.6) — uses ReactMarkdown for rich content ── */}
-      {praxis.body_text && (
-        <MarkdownPreview
-          source={praxis.body_text}
-          className="font-display mb-6 markdown-preview content-text"
-          style={{ lineHeight: 1.75, color: 'var(--color-text-primary)' }}
-        />
-      )}
+              {/* Author row: rainbow-ring avatar · Re: task · filed · base pts */}
+              <div className="flex items-center" style={{ gap: 'var(--space-md)', paddingBottom: 'var(--space-xl)', marginBottom: 'var(--space-xl)', borderBottom: '1px solid var(--faction-default-border)' }}>
+                <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
+                  <span style={{ display: 'block', width: 40, height: 40, borderRadius: '50%', padding: 3, background: 'var(--faction-default-rainbow)' }}>
+                    <span className="flex items-center justify-center font-display italic" style={{ width: '100%', height: '100%', borderRadius: '50%', background: 'var(--faction-default-card-bg)', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)' }} aria-hidden>
+                      {authorInitial}
+                    </span>
+                  </span>
+                </Link>
+                <div className="min-w-0 flex-1">
+                  <MemberByline
+                    praxis={praxis}
+                    linkClassName="font-display italic"
+                    linkStyle={{ fontSize: 'var(--text-xl)', color: 'var(--faction-default-card-text)', textDecoration: 'none' }}
+                  />
+                  <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-xs)' }}>
+                    {t('detail.default.filedRe', { task: praxis.task_title, date: formatTimestamp(praxis.created_at) })}
+                  </div>
+                </div>
+                <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>
+                  <div style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-heading)', lineHeight: 1, color: 'var(--faction-default-card-text)' }}>
+                    {praxis.task_point_value}
+                  </div>
+                  <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-xs)' }}>
+                    {t('detail.default.basePts')}
+                  </div>
+                </div>
+              </div>
 
-      {/* ── Voting (§13 preview — full redesign in Phase 8) ── */}
-      <div className="sidebar-card mb-4" style={{ padding: 'var(--space-lg) var(--space-lg)' }}>
-        <div className="flex items-baseline justify-between mb-3">
-          <span className="eyebrow">{t('detail.default.pointsFromVotes')}</span>
-          <PraxisScoreBreakdown state={state} align="right" />
-        </div>
-        <VoteUI
-          factionSlug={praxis.task_faction_slug}
-          praxisId={praxis.id}
-        />
-      </div>
+              {/* Metatask seals (#928) — read-only stack; nothing when none applied */}
+              {praxis.applied_metatasks.length > 0 && (
+                <div style={{ marginBottom: 'var(--space-lg)' }}>
+                  <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+                </div>
+              )}
 
-      {/* ── Meta ── */}
-      <div className="flex items-center gap-4 eyebrow mb-4">
-        <span>{t('detail.default.submitted', { date: formatTimestamp(praxis.created_at) })}</span>
-        {praxis.moderation_status === 'flagged' && (
-          <span style={{ border: '1px solid rgba(220,38,38,0.4)', color: 'var(--color-danger)', padding: 'var(--space-xs) var(--space-sm)', fontSize: 'var(--text-xs)' }}>
-            {t('detail.default.flagged')}
-          </span>
-        )}
-      </div>
+              {/* Evidence plate — rainbow-bordered, "Plate I" caption */}
+              {praxis.media_items.length > 0 && (
+                <div style={{ marginBottom: 'var(--space-lg)' }}>
+                  <div style={{ borderRadius: 10, padding: 5, background: 'var(--faction-default-rainbow)' }}>
+                    <div style={{ borderRadius: 6, background: 'var(--color-bg-surface)', padding: 'var(--space-sm)' }}>
+                      <MediaGallery media={praxis.media_items} layout="grid" />
+                    </div>
+                  </div>
+                  <div className="font-display italic" style={{ textAlign: 'center', fontSize: 'var(--text-md)', color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-sm)' }}>
+                    {t('detail.default.plate')}
+                  </div>
+                </div>
+              )}
 
-      <PraxisFlagBlock state={state} />
-
-      <PraxisVoterBreakdown state={state} />
-
-      {/* -- Metatask Panel -- */}
-      {(() => {
-        if (!state.praxis || !state.user?.character) return null;
-
-        const character = state.user.character;
-        const isMember = state.praxis.members.some(
-          (m) => m.character_id === character.id
-        );
-        if (!isMember) return null;
-
-        const level = character.level ?? 0;
-        const isAlbescent = character.faction_slug === "albescent";
-        const canEdit = isAlbescent || level >= 7;
-        const canSee = level >= 6 || isAlbescent;
-        if (!canSee) return null;
-
-        const appliedIds = new Set(
-          (state.praxis.applied_metatasks ?? []).map((t) => t.id)
-        );
-        const available = state.metatasks.filter(
-          (t) =>
-            !appliedIds.has(t.id) &&
-            (isAlbescent || t.metatask_faction_slug === character.faction_slug)
-        );
-
-        return (
-          <div className="sidebar-card mb-4" style={{ padding: "var(--space-lg) var(--space-lg)" }}>
-            <div className="flex items-center justify-between mb-3">
-              <span className="eyebrow">{t('detail.metatasks.heading')}</span>
-              {state.metataskLoading && (
-                <span className="eyebrow">{t('detail.metatasks.loading')}</span>
+              {/* The account — ruled divider + prose */}
+              {praxis.body_text && (
+                <>
+                  <div className="flex items-center" style={{ gap: 'var(--space-md)', margin: 'var(--space-xl) 0 var(--space-lg)' }}>
+                    <div style={{ height: 1, flex: 1, background: 'var(--faction-default-border)' }} />
+                    <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', whiteSpace: 'nowrap' }}>{t('detail.default.theAccount')}</span>
+                    <div style={{ height: 1, flex: 1, background: 'var(--faction-default-border)' }} />
+                  </div>
+                  <MarkdownPreview
+                    source={praxis.body_text}
+                    className="font-body markdown-preview content-text"
+                    style={{ lineHeight: 1.85, color: 'var(--faction-default-card-muted)' }}
+                  />
+                </>
               )}
             </div>
-
-            {/* Applied metatasks */}
-            {state.praxis.applied_metatasks && state.praxis.applied_metatasks.length > 0 ? (
-              <div style={{ marginBottom: canEdit ? "var(--space-md)" : 0 }}>
-                <span className="eyebrow" style={{ display: "block", marginBottom: 'var(--space-sm)' }}>{t('detail.metatasks.applied')}</span>
-                {state.praxis.applied_metatasks.map((metatask) => (
-                  <div key={metatask.id} className="flex items-center gap-2 mb-1" style={{ padding: "var(--space-xs) var(--space-sm)", background: "var(--color-bg-surface-alt)", fontSize: 'var(--text-md)' }}>
-                    <span className="flex-1 font-body">{metatask.title}</span>
-                    <span className="eyebrow">{t('detail.metatasks.appliedPoints', { points: metatask.point_value })}</span>
-                    {canEdit && (
-                      <button
-                        onClick={() => void state.handleRemoveMetatask(metatask.id)}
-                        disabled={state.removingMetataskId === metatask.id}
-                        style={{ background: "none", border: "1px solid rgba(220,38,38,0.3)", color: "var(--color-danger)", fontSize: 'var(--text-xs)', padding: "var(--space-xs) var(--space-sm)", cursor: "pointer", opacity: state.removingMetataskId === metatask.id ? 0.5 : 1 }}
-                      >
-                        {state.removingMetataskId === metatask.id ? t('detail.metatasks.removing') : t('detail.metatasks.remove')}
-                      </button>
-                    )}
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <p className="font-body" style={{ fontSize: 'var(--text-base)', color: "var(--color-text-tertiary)", marginBottom: canEdit ? "var(--space-md)" : 0 }}>
-                {t('detail.metatasks.appliedEmpty')}
-              </p>
-            )}
-
-            {/* Available metatasks */}
-            {canEdit && (
-              <>
-                <span className="eyebrow" style={{ display: "block", marginBottom: 'var(--space-sm)' }}>{t('detail.metatasks.available')}</span>
-                {state.metataskError && (
-                  <p className="font-body" style={{ fontSize: 'var(--text-sm)', color: "var(--color-danger)", marginBottom: 'var(--space-sm)' }}>
-                    {state.metataskError}
-                  </p>
-                )}
-                {available.length === 0 && !state.metataskLoading ? (
-                  <p className="font-body" style={{ fontSize: 'var(--text-base)', color: "var(--color-text-tertiary)" }}>
-                    {t('detail.metatasks.availableEmpty')}
-                  </p>
-                ) : (
-                  available.map((metatask) => (
-                    <div key={metatask.id} className="flex items-center gap-2 mb-1" style={{ padding: "var(--space-xs) var(--space-sm)", background: "var(--color-bg-surface-alt)", fontSize: 'var(--text-md)' }}>
-                      <span className="flex-1 font-body">{metatask.title}</span>
-                      <span className="eyebrow">{t('detail.metatasks.appliedPoints', { points: metatask.point_value })}</span>
-                      <button
-                        onClick={() => void state.handleApplyMetatask(metatask.id)}
-                        disabled={state.applyingMetataskId === metatask.id}
-                        style={{ background: "none", border: "1px solid var(--color-accent-primary)", color: "var(--color-accent-primary)", fontSize: 'var(--text-xs)', padding: "var(--space-xs) var(--space-sm)", cursor: "pointer", opacity: state.applyingMetataskId === metatask.id ? 0.5 : 1 }}
-                      >
-                        {state.applyingMetataskId === metatask.id ? t('detail.metatasks.applying') : t('detail.metatasks.apply')}
-                      </button>
-                    </div>
-                  ))
-                )}
-              </>
-            )}
-
-            {/* Read-only note */}
-            {!canEdit && canSee && (
-              <p className="font-body" style={{ fontSize: 'var(--text-sm)', color: "var(--color-text-tertiary)", fontStyle: "italic" }}>
-                {t('detail.metatasks.readOnlyNote')}
-              </p>
-            )}
           </div>
-        );
-      })()}
 
-      {/* -- end Metatask Panel -- */}
+          {/* ── RAIL — cast panel + ledger (sticky) ── */}
+          <div style={{ position: 'sticky', top: 84, display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
+
+            {/* Cast panel — the live na spectrum widget (ADR-0005, no average) */}
+            <div style={{ borderRadius: 12, background: 'var(--color-bg-surface-alt)', border: '1px solid var(--color-border)', padding: 'var(--space-lg)' }}>
+              <div className="eyebrow" style={{ color: 'var(--color-text-tertiary)', marginBottom: 'var(--space-xs)' }}>{t('detail.default.castHeading')}</div>
+              <div className="font-display italic" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)', marginBottom: 'var(--space-md)', lineHeight: 1.4 }}>
+                {t('detail.default.castPrompt')}
+              </div>
+              <VoteUI factionSlug={praxis.task_faction_slug} praxisId={praxis.id} />
+            </div>
+
+            {/* Points + backers ledger */}
+            <TheLedger praxis={praxis} votes={votes} voters={voters} />
+
+            {/* Flag block (invariant) */}
+            <PraxisFlagBlock state={state} />
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -232,7 +232,9 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 340px', gap: 'var(--space-2xl)', alignItems: 'start' }}>
 
           {/* ── THE PRAXIS SHEET — rainbow-bordered card ── */}
-          <div style={{ borderRadius: 16, padding: 6, background: 'var(--faction-default-rainbow)', boxShadow: '0 18px 44px -26px var(--color-overlay-strong)' }}>
+          {/* padding here is the rainbow-frame thickness (ornament geometry);
+              snapped from the design's 6px to --space-xs to stay on the scale. */}
+          <div style={{ borderRadius: 16, padding: 'var(--space-xs)', background: 'var(--faction-default-rainbow)', boxShadow: '0 18px 44px -26px var(--color-overlay-strong)' }}>
             <div style={{ borderRadius: 11, background: 'var(--faction-default-card-bg)', color: 'var(--faction-default-card-text)', padding: 'var(--space-2xl)' }}>
 
               {/* Eyebrow: ring dot + counts-for-everyone */}
@@ -255,7 +257,7 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
               {/* Author row: rainbow-ring avatar · Re: task · filed · base pts */}
               <div className="flex items-center" style={{ gap: 'var(--space-md)', paddingBottom: 'var(--space-xl)', marginBottom: 'var(--space-xl)', borderBottom: '1px solid var(--faction-default-border)' }}>
                 <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
-                  <span style={{ display: 'block', width: 40, height: 40, borderRadius: '50%', padding: 3, background: 'var(--faction-default-rainbow)' }}>
+                  <span style={{ display: 'block', width: 40, height: 40, borderRadius: '50%', padding: 'var(--space-xs)', background: 'var(--faction-default-rainbow)' }}>
                     <span className="flex items-center justify-center font-display italic" style={{ width: '100%', height: '100%', borderRadius: '50%', background: 'var(--faction-default-card-bg)', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)' }} aria-hidden>
                       {authorInitial}
                     </span>
@@ -291,7 +293,7 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
               {/* Evidence plate — rainbow-bordered, "Plate I" caption */}
               {praxis.media_items.length > 0 && (
                 <div style={{ marginBottom: 'var(--space-lg)' }}>
-                  <div style={{ borderRadius: 10, padding: 5, background: 'var(--faction-default-rainbow)' }}>
+                  <div style={{ borderRadius: 10, padding: 'var(--space-xs)', background: 'var(--faction-default-rainbow)' }}>
                     <div style={{ borderRadius: 6, background: 'var(--color-bg-surface)', padding: 'var(--space-sm)' }}>
                       <MediaGallery media={praxis.media_items} layout="grid" />
                     </div>

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
@@ -70,7 +70,9 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
       <PraxisAdminBar state={state} />
 
       {/* THE PRAXIS SHEET — rainbow-bordered card */}
-      <div style={{ position: 'relative', zIndex: 1, borderRadius: 16, padding: 5, background: 'var(--faction-default-rainbow)', boxShadow: '0 14px 34px -22px var(--color-overlay-strong)' }}>
+      {/* padding here is the rainbow-frame thickness (ornament geometry),
+          snapped to --space-xs to stay on the scale. */}
+      <div style={{ position: 'relative', zIndex: 1, borderRadius: 16, padding: 'var(--space-xs)', background: 'var(--faction-default-rainbow)', boxShadow: '0 14px 34px -22px var(--color-overlay-strong)' }}>
         <div style={{ borderRadius: 12, background: 'var(--faction-default-card-bg)', color: 'var(--faction-default-card-text)', padding: 'var(--space-lg)' }}>
 
           {/* Eyebrow: ring dot + counts-for-everyone */}
@@ -87,7 +89,7 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
           {/* Author row: rainbow-ring avatar · Re: task · filed · base pts */}
           <div className="flex items-center" style={{ gap: 'var(--space-md)', paddingBottom: 'var(--space-lg)', marginBottom: 'var(--space-lg)', borderBottom: '1px solid var(--faction-default-border)' }}>
             <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
-              <span style={{ display: 'block', width: 40, height: 40, borderRadius: '50%', padding: 3, background: 'var(--faction-default-rainbow)' }}>
+              <span style={{ display: 'block', width: 40, height: 40, borderRadius: '50%', padding: 'var(--space-xs)', background: 'var(--faction-default-rainbow)' }}>
                 <span className="flex items-center justify-center font-display italic" style={{ width: '100%', height: '100%', borderRadius: '50%', background: 'var(--faction-default-card-bg)', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)' }} aria-hidden>
                   {authorInitial}
                 </span>
@@ -122,7 +124,7 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
           {/* Evidence plate — rainbow-bordered, "Plate I" caption */}
           {praxis.media_items.length > 0 && (
             <div style={{ marginTop: 'var(--space-lg)' }}>
-              <div style={{ borderRadius: 10, padding: 4, background: 'var(--faction-default-rainbow)' }}>
+              <div style={{ borderRadius: 10, padding: 'var(--space-xs)', background: 'var(--faction-default-rainbow)' }}>
                 <div style={{ borderRadius: 6, background: 'var(--color-bg-surface)', padding: 'var(--space-sm)' }}>
                   <MediaGallery media={praxis.media_items} />
                 </div>

--- a/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx
@@ -1,19 +1,22 @@
 /**
- * Default MOBILE praxis-detail skin (#499) — single-column, thumb-first. Renders
- * the same invariant CONTENT slots as the desktop archetypes (finding title,
- * account body, re-task link, author byline, media, vote caster) plus the shared
- * behavior slots (admin bar, banners, owner actions, flag, voter breakdown), so
- * the slot guard holds. Every faction falls through here until it registers a
- * bespoke mobile skin. Consumes the same {@link PraxisDetailState} verbatim;
- * comments are mounted once by the PraxisDetail dispatcher below every skin.
+ * Default MOBILE praxis-read skin (#499) — the na spectrum-band editorial kit
+ * (CONTEXT.md "Default archetype"; ADR-0039), stacked single-column and thumb-
+ * first. The mobile twin of the desktop na rebuild (project 1eb2665a): a rainbow-
+ * bordered praxis SHEET (ring eyebrow, italic finding, author row with a rainbow-
+ * ring avatar + base pts, a rainbow-bordered EVIDENCE plate + "Plate I", a ruled
+ * "The account" prose block), then the ADR-0005 vote caster and a points/backers
+ * LEDGER. NO AVERAGE anywhere (ADR-0005/0014).
  *
- * Single-column flex layout, no fixed-px grid (SPEC-faction-ui-profile §1a).
+ * Every faction without a bespoke mobile skin falls through here, so the caster
+ * publishes `praxis.task_faction_slug` on VoteFactionContext — a wow praxis keeps
+ * its chronicle gate voice while na/albescent get the spectrum (#864). Single-
+ * column flex, no fixed-px grid (SPEC-faction-ui-profile §1a). Consumes the same
+ * {@link PraxisDetailState}; comments mount once from the dispatcher below.
  */
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import MediaGallery from '../../../components/MediaGallery'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
-import { factionCssVar } from '../../../utils/factions'
 import { formatTimestamp } from '../../../utils/dates'
 import type { PraxisDetailState } from '../usePraxisDetail'
 import {
@@ -21,7 +24,6 @@ import {
   PraxisStatusBanners,
   PraxisOwnerActions,
   PraxisFlagBlock,
-  PraxisVoterBreakdown,
   PraxisScoreBreakdown,
   MemberByline,
 } from '../shared'
@@ -29,134 +31,228 @@ import { VoteFactionContext } from '../../../components/vote/VoteShell'
 import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import { MobileStarVote } from './shared'
 
+function initials(name: string): string {
+  return (
+    name
+      .trim()
+      .split(/\s+/)
+      .map((word) => word[0])
+      .slice(0, 2)
+      .join('')
+      .toUpperCase() || '·'
+  )
+}
+
 export default function DefaultPraxisDetail({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
-  const { praxis } = state
+  const { praxis, votes, voters } = state
   if (!praxis) return null
 
-  const accent = factionCssVar(praxis.task_faction_slug, 'card-accent')
-  const initial = (praxis.created_by_display_name || '?')[0]?.toUpperCase() ?? '?'
+  const authorInitial = initials(praxis.created_by_display_name)
+  const backerCount = votes?.total_votes ?? voters.length
 
   return (
-    <div data-skin="default" className="page" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
-      {/* Breadcrumb */}
-      <nav
-        className="font-body"
-        style={{ fontSize: 'var(--text-base)', letterSpacing: '0.08em', color: 'var(--color-text-tertiary)' }}
-      >
-        <Link to="/tasks" style={{ color: accent, textDecoration: 'none' }}>
-          {t('detail.default.breadcrumbTasks')}
-        </Link>
-        {' › '}
-        <span style={{ color: 'var(--color-text-primary)' }}>{t('mobileDetail.back')}</span>
+    <div data-skin="default" className="page" style={{ position: 'relative', display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
+      {/* Full-page spectrum wash (`.na-backdrop` rule ships with the na kit #967). */}
+      <div className="na-backdrop" />
+
+      {/* Breadcrumb: Tasks / {task} / Praxis */}
+      <nav className="font-body" style={{ position: 'relative', zIndex: 1, fontSize: 'var(--text-base)', letterSpacing: '0.12em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)' }}>
+        <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>{t('detail.default.breadcrumbTasks')}</Link>
+        {' / '}
+        <Link to={`/tasks/${praxis.task_id}`} style={{ color: 'inherit', textDecoration: 'none' }}>{praxis.task_title}</Link>
+        {' / '}
+        <span style={{ color: 'var(--color-text-primary)' }}>{t('detail.default.breadcrumbPraxis')}</span>
       </nav>
 
       {/* Behavior slots (invariant) */}
       <PraxisStatusBanners state={state} />
       <PraxisAdminBar state={state} />
 
-      {/* Byline block */}
-      <div className="flex items-center gap-3">
-        <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
-          <span
-            className="flex items-center justify-center rounded-full"
-            style={{
-              width: 40,
-              height: 40,
-              background: accent,
-              color: 'var(--color-text-on-accent)',
-              fontFamily: 'var(--font-display)',
-              fontStyle: 'italic',
-              fontSize: 'var(--text-content)',
-            }}
-            aria-hidden
-          >
-            {initial}
-          </span>
-        </Link>
-        <div className="min-w-0 flex-1">
-          <MemberByline
-            praxis={praxis}
-            linkClassName="font-display italic"
-            linkStyle={{ fontSize: 'var(--text-xl)', color: 'var(--color-text-primary)', textDecoration: 'none' }}
-          />
-          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
-            {formatTimestamp(praxis.created_at)}
-          </span>
+      {/* THE PRAXIS SHEET — rainbow-bordered card */}
+      <div style={{ position: 'relative', zIndex: 1, borderRadius: 16, padding: 5, background: 'var(--faction-default-rainbow)', boxShadow: '0 14px 34px -22px var(--color-overlay-strong)' }}>
+        <div style={{ borderRadius: 12, background: 'var(--faction-default-card-bg)', color: 'var(--faction-default-card-text)', padding: 'var(--space-lg)' }}>
+
+          {/* Eyebrow: ring dot + counts-for-everyone */}
+          <div className="flex items-center" style={{ gap: 'var(--space-sm)', marginBottom: 'var(--space-md)' }}>
+            <span aria-hidden style={{ width: 24, height: 24, borderRadius: '50%', flex: 'none', background: 'var(--faction-default-ring)', WebkitMask: 'radial-gradient(circle, transparent 38%, black 40%)', mask: 'radial-gradient(circle, transparent 38%, black 40%)' }} />
+            <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>{t('detail.default.praxisEyebrow')}</span>
+          </div>
+
+          {/* Finding title */}
+          <h1 className="font-display italic content-title" style={{ fontWeight: 700, lineHeight: 1.08, margin: '0 0 var(--space-md)', color: 'var(--faction-default-card-text)', overflowWrap: 'anywhere' }}>
+            {praxis.title}
+          </h1>
+
+          {/* Author row: rainbow-ring avatar · Re: task · filed · base pts */}
+          <div className="flex items-center" style={{ gap: 'var(--space-md)', paddingBottom: 'var(--space-lg)', marginBottom: 'var(--space-lg)', borderBottom: '1px solid var(--faction-default-border)' }}>
+            <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
+              <span style={{ display: 'block', width: 40, height: 40, borderRadius: '50%', padding: 3, background: 'var(--faction-default-rainbow)' }}>
+                <span className="flex items-center justify-center font-display italic" style={{ width: '100%', height: '100%', borderRadius: '50%', background: 'var(--faction-default-card-bg)', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)' }} aria-hidden>
+                  {authorInitial}
+                </span>
+              </span>
+            </Link>
+            <div className="min-w-0 flex-1">
+              <MemberByline
+                praxis={praxis}
+                linkClassName="font-display italic"
+                linkStyle={{ fontSize: 'var(--text-xl)', color: 'var(--faction-default-card-text)', textDecoration: 'none' }}
+              />
+              <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-xs)' }}>
+                {t('detail.default.filedRe', { task: praxis.task_title, date: formatTimestamp(praxis.created_at) })}
+              </div>
+            </div>
+            <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>
+              <div style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-heading)', lineHeight: 1, color: 'var(--faction-default-card-text)' }}>
+                {praxis.task_point_value}
+              </div>
+              <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-xs)' }}>
+                {t('detail.default.basePts')}
+              </div>
+            </div>
+          </div>
+
+          {/* Owner actions (invariant) */}
+          <PraxisOwnerActions state={state} />
+
+          {/* Metatask seals (#932) — read-only stack; nothing when none applied */}
+          <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+
+          {/* Evidence plate — rainbow-bordered, "Plate I" caption */}
+          {praxis.media_items.length > 0 && (
+            <div style={{ marginTop: 'var(--space-lg)' }}>
+              <div style={{ borderRadius: 10, padding: 4, background: 'var(--faction-default-rainbow)' }}>
+                <div style={{ borderRadius: 6, background: 'var(--color-bg-surface)', padding: 'var(--space-sm)' }}>
+                  <MediaGallery media={praxis.media_items} />
+                </div>
+              </div>
+              <div className="font-display italic" style={{ textAlign: 'center', fontSize: 'var(--text-md)', color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-sm)' }}>
+                {t('detail.default.plate')}
+              </div>
+            </div>
+          )}
+
+          {/* The account — ruled divider + prose */}
+          {praxis.body_text && (
+            <>
+              <div className="flex items-center" style={{ gap: 'var(--space-md)', margin: 'var(--space-lg) 0 var(--space-md)' }}>
+                <div style={{ height: 1, flex: 1, background: 'var(--faction-default-border)' }} />
+                <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', whiteSpace: 'nowrap' }}>{t('detail.default.theAccount')}</span>
+                <div style={{ height: 1, flex: 1, background: 'var(--faction-default-border)' }} />
+              </div>
+              <MarkdownPreview
+                source={praxis.body_text}
+                className="font-body markdown-preview content-text"
+                style={{ lineHeight: 1.85, color: 'var(--faction-default-card-muted)' }}
+              />
+            </>
+          )}
         </div>
       </div>
 
-      {/* Finding title */}
-      <h1
-        className="font-display italic font-medium content-title"
-        style={{ lineHeight: 1.2, color: 'var(--color-text-primary)', margin: 0 }}
-      >
-        {praxis.title}
-      </h1>
-
-      {/* Owner actions (invariant) */}
-      <PraxisOwnerActions state={state} />
-
-      {/* Task context link */}
-      <Link
-        to={`/tasks/${praxis.task_id}`}
-        className="sidebar-card font-body flex items-center gap-2"
-        style={{
-          borderLeft: `4px solid ${accent}`,
-          borderRadius: '0 8px 8px 0',
-          padding: 'var(--space-md) var(--space-lg)',
-          textDecoration: 'none',
-        }}
-      >
-        <span className="eyebrow">{t('detail.default.completingTask')}</span>
-        <span style={{ fontSize: 'var(--text-lg)', fontWeight: 700, color: 'var(--color-text-primary)' }}>
-          {praxis.task_title}
-        </span>
-        <span style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-tertiary)', marginLeft: 'auto' }}>
-          {t('detail.default.points', { points: praxis.task_point_value })}
-        </span>
-      </Link>
-
-      {/* Metatask seals (#932) — read-only stack, below the task/points context,
-          above the media. Each seal keeps its issuing faction's voice; renders
-          nothing when none are applied. */}
-      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
-
-      {/* Full media */}
-      {praxis.media_items.length > 0 && <MediaGallery media={praxis.media_items} />}
-
-      {/* Account body */}
-      {praxis.body_text && (
-        <MarkdownPreview
-          source={praxis.body_text}
-          className="font-display markdown-preview content-text"
-          style={{ lineHeight: 1.75, color: 'var(--color-text-primary)' }}
-        />
-      )}
-
-      {/* Touch star-vote */}
-      <div className="sidebar-card" style={{ padding: 'var(--space-lg) var(--space-lg)' }}>
-        <div className="eyebrow" style={{ textAlign: 'center', marginBottom: 'var(--space-md)', color: 'var(--color-text-secondary)' }}>
-          {t('mobileDetail.ratePrompt')}
+      {/* Cast panel — thumb-first star caster (ADR-0005, no average) */}
+      <div style={{ position: 'relative', zIndex: 1, borderRadius: 12, background: 'var(--color-bg-surface-alt)', border: '1px solid var(--color-border)', padding: 'var(--space-lg)' }}>
+        <div className="eyebrow" style={{ textAlign: 'center', color: 'var(--color-text-tertiary)', marginBottom: 'var(--space-xs)' }}>{t('detail.default.castHeading')}</div>
+        <div className="font-display italic" style={{ textAlign: 'center', fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)', marginBottom: 'var(--space-md)' }}>
+          {t('detail.default.castPrompt')}
         </div>
-        <div style={{ marginBottom: 'var(--space-md)' }}>
-          <PraxisScoreBreakdown state={state} align="center" accent={accent} />
-        </div>
-        {/* The default skin serves every faction without a mobile archetype of
-            its own, so the gate's voice comes from the praxis, not a constant:
-            `wow` lands here and must still speak in the chronicle plum, while
-            `na`/`albescent` fall through to the spectrum (ADR-0039). */}
+        {/* The default skin serves every unskinned faction, so the gate voice
+            comes from the praxis, not a constant (#864). */}
         <VoteFactionContext.Provider value={praxis.task_faction_slug}>
-          <MobileStarVote
-            praxisId={praxis.id}
-            accent={accent}
-          />
+          <MobileStarVote praxisId={praxis.id} accent="var(--faction-default-card-accent)" />
         </VoteFactionContext.Provider>
       </div>
 
-      {/* Flag + voter breakdown (invariant) */}
-      <PraxisFlagBlock state={state} />
-      <PraxisVoterBreakdown state={state} />
+      {/* Points + backers ledger */}
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 1,
+          borderRadius: 12,
+          background: 'var(--faction-default-card-bg)',
+          color: 'var(--faction-default-card-text)',
+          border: '1px solid var(--faction-default-border)',
+          boxShadow: '0 14px 32px -18px var(--color-overlay-medium)',
+          padding: 'var(--space-lg)',
+        }}
+      >
+        {/* rainbow header rule */}
+        <div style={{ height: 4, borderRadius: 3, background: 'var(--faction-default-rainbow)', marginBottom: 'var(--space-lg)' }} />
+
+        {/* pts awarded · people backed it */}
+        <div style={{ display: 'flex', marginBottom: 'var(--space-lg)' }}>
+          <div style={{ flex: 1, paddingRight: 'var(--space-md)' }}>
+            <div style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--faction-default-card-text)' }}>
+              {`+${praxis.points_from_votes}`}
+            </div>
+            <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-sm)' }}>
+              {t('detail.default.ledgerAwarded')}
+            </div>
+          </div>
+          <div style={{ flex: 1, paddingLeft: 'var(--space-md)', borderLeft: '1px solid var(--faction-default-border)' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', fontFamily: 'var(--font-accent)', fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--faction-default-card-text)' }}>
+              <span aria-hidden style={{ fontSize: 'var(--text-title)', color: 'var(--faction-default-card-muted)' }}>&#10003;</span>
+              {backerCount}
+            </div>
+            <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-sm)' }}>
+              {t('detail.default.ledgerBacked', { count: backerCount })}
+            </div>
+          </div>
+        </div>
+
+        {/* earned-points breakdown (#641, ADR-0053): base × mult + votes */}
+        <div style={{ borderTop: '1px dashed var(--faction-default-border)', paddingTop: 'var(--space-md)', marginBottom: voters.length ? 'var(--space-lg)' : 0 }}>
+          <PraxisScoreBreakdown state={state} accent="var(--faction-default-card-text)" muted="var(--faction-default-card-muted)" font="var(--font-accent)" />
+        </div>
+
+        {/* Backed by — each backer + the rung they gave (value / 5). No average;
+            per-backer points aren't in the API, so the bar shows the rung only. */}
+        {voters.length > 0 ? (
+          <>
+            <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginBottom: 'var(--space-md)' }}>
+              {t('detail.default.ledgerBackedBy')}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-md)' }}>
+              {voters.map((voter) => (
+                <div key={voter.character_id} style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)' }}>
+                  <Link to={`/characters/${voter.character_id}`} style={{ textDecoration: 'none', flexShrink: 0 }}>
+                    <span style={{ width: 26, height: 26, borderRadius: '50%', display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--faction-default-card-muted)', color: 'var(--faction-default-card-bg)', fontFamily: 'var(--font-accent)', fontSize: 'var(--text-sm)' }}>
+                      {initials(voter.display_name)}
+                    </span>
+                  </Link>
+                  <Link to={`/characters/${voter.character_id}`} style={{ flex: 1, minWidth: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontFamily: 'var(--font-display)', fontStyle: 'italic', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)', textDecoration: 'none' }}>
+                    {voter.display_name}
+                  </Link>
+                  <div style={{ width: 96, height: 9, borderRadius: 5, background: 'var(--faction-default-border)', position: 'relative', overflow: 'hidden', flexShrink: 0 }}>
+                    <div style={{ position: 'absolute', inset: 0, width: `${(voter.value / 5) * 100}%`, background: 'var(--faction-default-rainbow)' }} />
+                  </div>
+                  <span style={{ width: 24, textAlign: 'right', fontFamily: 'var(--font-accent)', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)' }}>
+                    {voter.value}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', borderTop: '1px solid var(--faction-default-border)', marginTop: 'var(--space-md)', paddingTop: 'var(--space-md)' }}>
+              <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
+                {t('detail.default.ledgerBackers', { count: voters.length })}
+              </span>
+              <span style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-title)', color: 'var(--faction-default-card-text)' }}>
+                {t('detail.default.ledgerTotal', { points: praxis.points_from_votes })}
+              </span>
+            </div>
+          </>
+        ) : (
+          <p className="font-body" style={{ fontSize: 'var(--text-base)', color: 'var(--faction-default-card-muted)', margin: 0 }}>
+            {t('detail.default.ledgerEmpty')}
+          </p>
+        )}
+      </div>
+
+      {/* Flag block (invariant) */}
+      <div style={{ position: 'relative', zIndex: 1 }}>
+        <PraxisFlagBlock state={state} />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Rebuilds the **Default / na** Praxis Detail (desktop + mobile) to the na-kit redesign (project `1eb2665a`, `Default Praxis Detail.dc.html`), ported from the vendored source file rather than the issue prose. `default ≡ na ≡ Unaffiliated` is one visual identity — the spectrum-band editorial kit (ADR-0039/0046/0048).

## What changed
- `frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx` (desktop) — full rebuild: rainbow-bordered praxis **sheet** (ring eyebrow, big italic finding, author row with a rainbow-ring avatar + base pts, rainbow-bordered **EVIDENCE** plate + "Plate I", ruled "The account" prose) beside a sticky **rail**: the ADR-0005 cast panel (reuses the live na spectrum widget via `VoteUI` — not rebuilt) + a points/**backers ledger**.
- `frontend/src/pages/praxisDetail/mobileArchetypes/DefaultPraxisDetail.tsx` (mobile) — the same kit, single-column (SPEC-faction-ui-profile §1a), thumb-first `MobileStarVote` caster wrapped in `VoteFactionContext` so unskinned factions keep their gate voice.
- `frontend/src/locales/en/praxis.json` — new `detail.default.*` keys (eyebrow, base pts, filed-re, evidence/plate, the-account, cast heading/prompt, ledger labels).

Built on #890's repointed tokens (`--color-accent-primary` / `--color-bg-surface-alt`); no orphan token names reintroduced. Tokens only — rainbow via `--faction-default-rainbow` / `--faction-default-ring`. The `.na-backdrop` wash is mounted as a hook only; its rule ships with #967 (not added to index.css here).

**No new API endpoints consumed** — real praxis/vote/backer data comes from the existing `PraxisDetailState` (`praxis`, `votes`, `voters`).

**NO AVERAGE / aggregate score renders** (ADR-0005/0014) — the ledger shows points awarded (`points_from_votes`), how many people backed it (`total_votes`), and each backer's own rung as a rainbow bar (`value / 5`). The one earned-points readout is the ADR-0053 `base × mult + votes` breakdown.

## Verification
- `tsc --noEmit`: clean for app source (only the known `node:fs`/`node:url` stale-junction false alarm in test files, PR #675).
- `eslint`: clean.
- `vite build`: OK.
- `vitest` praxisDetail (149 tests, incl. desktop + mobile `archetypeSlots` slot/crown/seal/earned-points invariants) + locale catalog (33): all pass.
- Confirmed `--faction-default-rainbow` reaches the DOM; only the two Default archetypes + `praxis.json` changed — other factions' praxis-detail archetypes untouched.
- **Visual QA is outstanding** — no screenshot tooling / dev stack available in this environment.

## Deviations
- **Dark ledger palette → tokens (theme-aware, not always-dark).** The design draws the ledger as an always-dark receipt (`#17161d`/`#f0e6d0`/`#8b8272`). CLAUDE.md forbids hardcoded hex and there is no always-dark `--color-*` token to map onto, so it uses `--faction-default-card-bg`/`-text`/`-muted` — which match the design's palette **exactly in dark mode** and become the light na card in light mode. Rainbow accents stay `--faction-default-rainbow`. (`no-raw-style-values` does not actually flag hex, but the hardcode-hex ban does.)
- **Rainbow-frame thicknesses snapped to `--space-xs` (4px).** The design's frame/ring paddings (6/5/3px) are flagged by `no-raw-style-values`; snapped to the nearest scale token. Minor ornament-geometry change.
- **Per-backer "+N points" omitted.** The API has no per-voter point breakdown (a vote is a single 1-5 rung), so each backer row shows the rung as a rainbow bar (`value / 5`) + the numeric rung, and no fabricated per-backer points figure. Real backer rows only — none invented.
- **"Plate I" caption only.** The design's descriptive tail ("north fence, first light") is placeholder; there is no per-media caption in the data, so just the ornamental "Plate I" renders.
- **Metatask management panel dropped.** The old Default-only apply/remove metatask panel is removed to match the redesign and the peer UA archetype (which never had it); the read-only `MetaTaskSeal` stack (slot-tested) is kept. Applying metatasks lives in the compose surface (#933).
- **Account-body size:** content-text floor (18px) wins over the design's 13px prose (standing carve-out #623/#627).

## What to eyeball (visual QA outstanding)
An na / Unaffiliated Praxis Detail on **desktop AND mobile**:
- rainbow-bordered praxis sheet — ring eyebrow, big italic finding, rainbow-ring author avatar + base pts;
- rainbow-bordered evidence plate + "Plate I" caption (when media present);
- ruled "The account" prose;
- sticky vote panel using the **live na spectrum widget** (no average);
- dark backers ledger — points awarded, people backed, per-backer rainbow bars (check dark vs light mode, since the ledger is theme-aware rather than always-dark).

Closes #968
