### PR TITLE
fix(search): rank prefix/exact player matches before score (#989)

### DIFF
--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -3,7 +3,7 @@ import re
 from typing import Optional
 
 from fastapi import HTTPException
-from sqlalchemy import func, or_, select
+from sqlalchemy import case, func, or_, select
 from sqlalchemy.sql import Select, false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -528,6 +528,10 @@ async def list_characters_for_viewer(
     # display name can contain '@', so a leading one is a sigil to drop, not a
     # character to match (#624).
     term = search.lstrip("@") if search else None
+    # match_priority ranks recall by relevance so a prefix ("@P" → Pixie) beats a
+    # mere substring ("yum*P*") regardless of score; it is only meaningful when a
+    # term is present, so we thread it into the ORDER BY below (#989).
+    match_priority = None
     if term:
         # Match on handle OR display name so "@Mol" surfaces "Molly" (@mollusk).
         # The inserted mention is still @username; display_name only *matches*.
@@ -536,6 +540,30 @@ async def list_characters_for_viewer(
                 Character.username.ilike(f"%{term}%"),
                 Character.display_name.ilike(f"%{term}%"),
             )
+        )
+        # Substring ILIKE gives recall, but ordering by score alone buries the
+        # obvious prefix match below the row limit (#989). Rank exact matches
+        # first, then prefix, then any-substring — before score decides ties.
+        # The term is bound as a parameter throughout (no SQL injection); as with
+        # the substring ILIKE above we do not escape ``%``/``_`` in the literal, so
+        # they keep acting as wildcards, matching pre-existing behaviour.
+        term_lower = term.lower()
+        match_priority = case(
+            (
+                or_(
+                    func.lower(Character.username) == term_lower,
+                    func.lower(Character.display_name) == term_lower,
+                ),
+                0,
+            ),
+            (
+                or_(
+                    Character.username.ilike(f"{term}%"),
+                    Character.display_name.ilike(f"{term}%"),
+                ),
+                1,
+            ),
+            else_=2,
         )
     if faction_slug:
         query = query.where(Character.faction_slug == faction_slug)
@@ -560,11 +588,13 @@ async def list_characters_for_viewer(
     # and score alone leaves Postgres free to reshuffle equal-score rows between
     # requests — which flickers the sky's top-N membership and its crown, and
     # makes limit/offset paging silently duplicate and drop rows (#655).
-    query = (
-        query.order_by(CharacterStats.score.desc().nulls_last(), Character.id.asc())
-        .limit(limit)
-        .offset(offset)
+    order_columns = []
+    if match_priority is not None:
+        order_columns.append(match_priority.asc())
+    order_columns.extend(
+        [CharacterStats.score.desc().nulls_last(), Character.id.asc()]
     )
+    query = query.order_by(*order_columns).limit(limit).offset(offset)
 
     result = await session.execute(query)
     return list(result.all())

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -158,6 +158,71 @@ async def test_list_characters_search_ignores_handle_sigil(
     assert character2.id not in ids
 
 
+async def _seed_scored_character(
+    db_session: AsyncSession,
+    era: Era,
+    *,
+    email: str,
+    username: str,
+    score: int,
+) -> Character:
+    """Create an active 'ua' character with an explicit current-era score."""
+    account = Account(email=email)
+    db_session.add(account)
+    await db_session.flush()
+    ch = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username.capitalize(),
+        faction_slug="ua",
+    )
+    db_session.add(ch)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(
+            character_id=ch.id,
+            era_id=era.id,
+            score=score,
+            all_time_score=score,
+            level=0,
+            votes_spent_this_era=0,
+        )
+    )
+    await db_session.commit()
+    await db_session.refresh(ch)
+    return ch
+
+
+@pytest.mark.asyncio
+async def test_list_characters_search_ranks_prefix_above_higher_score_substring(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    era: Era,
+    faction_ua: Faction,
+):
+    """A prefix match outranks a higher-score substring match (#989).
+
+    "@P" should surface "Pixie" (a prefix match, low score) above "yump" (a
+    mere substring match, high score) — relevance is ranked before score, so
+    the obvious match no longer sinks below the row limit.
+    """
+    prefix_match = await _seed_scored_character(
+        db_session, era, email="pixie@example.com", username="pixie", score=1
+    )
+    substring_match = await _seed_scored_character(
+        db_session, era, email="yump@example.com", username="yump", score=9999
+    )
+
+    resp = await client.get("/characters", params={"search": "p"})
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert prefix_match.id in ids
+    assert substring_match.id in ids
+    # Prefix (priority 1) must sort ahead of substring (priority 2), despite the
+    # substring match having the far higher score.
+    assert ids.index(prefix_match.id) < ids.index(substring_match.id)
+
+
 @pytest.mark.asyncio
 async def test_list_characters_filter_by_faction(
     client: AsyncClient, character: Character, character2: Character


### PR DESCRIPTION
## Problem
`services/character.py` `list_characters_for_viewer(search=…)` matched the term as a substring anywhere (`ilike('%term%')`) for recall, then ordered purely by `CharacterStats.score DESC`. So "@P" surfaced the highest-score p-containing character ("yump") and the obvious prefix match ("Pixie") sank below the row limit. Relevance was never considered.

## Fix
Keep the substring `ilike` for recall; add a `match_priority` CASE as the leading ORDER BY key so relevance wins before score:

- exact (lowercased username or display_name equals term) → 0
- prefix (`ILIKE term||'%'`) → 1
- any substring → 2

`ORDER BY match_priority ASC, score DESC NULLS LAST, id ASC`. The term is bound as a parameter throughout (no SQL injection); as with the pre-existing substring `ilike`, `%`/`_` in the literal keep acting as wildcards (unchanged behaviour). The 8-row limit is untouched (still the caller's `limit`). `match_priority` is only added to the ORDER BY when a search term is present, so score-only listing paths are unaffected.

## Shared path
This one function backs BOTH the comment `@`-mention typeahead AND the collab/duel invite search (`InviteSearch`) — one fix improves both surfaces.

## Test
New integration test (`wz989_test`): seed a low-score prefix match ("pixie", score 1) + a high-score substring match ("yump", score 9999); assert the prefix match sorts FIRST for the 1-char query "p". Verified it FAILS against pre-fix code and PASSES with the fix.

`pytest tests/integration/test_characters.py tests/integration/test_praxes.py` → 126 passed.

## What to eyeball
Visual QA is outstanding (no dev stack / can't screenshot here):
- Comment `@`-mention dropdown: typing a name's first letters surfaces that player at the top (e.g. "@P" → Pixie above yump; "@M" → Mara above Nemesis).
- Collab/duel invite search: same — typing "@handle"'s first letters puts the intended player at the top rather than the highest-score incidental substring match.

Closes #989