### PR TITLE
Keep metatasks out of the task browse & block metatask signup (#1001)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -821,6 +821,7 @@ class SignupDenialReason(str, Enum):
     task_status_closed = "task_status_closed"
     already_active_member = "already_active_member"
     bank_full = "bank_full"
+    is_metatask = "is_metatask"
 
 
 @dataclass(frozen=True)
@@ -838,8 +839,9 @@ async def evaluate_signup(
     era: EraConfig = CURRENT_ERA,
 ) -> SignupEligibility:
     """The single sign-up predicate — true iff ``create_praxis``'s **type-agnostic**
-    gates would accept (ADR-0008). Owns the four gates every claim shares: level,
-    retired/pending faction carve-out, active-member, and the task-bank cap. The
+    gates would accept (ADR-0008). Owns the gates every claim shares: the task is
+    not a metatask, level, retired/pending faction carve-out, active-member, and
+    the task-bank cap. The
     mode-specific gates (duel-via-challenge, collab level) stay in
     :func:`allowed_praxis_modes` and are applied by :func:`_check_create_preconditions`.
 
@@ -847,6 +849,11 @@ async def evaluate_signup(
     """
     if character is None:
         return SignupEligibility(allowed=False)
+
+    # Metatasks are stickers applied to a praxis (edit-praxis seal stack), never
+    # signup targets — reject before any level/status work (#1001).
+    if task.task_type == TaskType.metatask:
+        return SignupEligibility(False, SignupDenialReason.is_metatask)
 
     era_row = await get_current_era_row(session)
     stats = await get_or_create_stats(session, character.id, era_row.id)
@@ -876,6 +883,11 @@ def _signup_denial_to_http(
     reason: Optional[SignupDenialReason], task: Task, era: EraConfig
 ) -> HTTPException:
     """Map a :class:`SignupDenialReason` to the route error it has always raised."""
+    if reason == SignupDenialReason.is_metatask:
+        return HTTPException(
+            status_code=400,
+            detail="Metatasks are applied to a praxis, not signed up for.",
+        )
     if reason == SignupDenialReason.below_level:
         return HTTPException(
             status_code=403, detail=f"This task requires level {task.level_required}."

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -215,8 +215,9 @@ async def list_tasks(
 ) -> list[Task]:
     """Query tasks with optional filters, excluding hidden-faction tasks.
 
-    If ``task_type`` is None or 'all', both standard and metatask rows are
-    returned. Pass 'standard' or 'metatask' to filter.
+    If ``task_type`` is None (the default) only standard rows are returned, so
+    metatasks never leak into the ordinary browse (#1001). Pass 'all' for both
+    types, or 'standard'/'metatask' for a single-type filter.
 
     Metatask rows are additionally gated by ``era.level_to_see_metatasks``
     (#453): ``viewer`` (the authenticated character, ``None`` for anonymous
@@ -260,15 +261,20 @@ async def list_tasks(
             query = query.where(Task.status == TaskStatus.active)
     # status == "all" -> no status filter, return tasks of every status
 
-    # Task type filter — default (None) and "all" both return every task type.
-    # Pass task_type="standard" or task_type="metatask" to filter.
-    if task_type is not None and task_type != "all":
+    # Task type filter — default (None) means STANDARD-ONLY so metatasks never
+    # leak into the ordinary browse (#1001); pass "all" to get every type, or
+    # "standard"/"metatask" for a single-type filter (422 on any other value).
+    if task_type == "all":
+        pass  # every type
+    elif task_type is not None:
         try:
             query = query.where(Task.task_type == TaskType(task_type))
         except ValueError:
             raise HTTPException(
                 status_code=422, detail=f"Invalid task_type: {task_type}"
             )
+    else:
+        query = query.where(Task.task_type == TaskType.standard)
 
     # Metatask visibility gate (#453): the metatask list only opens at
     # era.level_to_see_metatasks. Anonymous viewers are always below the gate.

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -20,7 +20,26 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
 from models.praxis import ModerationStatus, Praxis, PraxisMember, PraxisStatus
-from models.task import Task, TaskStatus
+from models.task import Task, TaskStatus, TaskType
+
+
+async def _make_metatask(db_session: AsyncSession, character: Character) -> Task:
+    """Seed an active metatask row (a praxis seal, never a signup target)."""
+    metatask = Task(
+        title="Seal Metatask",
+        description="",
+        point_value=5,
+        level_required=0,
+        status=TaskStatus.active,
+        task_type=TaskType.metatask,
+        created_by=character.id,
+        primary_faction_slug="ua",
+        metatask_faction_slug="ua",
+    )
+    db_session.add(metatask)
+    await db_session.commit()
+    await db_session.refresh(metatask)
+    return metatask
 
 
 # ---------------------------------------------------------------------------
@@ -68,6 +87,24 @@ async def test_create_solo_praxis(
     assert len(data["members"]) == 1
     assert data["members"][0]["character_id"] == character.id
     assert data["members"][0]["has_submitted"] is False
+
+
+@pytest.mark.asyncio
+async def test_create_solo_praxis_on_metatask_rejected(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    auth_headers: dict,
+):
+    """POST /praxes (solo) against a metatask row is a 400, not a created praxis (#1001)."""
+    metatask = await _make_metatask(db_session, character)
+    resp = await client.post(
+        "/praxes",
+        json={"task_id": metatask.id, "type": "solo", "title": "Nope"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+    assert "metatask" in resp.json()["detail"].lower()
 
 
 @pytest.mark.asyncio
@@ -973,6 +1010,27 @@ async def test_create_collab_praxis(
     assert data["status"] == "in_progress"
     member_ids = [m["character_id"] for m in data["members"]]
     assert character2.id in member_ids
+
+
+@pytest.mark.asyncio
+async def test_create_collab_praxis_on_metatask_rejected(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character2: Character,
+    auth_headers2: dict,
+):
+    """POST /praxes (collab) against a metatask row is a 400, not a created praxis (#1001).
+
+    character2 is level 5 and meets the collab gate — the metatask gate fires first.
+    """
+    metatask = await _make_metatask(db_session, character2)
+    resp = await client.post(
+        "/praxes",
+        json={"task_id": metatask.id, "type": "collab", "title": "Nope"},
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 400
+    assert "metatask" in resp.json()["detail"].lower()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_signup_eligibility.py
+++ b/backend/tests/integration/test_signup_eligibility.py
@@ -14,7 +14,7 @@ from models.character import Character
 from models.era import Era
 from models.faction import Faction
 from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
-from models.task import Task, TaskStatus
+from models.task import Task, TaskStatus, TaskType
 from services.praxis import (
     SignupDenialReason,
     can_submit_praxis_for_task,
@@ -44,6 +44,7 @@ async def _make_task(
     *,
     level_required: int = 0,
     status: TaskStatus = TaskStatus.active,
+    task_type: TaskType = TaskType.standard,
 ) -> Task:
     task = Task(
         title="Extra Task",
@@ -51,6 +52,7 @@ async def _make_task(
         point_value=5,
         level_required=level_required,
         status=status,
+        task_type=task_type,
         created_by=character.id,
         primary_faction_slug="ua",
     )
@@ -95,6 +97,21 @@ async def test_evaluate_signup_task_status_closed(
     result = await evaluate_signup(character, retired, db_session)
     assert result.allowed is False
     assert result.reason is SignupDenialReason.task_status_closed
+
+
+@pytest.mark.asyncio
+async def test_evaluate_signup_metatask_rejected(
+    db_session: AsyncSession, character: Character, era: Era, faction_ua: Faction
+):
+    """Metatasks are seals applied to a praxis, never signup targets (#1001).
+
+    The gate fires before level/status work, so an otherwise-eligible character
+    is still denied purely on task_type.
+    """
+    metatask = await _make_task(db_session, character, task_type=TaskType.metatask)
+    result = await evaluate_signup(character, metatask, db_session)
+    assert result.allowed is False
+    assert result.reason is SignupDenialReason.is_metatask
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -867,22 +867,23 @@ async def test_my_tasks_with_status_filter(
 
 
 # ---------------------------------------------------------------------------
-# Bug 9 — default list_tasks returns both standard and metatask rows
+# #1001 — default browse is standard-only; 'all' is the both-types escape hatch
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_list_tasks_default_returns_both_types(
+async def test_list_tasks_default_excludes_metatasks_at_see_gate(
     client: AsyncClient,
     db_session: AsyncSession,
     character: Character,
     auth_headers: dict,
     era,
 ):
-    """GET /tasks with no task_type filter returns both standard and metatasks.
+    """GET /tasks with no task_type filter returns ONLY standard tasks (#1001).
 
-    The viewer sits at ``era.level_to_see_metatasks`` — below the gate the
-    metatask row would be filtered out (#453, covered separately below).
+    The viewer sits AT ``era.level_to_see_metatasks`` — high enough to clear the
+    #453 visibility gate — yet the metatask still never appears in the default
+    browse, because the default is now standard-only regardless of level.
     """
     from models.task import TaskType
 
@@ -918,6 +919,63 @@ async def test_list_tasks_default_returns_both_types(
     )
 
     resp = await client.get("/tasks", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    ids = {t["id"] for t in data}
+    assert standard_task.id in ids
+    assert meta_task.id not in ids
+    assert all(t["task_type"] == "standard" for t in data)
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_all_returns_both_types(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    auth_headers: dict,
+    era,
+):
+    """GET /tasks?task_type=all returns both standard and metatasks (#1001).
+
+    The viewer sits at ``era.level_to_see_metatasks`` so the #453 gate is clear;
+    'all' is the explicit both-types escape hatch.
+    """
+    from models.task import TaskType
+
+    standard_task = Task(
+        title="Standard Task",
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        task_type=TaskType.standard,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    meta_task = Task(
+        title="Metatask",
+        description="",
+        point_value=5,
+        level_required=0,
+        status=TaskStatus.active,
+        task_type=TaskType.metatask,
+        created_by=character.id,
+        primary_faction_slug="ua",
+        metatask_faction_slug="ua",
+    )
+    db_session.add(standard_task)
+    db_session.add(meta_task)
+    await db_session.commit()
+    await db_session.refresh(standard_task)
+    await db_session.refresh(meta_task)
+
+    await _set_character_level(
+        db_session, character.id, era.id, CURRENT_ERA.level_to_see_metatasks
+    )
+
+    resp = await client.get(
+        "/tasks", params={"task_type": "all"}, headers=auth_headers
+    )
     assert resp.status_code == 200
     data = resp.json()
     ids = {t["id"] for t in data}
@@ -1105,18 +1163,21 @@ async def test_metatask_list_visible_at_see_gate(
     auth_headers: dict,
     era,
 ):
-    """A character at era.level_to_see_metatasks sees metatask rows."""
+    """A character at era.level_to_see_metatasks sees metatask rows when they
+    request them — the default browse stays standard-only (#1001)."""
     standard_task, meta_task = await _seed_standard_and_metatask(db_session, character)
     await _set_character_level(
         db_session, character.id, era.id, CURRENT_ERA.level_to_see_metatasks
     )
 
+    # Default browse is standard-only regardless of level (#1001).
     resp = await client.get("/tasks", headers=auth_headers)
     assert resp.status_code == 200
     ids = {t["id"] for t in resp.json()}
     assert standard_task.id in ids
-    assert meta_task.id in ids
+    assert meta_task.id not in ids
 
+    # Explicitly requesting the metatask list clears the #453 gate at level.
     resp_meta = await client.get(
         "/tasks", params={"task_type": "metatask"}, headers=auth_headers
     )


### PR DESCRIPTION
## What changed

Two independent backend holes let metatasks (`task_type='metatask'` Task rows) leak into the ordinary Tasks browse and be signed up for like standard tasks. Both are fixed here, backend-only.

### (a) Default listing is now standard-only
`backend/services/task.py::list_tasks` — when `task_type is None` the query previously returned every type, so a viewer at/above `era.level_to_see_metatasks` got metatasks mixed into the default browse. Default now means **standard-only**; `'all'` is the explicit both-types escape hatch; `'standard'`/`'metatask'` remain single-type filters (still 422 on a bad value). The `level_to_see_metatasks` gate (#453) now only matters when metatasks are explicitly requested, so a sub-gate viewer asking for `'metatask'` still gets an empty list.

### (b) Signup rejects metatasks
`backend/services/praxis.py::evaluate_signup` (the single shared signup predicate, ADR-0008) now rejects `task.task_type == TaskType.metatask` up front with a 400 ("Metatasks are applied to a praxis, not signed up for."). Added a `SignupDenialReason.is_metatask` member and its mapping in `_signup_denial_to_http`. One gate at the shared predicate, so every signup path (solo / collab / duel-init) inherits it.

No frontend change: the "standard" tab already omits `task_type`, so it now behaves as its own comment claims.

## Tests
- `test_signup_eligibility.py`: metatask signup denied at the predicate (`is_metatask`).
- `test_praxes.py`: creating a praxis against a metatask row is a 400 for both solo and collab.
- `test_tasks.py`: default browse excludes metatasks even at the see-gate; `task_type=all` returns both; the #453 gate test now requests the metatask list explicitly; `task_type=metatask`/`standard` filters unchanged.

Ran against a dedicated `wz1001_test` DB:
`TEST_DATABASE_URL=...wz1001_test pytest -q` → **762 passed**.

## What to eyeball (visual QA outstanding — no dev stack / screenshots)
- Browse tasks as a level-6+ character (clears `level_to_see_metatasks`) → the standard tab shows **no** metatasks.
- Try to sign up for a metatask (solo or collab) → **400**, no praxis created.
- The metatask list (explicit `task_type=metatask`) still opens only at/above the see-gate.

Closes #1001