### PR TITLE
#511/#904: one game-wide L0 onboarding task + faction task sets (Coven playable)

### DIFF
--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -359,10 +359,86 @@ ERA_1_TASKS = (
         description="Have a meal, and try to identify each ingredient. Then, make that meal yourself, and then try again to identify each ingredient again",
         faction_slug="everymen", level_required=2, point_value=10,
     ),
+    # -------------------------------------------------------------------------
+    # #904 — bring every faction (except Albescent, which hides — ADR-0048) to
+    # >=6 tasks in levels 1-7. Point ramp by level: L1->5, L2->10, L3->25,
+    # L4->50, L5->75, L6->100, L7->500. (Level 0 is reserved for the single
+    # game-wide onboarding task, seeded in seed.py, not here — #511.)
+    # -------------------------------------------------------------------------
+    # Cozy Coven — 6 new (soft-lit makers, tiny victories, gentle care).
     TaskDef(
-        title="FLIP THE SYSTEM",
-        description="TBD",
-        faction_slug="snide", level_required=0, point_value=500,
+        title="A Light Left On",
+        description="Leave a small comfort for whoever arrives after you — a note, a snack, a lamp switched on in a dark hall. Make the next person's moment softer than you found it.",
+        faction_slug="coven", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="Mend, Don't End",
+        description="Repair something instead of replacing it. Darn the sock, glue the mug, patch the knee. Give a tired object one more season by your own hand.",
+        faction_slug="coven", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="The Comfort Bake",
+        description="Bake something warm and give most of it away. The kitchen should smell like welcome by the time you're done. Store-bought is a different spell — this one you make.",
+        faction_slug="coven", level_required=3, point_value=25,
+    ),
+    TaskDef(
+        title="Gather the Weird Ones",
+        description="Host a small, low-stakes gathering for people who don't usually get invited — a tea, a craft night, a bad-movie evening. Cozy, not grand. Everyone leaves warmer than they came.",
+        faction_slug="coven", level_required=4, point_value=50,
+    ),
+    TaskDef(
+        title="A Room That Holds You",
+        description="Make a space cozier for someone else — a reading nook, a softened corner, a shelf of small comforts. When you're done it should feel like the room is gently keeping them.",
+        faction_slug="coven", level_required=6, point_value=100,
+    ),
+    TaskDef(
+        title="Keep a Light On All Year",
+        description="Take up an ongoing act of care for your circle across a full season — a standing soup night, a mending drawer, a monthly welcome for newcomers. Keep a light on for the weird ones long after the spell is cast.",
+        faction_slug="coven", level_required=7, point_value=500,
+    ),
+    # Snide — 4 new (sardonic, contrarian, subversive, intellectually sharp).
+    TaskDef(
+        title="Ruin a Perfectly Good Thing",
+        description="Take something everyone agrees is \"nice\" and make it interesting instead — improve it by breaking a rule it was too polite to question. Document the before, the crime, and the after.",
+        faction_slug="snide", level_required=2, point_value=10,
+    ),
+    TaskDef(
+        title="Steelman Your Enemy",
+        description="Take an idea you despise and argue it so well its believers would nod. Then explain, precisely, why you still think it's wrong. Contempt is easy; understanding is the sharper blade.",
+        faction_slug="snide", level_required=3, point_value=25,
+    ),
+    TaskDef(
+        title="Unsanctioned Maintenance",
+        description="Improve something without permission and without credit — reword the passive-aggressive break-room sign, fix the link nobody maintains, straighten what everyone ignores. Competence as quiet rebellion.",
+        faction_slug="snide", level_required=4, point_value=50,
+    ),
+    TaskDef(
+        title="Organize the Ungovernable",
+        description="Rally people around a small act of coordinated defiance against a pointless rule: a dress-code mutiny, a wave of scrupulously polite complaints. Harmless, deniable, impossible to ignore.",
+        faction_slug="snide", level_required=6, point_value=100,
+    ),
+    # Singularity — 2 new (systems, patterns, recursion, absurd-analytical).
+    TaskDef(
+        title="Sort Your Life",
+        description="Pick a messy, unsortable part of your life and impose a taxonomy on it anyway — your socks, your regrets, your browser tabs. Share the categories and defend the edge cases.",
+        faction_slug="singularity", level_required=1, point_value=5,
+    ),
+    TaskDef(
+        title="The Map Is the Territory",
+        description="Model a real system you're part of as nodes and flows. Then change one input in real life and record exactly how the model failed to predict it.",
+        faction_slug="singularity", level_required=4, point_value=50,
+    ),
+    # Ephemerists — 1 new (transience, absence, the overlooked).
+    TaskDef(
+        title="Archive of a Single Hour",
+        description="Record everything about one ordinary hour that will never happen exactly so again — the light, the sounds, who passed, what you almost said. Then let it go. Share the record, not the hour.",
+        faction_slug="ephemerists", level_required=5, point_value=75,
+    ),
+    # Everymen — 1 new (the commons, ordinary dignity, for-all).
+    TaskDef(
+        title="The Commons",
+        description="Improve something that belongs to everyone and no one — a shared path, a little free library, a bus-stop bench. Leave a public thing better than you found it, no name attached.",
+        faction_slug="everymen", level_required=4, point_value=50,
     ),
 )
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -175,6 +175,58 @@ async def sync_era_tasks(session, era, created_by_id: int) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Phase 3b: Onboarding task (game-wide, era-independent) — idempotent
+# ---------------------------------------------------------------------------
+
+# The single game-wide level-0 task (#511). It is NOT era content — it lives in
+# no `era_N.tasks` list — so it is seeded here on every run and exists in every
+# era regardless of era config. Level 0 is reserved for this one task; every
+# faction's roster content lives in levels 1-7 (#904). Faction is Albescent
+# (owner's call): task signup is gated on level only (`meets_task_level`), never
+# faction, so a brand-new unaffiliated (na) player can sign up, and Albescent
+# renders neutral/rainbow (#783/#794) so it reads as neutral to a newcomer.
+ONBOARDING_TASK_TITLE = "Take a Picture of \"Yourself\""
+ONBOARDING_TASK_DESCRIPTION = (
+    "Point a camera at yourself — but the quotation marks are doing work. "
+    "\"Yourself\" can be your face, or it can be the mug you can't start a "
+    "morning without, the view from where you think, the shoes that have "
+    "carried you, the desk that's unmistakably yours. Show us who you are. A "
+    "literal selfie is allowed, but never required."
+)
+ONBOARDING_TASK_FACTION_SLUG = "albescent"
+ONBOARDING_TASK_POINT_VALUE = 10
+
+
+async def ensure_onboarding_task(session, created_by_id: int) -> bool:
+    """Upsert the single game-wide level-0 onboarding task (keyed on title).
+
+    Mirrors ``ensure_placeholder_metatask``: this runs on every seed so the
+    onboarding self-portrait exists in every era, independent of era config
+    (#511). Guarded by a title lookup, so it is safe on a populated database.
+    Returns True if the task was created this run.
+    """
+    existing = (
+        await session.execute(
+            select(Task).where(Task.title == ONBOARDING_TASK_TITLE)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return False
+    session.add(Task(
+        title=ONBOARDING_TASK_TITLE,
+        description=ONBOARDING_TASK_DESCRIPTION,
+        point_value=ONBOARDING_TASK_POINT_VALUE,
+        level_required=0,
+        status=TaskStatus.active,
+        task_type=TaskType.standard,
+        created_by=created_by_id,
+        primary_faction_slug=ONBOARDING_TASK_FACTION_SLUG,
+    ))
+    await session.flush()
+    return True
+
+
+# ---------------------------------------------------------------------------
 # Phase 4: Meta Tasks (placeholder) — idempotent
 # ---------------------------------------------------------------------------
 
@@ -360,6 +412,14 @@ async def seed(env: str, yes: bool) -> None:
             print(f"  >Tasks ({new_tasks} new)")
         else:
             print(f"  >Tasks already exist ({task_count}) — skipping")
+
+        # ------------------------------------------------------------------
+        # Phase 3b: Onboarding task (game-wide level-0, era-independent)
+        # ------------------------------------------------------------------
+        if await ensure_onboarding_task(session, pixie_char.id):
+            print("  >Onboarding task (1 game-wide level-0)")
+        else:
+            print("  >Onboarding task already exists — skipping")
 
         # ------------------------------------------------------------------
         # Phase 4: Meta Tasks (placeholder) — idempotent

--- a/backend/tests/integration/test_seed_task_sync.py
+++ b/backend/tests/integration/test_seed_task_sync.py
@@ -26,7 +26,12 @@ from models.character import Character
 from models.era import Era
 from models.faction import Faction
 from models.task import Task, TaskType
-from seed import ensure_placeholder_metatask, sync_era_tasks
+from seed import (
+    ONBOARDING_TASK_TITLE,
+    ensure_onboarding_task,
+    ensure_placeholder_metatask,
+    sync_era_tasks,
+)
 
 
 def _standard_task(title: str, faction_slug: str = "ua") -> TaskDef:
@@ -74,6 +79,70 @@ async def test_task_sync_propagates_new_era_task_on_seeded_db(
         await db_session.execute(select(Task).where(Task.title == "Alpha Task"))
     ).scalars().all()
     assert len(alpha_rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_onboarding_task_seeded_once_and_is_the_only_level_zero_task(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+    faction_ua: Faction,
+):
+    """The game-wide L0 onboarding task is seeded on every run, idempotently (#511)."""
+    # The onboarding task is faction="albescent"; seed that FK target.
+    from models.faction import FactionStatus
+
+    if (
+        await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
+    ).scalar_one_or_none() is None:
+        db_session.add(Faction(slug="albescent", status=FactionStatus.visible))
+        await db_session.flush()
+
+    # Simulate a populated DB with era content (none of it level 0 anymore).
+    await sync_era_tasks(
+        db_session, _era_with_tasks(_standard_task("Alpha Task")), character.id
+    )
+    # _standard_task defaults to level_required=0; overwrite that task's level so
+    # the onboarding task is genuinely the only L0 row for the assertion below.
+    alpha = (
+        await db_session.execute(select(Task).where(Task.title == "Alpha Task"))
+    ).scalar_one()
+    alpha.level_required = 1
+    await db_session.flush()
+
+    created = await ensure_onboarding_task(db_session, character.id)
+    assert created is True
+
+    onboarding_rows = (
+        await db_session.execute(
+            select(Task).where(Task.title == ONBOARDING_TASK_TITLE)
+        )
+    ).scalars().all()
+    assert len(onboarding_rows) == 1
+    assert onboarding_rows[0].level_required == 0
+    assert onboarding_rows[0].primary_faction_slug == "albescent"
+    assert onboarding_rows[0].task_type == TaskType.standard
+
+    # It is the only standard level-0 task in the database.
+    level_zero_standard = (
+        await db_session.execute(
+            select(Task).where(
+                Task.level_required == 0, Task.task_type == TaskType.standard
+            )
+        )
+    ).scalars().all()
+    assert len(level_zero_standard) == 1
+    assert level_zero_standard[0].title == ONBOARDING_TASK_TITLE
+
+    # Idempotent: a second run creates nothing.
+    created_again = await ensure_onboarding_task(db_session, character.id)
+    assert created_again is False
+    onboarding_rows = (
+        await db_session.execute(
+            select(Task).where(Task.title == ONBOARDING_TASK_TITLE)
+        )
+    ).scalars().all()
+    assert len(onboarding_rows) == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_era_config.py
+++ b/backend/tests/unit/test_era_config.py
@@ -104,7 +104,62 @@ def test_era1_has_tasks():
 
 
 def test_era1_task_count():
-    assert len(ERA_1.tasks) == 46
+    # 45 pre-#904 (46 minus snide's removed L0 "FLIP THE SYSTEM", #511) + 14 new
+    # faction tasks (#904: coven 6, snide 4, singularity 2, ephemerists 1,
+    # everymen 1).
+    assert len(ERA_1.tasks) == 59
+
+
+def test_era1_config_has_no_level_zero_tasks():
+    """#511: level 0 is reserved for the single game-wide onboarding task, which
+    is seeded in seed.py (not era config). No era-config task may be level 0."""
+    level_zero = [task for task in ERA_1.tasks if task.level_required == 0]
+    assert level_zero == [], (
+        f"Era config must have no level-0 tasks (#511); found: "
+        f"{[task.title for task in level_zero]}"
+    )
+
+
+def test_era1_every_faction_except_albescent_has_six_tasks_in_levels_one_to_seven():
+    """#904: every faction with roster content reaches >=6 tasks in levels 1-7.
+
+    Albescent stays at 1 by design (it hides — ADR-0048). na is a system
+    faction with no roster content. WOW/UA already qualify and are untouched.
+    """
+    exempt = {"albescent", "na"}
+    counts: dict[str, int] = {}
+    for task in ERA_1.tasks:
+        if 1 <= task.level_required <= 7:
+            counts[task.faction_slug] = counts.get(task.faction_slug, 0) + 1
+    for slug in ERA_1.factions:
+        if slug in exempt:
+            continue
+        assert counts.get(slug, 0) >= 6, (
+            f"Faction '{slug}' has {counts.get(slug, 0)} tasks in levels 1-7; "
+            f"needs >=6 (#904)"
+        )
+
+
+def test_era1_new_faction_tasks_follow_the_point_ramp():
+    """#904: L1->5, L2->10, L3->25, L4->50, L5->75, L6->100, L7->500."""
+    ramp = {1: 5, 2: 10, 3: 25, 4: 50, 5: 75, 6: 100, 7: 500}
+    new_titles = {
+        "A Light Left On", "Mend, Don't End", "The Comfort Bake",
+        "Gather the Weird Ones", "A Room That Holds You",
+        "Keep a Light On All Year", "Ruin a Perfectly Good Thing",
+        "Steelman Your Enemy", "Unsanctioned Maintenance",
+        "Organize the Ungovernable", "Sort Your Life",
+        "The Map Is the Territory", "Archive of a Single Hour", "The Commons",
+    }
+    seen = set()
+    for task in ERA_1.tasks:
+        if task.title in new_titles:
+            seen.add(task.title)
+            assert task.point_value == ramp[task.level_required], (
+                f"Task '{task.title}' (L{task.level_required}) should be worth "
+                f"{ramp[task.level_required]}, got {task.point_value}"
+            )
+    assert seen == new_titles, f"Missing #904 tasks: {new_titles - seen}"
 
 
 def test_era1_task_faction_slugs_valid():


### PR DESCRIPTION
Builds #511 and #904 together — they both edit `backend/eras/era_1.py` and #511's L0 removal changes #904's counts, so they must land as one PR.

## #511 — exactly one game-wide level-0 task
- New idempotent seed phase `ensure_onboarding_task()` in `backend/seed.py` (mirrors `ensure_placeholder_metatask`, keyed on title) upserts the onboarding task **Take a Picture of "Yourself"** (`faction_slug="albescent"`, `level_required=0`, `point_value=10`) on every seed run, so it exists in every era regardless of era config. It lives in no `era_N.tasks` list.
- Removed the only other level-0 task: snide **"FLIP THE SYSTEM"** (was L0/500pt). Level 0 is now reserved for the one onboarding fixture.

## #904 — every faction (except Albescent) reaches ≥6 tasks in levels 1–7
Added to `era_1.py` using the point ramp L1→5, L2→10, L3→25, L4→50, L5→75, L6→100, L7→500. Counts added (post-#511): **coven +6, snide +4, singularity +2, ephemerists +1, everymen +1**. WOW's and UA's tasks are untouched (#784/ADR-0050 donor-slug hazard); Albescent stays at 1 (it hides — ADR-0048).

Verified counts after a fresh reseed (standard tasks, levels 1–7): coven 6, ephemerists 6, everymen 6, singularity 6, snide 7, ua 14, wow 13; albescent 1. Exactly one standard L0 task exists (the Albescent self-portrait).

## Tests
`pytest` (dedicated `wz904_test`): full suite **757 passed**. New guards in `test_era_config.py` (no L0 in config, every non-albescent faction ≥6 in L1–7, point-ramp check, count now 59) and `test_seed_task_sync.py` (onboarding task seeded once, idempotent, only standard L0 task). Also ran a genuine end-to-end reseed (`alembic upgrade head` + `seed.py`) on a throwaway DB.

Visual QA is outstanding — no dev stack / screenshot capability in this environment; verified via tests + a live reseed query only.

## What to eyeball (fresh reseed)
- Cozy Coven now has tasks (was zero) — its `collab_own_modifier` is reachable.
- The onboarding L0 self-portrait **Take a Picture of "Yourself"** exists (Albescent, 10pt) and is the only level-0 task.
- Snide's old L0 "FLIP THE SYSTEM" is gone.
- Copy is bot-adjacent to the issue text verbatim — owner may tweak wording on the PR (config-only).

Closes #511
Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)
