### PR TITLE
Allow Unaffiliated meta tasks in the propose form (#894)

### DIFF
--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -681,7 +681,7 @@
     "metaToggle": {
       "label": "Create as meta task",
       "hint": "applies as a bonus to all {{faction}} submissions",
-      "hintNoFaction": "pick a faction above — meta tasks must belong to one"
+      "hintNoFaction": "pick a faction above (Unaffiliated = anyone)"
     },
     "preview": {
       "metaHeading": "Meta task preview — {{faction}}",
@@ -692,7 +692,6 @@
       "pending": "Pending review"
     },
     "errors": {
-      "metaFactionRequired": "Meta tasks must belong to a specific faction.",
       "createMeta": "Could not create meta task.",
       "propose": "Could not propose task."
     },

--- a/frontend/src/pages/proposeTask/__tests__/metataskProposal.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/metataskProposal.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * #894 — wiring the "Create as meta task" checkbox.
+ *
+ * Two guarantees:
+ *  1. The checkbox is gated off the capability seam (`canProposeMetatask`,
+ *     which the backend derives from `era.level_to_propose_metatask`). A
+ *     sub-gate proposer never sees it (CLAUDE.md "hide unusable controls").
+ *  2. When checked, submission routes through `proposeMetatask` carrying the
+ *     picked faction as `metatask_faction_slug` — including `na`
+ *     (Unaffiliated = anyone), which the old faction guard wrongly rejected.
+ *
+ * The visibility half renders the pure `DefaultProposeTask` (no DOM needed).
+ * The routing half exercises the extracted pure planner `planProposalSubmission`
+ * — the repo has no DOM/renderHook, so hooks are tested via their pure core.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import DefaultProposeTask from '../archetypes/DefaultProposeTask'
+import {
+  UNAFFILIATED_FACTION_SLUG,
+  planProposalSubmission,
+  type ProposeTaskState,
+} from '../useProposeTask'
+
+function state(overrides: Partial<ProposeTaskState> = {}): ProposeTaskState {
+  return {
+    isLoggedIn: true,
+    canProposeTask: true,
+    canProposeMetatask: false,
+    currentLevel: 6,
+    success: false,
+    factions: [],
+    title: '',
+    setTitle: () => {},
+    description: '',
+    setDescription: () => {},
+    pointValue: '10',
+    setPointValue: () => {},
+    levelRequired: 0,
+    setLevelRequired: () => {},
+    factionSlug: UNAFFILIATED_FACTION_SLUG,
+    setFactionSlug: () => {},
+    notes: '',
+    setNotes: () => {},
+    isMetaTask: false,
+    setIsMetaTask: () => {},
+    metaBonusValue: '10',
+    setMetaBonusValue: () => {},
+    submitting: false,
+    error: null,
+    handleSubmit: async () => {},
+    handleCancel: () => {},
+    ...overrides,
+  }
+}
+
+function renderText(overrides: Partial<ProposeTaskState> = {}): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <DefaultProposeTask state={state(overrides)} />
+    </MemoryRouter>,
+  ).replace(/<[^>]*>/g, '')
+}
+
+describe('meta task checkbox — capability gate', () => {
+  it('is hidden below the propose-metatask gate', () => {
+    expect(renderText({ canProposeMetatask: false })).not.toContain(
+      'Create as meta task',
+    )
+  })
+
+  it('appears once the proposer is eligible', () => {
+    expect(renderText({ canProposeMetatask: true })).toContain(
+      'Create as meta task',
+    )
+  })
+})
+
+describe('planProposalSubmission — checkbox routes to proposeMetatask', () => {
+  const base = {
+    title: 'Meditate daily',
+    description: 'Sit for ten minutes',
+    pointValue: '10',
+    metaBonusValue: '25',
+    levelRequired: 3 as number | '',
+  }
+
+  it('routes a checked proposal through the metatask endpoint with the picked faction', () => {
+    const plan = planProposalSubmission({
+      ...base,
+      isMetaTask: true,
+      factionSlug: 'coven',
+    })
+    expect(plan.kind).toBe('metatask')
+    if (plan.kind !== 'metatask') throw new Error('expected metatask plan')
+    expect(plan.body.metatask_faction_slug).toBe('coven')
+    expect(plan.body.point_value).toBe(25)
+    expect(plan.body.level_required).toBe(3)
+  })
+
+  it('allows an Unaffiliated (na) metatask — anyone can apply it', () => {
+    const plan = planProposalSubmission({
+      ...base,
+      isMetaTask: true,
+      factionSlug: UNAFFILIATED_FACTION_SLUG,
+    })
+    expect(plan.kind).toBe('metatask')
+    if (plan.kind !== 'metatask') throw new Error('expected metatask plan')
+    expect(plan.body.metatask_faction_slug).toBe(UNAFFILIATED_FACTION_SLUG)
+  })
+
+  it('routes an unchecked proposal through the standard task endpoint', () => {
+    const plan = planProposalSubmission({
+      ...base,
+      isMetaTask: false,
+      factionSlug: 'coven',
+    })
+    expect(plan.kind).toBe('standard')
+    if (plan.kind !== 'standard') throw new Error('expected standard plan')
+    expect(plan.body.primary_faction_slug).toBe('coven')
+    expect(plan.body.point_value).toBe(10)
+  })
+})

--- a/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
@@ -76,12 +76,14 @@ describe('propose task — unaffiliated option', () => {
     expect(render({ factionSlug: 'ua' })).toContain('var(--faction-ua)')
   })
 
-  it('tells a metatask author to pick a faction while unaffiliated', () => {
+  it('reads Unaffiliated as a legitimate metatask issuer, not an error', () => {
+    // #894: `na` metatasks are allowed ("anyone"), so the helper next to the
+    // checkbox invites the choice rather than rejecting it.
     const unaffiliated = render({ canProposeMetatask: true }).replace(
       /<[^>]*>/g,
       '',
     )
-    expect(unaffiliated).toContain('meta tasks must belong to one')
+    expect(unaffiliated).toContain('Unaffiliated = anyone')
 
     const affiliated = render({
       canProposeMetatask: true,

--- a/frontend/src/pages/proposeTask/useProposeTask.ts
+++ b/frontend/src/pages/proposeTask/useProposeTask.ts
@@ -4,16 +4,23 @@
  * proposal-form treatment without re-implementing the data plumbing.
  *
  * Behaviour preserved 1:1 from the original page (faction list fetch, the
- * title/description length guards, the metatask faction guard, proposeTask vs
- * proposeMetatask branch, success state). The returned {@link ProposeTaskState}
- * is the stable contract every propose-task archetype consumes. The dispatch
- * key is the user-selected `factionSlug`, so a faction can ship a bespoke form
- * that appears once its pennant is chosen.
+ * title/description length guards, proposeTask vs proposeMetatask branch,
+ * success state). The returned {@link ProposeTaskState} is the stable contract
+ * every propose-task archetype consumes. The dispatch key is the user-selected
+ * `factionSlug`, so a faction can ship a bespoke form that appears once its
+ * pennant is chosen.
+ *
+ * Note: there is deliberately no "metatask faction guard" here. The picker is
+ * dual-purpose — its slug is a standard task's `primary_faction_slug` and a
+ * metatask's issuing `metatask_faction_slug` — and Unaffiliated (`na`) is a
+ * legitimate metatask issuer ("anyone"): the backend only requires a truthy
+ * slug and metatasks are faction-open, so anyone may apply an `na` metatask
+ * (#894).
  */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { proposeTask } from "../../api/tasks";
-import { proposeMetatask } from "../../api/metaTasks";
+import { proposeTask, type TaskCreate } from "../../api/tasks";
+import { proposeMetatask, type MetataskProposal } from "../../api/metaTasks";
 import { getFactions, type FactionOut } from "../../api/factions";
 import { useAuth } from "../../auth/AuthContext";
 import { extractError } from "../../utils/errors";
@@ -25,6 +32,59 @@ import i18n from "../../i18n";
 import { UNAFFILIATED_FACTION_SLUG } from "../../utils/factions";
 
 export { UNAFFILIATED_FACTION_SLUG };
+
+/** Raw form fields the submission planner reads. */
+export interface ProposalFields {
+  isMetaTask: boolean;
+  title: string;
+  description: string;
+  pointValue: string;
+  metaBonusValue: string;
+  levelRequired: number | "";
+  factionSlug: string;
+}
+
+/** Which endpoint {@link handleSubmit} will hit, plus its ready-built body. */
+export type ProposalPlan =
+  | { kind: "metatask"; body: MetataskProposal }
+  | { kind: "standard"; body: TaskCreate };
+
+/**
+ * Pure decision core of the submit handler: pick the endpoint and build its
+ * body from the raw form fields. Extracted so the routing — especially the
+ * Unaffiliated-metatask path (#894) — is unit-testable in a repo with no
+ * DOM/renderHook.
+ *
+ * The faction picker is dual-purpose: its slug becomes a standard task's
+ * `primary_faction_slug` and a metatask's issuing `metatask_faction_slug`. Any
+ * slug routes through unchanged, including `na` (Unaffiliated = anyone); the
+ * backend only requires a truthy slug and metatasks are faction-open (#894).
+ */
+export function planProposalSubmission(fields: ProposalFields): ProposalPlan {
+  const level = fields.levelRequired === "" ? 0 : fields.levelRequired;
+  if (fields.isMetaTask) {
+    return {
+      kind: "metatask",
+      body: {
+        title: fields.title,
+        description: fields.description,
+        metatask_faction_slug: fields.factionSlug,
+        point_value: parseInt(fields.metaBonusValue) || 10,
+        level_required: level,
+      },
+    };
+  }
+  return {
+    kind: "standard",
+    body: {
+      title: fields.title,
+      description: fields.description || undefined,
+      point_value: parseInt(fields.pointValue) || 10,
+      level_required: level,
+      primary_faction_slug: fields.factionSlug || undefined,
+    },
+  };
+}
 
 export interface ProposeTaskState {
   // Gating (faction-agnostic guards live in the dispatcher)
@@ -100,34 +160,24 @@ export function useProposeTask(): ProposeTaskState {
     }
     // Backend authoritatively enforces metatask proposal gating (level 6 or
     // admin). If the viewer isn't eligible the 403 surfaces via extractError.
-    if (
-      isMetaTask &&
-      (!factionSlug ||
-        factionSlug === UNAFFILIATED_FACTION_SLUG ||
-        factionSlug === "ua")
-    ) {
-      setError(i18n.t("forms:proposeTask.errors.metaFactionRequired"));
-      return;
-    }
+    // No faction guard: any picked slug — including `na` (Unaffiliated =
+    // anyone) — is a valid metatask issuer (#894).
     setSubmitting(true);
     setError(null);
     try {
-      if (isMetaTask) {
-        await proposeMetatask({
-          title,
-          description,
-          metatask_faction_slug: factionSlug,
-          point_value: parseInt(metaBonusValue) || 10,
-          level_required: levelRequired === "" ? 0 : levelRequired,
-        });
+      const plan = planProposalSubmission({
+        isMetaTask,
+        title,
+        description,
+        pointValue,
+        metaBonusValue,
+        levelRequired,
+        factionSlug,
+      });
+      if (plan.kind === "metatask") {
+        await proposeMetatask(plan.body);
       } else {
-        await proposeTask({
-          title,
-          description: description || undefined,
-          point_value: parseInt(pointValue) || 10,
-          level_required: levelRequired === "" ? 0 : levelRequired,
-          primary_faction_slug: factionSlug || undefined,
-        });
+        await proposeTask(plan.body);
       }
       setSuccess(true);
     } catch (err) {


### PR DESCRIPTION
## What & why

The propose form's **"Create as meta task"** checkbox and the `proposeMetatask()` caller already shipped in #791 — the issue's "zero callers / never sets task_type" premise was stale. The real remaining gap was the owner ruling: the frontend faction guard in `useProposeTask` rejected `na`/`ua`/empty, blocking a **Unaffiliated ("anyone") meta task**.

### Changes (frontend only)
- **Removed the slug-comparison guard** in `useProposeTask.handleSubmit`. Any picked slug — including `na` — is a valid metatask issuer. This also satisfies the "no slug comparisons; drive gates off `era.*` + the capability seam" constraint (the guard was all slug comparisons).
- **Extracted `planProposalSubmission`** — the pure endpoint+body decision core — so the routing is unit-testable in a repo with no DOM/renderHook.
- **Copy** (`forms.json`): `metaToggle.hintNoFaction` now reads "pick a faction above (Unaffiliated = anyone)"; dropped the now-dead `errors.metaFactionRequired`.
- **Tests**: checkbox is hidden below the `canProposeMetatask` capability gate; checking it routes through `proposeMetatask` with the picked faction, including `na`; unchecked routes through `proposeTask`.

The checkbox stays gated on the existing `canProposeMetatask` capability seam (backend derives it from `era.level_to_propose_metatask`) — **no hardcoded level 6**.

### Backend apply-gate check (ruling 3) — no change needed
Verified: `services/faction_service.faction_permits` returns `True` unconditionally (metatasks are faction-open), and `_check_metatask_eligibility` only layers the level gate + Albescent bypass on top. An `na`/"Anyone" metatask is therefore already applicable by anyone. **No backend change made.** The na metatask seal reuses the na/default rainbow treatment (#794) — no bespoke art.

## Verify
- `tsc --noEmit`: clean for all changed files (the only errors are the known `node:fs`/`node:url` junction false alarm from running under a worktree, PR #675 — CI's real `node_modules` resolves them).
- `eslint`: clean on changed files.
- `vite build`: OK.
- `vitest`: propose-task suite 9 passed (2 files).

## What to eyeball (visual QA outstanding — no dev stack / screenshots)
- As a **level-6+ proposer**, the "Create as meta task" checkbox appears below the MINIMUM LEVEL row (behind a dashed divider).
- Checking it + picking **Unaffiliated** submits an "Anyone" metatask (helper reads "pick a faction above (Unaffiliated = anyone)").
- **Sub-gate proposers** never see the checkbox.
- No backend apply-gate change was required.

Closes #894