### PR TITLE
Move metatask seal-stack up under Manner of Quest (#1002)

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -494,6 +494,22 @@ export default function CovenEditPraxis({ state }: Props) {
                 </div>
               )}
 
+            {/* Metatasks */}
+            {state.showSealStack && (
+              <div
+                style={{
+                  ...notepadPanel,
+                  marginBottom: "var(--space-lg)",
+                  borderStyle: "dashed",
+                }}
+              >
+                <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
+                  {t("editPraxis.coven.metatasksLabel")}
+                </span>
+                <MetataskSealStack state={state} />
+              </div>
+            )}
+
             {/* Title — notepad panel */}
             <div style={{ ...notepadPanel, marginBottom: "var(--space-lg)" }}>
               <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
@@ -662,22 +678,6 @@ export default function CovenEditPraxis({ state }: Props) {
                 />
               </div>
             </div>
-
-            {/* Metatasks */}
-            {state.showSealStack && (
-              <div
-                style={{
-                  ...notepadPanel,
-                  marginBottom: "var(--space-lg)",
-                  borderStyle: "dashed",
-                }}
-              >
-                <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                  {t("editPraxis.coven.metatasksLabel")}
-                </span>
-                <MetataskSealStack state={state} />
-              </div>
-            )}
 
             <ErrorBanner message={state.error} />
 

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -352,6 +352,14 @@ export default function DefaultEditPraxis({ state }: Props) {
               </div>
             )}
 
+            {/* Metatask seals. */}
+            {state.showSealStack && (
+              <div style={{ marginBottom: "var(--space-xl)" }}>
+                <div style={cap}>{t("editPraxis.na.metatasksLabel")}</div>
+                <MetataskSealStack state={state} />
+              </div>
+            )}
+
             {/* Headline. */}
             <div style={{ marginBottom: "var(--space-xl)" }}>
               <div style={{ ...cap, display: "flex", justifyContent: "space-between" }}>
@@ -506,14 +514,6 @@ export default function DefaultEditPraxis({ state }: Props) {
                 />
               </div>
             </div>
-
-            {/* Metatask seals. */}
-            {state.showSealStack && (
-              <div style={{ marginBottom: "var(--space-xl)" }}>
-                <div style={cap}>{t("editPraxis.na.metatasksLabel")}</div>
-                <MetataskSealStack state={state} />
-              </div>
-            )}
 
             <ErrorBanner message={state.error} />
 

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -281,6 +281,16 @@ export default function EphemeristsEditPraxis({ state }: Props) {
           </div>
         )}
 
+        {/* metatasks */}
+        {state.showSealStack && (
+          <div style={{ marginBottom: "var(--space-2xl)" }}>
+            <FieldLabel meta={t("editPraxis.ephemerists.metatasksMeta")}>
+              {t("editPraxis.ephemerists.metatasksLabel")}
+            </FieldLabel>
+            <MetataskSealStack state={state} />
+          </div>
+        )}
+
         {/* the finding (headline) */}
         <div style={{ marginBottom: "var(--space-xl)" }}>
           <FieldLabel
@@ -416,16 +426,6 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             }}
           />
         </div>
-
-        {/* metatasks */}
-        {state.showSealStack && (
-          <div style={{ marginBottom: "var(--space-2xl)" }}>
-            <FieldLabel meta={t("editPraxis.ephemerists.metatasksMeta")}>
-              {t("editPraxis.ephemerists.metatasksLabel")}
-            </FieldLabel>
-            <MetataskSealStack state={state} />
-          </div>
-        )}
 
         <ErrorBanner message={state.error} />
 

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -359,6 +359,9 @@ export default function EverymenEditPraxis({ state }: Props) {
         {/* Collab invite / duel challenge */}
         {state.showInviteBox && <InviteBlock state={state} />}
 
+        {/* Metatasks */}
+        {state.showSealStack && <MetatasksBlock state={state} />}
+
         {/* The job (headline) */}
         <div style={{ marginBottom: "var(--space-xl)" }}>
           <FieldLabel
@@ -534,9 +537,6 @@ export default function EverymenEditPraxis({ state }: Props) {
             </p>
           )}
         </div>
-
-        {/* Metatasks */}
-        {state.showSealStack && <MetatasksBlock state={state} />}
 
         <ErrorBanner message={state.error} />
 

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -297,6 +297,23 @@ export default function SingularityEditPraxis({ state }: Props) {
             </div>
           )}
 
+        {/* Metatasks */}
+        {state.showSealStack && (
+          <div style={{ marginBottom: "var(--space-xl)" }}>
+            <div style={{ fontSize: "var(--text-base)", color: dim, marginBottom: "var(--space-sm)" }}>
+              <span style={{ color: term }}>$ </span>{t("editPraxis.singularity.terminal.metataskCommand")}
+            </div>
+            <div
+              style={{
+                border: `1px dashed ${accent}`,
+                padding: "var(--space-sm)",
+              }}
+            >
+              <MetataskSealStack state={state} />
+            </div>
+          </div>
+        )}
+
         {/* Title */}
         <div style={{ marginBottom: "var(--space-xl)" }}>
           <div style={{ fontSize: "var(--text-base)", color: dim, marginBottom: "var(--space-xs)" }}>
@@ -580,23 +597,6 @@ export default function SingularityEditPraxis({ state }: Props) {
             />
           </div>
         </div>
-
-        {/* Metatasks */}
-        {state.showSealStack && (
-          <div style={{ marginBottom: "var(--space-xl)" }}>
-            <div style={{ fontSize: "var(--text-base)", color: dim, marginBottom: "var(--space-sm)" }}>
-              <span style={{ color: term }}>$ </span>{t("editPraxis.singularity.terminal.metataskCommand")}
-            </div>
-            <div
-              style={{
-                border: `1px dashed ${accent}`,
-                padding: "var(--space-sm)",
-              }}
-            >
-              <MetataskSealStack state={state} />
-            </div>
-          </div>
-        )}
 
         <ErrorBanner message={state.error} />
 

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -311,6 +311,26 @@ export default function SnideEditPraxis({ state }: Props) {
             </div>
           )}
 
+        {/* Metatasks */}
+        {state.showSealStack && (
+          <div
+            style={{
+              marginBottom: "var(--space-xl)",
+              padding: "var(--space-md) var(--space-lg)",
+              border: `2px dashed ${accentDeep}`,
+              background: lightBg,
+            }}
+          >
+            <span
+              className="eyebrow"
+              style={{ display: "block", marginBottom: "var(--space-sm)", color: accentDeep }}
+            >
+              {t("editPraxis.snide.metatasksLabel")}
+            </span>
+            <MetataskSealStack state={state} />
+          </div>
+        )}
+
         {/* Title — ransom note + editable input */}
         <div
           style={{
@@ -550,26 +570,6 @@ export default function SnideEditPraxis({ state }: Props) {
             }}
           />
         </div>
-
-        {/* Metatasks */}
-        {state.showSealStack && (
-          <div
-            style={{
-              marginBottom: "var(--space-xl)",
-              padding: "var(--space-md) var(--space-lg)",
-              border: `2px dashed ${accentDeep}`,
-              background: lightBg,
-            }}
-          >
-            <span
-              className="eyebrow"
-              style={{ display: "block", marginBottom: "var(--space-sm)", color: accentDeep }}
-            >
-              {t("editPraxis.snide.metatasksLabel")}
-            </span>
-            <MetataskSealStack state={state} />
-          </div>
-        )}
 
         <ErrorBanner message={state.error} />
 

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -322,6 +322,14 @@ export default function UaEditPraxis({ state }: Props) {
           </Plate>
         )}
 
+        {/* Metatasks */}
+        {state.showSealStack && (
+          <Plate>
+            <FieldLabel>{t("editPraxis.ua.metatasksLabel")}</FieldLabel>
+            <MetataskSealStack state={state} />
+          </Plate>
+        )}
+
         {/* Title */}
         <Plate>
           <FieldLabel>{t("editPraxis.ua.titleLabel")}</FieldLabel>
@@ -477,14 +485,6 @@ export default function UaEditPraxis({ state }: Props) {
             />
           </div>
         </div>
-
-        {/* Metatasks */}
-        {state.showSealStack && (
-          <Plate>
-            <FieldLabel>{t("editPraxis.ua.metatasksLabel")}</FieldLabel>
-            <MetataskSealStack state={state} />
-          </Plate>
-        )}
 
         <ErrorBanner message={state.error} />
 

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -403,6 +403,18 @@ export default function WowEditPraxis({ state }: Props) {
               </div>
             )}
 
+            {/* ── deeds of merit ── */}
+            {state.showSealStack && (
+              <div style={plate}>
+                <span
+                  style={{ ...eyebrowStyle, marginBottom: "var(--space-md)" }}
+                >
+                  {t("editPraxis.wow.metatasksLabel")}
+                </span>
+                <MetataskSealStack state={state} />
+              </div>
+            )}
+
             {/* ── title of thy chronicle ── */}
             <div style={plate}>
               <div
@@ -611,18 +623,6 @@ export default function WowEditPraxis({ state }: Props) {
                 })}
               </div>
             </div>
-
-            {/* ── deeds of merit ── */}
-            {state.showSealStack && (
-              <div style={plate}>
-                <span
-                  style={{ ...eyebrowStyle, marginBottom: "var(--space-md)" }}
-                >
-                  {t("editPraxis.wow.metatasksLabel")}
-                </span>
-                <MetataskSealStack state={state} />
-              </div>
-            )}
 
             <ErrorBanner message={state.error} />
 

--- a/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
@@ -333,15 +333,15 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
             </Window>
           )}
 
-          <Window title={t("editPraxis.coven.filesLabel", { pasted: state.media.length })}>
-            <MediaGrid state={state} />
-          </Window>
-
           {state.showSealStack && (
             <Window title={t("editPraxis.coven.metatasksLabel")}>
               <MetataskSealStack state={state} />
             </Window>
           )}
+
+          <Window title={t("editPraxis.coven.filesLabel", { pasted: state.media.length })}>
+            <MediaGrid state={state} />
+          </Window>
         </>
       ) : (
         <Window title={t("editPraxis.coven.previewLabel")}>

--- a/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
@@ -215,12 +215,6 @@ export default function DefaultEditPraxis({
             </div>
           )}
 
-          {/* Media grid + add */}
-          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
-            <span style={eyebrow}>{t("editPraxis.na.filesLabel")}</span>
-            <MediaGrid state={state} />
-          </div>
-
           {/* Metatasks */}
           {state.showSealStack && (
             <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
@@ -228,6 +222,12 @@ export default function DefaultEditPraxis({
               <MetataskSealStack state={state} />
             </div>
           )}
+
+          {/* Media grid + add */}
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
+            <span style={eyebrow}>{t("editPraxis.na.filesLabel")}</span>
+            <MediaGrid state={state} />
+          </div>
         </>
       ) : (
         // Preview

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
@@ -191,15 +191,15 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
             </Leaf>
           )}
 
-          <Leaf title={t('editPraxis.ephemerists.filesLabel')}>
-            <MediaGrid state={state} />
-          </Leaf>
-
           {state.showSealStack && (
             <Leaf title={t('editPraxis.ephemerists.metatasksLabel')}>
               <MetataskSealStack state={state} />
             </Leaf>
           )}
+
+          <Leaf title={t('editPraxis.ephemerists.filesLabel')}>
+            <MediaGrid state={state} />
+          </Leaf>
         </>
       ) : (
         <Leaf title={t('editPraxis.ephemerists.previewLabel')}>

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
@@ -180,15 +180,15 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
             </Plate>
           )}
 
-          <Plate title={t('editPraxis.everymen.filesLabel')}>
-            <MediaGrid state={state} />
-          </Plate>
-
           {state.showSealStack && (
             <Plate title={t('editPraxis.everymen.metatasksLabel')}>
               <MetataskSealStack state={state} />
             </Plate>
           )}
+
+          <Plate title={t('editPraxis.everymen.filesLabel')}>
+            <MediaGrid state={state} />
+          </Plate>
         </>
       ) : (
         <Plate title={t('editPraxis.everymen.previewLabel')}>

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
@@ -180,15 +180,15 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
             </Panel>
           )}
 
-          <Panel title={t('editPraxis.singularity.mobile.filesLabel')}>
-            <MediaGrid state={state} />
-          </Panel>
-
           {state.showSealStack && (
             <Panel title={t('editPraxis.singularity.mobile.metatasksLabel')}>
               <MetataskSealStack state={state} />
             </Panel>
           )}
+
+          <Panel title={t('editPraxis.singularity.mobile.filesLabel')}>
+            <MediaGrid state={state} />
+          </Panel>
         </>
       ) : (
         <Panel title={t('editPraxis.singularity.mobile.previewLabel')}>

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
@@ -187,15 +187,15 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
             </Plate>
           )}
 
-          <Plate title={t('editPraxis.snide.filesLabel')}>
-            <MediaGrid state={state} />
-          </Plate>
-
           {state.showSealStack && (
             <Plate title={t('editPraxis.snide.metatasksLabel')}>
               <MetataskSealStack state={state} />
             </Plate>
           )}
+
+          <Plate title={t('editPraxis.snide.filesLabel')}>
+            <MediaGrid state={state} />
+          </Plate>
         </>
       ) : (
         <Plate title={t('editPraxis.snide.previewLabel')}>

--- a/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
@@ -237,15 +237,15 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
             </Field>
           )}
 
-          <Field label={t('editPraxis.ua.filesLabel')}>
-            <MediaGrid state={state} />
-          </Field>
-
           {state.showSealStack && (
             <Field label={t('editPraxis.ua.metatasksLabel')}>
               <MetataskSealStack state={state} />
             </Field>
           )}
+
+          <Field label={t('editPraxis.ua.filesLabel')}>
+            <MediaGrid state={state} />
+          </Field>
         </>
       ) : (
         <Field label={t('editPraxis.ua.previewLabel')}>

--- a/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
@@ -372,18 +372,18 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
             </Plate>
           )}
 
+          {state.showSealStack && (
+            <Plate title={t("editPraxis.wow.metatasksLabel")}>
+              <MetataskSealStack state={state} />
+            </Plate>
+          )}
+
           <Plate
             title={t("editPraxis.wow.filesLabel")}
             aside={<Marginalia>{t("editPraxis.wow.fileHelper")}</Marginalia>}
           >
             <RelicGrid state={state} />
           </Plate>
-
-          {state.showSealStack && (
-            <Plate title={t("editPraxis.wow.metatasksLabel")}>
-              <MetataskSealStack state={state} />
-            </Plate>
-          )}
         </>
       ) : (
         <Plate title={t("editPraxis.wow.previewLabel")}>


### PR DESCRIPTION
Moves the metatask seal-stack (`{state.showSealStack && (…)}`, the "+ Add a metatask" block) up from the bottom of every Edit Praxis composer to sit **immediately after the `{state.showInviteBox && (…)}` block**, directly under the Manner-of-Quest mode selector.

Before this, the seal stack rendered below the chronicle and media, so a solo author scrolling the top of Edit Praxis never saw it — which (combined with the #905 seed gap that left prod with zero metatasks) read as "no metatask module." The invite box (collab/duel) and the seal stack (solo) are mutually exclusive contexts; both now live in the same region under the mode selector.

## What changed
Pure JSX relocation in all 16 archetypes — 8 desktop (`archetypes/`) + 8 mobile (`mobileArchetypes/`). In each, the `showSealStack` block is moved to sit right after `showInviteBox`. On desktop it moves up from after the media; on mobile it swaps ahead of the files/media panel. The block's markup, styling, label, and `showSealStack` gate are **identical** — only its position in the JSX changed (130 insertions / 130 deletions, perfectly balanced).

The `MetataskPicker` / `MetataskRemoveConfirm` modals (mounted once in `EditPraxis.tsx`) are **untouched** — they're position-independent.

No gate, backend, config, or behavior change. When the block appears/disappears is unchanged.

## Verification
- `tsc --noEmit`: 0 errors in editPraxis (total unchanged from baseline — the remaining are pre-existing `node:fs` stale-junction false alarms in `__tests__` utils).
- `eslint` on all 16 files: clean.
- `vite build`: OK.
- `vitest run src/pages/editPraxis`: 10 files / 61 tests pass. No suite asserts archetype-level block order, so none needed adjusting; the seal-stack/picker/modal component tests are unaffected.

I **cannot** screenshot (no dev stack / Browser renderer times out), so **visual QA is outstanding**.

## What to eyeball
On a **solo** draft in every faction's composer (**desktop + mobile**):
- The "+ Add a metatask" block sits **directly under the Solo · Collab · Duel selector**, above the title/chronicle.
- Switching to **collab/duel** swaps in the invite box in that same spot (seal stack hidden); switching back to **solo** shows the seal stack there again.
- Confirm this across all 8 factions × both form factors (16 skins).

Closes #1002
