### PR TITLE
Fix #985: one shared avatar-picker so edit shows the new portrait immediately

### DIFF
--- a/frontend/src/pages/CreateCharacter.tsx
+++ b/frontend/src/pages/CreateCharacter.tsx
@@ -53,7 +53,8 @@ function DesktopCreateCharacter({ state }: { state: CreateCharacterState }) {
     avatarPreview,
     avatarSource,
     setAvatarSource,
-    handleFile,
+    avatarError,
+    handleAvatarChange,
     handleAvatarConfirm,
     error,
     submitting,
@@ -110,10 +111,11 @@ function DesktopCreateCharacter({ state }: { state: CreateCharacterState }) {
             ref={fileInputRef}
             type="file"
             accept="image/*"
-            onChange={handleFile}
+            onChange={handleAvatarChange}
             className="font-body text-sm"
             style={{ marginTop: 'var(--space-sm)' }}
           />
+          {avatarError && <p className="font-body content-text text-red-600 mt-1">{avatarError}</p>}
 
           {/* Faction picker — only when the account holds invitations (ADR-0019) */}
           {showPicker && (

--- a/frontend/src/pages/EditCharacter.tsx
+++ b/frontend/src/pages/EditCharacter.tsx
@@ -103,6 +103,7 @@ function DesktopEditCharacter({ state }: { state: EditCharacterState }) {
     setBio,
     location,
     setLocation,
+    avatarPreview,
     avatarSource,
     setAvatarSource,
     avatarError,
@@ -119,6 +120,9 @@ function DesktopEditCharacter({ state }: { state: EditCharacterState }) {
 
   // Monogram tracks the display name as you type (falls back to the handle).
   const initial = (displayName.trim()[0] || character.username[0] || '?').toUpperCase()
+  // A freshly cropped portrait (object URL) shows immediately, before Save (#985);
+  // otherwise fall back to the persisted avatar.
+  const portraitSrc = avatarPreview ?? (character.avatar_url ? mediaUrl(character.avatar_url) : null)
 
   return (
     <div className="py-8" style={{ maxWidth: 640, margin: '0 auto' }}>
@@ -186,9 +190,9 @@ function DesktopEditCharacter({ state }: { state: EditCharacterState }) {
                   lineHeight: 1,
                 }}
               >
-                {character.avatar_url ? (
+                {portraitSrc ? (
                   <img
-                    src={mediaUrl(character.avatar_url)}
+                    src={portraitSrc}
                     alt={character.username}
                     style={{ width: '100%', height: '100%', objectFit: 'cover' }}
                   />

--- a/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
@@ -9,10 +9,11 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 // Initialize the i18n catalog so shared copy keys resolve to English text.
 import '../../../i18n'
 import { buildCreatePayload, type CreateCharacterState } from '../useCreateCharacter'
+import { createObjectUrlSlot } from '../useAvatarPicker'
 import type { EditCharacterState } from '../useEditCharacter'
 import DefaultCreateCharacter from '../mobileArchetypes/DefaultCreateCharacter'
 import DefaultEditCharacter from '../mobileArchetypes/DefaultEditCharacter'
@@ -54,7 +55,8 @@ function createState(overrides: Partial<CreateCharacterState>): CreateCharacterS
     avatarPreview: null,
     avatarSource: null,
     setAvatarSource: () => {},
-    handleFile: () => {},
+    avatarError: '',
+    handleAvatarChange: () => {},
     handleAvatarConfirm: () => {},
     error: null,
     submitting: false,
@@ -81,6 +83,7 @@ function editState(overrides: Partial<EditCharacterState>): EditCharacterState {
     avatarFile: null,
     avatarSource: null,
     setAvatarSource: () => {},
+    avatarPreview: null,
     avatarError: '',
     handleAvatarChange: () => {},
     handleAvatarConfirm: () => {},
@@ -137,6 +140,52 @@ describe('DefaultEditCharacter mobile skin', () => {
   it('links out to a joined faction detail page', () => {
     const { html } = render(<DefaultEditCharacter state={editState({ character: character({ faction_slug: 'wow' }) })} />)
     expect(html).toContain('href="/factions/wow"')
+  })
+
+  it('shows a freshly cropped portrait (preview) over the persisted avatar (#985)', () => {
+    const state = editState({
+      avatarPreview: 'blob:preview-123',
+      character: character({ avatar_url: 'avatars/old.png' }),
+    })
+    const { html } = render(<DefaultEditCharacter state={state} />)
+    expect(html, 'the preview object URL is rendered').toContain('src="blob:preview-123"')
+    expect(html, 'the stale persisted avatar is not').not.toContain('old.png')
+  })
+})
+
+describe('useAvatarPicker preview lifecycle — createObjectUrlSlot (#985)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('mints a preview URL on confirm and revokes the prior one when replaced', () => {
+    let counter = 0
+    const create = vi.fn(() => `blob:preview-${++counter}`)
+    const revoke = vi.fn()
+    // jsdom-less node has no object-URL API — provide the spies directly.
+    vi.stubGlobal('URL', { createObjectURL: create, revokeObjectURL: revoke })
+
+    const slot = createObjectUrlSlot()
+    const blob = new Blob(['x'])
+
+    // First confirm: a URL is minted, nothing to revoke yet.
+    const first = slot.set(blob)
+    expect(first).toBe('blob:preview-1')
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(revoke).not.toHaveBeenCalled()
+
+    // Replacing the crop revokes the prior URL and mints a fresh one.
+    const second = slot.set(blob)
+    expect(second).toBe('blob:preview-2')
+    expect(create).toHaveBeenCalledTimes(2)
+    expect(revoke).toHaveBeenCalledTimes(1)
+    expect(revoke).toHaveBeenCalledWith('blob:preview-1')
+
+    // Unmount cleanup releases the outstanding URL exactly once.
+    slot.revoke()
+    expect(revoke).toHaveBeenCalledTimes(2)
+    expect(revoke).toHaveBeenLastCalledWith('blob:preview-2')
+    expect(slot.current()).toBeNull()
   })
 })
 

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
@@ -29,7 +29,8 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
     avatarPreview,
     avatarSource,
     setAvatarSource,
-    handleFile,
+    avatarError,
+    handleAvatarChange,
     handleAvatarConfirm,
     error,
     submitting,
@@ -75,8 +76,9 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
         <div className="eyebrow" style={{ marginTop: 'var(--space-sm)', color: 'var(--color-text-tertiary)' }}>
           {t('createCharacter.mobile.step')}
         </div>
+        {avatarError && <p className="content-text" style={{ ...errorBox, marginTop: 'var(--space-sm)' }}>{avatarError}</p>}
       </div>
-      <input ref={fileRef} type="file" accept="image/*" onChange={handleFile} style={{ display: 'none' }} />
+      <input ref={fileRef} type="file" accept="image/*" onChange={handleAvatarChange} style={{ display: 'none' }} />
 
       {/* Name */}
       <div>

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
@@ -31,6 +31,7 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
     setDisplayName,
     bio,
     setBio,
+    avatarPreview,
     avatarSource,
     setAvatarSource,
     avatarError,
@@ -50,6 +51,9 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
   const initial = (displayName.trim()[0] || character.username[0] || '?').toUpperCase()
   const factionSlug = character.faction_slug
   const factionHref = factionSlug ? `/factions/${factionSlug}` : '/factions'
+  // A freshly cropped portrait (object URL) shows immediately, before Save (#985);
+  // otherwise fall back to the persisted avatar.
+  const portraitSrc = avatarPreview ?? (character.avatar_url ? mediaUrl(character.avatar_url) : null)
 
   return (
     <form data-skin="default" data-testid="mobile-edit-character" onSubmit={handleSubmit} style={page}>
@@ -66,8 +70,8 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
       <div style={{ textAlign: 'center' }}>
         <button type="button" onClick={() => fileRef.current?.click()} style={ringBtn}>
           <span style={ringInner}>
-            {character.avatar_url ? (
-              <img src={mediaUrl(character.avatar_url)} alt={character.username} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+            {portraitSrc ? (
+              <img src={portraitSrc} alt={character.username} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
             ) : (
               <span
                 style={{

--- a/frontend/src/pages/characterPaths/useAvatarPicker.ts
+++ b/frontend/src/pages/characterPaths/useAvatarPicker.ts
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from 'react'
+import { blobToFile } from '../../components/imageEdit/imageEditHelpers'
+
+/**
+ * The whole avatar pick/crop/preview/validate lifecycle, in ONE place (#985).
+ *
+ * Character creation and character editing both let you choose a portrait, crop
+ * it square, and see it before it is persisted. That logic used to be
+ * copy-pasted across {@link useCreateCharacter} and useEditCharacter, and the two
+ * copies drifted: the edit copy never built an `avatarPreview`, so a freshly
+ * picked avatar only appeared after Save → refetch → navigate ("the refresh").
+ * Consolidating here is what keeps the two flows from diverging again.
+ *
+ * The one subtlety is the object URL: `handleAvatarConfirm` creates a `blob:` URL
+ * for instant preview, and every URL must be revoked exactly once — when it is
+ * replaced by a newer crop and when the screen unmounts — or the browser leaks
+ * the backing blob. {@link createObjectUrlSlot} owns that bookkeeping.
+ *
+ * NOTE: praxis-media uploads (useEditPraxis / CollabSuccess) are a separate
+ * concern and deliberately do NOT share this hook.
+ */
+
+const MAX_AVATAR_SIZE = 10 * 1024 * 1024 // 10 MB
+const TOO_LARGE_MESSAGE = 'Portrait must be under 10 MB.'
+
+/**
+ * A single-slot holder for an object URL. `set` revokes whatever URL it was
+ * holding, mints a fresh one for the given blob, and returns it; `revoke`
+ * releases the current one. Extracted (and exported) so the preview lifecycle is
+ * unit-testable without a DOM.
+ */
+export interface ObjectUrlSlot {
+  set: (source: Blob) => string
+  revoke: () => void
+  current: () => string | null
+}
+
+export function createObjectUrlSlot(): ObjectUrlSlot {
+  let url: string | null = null
+  return {
+    set(source: Blob): string {
+      if (url) URL.revokeObjectURL(url)
+      url = URL.createObjectURL(source)
+      return url
+    },
+    revoke(): void {
+      if (url) URL.revokeObjectURL(url)
+      url = null
+    },
+    current(): string | null {
+      return url
+    },
+  }
+}
+
+export interface AvatarPicker {
+  /** The cropped file awaiting upload (null until a crop is confirmed). */
+  avatarFile: File | null
+  /** The raw file currently open in the crop modal (null when closed). */
+  avatarSource: File | null
+  setAvatarSource: (file: File | null) => void
+  /** Object URL of the just-cropped file — render this for instant feedback. */
+  avatarPreview: string | null
+  /** Avatar-scoped error (>10 MB, or an upload failure the caller reports). */
+  avatarError: string
+  setAvatarError: (message: string) => void
+  /** Hidden file-input onChange: validates size, then opens the crop modal. */
+  handleAvatarChange: (event: React.ChangeEvent<HTMLInputElement>) => void
+  /** Crop-modal confirm: stores the cropped file and its preview URL. */
+  handleAvatarConfirm: (blob: Blob) => void
+}
+
+export function useAvatarPicker(): AvatarPicker {
+  const [avatarFile, setAvatarFile] = useState<File | null>(null)
+  const [avatarSource, setAvatarSource] = useState<File | null>(null) // in the crop modal
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
+  const [avatarError, setAvatarError] = useState('')
+
+  // One object-URL slot per mounted picker; revoked on unmount.
+  const slotRef = useRef<ObjectUrlSlot | null>(null)
+  if (slotRef.current === null) slotRef.current = createObjectUrlSlot()
+
+  useEffect(() => {
+    const slot = slotRef.current!
+    return () => slot.revoke()
+  }, [])
+
+  const handleAvatarChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0] ?? null
+    event.target.value = ''
+    if (!file) return
+    if (file.size > MAX_AVATAR_SIZE) {
+      setAvatarError(TOO_LARGE_MESSAGE)
+      return
+    }
+    setAvatarError('')
+    // Crop/rotate to a square before it becomes the portrait (#514).
+    setAvatarSource(file)
+  }
+
+  const handleAvatarConfirm = (blob: Blob) => {
+    const file = blobToFile(blob, avatarSource?.name ?? 'avatar')
+    setAvatarFile(file)
+    setAvatarPreview(slotRef.current!.set(file)) // revokes the prior preview
+    setAvatarSource(null)
+  }
+
+  return {
+    avatarFile,
+    avatarSource,
+    setAvatarSource,
+    avatarPreview,
+    avatarError,
+    setAvatarError,
+    handleAvatarChange,
+    handleAvatarConfirm,
+  }
+}

--- a/frontend/src/pages/characterPaths/useCreateCharacter.ts
+++ b/frontend/src/pages/characterPaths/useCreateCharacter.ts
@@ -4,7 +4,7 @@ import { useAuth } from '../../auth/AuthContext'
 import { createCharacter, uploadCharacterAvatar, type CharacterCreate } from '../../api/characters'
 import { getInvitedFactions } from '../../api/me'
 import { extractError } from '../../utils/errors'
-import { blobToFile } from '../../components/imageEdit/imageEditHelpers'
+import { useAvatarPicker } from './useAvatarPicker'
 
 /**
  * Shared read/write model for Adaptive Character Creation (#273, ADR-0019),
@@ -16,7 +16,6 @@ import { blobToFile } from '../../components/imageEdit/imageEditHelpers'
 
 export const NAME_MAX = 22
 export const BIO_MAX = 160
-const MAX_AVATAR_SIZE = 10 * 1024 * 1024 // 10 MB
 
 /** Mirror of the server @handle derivation (services/character._derive_unique_username). */
 export function previewHandle(displayName: string): string {
@@ -52,7 +51,8 @@ export interface CreateCharacterState {
   avatarPreview: string | null
   avatarSource: File | null
   setAvatarSource: (file: File | null) => void
-  handleFile: (event: React.ChangeEvent<HTMLInputElement>) => void
+  avatarError: string
+  handleAvatarChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   handleAvatarConfirm: (blob: Blob) => void
   error: string | null
   submitting: boolean
@@ -70,35 +70,23 @@ export function useCreateCharacter(): CreateCharacterState {
   const [bio, setBio] = useState('')
   const [factionSlug, setFactionSlug] = useState<string>('') // '' = born na
   const [invited, setInvited] = useState<string[]>([])
-  const [avatarFile, setAvatarFile] = useState<File | null>(null)
-  const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
-  const [avatarSource, setAvatarSource] = useState<File | null>(null) // in the crop modal
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
+
+  // Avatar pick/crop/preview/validate — shared with edit (#985).
+  const {
+    avatarFile,
+    avatarSource,
+    setAvatarSource,
+    avatarPreview,
+    avatarError,
+    handleAvatarChange,
+    handleAvatarConfirm,
+  } = useAvatarPicker()
 
   useEffect(() => {
     void getInvitedFactions().then(setInvited).catch(() => setInvited([]))
   }, [])
-
-  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0] ?? null
-    e.target.value = ''
-    if (!file) return
-    if (file.size > MAX_AVATAR_SIZE) {
-      setError('Portrait must be under 10 MB.')
-      return
-    }
-    setError(null)
-    // Crop/rotate to a square before it becomes the portrait (#514).
-    setAvatarSource(file)
-  }
-
-  const handleAvatarConfirm = (blob: Blob) => {
-    const file = blobToFile(blob, avatarSource?.name ?? 'avatar')
-    setAvatarFile(file)
-    setAvatarPreview(URL.createObjectURL(file))
-    setAvatarSource(null)
-  }
 
   const trimmedName = displayName.trim()
   const canSubmit = trimmedName.length > 0 && !submitting
@@ -133,7 +121,8 @@ export function useCreateCharacter(): CreateCharacterState {
     avatarPreview,
     avatarSource,
     setAvatarSource,
-    handleFile,
+    avatarError,
+    handleAvatarChange,
     handleAvatarConfirm,
     error,
     submitting,

--- a/frontend/src/pages/characterPaths/useEditCharacter.ts
+++ b/frontend/src/pages/characterPaths/useEditCharacter.ts
@@ -9,7 +9,7 @@ import {
 } from '../../api/characters'
 import { useAuth } from '../../auth/AuthContext'
 import { extractError } from '../../utils/errors'
-import { blobToFile } from '../../components/imageEdit/imageEditHelpers'
+import { useAvatarPicker } from './useAvatarPicker'
 
 /**
  * Shared read/write model for Edit Character, lifted out of EditCharacter so the
@@ -17,9 +17,10 @@ import { blobToFile } from '../../components/imageEdit/imageEditHelpers'
  * editable fields (display_name, bio, location), the avatar upload, delete, and
  * validation live here; skins are presentation-only. `@handle` is the
  * auto-derived unique username (ADR-0019) — read-only, never an input.
+ *
+ * Avatar pick/crop/preview/validate is delegated to {@link useAvatarPicker}, the
+ * single source shared with create so the preview can't drift away again (#985).
  */
-
-const MAX_AVATAR_SIZE = 10 * 1024 * 1024 // 10 MB
 
 export interface EditCharacterState {
   id: string | undefined
@@ -35,6 +36,7 @@ export interface EditCharacterState {
   avatarFile: File | null
   avatarSource: File | null
   setAvatarSource: (file: File | null) => void
+  avatarPreview: string | null
   avatarError: string
   handleAvatarChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   handleAvatarConfirm: (blob: Blob) => void
@@ -53,31 +55,22 @@ export function useEditCharacter(): EditCharacterState {
   const [displayName, setDisplayName] = useState('')
   const [bio, setBio] = useState('')
   const [location, setLocation] = useState('')
-  const [avatarFile, setAvatarFile] = useState<File | null>(null)
-  const [avatarSource, setAvatarSource] = useState<File | null>(null) // in the crop modal
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(true)
-  const [avatarError, setAvatarError] = useState('')
 
-  const handleAvatarChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const f = e.target.files?.[0] || null
-    e.target.value = ''
-    if (!f) return
-    if (f.size > MAX_AVATAR_SIZE) {
-      setAvatarError('Avatar must be under 10 MB.')
-      return
-    }
-    setAvatarError('')
-    // Crop/rotate to a square before it becomes the avatar (#514).
-    setAvatarSource(f)
-  }
-
-  const handleAvatarConfirm = (blob: Blob) => {
-    setAvatarFile(blobToFile(blob, avatarSource?.name ?? 'avatar'))
-    setAvatarSource(null)
-  }
+  // Avatar pick/crop/preview/validate — shared with create (#985).
+  const {
+    avatarFile,
+    avatarSource,
+    setAvatarSource,
+    avatarPreview,
+    avatarError,
+    setAvatarError,
+    handleAvatarChange,
+    handleAvatarConfirm,
+  } = useAvatarPicker()
 
   useEffect(() => {
     if (!id) return
@@ -100,11 +93,19 @@ export function useEditCharacter(): EditCharacterState {
     if (!id || !character) return
     setSaving(true)
     setError('')
-    try {
-      const characterId = parseInt(id, 10)
-      if (avatarFile) {
+    const characterId = parseInt(id, 10)
+    // Avatar upload failures are avatar-scoped, not a generic save error (#985),
+    // so they surface next to the portrait rather than at the bottom of the form.
+    if (avatarFile) {
+      try {
         await uploadCharacterAvatar(characterId, avatarFile)
+      } catch (err) {
+        setAvatarError(extractError(err, 'Could not upload avatar.'))
+        setSaving(false)
+        return
       }
+    }
+    try {
       const updated = await updateCharacter(characterId, {
         display_name: displayName,
         bio: bio || undefined,
@@ -148,6 +149,7 @@ export function useEditCharacter(): EditCharacterState {
     avatarFile,
     avatarSource,
     setAvatarSource,
+    avatarPreview,
     avatarError,
     handleAvatarChange,
     handleAvatarConfirm,


### PR DESCRIPTION
## Problem
Editing an **existing** character: picking a new avatar showed no change and no success/failure indicator — the image only appeared after a page refresh. New-character creation was fine.

**Root cause:** the avatar pick/crop/preview/validate/upload state was copy-pasted across `useCreateCharacter` and `useEditCharacter`, and the two copies drifted. The edit copy never built an `avatarPreview`, so its views rendered only the persisted `character.avatar_url`; the real upload ran on Save → refetch → navigate, so the new avatar only appeared after landing back on the profile (the "refresh").

## Fix (owner call — ONE shared hook, not two copies)
- **New `useAvatarPicker` hook** (`frontend/src/pages/characterPaths/useAvatarPicker.ts`) owns the whole lifecycle: hidden file-input `handleAvatarChange`, crop-confirm `handleAvatarConfirm(blob)`, `avatarSource`, `avatarFile`, **`avatarPreview`** (object URL created on confirm and revoked on replace/unmount via an exported `createObjectUrlSlot`), the >10MB validation, and `avatarError`.
- **`useCreateCharacter` and `useEditCharacter` both consume it** — their duplicated avatar state/handlers are deleted. Create's behavior is unchanged; edit inherits the preview + avatar-scoped error.
- **Views render `avatarPreview ?? persisted avatar`** in the portrait circle: desktop `CreateCharacter.tsx` / `EditCharacter.tsx` and mobile `DefaultCreateCharacter` / `DefaultEditCharacter`.
- **Edit avatar-upload failures now set `avatarError`** (previously fell into the generic `error`), so the message shows next to the circle. Create now surfaces its >10MB error via `avatarError` beside the file input as well.
- Crop UI (`ImageEditModal` + `imageEditHelpers`) unchanged; praxis-media uploads deliberately not folded in.

## Tests
- New unit check on the preview lifecycle: `createObjectUrlSlot` mints a URL on confirm and **revokes the prior one** when replaced (spies on `URL.createObjectURL`/`revokeObjectURL`); unmount revoke releases the outstanding URL once.
- New view assertion: `DefaultEditCharacter` renders the `avatarPreview` object URL over a stale persisted `avatar_url`.
- Existing character-path tests updated for the shared surface (`handleAvatarChange`, `avatarError`, `avatarPreview`).

## Verify
`tsc --noEmit` clean (only the known `node:*` stale-junction false alarm remains), `eslint` clean, `vite build` OK, full vitest suite green (1532 passed). Both hooks grepped: no duplicated avatar state, both delegate to `useAvatarPicker`.

**Visual QA outstanding** — no dev stack / screenshots available in this environment.

## What to eyeball
- Edit an existing character → pick a new avatar → the circle updates **immediately, before Save** (no refresh needed).
- Edit → pick a >10MB file → an avatar-scoped error appears next to the circle.
- Create a character → avatar pick/crop/preview flow is unchanged.

Closes #985