### PR TITLE
Gate duel praxis until seal + label the duel rail by viewer (#999)

### DIFF
--- a/backend/routers/comments.py
+++ b/backend/routers/comments.py
@@ -35,7 +35,7 @@ async def list_praxis_comments(
     # A draft's discussion is member-only too (ADR-0024): mirror the detail 404
     # so the comments on an in_progress praxis don't leak to non-members.
     praxis = await get_praxis(praxis_id, session)
-    if not can_view_praxis(viewer, praxis):
+    if not await can_view_praxis(viewer, praxis, session):
         raise HTTPException(status_code=404, detail="Praxis not found.")
     comments = await list_comments(praxis_id=praxis_id, session=session)
     return [build_comment_out(c) for c in comments]

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -190,7 +190,7 @@ async def get_praxis_route(
     praxis = await get_praxis(praxis_id, session)
     # 404 (not 403) when not viewable — don't reveal existence of hidden or
     # of another character's in_progress draft (ADR-0024).
-    if not can_view_praxis(viewer, praxis):
+    if not await can_view_praxis(viewer, praxis, session):
         raise HTTPException(status_code=404, detail="Praxis not found.")
     return await build_praxis_out(praxis, session, viewer=viewer)
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Optional
 
 from fastapi import HTTPException
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, exists, func, not_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -550,12 +550,54 @@ async def get_praxis(
     return praxis
 
 
+# Statuses in which a duel is still live and its outcome incomplete: the
+# opponent has not yet committed a competing side (ADR-0011). While a duel sits
+# in one of these, a *submitted* side is author-only — revealing it early would
+# let the opponent crib the other body, or leak a private draft to spectators
+# (#999). Every terminal-ish state reveals: ``settled``/``resolved`` (both cast),
+# ``declined`` (no second party to protect), and forfeit (which keeps the duel
+# ``settled``) all fall outside this tuple.
+_LIVE_INCOMPLETE_DUEL_STATUSES = (DuelStatus.pending, DuelStatus.active)
+
+
+def _duel_side_hidden_condition(viewer_id: Optional[int]):
+    """SQL predicate — TRUE when the correlated ``Praxis`` row must be HIDDEN
+    because it is a side of a live, incomplete duel and ``viewer_id`` is not its
+    author (#999).
+
+    This is the single source of truth shared by BOTH visibility doors — the
+    ``/praxes/{id}`` detail gate (:func:`can_view_praxis`) and the feed/list
+    predicate (:func:`praxis_visibility_condition`). Keeping one helper means the
+    detail door and the feed predicate can never drift and leave the leak open on
+    one path while the other is patched. A submitted duel side is world-public
+    only once the duel seals (both cast) or otherwise terminates; until then only
+    its author may see it.
+    """
+    is_live_incomplete_side = exists(
+        select(Duel.id).where(
+            or_(
+                Duel.challenger_praxis_id == Praxis.id,
+                Duel.opponent_praxis_id == Praxis.id,
+            ),
+            Duel.status.in_(_LIVE_INCOMPLETE_DUEL_STATUSES),
+        )
+    )
+    if viewer_id is None:
+        # Anonymous / no character: never the author, so always hidden.
+        return is_live_incomplete_side
+    return and_(is_live_incomplete_side, Praxis.created_by_id != viewer_id)
+
+
 def praxis_visibility_condition(viewer_id: Optional[int]):
     """SQL predicate for who may see a praxis (ADR-0024).
 
     ``submitted`` praxes are public; an ``in_progress`` praxis is visible only to
     its members (character-scoped, matching ``_require_member``). Push this into
     the query so pagination stays honest instead of post-filtering a page.
+
+    Exception (#999): a ``submitted`` side of a live, incomplete duel stays
+    author-only until the duel seals — see :func:`_duel_side_hidden_condition`,
+    the same guard :func:`can_view_praxis` runs so the two doors can't drift.
     """
     visible = Praxis.status == PraxisStatus.submitted
     if viewer_id is not None:
@@ -563,7 +605,7 @@ def praxis_visibility_condition(viewer_id: Optional[int]):
             PraxisMember.character_id == viewer_id
         )
         visible = or_(visible, Praxis.id.in_(member_praxis_ids))
-    return visible
+    return and_(visible, not_(_duel_side_hidden_condition(viewer_id)))
 
 
 class PraxisSort(str, Enum):
@@ -1205,20 +1247,31 @@ async def delete_praxis(
     await session.flush()
 
 
-def can_view_praxis(viewer: Optional[Character], praxis: Praxis) -> bool:
+async def can_view_praxis(
+    viewer: Optional[Character], praxis: Praxis, session: AsyncSession
+) -> bool:
     """Whether ``viewer`` may see ``praxis`` (ADR-0024).
 
     - ``hidden`` (moderation) → never (mirror the existing hidden branch: 404).
-    - ``submitted`` → public.
+    - ``submitted`` → public, EXCEPT a live-incomplete duel side, which is
+      author-only until the duel seals (#999).
     - ``in_progress`` → members only (character-scoped, matching ``_require_member``;
       the account-vs-character question in #293 is deliberately not entangled here).
 
-    Reads only always-loaded columns/relationships (``members``), so it stays sync.
+    Async because the duel-seal gate needs a DB lookup. It evaluates the SAME
+    :func:`_duel_side_hidden_condition` the feed predicate uses, scoped to this
+    one row, so the detail door and the list door can never disagree.
     """
     if praxis.moderation_status == ModerationStatus.hidden:
         return False
     if praxis.status == PraxisStatus.submitted:
-        return True
+        viewer_id = viewer.id if viewer is not None else None
+        hidden = await session.scalar(
+            select(_duel_side_hidden_condition(viewer_id))
+            .select_from(Praxis)
+            .where(Praxis.id == praxis.id)
+        )
+        return not hidden
     if viewer is None:
         return False
     return viewer.id in {member.character_id for member in praxis.members}

--- a/backend/tests/integration/test_praxis_visibility.py
+++ b/backend/tests/integration/test_praxis_visibility.py
@@ -243,3 +243,259 @@ async def test_withdraw_settled_duel_side_forfeits(
     await db_session.refresh(duel)
     assert duel.status == DuelStatus.settled
     assert duel.forfeited_by_character_id == character.id
+
+
+# ---------------------------------------------------------------------------
+# Pre-seal duel-side exposure (#999) — a submitted duel side is author-only
+# while the duel is live and incomplete (pending/active); it reveals on seal.
+# ---------------------------------------------------------------------------
+
+
+async def _submitted_solo(
+    db_session: AsyncSession, task: Task, author: Character
+) -> Praxis:
+    """A *submitted* solo praxis authored by ``author`` (with its member row)."""
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=author.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.submitted,
+        title="Duel side",
+        body_text="secret proof",
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=praxis.id, character_id=author.id, has_submitted=True))
+    await db_session.commit()
+    await db_session.refresh(praxis)
+    return praxis
+
+
+@pytest.mark.asyncio
+async def test_active_incomplete_duel_side_is_author_only(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    auth_headers3: dict,
+):
+    """An `active` duel with only the challenger cast: that submitted side is
+    visible to its author only — not the opponent (no cribbing), not spectators.
+    Covers both doors: the /praxes/{id} detail gate and the feed list.
+    """
+    challenger_praxis = await _submitted_solo(db_session, active_task, character)
+    # Opponent accepted (praxis exists) but has NOT cast yet → duel is active.
+    opponent_praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character2.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        title="Opponent draft",
+        body_text="",
+    )
+    db_session.add(opponent_praxis)
+    await db_session.flush()
+    db_session.add(
+        PraxisMember(praxis_id=opponent_praxis.id, character_id=character2.id, has_submitted=False)
+    )
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_praxis_id=opponent_praxis.id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.active,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    cid = challenger_praxis.id
+
+    # Detail door: author 200; opponent AND spectator AND anon all 404.
+    assert (await client.get(f"/praxes/{cid}", headers=auth_headers)).status_code == 200
+    assert (await client.get(f"/praxes/{cid}", headers=auth_headers2)).status_code == 404
+    assert (await client.get(f"/praxes/{cid}", headers=auth_headers3)).status_code == 404
+    assert (await client.get(f"/praxes/{cid}")).status_code == 404
+
+    # Feed door: absent for opponent, spectator, anon; present for the author.
+    def _ids(resp):
+        return {p["id"] for p in resp.json()}
+
+    assert cid not in _ids(await client.get("/praxes", headers=auth_headers2))
+    assert cid not in _ids(await client.get("/praxes", headers=auth_headers3))
+    assert cid not in _ids(await client.get("/praxes"))
+    assert cid in _ids(await client.get("/praxes", headers=auth_headers))
+
+
+@pytest.mark.asyncio
+async def test_pending_duel_challenger_side_is_author_only(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A `pending` duel (opponent hasn't even accepted) whose challenger has cast:
+    the submitted side is still author-only until the duel seals."""
+    challenger_praxis = await _submitted_solo(db_session, active_task, character)
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.pending,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    cid = challenger_praxis.id
+    assert (await client.get(f"/praxes/{cid}", headers=auth_headers)).status_code == 200
+    assert (await client.get(f"/praxes/{cid}", headers=auth_headers2)).status_code == 404
+    assert cid not in {p["id"] for p in (await client.get("/praxes", headers=auth_headers2)).json()}
+
+
+@pytest.mark.asyncio
+async def test_settled_duel_both_sides_public(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    active_task: Task,
+    auth_headers3: dict,
+):
+    """Once a duel is `settled` (both cast) both bodies go public — a spectator
+    can open either side and both appear in the feed."""
+    challenger_praxis = await _submitted_solo(db_session, active_task, character)
+    opponent_praxis = await _submitted_solo(db_session, active_task, character2)
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_praxis_id=opponent_praxis.id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.settled,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    for pid in (challenger_praxis.id, opponent_praxis.id):
+        assert (await client.get(f"/praxes/{pid}", headers=auth_headers3)).status_code == 200
+    feed_ids = {p["id"] for p in (await client.get("/praxes", headers=auth_headers3)).json()}
+    assert {challenger_praxis.id, opponent_praxis.id} <= feed_ids
+
+
+@pytest.mark.asyncio
+async def test_forfeit_reveals_surviving_submitted_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    active_task: Task,
+    auth_headers3: dict,
+):
+    """A forfeited duel stays `settled`; the surviving submitted side is public
+    to spectators (the forfeiter's own side, being unsubmitted, is member-only
+    via the ordinary in_progress gate — ADR-0011)."""
+    survivor_praxis = await _submitted_solo(db_session, active_task, character2)
+    # Forfeiter withdrew their side → in_progress, hidden by the ordinary gate.
+    forfeiter_praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        title="Withdrawn side",
+        body_text="",
+    )
+    db_session.add(forfeiter_praxis)
+    await db_session.flush()
+    db_session.add(
+        PraxisMember(praxis_id=forfeiter_praxis.id, character_id=character.id, has_submitted=False)
+    )
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=forfeiter_praxis.id,
+        opponent_praxis_id=survivor_praxis.id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.settled,
+        forfeited_by_character_id=character.id,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    # Surviving submitted side: public to a spectator.
+    assert (
+        await client.get(f"/praxes/{survivor_praxis.id}", headers=auth_headers3)
+    ).status_code == 200
+    # Forfeiter's own in_progress side stays hidden (ordinary member-only gate).
+    assert (
+        await client.get(f"/praxes/{forfeiter_praxis.id}", headers=auth_headers3)
+    ).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_declined_duel_challenger_side_public(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers2: dict,
+):
+    """A `declined` duel reverts to a plain solo praxis — the challenger's
+    submitted side reveals as usual (no second party to protect)."""
+    challenger_praxis = await _submitted_solo(db_session, active_task, character)
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.declined,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    assert (
+        await client.get(f"/praxes/{challenger_praxis.id}", headers=auth_headers2)
+    ).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_can_view_and_list_service_gate_duel_side(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    active_task: Task,
+):
+    """Service-level assertions on the shared helper: `can_view_praxis` returns
+    False for non-authors of a live-incomplete duel side, and `list_praxes`
+    omits it for them while including it for the author."""
+    from services.praxis import can_view_praxis, list_praxes
+
+    challenger_praxis = await _submitted_solo(db_session, active_task, character)
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.active,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    # can_view_praxis: author yes; opponent, spectator, anon no.
+    assert await can_view_praxis(character, challenger_praxis, db_session) is True
+    assert await can_view_praxis(character2, challenger_praxis, db_session) is False
+    assert await can_view_praxis(character3, challenger_praxis, db_session) is False
+    assert await can_view_praxis(None, challenger_praxis, db_session) is False
+
+    # list_praxes: present for the author, absent for a spectator and for anon.
+    author_ids = {p.id for p in await list_praxes(db_session, viewer_id=character.id)}
+    spectator_ids = {p.id for p in await list_praxes(db_session, viewer_id=character3.id)}
+    anon_ids = {p.id for p in await list_praxes(db_session)}
+    assert challenger_praxis.id in author_ids
+    assert challenger_praxis.id not in spectator_ids
+    assert challenger_praxis.id not in anon_ids

--- a/frontend/src/components/duel/shared.tsx
+++ b/frontend/src/components/duel/shared.tsx
@@ -290,20 +290,30 @@ function RosterRow({
 /**
  * Per-side cast status, straight off `DuelSideOut.is_submitted` — the field that
  * has been on the wire since #313 and, until now, was never rendered anywhere.
+ *
+ * `spectator` (#999): a viewer who is not a party to the duel names BOTH sides by
+ * `display_name` — never "You". The seal-confirm skins always render for the
+ * caster (a party), so they leave it at the default and keep the "You" row.
  */
 export function RaceRoster({
   me,
   foe,
   theme,
+  spectator = false,
 }: {
   me: DuelSideOut
   foe: DuelSideOut
   theme: DuelSlotTheme
+  spectator?: boolean
 }) {
   const { t } = useTranslation('praxis')
   return (
     <ul className="flex flex-col gap-1 mt-2">
-      <RosterRow name={t('duelRoster.you')} cast={me.is_submitted} theme={theme} />
+      <RosterRow
+        name={spectator ? me.display_name : t('duelRoster.you')}
+        cast={me.is_submitted}
+        theme={theme}
+      />
       <RosterRow name={foe.display_name} cast={foe.is_submitted} theme={theme} />
     </ul>
   )
@@ -324,11 +334,19 @@ export function NextStepLine({
   me,
   foe,
   theme,
+  spectator = false,
 }: {
   duel: DuelDetailOut
   me: DuelSideOut
   foe: DuelSideOut
   theme: DuelSlotTheme
+  /**
+   * A viewer who is not a party to the duel (#999): every line is neutral
+   * third-person, keyed off the two sides' names, never "You". `me` is the
+   * challenger side under a spectator (the `duelSides` fallback), `foe` the
+   * opponent — so the names read correctly regardless of which page it renders on.
+   */
+  spectator?: boolean
 }) {
   const { t } = useTranslation('praxis')
   const style: CSSProperties = {
@@ -337,10 +355,20 @@ export function NextStepLine({
   }
 
   if (duel.forfeited_by_character_id != null) {
-    const iForfeited = duel.forfeited_by_character_id === me.character_id
+    const meForfeited = duel.forfeited_by_character_id === me.character_id
+    if (spectator) {
+      return (
+        <p style={style} className="mt-2 content-text">
+          {t('duelNextStep.spectator.wonByDefault', {
+            loser: meForfeited ? me.display_name : foe.display_name,
+            winner: meForfeited ? foe.display_name : me.display_name,
+          })}
+        </p>
+      )
+    }
     return (
       <p style={style} className="mt-2 content-text">
-        {iForfeited
+        {meForfeited
           ? t('duelNextStep.youForfeited')
           : t('duelNextStep.wonByDefault', { name: foe.display_name })}
       </p>
@@ -348,33 +376,64 @@ export function NextStepLine({
   }
 
   let line: string
-  switch (duel.status) {
-    case 'pending':
-      line = t('duelNextStep.pending', { name: foe.display_name })
-      break
-    case 'declined':
-      line = t('duelNextStep.declined', { name: foe.display_name })
-      break
-    case 'active':
-      // Both sides having cast is what SETTLES a duel, so inside `active` at
-      // most one side is submitted. Either they owe a cast, or you do.
-      line = me.is_submitted
-        ? t('duelNextStep.activeWaitingOnThem', { name: foe.display_name })
-        : t('duelNextStep.activeWaitingOnYou', { name: foe.display_name })
-      break
-    case 'settled':
-      line = t('duelNextStep.settled')
-      break
-    case 'resolved':
-      // The era closed and the outcome is frozen (ADR-0052). A null winner is a
-      // tie or a no-contest (an `active` duel that never became votable).
-      line =
-        duel.winner_character_id == null
-          ? t('duelNextStep.resolvedNoWinner')
-          : duel.winner_character_id === me.character_id
-            ? t('duelNextStep.resolvedYouWon', { name: foe.display_name })
-            : t('duelNextStep.resolvedYouLost', { name: foe.display_name })
-      break
+  if (spectator) {
+    switch (duel.status) {
+      case 'pending':
+        line = t('duelNextStep.spectator.pending', {
+          challenger: me.display_name,
+          opponent: foe.display_name,
+        })
+        break
+      case 'declined':
+        line = t('duelNextStep.spectator.declined', { opponent: foe.display_name })
+        break
+      case 'active':
+        line = t('duelNextStep.spectator.active')
+        break
+      case 'settled':
+        line = t('duelNextStep.spectator.settled')
+        break
+      case 'resolved':
+        line =
+          duel.winner_character_id == null
+            ? t('duelNextStep.spectator.resolvedNoWinner')
+            : t('duelNextStep.spectator.resolvedWon', {
+                name:
+                  duel.winner_character_id === me.character_id
+                    ? me.display_name
+                    : foe.display_name,
+              })
+        break
+    }
+  } else {
+    switch (duel.status) {
+      case 'pending':
+        line = t('duelNextStep.pending', { name: foe.display_name })
+        break
+      case 'declined':
+        line = t('duelNextStep.declined', { name: foe.display_name })
+        break
+      case 'active':
+        // Both sides having cast is what SETTLES a duel, so inside `active` at
+        // most one side is submitted. Either they owe a cast, or you do.
+        line = me.is_submitted
+          ? t('duelNextStep.activeWaitingOnThem', { name: foe.display_name })
+          : t('duelNextStep.activeWaitingOnYou', { name: foe.display_name })
+        break
+      case 'settled':
+        line = t('duelNextStep.settled')
+        break
+      case 'resolved':
+        // The era closed and the outcome is frozen (ADR-0052). A null winner is a
+        // tie or a no-contest (an `active` duel that never became votable).
+        line =
+          duel.winner_character_id == null
+            ? t('duelNextStep.resolvedNoWinner')
+            : duel.winner_character_id === me.character_id
+              ? t('duelNextStep.resolvedYouWon', { name: foe.display_name })
+              : t('duelNextStep.resolvedYouLost', { name: foe.display_name })
+        break
+    }
   }
 
   return (

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -504,7 +504,20 @@
     },
     "final": "{{standing}} · final — frozen at era close.",
     "finalNoContest": "No contest — this duel never became votable before era close.",
-    "factionSuffix": " · {{faction}}"
+    "factionSuffix": " · {{faction}}",
+    "spectatorPending": "⚔ {{challenger}} challenged {{opponent}} — awaiting a response.",
+    "spectatorDueling": "⚔ {{challenger}} vs {{opponent}} — dueling",
+    "spectatorWonByDefault": "⚔ {{winner}} won by default — {{loser}} forfeited.",
+    "spectatorStanding": {
+      "tied": "Tied",
+      "leads": "{{name}} leads"
+    },
+    "spectatorLive": "{{standing}} · live — the winner floats with the votes until era reset.",
+    "spectatorFinalStanding": {
+      "tied": "Tied",
+      "won": "{{name}} won"
+    },
+    "spectatorFinal": "{{standing}} · final — frozen at era close."
   },
   "duelStakes": {
     "heading": "What's at stake",
@@ -529,7 +542,16 @@
     "resolvedYouLost": "The era closed — {{name}} won this duel.",
     "resolvedNoWinner": "The era closed — this duel resolved with no winner.",
     "youForfeited": "You forfeited this duel.",
-    "wonByDefault": "{{name}} forfeited — you won by default."
+    "wonByDefault": "{{name}} forfeited — you won by default.",
+    "spectator": {
+      "pending": "{{challenger}} challenged {{opponent}} — awaiting a response.",
+      "declined": "{{opponent}} declined — no duel.",
+      "active": "The duel is underway — one side still to cast.",
+      "settled": "Both sides are in. The winner floats with the votes until era reset.",
+      "resolvedWon": "The era closed — {{name}} won this duel.",
+      "resolvedNoWinner": "The era closed — this duel resolved with no winner.",
+      "wonByDefault": "{{loser}} forfeited — {{winner}} won by default."
+    }
   },
   "duelSeal": {
     "heading": "Seal the duel?",

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -50,7 +50,14 @@ export default function PraxisDetail() {
     <>
       {/* Duel cross-link is neutral chrome above every archetype (#313); one
           shared faction-tokened widget, per the grilled #310 decision. */}
-      {state.duel && <DuelCrossLink praxis={state.praxis} duel={state.duel} state={state} />}
+      {state.duel && (
+        <DuelCrossLink
+          praxis={state.praxis}
+          duel={state.duel}
+          state={state}
+          viewerCharacterId={state.user?.character?.id ?? null}
+        />
+      )}
       <Archetype state={state} />
       {/* Comments are neutral chrome below every archetype (ADR-0006); a thread
           renders on a visible praxis only. Mounted at the dispatcher so it covers

--- a/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCrossLink.tsx
@@ -42,6 +42,7 @@ import {
   NextStepLine,
   RaceRoster,
   StakesTiles,
+  duelSides,
   type DuelSlotTheme,
 } from "../../components/duel/shared";
 import type { PraxisDetailState } from "./usePraxisDetail";
@@ -201,6 +202,7 @@ export default function DuelCrossLink({
   praxis,
   duel,
   state,
+  viewerCharacterId = null,
 }: {
   praxis: PraxisOut;
   duel: DuelDetailOut;
@@ -210,11 +212,26 @@ export default function DuelCrossLink({
    * lifecycle tests mount the rail without it, in which case `actions` stays null.
    */
   state?: PraxisDetailState;
+  /**
+   * The VIEWER's own character id (#999) — the seam that decides who is "You".
+   * Threaded from `usePraxisDetail`'s authed user at the mount site. `null` for
+   * an anonymous viewer.
+   */
+  viewerCharacterId?: number | null;
 }) {
   const { t } = useTranslation("praxis");
-  const isChallenger = praxis.id === duel.challenger.praxis_id;
-  const me: DuelSideOut = isChallenger ? duel.challenger : duel.opponent;
-  const foe: DuelSideOut = isChallenger ? duel.opponent : duel.challenger;
+  // Label by the VIEWER, not by which page we are on (#999). `duelSides` resolves
+  // "my side" from the viewer's character id; `viewer_is_participant` (backend,
+  // account-level) decides party-vs-spectator. The old
+  // `praxis.id === duel.challenger.praxis_id` cast whoever's page you were on as
+  // "You" — so a spectator on the challenger's page, or the opponent viewing the
+  // challenger's page, both saw the wrong side labelled "You". A spectator now
+  // gets neutral, named sides with no "You" copy; a party sees "You" on their own
+  // side from EITHER page (for a spectator `me` is the challenger, `foe` the
+  // opponent — the `duelSides` fallback — so the neutral copy reads correctly).
+  const spectator = !duel.viewer_is_participant;
+  const { me, foe } = duelSides(duel, viewerCharacterId);
+  const meIsChallenger = me.character_id === duel.challenger.character_id;
 
   const accent = factionCssVar(foe.faction_slug);
   const soft = factionCssVar(foe.faction_slug, "light");
@@ -269,18 +286,26 @@ export default function DuelCrossLink({
   // The rail body every live state shares: who has cast, what happens next, and
   // what it's worth. The slots own every branch inside them. `settled` passes
   // nextStep={false} — its own "live" standing line already says the same thing.
+  //
+  // A spectator (#999) gets the neutral roster + status line, but NOT the stakes:
+  // StakesTiles is inherently first-person ("If you win / If you lose"), a figure
+  // only a party has any stake in, so it is suppressed for a neutral observer.
   const body = (nextStep: boolean) => (
     <>
-      <RaceRoster me={me} foe={foe} theme={theme} />
-      {nextStep && <NextStepLine duel={duel} me={me} foe={foe} theme={theme} />}
-      <StakesTiles
-        viewerFactionSlug={me.faction_slug}
-        opponentFactionSlug={foe.faction_slug}
-        opponentName={foe.display_name}
-        taskPointValue={praxis.task_point_value}
-        status={duel.status}
-        theme={theme}
-      />
+      <RaceRoster me={me} foe={foe} theme={theme} spectator={spectator} />
+      {nextStep && (
+        <NextStepLine duel={duel} me={me} foe={foe} theme={theme} spectator={spectator} />
+      )}
+      {!spectator && (
+        <StakesTiles
+          viewerFactionSlug={me.faction_slug}
+          opponentFactionSlug={foe.faction_slug}
+          opponentName={foe.display_name}
+          taskPointValue={praxis.task_point_value}
+          status={duel.status}
+          theme={theme}
+        />
+      )}
     </>
   );
 
@@ -288,7 +313,30 @@ export default function DuelCrossLink({
   // forfeit can land on a duel in any live state. The foe link 404s if the
   // thrown side was withdrawn — a plain <Link>, so it never breaks this page.
   if (forfeited) {
-    const iForfeited = duel.forfeited_by_character_id === me.character_id;
+    const meForfeited = duel.forfeited_by_character_id === me.character_id;
+    if (spectator) {
+      // Neutral: name the winner (the survivor) and the forfeiter. No link — the
+      // forfeiter's thrown side may be unsubmitted (404), and the survivor's side
+      // is often the very page this rail sits on.
+      return (
+        <Skin
+          {...frame}
+          tally={null}
+          note={null}
+          body={null}
+          actions={null}
+          headline={
+            <span>
+              {t("duelCrossLink.spectatorWonByDefault", {
+                winner: meForfeited ? foe.display_name : me.display_name,
+                loser: meForfeited ? me.display_name : foe.display_name,
+              })}
+            </span>
+          }
+        />
+      );
+    }
+    const iForfeited = meForfeited;
     return (
       <Skin
         {...frame}
@@ -331,7 +379,14 @@ export default function DuelCrossLink({
         tally={null}
         note={null}
         headline={
-          <span>{t("duelCrossLink.pending", { name: foe.display_name })}</span>
+          <span>
+            {spectator
+              ? t("duelCrossLink.spectatorPending", {
+                  challenger: me.display_name,
+                  opponent: foe.display_name,
+                })
+              : t("duelCrossLink.pending", { name: foe.display_name })}
+          </span>
         }
         body={body(true)}
         actions={actions}
@@ -367,7 +422,12 @@ export default function DuelCrossLink({
         note={null}
         headline={
           <span style={{ fontWeight: 700 }}>
-            {t("duelCrossLink.dueling", { name: foe.display_name })}
+            {spectator
+              ? t("duelCrossLink.spectatorDueling", {
+                  challenger: me.display_name,
+                  opponent: foe.display_name,
+                })
+              : t("duelCrossLink.dueling", { name: foe.display_name })}
           </span>
         }
         body={body(true)}
@@ -376,6 +436,24 @@ export default function DuelCrossLink({
     );
   }
 
+  // The settled/resolved headline: "⚔ Duel vs {opponent}". For a spectator it
+  // names BOTH sides ("⚔ Duel {challenger} vs {opponent}") so no side reads as an
+  // implicit "you" (#999). The cross-link always points at the OTHER side (`foe`).
+  const duelHeadline = (
+    <span>
+      <span style={{ fontWeight: 700 }}>{t("duelCrossLink.duel")}</span>{" "}
+      {spectator && <>{me.display_name} </>}
+      {t("duelCrossLink.vs")}{" "}
+      {foe.praxis_id != null ? (
+        <Link to={`/praxes/${foe.praxis_id}`} style={{ color: accent }}>
+          <OpponentBadge side={foe} />
+        </Link>
+      ) : (
+        <OpponentBadge side={foe} />
+      )}
+    </span>
+  );
+
   // resolved: the era closed and the outcome was FROZEN (ADR-0052, #957). Render
   // the frozen final points + winner, never the live vote tally — the standing
   // must not keep floating under a reader after the contest is over (which is
@@ -383,15 +461,23 @@ export default function DuelCrossLink({
   // became votable resolves as a no-contest: null winner AND null final points,
   // so there is no frozen pair to show.
   if (duel.status === "resolved") {
-    const myFinal = isChallenger
+    const myFinal = meIsChallenger
       ? duel.challenger_final_points
       : duel.opponent_final_points;
-    const foeFinal = isChallenger
+    const foeFinal = meIsChallenger
       ? duel.opponent_final_points
       : duel.challenger_final_points;
     const hasTally = myFinal != null && foeFinal != null;
-    const finalStanding =
-      duel.winner_character_id == null
+    const finalStanding = spectator
+      ? duel.winner_character_id == null
+        ? t("duelCrossLink.spectatorFinalStanding.tied")
+        : t("duelCrossLink.spectatorFinalStanding.won", {
+            name:
+              duel.winner_character_id === me.character_id
+                ? me.display_name
+                : foe.display_name,
+          })
+      : duel.winner_character_id == null
         ? t("duelCrossLink.finalStanding.tied")
         : duel.winner_character_id === me.character_id
         ? t("duelCrossLink.finalStanding.won")
@@ -399,19 +485,7 @@ export default function DuelCrossLink({
     return (
       <Skin
         {...frame}
-        headline={
-          <span>
-            <span style={{ fontWeight: 700 }}>{t("duelCrossLink.duel")}</span>{" "}
-            {t("duelCrossLink.vs")}{" "}
-            {foe.praxis_id != null ? (
-              <Link to={`/praxes/${foe.praxis_id}`} style={{ color: accent }}>
-                <OpponentBadge side={foe} />
-              </Link>
-            ) : (
-              <OpponentBadge side={foe} />
-            )}
-          </span>
-        }
+        headline={duelHeadline}
         tally={
           /* The FROZEN score pair — a number the player cares about, so content
              tier (.content-title), mirroring the settled tally but never moving. */
@@ -426,7 +500,9 @@ export default function DuelCrossLink({
         note={
           <div className="content-text" style={{ marginTop: "var(--space-xs)", opacity: 0.85 }}>
             {hasTally
-              ? t("duelCrossLink.final", { standing: finalStanding })
+              ? t(spectator ? "duelCrossLink.spectatorFinal" : "duelCrossLink.final", {
+                  standing: finalStanding,
+                })
               : t("duelCrossLink.finalNoContest")}
           </div>
         }
@@ -437,9 +513,15 @@ export default function DuelCrossLink({
   }
 
   // settled: both sides cast. Live tally + cross-link, on top of the shared body.
+  // A spectator sees who LEADS by name, never "you're ahead/behind" (#999).
   const diff = me.points_from_votes - foe.points_from_votes;
-  const standing =
-    diff === 0
+  const standing = spectator
+    ? diff === 0
+      ? t("duelCrossLink.spectatorStanding.tied")
+      : t("duelCrossLink.spectatorStanding.leads", {
+          name: diff > 0 ? me.display_name : foe.display_name,
+        })
+    : diff === 0
       ? t("duelCrossLink.standing.tied")
       : diff > 0
       ? t("duelCrossLink.standing.ahead")
@@ -447,19 +529,7 @@ export default function DuelCrossLink({
   return (
     <Skin
       {...frame}
-      headline={
-        <span>
-          <span style={{ fontWeight: 700 }}>{t("duelCrossLink.duel")}</span>{" "}
-          {t("duelCrossLink.vs")}{" "}
-          {foe.praxis_id != null ? (
-            <Link to={`/praxes/${foe.praxis_id}`} style={{ color: accent }}>
-              <OpponentBadge side={foe} />
-            </Link>
-          ) : (
-            <OpponentBadge side={foe} />
-          )}
-        </span>
-      }
+      headline={duelHeadline}
       tally={
         /* A live score pair: a number the player cares about, so content tier
            (.content-title) rather than whatever the frame happens to set. */
@@ -471,7 +541,7 @@ export default function DuelCrossLink({
       }
       note={
         <div className="content-text" style={{ marginTop: "var(--space-xs)", opacity: 0.85 }}>
-          {t("duelCrossLink.live", { standing })}
+          {t(spectator ? "duelCrossLink.spectatorLive" : "duelCrossLink.live", { standing })}
         </div>
       }
       body={body(false)}

--- a/frontend/src/pages/praxisDetail/__tests__/DuelCrossLink.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/DuelCrossLink.test.tsx
@@ -5,6 +5,13 @@
  * #717 regression: pending and declined used to fall through to the settled
  * renderer, showing a live tally against someone who hadn't accepted or said no.
  * One case per DuelStatus below — the tally must appear for settled only.
+ *
+ * #999: labels key off the VIEWER, not the page. The default viewer here is a
+ * PARTICIPANT whose own side is the challenger (ME), so the first-person copy
+ * ("You've cast", "You won") is correct party copy — it used to be asserted
+ * against a hardcoded `viewer_is_participant: false`, which encoded the very bug
+ * this issue fixes. Dedicated spectator tests (no "You") and a wrong-page party
+ * test live at the bottom.
  */
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
@@ -37,6 +44,9 @@ const FOE: DuelSideOut = {
 // The read page always renders "my" side; id matches the challenger praxis.
 const PRAXIS = { id: 10 } as PraxisOut;
 
+// A spectator character who is neither side of the duel.
+const SPECTATOR_ID = 99;
+
 function duel(over: Partial<DuelDetailOut>): DuelDetailOut {
   return {
     id: 5,
@@ -45,7 +55,9 @@ function duel(over: Partial<DuelDetailOut>): DuelDetailOut {
     forfeited_by_character_id: null,
     challenger: ME,
     opponent: FOE,
-    viewer_is_participant: false,
+    // The default viewer is a PARTICIPANT (their side is the challenger, ME), so
+    // the first-person lifecycle copy below is correct party copy (#999).
+    viewer_is_participant: true,
     winner_character_id: null,
     challenger_final_points: null,
     opponent_final_points: null,
@@ -53,13 +65,17 @@ function duel(over: Partial<DuelDetailOut>): DuelDetailOut {
   };
 }
 
-function text(d: DuelDetailOut): string {
-  const html = renderToStaticMarkup(
+// Render as ME (the challenger) by default — a party whose own side is ME.
+function html(d: DuelDetailOut, viewerCharacterId: number | null = ME.character_id): string {
+  return renderToStaticMarkup(
     <MemoryRouter>
-      <DuelCrossLink praxis={PRAXIS} duel={d} />
+      <DuelCrossLink praxis={PRAXIS} duel={d} viewerCharacterId={viewerCharacterId} />
     </MemoryRouter>,
   );
-  return html.replace(/<[^>]*>/g, "");
+}
+
+function text(d: DuelDetailOut, viewerCharacterId: number | null = ME.character_id): string {
+  return html(d, viewerCharacterId).replace(/<[^>]*>/g, "");
 }
 
 // What the backend actually returns pre-accept (services/duel.py:107-118): the
@@ -73,16 +89,9 @@ const UNANSWERED_FOE: DuelSideOut = {
 
 describe("DuelCrossLink", () => {
   it("pending: says the challenge is unanswered, with no tally (#717)", () => {
-    const html = renderToStaticMarkup(
-      <MemoryRouter>
-        <DuelCrossLink
-          praxis={PRAXIS}
-          duel={duel({ status: "pending", opponent: UNANSWERED_FOE })}
-        />
-      </MemoryRouter>,
-    );
-    expect(html).not.toMatch(/href="\/praxes\//); // nothing to cross-link to
-    const t = html.replace(/<[^>]*>/g, "");
+    const h = html(duel({ status: "pending", opponent: UNANSWERED_FOE }));
+    expect(h).not.toMatch(/href="\/praxes\//); // nothing to cross-link to
+    const t = h.replace(/<[^>]*>/g, "");
     expect(t).toMatch(/waiting for Bob to accept/i);
     expect(t).not.toMatch(/ahead|behind|tied|live/i);
   });
@@ -101,13 +110,9 @@ describe("DuelCrossLink", () => {
   });
 
   it("settled: shows the live tally and who's ahead", () => {
-    const html = renderToStaticMarkup(
-      <MemoryRouter>
-        <DuelCrossLink praxis={PRAXIS} duel={duel({})} />
-      </MemoryRouter>,
-    );
-    expect(html).toMatch(/href="\/praxes\/20"/); // cross-link to opponent
-    const t = html.replace(/<[^>]*>/g, "");
+    const h = html(duel({}));
+    expect(h).toMatch(/href="\/praxes\/20"/); // cross-link to opponent
+    const t = h.replace(/<[^>]*>/g, "");
     expect(t).toMatch(/ahead/i); // 12 > 7
     expect(t).toMatch(/12/);
     expect(t).toMatch(/7/);
@@ -127,22 +132,17 @@ describe("DuelCrossLink", () => {
   // ── #957 resolved: frozen final points + winner, never the live tally ───────
 
   it("resolved: shows the FROZEN final points, not the live tally", () => {
-    const html = renderToStaticMarkup(
-      <MemoryRouter>
-        <DuelCrossLink
-          praxis={PRAXIS}
-          duel={duel({
-            status: "resolved",
-            winner_character_id: ME.character_id,
-            // Frozen values deliberately differ from the live points_from_votes
-            // (12 / 7) so a live-tally fallthrough would fail this test.
-            challenger_final_points: 9,
-            opponent_final_points: 4,
-          })}
-        />
-      </MemoryRouter>,
+    const h = html(
+      duel({
+        status: "resolved",
+        winner_character_id: ME.character_id,
+        // Frozen values deliberately differ from the live points_from_votes
+        // (12 / 7) so a live-tally fallthrough would fail this test.
+        challenger_final_points: 9,
+        opponent_final_points: 4,
+      }),
     );
-    const t = html.replace(/<[^>]*>/g, "");
+    const t = h.replace(/<[^>]*>/g, "");
     expect(t).toMatch(/9/);
     expect(t).toMatch(/4/);
     expect(t).not.toMatch(/12/); // the live tally must NOT appear
@@ -218,5 +218,72 @@ describe("DuelCrossLink", () => {
   it("declined: stops at the verdict — no roster, no race to run", () => {
     const t = text(duel({ status: "declined", opponent: UNANSWERED_FOE }));
     expect(t).not.toMatch(/sealed|still walking/i);
+  });
+
+  // ── #999 viewer-keyed labelling ─────────────────────────────────────────────
+  // A spectator (viewer_is_participant: false) gets neutral, named sides and NO
+  // "You" copy; a party sees "You" on THEIR own side regardless of the page.
+
+  it("spectator, settled: neutral named sides, no 'You', names the leader", () => {
+    const t = text(
+      duel({ viewer_is_participant: false }),
+      SPECTATOR_ID,
+    );
+    expect(t).not.toMatch(/\byou\b/i); // never first-person for a spectator
+    expect(t).not.toMatch(/you're ahead|you're behind/i);
+    expect(t).toMatch(/Alice/); // both sides named
+    expect(t).toMatch(/Bob/);
+    expect(t).toMatch(/Alice leads/i); // 12 > 7, named — not "you're ahead"
+  });
+
+  it("spectator, resolved: names the winner, no 'You'", () => {
+    const t = text(
+      duel({
+        viewer_is_participant: false,
+        status: "resolved",
+        winner_character_id: FOE.character_id,
+        challenger_final_points: 4,
+        opponent_final_points: 9,
+      }),
+      SPECTATOR_ID,
+    );
+    expect(t).not.toMatch(/\byou\b/i);
+    expect(t).toMatch(/Bob won/i);
+    expect(t).toMatch(/final/i);
+  });
+
+  it("spectator, forfeited: neutral won-by-default, no 'You'", () => {
+    const t = text(
+      duel({
+        viewer_is_participant: false,
+        forfeited_by_character_id: ME.character_id, // Alice (challenger) forfeited
+      }),
+      SPECTATOR_ID,
+    );
+    expect(t).not.toMatch(/\byou\b/i);
+    expect(t).toMatch(/Bob won by default/i);
+    expect(t).toMatch(/Alice forfeited/i);
+  });
+
+  it("party on the opponent's-eye view: 'You' follows the viewer, not the page", () => {
+    // Viewer is Bob (the opponent, character_id 2) but rendering ON THE
+    // CHALLENGER'S page (PRAXIS.id === 10 === Alice's praxis). "You" must land on
+    // Bob's side, not Alice's — the old page-keyed logic cast Alice as "You".
+    const t = text(
+      duel({
+        status: "active",
+        viewer_is_participant: true,
+        challenger: { ...ME, is_submitted: true }, // Alice has cast
+        opponent: { ...FOE, is_submitted: false }, // Bob (the viewer) has not
+      }),
+      FOE.character_id,
+    );
+    // Bob is "You" now, so his name is replaced by "You"; Alice is the named foe.
+    // (Tag-stripping glues words together, so no \b word boundary around "You".)
+    expect(t).not.toMatch(/Bob/);
+    expect(t).toMatch(/Alice/);
+    expect(t).toMatch(/You/);
+    // Viewer (Bob) hasn't cast → the next step is his.
+    expect(t).toMatch(/Cast your praxis to seal the duel/i);
   });
 });


### PR DESCRIPTION
Two bugs, one root cause: the duel surface never distinguished a **party** from a **spectator**, at either layer.

## Part A — Backend: submitted duel side leaked before the duel sealed
A submitted duel side went world-public the instant its own author cast, never consulting duel state — a spectator (or the opponent, pre-cast) could read it during a live, incomplete duel. Both visibility doors leaked independently.

- New shared guard `_duel_side_hidden_condition(viewer_id)` in `services/praxis.py`: a submitted side of a `pending`/`active` duel is visible to its **author only**.
- **Both** doors call it — `can_view_praxis` (the `/praxes/{id}` detail gate, now `async` for the duel lookup) and `praxis_visibility_condition` (the feed/list SQL predicate) — so the detail gate and the feed predicate can't drift.
- Reveal on `settled` (both cast), `resolved`, `declined`, or **forfeit** (which keeps the duel `settled`). The forfeiter's own withdrawn side stays hidden via the ordinary `in_progress` member-only gate (ADR-0011).
- Callers in `routers/praxes.py` and `routers/comments.py` now `await` it with the session.

## Part B — Frontend: duel panel said "You" by page, not by viewer
`DuelCrossLink` derived me/foe from which praxis **page** you were on, so a spectator on the challenger's page was cast as "You", and the opponent viewing the challenger's page saw the wrong side as "You".

- Labels now key off the **viewer's character id** via the existing `duelSides(duel, viewerCharacterId)`, honouring the backend `viewer_is_participant` flag (threaded from `usePraxisDetail`'s authed user at the mount).
- **Party**: "You" on their own side, from either page. **Spectator**: neutral, named sides + a spectator-framed status line, no "You" copy, and no first-person `StakesTiles`.
- `RaceRoster`/`NextStepLine` gain an additive `spectator` prop (default preserves the seal-confirm skins' party behaviour). Neutral copy added under `duelCrossLink.spectator*` / `duelNextStep.spectator`.

## Tests
- **Backend** (`wz999_test`): active/pending-incomplete duel → non-author (spectator **and** opponent) gets `can_view_praxis`=False and the side is absent from `list_praxes`; author sees own. Settled → both public. Forfeit → surviving submitted side public, forfeiter's own side hidden. Declined → challenger's side public. Plus a service-level assertion on the shared helper. All existing duel/praxis/vote/comment suites green (238+ tests).
- **Frontend**: spectator on a sealed duel → neutral named sides, no "You"; party sees "You" on **their** side even when rendered on the opponent's page. The lifecycle suite's default viewer is now a participant (its first-person copy is correct party copy — it previously asserted "You" against a hardcoded `viewer_is_participant: false`, which encoded the bug). `tsc` clean (only the known `node:` junction false alarm), eslint clean, `vite build` OK, 1534 vitest passed.

## What to eyeball (visual QA outstanding — no dev stack in this environment)
- As a **spectator**, you CANNOT open a duel side until it seals (404 during the live-incomplete window).
- The duel panel **never says "You" to a spectator** — both sides show by name with a neutral status line.
- A **participant** sees "You" on their own side from **either** page (their own or the opponent's).
- After **seal**, both sides are public and openable.

Closes #999