### PR TITLE
Hide the vote module for logged-in viewers who can't vote (#998)

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -69,7 +69,7 @@ from services.praxis import (
     unsubmit_praxis,
 )
 from services.media import process_and_save_media
-from services.vote import cast_vote_on_praxis
+from services.vote import cast_vote_on_praxis, viewer_can_vote_map
 from services.vote_tally import crowned_praxis_ids, viewer_votes_for
 
 logger = logging.getLogger(__name__)
@@ -166,6 +166,10 @@ async def list_praxes_route(
     # metatask's issuing faction, so it needs the TaskOut rows, not just the
     # summed metatask_points the card already carries.
     applied_metatasks = await applied_metatasks_for(praxes, session)
+    # Vote eligibility (#998): one ownership query + one duel query for the whole
+    # page — not the per-praxis predicate per card. Hides the vote module for a
+    # logged-in viewer who owns the praxis or is a participant in its duel.
+    viewer_can_vote = await viewer_can_vote_map(praxes, viewer, session)
     return [
         await build_praxis_card_out(
             praxis,
@@ -174,6 +178,7 @@ async def list_praxes_route(
             viewer_votes=viewer_votes,
             author_contributions=author_contributions,
             applied_metatasks=applied_metatasks,
+            viewer_can_vote=viewer_can_vote,
         )
         for praxis in praxes
     ]

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -79,6 +79,12 @@ class PraxisOut(BaseModel):
     duel_id: Optional[int] = None
     applied_metatasks: List[TaskOut] = []
     can_flag: bool = False      # populated by build_praxis_out; viewer-relative
+    # Viewer-relative (#998): False only when the viewer's account owns this
+    # praxis (author/collab co-owner, ADR-0013) or is a participant in its duel
+    # (#309) — the two PERMANENT vote blocks. Budget exhaustion is excluded (the
+    # module stays visible). Anonymous → True (client shows the login gate).
+    # Drives hiding the whole vote module for logged-in-but-ineligible viewers.
+    viewer_can_vote: bool = True
 
     model_config = {"from_attributes": True}
 
@@ -138,6 +144,9 @@ class PraxisCardOut(BaseModel):
     # viewer's account who voted this praxis, set only when the carried character
     # did not vote it. None otherwise (incl. anonymous). Computed, no column.
     voted_by_name: Optional[str] = None
+    # Viewer-relative (#998); see ``PraxisOut.viewer_can_vote``. Precomputed
+    # page-wide by the card-list route (no N+1) via ``viewer_can_vote_map``.
+    viewer_can_vote: bool = True
 
     model_config = {"from_attributes": True}
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -216,6 +216,14 @@ async def build_praxis_out(
 
     can_flag = await can_flag_praxis(viewer, praxis, session, era)
 
+    # Vote eligibility (#998): hide the whole vote module for a logged-in viewer
+    # who owns this praxis (A) or is a participant in its duel (B). Anonymous →
+    # True (the client shows its own login gate). Same predicate the vote
+    # endpoint enforces, so the UI cannot disagree with a 403.
+    from services.vote import viewer_can_vote as _viewer_can_vote
+
+    can_vote = await _viewer_can_vote(viewer, praxis, session)
+
     # Task Crown (ADR-0028): top submitted praxis for this task, computed live.
     if crowned_ids is None:
         crowned_ids = await crowned_praxis_ids([praxis.task_id], session)
@@ -267,6 +275,7 @@ async def build_praxis_out(
         duel_id=duel_id,
         can_flag=can_flag,
         applied_metatasks=applied_metatasks,
+        viewer_can_vote=can_vote,
     )
 
 
@@ -408,6 +417,7 @@ async def build_praxis_card_out(
     viewer_votes: Optional[dict[int, ViewerVote]] = None,
     author_contributions: Optional[dict[int, Contribution]] = None,
     applied_metatasks: Optional[dict[int, list[TaskOut]]] = None,
+    viewer_can_vote: Optional[dict[int, bool]] = None,
 ) -> PraxisCardOut:
     """Lightweight card for list views.
 
@@ -437,6 +447,11 @@ async def build_praxis_card_out(
     once via :func:`applied_metatasks_for` so the seal never becomes a per-card
     query (N+1). When absent, this builder loads the single praxis's metatasks
     itself (single-card callers). A missing entry means no metatasks applied.
+
+    ``viewer_can_vote`` maps praxis id → whether the viewer may vote (#998); list
+    routes precompute it once via :func:`~services.vote.viewer_can_vote_map` so
+    the ownership/duel-participation check is not a per-card query. ``None`` or a
+    missing entry defaults to ``True`` (the vote module renders as usual).
     """
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
@@ -513,6 +528,9 @@ async def build_praxis_card_out(
         media_items=[MediaItemOut.model_validate(item) for item in praxis.media_items],
         viewer_vote=viewer_vote_info.value if viewer_vote_info else None,
         voted_by_name=viewer_vote_info.voted_by_name if viewer_vote_info else None,
+        viewer_can_vote=(
+            viewer_can_vote.get(praxis.id, True) if viewer_can_vote else True
+        ),
     )
 
 

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -1,10 +1,13 @@
+from typing import Optional
+
 from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
-from models.praxis import ModerationStatus, Praxis
+from models.duel import Duel, DuelStatus
+from models.praxis import ModerationStatus, Praxis, PraxisMember
 from models.vote import Vote
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row, get_or_create_stats
@@ -44,50 +47,18 @@ async def cast_or_update_vote(
     if not 1 <= value <= 5:
         raise HTTPException(status_code=422, detail="Vote value must be between 1 and 5.")
 
-    # Account-level anti-self-vote. A collab is co-owned by all its members
-    # (ADR-0013), not just the created_by starter — so block any character on
-    # ANY current member's account. members + member.character are selectin-
-    # loaded, so no extra query in the common path. Solo praxis: one member
-    # (the creator) → identical to the old created_by check.
-    member_account_ids = {
-        member.character.account_id
-        for member in praxis.members
-        if member.character is not None
-    }
-    # Fallback if members somehow isn't populated: use created_by directly.
-    if not member_account_ids and praxis.created_by_id is not None:
-        author = praxis.created_by
-        if author is None:
-            author = await session.get(Character, praxis.created_by_id)
-        if author is not None:
-            member_account_ids = {author.account_id}
-    if voter.account_id in member_account_ids:
+    # Account-level anti-self-vote (A) and duel anti-participation (B) are the two
+    # PERMANENT ineligibility rules. They are factored into helpers so this
+    # enforcement path and the ``viewer_can_vote`` predicate that drives the UI
+    # share one source of truth (#998). Budget (below) is deliberately NOT part
+    # of that predicate — it is temporary and re-rating an existing vote is free.
+    if await _voter_account_owns_praxis(voter, praxis, session):
         raise HTTPException(status_code=403, detail="Cannot vote on your own praxis.")
-
-    # Duel anti-participation (#309): a duel participant — any life on their
-    # account — cannot rate EITHER side of a duel they're in, not just their own.
-    # Account-level anti-self-vote above only blocks the participant's own side.
-    from services.duel import get_duel_for_praxis
-
-    duel = await get_duel_for_praxis(praxis.id, session)
-    if duel is not None:
-        challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
-        challenger = (
-            await session.get(Character, challenger_praxis.created_by_id)
-            if challenger_praxis is not None
-            else None
+    if await _voter_in_praxis_duel(voter, praxis, session):
+        raise HTTPException(
+            status_code=403,
+            detail="Cannot vote on a duel you're a participant in.",
         )
-        opponent = await session.get(Character, duel.opponent_character_id)
-        participant_account_ids = {
-            participant.account_id
-            for participant in (challenger, opponent)
-            if participant is not None
-        }
-        if voter.account_id in participant_account_ids:
-            raise HTTPException(
-                status_code=403,
-                detail="Cannot vote on a duel you're a participant in.",
-            )
 
     result = await session.execute(
         select(Vote).where(
@@ -126,5 +97,147 @@ async def cast_or_update_vote(
     await session.flush()
     await session.refresh(vote)
     return vote
+
+
+# ---------------------------------------------------------------------------
+# Eligibility — the permanent, account-level rules (A + B) shared by the
+# enforcement path (``cast_or_update_vote``) and the UI (``viewer_can_vote``,
+# surfaced on PraxisOut / PraxisCardOut). Budget is intentionally excluded (#998).
+# ---------------------------------------------------------------------------
+
+
+async def _voter_account_owns_praxis(
+    voter: Character, praxis: Praxis, session: AsyncSession
+) -> bool:
+    """A. Ownership — ``voter``'s ACCOUNT owns ``praxis`` (author or any collab
+    co-owner). A collab is co-owned by all its members (ADR-0013), not just the
+    created_by starter — so this checks every current member's account. members
+    + member.character are selectin-loaded, so no extra query in the common path.
+    Solo praxis: one member (the creator) → identical to the old created_by check.
+    """
+    member_account_ids = {
+        member.character.account_id
+        for member in praxis.members
+        if member.character is not None
+    }
+    # Fallback if members somehow isn't populated: use created_by directly.
+    if not member_account_ids and praxis.created_by_id is not None:
+        author = praxis.created_by
+        if author is None:
+            author = await session.get(Character, praxis.created_by_id)
+        if author is not None:
+            member_account_ids = {author.account_id}
+    return voter.account_id in member_account_ids
+
+
+async def _voter_in_praxis_duel(
+    voter: Character, praxis: Praxis, session: AsyncSession
+) -> bool:
+    """B. Duel participation (#309) — ``voter``'s ACCOUNT is a participant in this
+    praxis's duel, on either side. A duel participant — any life on their
+    account — cannot rate EITHER side of a duel they're in, not just their own.
+    Uses the same active-duel window (pending/active/settled) as
+    :func:`services.duel.get_duel_for_praxis`.
+    """
+    from services.duel import get_duel_for_praxis
+
+    duel = await get_duel_for_praxis(praxis.id, session)
+    if duel is None:
+        return False
+    challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
+    challenger = (
+        await session.get(Character, challenger_praxis.created_by_id)
+        if challenger_praxis is not None
+        else None
+    )
+    opponent = await session.get(Character, duel.opponent_character_id)
+    participant_account_ids = {
+        participant.account_id
+        for participant in (challenger, opponent)
+        if participant is not None
+    }
+    return voter.account_id in participant_account_ids
+
+
+async def viewer_can_vote(
+    voter: Optional[Character], praxis: Praxis, session: AsyncSession
+) -> bool:
+    """Whether ``voter`` may vote on ``praxis`` under the PERMANENT rules (#998).
+
+    Returns ``False`` only when account-level ownership (A) or duel
+    participation (B) applies — the same two blocks ``cast_or_update_vote``
+    enforces. Budget exhaustion is NOT considered: it is temporary and
+    re-rating an existing vote is free, so the module stays visible for
+    out-of-budget viewers. Anonymous viewers (``voter is None``) get ``True`` —
+    the client shows its own login gate regardless.
+    """
+    if voter is None:
+        return True
+    if await _voter_account_owns_praxis(voter, praxis, session):
+        return False
+    if await _voter_in_praxis_duel(voter, praxis, session):
+        return False
+    return True
+
+
+async def viewer_can_vote_map(
+    praxes: list[Praxis], voter: Optional[Character], session: AsyncSession
+) -> dict[int, bool]:
+    """Page-wide ``viewer_can_vote`` for a list of praxes, without an N+1.
+
+    Mirrors how crowned_ids / viewer_votes / applied_metatasks are precomputed
+    by the card-list route: one ownership query and one duel query for the whole
+    page, rather than the per-praxis predicate per card. Anonymous viewer → all
+    ``True``.
+    """
+    if voter is None:
+        return {praxis.id: True for praxis in praxes}
+
+    praxis_ids = {praxis.id for praxis in praxes}
+    if not praxis_ids:
+        return {}
+    account_id = voter.account_id
+
+    # A. Ownership — praxis ids the viewer's ACCOUNT is a member of (any life).
+    owned_result = await session.execute(
+        select(PraxisMember.praxis_id)
+        .join(Character, Character.id == PraxisMember.character_id)
+        .where(
+            PraxisMember.praxis_id.in_(praxis_ids),
+            Character.account_id == account_id,
+        )
+    )
+    blocked_ids = set(owned_result.scalars().all())
+
+    # B. Duel participation — for every active duel touching a page praxis, block
+    # BOTH of its sides (that are on this page) when the viewer's account is a
+    # participant. One duel query for the page; the character lookups hit the
+    # identity map and duels-per-page are few, so no per-card query.
+    duel_result = await session.execute(
+        select(Duel).where(
+            (Duel.challenger_praxis_id.in_(praxis_ids))
+            | (Duel.opponent_praxis_id.in_(praxis_ids)),
+            Duel.status.in_([DuelStatus.pending, DuelStatus.active, DuelStatus.settled]),
+        )
+    )
+    for duel in duel_result.scalars().all():
+        challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
+        challenger = (
+            await session.get(Character, challenger_praxis.created_by_id)
+            if challenger_praxis is not None
+            else None
+        )
+        opponent = await session.get(Character, duel.opponent_character_id)
+        participant_account_ids = {
+            participant.account_id
+            for participant in (challenger, opponent)
+            if participant is not None
+        }
+        if account_id in participant_account_ids:
+            for side_id in (duel.challenger_praxis_id, duel.opponent_praxis_id):
+                if side_id in praxis_ids:
+                    blocked_ids.add(side_id)
+
+    return {praxis.id: praxis.id not in blocked_ids for praxis in praxes}
 
 

--- a/backend/tests/integration/test_viewer_can_vote.py
+++ b/backend/tests/integration/test_viewer_can_vote.py
@@ -1,0 +1,319 @@
+"""Integration tests for ``viewer_can_vote`` (#998).
+
+The vote module must be hidden for a logged-in viewer who can never vote on a
+praxis for a PERMANENT, account-level reason:
+  A. Ownership — the viewer's account owns the praxis (author or collab co-owner).
+  B. Duel participation — the viewer's account is a participant in its duel.
+
+The backend surfaces this as ``viewer_can_vote`` on ``PraxisOut`` (detail) and
+``PraxisCardOut`` (feed card). Budget exhaustion is deliberately excluded (the
+module stays visible), and anonymous viewers get ``True`` (client shows its own
+login gate). The predicate is the same one ``cast_or_update_vote`` enforces, so
+the UI flag can never disagree with a 403.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.account import Account
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.task import Task
+
+
+async def _create_and_submit_solo(
+    client: AsyncClient, task: Task, headers: dict
+) -> int:
+    create = await client.post(
+        "/praxes",
+        json={"task_id": task.id, "type": "solo", "title": "Praxis"},
+        headers=headers,
+    )
+    assert create.status_code == 201, create.text
+    praxis_id = create.json()["id"]
+    submit = await client.post(f"/praxes/{praxis_id}/submit", headers=headers)
+    assert submit.status_code == 200, submit.text
+    return praxis_id
+
+
+async def _card_for(client: AsyncClient, task_id: int, praxis_id: int, headers: dict):
+    """Fetch the feed card for ``praxis_id`` from the list route (exercises the
+    page-wide ``viewer_can_vote_map`` precompute)."""
+    resp = await client.get(f"/praxes?task_id={task_id}", headers=headers)
+    assert resp.status_code == 200, resp.text
+    cards = [c for c in resp.json() if c["id"] == praxis_id]
+    assert cards, f"praxis {praxis_id} not in feed"
+    return cards[0]
+
+
+# ---------------------------------------------------------------------------
+# A. Ownership — author / collab co-owner cannot vote → module hidden.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_author_cannot_vote_detail_and_card(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """The author sees ``viewer_can_vote is False`` on both detail and card."""
+    praxis_id = await _create_and_submit_solo(client, active_task, auth_headers)
+
+    detail = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert detail.status_code == 200
+    assert detail.json()["viewer_can_vote"] is False
+
+    card = await _card_for(client, active_task.id, praxis_id, auth_headers)
+    assert card["viewer_can_vote"] is False
+
+
+@pytest.mark.asyncio
+async def test_collab_co_owner_cannot_vote(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A collab co-owner who is NOT ``created_by`` still gets ``viewer_can_vote
+    is False`` (account-level ownership, ADR-0013)."""
+    create = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "collab", "title": "Shared"},
+        headers=auth_headers2,
+    )
+    assert create.status_code == 201
+    praxis_id = create.json()["id"]
+
+    invite = await client.post(
+        f"/praxes/{praxis_id}/invite",
+        json={"invitee_id": character.id},
+        headers=auth_headers2,
+    )
+    assert invite.status_code == 200
+    respond = await client.post(
+        f"/praxes/{praxis_id}/invite/{invite.json()['id']}/respond",
+        json={"accept": True},
+        headers=auth_headers,
+    )
+    assert respond.status_code == 200
+
+    # character is now a co-owner but not created_by → module hidden.
+    detail = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert detail.status_code == 200
+    assert detail.json()["viewer_can_vote"] is False
+
+
+# ---------------------------------------------------------------------------
+# B. Duel participation — either participant, either side → module hidden.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_duel_participant_cannot_vote_on_either_side(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Each participant sees ``viewer_can_vote is False`` on BOTH duel sides."""
+    from models.duel import Duel, DuelStatus
+
+    challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
+    opponent_pid = await _create_and_submit_solo(client, active_task, auth_headers2)
+    db_session.add(
+        Duel(
+            task_id=active_task.id,
+            challenger_praxis_id=challenger_pid,
+            opponent_character_id=character2.id,
+            opponent_praxis_id=opponent_pid,
+            status=DuelStatus.settled,
+        )
+    )
+    await db_session.commit()
+
+    # Challenger's account: both sides hidden.
+    for pid in (challenger_pid, opponent_pid):
+        body = (await client.get(f"/praxes/{pid}", headers=auth_headers)).json()
+        assert body["viewer_can_vote"] is False, f"challenger on {pid}"
+
+    # Opponent's account: both sides hidden (symmetric).
+    for pid in (challenger_pid, opponent_pid):
+        body = (await client.get(f"/praxes/{pid}", headers=auth_headers2)).json()
+        assert body["viewer_can_vote"] is False, f"opponent on {pid}"
+
+    # And in the feed card too (page-wide precompute).
+    card = await _card_for(client, active_task.id, challenger_pid, auth_headers)
+    assert card["viewer_can_vote"] is False
+
+
+# ---------------------------------------------------------------------------
+# Eligible viewers — third party (True), anonymous (True), out-of-budget (True).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_eligible_third_party_can_vote_detail_and_card(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """An unrelated logged-in viewer gets ``viewer_can_vote is True`` and votes."""
+    praxis_id = await _create_and_submit_solo(client, active_task, auth_headers)
+
+    detail = await client.get(f"/praxes/{praxis_id}", headers=auth_headers2)
+    assert detail.json()["viewer_can_vote"] is True
+    card = await _card_for(client, active_task.id, praxis_id, auth_headers2)
+    assert card["viewer_can_vote"] is True
+
+    # The flag agrees with the endpoint: the third party actually votes.
+    vote = await client.post(
+        f"/praxes/{praxis_id}/vote", json={"value": 4}, headers=auth_headers2
+    )
+    assert vote.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_anonymous_viewer_gets_true(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """Anonymous → ``viewer_can_vote is True`` (client shows its own login gate)."""
+    praxis_id = await _create_and_submit_solo(client, active_task, auth_headers)
+
+    detail = await client.get(f"/praxes/{praxis_id}")
+    assert detail.status_code == 200
+    assert detail.json()["viewer_can_vote"] is True
+
+    card = await _card_for(client, active_task.id, praxis_id, {})
+    assert card["viewer_can_vote"] is True
+
+
+@pytest.mark.asyncio
+async def test_out_of_budget_viewer_still_shows_module(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    era: Era,
+):
+    """Budget exhaustion is NOT part of ``viewer_can_vote``: an eligible viewer
+    who is out of budget still sees the module (re-rating is free), even though a
+    NEW vote would 403 with the budget message."""
+    praxis_id = await _create_and_submit_solo(client, active_task, auth_headers)
+
+    # Drain character2's budget: score 0, votes_spent absurdly high.
+    stats = (
+        await db_session.execute(
+            select(CharacterStats).where(
+                CharacterStats.character_id == character2.id,
+                CharacterStats.era_id == era.id,
+            )
+        )
+    ).scalar_one()
+    stats.score = 0
+    stats.votes_spent_this_era = 9999
+    await db_session.commit()
+
+    detail = await client.get(f"/praxes/{praxis_id}", headers=auth_headers2)
+    assert detail.json()["viewer_can_vote"] is True  # module stays visible
+
+    # The endpoint blocks a NEW vote on budget — a DIFFERENT reason than A/B.
+    vote = await client.post(
+        f"/praxes/{praxis_id}/vote", json={"value": 3}, headers=auth_headers2
+    )
+    assert vote.status_code == 403
+    assert "budget" in vote.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Shared source of truth — the predicate matches ``cast_or_update_vote``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_predicate_matches_cast_or_update_vote_for_owner_and_third_party(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """``viewer_can_vote`` is False exactly when ``cast_or_update_vote`` raises
+    for a PERMANENT reason (A ownership), and True for an eligible third party
+    who can actually cast."""
+    from services.praxis import get_praxis
+    from services.vote import viewer_can_vote
+
+    praxis_id = await _create_and_submit_solo(client, active_task, auth_headers)
+    praxis = await get_praxis(praxis_id, db_session)
+
+    # Owner: predicate False, and the endpoint 403s with the anti-self-vote reason.
+    assert await viewer_can_vote(character, praxis, db_session) is False
+    owner_vote = await client.post(
+        f"/praxes/{praxis_id}/vote", json={"value": 5}, headers=auth_headers
+    )
+    assert owner_vote.status_code == 403
+    assert owner_vote.json()["detail"] == "Cannot vote on your own praxis."
+
+    # Third party: predicate True, and anonymous also True.
+    assert await viewer_can_vote(character2, praxis, db_session) is True
+    assert await viewer_can_vote(None, praxis, db_session) is True
+
+
+@pytest.mark.asyncio
+async def test_predicate_false_for_duel_participant(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """The predicate returns False for a duel participant on either side, matching
+    the endpoint's duel anti-participation 403."""
+    from models.duel import Duel, DuelStatus
+    from services.praxis import get_praxis
+    from services.vote import viewer_can_vote
+
+    challenger_pid = await _create_and_submit_solo(client, active_task, auth_headers)
+    opponent_pid = await _create_and_submit_solo(client, active_task, auth_headers2)
+    db_session.add(
+        Duel(
+            task_id=active_task.id,
+            challenger_praxis_id=challenger_pid,
+            opponent_character_id=character2.id,
+            opponent_praxis_id=opponent_pid,
+            status=DuelStatus.settled,
+        )
+    )
+    await db_session.commit()
+
+    challenger_praxis = await get_praxis(challenger_pid, db_session)
+    opponent_praxis = await get_praxis(opponent_pid, db_session)
+
+    # character is the challenger; blocked on both sides.
+    assert await viewer_can_vote(character, challenger_praxis, db_session) is False
+    assert await viewer_can_vote(character, opponent_praxis, db_session) is False
+    # character2 is the opponent; blocked on both sides.
+    assert await viewer_can_vote(character2, challenger_praxis, db_session) is False
+    assert await viewer_can_vote(character2, opponent_praxis, db_session) is False

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -86,6 +86,14 @@ export interface PraxisOut {
   duel_id: number | null
   can_flag: boolean
   applied_metatasks: TaskOut[]
+  /**
+   * Viewer-relative (#998). `false` only when the logged-in viewer's account
+   * owns this praxis (author/collab co-owner) or is a participant in its duel —
+   * the two PERMANENT vote blocks the client can't compute itself. Drives hiding
+   * the whole vote module. Default `true` (incl. anonymous — the client shows
+   * its own login gate). Optional so a stale payload degrades to showing it.
+   */
+  viewer_can_vote?: boolean
 }
 
 export interface PraxisCardOut {
@@ -162,6 +170,12 @@ export interface PraxisCardOut {
    * other late-added card fields above.
    */
   applied_metatasks?: TaskOut[]
+  /**
+   * Viewer-relative (#998); see `PraxisOut.viewer_can_vote`. Precomputed
+   * page-wide by the feed route (no N+1). Optional so a stale cached payload
+   * degrades to showing the module rather than hiding it.
+   */
+  viewer_can_vote?: boolean
 }
 
 export interface PraxisCreate {

--- a/frontend/src/components/praxisCard/mobile/shared.tsx
+++ b/frontend/src/components/praxisCard/mobile/shared.tsx
@@ -487,6 +487,7 @@ export function MobileVoteFooter({ praxis }: { praxis: PraxisCardOut }) {
       factionSlug={praxis.task_faction_slug}
       praxisId={praxis.id}
       currentValue={praxis.viewer_vote ?? undefined}
+      viewerCanVote={praxis.viewer_can_vote}
     />
   )
 }

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -642,6 +642,7 @@ export function PraxisVoteFooter({
         factionSlug={praxis.task_faction_slug}
         praxisId={praxis.id}
         currentValue={praxis.viewer_vote ?? undefined}
+        viewerCanVote={praxis.viewer_can_vote}
       />
     </div>
   );

--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -1,6 +1,7 @@
 import type { } from 'react'
 import { pickVariant } from '../../utils/factionDispatch'
 import { surfaceMap } from '../../factions'
+import { useAuth } from '../../auth/AuthContext'
 import UnaffiliatedVote from './UnaffiliatedVote'
 import { VoteFactionContext } from './VoteShell'
 
@@ -16,12 +17,28 @@ export interface VoteUIProps {
   currentValue?: number
   points?: number | null
   totalVotes?: number
+  /**
+   * The backend's viewer-relative ``praxis.viewer_can_vote`` (#998). ``false``
+   * only when the logged-in viewer's account owns the praxis or is a duel
+   * participant — the two PERMANENT vote blocks the client can't compute itself.
+   * When ``false`` for a logged-in viewer the whole module is hidden; anonymous
+   * viewers fall through to each widget's own login gate regardless.
+   */
+  viewerCanVote?: boolean
 }
 
 export default function VoteUI({
   factionSlug,
+  viewerCanVote,
   ...props
 }: VoteUIProps & { factionSlug?: string | null }) {
+  const { user } = useAuth()
+  // Hide the whole module for a logged-in viewer the backend says can never
+  // vote here (ownership / duel participation, #998). Anonymous viewers fall
+  // through to the per-widget login gate — the login CTA is deliberate.
+  if (user && viewerCanVote === false) {
+    return null
+  }
   const Variant = pickVariant(surfaceMap('vote'), factionSlug, UnaffiliatedVote)
   // The slug is published to the shared chrome as well as dispatched on: the
   // logged-out gate speaks in the task faction's eyebrow voice (#855) and is

--- a/frontend/src/components/vote/__tests__/voteUI.test.tsx
+++ b/frontend/src/components/vote/__tests__/voteUI.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * VoteUI dispatcher — the single ineligibility guard (#998).
+ *
+ * The whole vote module must render NOTHING for a logged-in viewer the backend
+ * says can never vote here (`viewer_can_vote === false`: account ownership or
+ * duel participation — the two PERMANENT blocks). Anonymous viewers fall through
+ * to each widget's own login gate regardless, and an eligible / unknown viewer
+ * gets the ordinary widget.
+ *
+ * SSR-only harness (renderToStaticMarkup, no DOM, effects never run), so
+ * everything is asserted from the produced markup given props + a mocked
+ * `useAuth`. `na`/absent faction slug dispatches to the spectrum-sweep
+ * UnaffiliatedVote, whose logged-in markup is a row of five "Rate N — …"
+ * buttons and whose anonymous markup is the shared "Log in to vote" gate.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { CurrentUser } from '../../../api/auth'
+
+const mocks = vi.hoisted(() => ({
+  user: null as CurrentUser | null,
+  castVote: vi.fn(async () => ({}) as unknown),
+}))
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: mocks.user, refetch: async () => {} }),
+}))
+vi.mock('../../../api/votes', () => ({
+  castVote: mocks.castVote,
+}))
+
+import VoteUI from '../VoteUI'
+
+function currentUser(): CurrentUser {
+  return {
+    account_id: 1,
+    character: {
+      id: 9,
+      username: 'ada',
+      display_name: 'Ada',
+      bio: null,
+      avatar_url: null,
+      location: null,
+      level: 8,
+      score: 100,
+      all_time_score: 100,
+      faction_slug: 'na',
+      status: 'active',
+      created_at: '2026-01-01T00:00:00Z',
+    },
+    is_admin: false,
+    can_create_additional_character: false,
+    can_start_as_albescent: false,
+    albescent_revealed: false,
+    can_propose_task: false,
+    can_propose_metatask: false,
+    can_see_retired_tasks: false,
+    can_see_pending_tasks: false,
+    can_comment: true,
+    second_character_level_required: 5,
+    era_name: 'Era 3',
+    level_jump_reach: 0,
+    level_jump_available: false,
+  }
+}
+
+function render(viewerCanVote?: boolean): string {
+  return renderToStaticMarkup(
+    <VoteUI factionSlug={null} praxisId={7} viewerCanVote={viewerCanVote} />,
+  )
+}
+
+// UnaffiliatedVote's five rate buttons: aria-label "Rate {n} — {tier}" (#855).
+const RATE_BUTTON = /aria-label="Rate \d/
+const rateButtonCount = (html: string): number =>
+  (html.match(/aria-label="Rate \d/g) ?? []).length
+
+describe('VoteUI ineligibility guard (#998)', () => {
+  it('renders nothing for a logged-in viewer who cannot vote (viewer_can_vote false)', () => {
+    mocks.user = currentUser()
+    expect(render(false)).toBe('')
+  })
+
+  it('renders the widget for a logged-in viewer who can vote', () => {
+    mocks.user = currentUser()
+    expect(rateButtonCount(render(true))).toBe(5)
+  })
+
+  it('renders the widget when eligibility is unknown (undefined defaults to showing)', () => {
+    mocks.user = currentUser()
+    expect(rateButtonCount(render(undefined))).toBe(5)
+  })
+
+  it('shows the login gate for an anonymous viewer even when viewer_can_vote is false', () => {
+    mocks.user = null
+    const html = render(false)
+    expect(html.replace(/<[^>]*>/g, '')).toContain('Log in to vote')
+    expect(html).not.toMatch(RATE_BUTTON)
+  })
+})

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -422,6 +422,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
             <VoteUI
               factionSlug={praxis.task_faction_slug}
               praxisId={praxis.id}
+              viewerCanVote={praxis.viewer_can_vote}
             />
           </div>
         </div>

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -331,7 +331,7 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
               <div className="font-display italic" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)', marginBottom: 'var(--space-md)', lineHeight: 1.4 }}>
                 {t('detail.default.castPrompt')}
               </div>
-              <VoteUI factionSlug={praxis.task_faction_slug} praxisId={praxis.id} />
+              <VoteUI factionSlug={praxis.task_faction_slug} praxisId={praxis.id} viewerCanVote={praxis.viewer_can_vote} />
             </div>
 
             {/* Points + backers ledger */}

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -346,6 +346,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
           <VoteUI
             factionSlug={praxis.task_faction_slug}
             praxisId={praxis.id}
+            viewerCanVote={praxis.viewer_can_vote}
           />
         </div>
 

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -254,6 +254,7 @@ export default function EverymenPraxisDetail({ state }: { state: PraxisDetailSta
           <VoteUI
             factionSlug={praxis.task_faction_slug}
             praxisId={praxis.id}
+            viewerCanVote={praxis.viewer_can_vote}
           />
         </div>
 

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -419,6 +419,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
             <VoteUI
               factionSlug={praxis.task_faction_slug}
               praxisId={praxis.id}
+              viewerCanVote={praxis.viewer_can_vote}
             />
           </div>
 

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -401,6 +401,7 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
           <VoteUI
             factionSlug={praxis.task_faction_slug}
             praxisId={praxis.id}
+            viewerCanVote={praxis.viewer_can_vote}
           />
         </div>
 

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -454,6 +454,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
           <VoteUI
             factionSlug={praxis.task_faction_slug}
             praxisId={praxis.id}
+            viewerCanVote={praxis.viewer_can_vote}
           />
         </div>
 


### PR DESCRIPTION
## What & why

A logged-in but INELIGIBLE viewer used to see a fully interactive vote module and only discovered they couldn't vote by clicking → 403. This hides the module entirely for the two PERMANENT, account-level cases:

- **A. Ownership** — the viewer's ACCOUNT owns the praxis (author or any collab co-owner; anti-self-vote is account-level, ADR-0013).
- **B. Duel participation** — the viewer's ACCOUNT is a participant in this praxis's duel (#309), either side.

Out of scope (unchanged): budget exhaustion (temporary — re-rating is free, module stays visible) and logged-out (the `VoteLoginGate` CTA stays).

## Backend
- Factored the two blocks in `services/vote.py::cast_or_update_vote` into helpers and a shared `viewer_can_vote(voter, praxis, session) -> bool` predicate — one source of truth for the enforcement path and the UI. **Budget is not part of it.** Anonymous → `True`.
- Added `viewer_can_vote: bool` (default `true`) to **`PraxisOut`** and **`PraxisCardOut`**, populated in `build_praxis_out` and the card builder (following the `can_flag` pattern).
- The card-list route precomputes `viewer_can_vote` page-wide via `viewer_can_vote_map` (one ownership query + one duel query) — no N+1, mirroring crowned_ids / viewer_votes / applied_metatasks.

## Frontend
- Single guard in the shared dispatcher `components/vote/VoteUI.tsx`: `if (loggedIn && viewerCanVote === false) return null` (loggedIn from `useAuth`). Anonymous falls through to each widget's existing login gate.
- Threaded `viewerCanVote={praxis.viewer_can_vote}` at all 9 `<VoteUI>` mount sites (card desktop + mobile, and the 7 detail archetypes). Added `viewer_can_vote` to the FE `PraxisOut`/`PraxisCardOut` types.

## Tests
- Backend `pytest` on `wz998_test`: new `test_viewer_can_vote.py` — owner/collab/duel-participant → `False`; third party/anonymous/out-of-budget → `True`; the shared predicate matches `cast_or_update_vote`'s actual block. Full backend suite: **781 passed**.
- Frontend: new `voteUI.test.tsx` — VoteUI renders null when `loggedIn && viewerCanVote===false`, renders the widget otherwise, and still shows the login gate for anonymous. `tsc`/`eslint` clean, `vite build` OK, vitest **1545 passed**.

## What to eyeball (visual QA outstanding — no dev stack / no screenshots in this environment)
- As the **author** of a praxis (card + detail, mobile + desktop): the vote module is GONE (no heading, no control, no reason line).
- As a **duel participant** viewing either side: gone.
- As a **collab co-owner** viewing the shared praxis: gone.
- **Out of budget** but otherwise eligible: you still see the module (can re-rate).
- **Logged-out**: still see "Log in to vote".
- **Eligible third party**: votes normally.

Closes #998