### PR TITLE
#992: Label duel sides as "Duel" across sidebar, FieldDesk, and card chips

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -54,6 +54,7 @@ from services.praxis import (
     change_praxis_type,
     create_praxis,
     delete_praxis,
+    duel_id_map,
     flag_praxis,
     get_praxis,
     invite_to_praxis,
@@ -170,6 +171,10 @@ async def list_praxes_route(
     # page — not the per-praxis predicate per card. Hides the vote module for a
     # logged-in viewer who owns the praxis or is a participant in its duel.
     viewer_can_vote = await viewer_can_vote_map(praxes, viewer, session)
+    # Duel sides (#992): one duel query for the whole page — not the per-praxis
+    # duel lookup per card. A duel side is stored type='solo' + a non-null
+    # duel_id (ADR-0011), so the card mode label/chip gates on this, not type.
+    duel_ids = await duel_id_map(praxes, session)
     return [
         await build_praxis_card_out(
             praxis,
@@ -179,6 +184,7 @@ async def list_praxes_route(
             author_contributions=author_contributions,
             applied_metatasks=applied_metatasks,
             viewer_can_vote=viewer_can_vote,
+            duel_ids=duel_ids,
         )
         for praxis in praxes
     ]

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -147,6 +147,11 @@ class PraxisCardOut(BaseModel):
     # Viewer-relative (#998); see ``PraxisOut.viewer_can_vote``. Precomputed
     # page-wide by the card-list route (no N+1) via ``viewer_can_vote_map``.
     viewer_can_vote: bool = True
+    # Set when this praxis is a side of a duel (ADR-0011): a duel side is stored
+    # ``type='solo'`` + a non-null ``duel_id``, so mode labels/chips must gate on
+    # this, not ``type`` (#992). Precomputed page-wide by the card-list route (no
+    # N+1) via ``duel_id_map``; mirrors ``PraxisOut.duel_id``.
+    duel_id: Optional[int] = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -371,6 +371,49 @@ async def applied_metatasks_for(
     return metatasks_by_praxis
 
 
+async def duel_id_map(
+    praxes: list[Praxis],
+    session: AsyncSession,
+) -> dict[int, int]:
+    """Praxis id → duel id for each duel-side praxis on the page, in ONE query.
+
+    A duel side is stored ``type='solo'`` + a non-null ``duel_id`` (ADR-0011),
+    so card mode labels/chips must gate on duel presence, not ``type`` (#992).
+    Mirrors the per-praxis duel lookup in :func:`build_praxis_out` (same statuses
+    incl. ``resolved`` per ADR-0052, so a past duel's side still reads as a duel),
+    but batches every praxis id on the page into a single duel query rather than
+    one lookup per card (N+1). The result is handed to
+    :func:`build_praxis_card_out` via ``duel_ids``.
+
+    A praxis that is not a duel side is simply absent from the returned map (the
+    card builder treats a missing entry as ``duel_id=None``).
+    """
+    if not praxes:
+        return {}
+
+    praxis_ids = {p.id for p in praxes}
+    duel_result = await session.execute(
+        select(Duel).where(
+            (Duel.challenger_praxis_id.in_(praxis_ids))
+            | (Duel.opponent_praxis_id.in_(praxis_ids)),
+            Duel.status.in_(
+                [
+                    DuelStatus.pending,
+                    DuelStatus.active,
+                    DuelStatus.settled,
+                    DuelStatus.resolved,
+                ]
+            ),
+        )
+    )
+    mapping: dict[int, int] = {}
+    for duel in duel_result.scalars().all():
+        for side_id in (duel.challenger_praxis_id, duel.opponent_praxis_id):
+            if side_id in praxis_ids:
+                mapping[side_id] = duel.id
+    return mapping
+
+
 def _resolve_card_scoring(
     contribution: Optional[Contribution], task_point_value: int, tally_votes_points: int
 ) -> tuple[int, float, int, float]:
@@ -418,6 +461,7 @@ async def build_praxis_card_out(
     author_contributions: Optional[dict[int, Contribution]] = None,
     applied_metatasks: Optional[dict[int, list[TaskOut]]] = None,
     viewer_can_vote: Optional[dict[int, bool]] = None,
+    duel_ids: Optional[dict[int, int]] = None,
 ) -> PraxisCardOut:
     """Lightweight card for list views.
 
@@ -452,6 +496,12 @@ async def build_praxis_card_out(
     routes precompute it once via :func:`~services.vote.viewer_can_vote_map` so
     the ownership/duel-participation check is not a per-card query. ``None`` or a
     missing entry defaults to ``True`` (the vote module renders as usual).
+
+    ``duel_ids`` maps praxis id → its duel id when the praxis is a duel side
+    (#992, ADR-0011); list routes precompute it once via :func:`duel_id_map` so
+    the duel lookup is not a per-card query (N+1). When absent, this builder
+    loads the single praxis's duel id itself (single-card callers). A missing
+    entry means the praxis is not a duel side (``duel_id=None``).
     """
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
@@ -496,6 +546,13 @@ async def build_praxis_card_out(
             praxis.id, []
         )
 
+    # Duel side (#992, ADR-0011). Reuse the precomputed page-wide map when the
+    # list route supplies it; otherwise load this praxis's own duel id.
+    if duel_ids is not None:
+        praxis_duel_id = duel_ids.get(praxis.id)
+    else:
+        praxis_duel_id = (await duel_id_map([praxis], session)).get(praxis.id)
+
     return PraxisCardOut(
         id=praxis.id,
         task_id=praxis.task_id,
@@ -531,6 +588,7 @@ async def build_praxis_card_out(
         viewer_can_vote=(
             viewer_can_vote.get(praxis.id, True) if viewer_can_vote else True
         ),
+        duel_id=praxis_duel_id,
     )
 
 
@@ -1944,6 +2002,7 @@ __all__ = [
     "can_view_praxis",
     "create_praxis",
     "delete_praxis",
+    "duel_id_map",
     "evaluate_signup",
     "flag_praxis",
     "get_praxis",

--- a/backend/tests/integration/test_praxis_card_breakdown.py
+++ b/backend/tests/integration/test_praxis_card_breakdown.py
@@ -744,3 +744,52 @@ async def test_under_level_author_earns_zero_but_keeps_the_seal(
     assert len(card.applied_metatasks) == 1
     assert card.applied_metatasks[0].id == metatask.id
     assert_invariant(card)
+
+
+# ---------------------------------------------------------------------------
+# duel_id on the card payload (#992)
+# ---------------------------------------------------------------------------
+#
+# A duel side is stored type='solo' + a non-null duel_id (ADR-0011); the card
+# schema previously omitted duel_id, so the sidebar/FieldDesk/chip surfaces that
+# consume PraxisCardOut labelled every accepted duel "Solo". These assert the
+# card now carries duel_id so those surfaces can gate on duel presence.
+
+
+@pytest.mark.asyncio
+async def test_duel_side_card_carries_duel_id(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """Both sides of a duel carry the duel's id on their card (not None)."""
+    challenger = await _make_character(
+        db_session, era, faction_slug="ua", username="dchallenger", email="dch@x.com"
+    )
+    opponent = await _make_character(
+        db_session, era, faction_slug="ua", username="dopponent", email="dop@x.com"
+    )
+    task = await _make_task(db_session, challenger, faction_slug="ua", points=10)
+    challenger_praxis = await _make_solo(db_session, task, challenger)
+    opponent_praxis = await _make_solo(db_session, task, opponent)
+    await _make_duel(db_session, task, challenger_praxis, opponent, opponent_praxis)
+
+    challenger_card = await _load_card(db_session, challenger_praxis.id)
+    opponent_card = await _load_card(db_session, opponent_praxis.id)
+
+    # Stored type is solo (ADR-0011): the card must expose duel_id, not lean on
+    # type, so the frontend can label the side "Duel".
+    assert challenger_card.type == PraxisType.solo
+    assert challenger_card.duel_id is not None
+    assert opponent_card.duel_id == challenger_card.duel_id
+
+
+@pytest.mark.asyncio
+async def test_non_duel_solo_card_has_null_duel_id(
+    db_session: AsyncSession, era: Era, faction_ua: Faction, character: Character
+):
+    """A plain solo praxis (no duel) carries duel_id=None on its card."""
+    task = await _make_task(db_session, character, faction_slug="ua", points=10)
+    praxis = await _make_solo(db_session, task, character)
+
+    card = await _load_card(db_session, praxis.id)
+
+    assert card.duel_id is None

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -176,6 +176,13 @@ export interface PraxisCardOut {
    * degrades to showing the module rather than hiding it.
    */
   viewer_can_vote?: boolean
+  /**
+   * Set when this praxis is a side of a duel (ADR-0011): a duel side is stored
+   * `type='solo'` + a non-null `duel_id`, so mode labels/chips must gate on this,
+   * not `type` (#992). Null/absent when the praxis is not a duel side. Mirrors
+   * `PraxisOut.duel_id`; precomputed page-wide by the feed route (no N+1).
+   */
+  duel_id?: number | null
 }
 
 export interface PraxisCreate {

--- a/frontend/src/components/__tests__/factionCardSlots.test.tsx
+++ b/frontend/src/components/__tests__/factionCardSlots.test.tsx
@@ -164,8 +164,10 @@ const COLLAB: PraxisCardOut = {
   submit_proposed_at: "2026-01-03T00:00:00Z",
 };
 
-// Duel side — a mode chip, no crew roster.
-const DUEL: PraxisCardOut = { ...PRAXIS, type: "duel" };
+// Duel side — a mode chip, no crew roster. A duel side is stored type='solo' +
+// a non-null duel_id (ADR-0011, #992), NOT type='duel'; the chip gates on
+// duel_id, so the fixture must carry it.
+const DUEL: PraxisCardOut = { ...PRAXIS, type: "solo", duel_id: 42 };
 
 // Four images → gallery caps at three tiles with a "+1" overflow badge.
 const OVERFLOW: PraxisCardOut = {

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -7,7 +7,7 @@ import { relativeTime } from '../../utils/dates'
 import { factionCssVar, factionName } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import { useMyActiveTasks } from '../../hooks/useMyActiveTasks'
-import type { PraxisType } from '../../api/praxis'
+import { praxisModeLabel } from '../../utils/praxis'
 import { usePendingRequests } from '../../hooks/usePendingRequests'
 import { useRespondToRequest } from '../../hooks/useRespondToRequest'
 import { useGameConfig } from '../../hooks/useGameConfig'
@@ -62,12 +62,6 @@ export default function Sidebar() {
   const { pendingRequests, refetch: refetchPendingRequests } = usePendingRequests()
   const gameConfig = useGameConfig()
   const [globalActivity, setGlobalActivity] = useState<ActivityFeedItem[]>([])
-
-  const praxisTypeLabel: Record<PraxisType, string> = {
-    solo: t('praxisType.solo'),
-    collab: t('praxisType.collab'),
-    duel: t('praxisType.duel'),
-  }
 
   useEffect(() => {
     if (!user) return
@@ -274,7 +268,7 @@ export default function Sidebar() {
                     borderRadius: 999,
                   }}
                 >
-                  {praxisTypeLabel[praxis.type]}
+                  {praxisModeLabel(praxis, t)}
                 </span>
               </div>
             ))}

--- a/frontend/src/components/praxisCard/mobile/shared.tsx
+++ b/frontend/src/components/praxisCard/mobile/shared.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import type { PraxisCardOut } from '../../../api/praxis'
 import { factionName } from '../../../utils/factions'
+import { isDuelPraxis } from '../../../utils/praxis'
 import { relativeTime } from '../../../utils/dates'
 import { mediaUrl } from '../../../utils/media'
 import { rosterNames } from '../shared'
@@ -274,7 +275,9 @@ export function MobileModeChip({
   theme: MobileSlotTheme
 }) {
   const { t } = useTranslation('common')
-  const isDuel = praxis.type === 'duel'
+  // A duel side is stored type='solo' + a non-null duel_id (ADR-0011), so
+  // `type === 'duel'` never fires (#992) — gate on duel presence instead.
+  const isDuel = isDuelPraxis(praxis)
   const isPending = praxis.submit_proposed_at != null
   if (!isDuel && !isPending) return null
   const chip: CSSProperties = {

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -4,6 +4,7 @@ import { Link } from "react-router-dom";
 import type { CharacterOut } from "../../api/auth";
 import type { PraxisCardOut } from "../../api/praxis";
 import { factionName } from "../../utils/factions";
+import { isDuelPraxis } from "../../utils/praxis";
 import { mediaUrl } from "../../utils/media";
 import FactionAvatar from "../avatar/FactionAvatar";
 import VoteUI from "../vote/VoteUI";
@@ -431,7 +432,9 @@ export function PraxisModeChip({
   fonts?: PraxisCardFonts;
 }) {
   const { t } = useTranslation("common");
-  const isDuel = praxis.type === "duel";
+  // A duel side is stored type='solo' + a non-null duel_id (ADR-0011), so
+  // `type === 'duel'` never fires (#992) — gate on duel presence instead.
+  const isDuel = isDuelPraxis(praxis);
   const isCollab = praxis.type === "collab";
   const isPending = praxis.submit_proposed_at != null;
   if (!isDuel && !isCollab && !isPending) return null;

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
 /**
@@ -336,7 +337,7 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
                   className="shrink-0 eyebrow"
                   style={{ color: PINK, padding: 'var(--space-xs) var(--space-sm)', border: `1.5px solid ${NOTEPAD_BORDER}`, borderRadius: 999 }}
                 >
-                  {t(`praxisType.${praxis.type}`)}
+                  {praxisModeLabel(praxis, t)}
                 </span>
               </Link>
             ))}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionCssVar, factionFill, factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { praxisModeLabel } from '../../../utils/praxis'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
@@ -315,7 +316,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                     borderRadius: 999,
                   }}
                 >
-                  {t(`praxisType.${praxis.type}`)}
+                  {praxisModeLabel(praxis, t)}
                 </span>
               </Link>
             ))}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { praxisModeLabel } from '../../../utils/praxis'
 import { EphemeristsSigil } from '../../../components/cards/ephemeristsAtoms'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
@@ -216,7 +217,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
                   className="shrink-0"
                   style={{ fontFamily: DISPLAY, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: LAPIS, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${GOLD_DEEP}` }}
                 >
-                  {t(`praxisType.${praxis.type}`)}
+                  {praxisModeLabel(praxis, t)}
                 </span>
               </Link>
             ))}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
 /**
@@ -262,7 +263,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
                   className="shrink-0"
                   style={{ fontFamily: BODY_FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: CREAM, background: INK, padding: 'var(--space-xs) var(--space-sm)' }}
                 >
-                  {t(`praxisType.${praxis.type}`)}
+                  {praxisModeLabel(praxis, t)}
                 </span>
               </Link>
             ))}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
 /**
@@ -225,7 +226,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
                   className="shrink-0"
                   style={{ fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: AMBER, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${signal(30)}` }}
                 >
-                  {t(`praxisType.${praxis.type}`)}
+                  {praxisModeLabel(praxis, t)}
                 </span>
               </Link>
             ))}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
 /**
@@ -206,7 +207,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
                   className="shrink-0"
                   style={{ fontFamily: TYPE, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: ACID, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${LINE}` }}
                 >
-                  {t(`praxisType.${praxis.type}`)}
+                  {praxisModeLabel(praxis, t)}
                 </span>
               </Link>
             ))}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
@@ -5,6 +5,7 @@ import UaMandala from '../../../components/cards/UaMandala'
 import { UaSigil } from '../../../components/cards/UaSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 
 /**
@@ -247,7 +248,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
                   className="shrink-0"
                   style={{ ...smallCaps, color: ACCENT, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${RULE}` }}
                 >
-                  {t(`praxisType.${praxis.type}`)}
+                  {praxisModeLabel(praxis, t)}
                 </span>
               </Link>
             ))}

--- a/frontend/src/utils/__tests__/praxisModeLabel.test.tsx
+++ b/frontend/src/utils/__tests__/praxisModeLabel.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Duel mode labelling (#992).
+ *
+ * A duel is two solo praxes linked by a `Duel` row (ADR-0011): a duel side is
+ * stored `type='solo'` + a non-null `duel_id`, there is NO `type='duel'` praxis.
+ * So any surface that labels by `type` alone reads an accepted duel as "Solo".
+ * `praxisModeLabel` and the card mode chips gate on duel presence first; these
+ * assert that a duel side reads "Duel" while a plain solo/collab is unchanged.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+
+import i18n from "../../i18n";
+import { isDuelPraxis, praxisModeLabel } from "../praxis";
+import { PraxisModeChip } from "../../components/praxisCard/shared";
+import {
+  MobileModeChip,
+  type MobileSlotTheme,
+} from "../../components/praxisCard/mobile/shared";
+import type { PraxisCardOut } from "../../api/praxis";
+
+const t = i18n.getFixedT(null, "common");
+
+const DUEL_LABEL = t("praxisType.duel");
+const SOLO_LABEL = t("praxisType.solo");
+const COLLAB_LABEL = t("praxisType.collab");
+const DUEL_CHIP = t("collaborationCard.duel");
+
+/** A card fixture — only the mode fields matter; the rest satisfy the type. */
+function card(overrides: Partial<PraxisCardOut>): PraxisCardOut {
+  return {
+    id: 1,
+    task_id: 1,
+    task_title: "Task",
+    task_point_value: 10,
+    task_level_required: 0,
+    type: "solo",
+    status: "in_progress",
+    title: "A praxis",
+    moderation_status: "visible",
+    created_by_id: 1,
+    created_by_display_name: "Author",
+    created_by_avatar_url: "",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    submitted_at: null,
+    submit_proposed_at: null,
+    member_count: 1,
+    score: 10,
+    metatask_points: 0,
+    display_multiplier: 1,
+    points_from_votes: 0,
+    voter_count: 0,
+    is_top_for_task: false,
+    applied_metatasks: [],
+    task_faction_slug: null,
+    body_text: null,
+    created_by_faction_slug: null,
+    members: [],
+    media_items: [],
+    viewer_vote: null,
+    voted_by_name: null,
+    viewer_can_vote: true,
+    duel_id: null,
+    ...overrides,
+  } as PraxisCardOut;
+}
+
+const THEME: MobileSlotTheme = {
+  ink: "#000",
+  muted: "#666",
+  accent: "#c00",
+  paper: "#fff",
+};
+
+const text = (element: React.ReactElement): string =>
+  renderToStaticMarkup(element).replace(/<[^>]*>/g, "");
+
+describe("praxisModeLabel (#992)", () => {
+  it("labels a duel side 'Duel' even though it is stored type='solo'", () => {
+    const duelSide = card({ type: "solo", duel_id: 42 });
+    expect(isDuelPraxis(duelSide)).toBe(true);
+    expect(praxisModeLabel(duelSide, t)).toBe(DUEL_LABEL);
+  });
+
+  it("labels a plain solo (no duel) 'Solo'", () => {
+    const solo = card({ type: "solo", duel_id: null });
+    expect(isDuelPraxis(solo)).toBe(false);
+    expect(praxisModeLabel(solo, t)).toBe(SOLO_LABEL);
+  });
+
+  it("labels a collab 'Collab'", () => {
+    const collab = card({ type: "collab", duel_id: null });
+    expect(praxisModeLabel(collab, t)).toBe(COLLAB_LABEL);
+  });
+});
+
+describe("card mode chips gate on duel presence (#992)", () => {
+  it("desktop PraxisModeChip renders the Duel chip for a type='solo' duel side", () => {
+    const html = text(<PraxisModeChip praxis={card({ type: "solo", duel_id: 42 })} />);
+    expect(html).toContain(DUEL_CHIP);
+  });
+
+  it("desktop PraxisModeChip renders nothing for a plain solo", () => {
+    expect(
+      renderToStaticMarkup(<PraxisModeChip praxis={card({ type: "solo", duel_id: null })} />),
+    ).toBe("");
+  });
+
+  it("mobile MobileModeChip renders the Duel chip for a type='solo' duel side", () => {
+    const html = text(
+      <MobileModeChip praxis={card({ type: "solo", duel_id: 42 })} theme={THEME} />,
+    );
+    expect(html).toContain(DUEL_CHIP);
+  });
+
+  it("mobile MobileModeChip renders nothing for a plain solo", () => {
+    expect(
+      renderToStaticMarkup(
+        <MobileModeChip praxis={card({ type: "solo", duel_id: null })} theme={THEME} />,
+      ),
+    ).toBe("");
+  });
+});

--- a/frontend/src/utils/praxis.ts
+++ b/frontend/src/utils/praxis.ts
@@ -1,0 +1,28 @@
+import type { TFunction } from 'i18next'
+import type { PraxisCardOut } from '../api/praxis'
+
+/**
+ * Praxis mode helpers (#992).
+ *
+ * A duel is two solo praxes linked by a `Duel` row (ADR-0011): a duel side is
+ * stored `type='solo'` + a non-null `duel_id`, there is no `type='duel'` praxis.
+ * So any surface that labels a praxis by `type` alone reads an accepted duel as
+ * "Solo". Gate on duel presence FIRST, then fall back to the stored type.
+ */
+
+/** True when this praxis is a side of a duel — the `duel_id` is populated. */
+export function isDuelPraxis(praxis: Pick<PraxisCardOut, 'duel_id'>): boolean {
+  return praxis.duel_id != null
+}
+
+/**
+ * The mode label for a praxis: "Duel" when it is a duel side, otherwise the
+ * label for its stored type ("Solo" / "Collab"). Reads the `praxisType.*` keys
+ * from the `common` catalog.
+ */
+export function praxisModeLabel(
+  praxis: Pick<PraxisCardOut, 'type' | 'duel_id'>,
+  t: TFunction<'common'>,
+): string {
+  return isDuelPraxis(praxis) ? t('praxisType.duel') : t(`praxisType.${praxis.type}`)
+}


### PR DESCRIPTION
## What

An accepted duel showed up as **Solo** in the In-Progress sidebar (and elsewhere). Root cause per the issue: a duel side is stored `type='solo'` + a non-null `duel_id` (ADR-0011) — there is no `type='duel'` praxis — so any surface labelling by `type` alone reads "Solo".

**This turned out to be full-stack, not frontend-only.** `duel_id` was on `PraxisOut` (detail) but **not** on `PraxisCardOut` — the card/list schema the sidebar, FieldDesk lists, and mode chips all consume. So the frontend had nothing to gate on until the field was added to the card payload.

### Backend
- Added `duel_id: Optional[int] = None` to `PraxisCardOut` (`schemas/praxis.py`).
- New page-wide `duel_id_map` precompute (`services/praxis.py`) mirroring `viewer_can_vote_map` / `applied_metatasks_for` — one duel query per page, **no N+1**. Same statuses as `build_praxis_out` (incl. `resolved`, ADR-0052). Wired into the list route; single-card callers fall back to a per-praxis lookup.

### Frontend
- New `utils/praxis.ts`: `isDuelPraxis(praxis)` (`duel_id != null`) and `praxisModeLabel(praxis, t)` ("Duel" when a duel side, else the type label). `duel_id` added to the FE `PraxisCardOut` interface.
- Routed through the helper: the In-Progress **Sidebar** (dropped the type-only record), the **7 mobile FieldDesk** active-task lists (Coven/Default/Ephemerists/Everymen/Singularity/Snide/Ua), and the **desktop + mobile card mode chips** (whose `isDuel` gated on `type === 'duel'`, which per ADR-0011 never fires). `WowFieldDesk` shows faction+points with no mode label — n/a, verified.
- Fixed the `factionCardSlots` duel fixture from the bogus `type:'duel'` to the real `type:'solo'` + `duel_id` shape.

## Tests
- Backend: a duel-side praxis card carries `duel_id` (both sides share it); a plain solo is null. Full praxis/viewer-can-vote suites green on `wz992_test`.
- Frontend: new `praxisModeLabel.test.tsx` (SSR-style) — `duel_id` → "Duel" (helper + both chips), plain solo → "Solo", collab → "Collab". `tsc` clean (the check that proves the new field exists), eslint clean, `vite build` OK, full vitest 1552 green.

## What to eyeball
Visual QA is outstanding (no dev stack / Browser pane can't screenshot here):
- Accept a duel → the **In-Progress Tasks** sidebar shows **"Duel"**, not "Solo".
- Same duel on a **mobile FieldDesk** active-task list → **"Duel"**.
- The duel's **card mode chip** → shows the Duel chip.
- A **collab** still shows **"Collab"**; a **plain solo** still shows **"Solo"**.

Note: the praxis **detail** archetype pages also mislabel duels (e.g. `EverymenPraxisDetail` lacks duel copy) — that's a deliberate **separate follow-up**, out of scope here.

Closes #992