### PR TITLE
docs(adr): add the missing ADR-0055 and ADR-0056

### DIFF
--- a/docs/adr/0055-task-cards-show-base-points-and-a-live-multiplier-badge.md
+++ b/docs/adr/0055-task-cards-show-base-points-and-a-live-multiplier-badge.md
@@ -1,0 +1,54 @@
+# ADR-0055 — Task cards show base points + a live multiplier badge
+
+**Status:** Accepted
+**Date:** 2026-07-27
+**Relates to:** #1020 (epic), #1022, #1023
+**Distinct from:** ADR-0053 (Retire Merit) — that retired the post-vote, duel-inclusive
+praxis `display_multiplier`. This ADR is about a different, still-live mechanism: the
+pre-submission per-faction task multiplier.
+
+## Context
+
+The v2 faction task-card redesign (design project `0711d3a7-0074-4a60-8907-270f44168261`)
+needed to decide what "points" a card shows. Investigating surfaced a stale assumption:
+the per-faction task multiplier (`own_task_modifier`/`other_task_modifier`, resolved by
+`compute_faction_multiplier` on the backend and `computeDisplayPoints` in
+`utils/points.ts`) reads as dead code because `era_1.py` neutralizes every faction's
+modifier to 1.0 — but it is live infrastructure, not retired.
+
+Today, `displayPoints` passed into `TaskCard` is already the *product* (`base ×
+modifier`) computed by the caller. The v2 designs want to show base points and the
+multiplier as separate, legible pieces — partly for clarity, partly so a future era
+that ships a non-1.0 modifier doesn't require touching every card again.
+
+## Decision
+
+Task cards show **base points plus a `×multiplier` badge**, computed and rendered
+separately rather than pre-multiplied.
+
+- `CardProps` (`components/TaskCard.tsx`) changes from `{ task, displayPoints, onSignup }`
+  to `{ task, basePoints, multiplier, inProgressCount, onSignup }`. `basePoints` is
+  `task.point_value`.
+- A new `displayMultiplierFor(task)` helper sits beside `displayPointsFor` in
+  `utils/points.ts` and returns the **raw** `own_task_modifier`/`other_task_modifier`
+  factor for the viewer — never a derived `effective / base` ratio (that reconstruction
+  was the ADR-0053 dead-arithmetic trap).
+- The multiplier badge renders **only when the factor ≠ 1.0**. At `era_1` every faction
+  resolves to 1.0, so the badge is invisible today across every card — this ships with
+  zero visible change until a future era's `EraConfig` sets a non-1.0 modifier, at which
+  point every card lights up automatically with no further rebuild.
+- No backend work: the multiplier mechanism itself is unchanged, existing infrastructure.
+  F1 (#1021) separately adds `in_progress_count` to `TaskOut` for the same redesign's
+  "{n} in progress" element — an unrelated but co-shipped read.
+
+## Consequences
+
+- Cards become forward-compatible with era-tuned multipliers by construction, instead of
+  requiring a rebuild the day one first goes non-1.0.
+- Every `<TaskCard>` call site (`Tasks.tsx`, `Home.tsx`, and `DefaultTasks.tsx` once
+  unified per ADR-0056) and every currently-registered faction skin must move to the new
+  prop shape in the same change (F2, #1022) — a mechanical, non-visual pass across all 8
+  existing skins is required even though only the na/Default card is visually rebuilt in
+  F2; the other 8 get their full redesign in C1 (#1023).
+- `displayPointsFor` (the pre-multiplied helper) stops being threaded into cards; it may
+  still be used wherever a single combined number is wanted.

--- a/docs/adr/0056-task-cards-collapse-to-one-responsive-component-per-faction.md
+++ b/docs/adr/0056-task-cards-collapse-to-one-responsive-component-per-faction.md
@@ -1,0 +1,48 @@
+# ADR-0056 — Task cards collapse to one responsive component per faction
+
+**Status:** Proposed — under evaluation, not settled law
+**Date:** 2026-07-27
+**Relates to:** #1020 (epic), #1022, #1023
+**Tension with:** ADR-0035 (distinct mobile screens; a responsive squeeze of one
+component was rejected at the time)
+
+## Context
+
+Mobile task cards currently live on a separate `mobileTaskCard` manifest surface — a
+dedicated dispatcher (`mobileArchetypes/mobileTaskCard.tsx`) and 9 bespoke mobile files
+(`DefaultMobileTaskCard` + 8 factions), distinct from the desktop `taskCard` surface's 9
+files. ADR-0035 established that split deliberately.
+
+The v2 task-card designs are authored as a single responsive component per faction
+(`theme`/`platform` props switching internally), which reopens the question. The
+owner's framing: "won't know if one experience is good across both until I test" — this
+is explicitly an experiment to evaluate, not a considered reversal of ADR-0035.
+
+## Decision
+
+Rewire the mobile task-browse list (`DefaultTasks.tsx`) onto the shared `<TaskCard>`
+component (using `useFormFactor()` internally for the desktop/mobile size set and each
+design's conditional ornament), **as a reversible experiment**.
+
+- The `mobileTaskCard` surface, its dispatcher, `DefaultMobileTaskCard`, and all 9
+  mobile card files **stay in place but dormant** — not deleted. Reverting is flipping
+  the one `DefaultTasks.tsx` call site back to the old dispatcher.
+- Deletion of the dormant mobile surface is a separate, deferred cleanup, gated on the
+  owner's hands-on verdict after living with the unified cards — not part of this change.
+- This ADR does not overturn ADR-0035's reasoning; it authorizes one concrete trial of
+  the alternative ADR-0035 rejected, kept cheap to back out of.
+
+## Consequences
+
+- Until the owner accepts or rejects this experiment, the repo carries two parallel
+  task-card implementations per faction (18 files: 9 desktop + 9 dormant mobile) —
+  expected and intentional during the evaluation window, not drift to clean up
+  prematurely.
+- If accepted: a follow-up (not yet filed) retires the dormant `mobileTaskCard` surface
+  and its 9 files.
+- If rejected: `DefaultTasks.tsx`'s call site flips back to `mobileTaskCard`'s
+  dispatcher, and the unified component's mobile-sizing branch goes unused on mobile
+  going forward.
+- Status stays **Proposed** until that verdict — a marker for future readers that the
+  mobile-unification half of task-cards-v2 is provisional, unlike ADR-0055's
+  multiplier-display decision, which is settled.


### PR DESCRIPTION
## Why

#1020 (epic), #1022 and #1023 all cite **ADR-0055** and **ADR-0056** as their governing decisions — but neither file exists. The highest ADR on `main` is 0054, and I checked every local branch: nothing past 0054 anywhere. They were decided in the 2026-07-27 task-cards-v2 grill and simply never got written.

I hit this while verifying #1022's premises before dispatching a build agent for it. Rather than hand a builder two dangling references, writing them first.

## What

Both files transcribed from the epic body's own ADR-style prose, which already contained the full Context / Decision / Consequences for each — plus the surrounding detail from the grill (exact prop shape, the `displayMultiplierFor` raw-factor rule, the dormant-not-deleted mobile constraint). Format matches ADR-0048/0054.

- **ADR-0055 (Accepted)** — cards show base points + a `×multiplier` badge, computed separately rather than pre-multiplied. The multiplier is live infra (`own_task_modifier`/`other_task_modifier`), merely neutralized to 1.0 in `era_1`, so the badge is invisible today and lights up automatically when a future era ships a non-1.0 factor. Explicitly distinguished from ADR-0053, which retired a *different* multiplier (the post-vote praxis one) — that conflation was the stale premise the grill corrected.
- **ADR-0056 (Proposed — under evaluation)** — the mobile task list rewires onto the shared responsive `<TaskCard>`, a scoped tension with ADR-0035. Recorded as a **reversible experiment**: the `mobileTaskCard` surface + 9 files stay dormant, not deleted; revert = flip one call site. Status stays Proposed until the owner's hands-on verdict.

## What to eyeball

Docs only — no code, no CI risk beyond the docs path. Worth a read for whether ADR-0056's Proposed framing and the "don't delete the dormant files" constraint match what you actually decided in the grill, since #1022's builder will treat these as binding.