### PR TITLE
#1022: task-card contract (base + multiplier + in-progress), mobile unification, na card rebuild

### DIFF
--- a/frontend/src/components/TaskCard.tsx
+++ b/frontend/src/components/TaskCard.tsx
@@ -8,17 +8,50 @@ import { pickVariant } from '../utils/factionDispatch'
 import { surfaceMap } from '../factions'
 import type { } from 'react'
 
+/**
+ * The contract every faction task-card skin is built against (ADR-0055).
+ *
+ * Points arrive UNMULTIPLIED, with the viewer's faction modifier alongside,
+ * rather than as the pre-multiplied product the pre-v2 `displayPoints` prop
+ * carried. A card renders `basePoints`, and renders a `×multiplier` badge only
+ * when `isNeutralMultiplier(multiplier)` is false — which is never at `era_1`
+ * values, and automatic the day an era ships a non-1.0 modifier.
+ */
 export interface CardProps {
   task: TaskOut
-  displayPoints: number
+  /** `task.point_value` — the unmodified value, never `base × multiplier`. */
+  basePoints: number
+  /** Raw own/other task modifier for the viewer. 1.0 → no badge. */
+  multiplier: number
+  /** Characters actively working this task (#1021). 0 → no in-progress line. */
+  inProgressCount: number
   onSignup?: (id: number) => void
 }
+
+/**
+ * What the dispatcher itself accepts. The two derived props are optional here
+ * and required on {@link CardProps}: a surface with no viewer-faction context
+ * (a character profile's task list) has no multiplier to pass, and
+ * `inProgressCount` is a plain read off the task. Defaulting once here beats
+ * spelling both out at every call site — and keeps the skin contract total.
+ */
+export type TaskCardProps =
+  Omit<CardProps, 'multiplier' | 'inProgressCount'>
+  & Partial<Pick<CardProps, 'multiplier' | 'inProgressCount'>>
 
 // `na` / unaffiliated + any faction without a bespoke card → the spectrum
 // default skin (#418). No longer borrows UA's costume.
 export const DEFAULT_CARD = DefaultTaskCard
 
-export default function TaskCard({ task, displayPoints, onSignup }: CardProps) {
+export default function TaskCard({
+  task,
+  basePoints,
+  multiplier = 1,
+  // `in_progress_count` is optional on TaskOut so pre-#1021 fixtures stay
+  // valid; a live backend always sends it (int, default 0).
+  inProgressCount = task.in_progress_count ?? 0,
+  onSignup,
+}: TaskCardProps) {
   const { user } = useAuth()
   const { adminMode } = useAdminMode()
   const showAdminControls = user?.is_admin && adminMode
@@ -32,7 +65,13 @@ export default function TaskCard({ task, displayPoints, onSignup }: CardProps) {
   const isMetatask = task.task_type === 'metatask'
   return (
     <div style={{ position: 'relative' }}>
-      <Card task={task} displayPoints={displayPoints} onSignup={onSignup} />
+      <Card
+        task={task}
+        basePoints={basePoints}
+        multiplier={multiplier}
+        inProgressCount={inProgressCount}
+        onSignup={onSignup}
+      />
       {isMetatask && (
         <div
           style={{

--- a/frontend/src/components/__tests__/factionCardSlots.test.tsx
+++ b/frontend/src/components/__tests__/factionCardSlots.test.tsx
@@ -280,7 +280,9 @@ const taskArchetypes = {
 describe("task-card content-slot invariant", () => {
   for (const [slug, Card] of Object.entries(taskArchetypes)) {
     it(`${slug} renders title, task link, and points`, () => {
-      const { html, text } = markup(<Card task={TASK} displayPoints={4242} />);
+      const { html, text } = markup(
+        <Card task={TASK} basePoints={4242} multiplier={1} inProgressCount={0} />,
+      );
       expect(text, "title slot").toContain("Photosynthesis");
       expect(html, "task-link slot").toContain('href="/tasks/7"');
       expect(html, "points slot").toContain("4242");

--- a/frontend/src/components/cards/CovenTaskCard.tsx
+++ b/frontend/src/components/cards/CovenTaskCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import type { TaskOut } from "../../api/tasks";
+import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
 import LevelGem from "../ui/LevelGem";
 
@@ -9,12 +9,6 @@ import LevelGem from "../ui/LevelGem";
  * dotted-grid body, and an inner "notepad" panel holding the task in the
  * Caveat headline font. Visuals only — same prop contract as the other cards.
  */
-
-interface Props {
-  task: TaskOut;
-  displayPoints: number;
-  onSignup?: (id: number) => void;
-}
 
 /** Tiny four-point sparkle used in the title bar and footer pill accent. */
 function Sparkle({
@@ -51,9 +45,9 @@ function WindowDot({ color }: { color: string }) {
 
 export default function CovenTaskCard({
   task,
-  displayPoints,
+  basePoints,
   onSignup,
-}: Props) {
+}: CardProps) {
   return (
     <div
       style={{
@@ -136,7 +130,7 @@ export default function CovenTaskCard({
             className="card-meta"
             style={{ color: "var(--faction-coven-card-accent)" }}
           >
-            {i18n.t("feed:taskCard.coven.questMeta", { points: displayPoints })}
+            {i18n.t("feed:taskCard.coven.questMeta", { points: basePoints })}
           </div>
 
           <Link
@@ -190,7 +184,7 @@ export default function CovenTaskCard({
               color: "var(--faction-coven-card-accent)",
             }}
           >
-            ◆ {i18n.t("feed:taskCard.coven.points", { points: displayPoints })}
+            ◆ {i18n.t("feed:taskCard.coven.points", { points: basePoints })}
           </span>
         </div>
       </div>

--- a/frontend/src/components/cards/DefaultTaskCard.tsx
+++ b/frontend/src/components/cards/DefaultTaskCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import type { TaskOut } from "../../api/tasks";
+import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
 import DefaultSigil from "./DefaultSigil";
 
@@ -15,13 +15,7 @@ import DefaultSigil from "./DefaultSigil";
  */
 const MONO = "'Courier Prime', monospace";
 
-interface Props {
-  task: TaskOut;
-  displayPoints: number;
-  onSignup?: (id: number) => void;
-}
-
-export default function DefaultTaskCard({ task, displayPoints, onSignup }: Props) {
+export default function DefaultTaskCard({ task, basePoints, onSignup }: CardProps) {
   return (
     // Spectrum band → clean inner sheet.
     <div
@@ -114,7 +108,7 @@ export default function DefaultTaskCard({ task, displayPoints, onSignup }: Props
               color: "var(--faction-default-card-text)",
             }}
           >
-            {displayPoints}
+            {basePoints}
             <span style={{ fontSize: "var(--text-md)", marginLeft: "var(--space-xs)", color: "var(--faction-default-card-muted)" }}>
               {i18n.t("feed:taskCard.na.pointsUnit")}
             </span>

--- a/frontend/src/components/cards/DefaultTaskCard.tsx
+++ b/frontend/src/components/cards/DefaultTaskCard.tsx
@@ -1,140 +1,327 @@
+import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
-import DefaultSigil from "./DefaultSigil";
+import { isNeutralMultiplier } from "../../utils/points";
+import { useFormFactor } from "../../hooks/useFormFactor";
 
 /**
- * DefaultTaskCard — the task-card archetype for the UNAFFILIATED / no-faction
- * (`na`) state, and the fallback for any task whose faction has no bespoke card.
- * Where each faction commits to one loud archetype, the default stays
- * deliberately un-committed: a clean sheet wrapped in a thick spectrum band
- * (every faction colour at once = all paths open), marked with the seven-segment
- * ring. Replaces the old borrowed-UA `DEFAULT_CARD = UaTaskCard` (#418). All
- * colours via --faction-default-* tokens (no hardcoded hex — CLAUDE.md); flips
- * light/dark through the cascade.
+ * DefaultTaskCard — THE SPECTRUM SHEET. The task-card archetype for the
+ * UNAFFILIATED / no-faction (`na`) state, and the fallback for any task whose
+ * faction has no bespoke card yet. `na` ≡ Default is one identity: this IS the
+ * unaffiliated kit, not a generic neutral.
+ *
+ * Where each faction commits to one loud archetype, the unaffiliated card stays
+ * deliberately un-committed — a clean sheet ruled by the full spectrum, because
+ * every path is still open. The rainbow appears in exactly three places: the
+ * 3px band that IS the card's border, the conic ring the marks sit inside, and
+ * the tick beside the in-progress count. Lora italic carries the title, Courier
+ * Prime everything else.
+ *
+ * ONE RESPONSIVE COMPONENT (ADR-0056, a reversible experiment): `useFormFactor`
+ * picks the size set, not a different card. The dormant
+ * `mobileArchetypes/cards/DefaultMobileTaskCard` is still in the tree for the
+ * revert.
+ *
+ * All colour via `--faction-default-*` tokens — no hardcoded hex (CLAUDE.md);
+ * light/dark flips through the `[data-theme="dark"]` cascade, never a ternary.
  */
-const MONO = "'Courier Prime', monospace";
 
-export default function DefaultTaskCard({ task, basePoints, onSignup }: CardProps) {
+const MONO = "var(--font-body)";
+/**
+ * Lora, via the shared display token — deliberately NOT
+ * `--faction-default-card-font`, which is Bebas Neue: the face #839 chose for
+ * the unaffiliated PRAXIS card. The v2 task-card design names Lora + Courier
+ * Prime for this surface. If na should carry one display face everywhere, the
+ * fix is repointing that token in index.css, not branching here.
+ */
+const LORA = "var(--font-display)";
+
+interface SizeSet {
+  /** Card width. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
+  cardWidth: number;
+  /** Outer diameter of the conic points ring. Geometry. */
+  ringSize: number;
+  pad: string;
+  titleSize: string;
+  numeralSize: string;
+}
+
+const SIZES: Record<"desktop" | "mobile", SizeSet> = {
+  desktop: {
+    cardWidth: 384,
+    ringSize: 92,
+    pad: "var(--space-xl)",
+    titleSize: "var(--text-title)",
+    numeralSize: "var(--text-heading)",
+  },
+  mobile: {
+    cardWidth: 340,
+    ringSize: 80,
+    pad: "var(--space-lg)",
+    titleSize: "var(--text-content)",
+    numeralSize: "var(--text-title)",
+  },
+};
+
+/** Label-tier caption voice shared by every small mark on the sheet. */
+const CAPTION: CSSProperties = {
+  fontFamily: MONO,
+  letterSpacing: "0.2em",
+  textTransform: "uppercase",
+  color: "var(--faction-default-card-muted)",
+};
+
+export default function DefaultTaskCard({
+  task,
+  basePoints,
+  multiplier,
+  inProgressCount,
+  onSignup,
+}: CardProps) {
+  const formFactor = useFormFactor();
+  const size = SIZES[formFactor];
+  const showMultiplier = !isNeutralMultiplier(multiplier);
+
   return (
-    // Spectrum band → clean inner sheet.
     <div
-      style={{
-        minWidth: 240,
-        maxWidth: 292,
-        flex: "0 1 282px",
-        borderRadius: 10,
-        padding: "var(--space-sm)",
-        background: "var(--faction-default-rainbow)",
-        boxShadow: "0 12px 32px -14px rgba(0,0,0,0.4)",
-        boxSizing: "border-box",
-      }}
+      data-form-factor={formFactor}
+      style={{ width: size.cardWidth, maxWidth: "100%", boxSizing: "border-box" }}
     >
-      <div
+      <article
         style={{
-          background: "var(--faction-default-card-bg)",
-          borderRadius: 5,
-          padding: "var(--space-xl) var(--space-xl) var(--space-xl)",
+          position: "relative",
+          overflow: "hidden",
+          boxSizing: "border-box",
+          // The spectrum IS the border: a transparent 3px frame with the
+          // rainbow painted into the border box behind it, and the sheet
+          // painted into the padding box on top.
+          border: "3px solid transparent",
+          borderRadius: 14,
+          backgroundImage:
+            "linear-gradient(var(--faction-default-card-bg), var(--faction-default-card-bg)), var(--faction-default-rainbow)",
+          backgroundOrigin: "border-box",
+          backgroundClip: "padding-box, border-box",
+          boxShadow: "0 12px 32px -14px rgba(0,0,0,0.4)",
           color: "var(--faction-default-card-text)",
+          fontFamily: MONO,
+          padding: size.pad,
         }}
       >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "var(--space-md)",
-            marginBottom: "var(--space-lg)",
-            fontFamily: MONO,
-            fontSize: "var(--text-base)",
-            letterSpacing: "0.22em",
-            textTransform: "uppercase",
-            color: "var(--faction-default-card-muted)",
-          }}
+        {/* Everything but the CTA reads the full call — a card-sized target
+            that stays valid HTML (no <button> nested in an <a>). */}
+        <Link
+          to={`/tasks/${task.id}`}
+          style={{ display: "block", textDecoration: "none", color: "inherit" }}
         >
-          <DefaultSigil size={28} /> {i18n.t("feed:taskCard.na.eyebrow")}
-        </div>
-
-        <Link to={`/tasks/${task.id}`} style={{ textDecoration: "none", color: "inherit" }}>
-          <h3
-            className="content-title"
+          {/* Eyebrow — the uniform ordinal every faction card carries (#1020). */}
+          <div
             style={{
-              fontFamily: "var(--faction-default-card-font)",
+              ...CAPTION,
+              fontSize: "var(--text-base)",
+              letterSpacing: "0.22em",
+              marginBottom: "var(--space-lg)",
+            }}
+          >
+            {i18n.t("feed:taskCard.ordinal", { id: task.id })}
+          </div>
+
+          {/* Hero — level, a hairline, the marks in their ring, the modifier. */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-lg)",
+              marginBottom: "var(--space-lg)",
+            }}
+          >
+            <div
+              style={{
+                flex: "0 0 auto",
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "flex-start",
+                lineHeight: 1,
+              }}
+            >
+              <span
+                style={{ ...CAPTION, fontSize: "var(--text-sm)", marginBottom: "var(--space-xs)" }}
+              >
+                {i18n.t("feed:taskCard.na.levelCaption")}
+              </span>
+              <span
+                style={{
+                  fontFamily: LORA,
+                  fontWeight: 600,
+                  fontSize: size.numeralSize,
+                  lineHeight: 0.9,
+                }}
+              >
+                {task.level_required}
+              </span>
+            </div>
+
+            <div style={{ flex: 1, height: 1, background: "var(--faction-default-border)" }} />
+
+            <div
+              style={{
+                flex: "0 0 auto",
+                boxSizing: "border-box",
+                width: size.ringSize,
+                height: size.ringSize,
+                borderRadius: "50%",
+                padding: "var(--space-xs)",
+                background: "var(--faction-default-ring)",
+              }}
+            >
+              <div
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  borderRadius: "50%",
+                  background: "var(--faction-default-card-bg)",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  lineHeight: 0.9,
+                }}
+              >
+                <span style={{ fontFamily: LORA, fontWeight: 600, fontSize: size.numeralSize }}>
+                  {basePoints}
+                </span>
+                <span
+                  style={{ ...CAPTION, fontSize: "var(--text-xs)", marginTop: "var(--space-xs)" }}
+                >
+                  {i18n.t("feed:taskCard.na.pointsUnit")}
+                </span>
+              </div>
+            </div>
+
+            {/* Faction modifier — hidden at ×1.00, so invisible under era_1's
+                neutralized modifiers and automatic the day one moves
+                (ADR-0055). */}
+            {showMultiplier && (
+              <div
+                style={{
+                  flex: "0 0 auto",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: "var(--space-xs)",
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: LORA,
+                    fontWeight: 600,
+                    fontSize: "var(--text-xl)",
+                    lineHeight: 1,
+                    borderRadius: 5,
+                    padding: "var(--space-xs) var(--space-sm)",
+                    background: "var(--faction-default-card-text)",
+                    color: "var(--faction-default-card-bg)",
+                  }}
+                >
+                  {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
+                </span>
+                <span style={{ ...CAPTION, fontSize: "var(--text-xs)" }}>
+                  {i18n.t("feed:taskCard.modifierCaption")}
+                </span>
+              </div>
+            )}
+          </div>
+
+          <h3
+            style={{
+              fontFamily: LORA,
+              fontWeight: 600,
               fontStyle: "italic",
-              lineHeight: 1.08,
-              margin: "0 0 var(--space-md)",
-              color: "var(--faction-default-card-text)",
+              fontSize: size.titleSize,
+              lineHeight: 1.14,
+              margin: "0 0 var(--space-sm)",
               overflowWrap: "anywhere",
             }}
           >
             {task.title}
           </h3>
+
+          {task.description && (
+            <p
+              className="card-description"
+              style={{
+                fontFamily: MONO,
+                lineHeight: 1.55,
+                color: "var(--faction-default-card-muted)",
+                margin: "0 0 var(--space-lg)",
+              }}
+            >
+              {task.description}
+            </p>
+          )}
+
+          {inProgressCount > 0 && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-sm)",
+                marginBottom: "var(--space-lg)",
+              }}
+            >
+              <span
+                aria-hidden="true"
+                style={{
+                  width: 7,
+                  height: 7,
+                  borderRadius: 2,
+                  background: "var(--faction-default-rainbow)",
+                  display: "inline-block",
+                  flex: "none",
+                }}
+              />
+              <span
+                style={{
+                  fontFamily: MONO,
+                  fontSize: "var(--text-md)",
+                  letterSpacing: "0.04em",
+                  color: "var(--faction-default-card-muted)",
+                }}
+              >
+                {i18n.t("feed:taskCard.inProgress", { count: inProgressCount })}
+              </span>
+            </div>
+          )}
         </Link>
 
-        {task.description && (
-          <p
-            className="card-description"
-            style={{
-              lineHeight: 1.55,
-              color: "var(--faction-default-card-muted)",
-              margin: "0 0 var(--space-xl)",
-            }}
-          >
-            {task.description}
-          </p>
-        )}
-
-        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)" }}>
-          <span
-            style={{
-              fontFamily: MONO,
-              fontSize: "var(--text-base)",
-              letterSpacing: "0.08em",
-              textTransform: "uppercase",
-              color: "var(--faction-default-card-muted)",
-              border: "1px solid var(--faction-default-border)",
-              borderRadius: 99,
-              padding: "var(--space-xs) var(--space-md)",
-            }}
-          >
-            {i18n.t("feed:taskCard.na.level", { level: task.level_required })}
-          </span>
-          <span
-            className="content-title"
-            style={{
-              fontFamily: "var(--faction-default-card-font)",
-              fontStyle: "italic",
-              fontWeight: 700,
-              lineHeight: 1,
-              color: "var(--faction-default-card-text)",
-            }}
-          >
-            {basePoints}
-            <span style={{ fontSize: "var(--text-md)", marginLeft: "var(--space-xs)", color: "var(--faction-default-card-muted)" }}>
-              {i18n.t("feed:taskCard.na.pointsUnit")}
-            </span>
-          </span>
-          {onSignup && (
+        {onSignup && (
+          <div style={{ display: "flex", justifyContent: "center" }}>
             <button
               onClick={() => onSignup(task.id)}
               style={{
-                marginLeft: "auto",
                 cursor: "pointer",
-                fontFamily: "var(--faction-default-card-font)",
-                fontStyle: "italic",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                whiteSpace: "nowrap",
+                fontFamily: LORA,
+                fontWeight: 600,
                 fontSize: "var(--text-xl)",
-                letterSpacing: "0.03em",
-                padding: "var(--space-sm) var(--space-lg)",
-                borderRadius: 3,
+                letterSpacing: "0.14em",
+                textTransform: "uppercase",
+                padding: "var(--space-md) var(--space-2xl)",
+                borderRadius: 11,
                 color: "var(--faction-default-card-text)",
                 background: "transparent",
-                border: "1.5px solid var(--faction-default-card-accent)",
+                border:
+                  "1px solid color-mix(in srgb, var(--faction-default-card-accent) 35%, transparent)",
               }}
             >
               {i18n.t("feed:taskCard.na.signup")}
             </button>
-          )}
-        </div>
-      </div>
+          </div>
+        )}
+      </article>
     </div>
   );
 }

--- a/frontend/src/components/cards/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/cards/EphemeristsTaskCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { Trans } from "react-i18next";
-import type { TaskOut } from "../../api/tasks";
+import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
 import { EphEyebrow, LapisLastWord, toRoman } from "./ephemeristsAtoms";
 
@@ -13,13 +13,7 @@ import { EphEyebrow, LapisLastWord, toRoman } from "./ephemeristsAtoms";
  * Colors via the --eph-* / --faction-ephemerists-* tokens (theme-aware).
  */
 
-interface Props {
-  task: TaskOut;
-  displayPoints: number;
-  onSignup?: (id: number) => void;
-}
-
-export default function EphemeristsTaskCard({ task, displayPoints, onSignup }: Props) {
+export default function EphemeristsTaskCard({ task, basePoints, onSignup }: CardProps) {
   return (
     <div
       style={{
@@ -161,7 +155,7 @@ export default function EphemeristsTaskCard({ task, displayPoints, onSignup }: P
           {/* Points woven into the grade legend — a counter/legend accent, so it
               stays label-tier per the role vocabulary (§4), not a plain score. */}
           <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: "var(--text-lg)", color: "var(--eph-rubric)" }}>
-            {i18n.t("feed:taskCard.ephemerists.points", { points: displayPoints })}
+            {i18n.t("feed:taskCard.ephemerists.points", { points: basePoints })}
           </span>
         </div>
         <div style={{ fontSize: "var(--text-xs)", fontStyle: "italic", color: "var(--eph-muted)", marginTop: "var(--space-sm)", lineHeight: 1.35 }}>

--- a/frontend/src/components/cards/EverymenTaskCard.tsx
+++ b/frontend/src/components/cards/EverymenTaskCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import type { TaskOut } from "../../api/tasks";
+import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
 import LevelGem from "../ui/LevelGem";
 import { EverymenSigil } from "./EverymenSigil";
@@ -10,12 +10,6 @@ import { EverymenSigil } from "./EverymenSigil";
  * faint sunburst + halftone wash, rubber-stamped points seal, "Report for duty"
  * call to action wired to onSignup.
  */
-
-interface Props {
-  task: TaskOut;
-  displayPoints: number;
-  onSignup?: (id: number) => void;
-}
 
 /* ── poster atoms (self-contained) ─────────────────────────────── */
 
@@ -139,7 +133,7 @@ function PointsSeal({
 
 /* ── card ───────────────────────────────────────────────────────── */
 
-export default function EverymenTaskCard({ task, displayPoints, onSignup }: Props) {
+export default function EverymenTaskCard({ task, basePoints, onSignup }: CardProps) {
   return (
     <div
       style={{
@@ -249,10 +243,10 @@ export default function EverymenTaskCard({ task, displayPoints, onSignup }: Prop
               color: "var(--everymen-red)",
             }}
           >
-            {i18n.t("feed:taskCard.everymen.points", { points: displayPoints })}
+            {i18n.t("feed:taskCard.everymen.points", { points: basePoints })}
           </span>
         </div>
-        <PointsSeal points={displayPoints} />
+        <PointsSeal points={basePoints} />
       </div>
 
       {onSignup && (

--- a/frontend/src/components/cards/SingularityTaskCard.tsx
+++ b/frontend/src/components/cards/SingularityTaskCard.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
-import type { TaskOut } from "../../api/tasks";
+import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
 import { factionCssVar } from "../../utils/factions";
 
@@ -12,12 +12,6 @@ import { factionCssVar } from "../../utils/factions";
  * This card uses CSS variables for its colors even though it's always dark,
  * because the Singularity CSS vars are identical in both themes.
  */
-
-interface Props {
-  task: TaskOut;
-  displayPoints: number;
-  onSignup?: (id: number) => void;
-}
 
 // Static style objects, hoisted to module scope (#586) -- none of these close
 // over a prop, so re-allocating them on every render bought nothing.
@@ -173,9 +167,9 @@ function SprocketHoles() {
 
 export default function SingularityTaskCard({
   task,
-  displayPoints,
+  basePoints,
   onSignup,
-}: Props) {
+}: CardProps) {
   return (
     <div style={cardShellStyle}>
       {/* Scanline overlay */}
@@ -212,7 +206,7 @@ export default function SingularityTaskCard({
             {i18n.t("feed:taskCard.singularity.pointsLabel")}{" "}
             {/* Points value — a score, so .content-title per #627's re-cut (§4). */}
             <span className="content-title" style={pointsStyle}>
-              {displayPoints}
+              {basePoints}
             </span>
           </div>
           <div>

--- a/frontend/src/components/cards/SnideTaskCard.tsx
+++ b/frontend/src/components/cards/SnideTaskCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import type { TaskOut } from "../../api/tasks";
+import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
 import LevelGem from "../ui/LevelGem";
 import SnideMasthead from "./SnideMasthead";
@@ -10,12 +10,6 @@ import SnideMasthead from "./SnideMasthead";
  * ransom-letter title, pink scrawl, halftone screen. Loudest card in the grid.
  * Visuals only — same prop contract as the other faction cards.
  */
-
-interface Props {
-  task: TaskOut;
-  displayPoints: number;
-  onSignup?: (id: number) => void;
-}
 
 /** Mismatched cut-out letters — bg/colour/face/tilt picked deterministically per char. */
 const RANSOM_STYLES = [
@@ -100,9 +94,9 @@ function Ransom({ text, size = 22 }: { text: string; size?: number }) {
 
 export default function SnideTaskCard({
   task,
-  displayPoints,
+  basePoints,
   onSignup,
-}: Props) {
+}: CardProps) {
   return (
     <div
       style={{
@@ -212,7 +206,7 @@ export default function SnideTaskCard({
             color: "var(--faction-snide-acid)",
           }}
         >
-          {displayPoints}
+          {basePoints}
           <span style={{ fontSize: "var(--text-sm)", marginLeft: "var(--space-xs)" }}>
             {i18n.t("feed:taskCard.snide.pointsUnit")}
           </span>

--- a/frontend/src/components/cards/UaTaskCard.tsx
+++ b/frontend/src/components/cards/UaTaskCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import type { TaskOut } from "../../api/tasks";
+import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
 import LevelGem from "../ui/LevelGem";
 import {
@@ -34,13 +34,7 @@ import {
  * with the app like every other faction's.
  */
 
-interface Props {
-  task: TaskOut;
-  displayPoints: number;
-  onSignup?: (id: number) => void;
-}
-
-export default function UaTaskCard({ task, displayPoints, onSignup }: Props) {
+export default function UaTaskCard({ task, basePoints, onSignup }: CardProps) {
   return (
     <article
       style={{
@@ -79,7 +73,7 @@ export default function UaTaskCard({ task, displayPoints, onSignup }: Props) {
         >
           <UaEnsoScore
             size={96}
-            value={displayPoints}
+            value={basePoints}
             unit={i18n.t("tasks:ua.stats.honoraria")}
           />
         </div>
@@ -146,7 +140,7 @@ export default function UaTaskCard({ task, displayPoints, onSignup }: Props) {
         >
           <LevelGem level={task.level_required} factionSlug="ua" />
           <span style={{ ...UA_EYEBROW, letterSpacing: "0.16em" }}>
-            {i18n.t("feed:taskCard.ua.pointsLine", { points: displayPoints })}
+            {i18n.t("feed:taskCard.ua.pointsLine", { points: basePoints })}
           </span>
         </div>
       </div>

--- a/frontend/src/components/cards/WowTaskCard.tsx
+++ b/frontend/src/components/cards/WowTaskCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import type { TaskOut } from "../../api/tasks";
+import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
 import LevelGem from "../ui/LevelGem";
 import { WowSigil } from "./WowSigil";
@@ -39,12 +39,6 @@ import { WowSigil } from "./WowSigil";
  * Both themes come from the `[data-theme="dark"]` cascade — the rod tarnishes,
  * the parchment darkens, the struck-metal seal does not repaint.
  */
-
-interface Props {
-  task: TaskOut;
-  displayPoints: number;
-  onSignup?: (id: number) => void;
-}
 
 /** The gold/plum checker band that heads every decree. 11px per square. */
 const CHECKER =
@@ -90,7 +84,7 @@ function DecreeRod() {
   );
 }
 
-export default function WowTaskCard({ task, displayPoints, onSignup }: Props) {
+export default function WowTaskCard({ task, basePoints, onSignup }: CardProps) {
   return (
     <div
       style={{
@@ -169,7 +163,7 @@ export default function WowTaskCard({ task, displayPoints, onSignup }: Props) {
                   color: "var(--faction-wow-stamp-total)",
                 }}
               >
-                {displayPoints}
+                {basePoints}
               </div>
               <div
                 className="eyebrow"

--- a/frontend/src/components/cards/__tests__/defaultTaskCard.test.tsx
+++ b/frontend/src/components/cards/__tests__/defaultTaskCard.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * The na / Unaffiliated task card, and the prop plumbing every faction skin
+ * inherits (#1022, ADR-0055 + ADR-0056).
+ *
+ * Two things are pinned here. First, the card is ONE responsive component: the
+ * same element tree renders on both form factors and only the size set moves,
+ * so the mobile assertions are about `useFormFactor` reaching the card, not
+ * about a second file. Second, points arrive unmultiplied — the card must show
+ * `basePoints`, never `basePoints × multiplier`, or a future non-1.0 era
+ * multiplies twice.
+ *
+ * Rendered with `renderToStaticMarkup`; this repo has no jsdom, so effects
+ * never run and click behaviour is out of reach. These are render-shape
+ * assertions.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import type { TaskOut } from '../../../api/tasks'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+// Imported after the mock is registered.
+import DefaultTaskCard from '../DefaultTaskCard'
+import TaskCard from '../../TaskCard'
+
+const TASK: TaskOut = {
+  id: 7,
+  title: 'Photosynthesis',
+  description: 'Leave something small and honest where a stranger will find it.',
+  point_value: 18,
+  level_required: 2,
+  status: 'active',
+  task_type: 'standard',
+  created_by: 3,
+  primary_faction_slug: null,
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: '2026-01-01T00:00:00Z',
+  in_progress_count: 6,
+  can_submit_praxis: true,
+  allowed_modes: ['solo'],
+  eligible_for_current_user: true,
+}
+
+function markup(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+function card(props: Partial<{
+  multiplier: number
+  inProgressCount: number
+  onSignup: (id: number) => void
+}> = {}) {
+  return markup(
+    <DefaultTaskCard
+      task={TASK}
+      basePoints={TASK.point_value}
+      multiplier={props.multiplier ?? 1}
+      inProgressCount={props.inProgressCount ?? 0}
+      onSignup={props.onSignup}
+    />,
+  )
+}
+
+const SIGNUP = i18n.t('feed:taskCard.na.signup')
+
+describe('na task card — content slots', () => {
+  it('carries the uniform "Task {id}" ordinal, not a faction ordinal', () => {
+    const { text } = card()
+    expect(text).toContain(i18n.t('feed:taskCard.ordinal', { id: 7 }))
+    expect(text, 'no Task No. ornament from the design canvas').not.toContain('№')
+  })
+
+  it('renders the title behind a link to the task, the call, level and marks', () => {
+    const { html, text } = card()
+    expect(html, 'task-link slot').toContain('href="/tasks/7"')
+    expect(text, 'title slot').toContain('Photosynthesis')
+    expect(text, 'call slot').toContain('stranger will find it')
+    expect(text, 'level slot').toContain('2')
+    expect(text, 'points slot').toContain('18')
+  })
+
+  it('shows the in-progress count only when someone is working it', () => {
+    expect(card({ inProgressCount: 6 }).text).toContain(
+      i18n.t('feed:taskCard.inProgress', { count: 6 }),
+    )
+    expect(card({ inProgressCount: 0 }).text).not.toContain(
+      i18n.t('feed:taskCard.inProgress', { count: 0 }),
+    )
+  })
+
+  it('hides the sign-up CTA rather than disabling it when the viewer cannot sign up', () => {
+    expect(card({ onSignup: () => {} }).text).toContain(SIGNUP)
+    expect(card().text, 'no onSignup → no control').not.toContain(SIGNUP)
+  })
+})
+
+describe('na task card — base points + multiplier badge (ADR-0055)', () => {
+  it('shows base points and no badge at the era_1 neutral factor', () => {
+    const { text } = card({ multiplier: 1 })
+    expect(text, 'base points').toContain('18')
+    expect(text, 'no modifier caption').not.toContain(
+      i18n.t('feed:taskCard.modifierCaption'),
+    )
+  })
+
+  it('shows the badge on a tuned factor and STILL shows base points, unmultiplied', () => {
+    const { text } = card({ multiplier: 1.5 })
+    expect(text, 'badge').toContain(i18n.t('feed:taskCard.multiplier', { value: '1.50' }))
+    expect(text).toContain(i18n.t('feed:taskCard.modifierCaption'))
+    expect(text, 'base points, not 27').toContain('18')
+    expect(text, 'the product must not be pre-applied').not.toContain('27')
+  })
+
+  it('treats float slop as neutral', () => {
+    expect(card({ multiplier: 0.1 + 0.9 }).text).not.toContain(
+      i18n.t('feed:taskCard.modifierCaption'),
+    )
+  })
+})
+
+describe('na task card — one component, two form factors (ADR-0056)', () => {
+  it('renders every content slot on mobile as well as desktop', () => {
+    for (const formFactor of ['desktop', 'mobile'] as const) {
+      mocks.formFactor = formFactor
+      const { html, text } = card({ inProgressCount: 6, onSignup: () => {} })
+      expect(html, formFactor).toContain(`data-form-factor="${formFactor}"`)
+      expect(html, `${formFactor} task link`).toContain('href="/tasks/7"')
+      expect(text, `${formFactor} title`).toContain('Photosynthesis')
+      expect(text, `${formFactor} points`).toContain('18')
+      expect(text, `${formFactor} in progress`).toContain(
+        i18n.t('feed:taskCard.inProgress', { count: 6 }),
+      )
+      expect(text, `${formFactor} signup`).toContain(SIGNUP)
+    }
+    mocks.formFactor = 'desktop'
+  })
+})
+
+describe('TaskCard dispatcher — prop defaults', () => {
+  it('falls through to the na card for an unfactioned task', () => {
+    const { html } = markup(<TaskCard task={TASK} basePoints={TASK.point_value} />)
+    expect(html, 'na card is the fallback skin').toContain('data-form-factor=')
+  })
+
+  it('reads inProgressCount off the task when the caller omits it', () => {
+    const { text } = markup(<TaskCard task={TASK} basePoints={TASK.point_value} />)
+    expect(text).toContain(i18n.t('feed:taskCard.inProgress', { count: 6 }))
+  })
+
+  it('treats a pre-#1021 task with no in_progress_count as zero, not NaN', () => {
+    const legacy: TaskOut = { ...TASK, in_progress_count: undefined }
+    const { text } = markup(<TaskCard task={legacy} basePoints={legacy.point_value} />)
+    expect(text).not.toContain('NaN')
+    expect(text).not.toContain(i18n.t('feed:taskCard.inProgress', { count: 0 }))
+  })
+
+  it('defaults the multiplier to neutral, so a caller with no viewer context shows no badge', () => {
+    const { text } = markup(<TaskCard task={TASK} basePoints={TASK.point_value} />)
+    expect(text).not.toContain(i18n.t('feed:taskCard.modifierCaption'))
+  })
+})

--- a/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
+++ b/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
@@ -92,7 +92,15 @@ function routed(node: React.ReactNode): string {
 }
 
 const taskCard = () =>
-  routed(<UaTaskCard task={TASK} displayPoints={30} onSignup={() => {}} />)
+  routed(
+    <UaTaskCard
+      task={TASK}
+      basePoints={30}
+      multiplier={1}
+      inProgressCount={0}
+      onSignup={() => {}}
+    />,
+  )
 const feedRow = () => routed(<UaFeedFrame><span>card-body</span></UaFeedFrame>)
 const comment = () =>
   routed(<UaComment mode="row" comment={COMMENT} />)

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -136,10 +136,13 @@
     "title": "Task Crown — top praxis for this task"
   },
   "taskCard": {
+    "ordinal": "Task {{id}}",
+    "inProgress": "{{count}} in progress",
+    "multiplier": "×{{value}}",
+    "modifierCaption": "modifier",
     "na": {
-      "eyebrow": "Unaffiliated · all paths",
-      "level": "lvl {{level}}",
-      "pointsUnit": "pts",
+      "levelCaption": "Level",
+      "pointsUnit": "points",
       "signup": "Sign up ↗"
     },
     "albescent": {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -6,7 +6,7 @@ import { listPraxes, createPraxis, type PraxisCardOut } from '../api/praxis'
 import { listTasks, type TaskOut } from '../api/tasks'
 import { getGameConfig, type FactionConfigOut } from '../api/gameConfig'
 import { loginWithGoogle, devLogin } from '../api/auth'
-import { computeDisplayPoints } from '../utils/points'
+import { computeFactionMultiplier } from '../utils/points'
 import { extractError } from '../utils/errors'
 import PraxisCard from '../components/PraxisCard'
 import TaskCard from '../components/TaskCard'
@@ -199,8 +199,8 @@ export default function Home() {
         {newestTask ? (
           <TaskCard
             task={newestTask}
-            displayPoints={computeDisplayPoints(
-              newestTask.point_value,
+            basePoints={newestTask.point_value}
+            multiplier={computeFactionMultiplier(
               user?.character?.faction_slug,
               newestTask.primary_faction_slug,
               factionConfigs,

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -49,7 +49,7 @@ function DesktopTasks({ state }: { state: TasksState }) {
     loadMore,
     signupMsg,
     handleSignup,
-    displayPointsFor,
+    displayMultiplierFor,
   } = state
 
   const isMetatask = taskType === 'metatask'
@@ -114,7 +114,8 @@ function DesktopTasks({ state }: { state: TasksState }) {
                 <TaskCard
                   key={task.id}
                   task={task}
-                  displayPoints={displayPointsFor(task)}
+                  basePoints={task.point_value}
+                  multiplier={displayMultiplierFor(task)}
                   onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
                 />
               ))}

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -17,8 +17,9 @@ export default function Tasks() {
 
   // Mobile browse is faction-agnostic page chrome (#565): the page shows every
   // faction's tasks, and each card in the results list picks its own skin from
-  // its task's faction slug (via the MobileTaskCard dispatcher) — mirroring the
-  // desktop TaskCard per-item dispatch. No viewer-faction page skin.
+  // its task's faction slug. Both branches now hand that per-item dispatch to
+  // the same <TaskCard> (ADR-0056) — only the page chrome differs. No
+  // viewer-faction page skin.
   if (formFactor === 'mobile') return <DefaultTasks state={state} />
 
   return <DesktopTasks state={state} />

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -246,7 +246,7 @@ export default function DefaultProfileBody({
         ) : (
           <div className="flex flex-wrap gap-4 items-start">
             {proposedTasks.map((task) => (
-              <TaskCard key={task.id} task={task} displayPoints={task.point_value} />
+              <TaskCard key={task.id} task={task} basePoints={task.point_value} />
             ))}
           </div>
         )}

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -327,7 +327,7 @@ export function ProfileSkin({
         ) : (
           <div className="flex flex-wrap gap-4 items-start">
             {proposedTasks.map((task) => (
-              <TaskCard key={task.id} task={task} displayPoints={task.point_value} />
+              <TaskCard key={task.id} task={task} basePoints={task.point_value} />
             ))}
           </div>
         )}

--- a/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
+++ b/frontend/src/pages/characterProfile/mobileArchetypes/DefaultProfile.tsx
@@ -324,7 +324,7 @@ export default function DefaultProfile({
         ) : (
           <div className="flex flex-col gap-4 items-stretch">
             {proposedTasks.map((task) => (
-              <TaskCard key={task.id} task={task} displayPoints={task.point_value} />
+              <TaskCard key={task.id} task={task} basePoints={task.point_value} />
             ))}
           </div>
         )}

--- a/frontend/src/pages/characterProfile/mobileArchetypes/WowProfile.tsx
+++ b/frontend/src/pages/characterProfile/mobileArchetypes/WowProfile.tsx
@@ -280,7 +280,7 @@ export default function WowProfile({
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-lg)" }}>
             {proposedTasks.map((task) => (
-              <TaskCard key={task.id} task={task} displayPoints={task.point_value} />
+              <TaskCard key={task.id} task={task} basePoints={task.point_value} />
             ))}
           </div>
         )}

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
-import { computeDisplayPoints } from "../../../utils/points";
+import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
@@ -244,8 +244,8 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
                 <TaskCard
                   key={task.id}
                   task={task}
-                  displayPoints={computeDisplayPoints(
-                    task.point_value,
+                  basePoints={task.point_value}
+                  multiplier={computeFactionMultiplier(
                     viewerFactionSlug,
                     task.primary_faction_slug,
                     gameFactions,

--- a/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/DefaultFactionBody.tsx
@@ -4,7 +4,7 @@ import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import CharacterBadge from "../../../components/CharacterBadge";
 import { factionCssVar } from "../../../utils/factions";
-import { computeDisplayPoints } from "../../../utils/points";
+import { computeFactionMultiplier } from "../../../utils/points";
 import type { FactionDetailState } from "../useFactionDetail";
 
 /** Shared flex-wrap card grid — varied card sizes are intentional, not a CSS grid. */
@@ -80,8 +80,8 @@ export default function DefaultFactionBody({
               <TaskCard
                 key={task.id}
                 task={task}
-                displayPoints={computeDisplayPoints(
-                  task.point_value,
+                basePoints={task.point_value}
+                multiplier={computeFactionMultiplier(
                   viewerFactionSlug,
                   task.primary_faction_slug,
                   gameFactions,

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -5,7 +5,7 @@ import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
 import { EphemeristsSigil, Foxing, toRoman } from "../../../components/cards/ephemeristsAtoms";
-import { computeDisplayPoints } from "../../../utils/points";
+import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
@@ -174,8 +174,8 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                 <TaskCard
                   key={task.id}
                   task={task}
-                  displayPoints={computeDisplayPoints(
-                    task.point_value,
+                  basePoints={task.point_value}
+                  multiplier={computeFactionMultiplier(
                     viewerFactionSlug,
                     task.primary_faction_slug,
                     gameFactions,

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
-import { computeDisplayPoints } from "../../../utils/points";
+import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
@@ -194,8 +194,8 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                 <TaskCard
                   key={task.id}
                   task={task}
-                  displayPoints={computeDisplayPoints(
-                    task.point_value,
+                  basePoints={task.point_value}
+                  multiplier={computeFactionMultiplier(
                     viewerFactionSlug,
                     task.primary_faction_slug,
                     gameFactions,

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
-import { computeDisplayPoints } from "../../../utils/points";
+import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
@@ -213,8 +213,8 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                 <TaskCard
                   key={task.id}
                   task={task}
-                  displayPoints={computeDisplayPoints(
-                    task.point_value,
+                  basePoints={task.point_value}
+                  multiplier={computeFactionMultiplier(
                     viewerFactionSlug,
                     task.primary_faction_slug,
                     gameFactions,

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import TaskCard from "../../../components/TaskCard";
 import PraxisCard from "../../../components/PraxisCard";
 import { TaskCrown } from "../../../components/cards/TaskCrown";
-import { computeDisplayPoints } from "../../../utils/points";
+import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
@@ -245,8 +245,8 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                 <TaskCard
                   key={task.id}
                   task={task}
-                  displayPoints={computeDisplayPoints(
-                    task.point_value,
+                  basePoints={task.point_value}
+                  multiplier={computeFactionMultiplier(
                     viewerFactionSlug,
                     task.primary_faction_slug,
                     gameFactions,

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -11,7 +11,7 @@ import {
   UA_TEXT,
   uaShade,
 } from "../../../components/cards/uaAtoms";
-import { computeDisplayPoints } from "../../../utils/points";
+import { computeFactionMultiplier } from "../../../utils/points";
 import { factionName, factionDescription } from "../../../utils/factions";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
@@ -232,8 +232,8 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
                 <TaskCard
                   key={task.id}
                   task={task}
-                  displayPoints={computeDisplayPoints(
-                    task.point_value,
+                  basePoints={task.point_value}
+                  multiplier={computeFactionMultiplier(
                     viewerFactionSlug,
                     task.primary_faction_slug,
                     gameFactions,

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -44,6 +44,7 @@ const CANNED: TasksState = {
   signupMsg: null,
   handleSignup: async () => {},
   displayPointsFor: () => 0,
+  displayMultiplierFor: () => 1,
 }
 
 vi.mock('../useTasks', () => ({

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -2,12 +2,21 @@
  * Tasks form-factor dispatch — useFormFactor mocked 'mobile' selects the Default
  * mobile browse skin; 'desktop' keeps the existing flex-wrap list. Mirrors the
  * TaskDetail dispatch seam (#494/#496). useTasks is mocked to a canned state so
- * the branch under test renders without hitting the network / auth context.
+ * the branch under test renders without hitting the network.
+ *
+ * The second half covers the ADR-0056 rewire (#1022): mobile browse renders the
+ * SHARED <TaskCard>, so both branches must now show the same card and the same
+ * signup CTA, gated identically on `can_submit_praxis`. Before the rewire mobile
+ * had no CTA at all, so "the button is there on mobile" is the regression this
+ * pins.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi } from 'vitest'
 import '../../../i18n'
+import i18n from '../../../i18n'
+import type { CurrentUser } from '../../../api/auth'
+import type { TaskOut } from '../../../api/tasks'
 import type { TasksState } from '../useTasks'
 
 // Mutable form factor the mocked hook reports; each test sets it before render.
@@ -17,9 +26,45 @@ vi.mock('../../../hooks/useFormFactor', () => ({
   useFormFactor: () => dispatch.formFactor,
 }))
 
-// Canned, empty task set: exercises the dispatch branch without rendering
-// TaskCard (which needs auth/admin contexts) — an empty list hits each branch's
-// own empty state instead.
+const TASK: TaskOut = {
+  id: 7,
+  title: 'Photosynthesis',
+  description: 'Leave something small and honest where a stranger will find it.',
+  point_value: 18,
+  level_required: 2,
+  status: 'active',
+  task_type: 'standard',
+  created_by: 3,
+  primary_faction_slug: null,
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: '2026-01-01T00:00:00Z',
+  in_progress_count: 6,
+  can_submit_praxis: true,
+  allowed_modes: ['solo'],
+  eligible_for_current_user: true,
+}
+
+const VIEWER: CurrentUser = {
+  account_id: 1,
+  character: null,
+  is_admin: false,
+  can_create_additional_character: false,
+  can_start_as_albescent: false,
+  albescent_revealed: false,
+  can_propose_task: true,
+  can_propose_metatask: false,
+  can_see_retired_tasks: false,
+  can_see_pending_tasks: false,
+  can_comment: true,
+  second_character_level_required: 5,
+  era_name: 'Era 1',
+  level_jump_reach: 0,
+  level_jump_available: false,
+}
+
+// Canned task-browse state. Tests that only exercise the dispatch branch leave
+// the list empty and hit each branch's own empty state.
 const CANNED: TasksState = {
   user: null,
   tasks: [],
@@ -47,8 +92,11 @@ const CANNED: TasksState = {
   displayMultiplierFor: () => 1,
 }
 
+// What the mocked hook hands back; each test replaces it before rendering.
+const state: { current: TasksState } = { current: CANNED }
+
 vi.mock('../useTasks', () => ({
-  useTasks: () => CANNED,
+  useTasks: () => state.current,
   LEVEL_FILTERS: [0, 1, 2, 3, 4, 5],
 }))
 
@@ -62,17 +110,74 @@ function html(): string {
   )
 }
 
+function text(): string {
+  return html().replace(/<[^>]*>/g, '')
+}
+
+const SIGNUP = i18n.t('feed:taskCard.na.signup')
+
 describe('Tasks form-factor dispatch', () => {
   it('renders the Default mobile browse skin on mobile', () => {
     dispatch.formFactor = 'mobile'
+    state.current = CANNED
     expect(html()).toContain('mobile-tasks-browse')
   })
 
   it('renders the existing desktop list on desktop', () => {
     dispatch.formFactor = 'desktop'
+    state.current = CANNED
     const out = html()
     expect(out, 'no mobile skin').not.toContain('mobile-tasks-browse')
     // The desktop rubber-stamp status filter (FilterStamps) is desktop-only chrome.
     expect(out.toLowerCase(), 'desktop status filter').toContain('status:')
+  })
+})
+
+describe('task-browse card + CTA parity (ADR-0056)', () => {
+  it('renders the shared card at its mobile size on mobile', () => {
+    dispatch.formFactor = 'mobile'
+    state.current = { ...CANNED, user: VIEWER, tasks: [TASK] }
+    const out = html()
+    expect(out, 'shared TaskCard, sized for the phone').toContain(
+      'data-form-factor="mobile"',
+    )
+    expect(out, 'task link').toContain('href="/tasks/7"')
+    expect(out.replace(/<[^>]*>/g, ''), 'title').toContain('Photosynthesis')
+  })
+
+  it('shows the inline signup CTA on BOTH form factors when the viewer may sign up', () => {
+    for (const formFactor of ['mobile', 'desktop'] as const) {
+      dispatch.formFactor = formFactor
+      state.current = { ...CANNED, user: VIEWER, tasks: [TASK] }
+      expect(text(), formFactor).toContain(SIGNUP)
+    }
+  })
+
+  it('hides the CTA on both when the task refuses the viewer a praxis', () => {
+    const barred: TaskOut = { ...TASK, can_submit_praxis: false }
+    for (const formFactor of ['mobile', 'desktop'] as const) {
+      dispatch.formFactor = formFactor
+      state.current = { ...CANNED, user: VIEWER, tasks: [barred] }
+      expect(text(), formFactor).not.toContain(SIGNUP)
+    }
+  })
+
+  it('hides the CTA on both for a logged-out viewer', () => {
+    for (const formFactor of ['mobile', 'desktop'] as const) {
+      dispatch.formFactor = formFactor
+      state.current = { ...CANNED, user: null, tasks: [TASK] }
+      expect(text(), formFactor).not.toContain(SIGNUP)
+    }
+  })
+
+  it('surfaces the signup outcome message on mobile, where the CTA now lives', () => {
+    dispatch.formFactor = 'mobile'
+    state.current = {
+      ...CANNED,
+      user: VIEWER,
+      tasks: [TASK],
+      signupMsg: { id: 7, msg: 'Could not sign up.', ok: false },
+    }
+    expect(text()).toContain('Could not sign up.')
   })
 })

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 import type { TasksState } from '../useTasks'
-import MobileTaskCard from './mobileTaskCard'
+import TaskCard from '../../../components/TaskCard'
 import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import FactionSigilRow from '../../../components/ui/FactionSigilRow'
 import { ChipRow, Chip } from '../../../components/ui/ChipRow'
@@ -11,14 +11,22 @@ import { ChipRow, Chip } from '../../../components/ui/ChipRow'
  * level), NOT the desktop sidebar. Consumes the shared `useTasks()` state so a
  * chip tap updates the same filter state that keys the task read, and the
  * rendered set changes. The page chrome is faction-agnostic; each card in the
- * results list picks its own skin from its task's faction slug via the
- * `MobileTaskCard` dispatcher (#565). Mirrors the DefaultTaskDetail mobile idiom
- * (#496–#500).
+ * results list picks its own skin from its task's faction slug (#565). Mirrors
+ * the DefaultTaskDetail mobile idiom (#496–#500).
+ *
+ * The results list renders the SHARED `<TaskCard>` — the one call site
+ * ADR-0056's reversible experiment turns on. Each faction card sizes itself for
+ * the phone via `useFormFactor()`, and mobile inherits the inline signup CTA
+ * (gated on `can_submit_praxis` exactly as desktop is), the in-progress count
+ * and the multiplier badge, none of which the mobile-only cards had. The
+ * `mobileTaskCard` dispatcher and its nine cards stay in the tree, dormant:
+ * reverting is swapping this import and the two props back.
  */
 export default function DefaultTasks({ state }: { state: TasksState }) {
   const { t } = useTranslation('tasks')
   const { t: tc } = useTranslation('common')
   const {
+    user,
     tasks,
     loading,
     error,
@@ -37,7 +45,9 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
     setQuery,
     hasMore,
     loadMore,
-    displayPointsFor,
+    signupMsg,
+    handleSignup,
+    displayMultiplierFor,
   } = state
 
   const isMetatask = taskType === 'metatask'
@@ -106,6 +116,14 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
         ))}
       </ChipRow>
 
+      {/* Signup outcome — the CTA arrived with the shared card (ADR-0056), so
+          the message that answers it has to arrive too. */}
+      {signupMsg && (
+        <p className={`font-body content-text mt-3 border-2 px-3 py-2 ${signupMsg.ok ? 'border-border text-ink' : 'border-red-300 text-red-600'}`}>
+          {signupMsg.msg}
+        </p>
+      )}
+
       {/* Results */}
       <div className="mt-4">
         {loading && tasks.length === 0 ? (
@@ -122,7 +140,13 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
               <MetaTaskSeal metatasks={tasks} />
             ) : (
               tasks.map((task) => (
-                <MobileTaskCard key={task.id} task={task} points={displayPointsFor(task)} />
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  basePoints={task.point_value}
+                  multiplier={displayMultiplierFor(task)}
+                  onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
+                />
               ))
             )}
             {hasMore && (

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -79,7 +79,11 @@ export interface TasksState {
   signupMsg: SignupMessage | null
   handleSignup: (id: number) => Promise<void>
 
-  // Derived helper — the modified point value for a task given the viewer's faction.
+  /**
+   * Derived helper — base × the viewer's faction modifier, as one combined
+   * number. Task cards no longer take it (they take base and the factor apart,
+   * ADR-0055); it stays for any surface that wants the single figure.
+   */
   displayPointsFor: (task: TaskOut) => number
   /**
    * Derived helper — the RAW own/other task modifier the viewer earns on a

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -21,7 +21,7 @@ import { getFactions, type FactionOut } from '../../api/factions'
 import { getGameConfig, type FactionConfigOut } from '../../api/gameConfig'
 import { extractError } from '../../utils/errors'
 import { useAuth } from '../../auth/AuthContext'
-import { computeDisplayPoints } from '../../utils/points'
+import { computeDisplayPoints, computeFactionMultiplier } from '../../utils/points'
 import { usePagedResource } from '../../hooks/usePagedResource'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { useSearchQueryParam } from '../../hooks/useSearchQueryParam'
@@ -81,6 +81,13 @@ export interface TasksState {
 
   // Derived helper — the modified point value for a task given the viewer's faction.
   displayPointsFor: (task: TaskOut) => number
+  /**
+   * Derived helper — the RAW own/other task modifier the viewer earns on a
+   * task. Task cards render this beside base points instead of taking the
+   * product (ADR-0055); it is 1.0 for every faction at `era_1` values, so no
+   * card shows a modifier badge today.
+   */
+  displayMultiplierFor: (task: TaskOut) => number
 }
 
 export function useTasks(): TasksState {
@@ -157,6 +164,13 @@ export function useTasks(): TasksState {
       factionConfigs,
     )
 
+  const displayMultiplierFor = (task: TaskOut): number =>
+    computeFactionMultiplier(
+      user?.character?.faction_slug,
+      task.primary_faction_slug,
+      factionConfigs,
+    )
+
   return {
     user,
 
@@ -187,5 +201,6 @@ export function useTasks(): TasksState {
     handleSignup,
 
     displayPointsFor,
+    displayMultiplierFor,
   }
 }

--- a/frontend/src/utils/__tests__/points.test.ts
+++ b/frontend/src/utils/__tests__/points.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The faction task multiplier (ADR-0055).
+ *
+ * `computeFactionMultiplier` is what task cards render beside base points, so
+ * the thing worth pinning is that it returns the RAW own/other factor from the
+ * era config — not a reconstruction of `effective / base`, which rounds away
+ * and silently reads 1.0 on small values.
+ */
+import { describe, it, expect } from 'vitest'
+import type { FactionConfigOut } from '../../api/gameConfig'
+import {
+  computeDisplayPoints,
+  computeFactionMultiplier,
+  isNeutralMultiplier,
+} from '../points'
+
+function config(
+  slug: string,
+  own_task_modifier: number,
+  other_task_modifier: number,
+): FactionConfigOut {
+  return {
+    slug,
+    own_task_modifier,
+    other_task_modifier,
+    can_always_rejoin: false,
+    // Irrelevant to the task multiplier; the praxis-side modifiers are a
+    // separate axis (ADR-0053 retired the display one).
+    collab_own_modifier: 1,
+    collab_other_modifier: 1,
+    duel_win_modifier: 1,
+    duel_loss_modifier: 1,
+  }
+}
+
+// A tuned era: UA rewards its own, penalises everyone else's.
+const TUNED = [config('ua', 1.5, 0.5), config('snide', 1, 1)]
+// era_1's actual posture: the mechanism is live but neutralized everywhere.
+const ERA_1 = [config('ua', 1, 1), config('snide', 1, 1)]
+
+describe('computeFactionMultiplier', () => {
+  it('is neutral for a viewer with no character/faction', () => {
+    expect(computeFactionMultiplier(null, 'ua', TUNED)).toBe(1)
+    expect(computeFactionMultiplier(undefined, 'ua', TUNED)).toBe(1)
+  })
+
+  it('is neutral when the viewer wears a faction the config does not know', () => {
+    expect(computeFactionMultiplier('ua_masters', 'ua', TUNED)).toBe(1)
+  })
+
+  it('uses own_task_modifier on the viewer own faction task', () => {
+    expect(computeFactionMultiplier('ua', 'ua', TUNED)).toBe(1.5)
+  })
+
+  it('uses other_task_modifier on another faction task', () => {
+    expect(computeFactionMultiplier('ua', 'snide', TUNED)).toBe(0.5)
+  })
+
+  it('treats an unfactioned task and the na sentinel as own-faction', () => {
+    expect(computeFactionMultiplier('ua', null, TUNED)).toBe(1.5)
+    expect(computeFactionMultiplier('ua', 'na', TUNED)).toBe(1.5)
+  })
+
+  it('resolves to 1.0 for every viewer at era_1 values', () => {
+    for (const viewer of ['ua', 'snide']) {
+      for (const taskFaction of ['ua', 'snide', 'na', null]) {
+        expect(computeFactionMultiplier(viewer, taskFaction, ERA_1)).toBe(1)
+      }
+    }
+  })
+})
+
+describe('isNeutralMultiplier', () => {
+  it('is true at exactly 1 and at float slop around it', () => {
+    expect(isNeutralMultiplier(1)).toBe(true)
+    expect(isNeutralMultiplier(0.1 + 0.9)).toBe(true)
+  })
+
+  it('is false for a tuned modifier', () => {
+    expect(isNeutralMultiplier(1.5)).toBe(false)
+    expect(isNeutralMultiplier(0.5)).toBe(false)
+  })
+})
+
+describe('computeDisplayPoints', () => {
+  it('still applies the same factor and rounds', () => {
+    expect(computeDisplayPoints(10, 'ua', 'ua', TUNED)).toBe(15)
+    expect(computeDisplayPoints(10, 'ua', 'snide', TUNED)).toBe(5)
+    expect(computeDisplayPoints(7, 'ua', 'snide', TUNED)).toBe(4) // 3.5 → 4
+  })
+
+  it('agrees with base × computeFactionMultiplier', () => {
+    const base = 18
+    expect(computeDisplayPoints(base, 'ua', 'snide', TUNED)).toBe(
+      Math.round(base * computeFactionMultiplier('ua', 'snide', TUNED)),
+    )
+  })
+})

--- a/frontend/src/utils/points.ts
+++ b/frontend/src/utils/points.ts
@@ -4,16 +4,66 @@ import type { FactionConfigOut } from '../api/gameConfig'
 const UNAFFILIATED_FACTION_SLUG = 'na'
 
 /**
- * Compute the display point value for a task given the viewing player's faction.
+ * The identity multiplier. `era_1` neutralizes every faction's own/other task
+ * modifier to this, which is why no card shows a modifier badge today — the
+ * mechanism is live infrastructure, merely turned off (ADR-0055).
+ */
+const NEUTRAL_MULTIPLIER = 1
+
+/** Float slop tolerance — `0.1 + 0.2` arithmetic must not light up a badge. */
+const MULTIPLIER_EPSILON = 1e-9
+
+/**
+ * Resolve the per-faction task multiplier the viewer earns on a task.
  *
  * Mirrors `compute_faction_multiplier` in backend/services/scoring.py:
- * - If the player has no faction / unknown faction, return the raw base value.
+ * - If the player has no faction / unknown faction, there is no modifier (1.0).
  * - Tasks with no faction or the `na` sentinel are treated as own-faction
  *   (no penalty) — matches backend behavior.
  * - If the task faction matches the player's faction, use own_task_modifier.
  * - Otherwise use other_task_modifier.
  *
- * Returns a rounded integer.
+ * This is the RAW factor. Task cards render it beside base points rather than
+ * pre-multiplying (ADR-0055), and must never reconstruct it as
+ * `effective / base` — that reconstruction is the dead-arithmetic trap
+ * ADR-0053 named.
+ */
+export function computeFactionMultiplier(
+  playerFactionSlug: string | null | undefined,
+  taskFactionSlug: string | null | undefined,
+  factionConfigs: FactionConfigOut[],
+): number {
+  if (!playerFactionSlug) return NEUTRAL_MULTIPLIER
+
+  const playerFaction = factionConfigs.find((f) => f.slug === playerFactionSlug)
+  if (!playerFaction) return NEUTRAL_MULTIPLIER
+
+  const isOwnFaction =
+    !taskFactionSlug
+    || taskFactionSlug === playerFactionSlug
+    || taskFactionSlug === UNAFFILIATED_FACTION_SLUG
+
+  return isOwnFaction
+    ? playerFaction.own_task_modifier
+    : playerFaction.other_task_modifier
+}
+
+/**
+ * True when a multiplier is the identity and so carries no information — the
+ * gate every card's `×n` badge hides behind (ADR-0055). Shared so nine skins
+ * cannot drift into nine different float comparisons.
+ */
+export function isNeutralMultiplier(multiplier: number): boolean {
+  return Math.abs(multiplier - NEUTRAL_MULTIPLIER) < MULTIPLIER_EPSILON
+}
+
+/**
+ * Compute the display point value for a task given the viewing player's
+ * faction — base points with {@link computeFactionMultiplier} already applied,
+ * rounded to an integer.
+ *
+ * Task cards no longer consume this (they take base + multiplier separately,
+ * ADR-0055); it remains for surfaces that want a single combined number.
  */
 export function computeDisplayPoints(
   basePoints: number,
@@ -21,19 +71,8 @@ export function computeDisplayPoints(
   taskFactionSlug: string | null | undefined,
   factionConfigs: FactionConfigOut[],
 ): number {
-  if (!playerFactionSlug) return basePoints
-
-  const playerFaction = factionConfigs.find((f) => f.slug === playerFactionSlug)
-  if (!playerFaction) return basePoints
-
-  const isOwnFaction =
-    !taskFactionSlug
-    || taskFactionSlug === playerFactionSlug
-    || taskFactionSlug === UNAFFILIATED_FACTION_SLUG
-
-  const modifier = isOwnFaction
-    ? playerFaction.own_task_modifier
-    : playerFaction.other_task_modifier
-
-  return Math.round(basePoints * modifier)
+  return Math.round(
+    basePoints
+      * computeFactionMultiplier(playerFactionSlug, taskFactionSlug, factionConfigs),
+  )
 }


### PR DESCRIPTION
Stage 2 of the task-cards-v2 chain (#1020): the card contract the eight bespoke redesigns in #1023 get built against, plus the na/Unaffiliated card itself.

## What changed

**Card contract (ADR-0055).** `CardProps` is now `{ task, basePoints, multiplier, inProgressCount, onSignup }` — points arrive unmultiplied with the viewer's factor alongside, instead of the pre-multiplied `displayPoints`. All eight registered skins now *import* that one interface rather than each restating a local `Props`, so the contract lives in exactly one place. `computeFactionMultiplier` in `utils/points.ts` resolves the raw `own_task_modifier`/`other_task_modifier` (never `effective / base`); `computeDisplayPoints` delegates to it, so there is a single resolution path. `isNeutralMultiplier` is the shared 1.0 gate the badge hides behind. `useTasks` exposes `displayMultiplierFor` beside `displayPointsFor`.

**Every call site moved — there were 14, not 3.** Beyond `Tasks.tsx` / `Home.tsx` / `DefaultTasks.tsx`, the seven `*FactionBody` pages and four character-profile task lists also passed `displayPoints`. The faction-detail pages computed the product inline; they now pass the raw factor, which is what stops a future non-1.0 era from multiplying twice. The dispatcher defaults `multiplier` to 1 and `inProgressCount` to `task.in_progress_count ?? 0` (the field is optional on `TaskOut` per #1021), so the profile lists — which have no viewer-faction context — pass base points alone.

**Mobile unification (ADR-0056, reversible).** `DefaultTasks.tsx` renders the shared `<TaskCard>`. Mobile gains the inline signup CTA — gated on `can_submit_praxis` exactly as desktop — the `signupMsg` answer that CTA needs, the in-progress count and the multiplier badge, none of which the mobile-only cards had. **Nothing was deleted:** `mobileTaskCard.tsx`, the nine `*MobileTaskCard.tsx` files, `cards/shared.tsx` and their tests all stay in the tree and keep passing. They are now unreferenced by `DefaultTasks.tsx`, which is the intended dormant state; eslint does not flag them. Reverting the experiment is swapping one import and two props back.

**na/Default card rebuilt** to the "Unaffiliated" design — THE SPECTRUM SHEET. Level and the marks lead a hero row, the marks inside a conic rainbow ring, over an italic Lora title, the call, an in-progress tick and a centred sign-up. One responsive component: `useFormFactor()` picks the size set, not a different card.

## Design translation + deliberate departures

- `theme` prop → the `[data-theme]` cascade. `platform` prop → `useFormFactor()`. Every hex → existing `--faction-default-*` tokens (`index.css` is untouched — no new tokens were needed).
- The design's `taken`/`onOpen` canvas fakes → the real `onSignup` and a `/tasks/:id` `<Link>`. The link wraps everything *except* the CTA, so a card-sized read target does not nest a `<button>` inside an `<a>`.
- Eyebrow is the uniform **"Task {id}"** (#1020), not the design's `Task №`. The design's no-op in-progress ternary (both branches identical) is not reproduced — the label is one uniform i18n key.
- Type sits on the token scale, so the brief keeps `.card-description` (the 18px content floor) rather than the design's 12px, and the numerals land on `--text-heading`/`--text-title` rather than 30/26.
- **The corner glow is dropped.** It needs a warm low-alpha tint that no `--faction-default-*` token carries, and adding one means editing `index.css`, which is `frontend-style`'s file. Same for the hover lift (needs CSS, not inline styles).
- **Lora comes from `--font-display`, not `--faction-default-card-font`.** That token is Bebas Neue — the face #839 chose for the unaffiliated *praxis* card — and the v2 task-card design explicitly names "Lora + Courier Prime". Flagging rather than deciding: if `na` should carry one display face everywhere, the fix is repointing the token, not branching in the component. Noted at the site.
- The design draws Level as a caption + numeral rather than the shared `LevelGem`. The pre-existing `DefaultTaskCard` did not use `LevelGem` either, so this is not a regression, but it is a departure from WORLD_ZERO_STYLE §6.

Four **shared** copy keys were added under `feed:taskCard` — `ordinal`, `inProgress`, `multiplier`, `modifierCaption` — because all four are uniform across the nine cards. #1023 consumes the same ones. The na block keeps its `signup` key and swaps `eyebrow`/`level` for `levelCaption`.

## Verification

`tsc --noEmit` clean · `vite build` clean · `eslint src` clean (`no-raw-style-values` included; the legacy list is empty and stayed empty) · `vitest run` **1579 passed / 107 files**, up from 1552 / 105.

New coverage: `utils/__tests__/points.test.ts` (raw own/other resolution, including the two cases a reconstruction gets wrong — unknown viewer faction and the `na` sentinel counting as own-faction), `components/cards/__tests__/defaultTaskCard.test.tsx` (na slots on desktop **and** mobile from one component; badge hidden at 1.0 and under float slop; a tuned factor shows the badge while points stay unmultiplied — the double-count guard; dispatcher defaults, including a pre-#1021 task rendering 0 rather than `NaN`), and `pages/tasks/__tests__/dispatch.test.tsx` (the browse now renders a real task: shared card at mobile size, CTA on both form factors under the same gate, absent for a barred or logged-out viewer).

**Visual QA is outstanding** — I cannot screenshot and there is no dev stack in this environment.

## What to eyeball

1. **The seven non-na cards must look UNCHANGED** (Everymen, UA, WOW, S.N.I.D.E., Ephemerists, Singularity, Coven). Their migration is mechanical: they rendered the pre-multiplied number and now render `basePoints`, which is the same number at `era_1`'s 1.0 modifiers. Any visual difference is a bug.
2. **The na card is fully rebuilt** — a new archetype, not a tweak. `/tasks` with the faction filter off, and any task with no faction. Check: the 3px rainbow border reads as a frame (not a fill), the conic ring around the marks is a clean circle at both sizes, and the eyebrow reads "Task 7".
3. **Dark mode on the na card.** Everything flips through the cascade; the multiplier chip in particular inverts (ink chip in light, paper chip in dark).
4. **Mobile now shows cards and a signup CTA it never had before.** `/tasks` under 768px: the list is the shared card, and a task you can take shows "Sign up ↗". Sign up from mobile and confirm the redirect to the praxis editor and that a failure surfaces the inline message.
5. **The na card also reaches mobile character profiles and faction pages** (they render the shared `<TaskCard>`), so at phone width those lists now show the 340px responsive card instead of the old desktop-ish one. Worth a look — it is intended, but it is a wider blast radius than `/tasks`.
6. **The multiplier badge should be invisible everywhere today.** If you see a `×1.00` chip anywhere, the gate is wrong.
7. **The font question in §Departures** — is Lora right for the na task card while the na praxis card stays Bebas Neue?

Closes #1022
