### PR TITLE
#1023 wave A: Albescent, Coven, Ephemerists, Everymen task cards

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -80,6 +80,10 @@ Two traps, both of which have already been sprung:
 
 The one exception is the **reveal surfaces** — the invitation letter, the sealed placeholder, the `/factions` tile — which are only ever shown to an account already revealed to the society. They read the private `--albescent-reveal-*` palette by direct reference, never through `factionCssVar`. That palette is not a theme and must not become one.
 
+**What unfreezing a surface may and may not do (ADR-0048).** "Frozen" now means "frozen *until designed*", and surfaces come off the freeze one at a time — the praxis card first (#821), the task card second (#1023). Everything above still holds: none of them adds a `--faction-albescent-*` token, because the released surfaces are **`Default` plus a flourish**, never a skin of their own. Each renders the exact `Default*` component an unaffiliated player sees and washes MOTION over it (a rainbow drift, a spectrum edge that travels, an aurora that breathes) — the shimmer that reveals the society to someone already looking. `AlbescentTaskCard` is the shape to copy: it forwards its whole prop object to `DefaultTaskCard` and adds two overlay classes, so a change to the na card or to the card contract reaches Albescent with no edit.
+
+The **words** are covered by the same rule as the hues, and it is the easier one to get wrong: an unfrozen surface keeps `na`'s copy, including its sign-up verb. `feed:taskCard.albescent.*` still sits in the catalog, orphaned since #783 deleted the card it belonged to; re-wiring it would print a word no other player's card prints, on a surface every player can see.
+
 ### A faction's SPINE HUE and its SKIN are two different things (#812, #814, #838)
 
 Warriors of Whimsy is the case that proves it, and the case that got it wrong twice.
@@ -144,6 +148,10 @@ All fonts loaded from Google Fonts.
 | UA Masters  | `UnifrakturCook`   | `--faction-ua-masters-card-font`  |
 
 Use `factionCssVar(slug, 'card-font')` in components. Never hardcode the font family string directly.
+
+**A face can belong to a SURFACE rather than to a faction.** `--faction-{slug}-card-font` is read by a dozen surfaces each, so repointing one to satisfy a single redesign restyles eleven others by accident. When a design names a face for one surface only, give it a shared `--font-faction-*` token and reference that token from the one component — the same move `DefaultTaskCard` makes when it takes Lora rather than `--faction-default-card-font`. The v2 task cards (#1023) introduced four such faces: **Quicksand** (`--font-faction-rounded`) and **Grenze Gotisch** (`--font-faction-witch`) for Coven's spell slip, **Poiret One** (`--font-faction-deco`) and **Spectral** (`--font-faction-spectral`) for the Ephemerists plate. Coven's `card-font` is still Caveat and Ephemerists' is still Cinzel, and both still appear on their v2 cards — as the hand-lettering and the small caps respectively.
+
+Whichever route a face takes, **it must also be in the `index.html` loader**, added in the same commit. A family named but never requested renders as its generic fallback, and that fallback *is* the rendering — no check catches it except `fontsLoaded` comparing the two lists (#839).
 
 **Type scale** is defined as CSS variables in `index.css`. Use the variable names, not raw pixel values. It comes in **two tiers**, and the naming convention is the tier boundary made visible: the label tier is a size ramp with t-shirt names, the content tier is a **role vocabulary**.
 
@@ -292,7 +300,9 @@ The sidebar contains: character card, active tasks panel, recent activity panel,
 
 ## 6. Faction Card Archetypes
 
-**Core principle:** Each faction's tasks use a completely different card archetype. The card type IS the faction identity. All cards display: task name, faction name, point value, level requirement (via `LevelGem`).
+**Core principle:** Each faction's tasks use a completely different card archetype. The card type IS the faction identity. All cards display: task name, faction name, point value, level requirement.
+
+**Task cards v2 (ADR-0055 / ADR-0056) draw the level themselves.** The redesigned task cards are the one archetype family that does *not* reach for `LevelGem`: every design in the v2 kit draws the level as a numeral in its own display face — under tally strokes on the Ephemerists plate, over a braid on the Coven slip, beside a dashed rule on the Everymen bill. The gem stays the shared shape everywhere else (rosters, detail pages, praxis surfaces), and the reasoning below is unchanged for those; on this one surface the whole point of the redesign was that the hero row belongs to the faction. Two other v2 rules ride along and apply to every card in the family: it is **one responsive component** (`useFormFactor` picks a size set — never a second file, never a fixed-px grid), and it shows **base points** with a `×multiplier` badge gated on `isNeutralMultiplier`, which is invisible at `era_1` and lights up on its own the day an era ships a non-1.0 modifier.
 
 **The level gem** is the one shape shared across every archetype: a 45°-rotated square, always outlined and never filled, with a faction-coloured numeral and a mandatory tiny "LVL" caption. It is deliberately the exception to "no uniform shapes" — the level is a game-wide fact, not a faction one, and a player should recognise it instantly whether it sits on a ransom note or a roster row. Faction identity enters as stroke colour and glow only. Unaffiliated takes the spectrum on both stroke and numeral (ADR-0039); it never degrades to grey, and it never borrows another faction's hue.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Anton&family=Archivo+Black&family=Lora:ital,wght@0,500;0,600;1,400;1,500&family=Courier+Prime:wght@400;700&family=Special+Elite&family=Share+Tech+Mono&family=Bebas+Neue&family=Permanent+Marker&family=Cutive+Mono&family=UnifrakturCook:wght@700&family=Caveat:wght@400;500;700&family=MedievalSharp&family=IM+Fell+English:ital@1&family=Cinzel:wght@400;500;600;700;800&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500;1,600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Archivo+Black&family=Lora:ital,wght@0,500;0,600;1,400;1,500&family=Courier+Prime:wght@400;700&family=Special+Elite&family=Share+Tech+Mono&family=Bebas+Neue&family=Permanent+Marker&family=Cutive+Mono&family=UnifrakturCook:wght@700&family=Caveat:wght@400;500;700&family=MedievalSharp&family=IM+Fell+English:ital@1&family=Cinzel:wght@400;500;600;700;800&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500;1,600&family=Quicksand:wght@400;500;600;700&family=Grenze+Gotisch:wght@400;500;600;700&family=Poiret+One&family=Spectral:ital,wght@0,400;0,500;1,400;1,500&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/frontend/src/components/cards/AlbescentTaskCard.tsx
+++ b/frontend/src/components/cards/AlbescentTaskCard.tsx
@@ -1,0 +1,40 @@
+import type { CardProps } from "../TaskCard";
+import DefaultTaskCard from "./DefaultTaskCard";
+
+/**
+ * Albescent — the task card's tell (#1023, ADR-0048). The SECOND Albescent
+ * surface to unfreeze, and built to the same rule as the first (the praxis
+ * card): this is NOT a from-scratch skin. It is the exact spectrum
+ * {@link DefaultTaskCard} an unaffiliated player sees, with two flourishes
+ * washed over it — the rainbow edge comes alive and drifts, and an aurora blooms
+ * and breathes under the vellum.
+ *
+ * The design says the same thing the ADR does. Its palette IS the na card's, its
+ * layout IS the na card's slot for slot, and every delta is motion: a drifting
+ * spectrum edge, an aurora, a turning prism ring. A secret society hiding in
+ * plain sight is revealed by a shimmer, never by a colour — a repaint in
+ * Albescent's own hues would put it back in the spectrum and un-hide it, and a
+ * per-faction WORD would do the same (WORLD_ZERO_STYLE §3), which is why the
+ * card keeps na's copy down to the sign-up call. Every other Albescent surface
+ * stays frozen on Default until its own design lands (ADR-0046 / ADR-0048).
+ *
+ * Both flourishes are overlays: `.alb-task-edge` is a masked ring that lands on
+ * Default's own rainbow border so the border appears to move, and
+ * `.alb-task-aurora` blends over the sheet. index.css owns both, their dark
+ * halves and their reduced-motion guard — a component may not inject a
+ * stylesheet (#911).
+ *
+ * There is deliberately nothing between this and Default: it takes
+ * {@link CardProps} and forwards it whole, so a change to the contract or to the
+ * na card reaches Albescent with no edit here. That is the property a
+ * hand-copied skin could never keep.
+ */
+export default function AlbescentTaskCard(props: CardProps) {
+  return (
+    <div style={{ position: "relative", width: "fit-content", maxWidth: "100%" }}>
+      <DefaultTaskCard {...props} />
+      <span aria-hidden="true" className="alb-task-aurora" />
+      <span aria-hidden="true" className="alb-task-edge" />
+    </div>
+  );
+}

--- a/frontend/src/components/cards/CovenTaskCard.tsx
+++ b/frontend/src/components/cards/CovenTaskCard.tsx
@@ -1,193 +1,430 @@
+import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
-import LevelGem from "../ui/LevelGem";
+import { isNeutralMultiplier } from "../../utils/points";
+import { useFormFactor } from "../../hooks/useFormFactor";
 
 /**
- * Cozy Coven — wow.exe.
- * Lo-fi computer-witch window: pastel title bar with window dots, a faint
- * dotted-grid body, and an inner "notepad" panel holding the task in the
- * Caveat headline font. Visuals only — same prop contract as the other cards.
+ * Cozy Coven — THE CANDLELIT SPELL SLIP (task card v2, #1023).
+ *
+ * A slip of paper that fades pink → lavender under a gold twinkle field, headed
+ * by a pentagram badge and the coven's name hand-lettered in Caveat. A celtic
+ * braid, hearts tied off at both ends, rules off each section; the points sit in
+ * a glowing arcane sigil; a slow pentagram watermark turns behind the copy; and
+ * the call to action is a full-bleed pink band. Grenze Gotisch carries the
+ * title, Cormorant Garamond the reading copy, Quicksand the chrome.
+ *
+ * This REPLACES the lo-fi `coven.exe` window archetype wholesale (ADR-0055 /
+ * ADR-0056 — a full metaphor swap, not a tweak). The `--faction-coven-win-*`
+ * tokens stay declared: other surfaces still paint with them.
+ *
+ * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not a
+ * different card. The dormant `mobileArchetypes/cards/CovenMobileTaskCard` stays
+ * in the tree for the revert.
+ *
+ * All colour via `--faction-coven-slip-*`; light/dark flips through the
+ * `[data-theme="dark"]` cascade, never a ternary. Three of the design's inks are
+ * walked down for AA against the gradient's darkest stop — see index.css.
  */
 
-/** Tiny four-point sparkle used in the title bar and footer pill accent. */
-function Sparkle({
-  size = 10,
-  color = "currentColor",
-}: {
-  size?: number;
-  color?: string;
-}) {
+const CHROME = "var(--font-faction-rounded)"; /* Quicksand */
+const READING = "var(--font-faction-serif)"; /* Cormorant Garamond */
+const HAND = "var(--font-faction-script)"; /* Caveat */
+const DISPLAY = "var(--font-faction-witch)"; /* Grenze Gotisch */
+
+/** The masthead band the twinkle field is confined to, so no star lands in copy. */
+const MASTHEAD_HEIGHT = 72;
+
+interface SizeSet {
+  /** Card width. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
+  cardWidth: number;
+  bodyPad: string;
+  titleSize: string;
+  levelSize: string;
+  /** Outer box of the arcane sigil. Geometry. */
+  sigil: number;
+}
+
+const SIZES: Record<"desktop" | "mobile", SizeSet> = {
+  desktop: {
+    cardWidth: 384,
+    bodyPad: "0 var(--space-xl) var(--space-lg)",
+    titleSize: "var(--text-heading)",
+    levelSize: "var(--text-heading)",
+    sigil: 100,
+  },
+  mobile: {
+    cardWidth: 340,
+    bodyPad: "0 var(--space-lg) var(--space-lg)",
+    titleSize: "var(--text-title)",
+    levelSize: "var(--text-title)",
+    sigil: 88,
+  },
+};
+
+/** Small-caps caption voice — every label on the slip speaks in it. */
+const CAPTION: CSSProperties = {
+  fontFamily: CHROME,
+  fontWeight: 700,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+  color: "var(--faction-coven-slip-label)",
+};
+
+/** A four-point star, centred on (x, y) with arm length r. */
+function starPath(x: number, y: number, r: number): string {
+  const long = r * 2.6;
+  return `M${x} ${y - long} l${r} ${long} ${long} ${r} -${long} ${r} -${r} ${long} -${r} -${long} -${long} -${r} ${long} -${r} z`;
+}
+
+/** One heart, tied off at an end of the braid. */
+function Heart({ size = 10 }: { size?: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+    <svg width={size} height={size} viewBox="0 0 12 12" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
       <path
-        d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z"
-        fill={color}
+        d="M6 10.5 C1 7.3, 1.2 3.4, 3.6 2.6 C5 2.1, 5.8 3, 6 3.6 C6.2 3, 7 2.1, 8.4 2.6 C10.8 3.4, 11 7.3, 6 10.5 Z"
+        fill="var(--faction-coven-slip-deep)"
       />
     </svg>
   );
 }
 
-/** One colored window-control dot. */
-function WindowDot({ color }: { color: string }) {
+/** The braid with a heart at each end. `.cvn-braid` owns the thread's pigments. */
+function Thread({ style }: { style?: CSSProperties }) {
   return (
-    <span
+    <span aria-hidden="true" style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)", ...style }}>
+      <Heart />
+      <span className="cvn-braid" style={{ flex: 1, minWidth: 0 }} />
+      <Heart />
+    </span>
+  );
+}
+
+/** The gold twinkle field, clipped to the masthead band. */
+function TwinkleField() {
+  const stars: [number, number, number][] = [
+    [38, 26, 2.6],
+    [296, 34, 2],
+    [120, 18, 1.4],
+    [212, 44, 1.6],
+    [264, 16, 1.2],
+    [74, 48, 1.6],
+  ];
+  return (
+    <svg
+      width="100%"
+      height={MASTHEAD_HEIGHT}
+      viewBox={`0 0 340 ${MASTHEAD_HEIGHT}`}
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      style={{ position: "absolute", left: 0, top: 0, right: 0, zIndex: 0, pointerEvents: "none" }}
+    >
+      {stars.map(([x, y, r]) => (
+        <path key={`${x}-${y}`} d={starPath(x, y, r)} fill="var(--faction-coven-slip-gold)" opacity={0.8} />
+      ))}
+    </svg>
+  );
+}
+
+/** The points, held in a glowing arcane sigil. */
+function Sigil({ size, points }: { size: number; points: number }) {
+  const sparkles: [number, number, number][] = [
+    [50, 4, 3.4],
+    [88, 26, 2.4],
+    [14, 74, 2.8],
+    [84, 78, 1.9],
+    [16, 24, 1.7],
+  ];
+  return (
+    <div
       style={{
-        width: 9,
-        height: 9,
-        borderRadius: "50%",
-        background: color,
-        border: "1.2px solid rgba(255,255,255,0.7)",
+        position: "relative",
+        flex: "0 0 auto",
+        width: size,
+        height: size,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
       }}
-    />
+    >
+      <span
+        aria-hidden="true"
+        style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "var(--faction-coven-slip-sigil-halo)" }}
+      />
+      <span
+        aria-hidden="true"
+        style={{ position: "absolute", inset: "18%", borderRadius: "50%", background: "var(--faction-coven-slip-sigil-core)" }}
+      />
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 100 100"
+        aria-hidden="true"
+        style={{ position: "absolute", inset: 0, overflow: "visible" }}
+      >
+        <circle cx="50" cy="50" r="32" fill="none" stroke="var(--faction-coven-slip-pk)" strokeWidth="1.6" opacity="0.9" />
+        <g stroke="var(--faction-coven-slip-gold)" strokeWidth="1.1" strokeLinecap="round" opacity="0.8">
+          <path d="M50 8 v6" />
+          <path d="M50 86 v6" />
+          <path d="M8 50 h6" />
+          <path d="M86 50 h6" />
+        </g>
+        {sparkles.map(([x, y, r]) => (
+          <path key={`${x}-${y}`} d={starPath(x, y, r)} fill="var(--faction-coven-slip-gold)" opacity={0.9} />
+        ))}
+      </svg>
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          lineHeight: 0.85,
+        }}
+      >
+        <span
+          className="content-title"
+          style={{ fontFamily: READING, fontWeight: 600, color: "var(--faction-coven-slip-deep)" }}
+        >
+          {points}
+        </span>
+        {/* Ornament: the unit caption inside the drawn sigil, sized to the disc
+            rather than to the label ramp (WORLD_ZERO_STYLE §4a). */}
+        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: caption engraved inside the sigil. */}
+        <span style={{ ...CAPTION, fontSize: 8, marginTop: "var(--space-xs)" }}>
+          {i18n.t("feed:taskCard.coven.pointsUnit")}
+        </span>
+      </div>
+    </div>
   );
 }
 
 export default function CovenTaskCard({
   task,
   basePoints,
+  multiplier,
+  inProgressCount,
   onSignup,
 }: CardProps) {
+  const formFactor = useFormFactor();
+  const size = SIZES[formFactor];
+  const showMultiplier = !isNeutralMultiplier(multiplier);
+
   return (
     <div
-      style={{
-        minWidth: 168,
-        maxWidth: 210,
-        flex: "0 1 196px",
-        borderRadius: 12,
-        overflow: "hidden",
-        border: "2px solid var(--faction-coven-win-border)",
-        fontFamily: "var(--font-body)",
-        transition: "border-color 150ms",
-      }}
+      data-form-factor={formFactor}
+      style={{ width: size.cardWidth, maxWidth: "100%", boxSizing: "border-box" }}
     >
-      {/* title bar */}
-      <div
+      <article
         style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "var(--space-sm)",
-          padding: "var(--space-sm) var(--space-sm)",
+          position: "relative",
+          overflow: "hidden",
+          boxSizing: "border-box",
+          width: "100%",
           background:
-            "linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))",
-          borderBottom: "2px solid var(--faction-coven-win-border)",
+            "linear-gradient(158deg, var(--faction-coven-slip-from), var(--faction-coven-slip-mid) 36%, var(--faction-coven-slip-lav) 74%, var(--faction-coven-slip-vio))",
+          border: "2px solid var(--faction-coven-slip-border)",
+          borderRadius: 18,
+          boxShadow: "var(--faction-coven-slip-shadow)",
+          color: "var(--faction-coven-slip-ink)",
+          fontFamily: CHROME,
         }}
       >
-        <div style={{ display: "flex", gap: "var(--space-xs)" }}>
-          <WindowDot color="#fb7aa8" />
-          <WindowDot color="#f6c75e" />
-          <WindowDot color="#86cfa6" />
-        </div>
-        <span
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "var(--space-xs)",
-            fontSize: "var(--text-base)",
-            letterSpacing: "0.03em",
-            color: "var(--faction-coven-title-text)",
-          }}
-        >
-          <Sparkle size={9} color="var(--faction-coven-title-text)" />
-          {i18n.t("feed:taskCard.coven.windowTitle")}
-        </span>
-        <span
-          style={{
-            marginLeft: "auto",
-            fontSize: "var(--text-base)",
-            opacity: 0.75,
-            letterSpacing: "1.5px",
-            color: "var(--faction-coven-title-text)",
-          }}
-        >
-          ▭ ✕
-        </span>
-      </div>
+        <TwinkleField />
 
-      {/* dotted-grid body */}
-      <div
-        style={
-          {
-            padding: "var(--space-md) var(--space-md) var(--space-md)",
-            background: "var(--faction-coven-body-bg)",
-            backgroundImage:
-              "radial-gradient(var(--faction-coven-dot) 1.4px, transparent 1.4px)",
-            backgroundSize: "13px 13px",
-          } as React.CSSProperties
-        }
-      >
-        {/* notepad panel */}
-        <div
-          style={{
-            background: "var(--faction-coven-notepad-bg)",
-            border: "1.5px solid var(--faction-coven-notepad-border)",
-            borderRadius: 7,
-            padding: "var(--space-sm) var(--space-md)",
-            marginBottom: "var(--space-md)",
-          }}
+        {/* The turning pentagram watermark. `.cvn-wheel` owns the motion and its
+            reduced-motion guard (#911 — no component-injected <style>). */}
+        <svg
+          className="cvn-wheel"
+          width={420}
+          height={420}
+          viewBox="0 0 100 100"
+          aria-hidden="true"
+          style={{ position: "absolute", right: -118, bottom: -64, zIndex: 0, pointerEvents: "none", opacity: 0.09 }}
         >
-          <div
-            className="card-meta"
-            style={{ color: "var(--faction-coven-card-accent)" }}
-          >
-            {i18n.t("feed:taskCard.coven.questMeta", { points: basePoints })}
+          <path
+            d="M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z"
+            fill="none"
+            stroke="var(--faction-coven-slip-deep)"
+            strokeWidth="1.2"
+            strokeLinejoin="round"
+          />
+        </svg>
+
+        {/* Masthead — the badge, the hand-lettered name, a braid under both. */}
+        <div style={{ position: "relative", zIndex: 2, textAlign: "center", padding: "var(--space-md) var(--space-lg) var(--space-sm)" }}>
+          <svg width={34} height={34} viewBox="0 0 44 44" aria-hidden="true" style={{ display: "block", margin: "0 auto" }}>
+            <circle cx="22" cy="22" r="19" fill="var(--faction-coven-slip-pk)" opacity="0.18" />
+            <circle cx="22" cy="22" r="15" fill="none" stroke="var(--faction-coven-slip-gold)" strokeWidth="1" strokeDasharray="2 4" />
+            <path
+              d="M22 8 L30.2 33.3 L8.7 17.7 L35.3 17.7 L13.8 33.3 Z"
+              fill="none"
+              stroke="var(--faction-coven-slip-deep)"
+              strokeWidth="1.5"
+              strokeLinejoin="round"
+            />
+            <circle cx="22" cy="22" r="3" fill="var(--faction-coven-slip-gold)" />
+          </svg>
+          {/* eslint-disable-next-line local/no-raw-style-values -- ornament: hand-lettered Caveat masthead, not typeset copy. */}
+          <div style={{ fontFamily: HAND, fontSize: 26, lineHeight: 0.9, marginTop: "var(--space-xs)" }}>
+            {i18n.t("feed:taskCard.coven.masthead")}
           </div>
+          <Thread style={{ marginTop: "var(--space-sm)" }} />
+        </div>
 
-          <Link
-            to={`/tasks/${task.id}`}
-            style={{ textDecoration: "none", color: "inherit" }}
-          >
+        <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
+          {/* Everything but the CTA reads the full call — a card-sized target
+              that stays valid HTML (no <button> nested in an <a>). */}
+          <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
             <div
-              className="content-title"
               style={{
-                fontFamily: "var(--faction-coven-card-font)",
-                fontWeight: 700,
-                lineHeight: 1.05,
-                marginBottom: "var(--space-xs)",
-                color: "var(--faction-coven-card-text)",
+                fontFamily: HAND,
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: the ordinal is pencilled on the slip in Caveat.
+                fontSize: 19,
+                lineHeight: 1,
+                color: "var(--faction-coven-slip-label)",
+                textAlign: "center",
+                padding: "var(--space-md) 0",
+              }}
+            >
+              {i18n.t("feed:taskCard.ordinal", { id: task.id })}
+            </div>
+
+            <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)", marginBottom: "var(--space-md)" }}>
+              <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", gap: "var(--space-xs)" }}>
+                <span style={{ fontFamily: READING, fontWeight: 600, fontSize: size.levelSize, lineHeight: 0.8 }}>
+                  {task.level_required}
+                </span>
+                {/* eslint-disable-next-line local/no-raw-style-values -- ornament: caption set to the numeral beside it, not the label ramp. */}
+                <span style={{ ...CAPTION, fontSize: 8.5 }}>
+                  {i18n.t("feed:taskCard.coven.levelCaption")}
+                </span>
+              </div>
+
+              <Thread style={{ flex: 1, minWidth: 0 }} />
+
+              {/* The faction modifier — hidden at ×1.00, so invisible under
+                  era_1's neutralized modifiers and automatic the day one moves
+                  (ADR-0055). */}
+              {showMultiplier && (
+                <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "center", gap: "var(--space-xs)" }}>
+                  <span
+                    style={{
+                      fontFamily: CHROME,
+                      fontWeight: 700,
+                      fontSize: "var(--text-md)",
+                      lineHeight: 1,
+                      color: "var(--faction-coven-slip-cta-ink)",
+                      background:
+                        "linear-gradient(180deg, var(--faction-coven-slip-cta-from), var(--faction-coven-slip-cta-to))",
+                      border: "1.5px solid var(--faction-coven-slip-cta-to)",
+                      borderRadius: 20,
+                      padding: "var(--space-xs) var(--space-sm)",
+                      boxShadow: "0 3px 8px var(--faction-coven-slip-glow)",
+                    }}
+                  >
+                    {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
+                  </span>
+                  {/* eslint-disable-next-line local/no-raw-style-values -- ornament: caption tucked under the chip. */}
+                  <span style={{ ...CAPTION, fontSize: 7.5 }}>
+                    {i18n.t("feed:taskCard.modifierCaption")}
+                  </span>
+                </div>
+              )}
+
+              <Sigil size={size.sigil} points={basePoints} />
+            </div>
+
+            <h3
+              style={{
+                fontFamily: DISPLAY,
+                fontWeight: 600,
+                fontSize: size.titleSize,
+                lineHeight: 1.06,
+                letterSpacing: "0.005em",
+                margin: "0 0 var(--space-sm)",
                 overflowWrap: "anywhere",
               }}
             >
               {task.title}
-            </div>
-          </Link>
+            </h3>
 
-          {task.description && (
-            <div
-              className="card-description"
-              style={{ color: "var(--faction-coven-card-muted)" }}
-            >
-              {task.description}
-            </div>
-          )}
+            {task.description && (
+              <p
+                className="card-description"
+                style={{
+                  fontFamily: READING,
+                  fontStyle: "italic",
+                  lineHeight: 1.45,
+                  color: "var(--faction-coven-slip-soft)",
+                  margin: "0 0 var(--space-md)",
+                }}
+              >
+                {task.description}
+              </p>
+            )}
+
+            <Thread style={{ margin: "0 0 var(--space-sm)" }} />
+
+            {inProgressCount > 0 && (
+              <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
+                <svg width={15} height={15} viewBox="0 0 36 36" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
+                  <path
+                    d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
+                    fill="var(--faction-coven-slip-pk)"
+                  />
+                </svg>
+                <span
+                  style={{
+                    fontFamily: READING,
+                    fontStyle: "italic",
+                    fontSize: "var(--text-xl)",
+                    color: "var(--faction-coven-slip-soft)",
+                  }}
+                >
+                  {i18n.t("feed:taskCard.inProgress", { count: inProgressCount })}
+                </span>
+              </div>
+            )}
+          </Link>
         </div>
 
         {onSignup && (
           <button
             onClick={() => onSignup(task.id)}
-            className="btn-primary"
-            style={{ fontSize: "var(--text-xs)", padding: "var(--space-xs) var(--space-sm)", marginBottom: "var(--space-sm)" }}
+            style={{
+              position: "relative",
+              zIndex: 2,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "var(--space-sm)",
+              width: "100%",
+              background:
+                "linear-gradient(180deg, var(--faction-coven-slip-cta-from), var(--faction-coven-slip-cta-to))",
+              color: "var(--faction-coven-slip-cta-ink)",
+              fontFamily: CHROME,
+              fontWeight: 700,
+              fontSize: "var(--text-lg)",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              padding: "var(--space-md) 0",
+              border: "none",
+              borderTop: "1.5px solid var(--faction-coven-slip-cta-to)",
+            }}
           >
+            <svg width={12} height={12} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
+              <path
+                d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
+                fill="currentColor"
+              />
+            </svg>
             {i18n.t("feed:taskCard.coven.signup")}
           </button>
         )}
-
-        {/* status row */}
-        <div className="card-footer">
-          <LevelGem level={task.level_required} factionSlug="coven" />
-          {/* Points shown as a ◆ corner-counter — a badge/counter, so it stays
-              label-tier per the role vocabulary (§4), not a plain score number. */}
-          <span
-            style={{
-              fontSize: "var(--text-sm)",
-              letterSpacing: "0.1em",
-              color: "var(--faction-coven-card-accent)",
-            }}
-          >
-            ◆ {i18n.t("feed:taskCard.coven.points", { points: basePoints })}
-          </span>
-        </div>
-      </div>
+      </article>
     </div>
   );
 }

--- a/frontend/src/components/cards/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/cards/EphemeristsTaskCard.tsx
@@ -1,194 +1,596 @@
+import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
-import { Trans } from "react-i18next";
 import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
-import { EphEyebrow, LapisLastWord, toRoman } from "./ephemeristsAtoms";
+import { isNeutralMultiplier } from "../../utils/points";
+import { useFormFactor } from "../../hooks/useFormFactor";
 
 /**
- * The Ephemerists — THE DISCORDANT MAP (task card, ephemerists slug).
- * One place, three irreconcilable coordinate grids (cartesian, perspective,
- * polar) all claim the same sheet and disagree about where the point is.
- * House-of-Leaves apparatus crawls the margin; one title word is pulled into
- * the lapis-blue; a self-referential footnote points back at itself.
- * Colors via the --eph-* / --faction-ephemerists-* tokens (theme-aware).
+ * The Ephemerists — THE VALLEY PLATE (task card v2, #1023). Deco × Egypt: the
+ * deco-space card carried into a field journal out of the Valley.
+ *
+ * A papyrus plate ruled in brass, headed by a cavetto cornice whose night band
+ * holds a winged sun disc between two incised registers of glyphs — Egypt,
+ * Greece, the middle ages, 1925 — that surface and recede on a long, staggered
+ * cycle. The points ride a stepped octagon medallion; the level is a numeral
+ * over tally strokes; the call to action is a full-bleed band with an open eye
+ * and a ringed planet. Poiret One for display, Cinzel for the small caps,
+ * Spectral for the reading copy.
+ *
+ * This REPLACES "The Discordant Map" wholesale (ADR-0055 / ADR-0056 — a full
+ * metaphor swap). The `--eph-*` illuminated-codex family stays declared: every
+ * other Ephemerists surface still paints with it, and so does
+ * `ephemeristsAtoms`.
+ *
+ * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not a
+ * different card. The dormant `mobileArchetypes/cards/EphemeristsMobileTaskCard`
+ * stays in the tree for the revert.
+ *
+ * All colour via `--faction-ephemerists-plate-*`; light/dark flips through the
+ * `[data-theme="dark"]` cascade, never a ternary. `-brass` is a rule colour and
+ * never an ink — the "Level" caption the design sets in it takes `-caption`,
+ * which is the same hue walked down to AA (see index.css).
  */
 
-export default function EphemeristsTaskCard({ task, basePoints, onSignup }: CardProps) {
+/**
+ * Poiret One, via the shared display token — deliberately NOT
+ * `--faction-ephemerists-card-font`, which is Cinzel: that token is the codex's
+ * display face and is read by a dozen other Ephemerists surfaces. The v2 design
+ * names Poiret One for THIS surface only.
+ */
+const DECO = "var(--font-faction-deco)";
+const CAPS = "var(--font-faction-engraved)"; /* Cinzel */
+const READING = "var(--font-faction-spectral)"; /* Spectral */
+
+interface SizeSet {
+  /** Card width. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
+  cardWidth: number;
+  /** Masthead band height. Geometry. */
+  masthead: number;
+  /** Winged-disc width — the ornament narrows on the phone. Geometry. */
+  discWidth: number;
+  /** Medallion box. Geometry. */
+  medallion: number;
+  /** How far the journal rule bleeds past the text column. Geometry. */
+  ruleBleed: number;
+  bodyPad: string;
+  titleSize: string;
+  levelSize: string;
+  pointsSize: string;
+}
+
+const SIZES: Record<"desktop" | "mobile", SizeSet> = {
+  desktop: {
+    cardWidth: 384,
+    masthead: 110,
+    discWidth: 176,
+    medallion: 104,
+    ruleBleed: 14,
+    bodyPad: "0 var(--space-xl) var(--space-xl)",
+    titleSize: "var(--text-title)",
+    levelSize: "var(--text-display)",
+    pointsSize: "var(--text-heading)",
+  },
+  mobile: {
+    cardWidth: 340,
+    masthead: 98,
+    discWidth: 154,
+    medallion: 90,
+    ruleBleed: 11,
+    bodyPad: "0 var(--space-xl) var(--space-lg)",
+    titleSize: "var(--text-title)",
+    levelSize: "var(--text-heading)",
+    pointsSize: "var(--text-title)",
+  },
+};
+
+/** Incised small caps — the plate's whole label voice. */
+const SMALL_CAPS: CSSProperties = {
+  fontFamily: CAPS,
+  fontWeight: 500,
+  letterSpacing: "0.26em",
+  textTransform: "uppercase",
+};
+
+/**
+ * The glyph library. Egyptian signs beside later-era marks, all drawn as deco
+ * geometry on a 24-unit square. Stroke-only, so they read as incised rather than
+ * as illustration.
+ */
+const GLYPHS: Record<string, string> = {
+  ankh: "M12 22 V10 M6 15 H18 M12 10 a4 4 0 1 0 0.001 0 Z",
+  eye: "M3 12 C7 7 17 7 21 12 C17 16 7 16 3 12 M12 10.2 a1.8 1.8 0 1 0 .01 0 Z M15 15 L18 20 M8 15 L5 19",
+  feather: "M12 22 V4 M12 6 C15 7 17 10 17 13 M12 6 C9 7 7 10 7 13 M12 12 C14.6 12.8 16 14.6 16 17 M12 12 C9.4 12.8 8 14.6 8 17",
+  water: "M2 9 l4 3 4-3 4 3 4-3 4 3 M2 15 l4 3 4-3 4 3 4-3 4 3",
+  djed: "M12 22 V8 M6 8 H18 M6 12 H18 M7.5 4.6 H16.5 M9 2 H15",
+  reed: "M12 22 V7 C12 4 14 2.6 17 2.6 C17 6 15 7.4 12 7.4",
+  sun: "M12 12 a5 5 0 1 0 .01 0 Z M12 3 V6 M12 18 V21 M3 12 H6 M18 12 H21",
+  offering: "M4 8 H20 M6 8 V14 H18 V8 M9 14 V20 M15 14 V20 M4 20 H20",
+  scarab: "M12 4 C15.5 4 17.5 7 17.5 11 C17.5 16.6 15 20 12 20 C9 20 6.5 16.6 6.5 11 C6.5 7 8.5 4 12 4 M12 4 V20 M6.5 9 L2.5 6 M17.5 9 L21.5 6 M6.5 15 L2.5 18 M17.5 15 L21.5 18",
+  greekKey: "M2 20 V6 H16 V16 H8 V11 H12", // meander — Greek, c. 700 BC
+  chevrons: "M3 8 L12 3 L21 8 M3 14 L12 9 L21 14 M3 20 L12 15 L21 20", // deco, 1925
+  alchemy: "M12 3 L21 19 H3 Z M6.6 13.6 H17.4", // alchemical fire — medieval
+  hourglass: "M5 3 H19 M5 21 H19 M6.5 3 L12 12 L6.5 21 M17.5 3 L12 12 L17.5 21",
+  openEye: "M2 12 C6 5.4 18 5.4 22 12 M2 12 C6 18.6 18 18.6 22 12 M8.4 12 a3.6 3.6 0 1 0 7.2 0 a3.6 3.6 0 1 0 -7.2 0 M10.7 12 a1.3 1.3 0 1 0 2.6 0 a1.3 1.3 0 1 0 -2.6 0 M12 2.8 V5 M5 4.6 L6.8 6.6 M19 4.6 L17.2 6.6",
+  planet: "M5.8 12 a6.2 6.2 0 1 0 12.4 0 a6.2 6.2 0 1 0 -12.4 0 M1.8 16.2 A10.8 3.7 -22 0 1 22.2 7.8 A10.8 3.7 -22 0 1 1.8 16.2", // Saturn
+};
+
+const REGISTER_TOP = [
+  "ankh", "water", "feather", "eye", "djed", "greekKey",
+  "reed", "offering", "alchemy", "chevrons", "scarab", "sun",
+];
+const REGISTER_BOTTOM = [
+  "scarab", "greekKey", "sun", "reed", "chevrons", "ankh",
+  "water", "djed", "eye", "alchemy", "offering", "feather",
+];
+
+const GLYPH_SIZE = 13;
+
+/** One incised sign, at its own strength and its own phase in the cycle. */
+function Glyph({ name, x, y, strength, delay }: {
+  name: string
+  x: number
+  y: number
+  strength: number
+  delay: number
+}) {
+  return (
+    <g
+      className="epg-glyph"
+      transform={`translate(${x} ${y}) scale(${GLYPH_SIZE / 24}) translate(-12 -12)`}
+      style={{ ["--epg-op"]: strength, ["--epg-delay"]: `${delay}s` } as CSSProperties}
+    >
+      <path
+        d={GLYPHS[name]}
+        fill="none"
+        stroke="var(--faction-ephemerists-plate-gold)"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  );
+}
+
+/** A register of signs marching across the band. */
+function register(names: string[], y: number, strength: number, keyPrefix: string) {
+  return names.map((name, index) => (
+    <Glyph
+      key={`${keyPrefix}${index}`}
+      name={name}
+      x={20 + index * 27.5}
+      y={y}
+      strength={strength * (index % 3 === 0 ? 1 : 0.72)}
+      delay={((index * 7) % 12) * 1.6}
+    />
+  ));
+}
+
+/** One wing of the sun disc, drawn as deco stepped bars. */
+function Wing({ flip }: { flip?: boolean }) {
+  return (
+    <g transform={flip ? "scale(-1,1)" : undefined}>
+      {[0, 1, 2, 3, 4].map((i) => (
+        <rect
+          key={i}
+          x={13 + i * 11.4}
+          y={-6 + i * 1.5}
+          width={9.6}
+          height={8.4 - i * 1.4}
+          rx={1.4}
+          fill="var(--faction-ephemerists-plate-gold)"
+          opacity={0.9 - i * 0.13}
+        />
+      ))}
+      {[0, 1, 2, 3].map((i) => (
+        <rect
+          key={`covert-${i}`}
+          x={15 + i * 11.4}
+          y={4.2 + i * 1.6}
+          width={8}
+          height={3.4 - i * 0.5}
+          rx={1}
+          fill="var(--faction-ephemerists-plate-brass-light)"
+          opacity={0.62 - i * 0.11}
+        />
+      ))}
+    </g>
+  );
+}
+
+/** A stepped octagon, inset from the medallion's edge. */
+function Octagon({ inset, stroke, width, fill }: {
+  inset: number
+  stroke: string
+  width: number
+  fill?: string
+}) {
+  return (
+    <path
+      d="M30 4 L70 4 L96 30 L96 70 L70 96 L30 96 L4 70 L4 30 Z"
+      fill={fill ?? "none"}
+      stroke={stroke}
+      strokeWidth={width}
+      transform={`translate(50,50) scale(${(100 - inset * 2) / 100}) translate(-50,-50)`}
+    />
+  );
+}
+
+/** The cavetto cornice: fluted strokes under a stepped double rule. */
+function Cornice() {
+  return (
+    <div aria-hidden="true" style={{ position: "relative", zIndex: 3, background: "var(--faction-ephemerists-plate-band)" }}>
+      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the lead between cornice flutes; rounding it to a rung reflows the fluting. */}
+      <div style={{ display: "flex", height: 7, alignItems: "flex-end", gap: 3, padding: "0 var(--space-sm)", overflow: "hidden" }}>
+        {Array.from({ length: 40 }).map((_, i) => (
+          <span
+            key={i}
+            style={{
+              flex: 1,
+              height: i % 2 ? 6 : 3.5,
+              background: "var(--faction-ephemerists-plate-brass-light)",
+              opacity: i % 2 ? 0.5 : 0.28,
+            }}
+          />
+        ))}
+      </div>
+      <div style={{ height: 2, background: "var(--faction-ephemerists-plate-brass)", opacity: 0.9 }} />
+      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the gap in the cornice's stepped double rule. */}
+      <div style={{ height: 1, marginTop: 2, background: "var(--faction-ephemerists-plate-brass-light)", opacity: 0.55 }} />
+    </div>
+  );
+}
+
+/** A fluted band ruling the journal leaf, bleeding past the text column. */
+function JournalRule({ bleed }: { bleed: number }) {
   return (
     <div
+      aria-hidden="true"
       style={{
-        width: 214,
-        minHeight: 300,
-        flex: "0 1 214px",
-        position: "relative",
-        overflow: "hidden",
-        background: "var(--eph-vellum)",
-        color: "var(--eph-vellum-text)",
-        border: "1.5px solid var(--eph-ink)",
-        fontFamily: "var(--eph-serif)",
         display: "flex",
-        flexDirection: "column",
-        transition: "background 150ms, color 150ms",
+        alignItems: "flex-start",
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: the lead between the journal rule's flutes.
+        gap: 3,
+        height: 7,
+        overflow: "hidden",
+        marginLeft: -bleed,
+        marginRight: -bleed,
+        marginBottom: "var(--space-md)",
       }}
     >
-      <div style={{ position: "relative", zIndex: 5, padding: "var(--space-sm) 0 var(--space-xs)" }}>
-        <EphEyebrow motto={i18n.t("feed:taskCard.ephemerists.motto")} dark />
-      </div>
-
-      {/* The contested field — three grids disagreeing about one point */}
-      <div
-        style={{
-          position: "relative",
-          flex: 1,
-          minHeight: 188,
-          margin: "var(--space-xs) var(--space-xs)",
-          border: "1px solid var(--eph-gold-deep)",
-          overflow: "hidden",
-        }}
-      >
-        {/* cartesian — keyed to vellum-text so it stays legible in dark */}
-        <div
+      {Array.from({ length: 42 }).map((_, i) => (
+        <span
+          key={i}
           style={{
-            position: "absolute",
-            inset: 0,
-            opacity: 0.5,
-            backgroundImage:
-              "repeating-linear-gradient(0deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 16px), repeating-linear-gradient(90deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 16px)",
+            flex: 1,
+            height: i % 2 ? 7 : 4,
+            background: "var(--faction-ephemerists-plate-brass)",
+            opacity: i % 2 ? 0.55 : 0.3,
           }}
         />
-        {/* perspective grid */}
-        <svg
-          viewBox="0 0 200 188"
-          preserveAspectRatio="none"
-          style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.7 }}
-          aria-hidden="true"
-        >
-          <g stroke="var(--eph-lapis)" strokeWidth="0.9" fill="none">
-            {Array.from({ length: 11 }).map((_, i) => (
-              <line key={i} x1={i * 20} y1="188" x2="122" y2="40" />
-            ))}
-            {[60, 96, 124, 146, 163, 176].map((y, i) => (
-              <line key={i} x1="0" y1={y} x2="200" y2={y} />
-            ))}
-          </g>
-        </svg>
-        {/* polar */}
-        <svg
-          viewBox="0 0 200 188"
-          style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.72 }}
-          aria-hidden="true"
-        >
-          <g stroke="var(--eph-rubric)" strokeWidth="0.8" fill="none">
-            {[16, 34, 54, 76].map((r, i) => (
-              <circle key={i} cx="122" cy="88" r={r} />
-            ))}
-            {Array.from({ length: 12 }).map((_, i) => (
-              <line
-                key={i}
-                x1="122"
-                y1="88"
-                x2={122 + 80 * Math.cos((i * Math.PI) / 6)}
-                y2={88 + 80 * Math.sin((i * Math.PI) / 6)}
-              />
-            ))}
-          </g>
-        </svg>
-        {/* the disputed point */}
-        <div style={{ position: "absolute", left: "61%", top: "47%", transform: "translate(-50%,-50%)", zIndex: 4 }}>
-          <div
-            className="eph-twinkle"
-            style={{
-              width: 9,
-              height: 9,
-              borderRadius: "50%",
-              background: "var(--eph-gold-light)",
-              boxShadow: "0 0 10px 3px color-mix(in srgb, var(--eph-gold-light) 70%, transparent)",
-            }}
-          />
-        </div>
-        {/* three coordinate labels for one point — and none agree */}
-        <div style={{ position: "absolute", top: "8%", left: "6%", fontSize: "var(--text-xs)", letterSpacing: "0.04em", color: "var(--eph-vellum-text)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "var(--space-xs) var(--space-xs)" }}>
-          {i18n.t("feed:taskCard.ephemerists.coordXPrefix")}<span style={{ textDecoration: "line-through", opacity: 0.65 }}>8</span>{" "}
-          <span style={{ color: "var(--eph-lapis)", fontStyle: "italic" }}>9</span>
-        </div>
-        <div style={{ position: "absolute", top: "78%", left: "54%", fontSize: "var(--text-xs)", letterSpacing: "0.04em", color: "var(--eph-rubric)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "var(--space-xs) var(--space-xs)" }}>
-          {i18n.t("feed:taskCard.ephemerists.coordPolar")}
-        </div>
-        <div style={{ position: "absolute", top: "6%", left: "68%", fontSize: "var(--text-xs)", letterSpacing: "0.04em", color: "var(--eph-lapis)", background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)", padding: "var(--space-xs) var(--space-xs)" }}>
-          {i18n.t("feed:taskCard.ephemerists.vanishingLabel")}
-        </div>
-        {/* marginal apparatus climbing the gutter */}
-        <div style={{ position: "absolute", left: 2, bottom: 7, transformOrigin: "left bottom", transform: "rotate(-90deg)", whiteSpace: "nowrap", fontSize: "var(--text-xs)", letterSpacing: "0.05em", color: "var(--eph-muted)", opacity: 0.85 }}>
-          {i18n.t("feed:taskCard.ephemerists.marginalia")}
-        </div>
-      </div>
+      ))}
+    </div>
+  );
+}
 
-      {/* Legend / title */}
-      <div style={{ position: "relative", zIndex: 5, padding: "var(--space-sm) var(--space-lg) var(--space-md)", textAlign: "center" }}>
-        <Link to={`/tasks/${task.id}`} style={{ textDecoration: "none", color: "inherit" }}>
-          <div className="content-title" style={{ fontFamily: "var(--eph-display)", fontWeight: 700, lineHeight: 0.94 }}>
-            <LapisLastWord text={task.title} footnote />
-          </div>
-        </Link>
-        {task.description && (
-          <div
-            className="content-text"
-            style={{
-              lineHeight: 1.45,
-              fontStyle: "italic",
-              color: "var(--eph-muted)",
-              margin: "var(--space-xs) 0 var(--space-sm)",
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
-              overflow: "hidden",
-            }}
-          >
-            {task.description}
-          </div>
-        )}
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: "var(--space-sm)", fontSize: "var(--text-xs)" }}>
-          <span style={{ color: "var(--eph-vellum-text)" }}>
-            ▦ {i18n.t("feed:taskCard.ephemerists.grade", { grade: toRoman(task.level_required) })}
-          </span>
-          <span style={{ color: "var(--eph-gold-deep)" }}>·</span>
-          {/* Points woven into the grade legend — a counter/legend accent, so it
-              stays label-tier per the role vocabulary (§4), not a plain score. */}
-          <span style={{ fontFamily: "var(--eph-display)", fontWeight: 700, fontSize: "var(--text-lg)", color: "var(--eph-rubric)" }}>
-            {i18n.t("feed:taskCard.ephemerists.points", { points: basePoints })}
-          </span>
-        </div>
-        <div style={{ fontSize: "var(--text-xs)", fontStyle: "italic", color: "var(--eph-muted)", marginTop: "var(--space-sm)", lineHeight: 1.35 }}>
-          {/* The self-referential footnote is one <Trans> unit; "see †" is tag <1>. */}
-          <Trans
-            ns="feed"
-            i18nKey="taskCard.ephemerists.footnote"
-            components={{ 1: <span style={{ color: "var(--eph-lapis)" }} /> }}
-          />
-        </div>
-      </div>
+export default function EphemeristsTaskCard({
+  task,
+  basePoints,
+  multiplier,
+  inProgressCount,
+  onSignup,
+}: CardProps) {
+  const formFactor = useFormFactor();
+  const size = SIZES[formFactor];
+  const showMultiplier = !isNeutralMultiplier(multiplier);
+  const tallyStrokes = Math.min(9, Math.max(1, Math.round(task.level_required)));
 
-      {onSignup && (
-        <button
-          onClick={() => onSignup(task.id)}
+  return (
+    <div
+      data-form-factor={formFactor}
+      style={{ width: size.cardWidth, maxWidth: "100%", boxSizing: "border-box" }}
+    >
+      <article
+        style={{
+          position: "relative",
+          overflow: "hidden",
+          boxSizing: "border-box",
+          width: "100%",
+          background: "var(--faction-ephemerists-plate-bg)",
+          color: "var(--faction-ephemerists-plate-ink)",
+          border: "1px solid var(--faction-ephemerists-plate-brass)",
+          outline: "1px solid var(--faction-ephemerists-plate-brass-light)",
+          outlineOffset: 3,
+          boxShadow: "var(--faction-ephemerists-plate-shadow)",
+        }}
+      >
+        {/* Masthead — the night band, its glyph registers, the winged disc. */}
+        <div
           style={{
-            fontFamily: "var(--eph-serif)",
-            fontSize: "var(--text-sm)",
-            letterSpacing: "0.12em",
-            fontStyle: "italic",
-            padding: "var(--space-sm) var(--space-md)",
-            border: "none",
-            cursor: "pointer",
-            width: "100%",
-            background: "var(--eph-ink)",
-            color: "var(--eph-parchment)",
             position: "relative",
-            zIndex: 6,
+            overflow: "hidden",
+            height: size.masthead,
+            background: "var(--faction-ephemerists-plate-band)",
+            color: "var(--faction-ephemerists-plate-band-ink)",
           }}
         >
-          {i18n.t("feed:taskCard.ephemerists.signup")}
-        </button>
-      )}
+          <svg
+            width="100%"
+            height={size.masthead}
+            viewBox="0 0 340 110"
+            preserveAspectRatio="xMidYMid slice"
+            aria-hidden="true"
+            style={{ position: "absolute", inset: 0, zIndex: 1 }}
+          >
+            <path d="M8 24 H332 M8 86 H332" stroke="var(--faction-ephemerists-plate-brass-light)" strokeWidth="0.6" opacity="0.28" />
+            {register(REGISTER_TOP, 13, 0.34, "top")}
+            {register(REGISTER_BOTTOM, 97, 0.3, "bottom")}
+          </svg>
+
+          <div
+            style={{
+              position: "relative",
+              zIndex: 2,
+              height: "100%",
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "var(--space-xs)",
+            }}
+          >
+            <svg
+              width={size.discWidth}
+              height={40}
+              viewBox="-88 -20 176 40"
+              aria-hidden="true"
+              style={{ display: "block", flex: "0 0 auto" }}
+            >
+              <Wing />
+              <Wing flip />
+              <circle r={10} fill="none" stroke="var(--faction-ephemerists-plate-gold)" strokeWidth="1.5" />
+              <circle r={5} fill="var(--faction-ephemerists-plate-gold)" opacity={0.8} />
+              <path d="M-13 0 H-10.5 M10.5 0 H13" stroke="var(--faction-ephemerists-plate-brass-light)" strokeWidth="1" />
+            </svg>
+            <span
+              style={{
+                fontFamily: DECO,
+                fontSize: "var(--text-xl)",
+                letterSpacing: "0.3em",
+                textTransform: "uppercase",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {i18n.t("feed:taskCard.ephemerists.masthead")}
+            </span>
+          </div>
+        </div>
+        <Cornice />
+
+        {/* The journal leaf. */}
+        <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
+          {/* Everything but the CTA reads the full call — a card-sized target
+              that stays valid HTML (no <button> nested in an <a>). */}
+          <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+            {/* The cartouche, carrying the uniform ordinal (#1020). */}
+            <div style={{ display: "flex", justifyContent: "center", padding: "var(--space-md) 0 var(--space-xs)" }}>
+              <span
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: "var(--space-sm)",
+                  padding: "var(--space-xs) var(--space-md)",
+                  border: "1.5px solid var(--faction-ephemerists-plate-brass)",
+                  borderRadius: 12,
+                  background: "var(--faction-ephemerists-plate-wash)",
+                }}
+              >
+                <span aria-hidden="true" style={{ width: 1.5, height: 12, background: "var(--faction-ephemerists-plate-brass)" }} />
+                <span
+                  style={{
+                    ...SMALL_CAPS,
+                    fontWeight: 700,
+                    fontSize: "var(--text-base)",
+                    letterSpacing: "0.24em",
+                    whiteSpace: "nowrap",
+                  }}
+                >
+                  {i18n.t("feed:taskCard.ordinal", { id: task.id })}
+                </span>
+                <span aria-hidden="true" style={{ width: 1.5, height: 12, background: "var(--faction-ephemerists-plate-brass)" }} />
+              </span>
+            </div>
+
+            <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", padding: "var(--space-md) 0 var(--space-lg)" }}>
+              <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", gap: "var(--space-xs)", lineHeight: 1 }}>
+                <span style={{ ...SMALL_CAPS, fontSize: "var(--text-sm)", color: "var(--faction-ephemerists-plate-caption)" }}>
+                  {i18n.t("feed:taskCard.ephemerists.levelCaption")}
+                </span>
+                <span style={{ fontFamily: DECO, fontSize: size.levelSize, lineHeight: 0.8 }}>
+                  {task.level_required}
+                </span>
+                {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the pitch of the tally strokes, drawn at 1.6px wide. */}
+                <span aria-hidden="true" style={{ display: "flex", alignItems: "flex-end", gap: 2.5, height: 11 }}>
+                  {Array.from({ length: tallyStrokes }).map((_, i) => (
+                    <span
+                      key={i}
+                      style={{
+                        width: 1.6,
+                        height: 11 - (i % 3) * 2,
+                        opacity: 0.85,
+                        background: i === 4
+                          ? "var(--faction-ephemerists-plate-ochre)"
+                          : "var(--faction-ephemerists-plate-brass)",
+                      }}
+                    />
+                  ))}
+                </span>
+              </div>
+
+              {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the lead between three 1px hairlines. */}
+              <div aria-hidden="true" style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 3, overflow: "hidden" }}>
+                {[1, 0.7, 0.4].map((strength, i) => (
+                  <span
+                    key={strength}
+                    style={{
+                      height: 1,
+                      background: "var(--faction-ephemerists-plate-brass)",
+                      opacity: strength * 0.65,
+                      marginRight: i * 14,
+                    }}
+                  />
+                ))}
+              </div>
+
+              {/* The faction modifier — hidden at ×1.00, so invisible under
+                  era_1's neutralized modifiers and automatic the day one moves
+                  (ADR-0055). */}
+              {showMultiplier && (
+                <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "center", gap: "var(--space-xs)" }}>
+                  <span
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      padding: "var(--space-xs) var(--space-sm)",
+                      background: "var(--faction-ephemerists-plate-wash)",
+                      border: "1px solid var(--faction-ephemerists-plate-brass)",
+                      clipPath: "polygon(6px 0, 100% 0, 100% calc(100% - 6px), calc(100% - 6px) 100%, 0 100%, 0 6px)",
+                      fontFamily: CAPS,
+                      fontWeight: 600,
+                      fontSize: "var(--text-lg)",
+                      lineHeight: 1,
+                    }}
+                  >
+                    {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
+                  </span>
+                  <span style={{ ...SMALL_CAPS, fontSize: "var(--text-xs)", color: "var(--faction-ephemerists-plate-caption)" }}>
+                    {i18n.t("feed:taskCard.modifierCaption")}
+                  </span>
+                </div>
+              )}
+
+              {/* The stepped octagon medallion. */}
+              <div
+                style={{
+                  position: "relative",
+                  flex: "0 0 auto",
+                  width: size.medallion,
+                  height: size.medallion,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <svg width={size.medallion} height={size.medallion} viewBox="0 0 100 100" aria-hidden="true" style={{ position: "absolute", inset: 0 }}>
+                  <Octagon inset={0} stroke="var(--faction-ephemerists-plate-brass)" width={1.6} fill="var(--faction-ephemerists-plate-disc)" />
+                  <Octagon inset={6} stroke="var(--faction-ephemerists-plate-brass-light)" width={0.7} />
+                  <circle cx="50" cy="50" r="34" fill="none" stroke="var(--faction-ephemerists-plate-brass-light)" strokeWidth="0.7" opacity="0.55" />
+                  <path d="M18 74 H82" stroke="var(--faction-ephemerists-plate-brass-light)" strokeWidth="0.7" opacity="0.5" />
+                </svg>
+                <div style={{ position: "relative", display: "flex", flexDirection: "column", alignItems: "center", lineHeight: 0.82 }}>
+                  <span style={{ fontFamily: DECO, fontSize: size.pointsSize }}>{basePoints}</span>
+                  {/* Ornament: the unit engraved inside the medallion, sized to
+                      the disc rather than to the label ramp (§4a). */}
+                  {/* eslint-disable-next-line local/no-raw-style-values -- ornament: caption engraved inside the medallion. */}
+                  <span style={{ ...SMALL_CAPS, fontSize: 7, letterSpacing: "0.2em", marginTop: "var(--space-xs)", color: "var(--faction-ephemerists-plate-muted)" }}>
+                    {i18n.t("feed:taskCard.ephemerists.pointsUnit")}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <h3
+              style={{
+                fontFamily: DECO,
+                fontWeight: 400,
+                fontSize: size.titleSize,
+                letterSpacing: "0.02em",
+                lineHeight: 1.24,
+                margin: "0 0 var(--space-sm)",
+                overflowWrap: "anywhere",
+              }}
+            >
+              {task.title}
+            </h3>
+
+            {task.description && (
+              <p
+                className="card-description"
+                style={{
+                  fontFamily: READING,
+                  fontStyle: "italic",
+                  lineHeight: 1.55,
+                  color: "var(--faction-ephemerists-plate-muted)",
+                  margin: "0 0 var(--space-md)",
+                }}
+              >
+                {task.description}
+              </p>
+            )}
+
+            <JournalRule bleed={size.ruleBleed} />
+
+            {inProgressCount > 0 && (
+              <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
+                <svg width={15} height={15} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
+                  <path
+                    d={GLYPHS.hourglass}
+                    fill="none"
+                    stroke="var(--faction-ephemerists-plate-brass)"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                <span
+                  style={{
+                    fontFamily: READING,
+                    fontStyle: "italic",
+                    fontSize: "var(--text-xl)",
+                    color: "var(--faction-ephemerists-plate-muted)",
+                  }}
+                >
+                  {i18n.t("feed:taskCard.inProgress", { count: inProgressCount })}
+                </span>
+              </div>
+            )}
+          </Link>
+        </div>
+
+        {onSignup && (
+          <button
+            onClick={() => onSignup(task.id)}
+            style={{
+              position: "relative",
+              zIndex: 2,
+              cursor: "pointer",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "var(--space-md)",
+              width: "100%",
+              background: "var(--faction-ephemerists-plate-cta-bg)",
+              color: "var(--faction-ephemerists-plate-cta-ink)",
+              border: "none",
+              borderTop: "2px solid var(--faction-ephemerists-plate-brass)",
+              padding: "var(--space-md) 0",
+              fontFamily: CAPS,
+              fontWeight: 500,
+              fontSize: "var(--text-xl)",
+              letterSpacing: "0.24em",
+              textTransform: "uppercase",
+            }}
+          >
+            <svg width={17} height={17} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
+              <path d={GLYPHS.openEye} fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+            <span>{i18n.t("feed:taskCard.ephemerists.signup")}</span>
+            <svg width={16} height={16} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
+              <path d={GLYPHS.planet} fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        )}
+      </article>
     </div>
   );
 }

--- a/frontend/src/components/cards/EverymenTaskCard.tsx
+++ b/frontend/src/components/cards/EverymenTaskCard.tsx
@@ -1,273 +1,366 @@
+import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
-import LevelGem from "../ui/LevelGem";
-import { EverymenSigil } from "./EverymenSigil";
+import { isNeutralMultiplier } from "../../utils/points";
+import { useFormFactor } from "../../hooks/useFormFactor";
 
 /**
- * Everymen — "The Rally Bill".
- * Union / WW2 victory-poster: red masthead with cog sigils, cream poster body,
- * faint sunburst + halftone wash, rubber-stamped points seal, "Report for duty"
- * call to action wired to onSignup.
+ * Everymen — THE HELP WANTED BILL (task card v2, #1023).
+ *
+ * A WPA union broadsheet posted on a wall: a double-ruled red masthead flanked
+ * by toothed cogs, poster rays fanning out from behind it, a typewritten
+ * dispatch in Courier Prime, a rubber-stamp points seal struck a few degrees off
+ * true, a red dashed rule, and a full-bleed report-for-duty bar. Bebas Neue
+ * carries every headline and label; Courier Prime carries everything read.
+ *
+ * This replaces "The Rally Bill" (ADR-0055 / ADR-0056). Same family of
+ * references, rebuilt on the shared v2 information structure: eyebrow → LEVEL +
+ * POINTS hero → title → brief → in-progress → CTA.
+ *
+ * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, not a
+ * different card. The dormant `mobileArchetypes/cards/EverymenMobileTaskCard`
+ * stays in the tree for the revert.
+ *
+ * Colour comes almost entirely from the existing `--everymen-*` family, which
+ * the design's own palette turned out to match value-for-value; only the
+ * masthead, the CTA bar, the modifier ink and the three washes needed new
+ * `--faction-everymen-bill-*` tokens. Light/dark flips through the
+ * `[data-theme="dark"]` cascade, never a ternary.
  */
 
-/* ── poster atoms (self-contained) ─────────────────────────────── */
+const POSTER = "var(--faction-everymen-card-font)"; /* Bebas Neue */
+const TYPED = "var(--font-body)"; /* Courier Prime */
 
-// faint screen-print halftone wash.
-function Halftone({
-  color = "var(--everymen-ink)",
-  opacity = 0.07,
-  size = 4,
-}: {
-  color?: string;
-  opacity?: number;
-  size?: number;
-}) {
-  return (
-    <div
-      style={{
-        position: "absolute",
-        inset: 0,
-        pointerEvents: "none",
-        opacity,
-        backgroundImage: `radial-gradient(${color} 0.6px, transparent 0.7px)`,
-        backgroundSize: `${size}px ${size}px`,
-        zIndex: 1,
-      }}
-    />
-  );
+/**
+ * The sheet's ink — the paper's own text colour, which FLIPS with the paper.
+ * Deliberately not `--everymen-ink`, which is a near-black structure colour in
+ * dark and would vanish on a dark bill.
+ */
+const INK = "var(--everymen-paper-text)";
+
+interface SizeSet {
+  /** Card width. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
+  cardWidth: number;
+  mastPad: string;
+  bodyPad: string;
+  titleSize: string;
+  levelSize: string;
+  pointsSize: string;
+  /** Diameter of the rubber-stamp seal. Geometry. */
+  seal: number;
 }
 
-// radiating poster rays from an origin point.
-function Sunburst({
-  color = "var(--everymen-red)",
-  from = "50% 0%",
-  opacity = 0.1,
-  step = 7,
-}: {
-  color?: string;
-  from?: string;
-  opacity?: number;
-  step?: number;
-}) {
-  return (
-    <div
-      style={{
-        position: "absolute",
-        inset: 0,
-        pointerEvents: "none",
-        opacity,
-        zIndex: 0,
-        background: `repeating-conic-gradient(from 0deg at ${from}, ${color} 0deg ${step}deg, transparent ${step}deg ${step * 2}deg)`,
-      }}
-    />
-  );
+const SIZES: Record<"desktop" | "mobile", SizeSet> = {
+  desktop: {
+    cardWidth: 384,
+    mastPad: "var(--space-md) var(--space-lg)",
+    bodyPad: "var(--space-lg) var(--space-xl) var(--space-xl)",
+    titleSize: "var(--text-heading)",
+    levelSize: "var(--text-display)",
+    pointsSize: "var(--text-heading)",
+    seal: 70,
+  },
+  mobile: {
+    cardWidth: 340,
+    mastPad: "var(--space-sm) var(--space-lg)",
+    bodyPad: "var(--space-lg) var(--space-lg) var(--space-lg)",
+    titleSize: "var(--text-title)",
+    levelSize: "var(--text-heading)",
+    pointsSize: "var(--text-title)",
+    seal: 62,
+  },
+};
+
+/** Poster label voice — condensed caps, the bill's whole chrome. */
+const LABEL: CSSProperties = {
+  fontFamily: POSTER,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+};
+
+/**
+ * A toothed gear on a 24-unit square, built rather than drawn: eight long teeth
+ * on a hub, which no hand-written path holds legibly at three different sizes.
+ */
+function gearPath(): string {
+  const teeth = 8;
+  const radius = 9.5;
+  const tipLength = 5;
+  const tipHalf = 1.6;
+  const rootHalf = 2.6;
+  const point = (r: number, angle: number): [number, number] =>
+    [12 + r * Math.cos(angle), 12 + r * Math.sin(angle)];
+
+  let path = "";
+  for (let n = 0; n < teeth; n += 1) {
+    const start = (n / teeth) * Math.PI * 2;
+    const step = (Math.PI * 2) / teeth;
+    const rootA = point(radius, start - rootHalf / radius);
+    const tipA = point(radius + tipLength, start - tipHalf / (radius + tipLength));
+    const tipB = point(radius + tipLength, start + tipHalf / (radius + tipLength));
+    const rootB = point(radius, start + rootHalf / radius);
+    const nextRoot = point(radius, start + step - rootHalf / radius);
+    path += `${n === 0 ? "M" : "L"}${rootA[0]},${rootA[1]}`
+      + `L${tipA[0]},${tipA[1]}L${tipB[0]},${tipB[1]}L${rootB[0]},${rootB[1]}`
+      + `A${radius},${radius} 0 0 1 ${nextRoot[0]},${nextRoot[1]}`;
+  }
+  return `${path}Z`;
 }
 
-// little center ornament rule.
-function RuleDiamond({ color = "var(--everymen-red)" }: { color?: string }) {
+const GEAR_PATH = gearPath();
+
+function Gear({ size, fill, hub, opacity }: {
+  size: number
+  fill: string
+  hub: string
+  opacity?: number
+}) {
   return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "var(--space-xs)",
-        justifyContent: "center",
-        margin: "var(--space-sm) 0",
-      }}
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      style={{ display: "block", flex: "0 0 auto", opacity }}
     >
-      <div style={{ height: 1.5, flex: 1, background: color }} />
-      <div style={{ width: 5, height: 5, background: color, transform: "rotate(45deg)" }} />
-      <div style={{ height: 1.5, flex: 1, background: color }} />
-    </div>
+      <path d={GEAR_PATH} fill={fill} />
+      <circle cx="12" cy="12" r="3" fill={hub} />
+    </svg>
   );
 }
 
-// rubber-stamped circular points seal.
-function PointsSeal({
-  points,
-  color = "var(--everymen-red)",
-  rotate = -9,
-  size = 52,
-}: {
-  points: number;
-  color?: string;
-  rotate?: number;
-  size?: number;
-}) {
+export default function EverymenTaskCard({
+  task,
+  basePoints,
+  multiplier,
+  inProgressCount,
+  onSignup,
+}: CardProps) {
+  const formFactor = useFormFactor();
+  const size = SIZES[formFactor];
+  const showMultiplier = !isNeutralMultiplier(multiplier);
+
   return (
     <div
-      style={{
-        width: size,
-        height: size,
-        borderRadius: "50%",
-        border: `2px solid ${color}`,
-        boxShadow: `inset 0 0 0 2px ${color}`,
-        color,
-        transform: `rotate(${rotate}deg)`,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        lineHeight: 1,
-        opacity: 0.92,
-        mixBlendMode: "multiply",
-      }}
+      data-form-factor={formFactor}
+      style={{ width: size.cardWidth, maxWidth: "100%", boxSizing: "border-box" }}
     >
-      <span style={{ fontFamily: "var(--faction-everymen-card-font)", fontSize: size * 0.42 }}>
-        {points}
-      </span>
-      <span
+      <article
         style={{
-          fontFamily: "var(--font-body)",
-          fontSize: "var(--text-xs)",
-          letterSpacing: "0.18em",
-          marginTop: "var(--space-xs)",
+          position: "relative",
+          overflow: "hidden",
+          boxSizing: "border-box",
+          width: "100%",
+          background: "var(--everymen-paper)",
+          color: INK,
+          border: `2px solid ${INK}`,
+          borderRadius: 2,
+          padding: "var(--space-xs)",
+          boxShadow: "var(--faction-everymen-bill-shadow)",
         }}
       >
-        {i18n.t("feed:taskCard.everymen.sealUnit")}
-      </span>
-    </div>
-  );
-}
-
-/* ── card ───────────────────────────────────────────────────────── */
-
-export default function EverymenTaskCard({ task, basePoints, onSignup }: CardProps) {
-  return (
-    <div
-      style={{
-        maxWidth: 206,
-        flex: "0 1 206px",
-        background: "var(--everymen-paper)",
-        color: "var(--faction-everymen-card-text)",
-        border: "1.5px solid var(--everymen-ink)",
-        boxShadow:
-          "0 0 0 3px var(--everymen-paper), 0 0 0 4px var(--everymen-ink)",
-        position: "relative",
-        fontFamily: "var(--font-body)",
-      }}
-    >
-      {/* masthead */}
-      <div
-        style={{
-          background: "var(--everymen-red)",
-          borderBottom: "2px solid var(--everymen-gold)",
-          padding: "var(--space-sm) var(--space-sm) var(--space-sm)",
-          textAlign: "center",
-        }}
-      >
-        <div
-          className="card-meta"
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "var(--space-xs)",
-            color: "var(--everymen-cream)",
-            whiteSpace: "nowrap",
-            fontFamily: "var(--font-body)",
-          }}
-        >
-          <EverymenSigil size={11} color="var(--everymen-cream)" />
-          <span
+        <div style={{ position: "relative", overflow: "hidden", border: `1px solid ${INK}`, borderRadius: 1 }}>
+          {/* Poster rays and two corner glows, masked away from the copy. */}
+          <div
+            aria-hidden="true"
             style={{
-              fontFamily: "var(--faction-everymen-card-font)",
-              fontSize: "var(--text-xl)",
-              letterSpacing: "0.07em",
+              position: "absolute",
+              inset: 0,
+              pointerEvents: "none",
+              zIndex: 0,
+              backgroundImage:
+                "radial-gradient(40% 32% at 100% 0, var(--faction-everymen-bill-glow-gold), transparent 70%),"
+                + " radial-gradient(44% 38% at 0 100%, var(--faction-everymen-bill-glow-olive), transparent 70%),"
+                + " repeating-conic-gradient(from 0deg at 50% 16%, var(--faction-everymen-bill-ray) 0 5.2deg, transparent 5.2deg 10.4deg)",
+              WebkitMaskImage: "radial-gradient(130% 100% at 50% 16%, #000 40%, transparent 96%)",
+              maskImage: "radial-gradient(130% 100% at 50% 16%, #000 40%, transparent 96%)",
+            }}
+          />
+
+          {/* Masthead — cogs either side of the call, on the union's red bar. */}
+          <div
+            style={{
+              position: "relative",
+              zIndex: 2,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "var(--space-sm)",
+              padding: size.mastPad,
+              background: "var(--faction-everymen-bill-mast)",
+              color: "var(--faction-everymen-bill-mast-ink)",
+              borderBottom: "3px double var(--faction-everymen-bill-cta-bg)",
+              boxShadow: "inset 0 -6px 0 -4px var(--everymen-paper-deep)",
             }}
           >
-            {i18n.t("feed:taskCard.everymen.masthead")}
-          </span>
-          <EverymenSigil size={11} color="var(--everymen-cream)" />
-        </div>
-      </div>
+            <Gear size={15} fill="currentColor" hub="var(--faction-everymen-bill-mast)" opacity={0.95} />
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: poster lettering; Bebas at label-ramp sizes stops reading as a masthead. */}
+            <span style={{ ...LABEL, fontSize: 17, letterSpacing: "0.18em" }}>
+              {i18n.t("feed:taskCard.everymen.billMasthead")}
+            </span>
+            <Gear size={15} fill="currentColor" hub="var(--faction-everymen-bill-mast)" opacity={0.95} />
+          </div>
 
-      {/* body */}
-      <div style={{ position: "relative", padding: "var(--space-md) var(--space-lg) var(--space-md)", overflow: "hidden" }}>
-        <Sunburst opacity={0.08} step={6} />
-        <Halftone />
-        <div style={{ position: "relative", zIndex: 2 }}>
-          <Link to={`/tasks/${task.id}`} style={{ textDecoration: "none", color: "inherit" }}>
-            <div
-              className="content-title"
+          <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
+            {/* Everything but the CTA reads the full call — a card-sized target
+                that stays valid HTML (no <button> nested in an <a>). */}
+            <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+              {/* Dateline — the uniform ordinal every faction card carries. */}
+              <div
+                style={{
+                  fontFamily: TYPED,
+                  fontSize: "var(--text-sm)",
+                  letterSpacing: "0.2em",
+                  textTransform: "uppercase",
+                  color: "var(--everymen-muted)",
+                  marginBottom: "var(--space-md)",
+                }}
+              >
+                {i18n.t("feed:taskCard.ordinal", { id: task.id })}
+              </div>
+
+              <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginBottom: "var(--space-md)" }}>
+                <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1 }}>
+                  <span style={{ ...LABEL, fontSize: "var(--text-base)", color: "var(--everymen-olive)", marginBottom: "var(--space-xs)" }}>
+                    {i18n.t("feed:taskCard.everymen.levelCaption")}
+                  </span>
+                  <span style={{ fontFamily: POSTER, fontSize: size.levelSize, lineHeight: 0.82 }}>
+                    {task.level_required}
+                  </span>
+                </div>
+
+                <div aria-hidden="true" style={{ flex: 1, display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
+                  <span style={{ flex: 1, height: 0, borderTop: "2px dashed var(--everymen-red)" }} />
+                  <Gear size={15} fill="var(--everymen-red)" hub="var(--everymen-paper)" />
+                  <span style={{ flex: 1, height: 0, borderTop: "2px dashed var(--everymen-red)" }} />
+                </div>
+
+                {/* The faction modifier — hidden at ×1.00, so invisible under
+                    era_1's neutralized modifiers and automatic the day one moves
+                    (ADR-0055). */}
+                {showMultiplier && (
+                  <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "center", gap: "var(--space-xs)" }}>
+                    <span
+                      style={{
+                        ...LABEL,
+                        fontSize: "var(--text-lg)",
+                        letterSpacing: "0.04em",
+                        color: "var(--faction-everymen-bill-mult-ink)",
+                        border: "1.5px solid var(--everymen-gold)",
+                        borderRadius: 2,
+                        padding: "var(--space-xs) var(--space-sm)",
+                      }}
+                    >
+                      {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
+                    </span>
+                    <span style={{ ...LABEL, fontSize: "var(--text-xs)", color: "var(--everymen-muted)" }}>
+                      {i18n.t("feed:taskCard.modifierCaption")}
+                    </span>
+                  </div>
+                )}
+
+                {/* The rubber-stamp points seal, struck a few degrees off true. */}
+                <div
+                  style={{
+                    position: "relative",
+                    flex: "0 0 auto",
+                    width: size.seal,
+                    height: size.seal,
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    transform: "rotate(-4deg)",
+                    color: "var(--everymen-red)",
+                  }}
+                >
+                  <span
+                    aria-hidden="true"
+                    style={{
+                      position: "absolute",
+                      inset: 0,
+                      borderRadius: "50%",
+                      border: "2px solid var(--everymen-red)",
+                      boxShadow: "inset 0 0 0 3px var(--everymen-paper), inset 0 0 0 4px var(--everymen-red)",
+                    }}
+                  />
+                  <span style={{ fontFamily: POSTER, fontSize: size.pointsSize, lineHeight: 0.8 }}>
+                    {basePoints}
+                  </span>
+                  {/* eslint-disable-next-line local/no-raw-style-values -- ornament: stamp text, sized to the struck seal rather than the label ramp (§4a). */}
+                  <span style={{ ...LABEL, fontSize: 8, letterSpacing: "0.22em", marginTop: "var(--space-xs)" }}>
+                    {i18n.t("feed:taskCard.everymen.sealUnit")}
+                  </span>
+                </div>
+              </div>
+
+              <h3
+                style={{
+                  fontFamily: POSTER,
+                  fontSize: size.titleSize,
+                  lineHeight: 0.96,
+                  letterSpacing: "0.01em",
+                  textTransform: "uppercase",
+                  margin: "0 0 var(--space-sm)",
+                  overflowWrap: "anywhere",
+                }}
+              >
+                {task.title}
+              </h3>
+
+              {task.description && (
+                <p
+                  className="card-description"
+                  style={{
+                    fontFamily: TYPED,
+                    lineHeight: 1.55,
+                    color: "var(--everymen-muted)",
+                    margin: "0 0 var(--space-md)",
+                  }}
+                >
+                  {task.description}
+                </p>
+              )}
+
+              <div aria-hidden="true" style={{ borderTop: "2px dashed var(--everymen-red)", margin: "0 0 var(--space-md)" }} />
+
+              {inProgressCount > 0 && (
+                <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
+                  <Gear size={15} fill="var(--everymen-red)" hub="var(--everymen-paper)" />
+                  <span style={{ fontFamily: TYPED, fontSize: "var(--text-lg)", color: "var(--everymen-muted)" }}>
+                    {i18n.t("feed:taskCard.inProgress", { count: inProgressCount })}
+                  </span>
+                </div>
+              )}
+            </Link>
+          </div>
+
+          {onSignup && (
+            <button
+              onClick={() => onSignup(task.id)}
               style={{
-                fontFamily: "var(--faction-everymen-card-font)",
-                lineHeight: 0.98,
+                position: "relative",
+                zIndex: 2,
+                cursor: "pointer",
+                width: "100%",
+                background: "var(--faction-everymen-bill-cta-bg)",
+                color: "var(--faction-everymen-bill-cta-ink)",
+                fontFamily: POSTER,
+                fontSize: "var(--text-xl)",
+                letterSpacing: "0.22em",
+                textTransform: "uppercase",
                 textAlign: "center",
-                letterSpacing: "0.01em",
-                overflowWrap: "anywhere",
+                padding: "var(--space-md) 0",
+                border: "none",
+                borderTop: `2px solid ${INK}`,
               }}
             >
-              {task.title}
-            </div>
-          </Link>
-          <RuleDiamond />
-          {task.description && (
-            <div
-              className="card-description"
-              style={{
-                lineHeight: 1.55,
-                textAlign: "center",
-                color: "var(--everymen-muted)",
-                display: "-webkit-box",
-                WebkitLineClamp: 3,
-                WebkitBoxOrient: "vertical",
-                overflow: "hidden",
-              }}
-            >
-              {task.description}
-            </div>
+              {i18n.t("feed:taskCard.everymen.signup")}
+            </button>
           )}
         </div>
-      </div>
-
-      {/* dispatch strip */}
-      <div
-        className="card-footer"
-        style={{
-          alignItems: "center",
-          justifyContent: "space-between",
-          gap: "var(--space-sm)",
-          padding: "0 var(--space-lg) var(--space-md)",
-        }}
-      >
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-xs)" }}>
-          <LevelGem level={task.level_required} factionSlug="everymen" />
-          {/* Secondary points caption — the rubber-stamp PointsSeal is the score
-              display; this stays label-tier so it doesn't outshout the seal (§4). */}
-          <span
-            style={{
-              fontFamily: "var(--faction-everymen-card-font)",
-              fontSize: "var(--text-lg)",
-              color: "var(--everymen-red)",
-            }}
-          >
-            {i18n.t("feed:taskCard.everymen.points", { points: basePoints })}
-          </span>
-        </div>
-        <PointsSeal points={basePoints} />
-      </div>
-
-      {onSignup && (
-        <button
-          onClick={() => onSignup(task.id)}
-          style={{
-            fontFamily: "var(--font-body)",
-            fontSize: "var(--text-xs)",
-            textTransform: "uppercase",
-            letterSpacing: "0.14em",
-            padding: "var(--space-sm) var(--space-md)",
-            border: "none",
-            cursor: "pointer",
-            background: "var(--everymen-ink)",
-            color: "var(--everymen-paper)",
-            width: "100%",
-          }}
-        >
-          {i18n.t("feed:taskCard.everymen.signup")}
-        </button>
-      )}
+      </article>
     </div>
   );
 }

--- a/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
@@ -1,0 +1,168 @@
+/**
+ * The bespoke faction task cards, v2 (#1023 wave A — ADR-0055 + ADR-0056).
+ *
+ * One table rather than a file per skin: every card answers the SAME contract
+ * ({@link CardProps}), so the interesting assertions are identical and only the
+ * per-faction signup key differs. A card that stops honouring the contract flips
+ * one row red and names itself.
+ *
+ * Two things are pinned. First, each card is ONE responsive component: the same
+ * element tree renders on both form factors and only the size set moves, so the
+ * mobile assertions are about `useFormFactor` reaching the card, not about a
+ * second file. Second, points arrive UNMULTIPLIED — a card must show
+ * `basePoints`, never `basePoints × multiplier`, or a future non-1.0 era
+ * multiplies twice.
+ *
+ * Rendered with `renderToStaticMarkup`; this repo has no jsdom, so effects never
+ * run and click behaviour is out of reach. These are render-shape assertions.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ComponentType, ReactElement } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import type { TaskOut } from '../../../api/tasks'
+import type { CardProps } from '../../TaskCard'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+// Imported after the mock is registered.
+import CovenTaskCard from '../CovenTaskCard'
+import { surfaceMap } from '../../../factions'
+
+const TASK: TaskOut = {
+  id: 7,
+  title: 'Photosynthesis',
+  description: 'Leave something small and honest where a stranger will find it.',
+  point_value: 18,
+  level_required: 2,
+  status: 'active',
+  task_type: 'standard',
+  created_by: 3,
+  primary_faction_slug: null,
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: '2026-01-01T00:00:00Z',
+  in_progress_count: 6,
+  can_submit_praxis: true,
+  allowed_modes: ['solo'],
+  eligible_for_current_user: true,
+}
+
+interface Skin {
+  slug: string
+  Card: ComponentType<CardProps>
+  /**
+   * The faction's own signup copy — reused, never reinvented (#1020). Resolved
+   * here rather than held as a key string: `t()` takes a typed literal, and a
+   * `string` field would need a cast that defeats the catalog's key checking.
+   */
+  signup: string
+}
+
+const SKINS: Skin[] = [
+  { slug: 'coven', Card: CovenTaskCard, signup: i18n.t('feed:taskCard.coven.signup') },
+]
+
+function markup(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+function render(
+  { Card }: Skin,
+  props: Partial<Pick<CardProps, 'multiplier' | 'inProgressCount' | 'onSignup'>> = {},
+) {
+  return markup(
+    <Card
+      task={TASK}
+      basePoints={TASK.point_value}
+      multiplier={props.multiplier ?? 1}
+      inProgressCount={props.inProgressCount ?? 0}
+      onSignup={props.onSignup}
+    />,
+  )
+}
+
+describe.each(SKINS)('$slug task card v2 — content slots', (skin) => {
+  it('carries the uniform "Task {id}" ordinal, no faction ordinal', () => {
+    const { text } = render(skin)
+    expect(text).toContain(i18n.t('feed:taskCard.ordinal', { id: 7 }))
+    expect(text, 'no folio/fragment/dispatch ornament from the design canvas')
+      .not.toMatch(/№|Nº|Fragment|Folio|Dispatch/)
+  })
+
+  it('renders the title behind a link to the task, plus the call, level and points', () => {
+    const { html, text } = render(skin)
+    expect(html, 'task-link slot').toContain('href="/tasks/7"')
+    expect(text, 'title slot').toContain('Photosynthesis')
+    expect(text, 'call slot').toContain('stranger will find it')
+    expect(text, 'level slot').toContain('2')
+    expect(text, 'points slot').toContain('18')
+  })
+
+  it('shows the uniform in-progress line only when someone is working it', () => {
+    expect(render(skin, { inProgressCount: 6 }).text).toContain(
+      i18n.t('feed:taskCard.inProgress', { count: 6 }),
+    )
+    expect(render(skin, { inProgressCount: 0 }).text).not.toContain(
+      i18n.t('feed:taskCard.inProgress', { count: 0 }),
+    )
+  })
+
+  it('hides the sign-up CTA rather than disabling it when the viewer cannot sign up', () => {
+    expect(render(skin, { onSignup: () => {} }).text).toContain(skin.signup)
+    expect(render(skin).text, 'no onSignup → no control').not.toContain(skin.signup)
+  })
+})
+
+describe.each(SKINS)('$slug task card v2 — base points + modifier badge (ADR-0055)', (skin) => {
+  it('shows base points and no badge at the era_1 neutral factor', () => {
+    const { text } = render(skin, { multiplier: 1 })
+    expect(text, 'base points').toContain('18')
+    expect(text, 'no modifier caption').not.toContain(i18n.t('feed:taskCard.modifierCaption'))
+  })
+
+  it('shows the badge on a tuned factor and STILL shows base points, unmultiplied', () => {
+    const { text } = render(skin, { multiplier: 1.5 })
+    expect(text, 'badge').toContain(i18n.t('feed:taskCard.multiplier', { value: '1.50' }))
+    expect(text).toContain(i18n.t('feed:taskCard.modifierCaption'))
+    expect(text, 'base points, not 27').toContain('18')
+    expect(text, 'the product must not be pre-applied').not.toContain('27')
+  })
+
+  it('treats float slop as neutral', () => {
+    expect(render(skin, { multiplier: 0.1 + 0.9 }).text).not.toContain(
+      i18n.t('feed:taskCard.modifierCaption'),
+    )
+  })
+})
+
+describe.each(SKINS)('$slug task card v2 — one component, two form factors (ADR-0056)', (skin) => {
+  it('renders every content slot on mobile as well as desktop', () => {
+    for (const formFactor of ['desktop', 'mobile'] as const) {
+      mocks.formFactor = formFactor
+      const { html, text } = render(skin, { inProgressCount: 6, onSignup: () => {} })
+      expect(html, formFactor).toContain(`data-form-factor="${formFactor}"`)
+      expect(html, `${formFactor} task link`).toContain('href="/tasks/7"')
+      expect(text, `${formFactor} title`).toContain('Photosynthesis')
+      expect(text, `${formFactor} points`).toContain('18')
+      expect(text, `${formFactor} in progress`).toContain(
+        i18n.t('feed:taskCard.inProgress', { count: 6 }),
+      )
+      expect(text, `${formFactor} signup`).toContain(skin.signup)
+    }
+    mocks.formFactor = 'desktop'
+  })
+})
+
+describe.each(SKINS)('$slug renders through the taskCard manifest surface', (skin) => {
+  it('is the registered skin for its slug', () => {
+    expect(surfaceMap('taskCard')[skin.slug]).toBeDefined()
+  })
+})

--- a/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
@@ -35,6 +35,8 @@ vi.mock('../../../hooks/useFormFactor', () => ({
 import CovenTaskCard from '../CovenTaskCard'
 import EphemeristsTaskCard from '../EphemeristsTaskCard'
 import EverymenTaskCard from '../EverymenTaskCard'
+import AlbescentTaskCard from '../AlbescentTaskCard'
+import DefaultTaskCard from '../DefaultTaskCard'
 import { surfaceMap } from '../../../factions'
 
 const TASK: TaskOut = {
@@ -75,6 +77,17 @@ const SKINS: Skin[] = [
     signup: i18n.t('feed:taskCard.ephemerists.signup'),
   },
   { slug: 'everymen', Card: EverymenTaskCard, signup: i18n.t('feed:taskCard.everymen.signup') },
+  {
+    // Albescent's row reads na's key ON PURPOSE, and it is the one row where
+    // that is not an oversight: the card IS the na card plus a drift
+    // (ADR-0048), and a per-faction WORD is as identifying as a per-faction
+    // hue (WORLD_ZERO_STYLE §3). `feed:taskCard.albescent.signup` still exists
+    // in the catalog, orphaned since #783 deleted the bespoke card it belonged
+    // to; wiring it back would un-hide the society on an ordinary surface.
+    slug: 'albescent',
+    Card: AlbescentTaskCard,
+    signup: i18n.t('feed:taskCard.na.signup'),
+  },
 ]
 
 function markup(element: ReactElement): { html: string; text: string } {
@@ -172,5 +185,36 @@ describe.each(SKINS)('$slug task card v2 — one component, two form factors (AD
 describe.each(SKINS)('$slug renders through the taskCard manifest surface', (skin) => {
   it('is the registered skin for its slug', () => {
     expect(surfaceMap('taskCard')[skin.slug]).toBeDefined()
+  })
+})
+
+/* -------------------------------------------------------------------------- */
+/* Albescent — the one card in this wave that is NOT a bespoke skin            */
+/* -------------------------------------------------------------------------- */
+
+describe('albescent task card is na + drift, never a repaint (ADR-0048)', () => {
+  const props = { basePoints: TASK.point_value, multiplier: 1, inProgressCount: 6 }
+
+  it('contains the na sheet whole, and adds only the two flourish overlays', () => {
+    const albescent = markup(<AlbescentTaskCard task={TASK} {...props} />)
+    const unaffiliated = markup(<DefaultTaskCard task={TASK} {...props} />)
+
+    // The strongest statement of the rule: strip the wrapper and the two
+    // overlays and what is left is the unaffiliated card, byte for byte. A
+    // future edit that "just tweaks" one slot for Albescent fails here.
+    expect(albescent.html).toContain(unaffiliated.html)
+    expect(albescent.html, 'the drifting spectrum edge').toContain('alb-task-edge')
+    expect(albescent.html, 'the breathing aurora').toContain('alb-task-aurora')
+  })
+
+  it('speaks na words — a per-faction verb is as identifying as a per-faction hue', () => {
+    const { text, html } = markup(
+      <AlbescentTaskCard task={TASK} {...props} onSignup={() => {}} />,
+    )
+    expect(text).toContain(i18n.t('feed:taskCard.na.signup'))
+    expect(text, 'the orphaned pre-#783 Albescent verb must stay orphaned')
+      .not.toContain(i18n.t('feed:taskCard.albescent.signup'))
+    expect(html, 'no --faction-albescent-* token may reach a rendered surface')
+      .not.toContain('--faction-albescent')
   })
 })

--- a/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
@@ -33,6 +33,7 @@ vi.mock('../../../hooks/useFormFactor', () => ({
 
 // Imported after the mock is registered.
 import CovenTaskCard from '../CovenTaskCard'
+import EphemeristsTaskCard from '../EphemeristsTaskCard'
 import { surfaceMap } from '../../../factions'
 
 const TASK: TaskOut = {
@@ -67,6 +68,11 @@ interface Skin {
 
 const SKINS: Skin[] = [
   { slug: 'coven', Card: CovenTaskCard, signup: i18n.t('feed:taskCard.coven.signup') },
+  {
+    slug: 'ephemerists',
+    Card: EphemeristsTaskCard,
+    signup: i18n.t('feed:taskCard.ephemerists.signup'),
+  },
 ]
 
 function markup(element: ReactElement): { html: string; text: string } {

--- a/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../../../hooks/useFormFactor', () => ({
 // Imported after the mock is registered.
 import CovenTaskCard from '../CovenTaskCard'
 import EphemeristsTaskCard from '../EphemeristsTaskCard'
+import EverymenTaskCard from '../EverymenTaskCard'
 import { surfaceMap } from '../../../factions'
 
 const TASK: TaskOut = {
@@ -73,6 +74,7 @@ const SKINS: Skin[] = [
     Card: EphemeristsTaskCard,
     signup: i18n.t('feed:taskCard.ephemerists.signup'),
   },
+  { slug: 'everymen', Card: EverymenTaskCard, signup: i18n.t('feed:taskCard.everymen.signup') },
 ]
 
 function markup(element: ReactElement): { html: string; text: string } {

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -2,12 +2,16 @@
  * albescent — the faction that overrides nothing (#783).
  *
  * Every other manifest in this directory lists the surfaces its faction dresses
- * up. Albescent's is empty, and that is the whole design: it is a secret society
- * hiding in plain sight, so it must be indistinguishable from an unaffiliated
- * player on every surface. The manifest is override-only, so declaring nothing
- * hands Albescent the `Default*` archetype everywhere — including on surfaces
- * that do not exist yet, which is the property a hand-maintained list of
- * "Albescent renders Default here" wrappers could never keep.
+ * up. Albescent's started empty, and that was the whole design: it is a secret
+ * society hiding in plain sight, so it must be indistinguishable from an
+ * unaffiliated player on every surface. The manifest is override-only, so
+ * declaring nothing hands Albescent the `Default*` archetype everywhere —
+ * including on surfaces that do not exist yet, which is the property a
+ * hand-maintained list of "Albescent renders Default here" wrappers could never
+ * keep. ADR-0048 then made "frozen" mean "frozen UNTIL DESIGNED": the few rows
+ * below are surfaces whose design has landed, and each is `Default` PLUS a
+ * flourish rather than a skin of its own. Everything unlisted still falls
+ * through, and that remains the default state, not the exception.
  *
  * It had 22 bespoke components (#232) and a 35-declaration token block. Both are
  * gone. The wrappers went too rather than being thinned to pass-throughs: an
@@ -28,6 +32,7 @@
 import type { FactionManifest } from './manifest'
 
 import { AlbescentSelectCard } from '../components/cards/FactionSelectCard'
+import AlbescentTaskCard from '../components/cards/AlbescentTaskCard'
 import AlbescentVote from '../components/vote/AlbescentVote'
 import AlbescentPraxisCard from '../components/praxisCard/desktop/AlbescentPraxisCard'
 import AlbescentMobilePraxisCard from '../components/praxisCard/mobile/AlbescentMobilePraxisCard'
@@ -55,6 +60,17 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    */
   praxisCard: () => AlbescentPraxisCard,
   mobilePraxisCard: () => AlbescentMobilePraxisCard,
+
+  /**
+   * The task-card tell (#1023, ADR-0048) — the second surface to unfreeze, and
+   * the same "NA + drift" shape as the praxis cards above. It renders
+   * `DefaultTaskCard` and washes two flourishes over it (a drifting spectrum
+   * edge, a breathing aurora), so the design's whole delta from unaffiliated is
+   * MOTION. Note there is no `mobileTaskCard` sibling: the v2 task card is one
+   * responsive component (ADR-0056), so this single row covers both form
+   * factors.
+   */
+  taskCard: () => AlbescentTaskCard,
 
   /**
    * The ferrofluid vote widget (#843, the eighth of #821's eight). Same rule as

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -211,6 +211,13 @@
   --faction-default-border: rgba(0, 0, 0, 0.12);
   --faction-default-rainbow: linear-gradient(90deg, #c1272d 0%, #c2541f 17%, #ca8a04 33%, #16a34a 50%, #1d6e72 67%, #2563eb 83%, #be185d 100%);
   --faction-default-ring: conic-gradient(#c1272d 0 51deg, #c2541f 0 103deg, #ca8a04 0 154deg, #16a34a 0 206deg, #1d6e72 0 257deg, #2563eb 0 309deg, #be185d 0 360deg);
+  /* The same spectrum cut to TILE (#1023). Its last stop is its first, so a
+     surface that scrolls its background-position loops without a seam — which
+     the bar ramp above cannot do: red at 0% meets magenta at 100% and shows a
+     hard edge every cycle. Same argument as the two shorter ramps below; the
+     spectrum comes in ramps cut for their geometry. Only Albescent's drifting
+     card edge reads it today. */
+  --faction-default-rainbow-loop: linear-gradient(90deg, #c1272d 0%, #c2541f 14%, #ca8a04 28%, #16a34a 43%, #1d6e72 57%, #2563eb 72%, #be185d 86%, #c1272d 100%);
   --faction-default-card-bg: #fffdf9;
   --faction-default-card-text: #1a1209;
   --faction-default-card-accent: #1a1209;
@@ -1195,6 +1202,7 @@
   --faction-default-border: rgba(255, 255, 255, 0.12);
   --faction-default-rainbow: linear-gradient(90deg, #e2433f 0%, #e07a3a 17%, #e6b94f 33%, #4ade80 50%, #3aa0a4 67%, #60a5fa 83%, #f472b6 100%);
   --faction-default-ring: conic-gradient(#e2433f 0 51deg, #e07a3a 0 103deg, #e6b94f 0 154deg, #4ade80 0 206deg, #3aa0a4 0 257deg, #60a5fa 0 309deg, #f472b6 0 360deg);
+  --faction-default-rainbow-loop: linear-gradient(90deg, #e2433f 0%, #e07a3a 14%, #e6b94f 28%, #4ade80 43%, #3aa0a4 57%, #60a5fa 72%, #f472b6 86%, #e2433f 100%);
   --faction-default-card-bg: #1c1b24;
   --faction-default-card-text: #f0e6d0;
   --faction-default-card-accent: #f0e6d0;
@@ -2463,6 +2471,88 @@
 [data-theme="dark"] .alb-spark { color: #f2cc72; }
 @media (prefers-reduced-motion: no-preference) {
   .alb-spark { opacity: 0; animation: alb-spark 4.5s ease-in-out infinite; }
+}
+
+/* Albescent — the TASK CARD's tell (#1023, ADR-0048). The second surface to
+   unfreeze, and built to the same rule as the first: the exact spectrum sheet an
+   unaffiliated player sees, plus a flourish that reveals the society to someone
+   already looking. Two of them here — the card's rainbow edge comes ALIVE and
+   drifts, and an aurora blooms and breathes under the vellum. Neither repaints
+   anything: strip both classes and the card is `DefaultTaskCard`, byte for byte.
+
+   Both are drawn as OVERLAYS because the card they dress is a component, not
+   markup this file can reach into. Two consequences, both deliberate:
+
+   • The edge is a masked ring rather than a border — `mask … exclude` punches
+     the middle out of a 3px inset, so only the frame paints. It lands exactly on
+     Default's own static rainbow border, so the effect reads as that border
+     moving. Its radius must track Default's (14px); if that card's corner
+     changes, this follows.
+   • The aurora BLENDS rather than sits behind. `mix-blend-mode: multiply` on the
+     light sheet and `screen` on the dark one is what keeps ink legible through
+     an overlay — the design put the bloom UNDER the copy at `normal`, which is
+     not a position an overlay can take. Same call `.alb-rainbow` already makes. */
+@keyframes alb-task-edge { from { background-position: 0% 50%; } to { background-position: 300% 50%; } }
+@keyframes alb-task-drift {
+  0%, 100% { transform: translate3d(-6%, -4%, 0) scale(1.12) rotate(0deg); }
+  50% { transform: translate3d(6%, 5%, 0) scale(1.24) rotate(8deg); }
+}
+.alb-task-edge,
+.alb-task-aurora {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  border-radius: 14px;
+}
+.alb-task-edge {
+  padding: 3px;
+  background-image: var(--faction-default-rainbow-loop);
+  background-size: 300% 100%;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box exclude,
+    linear-gradient(#000 0 0);
+}
+.alb-task-aurora {
+  overflow: hidden;
+}
+.alb-task-aurora::before {
+  content: "";
+  position: absolute;
+  inset: 22%;
+  filter: blur(52px) saturate(0.62);
+  mix-blend-mode: multiply;
+  opacity: 0.34;
+  transform: translate3d(-6%, -4%, 0) scale(1.12);
+  background-image:
+    radial-gradient(62% 78% at 8% 16%, #c1272d, transparent 100%),
+    radial-gradient(58% 72% at 34% 4%, #c2541f, transparent 100%),
+    radial-gradient(60% 74% at 56% 18%, #ca8a04, transparent 100%),
+    radial-gradient(64% 78% at 84% 12%, #16a34a, transparent 100%),
+    radial-gradient(66% 80% at 98% 62%, #2563eb, transparent 100%),
+    radial-gradient(64% 78% at 62% 96%, #be185d, transparent 100%),
+    radial-gradient(60% 74% at 22% 92%, #1d6e72, transparent 100%);
+}
+[data-theme="dark"] .alb-task-aurora::before {
+  filter: blur(42px) saturate(0.95);
+  mix-blend-mode: screen;
+  opacity: 0.3;
+  background-image:
+    radial-gradient(62% 78% at 8% 16%, #e2433f, transparent 100%),
+    radial-gradient(58% 72% at 34% 4%, #e07a3a, transparent 100%),
+    radial-gradient(60% 74% at 56% 18%, #e6b94f, transparent 100%),
+    radial-gradient(64% 78% at 84% 12%, #4ade80, transparent 100%),
+    radial-gradient(66% 80% at 98% 62%, #60a5fa, transparent 100%),
+    radial-gradient(64% 78% at 62% 96%, #f472b6, transparent 100%),
+    radial-gradient(60% 74% at 22% 92%, #3aa0a4, transparent 100%);
+}
+@media (prefers-reduced-motion: no-preference) {
+  .alb-task-edge { animation: alb-task-edge 16s linear infinite; }
+  .alb-task-aurora::before { animation: alb-task-drift 52s ease-in-out infinite; }
 }
 
 /* UA — growing mandala: each rank blooms a fuller mandala; the emphasized cell

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -762,6 +762,38 @@
   --faction-ephemerists-vote-core-off: #556374; /* unreached star core */
   --faction-ephemerists-vote-spark: #fff4cf; /* rank-5 corner sparkles */
 
+  /* ══ Ephemerists — THE VALLEY PLATE (task card v2, #1023) ══
+     Deco × Egypt: the deco-space card carried into a field journal out of the
+     Valley. A papyrus plate under a cavetto-cornice masthead holding a winged
+     sun disc between incised glyph registers; the points ride a stepped octagon
+     medallion. This is a full metaphor swap away from THE DISCORDANT MAP, whose
+     `--eph-*` illuminated-codex family stays declared — every other Ephemerists
+     surface still paints with it.
+
+     ONE VALUE IS WALKED DOWN. `-brass` is a FRAME AND RULE colour, never an ink:
+     the design's #9A7A2E measures 2.97:1 on the plate, which is fine for a
+     hairline and wrong for the "Level" caption the design sets in it. That
+     caption takes `-caption` instead (4.75:1, same hue). Same shape as WOW's
+     chronicle gold, which is likewise never painted as text. */
+  --faction-ephemerists-plate-bg: #eadcb6; /* papyrus */
+  --faction-ephemerists-plate-ink: #2a2418;
+  --faction-ephemerists-plate-muted: #6b5f45; /* brief + in-progress */
+  --faction-ephemerists-plate-caption: #765a19; /* small-caps labels */
+  --faction-ephemerists-plate-brass: #9a7a2e; /* rules, borders — never an ink */
+  --faction-ephemerists-plate-brass-light: #c39b3d;
+  --faction-ephemerists-plate-gold: #e3c56a; /* glyphs + the winged disc */
+  --faction-ephemerists-plate-band: #1e2233; /* the cornice masthead */
+  --faction-ephemerists-plate-band-ink: #efe4c4;
+  --faction-ephemerists-plate-disc: #f6eed6; /* the medallion's field */
+  --faction-ephemerists-plate-ochre: #a6432b; /* the fifth tally stroke */
+  --faction-ephemerists-plate-cta-bg: #1e2233;
+  --faction-ephemerists-plate-cta-ink: #e9d79b;
+  /* The gold wash behind the cartouche and the ratio chip. A gradient token
+     rather than a hex + an alpha the component picks: the dark plate takes no
+     wash at all, and "no wash" is not an opacity a TSX ternary should decide. */
+  --faction-ephemerists-plate-wash: linear-gradient(180deg, rgba(227, 197, 106, 0.24), transparent);
+  --faction-ephemerists-plate-shadow: 0 18px 44px -26px rgba(42, 32, 16, 0.45);
+
   /* ══ Everymen — the rainbow's missing red (union/WW2 poster) ══
      Constants (cream/gold/ink) keep their role in both themes; the paper
      surface + its text FLIP in dark; accent red stays vivid; field is the
@@ -1180,6 +1212,30 @@
      value. The stamp leaf darkens with the vellum rather than lightening. */
   --eph-frame: rgba(58, 160, 164, 0.35);
   --eph-stamp-bg: #181208;
+
+  /* ══ Ephemerists — the Valley plate (dark, #1023) ══
+     Read off the design's own dark half. Two inversions worth naming, because
+     neither is what "darken the light values" would produce: the CTA bar swaps
+     ends (a brass BAR carrying dark ink, where light has dark bar / gold ink),
+     and the cartouche's gold wash disappears entirely rather than dimming — on
+     a night plate the wash reads as a smudge. The brass lifts far enough that
+     it clears AA on the plate here (7.22:1), but it stays a rule colour on both
+     sides: one token, one role. */
+  --faction-ephemerists-plate-bg: #171a26;
+  --faction-ephemerists-plate-ink: #f0e6c8;
+  --faction-ephemerists-plate-muted: #a2977a;
+  --faction-ephemerists-plate-caption: #c9a24b;
+  --faction-ephemerists-plate-brass: #c9a24b;
+  --faction-ephemerists-plate-brass-light: #e6c877;
+  --faction-ephemerists-plate-gold: #f2d98a;
+  --faction-ephemerists-plate-band: #0a0c15;
+  --faction-ephemerists-plate-band-ink: #f2d98a;
+  --faction-ephemerists-plate-disc: #12151f;
+  --faction-ephemerists-plate-ochre: #d9744c;
+  --faction-ephemerists-plate-cta-bg: #c9a24b;
+  --faction-ephemerists-plate-cta-ink: #12151f;
+  --faction-ephemerists-plate-wash: none;
+  --faction-ephemerists-plate-shadow: 0 20px 50px -26px rgba(0, 0, 0, 0.8);
 
   /* ── Warriors of Whimsy collage scrap layers (dark) ── */
   --faction-coven-scrap-deep: #091209;
@@ -2258,6 +2314,30 @@
   .ev-gear--cw { transform-origin: center; animation: ev-gear-cw var(--ev-gear-dur, 3s) linear infinite; }
   .ev-gear--ccw { transform-origin: center; animation: ev-gear-ccw var(--ev-gear-dur, 3s) linear infinite; }
   .ev-gear-spark { animation: ev-gear-spark var(--ev-spark-dur, 1s) ease-out infinite; animation-delay: var(--ev-spark-delay, 0s); }
+}
+
+/* Ephemerists — the Valley plate's incised glyph registers (#1023). Two rows of
+   signs (Egypt, Greece, the middle ages, 1925) surface and recede on a long,
+   staggered cycle behind the masthead. Per-glyph strength and phase arrive as
+   inline custom properties, so no two breathe together.
+
+   Note the inversion against the design, which wrote `opacity:0` as the base and
+   stilled the animation under reduced motion — that leaves every glyph
+   INVISIBLE for a reduced-motion reader. Here the base state IS the stilled
+   state (glyphs present at their own strength) and the motion is added under
+   `no-preference`, which is both the repo's convention and the only ordering
+   that degrades correctly. */
+@keyframes epg-breathe {
+  0%, 100% { opacity: 0; }
+  22%, 72% { opacity: var(--epg-op, 0.3); }
+}
+.epg-glyph { opacity: var(--epg-op, 0.3); }
+@media (prefers-reduced-motion: no-preference) {
+  .epg-glyph {
+    opacity: 0;
+    animation: epg-breathe 19s ease-in-out infinite;
+    animation-delay: var(--epg-delay, 0s);
+  }
 }
 
 /* Coven — the spell slip's braid (#1023): a slender celtic thread with a gold

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -583,6 +583,46 @@
   --faction-coven-vote-on: #d63f86;
   --faction-coven-vote-off: #a76389;
 
+  /* ══ Coven — THE CANDLELIT SPELL SLIP (task card v2, #1023) ══
+     The v2 task card retires the lo-fi `coven.exe` window above; a slip of
+     pink-to-lavender paper under a gold twinkle field, with the points held in
+     a glowing arcane sigil. The `-win-*` family stays declared because other
+     surfaces still read it — a card metaphor swap is not a licence to delete a
+     token another archetype paints with.
+
+     THREE VALUES ARE WALKED DOWN FROM THE DESIGN, all for the same reason: the
+     card ground is a GRADIENT, so an ink owes AA against its darkest stop
+     (#fbc4dd, not the near-white the design annotated against).
+       • soft   #b8517f → #973660  (3.11:1 → 4.66:1) — brief + in-progress copy
+       • label  #b06a92 → #83466a  (2.64:1 → 4.61:1) — the small caps
+       • the CTA band's two stops deepen so its white clears both ends
+         (#ec4f92/#c9327a gave 3.44:1 at the top; #d13a80/#b02a69 gives 4.54:1). */
+  --faction-coven-slip-from: #fdd9e8; /* gradient 0% */
+  --faction-coven-slip-mid: #fbc4dd; /* 36% — the darkest stop an ink meets */
+  --faction-coven-slip-lav: #e6dbf7; /* 74% */
+  --faction-coven-slip-vio: #e3d6f6; /* 100% */
+  --faction-coven-slip-border: #f4a9cc;
+  --faction-coven-slip-ink: #8f2557; /* title + level numeral */
+  --faction-coven-slip-deep: #c9327a; /* points numeral, braid strands */
+  --faction-coven-slip-pk: #ec4f92; /* sigil ring, heart, aura — ornament */
+  --faction-coven-slip-soft: #973660; /* brief + in-progress ink */
+  --faction-coven-slip-label: #83466a; /* small-caps captions */
+  --faction-coven-slip-gold: #f4c430; /* twinkles, braid bead, sigil ticks */
+  /* The sigil's two washes, declared as GRADIENTS rather than as a colour plus
+     an opacity the component tunes: the design's light and dark halves ramp at
+     different strengths, and an alpha chosen in TSX is a `dark ? a : b` in
+     numeric clothing. `-halo` is the pink bloom around the disc; `-core` is the
+     candle behind the numeral — it brightens on the light slip and DARKENS on
+     the dark one, staying the numeral's ground either way. */
+  --faction-coven-slip-sigil-halo: radial-gradient(circle, rgba(236, 79, 146, 0.38) 0%, rgba(236, 79, 146, 0.14) 55%, rgba(236, 79, 146, 0) 100%);
+  --faction-coven-slip-sigil-ground: #ffffff;
+  --faction-coven-slip-sigil-core: radial-gradient(circle, color-mix(in srgb, var(--faction-coven-slip-sigil-ground) 98%, transparent) 0%, color-mix(in srgb, var(--faction-coven-slip-sigil-ground) 70%, transparent) 62%, transparent 100%);
+  --faction-coven-slip-cta-from: #d13a80;
+  --faction-coven-slip-cta-to: #b02a69;
+  --faction-coven-slip-cta-ink: #ffffff;
+  --faction-coven-slip-glow: rgba(236, 79, 146, 0.3);
+  --faction-coven-slip-shadow: 0 14px 32px -14px rgba(236, 79, 146, 0.45);
+
   /* WOW — cream/gold/plum chronicle frame (the chronicle is WOW's, ADR-0050) */
   --faction-wow-chronicle-bg: var(--faction-wow-card-bg); /* cream parchment */
   --faction-wow-chronicle-gold: #c8a02a; /* frame + rules; theme-invariant */
@@ -1183,6 +1223,36 @@
   --faction-coven-vote-on: #f472b6;
   --faction-coven-vote-off: #c78aa6;
 
+  /* ══ Coven — the candlelit spell slip (dark, #1023) ══
+     Read off the design's own dark half, not derived by inverting the light
+     one. Two calls the design's annotation does not make:
+       • the CTA ink flips to INK. Its dark band is two LIGHT pinks
+         (#f472b6 → #f9a8d4) and white on them is 2.65:1 — the same call
+         --faction-coven-on-accent already makes for this faction.
+       • the aura darkens instead of brightening: it is a glow BEHIND the disc,
+         so on a night slip it reads as depth, not as a white plate. */
+  --faction-coven-slip-from: #4a2038;
+  --faction-coven-slip-mid: #5e2a46;
+  --faction-coven-slip-lav: #2e2145;
+  --faction-coven-slip-vio: #2b1c42;
+  --faction-coven-slip-border: #7a3358;
+  --faction-coven-slip-ink: #fbcfe4;
+  --faction-coven-slip-deep: #f9a8d4;
+  --faction-coven-slip-pk: #f472b6;
+  --faction-coven-slip-soft: #e58cb6;
+  /* Lifted from the design's #c78aa6, which pays 4.02:1 on the ramp's LIGHTEST
+     dark stop (#5e2a46). Same hue, one step up. */
+  --faction-coven-slip-label: #d29bb4;
+  --faction-coven-slip-gold: #f4d472;
+  --faction-coven-slip-sigil-halo: radial-gradient(circle, rgba(244, 114, 182, 0.55) 0%, rgba(244, 114, 182, 0.2) 55%, rgba(244, 114, 182, 0) 100%);
+  --faction-coven-slip-sigil-ground: #1a0713;
+  --faction-coven-slip-sigil-core: radial-gradient(circle, color-mix(in srgb, var(--faction-coven-slip-sigil-ground) 90%, transparent) 0%, color-mix(in srgb, var(--faction-coven-slip-sigil-ground) 60%, transparent) 62%, transparent 100%);
+  --faction-coven-slip-cta-from: #f472b6;
+  --faction-coven-slip-cta-to: #f9a8d4;
+  --faction-coven-slip-cta-ink: #14110b;
+  --faction-coven-slip-glow: rgba(244, 114, 182, 0.42);
+  --faction-coven-slip-shadow: 0 16px 38px -14px rgba(0, 0, 0, 0.7);
+
   /* WOW — cream/gold/plum chronicle (dark). The gold #c8a02a does NOT lift; the
      plum is what carries the flip (#7a4a9e → #c79be0). */
   --faction-wow-chronicle-bg: var(--faction-wow-card-bg);
@@ -1433,6 +1503,14 @@
      Ephemerists' private flourish token: a faction reading another faction's
      private token is how a later Ephemerists retype would silently restyle UA. */
   --font-faction-serif: "Cormorant Garamond", Georgia, serif;
+  /* Faces the v2 task cards introduce (#1023). Each is added to the index.html
+     loader in the same commit — a family named here but not requested there
+     renders as its generic fallback and NO check we run can see it (#839), so
+     the two edits are one edit. */
+  --font-faction-rounded: "Quicksand", "Trebuchet MS", sans-serif; /* Coven UI */
+  --font-faction-witch: "Grenze Gotisch", "Cormorant Garamond", Georgia, serif; /* Coven display */
+  --font-faction-deco: "Poiret One", "Cinzel", serif; /* Ephemerists display */
+  --font-faction-spectral: "Spectral", "EB Garamond", Georgia, serif; /* Ephemerists reading */
 
   /* Shared faction-page body grid — main column + right rail; collapses to one
      column on narrow viewports (rule below). Every faction skin reuses this. */
@@ -2180,6 +2258,35 @@
   .ev-gear--cw { transform-origin: center; animation: ev-gear-cw var(--ev-gear-dur, 3s) linear infinite; }
   .ev-gear--ccw { transform-origin: center; animation: ev-gear-ccw var(--ev-gear-dur, 3s) linear infinite; }
   .ev-gear-spark { animation: ev-gear-spark var(--ev-spark-dur, 1s) ease-out infinite; animation-delay: var(--ev-spark-delay, 0s); }
+}
+
+/* Coven — the spell slip's braid (#1023): a slender celtic thread with a gold
+   bead at each crossing, tiled horizontally. It lives here rather than in the
+   card because a data-URI SVG is a SEPARATE DOCUMENT — `var(--…)` inside one
+   never resolves, so the only way to keep the two pigments out of the TSX is to
+   let index.css own the whole mark, dark override included. */
+.cvn-braid {
+  display: block;
+  height: 12px;
+  background-repeat: repeat-x;
+  background-position: left center;
+  opacity: 0.85;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='12' viewBox='0 0 40 12'%3E%3Cg fill='none' stroke='%23c9327a' stroke-width='1.2' stroke-linecap='round'%3E%3Cpath d='M0 3 C10 3, 10 9, 20 9 C24 9, 26 8.2, 28 7'/%3E%3Cpath d='M32 5 C34 3.8, 36 3, 40 3'/%3E%3Cpath d='M0 9 C4 9, 6 8.2, 8 7'/%3E%3Cpath d='M12 5 C14 3.8, 16 3, 20 3 C30 3, 30 9, 40 9'/%3E%3C/g%3E%3Ccircle cx='20' cy='6' r='1.2' fill='%23f4c430' opacity='0.9'/%3E%3C/svg%3E");
+}
+[data-theme="dark"] .cvn-braid {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='12' viewBox='0 0 40 12'%3E%3Cg fill='none' stroke='%23f9a8d4' stroke-width='1.2' stroke-linecap='round'%3E%3Cpath d='M0 3 C10 3, 10 9, 20 9 C24 9, 26 8.2, 28 7'/%3E%3Cpath d='M32 5 C34 3.8, 36 3, 40 3'/%3E%3Cpath d='M0 9 C4 9, 6 8.2, 8 7'/%3E%3Cpath d='M12 5 C14 3.8, 16 3, 20 3 C30 3, 30 9, 40 9'/%3E%3C/g%3E%3Ccircle cx='20' cy='6' r='1.2' fill='%23f4d472' opacity='0.9'/%3E%3C/svg%3E");
+}
+
+/* Coven — the spell slip's pentagram watermark turns, once every two minutes
+   (#1023). The design injected this keyframe from the component; #911 retired
+   that whole shape repo-wide, so it lives here and the card carries only the
+   class. Motion is opt-in under `no-preference`, the repo's inverted form of
+   the design's `reduce → none`: stilled, the watermark is simply a static
+   pentagram, which is what it is at any single frame anyway. */
+@keyframes cvn-wheel { to { transform: rotate(360deg); } }
+.cvn-wheel { transform-origin: 50% 50%; }
+@media (prefers-reduced-motion: no-preference) {
+  .cvn-wheel { animation: cvn-wheel 120s linear infinite; }
 }
 
 /* Albescent — the secret-society tell (#821, ADR-0048): the na spectrum card

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -832,6 +832,39 @@
   --everymen-stamp-numeral: #7a1f18; /* the filled-in figures */
   --everymen-stamp-mult: #a9741a; /* gold — the multiplier figure only */
 
+  /* ══ Everymen — THE HELP WANTED BILL (task card v2, #1023) ══
+     A WPA union broadsheet: a cog masthead over a sunburst wash, a typewritten
+     dispatch, a rubber-stamp points seal and a full-bleed report-for-duty bar.
+
+     THIS BLOCK IS DELIBERATELY SHORT. The design's whole TOKENS object turned
+     out to BE the `--everymen-*` family already in this file — paper, paperDeep,
+     cream, muted, red, gold, goldDeep and olive match value-for-value in both
+     themes, and its "ink" role is `--everymen-paper-text` (which flips) rather
+     than `--everymen-ink` (which does not). Re-declaring those under a `-bill-`
+     name would have been a second place for one colour to live. What follows is
+     only the roles the family has no home for.
+
+     The masthead is theme-INVARIANT red-on-cream, which is a deliberate
+     divergence from `--everymen-masthead-text`: that token flips to ink in dark
+     because the dark bar is the lifted `#e2433f`, where cream fails. This bar
+     keeps the light red in both themes (cream on it measures 4.95:1 / 4.98:1),
+     so a bill printed at night is the same bill. */
+  --faction-everymen-bill-mast: #c1272d;
+  --faction-everymen-bill-mast-ink: #f4ecd6;
+  --faction-everymen-bill-cta-bg: #221a12;
+  --faction-everymen-bill-cta-ink: #f4ecd6;
+  /* The modifier badge's ink. The design sets it in its goldDeep, which pays
+     3.11:1 on the light paper; walked down the same hue to 4.66:1. In dark
+     `--everymen-gold-deep` already clears (5.14:1), so only light moves. */
+  --faction-everymen-bill-mult-ink: #855a12;
+  /* The three washes behind the sheet: poster rays from the masthead, plus a
+     gold and an olive corner glow. Ornament alphas, so they live here rather
+     than as opacity numbers in the card. */
+  --faction-everymen-bill-ray: rgba(34, 26, 18, 0.05);
+  --faction-everymen-bill-glow-gold: rgba(217, 154, 43, 0.14);
+  --faction-everymen-bill-glow-olive: rgba(91, 98, 56, 0.1);
+  --faction-everymen-bill-shadow: 0 12px 32px -16px rgba(34, 26, 18, 0.5);
+
   /* ── Gearworks vote widget (#821) — reached gears heat a cold→ember ramp with
      pale hubs; unreached gears are edge-only outlines; rank 5 throws sparks. The
      edge + rank-5 glow flip in the dark cascade (see the dark block). ── */
@@ -1389,6 +1422,17 @@
   --everymen-stamp-ink: #d67b6a;
   --everymen-stamp-numeral: #ece1c6;
   --everymen-stamp-mult: #e6b34a;
+  /* ── The Help Wanted bill (dark, #1023) ── The masthead does NOT flip: see the
+     light block for why a bill printed at night is the same bill. The CTA bar
+     deepens to the design's near-black red-brown, and the modifier badge hands
+     back to the family's own gold, which already clears on the dark paper. */
+  --faction-everymen-bill-cta-bg: #200c0a;
+  --faction-everymen-bill-cta-ink: #f3e7ce;
+  --faction-everymen-bill-mult-ink: var(--everymen-gold-deep);
+  --faction-everymen-bill-ray: rgba(243, 231, 206, 0.045);
+  --faction-everymen-bill-glow-gold: rgba(231, 185, 79, 0.1);
+  --faction-everymen-bill-glow-olive: rgba(138, 149, 90, 0.08);
+  --faction-everymen-bill-shadow: 0 12px 32px -14px rgba(0, 0, 0, 0.8);
   /* Gearworks: cooler edge for cold gears, a brighter single-halo rank-5 glow on
      the dark paper (the light double-drop-shadow would muddy against it). */
   --faction-everymen-vote-edge: #8a7856;

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -189,7 +189,10 @@
       "windowTitle": "coven.exe",
       "questMeta": "new quest · {{points}} pts",
       "signup": "sign up",
-      "points": "{{points}} pts"
+      "points": "{{points}} pts",
+      "masthead": "the cozy coven",
+      "levelCaption": "level",
+      "pointsUnit": "points"
     },
     "wow": {
       "signup": "Take Up the Quest",

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -169,7 +169,9 @@
       "masthead": "THE EVERYMEN",
       "sealUnit": "POINTS",
       "points": "{{points}} PTS",
-      "signup": "Report for duty"
+      "signup": "Report for duty",
+      "billMasthead": "Help Wanted!",
+      "levelCaption": "Grade"
     },
     "snide": {
       "dispatchNumber": "dispatch №{{number}}",

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -160,7 +160,10 @@
       "grade": "grade {{grade}}",
       "points": "{{points}} pvncta",
       "footnote": "† the road does not return you to where you began — <1>see †</1>",
-      "signup": "Triangulate the truth ▸"
+      "signup": "Triangulate the truth ▸",
+      "masthead": "Ephemerists",
+      "levelCaption": "Level",
+      "pointsUnit": "pvncta"
     },
     "everymen": {
       "masthead": "THE EVERYMEN",

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -298,6 +298,20 @@ const ARCHETYPE_PAIRS: Pair[] = [
     text: "--faction-coven-slip-deep",
   },
 
+  // Ephemerists — THE VALLEY PLATE (task card v2, #1023). Four surfaces, not
+  // one: the papyrus plate, the cornice's night band, the medallion's disc and
+  // the CTA bar, each carrying its own ink. `-brass` is absent from this list on
+  // purpose and for the same reason as WOW's chronicle gold — it rules and
+  // frames, it is never painted as text. The caption ink that REPLACED it in the
+  // one text slot the design gave it is measured here instead.
+  { what: "ephemerists plate, ink", surface: "--faction-ephemerists-plate-bg", text: "--faction-ephemerists-plate-ink" },
+  { what: "ephemerists plate, brief", surface: "--faction-ephemerists-plate-bg", text: "--faction-ephemerists-plate-muted" },
+  { what: "ephemerists plate, caption", surface: "--faction-ephemerists-plate-bg", text: "--faction-ephemerists-plate-caption" },
+  { what: "ephemerists cornice band, masthead", surface: "--faction-ephemerists-plate-band", text: "--faction-ephemerists-plate-band-ink" },
+  { what: "ephemerists medallion disc, points", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-ink" },
+  { what: "ephemerists medallion disc, unit", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-muted" },
+  { what: "ephemerists plate CTA band", surface: "--faction-ephemerists-plate-cta-bg", text: "--faction-ephemerists-plate-cta-ink" },
+
   // Albescent's FACTION tokens are gone (#783) — it renders Default's surfaces,
   // which `default` already covers. What remains is the always-light palette
   // private to the reveal surfaces (invitation letter, secret placeholder). It

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -268,6 +268,36 @@ const ARCHETYPE_PAIRS: Pair[] = [
     text: "--faction-wow-card-accent",
   },
 
+  // Coven — THE CANDLELIT SPELL SLIP (task card v2, #1023). The card ground is
+  // a four-stop GRADIENT, which is what makes this block necessary: the design
+  // annotated its inks against a near-white card, and three of them fail on the
+  // gradient's darkest stop (#fbc4dd), so index.css ships them walked down. The
+  // surface column below is that darkest stop deliberately — measuring the
+  // lightest one would reproduce the design's own mistake.
+  { what: "coven slip, ink", surface: "--faction-coven-slip-mid", text: "--faction-coven-slip-ink" },
+  { what: "coven slip, brief", surface: "--faction-coven-slip-mid", text: "--faction-coven-slip-soft" },
+  { what: "coven slip, caption", surface: "--faction-coven-slip-mid", text: "--faction-coven-slip-label" },
+  // ...and the lavender end of the same ramp, a different hue rather than a
+  // lighter shade of the pink, so the stop above does not cover it.
+  { what: "coven slip lavender, ink", surface: "--faction-coven-slip-vio", text: "--faction-coven-slip-ink" },
+  { what: "coven slip lavender, brief", surface: "--faction-coven-slip-vio", text: "--faction-coven-slip-soft" },
+  { what: "coven slip lavender, caption", surface: "--faction-coven-slip-vio", text: "--faction-coven-slip-label" },
+  // The CTA is a band, so BOTH its stops carry the label. The design's own two
+  // stops gave white 3.44:1 at the top; these are deepened until it clears, and
+  // the dark band takes ink rather than white for the reason
+  // --faction-coven-on-accent already states.
+  { what: "coven slip CTA band top", surface: "--faction-coven-slip-cta-from", text: "--faction-coven-slip-cta-ink" },
+  { what: "coven slip CTA band foot", surface: "--faction-coven-slip-cta-to", text: "--faction-coven-slip-cta-ink" },
+  // The points numeral never sits on the slip: the sigil's core wash puts its
+  // own ground behind it (white on the light slip, near-black on the dark one),
+  // which is exactly why that ground is a scalar token rather than an alpha
+  // chosen in the component.
+  {
+    what: "coven sigil ground, points numeral",
+    surface: "--faction-coven-slip-sigil-ground",
+    text: "--faction-coven-slip-deep",
+  },
+
   // Albescent's FACTION tokens are gone (#783) — it renders Default's surfaces,
   // which `default` already covers. What remains is the always-light palette
   // private to the reveal surfaces (invitation letter, secret placeholder). It

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -298,6 +298,28 @@ const ARCHETYPE_PAIRS: Pair[] = [
     text: "--faction-coven-slip-deep",
   },
 
+  // Everymen — THE HELP WANTED BILL (task card v2, #1023). Short, because the
+  // design's palette IS the `--everymen-*` family measured above; only the roles
+  // that family had no home for are new.
+  { what: "everymen bill masthead", surface: "--faction-everymen-bill-mast", text: "--faction-everymen-bill-mast-ink" },
+  { what: "everymen bill CTA bar", surface: "--faction-everymen-bill-cta-bg", text: "--faction-everymen-bill-cta-ink" },
+  // The modifier badge's ink, walked down off the design's goldDeep (3.11:1).
+  { what: "everymen bill modifier ink", surface: "--everymen-paper", text: "--faction-everymen-bill-mult-ink" },
+  // The "Grade" label. Olive on the paper was never measured before this card
+  // set a label in it.
+  { what: "everymen paper, olive label", surface: "--everymen-paper", text: "--everymen-olive" },
+  {
+    // The seal's points numeral. Red on the paper is 4.49:1 — a hair under the
+    // body floor, which is why nothing on this card sets PROSE in it. The
+    // numeral is 32px/24px Bebas, large display type, so AA_LARGE is its floor
+    // and it clears with room (the same call `ua primary` makes above). The
+    // 8px "POINTS" caption beneath it is stamp text, i.e. ornament (§4).
+    what: "everymen seal numeral, large display type",
+    surface: "--everymen-paper",
+    text: "--everymen-red",
+    floor: AA_LARGE,
+  },
+
   // Ephemerists — THE VALLEY PLATE (task card v2, #1023). Four surfaces, not
   // one: the papyrus plate, the cornice's night band, the medallion's disc and
   // the CTA bar, each carrying its own ink. `-brass` is absent from this list on


### PR DESCRIPTION
**Part of #1023** (epic #1020, governed by ADR-0055 and ADR-0056). Wave A of two —
wave B (Singularity, S.N.I.D.E., UA, Warriors of Whimsy) closes the issue. The
split exists because all eight cards add token blocks to the shared `index.css`.

## What landed

Four bespoke v2 task cards, each built off its vendored design, each ONE
responsive component over the `CardProps` contract from #1022.

| Faction | Archetype | Replaces |
|---|---|---|
| **Coven** | the candlelit spell slip — pink→lavender paper, gold twinkle field, celtic braid, points in a glowing arcane sigil | `coven.exe` window |
| **Ephemerists** | the Valley plate (deco × Egypt) — papyrus under a cavetto cornice, winged sun disc between incised glyph registers, stepped octagon medallion | The Discordant Map |
| **Everymen** | the Help Wanted bill — WPA union broadsheet, cog masthead, poster rays, rubber-stamp seal | The Rally Bill |
| **Albescent** | **net-new registration**: the na sheet + a drifting spectrum edge + a breathing aurora | (fell through to Default) |

Common to all four: uniform `Task {id}` ordinal, uniform `{n} in progress`, the
existing per-faction signup key on the CTA, base points with a `×multiplier`
badge gated on `isNeutralMultiplier`, and a size set picked by `useFormFactor()`.
The dormant `mobileTaskCard` files are untouched (ADR-0056's revert path).

## Two decisions to sanity-check

**1. Albescent's CTA keeps na's wording, not `feed:taskCard.albescent.signup`.**
That key ("acknowledge") is orphaned — #783 deleted the bespoke Albescent card it
belonged to, and nothing has read it since. Wiring it back would print a word no
other player's card prints, on a surface every player can see, which
`WORLD_ZERO_STYLE.md` §3 calls out as being exactly as identifying as a
per-faction hue. This is the one place wave A departs from the issue's "reuse the
faction's own signup key"; say the word and it flips in one line.

**2. Ephemerists keeps `"Triangulate the truth ▸"`.** Per the reuse rule — but
that copy belongs to the retired map metaphor and there is no longer anything on
the card to triangulate. Left as-is deliberately; a copy call, not a build one.

## Contrast: the designs' annotations were wrong in six places

Every ink lifted from a design was re-measured, and six failed AA against the
surface they actually sit on. All six are walked down in `index.css` with the
measurement in the comment, and 20 new rows in `factionContrast`'s
`ARCHETYPE_PAIRS` hold them:

- Coven's card ground is a four-stop **gradient** and the design annotated
  against a near-white card — its `soft` (3.11:1), `label` (2.64:1 light /
  4.02:1 dark) and both CTA stops (white at 3.44:1) fail on the darkest stop.
- Ephemerists' brass is 2.97:1 on the plate; it stays a **rule and frame colour,
  never an ink** (WOW's chronicle gold precedent) and the one caption the design
  set in it takes a walked-down sibling.
- Everymen's modifier gold is 3.11:1 on the paper.

## Things done differently from the designs, on purpose

- **No injected `<style>`** (#911). Three keyframe sets moved to `index.css`.
- **Reduced motion inverted for Ephemerists.** The design's base state is
  `opacity: 0` with the animation stilled under `reduce`, which leaves a
  reduced-motion reader with *no glyphs at all*. Here the stilled state is the
  base and motion is added under `no-preference`.
- **Roman numerals deleted, not ported** (the `ROMAN` converter is gone).
- **Coven's braid lives in CSS**, because a data-URI SVG is a separate document
  and `var()` cannot reach into one.
- **Everymen needed no new tokens for most of its palette** — the design's
  `TOKENS` object turned out to be the existing `--everymen-*` family
  value-for-value, so only the masthead, CTA bar, modifier ink and washes are new.
- **Four new fonts** (Quicksand, Grenze Gotisch, Poiret One, Spectral) wired into
  the `index.html` loader in the same commit as their tokens. Everymen needed
  none — Bebas Neue and Courier Prime were already there.

## What to eyeball

Visual QA is **outstanding** — I cannot screenshot (no renderer, no dev stack),
so everything below is unverified by eye and verified only by tsc / eslint /
vitest / `vite build`.

- The four factions' task cards: **Coven, Ephemerists, Everymen, Albescent**.
- **Both form factors** (desktop ≥768px and mobile <768px) — the size set,
  and the ornament that narrows on the phone (Ephemerists' winged disc + band).
- **Both themes**, via the `[data-theme="dark"]` cascade.
- The **multiplier badge should be INVISIBLE everywhere at era_1** — every
  faction's modifier is 1.0, so seeing a `×1.00` chip anywhere is a bug.
- Albescent specifically: it should look like an *unaffiliated* card that
  shimmers, not like a faction. If it reads as its own thing at a glance, the
  tell is too loud.
- The three animations (Coven's pentagram watermark, Ephemerists' breathing
  glyphs, Albescent's edge + aurora) with **reduced motion on** — nothing should
  disappear, only stop moving.

## Checks

`tsc --noEmit` clean · `eslint src` clean (style ratchet passes; the raw values
that remain are per-line ornament hatches with stated reasons) · `vitest run`
**1660 passed / 108 files**, including 38 new · `vite build` green, and the new
tokens/classes/keyframes were grepped out of the *built* CSS at media-query depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
