### PR TITLE
#1036: rebuild the UA task detail on the v2 shared anatomy

### DIFF
--- a/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * UA task detail — the rebuilt v2 skin (#1036).
+ *
+ * The shared slots are already guarded (`archetypeSlots`, `detailContract`), so
+ * this file only pins what is UA's and what a green build would otherwise hide.
+ * Every assertion below exists because the same thing has actually gone wrong on
+ * this exact faction before:
+ *
+ *  - **The mark renders.** #821 shipped a UA praxis card with NO ensō at all and
+ *    nobody noticed, because `tsc` has no opinion about ornament. The mask URL
+ *    is the only static-render evidence the circle is on the page.
+ *  - **Both faces resolve.** UA spent months silently rendering in IM Fell
+ *    English (#839) — a named-but-unloaded family falls back to a generic serif
+ *    and no check we run can see it. Asserting on the two font TOKENS at least
+ *    pins that the surface asks for UA's faces rather than inheriting.
+ *  - **The design's invented faction label never landed.** `ua-task-detail.jsx`
+ *    captions the faction line 'Unbroken Ascension', which is not this faction's
+ *    name; #1036 guessed a different wrong name ('Universal Assembly'). ADR-0050
+ *    is the precedent — a stale design label inverted two factions across a whole
+ *    wave. The line resolves from the catalog by slug instead.
+ *  - **No faction voice.** ADR-0057. The `ua.*` keys the old 681-line archetype
+ *    spoke are still in `tasks.json` (the faction pages share those namespaces;
+ *    #1039 sweeps them), so nothing but a test stops this file drifting back.
+ *  - **No gold.** #853 deleted the legacy gilt-salon family and UA's gold went to
+ *    WOW; the design's `gilt:#A98246` rule-stop has deliberately no token.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+// Initialize the i18n catalog so copy keys resolve to English text.
+import "../../../i18n";
+import UaTaskDetail from "../archetypes/UaTaskDetail";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut, TaskSignupOut } from "../../../api/tasks";
+
+const TASK: TaskOut = {
+  id: 207,
+  title: "Render the old library facade in charcoal",
+  description: "One vantage, one sitting. Smudges are testimony.",
+  point_value: 24,
+  level_required: 4,
+  status: "active",
+  task_type: "standard",
+  created_by: 31,
+  primary_faction_slug: "ua",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  in_progress_count: 17,
+  created_by_display_name: "Ines Aurel",
+  created_by_faction_slug: "ua",
+  created_by_level: 5,
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+const SIGNUP: TaskSignupOut = {
+  character_id: 88,
+  display_name: "Halden Voss",
+  avatar_url: "",
+  faction_slug: "ua",
+  level: 6,
+  status: "in_progress",
+  signed_up_at: "2026-01-03T00:00:00Z",
+};
+
+function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    submissions: [],
+    signups: [],
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: true,
+    levelJumpSignup: false,
+    slotsOpen: 2,
+    maxTaskSlots: 3,
+    basePoints: 24,
+    factionMultiplier: 1.0,
+    modifiedPoints: 24,
+    inProgressCount: 17,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  return { html, text: html.replace(/<[^>]*>/g, "") };
+}
+
+describe("UA task detail — the marks and the faces", () => {
+  it("draws the ensō, twice and only twice: the faction line and the total", () => {
+    const { html, text } = render(<UaTaskDetail state={baseState()} />);
+    // The one ensō (#908): the vendored brush drawing, painted through a mask.
+    // `Enso` emits the prefixed declaration too, so count only the -webkit- one
+    // — two of those is two marks, not four.
+    expect(html.match(/-webkit-mask-image:url\(\/factionMarks\/enso\.svg\)/g)).toHaveLength(2);
+    // The mark is reserved for the SCORE and the FACTION MARK — never a button
+    // seal, never a "best judged" badge, however the design draws it.
+    expect(text).toContain("24");
+    // The design's `enso-detailed.svg` was deliberately not vendored; a second
+    // ensō asset is exactly the drift the manifest exists to prevent.
+    expect(html).not.toContain("enso-detailed");
+  });
+
+  it("floats the lotus as a token-tinted ground wash, not an <img>", () => {
+    const { html } = render(<UaTaskDetail state={baseState()} />);
+    expect(html).toContain("var(--faction-ua-card-lotus)");
+    expect(html).toContain("var(--faction-ua-card-lotus-opacity)");
+    // An external SVG cannot read a custom property, so it could not dim.
+    expect(html).not.toContain('src="lotus.svg"');
+  });
+
+  it("asks for UA's two faces by token, not a generic serif (#839)", () => {
+    const { html } = render(<UaTaskDetail state={baseState()} />);
+    expect(html).toContain("var(--faction-ua-card-font)"); // Cormorant Garamond
+    expect(html).toContain("var(--faction-ua-body-font)"); // EB Garamond
+  });
+
+  it("paints only with live --faction-ua-* tokens — no legacy palette, no gilt", () => {
+    const { html } = render(<UaTaskDetail state={baseState()} />);
+    // #853 deleted the legacy gilt-salon family outright.
+    expect(html).not.toMatch(/--ua-(gold|gilt|paper|wall|line|ink|sub|muted|orange)/);
+    // The design's `gilt:#A98246` rule-stop has no token, deliberately.
+    expect(html).not.toContain("--faction-ua-gilt");
+    // No hex reaches the markup: every colour is a var() or a color-mix of one.
+    expect(html).not.toMatch(/#[0-9a-fA-F]{6}\b/);
+  });
+});
+
+describe("UA task detail — the shared contract in UA's dress", () => {
+  it("speaks the shared neutral copy and none of the retired UA voice", () => {
+    const { text } = render(<UaTaskDetail state={baseState()} />);
+    expect(text).toContain("Task Description");
+    expect(text).toContain("Discussion");
+    expect(text).toContain("Sign up");
+    // ADR-0057: the `ua.*` voice keys the old archetype spoke are still in
+    // tasks.json for the faction pages, and must not be reachable from here.
+    for (const retired of [
+      "Sealed work",
+      "The finest hand",
+      "Anno",
+      "Honoraria",
+      "On view",
+      "Matriculated",
+    ]) {
+      expect(text).not.toContain(retired);
+    }
+    // Nor the design's own words, which ADR-0057 cuts just as hard.
+    for (const drawn of [
+      "The Call",
+      "finished works",
+      "Best judged",
+      "Said aloud",
+      "In hand",
+      "Continue the work",
+    ]) {
+      expect(text).not.toContain(drawn);
+    }
+  });
+
+  it("names the faction from the catalog, never the design's invention", () => {
+    const { text } = render(<UaTaskDetail state={baseState()} />);
+    // ADR-0050: the vendored design captions this line 'Unbroken Ascension',
+    // and #1036 anticipated a different wrong label. Neither is a faction.
+    expect(text).not.toContain("Unbroken Ascension");
+    expect(text).not.toContain("Universal Assembly");
+    expect(text).toContain("UA");
+  });
+
+  it("renders no in-progress roster — the header count is the only tally", () => {
+    const { text } = render(<UaTaskDetail state={baseState({ signups: [SIGNUP] })} />);
+    expect(text).not.toContain("Halden Voss");
+    expect(text).toContain("In progress");
+    expect(text).toContain("17");
+  });
+
+  it("hides the ×mult badge at the identity factor and shows the raw one otherwise", () => {
+    expect(render(<UaTaskDetail state={baseState()} />).text).not.toContain("×");
+    const { text } = render(
+      <UaTaskDetail
+        state={baseState({ factionMultiplier: 1.25, modifiedPoints: 30 })}
+      />,
+    );
+    expect(text).toContain("×1.25");
+    // Base and total stay separately legible; the badge substitutes for neither,
+    // and neither is reconstructed from the other (ADR-0053 / ADR-0055).
+    expect(text).toContain("24");
+    expect(text).toContain("30");
+  });
+
+  it("draws the author byline and the brief in full, unclamped", () => {
+    const long = "x".repeat(2000);
+    const { html, text } = render(
+      <UaTaskDetail state={baseState({ task: { ...TASK, description: long } })} />,
+    );
+    expect(text).toContain("Ines Aurel");
+    expect(text).toContain("author · lvl 5");
+    expect(html).toContain('href="/characters/31"');
+    expect(text).toContain(long);
+  });
+
+  it("expands the gallery in place instead of the dead task_id feed link", () => {
+    const { html } = render(<UaTaskDetail state={baseState()} />);
+    // `/praxes?task_id=N` drops the filter — usePraxes reads no such param.
+    expect(html).not.toContain("task_id=");
+  });
+});

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -1,253 +1,153 @@
-import type { CSSProperties, ReactNode } from "react";
+import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
+import { Lotus } from "../../../components/factionMarks";
 import { UaSigil } from "../../../components/cards/UaSigil";
 import {
   UA_DISPLAY,
   UA_EYEBROW,
   UA_TEXT,
   UaEnsoScore,
-  UaInkColumn,
   uaShade,
 } from "../../../components/cards/uaAtoms";
+import { useFormFactor } from "../../../hooks/useFormFactor";
+import { factionCssVar, factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
-import { ErrorBanner, LevelJumpBanner, TaskDetailComments, relationOf } from "./shared";
-import type { TaskSignupOut } from "../../../api/tasks";
+import { isNeutralMultiplier } from "../../../utils/points";
+import { ErrorBanner, LevelJumpBanner, TaskDetailComments } from "./shared";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
- * UA task detail — the sheet (#851).
+ * UA (University of Asthmatics) task detail — THE VELLUM LEAF, page-sized
+ * (design `.design-sync/task-details-v2/ua-task-detail.jsx`, #1036).
  *
- * The gilt salon is dead: no crest shield, no gold-leaf sandwich, no dot-grid
- * parchment, no fleur-de-lis. A task reads as a sheet of sun-bleached stock
- * with one orange hairline down the left margin, the marks held in an ensō, and
- * quiet uppercase labels over hairline rules.
+ * The shared v2 anatomy (#1030) in UA's language: a sheet of mesa-sand vellum
+ * with a lotus bleeding off the left edge, sienna rules running out from every
+ * label, Cormorant Garamond on the title and the numerals, EB Garamond on
+ * everything read. The header sits beside one 460px action panel that holds the
+ * base value, the (usually absent) ×mult badge and the total inside an ensō.
+ * Then the brief in full, the praxis gallery, the discussion.
  *
- * The mandala is ABSENT here (brief §5). The pattern is allowed on exactly
- * three surfaces — page backdrop, faction hero, join card — and a detail page
- * is dense reading; the UA page backdrop already carries the texture behind it.
+ * WHAT THIS REPLACES: the 681-line "sheet" archetype built on `ua.*` voice keys
+ * (`salonWallHeading`, `critiqueHeading`, `commissionHeading`,
+ * `matriculatedHeading`, `finestHand`, `stats.anno/honoraria/onView`). Those
+ * keys stay in `tasks.json` — the faction pages share those namespaces and the
+ * sweep is #1039 — but nothing here reads them. ADR-0057: task detail carries
+ * NO faction voice, only the shared neutral `detail.*` copy. Dress is UA's;
+ * words are not.
  *
- * Both themes come from the `[data-theme="dark"]` cascade; the page dims with
- * the app. It also used to paint with four font tokens that are declared
- * nowhere in index.css (`--ua-display`, `--ua-engraved`, `--ua-mono`,
- * `--ua-serif`) — undefined custom properties that silently fell back to the
- * inherited face. Both are fixed here.
+ * THREE CONTRACT POINTS WORTH NOT RE-DERIVING:
+ * - **No in-progress roster.** The header's "In progress" count is the only
+ *   place that population appears (owner ruling 2026-07-28, reversing epic
+ *   #1028 decision 3). The old `HandsRow` of signup portraits is deleted, not
+ *   restyled.
+ * - **The ×mult badge renders only off the identity factor.** `era_1`
+ *   neutralises every faction, so it is invisible today (ADR-0055), and the
+ *   factor comes raw off the state contract — never `modifiedPoints /
+ *   basePoints` (ADR-0053's dead arithmetic).
+ * - **The gallery expands in place.** `/praxes?task_id=N` has always dropped the
+ *   filter (the feed reads no such param), so the old "view all" link showed the
+ *   whole feed; it is a show-more/show-fewer toggle now, as on na.
+ *
+ * ONE RESPONSIVE COMPONENT (ADR-0058): `useFormFactor()` picks the size set and
+ * drops the two-column split. `pages/taskDetail/mobileArchetypes/UaTaskDetail`
+ * stays registered but dormant — restoring the dispatcher branch is the whole
+ * revert, so it is not deleted.
+ *
+ * TWO MARKS, AND THE RESTRAINT IS THE POINT (WORLD_ZERO_STYLE §6). The design
+ * draws the ensō five times — the faction line, the points ring, a seal on the
+ * sign-up button, a badge on the best-judged praxis, and again in the header.
+ * The ensō is reserved for the SCORE and the FACTION MARK, so only those two
+ * survive: the 16px mark on the faction line and the ring around the total. A
+ * seal on a button is neither. `UaTaskCard` made the same cut for the same
+ * reason. The lotus is a different device with its own scope — a ground wash —
+ * and it is drawn as the design draws it.
+ *
+ * Both marks are token-tinted components ({@link Lotus} inline,
+ * {@link UaSigil} through a CSS mask), so the design's five `filter:` recolour
+ * hacks — including the sign-up seal's `brightness(0) invert(1)` / `brightness(0)`
+ * theme flip — have no translation and are simply gone. That is what ADR-0049's
+ * "tintable from a token" buys, and it is why there is no ternary anywhere here:
+ * both themes arrive through the `[data-theme="dark"]` cascade.
+ *
+ * NO NEW TOKENS. Every colour is an already-shipped `--faction-ua-*`. The
+ * design's `gilt:#A98246` rule-stop is the one value with no home, and that is
+ * correct: #853 deleted the legacy gilt-salon family outright and UA's gold went
+ * to WOW (#838). The rules run sienna → neutral hairline → transparent instead,
+ * which is the same gesture without resurrecting the palette that was killed.
  */
 
-/** Roman numeral for the practice's "ANNO" (level) label. */
-function romanLevel(n: number): string {
-  return (
-    ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"][
-      Math.max(0, Math.min(9, n - 1))
-    ] ?? String(n)
-  );
+/** Praxis shown before the gallery expands — `PraxisCard` is `flex 1 1 394px`. */
+const GALLERY_PREVIEW = 3;
+
+/** Initials fallback for an author with no uploaded avatar. */
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
 }
 
-const PANEL: CSSProperties = {
-  display: "flex",
-  alignItems: "center",
-  gap: "var(--space-lg)",
-  flexWrap: "wrap",
-  padding: "var(--space-lg) var(--space-xl)",
-  border: "1px solid var(--faction-ua-rule)",
-  borderRadius: "var(--radius-sm)",
-  background: "var(--faction-ua-card-bg)",
+interface SizeSet {
+  /** Action-panel width. UA runs the widest bar but Everymen; dress (§4a). */
+  panel: number;
+  /** The points ensō, and the lotus wash. Ornament geometry, so raw px. */
+  enso: number;
+  lotus: number;
+  lotusLeft: number;
+  lotusTop: number;
+  title: string;
+  level: string;
+  count: string;
+}
+
+const SIZES: Record<"desktop" | "mobile", SizeSet> = {
+  desktop: {
+    panel: 460,
+    enso: 124,
+    lotus: 880,
+    lotusLeft: -230,
+    lotusTop: -110,
+    title: "var(--text-display)",
+    level: "var(--text-heading)",
+    count: "var(--text-title)",
+  },
+  mobile: {
+    panel: 0,
+    enso: 104,
+    lotus: 560,
+    lotusLeft: -200,
+    lotusTop: 40,
+    title: "var(--text-heading)",
+    level: "var(--text-title)",
+    count: "var(--text-content)",
+  },
 };
-
-/**
- * The banner surface for a signup error.
- *
- * #848 turned `--faction-ua-light` from `rgba(194,84,31,.08)` into an opaque
- * `#f2e0cb`; what used to be a whisper behind this banner became a solid wash.
- * It now names the panel token it was always reaching for, and takes an accent
- * ink that clears AA on it in both themes.
- */
-const BANNER: CSSProperties = {
-  flexBasis: "100%",
-  marginTop: 0,
-  background: "var(--faction-ua-panel)",
-  border: "1px solid var(--faction-ua-border)",
-  borderRadius: "var(--radius-sm)",
-  color: "var(--faction-ua-card-accent)",
-};
-
-/** Solid-fill affordance — the practice's one saturated note. */
-const FILLED_ACTION: CSSProperties = {
-  cursor: "pointer",
-  fontFamily: UA_TEXT,
-  fontSize: "var(--text-xl)",
-  letterSpacing: "0.14em",
-  textTransform: "uppercase",
-  color: "var(--faction-ua-on-fill)",
-  background: "var(--faction-ua)",
-  border: "none",
-  borderRadius: "var(--radius-sm)",
-  padding: "var(--space-md) var(--space-xl)",
-  textDecoration: "none",
-};
-
-/** Section header — the eyebrow over a hairline that runs to the margin. */
-function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode }) {
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "var(--space-lg)",
-        marginBottom: "var(--space-lg)",
-      }}
-    >
-      <h2 style={{ ...UA_EYEBROW, margin: 0, whiteSpace: "nowrap" }}>{title}</h2>
-      <span
-        style={{ flex: 1, height: 1, background: "var(--faction-ua-rule)" }}
-      />
-      {trailing}
-    </div>
-  );
-}
-
-/** Those practising — signup portraits with friend/foe dots. */
-function HandsRow({
-  signups,
-  friends,
-  foes,
-}: {
-  signups: TaskSignupOut[];
-  friends: Set<number>;
-  foes: Set<number>;
-}) {
-  const { t } = useTranslation("tasks");
-  return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: "var(--space-md)",
-        flexWrap: "wrap",
-      }}
-    >
-      {signups.map((hand) => {
-        const rel = relationOf(hand.character_id, friends, foes);
-        return (
-          <Link
-            key={hand.character_id}
-            to={`/characters/${hand.character_id}`}
-            title={`${hand.display_name}${rel ? ` · ${rel}` : ""}`}
-            style={{ position: "relative", width: 40, height: 40, flexShrink: 0 }}
-          >
-            {hand.avatar_url ? (
-              <img
-                src={mediaUrl(hand.avatar_url)}
-                alt={hand.display_name}
-                style={{
-                  width: 40,
-                  height: 40,
-                  borderRadius: "50%",
-                  objectFit: "cover",
-                  border: "1.5px solid var(--faction-ua-rule)",
-                }}
-              />
-            ) : (
-              <span
-                style={{
-                  display: "flex",
-                  width: 40,
-                  height: 40,
-                  borderRadius: "50%",
-                  background: "var(--faction-ua-panel)",
-                  border: "1.5px solid var(--faction-ua-rule)",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  color: "var(--faction-ua-card-text)",
-                  fontFamily: UA_DISPLAY,
-                  fontWeight: 600,
-                  fontSize: "var(--text-content)",
-                }}
-              >
-                {hand.display_name[0]?.toUpperCase()}
-              </span>
-            )}
-            {rel && (
-              <span
-                title={rel}
-                style={{
-                  position: "absolute",
-                  right: -2,
-                  bottom: -2,
-                  width: 12,
-                  height: 12,
-                  borderRadius: "50%",
-                  background:
-                    rel === "friend"
-                      ? "var(--faction-ua)"
-                      : "var(--faction-ua-vermil)",
-                  border: "2px solid var(--faction-ua-card-bg)",
-                }}
-              />
-            )}
-          </Link>
-        );
-      })}
-      <span style={{ ...UA_EYEBROW, marginLeft: "var(--space-xs)" }}>
-        {t("ua.matriculated")}
-      </span>
-    </div>
-  );
-}
-
-/** One count from the sheet's head — a numeral over its label. */
-function StatCell({
-  label,
-  children,
-  last = false,
-}: {
-  label: string;
-  children: ReactNode;
-  last?: boolean;
-}) {
-  return (
-    <div
-      style={{
-        flex: "1 1 140px",
-        minWidth: 140,
-        padding: "var(--space-lg) var(--space-xl)",
-        borderRight: last ? undefined : "1px solid var(--faction-ua-hair)",
-      }}
-    >
-      <div
-        style={{
-          fontFamily: UA_DISPLAY,
-          fontWeight: 600,
-          fontSize: "var(--text-title)",
-          lineHeight: 1,
-          color: "var(--faction-ua-card-text)",
-        }}
-      >
-        {children}
-      </div>
-      <div style={{ ...UA_EYEBROW, marginTop: "var(--space-xs)" }}>{label}</div>
-    </div>
-  );
-}
 
 export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
   const { t } = useTranslation("tasks");
+  const formFactor = useFormFactor();
+  const desktop = formFactor !== "mobile";
+  const size = SIZES[formFactor];
+  const [showAllPraxis, setShowAllPraxis] = useState(false);
   const {
     task,
-    signups,
     submissions,
-    friends,
-    foes,
     mySubmission,
     isInProgress,
     inProgressPraxisId,
     canSignUp,
+    levelJumpSignup,
     slotsOpen,
     maxTaskSlots,
+    basePoints,
+    factionMultiplier,
     modifiedPoints,
-    topScore,
-    voteCount,
+    inProgressCount,
     sortedSubmissions,
     submissionSort,
     setSubmissionSort,
@@ -259,423 +159,737 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
   // Guarded non-null by the dispatcher.
   if (!task) return null;
 
-  const statusVoice =
-    task.status === "active" ? t("ua.statusOpen") : task.status;
-  const commissionNo = String(task.id).padStart(4, "0");
+  const slug = task.primary_faction_slug;
+  const isMetatask = task.task_type === "metatask";
+  const showMultiplier = !isNeutralMultiplier(factionMultiplier);
+  const authorName = task.created_by_display_name ?? "";
+  const hasAction =
+    canSignUp || !!mySubmission || (isInProgress && inProgressPraxisId !== null);
 
-  // The truest hand on the sheet wears a quiet orange tag.
-  const topId = submissions.length
-    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
-    : null;
+  const innerBox: CSSProperties = {
+    background: "var(--faction-ua-card-bg)",
+    border: "1px solid var(--faction-ua-rule)",
+    borderRadius: 5,
+    padding: desktop ? "var(--space-lg)" : "var(--space-md)",
+    boxSizing: "border-box",
+  };
+  /** The practice's one saturated note. Fill + on-fill: 4.59:1 / 5.59:1. */
+  const primaryAction: CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    width: "100%",
+    boxSizing: "border-box",
+    cursor: "pointer",
+    textAlign: "center",
+    textDecoration: "none",
+    fontFamily: UA_DISPLAY,
+    fontWeight: 600,
+    fontSize: desktop ? "var(--text-content)" : "var(--text-xl)",
+    letterSpacing: "0.02em",
+    color: "var(--faction-ua-on-fill)",
+    background: "var(--faction-ua)",
+    border: "1.5px solid var(--faction-ua-card-frame)",
+    borderRadius: 5,
+    padding: desktop
+      ? "var(--space-md) var(--space-xl)"
+      : "var(--space-sm) var(--space-lg)",
+  };
+  /** The quiet note under an action — slots, level, "you're on this task". */
+  const aside: CSSProperties = {
+    fontFamily: UA_TEXT,
+    fontSize: "var(--text-xl)",
+    lineHeight: 1.6,
+    color: "var(--faction-ua-card-muted)",
+  };
+
+  /**
+   * The rule that runs out from a label. The design fades sienna → gilt →
+   * transparent; UA has no gilt token any more (#853), so it fades into the
+   * neutral hairline instead.
+   */
+  const rule = (opacity: number) => (
+    <span
+      aria-hidden
+      style={{
+        flex: "1 1 20%",
+        minWidth: 20,
+        height: 1,
+        opacity,
+        background:
+          "linear-gradient(90deg, var(--faction-ua-card-frame), var(--faction-ua-rule) 55%, transparent)",
+      }}
+    />
+  );
+
+  const sectionHead = (label: ReactNode, gloss?: ReactNode) => (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        gap: "var(--space-md)",
+        marginBottom: "var(--space-md)",
+        flexWrap: "wrap",
+      }}
+    >
+      <span style={{ ...UA_EYEBROW, color: "var(--faction-ua-card-text)" }}>
+        {label}
+      </span>
+      {rule(0.7)}
+      {gloss}
+    </div>
+  );
+
+  // ── The worth: base, the (usually absent) ×mult badge, the total in the ensō ──
+  const worth = (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--space-sm)",
+        width: "100%",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          gap: "var(--space-sm)",
+        }}
+      >
+        <span style={{ ...UA_EYEBROW, letterSpacing: "0.16em" }}>
+          {t("detail.points.base")}
+        </span>
+        <span
+          style={{
+            fontFamily: UA_DISPLAY,
+            fontWeight: 700,
+            fontSize: desktop ? "var(--text-title)" : "var(--text-content)",
+            lineHeight: 0.9,
+            color: "var(--faction-ua-card-text)",
+          }}
+        >
+          {basePoints}
+        </span>
+        {showMultiplier && (
+          <span
+            style={{
+              marginLeft: "auto",
+              fontFamily: UA_DISPLAY,
+              fontWeight: 700,
+              fontSize: "var(--text-xl)",
+              lineHeight: 1,
+              whiteSpace: "nowrap",
+              color: "var(--faction-ua-card-chip-ink)",
+              background: "var(--faction-ua-card-chip-bg)",
+              borderRadius: 4,
+              padding: "var(--space-xs) var(--space-sm)",
+            }}
+          >
+            {t("detail.points.multiplier", {
+              multiplier: factionMultiplier.toFixed(2),
+            })}
+          </span>
+        )}
+      </div>
+      <div style={{ display: "flex" }}>{rule(1)}</div>
+      <div style={{ display: "flex", justifyContent: "center" }}>
+        {/* The mark's one sanctioned use besides the faction line. `vermil` is
+            the documented ink for exactly this numeral at display size. */}
+        <UaEnsoScore
+          size={size.enso}
+          value={modifiedPoints}
+          unit={t("detail.points.total")}
+          valueColor="var(--faction-ua-vermil)"
+        />
+      </div>
+    </div>
+  );
+
+  // ── The one action slot. Nothing renders when the viewer has no move to make:
+  //    an unusable control is worse than none.
+  const actionBody = (
+    <>
+      {canSignUp && (
+        <div>
+          <LevelJumpBanner state={state} />
+          <button onClick={handleSignup} style={primaryAction}>
+            {t("detail.signup.cta")}
+          </button>
+          <div style={{ ...aside, marginTop: "var(--space-sm)" }}>
+            {t("detail.signup.slots", { open: slotsOpen, max: maxTaskSlots })}
+            {!levelJumpSignup && (
+              <>
+                {" · "}
+                <span style={{ color: "var(--faction-ua-card-accent)" }}>
+                  {t("detail.signup.levelMet", { level: task.level_required })}
+                </span>
+              </>
+            )}
+          </div>
+          <ErrorBanner message={signupError} />
+        </div>
+      )}
+
+      {mySubmission && (
+        <div>
+          <div style={{ ...aside, marginBottom: "var(--space-sm)" }}>
+            {t("detail.submitted.text")}
+          </div>
+          <Link to={`/praxes/${mySubmission.id}/edit`} style={primaryAction}>
+            {t("detail.submitted.edit")}
+          </Link>
+        </div>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-sm)",
+              marginBottom: "var(--space-sm)",
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                width: 6,
+                height: 6,
+                flex: "none",
+                borderRadius: "50%",
+                background: "var(--faction-ua-glow)",
+              }}
+            />
+            <span style={{ ...aside, fontStyle: "italic" }}>
+              {t("detail.inProgress.text")}
+            </span>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-md)",
+              flexWrap: "wrap",
+            }}
+          >
+            <Link
+              to={`/praxes/${inProgressPraxisId}/edit`}
+              style={{ ...primaryAction, flex: 1, width: "auto" }}
+            >
+              {t("detail.inProgress.continue")}
+            </Link>
+            <button
+              onClick={handleDrop}
+              style={{
+                fontFamily: UA_TEXT,
+                fontStyle: "italic",
+                fontSize: "var(--text-lg)",
+                background: "none",
+                border: "none",
+                borderBottom: "1px solid var(--faction-ua-rule)",
+                cursor: "pointer",
+                padding: 0,
+                color: "var(--faction-ua-card-muted)",
+              }}
+            >
+              {t("detail.inProgress.drop")}
+            </button>
+          </div>
+          <ErrorBanner message={signupError} />
+        </div>
+      )}
+    </>
+  );
+
+  // The bar: worth + action inside one sienna-bound leaf.
+  const actionPanel = (
+    <div
+      style={{
+        position: "relative",
+        background: "var(--faction-ua-lift)",
+        border: "2px solid var(--faction-ua-card-frame)",
+        borderRadius: 7,
+        padding: "var(--space-xs)",
+        boxSizing: "border-box",
+        color: "var(--faction-ua-card-text)",
+        boxShadow: `0 16px 44px -30px ${uaShade(52)}`,
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: desktop ? "row" : "column",
+          gap: "var(--space-xs)",
+          alignItems: "stretch",
+        }}
+      >
+        <div
+          style={{
+            ...innerBox,
+            flex: "0 0 auto",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            minWidth: desktop ? 176 : undefined,
+          }}
+        >
+          {worth}
+        </div>
+        {hasAction && (
+          <div
+            style={{
+              ...innerBox,
+              flex: 1,
+              minWidth: 0,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+            }}
+          >
+            {actionBody}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  // ── Header: breadcrumb, faction line, title, author, the two counts ──
+  const header = (
+    <div>
+      <nav
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-sm)",
+          marginBottom: "var(--space-md)",
+          flexWrap: "wrap",
+        }}
+      >
+        <Link
+          to="/tasks"
+          style={{
+            ...UA_EYEBROW,
+            color: "var(--faction-ua-card-accent)",
+            textDecoration: "none",
+          }}
+        >
+          {t("detail.breadcrumb.tasks")}
+        </Link>
+        <span aria-hidden style={UA_EYEBROW}>
+          /
+        </span>
+        <span style={UA_EYEBROW}>
+          {t("detail.breadcrumb.current", { number: task.id })}
+        </span>
+      </nav>
+
+      {/* The faction line — the mark, then the name resolved from the catalog by
+          slug (ADR-0057). The design captions it 'Unbroken Ascension', which is
+          not this faction's name and not any faction's name; a shared-copy build
+          never reads it. ADR-0050 is the precedent for why that matters. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-sm)",
+          marginBottom: "var(--space-md)",
+          flexWrap: "wrap",
+        }}
+      >
+        <UaSigil width={16} height={16} />
+        <span style={{ ...UA_EYEBROW, fontSize: "var(--text-base)" }}>
+          {factionName(slug)}
+        </span>
+        {isMetatask && (
+          <span
+            style={{
+              fontFamily: UA_TEXT,
+              fontSize: "var(--text-md)",
+              textTransform: "uppercase",
+              letterSpacing: "0.16em",
+              padding: "var(--space-xs) var(--space-sm)",
+              borderRadius: 4,
+              // The pinned faction's own fill, never UA's — that is the seal.
+              ...factionFill(task.metatask_faction_slug, "pill"),
+            }}
+          >
+            {t("detail.meta")}
+          </span>
+        )}
+      </div>
+
+      <h1
+        style={{
+          fontFamily: UA_DISPLAY,
+          fontWeight: 700,
+          fontSize: size.title,
+          lineHeight: 1.08,
+          letterSpacing: "-0.015em",
+          margin: 0,
+          marginBottom: "var(--space-md)",
+          color: "var(--faction-ua-card-text)",
+          overflowWrap: "anywhere",
+        }}
+      >
+        {task.title}
+      </h1>
+
+      {isMetatask && (
+        <p
+          style={{
+            ...UA_EYEBROW,
+            marginTop: 0,
+            marginBottom: "var(--space-md)",
+            color: factionCssVar(task.metatask_faction_slug),
+          }}
+        >
+          {t("detail.metataskFor", {
+            faction: factionName(task.metatask_faction_slug),
+          })}
+        </p>
+      )}
+
+      {/* The proposing character's byline (#1029). */}
+      {authorName && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-sm)",
+            marginBottom: "var(--space-lg)",
+            flexWrap: "wrap",
+          }}
+        >
+          <Link
+            to={`/characters/${task.created_by}`}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-sm)",
+              textDecoration: "none",
+            }}
+          >
+            {task.created_by_avatar_url ? (
+              <img
+                src={mediaUrl(task.created_by_avatar_url)}
+                alt={authorName}
+                style={{
+                  width: 30,
+                  height: 30,
+                  borderRadius: "50%",
+                  objectFit: "cover",
+                  flex: "none",
+                  boxShadow: "0 0 0 1.5px var(--faction-ua-card-frame)",
+                }}
+              />
+            ) : (
+              <span
+                aria-hidden
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: 30,
+                  height: 30,
+                  flex: "none",
+                  borderRadius: "50%",
+                  overflow: "hidden",
+                  fontFamily: UA_DISPLAY,
+                  fontWeight: 700,
+                  fontSize: "var(--text-lg)",
+                  background: "var(--faction-ua-panel)",
+                  color: "var(--faction-ua-card-text)",
+                  boxShadow: "0 0 0 1.5px var(--faction-ua-card-frame)",
+                }}
+              >
+                {initialsOf(authorName)}
+              </span>
+            )}
+            <span
+              style={{
+                fontFamily: UA_TEXT,
+                fontSize: "var(--text-xl)",
+                color: "var(--faction-ua-card-text)",
+                borderBottom: "1px solid var(--faction-ua-rule)",
+              }}
+            >
+              {authorName}
+            </span>
+          </Link>
+          <span style={UA_EYEBROW}>
+            {t("detail.author", { level: task.created_by_level ?? 0 })}
+          </span>
+        </div>
+      )}
+
+      {/* Exactly two counts. The completed total lives on the gallery heading,
+          and there is deliberately no roster — this is the only place the
+          in-progress population appears. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: desktop ? "var(--space-xl)" : "var(--space-lg)",
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", lineHeight: 1 }}>
+          <span style={{ ...UA_EYEBROW, marginBottom: "var(--space-xs)" }}>
+            {t("detail.stats.level")}
+          </span>
+          <span
+            style={{
+              fontFamily: UA_DISPLAY,
+              fontWeight: 700,
+              fontSize: size.level,
+              lineHeight: 0.9,
+              color: "var(--faction-ua-card-text)",
+            }}
+          >
+            {task.level_required}
+          </span>
+        </div>
+        <span
+          aria-hidden
+          style={{
+            width: 1,
+            alignSelf: "stretch",
+            minHeight: 34,
+            background: "var(--faction-ua-rule)",
+          }}
+        />
+        <div style={{ display: "flex", flexDirection: "column", lineHeight: 1 }}>
+          <span style={{ ...UA_EYEBROW, marginBottom: "var(--space-xs)" }}>
+            {t("detail.stats.inProgress")}
+          </span>
+          <span
+            style={{
+              fontFamily: UA_DISPLAY,
+              fontWeight: 700,
+              fontSize: size.count,
+              lineHeight: 0.9,
+              color: "var(--faction-ua-card-text)",
+            }}
+          >
+            {inProgressCount}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+
+  // ── The brief, in full. No clamp, no "read more". ──
+  const brief = (
+    <section
+      style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}
+    >
+      {sectionHead(t("detail.brief.heading"))}
+      {task.description && (
+        <div
+          style={{
+            background: "var(--faction-ua-lift)",
+            border: "1px solid var(--faction-ua-hair)",
+            borderRadius: 6,
+            padding: desktop ? "var(--space-xl)" : "var(--space-lg)",
+          }}
+        >
+          <p
+            className="content-text"
+            style={{
+              fontFamily: UA_TEXT,
+              lineHeight: 1.72,
+              color: "var(--faction-ua-card-body)",
+              whiteSpace: "pre-wrap",
+              margin: 0,
+            }}
+          >
+            {task.description}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+
+  // ── The praxis gallery ──
+  const gallery = (
+    <section
+      style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-md)",
+          marginBottom: "var(--space-md)",
+          flexWrap: "wrap",
+        }}
+      >
+        <span style={{ ...UA_EYEBROW, color: "var(--faction-ua-card-text)" }}>
+          {t("detail.gallery.heading", { count: submissions.length })}
+        </span>
+        {rule(0.7)}
+        <span
+          style={{
+            display: "flex",
+            gap: "var(--space-xs)",
+            padding: "var(--space-xs)",
+            border: "1px solid var(--faction-ua-rule)",
+            borderRadius: 6,
+          }}
+        >
+          {(["score", "recent"] as const).map((sort) => {
+            const on = submissionSort === sort;
+            return (
+              <button
+                key={sort}
+                onClick={() => setSubmissionSort(sort)}
+                style={{
+                  ...UA_EYEBROW,
+                  cursor: "pointer",
+                  border: "none",
+                  borderRadius: 4,
+                  padding: "var(--space-xs) var(--space-sm)",
+                  background: on ? "var(--faction-ua)" : "transparent",
+                  color: on
+                    ? "var(--faction-ua-on-fill)"
+                    : "var(--faction-ua-card-muted)",
+                }}
+              >
+                {sort === "score"
+                  ? t("detail.gallery.sort.top")
+                  : t("detail.gallery.sort.recent")}
+              </button>
+            );
+          })}
+        </span>
+      </div>
+
+      {sortedSubmissions.length === 0 ? (
+        <p
+          className="content-text"
+          style={{
+            fontFamily: UA_TEXT,
+            color: "var(--faction-ua-card-muted)",
+            margin: 0,
+          }}
+        >
+          {t("detail.gallery.empty")}
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap gap-4 items-start">
+            {(showAllPraxis
+              ? sortedSubmissions
+              : sortedSubmissions.slice(0, GALLERY_PREVIEW)
+            ).map((praxis) => (
+              <PraxisCard key={praxis.id} praxis={praxis} />
+            ))}
+          </div>
+          {submissions.length > GALLERY_PREVIEW && (
+            <button
+              onClick={() => setShowAllPraxis((shown) => !shown)}
+              style={{
+                display: "inline-block",
+                marginTop: "var(--space-md)",
+                padding: 0,
+                fontFamily: UA_TEXT,
+                fontStyle: "italic",
+                fontSize: "var(--text-xl)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                color: "var(--faction-ua-card-accent)",
+              }}
+            >
+              {showAllPraxis
+                ? t("detail.gallery.showFewer")
+                : t("detail.gallery.viewAll", { count: submissions.length })}
+            </button>
+          )}
+        </>
+      )}
+    </section>
+  );
 
   return (
     <div
       className="py-8"
-      style={{ fontFamily: UA_TEXT, color: "var(--faction-ua-page-text)" }}
+      style={{
+        position: "relative",
+        overflow: "hidden",
+        fontFamily: UA_TEXT,
+        color: "var(--faction-ua-page-text)",
+      }}
     >
-      {/* ── Breadcrumb ── */}
-      <nav className="mb-4" style={UA_EYEBROW}>
-        <Link
-          to="/tasks"
-          style={{ color: "var(--faction-ua-card-accent)", textDecoration: "none" }}
-        >
-          {t("default.breadcrumb")}
-        </Link>
-        <span style={{ margin: "0 var(--space-sm)" }}>·</span>
-        <span>{t("ua.faction")}</span>
-        <span style={{ margin: "0 var(--space-sm)" }}>·</span>
-        <span style={{ color: "var(--faction-ua-card-accent)" }}>{task.title}</span>
-      </nav>
+      {/* The ground — mesa sand, one flat token, both themes. Fixed like the na
+          wash so the leaf reads as the page rather than as a card on the app's
+          rainbow watercolour. */}
+      <span
+        aria-hidden
+        style={{
+          position: "fixed",
+          inset: 0,
+          zIndex: 0,
+          pointerEvents: "none",
+          background: "var(--faction-ua-page)",
+        }}
+      />
+      {/* The lotus, bleeding off the left edge. Ornament geometry stays in raw
+          px (§4a); its opacity is a token, so dark mode lifts it through the
+          cascade rather than through the design's `saturate(1.35)`. */}
+      <Lotus
+        size={size.lotus}
+        color="var(--faction-ua-card-lotus)"
+        style={{
+          position: "absolute",
+          left: size.lotusLeft,
+          top: size.lotusTop,
+          zIndex: 0,
+          opacity: "var(--faction-ua-card-lotus-opacity)",
+          pointerEvents: "none",
+        }}
+      />
 
-      <div style={{ maxWidth: 920 }}>
+      <div
+        style={{
+          position: "relative",
+          zIndex: 1,
+          maxWidth: 1200,
+          margin: "0 auto",
+        }}
+      >
         <div
           style={{
             display: "flex",
-            flexDirection: "column",
-            gap: "var(--space-2xl)",
+            flexDirection: desktop ? "row" : "column",
+            alignItems: desktop ? "flex-start" : "stretch",
+            gap: "var(--space-xl)",
+            marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
           }}
         >
-          {/* ── THE SHEET — masthead + counts ── */}
+          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
           <div
             style={{
-              position: "relative",
-              overflow: "hidden",
-              border: "1px solid var(--faction-ua-rule)",
-              borderRadius: "var(--radius-md)",
-              background: "var(--faction-ua-card-bg)",
-              boxShadow: `0 14px 38px -24px ${uaShade(52)}`,
+              flex: desktop ? `0 0 ${size.panel}px` : "1 1 auto",
+              width: desktop ? size.panel : "100%",
+              marginTop: desktop ? "var(--space-sm)" : 0,
             }}
           >
-            <div
-              style={{
-                position: "relative",
-                background:
-                  "linear-gradient(160deg, var(--faction-ua-lift), var(--faction-ua-panel))",
-                borderBottom: "1px solid var(--faction-ua-hair)",
-                padding: "var(--space-2xl) var(--space-2xl) var(--space-xl)",
-              }}
-            >
-              <UaInkColumn
-                style={{
-                  left: "var(--space-md)",
-                  top: "var(--space-2xl)",
-                  bottom: "var(--space-xl)",
-                }}
-              />
-              <div
-                style={{
-                  position: "relative",
-                  paddingLeft: "var(--space-lg)",
-                  display: "flex",
-                  gap: "var(--space-2xl)",
-                  alignItems: "center",
-                  flexWrap: "wrap",
-                }}
-              >
-                <UaEnsoScore
-                  size={124}
-                  value={modifiedPoints}
-                  unit={t("ua.stats.honoraria")}
-                  valueColor="var(--faction-ua-vermil)"
-                />
-                <div style={{ flex: 1, minWidth: 260 }}>
-                  <div style={UA_EYEBROW}>{t("ua.masthead")}</div>
-                  <div style={{ ...UA_EYEBROW, letterSpacing: "0.3em" }}>
-                    {t("ua.commissionLine", { number: commissionNo })}
-                  </div>
-                  <h1
-                    style={{
-                      fontFamily: UA_DISPLAY,
-                      fontWeight: 600,
-                      fontSize: "var(--text-heading)",
-                      lineHeight: 1.06,
-                      letterSpacing: "-0.01em",
-                      color: "var(--faction-ua-card-text)",
-                      margin: "var(--space-sm) 0 var(--space-md)",
-                      overflowWrap: "anywhere",
-                    }}
-                  >
-                    {task.title}
-                  </h1>
-                  {/* The status tag. It used to paint its ink with
-                      --faction-ua-light, a background tint that was invisible
-                      at 8% alpha and pale cream once #848 made it opaque; the
-                      ink token for a solid fill is --faction-ua-on-fill. */}
-                  <span
-                    style={{
-                      display: "inline-flex",
-                      alignItems: "center",
-                      gap: "var(--space-sm)",
-                      background: "var(--faction-ua)",
-                      color: "var(--faction-ua-on-fill)",
-                      fontFamily: UA_TEXT,
-                      fontSize: "var(--text-md)",
-                      letterSpacing: "0.16em",
-                      textTransform: "uppercase",
-                      borderRadius: "var(--radius-sm)",
-                      padding: "var(--space-xs) var(--space-md)",
-                    }}
-                  >
-                    {statusVoice}
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            <div style={{ display: "flex", flexWrap: "wrap" }}>
-              <StatCell label={t("ua.stats.anno")}>
-                {romanLevel(task.level_required)}
-              </StatCell>
-              <StatCell label={t("ua.stats.honorariaUnit")}>
-                {modifiedPoints}
-              </StatCell>
-              <StatCell label={t("ua.stats.onView")} last>
-                <span
-                  style={{
-                    fontSize: "var(--text-content)",
-                    lineHeight: 1.2,
-                    color: "var(--faction-ua-card-body)",
-                  }}
-                >
-                  {t("ua.stats.onViewValue", {
-                    signups: signups.length,
-                    completed: submissions.length,
-                  })}
-                </span>
-              </StatCell>
-            </div>
+            {actionPanel}
           </div>
+        </div>
 
-          {/* ── Sign-up / signed-on states ── */}
-          <LevelJumpBanner state={state} />
-          {canSignUp && (
-            <div style={PANEL}>
-              <button onClick={handleSignup} style={FILLED_ACTION}>
-                {t("ua.signup.cta", { points: modifiedPoints })}
-              </button>
-              <div
-                style={{
-                  fontFamily: UA_TEXT,
-                  fontSize: "var(--text-content)",
-                  color: "var(--faction-ua-card-body)",
-                }}
-              >
-                {t("ua.signup.meta", {
-                  open: slotsOpen,
-                  max: maxTaskSlots,
-                  level: romanLevel(task.level_required),
-                })}
-              </div>
-              <ErrorBanner message={signupError} style={BANNER} />
-            </div>
-          )}
-
-          {mySubmission && (
-            <div style={PANEL}>
-              <span
-                style={{
-                  ...UA_EYEBROW,
-                  color: "var(--faction-ua-card-accent)",
-                }}
-              >
-                {t("ua.submitted.text")}
-              </span>
-              <Link
-                to={`/praxes/${mySubmission.id}/edit`}
-                style={{ ...FILLED_ACTION, marginLeft: "auto" }}
-              >
-                {t("ua.submitted.edit")}
-              </Link>
-            </div>
-          )}
-
-          {!mySubmission && isInProgress && inProgressPraxisId !== null && (
-            <div style={PANEL}>
-              <span
-                style={{
-                  ...UA_EYEBROW,
-                  color: "var(--faction-ua-card-accent)",
-                }}
-              >
-                {t("ua.inProgress.text")}
-              </span>
-              <Link
-                to={`/praxes/${inProgressPraxisId}/edit`}
-                style={{ ...FILLED_ACTION, marginLeft: "auto" }}
-              >
-                {t("ua.inProgress.continue")}
-              </Link>
-              <button
-                onClick={handleDrop}
-                style={{
-                  ...UA_EYEBROW,
-                  background: "none",
-                  border: "none",
-                  cursor: "pointer",
-                }}
-              >
-                {t("ua.inProgress.drop")}
-              </button>
-              <ErrorBanner message={signupError} style={BANNER} />
-            </div>
-          )}
-
-          {/* ── The Mark — the user-written brief ── */}
-          <section>
-            <SectionHead title={t("ua.commissionHeading")} />
-            <div
-              style={{
-                border: "1px solid var(--faction-ua-rule)",
-                borderRadius: "var(--radius-sm)",
-                background: "var(--faction-ua-card-bg)",
-                padding: "var(--space-xl)",
-                maxWidth: 660,
-              }}
-            >
-              <p
-                className="content-text"
-                style={{
-                  fontFamily: UA_TEXT,
-                  lineHeight: 1.7,
-                  color: "var(--faction-ua-card-body)",
-                  margin: 0,
-                  whiteSpace: "pre-wrap",
-                }}
-              >
-                {task.description || t("ua.commissionEmpty")}
-              </p>
-            </div>
-          </section>
-
-          {/* ── Those practising ── */}
-          {signups.length > 0 && (
-            <section>
-              <SectionHead title={t("ua.matriculatedHeading")} />
-              <HandsRow signups={signups} friends={friends} foes={foes} />
-            </section>
-          )}
-
-          {/* ── The Reading — read-only aggregate ── */}
-          <section>
-            <SectionHead title={t("ua.critiqueHeading")} />
-            {voteCount > 0 ? (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "var(--space-lg)",
-                }}
-              >
-                <UaEnsoScore
-                  size={96}
-                  value={topScore}
-                  valueColor="var(--faction-ua-vermil)"
-                />
-                <div>
-                  <div
-                    style={{
-                      fontFamily: UA_DISPLAY,
-                      fontWeight: 600,
-                      fontSize: "var(--text-title)",
-                      lineHeight: 1.1,
-                      color: "var(--faction-ua-card-text)",
-                    }}
-                  >
-                    {t("ua.critique.finest")}
-                  </div>
-                  <div style={{ ...UA_EYEBROW, marginTop: "var(--space-xs)" }}>
-                    {t("ua.critique.appraised", { count: voteCount })}
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <p
-                className="content-text"
-                style={{
-                  fontFamily: UA_TEXT,
-                  color: "var(--faction-ua-card-muted)",
-                }}
-              >
-                {t("ua.critique.none")}
-              </p>
-            )}
-          </section>
-
-          {/* ── Sealed work ── */}
-          <section>
-            <SectionHead
-              title={t("ua.salonWallHeading")}
-              trailing={
-                <div style={{ display: "flex", gap: "var(--space-sm)" }}>
-                  {(["score", "recent"] as const).map((sort) => {
-                    const on = submissionSort === sort;
-                    return (
-                      <button
-                        key={sort}
-                        onClick={() => setSubmissionSort(sort)}
-                        style={{
-                          ...UA_EYEBROW,
-                          padding: "var(--space-xs) var(--space-md)",
-                          borderRadius: "var(--radius-sm)",
-                          background: on
-                            ? "var(--faction-ua)"
-                            : "transparent",
-                          color: on
-                            ? "var(--faction-ua-on-fill)"
-                            : "var(--faction-ua-card-muted)",
-                          border: `1px solid ${
-                            on ? "var(--faction-ua)" : "var(--faction-ua-rule)"
-                          }`,
-                          cursor: "pointer",
-                        }}
-                      >
-                        {sort === "score"
-                          ? t("ua.sort.finest")
-                          : t("ua.sort.recent")}
-                      </button>
-                    );
-                  })}
-                </div>
-              }
-            />
-            {sortedSubmissions.length === 0 ? (
-              <p
-                className="content-text"
-                style={{
-                  fontFamily: UA_TEXT,
-                  color: "var(--faction-ua-card-muted)",
-                }}
-              >
-                {t("ua.empty")}
-              </p>
-            ) : (
-              <>
-                <div
-                  style={{
-                    display: "flex",
-                    flexWrap: "wrap",
-                    gap: "var(--space-2xl) var(--space-xl)",
-                    alignItems: "flex-start",
-                  }}
-                >
-                  {sortedSubmissions.slice(0, 4).map((s) => (
-                    <div
-                      key={s.id}
-                      style={{
-                        position: "relative",
-                        paddingTop: "var(--space-xl)",
-                      }}
-                    >
-                      {s.id === topId && (
-                        <div
-                          style={{
-                            position: "absolute",
-                            top: 0,
-                            left: "50%",
-                            transform: "translateX(-50%)",
-                            zIndex: 3,
-                            display: "inline-flex",
-                            alignItems: "center",
-                            gap: "var(--space-xs)",
-                            whiteSpace: "nowrap",
-                            background: "var(--faction-ua)",
-                            color: "var(--faction-ua-on-fill)",
-                            fontFamily: UA_TEXT,
-                            fontSize: "var(--text-md)",
-                            letterSpacing: "0.16em",
-                            textTransform: "uppercase",
-                            borderRadius: "var(--radius-sm)",
-                            padding: "var(--space-xs) var(--space-md)",
-                          }}
-                        >
-                          <UaSigil width={13} height={13} />
-                          {t("ua.finestHand")}
-                        </div>
-                      )}
-                      <PraxisCard praxis={s} />
-                    </div>
-                  ))}
-                </div>
-                {submissions.length > 4 && (
-                  <div style={{ marginTop: "var(--space-lg)" }}>
-                    <Link
-                      to={`/praxes?task_id=${task.id}`}
-                      style={{
-                        fontFamily: UA_TEXT,
-                        fontSize: "var(--text-content)",
-                        color: "var(--faction-ua-card-accent)",
-                        textDecoration: "none",
-                      }}
-                    >
-                      {t("ua.viewAll", { count: submissions.length })}
-                    </Link>
-                  </div>
-                )}
-              </>
-            )}
-          </section>
-          {/* Comments — shared slot, active-task gated (ADR-0006 + #1030). */}
-          <TaskDetailComments state={state} />
+        <div style={{ minWidth: 0 }}>
+          {brief}
+          {gallery}
+          {/* Comments — the shared slot, active-task gated (ADR-0006, #1030),
+              under UA's own section head so the thread draws no second one. */}
+          <TaskDetailComments
+            state={state}
+            heading={sectionHead(t("detail.comments.heading"))}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Rebuilds the University of Asthmatics task detail on the v2 shared anatomy (#1030), ported from `.design-sync/task-details-v2/ua-task-detail.jsx`.

Closes #1036

## What changed

- `frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx` — rebuilt (681 → ~700 lines, all of it new). One responsive component; `useFormFactor()` picks the size set and drops the two-column split (ADR-0058).
- `frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx` — new render check.

**Nothing else.** `frontend/src/factions/ua.ts` already registers `taskDetail`, so the registry needed no edit. `mobileArchetypes/UaTaskDetail.tsx` and its `mobileTaskDetail` row are untouched and still compile (dormant, ADR-0058). `tasks.json` is untouched — the `ua.*` voice keys the old archetype spoke stay for `UaFactionBody` / mobile `UaFactionPage`, and #1039 sweeps them. **No index.css change**: every colour is an already-shipped `--faction-ua-*` token.

## The layout

Header (breadcrumb · faction line · title · author byline · Level / In progress) beside a **460px** action panel holding base + the ×mult badge + the total inside an ensō — then the brief in full, the praxis gallery, the discussion. Page cap 1200. Mesa-sand ground, lotus bleeding off the left edge, sienna rules running out from every label, Cormorant Garamond on the title and numerals, EB Garamond on everything read.

## Deviations from the vendored design

| # | The design | What shipped | Why |
|---|---|---|---|
| 1 | Faction line reads `'Unbroken Ascension'` | `factionName(slug)` → `UA` from `factions.json` | Not this faction's name, not any faction's. ADR-0057 makes the faction line shared neutral copy; ADR-0050 is the precedent for why a stale design label matters. Pinned by a test. |
| 2 | Copy: `The Call`, `finished works`, `Best judged`, `Said aloud`, `set by`, `In hand`, `Continue the work`, `set down` | The shared `detail.*` keys only | ADR-0057 — no faction voice on this surface. Pinned by a test (both the design's words and the retired `ua.*` voice). |
| 3 | An in-progress roster is absent, but the epic's issue text demanded one | No roster | Owner ruling 2026-07-28, reversing epic #1028 decision 3. The header's "In progress" count is the only place the number appears. The old `HandsRow` of signup portraits is deleted, not restyled. |
| 4 | `src="enso-detailed.svg"` (258 KB, unvendored) | The repo's `<UaSigil>`/`<Enso>` mask | One ensō (#908). A second asset is exactly the drift the manifest prevents. |
| 5 | Five ensō: faction line, points ring, **sign-up button seal**, best-judged badge, header glyph | **Two**: the faction line and the total | WORLD_ZERO_STYLE §6 — the mark is reserved for the SCORE and the FACTION MARK. `UaTaskCard` made the same cut. This also dissolves the seal's `filter: brightness(0) invert(1)` / `brightness(0)` theme flip, which had no token-shaped translation. |
| 6 | `gilt: #A98246` as the middle stop of every rule | Rules fade `--faction-ua-card-frame` → `--faction-ua-rule` → transparent | UA has **no gilt token**: #853 deleted the legacy gilt-salon family outright and UA's gold went to WOW (#838). Same gesture, no resurrected palette. Pinned by a test. |
| 7 | Points numeral at 52px inside a 148px ensō | `UaEnsoScore` at 124/104, numeral at `--text-heading` | The ensō-with-a-numeral is a shared atom; forking its type scale for one surface is how a mark drifts between surfaces. |
| 8 | `t.ua` (= `--faction-ua-glow`) inks the numeral, the "points" caption and several small labels | `--faction-ua-vermil` for the display numeral, `--faction-ua-card-muted` / `-card-accent` for text | `--faction-ua-glow` is documented ORNAMENT ONLY (3.12:1) and never text. |
| 9 | Praxis gallery is a `repeat(3,1fr)` grid of mock cards, with `record №`, a "the work" plate and a ✦ best-judged ensō badge | Live `<PraxisCard>` in `flex flex-wrap gap-4` | Owner's call; `PraxisCard` carries its own `flex: 1 1 394px`, so three land per row at the 1200 cap and reflow on their own. |
| 10 | A mock comment thread + composer | `TaskDetailComments` under UA's own section head | ADR-0006 / #1030; the slot owns the `status === "active"` gate and passes `showHeading={false}`. |
| 11 | Mobile draws its own sticky back bar (`←`, `Task №N`, `open`/`in hand`) | Not built | The app's global mobile chrome owns back-navigation; a per-archetype bar would be a second one. |
| 12 | `filter: saturate(1.35) brightness(1.2)` etc. to recolour marks for dark | Token tint + `[data-theme="dark"]` cascade | ADR-0049. There is no ternary anywhere in the file. |
| 13 | `theme`/`platform`/`state` props with a local `TOKENS` map and `useState`-faked sign-up | `TaskDetailState` off `useTaskDetail` | Design harness scaffolding. |

Two inherited fixes carried over from the na reference build: the gallery now **expands in place** instead of linking to `/praxes?task_id=N` (dead on every archetype — `usePraxes` reads no such param), and the ×mult badge reads the **raw** `factionMultiplier` off the state contract rather than reconstructing `modifiedPoints / basePoints` (ADR-0053's dead arithmetic; ADR-0055's rule). At `era_1` every faction is neutralised, so the badge is correctly invisible today.

Metatask handling, which the old archetype did not have at all, is now present: the META pill takes the *pinned* faction's own fill via `factionFill(…, "pill")`, and the "Metatask for X" line follows.

## What to eyeball

Visual QA is **outstanding** — I cannot screenshot and there is no dev stack in this worktree. `tsc --noEmit`, `eslint src`, `vitest run` (108 files) and `vite build` are all green, and none of them prove any of the below:

1. **Both faces actually render.** Cormorant Garamond on the title/numerals, EB Garamond on the body — not a generic serif. UA spent months in the wrong face (#839); the test can only assert the *token*, not the resolved family.
2. **The ensō renders**, twice: 16px on the faction line, and around the total in the action panel. #821 shipped a UA praxis card with no ensō at all.
3. **The lotus bleed** off the left edge at 880px desktop / 560px mobile — that it reads as a ground wash and does not collide with the header text or fight the app chrome.
4. **The mesa-sand ground.** The archetype paints a fixed `--faction-ua-page` layer over the app's rainbow watercolour (same shape as `UaBackdrop` and the na wash). Check it does not clip or leak at the page edges, and that the global nav still reads on it.
5. **Dark mode**, toggled — every token used has a `[data-theme="dark"]` value, but the *composition* is unverified: the 2px sienna panel frame on the dimmed lift, the vermilion total on the dark inner box, the lotus at `0.22`.
6. **The 460px panel** at ~1200 and just below, and the single-column stack under 768.
7. **Contrast** — computed, not measured: vermilion total on the inner box is 4.94:1 light / 4.12:1 dark, which clears AA-large at display size and is the token's documented use. Everything else uses pairs already annotated in `index.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
