### PR TITLE
Fix na task detail: missing page surface, and sign-up hidden after drop

### DIFF
--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -60,7 +60,8 @@ function initialsOf(name: string): string {
  * Copy is neutral and shared (`detail.*`, ADR-0057) — no na voice, no faction
  * voice. Dress is na's alone: `--faction-default-*` (rainbow, ring, card sheet)
  * reached via the token / `factionFill`, NOT `factionCssVar`, which is neutral
- * grey for na. The full-page `.na-backdrop` wash lives in index.css.
+ * grey for na. The content column carries the page surface itself
+ * (`--faction-default-card-bg`); there is no separate backdrop element.
  */
 export default function DefaultTaskDetail({
   state,
@@ -753,16 +754,23 @@ export default function DefaultTaskDetail({
 
   return (
     <div className="py-8" style={{ position: "relative" }}>
-      {/* Full-page spectrum wash — the na "all paths open" backdrop (index.css,
-          shared with DefaultProfile #969). */}
-      <div className="na-backdrop" aria-hidden />
-
       <div
         style={{
           position: "relative",
           zIndex: 1,
           maxWidth: 1200,
           margin: "0 auto",
+          // The page surface the design puts everything on. This used to be a
+          // `<div className="na-backdrop">` whose rule was never written — the
+          // element rendered and painted nothing, so the whole column sat
+          // directly on the app shell. A class with no CSS behind it type-checks,
+          // lints and builds clean; only looking at it catches that.
+          background: "var(--faction-default-card-bg)",
+          color: "var(--faction-default-card-text)",
+          border: "1px solid var(--faction-default-border)",
+          borderRadius: 18,
+          padding: desktop ? "var(--space-2xl)" : "var(--space-lg)",
+          boxSizing: "border-box",
         }}
       >
         <div

--- a/frontend/src/pages/taskDetail/useTaskDetail.ts
+++ b/frontend/src/pages/taskDetail/useTaskDetail.ts
@@ -231,6 +231,17 @@ export function useTaskDetail(idParam: string | undefined): TaskDetailState {
       setIsInProgress(false);
       setInProgressPraxisId(null);
       setSubmissions((prev) => prev.filter((s) => s.id !== targetPraxisId));
+      // `canSignUp` gates on `task.can_submit_praxis`, which the SERVER computes
+      // and flips to false once you are on the task. Clearing local state alone
+      // leaves that stale `false` in place, so the sign-up button stayed hidden
+      // until a manual reload. Re-read the task — it also refreshes
+      // `in_progress_count`, which just went down by one.
+      try {
+        setTask((await getTask(task.id)) as TaskOut);
+      } catch {
+        // The drop itself succeeded; a failed re-read is not worth an error
+        // banner. The stale flag clears on the next navigation.
+      }
     } catch (err) {
       setSignupError(extractError(err, "Could not drop this task."));
     }


### PR DESCRIPTION
Two defects found by **live visual QA** of the task detail page (na skin, viewed
on an Albescent task, which falls through to Default until #1038).

Neither was catchable by the toolchain — both type-check, lint and build clean.

## 1 · The content column had no background

The root rendered:

```jsx
{/* Full-page spectrum wash — the na "all paths open" backdrop (index.css,
    shared with DefaultProfile #969). */}
<div className="na-backdrop" aria-hidden />
```

**There is no `.na-backdrop` rule.** `grep -rn "na-backdrop" frontend/src` returns
only the two lines in this file — the class and the comment asserting where it
lives were both invented. `DefaultProfile` has no such precedent either.

So the element rendered and painted nothing, and the whole column sat directly on
the app shell with no surface of its own.

**Fix:** the 1200-capped content column now carries the page surface itself —
`--faction-default-card-bg` / `--faction-default-card-text` with the na border and
a radius, so the header, brief, gallery and comments sit on a sheet. The inner
boxes keep `--color-bg-page`, so they still read as inset against it.

Owner's framing: *"the background doesn't need to be the whole page background but
does need to be the background for the collection of things on that page."*

## 2 · Sign up did not reappear after dropping a task

`canSignUp` is:

```ts
!!user && !mySubmission && !isInProgress && !!task?.can_submit_praxis
```

`can_submit_praxis` is **server-computed** and flips to `false` once you are on the
task. `handleDrop` cleared `isInProgress`, `inProgressPraxisId` and `submissions`
— all local — but never re-read the task, so the stale `false` survived and the
button stayed hidden until a manual reload.

**Fix:** after a successful delete, re-read the task. That also refreshes
`in_progress_count`, which just went down by one. A failed re-read is swallowed —
the drop itself succeeded, and the flag resolves on the next navigation; an error
banner there would be lying about what failed.

## Why the toolchain missed both

A `className` with no CSS behind it, and a stale server-derived boolean, are both
invisible to `tsc`, `eslint` and `vitest`. This is the
`docs/agents/design-fidelity.md` point restated: a green build proves the code
compiles, not that anything renders. It took someone looking at the page.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` 1722/1722 green.

Visual QA of the fix itself is **outstanding** — I still cannot screenshot.

## What to eyeball

- The task detail column now has a surface behind it, in **both** light and dark.
- The action panel's spectrum border should still separate it from that surface
  rather than blending — it shares the same token.
- Sign up → drop → the **Sign up button comes straight back**, no reload.
- After a drop, the header's "In progress" count should drop by one immediately.
- Metatask tasks (META pill, metatask-for line) still render.