### PR TITLE
#1037: WOW desktop task detail — the parchment field (net-new skin)

### DIFF
--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -38,15 +38,15 @@ const CORE_SIX = ['coven', 'snide', 'ephemerists', 'singularity', 'everymen', 'u
 
 // surface → slugs that ship a bespoke skin there. Everything in ALL_SLUGS not
 // listed (plus a junk slug and null) must fall through to the surface Default.
-// wow is Default on desktop praxis/task detail but bespoke on every mobile
-// surface; albescent is bespoke only on the praxis card.
+// wow is Default on desktop praxis detail but bespoke on task detail (#1037)
+// and on every mobile surface; albescent is bespoke only on the praxis card.
 //
 // There is no `mobileTaskCard` row: ADR-0056 retired that surface once the
 // owner's QA verdict accepted the unified card, so task cards partition on the
 // `taskCard` surface alone for both form factors.
 const BESPOKE: Record<string, string[]> = {
   praxisDetail: CORE_SIX,
-  taskDetail: CORE_SIX,
+  taskDetail: [...CORE_SIX, 'wow'],
   mobileTaskDetail: [...CORE_SIX, 'wow'],
   mobileFactionPage: [...CORE_SIX, 'wow'],
   mobileFieldDesk: [...CORE_SIX, 'wow'],

--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -91,8 +91,9 @@ const REQUIRED = SURFACE_KEYS.filter((surface) =>
 // a bespoke skin; until then WOW renders the generic Default (N/A), not Coven.
 // When a skin ships, drop the surface here and the "still pending" guard below
 // fails, forcing this allowlist to shrink in lockstep with the fix.
+// `taskDetail` left this set in #1037 — the parchment field, WOW's first
+// desktop task-detail page. Three bullets of #951 remain.
 const WOW_PENDING: ReadonlySet<string> = new Set([
-  'taskDetail',
   'praxisDetail',
   'factionCard',
   'factionBody',

--- a/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
+++ b/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
@@ -66,17 +66,22 @@ function Sentinel() {
  * `metaTaskSeal` — WOW's court-writ seal, the last faction seal skin, built from
  * the chronicle identity since the kit drew no wow specimen.
  *
- * EIGHT SURFACES ARE STILL UNCLAIMED, in two groups.
+ * and #1037's desktop `taskDetail` — THE PARCHMENT FIELD, the first of #951's
+ * four missing desktop surfaces to ship.
  *
- * `factionBody`, `factionCard`, and DESKTOP `taskDetail` / `praxisDetail` are
- * PENDING DESIGN BUGS, tracked by #951. #899/#900/#840 scoped them out on a
+ * SEVEN SURFACES ARE STILL UNCLAIMED, in two groups.
+ *
+ * `factionBody`, `factionCard` and DESKTOP `praxisDetail` are PENDING DESIGN
+ * BUGS, tracked by #951. #899/#900/#840 scoped them out on a
  * design-fidelity argument (the kit drew WOW's cards and hero, not the desktop
  * pages beneath them, so a page skin would be invention), but the owner ruled
  * (2026-07-23) that a faction missing a custom experience is a bug regardless:
  * WOW players get the generic Default on those pages. They fall to the neutral
  * Default (N/A), never to Coven — which is the point of pinning the set here.
  * When #951 ships a skin, move that surface into WOW_SKINNED and this list
- * shrinks; `surfaceDispatch.test.ts` enforces the same #951 allowlist.
+ * shrinks; `surfaceDispatch.test.ts` enforces the same #951 allowlist. #1037 is
+ * that shrink happening once: `taskDetail` moved down into WOW_SKINNED and out
+ * of both allowlists in the same commit.
  *
  * `mobileCreateCharacter` and `mobileEditCharacter`, `mobileFactionsDirectory`
  * and `mobilePlayersDirectory`: nothing in the kit describes them, #901 scoped
@@ -88,6 +93,7 @@ const WOW_SKINNED: ReadonlySet<FactionSurface> = new Set([
   'sigil',
   'avatar',
   'taskCard',
+  'taskDetail',
   'comment',
   'feedFrame',
   'praxisCard',
@@ -112,7 +118,7 @@ const WOW_SKINNED: ReadonlySet<FactionSurface> = new Set([
   'metaTaskSeal',
 ])
 
-describe('wow is partly skinned: twenty-five surfaces claimed, the rest fall back', () => {
+describe('wow is partly skinned: twenty-six surfaces claimed, the rest fall back', () => {
   it('registers a manifest now (#821)', () => {
     expect(FACTION_MANIFESTS.map((manifest) => manifest.slug)).toContain('wow')
   })

--- a/frontend/src/factions/wow.ts
+++ b/frontend/src/factions/wow.ts
@@ -29,6 +29,14 @@
  * chronicle: two chromes on one palette, deliberately unalike (#785's "the
  * praxis card mirrors the task card" clause is retired for WOW).
  *
+ * #1037 adds the desktop `taskDetail` — THE PARCHMENT FIELD: gold-and-plum
+ * parchment under a dot texture, bunting across the head, a struck points
+ * plaque, wavy gold→plum rules and a bunch of googly balloons. It is the first
+ * of #951's four missing desktop surfaces to ship; `praxisDetail`, `factionCard`
+ * and `factionBody` are still unclaimed. The `mobileTaskDetail` row below stays
+ * registered but DORMANT (ADR-0058) — the desktop archetype is responsive and
+ * serves both form factors.
+ *
  * #900 adds the PAGE-LEVEL desktop surfaces: the recruiting `factionHero`, the
  * `backdrop` wallpaper every WOW-context page sits on, the crested `profileBody`
  * and the `factionSelectCard` pledge placard. `factionBody` and `factionCard`
@@ -78,6 +86,7 @@ import WowMobileDuelSealConfirm from '../components/duel/WowMobileDuelSealConfir
 import WowDuelRail from '../pages/praxisDetail/duelRails/WowDuelRail'
 import WowMobileDuelRail from '../pages/praxisDetail/duelRails/WowMobileDuelRail'
 import WowFieldDesk from '../pages/fieldDesk/mobileArchetypes/WowFieldDesk'
+import WowTaskDetail from '../pages/taskDetail/archetypes/WowTaskDetail'
 import WowMobileTaskDetail from '../pages/taskDetail/mobileArchetypes/WowTaskDetail'
 import WowMobilePraxisDetail from '../pages/praxisDetail/mobileArchetypes/WowPraxisDetail'
 import WowMobileFactionPage from '../pages/factionDetail/mobileArchetypes/WowFactionPage'
@@ -89,6 +98,10 @@ export const WOW_MANIFEST: FactionManifest = {
   sigil: () => WowSigil,
   avatar: () => WowAvatar,
   taskCard: () => WowTaskCard,
+  // #1037 — the parchment field: WOW's FIRST desktop task-detail page. Until
+  // this row a WOW task rendered the na dossier on desktop (one of #951's four
+  // bullets; praxisDetail, factionCard and factionBody are still open).
+  taskDetail: () => WowTaskDetail,
   comment: () => WowComment,
   feedFrame: () => WowFeedFrame,
   praxisCard: () => WowPraxisCard,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3382,13 +3382,13 @@
   --faction-wow-detail-shadow: 0 18px 44px -18px rgba(0, 0, 0, 0.8);
 }
 
-/* Markup hook: `<div class="wow-detail-field" />`, the same shape as
-   `.na-backdrop` — a fixed sheet behind the page's own z-index 1 column. */
+/* The parchment ground for the task-detail COLUMN, not the viewport — the site
+   background shows around it (owner QA on #1055, applied to every task-detail
+   skin). The archetype supplies position / z-index / radius / padding; this rule
+   owns only the field and its dot texture.
+   (It was modelled on `.na-backdrop`, which IS a real full-viewport wash — but
+   that pattern was retired from this surface, not copied onto it.) */
 .wow-detail-field {
-  position: fixed;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
   background-color: var(--faction-wow-detail-field);
   background-image: radial-gradient(var(--faction-wow-detail-dot) 1px, transparent 1px);
   background-size: 5px 5px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3222,3 +3222,86 @@
   --faction-wow-mobile-header-from: var(--faction-wow-avatar-field);
   --faction-wow-mobile-header-to: var(--faction-wow-card-bg);
 }
+
+/* ══ WOW — TASK DETAIL, the parchment field (#1037) ══
+   WOW's first DESKTOP task-detail skin: gold-and-plum parchment under a fine dot
+   texture, bunting across the head, a struck points plaque, wavy gold→plum rules
+   and a bunch of googly balloons. Until this slice a WOW task rendered the na
+   dossier on desktop — one of #951's four bullets.
+
+   ALMOST NOTHING IS NEW. #1023's quest decree already minted the ribbon, the
+   plaque shadow, the blade, the balloon ramp and the eye parts, and this page
+   reads them verbatim rather than growing a parallel set. FIVE roles had no
+   name, and they are the whole block.
+
+   THREE PAIRINGS FROM THE DESIGN DID NOT SURVIVE MEASUREMENT, all against the
+   new page field (which is DARKER than the cream card, so every light-mode
+   claim measured on the card had to be recomputed):
+     • The design sets label text in its `muted` grey. On the field that is
+       --faction-wow-card-muted at 4.20:1 — under AA. Labels on the field take
+       --faction-wow-accent-deep instead (4.70:1 light, 9.49:1 dark), the same
+       walked-down olive-gold #860 landed on for the cards.
+     • The design's third text tier (`dim`, #a79668 light) is ~2.4:1 on its own
+       page and is not shipped at all; its lines fold into card-muted on a panel
+       and accent-deep on the field.
+     • The design paints the CTA in `t.plum`, which in dark is the LIFTED
+       #c79be0 under cream text. That is plum-as-ink used as a fill. The CTA and
+       the ×mult chip take the theme-invariant --faction-wow-plum-surface
+       (5.16:1 in both themes) — note 1 by that declaration already settled it.
+   Measured on the field: plum ink 5.11:1 light / 8.54:1 dark; body ink 12.38:1
+   light / 15.83:1 dark. Inside the plate: card-muted 4.52:1 light / 6.43:1 dark,
+   accent-deep 5.06:1 light. */
+:root {
+  /* The page ground. NOT --faction-wow-ground-from (the WowBackdrop wallpaper):
+     that is a full-page wash a WOW *viewer* carries between pages, while this is
+     the sheet this one page is printed on, and it is a shade deeper so the cream
+     cards read as laid ON something. */
+  --faction-wow-detail-field: #efe6ce;
+  /* The fine dot texture, 1px on a 5px grid. Ink-on-parchment in light, gilt
+     specks in dark — the only way a dot stays visible on both grounds. */
+  --faction-wow-detail-dot: rgba(74, 56, 10, 0.05);
+  /* The plate's inner boxes: a shade off the cream card so the two nested
+     parchments separate without a second border. */
+  --faction-wow-detail-inset: #f7eed8;
+  /* The edge of a plum FILL. Theme-invariant, because the surface it edges
+     (--faction-wow-plum-surface) is — a struck border does not repaint itself
+     when the lights go out, same reasoning as the gold (§3). */
+  --faction-wow-plum-edge: #5b3277;
+  /* The page's lift. Deeper than the card's --faction-wow-quest-shadow: a whole
+     plate throws a longer shadow than a card does. */
+  --faction-wow-detail-shadow: 0 12px 30px -16px rgba(74, 56, 10, 0.5);
+}
+[data-theme="dark"] {
+  --faction-wow-detail-field: #100c05;
+  --faction-wow-detail-dot: rgba(227, 184, 74, 0.06);
+  --faction-wow-detail-inset: #231b0c;
+  /* --faction-wow-plum-edge is theme-invariant; see the note above. */
+  --faction-wow-detail-shadow: 0 18px 44px -18px rgba(0, 0, 0, 0.8);
+}
+
+/* Markup hook: `<div class="wow-detail-field" />`, the same shape as
+   `.na-backdrop` — a fixed sheet behind the page's own z-index 1 column. */
+.wow-detail-field {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background-color: var(--faction-wow-detail-field);
+  background-image: radial-gradient(var(--faction-wow-detail-dot) 1px, transparent 1px);
+  background-size: 5px 5px;
+  transition: background-color 300ms;
+}
+
+/* The balloon bunch bobs and tilts. Class-gated on reduced-motion like every
+   other faction motion in the house, so the skin never writes `animation:`
+   inline and bypasses the gate; the bunch is pure ornament, carries no state,
+   and reads correctly stilled. The pupils inside it travel on the existing
+   `.wow-balloon-eye` wiggle. */
+@keyframes wow-balloon-bob {
+  0%, 100% { transform: translateY(0) rotate(3deg); }
+  40% { transform: translateY(-7px) rotate(-2deg); }
+  70% { transform: translateY(-3px) rotate(2deg); }
+}
+@media (prefers-reduced-motion: no-preference) {
+  .wow-balloon-bunch { animation: wow-balloon-bob 6s ease-in-out infinite; }
+}

--- a/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * WOW task detail — the parchment field (#1037).
+ *
+ * This is the NET-NEW case in the epic: WOW had no desktop `taskDetail`
+ * archetype at all, so a WOW task rendered the **na dossier** (one of #951's
+ * four bullets). Two of these tests exist purely because of that:
+ * `registers the taskDetail surface` pins the registry row that makes the page
+ * reachable, and `is not wearing the na dossier` pins that it stopped being the
+ * fallback — a green render proves neither on its own.
+ *
+ * `archetypeSlots.test.tsx` already walks this archetype for the shared content
+ * slots and `detailContract.test.tsx` for the comments gate, so neither is
+ * repeated here. What is left is what only WOW can get wrong: its dress, and
+ * ADR-0057's rule that the dress is the ONLY thing it may bring.
+ *
+ * Static markup only — no DOM, no effects (the harness runs none), so anything
+ * behind a fetch is asserted through its pre-fetch state.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import { surfaceMap } from "../../../factions";
+import WowTaskDetail from "../archetypes/WowTaskDetail";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut, TaskSignupOut } from "../../../api/tasks";
+
+const TASK: TaskOut = {
+  id: 663,
+  // No apostrophes in the fixtures: `renderToStaticMarkup` escapes them to
+  // `&#x27;`, which survives the tag-strip and breaks a plain substring check.
+  title: "Hauled the recycling to the depot",
+  description: "Take the whole block, not only your bin.",
+  point_value: 12,
+  level_required: 3,
+  status: "active",
+  task_type: "standard",
+  created_by: 31,
+  primary_faction_slug: "wow",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  in_progress_count: 4,
+  created_by_display_name: "Wren Abalone",
+  created_by_faction_slug: "wow",
+  created_by_level: 4,
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+const SIGNUP: TaskSignupOut = {
+  character_id: 88,
+  display_name: "Ossuary Pete",
+  avatar_url: "",
+  faction_slug: "snide",
+  level: 7,
+  status: "in_progress",
+  signed_up_at: "2026-01-03T00:00:00Z",
+};
+
+function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    submissions: [],
+    signups: [],
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: true,
+    levelJumpSignup: false,
+    slotsOpen: 5,
+    maxTaskSlots: 12,
+    basePoints: 12,
+    factionMultiplier: 1.0,
+    modifiedPoints: 12,
+    inProgressCount: 4,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  return { html, text: html.replace(/<[^>]*>/g, "") };
+}
+
+describe("wow task detail — the surface is reachable at all", () => {
+  it("registers the taskDetail surface, so a WOW task stops falling to na", () => {
+    // #951's first bullet. Before #1037 this entry was undefined and
+    // `pickVariant` handed a WOW task straight to DefaultTaskDetail.
+    expect(surfaceMap("taskDetail")["wow"]).toBeDefined();
+    expect(surfaceMap("taskDetail")["wow"]).toBe(WowTaskDetail);
+  });
+
+  it("renders the task without throwing", () => {
+    const { text } = render(<WowTaskDetail state={baseState()} />);
+    expect(text).toContain("Hauled the recycling to the depot");
+    expect(text).toContain("Take the whole block, not only your bin.");
+  });
+});
+
+describe("wow task detail — the dress is WOW's, and only the dress", () => {
+  it("lays the page on the parchment field, not the na spectrum", () => {
+    const { html } = render(<WowTaskDetail state={baseState()} />);
+    expect(html).toContain("wow-detail-field");
+    // The na kit's two ornaments. If either shows up here the archetype has
+    // been copied without being re-dressed.
+    expect(html).not.toContain("na-backdrop");
+    expect(html).not.toContain("--faction-default-rainbow");
+  });
+
+  it("draws the ribbon, the shield and the googly balloons", () => {
+    const { html } = render(<WowTaskDetail state={baseState()} />);
+    expect(html, "the barber ribbon over the action plate").toContain(
+      "--faction-wow-quest-ribbon",
+    );
+    expect(html, "the crossed-swords blades").toContain("--faction-wow-quest-blade");
+    expect(html, "the balloon bunch").toContain("wow-balloon-bunch");
+    // The pupils ride the faction's existing reduced-motion-gated wiggle rather
+    // than an inline `animation:`, which would bypass the gate.
+    expect(html).toContain("wow-balloon-eye");
+    expect(html).not.toContain("animation:");
+  });
+
+  it("speaks the shared neutral copy — none of the design's faction voice", () => {
+    const { text } = render(<WowTaskDetail state={baseState()} />);
+    expect(text).toContain("Task Description");
+    expect(text).toContain("Discussion");
+    expect(text).toContain("Sign up");
+    // ADR-0057: dress is WOW's, words are not. Every one of these is a word the
+    // vendored design puts on this page.
+    const lower = text.toLowerCase();
+    expect(lower, "the design's 'You're on this quest'").not.toContain("quest");
+    expect(lower, "the design's 'N submissions' heading").not.toContain("submission");
+    expect(lower, "the design's 'highest scored' sort tab").not.toContain("highest scored");
+    expect(lower, "the design's 'your points' plaque label").not.toContain("your points");
+  });
+});
+
+describe("wow task detail — the contract points it inherits", () => {
+  it("hides the multiplier badge at the identity factor", () => {
+    const { text } = render(<WowTaskDetail state={baseState()} />);
+    expect(text).not.toContain("×");
+  });
+
+  it("shows the raw multiplier once an era ships a real factor", () => {
+    const { text } = render(
+      <WowTaskDetail state={baseState({ factionMultiplier: 1.5, modifiedPoints: 18 })} />,
+    );
+    expect(text).toContain("×1.50");
+    // Base and total both stay legible; the badge replaces neither.
+    expect(text).toContain("12");
+    expect(text).toContain("18");
+  });
+
+  it("renders no in-progress roster, only the header count", () => {
+    // Owner ruling 2026-07-28, reversing epic #1028 decision 3. The design's own
+    // header comment says the header count covers it.
+    const { text } = render(<WowTaskDetail state={baseState({ signups: [SIGNUP] })} />);
+    expect(text).not.toContain("Ossuary Pete");
+    expect(text).toContain("In progress");
+    expect(text).toContain("4");
+  });
+
+  it("keeps the metatask pill and the metatask-for line", () => {
+    const { text } = render(
+      <WowTaskDetail
+        state={baseState({
+          task: { ...TASK, task_type: "metatask", metatask_faction_slug: "coven" },
+        })}
+      />,
+    );
+    expect(text).toContain("META");
+    expect(text).toContain("Metatask for Cozy Coven");
+  });
+
+  it("expands the gallery in place instead of the dead ?task_id= link", () => {
+    // `/praxes?task_id=N` has never filtered — `usePraxes` reads no such param —
+    // so every archetype's "view all" silently showed the whole feed (#1030).
+    const { html } = render(<WowTaskDetail state={baseState()} />);
+    expect(html).not.toContain("task_id=");
+  });
+});

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -1005,10 +1005,23 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
 
   return (
     <div className="py-8" style={{ position: "relative" }}>
-      {/* The parchment field with its fine dot texture (index.css). */}
-      <div className="wow-detail-field" aria-hidden />
-
-      <div style={{ position: "relative", zIndex: 1, maxWidth: 1200, margin: "0 auto" }}>
+      {/* The parchment field with its fine dot texture (index.css). It paints
+          the detail COLUMN, not the viewport: the owner's rule for this surface
+          is that the site background still shows around the component (QA on
+          #1055, applied to every skin). Was `position: fixed; inset: 0`. */}
+      <div
+        className="wow-detail-field"
+        style={{
+          position: "relative",
+          zIndex: 1,
+          maxWidth: 1200,
+          margin: "0 auto",
+          borderRadius: 18,
+          padding: desktop ? "var(--space-2xl)" : "var(--space-lg)",
+          overflow: "hidden",
+          boxSizing: "border-box",
+        }}
+      >
         <Bunting gap={size.buntingGap} />
 
         <div

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -1,0 +1,1055 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+import PraxisCard from "../../../components/PraxisCard";
+import { useFormFactor } from "../../../hooks/useFormFactor";
+import { factionCssVar, factionFill, factionName } from "../../../utils/factions";
+import { mediaUrl } from "../../../utils/media";
+import { isNeutralMultiplier } from "../../../utils/points";
+import { ErrorBanner, LevelJumpBanner, TaskDetailComments } from "./shared";
+import type { TaskDetailState } from "../useTaskDetail";
+
+/**
+ * Warriors of Whimsy — the task-detail page, NET-NEW (#1037).
+ *
+ * WOW had no desktop `taskDetail` archetype at all: `factions/wow.ts` registered
+ * `mobileTaskDetail` and nothing else, so until this file a WOW task rendered
+ * the **na dossier** on desktop. That is one of the four bullets in #951; the
+ * other three (`praxisDetail`, `factionCard`, `factionBody`) stay open.
+ *
+ * The dress, ported from `.design-sync/task-details-v2/wow-task-detail.jsx`:
+ * gold-and-plum parchment under a fine dot texture, bunting strung across the
+ * head of the page, a crossed-swords shield beside the faction line, a points
+ * plaque struck two degrees off true, wavy gold→plum rules dividing the
+ * sections, and a bundle of googly-eyed balloons whose pupils wiggle.
+ * MedievalSharp carries the display, Lora italic the quiet register — WOW's two
+ * faces (§3).
+ *
+ * ADR-0050 fixes this identity and the vendored design agrees with it for once:
+ * gold/plum/bunting/balloons is WOW; the pink candlelight and the pentagram ward
+ * are Coven's. Do not reconcile the two.
+ *
+ * Four contract points that are NOT this skin's to re-decide:
+ * - **No in-progress roster.** The header's "In progress" count is the only
+ *   place that population appears (owner ruling 2026-07-28, reversing epic
+ *   #1028 decision 3). The design's own header comment already says so.
+ * - **The `×mult` badge renders only off the identity factor.** `era_1`
+ *   neutralises every faction, so it is invisible today — correct (ADR-0055).
+ *   The factor arrives raw on the state contract; it is never reconstructed as
+ *   `modifiedPoints / basePoints` (ADR-0053's dead-arithmetic trap).
+ * - **Copy is the shared neutral `detail.*` catalog** (ADR-0057). The design
+ *   says "quest", "submissions", "highest scored"; every one of those is faction
+ *   voice and none of them ships. Dress is ours, words are not.
+ * - **The gallery mounts the live `<PraxisCard>`** in the shared
+ *   `flex flex-wrap gap-4`, not the design's `repeat(3,1fr)` grid of mock cards
+ *   (PraxisCard carries its own `flex: 1 1 394px` basis). The balloons therefore
+ *   live in this page's section dress, not inside thumbnails we do not own.
+ *
+ * ONE RESPONSIVE COMPONENT (ADR-0058): `useFormFactor()` picks the size set and
+ * drops the two-column split; `pages/taskDetail/mobileArchetypes/WowTaskDetail
+ * .tsx` and its `mobileTaskDetail` manifest row stay registered but DORMANT
+ * during the evaluation window — not deleted.
+ *
+ * Every colour is a shipped `--faction-wow-*` token; #1023's quest decree minted
+ * most of them and this page reuses them rather than growing a parallel set. The
+ * five it adds (the page field, its dot, the inner plate, the plum's edge and
+ * the page shadow) are delimited in `index.css` under the same heading as this
+ * file.
+ */
+
+const MED = "var(--faction-wow-card-font)"; /* MedievalSharp */
+const LORA = "var(--faction-wow-body-font)"; /* Lora */
+
+const INK = "var(--faction-wow-card-text)";
+const MUTED = "var(--faction-wow-card-muted)";
+/** Label ink. Olive-gold, the one measured to clear AA on BOTH grounds — the
+ *  cream card (5.32:1) and, unlike `--faction-wow-card-muted` (4.20:1), the
+ *  darker parchment field this page lays its headers straight onto. */
+const LABEL = "var(--faction-wow-accent-deep)";
+/** Plum as INK/ornament — flips with the theme. */
+const PLUM = "var(--faction-wow-card-accent)";
+/** Plum as a FILL — theme-invariant, 5.16:1 under `--faction-wow-on-plum`. */
+const PLUM_SURFACE = "var(--faction-wow-plum-surface)";
+const PLUM_EDGE = "var(--faction-wow-plum-edge)";
+const ON_PLUM = "var(--faction-wow-on-plum)";
+/** Frame + rule gold. Never an ink: 2.24:1 on the cream (§3). */
+const GOLD = "var(--faction-wow-chronicle-gold)";
+/** The burnt gold reserved for the total. 4.80:1 on the plaque. */
+const GILT = "var(--faction-wow-stamp-total)";
+const CARD = "var(--faction-wow-card-bg)";
+const PANEL = "var(--faction-wow-chronicle-panel)";
+const INSET = "var(--faction-wow-detail-inset)";
+const HAIR = "var(--faction-wow-chronicle-rule)";
+
+/**
+ * Praxis cards shown before the gallery expands. `PraxisCard` carries
+ * `flex: 1 1 394px`, so three land in a row at the 1200 cap and the row reflows
+ * on its own below that.
+ */
+const GALLERY_PREVIEW = 3;
+
+/** Pennants in the bunting strung across the head of the page. */
+const BUNTING_PENNANTS = 30;
+
+interface SizeSet {
+  /** The action plate's width. WOW's is 452 — dress, and deliberate. */
+  plate: number;
+  title: string;
+  sectionHead: string;
+  statBig: string;
+  stat: string;
+  plaqueTotal: string;
+  base: string;
+  cta: string;
+  /** Ornament geometry, exempt from the spacing scale (§4a). */
+  buntingGap: string;
+  panelPad: string;
+  boxPad: string;
+  sectionGap: string;
+}
+
+const SIZES: Record<"desktop" | "mobile", SizeSet> = {
+  desktop: {
+    plate: 452,
+    title: "var(--text-display)",
+    sectionHead: "var(--text-heading)",
+    statBig: "var(--text-heading)",
+    stat: "var(--text-title)",
+    plaqueTotal: "var(--text-display)",
+    base: "var(--text-title)",
+    cta: "var(--text-content)",
+    buntingGap: "var(--space-xl)",
+    panelPad: "var(--space-xl)",
+    boxPad: "var(--space-lg)",
+    sectionGap: "var(--space-2xl)",
+  },
+  mobile: {
+    plate: 452,
+    title: "var(--text-heading)",
+    sectionHead: "var(--text-title)",
+    statBig: "var(--text-title)",
+    stat: "var(--text-content)",
+    plaqueTotal: "var(--text-heading)",
+    base: "var(--text-content)",
+    cta: "var(--text-xl)",
+    buntingGap: "var(--space-lg)",
+    panelPad: "var(--space-lg)",
+    boxPad: "var(--space-md)",
+    sectionGap: "var(--space-xl)",
+  },
+};
+
+/** The decree's label voice — MedievalSharp small caps. */
+const EYEBROW: CSSProperties = {
+  fontFamily: MED,
+  fontSize: "var(--text-base)",
+  letterSpacing: "0.18em",
+  textTransform: "uppercase",
+};
+
+/** Lora italic, the faction's quiet register. */
+const QUIET: CSSProperties = {
+  fontFamily: LORA,
+  fontStyle: "italic",
+  lineHeight: 1.55,
+};
+
+/**
+ * The wavy gold→plum rule, stretched to whatever the flex row gives it. Built
+ * rather than written out: a `T`-chained quadratic of twenty segments is not a
+ * string anyone should maintain by hand, and `vectorEffect: non-scaling-stroke`
+ * is what keeps the line one weight however far it is stretched.
+ */
+const ZIG_PATH = (() => {
+  let path = "M0,4 Q3,1 6,4";
+  for (let x = 12; x <= 120; x += 6) path += ` T${x},4`;
+  return path;
+})();
+
+function Zig({ id, style }: { id: string; style?: CSSProperties }) {
+  const gradientId = `wow-detail-zig-${id}`;
+  return (
+    <span aria-hidden="true" style={{ display: "block", minWidth: 24, ...style }}>
+      <svg
+        width="100%"
+        height={8}
+        viewBox="0 0 120 8"
+        preserveAspectRatio="none"
+        style={{ display: "block", overflow: "visible" }}
+      >
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0" stopColor={GOLD} />
+            <stop offset="1" stopColor={PLUM} />
+          </linearGradient>
+        </defs>
+        <path
+          d={ZIG_PATH}
+          fill="none"
+          stroke={`url(#${gradientId})`}
+          strokeWidth="1.6"
+          vectorEffect="non-scaling-stroke"
+          strokeLinejoin="round"
+          strokeLinecap="round"
+          opacity="0.85"
+        />
+      </svg>
+    </span>
+  );
+}
+
+/** The star that leads every call to action. */
+function Star({ size, color }: { size: number; color: string }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      style={{ display: "block", flex: "0 0 auto" }}
+    >
+      <path
+        d="M12 1.5l3.1 6.6 7.2.9-5.3 5 1.4 7.1L12 17.8 5.6 21.1 7 14 1.7 9l7.2-.9L12 1.5z"
+        fill={color}
+      />
+    </svg>
+  );
+}
+
+/** The crossed-swords shield that marks the faction line. */
+function ShieldGlyph({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 20 20"
+      aria-hidden="true"
+      style={{ display: "block", flex: "0 0 auto" }}
+    >
+      <path
+        d="M4,5 H16 V11 Q16,16 10,18.5 Q4,16 4,11 Z"
+        fill={PLUM_SURFACE}
+        stroke={GILT}
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      <g stroke="var(--faction-wow-quest-blade)" strokeWidth="1.8" strokeLinecap="round">
+        <line x1="3.5" y1="16.8" x2="16.5" y2="3.6" />
+        <line x1="16.5" y1="16.8" x2="3.5" y2="3.6" />
+      </g>
+      <g fill={GILT}>
+        <circle cx="3.2" cy="17.3" r="1.1" />
+        <circle cx="16.8" cy="17.3" r="1.1" />
+      </g>
+    </svg>
+  );
+}
+
+/**
+ * One googly balloon on its string. The pupils travel on `.wow-balloon-eye`,
+ * the faction's existing reduced-motion-guarded wiggle, staggered per eye via
+ * `--wow-eye-delay` so no two in the bunch move together.
+ */
+function Balloon({
+  cx,
+  cy,
+  fill,
+  delay,
+}: {
+  cx: number;
+  cy: number;
+  fill: string;
+  delay: number;
+}) {
+  const eye = (offset: number, eyeDelay: number) => (
+    <>
+      <circle
+        cx={cx + offset}
+        cy={cy - 1}
+        r={2.4}
+        fill="var(--faction-wow-balloon-eye-white)"
+        stroke="var(--faction-wow-balloon-eye-ring)"
+        strokeWidth={0.8}
+      />
+      <circle
+        className="wow-balloon-eye"
+        cx={cx + offset}
+        cy={cy - 0.2}
+        r={1}
+        fill="var(--faction-wow-balloon-eye)"
+        style={{ "--wow-eye-delay": `${eyeDelay}s` } as CSSProperties}
+      />
+    </>
+  );
+  return (
+    <g>
+      <ellipse
+        cx={cx}
+        cy={cy}
+        rx={9}
+        ry={11}
+        fill={fill}
+        stroke="var(--faction-wow-balloon-outline)"
+        strokeWidth={1.2}
+      />
+      <path
+        d={`M${cx - 2},${cy + 10.3} L${cx + 2},${cy + 10.3} L${cx},${cy + 13.3} Z`}
+        fill={fill}
+        stroke="var(--faction-wow-balloon-outline)"
+        strokeWidth={1.1}
+        strokeLinejoin="round"
+      />
+      {eye(-3, delay)}
+      {eye(3, delay + 0.3)}
+    </g>
+  );
+}
+
+/**
+ * The bunch. The whole span bobs on `.wow-balloon-bunch`, which — like every
+ * other faction motion in the house — is a CLASS gated on
+ * `prefers-reduced-motion: no-preference`, never an inline `animation:` that
+ * would bypass the gate.
+ */
+function Balloons({ size }: { size: number }) {
+  return (
+    <span
+      className="wow-balloon-bunch"
+      aria-hidden="true"
+      style={{ display: "inline-block", flex: "0 0 auto", width: size, height: size * 1.25 }}
+    >
+      <svg width={size} height={size * 1.25} viewBox="0 0 44 56" style={{ display: "block" }}>
+        <g fill="none" stroke="var(--faction-wow-balloon-string)" strokeWidth={1}>
+          <path d="M12,28 Q16,41 22,51" />
+          <path d="M31,25 Q28,41 22,51" />
+          <path d="M22,36 Q23,44 22,51" />
+        </g>
+        <Balloon cx={12} cy={15} fill="var(--faction-wow-balloon-5)" delay={0} />
+        <Balloon cx={31} cy={12} fill="var(--faction-wow-balloon-5)" delay={0.2} />
+        <Balloon cx={22} cy={27} fill="var(--faction-wow-balloon-1)" delay={0.4} />
+        <circle cx={22} cy={51} r={1.6} fill={GILT} />
+      </svg>
+    </span>
+  );
+}
+
+/** Bunting strung across the head of the page. */
+function Bunting({ gap }: { gap: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        display: "flex",
+        alignItems: "flex-start",
+        gap: "var(--space-xs)",
+        height: 22,
+        overflow: "hidden",
+        opacity: 0.9,
+        marginBottom: gap,
+      }}
+    >
+      {Array.from({ length: BUNTING_PENNANTS }).map((_, index) => (
+        <span
+          key={index}
+          style={{
+            flex: 1,
+            minWidth: 0,
+            height: 0,
+            borderLeft: "7px solid transparent",
+            borderRight: "7px solid transparent",
+            borderTop: `18px solid ${index % 2 ? PLUM : GOLD}`,
+            transform: `translateY(${index % 2 ? 2 : 0}px)`,
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Initials fallback for an author with no uploaded avatar. */
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
+  const { t } = useTranslation("tasks");
+  const formFactor = useFormFactor();
+  const desktop = formFactor !== "mobile";
+  const size = SIZES[desktop ? "desktop" : "mobile"];
+  // The gallery expands IN PLACE. It deliberately does not link to
+  // `/praxes?task_id=N`: the praxis feed reads no such param, so that link has
+  // always dropped the filter and shown the whole feed (#1030 found it dead on
+  // every archetype).
+  const [showAllPraxis, setShowAllPraxis] = useState(false);
+  const {
+    task,
+    submissions,
+    mySubmission,
+    isInProgress,
+    inProgressPraxisId,
+    canSignUp,
+    levelJumpSignup,
+    slotsOpen,
+    maxTaskSlots,
+    basePoints,
+    factionMultiplier,
+    modifiedPoints,
+    inProgressCount,
+    sortedSubmissions,
+    submissionSort,
+    setSubmissionSort,
+    signupError,
+    handleSignup,
+    handleDrop,
+  } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!task) return null;
+
+  const slug = task.primary_faction_slug;
+  const isMetatask = task.task_type === "metatask";
+  const showMultiplier = !isNeutralMultiplier(factionMultiplier);
+  const authorName = task.created_by_display_name ?? "";
+  const hasAction =
+    canSignUp || !!mySubmission || (isInProgress && inProgressPraxisId !== null);
+
+  const framed: CSSProperties = {
+    background: CARD,
+    border: `2px solid ${GOLD}`,
+    borderRadius: 10,
+    boxSizing: "border-box",
+    boxShadow: "var(--faction-wow-detail-shadow)",
+  };
+  const innerBox: CSSProperties = {
+    background: INSET,
+    border: `1.5px solid ${HAIR}`,
+    borderRadius: 8,
+    padding: size.boxPad,
+    boxSizing: "border-box",
+  };
+  const divider = (
+    <span
+      aria-hidden
+      style={{ width: 1, alignSelf: "stretch", minHeight: 34, background: HAIR }}
+    />
+  );
+
+  /** MedievalSharp label, a wavy rule running out of it, an optional gloss. */
+  const sectionHead = (id: string, label: ReactNode, gloss?: ReactNode) => (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-md)",
+        marginBottom: "var(--space-md)",
+        flexWrap: "wrap",
+      }}
+    >
+      <span style={{ fontFamily: MED, fontSize: size.sectionHead, lineHeight: 1.08, color: INK }}>
+        {label}
+      </span>
+      <Zig id={id} style={{ flex: 1 }} />
+      {gloss !== undefined && (
+        <span style={{ ...EYEBROW, color: LABEL, flex: "0 0 auto" }}>{gloss}</span>
+      )}
+    </div>
+  );
+
+  // ── The worth: base, the (usually absent) ×mult chip, and the struck plaque ──
+  const worth = (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "var(--space-md)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "baseline",
+          justifyContent: "center",
+          gap: "var(--space-sm)",
+          flexWrap: "wrap",
+        }}
+      >
+        <span style={{ ...EYEBROW, color: LABEL }}>{t("detail.points.base")}</span>
+        <span style={{ fontFamily: MED, fontSize: size.base, lineHeight: 1, color: INK }}>
+          {basePoints}
+        </span>
+        {showMultiplier && (
+          <span
+            style={{
+              fontFamily: MED,
+              fontSize: "var(--text-lg)",
+              lineHeight: 1.3,
+              color: ON_PLUM,
+              background: PLUM_SURFACE,
+              border: `1.5px solid ${PLUM_EDGE}`,
+              borderRadius: 5,
+              padding: "var(--space-xs) var(--space-sm)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {t("detail.points.multiplier", { multiplier: factionMultiplier.toFixed(2) })}
+          </span>
+        )}
+      </div>
+
+      {/* The plaque, struck two degrees off true. */}
+      <div
+        style={{
+          position: "relative",
+          transform: "rotate(-2deg)",
+          background: PANEL,
+          border: `2px solid ${GOLD}`,
+          borderRadius: 6,
+          boxShadow: "2px 3px 0 var(--faction-wow-stamp-shadow)",
+          padding: "var(--space-md) var(--space-lg)",
+          textAlign: "center",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "center",
+            gap: "var(--space-xs)",
+          }}
+        >
+          <span
+            style={{ fontFamily: MED, fontSize: size.plaqueTotal, lineHeight: 0.8, color: GILT }}
+          >
+            {modifiedPoints}
+          </span>
+          {/* The ✦ is a dingbat, not text (§4) — the only reason it may be
+              painted in the gold, at 2.00:1 on the panel. */}
+          {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the faction glyph, sized to the numeral it trails. */}
+          <span aria-hidden="true" style={{ fontFamily: MED, fontSize: 15, color: GOLD }}>
+            ✦
+          </span>
+        </div>
+        <div
+          style={{
+            ...QUIET,
+            fontSize: "var(--text-md)",
+            color: PLUM,
+            marginTop: "var(--space-xs)",
+          }}
+        >
+          {t("detail.points.total")}
+        </div>
+      </div>
+    </div>
+  );
+
+  const ctaStyle = (ghost: boolean): CSSProperties => ({
+    display: "flex",
+    width: "100%",
+    boxSizing: "border-box",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "var(--space-sm)",
+    cursor: "pointer",
+    textAlign: "center",
+    textDecoration: "none",
+    fontFamily: MED,
+    fontSize: size.cta,
+    letterSpacing: "0.05em",
+    color: ghost ? PLUM : ON_PLUM,
+    background: ghost ? "transparent" : PLUM_SURFACE,
+    border: `2px solid ${ghost ? GOLD : PLUM_EDGE}`,
+    borderRadius: 7,
+    padding: desktop ? "var(--space-md) var(--space-lg)" : "var(--space-md)",
+  });
+
+  const quietNote: CSSProperties = {
+    ...QUIET,
+    fontSize: "var(--text-xl)",
+    color: MUTED,
+  };
+
+  // ── The one action slot. Nothing renders when the viewer has no move to make —
+  //    an unusable control is worse than none.
+  const actionBody = (
+    <>
+      {canSignUp && (
+        <div>
+          <LevelJumpBanner state={state} />
+          <button onClick={handleSignup} style={ctaStyle(false)}>
+            <Star size={13} color={ON_PLUM} />
+            {t("detail.signup.cta")}
+          </button>
+          <div style={{ ...quietNote, textAlign: "center", marginTop: "var(--space-sm)" }}>
+            {t("detail.signup.slots", { open: slotsOpen, max: maxTaskSlots })}
+            {!levelJumpSignup && (
+              <>
+                {" · "}
+                <span style={{ color: "var(--color-success)" }}>
+                  {t("detail.signup.levelMet", { level: task.level_required })}
+                </span>
+              </>
+            )}
+          </div>
+          <ErrorBanner message={signupError} />
+        </div>
+      )}
+
+      {mySubmission && (
+        <div>
+          <div
+            style={{
+              fontFamily: MED,
+              fontSize: size.sectionHead,
+              lineHeight: 1.08,
+              color: INK,
+              marginBottom: "var(--space-md)",
+            }}
+          >
+            {t("detail.submitted.text")}
+          </div>
+          <Link to={`/praxes/${mySubmission.id}/edit`} style={ctaStyle(true)}>
+            <Star size={13} color={GOLD} />
+            {t("detail.submitted.edit")}
+          </Link>
+        </div>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <div>
+          <div
+            style={{
+              fontFamily: MED,
+              fontSize: size.sectionHead,
+              lineHeight: 1.08,
+              color: INK,
+              marginBottom: "var(--space-md)",
+            }}
+          >
+            {t("detail.inProgress.text")}
+          </div>
+          <Link to={`/praxes/${inProgressPraxisId}/edit`} style={ctaStyle(true)}>
+            <Star size={13} color={GOLD} />
+            {t("detail.inProgress.continue")}
+          </Link>
+          <button
+            onClick={handleDrop}
+            style={{
+              ...quietNote,
+              display: "block",
+              width: "100%",
+              textAlign: "center",
+              marginTop: "var(--space-sm)",
+              background: "none",
+              border: "none",
+              cursor: "pointer",
+              padding: 0,
+            }}
+          >
+            {t("detail.inProgress.drop")}
+          </button>
+          <ErrorBanner message={signupError} />
+        </div>
+      )}
+    </>
+  );
+
+  // The action plate: 452px on desktop (WOW's own value; the set runs 420–520),
+  // full width once the column collapses.
+  const actionPlate = (
+    <div style={{ ...framed, position: "relative", overflow: "hidden", borderRadius: 11 }}>
+      <div aria-hidden style={{ height: 6, background: "var(--faction-wow-quest-ribbon)" }} />
+      <div
+        style={{
+          padding: "var(--space-md)",
+          display: "flex",
+          gap: "var(--space-md)",
+          alignItems: "stretch",
+        }}
+      >
+        <div
+          style={{
+            ...innerBox,
+            flex: "0 0 auto",
+            minWidth: desktop ? 176 : 132,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+          }}
+        >
+          {worth}
+        </div>
+        {hasAction && (
+          <div
+            style={{
+              ...innerBox,
+              flex: 1,
+              minWidth: 0,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+            }}
+          >
+            {actionBody}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  // ── Header: breadcrumb · shield + faction line · title · author · stats ──
+  const header = (
+    <div>
+      <nav
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-sm)",
+          marginBottom: "var(--space-md)",
+          flexWrap: "wrap",
+        }}
+      >
+        <Link to="/tasks" style={{ ...EYEBROW, color: PLUM, textDecoration: "none" }}>
+          {t("detail.breadcrumb.tasks")}
+        </Link>
+        <span aria-hidden style={{ ...EYEBROW, color: LABEL }}>
+          /
+        </span>
+        <span style={{ ...EYEBROW, color: LABEL }}>
+          {t("detail.breadcrumb.current", { number: task.id })}
+        </span>
+      </nav>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-sm)",
+          marginBottom: "var(--space-md)",
+          flexWrap: "wrap",
+        }}
+      >
+        <ShieldGlyph size={24} />
+        <span style={{ ...EYEBROW, fontSize: "var(--text-md)", color: LABEL }}>
+          {factionName(slug)}
+        </span>
+        {isMetatask && (
+          <span
+            style={{
+              ...EYEBROW,
+              fontSize: "var(--text-xs)",
+              letterSpacing: "0.15em",
+              padding: "var(--space-xs) var(--space-sm)",
+              borderRadius: 4,
+              // na → rainbow frame; a real faction → solid hue + on-fill ink.
+              ...factionFill(task.metatask_faction_slug, "pill"),
+            }}
+          >
+            {t("detail.meta")}
+          </span>
+        )}
+      </div>
+
+      <h1
+        style={{
+          fontFamily: MED,
+          fontWeight: 400,
+          fontSize: size.title,
+          lineHeight: 1.08,
+          margin: 0,
+          marginBottom: "var(--space-lg)",
+          color: INK,
+          overflowWrap: "anywhere",
+        }}
+      >
+        {task.title}
+      </h1>
+
+      {isMetatask && (
+        <p
+          style={{
+            ...QUIET,
+            fontSize: "var(--text-xl)",
+            margin: 0,
+            marginBottom: "var(--space-md)",
+            color: factionCssVar(task.metatask_faction_slug),
+          }}
+        >
+          {t("detail.metataskFor", { faction: factionName(task.metatask_faction_slug) })}
+        </p>
+      )}
+
+      {/* Author row — the proposing character's byline (#1029). */}
+      {authorName && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-md)",
+            marginBottom: "var(--space-lg)",
+            flexWrap: "wrap",
+          }}
+        >
+          <Link
+            to={`/characters/${task.created_by}`}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-sm)",
+              textDecoration: "none",
+            }}
+          >
+            {task.created_by_avatar_url ? (
+              <img
+                src={mediaUrl(task.created_by_avatar_url)}
+                alt={authorName}
+                style={{
+                  width: 30,
+                  height: 30,
+                  borderRadius: "50%",
+                  objectFit: "cover",
+                  flex: "none",
+                  border: `2px solid ${GOLD}`,
+                }}
+              />
+            ) : (
+              <span
+                aria-hidden
+                style={{
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  width: 30,
+                  height: 30,
+                  flex: "none",
+                  borderRadius: "50%",
+                  overflow: "hidden",
+                  fontFamily: MED,
+                  fontSize: "var(--text-lg)",
+                  background: CARD,
+                  border: `2px solid ${GOLD}`,
+                  color: PLUM,
+                }}
+              >
+                {initialsOf(authorName)}
+              </span>
+            )}
+            <span
+              style={{
+                fontFamily: MED,
+                fontSize: "var(--text-xl)",
+                color: INK,
+                borderBottom: `2px dotted ${PLUM}`,
+              }}
+            >
+              {authorName}
+            </span>
+          </Link>
+          <span style={{ ...EYEBROW, color: LABEL }}>
+            {t("detail.author", { level: task.created_by_level ?? 0 })}
+          </span>
+        </div>
+      )}
+
+      {/* Two stats. The completed count lives on the gallery heading, and there
+          is deliberately NO roster — the design's own header comment says the
+          in-progress count covers it. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: desktop ? "var(--space-xl)" : "var(--space-lg)",
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-xs)" }}>
+          <span style={{ ...EYEBROW, color: LABEL }}>{t("detail.stats.level")}</span>
+          <span style={{ fontFamily: MED, fontSize: size.statBig, lineHeight: 0.8, color: INK }}>
+            {task.level_required}
+          </span>
+        </div>
+        {divider}
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-xs)" }}>
+          <span style={{ ...EYEBROW, color: LABEL }}>{t("detail.stats.inProgress")}</span>
+          <span style={{ fontFamily: MED, fontSize: size.stat, lineHeight: 0.8, color: INK }}>
+            {inProgressCount}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+
+  // ── The brief, in full. No clamp, no "read more". ──
+  const brief = (
+    <section style={{ marginBottom: size.sectionGap }}>
+      {sectionHead("brief", t("detail.brief.heading"))}
+      <div style={{ ...framed, padding: size.panelPad }}>
+        {task.description && (
+          <p
+            className="content-text"
+            style={{
+              ...QUIET,
+              lineHeight: 1.65,
+              color: INK,
+              whiteSpace: "pre-wrap",
+              margin: 0,
+            }}
+          >
+            {task.description}
+          </p>
+        )}
+        <Zig id="brief-foot" style={{ marginTop: "var(--space-lg)" }} />
+      </div>
+    </section>
+  );
+
+  // ── The gallery. Live PraxisCards; the balloons are the section's dress. ──
+  const gallery = (
+    <section style={{ marginBottom: size.sectionGap }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-md)",
+          marginBottom: "var(--space-md)",
+          flexWrap: "wrap",
+        }}
+      >
+        <span
+          style={{ fontFamily: MED, fontSize: size.sectionHead, lineHeight: 1.08, color: INK }}
+        >
+          {t("detail.gallery.heading", { count: submissions.length })}
+        </span>
+        <Balloons size={34} />
+        <Zig id="gallery" style={{ flex: 1 }} />
+        <span
+          style={{
+            display: "flex",
+            gap: "var(--space-xs)",
+            padding: "var(--space-xs)",
+            border: `2px solid ${GOLD}`,
+            borderRadius: 8,
+            background: CARD,
+          }}
+        >
+          {(["score", "recent"] as const).map((sort) => (
+            <button
+              key={sort}
+              onClick={() => setSubmissionSort(sort)}
+              style={{
+                ...EYEBROW,
+                fontSize: "var(--text-sm)",
+                cursor: "pointer",
+                border: "none",
+                borderRadius: 6,
+                padding: "var(--space-sm) var(--space-md)",
+                color: submissionSort === sort ? ON_PLUM : LABEL,
+                background: submissionSort === sort ? PLUM_SURFACE : "transparent",
+              }}
+            >
+              {sort === "score"
+                ? t("detail.gallery.sort.top")
+                : t("detail.gallery.sort.recent")}
+            </button>
+          ))}
+        </span>
+      </div>
+
+      {sortedSubmissions.length === 0 ? (
+        <div
+          style={{
+            ...framed,
+            padding: size.panelPad,
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-lg)",
+          }}
+        >
+          <Balloons size={56} />
+          <p className="content-text" style={{ ...QUIET, color: MUTED, margin: 0 }}>
+            {t("detail.gallery.empty")}
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-wrap gap-4 items-start">
+            {(showAllPraxis
+              ? sortedSubmissions
+              : sortedSubmissions.slice(0, GALLERY_PREVIEW)
+            ).map((praxis) => (
+              <PraxisCard key={praxis.id} praxis={praxis} />
+            ))}
+          </div>
+          {submissions.length > GALLERY_PREVIEW && (
+            <button
+              onClick={() => setShowAllPraxis((shown) => !shown)}
+              style={{
+                display: "inline-block",
+                marginTop: "var(--space-md)",
+                padding: 0,
+                fontFamily: MED,
+                fontSize: "var(--text-content)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                color: PLUM,
+              }}
+            >
+              {showAllPraxis
+                ? t("detail.gallery.showFewer")
+                : t("detail.gallery.viewAll", { count: submissions.length })}
+            </button>
+          )}
+        </>
+      )}
+    </section>
+  );
+
+  return (
+    <div className="py-8" style={{ position: "relative" }}>
+      {/* The parchment field with its fine dot texture (index.css). */}
+      <div className="wow-detail-field" aria-hidden />
+
+      <div style={{ position: "relative", zIndex: 1, maxWidth: 1200, margin: "0 auto" }}>
+        <Bunting gap={size.buntingGap} />
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: desktop ? "row" : "column",
+            alignItems: desktop ? "flex-start" : "stretch",
+            gap: "var(--space-xl)",
+            marginBottom: size.sectionGap,
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+          <div
+            style={{
+              flex: desktop ? `0 0 ${size.plate}px` : "1 1 auto",
+              width: desktop ? size.plate : "100%",
+              marginTop: desktop ? "var(--space-sm)" : 0,
+            }}
+          >
+            {actionPlate}
+          </div>
+        </div>
+
+        <div style={{ minWidth: 0 }}>
+          {brief}
+          {gallery}
+          <TaskDetailComments
+            state={state}
+            heading={sectionHead("comments", t("detail.comments.heading"))}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -576,6 +576,17 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
     color: MUTED,
   };
 
+  /** The line above a CTA inside the plate. A tier below a section head — the
+   *  plate's text column is ~240px wide and a 32px MedievalSharp line breaks
+   *  three ways in it (the design sets this one at 24 for the same reason). */
+  const plateHeading: CSSProperties = {
+    fontFamily: MED,
+    fontSize: size.stat,
+    lineHeight: 1.08,
+    color: INK,
+    marginBottom: "var(--space-md)",
+  };
+
   // ── The one action slot. Nothing renders when the viewer has no move to make —
   //    an unusable control is worse than none.
   const actionBody = (
@@ -604,17 +615,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
 
       {mySubmission && (
         <div>
-          <div
-            style={{
-              fontFamily: MED,
-              fontSize: size.sectionHead,
-              lineHeight: 1.08,
-              color: INK,
-              marginBottom: "var(--space-md)",
-            }}
-          >
-            {t("detail.submitted.text")}
-          </div>
+          <div style={plateHeading}>{t("detail.submitted.text")}</div>
           <Link to={`/praxes/${mySubmission.id}/edit`} style={ctaStyle(true)}>
             <Star size={13} color={GOLD} />
             {t("detail.submitted.edit")}
@@ -624,17 +625,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
 
       {!mySubmission && isInProgress && inProgressPraxisId !== null && (
         <div>
-          <div
-            style={{
-              fontFamily: MED,
-              fontSize: size.sectionHead,
-              lineHeight: 1.08,
-              color: INK,
-              marginBottom: "var(--space-md)",
-            }}
-          >
-            {t("detail.inProgress.text")}
-          </div>
+          <div style={plateHeading}>{t("detail.inProgress.text")}</div>
           <Link to={`/praxes/${inProgressPraxisId}/edit`} style={ctaStyle(true)}>
             <Star size={13} color={GOLD} />
             {t("detail.inProgress.continue")}


### PR DESCRIPTION
Closes #1037

Part of #1028 (task details v2), wave C.

## This is the first time a WOW task ever renders a WOW detail page

WOW had **no** desktop `taskDetail` archetype. `factions/wow.ts` registered
`mobileTaskDetail` and nothing else, and `pages/taskDetail/archetypes/WowTaskDetail.tsx`
did not exist — so on desktop a Warriors of Whimsy task rendered the **na dossier**.
That is one of the four bullets in #951. This PR ships the archetype and the registry row,
and shrinks the #951 allowlist in both guard tests in the same commit.

**#951 stays open** for `praxisDetail`, `factionCard` and `factionBody`. I've commented
there saying which bullet is done.

## What shipped

- **New** `frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx` — one responsive
  component (`useFormFactor()`, ADR-0058), ported from
  `.design-sync/task-details-v2/wow-task-detail.jsx`. Gold-and-plum parchment under a fine
  dot texture, bunting across the head of the page, a crossed-swords shield on the faction
  line, a points plaque struck two degrees off true, wavy gold→plum rules, and a bunch of
  googly-eyed balloons. MedievalSharp display over Lora italic. Action plate **452px**,
  page cap **1200**.
- `frontend/src/factions/wow.ts` — the `taskDetail` row.
- `frontend/src/index.css` — one delimited `WOW — TASK DETAIL` block: **five** new tokens
  and two classes. Everything else is #1023's shipped `--faction-wow-*` vocabulary
  (ribbon, plaque shadow, blade, balloon ramp, eye parts, chronicle gold/panel/rule),
  reused rather than re-minted.
- `frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx` — 10 tests.
- `factions/__tests__/wowRendersDefault.test.tsx` + `factions/__tests__/surfaceDispatch.test.ts`
  — `taskDetail` moves out of both #951 pending lists and into `WOW_SKINNED`.

`pages/taskDetail/mobileArchetypes/WowTaskDetail.tsx` and its `mobileTaskDetail` row are
**untouched and still compiling** — dormant, not deleted (ADR-0058).

## New tokens (both themes, except one deliberately theme-invariant)

| Token | light | dark |
|---|---|---|
| `--faction-wow-detail-field` | `#efe6ce` | `#100c05` |
| `--faction-wow-detail-dot` | `rgba(74,56,10,.05)` | `rgba(227,184,74,.06)` |
| `--faction-wow-detail-inset` | `#f7eed8` | `#231b0c` |
| `--faction-wow-plum-edge` | `#5b3277` | *(theme-invariant — it edges the theme-invariant `--faction-wow-plum-surface`)* |
| `--faction-wow-detail-shadow` | `0 12px 30px -16px …` | `0 18px 44px -18px …` |

Plus `.wow-detail-field` (the page sheet, same shape as `.na-backdrop`) and
`.wow-balloon-bunch` + `@keyframes wow-balloon-bob`.

## Deviations from the vendored design — what it said, what shipped, why

**Forced by the epic's rules**

1. **No in-progress roster.** Owner ruling 2026-07-28 reversing epic decision 3. The
   design's own header comment already agreed (`no in-progress roster section — the
   header count covers it`), so this is not really a deviation from the *drawing*, only
   from the issue's original bullet.
2. **Every word is the shared neutral `detail.*` catalog** (ADR-0057). Cut: `The task`,
   `submissions`, `highest scored`, `newest`, `Comments`, `N notes`, `your points`,
   `X of Y spots open · level N and up`, and — the one flagged in the brief —
   **`You're on this quest`**, which is faction voice. It renders `You're on this task`.
   A test asserts the word "quest" never reaches the page.
3. **The praxis gallery mounts the live `<PraxisCard>`** in `flex flex-wrap gap-4`, not the
   design's `repeat(3,1fr)` grid of mock cards. Consequence: **the balloons moved.** The
   design put them inside praxis thumbnails, which this page does not own, so the bunch is
   now section dress — one at the gallery heading, a larger one in the empty state.
4. **Comments render via the shared `TaskDetailComments` slot** under a dressed WOW section
   head; the design's mock thread and its `Add a comment… / post` composer are not built
   (ADR-0006 — rows and composer stay author-themed).
5. **The multiplier badge only renders off ×1.00** and reads `factionMultiplier` raw off
   `useTaskDetail`, never `modifiedPoints / basePoints` (ADR-0053/ADR-0055). Invisible
   under `era_1`, which is correct.
6. **"View all" expands in place.** The design's `all N submissions →` becomes the shared
   `detail.gallery.viewAll` toggle; `/praxes?task_id=N` is dead on every archetype
   (`usePraxes` reads no such param) and a test pins that the link is gone.
7. **The design's third header stat (`completed`) is dropped** — the completed count lives
   on the gallery heading in the shared anatomy.
8. **No separate mobile chrome.** The design's mobile branch draws its own sticky back-bar
   with a `←`; that is app navigation, not a task-detail slot, so the mobile path is the
   same component with the column collapsed (ADR-0058, and the same call #901 made about
   the tab bar).

**Forced by contrast / tokens — three of the design's pairings did not survive measurement**

9. **Label ink is `--faction-wow-accent-deep`, not the design's `muted`.** On the *page
   field* (darker than the cream card) `--faction-wow-card-muted` measures **4.20:1** —
   under AA. `accent-deep` is **4.70:1 light / 9.49:1 dark**. Same walked-down olive-gold
   #860 landed on for the cards.
10. **The design's third text tier (`dim`, `#a79668`) is not shipped at all** — ~2.4:1 on
    its own page. Its lines fold into `card-muted` on a panel and `accent-deep` on the field.
11. **The CTA and the multiplier chip take `--faction-wow-plum-surface`, not `t.plum`.** In
    dark the design fills them with the *lifted* `#c79be0` under cream text — that is
    plum-as-ink used as a fill. `plum-surface` is 5.16:1 in both themes; index.css note 1
    by that declaration had already settled this for the task card.
12. **Frames stay `--faction-wow-chronicle-gold` in both themes.** The design dims its dark
    border to `#8a6a1f`; the shipped chronicle gold is theme-invariant on purpose (§3, "a
    metal-leaf frame does not brighten when the lights go out") and #1023's card already
    ships the undimmed frame — matching it beats matching the drawing.
13. **Hairlines are `--faction-wow-chronicle-rule`**, not the design's raw
    `rgba(138,109,31,.32)` / `rgba(199,155,224,.26)`.
14. **The bob is a class, not an inline `animation:`.** The design writes `animation:` into
    the balloon span's style object, which bypasses the reduced-motion gate. It is
    `.wow-balloon-bunch` behind `@media (prefers-reduced-motion: no-preference)`, and the
    pupils ride the faction's existing `.wow-balloon-eye` wiggle with the `--wow-eye-delay`
    stagger. A test asserts the markup contains no inline `animation:`.

**House conventions**

15. Sizes and spacing are `--text-*` / `--space-*` tokens, so the design's 27/23/15.5/13.5
    etc. land on tiers. One per-line ornament hatch: the dingbat trailing the plaque
    numeral (§4a's ornament-type carve-out, the same hatch #1023 used).
16. The plate's CTA heading is one tier below a section head — 32px MedievalSharp breaks
    three ways in the plate's ~240px text column. (The design sets this line at 24 for the
    same reason.)
17. The design's marks (`Zig`, the shield, the balloons) are **re-drawn locally** rather
    than imported from `WowTaskCard`, to keep this PR's footprint to one archetype file
    while #1023's card and the open WowVote-token PR are still in flight. Extracting a
    shared `wowQuest` vocabulary module is a reasonable follow-up; the tokens are already
    shared, only the ~90 lines of SVG are duplicated.

**ADR-0050 check:** I compared the vendored WOW and Coven designs specifically for the
inversion ADR-0050 records. `wow-task-detail.jsx` is gold-and-plum with bunting and
balloons; `coven-task-detail.jsx` is pink candlelight with a pentagram ward. **Correctly
assigned — no inversion this time**, and nothing in the vendored copy needed correcting.

## What to eyeball

- The **bunting** across the top: 30 pennants on a flex row, alternating gold/plum with
  every other one nudged 2px down. Check it doesn't collide with the `PageTitle` above it,
  and that it degrades sanely at narrow widths.
- The **plaque** at `rotate(-2deg)` inside the 452px plate — check the rotation doesn't
  clip against the inner box, and that a 4-digit points total still fits.
- **Balloon placement.** The bunch sits in the gallery heading row between the count and
  the wavy rule; check it reads as ornament and not as a broken image, and check the
  larger one in the empty state.
- **Dark mode**, all of it — especially the page field `#100c05` under the cream cards, and
  the balloon ramp (theme-invariant) against it.
- **Reduced motion**: the bunch should sit still and the pupils stop, with nothing
  disappearing.
- The **wavy gold→plum rules** stretching in flex rows (they use
  `vectorEffect="non-scaling-stroke"`, so stroke weight should stay constant).
- **Metatask** rendering — the META pill via `factionFill` and the "Metatask for X" line.
- The **multiplier badge is invisible today** (era_1 neutralises every faction). It is only
  visible in the test.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` **1738/1738 green** (108 files) ·
`vite build` green. I also grepped the **built** CSS to confirm the new tokens declare in
both `:root` and `[data-theme="dark"]`, and that `.wow-balloon-bunch` really sits nested
inside the `prefers-reduced-motion: no-preference` media query rather than being reparented
by the merge.

Fonts confirmed to resolve, not silently fall back: `--faction-wow-card-font` →
`--font-faction-medieval` → `"MedievalSharp", cursive`, and `--faction-wow-body-font` →
`--font-display` → `"Lora", Georgia, serif`; both faces (including Lora's italic axis) are
in `frontend/index.html`'s Google Fonts link.

**Visual QA is outstanding.** I cannot screenshot and there is no dev stack in this
environment, so none of the geometry above has been seen — a green build proves none of the
visual work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
