### PR TITLE
#1032: Ephemerists task detail — the Valley plate at page size

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2627,6 +2627,20 @@
     var(--faction-ephemerists-plate-page);
   transition: background 300ms;
 }
+/* The winged disc crowning the action panel (#1032). The design lifts the gold
+   off the papyrus with a hard night-blue offset plus a soft cast, and drops to a
+   plain soft cast on the dark plate where the hard edge would only smear. That
+   choice arrives here as a cascade rule rather than as the design's
+   `theme === 'dark' ? … : …` ternary in the component. */
+.eph-plate-crown {
+  filter:
+    drop-shadow(0 2px 0 var(--faction-ephemerists-plate-band))
+    drop-shadow(0 6px 14px rgba(30, 34, 51, 0.45));
+}
+[data-theme="dark"] .eph-plate-crown {
+  filter: drop-shadow(0 3px 7px rgba(0, 0, 0, 0.6));
+}
+
 [data-theme="dark"] .eph-plate-backdrop {
   background:
     radial-gradient(58% 40% at 50% 0%, rgba(201, 162, 75, 0.1), transparent 72%),

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2605,28 +2605,37 @@
   }
 }
 
-/* Ephemerists — the page ground under a page-sized Valley plate (task detail
-   v2, #1032). Sibling of `.na-backdrop`: a fixed full-bleed sheet the archetype
-   drops in behind its column, so the papyrus reaches the viewport edges instead
-   of stopping at the 1200 content cap.
+/* Ephemerists — the sheet a page-sized Valley plate is printed on (task detail
+   v2, #1032). The archetype's own content column wears it: this whole page IS
+   the plate, so the papyrus is the column's surface, not a tint under it.
 
-   Deliberately NOT `.eph-backdrop`, which is the illuminated-codex ground
+   NOT a fixed full-bleed backdrop, and that is the point. #1056 pulled that
+   pattern off the na build after live QA, and the layout says why: the routed
+   page sits inside a `position: relative; z-index: 5` wrapper, so a fixed
+   `z-index: 0` child of it is a POSITIONED descendant of that stacking context
+   and paints over the non-positioned sidebar beside it.
+
+   Deliberately NOT `.eph-backdrop` either — that is the illuminated-codex ground
    (`--eph-*`) every OTHER Ephemerists surface still paints on. The v2 plate is a
-   full metaphor swap (ADR-0055) and the two grounds must not be mistaken for
-   each other. The vignette is a corner-weighted darkening of the same papyrus,
-   kept off the reading column: quiet ink is measured against the flat page
-   value, and a wash that reached the text would invalidate that measurement. */
-.eph-plate-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
+   full metaphor swap (ADR-0055) and the two grounds must not be confused.
+
+   The wash only LIGHTENS (a gold bloom off the cornice) and never darkens. Both
+   inks this ground carries were walked down to a measured margin over the FLAT
+   page value, and a darkening vignette eats that margin exactly where the page
+   runs longest: `-nile` falls from 4.70 to 4.29 under a 5% black veil. That is
+   how a decorative gradient fails AA without anything reporting it. */
+.eph-plate-sheet {
   background:
     radial-gradient(58% 40% at 50% 0%, rgba(227, 197, 106, 0.16), transparent 72%),
-    radial-gradient(120% 90% at 50% 100%, transparent 62%, rgba(42, 32, 16, 0.14)),
     var(--faction-ephemerists-plate-page);
   transition: background 300ms;
 }
+[data-theme="dark"] .eph-plate-sheet {
+  background:
+    radial-gradient(58% 40% at 50% 0%, rgba(201, 162, 75, 0.1), transparent 72%),
+    var(--faction-ephemerists-plate-page);
+}
+
 /* The winged disc crowning the action panel (#1032). The design lifts the gold
    off the papyrus with a hard night-blue offset plus a soft cast, and drops to a
    plain soft cast on the dark plate where the hard edge would only smear. That
@@ -2639,13 +2648,6 @@
 }
 [data-theme="dark"] .eph-plate-crown {
   filter: drop-shadow(0 3px 7px rgba(0, 0, 0, 0.6));
-}
-
-[data-theme="dark"] .eph-plate-backdrop {
-  background:
-    radial-gradient(58% 40% at 50% 0%, rgba(201, 162, 75, 0.1), transparent 72%),
-    radial-gradient(120% 90% at 50% 100%, transparent 62%, rgba(0, 0, 0, 0.45)),
-    var(--faction-ephemerists-plate-page);
 }
 
 /* Coven — the spell slip's braid (#1023): a slender celtic thread with a gold

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -933,6 +933,31 @@
   --faction-ephemerists-plate-wash: linear-gradient(180deg, rgba(227, 197, 106, 0.24), transparent);
   --faction-ephemerists-plate-shadow: 0 18px 44px -26px rgba(42, 32, 16, 0.45);
 
+  /* ── THE VALLEY PLATE, page-sized (task detail v2, #1032) ──
+     The task card is one plate on the app's own page ground; task detail IS the
+     plate, so it needs a ground of its own, a second sheet for the panel cells,
+     and two hairline weights the card never had to name.
+
+     TWO VALUES ARE WALKED DOWN, for the same reason `-brass` became `-caption`
+     in the block above — the design's inks were measured against the plate, and
+     detail sets quiet type on the darker PAGE as well:
+       · design `faint` #9a8c6c → 2.43:1 on the plate. Unusable as an ink at any
+         size; there is no `-faint` token. Quiet type takes `-quiet` below.
+       · design `muted` #6b5f45 (`-plate-muted`) clears 4.60:1 on the plate but
+         only 4.31:1 on the page. `-quiet` is that same brown taken down until it
+         clears on ALL THREE grounds (page 5.25, plate 5.60, inner 6.20), so a
+         skin never has to know which sheet a label landed on.
+       · design `nile` #2e6e6a measures 4.34:1 on the plate / 4.24:1 on the page —
+         a near miss on the one hue that carries links and the "level met" yes.
+         Walked to #276460: page 4.70, plate 5.01, inner 5.55.
+     Dark needs no walk-down: the same roles clear 5.5–7.5 on the night plate. */
+  --faction-ephemerists-plate-page: #e4d5b0; /* the page ground under the plate */
+  --faction-ephemerists-plate-inner: #f2e7cb; /* the action panel's two cells */
+  --faction-ephemerists-plate-quiet: #5f5238; /* quiet ink — AA on all 3 grounds */
+  --faction-ephemerists-plate-nile: #276460; /* links, affirmations, the eye */
+  --faction-ephemerists-plate-rule: rgba(42, 36, 24, 0.1); /* journal ruling */
+  --faction-ephemerists-plate-line: rgba(42, 36, 24, 0.24); /* hairline borders */
+
   /* ══ Everymen — the rainbow's missing red (union/WW2 poster) ══
      Constants (cream/gold/ink) keep their role in both themes; the paper
      surface + its text FLIP in dark; accent red stays vivid; field is the
@@ -1449,6 +1474,13 @@
   --faction-ephemerists-plate-cta-ink: #12151f;
   --faction-ephemerists-plate-wash: none;
   --faction-ephemerists-plate-shadow: 0 20px 50px -26px rgba(0, 0, 0, 0.8);
+  /* Page-sized plate (#1032) — the night half of the block above. */
+  --faction-ephemerists-plate-page: #101320;
+  --faction-ephemerists-plate-inner: #1d2130;
+  --faction-ephemerists-plate-quiet: #a2977a;
+  --faction-ephemerists-plate-nile: #5fb3a6;
+  --faction-ephemerists-plate-rule: rgba(201, 162, 75, 0.12);
+  --faction-ephemerists-plate-line: rgba(201, 162, 75, 0.28);
 
   /* ── Warriors of Whimsy collage scrap layers (dark) ── */
   --faction-coven-scrap-deep: #091209;
@@ -2571,6 +2603,35 @@
     animation: epg-breathe 19s ease-in-out infinite;
     animation-delay: var(--epg-delay, 0s);
   }
+}
+
+/* Ephemerists — the page ground under a page-sized Valley plate (task detail
+   v2, #1032). Sibling of `.na-backdrop`: a fixed full-bleed sheet the archetype
+   drops in behind its column, so the papyrus reaches the viewport edges instead
+   of stopping at the 1200 content cap.
+
+   Deliberately NOT `.eph-backdrop`, which is the illuminated-codex ground
+   (`--eph-*`) every OTHER Ephemerists surface still paints on. The v2 plate is a
+   full metaphor swap (ADR-0055) and the two grounds must not be mistaken for
+   each other. The vignette is a corner-weighted darkening of the same papyrus,
+   kept off the reading column: quiet ink is measured against the flat page
+   value, and a wash that reached the text would invalidate that measurement. */
+.eph-plate-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(58% 40% at 50% 0%, rgba(227, 197, 106, 0.16), transparent 72%),
+    radial-gradient(120% 90% at 50% 100%, transparent 62%, rgba(42, 32, 16, 0.14)),
+    var(--faction-ephemerists-plate-page);
+  transition: background 300ms;
+}
+[data-theme="dark"] .eph-plate-backdrop {
+  background:
+    radial-gradient(58% 40% at 50% 0%, rgba(201, 162, 75, 0.1), transparent 72%),
+    radial-gradient(120% 90% at 50% 100%, transparent 62%, rgba(0, 0, 0, 0.45)),
+    var(--faction-ephemerists-plate-page);
 }
 
 /* Coven — the spell slip's braid (#1023): a slender celtic thread with a gold

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * The Ephemerists task detail — THE VALLEY PLATE (#1032).
+ *
+ * `archetypeSlots` already guards the content slots and `detailContract` the
+ * three shared decisions, for this skin along with every other. What is left,
+ * and what this file pins, is the stuff that is specific to rebuilding THIS
+ * archetype and that a green tsc/eslint/vitest would otherwise say nothing
+ * about:
+ *
+ *  1. The retired metaphor is actually gone. The 909-line "Discordant Map" and
+ *     its faction voice (`credence`, `ephemerides`, `commission`, `puncta`,
+ *     `triangulating`) were replaced, not wrapped — and ADR-0057 means none of
+ *     the DESIGN's words ("in full", "Bonus", "Ally"/"Rival") arrived either.
+ *  2. The Valley dress is present. A skin that rendered as unstyled boxes still
+ *     passes every slot test; the masthead band, the incised glyph registers and
+ *     the crowned panel leave stable markup hooks, so absence is detectable.
+ *  3. The roster stayed dead. The design BUILDS a full roster section — octagon
+ *     avatars, tally strokes, Ally/Rival tags, a "+N more players" row — and
+ *     never mounts it. Owner ruling 2026-07-28 cut it for every skin, so this is
+ *     the one place a future port-by-copying would reintroduce it.
+ *  4. Every `--faction-ephemerists-plate-*` token this skin paints with is
+ *     declared in BOTH themes. A token declared only in `:root` looks fine until
+ *     someone flips to dark, and nothing else we run compares the two blocks by
+ *     name.
+ *
+ * `sortedSubmissions` is left empty throughout: `<PraxisCard>` is the
+ * context-bound wrapper and this harness has no DOM and runs no effects (the
+ * gallery's own composition is guarded by factionCardSlots).
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import EphemeristsTaskDetail from "../archetypes/EphemeristsTaskDetail";
+import { surfaceMap } from "../../../factions";
+import { readThemes } from "../../../utils/__tests__/cssVars";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut, TaskSignupOut } from "../../../api/tasks";
+
+const TASK: TaskOut = {
+  id: 305,
+  title: "Catalogue every bench along the river walk",
+  description: "Walk the water from the lock to the last lamp.",
+  point_value: 30,
+  level_required: 4,
+  status: "active",
+  task_type: "standard",
+  created_by: 31,
+  primary_faction_slug: "ephemerists",
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  in_progress_count: 9,
+  created_by_display_name: "Wren Abalone",
+  created_by_faction_slug: "ephemerists",
+  created_by_level: 4,
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+const SIGNUP: TaskSignupOut = {
+  character_id: 88,
+  display_name: "Thessaly Vane",
+  avatar_url: "",
+  faction_slug: "ephemerists",
+  level: 6,
+  status: "in_progress",
+  signed_up_at: "2026-01-03T00:00:00Z",
+};
+
+function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    submissions: [],
+    signups: [],
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: true,
+    levelJumpSignup: false,
+    slotsOpen: 2,
+    maxTaskSlots: 3,
+    basePoints: 30,
+    factionMultiplier: 1.0,
+    modifiedPoints: 30,
+    inProgressCount: 9,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+  return { html, text: html.replace(/<[^>]*>/g, "") };
+}
+
+describe("Ephemerists task detail — the Valley plate", () => {
+  it("is what the manifest dispatches for the slug", () => {
+    expect(surfaceMap("taskDetail").ephemerists).toBe(EphemeristsTaskDetail);
+  });
+
+  it("speaks only the shared neutral copy", () => {
+    const { text } = render(<EphemeristsTaskDetail state={baseState()} />);
+    expect(text).toContain("Task Description");
+    expect(text).toContain("Discussion");
+    expect(text).toContain("Task №305");
+    // ADR-0057: the retired Discordant Map voice.
+    for (const retired of [
+      "credence",
+      "Ephemerides",
+      "Cartographers",
+      "Commission",
+      "puncta",
+      "triangulating",
+    ]) {
+      expect(text).not.toContain(retired);
+    }
+    // …and the design's own words, which are not authority either.
+    for (const invented of ["in full", "Bonus", "Ally", "Rival", "Say something"]) {
+      expect(text).not.toContain(invented);
+    }
+  });
+
+  it("wears the Valley dress — masthead band, incised registers, crowned panel", () => {
+    const { html, text } = render(<EphemeristsTaskDetail state={baseState()} />);
+    expect(html, "papyrus page ground").toContain("eph-plate-backdrop");
+    expect(html, "cornice masthead band").toContain("--faction-ephemerists-plate-band");
+    expect(html, "incised glyph registers").toContain("epg-glyph");
+    expect(html, "the disc crowning the action panel").toContain("eph-plate-crown");
+    expect(html, "the stepped octagon medallion").toContain("M30 4 L70 4 L96 30");
+    expect(text, "the masthead wordmark").toContain("The Ephemerists");
+    // The codex ground belongs to the OTHER Ephemerists surfaces now.
+    expect(html, "retired illuminated-codex ground").not.toContain("--eph-vellum");
+  });
+
+  it("renders no in-progress roster, only the header count", () => {
+    const { text } = render(
+      <EphemeristsTaskDetail state={baseState({ signups: [SIGNUP] })} />,
+    );
+    expect(text).not.toContain("Thessaly Vane");
+    expect(text).toContain("In progress");
+    expect(text).toContain("9");
+  });
+
+  it("hides the modifier row at the identity factor and shows it off it", () => {
+    const neutral = render(<EphemeristsTaskDetail state={baseState()} />);
+    expect(neutral.text).not.toContain("×");
+    expect(neutral.text, "the base is legible regardless").toContain("30");
+
+    const modified = render(
+      <EphemeristsTaskDetail
+        state={baseState({ factionMultiplier: 1.25, modifiedPoints: 38 })}
+      />,
+    );
+    expect(modified.text).toContain("×1.25");
+    expect(modified.text).toContain("38");
+  });
+
+  it("draws the brief in full — no clamp, no read-more", () => {
+    const long = "x".repeat(2000);
+    const { text } = render(
+      <EphemeristsTaskDetail
+        state={baseState({ task: { ...TASK, description: long } })}
+      />,
+    );
+    expect(text).toContain(long);
+  });
+
+  it("never links the gallery at the dead task_id filter", () => {
+    // `/praxes?task_id=N` drops the filter — `usePraxes` reads no such param —
+    // so the gallery expands in place instead (#1030's fix, inherited here).
+    const { html } = render(<EphemeristsTaskDetail state={baseState()} />);
+    expect(html).not.toContain("task_id=");
+  });
+});
+
+describe("the Valley plate's tokens", () => {
+  const themes = readThemes(
+    readFileSync(fileURLToPath(new URL("../../../index.css", import.meta.url)), "utf8"),
+  );
+  const source = readFileSync(
+    fileURLToPath(new URL("../archetypes/EphemeristsTaskDetail.tsx", import.meta.url)),
+    "utf8",
+  );
+  const referenced = [
+    ...new Set(source.match(/--faction-ephemerists-plate-[\w-]+/g) ?? []),
+  ];
+
+  it("names at least the whole plate family", () => {
+    expect(referenced.length).toBeGreaterThan(10);
+  });
+
+  for (const token of referenced) {
+    it(`${token} is declared in both themes`, () => {
+      expect(themes.light.has(token), "light / :root").toBe(true);
+      expect(themes.dark.has(token), '[data-theme="dark"]').toBe(true);
+    });
+  }
+});

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -137,7 +137,7 @@ describe("Ephemerists task detail — the Valley plate", () => {
 
   it("wears the Valley dress — masthead band, incised registers, crowned panel", () => {
     const { html, text } = render(<EphemeristsTaskDetail state={baseState()} />);
-    expect(html, "papyrus page ground").toContain("eph-plate-backdrop");
+    expect(html, "papyrus page sheet").toContain("eph-plate-sheet");
     expect(html, "cornice masthead band").toContain("--faction-ephemerists-plate-band");
     expect(html, "incised glyph registers").toContain("epg-glyph");
     expect(html, "the disc crowning the action panel").toContain("eph-plate-crown");

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -1,303 +1,444 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { Trans, useTranslation } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/PraxisCard";
+import { useFormFactor } from "../../../hooks/useFormFactor";
+import { factionCssVar, factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
-import { factionName } from "../../../utils/factions";
-import { EphemeristsSigil, Foxing, LapisLastWord } from "../../../components/cards/ephemeristsAtoms";
-import { ErrorBanner, LevelJumpBanner, TaskDetailComments, relationOf } from "./shared";
-import type { TaskSignupOut } from "../../../api/tasks";
+import { isNeutralMultiplier } from "../../../utils/points";
+import { ErrorBanner, LevelJumpBanner, TaskDetailComments } from "./shared";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
- * The Ephemerists task-detail archetype — the job rendered as a DISCORDANT MAP /
- * illuminated codex exhibit: a contested coordinate field on vellum, a Cinzel
- * title with one word pulled to lapis, the commission (brief), sealed
- * ephemerides (completions, the most-canonical wearing a fleur-de-lis), and a
- * read-only credence line in the faction's voice. Ported from the Ephemerists
- * design kit (EphemeristsTaskDetail.tsx); wired to the real
- * {@link TaskDetailState}. Reads only --eph-* / --faction-ephemerists-* tokens.
+ * The Ephemerists task detail — THE VALLEY PLATE at page size (task detail v2,
+ * #1032, design `.design-sync/task-details-v2/ephemerists-task-detail.jsx`).
  *
- * Decorative / not backend-backed (marked inline): the "commission no." (derived
- * from task.id) and the vellum coordinate diagram glyphs.
+ * Deco × Egypt, the same metaphor the v2 task card ships (#1023): a papyrus
+ * field journal out of the Valley. A cavetto-cornice masthead whose night band
+ * holds a winged sun disc between two incised registers of glyphs; the task
+ * number in a cartouche; the level a numeral over tally strokes; the worth on a
+ * stepped octagon medallion inside a panel crowned by a second winged disc; the
+ * brief on a ruled leaf with a red margin rule. Poiret One display, Cinzel small
+ * caps, Spectral reading.
+ *
+ * This REPLACES "The Discordant Map" — the 909-line illuminated-codex archetype
+ * built on `credenceHeading` / `ephemeridesHeading` / `cartographersHeading` /
+ * `commissionHeading` / `puncta` / `triangulating` and the coordinate diagram.
+ * A full metaphor swap (ADR-0055/0056); the `--eph-*` codex family stays
+ * declared because every OTHER Ephemerists surface still paints with it.
+ *
+ * Contract points inherited from the na reference build (#1030) — reasoning
+ * lives in `DefaultTaskDetail` and is not re-derived here:
+ * - **No in-progress roster.** The header count is the only place that
+ *   population appears (owner ruling 2026-07-28, reversing epic #1028 decision
+ *   3). The design builds a whole roster section — octagon avatars, tally
+ *   strokes, Ally/Rival tags, a "+N more players" row — and never mounts it in
+ *   either layout. That is dead code, deliberately not ported.
+ * - **The `×mult` row only renders off the identity factor**, read raw from the
+ *   state contract, never reconstructed as `modifiedPoints / basePoints`
+ *   (ADR-0053's dead-arithmetic trap). `era_1` neutralises every faction, so the
+ *   ledger's modifier row is correctly invisible today. The design draws a
+ *   `Bonus ×1.00` row unconditionally; here it hides at 1.0 like every other
+ *   skin's badge (ADR-0055).
+ * - **Copy is the shared neutral `detail.*` set** (ADR-0057). None of the
+ *   design's words survive, and none of the retired faction voice does either.
+ * - **The gallery expands in place.** `/praxes?task_id=N` has never filtered —
+ *   `usePraxes` reads no such param — so "view all" is a local expand.
+ *
+ * ONE RESPONSIVE COMPONENT (ADR-0058): `useFormFactor()` picks the size set and
+ * collapses the two-column split. `pages/taskDetail/mobileArchetypes/
+ * EphemeristsTaskDetail.tsx` and its `mobileTaskDetail` manifest row stay
+ * registered but DORMANT — restoring the dispatcher branch is the whole revert.
+ *
+ * Every colour is a `--faction-ephemerists-plate-*` token; light/dark flips
+ * through the `[data-theme="dark"]` cascade, never a ternary. `-brass` is a rule
+ * colour and never an ink; quiet type takes `-quiet`, which clears AA on the
+ * page, the plate AND the panel cells (see index.css).
  */
 
-const INK = "var(--eph-ink)";
-const VELLUM_TEXT = "var(--eph-vellum-text)";
-const MUTED = "var(--eph-muted)";
+/** Poiret One — the v2 display face. NOT `--faction-ephemerists-card-font`
+ *  (Cinzel), which is the codex's display token a dozen surfaces still read. */
+const DECO = "var(--font-faction-deco)";
+const CAPS = "var(--font-faction-engraved)"; /* Cinzel */
+const READING = "var(--font-faction-spectral)"; /* Spectral */
 
-/** Section header — a Cinzel label with a gold rule trailing off to nothing. */
-function SectionHead({
-  title,
-  gloss,
-}: {
-  title: string;
-  gloss?: string;
+const PLATE = "var(--faction-ephemerists-plate-bg)";
+const INNER = "var(--faction-ephemerists-plate-inner)";
+const INK = "var(--faction-ephemerists-plate-ink)";
+const QUIET = "var(--faction-ephemerists-plate-quiet)";
+const CAPTION = "var(--faction-ephemerists-plate-caption)";
+const BRASS = "var(--faction-ephemerists-plate-brass)";
+const BRASS_LIGHT = "var(--faction-ephemerists-plate-brass-light)";
+const GOLD = "var(--faction-ephemerists-plate-gold)";
+const BAND = "var(--faction-ephemerists-plate-band)";
+const BAND_INK = "var(--faction-ephemerists-plate-band-ink)";
+const DISC = "var(--faction-ephemerists-plate-disc)";
+const OCHRE = "var(--faction-ephemerists-plate-ochre)";
+const NILE = "var(--faction-ephemerists-plate-nile)";
+const CTA_BG = "var(--faction-ephemerists-plate-cta-bg)";
+const CTA_INK = "var(--faction-ephemerists-plate-cta-ink)";
+const RULE = "var(--faction-ephemerists-plate-rule)";
+const LINE = "var(--faction-ephemerists-plate-line)";
+const SHADOW = "var(--faction-ephemerists-plate-shadow)";
+const WASH = "var(--faction-ephemerists-plate-wash)";
+
+/**
+ * Praxis cards shown before the gallery expands. `PraxisCard` carries
+ * `flex: 1 1 394px`, so three land in one row at the 1200 cap and the row
+ * rewraps on its own — never the design's `repeat(3,1fr)`, which would squeeze
+ * every card instead.
+ */
+const GALLERY_PREVIEW = 3;
+
+/**
+ * The brief's leading, in px, and the pitch of the journal ruling under it.
+ * These are ONE number by construction: a ruled leaf whose rules miss the text's
+ * baselines reads as a printing error rather than as stationery. The design's 28
+ * was drawn for 15.5px type; `--text-content` is 18px (the #627 floor), so the
+ * ruling opens to match rather than the type closing to fit.
+ */
+const BRIEF_LEADING = 32;
+
+/**
+ * The glyph library — Egyptian signs beside later-era marks, drawn as deco
+ * geometry on a 24-unit square, stroke-only so they read as incised rather than
+ * illustrated.
+ *
+ * Duplicated from `components/cards/EphemeristsTaskCard.tsx`, which owns the
+ * same set for the card. Deliberate under this issue's two-file scope; the
+ * extraction target is `components/cards/ephemeristsAtoms.tsx`, and until the
+ * two are merged a change to one sign has to be made twice.
+ */
+const GLYPHS: Record<string, string> = {
+  ankh: "M12 22 V10 M6 15 H18 M12 10 a4 4 0 1 0 0.001 0 Z",
+  eye: "M3 12 C7 7 17 7 21 12 C17 16 7 16 3 12 M12 10.2 a1.8 1.8 0 1 0 .01 0 Z M15 15 L18 20 M8 15 L5 19",
+  feather: "M12 22 V4 M12 6 C15 7 17 10 17 13 M12 6 C9 7 7 10 7 13 M12 12 C14.6 12.8 16 14.6 16 17 M12 12 C9.4 12.8 8 14.6 8 17",
+  water: "M2 9 l4 3 4-3 4 3 4-3 4 3 M2 15 l4 3 4-3 4 3 4-3 4 3",
+  djed: "M12 22 V8 M6 8 H18 M6 12 H18 M7.5 4.6 H16.5 M9 2 H15",
+  reed: "M12 22 V7 C12 4 14 2.6 17 2.6 C17 6 15 7.4 12 7.4",
+  sun: "M12 12 a5 5 0 1 0 .01 0 Z M12 3 V6 M12 18 V21 M3 12 H6 M18 12 H21",
+  offering: "M4 8 H20 M6 8 V14 H18 V8 M9 14 V20 M15 14 V20 M4 20 H20",
+  scarab: "M12 4 C15.5 4 17.5 7 17.5 11 C17.5 16.6 15 20 12 20 C9 20 6.5 16.6 6.5 11 C6.5 7 8.5 4 12 4 M12 4 V20 M6.5 9 L2.5 6 M17.5 9 L21.5 6 M6.5 15 L2.5 18 M17.5 15 L21.5 18",
+  greekKey: "M2 20 V6 H16 V16 H8 V11 H12", // meander — Greek, c. 700 BC
+  chevrons: "M3 8 L12 3 L21 8 M3 14 L12 9 L21 14 M3 20 L12 15 L21 20", // deco, 1925
+  alchemy: "M12 3 L21 19 H3 Z M6.6 13.6 H17.4", // alchemical fire — medieval
+  hourglass: "M5 3 H19 M5 21 H19 M6.5 3 L12 12 L6.5 21 M17.5 3 L12 12 L17.5 21",
+  openEye: "M2 12 C6 5.4 18 5.4 22 12 M2 12 C6 18.6 18 18.6 22 12 M8.4 12 a3.6 3.6 0 1 0 7.2 0 a3.6 3.6 0 1 0 -7.2 0 M10.7 12 a1.3 1.3 0 1 0 2.6 0 a1.3 1.3 0 1 0 -2.6 0 M12 2.8 V5 M5 4.6 L6.8 6.6 M19 4.6 L17.2 6.6",
+  planet: "M5.8 12 a6.2 6.2 0 1 0 12.4 0 a6.2 6.2 0 1 0 -12.4 0 M1.8 16.2 A10.8 3.7 -22 0 1 22.2 7.8 A10.8 3.7 -22 0 1 1.8 16.2", // Saturn
+};
+
+/** The order the signs march in — the design's own register. */
+const REGISTER = [
+  "ankh", "water", "feather", "eye", "djed", "greekKey", "reed", "offering",
+  "alchemy", "chevrons", "scarab", "sun", "ankh", "water", "djed", "eye",
+];
+
+/** Distance between two signs in a register, in viewBox units. */
+const GLYPH_PITCH = 27.5;
+const GLYPH_SIZE = 13;
+
+/** Incised small caps — the plate's whole label voice. */
+const SMALL_CAPS: CSSProperties = {
+  fontFamily: CAPS,
+  fontWeight: 500,
+  letterSpacing: "0.24em",
+  textTransform: "uppercase",
+};
+
+/** One incised sign, at its own strength and its own phase in the cycle. */
+function Glyph({ name, x, y, strength, delay }: {
+  name: string
+  x: number
+  y: number
+  strength: number
+  delay: number
 }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: "var(--space-lg)", marginBottom: "var(--space-lg)" }}>
-      <h2
-        className="content-title"
-        style={{
-          fontFamily: "var(--eph-display)",
-          fontWeight: 600,
-          letterSpacing: "0.1em",
-          margin: 0,
-          color: VELLUM_TEXT,
-          whiteSpace: "nowrap",
-        }}
-      >
-        {title}
-      </h2>
-      <span
-        style={{
-          flex: 1,
-          height: 1,
-          background: "linear-gradient(90deg, var(--eph-gold), transparent)",
-        }}
+    <g
+      className="epg-glyph"
+      transform={`translate(${x} ${y}) scale(${GLYPH_SIZE / 24}) translate(-12 -12)`}
+      style={{ ["--epg-op"]: strength, ["--epg-delay"]: `${delay}s` } as CSSProperties}
+    >
+      <path
+        d={GLYPHS[name]}
+        fill="none"
+        stroke={GOLD}
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
-      {gloss && (
-        <span
-          style={{
-            fontFamily: "var(--eph-script)",
-            fontStyle: "italic",
-            fontSize: "var(--text-lg)",
-            color: MUTED,
-          }}
-        >
-          {gloss}
-        </span>
-      )}
+    </g>
+  );
+}
+
+/**
+ * A register of signs marching the full width of the band. The count follows the
+ * viewBox rather than the design's fixed 16: the masthead is page-wide here (up
+ * to the 1200 cap) and a fixed count would either stop short of the edge or,
+ * under `slice`, blow every sign up to a cartoon.
+ */
+function GlyphRegister({ width, y, strength, keyPrefix }: {
+  width: number
+  y: number
+  strength: number
+  keyPrefix: string
+}) {
+  const count = Math.ceil(width / GLYPH_PITCH);
+  return (
+    <>
+      {Array.from({ length: count }).map((_, index) => (
+        <Glyph
+          key={`${keyPrefix}${index}`}
+          name={REGISTER[index % REGISTER.length]}
+          x={18 + index * GLYPH_PITCH}
+          y={y}
+          strength={strength * (index % 3 === 0 ? 1 : 0.7)}
+          delay={((index * 7) % 12) * 1.6}
+        />
+      ))}
+    </>
+  );
+}
+
+/** One wing of the sun disc, drawn as deco stepped bars. */
+function Wing({ flip }: { flip?: boolean }) {
+  return (
+    <g transform={flip ? "scale(-1,1)" : undefined}>
+      {[0, 1, 2, 3, 4].map((i) => (
+        <rect
+          key={i}
+          x={13 + i * 11.4}
+          y={-6 + i * 1.5}
+          width={9.6}
+          height={8.4 - i * 1.4}
+          rx={1.4}
+          fill={GOLD}
+          opacity={0.9 - i * 0.13}
+        />
+      ))}
+      {[0, 1, 2, 3].map((i) => (
+        <rect
+          key={`covert-${i}`}
+          x={15 + i * 11.4}
+          y={4.2 + i * 1.6}
+          width={8}
+          height={3.4 - i * 0.5}
+          rx={1}
+          fill={BRASS_LIGHT}
+          opacity={0.62 - i * 0.11}
+        />
+      ))}
+    </g>
+  );
+}
+
+/** The winged sun disc, at whatever width it is asked for. */
+function WingedDisc({ width, height, className }: {
+  width: number
+  height: number
+  className?: string
+}) {
+  return (
+    <svg
+      className={className}
+      width={width}
+      height={height}
+      viewBox="-88 -20 176 40"
+      aria-hidden="true"
+      style={{ display: "block", flex: "0 0 auto" }}
+    >
+      <Wing />
+      <Wing flip />
+      <circle r={11} fill={DISC} stroke={BRASS} strokeWidth="1.6" />
+      <circle r={5.5} fill={GOLD} opacity={0.85} />
+    </svg>
+  );
+}
+
+/** A stepped octagon, inset from the medallion's edge. */
+function Octagon({ inset, stroke, width, fill }: {
+  inset: number
+  stroke: string
+  width: number
+  fill?: string
+}) {
+  return (
+    <path
+      d="M30 4 L70 4 L96 30 L96 70 L70 96 L30 96 L4 70 L4 30 Z"
+      fill={fill ?? "none"}
+      stroke={stroke}
+      strokeWidth={width}
+      transform={`translate(50,50) scale(${(100 - inset * 2) / 100}) translate(-50,-50)`}
+    />
+  );
+}
+
+/** The cavetto cornice: fluted strokes under a stepped double rule. */
+function Cornice() {
+  return (
+    <div aria-hidden="true" style={{ position: "relative", zIndex: 3, background: BAND }}>
+      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the lead between cornice flutes; rounding it to a rung reflows the fluting. */}
+      <div style={{ display: "flex", height: 7, alignItems: "flex-end", gap: 3, padding: "0 var(--space-sm)", overflow: "hidden" }}>
+        {Array.from({ length: 52 }).map((_, i) => (
+          <span
+            key={i}
+            style={{ flex: 1, height: i % 2 ? 6 : 3.5, background: BRASS_LIGHT, opacity: i % 2 ? 0.5 : 0.28 }}
+          />
+        ))}
+      </div>
+      <div style={{ height: 2, background: BRASS, opacity: 0.9 }} />
+      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the gap in the cornice's stepped double rule. */}
+      <div style={{ height: 1, marginTop: 2, background: BRASS_LIGHT, opacity: 0.55 }} />
     </div>
   );
 }
 
-/** The contested coordinate field — a vellum cartographic exhibit with three
- *  irreconcilable readings (cartesian grid, perspective rays, polar rings). */
-function DiscordantMap() {
-  const { t } = useTranslation("tasks");
+/** The cavetto band reused as a divider — the rule under every section head. */
+function FlutedRule() {
   return (
     <div
-      style={{
-        position: "relative",
-        minHeight: 320,
-        borderRight: "1px solid var(--eph-gold-deep)",
-        overflow: "hidden",
-        background: "var(--eph-vellum)",
-      }}
+      aria-hidden="true"
+      // eslint-disable-next-line local/no-raw-style-values -- ornament: the lead between the fluted rule's strokes.
+      style={{ display: "flex", alignItems: "flex-start", gap: 3, height: 7, overflow: "hidden" }}
     >
-      {/* cartesian grid */}
-      <div
-        style={{
-          position: "absolute",
-          inset: 0,
-          opacity: 0.5,
-          backgroundImage:
-            "repeating-linear-gradient(0deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 18px), repeating-linear-gradient(90deg, color-mix(in srgb, var(--eph-vellum-text) 26%, transparent) 0 1px, transparent 1px 18px)",
-        }}
-      />
-      {/* perspective vanishing rays (lapis) */}
-      <svg
-        viewBox="0 0 300 320"
-        preserveAspectRatio="none"
-        style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.7 }}
-        aria-hidden="true"
-      >
-        <g stroke="var(--eph-lapis)" strokeWidth="0.9" fill="none">
-          {[0, 40, 80, 120, 160, 200, 240, 280].map((x) => (
-            <line key={x} x1={x} y1="320" x2="185" y2="70" />
-          ))}
-          {[110, 160, 210, 250].map((y) => (
-            <line key={y} x1="0" y1={y} x2="300" y2={y} />
-          ))}
-        </g>
-      </svg>
-      {/* polar reading (rubric) */}
-      <svg
-        viewBox="0 0 300 320"
-        style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.72 }}
-        aria-hidden="true"
-      >
-        <g stroke="var(--eph-rubric)" strokeWidth="0.8" fill="none">
-          {[28, 58, 92, 128].map((r) => (
-            <circle key={r} cx="185" cy="150" r={r} />
-          ))}
-          {Array.from({ length: 8 }).map((_, i) => (
-            <line
-              key={i}
-              x1="185"
-              y1="150"
-              x2={185 + 130 * Math.cos((i * Math.PI) / 4)}
-              y2={150 + 130 * Math.sin((i * Math.PI) / 4)}
-            />
-          ))}
-        </g>
-      </svg>
-      {/* the contested point — a gold-leaf glimmer */}
-      <div
-        style={{
-          position: "absolute",
-          left: "62%",
-          top: "47%",
-          transform: "translate(-50%,-50%)",
-          width: 11,
-          height: 11,
-          borderRadius: "50%",
-          background: "var(--eph-gold-light)",
-          boxShadow: "0 0 14px 4px color-mix(in srgb, var(--eph-gold-light) 70%, transparent)",
-        }}
-      />
-      {/* decorative coordinate marginalia — not backend-backed */}
-      <div
-        style={{
-          position: "absolute",
-          top: "8%",
-          left: "6%",
-          fontSize: "var(--text-sm)",
-          color: VELLUM_TEXT,
-          background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)",
-          padding: "var(--space-xs) var(--space-xs)",
-        }}
-      >
-        {t("ephemerists.diagram.coordXPrefix")}<span style={{ textDecoration: "line-through", opacity: 0.65 }}>8</span>{" "}
-        <span style={{ color: "var(--eph-lapis)", fontStyle: "italic" }}>9</span>
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          top: "74%",
-          left: "50%",
-          fontSize: "var(--text-sm)",
-          color: "var(--eph-rubric)",
-          background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)",
-          padding: "var(--space-xs) var(--space-xs)",
-        }}
-      >
-        {t("ephemerists.diagram.coordPolar")}
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          top: "5%",
-          left: "62%",
-          fontSize: "var(--text-sm)",
-          color: "var(--eph-lapis)",
-          background: "color-mix(in srgb, var(--eph-vellum) 82%, transparent)",
-          padding: "var(--space-xs) var(--space-xs)",
-        }}
-      >
-        {t("ephemerists.diagram.coordVanishing")}
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          left: 4,
-          bottom: 8,
-          transformOrigin: "left bottom",
-          transform: "rotate(-90deg)",
-          whiteSpace: "nowrap",
-          fontSize: "var(--text-xs)",
-          color: MUTED,
-          opacity: 0.85,
-        }}
-      >
-        {t("ephemerists.diagram.widthNote")}
-      </div>
+      {Array.from({ length: 48 }).map((_, i) => (
+        <span
+          key={i}
+          style={{ flex: 1, height: i % 2 ? 7 : 4, background: BRASS, opacity: i % 2 ? 0.5 : 0.28 }}
+        />
+      ))}
     </div>
   );
 }
 
-/** Marginalia of cartographers — real signup avatars on the vellum margin,
- *  each linking to its character, friend/foe noted in the surveyor's voice. */
-function SurveyorRow({
-  signups,
-  friends,
-  foes,
-}: {
-  signups: TaskSignupOut[];
-  friends: Set<number>;
-  foes: Set<number>;
-}) {
-  const { t } = useTranslation("tasks");
+/** The level, struck as tally marks — every fifth stroke in ochre. */
+function Tally({ level }: { level: number }) {
+  const strokes = Math.min(9, Math.max(1, Math.round(level)));
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", flexWrap: "wrap" }}>
-      {signups.map((m) => {
-        const rel = relationOf(m.character_id, friends, foes);
-        const relColor = rel === "friend" ? "var(--eph-lapis)" : "var(--eph-rubric)";
-        return (
-          <Link
-            key={m.character_id}
-            to={`/characters/${m.character_id}`}
-            title={`${m.display_name}${rel ? ` · ${rel}` : ""}`}
-            style={{
-              position: "relative",
-              width: 38,
-              height: 38,
-              flexShrink: 0,
-              textDecoration: "none",
-            }}
-          >
-            {m.avatar_url ? (
-              <img
-                src={mediaUrl(m.avatar_url)}
-                alt={m.display_name}
-                style={{
-                  width: 38,
-                  height: 38,
-                  borderRadius: "50%",
-                  objectFit: "cover",
-                  border: "1.5px solid var(--eph-gold-deep)",
-                }}
-              />
-            ) : (
-              <span
-                style={{
-                  display: "flex",
-                  width: 38,
-                  height: 38,
-                  borderRadius: "50%",
-                  background: "var(--eph-vellum-deep)",
-                  border: "1.5px solid var(--eph-gold-deep)",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  color: "var(--eph-rubric)",
-                  fontFamily: "var(--eph-display)",
-                  fontSize: "var(--text-xl)",
-                }}
-              >
-                {m.display_name[0]?.toUpperCase()}
-              </span>
-            )}
-            {rel && (
-              <span
-                title={rel}
-                style={{
-                  position: "absolute",
-                  right: -2,
-                  bottom: -2,
-                  width: 11,
-                  height: 11,
-                  borderRadius: "50%",
-                  background: relColor,
-                  border: "1.5px solid var(--eph-vellum)",
-                }}
-              />
-            )}
-          </Link>
-        );
-      })}
-      <span
-        style={{
-          fontFamily: "var(--eph-script)",
-          fontStyle: "italic",
-          fontSize: "var(--text-lg)",
-          color: MUTED,
-          marginLeft: "var(--space-xs)",
-        }}
-      >
-        {t("ephemerists.triangulating")}
-      </span>
-    </div>
+    // eslint-disable-next-line local/no-raw-style-values -- ornament: the pitch of the tally strokes, drawn 1.6px wide.
+    <span aria-hidden="true" style={{ display: "flex", alignItems: "flex-end", gap: 2.5, height: 11 }}>
+      {Array.from({ length: strokes }).map((_, i) => (
+        <span
+          key={i}
+          style={{
+            width: 1.6,
+            height: 11 - (i % 3) * 2,
+            opacity: 0.85,
+            background: i === 4 ? OCHRE : BRASS,
+          }}
+        />
+      ))}
+    </span>
   );
+}
+
+/** One incised sign at label scale, set beside a line of type. */
+function Sign({ name, size, color, weight }: {
+  name: string
+  size: number
+  color: string
+  weight?: number
+}) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
+      <path
+        d={GLYPHS[name]}
+        fill="none"
+        stroke={color}
+        strokeWidth={weight ?? 1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+interface SizeSet {
+  /** Masthead band height. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
+  masthead: number
+  /** Width the masthead's registers are drawn to fill. Geometry. */
+  mastheadView: number
+  /** The wordmark's winged disc. Geometry. */
+  wordmarkDisc: number
+  /** The disc crowning the action panel, and the room reserved above it. */
+  crownWidth: number
+  crownHeight: number
+  crownReserve: number
+  /** The points medallion, and the ledger cell that holds it. Geometry. */
+  medallion: number
+  ledgerWidth: number
+  /**
+   * Minimum height for a small control (sort tabs, drop, expand). The standing
+   * Ephemerists carve-out in `docs/agents/design-fidelity.md` is that touch
+   * targets win but the geometry gets RE-SOLVED around them, rather than 44px
+   * boxes being dropped into ornament drawn for intrinsic sizes: the phone takes
+   * 44 and the rows it sits in wrap, the pointer build keeps the design's
+   * tighter chrome.
+   */
+  tapTarget: number
+  cellPadding: string
+  briefPadding: string
+  /** Where the ochre margin rule is struck, and where the ruling starts. */
+  marginRule: number
+  rulingOffset: number
+  titleSize: string
+  levelSize: string
+  pointsSize: string
+}
+
+const SIZES: Record<"desktop" | "mobile", SizeSet> = {
+  desktop: {
+    masthead: 108,
+    mastheadView: 1200,
+    wordmarkDisc: 176,
+    crownWidth: 400,
+    crownHeight: 91,
+    crownReserve: 96,
+    medallion: 104,
+    ledgerWidth: 150,
+    tapTarget: 32,
+    cellPadding: "var(--space-lg)",
+    briefPadding: "var(--space-xl) var(--space-xl) var(--space-lg) var(--space-3xl)",
+    marginRule: 26,
+    rulingOffset: 30,
+    titleSize: "var(--text-display)",
+    levelSize: "var(--text-heading)",
+    pointsSize: "var(--text-heading)",
+  },
+  mobile: {
+    masthead: 92,
+    mastheadView: 440,
+    wordmarkDisc: 150,
+    crownWidth: 290,
+    crownHeight: 66,
+    crownReserve: 74,
+    medallion: 88,
+    ledgerWidth: 116,
+    tapTarget: 44,
+    cellPadding: "var(--space-md)",
+    briefPadding: "var(--space-lg) var(--space-lg) var(--space-md) var(--space-xl)",
+    marginRule: 18,
+    rulingOffset: 22,
+    titleSize: "var(--text-heading)",
+    levelSize: "var(--text-title)",
+    pointsSize: "var(--text-title)",
+  },
+};
+
+/** The page cap the epic settled on. Geometry. */
+const PAGE_WIDTH = 1200;
+/** The action panel — 420, the narrowest in the set. Dress, and deliberate. */
+const PANEL_WIDTH = 420;
+
+/** Initials fallback for an author with no uploaded avatar. */
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
 }
 
 export default function EphemeristsTaskDetail({
@@ -306,21 +447,26 @@ export default function EphemeristsTaskDetail({
   state: TaskDetailState;
 }) {
   const { t } = useTranslation("tasks");
+  const desktop = useFormFactor() !== "mobile";
+  const size = SIZES[desktop ? "desktop" : "mobile"];
+  // The gallery expands in place. It deliberately does NOT link to
+  // `/praxes?task_id=N`: the praxis feed reads no such param, so that link has
+  // always dropped the filter and shown the whole feed.
+  const [showAllPraxis, setShowAllPraxis] = useState(false);
   const {
     task,
-    signups,
     submissions,
-    friends,
-    foes,
     mySubmission,
     isInProgress,
     inProgressPraxisId,
     canSignUp,
+    levelJumpSignup,
     slotsOpen,
     maxTaskSlots,
+    basePoints,
+    factionMultiplier,
     modifiedPoints,
-    topScore,
-    voteCount,
+    inProgressCount,
     sortedSubmissions,
     submissionSort,
     setSubmissionSort,
@@ -332,579 +478,705 @@ export default function EphemeristsTaskDetail({
   // Guarded non-null by the dispatcher.
   if (!task) return null;
 
-  // Decorative: the Ephemerists letter a "commission no." — derive from real id.
-  const commissionNo = `C-${task.id}`;
-  const isMeta = task.task_type === "metatask";
-  // The faction's voice: an active task is an OPEN commission; else honest status.
-  const statusLabel =
-    task.status === "active" ? t("ephemerists.statusOpen") : task.status;
-  // Top-rated ephemeris (most canonical) by real score.
-  const topId = submissions.length
-    ? submissions.reduce((a, b) => ((b.score ?? 0) > (a.score ?? 0) ? b : a)).id
-    : null;
+  const slug = task.primary_faction_slug;
+  const isMetatask = task.task_type === "metatask";
+  const showMultiplier = !isNeutralMultiplier(factionMultiplier);
+  const authorName = task.created_by_display_name ?? "";
+  const hasAction =
+    canSignUp || !!mySubmission || (isInProgress && inProgressPraxisId !== null);
 
-  return (
-    <div
-      className="py-8"
-      style={{ fontFamily: "var(--eph-serif)", color: VELLUM_TEXT }}
-    >
-      {/* ── Breadcrumb ── */}
-      <nav
+  const plate: CSSProperties = {
+    background: PLATE,
+    border: `1px solid ${LINE}`,
+    boxSizing: "border-box",
+  };
+  const cell: CSSProperties = {
+    background: INNER,
+    border: `1px solid ${LINE}`,
+    padding: size.cellPadding,
+    boxSizing: "border-box",
+  };
+  const eyebrow: CSSProperties = {
+    ...SMALL_CAPS,
+    fontSize: "var(--text-sm)",
+    color: CAPTION,
+  };
+  const quietItalic: CSSProperties = {
+    fontFamily: READING,
+    fontStyle: "italic",
+    fontSize: "var(--text-lg)",
+    lineHeight: 1.7,
+    color: QUIET,
+  };
+  const primaryButton: CSSProperties = {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: "var(--space-sm)",
+    width: "100%",
+    boxSizing: "border-box",
+    minHeight: 48,
+    cursor: "pointer",
+    textAlign: "center",
+    textDecoration: "none",
+    background: CTA_BG,
+    color: CTA_INK,
+    border: `2px solid ${BRASS}`,
+    padding: "var(--space-md) var(--space-sm)",
+    fontFamily: CAPS,
+    fontWeight: 500,
+    fontSize: "var(--text-lg)",
+    letterSpacing: "0.14em",
+    textTransform: "uppercase",
+  };
+  /** A quiet inline control — drop, expand. Sized for a thumb on the phone. */
+  const quietButton: CSSProperties = {
+    ...quietItalic,
+    display: "inline-flex",
+    alignItems: "center",
+    minHeight: size.tapTarget,
+    background: "none",
+    border: "none",
+    borderBottom: `1px solid ${LINE}`,
+    cursor: "pointer",
+    padding: 0,
+    color: NILE,
+  };
+
+  /** Small caps, a brass hairline running out, an optional gloss, a fluted rule. */
+  const sectionHead = (label: ReactNode, gloss?: ReactNode) => (
+    <div style={{ marginBottom: "var(--space-lg)" }}>
+      <div
         style={{
-          fontSize: "var(--text-base)",
-          letterSpacing: "0.14em",
-          textTransform: "uppercase",
-          color: MUTED,
-          fontFamily: "var(--eph-display)",
-          marginBottom: "var(--space-xl)",
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-md)",
+          marginBottom: "var(--space-sm)",
+          flexWrap: "wrap",
         }}
       >
-        <Link
-          to="/tasks"
-          style={{ color: "var(--faction-ephemerists)", textDecoration: "none" }}
+        <h2
+          style={{
+            ...SMALL_CAPS,
+            fontWeight: 600,
+            fontSize: "var(--text-md)",
+            color: INK,
+            margin: 0,
+            flex: "0 0 auto",
+          }}
         >
-          {t("ephemerists.breadcrumb")}
-        </Link>
-        <span style={{ opacity: 0.5, margin: "0 var(--space-sm)" }}>›</span>
-        <span>{t("ephemerists.faction")}</span>
-        <span style={{ opacity: 0.5, margin: "0 var(--space-sm)" }}>›</span>
-        <span style={{ color: "var(--eph-rubric)" }}>{task.title}</span>
-      </nav>
+          {label}
+        </h2>
+        <span aria-hidden style={{ flex: 1, minWidth: 24, height: 1, background: BRASS, opacity: 0.5 }} />
+        {gloss !== undefined && <span style={eyebrow}>{gloss}</span>}
+      </div>
+      <FlutedRule />
+    </div>
+  );
 
-      <div style={{ maxWidth: 920, display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
-        {/* ── Hero — the discordant exhibit ── */}
+  // ── The masthead: the night band, its two registers, the winged disc ──
+  const masthead = (
+    <div style={{ marginBottom: desktop ? "var(--space-xl)" : "var(--space-lg)" }}>
+      <div
+        style={{
+          position: "relative",
+          overflow: "hidden",
+          height: size.masthead,
+          background: BAND,
+          color: BAND_INK,
+        }}
+      >
+        <svg
+          width="100%"
+          height={size.masthead}
+          viewBox={`0 0 ${size.mastheadView} 108`}
+          preserveAspectRatio="xMidYMid slice"
+          aria-hidden="true"
+          style={{ position: "absolute", inset: 0, zIndex: 1 }}
+        >
+          <path
+            d={`M8 24 H${size.mastheadView - 8} M8 84 H${size.mastheadView - 8}`}
+            stroke={BRASS_LIGHT}
+            strokeWidth="0.6"
+            opacity="0.28"
+          />
+          <GlyphRegister width={size.mastheadView} y={13} strength={0.34} keyPrefix="top" />
+          <GlyphRegister width={size.mastheadView} y={95} strength={0.3} keyPrefix="bottom" />
+        </svg>
         <div
           style={{
             position: "relative",
-            background: "var(--eph-vellum)",
-            border: "1.5px solid var(--eph-ink)",
-            boxShadow: "0 14px 34px rgba(42,29,18,0.18)",
-            overflow: "hidden",
+            zIndex: 2,
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: "var(--space-xs)",
           }}
         >
-          <Foxing opacity={0.35} />
-          <div
+          <WingedDisc width={size.wordmarkDisc} height={38} />
+          <span
             style={{
-              position: "relative",
-              zIndex: 2,
-              display: "grid",
-              gridTemplateColumns: "300px 1fr",
+              fontFamily: DECO,
+              fontSize: "var(--text-xl)",
+              letterSpacing: "0.3em",
+              textTransform: "uppercase",
+              color: BAND_INK,
+              whiteSpace: "nowrap",
             }}
           >
-            <DiscordantMap />
-            <div
-              style={{
-                padding: "var(--space-2xl) var(--space-2xl)",
-                display: "flex",
-                flexDirection: "column",
-                justifyContent: "center",
-              }}
-            >
-              <div
+            {factionName(slug)}
+          </span>
+        </div>
+      </div>
+      <Cornice />
+    </div>
+  );
+
+  // ── Header: breadcrumb cartouche, faction line, title, author, stats ──
+  const header = (
+    <div>
+      <nav
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-sm)",
+          marginBottom: "var(--space-md)",
+          flexWrap: "wrap",
+        }}
+      >
+        <Link to="/tasks" style={{ ...eyebrow, color: NILE, textDecoration: "none" }}>
+          {t("detail.breadcrumb.tasks")}
+        </Link>
+        <span aria-hidden style={{ ...eyebrow, color: QUIET }}>
+          /
+        </span>
+        {/* The cartouche — the task's ordinal, ruled off at both ends. */}
+        <span
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "var(--space-sm)",
+            padding: "var(--space-xs) var(--space-md)",
+            border: `1.5px solid ${BRASS}`,
+            borderRadius: 12,
+            background: WASH,
+          }}
+        >
+          <span aria-hidden style={{ width: 1.5, height: 12, background: BRASS }} />
+          <span style={{ ...SMALL_CAPS, fontWeight: 700, fontSize: "var(--text-base)", color: INK, whiteSpace: "nowrap" }}>
+            {t("detail.breadcrumb.current", { number: task.id })}
+          </span>
+          <span aria-hidden style={{ width: 1.5, height: 12, background: BRASS }} />
+        </span>
+      </nav>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-sm)",
+          marginBottom: "var(--space-md)",
+          flexWrap: "wrap",
+        }}
+      >
+        <Sign name="ankh" size={19} color={BRASS} weight={1.6} />
+        <span style={{ ...eyebrow, fontSize: "var(--text-base)" }}>{factionName(slug)}</span>
+        {isMetatask && (
+          <span
+            style={{
+              ...SMALL_CAPS,
+              fontSize: "var(--text-xs)",
+              fontWeight: 600,
+              letterSpacing: "0.16em",
+              padding: "var(--space-xs) var(--space-sm)",
+              // na → rainbow frame; a real faction → solid hue + on-fill ink.
+              ...factionFill(task.metatask_faction_slug, "pill"),
+            }}
+          >
+            {t("detail.meta")}
+          </span>
+        )}
+      </div>
+
+      <h1
+        style={{
+          fontFamily: DECO,
+          fontWeight: 400,
+          fontSize: size.titleSize,
+          lineHeight: 1.16,
+          letterSpacing: "0.02em",
+          margin: 0,
+          marginBottom: "var(--space-lg)",
+          color: INK,
+          overflowWrap: "anywhere",
+        }}
+      >
+        {task.title}
+      </h1>
+
+      {isMetatask && (
+        <p
+          style={{
+            ...eyebrow,
+            color: factionCssVar(task.metatask_faction_slug),
+            margin: 0,
+            marginBottom: "var(--space-lg)",
+          }}
+        >
+          {t("detail.metataskFor", {
+            faction: factionName(task.metatask_faction_slug),
+          })}
+        </p>
+      )}
+
+      {/* Author row — the proposing character's byline (#1029). */}
+      {authorName && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-md)",
+            marginBottom: "var(--space-lg)",
+            flexWrap: "wrap",
+          }}
+        >
+          <Link
+            to={`/characters/${task.created_by}`}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-sm)",
+              textDecoration: "none",
+            }}
+          >
+            {task.created_by_avatar_url ? (
+              <img
+                src={mediaUrl(task.created_by_avatar_url)}
+                alt={authorName}
                 style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "var(--space-sm)",
-                  color: "var(--eph-gold)",
-                  marginBottom: "var(--space-sm)",
-                }}
-              >
-                <EphemeristsSigil size={13} color="var(--eph-gold)" />
-                <span
-                  style={{
-                    fontFamily: "var(--eph-display)",
-                    fontWeight: 600,
-                    fontSize: "var(--text-sm)",
-                    letterSpacing: "0.24em",
-                  }}
-                >
-                  {t("ephemerists.masthead")}
-                </span>
-              </div>
-              <div
-                style={{
-                  fontFamily: "var(--eph-script)",
-                  fontStyle: "italic",
-                  fontSize: "var(--text-lg)",
-                  color: MUTED,
-                  marginBottom: "var(--space-lg)",
-                }}
-              >
-                {t("ephemerists.statusLine", {
-                  status: statusLabel,
-                  number: commissionNo,
-                })}
-              </div>
-              {isMeta && (
-                <div
-                  style={{
-                    fontFamily: "var(--eph-display)",
-                    fontSize: "var(--text-md)",
-                    letterSpacing: "0.14em",
-                    textTransform: "uppercase",
-                    color: "var(--eph-rubric)",
-                    marginBottom: "var(--space-md)",
-                  }}
-                >
-                  {t("ephemerists.metataskFor", {
-                    faction: factionName(task.metatask_faction_slug),
-                  })}
-                </div>
-              )}
-              <h1
-                className="content-title"
-                style={{
-                  fontFamily: "var(--eph-display)",
-                  fontWeight: 700,
-                  lineHeight: 1.04,
-                  color: VELLUM_TEXT,
-                  margin: "0 0 var(--space-lg)",
-                  overflowWrap: "anywhere",
-                }}
-              >
-                <LapisLastWord text={task.title} footnote />
-              </h1>
-              <div
-                style={{
-                  height: 1,
-                  background: "linear-gradient(90deg, var(--eph-gold), transparent)",
-                  marginBottom: "var(--space-lg)",
+                  width: 30,
+                  height: 30,
+                  flex: "none",
+                  objectFit: "cover",
+                  borderRadius: "50%",
+                  border: `1px solid ${BRASS}`,
                 }}
               />
-              <div
+            ) : (
+              <span
+                aria-hidden
                 style={{
-                  display: "flex",
-                  gap: "var(--space-xl)",
-                  flexWrap: "wrap",
+                  display: "inline-flex",
                   alignItems: "center",
+                  justifyContent: "center",
+                  width: 30,
+                  height: 30,
+                  flex: "none",
+                  borderRadius: "50%",
+                  overflow: "hidden",
+                  background: DISC,
+                  border: `1px solid ${BRASS}`,
+                  fontFamily: CAPS,
+                  fontWeight: 500,
+                  fontSize: "var(--text-md)",
+                  color: INK,
                 }}
               >
-                <span
-                  style={{
-                    fontFamily: "var(--eph-display)",
-                    fontSize: "var(--text-lg)",
-                    color: VELLUM_TEXT,
-                  }}
-                >
-                  {t("ephemerists.grade", { level: task.level_required })}
+                {initialsOf(authorName)}
+              </span>
+            )}
+            <span
+              style={{
+                fontFamily: READING,
+                fontSize: "var(--text-content)",
+                color: INK,
+                borderBottom: `1px solid ${BRASS}`,
+              }}
+            >
+              {authorName}
+            </span>
+          </Link>
+          <span style={eyebrow}>
+            {t("detail.author", { level: task.created_by_level ?? 0 })}
+          </span>
+        </div>
+      )}
+
+      {/* Header stats — the level over its tally strokes, and the in-progress
+          count. There is deliberately no roster; this count is the only place
+          that population appears. */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-end",
+          gap: desktop ? "var(--space-xl)" : "var(--space-lg)",
+          flexWrap: "wrap",
+        }}
+      >
+        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-xs)", lineHeight: 1 }}>
+          <span style={eyebrow}>{t("detail.stats.level")}</span>
+          <span style={{ fontFamily: DECO, fontSize: size.levelSize, lineHeight: 0.8, color: INK }}>
+            {task.level_required}
+          </span>
+          <Tally level={task.level_required} />
+        </div>
+        <span aria-hidden style={{ width: 1, alignSelf: "stretch", minHeight: 38, background: LINE }} />
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
+          <Sign name="hourglass" size={15} color={BRASS} />
+          <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-xs)", lineHeight: 1 }}>
+            <span style={eyebrow}>{t("detail.stats.inProgress")}</span>
+            <span style={{ fontFamily: DECO, fontSize: size.pointsSize, lineHeight: 0.8, color: INK }}>
+              {inProgressCount}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  // ── The ledger: base, the (usually absent) modifier, the medallion total ──
+  const ledgerRow = (label: ReactNode, value: ReactNode) => (
+    <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-sm)" }}>
+      {label}
+      <span aria-hidden style={{ flex: 1, minWidth: 10, height: 1, background: LINE }} />
+      <span style={{ fontFamily: DECO, fontSize: "var(--text-content)", color: INK, whiteSpace: "nowrap" }}>
+        {value}
+      </span>
+    </div>
+  );
+
+  const scoreCell = (
+    <div
+      style={{
+        ...cell,
+        flex: "0 0 auto",
+        width: size.ledgerWidth,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: "var(--space-md)",
+      }}
+    >
+      <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
+        {ledgerRow(<span style={eyebrow}>{t("detail.points.base")}</span>, basePoints)}
+        {/* The modifier row — absent at ×1.00, so invisible under era_1's
+            neutralised modifiers and automatic the day one moves (ADR-0055).
+            The design labels it "Bonus"; ADR-0057 leaves no shared word for it,
+            so the label slot takes an incised ankh instead of an invented one. */}
+        {showMultiplier &&
+          ledgerRow(
+            <Sign name="ankh" size={11} color={BRASS} weight={1.4} />,
+            t("detail.points.multiplier", { multiplier: factionMultiplier.toFixed(2) }),
+          )}
+      </div>
+
+      {/* The stepped octagon medallion. */}
+      <div
+        style={{
+          position: "relative",
+          flex: "0 0 auto",
+          width: size.medallion,
+          height: size.medallion,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <svg
+          width={size.medallion}
+          height={size.medallion}
+          viewBox="0 0 100 100"
+          aria-hidden="true"
+          style={{ position: "absolute", inset: 0 }}
+        >
+          <Octagon inset={0} stroke={BRASS} width={1.6} fill={DISC} />
+          <Octagon inset={6} stroke={BRASS_LIGHT} width={0.7} />
+          <circle cx="50" cy="50" r="34" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.7" opacity="0.55" />
+          <path d="M16 70 H84" stroke={BRASS_LIGHT} strokeWidth="0.7" opacity="0.5" />
+        </svg>
+        <div style={{ position: "relative", display: "flex", flexDirection: "column", alignItems: "center", lineHeight: 0.82 }}>
+          <span style={{ fontFamily: DECO, fontSize: size.pointsSize, color: INK }}>{modifiedPoints}</span>
+          <span
+            style={{
+              ...SMALL_CAPS,
+              fontSize: "var(--text-xs)",
+              letterSpacing: "0.2em",
+              marginTop: "var(--space-xs)",
+              color: QUIET,
+            }}
+          >
+            {t("detail.points.total")}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+
+  // ── The summons: sign up / continue / edit. Nothing renders when the viewer
+  //    has no move to make — an unusable control is worse than none.
+  const summons = (
+    <>
+      {canSignUp && (
+        <div>
+          <LevelJumpBanner state={state} />
+          <button onClick={handleSignup} style={primaryButton}>
+            <Sign name="openEye" size={15} color={CTA_INK} weight={1.4} />
+            <span style={{ whiteSpace: "nowrap" }}>{t("detail.signup.cta")}</span>
+            <Sign name="planet" size={14} color={CTA_INK} weight={1.4} />
+          </button>
+          <div style={{ ...quietItalic, marginTop: "var(--space-sm)" }}>
+            {t("detail.signup.slots", { open: slotsOpen, max: maxTaskSlots })}
+            {!levelJumpSignup && (
+              <>
+                {" · "}
+                <span style={{ color: NILE }}>
+                  {t("detail.signup.levelMet", { level: task.level_required })}
                 </span>
-                <span
-                  className="content-title"
-                  style={{
-                    fontFamily: "var(--eph-display)",
-                    fontWeight: 700,
-                    color: "var(--eph-rubric)",
-                  }}
-                >
-                  {modifiedPoints}{" "}
-                  <span style={{ fontSize: "var(--text-md)", letterSpacing: "0.06em" }}>
-                    {t("ephemerists.puncta")}
-                  </span>
-                </span>
-                <span
-                  style={{
-                    fontFamily: "var(--eph-script)",
-                    fontStyle: "italic",
-                    fontSize: "var(--text-lg)",
-                    color: MUTED,
-                  }}
-                >
-                  {t("ephemerists.onView", {
-                    signups: signups.length,
-                    completed: submissions.length,
-                  })}
-                </span>
-              </div>
-              <div
-                style={{
-                  fontSize: "var(--text-sm)",
-                  fontStyle: "italic",
-                  color: MUTED,
-                  marginTop: "var(--space-lg)",
-                  lineHeight: 1.4,
-                }}
-              >
-                <Trans
-                  t={t}
-                  i18nKey="ephemerists.footnote"
-                  components={[
-                    <span key="0" style={{ color: "var(--eph-lapis)" }} />,
-                  ]}
-                />
-              </div>
-            </div>
+              </>
+            )}
+          </div>
+          <ErrorBanner message={signupError} />
+        </div>
+      )}
+
+      {mySubmission && (
+        <div>
+          <div style={{ ...quietItalic, marginBottom: "var(--space-sm)" }}>
+            {t("detail.submitted.text")}
+          </div>
+          <Link to={`/praxes/${mySubmission.id}/edit`} style={primaryButton}>
+            {t("detail.submitted.edit")}
+          </Link>
+        </div>
+      )}
+
+      {!mySubmission && isInProgress && inProgressPraxisId !== null && (
+        <div>
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)", marginBottom: "var(--space-sm)" }}>
+            <Sign name="openEye" size={15} color={NILE} />
+            <span style={{ ...quietItalic, color: NILE }}>{t("detail.inProgress.text")}</span>
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", flexWrap: "wrap" }}>
+            <Link to={`/praxes/${inProgressPraxisId}/edit`} style={{ ...primaryButton, flex: 1, width: "auto" }}>
+              {t("detail.inProgress.continue")}
+            </Link>
+            <button onClick={handleDrop} style={quietButton}>
+              {t("detail.inProgress.drop")}
+            </button>
+          </div>
+          <ErrorBanner message={signupError} />
+        </div>
+      )}
+    </>
+  );
+
+  // The worth beside the summons, one plate, crowned by a winged disc.
+  const actionPanel = (
+    <div style={{ position: "relative", paddingTop: size.crownReserve }}>
+      <div
+        aria-hidden
+        style={{
+          position: "absolute",
+          top: 0,
+          left: "50%",
+          transform: "translateX(-50%)",
+          zIndex: 2,
+          pointerEvents: "none",
+          maxWidth: "100%",
+        }}
+      >
+        <WingedDisc className="eph-plate-crown" width={size.crownWidth} height={size.crownHeight} />
+      </div>
+      <div
+        style={{
+          ...plate,
+          position: "relative",
+          zIndex: 1,
+          outline: `1px solid ${BRASS_LIGHT}`,
+          outlineOffset: 3,
+          boxShadow: SHADOW,
+          padding: "var(--space-sm)",
+          display: "flex",
+          flexDirection: "row",
+          gap: "var(--space-sm)",
+          alignItems: "stretch",
+        }}
+      >
+        {scoreCell}
+        {hasAction && (
+          <div
+            style={{
+              ...cell,
+              flex: 1,
+              minWidth: 0,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+            }}
+          >
+            {summons}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+
+  // ── The brief, in full, on a ruled leaf with a red margin rule ──
+  const brief = (
+    <section style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}>
+      {sectionHead(t("detail.brief.heading"))}
+      {task.description && (
+        <div
+          style={{
+            ...plate,
+            position: "relative",
+            padding: size.briefPadding,
+            backgroundImage: `repeating-linear-gradient(180deg, transparent 0 ${BRIEF_LEADING - 1}px, ${RULE} ${BRIEF_LEADING - 1}px ${BRIEF_LEADING}px)`,
+            backgroundPosition: `0 ${size.rulingOffset}px`,
+          }}
+        >
+          {/* The margin rule, struck in ochre down the gutter. */}
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              top: 0,
+              bottom: 0,
+              left: size.marginRule,
+              width: 1,
+              background: OCHRE,
+              opacity: 0.5,
+            }}
+          />
+          <p
+            className="content-text"
+            style={{
+              fontFamily: READING,
+              lineHeight: `${BRIEF_LEADING}px`,
+              color: INK,
+              whiteSpace: "pre-wrap",
+              overflowWrap: "anywhere",
+              margin: 0,
+            }}
+          >
+            {task.description}
+          </p>
+        </div>
+      )}
+    </section>
+  );
+
+  // ── The praxis gallery ──
+  const sortTab = (sort: "score" | "recent", label: string) => (
+    <button
+      key={sort}
+      onClick={() => setSubmissionSort(sort)}
+      style={{
+        ...SMALL_CAPS,
+        display: "inline-flex",
+        alignItems: "center",
+        minHeight: size.tapTarget,
+        cursor: "pointer",
+        border: "none",
+        padding: "var(--space-xs) var(--space-md)",
+        fontSize: "var(--text-sm)",
+        background: submissionSort === sort ? CTA_BG : "transparent",
+        color: submissionSort === sort ? CTA_INK : QUIET,
+      }}
+    >
+      {label}
+    </button>
+  );
+
+  const gallery = (
+    <section style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}>
+      <div style={{ marginBottom: "var(--space-lg)" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-md)",
+            marginBottom: "var(--space-sm)",
+            flexWrap: "wrap",
+          }}
+        >
+          <h2 style={{ ...SMALL_CAPS, fontWeight: 600, fontSize: "var(--text-md)", color: INK, margin: 0 }}>
+            {t("detail.gallery.heading", { count: submissions.length })}
+          </h2>
+          <span aria-hidden style={{ flex: 1, minWidth: 24, height: 1, background: BRASS, opacity: 0.5 }} />
+          {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the 2px reveal that reads as an engraved frame around the two tabs. */}
+          <span style={{ display: "flex", gap: 2, border: `1px solid ${LINE}`, padding: 2 }}>
+            {sortTab("score", t("detail.gallery.sort.top"))}
+            {sortTab("recent", t("detail.gallery.sort.recent"))}
+          </span>
+        </div>
+        <FlutedRule />
+      </div>
+
+      {sortedSubmissions.length === 0 ? (
+        <p className="content-text" style={{ fontFamily: READING, fontStyle: "italic", color: QUIET, margin: 0 }}>
+          {t("detail.gallery.empty")}
+        </p>
+      ) : (
+        <>
+          <div className="flex flex-wrap gap-4 items-start">
+            {(showAllPraxis ? sortedSubmissions : sortedSubmissions.slice(0, GALLERY_PREVIEW)).map(
+              (praxis) => (
+                <PraxisCard key={praxis.id} praxis={praxis} />
+              ),
+            )}
+          </div>
+          {submissions.length > GALLERY_PREVIEW && (
+            <button
+              onClick={() => setShowAllPraxis((shown) => !shown)}
+              style={{ ...quietButton, marginTop: "var(--space-lg)" }}
+            >
+              {showAllPraxis
+                ? t("detail.gallery.showFewer")
+                : t("detail.gallery.viewAll", { count: submissions.length })}
+            </button>
+          )}
+        </>
+      )}
+    </section>
+  );
+
+  return (
+    <div className="py-8" style={{ position: "relative", color: INK }}>
+      {/* The papyrus ground, full-bleed behind the column (index.css). */}
+      <div className="eph-plate-backdrop" aria-hidden />
+
+      <div style={{ position: "relative", zIndex: 1, maxWidth: PAGE_WIDTH, margin: "0 auto" }}>
+        {masthead}
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: desktop ? "row" : "column",
+            alignItems: desktop ? "flex-start" : "stretch",
+            gap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
+            marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
+          }}
+        >
+          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+          <div
+            style={{
+              flex: desktop ? `0 0 ${PANEL_WIDTH}px` : "1 1 auto",
+              width: desktop ? PANEL_WIDTH : "100%",
+              maxWidth: "100%",
+            }}
+          >
+            {actionPanel}
           </div>
         </div>
 
-        {/* ── The Commission (brief) ── */}
-        <section>
-          <SectionHead title={t("ephemerists.commissionHeading")} />
-          <div
-            className="font-body content-text"
-            style={{
-              position: "relative",
-              border: "1px solid var(--eph-gold-deep)",
-              background: "var(--eph-vellum)",
-              padding: "var(--space-2xl) var(--space-2xl)",
-              maxWidth: 660,
-              fontFamily: "var(--eph-serif)",
-              lineHeight: 1.7,
-              color: VELLUM_TEXT,
-              whiteSpace: "pre-wrap",
-            }}
-          >
-            <Foxing opacity={0.3} />
-            <span style={{ position: "relative", zIndex: 2 }}>
-              {task.description || t("ephemerists.commissionEmpty")}
-            </span>
-          </div>
-        </section>
-
-        {/* ── Signup CTA — only when the viewer may enroll ── */}
-        <LevelJumpBanner state={state} />
-        {canSignUp && (
-          <section
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "var(--space-lg)",
-              flexWrap: "wrap",
-              border: "1px solid var(--eph-ink)",
-              background: "var(--eph-vellum)",
-              padding: "var(--space-lg) var(--space-xl)",
-            }}
-          >
-            <button
-              onClick={handleSignup}
-              style={{
-                cursor: "pointer",
-                fontFamily: "var(--eph-serif)",
-                fontStyle: "italic",
-                fontSize: "var(--text-xl)",
-                letterSpacing: "0.06em",
-                color: "var(--eph-parchment)",
-                background: "var(--eph-ink)",
-                border: "none",
-                padding: "var(--space-md) var(--space-xl)",
-              }}
-            >
-              {t("ephemerists.signup.cta", { points: modifiedPoints })}
-            </button>
-            <div
-              style={{
-                fontFamily: "var(--eph-script)",
-                fontStyle: "italic",
-                fontSize: "var(--text-xl)",
-                color: MUTED,
-              }}
-            >
-              {t("ephemerists.signup.note")}
-            </div>
-            <div
-              style={{
-                marginLeft: "auto",
-                fontFamily: "var(--eph-display)",
-                fontSize: "var(--text-sm)",
-                letterSpacing: "0.1em",
-                color: "var(--eph-gold-deep)",
-                textTransform: "uppercase",
-              }}
-            >
-              {t("ephemerists.signup.meta", {
-                open: slotsOpen,
-                max: maxTaskSlots,
-                level: task.level_required,
-              })}
-            </div>
-          </section>
-        )}
-        {canSignUp && (
-          <ErrorBanner
-            message={signupError}
-            style={{
-              background: "color-mix(in srgb, var(--eph-rubric) 8%, transparent)",
-              border: "1px solid color-mix(in srgb, var(--eph-rubric) 30%, transparent)",
-              color: "var(--eph-rubric)",
-            }}
-          />
-        )}
-
-        {/* ── My enrolment states ── */}
-        {mySubmission && (
-          <section
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "var(--space-lg)",
-              flexWrap: "wrap",
-              border: "1px solid var(--eph-gold-deep)",
-              background: "var(--eph-vellum)",
-              padding: "var(--space-lg) var(--space-xl)",
-            }}
-          >
-            <span
-              className="content-text"
-              style={{
-                fontFamily: "var(--eph-script)",
-                fontStyle: "italic",
-                color: VELLUM_TEXT,
-              }}
-            >
-              {t("ephemerists.submitted.text")}
-            </span>
-            <Link
-              to={`/praxes/${mySubmission.id}/edit`}
-              style={{
-                fontFamily: "var(--eph-display)",
-                fontSize: "var(--text-md)",
-                letterSpacing: "0.1em",
-                textTransform: "uppercase",
-                color: "var(--eph-parchment)",
-                background: "var(--eph-lapis)",
-                padding: "var(--space-sm) var(--space-lg)",
-                textDecoration: "none",
-              }}
-            >
-              {t("ephemerists.submitted.edit")}
-            </Link>
-          </section>
-        )}
-
-        {!mySubmission && isInProgress && inProgressPraxisId !== null && (
-          <section
-            style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "var(--space-lg)",
-              flexWrap: "wrap",
-              border: "1px solid var(--eph-gold-deep)",
-              background: "var(--eph-vellum)",
-              padding: "var(--space-lg) var(--space-xl)",
-            }}
-          >
-            <span
-              className="content-text"
-              style={{
-                fontFamily: "var(--eph-script)",
-                fontStyle: "italic",
-                color: VELLUM_TEXT,
-              }}
-            >
-              {t("ephemerists.inProgress.text")}
-            </span>
-            <Link
-              to={`/praxes/${inProgressPraxisId}/edit`}
-              style={{
-                fontFamily: "var(--eph-display)",
-                fontSize: "var(--text-md)",
-                letterSpacing: "0.1em",
-                textTransform: "uppercase",
-                color: "var(--eph-parchment)",
-                background: "var(--eph-ink)",
-                padding: "var(--space-sm) var(--space-lg)",
-                textDecoration: "none",
-              }}
-            >
-              {t("ephemerists.inProgress.continue")}
-            </Link>
-            <button
-              onClick={handleDrop}
-              style={{
-                background: "none",
-                border: "none",
-                cursor: "pointer",
-                fontFamily: "var(--eph-script)",
-                fontStyle: "italic",
-                fontSize: "var(--text-xl)",
-                color: "var(--eph-rubric)",
-              }}
-            >
-              {t("ephemerists.inProgress.drop")}
-            </button>
-          </section>
-        )}
-
-        {/* ── Marginalia of cartographers (signups) ── */}
-        {signups.length > 0 && (
-          <section>
-            <SectionHead
-              title={t("ephemerists.cartographersHeading")}
-              gloss={t("ephemerists.cartographersGloss", {
-                count: signups.length,
-              })}
-            />
-            <SurveyorRow signups={signups} friends={friends} foes={foes} />
-          </section>
-        )}
-
-        {/* ── Credence (read-only vote aggregate) ── */}
-        <section>
-          <SectionHead title={t("ephemerists.credenceHeading")} />
-          {voteCount > 0 ? (
-            <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-md)" }}>
-              <span
-                className="content-title"
-                style={{
-                  fontFamily: "var(--eph-display)",
-                  fontWeight: 700,
-                  lineHeight: 0.8,
-                  color: "var(--eph-rubric)",
-                }}
-              >
-                {topScore}
-              </span>
-              <div style={{ paddingBottom: "var(--space-sm)" }}>
-                <div
-                  style={{
-                    fontFamily: "var(--eph-display)",
-                    fontSize: "var(--text-xl)",
-                    letterSpacing: "0.06em",
-                    color: VELLUM_TEXT,
-                  }}
-                >
-                  {t("ephemerists.credence.highest")}
-                </div>
-                <div
-                  style={{
-                    fontFamily: "var(--eph-script)",
-                    fontStyle: "italic",
-                    fontSize: "var(--text-lg)",
-                    color: MUTED,
-                  }}
-                >
-                  {t("ephemerists.credence.weighed", { count: voteCount })}
-                </div>
-              </div>
-            </div>
-          ) : (
-            <p
-              className="content-text"
-              style={{
-                fontFamily: "var(--eph-script)",
-                fontStyle: "italic",
-                color: MUTED,
-                margin: 0,
-              }}
-            >
-              {t("ephemerists.credence.none")}
-            </p>
-          )}
-        </section>
-
-        {/* ── Sealed Ephemerides (completed praxis) ── */}
-        <section>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: "var(--space-sm)",
-              flexWrap: "wrap",
-              marginBottom: "var(--space-lg)",
-            }}
-          >
-            <SectionHead
-              title={t("ephemerists.ephemeridesHeading")}
-              gloss={t("ephemerists.ephemeridesGloss", {
-                count: submissions.length,
-              })}
-            />
-            <div style={{ display: "flex", gap: 0 }}>
-              {(["score", "recent"] as const).map((sort) => {
-                const on = submissionSort === sort;
-                return (
-                  <button
-                    key={sort}
-                    onClick={() => setSubmissionSort(sort)}
-                    style={{
-                      fontFamily: "var(--eph-display)",
-                      fontSize: "var(--text-base)",
-                      letterSpacing: "0.1em",
-                      textTransform: "uppercase",
-                      padding: "var(--space-xs) var(--space-md)",
-                      background: on ? "var(--eph-ink)" : "transparent",
-                      color: on ? "var(--eph-gold-light)" : MUTED,
-                      border: `1px solid ${on ? "var(--eph-ink)" : "var(--eph-gold-deep)"}`,
-                      cursor: "pointer",
-                    }}
-                  >
-                    {sort === "score"
-                      ? t("ephemerists.sort.mostCanonical")
-                      : t("ephemerists.sort.recent")}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-
-          {sortedSubmissions.length === 0 ? (
-            <p
-              className="content-text"
-              style={{
-                fontFamily: "var(--eph-script)",
-                fontStyle: "italic",
-                color: MUTED,
-                margin: 0,
-              }}
-            >
-              {t("ephemerists.empty")}
-            </p>
-          ) : (
-            <>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-2xl) var(--space-xl)", alignItems: "flex-start" }}>
-                {sortedSubmissions.slice(0, 4).map((s) => (
-                  <div key={s.id} style={{ position: "relative", paddingTop: s.id === topId ? "var(--space-xl)" : 0 }}>
-                    {s.id === topId && (
-                      <div
-                        style={{
-                          position: "absolute",
-                          top: 0,
-                          left: "50%",
-                          transform: "translateX(-50%)",
-                          zIndex: 3,
-                          display: "inline-flex",
-                          alignItems: "center",
-                          gap: "var(--space-xs)",
-                          whiteSpace: "nowrap",
-                          background: INK,
-                          color: "var(--eph-gold-light)",
-                          fontFamily: "var(--eph-display)",
-                          fontSize: "var(--text-xs)",
-                          letterSpacing: "0.14em",
-                          padding: "var(--space-xs) var(--space-md)",
-                          boxShadow: "0 3px 8px rgba(42,29,18,0.35)",
-                        }}
-                      >
-                        <span style={{ fontSize: "var(--text-lg)", lineHeight: 1, color: "var(--eph-gold-light)" }}>⚜</span>{" "}
-                        {t("ephemerists.mostCanonical")}
-                      </div>
-                    )}
-                    <PraxisCard praxis={s} />
-                  </div>
-                ))}
-              </div>
-              {submissions.length > 4 && (
-                <div style={{ marginTop: "var(--space-lg)" }}>
-                  <Link
-                    to={`/praxes?task_id=${task.id}`}
-                    style={{
-                      fontFamily: "var(--eph-script)",
-                      fontStyle: "italic",
-                      fontSize: "var(--text-xl)",
-                      color: "var(--eph-rubric)",
-                      textDecoration: "none",
-                      borderBottom: "1px solid color-mix(in srgb, var(--eph-rubric) 40%, transparent)",
-                    }}
-                  >
-                    {t("ephemerists.viewAll", { count: submissions.length })}
-                  </Link>
-                </div>
-              )}
-            </>
-          )}
-        </section>
-        {/* Comments — shared slot, active-task gated (ADR-0006 + #1030). */}
-        <TaskDetailComments state={state} />
+        <div style={{ minWidth: 0 }}>
+          {brief}
+          {gallery}
+          <TaskDetailComments state={state} heading={sectionHead(t("detail.comments.heading"))} />
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -1152,38 +1152,60 @@ export default function EphemeristsTaskDetail({
   );
 
   return (
-    <div className="py-8" style={{ position: "relative", color: INK }}>
-      {/* The papyrus ground, full-bleed behind the column (index.css). */}
-      <div className="eph-plate-backdrop" aria-hidden />
-
-      <div style={{ position: "relative", zIndex: 1, maxWidth: PAGE_WIDTH, margin: "0 auto" }}>
+    <div className="py-8">
+      {/* The page IS the plate: the column carries the papyrus itself, headed by
+          the cornice masthead flush to its own edges. There is deliberately no
+          fixed full-bleed backdrop element — see the `.eph-plate-sheet` note in
+          index.css for what that pattern does to the sidebar. */}
+      <div
+        className="eph-plate-sheet"
+        style={{
+          maxWidth: PAGE_WIDTH,
+          margin: "0 auto",
+          boxSizing: "border-box",
+          color: INK,
+          border: `1px solid ${LINE}`,
+          boxShadow: SHADOW,
+        }}
+      >
         {masthead}
 
         <div
           style={{
-            display: "flex",
-            flexDirection: desktop ? "row" : "column",
-            alignItems: desktop ? "flex-start" : "stretch",
-            gap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
-            marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
+            padding: desktop
+              ? "0 var(--space-2xl) var(--space-2xl)"
+              : "0 var(--space-lg) var(--space-lg)",
           }}
         >
-          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
           <div
             style={{
-              flex: desktop ? `0 0 ${PANEL_WIDTH}px` : "1 1 auto",
-              width: desktop ? PANEL_WIDTH : "100%",
-              maxWidth: "100%",
+              display: "flex",
+              flexDirection: desktop ? "row" : "column",
+              alignItems: desktop ? "flex-start" : "stretch",
+              gap: desktop ? "var(--space-2xl)" : "var(--space-xl)",
+              marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
             }}
           >
-            {actionPanel}
+            <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+            <div
+              style={{
+                flex: desktop ? `0 0 ${PANEL_WIDTH}px` : "1 1 auto",
+                width: desktop ? PANEL_WIDTH : "100%",
+                maxWidth: "100%",
+              }}
+            >
+              {actionPanel}
+            </div>
           </div>
-        </div>
 
-        <div style={{ minWidth: 0 }}>
-          {brief}
-          {gallery}
-          <TaskDetailComments state={state} heading={sectionHead(t("detail.comments.heading"))} />
+          <div style={{ minWidth: 0 }}>
+            {brief}
+            {gallery}
+            <TaskDetailComments
+              state={state}
+              heading={sectionHead(t("detail.comments.heading"))}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -496,11 +496,19 @@ export default function EphemeristsTaskDetail({
     padding: size.cellPadding,
     boxSizing: "border-box",
   };
+  /**
+   * The page-ground label voice. `-quiet`, not `-caption`: the caption ink was
+   * measured against the PLATE (4.75:1) and only reaches 4.45:1 on the darker
+   * page this surface introduces. Labels that sit on a panel cell take
+   * `plateEyebrow` below, where the caption gold is both legal and better.
+   */
   const eyebrow: CSSProperties = {
     ...SMALL_CAPS,
     fontSize: "var(--text-sm)",
-    color: CAPTION,
+    color: QUIET,
   };
+  /** The same label voice on a panel cell, where the caption gold clears. */
+  const plateEyebrow: CSSProperties = { ...eyebrow, color: CAPTION };
   const quietItalic: CSSProperties = {
     fontFamily: READING,
     fontStyle: "italic",
@@ -860,7 +868,7 @@ export default function EphemeristsTaskDetail({
       }}
     >
       <div style={{ width: "100%", display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
-        {ledgerRow(<span style={eyebrow}>{t("detail.points.base")}</span>, basePoints)}
+        {ledgerRow(<span style={plateEyebrow}>{t("detail.points.base")}</span>, basePoints)}
         {/* The modifier row — absent at ×1.00, so invisible under era_1's
             neutralised modifiers and automatic the day one moves (ADR-0055).
             The design labels it "Bonus"; ADR-0057 leaves no shared word for it,
@@ -904,7 +912,7 @@ export default function EphemeristsTaskDetail({
               fontSize: "var(--text-xs)",
               letterSpacing: "0.2em",
               marginTop: "var(--space-xs)",
-              color: QUIET,
+              color: CAPTION,
             }}
           >
             {t("detail.points.total")}

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -334,6 +334,23 @@ const ARCHETYPE_PAIRS: Pair[] = [
   { what: "ephemerists medallion disc, unit", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-muted" },
   { what: "ephemerists plate CTA band", surface: "--faction-ephemerists-plate-cta-bg", text: "--faction-ephemerists-plate-cta-ink" },
 
+  // …and the three surfaces task detail (#1032) added, where the plate stops
+  // being one card on the app's ground and becomes the page. `-quiet` exists
+  // precisely because of the first row here: the DARKER page ground drops
+  // `-muted` to 4.31 and `-caption` to 4.45, both of which measure fine on the
+  // plate above. `-nile` was walked for the same reason (4.24 on the page as the
+  // design drew it) and carries every link plus the "level met" yes, so it is
+  // measured on all three grounds it lands on.
+  { what: "ephemerists page ground, quiet ink", surface: "--faction-ephemerists-plate-page", text: "--faction-ephemerists-plate-quiet" },
+  { what: "ephemerists page ground, links", surface: "--faction-ephemerists-plate-page", text: "--faction-ephemerists-plate-nile" },
+  { what: "ephemerists page ground, title", surface: "--faction-ephemerists-plate-page", text: "--faction-ephemerists-plate-ink" },
+  { what: "ephemerists plate, quiet ink", surface: "--faction-ephemerists-plate-bg", text: "--faction-ephemerists-plate-quiet" },
+  { what: "ephemerists panel cell, ink", surface: "--faction-ephemerists-plate-inner", text: "--faction-ephemerists-plate-ink" },
+  { what: "ephemerists panel cell, caption", surface: "--faction-ephemerists-plate-inner", text: "--faction-ephemerists-plate-caption" },
+  { what: "ephemerists panel cell, quiet ink", surface: "--faction-ephemerists-plate-inner", text: "--faction-ephemerists-plate-quiet" },
+  { what: "ephemerists panel cell, links", surface: "--faction-ephemerists-plate-inner", text: "--faction-ephemerists-plate-nile" },
+  { what: "ephemerists medallion disc, caption", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-caption" },
+
   // Singularity — THE TERMINAL SESSION (task card v2, #1023). The one card in
   // the wave that is DARK IN BOTH THEMES (§6), so every row here is measured
   // twice against a near-black ground rather than once against a light one. The


### PR DESCRIPTION
Rebuilds the Ephemerists task detail as **THE VALLEY PLATE at page size**, ported from
`.design-sync/task-details-v2/ephemerists-task-detail.jsx`. Replaces the 909-line
"Discordant Map" archetype — the largest in the set — wholesale.

Closes #1032

## What shipped

- `frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx` — one responsive
  component (`useFormFactor()` internally), same anatomy as the na reference build (#1030):
  breadcrumb cartouche · faction line · title · author row · Level/In-progress stats ·
  420px action panel · full brief · praxis gallery · comments.
- `frontend/src/index.css` — six new `--faction-ephemerists-plate-*` tokens (page, inner,
  quiet, nile, rule, line) in **both** `:root` and `[data-theme="dark"]`, plus
  `.eph-plate-sheet` and `.eph-plate-crown`.
- `frontend/src/utils/__tests__/factionContrast.test.ts` — 9 new measured pairs.
- `frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx` — new (27 tests).

The registry needed no change (`ephemerists.ts` already registers `taskDetail`), and
`mobileArchetypes/EphemeristsTaskDetail.tsx` + its `mobileTaskDetail` row are untouched and
still compile (ADR-0058). `tasks.json` was not edited — the dead `ephemerists.*` keys are
still read by the two faction-page files and belong to #1039.

## Deviations from the vendored design — what it said, what shipped, why

1. **No in-progress roster.** The design builds a complete roster section (octagon avatars,
   tally strokes, Ally/Rival tags, "+N more players →") and never mounts it in either
   layout. Owner ruling 2026-07-28. Not ported.
2. **The masthead IS mounted.** The design defines `masthead` and — like `roster` — never
   mounts it either. Unlike the roster there is no ruling against it, the design's own
   header comment names it as the page's dress ("cavetto-cornice masthead with a winged disc
   and two incised glyph registers"), and it is the mark the v2 task card already ships.
   **Please eyeball this one specifically** — it is the single largest judgement call here.
   Its registers are generated to fill the viewBox rather than the design's fixed 16, which
   at page width would otherwise slice up to cartoon size.
3. **The mobile sticky "← Task №N" bar is not ported.** It is mock chrome; the app has a
   global nav and the breadcrumb already carries the ordinal. Mobile gets the masthead at
   the smaller size instead.
4. **`Bonus ×1.00` hides at 1.0** like every other skin's badge (ADR-0055), and its label
   slot takes an incised ankh — ADR-0057 leaves no shared word for "Bonus".
5. **Every word is the shared `detail.*` set.** `Task description` / `in full` /
   `Discussion` / `Ally` / `Rival` / `Say something about this task…` / `Post` are all gone.
6. **Praxis gallery is the live `<PraxisCard>`** in `flex flex-wrap gap-4`, not the design's
   `repeat(3,1fr)` grid and not its mock cards.
7. **"View all" expands in place.** `/praxes?task_id=N` has never filtered (`usePraxes`
   reads no such param) — same fix na took.
8. **No fixed full-bleed backdrop.** I first shipped one (sibling of `.na-backdrop`), then
   #1056 landed and pulled that pattern off na after live QA. The layout is why: the routed
   page sits in a `position: relative; z-index: 5` wrapper, so a fixed `z-index: 0` child is
   a positioned descendant of that stacking context and paints over the non-positioned
   sidebar. The column carries the papyrus itself instead, masthead flush to its edges.
9. **Three inks walked down for contrast** (same shape as #1023's `-brass` → `-caption`).
   The page ground this surface introduces is DARKER than the plate the card was measured
   on: the design's `faint` #9a8c6c is 2.43:1 and has no token at all; `muted` falls to 4.31
   and `nile` to 4.24 on the page. `-quiet` (#5f5238) clears on all three grounds
   (5.25/5.60/6.20) and `-nile` ships at #276460 (4.70/5.01/5.55). Dark needed no walk-down.
   The sheet's wash only lightens for the same reason — a 5% darkening vignette drops
   `-nile` to 4.29.
10. **Brief leading opened 28 → 32px**, and the journal ruling with it. The design's 28 was
    drawn for 15.5px type; `--text-content` is 18px (the #627 floor), so the ruling moved
    rather than the type.
11. **Touch targets re-solved, not bolted on** (the standing Ephemerists carve-out in
    `design-fidelity.md`): sort tabs / drop / expand take `minHeight: 44` on the phone and
    the design's tighter chrome on the pointer build, in rows that already wrap. No 44px box
    was dropped into ornament drawn for intrinsic sizes.
12. **The glyph library is duplicated** from `components/cards/EphemeristsTaskCard.tsx`
    (two-file scope). Extraction target is `components/cards/ephemeristsAtoms.tsx`; until
    then a change to one sign has to be made twice.

## What to eyeball

- The masthead (deviation 2) — is a page-wide cornice band the right call, or should the
  page start at the breadcrumb?
- The crowned action panel: 420px, disc overlapping the plate's top edge, `.eph-plate-crown`
  drop-shadow in **both** themes (hard night-blue offset in light, soft cast in dark).
- The ruled brief leaf: do the rules land on the baselines, and does the ochre margin rule
  sit in the gutter at both sizes?
- Dark mode across the whole page — every value flips through the cascade.
- Mobile: the panel stays a two-cell row (116px ledger + summons) as the design draws it.
- Metatask rendering (pill + "Metatask for X" line).

## Verification

`tsc --noEmit` clean · `eslint` clean (incl. `--report-unused-disable-directives`) ·
`vitest` 1767/1767 across 108 files · `vite build` clean, and both `.eph-plate-sheet` rules
plus all 6 new token declarations verified present in the BUILT css (×2 each = light+dark).
Poiret One / Cinzel / Spectral are all already in `index.html`'s loader.

**Visual QA is outstanding** — I cannot screenshot and there is no dev stack in this
worktree. Everything above is structural verification; none of it proves the page looks
right.
