### PR TITLE
QA round 2: UA surface belongs to the component; correct #1056's false premise

### DIFF
--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -760,11 +760,18 @@ export default function DefaultTaskDetail({
           zIndex: 1,
           maxWidth: 1200,
           margin: "0 auto",
-          // The page surface the design puts everything on. This used to be a
-          // `<div className="na-backdrop">` whose rule was never written — the
-          // element rendered and painted nothing, so the whole column sat
-          // directly on the app shell. A class with no CSS behind it type-checks,
-          // lints and builds clean; only looking at it catches that.
+          // The page surface the design puts everything on, carried by the
+          // COLUMN rather than the viewport — the owner's rule for this surface
+          // is that the site background still shows around the component.
+          //
+          // This replaced a `<div className="na-backdrop">` full-page wash.
+          // NOTE, correcting #1056's commit message and PR body: that PR claimed
+          // `.na-backdrop` had no rule behind it. It does — index.css defines it
+          // with a dark-mode variant. The claim came from grepping a stale
+          // worktree that predated #1049. The change itself was still right (a
+          // full-bleed faction wash is not wanted here, and the column needed a
+          // surface and padding), but the stated reason was false; do not cite
+          // it as precedent for "a class with no CSS".
           background: "var(--faction-default-card-bg)",
           color: "var(--faction-default-card-text)",
           border: "1px solid var(--faction-default-border)",

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -818,48 +818,49 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
       className="py-8"
       style={{
         position: "relative",
-        overflow: "hidden",
         fontFamily: UA_TEXT,
         color: "var(--faction-ua-page-text)",
       }}
     >
-      {/* The ground — mesa sand, one flat token, both themes. Fixed like the na
-          wash so the leaf reads as the page rather than as a card on the app's
-          rainbow watercolour. */}
-      <span
-        aria-hidden
-        style={{
-          position: "fixed",
-          inset: 0,
-          zIndex: 0,
-          pointerEvents: "none",
-          background: "var(--faction-ua-page)",
-        }}
-      />
-      {/* The lotus, bleeding off the left edge. Ornament geometry stays in raw
-          px (§4a); its opacity is a token, so dark mode lifts it through the
-          cascade rather than through the design's `saturate(1.35)`. */}
-      <Lotus
-        size={size.lotus}
-        color="var(--faction-ua-card-lotus)"
-        style={{
-          position: "absolute",
-          left: size.lotusLeft,
-          top: size.lotusTop,
-          zIndex: 0,
-          opacity: "var(--faction-ua-card-lotus-opacity)",
-          pointerEvents: "none",
-        }}
-      />
-
+      {/* The vellum ground belongs to the DETAIL COMPONENT, not the viewport.
+          This used to be a `position: fixed; inset: 0` span, which painted UA's
+          sand over the whole site — including behind the chrome — and left the
+          column itself unpadded, so every line of copy ran to the edge. The
+          column now carries its own surface, its own padding and its own lotus,
+          and the site background shows around it. */}
       <div
         style={{
           position: "relative",
           zIndex: 1,
           maxWidth: 1200,
           margin: "0 auto",
+          background: "var(--faction-ua-page)",
+          border: "1px solid var(--faction-ua-rule)",
+          borderRadius: 18,
+          padding: desktop ? "var(--space-2xl)" : "var(--space-lg)",
+          overflow: "hidden",
+          boxSizing: "border-box",
         }}
       >
+        {/* The lotus, bleeding off the leaf's own left edge — clipped by the
+            column's `overflow: hidden` rather than by the viewport. `zIndex: -1`
+            paints it above this column's background but beneath its copy: the
+            column is positioned, so it owns the stacking context, and a
+            positioned `zIndex: 0` sibling would have sat ON TOP of the static
+            text. Ornament geometry stays in raw px (§4a); its opacity is a
+            token, so dark mode lifts it through the cascade. */}
+        <Lotus
+          size={size.lotus}
+          color="var(--faction-ua-card-lotus)"
+          style={{
+            position: "absolute",
+            left: size.lotusLeft,
+            top: size.lotusTop,
+            zIndex: -1,
+            opacity: "var(--faction-ua-card-lotus-opacity)",
+            pointerEvents: "none",
+          }}
+        />
         <div
           style={{
             display: "flex",


### PR DESCRIPTION
## 1 · UA task detail — owner QA on the merged #1055

> "The full page background should still be the site background. The task detail
> component should have the lotus. Putting every single bit of text right up to
> the edge is not ideal."

Three defects, one cause — UA treated the **viewport** as its canvas:

- the vellum ground was a `position: fixed; inset: 0` span, so UA's sand covered
  the whole site, chrome included;
- the lotus hung off the **page's** left edge rather than the component's;
- the 1200 column had no padding, so every line of copy ran to the edge.

**Fix:** the column carries the surface, a border, a radius and real padding, and
clips its own lotus. The site background shows around it.

The lotus moves to `zIndex: -1`. The column is positioned, so it owns the
stacking context — and a positioned `zIndex: 0` sibling paints **above** static
text, which is how an ornament layer silently covers copy. `-1` puts it above the
column's background and below its content.

## 2 · Correcting a false premise I shipped in #1056

#1056's body and commit message claimed `.na-backdrop` "was never written" and
was "a class with no CSS behind it".

**That is wrong.** `frontend/src/index.css` defines `.na-backdrop` with a
dark-mode variant. I grepped a **stale worktree** that predated #1049, saw two
hits in the TSX and none in the CSS, and asserted the class was fictional.

The change itself was still correct — a full-bleed faction wash is not wanted on
this surface (the owner has now said so explicitly for UA), and the column did
need a surface and padding. But the reason was false, and it was already being
picked up: the Ephemerists build flagged it as likely-to-be-cited precedent, and
the UA build reasoned *from* it when deciding how to paint its ground.

The source comment now carries the correction so it cannot be cited as evidence
for "a class with no CSS".

Credit where due: the #1032 agent caught this, not me.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` 1750/1750 green.

Visual QA of the fix is **outstanding** — I still cannot screenshot.

## What to eyeball

- UA task detail: the **site** background around the component, not UA sand
  edge-to-edge; the lotus inside the leaf, clipped by it; copy no longer touching
  the edges. Light and dark.
- The lotus must sit **behind** the text, not over it.
- na task detail unchanged in behaviour — only its comment changed.