### PR TITLE
SNIDE task detail: the xerox wall paints the column, not the viewport

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1800,11 +1800,15 @@
 }
 
 /* ══ S.N.I.D.E. flyposted-wall backdrop (faction-context pages; theme-aware) ══ */
-.snide-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
+/* The wall PAINT, shared by two mounts with different geometry:
+     • `.snide-backdrop`   — the full-viewport wall (SnideBackdrop.tsx) on
+       faction-context pages, where covering the page IS the point.
+     • `.snd-detail-sheet` — the task-detail COLUMN's ground. The owner's rule
+       for task detail is that the site background still shows around the
+       component (QA on #1055, then #1057), so this mount must NOT be fixed.
+   One declaration, so the two can never drift apart. */
+.snide-backdrop,
+.snd-detail-sheet {
   background-color: var(--faction-snide-wall);
   background-image:
     radial-gradient(40% 30% at 100% 0%, color-mix(in srgb, var(--faction-snide-acid) 18%, transparent), transparent 70%),
@@ -1815,11 +1819,27 @@
     linear-gradient(180deg, var(--faction-snide-wall), var(--faction-snide-wall-deep));
   background-size: 100% 100%, 100% 100%, 5px 5px, auto, auto, 100% 100%;
 }
-.snide-backdrop::after {
+/* Only the full-page mount is fixed. */
+.snide-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+.snide-backdrop::after,
+.snd-detail-sheet::after {
   content: "";
   position: absolute;
   inset: 0;
   background: radial-gradient(120% 90% at 50% 6%, transparent 42%, color-mix(in srgb, var(--faction-snide-wall-deep) 60%, transparent));
+}
+/* On the column the vignette needs an explicit z-index: the column is
+   positioned, so a positioned ::after would otherwise paint OVER the copy.
+   -1 puts it above the sheet's background and beneath its content. */
+.snd-detail-sheet::after {
+  z-index: -1;
+  border-radius: inherit;
+  pointer-events: none;
 }
 
 /* ══ Default (Unaffiliated / na) spectrum backdrop (faction-context pages; theme-aware) ══

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -941,11 +941,26 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
 
   return (
     <div className="py-8" style={{ position: "relative", fontFamily: TYPE, color: INK }}>
-      {/* The flyposted xerox wall — SNIDE's page ground (index.css, shared with
-          every faction-context SNIDE surface). */}
-      <div className="snide-backdrop" aria-hidden="true" />
-
-      <div style={{ position: "relative", zIndex: 1, maxWidth: 1200, margin: "0 auto" }}>
+      {/* The flyposted xerox wall, painted on the detail COLUMN rather than the
+          viewport: the owner's rule for this surface is that the site background
+          still shows around the component (QA on #1055, then #1057). This used
+          to mount `.snide-backdrop`, which is `position: fixed` because the
+          faction-context pages that share it DO want the whole page. index.css
+          now splits that rule — one paint, two mounts — so the wall cannot drift
+          between them. */}
+      <div
+        className="snd-detail-sheet"
+        style={{
+          position: "relative",
+          zIndex: 1,
+          maxWidth: 1200,
+          margin: "0 auto",
+          borderRadius: 18,
+          padding: desktop ? "var(--space-2xl)" : "var(--space-lg)",
+          overflow: "hidden",
+          boxSizing: "border-box",
+        }}
+      >
         <div
           style={{
             display: "flex",


### PR DESCRIPTION
Owner QA on the merged #1057: **"snide background takes over the whole page."**

Confirmed in the screenshot — SNIDE's wall covered the viewport, including
behind the right-hand sidebar.

## Cause

`SnideTaskDetail` mounted `.snide-backdrop`, which is `position: fixed; inset: 0`.

That rule is **not wrong** — it is shared with `components/backdrop/SnideBackdrop.tsx`,
which dresses faction-context pages where covering the whole page is the point.
So the class could not simply be changed.

## Fix

`index.css` now splits the rule:

- **one shared paint declaration** (`.snide-backdrop, .snd-detail-sheet`) — the
  wall colour, the acid/pink corner bleeds, the dot grain and the two diagonal
  scratch passes, so the two mounts can never drift apart;
- **`position: fixed` only on `.snide-backdrop`**, the full-page mount.

The task-detail column takes `.snd-detail-sheet` plus its own radius, padding and
`overflow: hidden`.

One subtlety worth keeping: the vignette `::after` needs `z-index: -1` on the
column mount. The column is positioned, so it owns the stacking context, and a
positioned `::after` paints **above** static content — the vignette would have
sat on top of the copy.

## This is the fifth skin corrected to the same rule

na (#1056), UA (#1060), Coven, Everymen and WOW were all corrected during the
wave; SNIDE reused an existing full-page class rather than minting one, so it
did not show up in the `position: fixed` sweep I ran over the others. That sweep
was looking at what each PR *added*, not what it *mounted*.

Ephemerists is the only skin that got this right unprompted — because #1056
landed while it was still building.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` 1847/1847 green ·
`vite build` clean.

Checked against the **built** stylesheet, not the source: both selectors sit at
nesting depth 0, and `position: fixed` survives only on `.snide-backdrop`.

Visual QA of the fix is **outstanding** — I cannot screenshot.

## What to eyeball

- SNIDE task detail: site background visible around the component; the wall
  clipped to the column, not running under the sidebar.
- The vignette darkening must sit **behind** the copy.
- A SNIDE **faction page** (SnideBackdrop's own surface) must still have its
  full-page wall — that mount is unchanged and is the thing most at risk here.