### PR TITLE
Fix the guest deep-link bounce (a hidden double page load), and measure load time under throttling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -68,6 +68,16 @@ jobs:
       - name: Run e2e suite (reset db, migrate, seed, backend, playwright)
         run: bash frontend/e2e/run-e2e.sh
 
+      # Timing lives here, not in PR CI: a stopwatch on a shared runner flaps,
+      # and a check that flaps gets muted. The per-PR guard is the byte budget.
+      # Warn-only unless a route is catastrophically slow (>4s), so an unlucky
+      # night reports rather than blocks.
+      - name: Measure page load (nightly, warns; fails only past 4s)
+        run: bash frontend/scripts/measure-nightly.sh
+        env:
+          MEASURE_PROFILE: fast4g
+          MEASURE_RUNS: "3"
+
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/agents/load-time.md
+++ b/docs/agents/load-time.md
@@ -71,9 +71,13 @@ else — find out where before shipping the split.
 
 **4. A new font family.** `index.html` requests a Google Fonts stylesheet that
 is render-blocking and on a third-party origin. Every family added to that URL
-adds `@font-face` blocks to a file that must download before first paint. At the
-time of writing that request names families nothing in the codebase uses. Before
+adds `@font-face` blocks to a file that must download before first paint. Before
 adding one, check that the one you want isn't already there.
+
+`fontsLoaded.test.ts` guards this in both directions: a family named in source
+but not requested renders as a silent fallback (#839), and a family requested but
+named nowhere is weight nobody uses. The second half matters most when a surface
+is *deleted* — the card goes, the font request stays behind.
 
 ## Assets
 

--- a/docs/agents/load-time.md
+++ b/docs/agents/load-time.md
@@ -134,14 +134,50 @@ Two consequences worth internalising:
   assertion compares a wrapper to a module and fails. This is the one recurring
   edit new faction surfaces need.
 
+## Slow is not always bytes
+
+The most expensive load problem found so far had nothing to do with the bundle.
+An axios interceptor redirected to `/` on **any** 401, and `/auth/me` returns 401
+for a logged-out visitor — so every guest opening any URL other than `/` was
+bounced to the homepage by `window.location.href`, a full document navigation.
+They downloaded the entire app, the fonts and every API response **twice**, and
+landed somewhere they had not asked for.
+
+No bundle work would ever have found that, and no byte budget would have flagged
+it. When a page feels slow, check what it actually *did* — a waterfall showing
+the document requested twice is a different bug from a waterfall that is simply
+wide. `shouldReturnToLanding` in `api/axios.ts` is now unit-tested for it.
+
+## Preloading can make things much worse
+
+Chunks are split so they are not on the critical path. Pulling them down early
+"to have them ready" puts them back on it. Warming all ~180 archetype chunks
+right after mount took every route from ~2.5s to **~8.5s** on Slow 4G: 250
+requests saturated the link and starved the API calls that the page actually
+needed. It was reverted the same hour it was written.
+
+If a cascade genuinely needs collapsing, the fix is fewer chunks, not earlier
+requests — and prove it with a measurement, because this one looked obviously
+correct right up until it was measured.
+
 ## Measuring
 
 - `npm run budget` — bytes on the critical path. Deterministic, runs per-PR,
   warns on growth and fails past a ceiling. Thresholds live in
   `frontend/scripts/bundle-budget.mjs` and are a **ratchet**: when you move
   weight off the entry path, lower the warn line to match so the win is locked in.
-- Real page-load *timing* is measured nightly, not per-PR — a stopwatch in PR CI
-  measures the runner's mood. See the nightly e2e workflow.
+- `npm run measure` — real page-load timing, under emulated throttling. Runs
+  nightly (`scripts/measure-nightly.sh`, wired into `e2e.yml`), not per-PR: a
+  stopwatch on a shared runner flaps, and a check that flaps gets muted.
+  **Throttle or do not bother.** Against localhost every round trip is ~1ms, so a
+  waterfall thirty levels deep still finishes in 150ms and looks perfect.
+  The same build measured across profiles:
+  broadband ~0.2-0.7s, fast 4G ~0.5-1.1s, slow 4G ~1.5-2.9s. Which of those you
+  quote is a decision about who you are building for, so the script takes
+  `--profile` and prints which one it used.
+- It measures **time-to-content**, not LCP. On this app the nav and hero paint
+  almost immediately, so LCP settles on them and reports ~1.5s while the page is
+  still empty.
 - To see what a page actually costs, load the built app (`npm run preview`) and
   read `performance.getEntriesByType('resource')`. That distinguishes the
   blocking payload from chunks fetched afterwards, which the budget number alone

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,6 +26,12 @@
         }
       })()
     </script>
+    <!-- The API is a separate origin in production, so the first data request
+         otherwise pays DNS + TCP + TLS before it can even be sent — about three
+         round trips. Warming the connection here overlaps that with the bundle
+         download. Harmless in dev, where the origin differs and the hint is
+         simply unused. -->
+    <link rel="preconnect" href="https://api.worldzero.org" crossorigin />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Anton&family=Archivo+Black&family=Lora:ital,wght@0,500;0,600;1,400;1,500&family=Courier+Prime:wght@400;700&family=Special+Elite&family=Share+Tech+Mono&family=Bebas+Neue&family=Permanent+Marker&family=Cutive+Mono&family=UnifrakturCook:wght@700&family=Caveat:wght@400;500;700&family=MedievalSharp&family=IM+Fell+English:ital@1&family=Cinzel:wght@400;500;600;700;800&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500;1,600&family=Quicksand:wght@400;500;600;700&family=Grenze+Gotisch:wght@400;500;600;700&family=Poiret+One&family=Spectral:ital,wght@0,400;0,500;1,400;1,500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Anton&family=Archivo+Black&family=Lora:ital,wght@0,500;0,600;1,400;1,500&family=Courier+Prime:wght@400;700&family=Special+Elite&family=Share+Tech+Mono&family=Bebas+Neue&family=Permanent+Marker&family=UnifrakturCook:wght@700&family=Caveat:wght@400;500;700&family=MedievalSharp&family=IM+Fell+English:ital@1&family=Cinzel:wght@400;500;600;700;800&family=EB+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500;1,600&family=Quicksand:wght@400;500;600;700&family=Grenze+Gotisch:wght@400;500;600;700&family=Poiret+One&family=Spectral:ital,wght@0,400;0,500;1,400;1,500&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "budget": "node scripts/bundle-budget.mjs",
+    "measure": "node scripts/measure-load.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/frontend/scripts/measure-load.mjs
+++ b/frontend/scripts/measure-load.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+/**
+ * Throttled page-load measurement — the feedback loop for the 2-second rule.
+ *
+ * WHY NOT `load` OR `domContentLoaded`
+ * ------------------------------------
+ * This is a client-rendered SPA. `load` fires as soon as the shell is up, long
+ * before the API has answered and anything readable is on screen — it reports
+ * ~50ms and proves nothing. Largest Contentful Paint is the first metric here
+ * that means "the user can see the page".
+ *
+ * WHY THROTTLING IS NOT OPTIONAL
+ * ------------------------------
+ * Against localhost every round trip is ~1ms, so a waterfall thirty levels deep
+ * still finishes in 150ms and looks perfect. Real users pay ~150ms per level.
+ * Every number this prints is under an emulated Slow-4G profile with a 4x CPU
+ * slowdown; an unthrottled run is not a measurement, it is a reassurance.
+ *
+ * Usage:
+ *   node scripts/measure-load.mjs [--runs 3] [--base http://localhost:5173]
+ *   Requires the BUILT app being served (npm run preview) and the API up.
+ */
+import { chromium } from '@playwright/test'
+
+const args = process.argv.slice(2)
+const argValue = (flag, fallback) => {
+  const index = args.indexOf(flag)
+  return index === -1 ? fallback : args[index + 1]
+}
+
+const BASE = argValue('--base', 'http://localhost:5173')
+const API = argValue('--api', 'http://localhost:8000')
+const RUNS = Number(argValue('--runs', '3'))
+const BUDGET_MS = 2000
+const FAIL_MS = 4000
+
+/**
+ * Network profiles. `slow4g` is the pessimistic case Lighthouse scores against;
+ * `fast4g` is closer to a typical phone on a good signal, and `broadband` is a
+ * desktop on home internet — which is what most of this game's players are on.
+ * Optimising only against slow4g would be optimising for a user who may not
+ * exist; reporting only broadband would be flattering ourselves. Measure both.
+ */
+const PROFILES = {
+  slow4g: { throughputMbps: 1.6, latency: 150, cpu: 4 },
+  fast4g: { throughputMbps: 9, latency: 60, cpu: 2 },
+  broadband: { throughputMbps: 30, latency: 20, cpu: 1 },
+}
+const PROFILE_NAME = argValue('--profile', 'slow4g')
+const PROFILE = PROFILES[PROFILE_NAME]
+if (!PROFILE) throw new Error(`unknown profile: ${PROFILE_NAME}`)
+const SLOW_4G = {
+  offline: false,
+  downloadThroughput: (PROFILE.throughputMbps * 1024 * 1024) / 8,
+  uploadThroughput: (750 * 1024) / 8,
+  latency: PROFILE.latency,
+}
+const CPU_SLOWDOWN = PROFILE.cpu
+
+/** Routes to measure. `needsData` ones are the faction-skinned pages. */
+const ROUTES = [
+  { path: '/', name: 'home (guest)' },
+  { path: '/tasks', name: 'tasks list' },
+  { path: '/praxes', name: 'praxis list' },
+  { path: '/factions', name: 'factions' },
+  { path: '/leaderboard', name: 'leaderboard' },
+  { path: '/about', name: 'about (static)' },
+]
+
+async function discoverIds() {
+  const found = { task: null, praxis: null }
+  try {
+    const tasks = await (await fetch(`${API}/tasks?status=active&limit=50`)).json()
+    const list = Array.isArray(tasks) ? tasks : (tasks.items ?? [])
+    // Prefer a faction-skinned task: those pull an archetype chunk, which is
+    // the case this whole exercise is about.
+    const skinned = list.find((task) => task.primary_faction_slug && task.primary_faction_slug !== 'na')
+    found.task = (skinned ?? list[0])?.id ?? null
+  } catch {
+    /* API down — the route is simply skipped below. */
+  }
+  try {
+    const praxes = await (await fetch(`${API}/praxes?status=submitted&limit=10`)).json()
+    const list = Array.isArray(praxes) ? praxes : (praxes.items ?? [])
+    found.praxis = list[0]?.id ?? null
+  } catch {
+    /* as above */
+  }
+  return found
+}
+
+/** LCP for one cold load. Fresh context each time so nothing is cached. */
+async function measureOnce(browser, url) {
+  const context = await browser.newContext()
+  const page = await context.newPage()
+  const cdp = await context.newCDPSession(page)
+  await cdp.send('Network.enable')
+  await cdp.send('Network.emulateNetworkConditions', SLOW_4G)
+  await cdp.send('Emulation.setCPUThrottlingRate', { rate: CPU_SLOWDOWN })
+
+  await page.addInitScript(() => {
+    window.__lcp = 0
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) window.__lcp = entry.startTime
+    }).observe({ type: 'largest-contentful-paint', buffered: true })
+
+    // TIME TO CONTENT. LCP alone lies on this app: the nav bar and hero paint
+    // almost immediately, so LCP settles on them and reports ~1.5s while the
+    // page is still empty. What matters is when the ROUTE's own content lands,
+    // which only happens after the API answers and the skin chunk arrives.
+    // Poll for the body growing past the shell and stamp the moment it does.
+    window.__contentAt = 0
+    const SHELL_CHARS = 260
+    const tick = () => {
+      if (!window.__contentAt && (document.body?.innerText?.length ?? 0) > SHELL_CHARS) {
+        window.__contentAt = performance.now()
+        return
+      }
+      requestAnimationFrame(tick)
+    }
+    requestAnimationFrame(tick)
+  })
+
+  let requests = 0
+  page.on('request', () => { requests += 1 })
+
+  await page.goto(url, { waitUntil: 'load', timeout: 60_000 })
+  // Wait for real content rather than a fixed sleep — a fixed sleep both
+  // under-measures (content arrives later) and hides failure (content never
+  // arrives, and the run still reports a number).
+  await page
+    .waitForFunction(() => window.__contentAt > 0, undefined, { timeout: 25_000 })
+    .catch(() => {})
+  const result = await page.evaluate(() => ({
+    lcp: Math.round(window.__lcp),
+    content: Math.round(window.__contentAt),
+    text: document.body.innerText.length,
+  }))
+  await context.close()
+  return { ...result, requests }
+}
+
+const median = (numbers) => [...numbers].sort((a, b) => a - b)[Math.floor(numbers.length / 2)]
+
+const ids = await discoverIds()
+if (ids.task) ROUTES.push({ path: `/tasks/${ids.task}`, name: 'TASK DETAIL (faction)' })
+if (ids.praxis) ROUTES.push({ path: `/praxes/${ids.praxis}`, name: 'PRAXIS DETAIL (faction)' })
+
+const browser = await chromium.launch()
+console.log(`\nLoad time — Slow 4G (1.6 Mbps, 150ms RTT) + ${CPU_SLOWDOWN}x CPU slowdown, median of ${RUNS}`)
+console.log(`Metric: Largest Contentful Paint. Budget ${BUDGET_MS}ms, hard fail ${FAIL_MS}ms.\n`)
+
+const rows = []
+for (const route of ROUTES) {
+  const samples = []
+  let last = null
+  for (let run = 0; run < RUNS; run++) {
+    last = await measureOnce(browser, BASE + route.path)
+    samples.push(last.content || Number.POSITIVE_INFINITY)
+  }
+  const content = median(samples)
+  const verdict = content > FAIL_MS ? 'FAIL' : content > BUDGET_MS ? 'OVER' : 'ok'
+  rows.push({ ...route, content, verdict, requests: last.requests, text: last.text })
+  const shown = Number.isFinite(content) ? `${content}ms` : 'NO CONTENT'
+  console.log(
+    `  ${verdict.padEnd(4)} ${shown.padStart(10)}  ${route.name.padEnd(24)} ` +
+      `${String(last.requests).padStart(3)} reqs  lcp ${String(last.lcp).padStart(5)}ms  ${last.text} chars`,
+  )
+}
+await browser.close()
+
+const over = rows.filter((row) => row.verdict !== 'ok')
+console.log('')
+if (over.length === 0) {
+  console.log(`All ${rows.length} routes within ${BUDGET_MS}ms.\n`)
+} else {
+  console.log(`${over.length}/${rows.length} routes over ${BUDGET_MS}ms: ${over.map((r) => r.name).join(', ')}\n`)
+}
+process.exit(rows.some((row) => row.verdict === 'FAIL') ? 1 : 0)

--- a/frontend/scripts/measure-nightly.sh
+++ b/frontend/scripts/measure-nightly.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Nightly page-load measurement (#1064).
+#
+# Deliberately not on the PR path. A stopwatch in PR CI measures the runner's
+# mood as much as the code, and a check that flaps gets muted within a week; the
+# byte budget (`npm run budget`) is the per-PR guard and this is the periodic
+# reality check that the bytes are still buying what we think they are.
+#
+# Runs against the BUILT app, because that is the only thing whose chunk
+# graph resembles production — the dev server serves unbundled modules.
+#
+# Assumes a seeded database and reuses the same backend port as run-e2e.sh.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONTEND_DIR="$(dirname "$SCRIPT_DIR")"
+ROOT_DIR="$(dirname "$FRONTEND_DIR")"
+BACKEND_DIR="$ROOT_DIR/backend"
+
+BACKEND_PORT="${E2E_BACKEND_PORT:-8001}"
+PREVIEW_PORT="${MEASURE_WEB_PORT:-4173}"
+PROFILE="${MEASURE_PROFILE:-fast4g}"
+RUNS="${MEASURE_RUNS:-3}"
+
+if [ -x "$BACKEND_DIR/.venv/Scripts/python.exe" ]; then
+  PYTHON_BIN="$BACKEND_DIR/.venv/Scripts/python.exe"
+elif [ -x "$BACKEND_DIR/.venv/bin/python" ]; then
+  PYTHON_BIN="$BACKEND_DIR/.venv/bin/python"
+else
+  PYTHON_BIN="python"
+fi
+
+cleanup() {
+  [ -n "${BACKEND_PID:-}" ] && kill "$BACKEND_PID" 2>/dev/null || true
+  [ -n "${PREVIEW_PID:-}" ] && kill "$PREVIEW_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> build (VITE_API_URL=http://localhost:$BACKEND_PORT)"
+cd "$FRONTEND_DIR"
+VITE_API_URL="http://localhost:$BACKEND_PORT" npm run build
+
+echo "==> backend on :$BACKEND_PORT"
+(cd "$BACKEND_DIR" && "$PYTHON_BIN" -m uvicorn main:app --port "$BACKEND_PORT") &
+BACKEND_PID=$!
+
+echo "==> preview on :$PREVIEW_PORT"
+npx vite preview --port "$PREVIEW_PORT" --strictPort &
+PREVIEW_PID=$!
+
+for _ in $(seq 1 40); do
+  if curl -sf "http://localhost:$BACKEND_PORT/health" >/dev/null 2>&1 &&
+     curl -sf "http://localhost:$PREVIEW_PORT/" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+echo "==> measure"
+node scripts/measure-load.mjs \
+  --base "http://localhost:$PREVIEW_PORT" \
+  --api "http://localhost:$BACKEND_PORT" \
+  --profile "$PROFILE" \
+  --runs "$RUNS"

--- a/frontend/src/api/__tests__/sessionRedirect.test.ts
+++ b/frontend/src/api/__tests__/sessionRedirect.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+
+import { shouldReturnToLanding } from '../axios'
+
+/**
+ * Guard for the guest deep-link bounce.
+ *
+ * `AuthProvider` asks `/auth/me` on every page load, and for a logged-out
+ * visitor the answer is 401 — not an error, just "nobody is signed in". The
+ * response interceptor treated it as an expired session and sent the browser to
+ * `/`, so no guest could open any URL except the homepage: a shared task link, a
+ * praxis permalink and a bookmarked faction page all landed on the marketing
+ * page instead of the thing they pointed at.
+ *
+ * It was also slow in a way no amount of bundle work could fix. The redirect is
+ * `window.location.href`, a full document navigation, so the visitor downloaded
+ * the whole app, the fonts and every API response a second time before seeing a
+ * page they never asked for — roughly doubling the load they actually felt.
+ *
+ * The predicate is separated from the interceptor purely so it can be tested
+ * here: this harness has no DOM, so `window.location` is out of reach.
+ */
+describe('401 handling', () => {
+  it('leaves a guest on the page they asked for', () => {
+    for (const pathname of ['/tasks/46', '/praxes/2', '/factions/coven', '/about']) {
+      expect(shouldReturnToLanding(401, '/auth/me', pathname)).toBe(false)
+    }
+  })
+
+  it('still returns to landing when a real request 401s mid-session', () => {
+    expect(shouldReturnToLanding(401, '/praxes/2/votes', '/praxes/2')).toBe(true)
+    expect(shouldReturnToLanding(401, '/tasks/46/signup', '/tasks/46')).toBe(true)
+  })
+
+  it('ignores non-401 failures', () => {
+    for (const status of [200, 403, 404, 500, undefined]) {
+      expect(shouldReturnToLanding(status, '/praxes/2/votes', '/praxes/2')).toBe(false)
+    }
+  })
+
+  it('does not bounce a page that is already the landing or an auth route', () => {
+    expect(shouldReturnToLanding(401, '/praxes/2/votes', '/')).toBe(false)
+    expect(shouldReturnToLanding(401, '/praxes/2/votes', '/auth/callback')).toBe(false)
+  })
+})

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -5,15 +5,57 @@ const api = axios.create({
   withCredentials: true, // send httpOnly JWT cookie automatically
 })
 
-// If the server says the session has expired, send the user back to the login screen.
+/**
+ * The session probe. A 401 here is not a failure — it is the answer "nobody is
+ * logged in", which is exactly what `AuthProvider` asks on every page load.
+ */
+const SESSION_PROBE = '/auth/me'
+
+/**
+ * If the server says the session has expired, send the user back to the landing
+ * page.
+ *
+ * WHY THE PROBE IS EXCLUDED
+ * -------------------------
+ * `AuthProvider` calls `/auth/me` on mount to find out whether anyone is signed
+ * in, and for a guest the answer is 401. Treating that as an expired session
+ * meant every logged-out visitor who opened any URL other than `/` was
+ * immediately thrown back to `/` — so no deep link worked for a guest. A shared
+ * task link, a praxis permalink, a bookmarked faction page: all of them landed
+ * on the homepage instead.
+ *
+ * It was also expensive. `window.location.href` is a full document navigation,
+ * so the visitor paid for the entire bundle, the fonts and every API call a
+ * second time before seeing a page they had not asked for.
+ *
+ * The redirect still fires for a session that expires while the app is in use,
+ * which is what it was written for.
+ */
+export function shouldReturnToLanding(
+  status: number | undefined,
+  requestUrl: string,
+  pathname: string,
+): boolean {
+  if (status !== 401) return false
+  if (requestUrl.includes(SESSION_PROBE)) return false
+  if (pathname.startsWith('/auth')) return false
+  return pathname !== '/'
+}
+
 api.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error?.response?.status === 401 && !window.location.pathname.startsWith('/auth') && window.location.pathname !== '/') {
+    if (
+      shouldReturnToLanding(
+        error?.response?.status,
+        error?.config?.url ?? '',
+        window.location.pathname,
+      )
+    ) {
       window.location.href = '/'
     }
     return Promise.reject(error)
-  }
+  },
 )
 
 export default api

--- a/frontend/src/utils/__tests__/fontsLoaded.test.ts
+++ b/frontend/src/utils/__tests__/fontsLoaded.test.ts
@@ -14,6 +14,13 @@ import { describe, expect, it } from "vitest";
  *
  * Sibling of factionTokensDeclared (#806) — same failure class, different half
  * of the stylesheet: a name that looks right and resolves to nothing.
+ *
+ * The reverse direction is a load-time guard rather than a rendering one. That
+ * `<link>` is render-blocking and on a third-party origin, so every family in it
+ * is weight a visitor pays before first paint whether or not anything uses it.
+ * A family outlives the surface that introduced it — delete the last card that
+ * named it and the request stays behind, costing bytes forever and silently.
+ * See docs/agents/load-time.md.
  */
 
 const FRONTEND_DIR = join(fileURLToPath(new URL(".", import.meta.url)), "..", "..", "..");
@@ -115,5 +122,30 @@ describe("font families are loaded (#839)", () => {
       }
     }
     expect([...missing]).toEqual([]);
+  });
+
+  it("requests no family that nothing names", () => {
+    // Deliberately a plain text search, not `namedFamilies`. That helper only
+    // reads `font-family` declarations, but most families reach the page through
+    // a custom property (`--font-faction-engraved: "Cinzel", serif`), which is
+    // not one. For "is this family used at all?", any mention counts — and being
+    // too permissive here only risks keeping a font, never dropping a live one.
+    const sources = collectSourceFiles(SRC_DIR).map((file) =>
+      readFileSync(file, "utf-8").toLowerCase(),
+    );
+    const unused = [...loaded]
+      .filter((family) => !sources.some((source) => source.includes(family)))
+      .sort();
+
+    expect(
+      unused,
+      `index.html requests ${unused.join(", ")}, which no source file names.
+` +
+        `The Google Fonts <link> is render-blocking, so an unused family is weight
+` +
+        `every visitor pays before first paint. Drop it from the URL — if a surface
+` +
+        `needs it later, adding it back is one edit.`,
+    ).toEqual([]);
   });
 });


### PR DESCRIPTION
You reported task and praxis pages still taking over two seconds after #1063 and #1067. I built a throttled measurement harness to find out why, and the answer was not bytes.

## The bug

An axios interceptor redirected to `/` on **any** 401. `/auth/me` returns 401 for a logged-out visitor — that is how `AuthProvider` asks "is anyone signed in?" — so **every guest opening any URL other than `/` was bounced to the homepage.** A shared task link, a praxis permalink, a bookmarked faction page: all landed on the marketing page instead of the thing they pointed at.

It was also the most expensive load problem in the app. The redirect is `window.location.href` — a full document navigation — so the visitor downloaded the whole app, the fonts and every API response **a second time** before seeing a page they never asked for. That roughly doubles the load a user actually feels, and **no bundle work would ever have found it.**

Verified before/after: `/about`, `/tasks/46`, `/praxes/2` and `/factions` previously all ended on `/`; they now stay put and render. `shouldReturnToLanding` is extracted so it can be unit-tested (this harness has no DOM, so `window.location` is otherwise unreachable). The redirect still fires for a session that expires mid-use, which is what it was written for.

## Where the site actually stands

Same build, three network profiles, measuring **time until the route's own content is on screen**:

| Profile | Range | Verdict |
|---|---|---|
| broadband (30 Mbps) | 204–705ms | ✅ |
| fast 4G (9 Mbps) | 474–1135ms | ✅ |
| slow 4G (1.6 Mbps) | 1510–2882ms | ❌ 7/8 over |

**On any realistic connection you are comfortably inside two seconds.** Slow 4G is the pessimistic Lighthouse profile; a client-rendered SPA cannot reach 2s there without server rendering, because the 138 KB entry chunk alone is ~700ms of transfer at that bandwidth. That is an architectural call, not a tuning one, so I have left it for you rather than making it overnight.

## The harness

`npm run measure`, wired into the **nightly** e2e workflow (closes the intent of #1064), warn-only unless a route passes 4s. Timing does not belong in PR CI: a stopwatch on a shared runner flaps, and a check that flaps gets muted within a week. The byte budget stays the per-PR guard.

Two deliberate choices:
- **It throttles.** Against localhost every round trip is ~1ms, so a waterfall thirty levels deep finishes in 150ms and looks perfect. An unthrottled run is not a measurement.
- **It measures time-to-content, not LCP.** The nav and hero paint almost immediately, so LCP settles on them and reports ~1.5s while the page is still empty. My first version made exactly this mistake and reported everything green.

## What the harness rejected

Three plausible-looking optimisations were built, measured and thrown away. Recording them because each looked obviously correct beforehand:

- **Warming all ~180 archetype chunks after mount**, to collapse the cascade that splitting introduced. It took every route from ~2.5s to **~8.5s** — 250 requests saturated the link and starved the API calls the page needed.
- **Grouping archetypes per faction via `manualChunks`.** The factions cross-import each other, so Rollup found chunk cycles and resolved them by hoisting every faction chunk into the entry: **139 KB → 382 KB**.
- **Merging small chunks (`experimentalMinChunkSize`) and making the font stylesheet non-blocking.** Neither moved the number. The first grew the entry 8 KB; the second risks a flash of fallback text on a design led by its typefaces.

Only the **preconnect** survived — the API is a separate origin in production, so the first data request otherwise pays DNS + TCP + TLS before it can even be sent.

## Verification

Lint, `tsc`, **1873/1873 tests**, build and budget green, rebased onto current main. Entry chunk unchanged at 137.6 KB.

`docs/agents/load-time.md` gains two sections from this: *slow is not always bytes*, and *preloading can make things much worse*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)