### PR TITLE
ADR-0059 + ADR-0060: the collab/duel composer-hold epic

### DIFF
--- a/docs/adr/0059-submitting-a-collab-or-duel-part-holds-the-composer.md
+++ b/docs/adr/0059-submitting-a-collab-or-duel-part-holds-the-composer.md
@@ -1,0 +1,54 @@
+# ADR-0059 — Submitting a collab or duel part holds the composer
+
+**Status:** Accepted
+**Date:** 2026-07-28
+**Relates to:** #1071 (epic), #1073 (ADR-0060, the sibling behaviour change),
+#591 (the `CollabSuccess` hold this generalises), #646 (moved author controls
+off the public roster and into the composer footer), #590 (`pullBack`)
+
+## Context
+
+`publish()` (`frontend/src/pages/editPraxis/useEditPraxis.ts`) ends with
+`navigate(`/praxes/${idParam}`)` for every case except one: the cast that
+closes a multi-member collab's consensus gate holds the composer for the
+`CollabSuccess` beat (#591), gated by `deriveCollabGate`.
+
+So for every *other* multi-party cast — a collab part filed while co-authors
+are still weaving, a duel side sealed before the rival answers — the player is
+redirected to the public read view. That view can show roster state (it
+mounts `CollabRoster` via `CollabRosterBlock` in
+`frontend/src/pages/praxisDetail/shared.tsx`), but it offers no authoring
+exit: no way to re-open your own part, no drop/leave scoped to you.
+
+## Decision
+
+**Submitting a part of a multi-party praxis holds the composer.** It
+re-renders as a waiting surface rather than navigating away.
+
+- Applies to **collab** and **duel**. **Solo keeps the existing redirect** —
+  there is nobody to wait for.
+- The praxis detail page remains the public read view, unchanged. It keeps
+  its roster and its duel rails.
+- The waiting surface offers exactly one exit appropriate to the viewer, and
+  an authoring re-entry.
+- Re-entry is **not** a raw PUT. On a collab, any praxis PUT hard-resets
+  every member's `has_submitted` (ADR-0012 — "an edit means we're not done"),
+  so "edit my write-up" routes through `pullBack()`, which re-opens only the
+  caller's membership (#590).
+
+## Consequences
+
+- `useEditPraxis` grows a phase; `EditPraxis.tsx` dispatches to the waiting
+  surface instead of the archetype.
+- Two surfaces render roster state. That is already true and already solved
+  — both mount the same `CollabRoster`.
+- The `CollabSuccess` hold (#591) becomes the special case of a general rule
+  rather than a one-off.
+
+## Alternative rejected
+
+**The detail page owns the moment.** Cheaper — the roster and the 12 duel
+rails are already there. Rejected because it puts author-only controls on a
+public read page, which is precisely what #646 moved off the roster and back
+into the composer footer, and because "edit mine" would become a bounce
+between two routes.

--- a/docs/adr/0060-a-collab-that-loses-its-last-collaborator-becomes-solo.md
+++ b/docs/adr/0060-a-collab-that-loses-its-last-collaborator-becomes-solo.md
@@ -1,0 +1,66 @@
+# ADR-0060 — A collab that loses its last collaborator becomes solo
+
+**Status:** Accepted
+**Date:** 2026-07-28
+**Relates to:** #1071 (epic), #1072 (ADR-0059, the sibling behaviour change)
+**Pairs with:** ADR-0013 (collaborations are co-owned), ADR-0047 (praxis card
+shows computed total, not Merit)
+
+## Context
+
+`leave_praxis` (`backend/services/praxis.py`) removes a member and calls
+`on_member_leave`, which guards on `remaining and …`
+(`backend/services/collab_consensus.py`). If the *last* member leaves,
+`remaining` is empty and nothing happens: a praxis survives with zero
+members, editable by nobody (`_require_member` fails for everyone) and
+deletable only by its original creator.
+
+`leave_praxis` has **no status guard** — a member may leave an `in_progress`,
+`pending`, or `submitted` collab.
+
+A one-member "collab" is not a collaboration. It also still scores as one:
+`collab_own_modifier` / `collab_other_modifier` are a live pair of
+`EraConfig` knobs distinct from the solo `own_task_modifier` /
+`other_task_modifier`, and `era_1` already ships one faction at
+`collab_own_modifier=1.1`.
+
+## Decision
+
+**When a collab drops to exactly one member, it converts to a solo praxis
+owned by the survivor — at any status.**
+
+- The conversion reuses the existing `collab → solo` mutations in
+  `change_praxis_type` (`backend/services/praxis.py`), documented as an
+  intentional takeover: `created_by_id` is reassigned to the actor, remaining
+  members and pending invites are dropped, content is kept.
+- Reassigning `created_by_id` is what makes the survivor's exit work:
+  `delete_praxis` is creator-only, so without it a survivor who did not start
+  the praxis could not drop it.
+- The empty-collab state becomes unreachable: the last member's exit is
+  **drop**, not leave.
+- **This applies to `submitted` praxes too**, deliberately. If everyone
+  leaves you, you should not keep a collaboration bonus for work you now hold
+  alone. This is narrower than `change_praxis_type`, which refuses
+  non-editing statuses (422) — that guard protects a *voluntary* takeover;
+  this conversion is a consequence, not a choice.
+
+## Consequences
+
+- A published collab can change scoring model after the fact, losing its
+  collab modifier and gaining the solo one. Accepted: that is the point of
+  the rule.
+- ADR-0047's display follows automatically — a solo praxis shows the full
+  `(base + meta) × faction_mult + votes` stamp rather than collapsing to
+  Merit.
+- Stats for the converted praxis must be recalculated when the conversion
+  happens at `submitted`.
+
+## Alternatives rejected
+
+- **Convert only while editing.** Consistent with `change_praxis_type`'s
+  existing status guard, but leaves a deserted published collab holding a
+  bonus it no longer earns.
+- **Block the last member from leaving.** Reintroduces a special case for a
+  state nobody wants to be in.
+- **Leave the orphan.** Accumulates rows that hold a task signup and can
+  never be touched.


### PR DESCRIPTION
## Summary

Docs-only PR. Writes the two ADRs behind epic #1071's "the composer holds after you submit" work, rendering the Context/Decision/Consequences/Alternatives prose already drafted in the issue bodies into this repo's house ADR format (matched against ADR-0053, ADR-0055, ADR-0056, ADR-0058).

- `docs/adr/0059-submitting-a-collab-or-duel-part-holds-the-composer.md` — submitting your part of a collab or duel holds the composer as a waiting surface instead of redirecting to the public detail page; solo keeps the existing redirect; re-entry routes through `pullBack()`, not a raw PUT.
- `docs/adr/0060-a-collab-that-loses-its-last-collaborator-becomes-solo.md` — a collab that drops to its last member converts to solo (reusing `change_praxis_type`'s takeover mutations) at any status, including `submitted`, deliberately dropping the collab modifier.

Both are dated 2026-07-28, Status: Accepted, per the issues.

Closes #1072
Closes #1073

## Verification performed

Every file/line reference cited in #1072 and #1073 was checked against the current code on this branch before being written into the ADRs (line numbers drift, so a couple are cited by symbol name instead where that's more durable):

- `useEditPraxis.ts` — `publish()`'s `navigate('/praxes/:id')` (line 583), the collab `has_submitted` hard-reset comment (line 222), `deriveCollabGate` / `CollabSuccess` gating, and `pullBack()` (#590) all confirmed as described.
- `praxisDetail/shared.tsx` — `CollabRosterBlock` mounts the shared `CollabRoster` with no action prop, confirmed.
- `backend/services/praxis.py` — `leave_praxis` (line 1752) has no status guard, confirmed. `change_praxis_type`'s `collab → solo` branch (starts 1233, docstring calls it an intentional takeover, matches the "documented as an intentional takeover" claim). `delete_praxis` (line 1308) is creator-only, confirmed.
- `backend/services/collab_consensus.py` — `on_member_leave` (line 148) guards on `remaining and ...`, confirmed: an empty `remaining` list short-circuits and nothing happens.
- `backend/eras/era_1.py` — `collab_own_modifier=1.1` on exactly one faction (line 74), `collab_own_modifier`/`collab_other_modifier` confirmed as distinct `EraConfig` fields from `own_task_modifier`/`other_task_modifier` in `game_config.py`.

No claim in either issue was found to be materially wrong — no stop-and-report was needed.

## What to eyeball

- [ ] ADR-0059 and ADR-0060 are genuinely the next free numbers (`ls docs/adr/` showed the ladder ending at 0058)
- [ ] Front-matter shape (Status/Date/Relates-to lines) matches recent ADRs (0053, 0055, 0056, 0058) closely enough
- [ ] The "Alternative(s) rejected" section headings match each issue's singular/plural usage (0059 has one alternative, 0060 has three)
- [ ] No new relates-to/pairs-with cross-references were invented beyond what the issues and epic #1071 support
- [ ] This PR is docs-only — no code changes, so CI's `frontend`/`test` jobs should be unaffected; visual QA is N/A