### PR TITLE
Expose collab_auto_submit_days on GameConfigOut (#1078)

### DIFF
--- a/backend/routers/game_config.py
+++ b/backend/routers/game_config.py
@@ -44,6 +44,7 @@ async def get_game_config() -> GameConfigOut:
         level_thresholds=list(CURRENT_ERA.level_thresholds),
         duel_level_required=CURRENT_ERA.duel_level_required,
         collaboration_level_required=CURRENT_ERA.collaboration_level_required,
+        collab_auto_submit_days=CURRENT_ERA.collab_auto_submit_days,
         max_task_signups=CURRENT_ERA.max_task_signups,
         vote_budget_base=CURRENT_ERA.vote_budget_base,
         vote_budget_multiplier=CURRENT_ERA.vote_budget_multiplier,

--- a/backend/schemas/game_config.py
+++ b/backend/schemas/game_config.py
@@ -32,6 +32,7 @@ class GameConfigOut(BaseModel):
     level_thresholds: list[int]
     duel_level_required: int
     collaboration_level_required: int
+    collab_auto_submit_days: int
     max_task_signups: int
     vote_budget_base: int
     vote_budget_multiplier: float

--- a/backend/tests/integration/test_game_config.py
+++ b/backend/tests/integration/test_game_config.py
@@ -17,6 +17,10 @@ async def test_get_game_config_returns_current_era(client: AsyncClient):
     assert data["max_task_signups"] == CURRENT_ERA.max_task_signups
     assert data["vote_budget_base"] == CURRENT_ERA.vote_budget_base
 
+    # Pending-publish silence-is-consent window (ADR-0012): duration only,
+    # since submit_proposed_at (the start) is already on PraxisOut.
+    assert data["collab_auto_submit_days"] == CURRENT_ERA.collab_auto_submit_days
+
     # Every configured faction is present with its scoring modifiers.
     assert len(data["factions"]) == len(CURRENT_ERA.factions)
     slugs = {faction["slug"] for faction in data["factions"]}

--- a/frontend/src/api/gameConfig.ts
+++ b/frontend/src/api/gameConfig.ts
@@ -34,6 +34,7 @@ export interface GameConfigOut {
   level_thresholds: number[]
   duel_level_required: number
   collaboration_level_required: number
+  collab_auto_submit_days: number
   max_task_signups: number
   vote_budget_base: number
   vote_budget_multiplier: number


### PR DESCRIPTION
## Summary

Adds the ADR-0012 pending-publish window duration to the game-config payload. The window's *start* (`submit_proposed_at`) was already on the wire via `PraxisOut` / `PraxisCardOut`; only the duration was missing, so the collab waiting surface (#1080) had no way to render its countdown without hardcoding a number.

Four one-line additions plus a test assertion:

- `backend/schemas/game_config.py` — `collab_auto_submit_days: int` on `GameConfigOut`
- `backend/routers/game_config.py` — populated from `CURRENT_ERA.collab_auto_submit_days`, matching how every neighbouring field is built
- `frontend/src/api/gameConfig.ts` — matching client type
- `backend/tests/integration/test_game_config.py` — asserts the response matches the era config rather than a literal

No value is hardcoded anywhere: `era_1` ships `collab_auto_submit_days=10` and the test compares against `CURRENT_ERA`, so a future era changing the window needs no code change here.

Closes #1078

## What to eyeball

- [ ] `GET /game-config` returns `collab_auto_submit_days: 10` under era 1
- [ ] Nothing renders differently — this is wire-only; no UI consumes the field until #1080 lands
- [ ] Visual QA is N/A for this PR (no rendered change), and was not performed