### PR TITLE
Widen ScoreStampProps to the structural ScoredPraxis (#1079)

### DIFF
--- a/frontend/src/components/praxisCard/scoreStamp/ScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/ScoreStamp.tsx
@@ -1,4 +1,4 @@
-import type { PraxisCardOut } from "../../../api/praxis";
+import type { ScoredPraxis } from "./scoreBreakdown";
 import { pickVariant } from "../../../utils/factionDispatch";
 import { surfaceMap } from "../../../factions";
 import DefaultScoreStamp from "./DefaultScoreStamp";
@@ -23,8 +23,30 @@ import DefaultScoreStamp from "./DefaultScoreStamp";
  * mobile guidance reuses the card's score presentation unchanged), which is why
  * the invented mobile `BASE ∣ MULT ∣ VOTES ∣ TOT` strip is gone.
  */
+/**
+ * Everything ANY stamp reads off a praxis — structural, like the `ScoredPraxis`
+ * it extends, so both `PraxisCardOut` (cards) and `PraxisOut` (detail, and the
+ * composer) satisfy it without a cast (#1079).
+ *
+ * The score terms belong to `scoreBreakdown`'s contract; these two do not, so
+ * they are declared HERE rather than pushed into `ScoredPraxis`. `ScoredPraxis`
+ * is the arithmetic the shared selector performs — a crown flag and a dispatch
+ * slug are presentation inputs of this surface, and a future consumer that only
+ * wants the rows shouldn't have to carry them.
+ *
+ * These are the only two extras, verified across all eight registered stamps:
+ * every skin reads `score` + the breakdown terms, plus `is_top_for_task` for the
+ * crown; the dispatcher alone reads `task_faction_slug`.
+ */
+export interface StampablePraxis extends ScoredPraxis {
+  /** Task Crown — top-scoring submitted praxis for its task (ADR-0028). */
+  is_top_for_task: boolean;
+  /** The task's faction: what the stamp surface dispatches on (ADR-0039). */
+  task_faction_slug: string | null;
+}
+
 export interface ScoreStampProps {
-  praxis: PraxisCardOut;
+  praxis: StampablePraxis;
   /**
    * Set false when the surface draws its own TaskCrown (the faction pages, and
    * the mobile cards, whose body already floats one over the frame).

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -13,7 +13,8 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
 import '../../../../i18n'
-import type { PraxisCardOut } from '../../../../api/praxis'
+import type { PraxisCardOut, PraxisOut } from '../../../../api/praxis'
+import type { ScoreStampProps } from '../ScoreStamp'
 import { pickVariant } from '../../../../utils/factionDispatch'
 import { resolvedArchetype } from '../../../../factions/lazyArchetype'
 import { surfaceMap } from '../../../../factions'
@@ -338,4 +339,89 @@ describe('#842 stamps across the conditional states (ADR-0047)', () => {
       expect(html).not.toMatch(HEX)
     })
   }
+})
+
+/**
+ * The stamp's prop type is structural (#1079). `ScoredPraxis` always claimed to
+ * be satisfied by BOTH payload shapes (ADR-0053), but the component prop was
+ * pinned to `PraxisCardOut`, so the detail/composer payload could only reach a
+ * stamp through a cast — and a cast would have hidden a genuinely missing field
+ * instead of failing the build.
+ *
+ * These cases pin the claim from the other side: a real `PraxisOut` literal,
+ * with no `as` anywhere, both type-checks and renders the SAME markup a card
+ * payload renders. If a skin ever starts reading a card-only field, the literal
+ * below stops compiling — which is the whole point of widening rather than
+ * casting.
+ */
+describe('PraxisOut satisfies the stamp contract without a cast (#1079)', () => {
+  /** A complete detail payload — every field spelled out, nothing asserted. */
+  const detail: PraxisOut = {
+    id: 7,
+    task_id: 3,
+    task_title: 'Walk the long way home',
+    task_point_value: 12,
+    task_level_required: 1,
+    task_faction_slug: null,
+    type: 'solo',
+    status: 'submitted',
+    title: 'The long way',
+    body_text: null,
+    moderation_status: 'visible',
+    admin_note: null,
+    flagged_at: null,
+    submitted_at: '2026-07-28T00:00:00Z',
+    submit_proposed_at: null,
+    created_by_id: 5,
+    created_by_display_name: 'Wanderer',
+    created_by_faction_slug: null,
+    created_at: '2026-07-27T00:00:00Z',
+    updated_at: '2026-07-28T00:00:00Z',
+    members: [],
+    invites: [],
+    media_items: [],
+    score: 13.6,
+    metatask_points: 0,
+    display_multiplier: 0.8,
+    points_from_votes: 4,
+    is_top_for_task: false,
+    duel_id: null,
+    can_flag: true,
+    applied_metatasks: [],
+  }
+
+  it('type-checks as ScoreStampProps — the assertion is the assignment itself', () => {
+    const props: ScoreStampProps = { praxis: detail }
+    expect(props.praxis.score).toBe(13.6)
+  })
+
+  it('renders byte-identically from a detail payload and a card payload', () => {
+    const fromDetail = renderToStaticMarkup(<DefaultScoreStamp praxis={detail} />)
+    const fromCard = renderToStaticMarkup(
+      <DefaultScoreStamp praxis={praxis({ is_top_for_task: false, task_faction_slug: null })} />,
+    )
+    expect(fromDetail).toBe(fromCard)
+  })
+
+  it('carries the crown flag through, so the detail payload can wear a crown', () => {
+    const crowned = renderToStaticMarkup(
+      <DefaultScoreStamp praxis={{ ...detail, is_top_for_task: true }} />,
+    )
+    const bare = renderToStaticMarkup(<DefaultScoreStamp praxis={detail} />)
+    expect(crowned).not.toBe(bare)
+    expect(
+      renderToStaticMarkup(
+        <DefaultScoreStamp praxis={{ ...detail, is_top_for_task: true }} showCrown={false} />,
+      ),
+    ).toBe(bare)
+  })
+
+  it('feeds the dispatcher its slug from a detail payload too', () => {
+    const covenDetail: PraxisOut = { ...detail, task_faction_slug: 'coven' }
+    expect(
+      resolvedArchetype(
+        pickVariant(surfaceMap('scoreStamp'), covenDetail.task_faction_slug, DefaultScoreStamp),
+      ),
+    ).toBe(CovenScoreStamp)
+  })
 })


### PR DESCRIPTION
Closes #1079

`ScoreStampProps.praxis` was typed `PraxisCardOut`, narrower than the stamp's own logic-layer contract — `ScoredPraxis` in `scoreBreakdown.ts` has been deliberately structural since ADR-0053, "so both `PraxisCardOut` (cards) and `PraxisOut` (detail) satisfy it". Only the component prop disagreed, which is what stops #1080's composer (holding a `PraxisOut`) from mounting the stamp.

## What every stamp actually reads

Audited all eight registered stamps (`Default`, `Coven`, `Ephemerists`, `Everymen`, `Singularity`, `Snide`, `Ua`, `Wow`) plus the dispatcher, field by field. The complete set is:

- the five `ScoredPraxis` terms, via `scoreBreakdown(praxis)` — every skin
- `praxis.score` for the early null-return — every skin
- `praxis.is_top_for_task` for the crown — every skin
- `praxis.task_faction_slug` — the dispatcher only

Nothing reaches for a card-only field, so nothing had to be added to the structural interface and no field is unsatisfiable by `PraxisOut`. Both payloads carry `is_top_for_task: boolean` and `task_faction_slug: string | null` already.

## Where the interface lives, and why

New `StampablePraxis extends ScoredPraxis`, declared in `ScoreStamp.tsx` next to `ScoreStampProps` — **not** by widening `ScoredPraxis` itself.

`ScoredPraxis` is the arithmetic contract of the shared row selector: the terms it needs to decide which rows exist. A crown flag and a dispatch slug are presentation inputs of *this surface*, not score terms. Folding them into `ScoredPraxis` would mean a future consumer that only wants the breakdown rows has to carry a faction slug it never reads, and would blur the ADR-0049 logic/presentation seam that module exists to hold. Extending it keeps `ScoredPraxis` honest and gives the surface one named type for its own requirement.

The dispatcher and all eight skins are otherwise untouched — no logic, no markup, no styles changed. No `as` casts were added anywhere.

## Proof that a `PraxisOut` passes without a cast

Four cases added to `scoreStamp.test.tsx`, built on a fully-spelled-out `PraxisOut` literal with no `as` anywhere (a cast would have hidden a genuinely missing field instead of failing the build):

- the type-level assertion is the assignment itself: `const props: ScoreStampProps = { praxis: detail }`
- the detail payload and an equivalent card payload render **byte-identical** markup
- the crown flag carries through from a detail payload (and `showCrown={false}` still suppresses it)
- the dispatcher resolves `CovenScoreStamp` from a detail payload's slug

If a skin ever starts reading a card-only field, that literal stops compiling — which is the point of widening rather than casting.

## Verification

- `tsc --noEmit` — clean
- `vitest run` — 117 files, 1877 tests, all green (62 in the stamp file, up from 58)
- `eslint src/components/praxisCard/scoreStamp` — clean
- `vite build` — clean

Visual QA is outstanding: this environment can't screenshot and has no running dev stack.

## What to eyeball

This should be a **visual no-op** — a type widening only, with a test asserting the rendered markup is byte-identical across both payload shapes. Nothing here changes a pixel by design, so any difference you spot is a bug. Where a regression would show:

- **Praxis cards across every faction** — the score box, the multiplier chip, the meta and votes rows, the total mark (UA's ensō, Everymen's roundel, the Ephemerists' rubric, Snide's numeral, Singularity's register, WOW's ✦, Coven's ✨, the unaffiliated rainbow total)
- **The Task Crown** on a top-scoring praxis — present where it was, absent where `showCrown={false}` (faction pages, mobile cards, which draw their own)
- **Faction pages** — cards there pass `showCrown={false}`
- **Mobile praxis cards** — same stamp component, same expectation
- **`albescent` / `na` / null-slug praxes** — still fall through to the unaffiliated Default stamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)
