### PR TITLE
Kicking requires an open praxis (#1076)

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -1722,13 +1722,26 @@ async def kick_member(
     requester_id: int,
     session: AsyncSession,
 ) -> None:
-    """Remove a member. Any member may kick another (incl. the creator); not self (ADR-0013)."""
+    """Remove a member. Any member may kick another (incl. the creator); not self (ADR-0013).
+
+    Only while the praxis is still open (``in_progress`` or ``pending``). A kick
+    resets the whole group back to drafting, so allowing it on a published praxis
+    would silently unpublish it and wipe every member's cast — reopen first, then
+    kick. Leaving is deliberately not restricted this way (ADR-0012): a member may
+    walk away from a published collab without dragging it back into editing.
+    """
     praxis = await get_praxis(praxis_id, session)
 
     _require_member(praxis, requester_id, "kick from")
 
     if member_id == requester_id:
         raise HTTPException(status_code=400, detail="Cannot kick yourself.")
+
+    if praxis.status not in (PraxisStatus.in_progress, PraxisStatus.pending):
+        raise HTTPException(
+            status_code=422,
+            detail="Cannot kick from a published praxis. Move it to editing first.",
+        )
 
     member_result = await session.execute(
         select(PraxisMember).where(

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -1527,6 +1527,69 @@ async def test_collab_non_creator_can_kick_creator(
     assert character.id in remaining
 
 
+@pytest.mark.asyncio
+async def test_kick_refused_on_submitted_collab(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Kicking is open-praxis only (#1076): a published collab refuses with 422.
+
+    A kick resets the whole group back to drafting, so on a published praxis it
+    would silently unpublish it and wipe every cast. Reopen first.
+    """
+    praxis_id = await _two_member_collab(
+        client, active_task, auth_headers2, character.id, auth_headers
+    )
+    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
+    submit2 = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
+    assert submit2.json()["status"] == "submitted"
+
+    resp = await client.post(
+        f"/praxes/{praxis_id}/kick/{character2.id}", headers=auth_headers
+    )
+    assert resp.status_code == 422
+
+    # Nothing moved: still published, still two members, both still cast.
+    after = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    data = after.json()
+    assert data["status"] == "submitted"
+    assert {m["character_id"] for m in data["members"]} == {character.id, character2.id}
+    assert all(m["has_submitted"] for m in data["members"])
+
+
+@pytest.mark.asyncio
+async def test_kick_on_pending_collab_still_resets_casts(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """The ADR-0013 reset survives the #1076 guard: a pending kick is still allowed
+    and still drops the group back to drafting, clearing the remaining cast."""
+    praxis_id = await _two_member_collab(
+        client, active_task, auth_headers2, character.id, auth_headers
+    )
+    # The kicker casts first, so the collab is pending with their own cast in.
+    opened = await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers)
+    assert opened.json()["status"] == "pending"
+
+    resp = await client.post(
+        f"/praxes/{praxis_id}/kick/{character2.id}", headers=auth_headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "in_progress"
+    assert data["submit_proposed_at"] is None
+    assert {m["character_id"] for m in data["members"]} == {character.id}
+    assert not any(m["has_submitted"] for m in data["members"])
+
+
 # ---------------------------------------------------------------------------
 # Collab lazy-consensus publish (ADR-0012): pending-publish window + timeout + leave
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -64,8 +64,9 @@ export function CollabRoster({
   /**
    * Remove another member (#959). Receives the target's CHARACTER id. When
    * provided, a kick × renders on every OTHER member's pill — but only if the
-   * viewer is themselves a member, mirroring the backend `kick_member` guard
-   * ("any member may kick any other, not self"). The confirm step lives here so
+   * viewer is themselves a member and the collab is still open, mirroring the
+   * backend `kick_member` guard ("any member may kick any other, not self, and
+   * only while in_progress/pending" — #1076). The confirm step lives here so
    * both the composer and the read-only detail block get it for free; the
    * callback only has to run the API call + refresh.
    */
@@ -78,9 +79,14 @@ export function CollabRoster({
   const accent = factionCssVar(factionSlug, 'card-accent')
   const pct = Math.round((gate.castCount / gate.memberCount) * 100)
 
-  // Mirror the backend: only a member may kick, and never themselves.
+  // Mirror the backend: only a member may kick, never themselves, and only
+  // while the praxis is still open (#1076). `published` is that last condition
+  // in roster terms — the backend seals a collab to `submitted` exactly when
+  // every member has cast, and every route back out clears all of them, so S4
+  // and `status === 'submitted'` are the same fact. Keeping it derived means the
+  // rule lives in this one component, not re-stated at each call site.
   const viewerIsMember = members.some((m) => m.character_id === currentCharacterId)
-  const canKick = onKick != null && viewerIsMember
+  const canKick = onKick != null && viewerIsMember && gate.state !== 'published'
 
   const handleKick = (member: PraxisMemberOut) => {
     if (!onKick) return

--- a/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
+++ b/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
@@ -62,3 +62,45 @@ describe('CollabRoster render', () => {
     expect(html).not.toContain('weaving')
   })
 })
+
+// Mirrors the backend `kick_member` guard — see the comment above `canKick`.
+describe('CollabRoster kick × visibility (#959, #1076)', () => {
+  const kick = () => {}
+
+  it('offers the × on another member while the collab is still open', () => {
+    const html = renderToStaticMarkup(
+      <CollabRoster
+        members={[member(1, true), member(2, false)]}
+        currentCharacterId={1}
+        factionSlug={null}
+        onKick={kick}
+      />,
+    )
+    expect(html).toContain('kick M2 from the collab')
+    expect(html).not.toContain('kick M1 from the collab') // never on my own pill
+  })
+
+  it('withholds the × once every member has cast (the praxis is published)', () => {
+    const html = renderToStaticMarkup(
+      <CollabRoster
+        members={[member(1, true), member(2, true)]}
+        currentCharacterId={1}
+        factionSlug={null}
+        onKick={kick}
+      />,
+    )
+    expect(html).not.toContain('kick M2 from the collab')
+  })
+
+  it('withholds the × from a non-member viewer', () => {
+    const html = renderToStaticMarkup(
+      <CollabRoster
+        members={[member(1, false), member(2, false)]}
+        currentCharacterId={99}
+        factionSlug={null}
+        onKick={kick}
+      />,
+    )
+    expect(html).not.toContain('kick M2 from the collab')
+  })
+})


### PR DESCRIPTION
Closes #1076

Kicking now requires an open praxis. `kick_member` checked membership and not-self but never the status, so a kick could land on a published collab — and because a kick resets the whole group back to drafting (ADR-0013), that silently pulled a published praxis out of scoring and wiped every member's cast, with no warning and no way to see it coming.

## Backend

`kick_member` (`backend/services/praxis.py`) refuses with **422** unless the praxis is `in_progress` or `pending`: *"Cannot kick from a published praxis. Move it to editing first."* The docstring says why, and says why leaving is deliberately not restricted the same way.

`leave_praxis` / `on_member_leave` are untouched — a member may still walk away from a published collab (#1075 owns that path).

Two integration tests in `backend/tests/integration/test_praxes.py`:
- `test_kick_refused_on_submitted_collab` — 422, and nothing moved: still `submitted`, still two members, both still cast.
- `test_kick_on_pending_collab_still_resets_casts` — the **existing** ADR-0013 behaviour still works: a `pending` kick is allowed, drops the collab back to `in_progress`, closes the window, and clears the remaining member's cast.

## Frontend

The guard lives **inside `CollabRoster`**, not at the call sites. Two reasons:

1. The roster already owns the mirror of this backend rule — it computes `viewerIsMember` for the "any member, never self" half of `kick_member`, and its `onKick` docstring commits to that. Adding the status half next to it keeps one mirror, not two.
2. It is derived from the roster's own `published` state (`gate.state`) rather than a new `praxisStatus` prop. `_apply_seal` is the only writer of `status = submitted` and it marks every member cast; every route back out (`on_member_edit`, `on_member_kicked`, `unsubmit_praxis`) clears all of them. So for a collab, "everyone has cast" and `status === 'submitted'` are the same fact, and one line covers both call sites without either of them re-stating the rule.

Practically that closes the composer path (`editPraxis/archetypes/controls.tsx` renders the roster whatever the status — that file is untouched here, another PR is editing it). The detail page's `CollabRosterBlock` already returns null outside `in_progress`/`pending`, so it was covered by construction; the roster guard means it stays covered if that block's condition ever loosens.

Three tests in `CollabRoster.test.tsx` cover ×-present while open, ×-absent once every member has cast, and ×-absent for a non-member viewer.

`window.confirm` in the roster is left alone — that's #1082.

## Verification

- `pytest` full backend suite on a dedicated `wz1076_test` DB: **793 passed**.
- `tsc --noEmit` clean (`tsc --version` → 5.9.3, so it really ran), `vite build` clean, `eslint` clean on both touched frontend files.
- `vitest` — 10 in `CollabRoster.test.tsx`, 194 across `collab/` + `praxisDetail/`.
- **Visual QA is outstanding**: no dev stack and no screenshot capability in this environment, so the roster was verified by rendered-markup assertions, not by eye.

## What to eyeball

- A published (Live) collab you are a member of, on the praxis detail page and in the composer: no × on anyone's pill, and the roster otherwise looks unchanged.
- The same collab while still drafting or mid-consensus: the × is still there on other members, still absent on your own pill, still behind its confirm.
- Kick someone from a `pending` collab and confirm the group visibly drops back to drafting — casts cleared, countdown gone.
- If you can hit `POST /praxes/{id}/kick/{member_id}` on a Live collab directly, the 422 message should read as a next step, not a dead end.
