### PR TITLE
Measure the residual routes for #1064, write job summary

### DIFF
--- a/frontend/scripts/measure-load.mjs
+++ b/frontend/scripts/measure-load.mjs
@@ -20,6 +20,7 @@
  *   node scripts/measure-load.mjs [--runs 3] [--base http://localhost:5173]
  *   Requires the BUILT app being served (npm run preview) and the API up.
  */
+import { appendFile } from 'node:fs/promises'
 import { chromium } from '@playwright/test'
 
 const args = process.argv.slice(2)
@@ -57,18 +58,29 @@ const SLOW_4G = {
 }
 const CPU_SLOWDOWN = PROFILE.cpu
 
-/** Routes to measure. `needsData` ones are the faction-skinned pages. */
+/**
+ * Routes to measure. `needsData` ones are the faction-skinned pages.
+ * `authenticate: true` logs the measuring context into a dev bot account via
+ * POST /auth/dev-login (ADR-none — same dev-only seam the e2e suite uses,
+ * see frontend/e2e/auth.setup.ts) before navigating, so RootLanding renders
+ * FieldDesk instead of the marketing Home. That endpoint 404s outside
+ * ENVIRONMENT=development, so this route is skipped (not faked) if it does.
+ */
 const ROUTES = [
   { path: '/', name: 'home (guest)' },
+  { path: '/', name: 'home (logged in — FieldDesk)', authenticate: true },
   { path: '/tasks', name: 'tasks list' },
   { path: '/praxes', name: 'praxis list' },
   { path: '/factions', name: 'factions' },
+  // Bespoke-skin slug, not `na`: faction-skinned routes pull a per-faction
+  // chunk on demand, which is the interesting case for this measurement.
+  { path: '/factions/coven', name: 'faction detail (coven)' },
   { path: '/leaderboard', name: 'leaderboard' },
   { path: '/about', name: 'about (static)' },
 ]
 
 async function discoverIds() {
-  const found = { task: null, praxis: null }
+  const found = { task: null, praxis: null, character: null }
   try {
     const tasks = await (await fetch(`${API}/tasks?status=active&limit=50`)).json()
     const list = Array.isArray(tasks) ? tasks : (tasks.items ?? [])
@@ -86,12 +98,44 @@ async function discoverIds() {
   } catch {
     /* as above */
   }
+  try {
+    const characters = await (await fetch(`${API}/characters?limit=50`)).json()
+    const list = Array.isArray(characters) ? characters : (characters.items ?? [])
+    found.character = list[0]?.id ?? null
+  } catch {
+    /* as above */
+  }
   return found
 }
 
-/** LCP for one cold load. Fresh context each time so nothing is cached. */
-async function measureOnce(browser, url) {
+/**
+ * Dev-only bot login (see ROUTES comment above). Shares cookie storage with
+ * pages created from the same context, so calling this before `page.goto`
+ * is enough to make the load authenticated. Returns false — never throws —
+ * so a production build (where the endpoint 404s) or a down API degrades
+ * into "skip this route" rather than a crashed run.
+ */
+async function authenticate(context) {
+  try {
+    const res = await context.request.post(`${API}/auth/dev-login?key=measure-nightly&name=Measure%20Bot`)
+    return res.ok()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * LCP for one cold load. Fresh context each time so nothing is cached.
+ * Returns `{ skipped: true }` if `requireAuth` was set and dev-login didn't
+ * succeed — the caller decides how to report that, this function never
+ * silently measures a guest load and calls it authenticated.
+ */
+async function measureOnce(browser, url, { requireAuth = false } = {}) {
   const context = await browser.newContext()
+  if (requireAuth && !(await authenticate(context))) {
+    await context.close()
+    return { skipped: true }
+  }
   const page = await context.newPage()
   const cdp = await context.newCDPSession(page)
   await cdp.send('Network.enable')
@@ -145,18 +189,31 @@ const median = (numbers) => [...numbers].sort((a, b) => a - b)[Math.floor(number
 const ids = await discoverIds()
 if (ids.task) ROUTES.push({ path: `/tasks/${ids.task}`, name: 'TASK DETAIL (faction)' })
 if (ids.praxis) ROUTES.push({ path: `/praxes/${ids.praxis}`, name: 'PRAXIS DETAIL (faction)' })
+if (ids.character) ROUTES.push({ path: `/characters/${ids.character}`, name: 'CHARACTER DETAIL' })
 
 const browser = await chromium.launch()
-console.log(`\nLoad time — Slow 4G (1.6 Mbps, 150ms RTT) + ${CPU_SLOWDOWN}x CPU slowdown, median of ${RUNS}`)
+const headerLine = `Load time — ${PROFILE_NAME} (${PROFILE.throughputMbps} Mbps, ${PROFILE.latency}ms RTT) + ${CPU_SLOWDOWN}x CPU slowdown, median of ${RUNS}`
+console.log(`\n${headerLine}`)
 console.log(`Metric: Largest Contentful Paint. Budget ${BUDGET_MS}ms, hard fail ${FAIL_MS}ms.\n`)
 
 const rows = []
+const skipped = []
 for (const route of ROUTES) {
   const samples = []
   let last = null
+  let routeSkipped = false
   for (let run = 0; run < RUNS; run++) {
-    last = await measureOnce(browser, BASE + route.path)
+    last = await measureOnce(browser, BASE + route.path, { requireAuth: route.authenticate })
+    if (last.skipped) {
+      routeSkipped = true
+      break
+    }
     samples.push(last.content || Number.POSITIVE_INFINITY)
+  }
+  if (routeSkipped) {
+    skipped.push(route.name)
+    console.log(`  SKIP        —         ${route.name.padEnd(24)} dev-login unavailable (down, or ENVIRONMENT=production disables it)`)
+    continue
   }
   const content = median(samples)
   const verdict = content > FAIL_MS ? 'FAIL' : content > BUDGET_MS ? 'OVER' : 'ok'
@@ -176,4 +233,32 @@ if (over.length === 0) {
 } else {
   console.log(`${over.length}/${rows.length} routes over ${BUDGET_MS}ms: ${over.map((r) => r.name).join(', ')}\n`)
 }
+if (skipped.length > 0) {
+  console.log(`${skipped.length} route(s) skipped, not measured: ${skipped.join(', ')}\n`)
+}
+
+// GitHub job summary: append so a regression trend is visible on the run
+// page without re-running the job. `$GITHUB_STEP_SUMMARY` only exists inside
+// Actions — a local run leaves this whole block a no-op.
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const summaryLines = [
+    '## Page load',
+    '',
+    headerLine,
+    '',
+    'Metric: time-to-route-content (not raw LCP — the shell paints before the route does; see script header).',
+    '',
+    '| Route | Median (ms) | Budget (ms) | Verdict |',
+    '| --- | --- | --- | --- |',
+    ...rows.map((row) => {
+      const shown = Number.isFinite(row.content) ? row.content : 'NO CONTENT'
+      return `| ${row.name} | ${shown} | ${BUDGET_MS} | ${row.verdict.toUpperCase()} |`
+    }),
+  ]
+  if (skipped.length > 0) {
+    summaryLines.push('', `Skipped (not measured): ${skipped.join(', ')}`)
+  }
+  await appendFile(process.env.GITHUB_STEP_SUMMARY, summaryLines.join('\n') + '\n')
+}
+
 process.exit(rows.some((row) => row.verdict === 'FAIL') ? 1 : 0)


### PR DESCRIPTION
## Most of #1064 was already shipped by #1070

That PR already added `.github/workflows/e2e.yml`'s nightly `Measure page load` step running `frontend/scripts/measure-nightly.sh`, and `frontend/scripts/measure-load.mjs` already has the 2000ms/4000ms warn-vs-fail bands, median-of-N cold loads with a fresh context each time, CDP throttling by named profile, and runs against the built app via `vite preview`. It deliberately measures time-to-route-content rather than raw LCP — a documented, intentional improvement — and this PR keeps that as-is.

This PR closes the two residual gaps identified in the [triage correction on #1064](https://github.com/pixieofhugs/WorldZeroPlayground/issues/1064).

## What changed

**1. Three missing routes, now measured:**
- `/` **logged in** (FieldDesk) — `RootLanding` in `frontend/src/App.tsx` renders `FieldDesk` for an authenticated account and `Home` for guests. The measuring context now authenticates via `POST /auth/dev-login` (the same dev-only seam `frontend/e2e/auth.setup.ts` uses) before navigating. If dev-login isn't available (API down, or `ENVIRONMENT=production` where the endpoint 404s), the route is **skipped and logged as SKIP**, never silently measured as a guest load and mislabeled.
- `/characters/:id` — resolved the same way `discoverIds()` already resolves `ids.task`/`ids.praxis`, via `GET /characters`.
- `/factions/coven` — a bespoke-skin slug rather than `na`, since faction-skinned routes pull a per-faction chunk on demand, which is the case this whole exercise is about.

**2. Job summary.** When `$GITHUB_STEP_SUMMARY` is set, the script now appends a markdown table (route / median ms / budget / verdict) plus a header line naming the throttling profile and run count, so a regression trend is visible on the Actions run page without re-running the job. Guarded so a local run with the env var unset is a no-op — unchanged from today.

Side fix: the console header used to hardcode `"Slow 4G (1.6 Mbps, 150ms RTT)"` regardless of `--profile`. Since the summary reuses that header text, it now prints the actual profile in use (matters for nightly, which runs `fast4g`).

## What I actually executed vs. reasoned about

I could not run the full pipeline (needs a seeded DB + backend + built frontend on a real network profile). What I did verify directly:
- `node --check` on the script (syntax).
- `eslint scripts/measure-load.mjs` — clean.
- Built a throwaway pair of stub HTTP servers (fake API + fake "built app") standing in for the backend/vite-preview, and ran the real script against them end to end. Confirmed: all 11 routes measure (including the 3 new ones), a run with `GITHUB_STEP_SUMMARY` pointed at a temp file writes the expected table there, a run without the env var writes nothing, and pointing `--api` at a closed port produces a clean `SKIP` line for the authenticated route instead of a crash or a faked measurement.
- Did not run against the real seeded DB/backend, so I can't confirm the real dev-login response shape end-to-end beyond what's in `backend/routers/auth.py`, or that `coven` always has enough seed data to render a non-trivial faction detail page every era.

## What to eyeball

- The wording/format of the SKIP line and job-summary table (`frontend/scripts/measure-load.mjs`).
- Whether `coven` is the faction you want as the fixed bespoke-skin slug, vs. picking one at random from the bespoke set.
- A real nightly run's Job Summary tab once this merges, to confirm GitHub renders the table as expected (I only verified the raw markdown, not GitHub's rendering).

Closes #1064