### PR TITLE
A collab creator may leave; Delete names its crew-destroying cost (#1074)

### DIFF
--- a/frontend/src/components/collab/__tests__/collabCopy.test.ts
+++ b/frontend/src/components/collab/__tests__/collabCopy.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect } from 'vitest'
 import '../../../i18n'
-import { collabCopy } from '../collabCopy'
+import { collabCopy, SHARED_DEFAULT_COLLAB_KEYS } from '../collabCopy'
 import type { CollabCopyKey } from '../collabCopy'
 import forms from '../../../locales/en/forms.json'
 
@@ -24,6 +24,14 @@ const FACTION_SLUGS = [
 ] as const
 
 const SHARED_KEYS = Object.keys(forms.editPraxis.collab) as CollabCopyKey[]
+// The keys a faction MUST voice. Everything else (SHARED_DEFAULT_COLLAB_KEYS)
+// carries the shared mechanics wording for leave/delete and may be left alone —
+// see the constant's docstring. A faction that does voice one of those still
+// passes: the assertions below are "covers all required" + "no stray keys",
+// not exact equality (#1074).
+const REQUIRED_KEYS = SHARED_KEYS.filter(
+  (key) => !SHARED_DEFAULT_COLLAB_KEYS.includes(key),
+)
 
 describe('collabCopy — faction override resolution', () => {
   it('resolves a faction override when one exists', () => {
@@ -54,9 +62,23 @@ describe('collabCopy — faction override resolution', () => {
 })
 
 describe('collabCopy — catalog completeness', () => {
-  it.each(FACTION_SLUGS)('%s overrides every shared collab key', (slug) => {
+  it.each(FACTION_SLUGS)('%s overrides every voiced collab key', (slug) => {
     const block = forms.editPraxis[slug].collab as Record<string, string>
-    expect(Object.keys(block).sort()).toEqual([...SHARED_KEYS].sort())
+    expect(Object.keys(block).sort()).toEqual(
+      expect.arrayContaining([...REQUIRED_KEYS].sort()),
+    )
+  })
+
+  // A key in a faction block that the shared block doesn't have is a typo or a
+  // rename that only landed on one side: it would resolve for that faction and
+  // silently throw the missing-key error for every other.
+  it.each(FACTION_SLUGS)('%s invents no collab key of its own', (slug) => {
+    const block = forms.editPraxis[slug].collab as Record<string, string>
+    expect(
+      Object.keys(block).filter(
+        (key) => !SHARED_KEYS.includes(key as CollabCopyKey),
+      ),
+    ).toEqual([])
   })
 
   it.each(FACTION_SLUGS)('%s resolves every key to non-empty copy', (slug) => {

--- a/frontend/src/components/collab/collabCopy.ts
+++ b/frontend/src/components/collab/collabCopy.ts
@@ -41,6 +41,29 @@ export type CollabCopyKey =
   | 'successHeading'
   | 'successBody'
   | 'successContinue'
+  | 'leaveDescription'
+  | 'deleteAction'
+  | 'deleteDescription'
+  | 'deleteConfirm'
+
+/**
+ * Keys that are content to speak in the shared voice (#1074).
+ *
+ * Most collab keys are voiced by every faction — the roster's diction is part of
+ * the faction's identity, and `collabCopy.test.ts` holds each faction to the full
+ * set. These ones ship with a shared default only: they describe the *mechanics*
+ * of leaving versus deleting a co-owned praxis (ADR-0013), which every faction
+ * agrees on, and a warning about destroying other people's work is a poor place
+ * to be clever. A faction may still override any of them; nothing here stops it,
+ * and the resolver is unchanged. The list exists so the completeness test knows
+ * which keys a silent faction is allowed to leave alone.
+ */
+export const SHARED_DEFAULT_COLLAB_KEYS: readonly CollabCopyKey[] = [
+  'leaveDescription',
+  'deleteAction',
+  'deleteDescription',
+  'deleteConfirm',
+]
 
 /**
  * Resolve one collab copy key in the given faction's voice, falling back to the

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -169,7 +169,11 @@
       "pullBackAction": "Pull my part back",
       "successHeading": "The proof is woven",
       "successBody": "Every part is cast — your collab is live.",
-      "successContinue": "View the praxis"
+      "successContinue": "View the praxis",
+      "leaveDescription": "Bow out of this collab. The others keep the praxis and carry on without you.",
+      "deleteAction": "Delete for everyone",
+      "deleteDescription": "Destroys the whole collab — every member's part goes with it. To bow out on your own, leave instead.",
+      "deleteConfirm": "Delete this collab? It is destroyed for everyone, including the parts the other members have already put in. If you only want out yourself, leave instead."
     },
     "toolbar": {
       "label": "formatting",

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/collabExits.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/collabExits.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * The two collab exits in the composer footer (#1074).
+ *
+ * ADR-0013: a collab is co-owned by its members and `created_by_id` is only the
+ * historical "who started it" fact. So **Leave** — you bow out, the crew carries
+ * on — belongs to every member, creator included. **Delete** destroys the praxis
+ * with everyone's parts in it and stays the creator's alone (the backend is the
+ * authority; the UI just doesn't draw what a member could never use).
+ *
+ * renderToStaticMarkup only — no DOM, no effects — matching the other editPraxis
+ * suites.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import "../../../../i18n";
+import i18n from "../../../../i18n";
+import type { PraxisMemberOut, PraxisOut } from "../../../../api/praxis";
+import type { EditPraxisState } from "../../useEditPraxis";
+import { collabCopy } from "../../../../components/collab/collabCopy";
+import { DropButton, InviteSearch } from "../controls";
+
+const CREATOR_ID = 1;
+const JOINER_ID = 2;
+
+function member(id: number): PraxisMemberOut {
+  return {
+    id,
+    praxis_id: 1,
+    character_id: id,
+    character_display_name: `M${id}`,
+    has_submitted: false,
+    joined_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function praxisState({
+  currentCharacterId,
+  memberIds = [CREATOR_ID, JOINER_ID],
+  type = "collab",
+}: {
+  currentCharacterId: number;
+  memberIds?: number[];
+  type?: string;
+}): EditPraxisState {
+  const praxis = {
+    id: 1,
+    type,
+    created_by_id: CREATOR_ID,
+    members: memberIds.map(member),
+    invites: [],
+    duel_id: null,
+    task_faction_slug: null,
+    task_point_value: 20,
+  } as unknown as PraxisOut;
+  return {
+    praxis,
+    duelMode: false,
+    currentCharacterId,
+    inviteQuery: "",
+    inviteResults: [],
+    inviteOpen: false,
+    inviting: false,
+    setInviteQuery: () => {},
+    setInviteOpen: () => {},
+    sendInvite: async () => {},
+    sendChallenge: async () => {},
+    kickMember: async () => {},
+    cancelInvite: async () => {},
+    leaveCollab: async () => {},
+    cancel: async () => {},
+  } as unknown as EditPraxisState;
+}
+
+const LEAVE_LABEL = i18n.t("forms:editPraxis.leaveAction");
+const DROP_SKIN = { label: "ARCHETYPE_DROP", style: {} };
+
+describe("Leave — every member's exit, the creator included (#1074)", () => {
+  it("offers Leave to the member who started the collab", () => {
+    const html = renderToStaticMarkup(
+      <InviteSearch state={praxisState({ currentCharacterId: CREATOR_ID })} skin={{}} />,
+    );
+    expect(html).toContain(LEAVE_LABEL);
+  });
+
+  it("still offers Leave to a member who joined", () => {
+    const html = renderToStaticMarkup(
+      <InviteSearch state={praxisState({ currentCharacterId: JOINER_ID })} skin={{}} />,
+    );
+    expect(html).toContain(LEAVE_LABEL);
+  });
+
+  it("says what leaving does — the crew keeps the praxis", () => {
+    const html = renderToStaticMarkup(
+      <InviteSearch state={praxisState({ currentCharacterId: CREATOR_ID })} skin={{}} />,
+    );
+    expect(html).toContain(collabCopy(null, "leaveDescription"));
+  });
+
+  it("offers nothing to leave to someone who is not a member", () => {
+    const html = renderToStaticMarkup(
+      <InviteSearch state={praxisState({ currentCharacterId: 99 })} skin={{}} />,
+    );
+    expect(html).not.toContain(LEAVE_LABEL);
+  });
+
+  it("offers nothing to leave on a solo praxis", () => {
+    const html = renderToStaticMarkup(
+      <InviteSearch
+        state={praxisState({
+          currentCharacterId: CREATOR_ID,
+          memberIds: [CREATOR_ID],
+          type: "solo",
+        })}
+        skin={{}}
+      />,
+    );
+    expect(html).not.toContain(LEAVE_LABEL);
+  });
+});
+
+describe("Delete — the creator's alone, and it names its cost (#1074)", () => {
+  it("names the consequence when other members' parts are at stake", () => {
+    const html = renderToStaticMarkup(
+      <DropButton
+        state={praxisState({ currentCharacterId: CREATOR_ID })}
+        skin={DROP_SKIN}
+      />,
+    );
+    // The archetype's "drop task" wording undersells destroying a crew's work.
+    expect(html).toContain(collabCopy(null, "deleteAction"));
+    expect(html).not.toContain(DROP_SKIN.label);
+    // Apostrophes are HTML-escaped in the emitted markup, so assert on a
+    // punctuation-free fragment of the description rather than the whole line.
+    expect(html).toContain("Destroys the whole collab");
+  });
+
+  it("is not drawn at all for a member who did not start the collab", () => {
+    const html = renderToStaticMarkup(
+      <DropButton
+        state={praxisState({ currentCharacterId: JOINER_ID })}
+        skin={DROP_SKIN}
+      />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("keeps the archetype's own label on a solo praxis", () => {
+    const html = renderToStaticMarkup(
+      <DropButton
+        state={praxisState({
+          currentCharacterId: CREATOR_ID,
+          memberIds: [CREATOR_ID],
+          type: "solo",
+        })}
+        skin={DROP_SKIN}
+      />,
+    );
+    expect(html).toContain(DROP_SKIN.label);
+    expect(html).not.toContain(collabCopy(null, "deleteAction"));
+  });
+
+  it("keeps the archetype's own label on a collab with nobody else in it", () => {
+    const html = renderToStaticMarkup(
+      <DropButton
+        state={praxisState({
+          currentCharacterId: CREATOR_ID,
+          memberIds: [CREATOR_ID],
+        })}
+        skin={DROP_SKIN}
+      />,
+    );
+    expect(html).toContain(DROP_SKIN.label);
+  });
+
+  it("reads as a different act from Leave", () => {
+    expect(collabCopy(null, "deleteAction")).not.toBe(LEAVE_LABEL);
+  });
+});

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -49,15 +49,18 @@ export function InviteSearch({
   const onPick = duelMode ? state.sendChallenge : state.sendInvite;
   // Cast progress drives the roster + hides "invite another" once weaving starts (#591).
   const castCount = praxis.members.filter((m) => m.has_submitted).length;
-  // A non-creator collab member can drop out from here (#958) — a standalone exit
-  // that doesn't require the bank-full drop-to-accept modal. The creator instead
-  // deletes/drops the whole draft (DropButton), so the leave control is hidden for
-  // them; duel mode has no membership to leave.
-  const isCreator = praxis.created_by_id === state.currentCharacterId;
+  // Any collab member can drop out from here (#958) — a standalone exit that
+  // doesn't require the bank-full drop-to-accept modal. That includes whoever
+  // started it: a collab is co-owned by its members and `created_by_id` is only
+  // the historical "who started it" fact, carrying no powers over the others
+  // (ADR-0013, #1074). The backend's `leave_praxis` has always agreed — it checks
+  // membership and nothing else. Leaving and deleting are different acts, not two
+  // labels for one: you leave and the crew carries on, whereas Delete (DropButton)
+  // destroys the praxis with everyone's work in it, so that one stays the
+  // creator's alone. Duel mode has no membership to leave.
   const canLeaveCollab =
     !duelMode &&
     praxis.type === "collab" &&
-    !isCreator &&
     praxis.members.some((member) => member.character_id === state.currentCharacterId);
   return (
     <div>
@@ -280,6 +283,9 @@ export function InviteSearch({
         <button
           type="button"
           onClick={() => void state.leaveCollab()}
+          // Spelling out the outcome next to a delete control that reads
+          // superficially similar: this one only removes you (#1074).
+          title={collabCopy(praxis.task_faction_slug, "leaveDescription")}
           className="font-body eyebrow hover:underline"
           style={{
             display: "block",
@@ -360,13 +366,34 @@ export function DropButton({
   skin?: DropButtonSkin;
 }) {
   const { t } = useTranslation("forms");
+  const praxis = state.praxis;
+  const isCollab = praxis?.type === "collab";
+  // Deleting destroys the praxis for the whole crew, so it stays the creator's
+  // alone — the backend is the authority (`delete_praxis`), this only declines to
+  // draw a control the viewer could never use. Every other member's exit is
+  // Leave, which is now theirs too (#1074, ADR-0013).
+  const isCreator = praxis?.created_by_id === state.currentCharacterId;
+  if (isCollab && !isCreator) return null;
+  // With other people's parts inside it, the archetype's "drop task" label
+  // undersells what the button does. Both the label and the consequence come
+  // from collabCopy, so a faction may voice them; the shared default carries the
+  // warning if it doesn't.
+  const crewAtStake = isCollab && praxis.members.length > 1;
+  const label = crewAtStake
+    ? collabCopy(praxis.task_faction_slug, "deleteAction")
+    : (skin?.label ?? t("editPraxis.dropTask"));
   return (
     <button
       type="button"
       onClick={() => void state.cancel()}
+      title={
+        crewAtStake
+          ? collabCopy(praxis.task_faction_slug, "deleteDescription")
+          : undefined
+      }
       style={skin?.style}
     >
-      {skin?.label ?? t("editPraxis.dropTask")}
+      {label}
     </button>
   );
 }

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -35,6 +35,7 @@ import {
   type DuelDetailOut,
 } from "../../api/duel";
 import { deriveCollabGate } from "../../components/collab/CollabRoster";
+import { collabCopy } from "../../components/collab/collabCopy";
 import { getGameConfig } from "../../api/gameConfig";
 import { listRelationships } from "../../api/relationships";
 import { getTask, type TaskOut } from "../../api/tasks";
@@ -139,9 +140,10 @@ export interface EditPraxisState {
   /** Pull my own cast back on a pending collab (#591). */
   pullBack: () => Promise<void>;
   /**
-   * Leave a collab I was invited into — drop my own membership without the
-   * bank-full drop-to-accept modal (#958). Creator can't leave (they delete/drop
-   * the whole draft via `cancel`); the button is hidden for them.
+   * Drop my own membership from a collab without the bank-full drop-to-accept
+   * modal (#958). Open to every member, the creator included — a collab is
+   * co-owned and `created_by_id` grants no powers (ADR-0013, #1074). Distinct
+   * from `cancel`, which deletes the praxis for everyone.
    */
   leaveCollab: () => Promise<void>;
   cancel: () => Promise<void>;
@@ -608,11 +610,12 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     }
   }, [idParam, refetch]);
 
-  // Drop my own membership from a collab I was invited into (#958). Distinct from
-  // `cancel` (creator deletes the whole draft) and `pullBack` (retract my cast but
+  // Drop my own membership from a collab (#958). Distinct from `cancel` (deletes
+  // the whole praxis, everyone's part with it) and `pullBack` (retract my cast but
   // stay a member): leaving removes me entirely, so I'm sent back to the task list.
-  // Backend `leave_praxis` re-checks membership and can complete consensus for
-  // whoever stays; the gate on the button already hides it from the creator.
+  // Backend `leave_praxis` re-checks membership — membership is the only condition,
+  // which is how the creator leaves too (ADR-0013, #1074) — and can complete
+  // consensus for whoever stays.
   const leaveCollab = useCallback(async () => {
     if (!praxis) return;
     const confirmed = window.confirm(
@@ -638,8 +641,16 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
 
   const cancel = useCallback(async () => {
     if (!praxis) return;
+    // Deleting a collab is not "dropping my task": it destroys the praxis with
+    // every member's part still in it, which is why it stays the creator's alone
+    // (enforced by the backend's `delete_praxis`). A member who only wants out
+    // has `leaveCollab` — the creator included (ADR-0013). Say which of the two
+    // this is before it happens, in the faction's voice where it has one (#1074).
+    const crewAtStake = praxis.type === "collab" && praxis.members.length > 1;
     const confirmed = window.confirm(
-      i18n.t("forms:editPraxis.confirm.dropTask"),
+      crewAtStake
+        ? collabCopy(praxis.task_faction_slug, "deleteConfirm")
+        : i18n.t("forms:editPraxis.confirm.dropTask"),
     );
     if (!confirmed) return;
     if (autosaveTimerRef.current) {


### PR DESCRIPTION
Closes #1074

ADR-0013 says a collab is co-owned by its members and `created_by_id` survives
only as the historical "who started it" fact. The backend has always agreed —
`leave_praxis` checks membership and nothing else. The composer did not: it hid
**Leave** from the creator, and carried a comment justifying the hiding on the
grounds that the creator "deletes/drops the whole draft instead".

## What changed

**Leave is every member's, creator included.** `!isCreator` is gone from
`canLeaveCollab`, and the comment that justified it is replaced with why both
get it (and why Delete is a different act, not a second name for the same one).
Two more comments in `useEditPraxis.ts` asserted the same removed behaviour
("Creator can't leave"; "the gate on the button already hides it from the
creator") and are corrected — left in place they would have been the next
reader's false premise.

**Delete says what it destroys.** When the collab holds other members' parts,
`DropButton` swaps the archetype's "drop task" label for `deleteAction`
("Delete for everyone"), carries `deleteDescription` as its title, and
`cancel()` confirms with `deleteConfirm` instead of the solo "Drop this task?
Your draft will be lost." — which was simply untrue for a crew. All three
resolve through `collabCopy`, so a faction may voice them; only the shared
defaults are authored here (see below). A solo praxis, or a collab with nobody
else in it, is unchanged.

**Delete is no longer drawn for a member who did not start the collab.** It
already 403'd for them (`delete_praxis`); the backend guard is untouched and
unduplicated — this is visibility only, per the "hide controls a user can't
use" convention. Their exit is Leave.

## The catalog trap, and how it was handled

`collabCopy.test.ts` asserted each faction's collab block matched the shared
block **exactly**, so any new shared key would have dragged nine faction voices
along with it. The four new keys are declared in
`SHARED_DEFAULT_COLLAB_KEYS`: they describe the *mechanics* of leaving versus
deleting a co-owned praxis, which every faction agrees on, and a warning about
destroying other people's work is a poor place to be clever. The test now
asserts "covers every voiced key" plus a new "invents no key of its own" case,
so a faction that later chooses to voice one still passes.

## Scope note

The brief scoped this to `controls.tsx` plus the locale catalog. I also touched
`useEditPraxis.ts` (5 lines in `cancel()` plus the two stale comments): the
confirm dialog is the delete path's copy, and leaving it saying "your draft
will be lost" while it destroys four people's parts would have shipped the same
class of lie this issue is about. `window.confirm` itself is untouched (#1082).
`PublishButton` and the duel pull-back path are untouched (#1077).

## Verification

- `tsc --noEmit` clean; `vite build` clean; `eslint` clean on all changed files.
- `vitest run` — 118 files / 1891 tests pass, including 10 new cases in
  `archetypes/__tests__/collabExits.test.tsx`.
- **Visual QA is outstanding** — no dev stack and no screenshots available in
  this environment. Everything below was verified through markup assertions
  only.

## Known edge, flagged not fixed

`leave_praxis` does not reassign `created_by_id`. If the creator leaves a collab
with 2+ members still in it, nobody can delete it from the composer — which
matches the backend (everyone else 403s), and the remaining members still have
Leave. Once #1071's decision 10 (a collab that drops to one member becomes solo,
ADR-0060) lands, that praxis is solo and Delete returns.

## What to eyeball

- **A collab you created, 2+ members, desktop** — Leave now appears under the
  roster (it did not before); Delete reads "Delete for everyone" instead of the
  faction's drop label, and its confirm names the crew. Check the label still
  fits the footer in Coven, Snide, and WOW, whose drop labels are the longest.
- **The same collab, mobile archetypes** — same two controls in the stacked
  footer (`mobileArchetypes/*Composer.tsx`); confirm the longer Delete label
  doesn't wrap into the file bar.
- **A collab you joined (not creator), desktop and mobile** — Leave unchanged;
  Delete should now be **absent** from the footer, not greyed. Worth checking
  the footer doesn't collapse oddly with one control gone (Ephemerists and
  Singularity space their footers most tightly).
- **A solo praxis, any faction** — footer must be pixel-identical to today:
  the faction's own drop label, the old "Drop this task?" confirm, no Leave.
- **A duel side** — no Leave (there is no membership), Delete unchanged.
- **An unaffiliated (`na`) task** — the shared voice is what renders; check it
  reads in the Default kit's register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
