### PR TITLE
A duel side can pull back from the composer — neutral before the duel settles (#1077)

### DIFF
--- a/frontend/src/components/collab/collabCopy.ts
+++ b/frontend/src/components/collab/collabCopy.ts
@@ -13,6 +13,12 @@ import i18n from '../../i18n'
  * dev/test missing-key throw before the result could be inspected. A faction
  * with no entry for a key is a normal miss, not a defect.
  *
+ * Despite the name, this is the resolver for the whole *multi-party composer
+ * footer*, not just the roster: the one footer button casts and pulls back for
+ * a collab, and (since #1077) for a duel side too, and it is hookless by
+ * contract, so its words cannot come from `useTranslation`. Duel keys are
+ * prefixed `duel*` and sit in the same shared block.
+ *
  * Keys are runtime-dynamic (the slug comes from the task), so they can't be the
  * typed literals `t()` expects — resolve through a plain-string view of `t`, as
  * the taunt resolver does. The catalog still owns every word; only the
@@ -38,6 +44,7 @@ export type CollabCopyKey =
   | 'castAction'
   | 'castFinalAction'
   | 'pullBackAction'
+  | 'duelPullBackAction'
   | 'successHeading'
   | 'successBody'
   | 'successContinue'
@@ -57,12 +64,20 @@ export type CollabCopyKey =
  * to be clever. A faction may still override any of them; nothing here stops it,
  * and the resolver is unchanged. The list exists so the completeness test knows
  * which keys a silent faction is allowed to leave alone.
+ *
+ * `duelPullBackAction` (#1077) joins them: it is the same composer footer button
+ * in its duel guise, so it resolves through the same hookless resolver, but the
+ * line is a plain statement of a mechanic (at `active` your cast reopens for
+ * free — forfeit begins only at `settled`, ADR-0011 §Forfeit) and a faction
+ * flourish here risks reading as a consequence. Shared voice until a faction
+ * asks for its own.
  */
 export const SHARED_DEFAULT_COLLAB_KEYS: readonly CollabCopyKey[] = [
   'leaveDescription',
   'deleteAction',
   'deleteDescription',
   'deleteConfirm',
+  'duelPullBackAction',
 ]
 
 /**

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -167,6 +167,7 @@
       "castAction": "Cast my part",
       "castFinalAction": "Cast — send it live",
       "pullBackAction": "Pull my part back",
+      "duelPullBackAction": "Pull my entry back",
       "successHeading": "The proof is woven",
       "successBody": "Every part is cast — your collab is live.",
       "successContinue": "View the praxis",

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
@@ -1,15 +1,17 @@
 /**
- * PublishButton collab gate (#646). Multi-member collabs cast and pull back
- * through the footer's PublishButton (the roster is pure display); this proves
- * the gate picks the right action + faction-voiced label. PublishButton uses no
- * hooks, so it's invoked directly: we read the returned <button>'s onClick to
- * fire the action headlessly and renderToStaticMarkup for the visible label.
+ * PublishButton collab gate (#646) and duel pull-back (#1077). Multi-member
+ * collabs — and, once cast, duel sides — act through the footer's PublishButton
+ * (the roster is pure display); this proves the gate picks the right action +
+ * label. PublishButton uses no hooks, so it's invoked directly: we read the
+ * returned <button>'s onClick to fire the action headlessly and
+ * renderToStaticMarkup for the visible label.
  */
 import type { ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect, vi } from "vitest";
 import "../../../../i18n";
 import type { PraxisMemberOut, PraxisOut } from "../../../../api/praxis";
+import type { DuelDetailOut, DuelStatus } from "../../../../api/duel";
 import type { EditPraxisState } from "../../useEditPraxis";
 import { collabCopy } from "../../../../components/collab/collabCopy";
 import { PublishButton, type PublishButtonSkin } from "../controls";
@@ -67,6 +69,72 @@ function renderButton(state: EditPraxisState): ReactElement<{
   }>;
 }
 
+/** Same, for the states where the button is expected to render nothing. */
+function renderMaybe(state: EditPraxisState): ReactElement | null {
+  return PublishButton({ state, skin: SKIN }) as ReactElement | null;
+}
+
+function duelSide(characterId: number, submitted: boolean) {
+  return {
+    praxis_id: characterId,
+    character_id: characterId,
+    display_name: `C${characterId}`,
+    faction_slug: "na",
+    avatar_url: "",
+    points_from_votes: 0,
+    is_submitted: submitted,
+  };
+}
+
+/**
+ * A duel side's composer state. `praxis.type` stays `'solo'` for a duel side
+ * (ADR-0011) — `duelMode` is what marks it, exactly as the hook computes it.
+ */
+function duelState(
+  duelStatus: DuelStatus,
+  overrides: {
+    isPublished?: boolean;
+    rivalCast?: boolean;
+    factionSlug?: string | null;
+    publish?: () => Promise<void>;
+    pullBack?: () => Promise<void>;
+    requestDuelSeal?: () => void;
+  } = {},
+): EditPraxisState {
+  const praxis = {
+    id: 1,
+    type: "solo",
+    duel_id: 7,
+    members: [],
+    task_faction_slug: overrides.factionSlug ?? null,
+    task_point_value: 20,
+  } as unknown as PraxisOut;
+  const duel: DuelDetailOut = {
+    id: 7,
+    task_id: 3,
+    status: duelStatus,
+    forfeited_by_character_id: null,
+    challenger: duelSide(1, overrides.isPublished ?? true),
+    opponent: duelSide(2, overrides.rivalCast ?? false),
+    viewer_is_participant: true,
+    winner_character_id: null,
+    challenger_final_points: null,
+    opponent_final_points: null,
+  };
+  return {
+    praxis,
+    duel,
+    duelMode: true,
+    submitting: false,
+    switchingMode: null,
+    isPublished: overrides.isPublished ?? true,
+    currentCharacterId: 1,
+    publish: overrides.publish ?? (async () => {}),
+    pullBack: overrides.pullBack ?? (async () => {}),
+    requestDuelSeal: overrides.requestDuelSeal ?? (() => {}),
+  } as unknown as EditPraxisState;
+}
+
 describe("PublishButton — collab cast/pull-back gate (#646)", () => {
   it("a multi-member collab I have not cast shows the cast label and calls publish", () => {
     const publish = vi.fn(async () => {});
@@ -122,5 +190,87 @@ describe("PublishButton — collab cast/pull-back gate (#646)", () => {
       pullBack: async () => {},
     } as unknown as EditPraxisState;
     expect(renderToStaticMarkup(renderButton(state))).toContain("SOLO_IDLE");
+  });
+});
+
+describe("PublishButton — duel pull-back before the duel settles (#1077)", () => {
+  it("offers a neutral pull-back once I have cast and the rival has not", () => {
+    const publish = vi.fn(async () => {});
+    const pullBack = vi.fn(async () => {});
+    const requestDuelSeal = vi.fn();
+    const el = renderButton(
+      duelState("active", { publish, pullBack, requestDuelSeal }),
+    );
+
+    expect(renderToStaticMarkup(el)).toContain(
+      collabCopy(null, "duelPullBackAction"),
+    );
+    el.props.onClick();
+    expect(pullBack).toHaveBeenCalledTimes(1);
+    expect(publish).not.toHaveBeenCalled();
+    expect(requestDuelSeal).not.toHaveBeenCalled();
+  });
+
+  it("says nothing about forfeit — that only begins at settled (ADR-0011)", () => {
+    const html = renderToStaticMarkup(renderButton(duelState("active")));
+    expect(html).not.toMatch(/forfeit|discard|wins/i);
+  });
+
+  // Cast before the rival even accepted: the same trap (author-only entry, no
+  // way back in) and the same free reopen, since the duel has not settled.
+  it("offers the same pull-back on a duel still awaiting acceptance", () => {
+    const pullBack = vi.fn(async () => {});
+    const el = renderButton(duelState("pending", { pullBack }));
+
+    expect(renderToStaticMarkup(el)).toContain(
+      collabCopy(null, "duelPullBackAction"),
+    );
+    el.props.onClick();
+    expect(pullBack).toHaveBeenCalledTimes(1);
+  });
+
+  // Both sides cast → the duel settles, and from there unsubmitting IS a
+  // forfeit. That decision lives on the detail page, never in the composer.
+  it("renders nothing once both sides have cast and the duel settled", () => {
+    expect(renderMaybe(duelState("settled", { rivalCast: true }))).toBeNull();
+  });
+
+  it("renders nothing for a resolved duel", () => {
+    expect(renderMaybe(duelState("resolved", { rivalCast: true }))).toBeNull();
+  });
+
+  it("renders nothing for a plain published solo praxis", () => {
+    const state = {
+      praxis: { id: 1, type: "solo", members: [] },
+      duel: null,
+      duelMode: false,
+      submitting: false,
+      switchingMode: null,
+      isPublished: true,
+      currentCharacterId: 1,
+      publish: async () => {},
+      pullBack: async () => {},
+    } as unknown as EditPraxisState;
+    expect(renderMaybe(state)).toBeNull();
+  });
+
+  it("still opens the seal confirmation on the cast that has not happened yet", () => {
+    const publish = vi.fn(async () => {});
+    const pullBack = vi.fn(async () => {});
+    const requestDuelSeal = vi.fn();
+    const el = renderButton(
+      duelState("active", {
+        isPublished: false,
+        publish,
+        pullBack,
+        requestDuelSeal,
+      }),
+    );
+
+    expect(renderToStaticMarkup(el)).toContain("SOLO_IDLE");
+    el.props.onClick();
+    expect(requestDuelSeal).toHaveBeenCalledTimes(1);
+    expect(pullBack).not.toHaveBeenCalled();
+    expect(publish).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -676,11 +676,12 @@ export function ModePicker<O extends { key: PraxisType }>({
 }
 
 /* -------------------------------------------------------------------------- */
-/* PublishButton — renders nothing once published and is disabled while        */
-/* saving / submitting / switching mode. The archetype arranges it inside its   */
-/* bespoke file bar and supplies faction-voiced labels via skin. (The old       */
-/* Save Draft button was removed in #297 — autosave persists title/body and     */
-/* media uploads on pick, so no manual draft-save control is needed.)           */
+/* PublishButton — renders nothing once published (with one duel exception,     */
+/* below) and is disabled while saving / submitting / switching mode. The       */
+/* archetype arranges it inside its bespoke file bar and supplies faction-voiced */
+/* labels via skin. (The old Save Draft button was removed in #297 — autosave    */
+/* persists title/body and media uploads on pick, so no manual draft-save        */
+/* control is needed.)                                                          */
 /* -------------------------------------------------------------------------- */
 export interface PublishButtonSkin {
   style: CSSProperties;
@@ -696,17 +697,33 @@ export function PublishButton({
   state: EditPraxisState;
   skin: PublishButtonSkin;
 }) {
-  if (state.isPublished) return null;
+  const praxis = state.praxis;
+  // The one published state that keeps its footer button (#1077). A duel side
+  // that casts goes straight to `submitted` while the duel stays `active` —
+  // meaning the rival has not answered yet, since a second cast settles it
+  // (`maybe_settle_duel`). Pulling back there is a free, neutral reopen:
+  // `unsubmit_praxis` only marks a forfeit for a *settled* duel (ADR-0011
+  // §Forfeit), so nothing is lost and nobody wins. It is also the promise the
+  // seal dialog already made on the way in (`duelSeal.reopenNote`). Every other
+  // published praxis — solo, collab, or a duel already settled, where forfeit
+  // does begin and lives on the detail page instead — still renders nothing.
+  const duelPullBack =
+    state.isPublished && state.duelMode && state.duel?.status === "active";
+  if (state.isPublished && !duelPullBack) return null;
   // Multi-member collabs cast (and pull back) through this same footer button
   // (#646). The consensus gate decides the action and the faction-voiced idle
   // label; the busy label stays the archetype's mode-agnostic present participle.
-  const praxis = state.praxis;
   const collab =
     praxis?.type === "collab" && praxis.members.length > 1
       ? deriveCollabGate(praxis.members, state.currentCharacterId)
       : null;
-  const idleLabel =
-    collab && praxis
+  // Neutral wording, deliberately: no forfeit language and no consequence
+  // dialog at `active` (#718 rejected that framing once already — see
+  // CovenDuelRail's header). Shared voice for now, like the other mechanics
+  // lines in `SHARED_DEFAULT_COLLAB_KEYS`.
+  const idleLabel = duelPullBack
+    ? collabCopy(praxis?.task_faction_slug, "duelPullBackAction")
+    : collab && praxis
       ? collabCopy(
           praxis.task_faction_slug,
           collab.iCast
@@ -719,13 +736,15 @@ export function PublishButton({
   // A duel side asks before it casts (#718): the button opens the seal
   // confirmation, whose confirm calls this same `publish()`. Only once an
   // opponent is actually attached — duel mode with an empty opponent slot casts
-  // as an ordinary solo praxis, so there is nothing to warn about.
+  // as an ordinary solo praxis, so there is nothing to warn about. Once cast,
+  // the same button reverses it through `pullBack` and asks nothing.
   const sealsADuel = state.duelMode && state.duel != null;
-  const onClick = collab?.iCast
-    ? state.pullBack
-    : sealsADuel
-      ? async () => state.requestDuelSeal()
-      : state.publish;
+  const onClick =
+    duelPullBack || collab?.iCast
+      ? state.pullBack
+      : sealsADuel
+        ? async () => state.requestDuelSeal()
+        : state.publish;
   return (
     <button
       type="button"

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -699,16 +699,23 @@ export function PublishButton({
 }) {
   const praxis = state.praxis;
   // The one published state that keeps its footer button (#1077). A duel side
-  // that casts goes straight to `submitted` while the duel stays `active` —
-  // meaning the rival has not answered yet, since a second cast settles it
-  // (`maybe_settle_duel`). Pulling back there is a free, neutral reopen:
-  // `unsubmit_praxis` only marks a forfeit for a *settled* duel (ADR-0011
-  // §Forfeit), so nothing is lost and nobody wins. It is also the promise the
-  // seal dialog already made on the way in (`duelSeal.reopenNote`). Every other
-  // published praxis — solo, collab, or a duel already settled, where forfeit
-  // does begin and lives on the detail page instead — still renders nothing.
+  // that casts goes straight to `submitted` while the duel is still unsettled —
+  // `active` (accepted, and the rival has not answered, because a second cast
+  // settles it: `maybe_settle_duel`) or `pending` (cast before the rival even
+  // accepted). Both are the same trap: the entry is author-only until the duel
+  // completes (#999), the composer is locked, and there is no way back into it.
+  //
+  // Pulling back from either is a free, neutral reopen. `unsubmit_praxis` marks
+  // a forfeit only for a *settled* duel (ADR-0011 §Forfeit), so the praxis just
+  // returns to `in_progress` with `forfeited_by_character_id` still NULL and the
+  // duel untouched — the promise the seal dialog already made on the way in
+  // (`duelSeal.reopenNote`). Listed, not negated: `settled`/`resolved` are where
+  // forfeit begins and belong to the detail page, and a `declined` challenge
+  // leaves an ordinary published solo praxis, which stays unpublishable-back.
   const duelPullBack =
-    state.isPublished && state.duelMode && state.duel?.status === "active";
+    state.isPublished &&
+    state.duelMode &&
+    (state.duel?.status === "active" || state.duel?.status === "pending");
   if (state.isPublished && !duelPullBack) return null;
   // Multi-member collabs cast (and pull back) through this same footer button
   // (#646). The consensus gate decides the action and the faction-voiced idle
@@ -718,8 +725,8 @@ export function PublishButton({
       ? deriveCollabGate(praxis.members, state.currentCharacterId)
       : null;
   // Neutral wording, deliberately: no forfeit language and no consequence
-  // dialog at `active` (#718 rejected that framing once already — see
-  // CovenDuelRail's header). Shared voice for now, like the other mechanics
+  // dialog before the duel settles (#718 rejected that framing once already —
+  // see CovenDuelRail's header). Shared voice for now, like the other mechanics
   // lines in `SHARED_DEFAULT_COLLAB_KEYS`.
   const idleLabel = duelPullBack
     ? collabCopy(praxis?.task_faction_slug, "duelPullBackAction")

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -592,6 +592,10 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
 
   // Pull my own part back out of a pending collab (#591) — clears my cast so the
   // composer unlocks for editing. Backend re-opens only my membership (#590).
+  // Also the duel side's neutral reopen (#1077): same endpoint, and for a duel
+  // still at `active` it takes the praxis back to `in_progress` without touching
+  // `forfeited_by_character_id` — forfeit begins only at `settled` (ADR-0011
+  // §Forfeit). No confirm: the consequence-free case earns none.
   const pullBack = useCallback(async () => {
     if (!idParam) return;
     setSubmitting(true);


### PR DESCRIPTION
A duel side that casts goes to `submitted` immediately, and `PublishButton`
opened with `if (state.isPublished) return null` — so a duelist had no way back
into their own entry from the composer at all, while the entry is author-only
until the duel completes (#999). Collab members already had this (they sit at
`pending`, so `collab.iCast` routes the same footer button to `pullBack()`).

Closes #1077

## The rule, built straight

Forfeit begins **only at `settled`**. `unsubmit_praxis` (`backend/services/praxis.py`)
runs its forfeit branch under `duel.status == DuelStatus.settled` and nowhere
else, so pulling back before that returns the praxis to `in_progress` with
`forfeited_by_character_id` still NULL and the duel untouched. Verified in the
source, not assumed. No backend change here.

So the button is **neutral**: label "Pull my entry back", no consequence dialog,
no forfeit language. The design draws the opposite (forfeit at `active`, nothing
at `settled`); it is not built. #718 rejected the same framing once already
(`CovenDuelRail.tsx` header), and the seal dialog on the way *in* already
promises this exact reopen (`duelSeal.reopenNote`). The detail page's rail keeps
its existing split unchanged — neutral `unsubmit` at `active`, escalated forfeit
dialog at `settled` (`PraxisSubmitControls`).

## The gate

`state.isPublished && state.duelMode && (duel.status === 'active' || 'pending')`.
Listed, not negated, so a plain published solo/collab still renders nothing, and
so do `settled` / `resolved` / `declined`.

**One judgement call to sanity-check:** the issue names `active`; I also included
`pending` (you cast before the rival accepted). Same trap, same rule — the duel
has not settled, so the reopen is equally free, and the backend groups the two as
"live, incomplete" for visibility (`_LIVE_INCOMPLETE_DUEL_STATUSES`). If you want
it strictly `active`, it is one clause to drop.

## Copy

Shared default only: `forms:editPraxis.collab.duelPullBackAction` =
"Pull my entry back", resolved through the existing `collabCopy` (the hookless
resolver the same footer button already uses) and listed in
`SHARED_DEFAULT_COLLAB_KEYS`, so no faction is forced to voice a mechanics line —
32 strings not written. A faction may still override it. The resolver's docstring
now says it serves the whole multi-party composer footer, not just the roster.

## Checks

- `tsc --noEmit` clean; `vite build` clean (entry unchanged at 138.79 KB gzip);
  `eslint` clean on the changed files.
- `vitest run` — 117 files / 1854 tests pass, including 6 new cases on the duel
  gate and the existing `collabCopy` completeness suite (which picks the new
  shared key up automatically).
- **Visual QA is outstanding** — no screenshots and no dev stack available in this
  environment. Everything above is source/test verification.

## What to eyeball

- **Duel `active`, you cast, rival has not** — desktop and mobile composer: the
  footer button is present and reads "Pull my entry back" (not the archetype's
  publish label, not anything about forfeit). Tapping it unlocks the composer;
  the duel stays `active` and `forfeited_by_character_id` stays NULL.
- **Duel `pending`, you cast before the rival accepted** — same button, same
  neutral wording.
- **Duel `settled`, both cast** — composer footer shows **nothing**; forfeit is
  still only reachable from the detail page's rail, with its red dialog intact.
- **Plain published solo praxis, and a published (live) collab** — composer
  footer still shows nothing.
- **Duel not yet cast** — the button still opens the seal confirmation (#718),
  unchanged.
- Both form factors: the mobile skins gate only `DropButton` on `!isPublished`,
  so the pull-back button should appear alone in the phone footer bar with no
  stray "drop" beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
