### PR TITLE
A collab that drops to one member converts to solo, at any status (#1075)

### DIFF
--- a/backend/services/collab_consensus.py
+++ b/backend/services/collab_consensus.py
@@ -7,6 +7,11 @@ resets the whole group. This module owns that window/deadline math and the
 ``has_submitted`` bookkeeping so the rule lives in one place instead of leaking
 across submit/leave/kick/edit/read in ``services.praxis``.
 
+This module also owns the ``collab → solo`` mutation (:func:`convert_to_solo`),
+because a collab that drops to one member converts (ADR-0060) and the *voluntary*
+takeover in ``services.praxis.change_praxis_type`` must not drift from it. It
+lives here rather than there because ``services.praxis`` imports this module.
+
 The praxis lifecycle/membership functions call these transitions; they no longer
 carry the window logic inline. Duel settling is deliberately NOT here — it
 depends on ``services.duel`` (which imports ``services.praxis``), so keeping it
@@ -18,7 +23,7 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
-from models.praxis import Praxis, PraxisStatus, PraxisType
+from models.praxis import Praxis, PraxisInviteStatus, PraxisStatus, PraxisType
 from services.character_stats import recalculate_character_stats
 from services.era import get_current_era_row
 
@@ -145,11 +150,73 @@ async def on_submit(
     return False
 
 
+async def convert_to_solo(
+    praxis: Praxis,
+    new_owner_character_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> None:
+    """The shared ``collab → solo`` mutation. One body, two callers, no drift.
+
+    - ``services.praxis.change_praxis_type`` — a *voluntary* takeover (#321): any
+      member may claim the praxis, and passes itself as the new owner.
+    - :func:`on_member_leave` — an *involuntary* conversion when a collab drops to
+      its last member, at any status (ADR-0060); the survivor is the new owner.
+
+    What it does: retype the praxis, hand ``created_by_id`` to the new owner, drop
+    every other member and every pending invite, and close any open ADR-0012
+    pending-publish window. Content, id and media are preserved — never
+    delete+recreate. The ``created_by_id`` reassignment is load-bearing:
+    ``delete_praxis`` is creator-only, so without it a survivor who did not start
+    the praxis could not drop it and would be stranded holding a task signup.
+
+    What it deliberately leaves at the call site: authorization, status guards
+    (the takeover keeps its own 422 — that guard protects a *choice*, and this
+    conversion is a *consequence*), and stat recalculation.
+
+    The window is cancelled *before* the retype, because ``on_member_edit``
+    no-ops on a non-collab — and only while the praxis is unpublished, because on
+    a ``submitted`` praxis ``on_member_edit`` would unpublish it and wipe every
+    cast. ADR-0060's submitted case must not do that: the praxis stays Live and
+    only its scoring model changes.
+    """
+    if praxis.status != PraxisStatus.submitted:
+        await on_member_edit(praxis, session, era)
+
+    # Mutate the loaded collections so the delete-orphan cascade fires *and* the
+    # returned/serialized praxis reflects the drop (session.delete alone would
+    # leave the selectin-cached collections stale).
+    praxis.type = PraxisType.solo
+    praxis.created_by_id = new_owner_character_id
+    for member in list(praxis.members):
+        if member.character_id != new_owner_character_id:
+            praxis.members.remove(member)
+    for invite in list(praxis.invites):
+        if invite.status == PraxisInviteStatus.pending:
+            praxis.invites.remove(invite)
+    await session.flush()
+
+
 async def on_member_leave(
     praxis: Praxis, session: AsyncSession, era: EraConfig
 ) -> None:
-    """Release a hold on leave: if everyone who stayed has already submitted, the
-    collab reaches consensus and goes Live. Call after removing the leaver."""
+    """Release a hold on leave, then convert a deserted collab. Call after
+    removing the leaver.
+
+    Two transitions, in this order:
+
+    1. If everyone who stayed has already submitted, the departure completes the
+       consensus and the collab goes Live.
+    2. ADR-0060: if exactly one member remains, the praxis is no longer a
+       collaboration — convert it to a solo praxis owned by the survivor, at any
+       status. This is why the zero-member state is unreachable: the last
+       member's exit is *drop*, not leave.
+
+    The order matters. Converting first would cancel the pending-publish window
+    and wipe the survivor's own cast, discarding a consensus the departure had
+    just completed. Sealing first, then converting, keeps the Live praxis Live
+    and merely reprices it.
+    """
     remaining = praxis.members
     if (
         remaining
@@ -157,6 +224,19 @@ async def on_member_leave(
         and all(m.has_submitted for m in remaining)
     ):
         await seal_to_live(praxis, session, era)
+
+    if praxis.type == PraxisType.collab and len(praxis.members) == 1:
+        survivor_character_id = praxis.members[0].character_id
+        await convert_to_solo(praxis, survivor_character_id, session, era)
+        if praxis.status == PraxisStatus.submitted:
+            # Unlike the takeover path, this fires on scored praxes: the
+            # collab_own/other_modifier pair gives way to own/other_task_modifier
+            # under an already-published praxis, so the survivor is repriced.
+            era_row = await get_current_era_row(session)
+            await recalculate_character_stats(
+                survivor_character_id, session, era, era_row=era_row
+            )
+            await session.flush()
 
 
 async def on_member_kicked(praxis: Praxis, session: AsyncSession) -> None:

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -1283,24 +1283,16 @@ async def change_praxis_type(
             )
         praxis.type = PraxisType.collab
     else:
-        # collab → solo: the actor takes it over as their own solo praxis.
-        # A type change is a structural edit — clear any pending-publish window
-        # (ADR-0012) while this is still a collab, so a later flip back to collab
-        # can't inherit a stale, already-lapsed window and instantly auto-seal.
-        await cancel_pending_publish_on_edit(praxis, session, era)
-        # Mutate the loaded collections so the delete-orphan cascade fires *and*
-        # the returned/serialized praxis reflects the drop (session.delete alone
-        # would leave the selectin-cached collections stale).
-        praxis.type = PraxisType.solo
-        praxis.created_by_id = character_id
-        for member in list(praxis.members):
-            if member.character_id != character_id:
-                praxis.members.remove(member)
-        for invite in list(praxis.invites):
-            if invite.status == PraxisInviteStatus.pending:
-                praxis.invites.remove(invite)
+        # collab → solo: the actor takes it over as their own solo praxis. The
+        # mutation itself is shared with the ADR-0060 involuntary conversion
+        # (a collab that drops to one member) so the two cannot drift. What
+        # stays here is what makes this a *takeover*: the 422 status guard above
+        # and the choice of the actor as the new owner.
+        await collab_consensus.convert_to_solo(praxis, character_id, session, era)
 
-    # in_progress praxes aren't scored, so no stat recalc is needed here.
+    # in_progress praxes aren't scored, so no stat recalc is needed here. The
+    # ADR-0060 conversion cannot reuse that reasoning — it can fire on a
+    # submitted praxis — so it recalcs at its own call site.
     await session.flush()
     return await get_praxis(praxis_id, session)
 

--- a/backend/tests/integration/test_collab_solo_conversion.py
+++ b/backend/tests/integration/test_collab_solo_conversion.py
@@ -1,0 +1,278 @@
+"""ADR-0060 — a collab that drops to one member converts to solo, at any status.
+
+``leave_praxis`` has no status guard, so a member may walk away from an
+``in_progress``, ``pending`` or ``submitted`` collab. When their departure
+leaves exactly one member behind, the praxis stops being a collaboration:
+``on_member_leave`` retypes it to ``solo`` and hands ``created_by_id`` to the
+survivor. Before this, an emptying collab silently did nothing and could reach
+a zero-member state that nobody could edit and only its original creator could
+delete.
+
+The published case deliberately reprices: a deserted collab must not keep a
+collaboration bonus for work one character now holds alone.
+"""
+import dataclasses
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA, EraConfig
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task
+from services.character_stats import recalculate_character_stats
+from services.praxis import leave_praxis
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _era_with_collab_bonus(slug: str, collab_own_modifier: float) -> EraConfig:
+    """``CURRENT_ERA`` with one faction's collab own-faction modifier overridden.
+
+    The conversion is only *observable* in a score where the collab and solo
+    modifiers differ. Era 1 flattens almost everything to 1.0 (#452), so rather
+    than pinning the test to whichever faction currently carries a bonus, tune a
+    copy of the live config and pass it down as the ``era`` argument — exactly
+    how the services take it.
+    """
+    tuned = dataclasses.replace(
+        CURRENT_ERA.factions[slug], collab_own_modifier=collab_own_modifier
+    )
+    factions = dict(CURRENT_ERA.factions)
+    factions[slug] = tuned
+    return dataclasses.replace(CURRENT_ERA, factions=factions)
+
+
+async def _collab_with_members(
+    client: AsyncClient,
+    task: Task,
+    creator_headers: dict,
+    invitees: list[tuple[int, dict]],
+) -> int:
+    """Create a collab and walk each ``(character_id, headers)`` through an invite."""
+    create_resp = await client.post(
+        "/praxes",
+        json={
+            "task_id": task.id,
+            "type": "collab",
+            "title": "Group Work",
+            "body_text": "Everyone chipped in.",
+        },
+        headers=creator_headers,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    for invitee_id, invitee_headers in invitees:
+        invite_resp = await client.post(
+            f"/praxes/{praxis_id}/invite",
+            json={"invitee_id": invitee_id},
+            headers=creator_headers,
+        )
+        assert invite_resp.status_code in (200, 201)
+        accept_resp = await client.post(
+            f"/praxes/{praxis_id}/invite/{invite_resp.json()['id']}/respond",
+            json={"accept": True},
+            headers=invitee_headers,
+        )
+        assert accept_resp.status_code == 200
+
+    return praxis_id
+
+
+async def _member_count(session: AsyncSession, praxis_id: int) -> int:
+    """Membership count straight from the DB, not from a cached collection."""
+    return await session.scalar(
+        select(func.count())
+        .select_from(PraxisMember)
+        .where(PraxisMember.praxis_id == praxis_id)
+    )
+
+
+async def _score(session: AsyncSession, character_id: int, era_id: int) -> int:
+    result = await session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character_id,
+            CharacterStats.era_id == era_id,
+        )
+    )
+    return result.scalar_one().score
+
+
+# ---------------------------------------------------------------------------
+# in_progress: the ordinary desertion
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_member_collab_converts_to_solo_when_one_leaves(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A two-member ``in_progress`` collab losing a member becomes the survivor's solo.
+
+    Content survives (id, title, body — never delete+recreate) and the survivor
+    can drop it, which is only true because ``created_by_id`` moved: ``delete_praxis``
+    is creator-only.
+    """
+    praxis_id = await _collab_with_members(
+        client, active_task, auth_headers2, [(character.id, auth_headers)]
+    )
+
+    leave_resp = await client.post(f"/praxes/{praxis_id}/leave", headers=auth_headers2)
+    assert leave_resp.status_code == 200
+
+    view = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert view.status_code == 200
+    data = view.json()
+    assert data["type"] == "solo"
+    assert data["status"] == "in_progress"
+    assert data["created_by_id"] == character.id
+    assert data["title"] == "Group Work"
+    assert data["body_text"] == "Everyone chipped in."
+    assert [member["character_id"] for member in data["members"]] == [character.id]
+
+    drop_resp = await client.delete(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert drop_resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_conversion_drops_pending_invites(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """An invite nobody accepted cannot survive the collab it was issued for.
+
+    Only *pending* invites are dropped — the accepted one is the survivor's own
+    membership history and stays, matching the takeover path.
+    """
+    praxis_id = await _collab_with_members(
+        client, active_task, auth_headers2, [(character.id, auth_headers)]
+    )
+    invite_resp = await client.post(
+        f"/praxes/{praxis_id}/invite",
+        json={"invitee_id": character3.id},
+        headers=auth_headers2,
+    )
+    assert invite_resp.status_code in (200, 201)
+
+    await client.post(f"/praxes/{praxis_id}/leave", headers=auth_headers2)
+
+    view = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert view.status_code == 200
+    invites = view.json()["invites"]
+    assert not [invite for invite in invites if invite["status"] == "pending"]
+    assert [invite["invitee_id"] for invite in invites] == [character.id]
+
+
+# ---------------------------------------------------------------------------
+# submitted: the conversion reprices an already-scored praxis
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_submitted_collab_dropping_to_one_reprices_the_survivor(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+    auth_headers3: dict,
+):
+    """A published three-member collab losing two members converts and rescores.
+
+    The survivor is deliberately NOT the creator, so this also pins the
+    ``created_by_id`` handover on the published path — without it the praxis
+    would stop counting for anyone (``recalculate_character_stats`` gathers solo
+    praxes by ``created_by_id``).
+
+    Driven through the service rather than the route so a tuned ``era`` can be
+    passed in; the routes always pass ``CURRENT_ERA``.
+    """
+    praxis_id = await _collab_with_members(
+        client,
+        active_task,
+        auth_headers2,
+        [(character.id, auth_headers), (character3.id, auth_headers3)],
+    )
+    for headers in (auth_headers, auth_headers2, auth_headers3):
+        submit_resp = await client.post(
+            f"/praxes/{praxis_id}/submit", headers=headers
+        )
+        assert submit_resp.status_code == 200
+    assert submit_resp.json()["status"] == "submitted"
+
+    tuned_era = _era_with_collab_bonus("ua", 1.5)
+    faction = tuned_era.factions["ua"]
+    collab_total = round(active_task.point_value * faction.collab_own_modifier)
+    solo_total = round(active_task.point_value * faction.own_task_modifier)
+    assert collab_total != solo_total  # the tuning must actually bite
+
+    # Price the survivor under the tuned era while this is still a collab.
+    await recalculate_character_stats(character.id, db_session, tuned_era)
+    assert await _score(db_session, character.id, era.id) == collab_total
+
+    # The creator goes first: two members remain, so nothing converts yet.
+    await leave_praxis(praxis_id, character2.id, db_session, tuned_era)
+    praxis = await db_session.get(Praxis, praxis_id)
+    assert praxis.type == PraxisType.collab
+    assert await _member_count(db_session, praxis_id) == 2
+
+    # The second departure leaves exactly one member — convert.
+    await leave_praxis(praxis_id, character3.id, db_session, tuned_era)
+
+    praxis = await db_session.get(Praxis, praxis_id)
+    assert praxis.type == PraxisType.solo
+    assert praxis.status == PraxisStatus.submitted  # stays Live; only the pricing moves
+    assert praxis.created_by_id == character.id
+    assert await _member_count(db_session, praxis_id) == 1
+
+    # No manual recalc here — the conversion is responsible for it.
+    assert await _score(db_session, character.id, era.id) == solo_total
+
+
+# ---------------------------------------------------------------------------
+# the zero-member state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_zero_member_state_is_unreachable(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """The last member's exit is *drop*, not leave — leaving a solo is refused."""
+    praxis_id = await _collab_with_members(
+        client, active_task, auth_headers2, [(character.id, auth_headers)]
+    )
+    first_leave = await client.post(f"/praxes/{praxis_id}/leave", headers=auth_headers2)
+    assert first_leave.status_code == 200
+
+    second_leave = await client.post(f"/praxes/{praxis_id}/leave", headers=auth_headers)
+    assert second_leave.status_code == 400
+    assert await _member_count(db_session, praxis_id) == 1

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -1700,7 +1700,14 @@ async def test_collab_leave_completes_consensus(
     auth_headers: dict,
     auth_headers2: dict,
 ):
-    """If the only un-submitted member leaves, the collab goes Live for those who stayed."""
+    """If the only un-submitted member leaves, the collab goes Live for those who stayed.
+
+    The seal runs BEFORE the ADR-0060 one-member conversion, and that ordering is
+    the point of this test: converting first would cancel the pending-publish
+    window and wipe the survivor's own cast, throwing away the consensus the
+    departure had just completed. Sealing first keeps it Live, then reprices it
+    as a solo praxis.
+    """
     praxis_id = await _two_member_collab(
         client, active_task, auth_headers2, character.id, auth_headers
     )
@@ -1714,6 +1721,8 @@ async def test_collab_leave_completes_consensus(
     assert data["status"] == "submitted"
     remaining = {m["character_id"] for m in data["members"]}
     assert remaining == {character2.id}
+    # One member left standing, so it is no longer a collaboration (ADR-0060).
+    assert data["type"] == "solo"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A collab that drops to one member is not a collaboration. Before this, a departure that emptied one silently did nothing: `on_member_leave` guarded on `remaining and …`, so the praxis survived with zero members — editable by nobody (`_require_member` fails for everyone) and deletable only by its original creator.

`on_member_leave` now converts: after the leaver is removed, if exactly one member remains the praxis becomes a solo owned by the survivor, **at any status**. The zero-member state is unreachable — the last member's exit is *drop*, not leave.

Closes #1075

## The shared mutation

`change_praxis_type`'s `collab → solo` branch and this path must not drift, so the mutation moved into one helper both call: `collab_consensus.convert_to_solo(praxis, new_owner_character_id, session, era)`.

**Pulled up** (identical for both): retype to `solo`; hand `created_by_id` to the new owner; drop every non-owner member and every pending invite via the loaded collections (so delete-orphan fires and the serialized praxis isn't stale); close any open ADR-0012 pending-publish window.

**Deliberately left behind at the call sites:**

- `change_praxis_type`'s **422 status guard** — untouched. It protects a *voluntary* takeover; this conversion is a consequence, not a choice, and fires at any status (ADR-0060).
- **Who the new owner is.** The takeover passes the actor; the leave path passes the survivor.
- **Stat recalculation.** `change_praxis_type` skips it because `in_progress` praxes aren't scored. That reasoning does not survive here, so the recalc lives in `on_member_leave`, conditional on `status == submitted`, and reuses `recalculate_character_stats` (no hand-rolled arithmetic).

It lives in `collab_consensus` rather than `services/praxis` because `services.praxis` imports that module; the reverse would be an import cycle.

## Two things the extraction had to get right

1. **`cancel_pending_publish_on_edit` is skipped when the praxis is `submitted`.** It is an alias for `on_member_edit`, which *unpublishes* a Live collab and wipes every cast. On the submitted path that would zero the score rather than reprice it, which is the opposite of what ADR-0060 asks for. Behaviour for `change_praxis_type` is unchanged — its 422 already guarantees `in_progress`/`pending` there.
2. **The seal runs before the conversion.** If the departing member was the last hold-out, the existing ADR-0012 branch seals the collab Live first; converting first would cancel the window and clear the survivor's own `has_submitted`, discarding a consensus the departure had just completed. `test_collab_leave_completes_consensus` now pins that ordering.

## Not done, on purpose

- **No status guard added to `leave_praxis`.** Leaving stays legal at every status; ADR-0060 depends on it.
- **`kick_member` untouched.** PR #1098 (#1076) refuses a kick on a published praxis because a kick resets the group back to drafting. That is a different transition and the pattern is deliberately not copied onto leave.
- Backend only. No frontend file touched.

## Tests

`backend/tests/integration/test_collab_solo_conversion.py` — the issue's three checks plus the invite drop:

- two-member `in_progress` collab, one leaves → survivor owns a solo, title/body/id intact, and `DELETE /praxes/{id}` succeeds (only true because `created_by_id` moved — `delete_praxis` is creator-only)
- three-member **`submitted`** collab, two leave → `solo`, still `submitted`, survivor repriced off the collab modifier onto the solo one, with **no manual recalc in the test**. The survivor is deliberately *not* the creator, which also pins the `created_by_id` handover on the published path: `recalculate_character_stats` gathers solo praxes by `created_by_id`, so without it the praxis would stop counting for anyone.
- leaving is refused (400) once the praxis is solo, and the DB member count stays at 1
- a pending invite is dropped by the conversion; the accepted one stays

Era 1 flattens nearly every modifier to 1.0, so the repricing test passes a `dataclasses.replace` copy of `CURRENT_ERA` down as the `era` argument (the same trick `test_praxis_card_breakdown.py` uses) rather than pinning itself to whichever faction currently ships a bonus. It asserts `collab_total != solo_total` first so the tuning can't silently stop biting.

```
cd backend && TEST_DATABASE_URL=postgresql+asyncpg://…/wz1075_test pytest -q
797 passed  (before: 792; +5 new/changed)
```

Full suite, not just the new file. No migration — no schema change.

Visual QA is outstanding: this is backend-only and there is no dev stack here, so it was verified by the integration suite alone.

## What to eyeball

- **The `submitted` conversion is a real, silent rescore of a published praxis.** ADR-0060 §Consequences accepts it, but it means a survivor's score can drop with no action of their own. Confirm that is wanted before this ships to players.
- **The seal-then-convert ordering** in `on_member_leave` — a Live collab with one member left standing ends up `submitted` *and* `solo`. Check that reads right in the feed and on the praxis card (ADR-0053 will now show the full stamp rather than the collab presentation).
- **`leave_praxis` returns the converted `PraxisOut` to the leaver**, so the response the frontend gets back from `leavePraxis()` now says `type: "solo"` and lists someone else as `created_by_id`. Nothing in `frontend/src` was changed; worth confirming the composer/feed handle that shape.
- **Accepted invites survive the conversion** (only pending ones are dropped) — this matches the pre-existing takeover behaviour, but it does mean a solo praxis can carry an invite row naming a character who is no longer a member.
- **`convert_to_solo` skips the window cancel on `submitted`.** If a `submitted` praxis could ever hold a non-null `submit_proposed_at`, that field would now be left set. `_apply_seal` is the only writer of `status = submitted` and it nulls the field, so this should be unreachable — but it is the one assumption the branch rests on.
