### PR TITLE
ADR-0061 + ADR-0062: praxis detail is one shared page, published-only

### DIFF
--- a/docs/adr/0061-praxis-detail-is-one-shared-page-every-faction-dresses.md
+++ b/docs/adr/0061-praxis-detail-is-one-shared-page-every-faction-dresses.md
@@ -1,0 +1,68 @@
+# ADR-0061 — Praxis detail is one shared page; every faction dresses it
+
+**Status:** Accepted
+**Date:** 2026-07-28
+**Relates to:** #1085 (epic), #1087 (ADR-0062, the sibling behaviour change)
+**Extends:** ADR-0057 (task detail pages carry no faction voice) — same doctrine,
+a second surface
+**Tension with:** ADR-0016 (per-faction surfaces share one data contract;
+archetypes own only presentation) — gains a second per-surface exception
+
+## Context
+
+Praxis detail today ships bespoke skins for the `CORE_SIX` factions (coven,
+snide, ephemerists, singularity, everymen, ua) plus a mobile-only bespoke skin
+for wow; together with the shared Default (na / Unaffiliated) skin that is
+seven factions already carrying their own praxis-detail vocabulary.
+Albescent is frozen as a wrapper over Default (ADR-0046/0048), not a skin of
+its own, so it does not add an eighth.
+
+Each of those seven invented its own words for identical slots. In
+`frontend/src/locales/en/praxis.json` the body-content heading alone is six
+near-synonym keys naming one slot — `theAccount` (default, ephemerists) /
+`theWork` (everymen) / `whatIDid` (coven) / `theConfession` (snide) /
+`processLog` (singularity) / `theProcess` (ua) — and the media/evidence
+heading repeats the pattern: `evidence` (ephemerists, snide) / `proofOfWork`
+(everymen) / `keepsakes` (coven) / `artifacts` (singularity) / `thePlate`
+(ua). Twelve near-synonym keys for two slots that read identically on every
+skin.
+
+The Unaffiliated redesign (project `bebdf7c7-6a54-42ea-b3b4-6d908a506f84`) is
+the first of these seven to rebuild; the other six are committed to its
+layout and API contract (epic #1085).
+
+## Decision
+
+**Praxis detail is one shared page. A faction skin brings dress and no
+copy.**
+
+- A single neutral `detail.*` block; every archetype reads the same keys.
+  Where a design's word differs from the domain noun in `CONTEXT.md`, the
+  domain noun wins.
+- The layout is the contract: main column + aside + comments region,
+  collapsing to one stacked column on mobile.
+- **The neutral rule covers the page's own slots and stops at the speaker's
+  voice.** Comment rows dispatch on `comment.author.faction_slug`, not the
+  page's — a Snide player's comment reads Snide on a Coven praxis.
+  `comments.<faction>.*` and the seven `*Comment` skins are **out of scope**
+  and must not be swept later by inference from this ADR.
+
+## Consequences
+
+- A praxis page reads identically across all nine factions and differs only
+  in dress.
+- The per-faction `detail.<faction>.*` blocks are deleted as each archetype
+  goes.
+- A future faction skin cannot introduce copy on this surface, only dress.
+- Extends ADR-0057's doctrine to a second surface. ADR-0016's
+  presentation/voice boundary now carries two per-surface exceptions.
+
+## Alternative rejected
+
+**Voice returns with each design.** Argued seriously at grill: a praxis is
+somebody's account of a thing they did, and "The Confession" over a Snide
+write-up does more work than a task page's labels ever did. Rejected because
+the seven designs are already locked to one layout and one contract —
+leaving copy free re-grows the catalog being deleted, and the nine
+task-detail designs proved that per-design "neutral" wording fragments even
+when nobody intends voice.

--- a/docs/adr/0062-praxis-detail-is-published-only.md
+++ b/docs/adr/0062-praxis-detail-is-published-only.md
@@ -1,0 +1,69 @@
+# ADR-0062 — Praxis detail is a published-only reading surface
+
+**Status:** Accepted
+**Date:** 2026-07-28
+**Relates to:** #1085 (epic), #1086 (ADR-0061, the sibling behaviour change)
+**Depends on:** ADR-0059 (submitting a collab or duel part holds the
+composer) — this ADR's argument only holds once every open multi-party state
+has a composer home
+**Widens:** ADR-0024 (an in-progress praxis is private) — the member-only
+guard grows a second status
+
+## Context
+
+`PraxisDetail.tsx` (`frontend/src/pages/PraxisDetail.tsx`) redirects
+`in_progress` to the composer (ADR-0024: an in-progress praxis is
+member-only). It does **not** redirect `PraxisStatus.pending` — a collab
+mid-consensus renders the detail page today behind a "PENDING PUBLISH —
+waiting on co-authors to submit" banner (`detail.banners.pendingPublishLabel`
+/ `pendingPublishBody`, `frontend/src/pages/praxisDetail/shared.tsx:278`).
+
+Meanwhile #1071 (ADR-0059) made the composer hold after you submit, giving
+every open multi-party state a home there. Leaving `pending` on detail gives
+one state two owners that describe it differently.
+
+## Decision
+
+**Praxis detail is a published-only reading surface. Every open state
+belongs to the composer.**
+
+- The guard widens to `in_progress || pending`.
+- `detail.banners.pendingPublish*` and `detail.banners.inEditing*` are
+  deleted — the first becomes unreachable, the second already was.
+- Detail then covers exactly three axes: `status` published-only,
+  `moderation_status` (`visible` / `flagged` / `failed`, the last carrying
+  `admin_note`), and `is_top_for_task` — crossed with visitor / owner /
+  steward.
+
+## The naming trap this ADR exists to prevent
+
+`pending` reads as "waiting on the other party". **It is collab-only — solo
+and duel never enter it** (`backend/models/praxis.py`, the `PraxisStatus`
+enum comment on `pending`; the status is assigned only in
+`backend/services/collab_consensus.py`). A duel side that has cast is
+`submitted` with the duel still `active`, which is why #999 needs
+`_duel_side_hidden_condition` (`backend/services/praxis.py`) to hide it
+rather than relying on status.
+
+So state the rule by intent, not by enum: *drafting, mid-consensus, or
+waiting on a rival — all composer.*
+
+## Why the redirect is safe
+
+`praxis_visibility_condition` (`backend/services/praxis.py`) exposes
+`submitted` praxes publicly plus the viewer's own member praxes. A `pending`
+praxis is not `submitted`, so only members reach it, and every member has a
+destination in the composer — the waiting surface if they have cast, the
+ordinary composer if they are the holdout. The redirect cannot strand a
+viewer.
+
+## Consequences
+
+- One state, one owner: `pending` is read only by the composer's waiting
+  surface, never by detail.
+- `detail.banners.pendingPublish*` and `detail.banners.inEditing*` are
+  deleted from `praxis.json` rather than left dormant — both are
+  unreachable once the guard widens.
+- Detail's remaining state space is exactly `moderation_status ×
+  is_top_for_task`, crossed with visitor / owner / steward — no `status`
+  branching left to reason about beyond the redirect itself.


### PR DESCRIPTION
## Summary

Two docs-only ADRs for the praxis-detail epic (#1085), children #1086 and #1087.

- **ADR-0061** — Praxis detail is one shared page; every faction dresses it. A single neutral `detail.*` copy set replaces the per-faction near-synonym vocabularies (`theAccount`/`theWork`/`whatIDid`/`processLog`/`theConfession`/`theProcess` for the body heading; `evidence`/`proofOfWork`/`keepsakes`/`artifacts`/`thePlate` for the media heading). Extends ADR-0057's doctrine to a second surface. Explicitly scopes out `comments.<faction>.*` and the seven `*Comment` skins — comment voice stays live.
- **ADR-0062** — Praxis detail is a published-only reading surface. Widens the `PraxisDetail.tsx` redirect guard from `in_progress` to `in_progress || pending`, now that #1071/ADR-0059 gives every open multi-party state (collab mid-consensus, a duel side awaiting its rival) a home in the composer. Deletes the now-unreachable `pendingPublish*`/`inEditing*` banner copy.

Closes #1086
Closes #1087

## Reference corrected during research

#1086's context cited "eight near-synonym sets" for the body heading, listing `theFinding` and `theChronicle` among them. I checked actual usage in the archetype `.tsx` files: those two keys are pre-title eyebrow labels (Coven, Wow), not the body-content heading. The real body-heading set is six keys (`theAccount`/`theWork`/`whatIDid`/`processLog`/`theConfession`/`theProcess`) and the media-heading set is a separate six (`evidence`/`proofOfWork`/`keepsakes`/`artifacts`/`thePlate`, with `evidence` reused twice). Rewrote ADR-0061's Context with the verified counts and per-faction attributions rather than the issue's list verbatim. This doesn't change either ADR's decision or reasoning — only the illustrative count in the context.

Everything else — the `PraxisDetail.tsx` redirect guard (redirects `in_progress`, not `pending`), the banner at `praxisDetail/shared.tsx:278`, `PraxisStatus.pending` being collab-only and assigned only in `collab_consensus.py`, `_duel_side_hidden_condition` and `praxis_visibility_condition` in `backend/services/praxis.py`, and the `CORE_SIX`/wow/albescent archetype count — checked out exactly as the issues described.

## What to eyeball

- [ ] ADR-0061's front matter (Relates to / Extends / Tension with) matches this repo's convention from ADR-0059/0060/0057
- [ ] ADR-0061's corrected key-count claim in Context reads accurately against `frontend/src/locales/en/praxis.json`
- [ ] ADR-0062's three-axis close (`status` / `moderation_status` / `is_top_for_task`) matches what `PraxisDetail.tsx` will actually need to branch on once `pending` is gone
- [ ] Both files are numbered 0061/0062 and don't collide with anything landed on `main` since this branch was cut
- [ ] Status/Date front matter reads "Accepted" / 2026-07-28 on both, consistent with ADR-0059/0060

Docs-only change — no code touched, no tests to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)