### PR TITLE
Unsubmit on praxis detail says what it actually does, per praxis kind (#1094)

### DIFF
--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -140,8 +140,15 @@
       "submit": "Submit",
       "submittedWaiting": "You've submitted — waiting on co-authors",
       "unsubmit": "unsubmit",
+      "unsubmitDuelLive": "pull my entry back",
       "confirmPrompt": "Sure? Points & votes will pause.",
+      "confirmPromptCollab": "Sure? This reopens the praxis for the whole group — every member's part is uncast, and points & votes pause.",
+      "confirmPromptCollabPart": "Sure? This pulls back only your part — your co-authors' casts stand.",
+      "confirmPromptDuelLive": "Sure? Nothing is forfeited — the duel hasn't settled, so this is a free reopen. Points & votes pause.",
       "confirmUnsubmit": "Yes, unsubmit",
+      "confirmUnsubmitCollab": "Yes, reopen for everyone",
+      "confirmUnsubmitCollabPart": "Yes, pull my part back",
+      "confirmUnsubmitDuelLive": "Yes, pull my entry back",
       "cancel": "Cancel"
     },
     "flag": {

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -144,7 +144,7 @@
       "confirmPrompt": "Sure? Points & votes will pause.",
       "confirmPromptCollab": "Sure? This reopens the praxis for the whole group — every member's part is uncast, and points & votes pause.",
       "confirmPromptCollabPart": "Sure? This pulls back only your part — your co-authors' casts stand.",
-      "confirmPromptDuelLive": "Sure? Nothing is forfeited — the duel hasn't settled, so this is a free reopen. Points & votes pause.",
+      "confirmPromptDuelLive": "Sure? The duel hasn't settled and your rival hasn't cast, so this is a free reopen — nothing is marked against you. Points & votes pause.",
       "confirmUnsubmit": "Yes, unsubmit",
       "confirmUnsubmitCollab": "Yes, reopen for everyone",
       "confirmUnsubmitCollabPart": "Yes, pull my part back",

--- a/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * The unsubmit confirm says what the unsubmit actually does (#1094).
+ *
+ * One prompt used to cover every praxis — "Sure? Points & votes will pause." —
+ * which is true of a solo and of nothing else. Each case below is asserted
+ * against `unsubmit_praxis` (`backend/services/praxis.py`), not against the
+ * words alone:
+ *
+ *  - published collab: the whole group reopens and EVERY member's
+ *    `has_submitted` clears, so the prompt must not read as "your part".
+ *  - collab mid-consensus (`pending`, caller has cast): `on_member_unsubmit`
+ *    pulls back only the caller's part; co-authors' casts stand. Pending
+ *    praxes are unscored, so there is no points-and-votes half to promise.
+ *  - duel `active` AND duel `pending`: both are pre-settlement, a forfeit is
+ *    marked only at `settled` (ADR-0011 §Forfeit), so the copy is neutral and
+ *    carries no consequence language. `pending` is here deliberately — the
+ *    issue's four-case list named only `active`, but the backend pairs the two
+ *    in `_LIVE_INCOMPLETE_DUEL_STATUSES` and #1077 already treats them
+ *    identically in the composer's pull-back.
+ *  - solo: byte-for-byte the shipped string.
+ *
+ * The `settled` duel forfeit dialog is covered by `duelForfeitWarning.test.tsx`
+ * and is unchanged here — it is caught before this copy table is reached.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import { PraxisSubmitControls, unsubmitCase } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import type { PraxisOut, PraxisMemberOut, PraxisStatus } from '../../../api/praxis'
+import type { CharacterOut, CurrentUser } from '../../../api/auth'
+import type { DuelDetailOut, DuelSideOut, DuelStatus } from '../../../api/duel'
+
+/**
+ * Rendered text with tags stripped and the entities React escapes (`&`, `'`)
+ * put back, so an assertion can quote the catalog string as an editor wrote it.
+ */
+function text(element: ReactElement): string {
+  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+    .replace(/<[^>]*>/g, '')
+    .replace(/&#x27;|&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&amp;/g, '&')
+}
+
+function member(characterId: number, name: string, hasSubmitted: boolean): PraxisMemberOut {
+  return {
+    id: characterId * 10,
+    praxis_id: 1,
+    character_id: characterId,
+    character_display_name: name,
+    has_submitted: hasSubmitted,
+    joined_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+function praxis(overrides: Partial<PraxisOut> = {}): PraxisOut {
+  return {
+    id: 1,
+    task_id: 7,
+    task_title: 'Mangrove',
+    task_point_value: 30,
+    task_level_required: 3,
+    task_faction_slug: null,
+    type: 'solo',
+    status: 'submitted' as PraxisStatus,
+    title: 'Reforestation',
+    body_text: 'Seedlings.',
+    moderation_status: 'visible',
+    admin_note: null,
+    flagged_at: null,
+    submitted_at: '2026-01-02T00:00:00Z',
+    submit_proposed_at: null,
+    created_by_id: 1,
+    created_by_display_name: 'Ada',
+    created_by_faction_slug: 'wow',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+    members: [member(1, 'Ada', true)],
+    invites: [],
+    media_items: [],
+    score: 0,
+    metatask_points: 0,
+    display_multiplier: 1.0,
+    points_from_votes: 0,
+    is_top_for_task: false,
+    duel_id: null,
+    can_flag: true,
+    applied_metatasks: [],
+    ...overrides,
+  } as PraxisOut
+}
+
+const ME: DuelSideOut = {
+  praxis_id: 1,
+  character_id: 1,
+  display_name: 'Ada',
+  faction_slug: 'wow',
+  avatar_url: '',
+  points_from_votes: 0,
+  is_submitted: true,
+}
+const FOE: DuelSideOut = {
+  praxis_id: 2,
+  character_id: 2,
+  display_name: 'Rax',
+  faction_slug: 'snide',
+  avatar_url: '',
+  points_from_votes: 0,
+  is_submitted: false,
+}
+
+function duel(status: DuelStatus): DuelDetailOut {
+  return {
+    id: 5,
+    task_id: 7,
+    status,
+    forfeited_by_character_id: null,
+    challenger: ME,
+    opponent: FOE,
+    viewer_is_participant: true,
+    winner_character_id: null,
+    challenger_final_points: null,
+    opponent_final_points: null,
+  }
+}
+
+function user(): CurrentUser {
+  const character: CharacterOut = {
+    id: 1,
+    username: 'ada',
+    display_name: 'Ada',
+    bio: null,
+    avatar_url: null,
+    location: null,
+    level: 5,
+    score: 0,
+    all_time_score: 0,
+    faction_slug: 'wow',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+  }
+  return {
+    account_id: 1,
+    character,
+    is_admin: false,
+    can_create_additional_character: false,
+    can_start_as_albescent: false,
+    albescent_revealed: false,
+    can_propose_task: false,
+    can_propose_metatask: false,
+    can_see_retired_tasks: false,
+    can_see_pending_tasks: false,
+    can_comment: true,
+    second_character_level_required: 5,
+    era_name: 'Era 1',
+    level_jump_reach: 0,
+    level_jump_available: false,
+  }
+}
+
+function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: praxis(),
+    fetchError: null,
+    votes: null,
+    voters: [],
+    duel: null,
+    isOwner: true,
+    showAdminBar: false,
+    user: user(),
+    withdrawing: false,
+    showWithdrawConfirm: true,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: '',
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: '',
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleResubmit: async () => {},
+    handleFlag: async () => {},
+    handleKickMember: async () => {},
+    metatasks: [],
+    metataskLoading: false,
+    metataskError: null,
+    applyingMetataskId: null,
+    removingMetataskId: null,
+    handleApplyMetatask: async () => {},
+    handleRemoveMetatask: async () => {},
+    ...overrides,
+  } as PraxisDetailState
+}
+
+const COLLAB_MEMBERS = [member(1, 'Ada', true), member(2, 'Beth', true)]
+
+describe('unsubmitCase — the branch, straight off the backend', () => {
+  it('a solo praxis is solo', () => {
+    expect(unsubmitCase(praxis(), null)).toBe('solo')
+  })
+
+  it('a published collab reopens the whole group', () => {
+    expect(unsubmitCase(praxis({ members: COLLAB_MEMBERS }), null)).toBe('collabGroup')
+  })
+
+  it('a collab mid-consensus pulls back only the caller part', () => {
+    const pending = praxis({ members: COLLAB_MEMBERS, status: 'pending' as PraxisStatus })
+    expect(unsubmitCase(pending, null)).toBe('collabOwnPart')
+  })
+
+  it.each<DuelStatus>(['pending', 'active'])(
+    'a duel at %s is a free live reopen, not a forfeit',
+    (status) => {
+      expect(unsubmitCase(praxis({ duel_id: 5 }), duel(status))).toBe('duelLive')
+    },
+  )
+
+  it('a settled duel is NOT duelLive — the forfeit branch owns it', () => {
+    expect(unsubmitCase(praxis({ duel_id: 5 }), duel('settled'))).not.toBe('duelLive')
+  })
+})
+
+describe('unsubmit confirm copy (#1094)', () => {
+  it('solo: the shipped prompt is unchanged', () => {
+    const rendered = text(<PraxisSubmitControls state={state({})} />)
+    expect(rendered).toMatch(/Sure\? Points & votes will pause\./)
+    expect(rendered).toMatch(/Yes, unsubmit/)
+  })
+
+  it('collab: the prompt says the whole group reopens, not just your part', () => {
+    const rendered = text(
+      <PraxisSubmitControls state={state({ praxis: praxis({ members: COLLAB_MEMBERS }) })} />,
+    )
+    expect(rendered).toMatch(/whole group/i)
+    expect(rendered).toMatch(/every member's part is uncast/i)
+    expect(rendered).toMatch(/Yes, reopen for everyone/i)
+    // The solo promise must not be the thing a co-author reads.
+    expect(rendered).not.toMatch(/Sure\? Points & votes will pause\./)
+  })
+
+  it('collab mid-consensus: only your part comes back, and no scoring promise', () => {
+    const rendered = text(
+      <PraxisSubmitControls
+        state={state({
+          praxis: praxis({ members: COLLAB_MEMBERS, status: 'pending' as PraxisStatus }),
+        })}
+      />,
+    )
+    expect(rendered).toMatch(/only your part/i)
+    expect(rendered).toMatch(/co-authors' casts stand/i)
+    expect(rendered).toMatch(/Yes, pull my part back/i)
+  })
+
+  it.each<DuelStatus>(['pending', 'active'])(
+    'duel at %s: neutral pull-back wording, no forfeit language',
+    (status) => {
+      const rendered = text(
+        <PraxisSubmitControls
+          state={state({ praxis: praxis({ duel_id: 5 }), duel: duel(status) })}
+        />,
+      )
+      expect(rendered).toMatch(/free reopen/i)
+      expect(rendered).toMatch(/Yes, pull my entry back/i)
+      expect(rendered).not.toMatch(/forfeit/i)
+      expect(rendered).not.toMatch(/wins by default/i)
+      // Nor the solo prompt it used to fall through to.
+      expect(rendered).not.toMatch(/Sure\? Points & votes will pause\./)
+    },
+  )
+
+  it.each<DuelStatus>(['pending', 'active'])(
+    'duel at %s: the trigger itself is the neutral pull-back verb',
+    (status) => {
+      const rendered = text(
+        <PraxisSubmitControls
+          state={state({
+            praxis: praxis({ duel_id: 5 }),
+            duel: duel(status),
+            showWithdrawConfirm: false,
+          })}
+        />,
+      )
+      expect(rendered).toMatch(/pull my entry back/i)
+      expect(rendered).not.toMatch(/forfeit/i)
+    },
+  )
+})

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -20,6 +20,7 @@ import { CollabRoster } from '../../components/collab/CollabRoster'
 import DuelSealConfirm from '../../components/duel/DuelSealConfirm'
 import type { PraxisDetailState } from './usePraxisDetail'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
+import type { DuelDetailOut } from '../../api/duel'
 import { flagReasonOptions } from '../../utils/flagReasons'
 import { scoreBreakdown } from '../../components/praxisCard/scoreStamp/scoreBreakdown'
 
@@ -339,6 +340,73 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
 }
 
 /**
+ * Which reopen the quiet unsubmit control is actually about to perform (#1094).
+ *
+ * The control used to show ONE prompt — "Sure? Points & votes will pause." — for
+ * every praxis, which is only true of a solo. Each branch below is `unsubmit_praxis`
+ * (`services/praxis.py`) read back as a sentence:
+ *
+ *  - `duelLive` — a duel still `pending` or `active`. Both are pre-settlement:
+ *    a forfeit is marked only at `status == settled` (ADR-0011 §Forfeit), so the
+ *    reopen is free and neutral and nothing is marked. `pending` sits alongside
+ *    `active` in the backend's own `_LIVE_INCOMPLETE_DUEL_STATUSES`, and #1077
+ *    already treats the pair identically in the composer's pull-back — a
+ *    challenger who casts before the rival accepts is in the same free state.
+ *    A `settled` duel never reaches here: it is caught by `forfeitsOnUnsubmit`
+ *    above and gets the forfeit dialog instead.
+ *  - `collabOwnPart` — a collab mid-consensus (`pending`) where the viewer has
+ *    cast. The backend runs `on_member_unsubmit`: only the caller's part comes
+ *    back and co-authors' casts stand. Pending praxes are unscored, so there is
+ *    no points-and-votes half to warn about.
+ *  - `collabGroup` — a published collab. The whole group reopens and EVERY
+ *    member's `has_submitted` clears, not just the viewer's.
+ *  - `solo` — the original copy, unchanged.
+ */
+export type UnsubmitCase = 'solo' | 'collabGroup' | 'collabOwnPart' | 'duelLive'
+
+export function unsubmitCase(
+  praxis: PraxisOut,
+  duel: DuelDetailOut | null,
+): UnsubmitCase {
+  if (duel && (duel.status === 'pending' || duel.status === 'active')) return 'duelLive'
+  if (praxis.members.length <= 1) return 'solo'
+  return praxis.status === 'pending' ? 'collabOwnPart' : 'collabGroup'
+}
+
+/**
+ * Trigger label / confirm prompt / confirm-button label, one row per case.
+ * `as const` keeps the literals narrow so the typed `t()` key union still
+ * checks every string here against the shipped catalog.
+ */
+const UNSUBMIT_COPY = {
+  solo: {
+    trigger: 'detail.owner.unsubmit',
+    prompt: 'detail.owner.confirmPrompt',
+    confirm: 'detail.owner.confirmUnsubmit',
+  },
+  collabGroup: {
+    trigger: 'detail.owner.unsubmit',
+    prompt: 'detail.owner.confirmPromptCollab',
+    confirm: 'detail.owner.confirmUnsubmitCollab',
+  },
+  collabOwnPart: {
+    trigger: 'detail.owner.unsubmit',
+    prompt: 'detail.owner.confirmPromptCollabPart',
+    confirm: 'detail.owner.confirmUnsubmitCollabPart',
+  },
+  // The composer's vocabulary for the same free beat (#1077, "Pull my entry
+  // back") — one event, one set of words, no consequence language.
+  duelLive: {
+    trigger: 'detail.owner.unsubmitDuelLive',
+    prompt: 'detail.owner.confirmPromptDuelLive',
+    confirm: 'detail.owner.confirmUnsubmitDuelLive',
+  },
+} as const satisfies Record<
+  UnsubmitCase,
+  { trigger: string; prompt: string; confirm: string }
+>
+
+/**
  * The submit / pull-back / forfeit control for a praxis you own — the one
  * mutation seam that changes its cast state (and, for a duel side, the duel's).
  * Extracted from PraxisOwnerActions (#752) so the duel RAIL can render it beside
@@ -381,6 +449,10 @@ export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
   const isPendingHoldout =
     isCollab && praxis.status === 'pending' && viewerMember?.has_submitted !== true
 
+  // What the quiet unsubmit is about to do, in its own words (#1094). The
+  // settled-duel forfeit is handled above and never reaches this table.
+  const unsubmitCopy = UNSUBMIT_COPY[unsubmitCase(praxis, duel)]
+
   return praxis.status === 'in_progress' && viewerSubmittedWaiting ? (
     <span className="eyebrow" style={{ color: 'var(--color-success)', fontWeight: 700 }}>
       {t('detail.owner.submittedWaiting')}
@@ -418,17 +490,17 @@ export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
     </>
   ) : !showWithdrawConfirm ? (
     <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}>
-      {t('detail.owner.unsubmit')}
+      {t(unsubmitCopy.trigger)}
     </button>
   ) : (
     <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', flexWrap: 'wrap' }}>
-      <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t('detail.owner.confirmPrompt')}</span>
+      <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t(unsubmitCopy.prompt)}</span>
       <button
         onClick={handleWithdraw}
         disabled={withdrawing}
         style={{ background: 'rgba(220,38,38,0.1)', border: '1.5px solid var(--color-danger)', color: 'var(--color-danger)', fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', padding: 'var(--space-xs) var(--space-md)', cursor: 'pointer', borderRadius: 0 }}
       >
-        {withdrawing ? t('detail.owner.submitting') : t('detail.owner.confirmUnsubmit')}
+        {withdrawing ? t('detail.owner.submitting') : t(unsubmitCopy.confirm)}
       </button>
       <button onClick={() => setShowWithdrawConfirm(false)} className="btn-outline" style={{ fontSize: 'var(--text-sm)', padding: 'var(--space-xs) var(--space-md)' }}>{t('detail.owner.cancel')}</button>
     </div>


### PR DESCRIPTION
The owner's quiet unsubmit on praxis detail showed **one** prompt for every
praxis — `detail.owner.confirmPrompt`, "Sure? Points & votes will pause." That
is true of a solo and of nothing else.

`unsubmitCase()` (new, exported from `pages/praxisDetail/shared.tsx`) reads
`unsubmit_praxis` in `backend/services/praxis.py` back as four sentences, and
a small `UNSUBMIT_COPY` table maps each case to a trigger label, a prompt and a
confirm-button label. No backend file was touched.

## One premise in the issue was already fixed

**The settled-duel forfeit warning is shipped.** #718 → #751 → #752 replaced
the inline expand with the dispatched `DuelSealConfirm mode="forfeit"`, mounted
from `PraxisSubmitControls` behind `forfeitsOnUnsubmit` (`duel.status ===
'settled' && forfeited_by_character_id == null`). It already names the winner
and quotes the real cost from `useDuelStakes`, and
`__tests__/duelForfeitWarning.test.tsx` guards it. So the *most* destructive
case was correct; the three quieter ones were not. This PR leaves the forfeit
path completely alone and fixes what falls through it.

## The cases, each verified against the backend

| case | what the backend does | copy |
|---|---|---|
| solo | reopens; votes preserved but stop scoring | **unchanged** |
| collab, `submitted` | whole group reopens, **every** member's `has_submitted` clears, all members' stats recalc | "reopens the praxis for the whole group — every member's part is uncast" / "Yes, reopen for everyone" |
| collab, `pending` (mid-consensus, caller has cast) | `collab_consensus.on_member_unsubmit` — only the caller's part; co-authors' casts stand; pending praxes are unscored | "pulls back only your part — your co-authors' casts stand" / "Yes, pull my part back" |
| duel `pending` / `active` | pre-settlement; `forfeited_by_character_id` stays NULL | "the duel hasn't settled and your rival hasn't cast, so this is a free reopen — nothing is marked against you" / "Yes, pull my entry back" |
| duel `settled` | forfeit | untouched — caught upstream, never reaches the table |

The collab-`pending` row is a **fifth** case the issue's four-case list didn't
name. It is reachable today (a co-author who has cast, on a `pending` collab,
gets the confirm) and the group-reopen wording would have been wrong for it, so
it got its own row rather than being folded into "collab".

**`pending` duels are handled like `active`**, as asked. The issue named only
`active`, but `pending` sits beside it in the backend's own
`_LIVE_INCOMPLETE_DUEL_STATUSES`, and #1077 shipped the composer's neutral
pull-back for both — a challenger who casts before the rival accepts is in the
identical pre-settlement state. Letting `pending` fall through would have given
it the solo "points will pause" line.

## Reuse, not a second vocabulary

The duel-live row borrows #1077's composer wording ("Pull my entry back") and
the collab-part row borrows its "Pull my part back", so one event reads the
same in the composer and on detail. The forfeit dialog stays the shared
`DuelSealConfirm`. Nothing new was styled; the confirm chrome is the existing
inline cluster.

The duel-live prompt deliberately avoids the word "forfeit" **even in denial** —
`duelForfeitWarning.test.tsx` forbids forfeit language before settlement, and
that rule is correct: a player skimming should not see the word at a moment
when nothing is at stake.

## `duel_loss_modifier`, as actually found in `backend/eras/era_1.py`

The issue's numbers hold. Eight of the nine faction configs (`ua`, `wow`,
`coven`, `ephemerists`, `everymen`, `singularity`, `albescent`, `na`) are
`duel_win_modifier=1.5` / `duel_loss_modifier=0.5`; `snide` is `2.0` / **`0.0`**
— a losing Snide duelist earns literally nothing. No copy in this PR hardcodes
either figure; the forfeit dialog already derives them live from
`FactionConfigOut` via `useDuelStakes`.

## Verification

- `tsc --noEmit` — clean. (The catalog keys are typed, so every string in the
  copy table is checked against `praxis.json` at compile time.)
- `vitest run` — **118 files / 1867 tests pass**, including the 6 pre-existing
  forfeit tests, unchanged.
- `eslint` on both touched files — clean.
- `vite build` — clean.
- **Visual QA is outstanding**: no dev stack and the Browser pane renderer times
  out here, so nothing below was seen on screen.

New tests: `frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx`
— nine cases over the hookless `PraxisSubmitControls` plus `unsubmitCase()`
directly, including an assertion that a `settled` duel never reaches the table.

## What to eyeball

1. **Solo, published** — unsubmit still reads "Sure? Points & votes will pause." / "Yes, unsubmit". Byte-for-byte unchanged.
2. **Collab, published** — the prompt names the whole group and says every member's part is uncast; the confirm reads "Yes, reopen for everyone". (Bonus: a collab still `pending` mid-consensus should instead say *only your part*, co-authors' casts stand.)
3. **Duel, `settled`** — unchanged from today: the red "Forfeit" trigger opens the faction-skinned forfeit dialog with "wins by default" and the live cost figure. Confirm this PR did not disturb it.
4. **Duel, `active`** (you cast, rival hasn't) — trigger reads "pull my entry back", prompt is neutral, the word "forfeit" appears nowhere. **Also check `pending`** (you cast before the rival accepted) — it must read identically.

Closes #1094

🤖 Generated with [Claude Code](https://claude.com/claude-code)
