### PR TITLE
Praxis detail v2 — the Unaffiliated page, and one component per faction (#1088)

### DIFF
--- a/docs/adr/0061-praxis-detail-is-one-shared-page-every-faction-dresses.md
+++ b/docs/adr/0061-praxis-detail-is-one-shared-page-every-faction-dresses.md
@@ -7,6 +7,9 @@
 a second surface
 **Tension with:** ADR-0016 (per-faction surfaces share one data contract;
 archetypes own only presentation) — gains a second per-surface exception
+**Amends:** ADR-0006 (comments are neutral chrome below every archetype) — on
+this surface the thread is a layout region the archetype mounts, not chrome the
+dispatcher appends; see "Comments are the third region" below
 
 ## Context
 
@@ -46,6 +49,21 @@ copy.**
   page's — a Snide player's comment reads Snide on a Coven praxis.
   `comments.<faction>.*` and the seven `*Comment` skins are **out of scope**
   and must not be swept later by inference from this ADR.
+
+### Comments are the third region (amending ADR-0006)
+
+ADR-0006 called the comment thread "neutral chrome below every archetype", and
+`PraxisDetail.tsx` mounted it there, outside whatever the archetype drew. The
+layout contract above makes comments a **region of the page**, beneath the main
+column and the aside and inside the page's own surface — so the **archetype**
+mounts the thread and the **layout** draws its section head, passing
+`showHeading={false}` so one list carries one heading (the #1029 trap).
+
+Nothing about ADR-0006's substance changes: the thread is still neutral, still
+never blanket-themed, still gated to a `visible` praxis. Only its mount point
+moves, and the gate moves with it — into the shared `PraxisDetailComments`
+slot — so a faction skin cannot forget it. This is the same move task detail
+made in #1030.
 
 ## Consequences
 

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -198,6 +198,7 @@
       "ptsMultVotes": "pts × bonus + votes",
       "heading": "Score",
       "base": "Base",
+      "multiplier": "Multiplier",
       "meta": "Metatasks",
       "votes": "From votes",
       "total": "Total"

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -101,6 +101,27 @@
     "loading": "Loading...",
     "retry": "Try refreshing.",
     "notFound": "Not found.",
+    "breadcrumb": {
+      "tasks": "Tasks",
+      "current": "Praxis"
+    },
+    "back": "Praxes",
+    "sections": {
+      "proof": "Proof",
+      "writeUp": "Write-up",
+      "members": "Members",
+      "comments": "Discussion"
+    },
+    "taskRef": {
+      "label": "Completing task",
+      "level": "Level {{level}}",
+      "points": "{{points}} pts"
+    },
+    "filed": "Filed {{date}}",
+    "vote": {
+      "heading": "Cast your vote",
+      "prompt": "How much did this move you?"
+    },
     "errors": {
       "load": "Couldn't load this praxis.",
       "moderate": "Moderation failed.",
@@ -119,7 +140,9 @@
       "inEditingBody": "This praxis is in editing mode. Points and votes are paused until submitted.",
       "pendingPublishLabel": "PENDING PUBLISH",
       "pendingPublishBody": "Waiting on co-authors to submit.",
-      "failedTitle": "This praxis was marked as failed."
+      "failedTitle": "This praxis was marked as failed.",
+      "flaggedLabel": "FLAGGED",
+      "flaggedBody": "This praxis is flagged and awaiting admin review."
     },
     "admin": {
       "eyebrow": "ADMIN · Status:",
@@ -172,7 +195,12 @@
       "count_other": "{{count}} votes"
     },
     "score": {
-      "ptsMultVotes": "pts × bonus + votes"
+      "ptsMultVotes": "pts × bonus + votes",
+      "heading": "Score",
+      "base": "Base",
+      "meta": "Metatasks",
+      "votes": "From votes",
+      "total": "Total"
     },
     "metatasks": {
       "heading": "Metatasks",

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -6,15 +6,20 @@
  * consumes the same `PraxisDetailState`; only the visual treatment differs.
  * Mirrors the TaskDetail / EditPraxis dispatchers. The loading / error /
  * not-found guards live here so archetypes can assume a non-null praxis.
+ *
+ * ONE ARCHETYPE PER FACTION, NOT TWO (#1088, ADR-0056/0058 terms). The
+ * `formFactor === 'mobile'` branch is gone: this always dispatches through the
+ * `praxisDetail` surface and the archetype calls `useFormFactor()` itself for
+ * its own size set — the shape task cards and task detail already use. The
+ * `mobilePraxisDetail` archetypes stay registered but are no longer reachable
+ * from here; #1089 deletes them.
  */
 import { useTranslation } from 'react-i18next'
 import { Navigate, useParams } from 'react-router-dom'
 import { usePraxisDetail } from './praxisDetail/usePraxisDetail'
 import { pickVariant } from '../utils/factionDispatch'
 import { surfaceMap } from '../factions'
-import { useFormFactor } from '../hooks/useFormFactor'
 import DefaultPraxisDetail from './praxisDetail/archetypes/DefaultPraxisDetail'
-import DefaultMobilePraxisDetail from './praxisDetail/mobileArchetypes/DefaultPraxisDetail'
 import CommentThread from '../components/comments/CommentThread'
 import DuelCrossLink from './praxisDetail/DuelCrossLink'
 
@@ -22,7 +27,6 @@ export default function PraxisDetail() {
   const { t } = useTranslation('praxis')
   const { id } = useParams<{ id: string }>()
   const state = usePraxisDetail(id)
-  const formFactor = useFormFactor()
 
   if (state.loading) return <div className="py-8 font-body text-muted">{t('detail.loading')}</div>
   if (state.fetchError) return (
@@ -42,14 +46,23 @@ export default function PraxisDetail() {
     return <Navigate to={`/praxes/${state.praxis.id}/edit`} replace />
   }
 
-  const Archetype =
-    formFactor === 'mobile'
-      ? pickVariant(surfaceMap('mobilePraxisDetail'), state.praxis.task_faction_slug, DefaultMobilePraxisDetail)
-      : pickVariant(surfaceMap('praxisDetail'), state.praxis.task_faction_slug, DefaultPraxisDetail)
+  const Archetype = pickVariant(
+    surfaceMap('praxisDetail'),
+    state.praxis.task_faction_slug,
+    DefaultPraxisDetail,
+  )
+  // ADR-0061 makes comments the page LAYOUT's third region, so the rebuilt
+  // Unaffiliated page mounts its own thread (amending ADR-0006's "neutral chrome
+  // below every archetype"). The six legacy faction archetypes still expect the
+  // dispatcher to mount it; they go with #1089, and this shim goes with them.
+  // The identity test is exact: `pickVariant` hands back this very component for
+  // every faction that registers no praxis-detail archetype of its own.
+  const archetypeOwnsComments = Archetype === DefaultPraxisDetail
   return (
     <>
       {/* Duel cross-link is neutral chrome above every archetype (#313); one
-          shared faction-tokened widget, per the grilled #310 decision. */}
+          shared faction-tokened widget, per the grilled #310 decision. #1090
+          replaces it with the design's duel card, inside the page layout. */}
       {state.duel && (
         <DuelCrossLink
           praxis={state.praxis}
@@ -59,10 +72,7 @@ export default function PraxisDetail() {
         />
       )}
       <Archetype state={state} />
-      {/* Comments are neutral chrome below every archetype (ADR-0006); a thread
-          renders on a visible praxis only. Mounted at the dispatcher so it covers
-          all faction archetypes, not just the default. */}
-      {state.praxis.moderation_status === 'visible' && (
+      {!archetypeOwnsComments && state.praxis.moderation_status === 'visible' && (
         <div className="max-w-2xl">
           <CommentThread target="praxes" targetId={state.praxis.id} />
         </div>

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -1,0 +1,313 @@
+/**
+ * Praxis detail v2 — the Unaffiliated page's own contract (#1088, ADR-0061).
+ *
+ * `archetypeSlots.test.tsx` guards the slots EVERY praxis-detail archetype must
+ * emit. This file guards what is specific to the rebuilt Unaffiliated page: the
+ * layout contract (breadcrumb / grid / comments region), the responsive move of
+ * the score block, and that each state axis the issue lists actually renders.
+ *
+ * Harness note: `renderToStaticMarkup`, no DOM, no effects (see
+ * SPEC-testing.md). `useFormFactor` is therefore MOCKED rather than driven off
+ * `matchMedia` — the mobile assertions are about the form factor reaching the
+ * page, not about a real viewport. Light vs dark is a pure `[data-theme]` CSS
+ * cascade with no branch in this component, so there is nothing here to assert
+ * about it; it is an eyeball check.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../i18n";
+import type { PraxisDetailState } from "../usePraxisDetail";
+import type { PraxisOut, PraxisMemberOut } from "../../../api/praxis";
+import type { DuelDetailOut } from "../../../api/duel";
+import type { CurrentUser } from "../../../api/auth";
+
+const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
+vi.mock("../../../hooks/useFormFactor", () => ({
+  useFormFactor: () => mocks.formFactor,
+}));
+
+// Imported after the mock so the archetype picks it up.
+const { default: DefaultPraxisDetail } = await import("../archetypes/DefaultPraxisDetail");
+
+const MEMBER: PraxisMemberOut = {
+  id: 101,
+  praxis_id: 1,
+  character_id: 3,
+  character_display_name: "Ada",
+  has_submitted: true,
+  joined_at: "2026-01-01T00:00:00Z",
+};
+
+const CO_MEMBER: PraxisMemberOut = {
+  id: 102,
+  praxis_id: 1,
+  character_id: 4,
+  character_display_name: "Beth",
+  has_submitted: true,
+  joined_at: "2026-01-02T00:00:00Z",
+};
+
+const PRAXIS: PraxisOut = {
+  id: 1,
+  task_id: 7,
+  task_title: "A Chore Nobody Logged",
+  task_point_value: 12,
+  task_level_required: 2,
+  task_faction_slug: null,
+  type: "solo",
+  status: "submitted",
+  title: "The Long Way Round",
+  body_text: "Walked the whole ridge before dark.",
+  moderation_status: "visible",
+  admin_note: null,
+  flagged_at: null,
+  submitted_at: "2026-01-03T00:00:00Z",
+  submit_proposed_at: null,
+  created_by_id: 3,
+  created_by_display_name: "Ada",
+  created_by_faction_slug: null,
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-03T00:00:00Z",
+  members: [MEMBER],
+  invites: [],
+  media_items: [
+    {
+      id: 9,
+      praxis_id: 1,
+      type: "image",
+      file_path: "proof.png",
+      display_order: 0,
+      created_at: "2026-01-03T00:00:00Z",
+    },
+  ],
+  // (base 12 + meta 0) × 1.0 + 4 from votes.
+  score: 16,
+  metatask_points: 0,
+  display_multiplier: 1.0,
+  points_from_votes: 4,
+  is_top_for_task: false,
+  duel_id: null,
+  can_flag: true,
+  applied_metatasks: [],
+};
+
+const VIEWER: CurrentUser = {
+  id: 50,
+  email: "ada@example.com",
+  display_name: "Ada",
+  is_admin: false,
+  can_comment: true,
+  character: {
+    id: 3,
+    display_name: "Ada",
+    faction_slug: null,
+    level: 4,
+    points: 120,
+    avatar_url: null,
+  },
+} as unknown as CurrentUser;
+
+function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: PRAXIS,
+    fetchError: null,
+    votes: { praxis_id: 1, total_votes: 2, total_score: 4 },
+    voters: [
+      { character_id: 11, display_name: "Cy", avatar_url: "", faction_slug: "", value: 5 },
+      { character_id: 12, display_name: "Dov", avatar_url: "", faction_slug: "", value: 3 },
+    ],
+    duel: null as DuelDetailOut | null,
+    isOwner: false,
+    showAdminBar: false,
+    user: null,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: "",
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: "",
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleResubmit: async () => {},
+    handleFlag: async () => {},
+    handleKickMember: async () => {},
+    metatasks: [],
+    metataskLoading: false,
+    metataskError: null,
+    applyingMetataskId: null,
+    removingMetataskId: null,
+    handleApplyMetatask: async () => {},
+    handleRemoveMetatask: async () => {},
+    ...overrides,
+  };
+}
+
+function render(
+  next: PraxisDetailState,
+  formFactor: "desktop" | "mobile" = "desktop",
+): { html: string; text: string } {
+  mocks.formFactor = formFactor;
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <DefaultPraxisDetail state={next} />
+    </MemoryRouter>,
+  );
+  return { html, text: html.replace(/<[^>]*>/g, "") };
+}
+
+/** Where a marker sits in the markup — the seam the responsive move is about. */
+function indexOf(html: string, needle: string): number {
+  const at = html.indexOf(needle);
+  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1);
+  return at;
+}
+
+describe("Unaffiliated praxis detail — layout contract", () => {
+  it("draws the breadcrumb on desktop and the back link on mobile", () => {
+    const wide = render(state());
+    expect(wide.html, "breadcrumb links to the task bank").toContain('href="/tasks"');
+    expect(wide.html, "breadcrumb links to the task").toContain('href="/tasks/7"');
+    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxes"');
+
+    const phone = render(state(), "mobile");
+    expect(phone.html, "phone back link to the praxis index").toContain('href="/praxes"');
+    expect(phone.text, "and its label").toContain("Praxes");
+    expect(phone.text, "centred page label").toContain("Praxis");
+  });
+
+  it("moves the score block above the proof on mobile and into the aside on desktop", () => {
+    // The score heading and the proof heading are the two anchors; only their
+    // ORDER changes, and each renders exactly once at both form factors.
+    const wide = render(state());
+    expect(wide.text.match(/Score/g)?.length, "one score block on desktop").toBe(1);
+    expect(indexOf(wide.html, "Proof"), "proof precedes the aside rail").toBeLessThan(
+      indexOf(wide.html, "Score"),
+    );
+
+    const phone = render(state(), "mobile");
+    expect(phone.text.match(/Score/g)?.length, "one score block on mobile").toBe(1);
+    expect(indexOf(phone.html, "Score"), "rail rides above the proof on mobile").toBeLessThan(
+      indexOf(phone.html, "Proof"),
+    );
+  });
+
+  it("carries its ground on the column, never the viewport", () => {
+    // WORLD_ZERO_STYLE §5 / #1028: the site background must still show around
+    // the page. `.na-backdrop` is `position: fixed; inset: 0`.
+    expect(render(state()).html).not.toContain("na-backdrop");
+  });
+
+  it("mounts the comments region with the layout's heading, not the thread's", () => {
+    const { text } = render(state());
+    expect(text, "the layout's section head").toContain("Discussion");
+    expect(text, "and not a second heading for the same list").not.toContain("0 comments");
+  });
+
+  it("hides the comment region on a praxis that is not visible", () => {
+    const hidden = state({ praxis: { ...PRAXIS, moderation_status: "hidden" } });
+    expect(render(hidden).text).not.toContain("Discussion");
+  });
+});
+
+describe("Unaffiliated praxis detail — the state axes", () => {
+  it("renders the score readout from the shared resolver", () => {
+    const { text } = render(state());
+    expect(text, "base").toContain("12");
+    expect(text, "points from votes").toContain("4");
+    expect(text, "total").toContain("16.0");
+  });
+
+  it("shows the multiplier row only when the factor is not 1.0", () => {
+    expect(render(state()).text, "neutral era hides it").not.toContain("Multiplier");
+    const boosted = state({
+      praxis: { ...PRAXIS, display_multiplier: 1.1, score: 17.2 },
+    });
+    const { text } = render(boosted);
+    expect(text).toContain("Multiplier");
+    expect(text).toContain("×1.10");
+  });
+
+  it("names the metatask contribution only when one is applied", () => {
+    expect(render(state()).text).not.toContain("Metatasks");
+    const sealed = state({
+      praxis: { ...PRAXIS, metatask_points: 5, score: 21 },
+    });
+    expect(render(sealed).text).toContain("Metatasks");
+  });
+
+  it("banners flagged, failed-with-note, and the crown", () => {
+    expect(render(state()).text, "clean praxis has no banner").not.toContain("FLAGGED");
+
+    const flagged = state({ praxis: { ...PRAXIS, moderation_status: "flagged" } });
+    expect(render(flagged).text).toContain("FLAGGED");
+
+    const failed = state({
+      praxis: {
+        ...PRAXIS,
+        moderation_status: "failed",
+        admin_note: "The photo is of a different ridge.",
+      },
+    });
+    expect(render(failed).text, "the admin note is the banner's body").toContain(
+      "The photo is of a different ridge.",
+    );
+
+    const crowned = state({ praxis: { ...PRAXIS, is_top_for_task: true } });
+    expect(render(crowned).text).toContain("TASK CROWN");
+    expect(render(state()).text).not.toContain("TASK CROWN");
+  });
+
+  it("credits every co-author and shows the members section on a published collab", () => {
+    const solo = render(state());
+    expect(solo.html, "solo links one author").toContain('href="/characters/3"');
+    expect(solo.text, "and draws no members section").not.toContain("Members");
+
+    const collab = state({
+      praxis: { ...PRAXIS, type: "collab", members: [MEMBER, CO_MEMBER] },
+    });
+    const { html, text } = render(collab);
+    expect(html, "each co-author is reachable").toContain('href="/characters/4"');
+    expect(text).toContain("Beth");
+    expect(text, "the crew reads as Members, the domain noun").toContain("Members");
+  });
+
+  it("shows owner controls to a member and nothing to a visitor", () => {
+    expect(render(state()).html, "a visitor gets no edit link").not.toContain(
+      'href="/praxes/1/edit"',
+    );
+    const owner = state({ isOwner: true, user: VIEWER });
+    expect(render(owner).html).toContain('href="/praxes/1/edit"');
+  });
+
+  it("shows the steward bar only in admin mode", () => {
+    expect(render(state()).text).not.toContain("ADMIN");
+    const steward = state({ showAdminBar: true });
+    expect(render(steward).text).toContain("ADMIN");
+  });
+
+  it("lists who voted and each voter's own rung, never an average", () => {
+    const { html, text } = render(state());
+    expect(text).toContain("Who voted");
+    expect(html).toContain('href="/characters/11"');
+    expect(text, "the count, not the mean").toContain("2 votes");
+
+    const unvoted = state({ voters: [] });
+    expect(render(unvoted).text, "no empty voter panel").not.toContain("Who voted");
+  });
+});

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -1,49 +1,94 @@
 /**
- * Default (Unaffiliated / na) praxis-read archetype — the spectrum-band editorial
- * kit (CONTEXT.md "Default archetype"; ADR-0039/0046/0048). Rebuilt to the na
- * redesign (project 1eb2665a, `Default Praxis Detail.dc.html`): "one filed praxis
- * in full" — a rainbow-bordered praxis SHEET (ring eyebrow, big italic finding,
- * author row with a rainbow-ring avatar + base pts, a rainbow-bordered EVIDENCE
- * plate with a "Plate I" caption, a ruled "The account" prose block) beside a
- * sticky rail: the ADR-0005 vote panel (the live na spectrum widget via VoteUI)
- * and a points/backers LEDGER. NO AVERAGE anywhere (ADR-0005/0014) — the ledger
- * shows points awarded, how many people backed it, and each backer's own rung.
+ * Unaffiliated (`default` ≡ `na`) praxis detail — praxis detail v2 (#1088,
+ * epic #1085; design project bebdf7c7, `Unaffiliated Praxis Detail.dc.html`).
  *
- * This is also VoteUI/archetype fallback for themed-but-unskinned factions (wow,
- * albescent): the chrome wears the na spectrum, while VoteUI still dispatches the
- * vote widget on the praxis's own task faction, so a wow praxis votes in its own
- * voice (ADR-0039).
+ * This is the REFERENCE implementation of the layout contract the seven future
+ * faction designs inherit (ADR-0061). It is not a placeholder: `default` ≡ `na`
+ * ≡ Unaffiliated is one visual identity (ADR-0039/0046/0048), so this IS the
+ * Unaffiliated skin and the fall-through every undressed faction renders.
  *
- * Tokens only: --faction-default-* (rainbow via --faction-default-rainbow /
- * -ring) + --color-*. The full-page wash is the shared `.na-backdrop` hook (its
- * rule is owned by the na-kit / Task Detail #967; this surface only mounts the
- * hook). Invariant behavior slots (admin bar, banners, owner actions, flag) come
- * from the shared module.
+ * ## The contract
+ *
+ * - **Desktop** — breadcrumb, then main column + a 340px aside, then a comments
+ *   region beneath both.
+ * - **Mobile** — one stacked column (a back link and a centred label instead of
+ *   the breadcrumb), with the score and duel blocks moved above the proof.
+ * - **Main** — moderation banners · byline · title · owner actions · task
+ *   reference · proof · write-up · members · metatasks.
+ * - **Aside** — score · duel · vote · voters · flag.
+ *
+ * ## One responsive component, no mobile twin (ADR-0056/0058)
+ *
+ * `useFormFactor()` picks the size set and collapses the split; the dispatcher
+ * no longer branches on form factor. Score and duel are built ONCE and moved by
+ * where they are mounted — never drawn twice and hidden, which would duplicate
+ * the DOM and is what the design doc's twin markup would have produced. Mobile
+ * stacks with flow, never a fixed-px grid (SPEC-faction-ui-profile §1a); the
+ * 340px aside track is desktop-only.
+ *
+ * ## Copy and dress
+ *
+ * Copy is one neutral shared `detail.*` set (ADR-0061) — no na voice, no faction
+ * voice; where the design's word differed from the domain noun in CONTEXT.md the
+ * domain noun won ("Members", not "the crew"). Dress is na's alone: the spectrum
+ * via `--faction-default-*` tokens plus `--color-*`, flipping light/dark through
+ * the `[data-theme="dark"]` cascade with no `dark ?` branch. The page surface is
+ * carried by the COLUMN, not the viewport — the site background still shows
+ * around the component (WORLD_ZERO_STYLE §5, the #1028 ruling), which is why
+ * there is no `.na-backdrop` full-bleed wash here.
+ *
+ * ## Reused, not rebuilt
+ *
+ * `TaskCrown` (via the shared crown banner) · `ScoreStamp` (#1091 restyles it;
+ * this file only mounts it) · `VoteUI`, which dispatches the vote surface on the
+ * TASK's faction so an unskinned faction still votes in its own voice ·
+ * `CollabRoster` for the members · `MediaGallery` · `MetaTaskSeal`, read-only:
+ * `apply_metatask` requires `in_progress`, so the design's "Available" chips
+ * would 422 on every tap (#1093 removes the dead wiring).
+ *
+ * ## The duel slot
+ *
+ * The rail is still mounted by the dispatcher above the archetype
+ * (`DuelCrossLink`), where every faction archetype picks it up. #1090 replaces
+ * it with the design's duel card and lands it in the slots marked below — one
+ * block, in the aside on desktop and above the proof on mobile.
  */
+import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import MediaGallery from '../../../components/MediaGallery'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import VoteUI from '../../../components/vote/VoteUI'
+import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
+import {
+  scoreBreakdown,
+  formatMult,
+} from '../../../components/praxisCard/scoreStamp/scoreBreakdown'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
+import { CollabRoster } from '../../../components/collab/CollabRoster'
+import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
 import {
   PraxisAdminBar,
   PraxisStatusBanners,
   PraxisOwnerActions,
   PraxisFlagBlock,
+  PraxisDetailComments,
   MemberByline,
-  praxisBreakdownParts,
+  orderedMembers,
 } from '../shared'
-import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import type { PraxisDetailState } from '../usePraxisDetail'
-import type { PraxisOut } from '../../../api/praxis'
-import type { VoteSummary, VoterDetail } from '../../../api/votes'
 
+/** The na spectrum — the one ornament this whole page is built out of. */
+const SPECTRUM = 'var(--faction-default-rainbow)'
+
+/** Initials fallback for a member with no uploaded avatar. */
 function initials(name: string): string {
   return (
     name
       .trim()
       .split(/\s+/)
+      .filter(Boolean)
       .map((word) => word[0])
       .slice(0, 2)
       .join('')
@@ -52,295 +97,620 @@ function initials(name: string): string {
 }
 
 /**
- * The points / backers LEDGER (the design's dark "take" panel).
- *
- * DEVIATION (named per docs/agents/design-fidelity.md): the design draws this as
- * an ALWAYS-dark receipt (#17161d/#f0e6d0/#8b8272). CLAUDE.md forbids hardcoded
- * hex and there is no always-dark `--color-*` token to map onto, so it uses the
- * `--faction-default-card-*` family — which matches the design's palette exactly
- * in dark mode and becomes the light na card in light mode (theme-aware, not
- * always-dark). Rainbow accents stay `--faction-default-rainbow`.
- *
- * Every number here is honest live data (ADR-0005): `points_from_votes` awarded,
- * `total_votes` backers, and each backer's own rung as a rainbow bar (value / 5).
- * NO AVERAGE. The design's per-backer "+N points" is NOT available from the API
- * (there is no per-voter point breakdown — a vote is a single 1-5 rung), so the
- * bar shows the rung and no fabricated per-backer points figure is invented.
+ * One spectrum-ringed initials disc. Collab bylines stack these, overlapping,
+ * so a shared praxis reads as shared before a single name is parsed.
  */
-function TheLedger({
-  praxis,
-  votes,
-  voters,
-}: {
-  praxis: PraxisOut
-  votes: VoteSummary | null
-  voters: VoterDetail[]
-}) {
-  const { t } = useTranslation('praxis')
-  // The single earned-points breakdown (#641, ADR-0053): the payload's own
-  // terms, `{base} × {mult} + {votes}`, the `× {mult}` term omitted at ×1.0.
-  const { base, votePoints, isPlain, multiplierLabel } = praxisBreakdownParts(praxis)
-  const backerCount = votes?.total_votes ?? voters.length
-
+function MemberDisc({ name, size }: { name: string; size: number }) {
   return (
-    <div
+    <span
+      aria-hidden
       style={{
-        position: 'relative',
-        overflow: 'hidden',
-        borderRadius: 12,
-        background: 'var(--faction-default-card-bg)',
-        color: 'var(--faction-default-card-text)',
-        border: '1px solid var(--faction-default-border)',
-        boxShadow: '0 14px 32px -18px var(--color-overlay-medium)',
-        padding: 'var(--space-lg) var(--space-lg) var(--space-xl)',
+        display: 'block',
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        padding: 'var(--space-xs)',
+        background: SPECTRUM,
+        flexShrink: 0,
       }}
     >
-      {/* rainbow header rule */}
-      <div style={{ height: 4, borderRadius: 3, background: 'var(--faction-default-rainbow)', marginBottom: 'var(--space-lg)' }} />
-
-      {/* pts awarded · people backed it */}
-      <div style={{ display: 'flex', marginBottom: 'var(--space-lg)' }}>
-        <div style={{ flex: 1, paddingRight: 'var(--space-md)' }}>
-          <div style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--faction-default-card-text)' }}>
-            {`+${praxis.points_from_votes}`}
-          </div>
-          <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-sm)' }}>
-            {t('detail.default.ledgerAwarded')}
-          </div>
-        </div>
-        <div style={{ flex: 1, paddingLeft: 'var(--space-md)', borderLeft: '1px solid var(--faction-default-border)' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', fontFamily: 'var(--font-accent)', fontSize: 'var(--text-display)', lineHeight: 0.85, color: 'var(--faction-default-card-text)' }}>
-            <span aria-hidden style={{ fontSize: 'var(--text-title)', color: 'var(--faction-default-card-muted)' }}>&#10003;</span>
-            {backerCount}
-          </div>
-          <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-sm)' }}>
-            {t('detail.default.ledgerBacked', { count: backerCount })}
-          </div>
-        </div>
-      </div>
-
-      {/* earned-points breakdown (#641, ADR-0053): base × mult + votes */}
-      <div style={{ borderTop: '1px dashed var(--faction-default-border)', paddingTop: 'var(--space-md)', marginBottom: voters.length ? 'var(--space-lg)' : 0 }}>
-        <span style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-title)', color: 'var(--faction-default-card-text)', whiteSpace: 'nowrap' }}>
-          {base}
-          {!isPlain && (
-            <>
-              <span aria-hidden style={{ opacity: 0.55, margin: '0 var(--space-xs)' }}>&#215;</span>
-              {multiplierLabel}
-            </>
-          )}
-          <span aria-hidden style={{ opacity: 0.55, margin: '0 var(--space-xs)' }}>+</span>
-          {votePoints}
-        </span>
-        <span className="eyebrow" style={{ display: 'block', marginTop: 'var(--space-xs)', color: 'var(--faction-default-card-muted)' }}>
-          {isPlain ? t('detail.default.pointsFromVotes') : t('detail.score.ptsMultVotes')}
-        </span>
-      </div>
-
-      {/* Backed by — each backer + the rung they gave (value / 5) */}
-      {voters.length > 0 ? (
-        <>
-          <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginBottom: 'var(--space-md)' }}>
-            {t('detail.default.ledgerBackedBy')}
-          </div>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-md)' }}>
-            {voters.map((voter) => (
-              <div key={voter.character_id} style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)' }}>
-                <Link to={`/characters/${voter.character_id}`} style={{ textDecoration: 'none', flexShrink: 0 }}>
-                  <span
-                    style={{
-                      width: 26,
-                      height: 26,
-                      borderRadius: '50%',
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      background: 'var(--faction-default-card-muted)',
-                      color: 'var(--faction-default-card-bg)',
-                      fontFamily: 'var(--font-accent)',
-                      fontSize: 'var(--text-sm)',
-                    }}
-                  >
-                    {initials(voter.display_name)}
-                  </span>
-                </Link>
-                <Link
-                  to={`/characters/${voter.character_id}`}
-                  style={{ width: 92, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', fontFamily: 'var(--font-display)', fontStyle: 'italic', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)', textDecoration: 'none' }}
-                >
-                  {voter.display_name}
-                </Link>
-                <div style={{ flex: 1, height: 9, borderRadius: 5, background: 'var(--faction-default-border)', position: 'relative', overflow: 'hidden' }}>
-                  <div style={{ position: 'absolute', inset: 0, width: `${(voter.value / 5) * 100}%`, background: 'var(--faction-default-rainbow)' }} />
-                </div>
-                <span style={{ width: 24, textAlign: 'right', fontFamily: 'var(--font-accent)', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)' }}>
-                  {voter.value}
-                </span>
-              </div>
-            ))}
-          </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', borderTop: '1px solid var(--faction-default-border)', marginTop: 'var(--space-md)', paddingTop: 'var(--space-md)' }}>
-            <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
-              {t('detail.default.ledgerBackers', { count: voters.length })}
-            </span>
-            <span style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-title)', color: 'var(--faction-default-card-text)' }}>
-              {t('detail.default.ledgerTotal', { points: praxis.points_from_votes })}
-            </span>
-          </div>
-        </>
-      ) : (
-        <p className="font-body" style={{ fontSize: 'var(--text-base)', color: 'var(--faction-default-card-muted)', margin: 0 }}>
-          {t('detail.default.ledgerEmpty')}
-        </p>
-      )}
-    </div>
+      <span
+        className="flex items-center justify-center font-display italic"
+        style={{
+          width: '100%',
+          height: '100%',
+          borderRadius: '50%',
+          background: 'var(--faction-default-card-bg)',
+          fontSize: 'var(--text-lg)',
+          color: 'var(--faction-default-card-text)',
+        }}
+      >
+        {initials(name)}
+      </span>
+    </span>
   )
 }
 
 export default function DefaultPraxisDetail({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
-  const { praxis, votes, voters } = state
+  const desktop = useFormFactor() !== 'mobile'
+  const { praxis, voters } = state
 
   // Guarded non-null by the dispatcher.
   if (!praxis) return null
 
-  const authorInitial = initials(praxis.created_by_display_name)
+  const members = orderedMembers(praxis)
+  const isCollab = members.length > 1
+  // The shared banners already draw the roster while a collab is still
+  // resolving (`in_progress` / `pending`). The Members section below is the
+  // PUBLISHED half of that same fact, so it takes the complement — one roster
+  // on the page, never two.
+  const rosterInBanners = praxis.status === 'in_progress' || praxis.status === 'pending'
 
-  return (
-    <div style={{ position: 'relative' }}>
-      {/* Full-page spectrum wash. The `.na-backdrop` rule ships with the na kit
-          / Task Detail (#967); mounting the hook here is harmless until it lands. */}
-      <div className="na-backdrop" />
+  const { base, mult, meta, votes, total } = scoreBreakdown(praxis)
 
-      <div className="py-8" style={{ position: 'relative', zIndex: 1, maxWidth: 1080, marginInline: 'auto' }}>
-        {/* ── Breadcrumb: Tasks / {task} / Praxis ── */}
-        <nav className="font-body mb-4" style={{ fontSize: 'var(--text-sm)', letterSpacing: '0.16em', textTransform: 'uppercase', color: 'var(--color-text-tertiary)' }}>
-          <Link to="/tasks" style={{ color: 'inherit', textDecoration: 'none' }}>{t('detail.default.breadcrumbTasks')}</Link>
-          {' / '}
-          <Link to={`/tasks/${praxis.task_id}`} style={{ color: 'inherit', textDecoration: 'none' }}>
-            {praxis.task_title}
-          </Link>
-          {' / '}
-          <span style={{ color: 'var(--color-text-primary)' }}>{t('detail.default.breadcrumbPraxis')}</span>
-        </nav>
+  /** A spectrum hairline running out from a label — the page's only rule. */
+  const sectionHead = (label: ReactNode, trailing?: ReactNode) => (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 'var(--space-sm)',
+        marginBottom: 'var(--space-md)',
+        flexWrap: 'wrap',
+      }}
+    >
+      <span
+        className="eyebrow"
+        style={{ letterSpacing: '0.22em', color: 'var(--color-text-primary)' }}
+      >
+        {label}
+      </span>
+      <span
+        aria-hidden
+        style={{
+          flex: '1 1 20%',
+          minWidth: 20,
+          height: 2,
+          borderRadius: 2,
+          background: SPECTRUM,
+        }}
+      />
+      {trailing}
+    </div>
+  )
 
-        {/* ── Behavior slots (invariant) ── */}
-        <PraxisStatusBanners state={state} />
-        <PraxisAdminBar state={state} />
+  /** Aside / rail panel chrome, shared by score, vote and voters. */
+  const panel: CSSProperties = {
+    border: '1px solid var(--faction-default-card-line)',
+    borderRadius: 12,
+    background: 'var(--faction-default-stamp-bg)',
+    color: 'var(--faction-default-card-text)',
+    padding: 'var(--space-lg)',
+  }
 
-        {/* ── Layout: sheet / rail ── */}
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 340px', gap: 'var(--space-2xl)', alignItems: 'start' }}>
+  // ── Navigation: breadcrumb on desktop, back link + label on mobile ─────────
+  const breadcrumb = (
+    <nav
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-sm)',
+        marginBottom: 'var(--space-md)',
+        flexWrap: 'wrap',
+      }}
+    >
+      <Link
+        to="/tasks"
+        className="eyebrow"
+        style={{
+          letterSpacing: '0.2em',
+          color: 'var(--faction-default-card-accent)',
+          textDecoration: 'none',
+        }}
+      >
+        {t('detail.breadcrumb.tasks')}
+      </Link>
+      <span aria-hidden className="eyebrow">
+        ›
+      </span>
+      <Link
+        to={`/tasks/${praxis.task_id}`}
+        className="eyebrow"
+        style={{
+          letterSpacing: '0.2em',
+          color: 'var(--faction-default-card-accent)',
+          textDecoration: 'none',
+        }}
+      >
+        {praxis.task_title}
+      </Link>
+      <span aria-hidden className="eyebrow">
+        ›
+      </span>
+      <span className="eyebrow" style={{ letterSpacing: '0.2em' }}>
+        {t('detail.breadcrumb.current')}
+      </span>
+    </nav>
+  )
 
-          {/* ── THE PRAXIS SHEET — rainbow-bordered card ── */}
-          {/* padding here is the rainbow-frame thickness (ornament geometry);
-              snapped from the design's 6px to --space-xs to stay on the scale. */}
-          <div style={{ borderRadius: 16, padding: 'var(--space-xs)', background: 'var(--faction-default-rainbow)', boxShadow: '0 18px 44px -26px var(--color-overlay-strong)' }}>
-            <div style={{ borderRadius: 11, background: 'var(--faction-default-card-bg)', color: 'var(--faction-default-card-text)', padding: 'var(--space-2xl)' }}>
+  // The phone affordance the design draws instead of the breadcrumb. Not
+  // sticky: the mobile shell already owns a sticky top bar, and a second one
+  // stacked under it is a dress decision, not a layout one.
+  const mobileBar = (
+    <nav
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-sm)',
+        marginBottom: 'var(--space-md)',
+      }}
+    >
+      <Link
+        to="/praxes"
+        className="eyebrow"
+        style={{
+          letterSpacing: '0.2em',
+          color: 'var(--faction-default-card-accent)',
+          textDecoration: 'none',
+        }}
+      >
+        <span aria-hidden>‹ </span>
+        {t('detail.back')}
+      </Link>
+      <span
+        className="eyebrow"
+        style={{ flex: 1, textAlign: 'center', letterSpacing: '0.2em' }}
+      >
+        {t('detail.breadcrumb.current')}
+      </span>
+      {/* Balances the centred label against the back link's width. */}
+      <span aria-hidden style={{ width: 44 }} />
+    </nav>
+  )
 
-              {/* Eyebrow: ring dot + counts-for-everyone */}
-              <div className="flex items-center" style={{ gap: 'var(--space-sm)', marginBottom: 'var(--space-lg)' }}>
-                <span aria-hidden style={{ width: 26, height: 26, borderRadius: '50%', flex: 'none', background: 'var(--faction-default-ring)', WebkitMask: 'radial-gradient(circle, transparent 38%, black 40%)', mask: 'radial-gradient(circle, transparent 38%, black 40%)' }} />
-                <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>{t('detail.default.praxisEyebrow')}</span>
-              </div>
+  // ── Moderation banners ────────────────────────────────────────────────────
+  // The crown hero, the in-editing / pending-publish notice and the failed note
+  // (with its `admin_note`) are shared invariant chrome; the flagged notice is
+  // the third moderation state the v2 contract asks for and has no shared slot,
+  // so it renders here. `PraxisAdminBar` is the steward bar.
+  const banners = (
+    <>
+      <PraxisStatusBanners state={state} />
+      {praxis.moderation_status === 'flagged' && (
+        <div
+          style={{
+            border: '2px solid var(--color-warning)',
+            borderRadius: 8,
+            padding: 'var(--space-sm) var(--space-lg)',
+            marginBottom: 'var(--space-md)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+            flexWrap: 'wrap',
+          }}
+        >
+          <span className="eyebrow" style={{ color: 'var(--color-warning)' }}>
+            {t('detail.banners.flaggedLabel')}
+          </span>
+          <span className="font-body content-text" style={{ color: 'var(--color-text-secondary)' }}>
+            {t('detail.banners.flaggedBody')}
+          </span>
+        </div>
+      )}
+      <PraxisAdminBar state={state} />
+    </>
+  )
 
-              {/* Finding title */}
-              <h1
-                className="font-display italic"
-                style={{ fontWeight: 700, fontSize: 'var(--text-display)', lineHeight: 1.06, margin: '0 0 var(--space-lg)', color: 'var(--faction-default-card-text)', overflowWrap: 'anywhere' }}
-              >
-                {praxis.title}
-              </h1>
-
-              {/* Owner actions (invariant) */}
-              <PraxisOwnerActions state={state} />
-
-              {/* Author row: rainbow-ring avatar · Re: task · filed · base pts */}
-              <div className="flex items-center" style={{ gap: 'var(--space-md)', paddingBottom: 'var(--space-xl)', marginBottom: 'var(--space-xl)', borderBottom: '1px solid var(--faction-default-border)' }}>
-                <Link to={`/characters/${praxis.created_by_id}`} className="shrink-0">
-                  <span style={{ display: 'block', width: 40, height: 40, borderRadius: '50%', padding: 'var(--space-xs)', background: 'var(--faction-default-rainbow)' }}>
-                    <span className="flex items-center justify-center font-display italic" style={{ width: '100%', height: '100%', borderRadius: '50%', background: 'var(--faction-default-card-bg)', fontSize: 'var(--text-lg)', color: 'var(--faction-default-card-text)' }} aria-hidden>
-                      {authorInitial}
-                    </span>
-                  </span>
-                </Link>
-                <div className="min-w-0 flex-1">
-                  <MemberByline
-                    praxis={praxis}
-                    linkClassName="font-display italic"
-                    linkStyle={{ fontSize: 'var(--text-xl)', color: 'var(--faction-default-card-text)', textDecoration: 'none' }}
-                  />
-                  <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-xs)' }}>
-                    {t('detail.default.filedRe', { task: praxis.task_title, date: formatTimestamp(praxis.created_at) })}
-                  </div>
-                </div>
-                <div style={{ marginLeft: 'auto', textAlign: 'right', flexShrink: 0 }}>
-                  <div style={{ fontFamily: 'var(--font-accent)', fontSize: 'var(--text-heading)', lineHeight: 1, color: 'var(--faction-default-card-text)' }}>
-                    {praxis.task_point_value}
-                  </div>
-                  <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-xs)' }}>
-                    {t('detail.default.basePts')}
-                  </div>
-                </div>
-              </div>
-
-              {/* Metatask seals (#928) — read-only stack; nothing when none applied */}
-              {praxis.applied_metatasks.length > 0 && (
-                <div style={{ marginBottom: 'var(--space-lg)' }}>
-                  <MetaTaskSeal metatasks={praxis.applied_metatasks} />
-                </div>
-              )}
-
-              {/* Evidence plate — rainbow-bordered, "Plate I" caption */}
-              {praxis.media_items.length > 0 && (
-                <div style={{ marginBottom: 'var(--space-lg)' }}>
-                  <div style={{ borderRadius: 10, padding: 'var(--space-xs)', background: 'var(--faction-default-rainbow)' }}>
-                    <div style={{ borderRadius: 6, background: 'var(--color-bg-surface)', padding: 'var(--space-sm)' }}>
-                      <MediaGallery media={praxis.media_items} layout="grid" />
-                    </div>
-                  </div>
-                  <div className="font-display italic" style={{ textAlign: 'center', fontSize: 'var(--text-md)', color: 'var(--faction-default-card-muted)', marginTop: 'var(--space-sm)' }}>
-                    {t('detail.default.plate')}
-                  </div>
-                </div>
-              )}
-
-              {/* The account — ruled divider + prose */}
-              {praxis.body_text && (
-                <>
-                  <div className="flex items-center" style={{ gap: 'var(--space-md)', margin: 'var(--space-xl) 0 var(--space-lg)' }}>
-                    <div style={{ height: 1, flex: 1, background: 'var(--faction-default-border)' }} />
-                    <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)', whiteSpace: 'nowrap' }}>{t('detail.default.theAccount')}</span>
-                    <div style={{ height: 1, flex: 1, background: 'var(--faction-default-border)' }} />
-                  </div>
-                  <MarkdownPreview
-                    source={praxis.body_text}
-                    className="font-body markdown-preview content-text"
-                    style={{ lineHeight: 1.85, color: 'var(--faction-default-card-muted)' }}
-                  />
-                </>
-              )}
-            </div>
-          </div>
-
-          {/* ── RAIL — cast panel + ledger (sticky) ── */}
-          <div style={{ position: 'sticky', top: 84, display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
-
-            {/* Cast panel — the live na spectrum widget (ADR-0005, no average) */}
-            <div style={{ borderRadius: 12, background: 'var(--color-bg-surface-alt)', border: '1px solid var(--color-border)', padding: 'var(--space-lg)' }}>
-              <div className="eyebrow" style={{ color: 'var(--color-text-tertiary)', marginBottom: 'var(--space-xs)' }}>{t('detail.default.castHeading')}</div>
-              <div className="font-display italic" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)', marginBottom: 'var(--space-md)', lineHeight: 1.4 }}>
-                {t('detail.default.castPrompt')}
-              </div>
-              <VoteUI factionSlug={praxis.task_faction_slug} praxisId={praxis.id} viewerCanVote={praxis.viewer_can_vote} />
-            </div>
-
-            {/* Points + backers ledger */}
-            <TheLedger praxis={praxis} votes={votes} voters={voters} />
-
-            {/* Flag block (invariant) */}
-            <PraxisFlagBlock state={state} />
+  // ── Byline · title · owner actions · task reference ───────────────────────
+  const header = (
+    <>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-md)',
+          marginBottom: 'var(--space-md)',
+        }}
+      >
+        {/* Stacked discs, one per member — a collab reads as shared before a
+            single name is parsed. A payload with no member rows still credits
+            its creator, so the author is always reachable from the byline. */}
+        <span style={{ display: 'flex', alignItems: 'center' }}>
+          {(members.length > 0
+            ? members.map((member) => ({
+                id: member.character_id,
+                name: member.character_display_name || `#${member.character_id}`,
+              }))
+            : [{ id: praxis.created_by_id, name: praxis.created_by_display_name }]
+          ).map((author, index) => (
+            <Link
+              key={author.id}
+              to={`/characters/${author.id}`}
+              style={{
+                display: 'block',
+                // Each disc after the first laps the one before it — the lap is
+                // a spacing step off the scale, negated, not a loose pixel.
+                marginLeft: index === 0 ? 0 : 'calc(-1 * var(--space-lg))',
+                zIndex: index,
+              }}
+            >
+              <MemberDisc name={author.name} size={desktop ? 44 : 38} />
+            </Link>
+          ))}
+        </span>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <MemberByline
+            praxis={praxis}
+            linkClassName="font-display italic"
+            linkStyle={{
+              fontSize: desktop ? 'var(--text-title)' : 'var(--text-content)',
+              color: 'var(--faction-default-card-text)',
+              textDecoration: 'none',
+            }}
+          />
+          <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
+            {t('detail.filed', {
+              date: formatTimestamp(praxis.submitted_at ?? praxis.created_at),
+            })}
           </div>
         </div>
+      </div>
+
+      <h1
+        className="font-display italic"
+        style={{
+          fontWeight: 700,
+          fontSize: desktop ? 'var(--text-display)' : 'var(--text-heading)',
+          lineHeight: 1.08,
+          margin: '0 0 var(--space-md)',
+          color: 'var(--faction-default-card-text)',
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {praxis.title || praxis.task_title}
+      </h1>
+
+      <PraxisOwnerActions state={state} />
+
+      {/* Task reference — what this praxis is a doing OF. */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 'var(--space-sm)',
+          flexWrap: 'wrap',
+          borderTop: '1px solid var(--faction-default-card-line)',
+          borderBottom: '1px solid var(--faction-default-card-line)',
+          padding: 'var(--space-md) 0',
+          marginBottom: 'var(--space-xl)',
+        }}
+      >
+        <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
+          {t('detail.taskRef.label')}
+        </span>
+        <Link
+          to={`/tasks/${praxis.task_id}`}
+          className="font-display italic content-text"
+          style={{ color: 'var(--faction-default-card-text)', textDecoration: 'none' }}
+        >
+          {praxis.task_title}
+        </Link>
+        <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--faction-default-card-muted)' }}>
+          {t('detail.taskRef.level', { level: praxis.task_level_required })}
+          {' · '}
+          {t('detail.taskRef.points', { points: praxis.task_point_value })}
+        </span>
+      </div>
+    </>
+  )
+
+  // ── Score (built once; aside on desktop, above the proof on mobile) ────────
+  //
+  // Reads twice, as the design specifies: the stamp carries the total mark, and
+  // the strip below it spells the working out. Neither number is computed here —
+  // `scoreBreakdown()` is the single resolver (ADR-0053), so the two readouts
+  // and every praxis card agree by construction. The design's own arithmetic
+  // (a multiplier derived from the vote average) is NOT built; #1091 restyles
+  // the stamp.
+  const scoreRow = (label: string, value: ReactNode) => (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        justifyContent: 'space-between',
+        gap: 'var(--space-md)',
+        padding: 'var(--space-xs) 0',
+      }}
+    >
+      <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
+        {label}
+      </span>
+      <span
+        className="font-body"
+        style={{ fontSize: 'var(--text-content)', color: 'var(--faction-default-card-text)' }}
+      >
+        {value}
+      </span>
+    </div>
+  )
+
+  const scoreBlock = (
+    <section style={panel}>
+      {sectionHead(t('detail.score.heading'))}
+      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 'var(--space-lg)' }}>
+        {/* The crown already has its own hero banner above; one mark per page. */}
+        <ScoreStamp praxis={praxis} showCrown={false} />
+      </div>
+      {scoreRow(t('detail.score.base'), base)}
+      {mult !== null && scoreRow(t('detail.score.multiplier'), formatMult(mult))}
+      {meta !== null && scoreRow(t('detail.score.meta'), `+${meta}`)}
+      {scoreRow(t('detail.score.votes'), `+${votes}`)}
+      <div
+        style={{
+          borderTop: '1px solid var(--faction-default-card-line)',
+          marginTop: 'var(--space-xs)',
+          paddingTop: 'var(--space-xs)',
+        }}
+      >
+        {scoreRow(t('detail.score.total'), total.toFixed(1))}
+      </div>
+    </section>
+  )
+
+  // ── Duel (built once; aside on desktop, above the proof on mobile) ─────────
+  // #1090 lands the design's duel card here. Until it does, the duel rail stays
+  // where every archetype already picks it up — mounted by the dispatcher above
+  // the page — so nothing is drawn twice and no faction loses its rail.
+  const duelBlock: ReactNode = null
+
+  const rail = (
+    <>
+      {scoreBlock}
+      {duelBlock}
+    </>
+  )
+
+  // ── Vote · voters · flag ──────────────────────────────────────────────────
+  const voteBlock = (
+    <section style={panel}>
+      {sectionHead(t('detail.vote.heading'))}
+      <p
+        className="font-display italic content-text"
+        style={{ margin: '0 0 var(--space-md)', color: 'var(--faction-default-card-muted)' }}
+      >
+        {t('detail.vote.prompt')}
+      </p>
+      {/* Dispatched on the TASK's faction, so an unskinned faction falling
+          through to this page still votes in its own voice (ADR-0039). */}
+      <VoteUI
+        factionSlug={praxis.task_faction_slug}
+        praxisId={praxis.id}
+        viewerCanVote={praxis.viewer_can_vote}
+      />
+    </section>
+  )
+
+  // Per-voter values come straight off `GET /praxes/{id}/voters`, already
+  // fetched by `usePraxisDetail`. Each voter's own rung is a spectrum bar
+  // (value / 5). NO AVERAGE anywhere (ADR-0014): the standing is the sum and
+  // the count, never the mean — and there is no per-voter points figure in the
+  // payload, so none is invented.
+  const votersBlock = voters.length > 0 && (
+    <section style={panel}>
+      {sectionHead(
+        t('detail.voters.heading'),
+        <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
+          {t('detail.voters.count', { count: voters.length })}
+        </span>,
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-md)' }}>
+        {voters.map((voter) => (
+          <div
+            key={voter.character_id}
+            style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)' }}
+          >
+            <Link
+              to={`/characters/${voter.character_id}`}
+              className="font-display italic"
+              style={{
+                flex: '1 1 auto',
+                minWidth: 0,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                fontSize: 'var(--text-content)',
+                color: 'var(--faction-default-card-text)',
+                textDecoration: 'none',
+              }}
+            >
+              {voter.display_name}
+            </Link>
+            <span
+              aria-hidden
+              style={{
+                width: 84,
+                height: 9,
+                borderRadius: 5,
+                background: 'var(--faction-default-card-line)',
+                position: 'relative',
+                overflow: 'hidden',
+                flexShrink: 0,
+              }}
+            >
+              <span
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  width: `${(voter.value / 5) * 100}%`,
+                  background: SPECTRUM,
+                }}
+              />
+            </span>
+            <span
+              className="font-body"
+              style={{
+                width: 20,
+                textAlign: 'right',
+                fontSize: 'var(--text-content)',
+                color: 'var(--faction-default-card-text)',
+              }}
+            >
+              {voter.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+
+  const asideRest = (
+    <>
+      {voteBlock}
+      {votersBlock}
+      <PraxisFlagBlock state={state} />
+    </>
+  )
+
+  // ── Proof · write-up · members · metatasks ────────────────────────────────
+  const proof = praxis.media_items.length > 0 && (
+    <section style={{ marginBottom: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}>
+      {sectionHead(t('detail.sections.proof'))}
+      <div style={{ borderRadius: 10, padding: 'var(--space-xs)', background: SPECTRUM }}>
+        <div
+          style={{
+            borderRadius: 6,
+            background: 'var(--faction-default-stamp-bg)',
+            padding: 'var(--space-sm)',
+          }}
+        >
+          <MediaGallery media={praxis.media_items} layout={desktop ? 'grid' : 'column'} />
+        </div>
+      </div>
+    </section>
+  )
+
+  const writeUp = praxis.body_text && (
+    <section style={{ marginBottom: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}>
+      {sectionHead(t('detail.sections.writeUp'))}
+      <MarkdownPreview
+        source={praxis.body_text}
+        className="font-body markdown-preview content-text"
+        style={{ lineHeight: 1.85, color: 'var(--faction-default-card-text)' }}
+      />
+    </section>
+  )
+
+  const crew = isCollab && !rosterInBanners && (
+    <section style={{ marginBottom: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}>
+      {sectionHead(t('detail.sections.members'))}
+      <CollabRoster
+        members={praxis.members}
+        currentCharacterId={state.user?.character?.id ?? null}
+        factionSlug={praxis.task_faction_slug}
+        taskPointValue={praxis.task_point_value}
+        onKick={state.handleKickMember}
+      />
+    </section>
+  )
+
+  // Read-only (#1093 clears the dead apply wiring): `apply_metatask` requires
+  // `status == in_progress`, so a chip on this page would 422 on every tap.
+  const metatasks = praxis.applied_metatasks.length > 0 && (
+    <section style={{ marginBottom: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}>
+      {sectionHead(t('detail.metatasks.heading'))}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+    </section>
+  )
+
+  return (
+    <div className="py-8" style={{ position: 'relative' }}>
+      {desktop ? breadcrumb : mobileBar}
+
+      <div
+        style={{
+          position: 'relative',
+          maxWidth: 1200,
+          margin: '0 auto',
+          // The page surface the design puts everything on, carried by the
+          // COLUMN rather than the viewport — the site background must still
+          // show around the component (WORLD_ZERO_STYLE §5, the #1028 ruling).
+          background: 'var(--faction-default-card-bg)',
+          color: 'var(--faction-default-card-text)',
+          border: '1px solid var(--faction-default-border)',
+          borderRadius: 18,
+          padding: desktop ? 'var(--space-2xl)' : 'var(--space-lg)',
+          boxSizing: 'border-box',
+          overflow: 'hidden',
+        }}
+      >
+        {/* The spectrum band across the sheet head — the na tell. */}
+        <span
+          aria-hidden
+          style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 4, background: SPECTRUM }}
+        />
+
+        {banners}
+
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: desktop ? 'row' : 'column',
+            alignItems: 'stretch',
+            gap: desktop ? 'var(--space-2xl)' : 'var(--space-xl)',
+          }}
+        >
+          <div style={{ flex: '1 1 auto', minWidth: 0 }}>
+            {header}
+            {/* Mobile stacks the rail above the proof — one block each, moved,
+                never a second copy hidden at the other breakpoint. */}
+            {!desktop && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 'var(--space-lg)',
+                  marginBottom: 'var(--space-xl)',
+                }}
+              >
+                {rail}
+              </div>
+            )}
+            {proof}
+            {writeUp}
+            {crew}
+            {metatasks}
+            {!desktop && (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
+                {asideRest}
+              </div>
+            )}
+          </div>
+
+          {desktop && (
+            <aside
+              style={{
+                flex: '0 0 340px',
+                width: 340,
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 'var(--space-lg)',
+              }}
+            >
+              {rail}
+              {asideRest}
+            </aside>
+          )}
+        </div>
+
+        {/* The third layout region (ADR-0061, amending ADR-0006): comments sit
+            beneath both columns, inside the page's own sheet, and the layout
+            draws the heading so the thread does not draw a second one. */}
+        <PraxisDetailComments
+          state={state}
+          heading={sectionHead(t('detail.sections.comments'))}
+          style={{ marginTop: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}
+        />
       </div>
     </div>
   )

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -17,6 +17,7 @@ import { Link } from 'react-router-dom'
 import { reframeLabel } from '../../components/vote/voteReframes'
 import { TaskCrown } from '../../components/cards/TaskCrown'
 import { CollabRoster } from '../../components/collab/CollabRoster'
+import CommentThread from '../../components/comments/CommentThread'
 import DuelSealConfirm from '../../components/duel/DuelSealConfirm'
 import type { PraxisDetailState } from './usePraxisDetail'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
@@ -224,6 +225,47 @@ export function CollabRosterBlock({ state }: { state: PraxisDetailState }) {
         onKick={handleKickMember}
       />
     </div>
+  )
+}
+
+// ── Comments region (ADR-0061, amending ADR-0006) ────────────────────────────
+
+/**
+ * The comments slot a rebuilt praxis-detail archetype mounts itself.
+ *
+ * ADR-0006 put the thread below every archetype as neutral chrome, and the
+ * dispatcher mounted it there. ADR-0061 makes comments the page layout's THIRD
+ * region — beneath the main column and the aside, inside the archetype's own
+ * sheet — so the skin can dress its section head and place the thread. The
+ * `moderation_status === 'visible'` gate lives here rather than in each
+ * archetype: a thread renders on a visible praxis only, and one skin forgetting
+ * that is exactly the drift this prevents (the task-detail lesson, #1030).
+ *
+ * Pass `heading` to supply a dressed section head; the thread's own
+ * `{n} comments` `<h3>` is then suppressed so the page carries ONE heading for
+ * one list (the #1029 trap, warned about on `CommentThread`'s own prop).
+ *
+ * The ROWS stay faction-dispatched on `comment.author.faction_slug` — a Snide
+ * player's comment reads Snide on any page. ADR-0061 draws that boundary
+ * explicitly: the neutral rule covers the page's own slots and stops at the
+ * speaker's voice.
+ */
+export function PraxisDetailComments({
+  state,
+  heading,
+  style,
+}: {
+  state: PraxisDetailState
+  heading?: ReactNode
+  style?: CSSProperties
+}) {
+  const { praxis } = state
+  if (!praxis || praxis.moderation_status !== 'visible') return null
+  return (
+    <section style={style}>
+      {heading}
+      <CommentThread target="praxes" targetId={praxis.id} showHeading={heading === undefined} />
+    </section>
   )
 }
 


### PR DESCRIPTION
Rebuilds `DefaultPraxisDetail` as the new Unaffiliated praxis detail page and collapses the form-factor split, per the design in project `bebdf7c7` and the eight grill decisions on #1085.

Closes #1088

## What changed

- **`pages/PraxisDetail.tsx`** — the `formFactor === 'mobile'` branch is gone. The dispatcher always resolves through the `praxisDetail` manifest surface; the archetype calls `useFormFactor()` itself. Same terms as ADR-0056/0058, the shape task cards and task detail already use. The `mobilePraxisDetail` archetypes stay registered but unreachable (#1089 deletes them).
- **`pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx`** — full rebuild to the v2 layout contract: breadcrumb → main column + 340px aside → comments region, collapsing to one stacked column on mobile with the score block moved above the proof. `default` ≡ `na` ≡ Unaffiliated is one identity (ADR-0039/0046/0048), so this *is* the Unaffiliated skin.
- **`pages/praxisDetail/shared.tsx`** — new `PraxisDetailComments` slot: the `moderation_status === 'visible'` gate plus `showHeading={heading === undefined}`, so the layout draws the section head and the thread does not draw a second one (the #1029 trap). Comment ROWS stay dispatched on `comment.author.faction_slug` — untouched, per ADR-0061's explicit boundary.
- **`locales/en/praxis.json`** — one neutral `detail.*` set (`breadcrumb`, `back`, `sections`, `taskRef`, `filed`, `vote`, `score.{heading,base,multiplier,meta,votes,total}`, `banners.flagged*`). The eight `detail.<faction>.*` blocks are left alone for #1089.
- **`docs/adr/0061-…md`** — records the ADR-0006 amendment the issue asks for ("Comments are the third region").
- **New test** `__tests__/unaffiliatedDetailV2.test.tsx` (13 cases) covering the layout contract and the state axes.

## The three design-vs-issue gaps, and how each was resolved

1. **Mobile gets a back link, not the breadcrumb.** Built both affordances: a `<nav>` breadcrumb `Tasks › {task} › Praxis` on desktop, and `‹ Praxes` + a centred `Praxis` label on mobile. **Deviation:** the mobile bar is *not* sticky. The mobile shell already owns a sticky `h-12` header (`MobileLayout`), and a second sticky bar stacked under a blurred one is a dress decision — flagged for `frontend-style` rather than guessed at.
2. **Score/duel drawn twice in the markup.** Built **once** each and moved by mount point: on desktop they sit in the aside, on mobile they render above the proof inside the single column. Nothing is duplicated-and-hidden, and there is no fixed-px inline grid on the mobile path (SPEC-faction-ui-profile §1a) — the 340px track is a desktop-only `flex: 0 0 340px`, mobile is flow.
3. **Phone status-bar chrome** ("9:41", "WZ · 5G") — not built, per the epic.

## Deliberately not built (already decided)

Metatask "Available" chips (`apply_metatask` requires `in_progress`; read-only `MetaTaskSeal` stack only, dead wiring left for #1093) · the design's invented score arithmetic (`ScoreStamp` is mounted as-is; #1091 restyles it, and the strip beside it reads straight off `scoreBreakdown()` — `(base + meta) × mult + votes`, ADR-0053) · the declined duel card · flattened comment rows · a left sidebar.

## Two judgement calls worth reviewing

- **The duel slot is empty for now.** #1090 owns replacing `DuelCrossLink` with the design's duel card, and this PR was told not to touch it. Moving the existing rail into a 340px aside would have meant deleting the dispatcher-level mount, which every *other* faction archetype still depends on — so the rail stays exactly where it is and the archetype marks the slot where #1090 lands. No behaviour change for duel praxes.
- **A three-line transitional shim in the dispatcher.** The rebuilt page mounts its own comments; the six legacy faction archetypes do not, and would otherwise lose their thread between this PR and #1089. The dispatcher keeps mounting `CommentThread` for them, gated on `Archetype !== DefaultPraxisDetail`. The shim is commented to be deleted with #1089.

## Other notes

- **Ground.** No `.na-backdrop`: that rule is `position: fixed; inset: 0`, and the owner's rule for detail surfaces is that the site background shows *around* the component (WORLD_ZERO_STYLE §5, the #1028 ruling). The page surface is carried by the column, exactly as `DefaultTaskDetail` does. A test pins this.
- **Copy.** Where the design's word differed from the domain noun in `CONTEXT.md`, the noun won: the design's "the crew" ships as **Members**.
- **Tokens.** Every size, space and colour goes through `--text-*` / `--space-*` / `--faction-default-*` / `--color-*`; no hex, no `dark ? a : b`. The avatar overlap is `calc(-1 * var(--space-lg))` rather than a negated raw pixel.
- **No backend work.** `GET /praxes/{id}/voters` was already fetched by `usePraxisDetail`.

## Verification

`tsc --noEmit` clean · `eslint src` clean (0 problems; the `no-raw-style-values` ratchet applies in full to this rebuilt file) · `vitest run` **122 files / 1919 tests passed** · `vite build` succeeds.

**Visual QA is outstanding** — this environment cannot screenshot and has no dev stack, so nothing below has been seen rendered.

## What to eyeball

Desktop and mobile, light and dark, for each:

1. **Published solo, uncrowned, as a visitor** — breadcrumb, byline disc, title, task reference, proof grid, write-up, score stamp + strip in the aside, vote widget, voters list, flag card, Discussion region.
2. **Published solo, crowned** — the crown hero banner above the sheet; the score stamp deliberately does *not* draw a second crown.
3. **Published collab (3 members), as one of the members** — overlapping spectrum discs, the Oxford-joined byline, the **Members** roster reading "published", the owner edit/unsubmit row.
4. **A `pending` collab** — exactly ONE roster on the page (the shared banner's), not two. (#1092 will redirect this case away entirely.)
5. **A duel side** — the duel rail still renders above the page, unchanged; check nothing collides with the new breadcrumb.
6. **`flagged`** — the FLAGGED banner; the flag card hides itself.
7. **`failed` with an `admin_note`** — the note renders as the banner body; comments region absent.
8. **As a steward (admin mode on)** — the moderation bar sits under the banners and above the byline.
9. **A praxis with no media and no body** — proof and write-up sections vanish cleanly, no empty rules.
10. **A praxis with zero votes** — the voters panel is absent (hidden, not empty), and the score strip still reads `+0`.
11. **A praxis with an applied metatask** — the seal stack renders read-only, with no `+` chip anywhere.
12. **Mobile ordering specifically** — back link, byline, title, task reference, **score**, proof, write-up, members, metatasks, vote, voters, flag, Discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
