### PR TITLE
Save draft: flush the autosave and return to the player's profile (#1081)

### DIFF
--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -96,6 +96,7 @@
       "titleRequired": "Title is required.",
       "titleTooLong": "Title must be 200 characters or fewer.",
       "publish": "Could not publish proof.",
+      "saveDraft": "Could not save your draft — your writing is still here, so try again in a moment.",
       "drop": "Could not drop the task.",
       "changeMode": "Could not change mode.",
       "upload": "Could not upload {{name}}.",
@@ -230,6 +231,7 @@
       "table": "table"
     },
     "dropTask": "drop task",
+    "saveDraft": "save draft",
     "mobile": {
       "write": "Write",
       "preview": "Preview",

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -31,6 +31,7 @@ import {
   InviteSearch,
   ModePicker,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -693,6 +694,7 @@ export default function CovenEditPraxis({ state }: Props) {
                 flexWrap: "wrap",
               }}
             >
+              <SaveDraftButton state={state} />
               <DropButton
                 state={state}
                 skin={{

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -26,6 +26,7 @@ import {
   InviteSearch,
   ModePicker,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -547,6 +548,7 @@ export default function DefaultEditPraxis({ state }: Props) {
                   },
                 }}
               />
+              <SaveDraftButton state={state} />
               <DropButton
                 state={state}
                 skin={{

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -23,6 +23,7 @@ import {
   InviteSearch,
   ModePicker,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -440,6 +441,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <SaveDraftButton state={state} />
           <DropButton
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -26,6 +26,7 @@ import {
   InviteSearch,
   ModePicker,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -553,6 +554,7 @@ export default function EverymenEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <SaveDraftButton state={state} />
           <DropButton
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -16,6 +16,7 @@ import {
   InviteSearch,
   ModePicker,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -612,6 +613,7 @@ export default function SingularityEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <SaveDraftButton state={state} />
           <DropButton
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -26,6 +26,7 @@ import {
   InviteSearch,
   ModePicker,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -585,6 +586,7 @@ export default function SnideEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <SaveDraftButton state={state} />
           <DropButton
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -42,6 +42,7 @@ import {
   InviteSearch,
   ModePicker,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -500,6 +501,7 @@ export default function UaEditPraxis({ state }: Props) {
             flexWrap: "wrap",
           }}
         >
+          <SaveDraftButton state={state} />
           <DropButton
             state={state}
             skin={{

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -37,6 +37,7 @@ import {
   InviteSearch,
   ModePicker,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -638,6 +639,7 @@ export default function WowEditPraxis({ state }: Props) {
                 borderTop: `1px solid ${panelBorder}`,
               }}
             >
+              <SaveDraftButton state={state} />
               <DropButton
                 state={state}
                 skin={{

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/SaveDraftButton.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/SaveDraftButton.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * SaveDraftButton (#1081) — the composer's third exit: keep the draft and go.
+ *
+ * The button itself is thin on purpose (the flush lives in the hook, proved in
+ * `useEditPraxis.test.ts`), so what's worth pinning here is where it does and
+ * does not appear: a cast or moderated praxis has no draft to save, and per the
+ * house rule that state hides the control rather than greying it out.
+ */
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect, vi } from "vitest";
+import "../../../../i18n";
+import i18n from "../../../../i18n";
+import type { PraxisOut } from "../../../../api/praxis";
+import type { EditPraxisState } from "../../useEditPraxis";
+import { SaveDraftButton } from "../controls";
+
+const LABEL = i18n.t("forms:editPraxis.saveDraft");
+
+function draftState(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
+  return {
+    praxis: {
+      id: 1,
+      type: "solo",
+      members: [],
+      task_faction_slug: null,
+    } as unknown as PraxisOut,
+    submitting: false,
+    switchingMode: null,
+    controlsLocked: false,
+    isPublished: false,
+    currentCharacterId: 1,
+    saveDraft: async () => {},
+    ...overrides,
+  } as unknown as EditPraxisState;
+}
+
+/**
+ * The component calls `useTranslation`, so it can't be invoked bare like
+ * PublishButton is next door. Rendering it inside a probe gives the hooks a
+ * renderer to live in while still handing back the element, whose onClick is
+ * what proves the wiring — renderToStaticMarkup emits no handlers.
+ */
+function renderThroughProbe(state: EditPraxisState): ReactElement<{
+  onClick: () => void;
+  disabled: boolean;
+}> | null {
+  let captured: ReactElement | null = null;
+  function Probe() {
+    captured = SaveDraftButton({ state });
+    return null;
+  }
+  renderToStaticMarkup(<Probe />);
+  return captured as ReactElement<{
+    onClick: () => void;
+    disabled: boolean;
+  }> | null;
+}
+
+describe("SaveDraftButton — the third exit (#1081)", () => {
+  it("offers the neutral shared label on an open draft", () => {
+    const html = renderToStaticMarkup(<SaveDraftButton state={draftState()} />);
+    expect(html).toContain(LABEL);
+  });
+
+  it("calls saveDraft — and asks nothing first, because it destroys nothing", () => {
+    const saveDraft = vi.fn(async () => {});
+    const element = renderThroughProbe(draftState({ saveDraft }));
+
+    element?.props.onClick();
+    expect(saveDraft).toHaveBeenCalledTimes(1);
+  });
+
+  it("is not drawn once the praxis is cast or moderated — there is no draft left", () => {
+    const html = renderToStaticMarkup(
+      <SaveDraftButton
+        state={draftState({ controlsLocked: true, isPublished: true })}
+      />,
+    );
+    expect(html).toBe("");
+  });
+
+  it("stands down while a publish is in flight", () => {
+    const element = renderThroughProbe(draftState({ submitting: true }));
+    expect(element?.props.disabled).toBe(true);
+  });
+
+  it("stands down while a mode switch is in flight", () => {
+    const element = renderThroughProbe(draftState({ switchingMode: "collab" }));
+    expect(element?.props.disabled).toBe(true);
+  });
+
+  it("takes a faction's own voice when an archetype supplies one", () => {
+    const html = renderToStaticMarkup(
+      <SaveDraftButton state={draftState()} skin={{ label: "PARK IT" }} />,
+    );
+    expect(html).toContain("PARK IT");
+    expect(html).not.toContain(LABEL);
+  });
+});

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -398,6 +398,60 @@ export function DropButton({
   );
 }
 
+/* -------------------------------------------------------------------------- */
+/* SaveDraftButton — the composer's third exit (#1081): keep the draft, leave.  */
+/*                                                                              */
+/* Publish files the praxis and Drop destroys it; until now there was no way to */
+/* simply stop for the night. The click flushes the queued autosave and lands   */
+/* on the player's own profile, where their in_progress praxes are listed.      */
+/*                                                                              */
+/* Deliberately unskinned by default, like the collab Leave link above: this is */
+/* a mechanics affordance, not a faction gesture, and the shared neutral        */
+/* treatment keeps a wide 16-archetype footprint to one line per footer. The    */
+/* optional skin is the escape hatch if a faction later wants its own voice.    */
+/*                                                                              */
+/* Nothing here asks first — saving a draft destroys nothing, so a confirm      */
+/* would be ceremony. (The composer has `askConfirm` for the ones that do.)     */
+/* -------------------------------------------------------------------------- */
+export interface SaveDraftButtonSkin {
+  style?: CSSProperties;
+  label?: string;
+}
+
+export function SaveDraftButton({
+  state,
+  skin,
+}: {
+  state: EditPraxisState;
+  skin?: SaveDraftButtonSkin;
+}) {
+  const { t } = useTranslation("forms");
+  // A cast or moderated praxis has no draft to save — the autosave effect sits
+  // the same states out, and the archetype is read-only in them. Hide rather
+  // than disable, as everywhere else.
+  if (state.controlsLocked) return null;
+  return (
+    <button
+      type="button"
+      onClick={() => void state.saveDraft()}
+      // Not while a publish or a mode switch is in flight: both end up writing
+      // the same fields, and both change where the player should be sent.
+      disabled={state.submitting || state.switchingMode !== null}
+      className="font-body eyebrow hover:underline"
+      style={{
+        background: "none",
+        border: "none",
+        padding: 0,
+        cursor: "pointer",
+        color: "var(--color-text-tertiary)",
+        ...skin?.style,
+      }}
+    >
+      {skin?.label ?? t("editPraxis.saveDraft")}
+    </button>
+  );
+}
+
 /* The editable seal stack (#933) lives in `../MetataskSealStack` — deliberately
  * OUTSIDE this module so `controls.tsx` never imports MetaTaskSeal (and through
  * it the faction registry). See that file's header for why the cycle matters. */

--- a/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/CovenEditPraxis.tsx
@@ -26,6 +26,7 @@ import {
   FilePicker,
   InviteSearch,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "../archetypes/controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -386,6 +387,7 @@ export default function CovenEditPraxis({ state }: { state: EditPraxisState }) {
           borderTop: `1.5px solid ${WIN_BORDER}`,
         }}
       >
+        <SaveDraftButton state={state} />
         {!state.isPublished && (
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/DefaultEditPraxis.tsx
@@ -21,6 +21,7 @@ import {
   FilePicker,
   InviteSearch,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "../archetypes/controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -272,6 +273,7 @@ export default function DefaultEditPraxis({
           borderTop: `1px solid ${BORDER}`,
         }}
       >
+        <SaveDraftButton state={state} />
         {!state.isPublished && (
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EphemeristsComposer.tsx
@@ -13,6 +13,7 @@ import {
   FilePicker,
   InviteSearch,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
@@ -233,6 +234,7 @@ export default function EphemeristsComposer({ state }: { state: EditPraxisState 
           borderTop: `1px solid ${GOLD}`,
         }}
       >
+        <SaveDraftButton state={state} />
         {!state.isPublished && (
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/EverymenComposer.tsx
@@ -13,6 +13,7 @@ import {
   FilePicker,
   InviteSearch,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
@@ -222,6 +223,7 @@ export default function EverymenComposer({ state }: { state: EditPraxisState }) 
           borderTop: `2px solid ${INK}`,
         }}
       >
+        <SaveDraftButton state={state} />
         {!state.isPublished && (
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SingularityComposer.tsx
@@ -13,6 +13,7 @@ import {
   FilePicker,
   InviteSearch,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
@@ -223,6 +224,7 @@ export default function SingularityComposer({ state }: { state: EditPraxisState 
           borderTop: `1px solid ${BORDER_HARD}`,
         }}
       >
+        <SaveDraftButton state={state} />
         {!state.isPublished && (
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/SnideComposer.tsx
@@ -13,6 +13,7 @@ import {
   FilePicker,
   InviteSearch,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
@@ -229,6 +230,7 @@ export default function SnideComposer({ state }: { state: EditPraxisState }) {
           borderTop: `1px solid ${ACID}`,
         }}
       >
+        <SaveDraftButton state={state} />
         {!state.isPublished && (
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/UaComposer.tsx
@@ -14,6 +14,7 @@ import {
   FilePicker,
   InviteSearch,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from '../archetypes/controls'
 import { MetataskSealStack } from '../MetataskSealStack'
@@ -280,6 +281,7 @@ export default function UaComposer({ state }: { state: EditPraxisState }) {
           borderTop: `1px solid ${HAIR}`,
         }}
       >
+        <SaveDraftButton state={state} />
         {!state.isPublished && (
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/WowEditPraxis.tsx
@@ -32,6 +32,7 @@ import {
   FilePicker,
   InviteSearch,
   PublishButton,
+  SaveDraftButton,
   TitleField,
 } from "../archetypes/controls";
 import { MetataskSealStack } from "../MetataskSealStack";
@@ -436,6 +437,7 @@ export default function WowEditPraxis({ state }: { state: EditPraxisState }) {
           borderTop: `1.5px solid ${GOLD}`,
         }}
       >
+        <SaveDraftButton state={state} />
         {!state.isPublished && (
           <DropButton
             state={state}

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -116,6 +116,7 @@ function baseState(slug: string | null): EditPraxisState {
     cancelRemoveMetatask: () => {},
     submitting: false,
     publish: async () => {},
+    saveDraft: async () => {},
     pullBack: async () => {},
     reopenForEdit: async () => {},
     leaveCollab: async () => {},

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/modePicker.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/modePicker.test.tsx
@@ -115,6 +115,7 @@ function baseState(): EditPraxisState {
     cancelRemoveMetatask: () => {},
     submitting: false,
     publish: async () => {},
+    saveDraft: async () => {},
     pullBack: async () => {},
     reopenForEdit: async () => {},
     leaveCollab: async () => {},

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
@@ -117,6 +117,7 @@ function stateWith(publish: () => Promise<void>): EditPraxisState {
     cancelRemoveMetatask: () => {},
     submitting: false,
     publish,
+    saveDraft: async () => {},
     pullBack: async () => {},
     reopenForEdit: async () => {},
     leaveCollab: async () => {},

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
@@ -126,6 +126,7 @@ function baseState(): EditPraxisState {
     cancelRemoveMetatask: () => {},
     submitting: false,
     publish: async () => {},
+    saveDraft: async () => {},
     pullBack: async () => {},
     reopenForEdit: async () => {},
     leaveCollab: async () => {},

--- a/frontend/src/pages/editPraxis/useEditPraxis.test.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.test.ts
@@ -3,11 +3,17 @@
  * duel), so the draft is always preserved — only genuinely destructive
  * transitions warn: leaving a live duel, or collab→solo dropping co-authors.
  */
-import { describe, it, expect } from "vitest";
-import { hasUnsavedEdits } from "./useEditPraxis";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { updatePraxis } from "../../api/praxis";
+import { draftNeedsTitle, flushEdits, hasUnsavedEdits } from "./useEditPraxis";
 // The mode-switch confirm moved out of the hook with the rest of them (#1082)
 // and now returns a whole ConfirmRequest instead of a `window.confirm` string.
 import { modeSwitchConfirm } from "../../components/confirm/composerConfirms";
+
+vi.mock("../../api/praxis", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../api/praxis")>()),
+  updatePraxis: vi.fn(async () => ({})),
+}));
 
 /**
  * Dirty-check gating the pre-submit PUT (#360). persistEdits only fires
@@ -30,6 +36,108 @@ describe("hasUnsavedEdits", () => {
 
   it("is true before hydration (refs still null), preserving the old always-save behavior", () => {
     expect(hasUnsavedEdits("Title", "", null, null)).toBe(true);
+  });
+});
+
+/**
+ * The manual flush behind Publish and Save draft (#1081). The harness runs no
+ * effects, so the 2s debounce can't be exercised through the component — but
+ * `flushEdits` takes its cancel as an argument precisely so the ordering that
+ * makes a manual save safe is provable by calling it directly.
+ */
+describe("flushEdits", () => {
+  const put = vi.mocked(updatePraxis);
+  let log: string[];
+  const cancelQueuedAutosave = () => {
+    log.push("cancel");
+  };
+
+  beforeEach(() => {
+    log = [];
+    put.mockClear();
+    put.mockImplementation(async () => {
+      log.push("put");
+      return {} as Awaited<ReturnType<typeof updatePraxis>>;
+    });
+  });
+
+  it("cancels the queued autosave BEFORE writing, never after", async () => {
+    await flushEdits({
+      praxisId: 7,
+      title: "Title",
+      body: "typed one keystroke ago",
+      lastSavedTitle: "Title",
+      lastSavedBody: "",
+      cancelQueuedAutosave,
+    });
+    // Cancel-then-write. The other order lets a debounce holding stale text land
+    // after the manual save and overwrite it.
+    expect(log).toEqual(["cancel", "put"]);
+  });
+
+  it("writes the text it was handed, so the last keystrokes go out too", async () => {
+    const wrote = await flushEdits({
+      praxisId: 7,
+      title: "Title",
+      body: "typed one keystroke ago",
+      lastSavedTitle: "Title",
+      lastSavedBody: "",
+      cancelQueuedAutosave,
+    });
+    expect(wrote).toBe(true);
+    expect(put).toHaveBeenCalledWith(7, {
+      title: "Title",
+      body_text: "typed one keystroke ago",
+    });
+  });
+
+  it("still cancels the debounce when nothing changed, but issues no PUT (#360)", async () => {
+    const wrote = await flushEdits({
+      praxisId: 7,
+      title: "Title",
+      body: "Body",
+      lastSavedTitle: "Title",
+      lastSavedBody: "Body",
+      cancelQueuedAutosave,
+    });
+    // On a collab that skipped PUT is load-bearing: it would reset every
+    // member's has_submitted (ADR-0012).
+    expect(wrote).toBe(false);
+    expect(log).toEqual(["cancel"]);
+    expect(put).not.toHaveBeenCalled();
+  });
+
+  it("sends an empty body as undefined rather than an empty string", async () => {
+    await flushEdits({
+      praxisId: 7,
+      title: "Title",
+      body: "",
+      lastSavedTitle: "",
+      lastSavedBody: "",
+      cancelQueuedAutosave,
+    });
+    expect(put).toHaveBeenCalledWith(7, { title: "Title", body_text: undefined });
+  });
+});
+
+/**
+ * Save draft navigates away, so the one write it depends on has to be one the
+ * backend will accept — otherwise the body text leaves with the page (#1081).
+ */
+describe("draftNeedsTitle", () => {
+  it("refuses to leave when unsaved writing has no title to be saved under", () => {
+    expect(draftNeedsTitle("", "a body I just typed", "", "")).toBe(true);
+    expect(draftNeedsTitle("   ", "a body I just typed", "", "")).toBe(true);
+  });
+
+  it("lets a titled draft go", () => {
+    expect(draftNeedsTitle("Title", "a body I just typed", "Title", "")).toBe(
+      false,
+    );
+  });
+
+  it("lets an untitled but fully-persisted draft go — there is nothing to lose", () => {
+    expect(draftNeedsTitle("", "", "", "")).toBe(false);
   });
 });
 

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -217,6 +217,15 @@ export interface EditPraxisState {
   // Save / publish / drop
   submitting: boolean;
   publish: () => Promise<void>;
+  /**
+   * The composer's third exit (#1081): keep the draft and leave.
+   *
+   * Flushes the queued autosave — cancel, then write the text in hand, the same
+   * two steps publish runs — and navigates to the player's own profile, where
+   * their `in_progress` praxes are listed. Refuses to leave (and says so) if the
+   * flush can't be written, so no keystroke is lost on the way out.
+   */
+  saveDraft: () => Promise<void>;
   /** Pull my own cast back on a pending collab (#591). */
   pullBack: () => Promise<void>;
   /**
@@ -321,6 +330,71 @@ export function hasUnsavedEdits(
   lastSavedBody: string | null,
 ): boolean {
   return title !== lastSavedTitle || body !== lastSavedBody;
+}
+
+/**
+ * The composer's one manual write: **cancel the queued autosave first, then
+ * persist the text in hand** — in that order, and never one without the other.
+ *
+ * The ordering is the whole correctness of a manual save (#1081). A queued
+ * debounce holds a *stale* closure over title/body; leaving it armed lets it
+ * land after the manual PUT and re-write older text, while cancelling without
+ * writing drops every keystroke typed inside the 2s window. Publish has always
+ * done both (#360); Save draft needs exactly the same two steps, so they live
+ * here once rather than being re-typed at each call site.
+ *
+ * Exported (and dependency-injected on `cancelQueuedAutosave`) so the ordering
+ * is provable in a test that calls it directly — the frontend harness runs no
+ * effects, so the debounce timer can't be exercised through the component.
+ *
+ * Returns whether a PUT actually went out: nothing changed since the last save
+ * → no request at all (#360; on a collab a PUT would reset every member's
+ * `has_submitted`, ADR-0012).
+ */
+export async function flushEdits(options: {
+  praxisId: number;
+  title: string;
+  body: string;
+  lastSavedTitle: string | null;
+  lastSavedBody: string | null;
+  cancelQueuedAutosave: () => void;
+}): Promise<boolean> {
+  const {
+    praxisId,
+    title,
+    body,
+    lastSavedTitle,
+    lastSavedBody,
+    cancelQueuedAutosave,
+  } = options;
+  // First, always — even on the clean path, where the queued write would be a
+  // no-op PUT the collab consensus rules can't afford.
+  cancelQueuedAutosave();
+  if (!hasUnsavedEdits(title, body, lastSavedTitle, lastSavedBody)) return false;
+  await updatePraxis(praxisId, { title, body_text: body || undefined });
+  return true;
+}
+
+/**
+ * Save draft can't leave when the flush it's about to run would be rejected.
+ *
+ * The backend requires a title, which is why the autosave effect sits out a
+ * blank one. That's harmless while the player stays on the page — but Save
+ * draft *navigates away*, so a blank title with unsaved body text would strand
+ * the writing with nowhere to land. Refuse the exit and say why instead (#1081).
+ *
+ * A blank title with nothing unsaved is not this case: there is no pending
+ * write to reject, so leaving is free.
+ */
+export function draftNeedsTitle(
+  title: string,
+  body: string,
+  lastSavedTitle: string | null,
+  lastSavedBody: string | null,
+): boolean {
+  return (
+    hasUnsavedEdits(title, body, lastSavedTitle, lastSavedBody) && !title.trim()
+  );
 }
 
 export function useEditPraxis(idParam: string | undefined): EditPraxisState {
@@ -634,30 +708,32 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   );
 
   // ---- Save / publish ----
+  const cancelQueuedAutosave = useCallback(() => {
+    if (autosaveTimerRef.current) {
+      clearTimeout(autosaveTimerRef.current);
+      autosaveTimerRef.current = null;
+    }
+  }, []);
+
+  /** Cancel-then-write, then remember what was written. Resolves to whether a
+   * PUT went out — see `flushEdits` for why the order matters. */
   const persistEdits = useCallback(
     async (praxisId: number) => {
-      // Cancel any queued autosave so it can't race the manual write.
-      if (autosaveTimerRef.current) {
-        clearTimeout(autosaveTimerRef.current);
-        autosaveTimerRef.current = null;
+      const wrote = await flushEdits({
+        praxisId,
+        title,
+        body,
+        lastSavedTitle: lastSavedTitleRef.current,
+        lastSavedBody: lastSavedBodyRef.current,
+        cancelQueuedAutosave,
+      });
+      if (wrote) {
+        lastSavedTitleRef.current = title;
+        lastSavedBodyRef.current = body;
       }
-      // Nothing changed since the last save → skip the PUT entirely (#360).
-      // On a collab the PUT would reset every member's has_submitted.
-      if (
-        !hasUnsavedEdits(
-          title,
-          body,
-          lastSavedTitleRef.current,
-          lastSavedBodyRef.current,
-        )
-      ) {
-        return;
-      }
-      await updatePraxis(praxisId, { title, body_text: body || undefined });
-      lastSavedTitleRef.current = title;
-      lastSavedBodyRef.current = body;
+      return wrote;
     },
-    [title, body],
+    [title, body, cancelQueuedAutosave],
   );
 
   const publish = useCallback(async () => {
@@ -729,6 +805,58 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       setSubmitting(false);
     }
   }, [idParam, title, persistEdits, navigate, refetch, user?.character?.id, duel]);
+
+  // The third exit (#1081). Publish files the praxis and Drop destroys it; this
+  // is the one that keeps the draft and simply leaves.
+  //
+  // Almost every byte is already persisted by the time it's pressed — title and
+  // body on the 2s debounce, media the moment it's picked — so the work here is
+  // the flush, not a save: the queued autosave is cancelled and the text in hand
+  // written in its place, exactly as publish does. Without that, the keystrokes
+  // typed inside the debounce window would be discarded by the unmount.
+  //
+  // Destination is the player's own profile, whose praxis grid shows them their
+  // own `in_progress` work (`praxis_visibility_condition` ORs in the viewer's
+  // member praxes) — i.e. the draft they just saved, waiting where they left it.
+  const saveDraft = useCallback(async () => {
+    if (!idParam) return;
+    if (
+      draftNeedsTitle(
+        title,
+        body,
+        lastSavedTitleRef.current,
+        lastSavedBodyRef.current,
+      )
+    ) {
+      // Stay put: the body is still in the box, and leaving would strand it.
+      setError(i18n.t("forms:editPraxis.errors.titleRequired"));
+      return;
+    }
+    const dirty = hasUnsavedEdits(
+      title,
+      body,
+      lastSavedTitleRef.current,
+      lastSavedBodyRef.current,
+    );
+    setError("");
+    if (dirty) setSaveStatus("saving");
+    try {
+      await persistEdits(parseInt(idParam, 10));
+    } catch (err) {
+      // The write failed, so the only copy of this text is the one on screen.
+      // Report and hold — navigating now would be the data loss the flush exists
+      // to prevent.
+      if (dirty) setSaveStatus("error");
+      setError(extractError(err, i18n.t("forms:editPraxis.errors.saveDraft")));
+      return;
+    }
+    if (dirty) {
+      setAutosaveAt(new Date());
+      setSaveStatus("saved");
+    }
+    const characterId = user?.character?.id;
+    navigate(characterId != null ? `/characters/${characterId}` : "/tasks");
+  }, [idParam, title, body, persistEdits, navigate, user?.character?.id]);
 
   // Pull my own part back out of a pending collab (#591) — clears my cast so the
   // composer unlocks for editing. Backend re-opens only my membership (#590).
@@ -824,10 +952,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
         : dropTaskConfirm(),
     );
     if (!confirmed) return;
-    if (autosaveTimerRef.current) {
-      clearTimeout(autosaveTimerRef.current);
-      autosaveTimerRef.current = null;
-    }
+    cancelQueuedAutosave();
     try {
       await deletePraxis(praxis.id);
     } catch (err) {
@@ -835,7 +960,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       return;
     }
     navigate("/tasks");
-  }, [praxis, navigate, askConfirm]);
+  }, [praxis, navigate, askConfirm, cancelQueuedAutosave]);
 
   // ---- Mode switching ----
   const changeMode = useCallback(
@@ -1302,6 +1427,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
 
     submitting,
     publish,
+    saveDraft,
     pullBack,
     reopenForEdit,
     leaveCollab,


### PR DESCRIPTION
Closes #1081

The composer had two exits: publish it, or destroy it. This adds the third — keep the draft and go — and takes the player to their own profile, where the draft is waiting.

## What it actually does

Almost nothing is unsaved by the time the button is pressed: title and body ride the 2s debounce, media uploads the moment it's picked. So the work is the **flush**, not a save — cancel the queued autosave, then write the text in hand, exactly the two steps `publish()` has run since #360. Cancelling without writing is what loses the keystrokes typed inside the debounce window; writing without cancelling lets a stale debounce land afterwards and overwrite the manual save.

That pair is now `flushEdits()` in `useEditPraxis.ts` — exported, with its cancel passed in, so the *ordering* is provable in a test that calls it directly (the harness runs no effects, so the timer can't be driven through the component). `persistEdits` delegates to it, so publish and Save draft share one implementation rather than two copies of a subtle order.

No new endpoint, no new persistence state. `saveDraft()` reuses `saveStatus`/`autosaveAt`, so the composer's own autosave chip reflects the flush on the way out.

## Destination

`/characters/:id` — the player's own profile. Verified rather than assumed: `praxis_visibility_condition` ORs in the viewer's member praxes, so `GET /characters/{id}/praxes` returns the author their own `in_progress` work.

One caveat worth knowing: that endpoint filters on `Praxis.created_by_id == character_id`, so a **collab draft someone else started** won't be on your profile grid even though you're a member. Solo drafts — the case this button exists for — are.

## Decisions

- **Not on the waiting surface.** `EditPraxis.tsx` renders `PraxisWaitingSurface` *in place of* the archetype at `phase === "waiting"`, so putting the button in the archetype footers excludes it there for free. That's right: once you've cast, you aren't drafting, and the surface already owns its own re-entry (`reopenForEdit`). The holdout case (others cast, you haven't) keeps the normal composer and keeps Save draft, which is also right.
- **No confirm.** Saving a draft destroys nothing, so it asks nothing. (`askConfirm` is there if that judgement is ever reversed — no `window.confirm` was added, per #1082.)
- **Hidden, not disabled, once `controlsLocked`** — a cast or moderated praxis has no draft to save, and the autosave effect sits those states out too. It *is* `disabled` while a publish or mode switch is in flight, matching `PublishButton` next door: transient busy, not "you may not".
- **A blank title refuses the exit.** The backend rejects an empty title, which is why the autosave skips one. Harmless while you stay on the page; not harmless when the next step is navigation. With unsaved body text and no title you get the same "Title is required" the publish path gives, and you stay put. Untitled *and* fully persisted still leaves freely.
- **One shared neutral label**, `editPraxis.saveDraft` → "save draft", not eight faction voices — the same shared-voice call `SHARED_DEFAULT_COLLAB_KEYS` makes for mechanics lines. `SaveDraftButton` takes an optional skin (style + label), so a faction can claim it later without touching the other fifteen.

## Footprint

Per #646 this is the global footer swap: 8 desktop + 8 mobile archetypes. The blast radius is kept to **two lines per file** (one import, one `<SaveDraftButton state={state} />`) by making the control unskinned by default — the same shape as the collab Leave link already living in `controls.tsx`. It sits immediately before the Drop control in every footer, so the two exits read as a pair with Publish left alone.

Four mobile test fixtures gained a `saveDraft` stub for the widened `EditPraxisState`.

## Verification

- `tsc --noEmit` clean; `vite build` clean; `eslint src` clean.
- Full suite `1947 passed (124 files)`, including 6 new `SaveDraftButton` tests and 7 new `flushEdits` / `draftNeedsTitle` tests.
- **Visual QA is outstanding** — no screenshots and no dev stack available in this environment.

## For `frontend-style`

Nothing was redesigned here, but two things want a designer's eye and I deliberately did not decide them:
1. The neutral tertiary treatment (`--color-text-tertiary`, `.font-body .eyebrow`) sits inside eight bespoke footers — the Singularity terminal and the Coven notepad especially will want their own voice.
2. The **mobile sticky bar now carries three controls** (save draft · drop · PUBLISH with `flex: 1`). That's the tightest spot in the change.

## What to eyeball

- **Desktop footers (8):** `save draft` renders immediately *before* the drop control in every archetype — Default/Coven/Ephemerists/Everymen/Singularity/Snide/UA/WOW. On Default that reads `[Publish] save draft drop`; on Coven/Snide/UA it's `save draft drop … [Publish]`.
- **Mobile sticky bars (8):** the same button, first in the bar, ahead of `{!state.isPublished && <DropButton/>}` and the flex-1 publish button. Check it doesn't crowd the bar on a narrow phone.
- **Type, then hit Save draft immediately** (inside the 2s window). The typed text must be on the profile — this is the one real correctness risk, and the whole reason the flush is cancel-*then*-write.
- **Clear the title, type a body, hit Save draft.** It should refuse to leave and say "Title is required" rather than navigating away with the body unwritten.
- **Save draft with nothing changed.** No PUT should go out at all (on a collab that PUT would reset everyone's cast, ADR-0012) — it should just leave.
- **The waiting surface** (cast your part of a collab, or a duel side at `pending`/`active`): Save draft must NOT be there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
