### PR TITLE
Praxis detail: the real score model, published-only, and read-only metatasks (#1091, #1092, #1093)

### DIFF
--- a/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
@@ -4,44 +4,113 @@ import { scoreBreakdown, formatMult } from "./scoreBreakdown";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
- * The Default / `na` score stamp — the unaffiliated SPECTRUM sheet (ADR-0039,
+ * The Default / `na` score stamp — the unaffiliated SPECTRUM stamp (ADR-0039,
  * ADR-0049), and the fall-through every faction renders until its own slice
- * lands (#840 / #841 / #842).
+ * lands.
  *
- * Two objects, as the design specifies: a bordered SCORE BOX (`base 12`, the
- * `×0.80` chip, the italic `+ 4 from votes`) and, under a rainbow hairline, the
- * unaffiliated TOTAL MARK — the total background-clipped to the community
- * rainbow over a `POINTS` label. Unlike UA (whose ensō sits outside the box),
- * the unaffiliated mark is nested inside the box's border; that is how the
- * prototype draws it.
+ * Rebuilt to the Unaffiliated praxis-detail design (#1091, epic #1085). That
+ * skin IS the unaffiliated one, so "restyle the default stamp" and "build the
+ * design's score rail" are the same object: a STRUCK DISC carrying the total
+ * over a `POINTS` caption, then the working out as RULED LEADER-LINE ROWS —
+ * `LABEL … hairline … value` — and, under a rule of its own, the votes tally.
+ * A 2px spectrum bar is pinned across the top edge.
  *
- * The rainbow-band frame #821 wrapped this in is gone — it had no design source.
+ * ## The design's arithmetic is not built
+ *
+ * The design computes `mult = clamp(voteAverage / 3, 0.5, 1.6)` and
+ * `total = 12 * mult + 4`, labels the result "Faction ×1.17", and prints "4
+ * votes" as a COUNT. All three are wrong. The model is
+ * `(base + meta) × faction_mult + votes` (ADR-0014/0047/0053): the multiplier is
+ * `own_task_modifier` / `other_task_modifier` and has nothing to do with how
+ * anyone voted, votes are additive POINTS (`points_from_votes`), and meta sits
+ * INSIDE the multiplier, not beside it. So the presentation is the design's and
+ * every number comes from `scoreBreakdown()`.
+ *
+ * ## Row selection is not ours
+ *
+ * `scoreBreakdown()` is the single row-selection authority (ADR-0053) and every
+ * rule below is its call, not this file's:
+ *   - the MULT row appears only when the multiplier is not ×1.0. `era_1`
+ *     neutralises it to 1.0 for every faction, so the row is dark today and
+ *     lights up on its own if an era ever configures one.
+ *   - the META row appears only when metatask points are > 0.
+ *   - the VOTES tally is drawn ALWAYS, including `+0` — an absent row cannot
+ *     say "nobody has voted yet".
+ * Nothing is derived by subtraction; that was the bug ADR-0053 retired.
+ *
+ * ## Size
+ *
+ * ONE width everywhere (`--text-*`-scaled type, geometry in raw px per §4a).
+ * The stamp is size-agnostic by contract — the same component renders in a
+ * praxis card's gutter, in the mobile card, on the composer's waiting surface
+ * and in the detail page's aside — so it self-constrains rather than reading its
+ * container. The design's two-COLUMN arrangement (disc left, rows right) is the
+ * one thing not carried over: at the ~232px it needs, the stamp starves the
+ * praxis card's title column, so the same pieces stack in one column instead.
+ *
  * Colours are only `--faction-default-*` tokens, so the whole stamp flips
  * through the `[data-theme="dark"]` cascade with no `dark ?` branch.
  */
+
+/** The struck disc — ornament geometry, the design's own 96 (§4a). */
+const DISC = 96;
+/** Inset of the disc's hairline ring from its edge. */
+const RING_INSET = 5;
+/**
+ * One width in every mount. Wide enough for the 96px disc plus the stamp's
+ * padding, narrow enough that a praxis card's title column still reads.
+ */
+const STAMP_WIDTH = 150;
+
 export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
   const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
+
+  /** The working out, in reading order. Selection belongs to scoreBreakdown. */
+  const rows: { key: string; label: string; value: string }[] = [
+    { key: "base", label: t("card.stamp.base"), value: `${base}` },
+  ];
+  if (mult !== null) {
+    rows.push({ key: "mult", label: t("card.stamp.mult"), value: formatMult(mult) });
+  }
+  if (meta !== null) {
+    rows.push({ key: "meta", label: t("card.stamp.meta"), value: `+${meta}` });
+  }
+
   return (
     <div
       style={{
         position: "relative",
-        flexShrink: 0,
-        minWidth: 116,
         boxSizing: "border-box",
+        flexShrink: 0,
+        width: "100%",
+        maxWidth: STAMP_WIDTH,
         border: "1px solid var(--faction-default-card-line)",
-        borderRadius: 8,
+        borderRadius: 10,
         background: "var(--faction-default-stamp-bg)",
         color: "var(--faction-default-card-text)",
         boxShadow: "0 2px 6px rgba(34, 26, 18, 0.1)",
-        // A sheet of scrap tucked into the record, not a printed field.
-        transform: "rotate(-1deg)",
-        padding: "var(--space-sm) var(--space-md) var(--space-md)",
-        lineHeight: 1.1,
+        padding: "var(--space-md)",
       }}
     >
+      {/* The spectrum bar across the top edge — the na tell, and the rainbow's
+          one structural appearance on this object (the total below is the
+          other, clipped to type). */}
+      <span
+        aria-hidden
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 2,
+          borderRadius: "10px 10px 0 0",
+          background: "var(--faction-default-rainbow)",
+        }}
+      />
+
       {crowned && (
         <TaskCrown
           size={26}
@@ -51,119 +120,131 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
         />
       )}
 
-      {/* Score box — base numeral with the multiplier chip pinned right. */}
+      {/* The struck disc: total over its unit caption, tilted off-square so it
+          reads as a mark pressed into the sheet rather than a printed field. */}
       <div
         style={{
           display: "flex",
-          alignItems: "center",
-          gap: "var(--space-sm)",
-          whiteSpace: "nowrap",
+          justifyContent: "center",
+          marginBottom: "var(--space-md)",
         }}
       >
         <span
           style={{
-            fontFamily: "var(--font-body)",
-            fontSize: "var(--text-sm)",
-            letterSpacing: "0.1em",
-            textTransform: "uppercase",
-            color: "var(--faction-default-vote-off)",
+            position: "relative",
+            width: DISC,
+            height: DISC,
+            flexShrink: 0,
+            borderRadius: "50%",
+            border: "2px solid var(--faction-default-card-line)",
+            transform: "rotate(-7deg)",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            lineHeight: 1,
           }}
         >
-          {t("card.stamp.base")}
-        </span>
-        <span
-          style={{
-            fontFamily: "var(--faction-default-card-font)",
-            fontSize: "var(--text-title)",
-            lineHeight: 0.8,
-          }}
-        >
-          {base}
-        </span>
-        {mult !== null && (
+          {/* The inset hairline ring inside the disc's edge. */}
+          <span
+            aria-hidden
+            style={{
+              position: "absolute",
+              inset: RING_INSET,
+              borderRadius: "50%",
+              border: "1px solid var(--faction-default-card-line)",
+            }}
+          />
           <span
             style={{
-              marginLeft: "auto",
               fontFamily: "var(--faction-default-card-font)",
-              fontSize: "var(--text-lg)",
-              letterSpacing: "0.04em",
-              // Rainbow appearance 2 of 4 is the RULE below; the chip carries
-              // the design's own short green-to-blue ramp, not the spectrum.
-              color: "var(--faction-default-chip-text)",
-              background: "var(--faction-default-chip)",
-              borderRadius: 3,
-              padding: "0 var(--space-xs)",
+              fontSize: "var(--text-heading)",
+              lineHeight: 1,
+              // The total, clipped to the design's warmer four-stop ramp rather
+              // than the full seven-stop spectrum, which smears to mud at four
+              // glyphs wide.
+              background: "var(--faction-default-total-rainbow)",
+              WebkitBackgroundClip: "text",
+              backgroundClip: "text",
+              color: "transparent",
             }}
           >
-            {formatMult(mult)}
+            {total.toFixed(1)}
           </span>
-        )}
+          <span
+            style={{
+              fontFamily: "var(--font-body)",
+              fontSize: "var(--text-base)",
+              textTransform: "uppercase",
+              letterSpacing: "0.16em",
+              color: "var(--faction-default-gold)",
+              marginTop: "var(--space-xs)",
+            }}
+          >
+            {t("card.stamp.points")}
+          </span>
+        </span>
       </div>
 
-      {meta !== null && (
+      {/* Ruled leader-line rows — label, a hairline running out to fill the gap,
+          then the figure. */}
+      {rows.map((row) => (
         <div
+          key={row.key}
           style={{
-            fontFamily: "var(--font-body)",
-            fontStyle: "italic",
-            fontSize: "var(--text-base)",
-            color: "var(--faction-default-card-muted)",
-            marginTop: "var(--space-xs)",
+            display: "flex",
+            alignItems: "baseline",
+            gap: "var(--space-xs)",
+            padding: "var(--space-xs) 0",
           }}
         >
-          {t("card.stamp.meta")} +{meta}
+          <span
+            style={{
+              fontFamily: "var(--font-body)",
+              fontSize: "var(--text-base)",
+              textTransform: "uppercase",
+              letterSpacing: "0.16em",
+              color: "var(--faction-default-card-muted)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {row.label}
+          </span>
+          <span
+            aria-hidden
+            style={{
+              flex: "1 1 auto",
+              minWidth: 6,
+              height: 1,
+              background: "var(--faction-default-card-line)",
+            }}
+          />
+          <span
+            style={{
+              fontFamily: "var(--faction-default-card-font)",
+              fontSize: "var(--text-lg)",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {row.value}
+          </span>
         </div>
-      )}
+      ))}
 
+      {/* The tally, under a rule of its own. Always drawn: `+ 0 from votes` is a
+          fact about this praxis, not a missing row. */}
       <div
         style={{
-          fontFamily: "var(--font-body)",
-          fontStyle: "italic",
-          fontSize: "var(--text-base)",
-          letterSpacing: "0.04em",
-          color: "var(--faction-default-card-muted)",
+          borderTop: "1px solid var(--faction-default-card-line)",
           marginTop: "var(--space-xs)",
+          paddingTop: "var(--space-sm)",
+          fontFamily: "var(--font-body)",
+          fontSize: "var(--text-base)",
+          letterSpacing: "0.06em",
+          color: "var(--faction-default-card-muted)",
         }}
       >
         {t("card.stamp.fromVotes", { votes })}
-      </div>
-
-      {/* Rainbow hairline, then the total mark. */}
-      <div
-        aria-hidden
-        style={{
-          height: 1,
-          background: "var(--faction-default-rainbow)",
-          margin: "var(--space-sm) 0",
-        }}
-      />
-      <div style={{ display: "flex", alignItems: "baseline", gap: "var(--space-xs)", lineHeight: 1 }}>
-        <span
-          style={{
-            fontFamily: "var(--faction-default-card-font)",
-            fontSize: "var(--text-heading)",
-            lineHeight: 1.15,
-            // Rainbow appearance 3 of 4: the total, clipped to the design's
-            // warmer four-stop ramp rather than the full seven-stop spectrum,
-            // which smears to mud at four glyphs wide.
-            background: "var(--faction-default-total-rainbow)",
-            WebkitBackgroundClip: "text",
-            backgroundClip: "text",
-            color: "transparent",
-          }}
-        >
-          {total.toFixed(1)}
-        </span>
-        <span
-          style={{
-            fontFamily: "var(--faction-default-card-font)",
-            fontSize: "var(--text-base)",
-            letterSpacing: "0.06em",
-            textTransform: "uppercase",
-            color: "var(--faction-default-gold)",
-          }}
-        >
-          {t("card.stamp.points")}
-        </span>
       </div>
     </div>
   );

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -342,6 +342,74 @@ describe('#842 stamps across the conditional states (ADR-0047)', () => {
 })
 
 /**
+ * The rebuilt unaffiliated stamp (#1091, epic #1085) — the Unaffiliated praxis
+ * detail design's score rail, which is the same object as the `na` card stamp.
+ *
+ * What is pinned here is what a rebuild could quietly lose: the design's own
+ * arithmetic. It computes a multiplier from the VOTE AVERAGE, labels the result
+ * "Faction ×1.17", puts meta OUTSIDE that multiplier, and prints votes as a
+ * COUNT. None of it is built — `scoreBreakdown()` is the resolver and the rows
+ * below are its rules, not this skin's.
+ */
+describe('the rebuilt unaffiliated stamp keeps the real model (#1091)', () => {
+  it('hides the multiplier row under a neutral era and shows it otherwise', () => {
+    // era_1 neutralises own/other_task_modifier to 1.0 for every faction, so
+    // the row is dark today and lights up on its own if an era configures one.
+    const neutral = text(
+      renderToStaticMarkup(<DefaultScoreStamp praxis={praxis({ display_multiplier: 1 })} />),
+    )
+    expect(neutral).not.toContain('mult')
+    expect(neutral).not.toContain('×')
+
+    const live = text(
+      renderToStaticMarkup(<DefaultScoreStamp praxis={praxis({ display_multiplier: 1.1 })} />),
+    )
+    expect(live).toContain('mult')
+    expect(live).toContain('×1.10')
+  })
+
+  it('shows the metatask row only when metatask points are live', () => {
+    const sealed = text(
+      renderToStaticMarkup(<DefaultScoreStamp praxis={praxis({ metatask_points: 4 })} />),
+    )
+    expect(sealed).toContain('meta')
+    expect(sealed).toContain('+4')
+    expect(
+      text(renderToStaticMarkup(<DefaultScoreStamp praxis={praxis({ metatask_points: 0 })} />)),
+    ).not.toContain('meta')
+  })
+
+  it('draws the votes tally even at zero — an absent row cannot say "nobody voted"', () => {
+    const unvoted = text(
+      renderToStaticMarkup(
+        <DefaultScoreStamp praxis={praxis({ points_from_votes: 0, score: 12 })} />,
+      ),
+    )
+    expect(unvoted).toContain('0 from votes')
+  })
+
+  it('states votes as POINTS, never as a count of voters', () => {
+    // `points_from_votes` is a points figure. The design printed "4 votes" as a
+    // tally of people; the payload carries no such number and none is invented.
+    const html = text(
+      renderToStaticMarkup(
+        <DefaultScoreStamp praxis={praxis({ points_from_votes: 7, score: 19 })} />,
+      ),
+    )
+    expect(html).toContain('7 from votes')
+  })
+
+  it('keeps the struck disc and the spectrum bar, both from tokens', () => {
+    const markup = renderToStaticMarkup(<DefaultScoreStamp praxis={praxis({})} />)
+    // The disc is tilted off-square — a mark pressed in, not a printed field.
+    expect(markup).toContain('rotate(-7deg)')
+    // The spectrum is the shared token, never a pasted gradient literal.
+    expect(markup).toContain('var(--faction-default-rainbow)')
+    expect(markup).not.toMatch(HEX)
+  })
+})
+
+/**
  * The stamp's prop type is structural (#1079). `ScoredPraxis` always claimed to
  * be satisfied by BOTH payload shapes (ADR-0053), but the component prop was
  * pinned to `PraxisCardOut`, so the detail/composer payload could only reach a

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -136,10 +136,6 @@
     "banners": {
       "crownLabel": "TASK CROWN",
       "crownBody": "The top-scoring praxis for this task — held until another entry out-votes it.",
-      "inEditingLabel": "IN EDITING",
-      "inEditingBody": "This praxis is in editing mode. Points and votes are paused until submitted.",
-      "pendingPublishLabel": "PENDING PUBLISH",
-      "pendingPublishBody": "Waiting on co-authors to submit.",
       "failedTitle": "This praxis was marked as failed.",
       "flaggedLabel": "FLAGGED",
       "flaggedBody": "This praxis is flagged and awaiting admin review."

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -128,10 +128,7 @@
       "withdraw": "Could not withdraw this praxis.",
       "resubmit": "Could not resubmit.",
       "flag": "Could not flag this praxis.",
-      "flagReasonMissing": "Pick a reason first.",
-      "metataskLoad": "Failed to load metatasks.",
-      "metataskApply": "Failed to apply metatask.",
-      "metataskRemove": "Failed to remove metatask."
+      "flagReasonMissing": "Pick a reason first."
     },
     "banners": {
       "crownLabel": "TASK CROWN",
@@ -200,18 +197,7 @@
       "total": "Total"
     },
     "metatasks": {
-      "heading": "Metatasks",
-      "loading": "loading...",
-      "applied": "Applied",
-      "appliedPoints": "+{{points}} pts",
-      "remove": "remove",
-      "removing": "...",
-      "appliedEmpty": "No metatasks applied yet.",
-      "available": "Available",
-      "availableEmpty": "No eligible metatasks available.",
-      "apply": "apply",
-      "applying": "...",
-      "readOnlyNote": "Reach level 7 to apply metatasks."
+      "heading": "Metatasks"
     },
     "seal": {
       "label": "{{faction}} Metatask",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -189,12 +189,7 @@
     },
     "score": {
       "ptsMultVotes": "pts × bonus + votes",
-      "heading": "Score",
-      "base": "Base",
-      "multiplier": "Multiplier",
-      "meta": "Metatasks",
-      "votes": "From votes",
-      "total": "Total"
+      "heading": "Score"
     },
     "metatasks": {
       "heading": "Metatasks"

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -39,10 +39,15 @@ export default function PraxisDetail() {
   )
   if (!state.praxis) return <div className="py-8 font-body text-muted">{t('detail.notFound')}</div>
 
-  // ADR-0024: the public detail view never renders a draft. Only members reach
-  // here (the API 404s everyone else) — route them to the editor, the sole
-  // surface for in_progress work.
-  if (state.praxis.status === 'in_progress') {
+  // ADR-0062: detail is a published-only reading surface. State the rule by
+  // INTENT, not by enum — drafting, mid-consensus, or waiting on a rival: all
+  // composer. `in_progress` is the draft (ADR-0024, member-only); `pending` is
+  // a collab mid-consensus and is collab-ONLY — a duel side that has cast is
+  // `submitted` with the duel still active, so never reach for `pending` to
+  // mean "waiting on the other party". Only members can load either status
+  // (praxis_visibility_condition), and #1071's waiting surface gives every one
+  // of them somewhere to land, so this redirect cannot strand a viewer.
+  if (state.praxis.status === 'in_progress' || state.praxis.status === 'pending') {
     return <Navigate to={`/praxes/${state.praxis.id}/edit`} replace />
   }
 

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -113,13 +113,6 @@ function state(): PraxisDetailState {
     handleResubmit: async () => {},
     handleFlag: async () => {},
     handleKickMember: async () => {},
-    metatasks: [],
-    metataskLoading: false,
-    metataskError: null,
-    applyingMetataskId: null,
-    removingMetataskId: null,
-    handleApplyMetatask: async () => {},
-    handleRemoveMetatask: async () => {},
   };
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -164,13 +164,6 @@ function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
     handleResubmit: async () => {},
     handleFlag: async () => {},
     handleKickMember: async () => {},
-    metatasks: [],
-    metataskLoading: false,
-    metataskError: null,
-    applyingMetataskId: null,
-    removingMetataskId: null,
-    handleApplyMetatask: async () => {},
-    handleRemoveMetatask: async () => {},
     ...overrides,
   };
 }

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -2,9 +2,9 @@
  * #521 — collab submit indicators on the shared praxis-detail slots.
  *
  * Two invariant slots reflect the collab publish lifecycle (ADR-0012):
- *   - PraxisStatusBanners swaps the neutral "IN EDITING" banner for a
- *     "PENDING PUBLISH — waiting on co-authors" banner once submit_proposed_at
- *     is set (still status=in_progress).
+ *   - PraxisStatusBanners USED to swap a neutral "IN EDITING" banner for a
+ *     "PENDING PUBLISH — waiting on co-authors" banner. ADR-0062 deleted both:
+ *     detail is published-only, so the tests below assert their absence.
  *   - PraxisOwnerActions replaces the green Submit control with a
  *     "you've submitted — waiting on co-authors" state for a member who has
  *     already submitted an in-editing collab. The edit affordance stays.
@@ -178,8 +178,16 @@ function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
 const ADA = () => member(1, "Ada", true);
 const BETH = () => member(2, "Beth", false);
 
-describe("PraxisStatusBanners pending-publish (#521)", () => {
-  it("shows the pending-publish banner when submit_proposed_at is set", () => {
+/**
+ * ADR-0062 (#1092) retired the pair #521 added here. Detail is a published-only
+ * reading surface: the dispatcher redirects `in_progress` AND `pending` to the
+ * composer, so neither banner can paint, and the composer's waiting surface
+ * (#1071) is the one owner of an open praxis. These assertions are inverted on
+ * purpose — the copy keys are deleted, so a re-added banner would render its own
+ * key name and fail here.
+ */
+describe("PraxisStatusBanners open-state banners are gone (ADR-0062)", () => {
+  it("draws no publish-state banner for a collab awaiting its co-authors", () => {
     const t = text(
       <PraxisStatusBanners
         state={state({
@@ -187,12 +195,12 @@ describe("PraxisStatusBanners pending-publish (#521)", () => {
         })}
       />,
     );
-    expect(t).toContain("PENDING PUBLISH");
-    expect(t).toContain("Waiting on co-authors to submit.");
+    expect(t).not.toContain("PENDING PUBLISH");
+    expect(t).not.toContain("pendingPublish");
     expect(t).not.toContain("IN EDITING");
   });
 
-  it("shows the neutral IN EDITING banner when not yet proposed", () => {
+  it("draws no publish-state banner for a collab still drafting", () => {
     const t = text(
       <PraxisStatusBanners
         state={state({
@@ -200,7 +208,8 @@ describe("PraxisStatusBanners pending-publish (#521)", () => {
         })}
       />,
     );
-    expect(t).toContain("IN EDITING");
+    expect(t).not.toContain("IN EDITING");
+    expect(t).not.toContain("inEditing");
     expect(t).not.toContain("PENDING PUBLISH");
   });
 });

--- a/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
@@ -206,13 +206,6 @@ function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
     handleWithdraw: async () => {},
     handleResubmit: async () => {},
     handleFlag: async () => {},
-    metatasks: [],
-    metataskLoading: false,
-    metataskError: null,
-    applyingMetataskId: null,
-    removingMetataskId: null,
-    handleApplyMetatask: async () => {},
-    handleRemoveMetatask: async () => {},
     ...overrides,
   } as PraxisDetailState
 }

--- a/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/mobileArchetypeSlots.test.tsx
@@ -98,13 +98,6 @@ function state(): PraxisDetailState {
     handleResubmit: async () => {},
     handleFlag: async () => {},
     handleKickMember: async () => {},
-    metatasks: [],
-    metataskLoading: false,
-    metataskError: null,
-    applyingMetataskId: null,
-    removingMetataskId: null,
-    handleApplyMetatask: async () => {},
-    handleRemoveMetatask: async () => {},
   }
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -226,22 +226,34 @@ describe("Unaffiliated praxis detail — the state axes", () => {
     expect(text, "total").toContain("16.0");
   });
 
+  // #1091: the rows come from the mounted `ScoreStamp` now, so they speak the
+  // shared `card.stamp.*` vocabulary the praxis cards already use. The page's
+  // own duplicate strip is gone — one readout, one set of words.
   it("shows the multiplier row only when the factor is not 1.0", () => {
-    expect(render(state()).text, "neutral era hides it").not.toContain("Multiplier");
+    expect(render(state()).text, "neutral era hides it").not.toContain("mult");
     const boosted = state({
       praxis: { ...PRAXIS, display_multiplier: 1.1, score: 17.2 },
     });
     const { text } = render(boosted);
-    expect(text).toContain("Multiplier");
+    expect(text).toContain("mult");
     expect(text).toContain("×1.10");
   });
 
   it("names the metatask contribution only when one is applied", () => {
-    expect(render(state()).text).not.toContain("Metatasks");
+    expect(render(state()).text).not.toContain("meta");
     const sealed = state({
       praxis: { ...PRAXIS, metatask_points: 5, score: 21 },
     });
-    expect(render(sealed).text).toContain("Metatasks");
+    expect(render(sealed).text).toContain("meta");
+  });
+
+  // Re-affirmed 2026-07-20 against a design that hid it: an absent row cannot
+  // say "nobody has voted yet", so the tally is drawn at zero too.
+  it("always draws the votes tally, including +0", () => {
+    const unvoted = state({
+      praxis: { ...PRAXIS, points_from_votes: 0, score: 12 },
+    });
+    expect(render(unvoted).text).toContain("from votes");
   });
 
   it("banners flagged, failed-with-note, and the crown", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -147,13 +147,6 @@ function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
     handleResubmit: async () => {},
     handleFlag: async () => {},
     handleKickMember: async () => {},
-    metatasks: [],
-    metataskLoading: false,
-    metataskError: null,
-    applyingMetataskId: null,
-    removingMetataskId: null,
-    handleApplyMetatask: async () => {},
-    handleRemoveMetatask: async () => {},
     ...overrides,
   };
 }

--- a/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
@@ -197,13 +197,6 @@ function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
     handleResubmit: async () => {},
     handleFlag: async () => {},
     handleKickMember: async () => {},
-    metatasks: [],
-    metataskLoading: false,
-    metataskError: null,
-    applyingMetataskId: null,
-    removingMetataskId: null,
-    handleApplyMetatask: async () => {},
-    handleRemoveMetatask: async () => {},
     ...overrides,
   } as PraxisDetailState
 }

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -39,8 +39,9 @@
  *
  * ## Reused, not rebuilt
  *
- * `TaskCrown` (via the shared crown banner) · `ScoreStamp` (#1091 restyles it;
- * this file only mounts it) · `VoteUI`, which dispatches the vote surface on the
+ * `TaskCrown` (via the shared crown banner) · `ScoreStamp`, which since #1091
+ * carries the whole score rail — disc, ruled rows and votes tally — so this file
+ * only mounts it · `VoteUI`, which dispatches the vote surface on the
  * TASK's faction so an unskinned faction still votes in its own voice ·
  * `CollabRoster` for the members · `MediaGallery` · `MetaTaskSeal`, read-only:
  * `apply_metatask` requires `in_progress`, so the design's "Available" chips
@@ -60,10 +61,6 @@ import MediaGallery from '../../../components/MediaGallery'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
 import VoteUI from '../../../components/vote/VoteUI'
 import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
-import {
-  scoreBreakdown,
-  formatMult,
-} from '../../../components/praxisCard/scoreStamp/scoreBreakdown'
 import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
 import { CollabRoster } from '../../../components/collab/CollabRoster'
 import { useFormFactor } from '../../../hooks/useFormFactor'
@@ -146,8 +143,6 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
   // PUBLISHED half of that same fact, so it takes the complement — one roster
   // on the page, never two.
   const rosterInBanners = praxis.status === 'in_progress' || praxis.status === 'pending'
-
-  const { base, mult, meta, votes, total } = scoreBreakdown(praxis)
 
   /** A spectrum hairline running out from a label — the page's only rule. */
   const sectionHead = (label: ReactNode, trailing?: ReactNode) => (
@@ -407,53 +402,23 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
 
   // ── Score (built once; aside on desktop, above the proof on mobile) ────────
   //
-  // Reads twice, as the design specifies: the stamp carries the total mark, and
-  // the strip below it spells the working out. Neither number is computed here —
-  // `scoreBreakdown()` is the single resolver (ADR-0053), so the two readouts
-  // and every praxis card agree by construction. The design's own arithmetic
-  // (a multiplier derived from the vote average) is NOT built; #1091 restyles
-  // the stamp.
-  const scoreRow = (label: string, value: ReactNode) => (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'baseline',
-        justifyContent: 'space-between',
-        gap: 'var(--space-md)',
-        padding: 'var(--space-xs) 0',
-      }}
-    >
-      <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
-        {label}
-      </span>
-      <span
-        className="font-body"
-        style={{ fontSize: 'var(--text-content)', color: 'var(--faction-default-card-text)' }}
-      >
-        {value}
-      </span>
-    </div>
-  )
-
+  // ONE readout, and it is not this file's (#1091). `ScoreStamp` carries the
+  // struck disc, the ruled leader-line rows and the votes tally — the whole of
+  // the design's score rail — dispatched on the task's faction so an unskinned
+  // faction still gets its own total mark here. #1088 drew a second strip of
+  // rows under the stamp that restated exactly the same terms; it is gone, so
+  // card, composer and detail cannot drift apart.
+  //
+  // The design's own arithmetic is NOT built. It derives a multiplier from the
+  // VOTE AVERAGE, calls it the faction multiplier, and prints votes as a count.
+  // The model is `(base + meta) × faction_mult + votes` (ADR-0014/0047/0053),
+  // resolved once by `scoreBreakdown()` inside the stamp.
   const scoreBlock = (
     <section style={panel}>
       {sectionHead(t('detail.score.heading'))}
-      <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 'var(--space-lg)' }}>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
         {/* The crown already has its own hero banner above; one mark per page. */}
         <ScoreStamp praxis={praxis} showCrown={false} />
-      </div>
-      {scoreRow(t('detail.score.base'), base)}
-      {mult !== null && scoreRow(t('detail.score.multiplier'), formatMult(mult))}
-      {meta !== null && scoreRow(t('detail.score.meta'), `+${meta}`)}
-      {scoreRow(t('detail.score.votes'), `+${votes}`)}
-      <div
-        style={{
-          borderTop: '1px solid var(--faction-default-card-line)',
-          marginTop: 'var(--space-xs)',
-          paddingTop: 'var(--space-xs)',
-        }}
-      >
-        {scoreRow(t('detail.score.total'), total.toFixed(1))}
       </div>
     </section>
   )

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -44,7 +44,7 @@
  * TASK's faction so an unskinned faction still votes in its own voice ·
  * `CollabRoster` for the members · `MediaGallery` · `MetaTaskSeal`, read-only:
  * `apply_metatask` requires `in_progress`, so the design's "Available" chips
- * would 422 on every tap (#1093 removes the dead wiring).
+ * would 422 on every tap (#1093 removed the dead wiring behind them).
  *
  * ## The duel slot
  *
@@ -614,8 +614,12 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
     </section>
   )
 
-  // Read-only (#1093 clears the dead apply wiring): `apply_metatask` requires
-  // `status == in_progress`, so a chip on this page would 422 on every tap.
+  // READ-ONLY, by construction (#1093). `MetaTaskSeal` omits the peel control
+  // and the add slot when it gets neither `removable` nor `onAdd`, and each seal
+  // wears its ISSUING faction's dress (#927/#933). The design's "Available"
+  // chips are deliberately absent: `apply_metatask` (services/praxis.py)
+  // requires `status == in_progress`, so every chip would 422 on tap — and the
+  // composer already agrees, gating `canSealMetatask` on `!controlsLocked`.
   const metatasks = praxis.applied_metatasks.length > 0 && (
     <section style={{ marginBottom: desktop ? 'var(--space-2xl)' : 'var(--space-xl)' }}>
       {sectionHead(t('detail.metatasks.heading'))}

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -673,11 +673,18 @@ export function PraxisVoterBreakdown({ state }: { state: PraxisDetailState }) {
 
 // ── Single earned-points breakdown (#641, ADR-0053) ──────────────────────────
 //
-// The one explicit score readout a detail page shows. The arithmetic is NOT
-// done here: `scoreBreakdown()` is the single resolver for cards and detail
-// alike, so the two surfaces cannot disagree. What lives here is the detail
-// page's own PRESENTATION — the inline `{base} × {mult} + {votes}` form and the
-// per-faction accent/muted/font theming each of the 14 archetypes passes in.
+// LEGACY, AND ON ITS WAY OUT WITH #1089. This is the inline readout the SIX
+// legacy desktop archetypes and the EIGHT mobile ones still render; #1091
+// removed its last non-legacy caller by giving the rebuilt Unaffiliated page the
+// dispatched `ScoreStamp` instead. It cannot be deleted here because every
+// remaining caller is a file #1089 deletes — so it dies with them, along with
+// `detail.score.ptsMultVotes`, rather than being ripped out from under fourteen
+// shipped skins. Do not add a new caller.
+//
+// The arithmetic is NOT done here: `scoreBreakdown()` is the single resolver for
+// cards and detail alike, so the two surfaces cannot disagree. What lives here
+// is the detail page's own PRESENTATION — the inline `{base} × {mult} + {votes}`
+// form and the per-faction accent/muted/font theming each archetype passes in.
 //
 // This used to derive the multiplier as `(score − votePoints) / base`. Against
 // Merit (`base + votes`) that reduced to `base / base` — 1.0 unconditionally —

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -7,7 +7,8 @@
  *
  * Invariant slots owned here:
  *   - Admin moderation bar
- *   - Withdrawn / failed banners (IN EDITING + failed note)
+ *   - Crown hero + failed note (ADR-0062 removed the open-state banners: detail
+ *     is published-only, so there is no IN EDITING / PENDING PUBLISH to draw)
  *   - Owner actions (edit / withdraw / resubmit)
  *   - Flag block
  */
@@ -311,28 +312,11 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
           </div>
         </div>
       )}
-      {/* A collab that has been proposed for publish (submit_proposed_at set)
-          is still in editing, but the neutral "IN EDITING" copy under-reports
-          it — swap in the pending-publish wording (ADR-0012). */}
-      {praxis.status === 'in_progress' && (
-        <div style={{ background: 'rgba(245,158,11,0.1)', border: '2px solid rgba(245,158,11,0.3)', borderRadius: 8, padding: 'var(--space-sm) var(--space-lg)', marginBottom: 'var(--space-md)', display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
-          {praxis.submit_proposed_at != null ? (
-            <>
-              <span className="eyebrow">{t('detail.banners.pendingPublishLabel')}</span>
-              <span className="font-body content-text" style={{ color: 'var(--color-warning)', fontWeight: 700 }}>
-                {t('detail.banners.pendingPublishBody')}
-              </span>
-            </>
-          ) : (
-            <>
-              <span className="eyebrow">{t('detail.banners.inEditingLabel')}</span>
-              <span className="font-body content-text" style={{ color: 'var(--color-warning)', fontWeight: 700 }}>
-                {t('detail.banners.inEditingBody')}
-              </span>
-            </>
-          )}
-        </div>
-      )}
+      {/* The "IN EDITING" / "PENDING PUBLISH" pair used to sit here. Both are
+          gone with ADR-0062: detail redirects `in_progress` AND `pending` to the
+          composer, so neither banner could ever paint again. An open praxis now
+          has one owner — the composer's waiting surface (#1071) — instead of two
+          that described it differently. */}
       {praxis.moderation_status === 'failed' && praxis.admin_note && (
         <div style={{ background: 'rgba(220,38,38,0.05)', border: '2px solid rgba(220,38,38,0.3)', borderRadius: 8, padding: 'var(--space-sm) var(--space-lg)', marginBottom: 'var(--space-md)', display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
           {/* Ornament: a ✗ dingbat used as an icon, not readable text. Sized

--- a/frontend/src/pages/praxisDetail/usePraxisDetail.ts
+++ b/frontend/src/pages/praxisDetail/usePraxisDetail.ts
@@ -16,8 +16,6 @@ import {
   unsubmitPraxis,
   submitPraxis,
   flagPraxis,
-  applyMetatask,
-  removeMetatask,
   kickMember,
   type PraxisOut,
 } from "../../api/praxis";
@@ -29,7 +27,6 @@ import { moderatePraxis } from "../../api/admin";
 import { extractError } from "../../utils/errors";
 import { seedViewerVote, useVoteOverride } from "../../components/vote/voteOverrides";
 import type { CurrentUser } from "../../api/auth";
-import { listTasks, type TaskOut } from "../../api/tasks";
 import { FLAG_REASON_OTHER, type FlagReason } from "../../utils/flagReasons";
 
 export interface PraxisDetailState {
@@ -87,14 +84,15 @@ export interface PraxisDetailState {
   /** Remove another member from the collab (#959) — target is a character id. */
   handleKickMember: (memberId: number) => Promise<void>;
 
-  // Metatasks
-  metatasks: TaskOut[];
-  metataskLoading: boolean;
-  metataskError: string | null;
-  applyingMetataskId: number | null;
-  removingMetataskId: number | null;
-  handleApplyMetatask: (taskId: number) => Promise<void>;
-  handleRemoveMetatask: (taskId: number) => Promise<void>;
+  // Metatasks are READ-ONLY on detail (#1093): the seal stack draws
+  // `praxis.applied_metatasks` and nothing here applies or peels one. The apply
+  // wiring this state used to carry — the metatask catalog fetch plus
+  // apply/remove handlers — is deleted rather than left dormant, because
+  // `apply_metatask` (services/praxis.py) requires `status == in_progress` and
+  // 422s otherwise, so every control it could have fed was already dead.
+  // Letting an owner seal a metatask after publishing reopens scoring on a
+  // praxis that may already hold votes; that is a rule change and needs its own
+  // ADR, not a re-added handler.
 }
 
 /**
@@ -122,11 +120,6 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
   const [votes, setVotes] = useState<VoteSummary | null>(null);
   const [voters, setVoters] = useState<VoterDetail[]>([]);
   const [duel, setDuel] = useState<DuelDetailOut | null>(null);
-  const [metatasks, setMetatasks] = useState<TaskOut[]>([]);
-  const [metataskLoading, setMetataskLoading] = useState(false);
-  const [metataskError, setMetataskError] = useState<string | null>(null);
-  const [applyingMetataskId, setApplyingMetataskId] = useState<number | null>(null);
-  const [removingMetataskId, setRemovingMetataskId] = useState<number | null>(null);
 
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
@@ -196,44 +189,6 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
       cancelled = true;
     };
   }, [praxis?.duel_id]);
-
-  useEffect(() => {
-    if (!praxis) return;
-    setMetataskLoading(true);
-    listTasks({ task_type: "metatask" })
-      .then(setMetatasks)
-      .catch((err) => setMetataskError(extractError(err, t("detail.errors.metataskLoad"))))
-      .finally(() => setMetataskLoading(false));
-  }, [praxis?.id]);
-
-  const handleApplyMetataskFn = async (taskId: number) => {
-    if (!praxis) return;
-    setApplyingMetataskId(taskId);
-    setMetataskError(null);
-    try {
-      const updated = await applyMetatask(praxis.id, taskId);
-      setPraxis(updated);
-    } catch (err) {
-      setMetataskError(extractError(err, t("detail.errors.metataskApply")));
-    } finally {
-      setApplyingMetataskId(null);
-    }
-  };
-
-  const handleRemoveMetataskFn = async (taskId: number) => {
-    if (!praxis) return;
-    setRemovingMetataskId(taskId);
-    setMetataskError(null);
-    try {
-      await removeMetatask(praxis.id, taskId);
-      const updated = await getPraxis(praxis.id);
-      setPraxis(updated);
-    } catch (err) {
-      setMetataskError(extractError(err, t("detail.errors.metataskRemove")));
-    } finally {
-      setRemovingMetataskId(null);
-    }
-  };
 
   const handleWithdraw = async () => {
     if (!praxis) return;
@@ -367,14 +322,6 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
     flagError,
     setFlagError,
     flagSubmitted,
-
-    metatasks,
-    metataskLoading,
-    metataskError,
-    applyingMetataskId,
-    removingMetataskId,
-    handleApplyMetatask: handleApplyMetataskFn,
-    handleRemoveMetatask: handleRemoveMetataskFn,
 
     handleModerate,
     handleWithdraw,


### PR DESCRIPTION
Three issues, one PR — they all land on `pages/praxisDetail/`, `locales/en/praxis.json`
and the shared score plumbing, so they cannot be separated without conflicting.

Closes #1091
Closes #1092
Closes #1093

Part of epic #1085. Carries ADR-0062.

---

## #1091 — mount `ScoreStamp`, drop the invented arithmetic

`DefaultScoreStamp` is rebuilt to the Unaffiliated design's score rail: a struck
96px disc carrying the total over a Courier-Prime `POINTS` caption, an inset
hairline ring inside it, ruled leader-line rows (`LABEL … hairline … value`) for
the working, and the votes tally under a rule of its own — all with a 2px
spectrum bar pinned across the top edge. That skin **is** the Unaffiliated one,
so restyling the default stamp and building the design's rail were one job, and
`ScoreStamp` is size-agnostic so desktop and mobile share it.

**The design's arithmetic is not built.** It computes
`mult = clamp(voteAverage / 3, 0.5, 1.6)` and `total = 12 * mult + 4`, labels the
result "Faction ×1.17", places meta *outside* the multiplier, and prints votes as
a *count* ("4 votes"). The model is `(base + meta) × faction_mult + votes`
(ADR-0014/0047/0053): the multiplier is `own_task_modifier` /
`other_task_modifier` and has nothing to do with how anyone voted, votes are
additive **points** (`points_from_votes`), and meta sits inside the multiplier.
The design's own example under the real model is `(12 + 4) × 1.0 + votes`.

`scoreBreakdown()` remains the single row-selection authority (ADR-0053) and
every rule is its call, not the skin's — mult row only when not 1.0 (dark under
`era_1`, lights up on its own if an era ever configures one), meta row only when
greater than 0, **votes tally always, `+0` included**. Nothing is derived by
subtraction.

Detail's duplicate readout is gone: #1088 drew a strip of rows under the stamp
restating the same terms in a second vocabulary
(`detail.score.{base,multiplier,meta,votes,total}`). One readout now, so card,
composer and detail cannot drift. The now-orphaned row-label keys are deleted
with it.

## #1092 — praxis detail is published-only (ADR-0062)

The dispatcher's redirect widens from `in_progress` to `in_progress || pending`,
and `detail.banners.pendingPublish{Label,Body}` / `inEditing{Label,Body}` are
deleted along with the block that rendered them.

The guard is stated **by intent, not by enum**, per the ADR: drafting,
mid-consensus, or waiting on a rival — all composer. `pending` is collab-**only**;
a duel side that has cast is `submitted` with the duel still `active`, which is
why #999 needs `_duel_side_hidden_condition` rather than a status check. Nothing
here reaches for `pending` to mean "waiting on the other party".

Safe because `praxis_visibility_condition` only exposes a `pending` praxis to its
members, and #1071's waiting surface gives every one of them somewhere to land.

## #1093 — metatasks are read-only on detail

The shipped look is kept exactly as #1088 left it —
`<MetaTaskSeal metatasks={praxis.applied_metatasks} />`, no `removable`, no
`onAdd`, so the peel control and the add slot are omitted by construction and
each seal wears its issuing faction's dress (#927/#933).

The dead wiring behind it is deleted: `usePraxisDetail` carried a metatask
**catalog fetch** (`listTasks({task_type:'metatask'})` fired on every detail
view), `applyMetatask` / `removeMetatask` handlers and five status fields; and
`praxis.json` carried `detail.metatasks.{available,apply,applying,readOnlyNote}`
plus six more orphans (`loading`, `applied`, `appliedPoints`, `remove`,
`removing`, `appliedEmpty`) and three `detail.errors.metatask*` strings. None of
it could work — `apply_metatask` requires `status == in_progress` and 422s
otherwise, and the composer agrees (`canSealMetatask` requires `!controlsLocked`)
— but read together it said "detail can apply metatasks".

**Not in scope, deliberately:** letting an owner seal a metatask after publishing
reopens scoring on a praxis that may already hold votes. That is a rule change
needing a recalc path and its own ADR, not a re-added handler. I do not think it
is wanted here.

---

## Premises that were already true, or stale after #1088

- **#1091 "detail already calls `scoreBreakdown()`" — true, and further along
  than the issue reads.** #1088's rebuilt page already fed the stamp real values
  and already refused the design's arithmetic. The live gap was that it drew the
  rows *twice*: once inside `ScoreStamp` and again as its own strip.
- **#1091 "delete `ScoreLine` and friends around `shared.tsx:578-663`" —
  BLOCKED, and left in place on purpose.** The component is
  `PraxisScoreBreakdown` / `praxisBreakdownParts`, and it has **fourteen** live
  callers: the six legacy desktop archetypes and all eight mobile ones. #1088's
  rebuilt Default page never used it. Deleting it now (and
  `detail.score.ptsMultVotes` with it) would rip the score readout out of
  fourteen shipped skins that #1089 is about to delete anyway. It is marked
  LEGACY with a "do not add a new caller" note and an explicit hand-off to
  #1089. The drift the issue names is already prevented: `praxisBreakdownParts`
  delegates to `scoreBreakdown()` and derives nothing.
- **#1092 "`shared.tsx:278` renders the banner" — stale line number, live
  block.** It had moved to ~317 after #1088 and #1094. Found by reading, not by
  line.
- **#1093 "`DefaultPraxisDetail:289` already does exactly this" — true, at line
  619 after the rebuild.** This issue was a keep plus a cleanup, as written.
- **#1093's key list was incomplete.** The issue names four orphan keys; there
  are ten in `detail.metatasks` plus three in `detail.errors`. All the orphans
  are deleted — leaving `remove` / `removing` / `applied` behind would have kept
  saying the same wrong thing.

## Scope kept out

- The six legacy faction archetypes, their `detail.<faction>.*` blocks, and the
  3-line `archetypeOwnsComments` shim in `PraxisDetail.tsx` — all #1089.
- `DuelCrossLink` and the duel rails — #1090.
- `frontend/src/pages/editPraxis/` and `backend/` — untouched.

## One deliberate deviation from the design, flagged for `frontend-style`

The design arranges the rail in **two columns** — disc left, ruled rows right —
inside a 340px aside. The stamp cannot take that width, because the *same*
component renders in a desktop praxis card's gutter: at the ~232px the
side-by-side needs, it leaves ~102px for the card's title column (the card is
`flex: 1 1 394px`). There is no container query available and the card's stamp
slot is shared by all nine faction skins, so the stamp self-constrains to one
width (150px) and the same pieces stack in one column. Every element of the
design's markup is present — spectrum bar, struck disc at −7°, inset hairline
ring, 31px-tier total, letterspaced Courier caption, ruled leader lines, tally
under its own rule — only the arrangement collapses. If the aside should get the
two-column version, that is a styling call for `frontend-style`, not something I
should decide by widening the stamp surface's props.

Ratchet notes: the design's 96 / 31 / 10 / `.16em` figures land on tokens or on
§4a ornament geometry — the 96px disc and 5px ring inset are `width` / `height` /
`inset` (geometry, explicitly out of the rule); 31px maps to `--text-heading`;
10px to `--text-base`; `.16em` is letter-spacing, not a length on the spacing
scale. No hex anywhere (the suite's `HEX` guard covers the stamp), and the
spectrum comes from `var(--faction-default-rainbow)`, not a pasted gradient.

## Verification

- `tsc --noEmit` — clean
- `eslint src` — clean (includes the `no-raw-style-values` ratchet on the rebuilt
  stamp, which is a de-grandfathered file)
- `vitest run` — 1940 passed / 123 files
- `vite build` — clean; entry chunk 139.64 kB gzip (unchanged from `main`)

New tests: five cases pinning the rebuilt stamp's row selection and geometry
(`scoreStamp.test.tsx`), a `+0` votes-tally case on the detail page, and the
`collabSubmitIndicators` banner assertions inverted to guard ADR-0062.

**Visual QA is outstanding.** There is no dev stack here and the Browser pane
renderer times out, so nothing below has been looked at.

## What to eyeball

Both form factors, light and dark:

1. **A praxis with metatasks and votes** — the stamp should read `base` / `meta` /
   `+ N from votes` with the total in the disc, and **no** multiplier row
   (`era_1` neutralises every faction to 1.0).
2. **A praxis with zero votes** — the `+ 0 from votes` tally must still be there,
   under its rule. An absent row cannot say "nobody has voted yet".
3. **A `pending` collab** (you have cast, a co-author has not) — opening it must
   land you in the composer's waiting surface, not on detail. Then the holdout's
   view: the ordinary composer. No `PENDING PUBLISH` or `IN EDITING` copy left
   anywhere.
4. **The metatask seal stack** — seals only, no add slot, no peel control, each
   seal in its issuing faction's dress.
5. **The `na` / albescent praxis CARD**, since the stamp is shared: the card's
   score gutter is now the struck disc rather than the old sheet, and it is 34px
   wider (150 vs 116). Worth checking the title column still breathes at the
   narrow end of the card grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
