### PR TITLE
Nudge a collaborator or duel rival — feed-delivered, rate-limited, and actually sent (#1083)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -203,6 +203,18 @@ A member removing **their own** `PraxisMember` from a collab. Distinct from **ki
 scoring). Three different removals — keep them named apart.
 _Avoid_: "withdraw" for a member leaving (withdraw is praxis-level, not member-level).
 
+**Nudge** *(`Nudge`; tablename `nudge`)*:
+One player reminding the player a shared praxis is still waiting on. Delivered as an
+**activity-feed item**, never a message — the `Message` model has no player-facing reader
+(admin moderation only), so a nudge posted there arrives nowhere. Stored as its own row
+(`from_character_id`, `to_character_id`, `praxis_id`, `created_at`), and `praxis_id` is
+always **the praxis the recipient owes**: the shared collab, or the *rival's* side of a duel
+— never the sender's. Who may send it: a collab member **who has cast**, or a duel
+participant **while the duel is `active`**. Rate-limited to **one per sender → recipient →
+praxis per 24h**; that limit is a safety control, not a nicety.
+_Avoid_: "poke"/"ping"/"reminder" as the domain term, and "notification" — there is no
+notifications inbox and a nudge does not create one.
+
 **Editing mode**:
 A submitted praxis taken back into editing by its creator. Its votes are **preserved but do
 not count** toward score while in editing mode; resubmitting returns it to `submitted` and

--- a/backend/alembic/versions/0009_nudge_table.py
+++ b/backend/alembic/versions/0009_nudge_table.py
@@ -1,0 +1,73 @@
+"""Add the `nudge` table (#1083).
+
+One row per poke: sender, recipient, the praxis the recipient owes, and when.
+See ``models/nudge.py`` for why this is its own table rather than a `kind` enum
+on ``Message`` — the short version is that a new enum value would have to be
+added to ``0001_squashed``'s ``ENUMS`` list as well as the model, for the same
+one migration, and it would weld a system poke to a future DM inbox.
+
+``0001_squashed`` builds a *fresh* DB with ``Base.metadata.create_all``, so CI
+and a local reset already land on this shape the moment the model exists. A
+deployed DB is stamped further down the chain and never re-runs the baseline —
+hence this revision. Idempotent on both: ``IF NOT EXISTS`` throughout, and the
+FK constraints are created inside DO blocks because Postgres has no
+``ADD CONSTRAINT IF NOT EXISTS`` (the 0008 pattern).
+
+No enum, no backfill: the table starts empty everywhere.
+
+Revision ID: 0009_nudge_table
+Revises: 0008_duel_resolved_era
+Create Date: 2026-07-28
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0009_nudge_table"
+down_revision: Union[str, None] = "0008_duel_resolved_era"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS nudge (
+            id SERIAL PRIMARY KEY,
+            from_character_id INTEGER NOT NULL,
+            to_character_id INTEGER NOT NULL,
+            praxis_id INTEGER NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    for constraint, column, target in (
+        ("nudge_from_character_id_fkey", "from_character_id", "character (id)"),
+        ("nudge_to_character_id_fkey", "to_character_id", "character (id)"),
+        ("nudge_praxis_id_fkey", "praxis_id", "praxis (id)"),
+    ):
+        op.execute(
+            f"""
+            DO $$ BEGIN
+                ALTER TABLE nudge
+                    ADD CONSTRAINT {constraint}
+                    FOREIGN KEY ({column}) REFERENCES {target};
+            EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+            """
+        )
+
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_nudge_sender_recipient_praxis"
+        " ON nudge (from_character_id, to_character_id, praxis_id, created_at)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_nudge_recipient_created"
+        " ON nudge (to_character_id, created_at)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_nudge_recipient_created")
+    op.execute("DROP INDEX IF EXISTS ix_nudge_sender_recipient_praxis")
+    op.execute("DROP TABLE IF EXISTS nudge")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -28,6 +28,7 @@ from models.contact import ContactMessage
 from models.taunt_message import TauntMessage
 from models.faction_defection_history import FactionDefectionHistory
 from models.invitation_letter import InvitationLetter
+from models.nudge import Nudge
 
 __all__ = [
     "Faction",
@@ -63,4 +64,5 @@ __all__ = [
     "TauntMessage",
     "FactionDefectionHistory",
     "InvitationLetter",
+    "Nudge",
 ]

--- a/backend/models/nudge.py
+++ b/backend/models/nudge.py
@@ -1,0 +1,64 @@
+"""One player poking another to file the part a shared praxis is waiting on (#1083).
+
+A small purpose-built table, deliberately **not** a `kind` enum + `praxis_id` on
+``Message``. ``Message`` is the seed of a future player-to-player inbox; welding
+a system poke to it would (a) make every future DM feature carry a nudge branch,
+and (b) cost a new enum value in ``0001_squashed``'s ``ENUMS`` list on top of the
+model edit. The repo already prefers a narrow table per fact — ``taunt_message``,
+``invitation_letter``, ``faction_defection_history`` — and this is one row of
+four columns.
+
+Nothing renders from this table directly. Delivery is the **activity feed**
+(ADR-0036 registry entry ``nudge``), because that is where this game already
+puts "someone did a thing involving you", and it lands beside the
+``awaiting_submission`` row the recipient already has. The ``Message`` routes
+have no player-facing reader at all — only the admin moderation tab — so a nudge
+sent as a message would arrive nowhere.
+
+``praxis_id`` is always **the praxis the RECIPIENT owes a submission on**, never
+the sender's. For a collab those are the same row; for a duel they are the two
+linked sides (ADR-0011) and the recipient's is the one their feed card can link
+to — the sender's side is hidden from them while the duel is live and incomplete
+(``_duel_side_hidden_condition``, #999).
+
+The (from, to, praxis) triple plus ``created_at`` is also the rate-limit key: one
+nudge per sender → recipient → praxis per 24h. That limit is a safety control,
+not a nicety — an unlimited poke button aimed at a named player is a harassment
+vector — so the index below exists to keep the check cheap enough that it is
+never tempting to skip.
+"""
+
+from sqlalchemy import ForeignKey, Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+from models.mixins import CreatedAtMixin
+
+
+class Nudge(CreatedAtMixin, Base):
+    __tablename__ = "nudge"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    from_character_id: Mapped[int] = mapped_column(
+        ForeignKey("character.id"), nullable=False
+    )
+    to_character_id: Mapped[int] = mapped_column(
+        ForeignKey("character.id"), nullable=False
+    )
+    # The praxis the recipient still owes — see the module docstring.
+    praxis_id: Mapped[int] = mapped_column(ForeignKey("praxis.id"), nullable=False)
+
+    __table_args__ = (
+        # Serves both readers: the rate-limit probe (exact triple + recent
+        # created_at) and the roster's `nudged_at` lookup (viewer → every member
+        # of one praxis).
+        Index(
+            "ix_nudge_sender_recipient_praxis",
+            "from_character_id",
+            "to_character_id",
+            "praxis_id",
+            "created_at",
+        ),
+        # The feed source reads the recipient's inbox side, newest first.
+        Index("ix_nudge_recipient_created", "to_character_id", "created_at"),
+    )

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -39,6 +39,7 @@ class InviteResponse(BaseModel):
 
 class MetataskApply(BaseModel):
     task_id: int
+from schemas.nudge import NudgeOut
 from schemas.vote import VoteOut
 from services.praxis import (
     _build_invite_out,
@@ -70,6 +71,7 @@ from services.praxis import (
     unsubmit_praxis,
 )
 from services.media import process_and_save_media
+from services.nudge import send_nudge
 from services.vote import cast_vote_on_praxis, viewer_can_vote_map
 from services.vote_tally import crowned_praxis_ids, viewer_votes_for
 
@@ -431,6 +433,32 @@ async def cancel_invite_route(
         session=session,
     )
     return Response(status_code=204)
+
+
+@router.post("/{praxis_id}/nudge/{character_id}", response_model=NudgeOut)
+async def nudge_route(
+    praxis_id: int,
+    character_id: int,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+):
+    """Poke the player this praxis is still waiting on (#1083).
+
+    ``praxis_id`` is the praxis the RECIPIENT owes — the shared collab, or the
+    rival's own side of the duel (ADR-0011), never the sender's. That is what
+    the recipient's feed card links to, and what the rate limit is keyed on.
+
+    Every rule (member-who-has-cast for a collab, participant-of-an-active-duel
+    for a duel, one per 24h) lives in ``services.nudge``; this handler is thin on
+    purpose so a second caller cannot acquire a second set of them.
+    """
+    nudge = await send_nudge(
+        praxis_id=praxis_id,
+        from_character_id=character.id,
+        to_character_id=character_id,
+        session=session,
+    )
+    return NudgeOut.model_validate(nudge)
 
 
 @router.post("/{praxis_id}/kick/{member_id}", response_model=PraxisOut)

--- a/backend/schemas/activity_feed.py
+++ b/backend/schemas/activity_feed.py
@@ -17,6 +17,7 @@ class ActivityFeedItem(BaseModel):
     - collab_invite: someone invited you to collaborate
     - duel_challenge: someone challenged you to a duel
     - friend_signup: a friend signed up for a task you're doing
+    - nudge: a collaborator or duel rival poked you to file your part
     """
 
     type: str

--- a/backend/schemas/duel.py
+++ b/backend/schemas/duel.py
@@ -43,6 +43,10 @@ class DuelSideOut(BaseModel):
     avatar_url: str
     points_from_votes: int
     is_submitted: bool
+    # When the VIEWER last nudged this side's character about this side's praxis
+    # (#1083), NULL once the 24h window lapses — the duel twin of
+    # `PraxisMemberOut.nudged_at`, and the same server-owned disabled state.
+    nudged_at: Optional[datetime] = None
 
 
 class DuelDetailOut(BaseModel):

--- a/backend/schemas/nudge.py
+++ b/backend/schemas/nudge.py
@@ -1,0 +1,22 @@
+"""Schemas for nudges (#1083)."""
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class NudgeOut(BaseModel):
+    """Confirmation that one nudge was recorded.
+
+    The caller does not render this: the roster row's disabled state comes from
+    ``PraxisMemberOut.nudged_at`` / ``DuelSideOut.nudged_at`` on the next read,
+    so the button survives a reload. This exists so the POST has an honest body
+    and so a client can show the sent-at time without a second round trip.
+    """
+
+    id: int
+    praxis_id: int
+    from_character_id: int
+    to_character_id: int
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -23,6 +23,13 @@ class PraxisMemberOut(BaseModel):
     character_display_name: str  # populated by build_praxis_out
     has_submitted: bool
     joined_at: datetime
+    # When the VIEWER last nudged this member about this praxis (#1083), and
+    # NULL once that 24h window lapses — so "there is a timestamp here" and "you
+    # may not nudge again yet" are one fact, resolved server-side by
+    # `services.nudge.NUDGE_COOLDOWN`. The roster button reads its disabled
+    # state from this rather than from local React state, which is what made the
+    # design's version dishonest: a reload un-nudged it.
+    nudged_at: Optional[datetime] = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -27,6 +27,7 @@ from models.comment import Comment, CommentMention
 from models.era import Era
 from models.faction_defection_history import FactionDefectionHistory
 from models.invitation_letter import InvitationLetter
+from models.nudge import Nudge
 from models.relationship import Relationship, RelationshipStatus, RelationshipType
 from models.duel import Duel, DuelStatus
 from models.praxis import ModerationStatus, Praxis, PraxisInvite, PraxisInviteStatus, PraxisMember, PraxisStatus, PraxisType
@@ -81,6 +82,7 @@ FEED_ITEM_TYPE_FOE_COMPLETION = "foe_completion"
 FEED_ITEM_TYPE_COMMENT_MENTION = "comment_mention"
 FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED = "collaborator_submitted"
 FEED_ITEM_TYPE_AWAITING_SUBMISSION = "awaiting_submission"
+FEED_ITEM_TYPE_NUDGE = "nudge"
 
 # --- Filter tabs ------------------------------------------------------------
 FILTER_ALL = "all"
@@ -745,6 +747,68 @@ def _awaiting_submission_item(row: Any) -> ActivityFeedItemDC:
     )
 
 
+def _nudge_query(ctx: FeedContext) -> Select:
+    """Nudges the viewer has RECEIVED (#1083).
+
+    The nudge's whole delivery mechanism. It is not a message: the ``Message``
+    model has no player-facing reader, only the admin moderation tab, so a nudge
+    posted there would arrive nowhere. The feed is where this game already puts
+    "someone did a thing involving you", and this row lands beside the
+    ``awaiting_submission`` row the recipient already has for the same praxis.
+
+    ``Nudge.praxis_id`` is always the praxis the RECIPIENT owes, so the join to
+    ``Praxis``/``Task`` gives the card a title and a link the recipient can
+    actually open — their own editor.
+    """
+    sender = aliased(Character)
+    query = (
+        select(
+            Nudge.id,
+            Nudge.created_at,
+            Nudge.praxis_id,
+            Nudge.from_character_id,
+            Praxis.type.label("praxis_type"),
+            Task.title.label("task_title"),
+            Task.point_value.label("task_point_value"),
+            Task.primary_faction_slug.label("task_faction_slug"),
+            sender.display_name.label("from_display_name"),
+            sender.faction_slug.label("from_faction_slug"),
+            sender.avatar_url.label("from_avatar_url"),
+        )
+        .join(Praxis, Nudge.praxis_id == Praxis.id)
+        .join(Task, Praxis.task_id == Task.id)
+        .join(sender, Nudge.from_character_id == sender.id)
+        .where(Nudge.to_character_id == ctx.character_id)
+    )
+    if ctx.before is not None:
+        query = query.where(Nudge.created_at < ctx.before)
+    return query.order_by(Nudge.created_at.desc()).limit(SUB_QUERY_LIMIT)
+
+
+def _nudge_item(row: Any) -> ActivityFeedItemDC:
+    return ActivityFeedItemDC(
+        type=FEED_ITEM_TYPE_NUDGE,
+        timestamp=row.created_at,
+        actor_display_name=row.from_display_name,
+        actor_faction_slug=row.from_faction_slug,
+        actor_avatar_url=row.from_avatar_url,
+        payload={
+            "nudge_id": row.id,
+            "praxis_id": row.praxis_id,
+            # A duel side is `type='solo'` + a Duel row (ADR-0011), so this
+            # reads 'solo' for a duel and the card badges off it the same way
+            # `awaiting_submission` does — deliberately not re-deriving the duel
+            # here, where the row it sits beside is the one that carries it.
+            "praxis_type": row.praxis_type.value,
+            "from_character_id": row.from_character_id,
+            "from_name": row.from_display_name,
+            "task_title": row.task_title,
+            "task_point_value": row.task_point_value,
+            "task_faction_slug": row.task_faction_slug,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # The registry — one entry per feed type. Adding a type is one line here.
 # ---------------------------------------------------------------------------
@@ -822,6 +886,19 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_awaiting_submission_query,
         to_item=_awaiting_submission_item,
+    ),
+    FeedSource(
+        # A nudge received (#1083). ALL + YOUR_STUFF, deliberately NOT REQUESTS:
+        # the obligation it refers to is already a `requests` row
+        # (`awaiting_submission`) for the same praxis, so counting the poke there
+        # too would badge one outstanding action twice — and a bell that
+        # increments because someone pressed a button at you is the wrong shape
+        # for a tab whose other members all want a decision.
+        item_type=FEED_ITEM_TYPE_NUDGE,
+        filters=frozenset({FILTER_ALL, FILTER_YOUR_STUFF}),
+        needs=frozenset(),
+        query=_nudge_query,
+        to_item=_nudge_item,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_INVITATION_LETTER,

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -28,6 +28,7 @@ from models.praxis import (
 from models.task import Task
 from schemas.duel import DuelDetailOut, DuelOut, DuelSideOut
 from services.character_stats import recalculate_character_stats
+from services.nudge import latest_nudge_at
 from services.vote_tally import get_tally, tally_votes
 from services.era import get_current_era_row, get_or_create_stats
 from services.praxis import (
@@ -104,7 +105,27 @@ async def get_duel_detail(
     ]
     tallies = await tally_votes(praxis_ids, session)
 
-    def _side(character: Optional[Character], praxis: Optional[Praxis], praxis_id: Optional[int]) -> DuelSideOut:
+    # Viewer-relative nudge state (#1083), keyed per side because the rate limit
+    # is (sender, recipient, praxis) and each side is its own praxis. Two point
+    # lookups rather than a map: a duel has exactly two rows.
+    async def _nudged_at(
+        character: Optional[Character], praxis_id: Optional[int]
+    ) -> Optional[datetime]:
+        if viewer is None or character is None or praxis_id is None:
+            return None
+        return await latest_nudge_at(praxis_id, viewer.id, character.id, session)
+
+    challenger_nudged_at = await _nudged_at(
+        challenger_character, duel.challenger_praxis_id
+    )
+    opponent_nudged_at = await _nudged_at(opponent_character, duel.opponent_praxis_id)
+
+    def _side(
+        character: Optional[Character],
+        praxis: Optional[Praxis],
+        praxis_id: Optional[int],
+        nudged_at: Optional[datetime] = None,
+    ) -> DuelSideOut:
         return DuelSideOut(
             praxis_id=praxis_id,
             character_id=character.id if character is not None else 0,
@@ -115,6 +136,7 @@ async def get_duel_detail(
                 get_tally(tallies, praxis_id).points_from_votes if praxis_id is not None else 0
             ),
             is_submitted=praxis is not None and praxis.status == PraxisStatus.submitted,
+            nudged_at=nudged_at,
         )
 
     participant_account_ids = {
@@ -131,8 +153,18 @@ async def get_duel_detail(
         task_id=duel.task_id,
         status=duel.status,
         forfeited_by_character_id=duel.forfeited_by_character_id,
-        challenger=_side(challenger_character, challenger_praxis, duel.challenger_praxis_id),
-        opponent=_side(opponent_character, opponent_praxis, duel.opponent_praxis_id),
+        challenger=_side(
+            challenger_character,
+            challenger_praxis,
+            duel.challenger_praxis_id,
+            challenger_nudged_at,
+        ),
+        opponent=_side(
+            opponent_character,
+            opponent_praxis,
+            duel.opponent_praxis_id,
+            opponent_nudged_at,
+        ),
         viewer_is_participant=viewer_is_participant,
         winner_character_id=duel.winner_character_id,
         challenger_final_points=duel.challenger_final_points,

--- a/backend/services/nudge.py
+++ b/backend/services/nudge.py
@@ -1,0 +1,264 @@
+"""Nudging a collaborator or a duel rival who has not filed yet (#1083).
+
+The whole feature is three rules, and they are the reason this is a service and
+not four lines in a route:
+
+1. **Collab — you must have cast.** Any member who has already filed their own
+   part may nudge a member who has not. You do not get to hurry people you have
+   not caught up with, and the public does not get to hurry anyone.
+2. **Duel — participant only, and only while the duel is ``active``.** See
+   :func:`_authorize_duel` for why ``pending`` is excluded even though it is
+   also a live-incomplete status.
+3. **One nudge per sender → recipient → praxis per 24h**, 422 on a repeat.
+
+Rule 3 is a safety control, not a nicety. A button that pokes a *named* player
+on demand is a harassment vector the moment it is unlimited, so the window is
+enforced here, on the write path, rather than by hiding the button — a disabled
+button is a UI preference and this is a rule.
+
+Delivery is the activity feed, never a message: see ``models/nudge.py``.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.duel import Duel, DuelStatus
+from models.nudge import Nudge
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+
+# One per sender → recipient → praxis per 24h (#1083). Expressed as a window
+# rather than a stored "next allowed at" so the rule is re-readable from the
+# rows alone: `created_at > now() - NUDGE_COOLDOWN`.
+NUDGE_COOLDOWN = timedelta(days=1)
+
+# A praxis that is still waiting on someone. `pending` is a collab mid-consensus
+# (ADR-0012) — the window is open and a member can still be the holdout — so it
+# counts as unfinished exactly the way `_awaiting_submission_query` treats it.
+_OPEN_PRAXIS_STATUSES = (PraxisStatus.in_progress, PraxisStatus.pending)
+
+
+async def _load_praxis_with_members(praxis_id: int, session: AsyncSession) -> Praxis:
+    """The target praxis and its member rows, or 404."""
+    result = await session.execute(
+        select(Praxis).where(Praxis.id == praxis_id)
+    )
+    praxis = result.scalar_one_or_none()
+    if praxis is None:
+        raise HTTPException(status_code=404, detail="Praxis not found.")
+    return praxis
+
+
+async def _member(
+    praxis_id: int, character_id: int, session: AsyncSession
+) -> Optional[PraxisMember]:
+    result = await session.execute(
+        select(PraxisMember).where(
+            PraxisMember.praxis_id == praxis_id,
+            PraxisMember.character_id == character_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def _authorize_collab(
+    praxis: Praxis, from_character_id: int, session: AsyncSession
+) -> None:
+    """Rule 1: the sender must be a member of this collab AND have cast."""
+    sender = await _member(praxis.id, from_character_id, session)
+    if sender is None:
+        raise HTTPException(
+            status_code=403,
+            detail="Only a member of this collaboration can nudge.",
+        )
+    if not sender.has_submitted:
+        raise HTTPException(
+            status_code=403,
+            detail="File your own part before nudging anyone else.",
+        )
+
+
+async def _authorize_duel(
+    praxis: Praxis, from_character_id: int, session: AsyncSession
+) -> None:
+    """Rule 2: the sender must be the other side of an ``active`` duel.
+
+    ``pending`` is the other live-incomplete duel status
+    (``_LIVE_INCOMPLETE_DUEL_STATUSES`` in ``services/praxis.py``) and is
+    deliberately **excluded**, on two grounds:
+
+    - At ``pending`` there is no opponent praxis at all — ``opponent_praxis_id``
+      is NULL until the challenge is accepted — so there is no praxis for the
+      recipient to owe, and this whole feature is keyed to one.
+    - What is outstanding at ``pending`` is a *decision*, not a submission, and
+      it already sits in the rival's ``requests`` tab as a ``duel_challenge``
+      feed item with accept/decline on it. A poke there would be pressure on a
+      choice rather than a reminder about a task.
+
+    The issue names only ``active``; this is why that is the right reading and
+    not an omission.
+    """
+    result = await session.execute(
+        select(Duel).where(
+            (Duel.challenger_praxis_id == praxis.id)
+            | (Duel.opponent_praxis_id == praxis.id)
+        )
+    )
+    duel = result.scalar_one_or_none()
+    if duel is None:
+        raise HTTPException(
+            status_code=403,
+            detail="This praxis is not part of a duel.",
+        )
+    if duel.status != DuelStatus.active:
+        raise HTTPException(
+            status_code=422,
+            detail="Only an active duel can be nudged.",
+        )
+
+    # The *other* side. A duel is two linked solo praxes (ADR-0011), so the
+    # sender is a participant exactly when they authored the side that is not
+    # the target — which also rules out nudging yourself through the duel path.
+    other_praxis_id = (
+        duel.opponent_praxis_id
+        if duel.challenger_praxis_id == praxis.id
+        else duel.challenger_praxis_id
+    )
+    sender_side = (
+        await session.get(Praxis, other_praxis_id)
+        if other_praxis_id is not None
+        else None
+    )
+    if sender_side is None or sender_side.created_by_id != from_character_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Only the rival in this duel can nudge.",
+        )
+
+
+async def latest_nudge_at(
+    praxis_id: int,
+    from_character_id: int,
+    to_character_id: int,
+    session: AsyncSession,
+    *,
+    now: Optional[datetime] = None,
+) -> Optional[datetime]:
+    """When ``from`` last nudged ``to`` about ``praxis`` — **within the window**.
+
+    Returns None once the cooldown has lapsed, which is the whole point: this is
+    the value the roster row reads its disabled state from, so "there is a
+    timestamp" and "you may not nudge again yet" are the same fact, resolved by
+    the same constant, on the server. A raw last-nudged-ever timestamp would put
+    the 24h arithmetic on the client where it can drift from :data:`NUDGE_COOLDOWN`.
+    """
+    cutoff = (now or datetime.now(timezone.utc)) - NUDGE_COOLDOWN
+    result = await session.execute(
+        select(Nudge.created_at)
+        .where(
+            Nudge.praxis_id == praxis_id,
+            Nudge.from_character_id == from_character_id,
+            Nudge.to_character_id == to_character_id,
+            Nudge.created_at > cutoff,
+        )
+        .order_by(Nudge.created_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def nudged_at_map(
+    praxis_id: int,
+    from_character_id: int,
+    session: AsyncSession,
+    *,
+    now: Optional[datetime] = None,
+) -> dict[int, datetime]:
+    """``{recipient_character_id: nudged_at}`` for one viewer on one praxis.
+
+    The roster is a list, so the per-row lookup is done once as a map rather
+    than N times. Same window as :func:`latest_nudge_at`.
+    """
+    cutoff = (now or datetime.now(timezone.utc)) - NUDGE_COOLDOWN
+    result = await session.execute(
+        select(Nudge.to_character_id, Nudge.created_at)
+        .where(
+            Nudge.praxis_id == praxis_id,
+            Nudge.from_character_id == from_character_id,
+            Nudge.created_at > cutoff,
+        )
+        .order_by(Nudge.created_at.desc())
+    )
+    latest: dict[int, datetime] = {}
+    for to_character_id, created_at in result.all():
+        latest.setdefault(to_character_id, created_at)
+    return latest
+
+
+async def send_nudge(
+    praxis_id: int,
+    from_character_id: int,
+    to_character_id: int,
+    session: AsyncSession,
+) -> Nudge:
+    """Record one nudge, or raise.
+
+    ``praxis_id`` is the praxis the **recipient** owes — the shared collab for a
+    collab, the rival's own side for a duel. That is what the recipient's feed
+    card links to and what the rate limit is keyed on.
+    """
+    if from_character_id == to_character_id:
+        raise HTTPException(status_code=400, detail="You cannot nudge yourself.")
+
+    praxis = await _load_praxis_with_members(praxis_id, session)
+
+    if praxis.status not in _OPEN_PRAXIS_STATUSES:
+        raise HTTPException(
+            status_code=422,
+            detail="Nothing is outstanding on this praxis.",
+        )
+
+    # The recipient must actually owe something here. Checking the member row
+    # rather than the praxis status covers both shapes at once: a collab member
+    # who has cast while the group waits on others, and a duel side that has
+    # already been filed.
+    recipient = await _member(praxis_id, to_character_id, session)
+    if recipient is None:
+        raise HTTPException(
+            status_code=403,
+            detail="That player is not part of this praxis.",
+        )
+    if recipient.has_submitted:
+        raise HTTPException(
+            status_code=422,
+            detail="That player has already filed their part.",
+        )
+
+    if praxis.type == PraxisType.collab:
+        await _authorize_collab(praxis, from_character_id, session)
+    else:
+        # A duel side is `type='solo'` + a Duel row (ADR-0011) — never
+        # `type='duel'` — so anything that is not a collab is routed here and
+        # `_authorize_duel` 403s a genuinely solo praxis by finding no duel.
+        await _authorize_duel(praxis, from_character_id, session)
+
+    if await latest_nudge_at(
+        praxis_id, from_character_id, to_character_id, session
+    ) is not None:
+        raise HTTPException(
+            status_code=422,
+            detail="You already nudged this player about this praxis today.",
+        )
+
+    nudge = Nudge(
+        from_character_id=from_character_id,
+        to_character_id=to_character_id,
+        praxis_id=praxis_id,
+    )
+    session.add(nudge)
+    await session.flush()
+    await session.refresh(nudge)
+    return nudge

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -47,6 +47,7 @@ from services.praxis_scoring import Contribution, compute_contributions
 from services.faction_service import faction_permits
 from services.meta_task import metatask_cap_for_level
 from services.era import get_current_era_row, get_or_create_stats
+from services.nudge import nudged_at_map
 from services.level_jump import available_level_reach, consume_level_jump
 from models.duel import Duel, DuelStatus
 from services.vote_tally import crowned_praxis_ids, get_tally, tally_votes, ViewerVote
@@ -82,7 +83,17 @@ def _require_member(praxis: Praxis, character_id: int, action: str) -> None:
         raise HTTPException(status_code=403, detail=f"Only a member can {action} this praxis.")
 
 
-def _build_member_out(member: PraxisMember) -> PraxisMemberOut:
+def _build_member_out(
+    member: PraxisMember,
+    nudged_at: Optional[datetime] = None,
+) -> PraxisMemberOut:
+    """One roster row.
+
+    ``nudged_at`` is viewer-relative and only the single-praxis
+    :func:`build_praxis_out` supplies it — a card in a list has no nudge button,
+    and threading the lookup through every list route would buy an N+1 for a
+    field nothing there reads.
+    """
     return PraxisMemberOut(
         id=member.id,
         praxis_id=member.praxis_id,
@@ -90,6 +101,7 @@ def _build_member_out(member: PraxisMember) -> PraxisMemberOut:
         character_display_name=member.character.display_name,
         has_submitted=member.has_submitted,
         joined_at=member.joined_at,
+        nudged_at=nudged_at,
     )
 
 
@@ -171,7 +183,16 @@ async def build_praxis_out(
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
 
-    members = [_build_member_out(m) for m in praxis.members]
+    # Viewer-relative nudge state (#1083): when the viewer last poked each member
+    # about THIS praxis, within the rate-limit window. One map, not one query per
+    # row; empty for an anonymous reader, who can never nudge anyway.
+    nudged_at_by_character = (
+        await nudged_at_map(praxis.id, viewer.id, session) if viewer is not None else {}
+    )
+    members = [
+        _build_member_out(m, nudged_at_by_character.get(m.character_id))
+        for m in praxis.members
+    ]
 
     # Invites only visible to members
     effective_viewer_id = viewer.id if viewer is not None else None

--- a/backend/tests/integration/test_nudge.py
+++ b/backend/tests/integration/test_nudge.py
@@ -1,0 +1,613 @@
+"""Nudging a collaborator or duel rival (#1083).
+
+The three rules are the feature, so they are what this file pins:
+
+1. **Collab** — a member who has cast may nudge a member who has not. A member
+   who has not cast may not, and a non-member may not at all.
+2. **Duel** — a participant may nudge the rival while the duel is ``active``,
+   and nobody else may. ``pending`` and ``settled`` are both refused.
+3. **Rate limit** — one per sender → recipient → praxis per 24h, 422 on a
+   repeat, and the button's disabled state (``nudged_at``) comes back from the
+   server so a reload cannot un-nudge it.
+
+Plus the delivery check the issue leads with: the nudge lands in the
+RECIPIENT's activity feed, not in a message nobody reads.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.duel import Duel, DuelStatus
+from models.nudge import Nudge
+from models.praxis import (
+    ModerationStatus,
+    Praxis,
+    PraxisMember,
+    PraxisStatus,
+    PraxisType,
+)
+from models.task import Task
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _set_cast(
+    session: AsyncSession, praxis_id: int, character_id: int, cast: bool
+) -> None:
+    """Mark one member's part filed / not filed."""
+    await session.execute(
+        update(PraxisMember)
+        .where(
+            PraxisMember.praxis_id == praxis_id,
+            PraxisMember.character_id == character_id,
+        )
+        .values(
+            has_submitted=cast,
+            submitted_at=datetime.now(timezone.utc) if cast else None,
+        )
+    )
+    await session.commit()
+
+
+async def _backdate_nudges(session: AsyncSession, delta: timedelta) -> None:
+    """Age every stored nudge, so the 24h window can be crossed without sleeping."""
+    result = await session.execute(select(Nudge))
+    for nudge in result.scalars().all():
+        nudge.created_at = datetime.now(timezone.utc) - delta
+    await session.commit()
+
+
+async def _make_duel(
+    session: AsyncSession,
+    task: Task,
+    challenger: Character,
+    opponent: Character,
+    status: DuelStatus,
+    *,
+    opponent_submitted: bool = False,
+    challenger_submitted: bool = True,
+) -> tuple[Duel, Praxis, Praxis]:
+    """Two linked solo praxes + the Duel row (ADR-0011).
+
+    Built directly rather than through the challenge/accept routes: what is under
+    test is the nudge gate at each duel status, not how a duel gets there.
+    """
+
+    def _side(character: Character, submitted: bool) -> Praxis:
+        return Praxis(
+            task_id=task.id,
+            created_by_id=character.id,
+            type=PraxisType.solo,
+            status=PraxisStatus.submitted if submitted else PraxisStatus.in_progress,
+            moderation_status=ModerationStatus.visible,
+            title="side",
+            body_text="proof",
+        )
+
+    challenger_praxis = _side(challenger, challenger_submitted)
+    opponent_praxis = _side(opponent, opponent_submitted)
+    session.add_all([challenger_praxis, opponent_praxis])
+    await session.flush()
+
+    session.add_all(
+        [
+            PraxisMember(
+                praxis_id=challenger_praxis.id,
+                character_id=challenger.id,
+                has_submitted=challenger_submitted,
+            ),
+            PraxisMember(
+                praxis_id=opponent_praxis.id,
+                character_id=opponent.id,
+                has_submitted=opponent_submitted,
+            ),
+        ]
+    )
+
+    duel = Duel(
+        task_id=task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_character_id=opponent.id,
+        # A pending duel has no opponent side yet — that is the whole reason
+        # `pending` cannot be nudged.
+        opponent_praxis_id=(
+            opponent_praxis.id if status != DuelStatus.pending else None
+        ),
+        status=status,
+    )
+    session.add(duel)
+    await session.commit()
+    await session.refresh(duel)
+    return duel, challenger_praxis, opponent_praxis
+
+
+# ---------------------------------------------------------------------------
+# Delivery — the feed, not an inbox
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nudge_lands_in_the_recipients_feed(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+    auth_headers2: dict,
+) -> None:
+    """The headline check: nudge → the recipient sees it in their activity feed."""
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+
+    response = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["from_character_id"] == character.id
+    assert body["to_character_id"] == character2.id
+    assert body["praxis_id"] == praxis_collab.id
+
+    feed = await client.get("/activity-feed", headers=auth_headers2)
+    assert feed.status_code == 200
+    nudges = [item for item in feed.json()["items"] if item["type"] == "nudge"]
+    assert len(nudges) == 1
+    assert nudges[0]["actor_display_name"] == character.display_name
+    assert nudges[0]["payload"]["praxis_id"] == praxis_collab.id
+    assert nudges[0]["payload"]["task_title"] == "Test Task"
+
+
+@pytest.mark.asyncio
+async def test_the_sender_does_not_see_their_own_nudge(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    """A nudge is a thing that happened TO you, so it is one-directional."""
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+    await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+
+    feed = await client.get("/activity-feed", headers=auth_headers)
+    assert [item for item in feed.json()["items"] if item["type"] == "nudge"] == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 3 — the rate limit (a safety control, not a nicety)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_second_nudge_inside_24h_is_refused(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+
+    first = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert first.status_code == 200
+
+    second = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert second.status_code == 422, second.text
+
+    # And it wrote nothing — a refused poke must not extend the window either.
+    stored = (await db_session.execute(select(Nudge))).scalars().all()
+    assert len(stored) == 1
+
+
+@pytest.mark.asyncio
+async def test_the_window_reopens_after_24h(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+    await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+
+    await _backdate_nudges(db_session, timedelta(days=1, hours=1))
+
+    again = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert again.status_code == 200, again.text
+
+
+@pytest.mark.asyncio
+async def test_the_limit_is_per_recipient_not_per_sender(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    auth_headers: dict,
+) -> None:
+    """Two outstanding members are two separate 24h windows."""
+    db_session.add(
+        PraxisMember(praxis_id=praxis_collab.id, character_id=character3.id)
+    )
+    await db_session.commit()
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+
+    first = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    second = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character3.id}", headers=auth_headers
+    )
+    assert (first.status_code, second.status_code) == (200, 200)
+
+
+# ---------------------------------------------------------------------------
+# Button state comes from the server (a reload must not un-nudge it)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_roster_row_carries_nudged_at_and_it_survives_a_reload(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+    auth_headers2: dict,
+) -> None:
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+
+    before = await client.get(f"/praxes/{praxis_collab.id}", headers=auth_headers)
+    rows = {m["character_id"]: m for m in before.json()["members"]}
+    assert rows[character2.id]["nudged_at"] is None
+
+    await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+
+    # The reload — the whole point of not keeping this in React state.
+    after = await client.get(f"/praxes/{praxis_collab.id}", headers=auth_headers)
+    rows = {m["character_id"]: m for m in after.json()["members"]}
+    assert rows[character2.id]["nudged_at"] is not None
+    # Viewer-relative: the recipient has nudged nobody, so their read is clean.
+    theirs = await client.get(f"/praxes/{praxis_collab.id}", headers=auth_headers2)
+    theirs_rows = {m["character_id"]: m for m in theirs.json()["members"]}
+    assert theirs_rows[character.id]["nudged_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_nudged_at_clears_once_the_window_lapses(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    """`nudged_at` means "you may not nudge again yet", so it must expire with it."""
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+    await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    await _backdate_nudges(db_session, timedelta(days=1, hours=1))
+
+    reloaded = await client.get(f"/praxes/{praxis_collab.id}", headers=auth_headers)
+    rows = {m["character_id"]: m for m in reloaded.json()["members"]}
+    assert rows[character2.id]["nudged_at"] is None
+
+
+# ---------------------------------------------------------------------------
+# Rule 1 — collab authorization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_member_who_has_not_cast_cannot_nudge(
+    client,
+    praxis_collab: Praxis,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    """You do not get to hurry people you have not caught up with."""
+    response = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.asyncio
+async def test_a_non_member_cannot_nudge_a_collab(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    auth_headers3: dict,
+) -> None:
+    """Not the public — even a caster elsewhere is a stranger to this circle."""
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+    response = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers3
+    )
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.asyncio
+async def test_cannot_nudge_a_member_who_has_already_cast(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+    await _set_cast(db_session, praxis_collab.id, character2.id, True)
+
+    response = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+async def test_cannot_nudge_yourself(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    auth_headers: dict,
+) -> None:
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+    response = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character.id}", headers=auth_headers
+    )
+    assert response.status_code == 400, response.text
+
+
+@pytest.mark.asyncio
+async def test_cannot_nudge_a_stranger_who_is_not_in_the_praxis(
+    client,
+    db_session: AsyncSession,
+    praxis_collab: Praxis,
+    character: Character,
+    character3: Character,
+    auth_headers: dict,
+) -> None:
+    await _set_cast(db_session, praxis_collab.id, character.id, True)
+    response = await client.post(
+        f"/praxes/{praxis_collab.id}/nudge/{character3.id}", headers=auth_headers
+    )
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.asyncio
+async def test_anonymous_cannot_nudge(
+    client, praxis_collab: Praxis, character2: Character
+) -> None:
+    response = await client.post(f"/praxes/{praxis_collab.id}/nudge/{character2.id}")
+    assert response.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Rule 2 — duel authorization
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_duel_participant_may_nudge_the_rival_while_active(
+    client,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+    auth_headers2: dict,
+) -> None:
+    _, _, opponent_praxis = await _make_duel(
+        db_session, active_task, character, character2, DuelStatus.active
+    )
+
+    # The praxis nudged is the RIVAL's side — the one they owe.
+    response = await client.post(
+        f"/praxes/{opponent_praxis.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+
+    feed = await client.get("/activity-feed", headers=auth_headers2)
+    nudges = [item for item in feed.json()["items"] if item["type"] == "nudge"]
+    assert len(nudges) == 1
+    assert nudges[0]["payload"]["praxis_id"] == opponent_praxis.id
+
+
+@pytest.mark.asyncio
+async def test_a_non_participant_cannot_nudge_a_duel_side(
+    client,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    auth_headers3: dict,
+) -> None:
+    _, _, opponent_praxis = await _make_duel(
+        db_session, active_task, character, character2, DuelStatus.active
+    )
+    response = await client.post(
+        f"/praxes/{opponent_praxis.id}/nudge/{character2.id}", headers=auth_headers3
+    )
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.asyncio
+async def test_a_pending_duel_cannot_be_nudged(
+    client,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    """`pending` is live-incomplete too, and is still refused.
+
+    At `pending` the opponent has not accepted, so there is no opponent praxis to
+    owe anything — and what IS outstanding is a decision, which already sits in
+    their requests tab as a `duel_challenge`.
+    """
+    _, challenger_praxis, opponent_praxis = await _make_duel(
+        db_session, active_task, character, character2, DuelStatus.pending
+    )
+    response = await client.post(
+        f"/praxes/{opponent_praxis.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    # The un-linked side is not part of any duel as far as the gate can see.
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.asyncio
+async def test_a_settled_duel_cannot_be_nudged(
+    client,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    """Once both sides are in there is nothing left to hurry."""
+    _, _, opponent_praxis = await _make_duel(
+        db_session,
+        active_task,
+        character,
+        character2,
+        DuelStatus.settled,
+        opponent_submitted=True,
+    )
+    response = await client.post(
+        f"/praxes/{opponent_praxis.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert response.status_code == 422, response.text
+
+
+@pytest.mark.asyncio
+async def test_a_plain_solo_praxis_cannot_be_nudged(
+    client,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    """Nobody is waiting on a stranger's private draft (ADR-0024)."""
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character2.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        moderation_status=ModerationStatus.visible,
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add(
+        PraxisMember(praxis_id=praxis.id, character_id=character2.id)
+    )
+    await db_session.commit()
+
+    response = await client.post(
+        f"/praxes/{praxis.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert response.status_code == 403, response.text
+
+
+@pytest.mark.asyncio
+async def test_duel_side_carries_nudged_at(
+    client,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    duel, _, opponent_praxis = await _make_duel(
+        db_session, active_task, character, character2, DuelStatus.active
+    )
+    await client.post(
+        f"/praxes/{opponent_praxis.id}/nudge/{character2.id}", headers=auth_headers
+    )
+
+    detail = await client.get(f"/duels/{duel.id}/detail", headers=auth_headers)
+    assert detail.status_code == 200, detail.text
+    body = detail.json()
+    assert body["opponent"]["nudged_at"] is not None
+    assert body["challenger"]["nudged_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_duel_rate_limit_is_enforced_too(
+    client,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    _, _, opponent_praxis = await _make_duel(
+        db_session, active_task, character, character2, DuelStatus.active
+    )
+    first = await client.post(
+        f"/praxes/{opponent_praxis.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    second = await client.post(
+        f"/praxes/{opponent_praxis.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert (first.status_code, second.status_code) == (200, 422)
+
+
+@pytest.mark.asyncio
+async def test_the_duel_status_gate_itself_refuses_pending(
+    client,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+) -> None:
+    """Pin the `status == active` check, not just the missing-opponent-side case.
+
+    The test above proves a realistic pending duel is refused because it has no
+    opponent praxis. This one links both sides and *then* sets `pending`, so the
+    only thing standing between the sender and a nudge is the status check —
+    which is what would silently rot if someone widened the gate to
+    `_LIVE_INCOMPLETE_DUEL_STATUSES`.
+    """
+    duel, _, opponent_praxis = await _make_duel(
+        db_session, active_task, character, character2, DuelStatus.active
+    )
+    duel.status = DuelStatus.pending
+    await db_session.commit()
+
+    response = await client.post(
+        f"/praxes/{opponent_praxis.id}/nudge/{character2.id}", headers=auth_headers
+    )
+    assert response.status_code == 422, response.text

--- a/frontend/src/api/duel.ts
+++ b/frontend/src/api/duel.ts
@@ -36,6 +36,8 @@ export interface DuelSideOut {
   avatar_url: string
   points_from_votes: number
   is_submitted: boolean
+  /** The duel twin of `PraxisMemberOut.nudged_at` (#1083); same server-owned window. */
+  nudged_at?: string | null
 }
 
 export interface DuelDetailOut {

--- a/frontend/src/api/nudge.ts
+++ b/frontend/src/api/nudge.ts
@@ -1,0 +1,38 @@
+import api from './axios'
+import { notifyRequestsChanged } from '../utils/requestsBus'
+
+/**
+ * Nudging the player a shared praxis is still waiting on (#1083).
+ *
+ * The design drew this as `setNudged({...})` — local React state that lights the
+ * button up and sends nothing. That was rejected: it reads as sent and isn't, a
+ * reload un-nudges it, and you can poke forever. So there is a real write, and
+ * the button's disabled state is read back from the server as `nudged_at` on the
+ * roster row (`PraxisMemberOut`) or the duel side (`DuelSideOut`) — never held
+ * here.
+ *
+ * `praxisId` is the praxis the RECIPIENT owes: the shared collab, or the RIVAL's
+ * own side of the duel (a duel is two linked solo praxes, ADR-0011). Not yours.
+ */
+
+export interface NudgeOut {
+  id: number
+  praxis_id: number
+  from_character_id: number
+  to_character_id: number
+  created_at: string
+}
+
+export async function sendNudge(
+  praxisId: number,
+  toCharacterId: number,
+): Promise<NudgeOut> {
+  const { data } = await api.post<NudgeOut>(
+    `/praxes/${praxisId}/nudge/${toCharacterId}`,
+  )
+  // The recipient's feed just gained a row. Nothing in the SENDER's own feed
+  // changes, but the bus is how every feed surface learns to refetch and the
+  // sender may well be looking at their own — cheap, and never stale.
+  notifyRequestsChanged()
+  return data
+}

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -30,6 +30,15 @@ export interface PraxisMemberOut {
   character_display_name: string
   has_submitted: boolean
   joined_at: string
+  /**
+   * When the VIEWER last nudged this member about this praxis (#1083), and null
+   * once that 24h window lapses. The server owns both facts through one
+   * constant, so "there is a timestamp" and "you may not nudge again yet" can
+   * never disagree — and a reload cannot un-nudge the button, which is what made
+   * the design's local-state version dishonest. Absent on list-route cards,
+   * which have no nudge button.
+   */
+  nudged_at?: string | null
 }
 
 export interface PraxisInviteOut {

--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -11,6 +11,7 @@ import { normalizeFeedItem, FACTION_ROW_TYPES } from '../feed/normalizeFeedItem'
 import FeedRowContent from '../feed/FeedRowContent'
 import type { ActivityFeedItem } from '../../api/activityFeed'
 import '../../i18n'
+import { collabCopy } from '../collab/collabCopy'
 
 function item(type: string, payload: Record<string, unknown>): ActivityFeedItem {
   return {
@@ -52,6 +53,47 @@ describe('normalizeFeedItem', () => {
     expect(row.headlineHref).toBe('/praxes/12')
     expect(row.points).toBe('25 pts')
     expect(row.badge?.label).toBe('Your Stuff')
+  })
+
+  it('maps a nudge to a row linking into the recipient own editor (#1083)', () => {
+    // The nudge lands BESIDE the `awaiting_submission` row for the same praxis,
+    // so it borrows that row's badge and its /edit link — the reminder and the
+    // obligation are two cards about one thing.
+    const row = normalizeFeedItem(
+      item('nudge', {
+        nudge_id: 4,
+        praxis_id: 12,
+        praxis_type: 'collab',
+        from_character_id: 8,
+        from_name: 'Ada',
+        task_title: 'Plant a tree',
+        task_point_value: 25,
+      }),
+    )!
+    expect(row.actor).toBe('Ada')
+    // Copy comes through collabCopy (shared default + faction overrides), not
+    // the `feed` catalog — it is the composer's own vocabulary.
+    expect(row.action).toBe(collabCopy('coven', 'nudgeFeedAction'))
+    expect(row.actorHref).toBe('/characters/8')
+    expect(row.headline).toBe('Plant a tree')
+    expect(row.headlineHref).toBe('/praxes/12/edit')
+    expect(row.badge?.label).toBe('Collab')
+  })
+
+  it('badges a duel nudge as a duel', () => {
+    const row = normalizeFeedItem(
+      item('nudge', {
+        nudge_id: 5,
+        praxis_id: 13,
+        // A duel side is type='solo' + a duel_id (ADR-0011), so anything that is
+        // not a collab reads as the duel side it is.
+        praxis_type: 'solo',
+        from_character_id: 8,
+        task_title: 'Out-walk me',
+      }),
+    )!
+    expect(row.badge?.label).toBe('Duel')
+    expect(row.headlineHref).toBe('/praxes/13/edit')
   })
 
   it('resolves a taunt from the catalog, quotes it, and drops points', () => {

--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -59,6 +59,7 @@ export function CollabRoster({
   factionSlug,
   taskPointValue,
   onKick,
+  onNudge,
 }: {
   members: readonly PraxisMemberOut[]
   currentCharacterId: number | null | undefined
@@ -74,6 +75,15 @@ export function CollabRoster({
    * callback only has to run the API call + refresh.
    */
   onKick?: (memberId: number) => void | Promise<void>
+  /**
+   * Poke a member who has not cast yet (#1083). Receives the target's CHARACTER
+   * id. When provided, a Nudge button renders on every OTHER member's pill that
+   * is still weaving — but only if the VIEWER has cast, mirroring the backend
+   * rule ("any member who has cast may nudge a member who has not"): you do not
+   * get to hurry people you have not caught up with. Left undefined on the
+   * read-only detail mount, which draws no author controls at all (#646).
+   */
+  onNudge?: (characterId: number) => void | Promise<void>
 }) {
   const { t } = useTranslation('forms')
   // The member a kick is waiting on confirmation for (#1082). Declared before
@@ -93,6 +103,11 @@ export function CollabRoster({
   // rule lives in this one component, not re-stated at each call site.
   const viewerIsMember = members.some((m) => m.character_id === currentCharacterId)
   const canKick = onKick != null && viewerIsMember && gate.state !== 'published'
+
+  // Mirror the backend's nudge rule (#1083): a member who has CAST may nudge a
+  // member who has not. `gate.iCast` is that condition already derived, so the
+  // rule is read from the same place the banner is and cannot drift from it.
+  const canNudge = onNudge != null && viewerIsMember && gate.iCast
 
   // A kick resets everyone's cast (ADR-0013), so it confirms before firing.
   // The dialog is mounted from HERE rather than from the EditPraxis dispatcher
@@ -163,6 +178,41 @@ export function CollabRoster({
               <span className="eyebrow text-[9px]" style={{ color: cast ? accent : 'var(--color-warning)' }}>
                 {cast ? `✓ ${collabCopy(factionSlug, 'pillCast')}` : collabCopy(factionSlug, 'pillWeaving')}
               </span>
+              {/* Nudge — only on a member who is still weaving, never my own row
+                  (#1083). Disabled state comes from `member.nudged_at`, which the
+                  server sends and clears when the 24h window lapses; nothing
+                  about it is remembered here, so a reload cannot un-nudge it. */}
+              {canNudge && !isMe && !cast && (
+                <button
+                  type="button"
+                  disabled={member.nudged_at != null}
+                  onClick={() => onNudge?.(member.character_id)}
+                  title={collabCopy(factionSlug, 'nudgeDescription')}
+                  aria-label={collabCopy(
+                    factionSlug,
+                    member.nudged_at != null ? 'nudgeSentAria' : 'nudgeAria',
+                    { name: member.character_display_name },
+                  )}
+                  className="eyebrow text-[9px] px-2 py-1"
+                  style={{
+                    borderRadius: 4,
+                    border: `1px solid ${
+                      member.nudged_at != null ? 'var(--color-border)' : accent
+                    }`,
+                    background: 'transparent',
+                    color:
+                      member.nudged_at != null
+                        ? 'var(--color-text-tertiary)'
+                        : accent,
+                    cursor: member.nudged_at != null ? 'default' : 'pointer',
+                  }}
+                >
+                  {collabCopy(
+                    factionSlug,
+                    member.nudged_at != null ? 'nudgeSentAction' : 'nudgeAction',
+                  )}
+                </button>
+              )}
               {/* Kick × — on every OTHER member's pill (never my own), gated to
                   members (#959). The glyph is an ornament; the button's name is
                   the aria-label so screen readers and the e2e locator resolve it. */}

--- a/frontend/src/components/collab/collabCopy.ts
+++ b/frontend/src/components/collab/collabCopy.ts
@@ -88,6 +88,14 @@ export type CollabCopyKey =
   | 'duelPillSealed'
   | 'duelPillWriting'
   | 'duelPullBackDescription'
+  // Nudging the person the praxis is still waiting on (#1083).
+  | 'nudgeAction'
+  | 'nudgeSentAction'
+  | 'nudgeAria'
+  | 'nudgeSentAria'
+  | 'nudgeDescription'
+  | 'duelNudgeAria'
+  | 'nudgeFeedAction'
 
 /**
  * Keys that are content to speak in the shared voice (#1074).
@@ -114,6 +122,14 @@ export type CollabCopyKey =
  * and a dialog whose whole job is to state a consequence plainly is the worst
  * place in the composer to be in character. Adding them here is also what keeps
  * a new shared key from silently owing eight faction translations.
+ *
+ * The `nudge*` block (#1083) joins them too, and the issue asks for it by name:
+ * a voiced block historically drags all eight factions with it, and this one is
+ * four words on a button plus one feed line. What it says is a mechanic and a
+ * limit — one reminder, once a day, signed with your name — and the feed line in
+ * particular is read by the RECIPIENT, whose faction is not the sender's, so a
+ * sender-voiced quip there would land in someone else's room. Overrides stay
+ * available for whichever faction earns one first.
  *
  * The whole `awaiting*` / `duelAwaiting*` block (#1080) joins them for the same
  * reason, plus one of its own: the waiting surface is **one shared, token-themed
@@ -164,6 +180,13 @@ export const SHARED_DEFAULT_COLLAB_KEYS: readonly CollabCopyKey[] = [
   'duelPillSealed',
   'duelPillWriting',
   'duelPullBackDescription',
+  'nudgeAction',
+  'nudgeSentAction',
+  'nudgeAria',
+  'nudgeSentAria',
+  'nudgeDescription',
+  'duelNudgeAria',
+  'nudgeFeedAction',
 ]
 
 /**

--- a/frontend/src/components/feed/normalizeFeedItem.ts
+++ b/frontend/src/components/feed/normalizeFeedItem.ts
@@ -3,6 +3,7 @@ import i18n from '../../i18n'
 import { factionName } from '../../utils/factions'
 import { relativeTime } from '../../utils/dates'
 import { resolveTaunt } from '../../utils/taunts'
+import { collabCopy } from '../collab/collabCopy'
 
 /**
  * Full-adoption activity feed (#376): the faction owns the whole "someone did X"
@@ -30,6 +31,7 @@ export const FACTION_ROW_TYPES = new Set([
   'global_task',
   'collaborator_submitted',
   'awaiting_submission',
+  'nudge',
 ])
 
 export interface FeedRow {
@@ -138,6 +140,37 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.points', { points: p.task_point_value })
             : null,
         level: p.task_level_required ?? null,
+        time,
+      }
+    case 'nudge':
+      // Someone poked you to file (#1083). It lands BESIDE the
+      // `awaiting_submission` row for the same praxis — the reminder and the
+      // obligation are two cards about one thing — so it borrows that row's
+      // badge and its link straight into the editor.
+      //
+      // The action line resolves through `collabCopy`, not the `feed` catalog:
+      // it is the composer's own vocabulary, shared-default with faction
+      // overrides where authored. Framed in the SENDER's voice, because
+      // `context_faction_slug` is the actor's faction and a nudge is something a
+      // named person did to you.
+      return {
+        slug,
+        actor,
+        actorHref:
+          p.from_character_id != null ? `/characters/${p.from_character_id}` : null,
+        action: collabCopy(slug, 'nudgeFeedAction'),
+        badge:
+          p.praxis_type === 'collab'
+            ? { type: 'collab', label: i18n.t('feed:badge.collab') }
+            : { type: 'duel', label: i18n.t('feed:badge.duel') },
+        headline: p.task_title ?? null,
+        headlineHref: p.praxis_id != null ? `/praxes/${p.praxis_id}/edit` : null,
+        headlineQuoted: false,
+        points:
+          p.task_point_value != null
+            ? i18n.t('feed:row.points', { points: p.task_point_value })
+            : null,
+        level: null,
         time,
       }
     case 'vote_on_mine':

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -110,7 +110,8 @@
       "updateMetatask": "Could not update metatask.",
       "duelUnderway": "This duel is already underway — it can't be cancelled from here.",
       "fileTooLarge_one": "File too large (50 MB limit): {{names}}",
-      "fileTooLarge_other": "Files too large (50 MB limit): {{names}}"
+      "fileTooLarge_other": "Files too large (50 MB limit): {{names}}",
+      "nudge": "Could not nudge {{name}}."
     },
     "confirm": {
       "dismiss": "Never mind",
@@ -214,7 +215,14 @@
       "duelPendingLine": "Sealed {{elapsed}}. {{name}} has not answered the challenge yet.",
       "duelPillSealed": "sealed",
       "duelPillWriting": "still writing",
-      "duelPullBackDescription": "Takes your entry back out so you can change it. The duel is untouched until it settles, so this costs you nothing."
+      "duelPullBackDescription": "Takes your entry back out so you can change it. The duel is untouched until it settles, so this costs you nothing.",
+      "nudgeAction": "Nudge",
+      "nudgeSentAction": "Nudged",
+      "nudgeAria": "Nudge {{name}} to file their part",
+      "nudgeSentAria": "You already nudged {{name}} today — you can nudge them again tomorrow",
+      "nudgeDescription": "Sends one reminder to their feed. Once a day, and it is signed with your name.",
+      "duelNudgeAria": "Nudge {{name}} to answer",
+      "nudgeFeedAction": "nudged you to file your part of"
     },
     "toolbar": {
       "label": "formatting",

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/collabExits.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/collabExits.test.tsx
@@ -65,6 +65,7 @@ function praxisState({
     sendInvite: async () => {},
     sendChallenge: async () => {},
     kickMember: async () => {},
+    nudge: async () => {},
     cancelInvite: async () => {},
     leaveCollab: async () => {},
     cancel: async () => {},

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/dispatch.test.tsx
@@ -97,6 +97,7 @@ function baseState(slug: string | null): EditPraxisState {
     sendInvite: async () => {},
     cancelInvite: async () => {},
     kickMember: async () => {},
+    nudge: async () => {},
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/modePicker.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/modePicker.test.tsx
@@ -96,6 +96,7 @@ function baseState(): EditPraxisState {
     sendInvite: async () => {},
     cancelInvite: async () => {},
     kickMember: async () => {},
+    nudge: async () => {},
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/submitWiring.test.tsx
@@ -98,6 +98,7 @@ function stateWith(publish: () => Promise<void>): EditPraxisState {
     sendInvite: async () => {},
     cancelInvite: async () => {},
     kickMember: async () => {},
+    nudge: async () => {},
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},

--- a/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/mobileArchetypes/__tests__/uaDispatch.test.tsx
@@ -107,6 +107,7 @@ function baseState(): EditPraxisState {
     sendInvite: async () => {},
     cancelInvite: async () => {},
     kickMember: async () => {},
+    nudge: async () => {},
     duel: null,
     sendChallenge: async () => {},
     cancelDuel: async () => {},

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -34,6 +34,7 @@ import {
   issueChallenge,
   type DuelDetailOut,
 } from "../../api/duel";
+import { sendNudge } from "../../api/nudge";
 import { deriveCollabGate } from "../../components/collab/CollabRoster";
 import {
   deleteCollabConfirm,
@@ -176,6 +177,14 @@ export interface EditPraxisState {
   cancelInvite: (inviteId: number) => Promise<void>;
   /** Remove another member from the collab (#959) — target is a character id. */
   kickMember: (memberId: number) => Promise<void>;
+  /**
+   * Poke the player this praxis is still waiting on (#1083) — target is a
+   * character id. For a collab that is a member who has not cast; for a duel it
+   * is the rival, and the write is aimed at THEIR side's praxis, not yours.
+   * Refreshes afterwards so the button's disabled state comes back from the
+   * server rather than being remembered here.
+   */
+  nudge: (characterId: number) => Promise<void>;
 
   // Duel challenge (#311) — selecting duel attaches a challenge to this praxis;
   // the praxis stays type='solo' and gains a duel_id.
@@ -1174,6 +1183,46 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     [praxis],
   );
 
+  // Poke whoever this praxis is waiting on (#1083). Every rule lives on the
+  // server — who may nudge, and the one-per-24h limit — so this fires and then
+  // RE-READS. It deliberately keeps no local "nudged" flag: the design's version
+  // did exactly that, which made the button read as sent when nothing had been,
+  // and let a reload clear it. `nudged_at` on the refreshed roster row / duel
+  // side is the only thing the button believes.
+  const nudge = useCallback(
+    async (characterId: number) => {
+      if (!praxis) return;
+      setError("");
+      // A duel is two linked solo praxes (ADR-0011): the praxis the rival owes
+      // is THEIR side, not the one this composer is holding.
+      const duelSide =
+        duel != null
+          ? [duel.challenger, duel.opponent].find(
+              (side) => side.character_id === characterId,
+            )
+          : undefined;
+      const targetPraxisId = duelSide?.praxis_id ?? praxis.id;
+      const name =
+        duelSide?.display_name ??
+        praxis.members.find((member) => member.character_id === characterId)
+          ?.character_display_name ??
+        "";
+      try {
+        await sendNudge(targetPraxisId, characterId);
+        const refreshed = await getPraxis(praxis.id);
+        setPraxis(refreshed);
+        if (refreshed.duel_id != null) {
+          setDuel(await getDuelDetail(refreshed.duel_id));
+        }
+      } catch (err) {
+        setError(
+          extractError(err, i18n.t("forms:editPraxis.errors.nudge", { name })),
+        );
+      }
+    },
+    [praxis, duel],
+  );
+
   // ---- Duel challenge (#311): pick an opponent, cancel a pending challenge ----
   const sendChallenge = useCallback(
     async (character: CharacterOut) => {
@@ -1403,6 +1452,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     sendInvite,
     cancelInvite,
     kickMember,
+    nudge,
 
     duel,
     sendChallenge,

--- a/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
+++ b/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
@@ -15,10 +15,17 @@
  * per-faction masthead; those are a follow-up wave if this reads flat once live,
  * not a debt taken on here.
  *
- * Three things the design draws that are deliberately absent:
- *  - **Nudge.** It ships on its own issue. A `setNudged` local-state stub that
- *    lights up and sends nothing was rejected as dishonest, so there is no
- *    affordance at all.
+ * Nudge (#1083) landed after this surface and is drawn here now — but not as the
+ * design drew it. The design's `setNudged({...})` was local React state: the
+ * button flipped to "Nudged" and nothing left the browser, so it read as sent
+ * when it wasn't, a reload un-nudged it, and you could poke forever. This one
+ * writes, is rate-limited to one per person per praxis per 24h on the server,
+ * lands in the recipient's activity feed, and reads its disabled state from
+ * `nudged_at` on the wire. It appears only where the rule allows: on a collab
+ * member who has not cast (and only once YOU have), and on a duel rival while
+ * the duel is `active`.
+ *
+ * Two things the design draws that are still deliberately absent:
  *  - **A duel countdown.** Nothing backs one (see `waitingClock.ts`). The duel
  *    gets a plain elapsed line; the ring is the collab's.
  *  - **"Forfeit the duel".** The design offers it at `active` and hides it at
@@ -213,14 +220,22 @@ function DuelSidePanel({
   factionSlug,
   title,
   body,
+  onNudge,
 }: {
   side: DuelSideOut;
   mine: boolean;
   factionSlug: string | null | undefined;
   title?: string;
   body?: string;
+  /**
+   * Poke the rival (#1083). Passed only for the rival's panel, and only while
+   * the duel is `active` — the caller owns that condition because it is the one
+   * holding the duel status. Never passed for your own side.
+   */
+  onNudge?: () => void | Promise<void>;
 }) {
   const accent = factionCssVar(factionSlug, "card-accent");
+  const nudged = side.nudged_at != null;
   return (
     <div
       className="flex flex-col gap-2"
@@ -257,6 +272,29 @@ function DuelSidePanel({
             : collabCopy(factionSlug, "duelPillWriting")}
         </span>
       </div>
+      {onNudge && (
+        <button
+          type="button"
+          disabled={nudged}
+          onClick={() => void onNudge()}
+          title={collabCopy(factionSlug, "nudgeDescription")}
+          aria-label={collabCopy(
+            factionSlug,
+            nudged ? "nudgeSentAria" : "duelNudgeAria",
+            { name: side.display_name },
+          )}
+          className="eyebrow self-start px-2 py-1"
+          style={{
+            borderRadius: 4,
+            border: `1px solid ${nudged ? "var(--color-border)" : accent}`,
+            background: "transparent",
+            color: nudged ? "var(--color-text-tertiary)" : accent,
+            cursor: nudged ? "default" : "pointer",
+          }}
+        >
+          {collabCopy(factionSlug, nudged ? "nudgeSentAction" : "nudgeAction")}
+        </button>
+      )}
       {mine ? (
         <>
           <span className="font-body content-title" style={{ fontWeight: 700 }}>
@@ -436,7 +474,20 @@ export default function PraxisWaitingSurface({
               title={state.title}
               body={state.body}
             />
-            <DuelSidePanel side={sides.foe} mine={false} factionSlug={slug} />
+            {/* The rival's nudge, gated on `active` exactly as the backend is:
+                at `pending` they have not accepted yet and the outstanding thing
+                is a decision (already in their requests tab as a challenge), and
+                once the duel settles there is nothing left to hurry. */}
+            <DuelSidePanel
+              side={sides.foe}
+              mine={false}
+              factionSlug={slug}
+              onNudge={
+                duel?.status === "active"
+                  ? () => state.nudge(sides.foe.character_id)
+                  : undefined
+              }
+            />
           </div>
         ) : (
           <CollabRoster
@@ -445,6 +496,7 @@ export default function PraxisWaitingSurface({
             factionSlug={slug}
             taskPointValue={praxis.task_point_value}
             onKick={state.kickMember}
+            onNudge={state.nudge}
           />
         )}
       </section>

--- a/frontend/src/pages/editPraxis/waiting/__tests__/praxisWaitingSurface.test.tsx
+++ b/frontend/src/pages/editPraxis/waiting/__tests__/praxisWaitingSurface.test.tsx
@@ -25,7 +25,12 @@ const WINDOW_DAYS = 10;
 const OPENED = "2026-01-01T00:00:00Z";
 const THREE_DAYS_IN = Date.parse(OPENED) + 3 * 24 * 60 * 60 * 1000;
 
-function member(id: number, name: string, hasSubmitted: boolean): PraxisMemberOut {
+function member(
+  id: number,
+  name: string,
+  hasSubmitted: boolean,
+  nudgedAt: string | null = null,
+): PraxisMemberOut {
   return {
     id,
     praxis_id: 1,
@@ -33,6 +38,7 @@ function member(id: number, name: string, hasSubmitted: boolean): PraxisMemberOu
     character_display_name: name,
     has_submitted: hasSubmitted,
     joined_at: OPENED,
+    nudged_at: nudgedAt,
   };
 }
 
@@ -122,6 +128,7 @@ function state(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
     cancel: async () => {},
     reopenForEdit: async () => {},
     kickMember: async () => {},
+    nudge: async () => {},
     ...overrides,
   } as unknown as EditPraxisState;
 }
@@ -180,8 +187,133 @@ describe("collab — my part is in, the crew is not", () => {
     expect(html).toContain("clears every member");
   });
 
-  it("draws no Nudge affordance — it ships on its own issue", () => {
-    expect(html.toLowerCase()).not.toContain("nudge");
+  // #1080 pinned the ABSENCE of this control ("it ships on its own issue").
+  // #1083 is that issue, so the assertion inverts — and gains the conditions
+  // that make this version honest rather than the design's local-state one.
+  it("offers a Nudge on each member who has not cast", () => {
+    expect(html).toContain(collabCopy(SLUG, "nudgeAction"));
+    expect(html).toContain(
+      collabCopy(SLUG, "nudgeAria", { name: "Rax" }),
+    );
+    expect(html).toContain(
+      collabCopy(SLUG, "nudgeAria", { name: "Sable" }),
+    );
+  });
+
+  it("never offers a Nudge on my own row", () => {
+    expect(html).not.toContain(collabCopy(SLUG, "nudgeAria", { name: "Wren" }));
+  });
+});
+
+describe("nudge — the honest version (#1083)", () => {
+  const duelSide = (
+    status: DuelStatus,
+    foeNudgedAt: string | null = null,
+  ): EditPraxisState =>
+    state({
+      praxis: praxis({
+        type: "solo",
+        status: "submitted",
+        duel_id: 7,
+        members: [member(ME, "Wren", true)],
+        submit_proposed_at: null,
+      }),
+      duel: {
+        ...duelDetail(status),
+        opponent: { ...duelDetail(status).opponent, nudged_at: foeNudgedAt },
+      },
+    });
+
+  it("hides the Nudge entirely from a member who has not cast", () => {
+    // The backend rule, drawn: you do not get to hurry people you have not
+    // caught up with. Hidden rather than disabled — the repo shows no control a
+    // viewer could never use.
+    const html = render({
+      state: state({
+        currentCharacterId: THEM,
+        praxis: praxis({
+          members: [
+            member(ME, "Wren", true),
+            member(THEM, "Rax", false),
+            member(A_THIRD, "Sable", false),
+          ],
+        }),
+      }),
+      autoSubmitDays: WINDOW_DAYS,
+    });
+    expect(html).not.toContain(collabCopy(SLUG, "nudgeAria", { name: "Sable" }));
+  });
+
+  it("offers no Nudge on a member who has already cast", () => {
+    const html = render({
+      state: state({
+        praxis: praxis({
+          members: [
+            member(ME, "Wren", true),
+            member(THEM, "Rax", true),
+            member(A_THIRD, "Sable", false),
+          ],
+        }),
+      }),
+      autoSubmitDays: WINDOW_DAYS,
+    });
+    expect(html).not.toContain(collabCopy(SLUG, "nudgeAria", { name: "Rax" }));
+    expect(html).toContain(collabCopy(SLUG, "nudgeAria", { name: "Sable" }));
+  });
+
+  it("reads its spent state off the SERVER, so a reload cannot un-nudge it", () => {
+    // `nudged_at` arrives on the roster row. Nothing here remembers a click —
+    // that is precisely what made the design's `setNudged` version dishonest.
+    const html = render({
+      state: state({
+        praxis: praxis({
+          members: [
+            member(ME, "Wren", true),
+            member(THEM, "Rax", false, "2026-01-02T00:00:00Z"),
+            member(A_THIRD, "Sable", false),
+          ],
+        }),
+      }),
+      autoSubmitDays: WINDOW_DAYS,
+    });
+    expect(html).toContain(collabCopy(SLUG, "nudgeSentAction"));
+    expect(html).toContain(
+      collabCopy(SLUG, "nudgeSentAria", { name: "Rax" }),
+    );
+    expect(html).toContain("disabled");
+  });
+
+  it("offers the rival a Nudge while the duel is active", () => {
+    const html = render({
+      state: duelSide("active"),
+      autoSubmitDays: WINDOW_DAYS,
+    });
+    expect(html).toContain(collabCopy(SLUG, "duelNudgeAria", { name: "Rax" }));
+  });
+
+  it("draws no Nudge on a pending duel — the rival has not accepted yet", () => {
+    const html = render({
+      state: duelSide("pending"),
+      autoSubmitDays: WINDOW_DAYS,
+    });
+    expect(html).not.toContain(collabCopy(SLUG, "duelNudgeAria", { name: "Rax" }));
+  });
+
+  it("never draws a Nudge on my own duel side", () => {
+    const html = render({
+      state: duelSide("active"),
+      autoSubmitDays: WINDOW_DAYS,
+    });
+    expect(html).not.toContain(collabCopy(SLUG, "duelNudgeAria", { name: "Wren" }));
+  });
+
+  it("spends the duel Nudge from the server's nudged_at too", () => {
+    const html = render({
+      state: duelSide("active", "2026-01-02T00:00:00Z"),
+      autoSubmitDays: WINDOW_DAYS,
+    });
+    expect(html).toContain(collabCopy(SLUG, "nudgeSentAction"));
+    expect(html).toContain("disabled");
   });
 });
 


### PR DESCRIPTION
Closes #1083

Last child of epic #1071. The waiting surface (#1080) gains its button, and it is a real one.

## Not the design's version

The design draws this as `setNudged({...})` — local React state. The button flips to "Nudged" and nothing leaves the browser: it reads as sent when it isn't, a reload un-nudges it, and you can poke forever. Every one of those is fixed here.

## Delivery: the activity feed

I checked the premise before building on it. `Message` and `routers/messages.py` exist, but the only player-facing reader is the admin moderation tab — a nudge sent as a message lands where no player will see it. So delivery is one new `FeedSource` in the ADR-0036 registry (`backend/services/activity_feed.py`), and the recipient sees the nudge beside the `awaiting_submission` row they already have for the same praxis.

It sits in **ALL + YOUR_STUFF, deliberately not REQUESTS**: the obligation it refers to is already a `requests` row, so counting the poke there would badge one outstanding action twice — and a bell that increments because someone pressed a button at you is the wrong shape for a tab whose other members all want a decision.

## Storage

A four-column `nudge` table (`backend/models/nudge.py`) plus migration `0009_nudge_table.py` — not a `praxis_id` + `kind` enum on `Message`, which would weld system pokes to a future DM inbox and cost a new value in `0001_squashed`'s `ENUMS` list on top of the model edit.

**`praxis_id` is always the praxis the RECIPIENT owes**, never the sender's. For a collab those are the same row; for a duel they are the two linked sides (ADR-0011), and the recipient's is the one their feed card can actually open — the sender's side is hidden from them while the duel is live (`_duel_side_hidden_condition`, #999).

## The rules (`backend/services/nudge.py`)

- **Collab** — a member **who has cast** may nudge a member who has not. Not a member who hasn't cast, not the public.
- **Duel** — a participant may nudge the rival, **only while the duel is `active`**.
- **Rate limit** — one per sender to recipient to praxis per 24h, `created_at > now() - 1 day`, 422 on a repeat. This is a safety control, not a nicety: an unlimited poke button aimed at a named player is a harassment vector, so it is enforced on the write path rather than by hiding the button.

### `pending` duels: deliberately excluded, as asked

`_LIVE_INCOMPLETE_DUEL_STATUSES` is `(pending, active)`, and I looked at whether the gate should be that tuple. It should not, on two grounds:

1. At `pending`, `opponent_praxis_id` is **NULL** — there is no opponent praxis, so there is no praxis for the recipient to owe, and this whole feature is keyed to one.
2. What is outstanding at `pending` is a **decision**, not a submission, and it already sits in the rival's `requests` tab as a `duel_challenge` with accept/decline on it. A poke there is pressure on a choice, not a reminder about a task.

Two tests pin this: one for the realistic pending duel (no opponent side), one that links both sides and *then* sets `pending`, so the only thing standing in the way is the status check — which is what would silently rot if someone widened the gate.

### One asymmetry, flagged rather than smoothed over

The collab rule requires the sender to have cast; the duel rule (as the issue writes it) requires only participation. I implemented it as written. In practice the button only renders on the waiting surface, which you only reach *after* filing, so the sender has cast either way — but the server does not currently require it for a duel. Say the word and it's one line.

## Button state comes from the server

`PraxisMemberOut.nudged_at` and `DuelSideOut.nudged_at` carry **the most recent nudge from the viewer to that player on that praxis, within the rate-limit window** — and go NULL once it lapses. So "there is a timestamp" and "you may not nudge again yet" are one fact resolved by one constant (`NUDGE_COOLDOWN`), server-side; the client does no date arithmetic that could drift. Nothing about a click is remembered in React.

## Copy

Resolves through `collabCopy` — shared defaults in `forms:editPraxis.collab.*`, faction overrides where authored — and every new key is in `SHARED_DEFAULT_COLLAB_KEYS`, so **no faction is dragged into voicing eight new lines**. The feed line especially: it is read by the *recipient*, whose faction is not the sender's, so a sender-voiced quip there would land in someone else's room.

## Tests

**Backend — 21 new integration tests** (`backend/tests/integration/test_nudge.py`), covering every item on the issue's check list:

- nudge, then the recipient's feed shows it; the sender's does not
- second nudge inside 24h refused (and writes nothing); window reopens after 24h; limit is per-recipient, not per-sender
- `nudged_at` survives a reload, is viewer-relative, and clears when the window lapses
- collab: non-caster refused, non-member refused, already-cast target refused, self refused, stranger refused
- duel: participant while `active` allowed; non-participant, `pending` (both paths), `settled`, and plain-solo all refused; rate limit enforced
- anonymous refused

**Frontend** — 10 new tests across the waiting surface and the feed normalizer, mirroring the same conditions. #1080's `draws no Nudge affordance — it ships on its own issue` assertion is **inverted**: this is that issue.

## Gates run locally

- `pytest` — **818 passed** (no pre-existing failures)
- `tsc --noEmit` clean, `vitest` **1957 passed**, `eslint` clean, `vite build` clean
- **Migration verified separately**, since the integration conftest builds schema via `Base.metadata.create_all` and bypasses Alembic: `alembic upgrade head` on an **empty** DB (clean), then the table dropped and the version rewound to `0008` and re-run, proving `0009` creates it on a deployed-shaped DB too. `alembic check` reports no drift.
- Entry chunk **139.93 to 140.09 kB gzip** (+0.16 kB) — measured against base, no barrel regression from the new `collabCopy` import in the feed normalizer.

**Visual QA is outstanding.** There is no dev stack here and the Browser pane renderer times out, so nothing below has been seen rendered — only asserted in `renderToStaticMarkup`.

## What to eyeball

1. **The roster row, before and after.** Open a collab waiting surface where you have cast and someone else has not. The Nudge should sit between the "still weaving" pill and the kick glyph; check it does not crowd them at narrow widths. Click it: it should become a muted, non-clickable "Nudged" — **and still say that after a full page reload.**
2. **A member who has not cast.** Log in as the holdout: there should be **no** Nudge on anyone's row at all (hidden, not disabled). And no Nudge ever on your own row.
3. **The duel side.** On an `active` duel, the rival's panel should carry the button above the "Sealed until they submit" line. On a `pending` duel it should be absent entirely.
4. **The recipient's feed.** As the nudged player, open Updates: a row in the *sender's* faction frame reading "<name> nudged you to file your part of <task>", badged Collab or Duel, linking to `/praxes/:id/edit`. It should read sensibly sitting next to the "Waiting on your submission" row for the same praxis.
5. **The refused repeat.** Nudge, reload, and force a second attempt at the same person on the same praxis within the day (the button will be disabled — hit the endpoint directly, or clear `nudged_at`). Expect a 422 surfaced as "Could not nudge <name>." in the composer's error banner rather than a silent no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
