### PR TITLE
Foundation for the seven praxis-detail skins: amend ADR-0061, reconcile the shared layout

### DIFF
--- a/docs/adr/0061-praxis-detail-is-one-shared-page-every-faction-dresses.md
+++ b/docs/adr/0061-praxis-detail-is-one-shared-page-every-faction-dresses.md
@@ -39,6 +39,10 @@ layout and API contract (epic #1085).
 **Praxis detail is one shared page. A faction skin brings dress and no
 copy.**
 
+*(Narrowed by the Amendment below, 2026-07-28: "and no copy" now binds only
+the page's moderation and system chrome. Content slots carry the skin's
+voice. Everything else in this Decision stands unchanged.)*
+
 - A single neutral `detail.*` block; every archetype reads the same keys.
   Where a design's word differs from the domain noun in `CONTEXT.md`, the
   domain noun wins.
@@ -72,6 +76,8 @@ made in #1030.
 - The per-faction `detail.<faction>.*` blocks are deleted as each archetype
   goes.
 - A future faction skin cannot introduce copy on this surface, only dress.
+  *(Narrowed 2026-07-28 — see the Amendment. A skin may introduce copy in the
+  page's content slots; it still cannot touch the chrome.)*
 - Extends ADR-0057's doctrine to a second surface. ADR-0016's
   presentation/voice boundary now carries two per-surface exceptions.
 
@@ -84,3 +90,70 @@ the seven designs are already locked to one layout and one contract —
 leaving copy free re-grows the catalog being deleted, and the nine
 task-detail designs proved that per-design "neutral" wording fragments even
 when nobody intends voice.
+
+## Amendment (2026-07-28) — voice returns to the content slots; chrome stays neutral
+
+Raised by the seven skin issues (#1117–#1123), each of which specifies its
+faction's words for the same six or so slots. This amendment is additive:
+nothing above is deleted, and the two statements it narrows carry a dated
+pointer to here.
+
+### The rule
+
+**Content slots carry the skin's voice. Moderation and system chrome do
+not.**
+
+- **Voiced** — the page's content slots: the body/write-up heading, the media
+  or proof heading, the crew/members heading, the metatasks heading, the duel
+  heading, the comments heading, the post button, and the vote/voters labels.
+  A skin registers its own block for these.
+- **Neutral, shared, unchanged** — the **report/flag card**, the **steward
+  bar**, the **moderation banners** (crown, flagged, failed) and the
+  **errors**. In the catalog these are `detail.flag.*`, `detail.admin.*`,
+  `detail.banners.*` and `detail.errors.*`: one set of words, read by every
+  skin, in every faction's dress. All eight faction designs draw them this
+  way — the report card is deliberately outside the costume, with its own
+  neutral token set.
+
+### What this narrows
+
+Only the blanket "no copy". The Decision's "a faction skin brings dress and no
+copy" and the Consequence "a future faction skin cannot introduce copy on this
+surface" now apply to **system chrome alone**. The layout contract, the single
+shared API contract, and the comments boundary are untouched.
+
+### Why — and what the original argument keeps
+
+The rejected alternative above ("Voice returns with each design") was rejected
+because free copy re-grows the deleted catalog and because per-design
+"neutral" wording fragments. **That argument is not overturned; it is where
+the line is now drawn.** It is exactly true of chrome, and chrome is where it
+matters most: a report card, a steward action or a failure notice is the
+*platform* speaking, and it has to read identically everywhere or it stops
+reading as the system at all. Fragmenting those words costs trust, not
+flavour.
+
+What the amendment accepts instead is the rejected alternative's *premise*,
+limited to content: a praxis is somebody's account of a thing they did, so
+naming that account is the faction's line to speak. This is the same boundary
+this ADR already drew for comment rows — **the neutral rule stops at the
+speaker's voice** — applied one step out. A comment row is the author
+speaking; a content slot is the faction's page speaking about a member's
+work; the chrome is the platform speaking. One question ("whose voice is
+this?"), three consistent answers.
+
+The cost is taken knowingly: the near-synonym body and media headings this
+ADR's Context complains about will re-grow, this time as a deliberate,
+designed set rather than accreted drift. That set is the deliverable of
+#1117–#1123, not a side effect.
+
+### Relations, restated
+
+- **ADR-0057** (task detail carries no faction voice) is still extended, but
+  now only for chrome. The two surfaces legitimately differ: a task is the
+  system's posted assignment, a praxis is a member's account of doing it.
+- **The comments boundary is unchanged and still out of scope.** Rows
+  dispatch on `comment.author.faction_slug`; `comments.<faction>.*` and the
+  seven `*Comment` skins are not touched by this amendment any more than they
+  were by the original Decision, and must not be swept by inference from
+  either.

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -21,6 +21,7 @@ import type { PraxisDetailState } from "../usePraxisDetail";
 import type { PraxisOut, PraxisMemberOut } from "../../../api/praxis";
 import type { DuelDetailOut } from "../../../api/duel";
 import type { CurrentUser } from "../../../api/auth";
+import { PraxisFlagBlock } from "../shared";
 
 const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "desktop" | "mobile" }));
 vi.mock("../../../hooks/useFormFactor", () => ({
@@ -203,6 +204,51 @@ describe("Unaffiliated praxis detail — layout contract", () => {
     // WORLD_ZERO_STYLE §5 / #1028: the site background must still show around
     // the page. `.na-backdrop` is `position: fixed; inset: 0`.
     expect(render(state()).html).not.toContain("na-backdrop");
+  });
+
+  // ─── The eight-design contract (#1117–#1123) ──────────────────────────────
+  //
+  // This page is the foundation the seven faction skins dress, so where the
+  // Unaffiliated design differs from the other eight, the eight win. These are
+  // the three facts that differed; guarded here so each skin inherits them
+  // instead of working around them seven times.
+
+  it("gives the desktop aside a 330px track, not the Unaffiliated design's 340", () => {
+    const wide = render(state());
+    expect(wide.html, "the eight designs' aside track").toContain("0 0 330px");
+    expect(wide.html, "the outlier width is gone").not.toContain("340px");
+
+    // Mobile drops the TRACK, not its contents — the rail stacks into flow.
+    expect(render(state(), "mobile").html, "no fixed track on mobile").not.toContain(
+      "0 0 330px",
+    );
+  });
+
+  it("shows the crown at BOTH form factors on a crowned praxis", () => {
+    // Never form-factor gated: it comes from the shared banners, keyed only on
+    // `is_top_for_task` and mounted above the split. One design (Everymen)
+    // draws `showCrownMobile: false`; that is the outlier.
+    const crowned = state({ praxis: { ...PRAXIS, is_top_for_task: true } });
+    expect(render(crowned, "desktop").text, "crown on desktop").toContain("TASK CROWN");
+    expect(render(crowned, "mobile").text, "crown on mobile too").toContain("TASK CROWN");
+    expect(render(state(), "mobile").text, "and only when crowned").not.toContain(
+      "TASK CROWN",
+    );
+  });
+
+  it("leaves the report card outside the costume", () => {
+    // ADR-0061 as amended (2026-07-28): moderation and system chrome stay
+    // neutral in every faction's dress. The card must not pick up the page's
+    // faction tokens — including by INHERITING the sheet's text colour, which
+    // is why every text node inside it carries its own neutral token.
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <PraxisFlagBlock state={state()} />
+      </MemoryRouter>,
+    );
+    expect(html, "renders at all").toContain("Flag this praxis");
+    expect(html, "neutral card chrome").toContain("sidebar-card");
+    expect(html, "no faction dress anywhere inside").not.toContain("--faction-");
   });
 
   it("mounts the comments region with the layout's heading, not the thread's", () => {

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -9,13 +9,29 @@
  *
  * ## The contract
  *
- * - **Desktop** — breadcrumb, then main column + a 340px aside, then a comments
+ * Reconciled to the EIGHT faction designs, not to this one (#1117–#1123). Where
+ * the Unaffiliated design differs it is the outlier and the eight win — the
+ * seven skins inherit this file, so a fact that is wrong here would be worked
+ * around seven times.
+ *
+ * - **Desktop** — breadcrumb, then main column + a 330px aside, then a comments
  *   region beneath both.
  * - **Mobile** — one stacked column (a back link and a centred label instead of
  *   the breadcrumb), with the score and duel blocks moved above the proof.
  * - **Main** — moderation banners · byline · title · owner actions · task
  *   reference · proof · write-up · members · metatasks.
  * - **Aside** — score · duel · vote · voters · flag.
+ * - **The crown renders at BOTH form factors.** It is never form-factor gated:
+ *   it comes from the shared `PraxisStatusBanners`, keyed only on
+ *   `is_top_for_task`, mounted above the split so both layouts get it. One
+ *   design (Everymen) draws `showCrownMobile: false`; that is the outlier too.
+ * - **The report/flag card and the steward bar are NOT skinned.** All eight
+ *   faction designs leave them outside the costume, on their own neutral token
+ *   set — so `PraxisFlagBlock` / `PraxisAdminBar` are mounted bare here, taking
+ *   none of the `panel` dress the score, vote and voters blocks wear, and they
+ *   accept no style prop to make skinning them the easy path. Their copy is
+ *   neutral and shared for the same reason (ADR-0061 as amended, 2026-07-28:
+ *   content slots carry a skin's voice, moderation and system chrome do not).
  *
  * ## One responsive component, no mobile twin (ADR-0056/0058)
  *
@@ -24,13 +40,18 @@
  * where they are mounted — never drawn twice and hidden, which would duplicate
  * the DOM and is what the design doc's twin markup would have produced. Mobile
  * stacks with flow, never a fixed-px grid (SPEC-faction-ui-profile §1a); the
- * 340px aside track is desktop-only.
+ * 330px aside TRACK is desktop-only, which is a different claim from the crown
+ * above — the track disappears on mobile, its contents do not.
  *
  * ## Copy and dress
  *
  * Copy is one neutral shared `detail.*` set (ADR-0061) — no na voice, no faction
  * voice; where the design's word differed from the domain noun in CONTEXT.md the
- * domain noun won ("Members", not "the crew"). Dress is na's alone: the spectrum
+ * domain noun won ("Members", not "the crew"). THIS page stays wholly neutral
+ * even under the 2026-07-28 amendment: `default` ≡ `na` is the unaffiliated
+ * identity, so the shared neutral set is already its voice. A faction skin may
+ * register its own copy for the CONTENT slots above; the chrome slots keep
+ * reading these same keys. Dress is na's alone: the spectrum
  * via `--faction-default-*` tokens plus `--color-*`, flipping light/dark through
  * the `[data-theme="dark"]` cascade with no `dark ?` branch. The page surface is
  * carried by the COLUMN, not the viewport — the site background still shows
@@ -667,8 +688,8 @@ export default function DefaultPraxisDetail({ state }: { state: PraxisDetailStat
           {desktop && (
             <aside
               style={{
-                flex: '0 0 340px',
-                width: 340,
+                flex: '0 0 330px',
+                width: 330,
                 display: 'flex',
                 flexDirection: 'column',
                 gap: 'var(--space-lg)',

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -481,6 +481,24 @@ export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
 
 // ── Flag block ────────────────────────────────────────────────────────────────
 
+/**
+ * The report card — NEUTRAL CHROME, deliberately outside the costume.
+ *
+ * All eight faction praxis-detail designs draw this card the same way: shared
+ * neutral copy on its own neutral token set, wearing none of the skin's dress
+ * while every panel around it does. Only the Unaffiliated design skinned it, and
+ * it is the outlier (#1117–#1123). ADR-0061 as amended (2026-07-28) states the
+ * rule the designs were drawing: content slots carry a skin's voice, moderation
+ * and system chrome do not — the report card, the steward bar, the banners and
+ * the errors read one shared neutral block in every faction's dress.
+ *
+ * That is enforced structurally rather than by convention: this component takes
+ * `state` and nothing else, so there is no `style` seam to dress it through, and
+ * every text node inside carries an explicit `--color-*` token or `.eyebrow`'s
+ * own neutral colour — so it cannot inherit a skin's sheet colour by accident.
+ * `PraxisAdminBar` above is built the same way for the same reason. If a skin
+ * ever needs this card to look different, that is an ADR change, not a prop.
+ */
 export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
   const { praxis, showFlagForm, setShowFlagForm, flagReason, setFlagReason, flagDetail, setFlagDetail, flagging, flagError, setFlagError, flagSubmitted, handleFlag } = state


### PR DESCRIPTION
Foundation for #1117–#1123. **Closes no issue** — all seven skin issues stay open; this is the base they build on, so that seven agents do not each work around the same wrong foundation.

No skin is built here. No `comments.<faction>.*` or `*Comment` file is touched. The score stamp, duel card and metatask block are untouched.

## 1. ADR-0061 amended

All seven skin issues specify their faction's voice under a heading reading "Copy (ADR-0061 **as amended**)" — but no amendment existed on `main`. The ADR as merged says the opposite: *"a faction skin brings dress and no copy"*.

The issues are the newer artifact and state the rule explicitly, so this writes the amendment rather than re-deciding the question. It follows the pattern PR #1113 used on ADR-0059: **additive, dated, original text preserved**. Nothing is deleted or rewritten — the Decision and Consequences stand verbatim, each narrowed statement gains a dated pointer, and the rule lands in its own `## Amendment (2026-07-28)` section.

The rule: **content slots carry the skin's voice; moderation and system chrome do not** — naming the report card, steward bar, banners and errors, and mapping them to the concrete catalog blocks (`detail.flag.*`, `detail.admin.*`, `detail.banners.*`, `detail.errors.*`) so it is enforceable rather than a vibe.

On the **why**, which is the part the ADR must not lose: the original rejected-alternative argued that per-design "neutral" wording fragments. The amendment does **not** overturn that — it says that argument is exactly where the line is now drawn, because chrome is the *platform* speaking and has to read identically everywhere or it stops reading as the system. Content takes the rejected alternative's *premise* instead (a praxis is somebody's account of a thing they did). That is the same boundary ADR-0061 already used for comment rows — the neutral rule stops at the speaker's voice — applied one step out: author / faction page / platform, one question and three consistent answers.

The amendment also states plainly what it costs (the near-synonym body and media headings the Context complains about will re-grow, this time designed rather than accreted) and restates the `comments.<faction>.*` boundary as untouched.

## 2. Shared layout reconciled to the eight designs

Each of the three facts was verified against the code before being changed. **One was wrong; two were already correct and were left alone.**

| Fact | Verdict |
|---|---|
| Aside track `330px` | **WRONG — fixed.** `DefaultPraxisDetail.tsx` shipped `flex: '0 0 340px'` / `width: 340`. |
| Crown at **both** form factors | **Already correct.** It is never form-factor gated: it comes from the shared `PraxisStatusBanners`, keyed only on `is_top_for_task`, mounted above the desktop/mobile split — so both layouts already draw it. The design's `top: 96px` vs `18px` is positioning inside its own phone frame; our banner sits in flow. No code change. |
| Report/flag card un-skinned | **Already correct.** `PraxisFlagBlock` takes `state` and nothing else — there is no `style` seam to dress it through — uses `.sidebar-card` with `--color-*` tokens only, and is mounted bare rather than wearing the faction `panel` dress that score/vote/voters take. Every text node inside carries its own neutral token or `.eyebrow`'s, so it cannot inherit a skin's sheet colour either. No code change. |

The premise that the docstring claimed a desktop-only crown did not hold up — it made no such claim. What it did claim wrongly was 340px, twice.

**Docstrings updated** so the source stops lying. The contract block now records all three facts, *including the two that were already right*: seven skins inherit this file, and an unstated fact gets re-derived seven times. `PraxisFlagBlock` gains a docstring explaining that its neutrality is structural, not conventional. The "340px aside is desktop-only" line was also disambiguated — the **track** is desktop-only, its contents are not, which is a different claim from the crown's and is exactly the confusion that could have produced a hidden mobile crown.

## Verification

- `tsc --noEmit` — **0 errors** (`tsc --version` confirmed to actually run at 5.9.3, so this is not the false-0 junction pass)
- `vitest run src/pages/praxisDetail` — **74 passed / 8 files**, including 3 new regression tests guarding all three facts
- `eslint src/pages/praxisDetail` — **clean**
- `vite build` — **green**; entry chunk 136.73 KB gzip, unchanged

**Visual QA is outstanding** — there is no dev stack in this worktree and the Browser pane renderer times out, so nothing here was eyeballed.

## What to eyeball

1. **The aside width at desktop** — the rail should now be 330px, and the main column correspondingly 10px wider.
2. **The crown on a crowned praxis at BOTH form factors** — desktop and mobile. This is the one that was asserted broken and was not; confirm it really does paint on a phone.
3. **The report/flag card's appearance** — it should read as neutral system chrome sitting inside the na sheet, not as part of the costume. This is the reference for all seven skins, so if it looks wrong here it will look wrong eight times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
