### PR TITLE
na fills go rainbow where a gradient fits: the feed's headline rule and the Meadow's wash (#983, #805)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -77,6 +77,16 @@ A measurement belongs to a **hue on a ground**. It survives exactly as long as b
 
 The third variant of this — a design kit's own annotations measured against the kit's plate rather than ours — is §6's, under "Reading a design kit".
 
+### Unaffiliated grey is usually a FILL written as a border (#983, #805)
+
+ADR-0039 draws one line: an unaffiliated player's identity is a gradient, so it appears wherever a gradient is expressible (`background:`, an SVG `fill=`) and stays neutral grey where one is not (`color:`, `border: Npx solid`). The line holds. What keeps going wrong is which side a given accent is actually on — and the answer is usually decided by how somebody happened to type it, not by what it is.
+
+**A rule drawn as a `border` is a fill that lost an argument with the shorthand.** The feed's headline accent read grey for every `na` row purely because it was written `borderLeft: 3px solid ${accent}`; drawn instead as a 3px element it is a fill, and the spectrum arrives with no ADR amendment and no change for the seven themed factions. Same story in the Meadow: an SVG `fill` takes `url(#…)`, so the bloom's soft wash was never a scalar — it had simply been switched off (`fill="none"`) for unaffiliated players, which cost them the flower shape and left a scatter of hard dots. **Before accepting that a surface owes `na` grey, check whether it is genuinely ink or merely a fill in a scalar's clothing.**
+
+**The spectrum comes in ramps cut for their geometry, and the cut is `factionFill`'s job, not the caller's.** `bar` is a 90deg ramp, `dot` a conic (a 7-stop linear at 10–12px is mud), and `rule` — `bar` stood on end — a 180deg one, because seven stops across a 3px-wide vertical rule is the same mud in the other axis. A themed faction returns the identical solid hue for all of them; only `na` is shape-dependent, which is what lets a call site swap `factionCssVar` for `factionFill` without restyling anybody else.
+
+**What stays grey stays grey, and it is a decision.** Actor names, kickers and links in the feed are single-ink text: no stop of a seven-stop ramp is legible as one (#649), and `background-clip: text` buys the spectrum at the price of text selection and high-contrast modes. Unaffiliated actor text is grey on purpose. Reporting it as a bug is how the wrong fix gets built.
+
 ### Albescent has no theme, on purpose (#783)
 
 Albescent is a secret society hiding in plain sight, so it is the one faction with **no `--faction-albescent-*` block and no slot in `FACTION_RAINBOW_ORDER`**. It maps to `default` in `CSS_KEY`, exactly as `na` does, which makes `isKnownFaction('albescent')` **false**. That is the intended outcome, not a gap: every surface that branches on that predicate hands Albescent the unaffiliated treatment automatically, including surfaces built later.

--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -194,4 +194,44 @@ describe('FeedRowContent', () => {
     const covenHtml = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={covenRow} avatarUrl={null} /></MemoryRouter>)
     expect(covenHtml).not.toContain('--faction-default-ring')
   })
+
+  // #983: the headline rule read grey for `na` only because it was written as a
+  // `border`, which is a scalar and so can never hold a gradient. Drawn as a
+  // filled bar it is a fill, and ADR-0039 gives it the spectrum unamended.
+  it('draws the headline rule as a filled bar, never a border', () => {
+    const row = completionRow('coven')
+    const html = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={row} avatarUrl={null} /></MemoryRouter>)
+    expect(html).not.toContain('border-left')
+    expect(html).toContain('background:var(--faction-coven)')
+  })
+
+  it('gives an na headline rule the VERTICAL rainbow, not the horizontal one', () => {
+    // The cut matters as much as the spectrum: the bar's 90deg ramp across a 3px
+    // rule is seven stops in three pixels, i.e. mud.
+    const html = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={completionRow('na')} avatarUrl={null} /></MemoryRouter>)
+    expect(html).toContain('--faction-default-rainbow-vertical')
+  })
+
+  it('hands albescent exactly what na gets, rule included (#783)', () => {
+    const naHtml = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={completionRow('na')} avatarUrl={null} /></MemoryRouter>)
+    const albHtml = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={completionRow('albescent')} avatarUrl={null} /></MemoryRouter>)
+    expect(albHtml).toBe(naHtml)
+  })
+
+  // The other half of ADR-0039, and the half that looks like a bug: an actor's
+  // NAME is single-ink text, no stop of a seven-stop ramp is legible as one
+  // (#649), so `na` keeps the neutral grey. Deliberate, not a fallback.
+  it('leaves an na actor name neutral grey', () => {
+    const html = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={completionRow('na')} avatarUrl={null} /></MemoryRouter>)
+    expect(html).toContain('color:#6b6a7a')
+    expect(html).not.toContain('background-clip:text')
+  })
 })
+
+/** A friend-completion row (actor + headline + points) in a given faction. */
+function completionRow(slug: string) {
+  return normalizeFeedItem({
+    ...item('friend_completion', { character_id: 3, praxis_id: 7, task_title: 'Reforest', task_point_value: 40 }),
+    context_faction_slug: slug,
+  })!
+}

--- a/frontend/src/components/feed/FeedRowContent.tsx
+++ b/frontend/src/components/feed/FeedRowContent.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import i18n from '../../i18n'
-import { factionColor, isKnownFaction } from '../../utils/factions'
+import { factionColor, factionFill, isKnownFaction } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import FeedBadge from './FeedBadge'
 import type { FeedRow } from './normalizeFeedItem'
@@ -11,6 +11,12 @@ import type { FeedRow } from './normalizeFeedItem'
  * inside the faction's frame (FactionFeedFrame). The faction's accent colors the
  * actor, avatar, and headline rule so the row reads in the faction's voice; the
  * frame supplies the physical chrome. No per-event-type card.
+ *
+ * Two of those three accents are FILLS and one is ink, which is the whole of
+ * ADR-0039 on this surface (#983). The monogram disc and the headline rule are
+ * painted elements, so they ask `factionFill` and an unaffiliated actor gets the
+ * spectrum. The actor's NAME is a single-ink `color:` — no stop of a seven-stop
+ * ramp is legible as text (#649) — so `na` stays neutral grey there on purpose.
  */
 export default function FeedRowContent({
   row,
@@ -19,6 +25,8 @@ export default function FeedRowContent({
   row: FeedRow
   avatarUrl: string | null
 }) {
+  // Scalar ink only — the actor's name and the real-faction monogram gradient.
+  // Never a fill: those go through factionFill so `na` reaches the spectrum.
   const accent = factionColor(row.slug)
   const known = isKnownFaction(row.slug)
   const initial = row.actor?.[0]?.toUpperCase() ?? '·'
@@ -133,37 +141,51 @@ export default function FeedRowContent({
             // Aligns the headline rule with the text column: --space-3xl (40px) is
             // the 28px avatar plus the --space-md row gap.
             marginLeft: row.actor ? 'var(--space-3xl)' : 0,
-            borderLeft: `3px solid ${accent}`,
-            paddingLeft: 'var(--space-md)',
+            display: 'flex',
+            gap: 'var(--space-md)',
           }}
         >
-          {row.headlineQuoted ? (
-            <p
-              className="font-body"
-              style={{ margin: 0, fontSize: 'var(--text-content)', fontStyle: 'italic', color: 'var(--color-text-primary)', lineHeight: 1.4 }}
-            >
-              {i18n.t('feed:row.quotedHeadline', { headline: row.headline })}
-            </p>
-          ) : row.headlineHref ? (
-            <Link
-              to={row.headlineHref}
-              className="font-body"
-              style={{ fontSize: 'var(--text-content)', fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', display: 'block', lineHeight: 1.3 }}
-            >
-              {row.headline}
-            </Link>
-          ) : (
-            <span className="font-body" style={{ fontSize: 'var(--text-content)', fontWeight: 700, color: 'var(--color-text-primary)', display: 'block', lineHeight: 1.3 }}>
-              {row.headline}
-            </span>
-          )}
-          {(row.points || row.level != null) && (
-            <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
-              {row.points}
-              {row.points && row.level != null ? ' · ' : ''}
-              {row.level != null ? i18n.t('feed:row.level', { level: row.level }) : ''}
-            </span>
-          )}
+          {/* The headline rule is a FILLED BAR, not a border (#983). It was only
+              ever a border by accident of how it was written, and `border: 3px
+              solid X` is a scalar — the one place a gradient cannot go — so an
+              unaffiliated row could never be anything but grey there. Drawn as an
+              element it is a fill, and ADR-0039 hands it the spectrum with no
+              amendment. `rule` rather than `bar`: the ramp has to run DOWN a 3px
+              column. Ornament geometry — the 3px width is the drawn rule itself,
+              not layout spacing. */}
+          <span
+            aria-hidden
+            style={{ width: 3, flexShrink: 0, alignSelf: 'stretch', ...factionFill(row.slug, 'rule') }}
+          />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {row.headlineQuoted ? (
+              <p
+                className="font-body"
+                style={{ margin: 0, fontSize: 'var(--text-content)', fontStyle: 'italic', color: 'var(--color-text-primary)', lineHeight: 1.4 }}
+              >
+                {i18n.t('feed:row.quotedHeadline', { headline: row.headline })}
+              </p>
+            ) : row.headlineHref ? (
+              <Link
+                to={row.headlineHref}
+                className="font-body"
+                style={{ fontSize: 'var(--text-content)', fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none', display: 'block', lineHeight: 1.3 }}
+              >
+                {row.headline}
+              </Link>
+            ) : (
+              <span className="font-body" style={{ fontSize: 'var(--text-content)', fontWeight: 700, color: 'var(--color-text-primary)', display: 'block', lineHeight: 1.3 }}>
+                {row.headline}
+              </span>
+            )}
+            {(row.points || row.level != null) && (
+              <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+                {row.points}
+                {row.points && row.level != null ? ' · ' : ''}
+                {row.level != null ? i18n.t('feed:row.level', { level: row.level }) : ''}
+              </span>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -211,6 +211,13 @@
   --faction-default-border: rgba(0, 0, 0, 0.12);
   --faction-default-rainbow: linear-gradient(90deg, #c1272d 0%, #c2541f 17%, #ca8a04 33%, #16a34a 50%, #1d6e72 67%, #2563eb 83%, #be185d 100%);
   --faction-default-ring: conic-gradient(#c1272d 0 51deg, #c2541f 0 103deg, #ca8a04 0 154deg, #16a34a 0 206deg, #1d6e72 0 257deg, #2563eb 0 309deg, #be185d 0 360deg);
+  /* The bar ramp stood on end (#983), for a vertical RULE — the left-edge
+     accent a feed row, a quoted block or a callout draws. Same seven stops,
+     same cut, 180deg: a rule is ~3px wide and tens of px tall, so the 90deg
+     ramp above would spend the whole spectrum across those 3px (≈0.4px a
+     stop) and read as one muddy smear, exactly the failure --faction-default-ring
+     exists to avoid on a 10px dot. Ramps are cut for their geometry. */
+  --faction-default-rainbow-vertical: linear-gradient(180deg, #c1272d 0%, #c2541f 17%, #ca8a04 33%, #16a34a 50%, #1d6e72 67%, #2563eb 83%, #be185d 100%);
   /* The same spectrum cut to TILE (#1023). Its last stop is its first, so a
      surface that scrolls its background-position loops without a seam — which
      the bar ramp above cannot do: red at 0% meets magenta at 100% and shows a
@@ -1458,6 +1465,7 @@
   --faction-default-border: rgba(255, 255, 255, 0.12);
   --faction-default-rainbow: linear-gradient(90deg, #e2433f 0%, #e07a3a 17%, #e6b94f 33%, #4ade80 50%, #3aa0a4 67%, #60a5fa 83%, #f472b6 100%);
   --faction-default-ring: conic-gradient(#e2433f 0 51deg, #e07a3a 0 103deg, #e6b94f 0 154deg, #4ade80 0 206deg, #3aa0a4 0 257deg, #60a5fa 0 309deg, #f472b6 0 360deg);
+  --faction-default-rainbow-vertical: linear-gradient(180deg, #e2433f 0%, #e07a3a 17%, #e6b94f 33%, #4ade80 50%, #3aa0a4 67%, #60a5fa 83%, #f472b6 100%);
   --faction-default-rainbow-loop: linear-gradient(90deg, #e2433f 0%, #e07a3a 14%, #e6b94f 28%, #4ade80 43%, #3aa0a4 57%, #60a5fa 72%, #f472b6 86%, #e2433f 100%);
   --faction-default-rainbow-conic: conic-gradient(#e2433f 0%, #e07a3a 14%, #e6b94f 28%, #4ade80 43%, #3aa0a4 57%, #60a5fa 72%, #f472b6 86%, #e2433f 100%);
   --faction-default-card-bg: #1c1b24;

--- a/frontend/src/pages/players/Meadow.tsx
+++ b/frontend/src/pages/players/Meadow.tsx
@@ -43,7 +43,9 @@ const GOLDEN_ANGLE_DEG = 137.5
  * `FACTION_RAINBOW_ORDER[i % length]`: any mismatch wraps the cycle and lands
  * the same hue on two ADJACENT petals (petal 0 and the last petal are
  * neighbours on the circle), which reads as one fat blob rather than a
- * spectrum. Albescent leaving the order (#783) took this from 7 to 6.
+ * spectrum. Both petal layers read it, so the count moves with the array and
+ * never with a literal: Albescent leaving the order (#783) took it to 6, and
+ * WOW rejoining with a yellow (#812) took it back to 7.
  */
 const PETAL_COUNT = FACTION_RAINBOW_ORDER.length
 // Bloom diameters (px). Deliberately the same ramp as the sky's orbs so the two
@@ -269,7 +271,10 @@ export default function Meadow({
   )
 }
 
-/** A single flower: petals in the faction hue, avatar as the centre disc.
+/** A single flower: two petal layers in the faction hue — a large soft wash
+ *  beneath a smaller solid petal — with the avatar as the centre disc. Both
+ *  layers walk the spectrum for an unaffiliated player; a bloom missing its wash
+ *  reads as a ring of dots rather than a flower (#805).
  *  Exported so the legend can draw the same glyph rather than a second flower. */
 export function MeadowBloom({
   size,
@@ -285,14 +290,25 @@ export function MeadowBloom({
   // slug has one hue or seven before asking for a colour (ADR-0039). See the
   // isKnownFaction docblock in utils/factions for why `na` is not known (#749).
   const known = isKnownFaction(slug)
-  const petalColor = (index: number): string => {
-    if (champion) return 'var(--meadow-champion-petal)'
-    // Unaffiliated wears the whole spectrum — one faction per petal, canonical
-    // order — rather than borrowing any single faction's hue (ADR-0039).
-    if (!known) return factionCssVar(FACTION_RAINBOW_ORDER[index % FACTION_RAINBOW_ORDER.length])
-    return factionCssVar(slug)
-  }
-  const washColor = champion ? 'var(--meadow-champion-petal)' : factionCssVar(slug, 'light')
+  /** Which slug paints petal `index`. Unaffiliated wears the whole spectrum —
+   *  one faction per petal, canonical order — rather than borrowing any single
+   *  faction's hue (ADR-0039). */
+  const petalSlug = (index: number): string | null =>
+    known ? slug : FACTION_RAINBOW_ORDER[index % FACTION_RAINBOW_ORDER.length]
+  const petalColor = (index: number): string =>
+    champion ? 'var(--meadow-champion-petal)' : factionCssVar(petalSlug(index))
+  /**
+   * The soft outer petal, a half-step off the solid one. It walks the SAME
+   * spectrum (#805): an SVG `fill` accepts a gradient, so this is a fill and not
+   * one of ADR-0039's scalar contexts — nothing here was ever owed grey. It used
+   * to be suppressed outright for unaffiliated players (`fill="none"`), which
+   * left them with only the hard inner petals and made four of the twelve blooms
+   * read as a scatter of dots beside everyone else's flowers.
+   */
+  const washColor = (index: number): string =>
+    champion
+      ? 'var(--meadow-champion-petal)'
+      : factionCssVar(petalSlug(index), 'light')
 
   return (
     <span style={{ position: 'relative', display: 'block', width: size, height: size }}>
@@ -305,7 +321,7 @@ export function MeadowBloom({
             cy={28}
             rx={17}
             ry={26}
-            fill={known || champion ? washColor : 'none'}
+            fill={washColor(index)}
             transform={`rotate(${(index * 360) / PETAL_COUNT + 180 / PETAL_COUNT} 50 50)`}
           />
         ))}

--- a/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
+++ b/frontend/src/pages/players/__tests__/playersDirectory.test.tsx
@@ -211,6 +211,39 @@ describe('light-theme meadow (#684)', () => {
     // sees, and a near-black petal would announce the society exists.
     expect(html).not.toContain('--faction-albescent')
   })
+
+  // #805: the bloom is TWO petal layers — a large soft wash under a smaller
+  // solid petal. The wash used to be suppressed outright for an unaffiliated
+  // player (`fill="none"`), so their bloom lost its flower shape and read as a
+  // scatter of dots beside everyone else's. An SVG `fill` takes a gradient, so
+  // this was never one of ADR-0039's scalar contexts: it walks the spectrum.
+  it('gives the unaffiliated bloom its soft wash, in the spectrum light tints', () => {
+    const { html } = render(
+      <Meadow players={ranked(PLAYERS)} maxScore={2140} myCharId={null} {...STAGE} />,
+    )
+    for (const slug of FACTION_RAINBOW_ORDER) {
+      expect(html, `${slug} wash petal`).toContain(`--faction-${slug}-light)`)
+    }
+    // The wash layer is the rx 17 / ry 26 ellipse; none of them may be blank.
+    expect(html, 'no wash petal is suppressed').not.toContain('rx="17" ry="26" fill="none"')
+  })
+
+  it('still washes a themed bloom in its own single hue', () => {
+    // The other half: only the unaffiliated bloom is shape-dependent. Reza is
+    // Ephemerists and Wren is Everymen, so each wash is one tint, not seven.
+    // (Neither may be the champion — the champion's own gilt overrides both
+    // petal layers before the faction is consulted.)
+    const { html } = render(
+      <Meadow
+        players={ranked([PLAYERS[1], player({ id: 44, display_name: 'Wren', faction_slug: 'everymen', score: 100 })])}
+        maxScore={2140}
+        myCharId={null}
+        {...STAGE}
+      />,
+    )
+    expect(html).toContain('--faction-everymen-light)')
+    expect(html).not.toContain('--faction-coven-light)')
+  })
 })
 
 // §3's load-bearing invariant. Asserted on the placement function, not the DOM —

--- a/frontend/src/utils/__tests__/factionAlbescentHidesInPlainSight.test.ts
+++ b/frontend/src/utils/__tests__/factionAlbescentHidesInPlainSight.test.ts
@@ -42,7 +42,7 @@ const SUFFIXES = [
   "on-fill",
 ];
 
-const SHAPES: FactionFillShape[] = ["bar", "dot", "pill", "frame"];
+const SHAPES: FactionFillShape[] = ["bar", "dot", "pill", "frame", "rule"];
 
 describe("Albescent is indistinguishable from unaffiliated", () => {
   it("resolves every CSS variable to exactly what `na` resolves to", () => {

--- a/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
+++ b/frontend/src/utils/__tests__/factionRainbowOrder.test.ts
@@ -157,6 +157,34 @@ describe("factionFill (#636 / ADR-0039)", () => {
     });
   });
 
+  // ── rule: the bar stood on end (#983) ──
+
+  it("turns na's ramp 180deg for a vertical rule", () => {
+    // A rule is ~3px wide and tens of px tall. The bar's 90deg ramp would spend
+    // all seven stops across those 3px, which is the same mud `dot` exists to
+    // avoid — so the vertical cut is the shape's whole reason to exist.
+    expect(factionFill("na", "rule")).toEqual({
+      background: "var(--faction-default-rainbow-vertical)",
+    });
+    expect(factionFill("na", "rule")).not.toEqual(factionFill("na", "bar"));
+  });
+
+  it("gives a real faction the same solid hue for rule as for bar", () => {
+    // Only na's fill is shape-dependent (ADR-0039): a themed faction's vertical
+    // rule and horizontal bar are one colour, so converting a border to a rule
+    // must not perturb how seven of the eight surfaces look.
+    for (const slug of ["everymen", "coven", "wow"]) {
+      expect(factionFill(slug, "rule")).toEqual(factionFill(slug, "bar"));
+    }
+  });
+
+  it("unregistered / null slugs rule like na (default), not ua", () => {
+    expect(factionFill("not_a_faction", "rule")).toEqual(
+      factionFill("na", "rule"),
+    );
+    expect(factionFill(null, "rule")).toEqual(factionFill("na", "rule"));
+  });
+
   it("keeps bar / dot / pill byte-identical after adding frame", () => {
     // Guards the refactor: the new shape must not perturb the existing three.
     expect(factionFill("na", "bar")).toEqual({

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -153,8 +153,15 @@ export function factionCssVar(
  * `"frame"` is the border-only case (#794): a rainbow *ring* for a surface that
  * needs a scalar accent (a selection ring, a card edge) rather than a fill, so
  * na stops falling back to grey there too.
+ *
+ * `"rule"` is `"bar"` stood on end (#983): the vertical left-edge accent a feed
+ * row or a quoted block draws. It is its own shape rather than a caller's
+ * problem because the bar's ramp runs 90deg — spend that across a 3px-wide rule
+ * and the spectrum lands ~0.4px a stop, which is the same mud `"dot"` exists to
+ * avoid. Every faction returns the identical value for `"bar"` and `"rule"`;
+ * only na's ramp turns.
  */
-export type FactionFillShape = "bar" | "dot" | "pill" | "frame";
+export type FactionFillShape = "bar" | "dot" | "pill" | "frame" | "rule";
 
 /**
  * A faction FILL as a style object to spread onto the filled element.
@@ -164,6 +171,9 @@ export type FactionFillShape = "bar" | "dot" | "pill" | "frame";
  * slugs are shape-dependent, because their identity is a gradient, not a hue
  * (ADR-0039):
  *   - `"bar"`  → the linear rainbow (`--faction-default-rainbow`)
+ *   - `"rule"` → the same ramp turned 180deg (`--faction-default-rainbow-vertical`)
+ *                for a vertical rule, where the horizontal ramp would compress
+ *                seven stops into the rule's ~3px width
  *   - `"dot"`  → the conic rainbow (`--faction-default-ring`; a 7-stop linear is
  *                mud at 10–12px)
  *   - `"pill"` → the rainbow as a *frame* (border-box) around a neutral paper
@@ -231,12 +241,13 @@ export function factionFill(
   }
 
   if (isDefault) {
-    return {
-      background:
-        shape === "dot"
-          ? "var(--faction-default-ring)"
-          : "var(--faction-default-rainbow)",
-    };
+    // bar / rule / dot: one spectrum, three cuts, picked by the geometry the
+    // fill lands on rather than by the caller remembering to rotate it.
+    if (shape === "dot") return { background: "var(--faction-default-ring)" };
+    if (shape === "rule") {
+      return { background: "var(--faction-default-rainbow-vertical)" };
+    }
+    return { background: "var(--faction-default-rainbow)" };
   }
   return { background: `var(--faction-${key})` };
 }
@@ -279,13 +290,19 @@ export function isKnownFaction(slug: string | null | undefined): boolean {
  * indistinguishable at every call site. `factionAlbescentHidesInPlainSight`
  * asserts that equality directly.
  *
- * The four call sites are all feed cards (`FeedRowContent`,
- * `FeedCardInvitationLetter`, `FeedCardCollabInvite`, `FeedCardDuelChallenge`).
- * None of them branches on `isKnownFaction`, so the whole feed renders `na` as
- * flat grey rather than the spectrum. That is pre-existing ADR-0039 debt owed to
- * *unaffiliated* players, not something Albescent introduces — and it must be
- * paid for both slugs at once, or the two stop matching and Albescent becomes
- * conspicuous again.
+ * The remaining call sites are all feed cards (`FeedRowContent`,
+ * `FeedCardInvitationLetter`, `FeedCardCollabInvite`, `FeedCardDuelChallenge`),
+ * and what survives there is deliberate rather than debt (#983). Every FILL in
+ * those cards — the monogram disc, the actor disc, the task dot, the headline
+ * rule — now goes through `factionFill`, so `na` and `albescent` carry the
+ * spectrum. What still reads this function is genuine SCALAR ink: the actor's
+ * name, the invitation letter's kicker and link. ADR-0039 §2 keeps those grey,
+ * because no single stop is legible across seven (#649), and a
+ * `background-clip: text` rainbow would cost text selection and high-contrast
+ * modes. **Grey unaffiliated actor text is the decision, not a fallback.**
+ *
+ * Whatever changes here must change for both slugs at once, or the two stop
+ * matching and Albescent becomes conspicuous again.
  *
  * Prefer {@link factionFill} for any `background:` that renders a dynamic slug.
  * This function survives for raw-hex contexts (canvas, SVG, `${hex}88` alpha


### PR DESCRIPTION
Closes #983
Closes #805

Two surfaces, one doctrine. **ADR-0039 is untouched** — an unaffiliated player's identity is a gradient, not a hue, so it appears only where a gradient is expressible. What both issues found is not a doctrine problem: it is accents that *are* fills but were written as something a gradient cannot live in, and so could only ever render grey.

## The seam: `factionFill(slug, "rule")`

`bar` is a 90deg ramp. Spend it across a 3px-wide vertical rule and seven stops land ~0.4px apart — the same mud `dot`'s conic exists to avoid at 10–12px. So the vertical accent gets its own cut, `--faction-default-rainbow-vertical` (180deg, both themes), and `factionFill` picks it by shape rather than making every caller remember to rotate a gradient.

Every themed faction returns **the identical value for `bar` and `rule`** (asserted), which is what lets a border become a filled element with no visual change for the other seven.

## #983 — the feed, use by use

| Use | Verdict |
|---|---|
| `FeedRowContent` headline rule | **Converted.** Was `borderLeft: 3px solid ${accent}` — a scalar, hence permanently grey. Redrawn as a 3px filled `<span>` on `factionFill(row.slug, 'rule')`. Also fixes a quieter bug: `factionColor` is the *light-mode* hex, so this rule never dark-moded for anyone. |
| `FeedRowContent` monogram disc | **Already correct** — it branches on `isKnownFaction` and paints `--faction-default-ring` with the monogram on a neutral interior (ADR-0039 §4). The issue's "none of them branch on `isKnownFaction`" is stale; so is the same claim in the `factionColor` docblock, which is rewritten. |
| `FeedCardDuelChallenge` / `FeedCardCollabInvite` actor disc + task dot | **Already correct** — both already route through `factionFill(…, 'dot')`. |
| `FeedRowContent` actor name | **Left grey, deliberately.** Single-ink `color:`; no stop of a seven-stop ramp is legible as text (#649), and `background-clip: text` costs text selection and high-contrast modes. |
| `FeedCardInvitationLetter` kicker, faction name, link | **Left grey, deliberately.** All three are `color:` — same reasoning. |

Every conversion goes through the value test (`resolveCssKey` → `default`), never key presence (#749), so `albescent` moves with `na` for free; a test asserts the two rows render byte-identical HTML.

## #805 — the Meadow bloom

Built the wash. Each bloom is two petal layers — a large soft wash under a smaller solid petal — and the wash was `fill='none'` for unaffiliated players, so they lost the flower shape and read as a scatter of hard dots. An SVG `fill` accepts `url(#…)`, so this was never a scalar context: it now walks the spectrum exactly as `petalColor` does, via a shared `petalSlug(index)` so the two layers cannot drift.

**The "compounding leak" is stale — confirmed, and here is why it looked real.** `FACTION_RAINBOW_ORDER` has seven entries and no `albescent`; there is no near-black petal and no dark blot. The issue was right when it was written: Meadow landed in `26a6fc14` (2026-07-18 16:22) and #783's collapse landed in `aa42180c` (2026-07-19 01:08), nine hours later — so the screenshot really did show `#1c1c1a` petals, and #783 closed it at the source exactly as the issue's own Q2 recommended. Nothing to fix; three existing tests already guard it.

Nothing else from #805 is touched: the sky/butterflies/stems fidelity gap (Q3/Q4) and ink-coloured scores (Q5) remain open design questions.

## One thing spotted, deliberately not changed

`DefaultFeedFrame` (`FactionFeedFrame.tsx`) draws the card's 4px left edge as `border-left: 4px solid factionCssVar(slug, 'card-accent')`. That is border-shaped too — but `card-accent` is a per-faction *ink*, not a spine hue, so converting it would repaint all eight factions' feed cards, and for `na` it currently resolves to `--faction-default-card-accent` (near-black `#1a1209`), which is neither grey nor spectrum. That is a design call outside this issue's four files. Flagging rather than guessing.

## Checks

`tsc --noEmit` clean · `eslint src --max-warnings=0` clean · `vitest run` 1847/1847 · `vite build` clean, and both new declarations verified in the **emitted** stylesheet at depth 1 under `:root` and `[data-theme=dark]` respectively.

**Visual QA is outstanding** — no screenshot renderer and no dev stack in this environment.

## What to eyeball

1. **An `na` actor's feed row** (Updates): the headline rule should run red→magenta *down* its 3px column, not read as one smeared colour. Check a one-line headline too — that is the shortest run the ramp gets.
2. **A themed row beside it** (coven, everymen): the rule must look exactly as it did before — same 3px, same colour, same gap to the text.
3. **Dark mode, both of the above.** The rule used to be a light-mode hex; it is a token now, so it should brighten.
4. **The actor name on that same `na` row stays grey.** That is the decision, not a missed spot.
5. **An `albescent` player's row** should be indistinguishable from the `na` one.
6. **The Meadow** (light theme, Players): every unaffiliated bloom should read as a *flower* — a soft spectrum halo under the hard petals — not a ring of dots. Compare against a themed bloom's single-tint halo and the champion's gilt.
7. **The Meadow legend**, which reuses `MeadowBloom` — the change reaches it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
