### PR TITLE
ADR-0063, ADR-0064, and reverse ADR-0046 — praxis detail v2 records

### DIFF
--- a/docs/adr/0046-albescent-is-frozen-new-surfaces-fall-through-to-na.md
+++ b/docs/adr/0046-albescent-is-frozen-new-surfaces-fall-through-to-na.md
@@ -1,6 +1,6 @@
 # ADR-0046 — Albescent is frozen: new surfaces fall through to NA
 
-**Status:** Accepted
+**Status:** Reversed
 **Date:** 2026-07-18
 **Relates to:** #726 (the duel skin this decision parks), #718 (the duel-skin
 epic whose per-faction issues this halts one of), ADR-0027 + #390 (Albescent as
@@ -45,6 +45,17 @@ The forces:
    immediately and have to be undone in full when the reskin lands.
 
 ## Decision
+
+> **Reversed (2026-07-28).** The hold was conditional on Albescent's visual
+> direction being unsettled. That direction landed with the praxis-detail v2
+> designs (project `bebdf7c7-6a54-42ea-b3b4-6d908a506f84`), so the freeze no
+> longer applies. Albescent registers surfaces like any other faction. See
+> #1085.
+>
+> **One consequence recorded here:** #726 (Albescent duel rail skins, closed
+> `wontfix`) **stays closed.** It targeted the duel rail, and ADR-0064 deletes
+> all twelve rails — the surface it would have skinned no longer exists. It
+> was closed for the freeze; it stays closed for a better reason.
 
 **Albescent is frozen. No new Albescent skins until further notice.**
 

--- a/docs/adr/0063-praxis-detail-collapses-to-one-responsive-component-per-faction.md
+++ b/docs/adr/0063-praxis-detail-collapses-to-one-responsive-component-per-faction.md
@@ -1,0 +1,91 @@
+# ADR-0063 — Praxis detail collapses to one responsive component per faction
+
+**Status:** Accepted
+**Date:** 2026-07-28
+**Relates to:** #1085 (epic), #1125 (this ADR's issue), #1088 (the collapse + the
+Unaffiliated rebuild), #1089 (the retirement)
+**Parallel to:** ADR-0056 (task cards), ADR-0058 (task detail) — the same
+collapse, a third surface
+
+## Context
+
+Praxis detail split hard by form factor: seven desktop archetypes (six
+per-faction plus Default) and eight mobile ones (six per-faction, Wow's
+mobile-only skin, and Default's own mobile twin), dispatched through two
+manifest surfaces (`praxisDetail`, `mobilePraxisDetail`) by a
+`formFactor === 'mobile'` branch in `PraxisDetail.tsx`.
+
+The repo had already made this call twice, in the same week:
+
+- **ADR-0056** — task cards collapse to one responsive component per faction.
+- **ADR-0058** — task detail does the same: *"Drop the `formFactor === 'mobile'`
+  branch… Each archetype calls `useFormFactor()` internally for its own size
+  set and conditional ornament. One responsive component per faction; no
+  mobile twin."*
+
+The praxis-detail v2 designs made the cost concrete: eight faction designs
+were committed (epic #1085, project `bebdf7c7-6a54-42ea-b3b4-6d908a506f84`).
+Keeping the split would have meant sixteen archetypes maintained against
+eight designs; collapsing meant eight and eight.
+
+The designs also settled the shape question the split was protecting. Every
+one of them is the same page at two widths — a three-region grid on desktop
+that stacks to one column on mobile, with score and duel moving above the
+proof. None is structurally a different page on a phone.
+
+## Decision
+
+**One responsive praxis-detail component per faction. No mobile twin.**
+
+- `PraxisDetail.tsx` no longer branches on `formFactor === 'mobile'`; it
+  always dispatches through the `praxisDetail` manifest surface (#1088).
+- Each archetype calls `useFormFactor()` internally for its own size set and
+  conditional ornament — the same shape ADR-0056 and ADR-0058 established for
+  task cards and task detail.
+- **Unlike those two, the collapse was not adopted as a reversible
+  experiment.** #1089 retired `pages/praxisDetail/mobileArchetypes/*` and the
+  `mobilePraxisDetail` manifest surface outright — the field, its
+  `SURFACE_KEYS` entry, and every faction registration — in the same wave as
+  the collapse itself, alongside the fourteen praxis-detail archetypes (six
+  desktop, eight mobile) and their `detail.<faction>.*` copy blocks. There is
+  no dormant revert path left in the tree; git history is the only way back.
+- The difference from ADR-0056/0058's terms is deliberate, not an oversight.
+  Those two surfaces were unproven collapses evaluated against designs that
+  did not yet exist for every faction, so their mobile twins stayed
+  registered-but-dormant — a verdict against the collapse had somewhere to
+  fall back to. Here, all eight praxis-detail designs were already committed
+  before a single faction archetype was rebuilt: the mobile skins were
+  **superseded by a committed design**, not held open pending one. Keeping
+  fourteen files compiling — and countable as live i18n consumers, the trap
+  ADR-0058 documented for task detail's own dormant tree — would have bought
+  a revert path against a question the designs had already settled.
+
+## Consequences
+
+- Future faction praxis-detail work is 7 designs and 7 components, not 14 and
+  14.
+- The duel rail's own split (`*DuelRail` / `*MobileDuelRail`) is retired
+  separately, in the same epic — see ADR-0064.
+- `praxisDetail` remains a registered manifest surface with, as of this
+  record, **zero faction registrations** — every slug falls through to
+  `DefaultPraxisDetail`, and the seven other factions re-register it one at a
+  time as their own designs land (#1117–#1123, #1140). That is override-only
+  working as documented (#782), not a gap — the same partial-registration
+  doctrine ADR-0046/0048 rely on. `mobilePraxisDetail`, by contrast, is
+  retired outright: there is no partial-registration story for a surface that
+  no longer exists, and no future issue should try to re-register it.
+
+## Alternative rejected
+
+**Keep the split.** The mobile archetypes were the thinner files (157–266
+lines against the desktop archetypes' 268–466), so the split was already
+buying less than it cost, and none of the eight designs draws a phone page
+that is structurally different from its desktop counterpart — every one is
+the same three-region layout collapsing to a single stacked column.
+
+**Hold the mobile archetypes dormant, on ADR-0056/0058's terms.** Considered
+and rejected for the same reason the collapse itself was not run as an
+experiment: the committed designs left nothing open to revert to. Keeping
+fourteen files compiling to protect a decision that eight finished designs
+had already made would have been pure carrying cost, paid by the i18n sweep
+and the style ratchet for no live option on the other end.

--- a/docs/adr/0064-the-praxis-read-page-owns-its-chrome.md
+++ b/docs/adr/0064-the-praxis-read-page-owns-its-chrome.md
@@ -1,0 +1,106 @@
+# ADR-0064 — The praxis read page owns its chrome (duel + comments become layout slots)
+
+**Status:** Accepted
+**Date:** 2026-07-28
+**Relates to:** #1085 (epic), #1126 (this ADR's issue), #1088 (comments moved
+into the archetype), #1090 (the duel rail replaced by the aside card)
+**Depends on:** ADR-0059 (submitting a collab or duel part holds the
+composer) — the run-up narration this ADR drops from detail only has
+somewhere to land because ADR-0059 already built the composer's waiting
+surface
+**Amends:** ADR-0006 (comments are neutral chrome below every archetype) —
+comments become a layout region the archetype mounts, not chrome the
+dispatcher appends
+
+## Context
+
+Two blocks used to be mounted by the dispatcher, outside the faction
+archetype, in `PraxisDetail.tsx`:
+
+- **The duel rail** — `DuelCrossLink`, above the archetype. Introduced by
+  #313 and grown to a full rail by #718, on the grilled #310 decision that it
+  is *"a mechanism, not a per-faction identity statement"*: one shared
+  faction-tokened component dropped above every archetype, inheriting the
+  **opponent's** tokens so the foreign element looked foreign.
+- **The comment thread** — `CommentThread`, below the archetype at
+  `max-w-2xl`.
+
+Both predated the page having a layout worth speaking of. The v2 designs gave
+it one: a three-region grid — main column, 330px aside, comments spanning
+both — and all eight place the duel panel **in the aside** and the comments
+**inside the grid**. A `max-w-2xl` thread hanging under a 1240px two-column
+page was precisely what the redesign fixed.
+
+Two objections from #718 no longer applied. It had declined the design's
+two-pane duel workspace because *"no praxis-detail surface has a two-column
+layout and mobile forbids one outright"* — this design introduced the two
+columns, and stacks them on mobile. And it had kept the full lifecycle rail
+because the read page was the only home for the duel's run-up; ADR-0059
+moved that to the composer.
+
+## Decision
+
+**The praxis read page owns its chrome. The duel panel and the comment
+thread are slots in the archetype's layout, not dispatcher mounts.**
+
+- `PraxisDetail.tsx` no longer mounts `DuelCrossLink` or `CommentThread`.
+  `DefaultPraxisDetail` renders both, in its own regions (#1088, #1090); the
+  dispatcher's own header comment now spells out that nothing is mounted
+  around the archetype any more.
+- The layout contract every faction skin inherits therefore has two required
+  slots: **duel** (aside) and **comments** (full width, beneath both
+  columns) — the latter via the shared `PraxisDetailComments`
+  (`pages/praxisDetail/shared.tsx`), which carries the `visible` gate so a
+  skin cannot forget it.
+- `DuelCrossLink` and the twelve `*DuelRail` components are **deleted**
+  (#1090; confirmed on disk — no `*DuelRail` component remains, only
+  comments citing the retirement). The read page's duel panel is now
+  `DuelCard` (`pages/praxisDetail/DuelCard.tsx`), the compact card the
+  designs drew: one label, two rows, one footer verdict line, with three
+  readings and no card at all on one status:
+  - **live** (`settled`) — the leader-by-margin sentence, phrased so the
+    winner still floats with the votes until era close (ADR-0011/0052);
+    nothing here may read as decided.
+  - **won by default** (`forfeited_by_character_id` set) — the forfeiter's
+    row dims to an em-dash; their total is *absent*, not losing, because the
+    tally stops deciding the duel once a side forfeits.
+  - **final** (`resolved`) — the frozen pair, or the no-contest line where
+    the duel never became votable before era close.
+  - **`declined`** draws nothing — the duel link dropped and the praxis is
+    an ordinary `type=solo` praxis (ADR-0011), so there is no duel to read
+    out. **`pending` / `active`** also draw nothing here; the run-up is
+    reachable only through the composer's waiting surface (ADR-0059), which
+    is why that ADR is listed as a dependency above rather than a sibling.
+- `CommentThread` is rendered by the archetype with `showHeading={false}`;
+  the layout draws the section header in the faction's own voice. The
+  thread's own prop docstring already warned against two headings for one
+  list.
+- **Comment rows are unaffected.** They dispatch on
+  `comment.author.faction_slug`, not the page's, and keep their own skins
+  (ADR-0061).
+
+## Consequences
+
+- A faction that has not authored a praxis-detail skin still gets both
+  slots, because it falls through to `Default*` — partial registration stays
+  the normal case (the same zero-registration state ADR-0063 records for
+  `praxisDetail` itself).
+- The run-up states the rail used to narrate (`pending`, `active`, next-step
+  line, stakes tiles, cast roster) have exactly one home: the composer's
+  waiting surface (ADR-0059). Nothing renders them twice.
+- `components/duel/shared.tsx` lost its rail consumer — the per-`DuelStatus`
+  `NextStepLine` — but **keeps** the duel seal and forfeit confirms
+  (`SealActions`, `useDuelSealCopy`, and the twelve `*DuelSealConfirm.tsx` /
+  `*MobileDuelSealConfirm.tsx` skins), verified present on disk before
+  anything in that file was touched.
+- Retires the #310 "chrome above the archetype" mechanism for this surface
+  only. Other dispatcher-mounted chrome is untouched.
+
+## Alternative rejected
+
+**Keep both mounted outside and drop the design's placement.** Cheaper —
+nothing to build, and seven future designs would inherit the rail free.
+Rejected because it leaves a full-width duel band above a two-column page
+and a narrow comment thread below it, and because the rail's remaining job
+after ADR-0059 was one state, which the card covers in a third of the
+space.


### PR DESCRIPTION
## Summary

Three docs-only changes, all recording the already-shipped praxis-detail v2 work (epic #1085), verified against the code before writing:

- **ADR-0063** — praxis detail collapses to one responsive component per faction. Records both the collapse (#1088) and the outright retirement of the fourteen faction archetypes + the `mobilePraxisDetail` surface (#1089). Unlike ADR-0056/0058, this one did **not** keep a dormant revert path — the mobile skins were superseded by committed designs, not held as a reversible experiment. Also records that `praxisDetail` deliberately stays a registered surface with zero registrations (Default only), pending the seven faction skin issues (#1117–#1123, #1140).
- **ADR-0064** — the praxis read page owns its chrome. Records that `DuelCrossLink` and the twelve `*DuelRail` components are deleted, replaced by `DuelCard` in the archetype's aside (three readings: live / won-by-default / final, no card on `declined`), and that `CommentThread` moved into the archetype with `showHeading={false}`. `PraxisDetail.tsx` no longer mounts either (#1090).
- **ADR-0046 amended in place** (no new ADR, per the issue) — status set to **Reversed**, amendment note added under the Decision heading (Albescent's visual direction has settled), rest of the file left intact. Records that #726 stays closed — for a new reason, since ADR-0064 deleted the duel rail it targeted.

## Verification performed

Every claim in both new ADRs was checked against the code on disk before writing, not transcribed from the issues:

- Confirmed `frontend/src/pages/praxisDetail/mobileArchetypes/` no longer exists and no `mobilePraxisDetail` references remain outside a dispatcher comment.
- Confirmed no `*DuelRail` component files exist anywhere in `frontend/src` — only comments citing the retirement (#1090) remain.
- Read `frontend/src/pages/praxisDetail/DuelCard.tsx` in full: it renders only for `duel.status` `settled`/`resolved` (three readings: live, won-by-default, final) and returns `null` otherwise, including `declined` — matches the issue's claim exactly.
- Confirmed `PraxisDetail.tsx` no longer mounts `DuelCrossLink` or `CommentThread`; both are mounted by `DefaultPraxisDetail`/`shared.tsx` instead, with `CommentThread` passed `showHeading={heading === undefined}`.
- Confirmed `grep -rln "praxisDetail:" frontend/src/factions/*.ts` returns nothing — zero faction registrations today, consistent with #1117–#1123 and #1140 being open.
- Confirmed `components/duel/shared.tsx` still exports `SealActions`/`useDuelSealCopy` and all twelve `*DuelSealConfirm.tsx`/`*MobileDuelSealConfirm.tsx` files still exist — it lost only its rail consumer (`NextStepLine`), not the seal confirms.

No claim needed correcting — everything in the prompt matched the code, so both ADRs are written as given (in the tense of decisions already carried out).

## Test plan

- [ ] Docs-only PR — no code changed, so `pytest` / `tsc` / `vite build` / `eslint` are unaffected by these edits (CI still runs but should be green independent of this change).
- [ ] Visual QA is **N/A** — no UI touched, no dev stack available in this worktree.
- [ ] Eyeball ADR-0063 and ADR-0064 for house-style fit against ADR-0059–0062 (Status/Date/Relates-to header block, Context → Decision → Consequences → Alternative rejected shape).
- [ ] Eyeball the ADR-0046 amendment: status line now `Reversed`, blockquote note under the Decision heading, rest of file (Context, Consequences, Alternatives considered) untouched.
- [ ] Confirm `docs/adr/` is the only directory touched (`git diff --stat main...claude/b3-adr63`).

Closes #1125
Closes #1126
Closes #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)