### PR TITLE
Cozy Coven praxis detail — the candlelit ward over the shared layout (#1117)

### DIFF
--- a/frontend/src/factions/coven.ts
+++ b/frontend/src/factions/coven.ts
@@ -24,6 +24,7 @@ const CovenFieldDesk = lazyArchetype(() => import('../pages/fieldDesk/mobileArch
 const CovenMobileDuelSealConfirm = lazyArchetype(() => import('../components/duel/CovenMobileDuelSealConfirm'))
 const CovenMobileEditPraxis = lazyArchetype(() => import('../pages/editPraxis/mobileArchetypes/CovenEditPraxis'))
 const CovenMobilePraxisCard = lazyArchetype(() => import('../components/praxisCard/mobile/CovenMobilePraxisCard'))
+const CovenPraxisDetail = lazyArchetype(() => import('../pages/praxisDetail/archetypes/CovenPraxisDetail'))
 const CovenProfileBody = lazyArchetype(() => import('../pages/characterProfile/archetypes/CovenProfileBody'))
 const CovenTaskCard = lazyArchetype(() => import('../components/cards/CovenTaskCard'))
 const CovenTaskDetail = lazyArchetype(() => import('../pages/taskDetail/archetypes/CovenTaskDetail'))
@@ -51,6 +52,7 @@ export const COVEN_MANIFEST: FactionManifest = {
   feedFrame: () => CovenFeedFrame,
   vote: () => CovenVote,
   taskDetail: () => CovenTaskDetail,
+  praxisDetail: () => CovenPraxisDetail,
   editPraxis: () => CovenEditPraxis,
   factionHero: () => CovenFactionHero,
   factionBody: () => CovenFactionBody,

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -190,6 +190,13 @@
       "bonus": "+{{points}} PTS",
       "remove": "Remove metatask",
       "add": "+ Add a metatask"
+    },
+    "coven": {
+      "writeUp": "What it looked like",
+      "members": "Cast together by",
+      "metatasks": "Charms added",
+      "duel": "A friendly duel",
+      "comments": "Comments"
     }
   },
   "comments": {

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -1,0 +1,413 @@
+/**
+ * Cozy Coven praxis detail — the skin's own contract (#1117, epic #1085).
+ *
+ * `archetypeSlots.test.tsx` walks the registry and guards the slots EVERY
+ * archetype must emit, and it picks this page up automatically the moment the
+ * manifest line lands. This file guards what is specific to the Coven skin:
+ *
+ *  - the layout contract it inherits from the eight faction designs (#1129) —
+ *    the 330px aside track, the responsive move of the score/duel rail, and the
+ *    crown at BOTH form factors;
+ *  - the five voiced content slots (ADR-0061 as amended, 2026-07-28);
+ *  - and the chrome the voice must NOT reach: the report card, the steward bar
+ *    and the moderation banners keep the shared neutral words.
+ *
+ * Harness note: `renderToStaticMarkup`, no DOM, no effects (SPEC-testing.md), so
+ * `useFormFactor` is MOCKED rather than driven off `matchMedia`. Light vs dark
+ * is a pure `[data-theme]` cascade with no branch in the component, and the
+ * candle/haze/wheel motions live in index.css behind
+ * `prefers-reduced-motion` — neither is assertable here; both are eyeball checks.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import type { PraxisOut, PraxisMemberOut } from '../../../api/praxis'
+import type { DuelDetailOut, DuelSideOut } from '../../../api/duel'
+import type { TaskOut } from '../../../api/tasks'
+import type { CurrentUser } from '../../../api/auth'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'desktop' | 'mobile' }))
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+// Imported after the mock so the archetype picks it up.
+const { default: CovenPraxisDetail } = await import('../archetypes/CovenPraxisDetail')
+
+const MEMBER: PraxisMemberOut = {
+  id: 101,
+  praxis_id: 1,
+  character_id: 3,
+  character_display_name: 'Ada',
+  has_submitted: true,
+  joined_at: '2026-01-01T00:00:00Z',
+}
+
+const CO_MEMBER: PraxisMemberOut = {
+  id: 102,
+  praxis_id: 1,
+  character_id: 4,
+  character_display_name: 'Beth',
+  has_submitted: true,
+  joined_at: '2026-01-02T00:00:00Z',
+}
+
+const PRAXIS: PraxisOut = {
+  id: 1,
+  task_id: 7,
+  task_title: 'Sweep The Stoop',
+  task_point_value: 12,
+  task_level_required: 2,
+  task_faction_slug: 'coven',
+  type: 'solo',
+  status: 'submitted',
+  title: 'The Long Way Round',
+  body_text: 'Walked the whole ridge before dark.',
+  moderation_status: 'visible',
+  admin_note: null,
+  flagged_at: null,
+  submitted_at: '2026-01-03T00:00:00Z',
+  submit_proposed_at: null,
+  created_by_id: 3,
+  created_by_display_name: 'Ada',
+  created_by_faction_slug: 'coven',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-03T00:00:00Z',
+  members: [MEMBER],
+  invites: [],
+  media_items: [
+    {
+      id: 9,
+      praxis_id: 1,
+      type: 'image',
+      file_path: 'proof.png',
+      display_order: 0,
+      created_at: '2026-01-03T00:00:00Z',
+    },
+  ],
+  // (base 12 + meta 0) × 1.0 + 4 from votes.
+  score: 16,
+  metatask_points: 0,
+  display_multiplier: 1.0,
+  points_from_votes: 4,
+  is_top_for_task: false,
+  duel_id: null,
+  can_flag: true,
+  applied_metatasks: [],
+}
+
+const MINE: DuelSideOut = {
+  praxis_id: 1,
+  character_id: 3,
+  display_name: 'Ada',
+  faction_slug: 'coven',
+  avatar_url: '',
+  points_from_votes: 18,
+  is_submitted: true,
+}
+
+const RIVAL: DuelSideOut = {
+  praxis_id: 2,
+  character_id: 4,
+  display_name: 'Rax',
+  faction_slug: 'snide',
+  avatar_url: '',
+  points_from_votes: 15.4,
+  is_submitted: true,
+}
+
+function duel(overrides: Partial<DuelDetailOut> = {}): DuelDetailOut {
+  return {
+    id: 5,
+    task_id: 7,
+    status: 'settled',
+    forfeited_by_character_id: null,
+    challenger: MINE,
+    opponent: RIVAL,
+    viewer_is_participant: false,
+    winner_character_id: null,
+    challenger_final_points: null,
+    opponent_final_points: null,
+    ...overrides,
+  }
+}
+
+const SEAL_METATASK: TaskOut = {
+  id: 501,
+  title: 'Composting',
+  description: null,
+  point_value: 60,
+  level_required: 0,
+  status: 'active',
+  task_type: 'metatask',
+  created_by: 9,
+  primary_faction_slug: null,
+  metatask_faction_slug: 'coven',
+  is_task_vision_eligible: false,
+  created_at: '2026-01-01T00:00:00Z',
+  can_submit_praxis: false,
+  allowed_modes: [],
+  eligible_for_current_user: false,
+}
+
+const VIEWER: CurrentUser = {
+  id: 50,
+  email: 'ada@example.com',
+  display_name: 'Ada',
+  is_admin: false,
+  can_comment: true,
+  character: {
+    id: 3,
+    display_name: 'Ada',
+    faction_slug: 'coven',
+    level: 4,
+    points: 120,
+    avatar_url: null,
+  },
+} as unknown as CurrentUser
+
+function state(overrides: Partial<PraxisDetailState> = {}): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: PRAXIS,
+    fetchError: null,
+    votes: { praxis_id: 1, total_votes: 2, total_score: 4 },
+    voters: [
+      { character_id: 11, display_name: 'Cy', avatar_url: '', faction_slug: '', value: 5 },
+      { character_id: 12, display_name: 'Dov', avatar_url: '', faction_slug: '', value: 3 },
+    ],
+    duel: null as DuelDetailOut | null,
+    isOwner: false,
+    showAdminBar: false,
+    user: null,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: '',
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: '',
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleFlag: async () => {},
+    handleKickMember: async () => {},
+    ...overrides,
+  }
+}
+
+function render(
+  next: PraxisDetailState,
+  formFactor: 'desktop' | 'mobile' = 'desktop',
+): { html: string; text: string } {
+  mocks.formFactor = formFactor
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <CovenPraxisDetail state={next} />
+    </MemoryRouter>,
+  )
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+/** Where a marker sits in the markup — the seam the responsive move is about. */
+function indexOf(html: string, needle: string): number {
+  const at = html.indexOf(needle)
+  expect(at, `marker missing: ${needle}`).toBeGreaterThan(-1)
+  return at
+}
+
+describe('Coven praxis detail — the shared layout contract', () => {
+  it('draws the breadcrumb on desktop and the back link on mobile', () => {
+    const wide = render(state())
+    expect(wide.html, 'breadcrumb links to the task bank').toContain('href="/tasks"')
+    expect(wide.html, 'breadcrumb links to the task').toContain('href="/tasks/7"')
+    expect(wide.html, 'no phone back link on desktop').not.toContain('href="/praxes"')
+
+    const phone = render(state(), 'mobile')
+    expect(phone.html, 'phone back link to the praxis index').toContain('href="/praxes"')
+    expect(phone.text, 'and its label').toContain('Praxes')
+  })
+
+  it('gives the desktop aside the eight designs 330px track, and none on mobile', () => {
+    expect(render(state()).html, 'the aside track').toContain('0 0 330px')
+    expect(render(state(), 'mobile').html, 'mobile stacks in flow').not.toContain('0 0 330px')
+    expect(render(state()).html, 'the Unaffiliated outlier width is not copied').not.toContain(
+      '340px',
+    )
+  })
+
+  it('moves the score block above the proof on mobile and into the aside on desktop', () => {
+    const wide = render(state())
+    expect(wide.text.match(/Score/g)?.length, 'one score block on desktop').toBe(1)
+    expect(indexOf(wide.html, 'Proof'), 'proof precedes the aside rail').toBeLessThan(
+      indexOf(wide.html, 'Score'),
+    )
+
+    const phone = render(state(), 'mobile')
+    expect(phone.text.match(/Score/g)?.length, 'one score block on mobile').toBe(1)
+    expect(indexOf(phone.html, 'Score'), 'rail rides above the proof on mobile').toBeLessThan(
+      indexOf(phone.html, 'Proof'),
+    )
+  })
+
+  it('shows the crown at BOTH form factors on a crowned praxis', () => {
+    const crowned = state({ praxis: { ...PRAXIS, is_top_for_task: true } })
+    expect(render(crowned, 'desktop').text, 'crown on desktop').toContain('TASK CROWN')
+    expect(render(crowned, 'mobile').text, 'crown on mobile too').toContain('TASK CROWN')
+    expect(render(state(), 'mobile').text, 'and only when crowned').not.toContain('TASK CROWN')
+  })
+
+  it('carries the candlelight ground on the column, never the viewport', () => {
+    // WORLD_ZERO_STYLE §5 / #1028: the site background must still show around
+    // the page. The wash is the column's own class, and index.css paints it
+    // there — nothing here may go full-bleed.
+    const { html } = render(state())
+    expect(html, 'the ward ground').toContain('coven-candle-backdrop')
+    expect(html, 'no full-viewport layer').not.toContain('position:fixed')
+  })
+
+  it('mounts the metatask seals read-only', () => {
+    const sealed = state({ praxis: { ...PRAXIS, applied_metatasks: [SEAL_METATASK] } })
+    const { text } = render(sealed)
+    expect(text, 'the seal renders').toContain('Composting')
+    // `apply_metatask` requires `in_progress`, so an add chip would 422 (#1093).
+    expect(text, 'no add slot on a published praxis').not.toContain('Add a metatask')
+  })
+})
+
+describe('Coven praxis detail — the faction voice', () => {
+  it('speaks Coven in the five content slots', () => {
+    const collab = state({
+      praxis: {
+        ...PRAXIS,
+        type: 'collab',
+        members: [MEMBER, CO_MEMBER],
+        applied_metatasks: [SEAL_METATASK],
+      },
+      duel: duel(),
+    })
+    const { text } = render(collab)
+    expect(text, 'the write-up').toContain('What it looked like')
+    expect(text, 'the crew').toContain('Cast together by')
+    expect(text, 'the metatasks').toContain('Charms added')
+    expect(text, 'the duel').toContain('A friendly duel')
+    expect(text, 'the comments region').toContain('Comments')
+
+    // …and the shared neutral headings the design leaves in the game's words.
+    expect(text, 'the proof heading stays shared').toContain('Proof')
+    expect(text, 'the duel head replaces the shared one').not.toContain('The duel')
+    expect(text, 'the crew head replaces the shared one').not.toContain('Members')
+  })
+
+  it('leaves moderation and system chrome in the shared neutral words', () => {
+    // ADR-0061 as amended (2026-07-28): content slots carry the skin's voice,
+    // the platform's own words do not.
+    const flagged = state({ praxis: { ...PRAXIS, moderation_status: 'flagged' } })
+    expect(render(flagged).text, 'the flagged banner').toContain('FLAGGED')
+
+    const failed = state({
+      praxis: {
+        ...PRAXIS,
+        moderation_status: 'failed',
+        admin_note: 'The photo is of a different ridge.',
+      },
+    })
+    expect(render(failed).text, 'the admin note is the banner body').toContain(
+      'The photo is of a different ridge.',
+    )
+
+    const steward = state({ showAdminBar: true })
+    expect(render(steward).text, 'the steward bar').toContain('ADMIN')
+  })
+
+  it('leaves the report card outside the costume', () => {
+    // `PraxisFlagBlock` is mounted BARE — it wears `.sidebar-card` and neutral
+    // `--color-*` tokens while every panel beside it wears the ward's dress.
+    const { html, text } = render(state())
+    expect(text, 'neutral copy').toContain('Flag this praxis')
+    expect(html, 'neutral card chrome').toContain('sidebar-card')
+  })
+
+  it('mounts the comment thread with the layout heading, not the threads own', () => {
+    const { text } = render(state())
+    expect(text, 'one heading for one list (#1029)').not.toContain('0 comments')
+  })
+
+  it('hides the comment region on a praxis that is not visible', () => {
+    const hidden = state({ praxis: { ...PRAXIS, moderation_status: 'hidden' } })
+    expect(render(hidden).text).not.toContain('Comments')
+  })
+})
+
+describe('Coven praxis detail — the state axes', () => {
+  it('renders the score readout from the shared resolver', () => {
+    const { text } = render(state())
+    expect(text, 'base').toContain('12')
+    expect(text, 'points from votes').toContain('4')
+    expect(text, 'total').toContain('16')
+  })
+
+  it('credits every co-author and reaches each one', () => {
+    const solo = render(state())
+    expect(solo.html, 'solo links one author').toContain('href="/characters/3"')
+    expect(solo.text, 'and draws no crew section').not.toContain('Cast together by')
+
+    const collab = state({
+      praxis: { ...PRAXIS, type: 'collab', members: [MEMBER, CO_MEMBER] },
+    })
+    const { html, text } = render(collab)
+    expect(html, 'each co-author is reachable').toContain('href="/characters/4"')
+    expect(text).toContain('Beth')
+  })
+
+  it('shows owner controls to a member and nothing to a visitor', () => {
+    expect(render(state()).html, 'a visitor gets no edit link').not.toContain(
+      'href="/praxes/1/edit"',
+    )
+    const owner = state({ isOwner: true, user: VIEWER })
+    expect(render(owner).html).toContain('href="/praxes/1/edit"')
+  })
+
+  it('lists who voted and each voters own rung, never an average', () => {
+    const { html, text } = render(state())
+    expect(text).toContain('Who voted')
+    expect(html).toContain('href="/characters/11"')
+    expect(text, 'the count, not the mean').toContain('2 votes')
+
+    expect(render(state({ voters: [] })).text, 'no empty voter panel').not.toContain('Who voted')
+  })
+
+  it('draws the duel card only on an outcome, at both form factors', () => {
+    // The three readings belong to `DuelCard` (#1090) and are guarded in
+    // `duelCard.test.tsx`; this asserts the MOUNT — that the skin hands the card
+    // its panel and heading, and that a declined challenge draws nothing.
+    const live = state({ duel: duel(), praxis: { ...PRAXIS, type: 'duel', duel_id: 5 } })
+    expect(render(live).text, 'the live reading, in the aside').toContain('leads by')
+    expect(render(live, 'mobile').text, 'and above the proof on the phone').toContain('leads by')
+
+    const declined = state({
+      duel: duel({ status: 'declined' }),
+      praxis: { ...PRAXIS, type: 'duel', duel_id: 5 },
+    })
+    expect(render(declined).text, 'a declined challenge draws no card').not.toContain(
+      'A friendly duel',
+    )
+    expect(render(state()).text, 'and a solo praxis has none either').not.toContain(
+      'A friendly duel',
+    )
+  })
+})

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -1,0 +1,786 @@
+/**
+ * Cozy Coven — THE CANDLELIT WARD, praxis detail (#1117, epic #1085; design
+ * project bebdf7c7, `Coven Praxis Detail.dc.html`).
+ *
+ * The first faction skin over the shared praxis-detail layout. It is the same
+ * page `DefaultPraxisDetail` draws — same regions, same slots, same API
+ * contract (ADR-0061) — wearing the ward the task detail (#1031) and the spell
+ * slip (#1023) already established for this faction: a candlelight haze
+ * drifting over the column, a pentagram watermark turning behind the copy,
+ * braided thread rules heading every section, and a candle flicker under the
+ * score. Grenze Gotisch carries the display, Cormorant Garamond the reading
+ * voice, Caveat the hand, Quicksand the chrome.
+ *
+ * ## Nothing here is new dress
+ *
+ * Every colour is a shipped `--faction-coven-slip-*` / `--faction-coven-ward-*`
+ * token, and all four motions (`cvn-haze` on `.coven-candle-backdrop`,
+ * `.cvn-candle`, `.cvn-wheel`, `.cvn-braid`) are index.css rules this file only
+ * names. So the light/dark flip and the `prefers-reduced-motion` guard run
+ * through the cascade, never a `dark ?` branch and never an inline `animation:`
+ * that would bypass the guard. **This skin adds no CSS at all** — the ward was
+ * measured for these exact two grounds in #1031 and the inks are reused on the
+ * same pair (page under the haze, panel a shade above it).
+ *
+ * ## The layout contract, inherited not re-derived (#1129)
+ *
+ * - Desktop: main column + a **330px** aside, comments beneath both.
+ * - Mobile: one stacked column; the score and duel blocks move ABOVE the proof.
+ *   ONE responsive component (ADR-0063) — `useFormFactor()` picks the size set;
+ *   there is no mobile twin, and no block is drawn twice and hidden.
+ * - The crown renders at **both** form factors. It is not this file's decision:
+ *   `PraxisStatusBanners` draws it off `is_top_for_task`, mounted above the
+ *   split so both layouts get it.
+ * - The **report card and the steward bar are NOT dressed** (ADR-0061 as
+ *   amended, 2026-07-28). `PraxisFlagBlock` / `PraxisAdminBar` are mounted bare,
+ *   wearing none of the panel dress every block beside them wears, and they take
+ *   no style prop to make dressing them possible. Same for the moderation
+ *   banners and the errors: content slots carry Coven's voice, the platform's
+ *   own words stay neutral in every faction's dress.
+ *
+ * ## The voice, and where it stops
+ *
+ * Five content slots read `detail.coven.*` — the write-up ("What it looked
+ * like"), the crew ("Cast together by"), the metatasks ("Charms added"), the
+ * duel ("A friendly duel") and the comments ("Comments"). Everything else reads
+ * the shared neutral `detail.*` keys, including the proof, score, vote and
+ * voters heads, which the design leaves in the game's words.
+ *
+ * The design's sixth voiced string, the comment composer's **"post"**, is
+ * deliberately NOT built. That button lives inside `CommentThread`'s composer,
+ * which dispatches on the VIEWER's faction, not the page's — a Snide player
+ * commenting here posts in Snide. ADR-0061 protects that boundary explicitly
+ * ("the neutral rule stops at the speaker's voice") and puts `comments.*` and
+ * the seven `*Comment` skins out of scope, so voicing it would have to be done
+ * on `CovenComment`, where it would follow a Coven viewer onto every other
+ * faction's page.
+ *
+ * ## Reused, not rebuilt
+ *
+ * `ScoreStamp`, which since #1091 carries the whole score rail and dispatches to
+ * `CovenScoreStamp` on a Coven task · `VoteUI`, which resolves this faction's
+ * own `CovenVote` (the design's `WowVote` import is a bug) and additionally owns
+ * the `viewer_can_vote` gate and the `VoteFactionContext` the logged-out gate
+ * reads, neither of which the widget carries itself · `CollabRoster` ·
+ * `MediaGallery` · `MetaTaskSeal`, read-only: `apply_metatask` requires
+ * `in_progress`, so an add chip would 422 on a published praxis · `DuelCard`,
+ * which narrates all three readings (live / won by default / final) and draws
+ * nothing on a declined challenge — the design draws only the live one, and is
+ * not re-narrated here · `CommentThread` via `PraxisDetailComments` with the
+ * layout's own heading, so one list carries one heading (the #1029 trap).
+ *
+ * The score ARITHMETIC is not built either: the design invents its own, and
+ * `scoreBreakdown()` (ADR-0053) is the single authority the mounted stamp reads.
+ */
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import MediaGallery from '../../../components/MediaGallery'
+import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
+import VoteUI from '../../../components/vote/VoteUI'
+import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
+import MetaTaskSeal from '../../../components/metaTaskSeal/MetaTaskSeal'
+import { CollabRoster } from '../../../components/collab/CollabRoster'
+import { DuelCard } from '../DuelCard'
+import { useFormFactor } from '../../../hooks/useFormFactor'
+import { formatTimestamp } from '../../../utils/dates'
+import {
+  PraxisAdminBar,
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisFlagBlock,
+  PraxisDetailComments,
+  MemberByline,
+  orderedMembers,
+} from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+
+/* The four faces, exactly as the spell slip and the ward page name them. */
+const CHROME = 'var(--font-faction-rounded)' /* Quicksand */
+const READING = 'var(--font-faction-serif)' /* Cormorant Garamond */
+const HAND = 'var(--font-faction-script)' /* Caveat */
+const DISPLAY = 'var(--font-faction-witch)' /* Grenze Gotisch */
+
+const INK = 'var(--faction-coven-slip-ink)'
+const DEEP = 'var(--faction-coven-slip-deep)'
+const SOFT = 'var(--faction-coven-slip-soft)'
+const LABEL = 'var(--faction-coven-slip-label)'
+const GOLD = 'var(--faction-coven-slip-gold)'
+const PINK = 'var(--faction-coven-slip-pk)'
+const BORDER = 'var(--faction-coven-slip-border)'
+const CARD = 'var(--faction-coven-ward-card)'
+const PAGE = 'var(--faction-coven-ward-page)'
+
+/** The aside track, from the eight faction designs (#1129). Layout, not dress. */
+const ASIDE_TRACK = 330
+
+interface SizeSet {
+  /** The byline's ringed disc. Ornament geometry (WORLD_ZERO_STYLE §4a). */
+  disc: number
+  /** The turning pentagram watermark. Ornament geometry. */
+  wheel: number
+  titleSize: string
+  headingSize: string
+}
+
+const SIZES: Record<'desktop' | 'mobile', SizeSet> = {
+  desktop: {
+    disc: 46,
+    wheel: 620,
+    titleSize: 'var(--text-display)',
+    headingSize: 'var(--text-title)',
+  },
+  mobile: {
+    disc: 38,
+    wheel: 420,
+    titleSize: 'var(--text-heading)',
+    headingSize: 'var(--text-title)',
+  },
+}
+
+/** Small-caps caption voice — every label on the ward speaks in it. */
+const CAPTION: CSSProperties = {
+  fontFamily: CHROME,
+  fontWeight: 700,
+  fontSize: 'var(--text-sm)',
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  color: LABEL,
+}
+
+/** The braided thread rule. `.cvn-braid` owns the strands' pigments (index.css). */
+function Braid({ style }: { style?: CSSProperties }) {
+  return <span aria-hidden className="cvn-braid" style={{ minWidth: 20, ...style }} />
+}
+
+/** Initials fallback for a member with no uploaded avatar. */
+function initials(name: string): string {
+  return (
+    name
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((word) => word[0])
+      .slice(0, 2)
+      .join('')
+      .toUpperCase() || '·'
+  )
+}
+
+/**
+ * One member's disc: a pink ring round a candle-lit field, the initials
+ * hand-lettered inside. Collab bylines stack these, overlapping, so a shared
+ * praxis reads as shared before a single name is parsed.
+ */
+function MemberDisc({ name, size }: { name: string; size: number }) {
+  return (
+    <span
+      aria-hidden
+      style={{
+        display: 'block',
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        // Ring-stroke inset: the padding IS the drawn band (WORLD_ZERO_STYLE §4a).
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: the drawn ring's stroke width.
+        padding: 2,
+        background: `linear-gradient(150deg, ${PINK}, ${GOLD})`,
+        flexShrink: 0,
+        boxShadow: '0 3px 10px var(--faction-coven-slip-glow)',
+      }}
+    >
+      <span
+        className="flex items-center justify-center"
+        style={{
+          width: '100%',
+          height: '100%',
+          borderRadius: '50%',
+          background: CARD,
+          fontFamily: HAND,
+          fontSize: 'var(--text-content)',
+          fontWeight: 700,
+          color: DEEP,
+        }}
+      >
+        {initials(name)}
+      </span>
+    </span>
+  )
+}
+
+export default function CovenPraxisDetail({ state }: { state: PraxisDetailState }) {
+  const { t } = useTranslation('praxis')
+  const formFactor = useFormFactor()
+  const desktop = formFactor !== 'mobile'
+  const size = SIZES[formFactor]
+  const { praxis, voters } = state
+
+  // Guarded non-null by the dispatcher.
+  if (!praxis) return null
+
+  const members = orderedMembers(praxis)
+  const isCollab = members.length > 1
+
+  /** Display label, braided rule, optional gloss — the page's only section head. */
+  const sectionHead = (label: ReactNode, gloss?: ReactNode) => (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-md)',
+        marginBottom: 'var(--space-md)',
+        flexWrap: 'wrap',
+      }}
+    >
+      <span
+        style={{
+          fontFamily: DISPLAY,
+          fontWeight: 600,
+          fontSize: size.headingSize,
+          lineHeight: 1.06,
+          letterSpacing: '0.02em',
+          color: INK,
+        }}
+      >
+        {label}
+      </span>
+      <Braid style={{ flex: 1 }} />
+      {gloss !== undefined && <span style={{ ...CAPTION, flex: '0 0 auto' }}>{gloss}</span>}
+    </div>
+  )
+
+  /** Aside / rail panel chrome — paper laid on the wash, shared by every block. */
+  const panel: CSSProperties = {
+    background: CARD,
+    border: `2px solid ${BORDER}`,
+    borderRadius: 16,
+    boxSizing: 'border-box',
+    boxShadow: 'var(--faction-coven-slip-shadow)',
+    padding: 'var(--space-lg)',
+  }
+
+  const sectionGap = desktop ? 'var(--space-2xl)' : 'var(--space-xl)'
+
+  // ── Navigation: breadcrumb on desktop, back link + label on mobile ─────────
+  const crumbLink: CSSProperties = {
+    ...CAPTION,
+    color: DEEP,
+    textDecoration: 'none',
+  }
+
+  const breadcrumb = (
+    <nav
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-sm)',
+        marginBottom: 'var(--space-md)',
+        flexWrap: 'wrap',
+      }}
+    >
+      <Link to="/tasks" style={crumbLink}>
+        {t('detail.breadcrumb.tasks')}
+      </Link>
+      <span aria-hidden style={{ ...CAPTION, color: SOFT }}>
+        ✿
+      </span>
+      <Link to={`/tasks/${praxis.task_id}`} style={crumbLink}>
+        {praxis.task_title}
+      </Link>
+      <span aria-hidden style={{ ...CAPTION, color: SOFT }}>
+        ✿
+      </span>
+      <span style={CAPTION}>{t('detail.breadcrumb.current')}</span>
+    </nav>
+  )
+
+  // The phone affordance the design draws instead of the breadcrumb. Not sticky:
+  // the mobile shell already owns a sticky top bar.
+  const mobileBar = (
+    <nav
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-sm)',
+        marginBottom: 'var(--space-md)',
+      }}
+    >
+      <Link to="/praxes" style={crumbLink}>
+        <span aria-hidden>‹ </span>
+        {t('detail.back')}
+      </Link>
+      <span style={{ ...CAPTION, flex: 1, textAlign: 'center' }}>
+        {t('detail.breadcrumb.current')}
+      </span>
+      {/* Balances the centred label against the back link's width. */}
+      <span aria-hidden style={{ width: 44 }} />
+    </nav>
+  )
+
+  // ── Moderation banners — NEUTRAL, in Coven's dress (ADR-0061 as amended) ───
+  // The crown hero and the failed note are the shared banners; the flagged
+  // notice has no shared slot, so it renders here — on the same `--color-*`
+  // warning tokens `DefaultPraxisDetail` uses, deliberately not on the ward's
+  // pinks. `PraxisAdminBar` is the steward bar, mounted bare for the same
+  // reason as the report card.
+  const banners = (
+    <>
+      <PraxisStatusBanners state={state} />
+      {praxis.moderation_status === 'flagged' && (
+        <div
+          style={{
+            border: '2px solid var(--color-warning)',
+            borderRadius: 8,
+            padding: 'var(--space-sm) var(--space-lg)',
+            marginBottom: 'var(--space-md)',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+            flexWrap: 'wrap',
+          }}
+        >
+          <span className="eyebrow" style={{ color: 'var(--color-warning)' }}>
+            {t('detail.banners.flaggedLabel')}
+          </span>
+          <span className="font-body content-text" style={{ color: 'var(--color-text-secondary)' }}>
+            {t('detail.banners.flaggedBody')}
+          </span>
+        </div>
+      )}
+      <PraxisAdminBar state={state} />
+    </>
+  )
+
+  // ── Byline · title · owner actions · task reference ───────────────────────
+  const header = (
+    <>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-md)',
+          marginBottom: 'var(--space-md)',
+        }}
+      >
+        {/* Stacked discs, one per member. A payload with no member rows still
+            credits its creator, so the author is always reachable here. */}
+        <span style={{ display: 'flex', alignItems: 'center' }}>
+          {(members.length > 0
+            ? members.map((member) => ({
+                id: member.character_id,
+                name: member.character_display_name || `#${member.character_id}`,
+              }))
+            : [{ id: praxis.created_by_id, name: praxis.created_by_display_name }]
+          ).map((author, index) => (
+            <Link
+              key={author.id}
+              to={`/characters/${author.id}`}
+              style={{
+                display: 'block',
+                // Each disc after the first laps the one before it — a spacing
+                // step off the scale, negated, not a loose pixel.
+                marginLeft: index === 0 ? 0 : 'calc(-1 * var(--space-lg))',
+                zIndex: index,
+              }}
+            >
+              <MemberDisc name={author.name} size={size.disc} />
+            </Link>
+          ))}
+        </span>
+        <div style={{ minWidth: 0, flex: 1 }}>
+          <MemberByline
+            praxis={praxis}
+            linkStyle={{
+              fontFamily: READING,
+              fontWeight: 600,
+              fontSize: desktop ? 'var(--text-title)' : 'var(--text-content)',
+              color: INK,
+              textDecoration: 'none',
+            }}
+          />
+          <div style={CAPTION}>
+            {t('detail.filed', {
+              date: formatTimestamp(praxis.submitted_at ?? praxis.created_at),
+            })}
+          </div>
+        </div>
+      </div>
+
+      <h1
+        style={{
+          fontFamily: DISPLAY,
+          fontWeight: 600,
+          fontSize: size.titleSize,
+          lineHeight: 1.04,
+          margin: '0 0 var(--space-md)',
+          color: INK,
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {praxis.title || praxis.task_title}
+      </h1>
+
+      <PraxisOwnerActions state={state} />
+
+      {/* Task reference — what this praxis is a doing OF. Braid above and below,
+          the ward's version of a ruled band. */}
+      <div style={{ marginBottom: sectionGap }}>
+        <Braid />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            gap: 'var(--space-sm)',
+            flexWrap: 'wrap',
+            padding: 'var(--space-md) 0',
+          }}
+        >
+          <span style={CAPTION}>{t('detail.taskRef.label')}</span>
+          <Link
+            to={`/tasks/${praxis.task_id}`}
+            className="content-text"
+            style={{ fontFamily: READING, fontWeight: 600, color: DEEP, textDecoration: 'none' }}
+          >
+            {praxis.task_title}
+          </Link>
+          <span style={{ ...CAPTION, marginLeft: 'auto' }}>
+            {t('detail.taskRef.level', { level: praxis.task_level_required })}
+            {' · '}
+            {t('detail.taskRef.points', { points: praxis.task_point_value })}
+          </span>
+        </div>
+        <Braid />
+      </div>
+    </>
+  )
+
+  // ── Score (built once; aside on desktop, above the proof on mobile) ────────
+  //
+  // ONE readout, and it is not this file's (#1091). `ScoreStamp` carries the
+  // whole rail — the sticker, its dashed rule, the highlighter multiplier chip
+  // and the votes tally — and dispatches to `CovenScoreStamp` on a Coven task.
+  // The design's own arithmetic (its own fudge factor over the vote average) is
+  // NOT built: `scoreBreakdown()` is the single authority (ADR-0053).
+  //
+  // The candle sits behind it: `.cvn-candle` carries the flicker and its
+  // reduced-motion guard, so stilled it is simply a steady glow.
+  const scoreBlock = (
+    <section style={{ ...panel, position: 'relative', overflow: 'hidden' }}>
+      {sectionHead(t('detail.score.heading'))}
+      <span
+        aria-hidden
+        className="cvn-candle"
+        style={{
+          position: 'absolute',
+          left: '50%',
+          top: '55%',
+          width: 200,
+          height: 200,
+          marginLeft: -100,
+          marginTop: -100,
+          borderRadius: '50%',
+          background: 'var(--faction-coven-slip-sigil-halo)',
+          pointerEvents: 'none',
+        }}
+      />
+      <div style={{ position: 'relative', display: 'flex', justifyContent: 'center' }}>
+        {/* The crown already has its own hero banner above; one mark per page. */}
+        <ScoreStamp praxis={praxis} showCrown={false} />
+      </div>
+    </section>
+  )
+
+  // ── Duel (built once; aside on desktop, above the proof on mobile) ─────────
+  //
+  // Panel chrome and section head are handed in, so the card wears the ward
+  // rather than its own dress. It self-hides for a praxis with no duel, for a
+  // DECLINED challenge, and for the run-up the composer owns (#1071/ADR-0059).
+  const duelBlock: ReactNode = (
+    <DuelCard state={state} style={panel} heading={sectionHead(t('detail.coven.duel'))} />
+  )
+
+  const rail = (
+    <>
+      {scoreBlock}
+      {duelBlock}
+    </>
+  )
+
+  // ── Vote · voters · flag ──────────────────────────────────────────────────
+  const voteBlock = (
+    <section style={panel}>
+      {sectionHead(t('detail.vote.heading'))}
+      <p
+        className="content-text"
+        style={{ fontFamily: HAND, margin: '0 0 var(--space-md)', color: SOFT }}
+      >
+        {t('detail.vote.prompt')}
+      </p>
+      {/* Dispatched on the TASK's faction — this page's own `CovenVote` moon
+          plate. `VoteUI` also owns the `viewer_can_vote` gate and publishes the
+          slug the widget's logged-out gate reads, so the widget is never
+          mounted bare (the design's `WowVote` import is a bug either way). */}
+      <VoteUI
+        factionSlug={praxis.task_faction_slug}
+        praxisId={praxis.id}
+        viewerCanVote={praxis.viewer_can_vote}
+      />
+    </section>
+  )
+
+  // Per-voter values come straight off `GET /praxes/{id}/voters`, already
+  // fetched by `usePraxisDetail`. NO AVERAGE anywhere (ADR-0014): the standing
+  // is the sum and the count, never the mean — and there is no per-voter points
+  // figure in the payload, so none is invented. Each voter's rung is a candle
+  // burning from pink into gold.
+  const votersBlock = voters.length > 0 && (
+    <section style={panel}>
+      {sectionHead(
+        t('detail.voters.heading'),
+        t('detail.voters.count', { count: voters.length }),
+      )}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-md)' }}>
+        {voters.map((voter) => (
+          <div
+            key={voter.character_id}
+            style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)' }}
+          >
+            <Link
+              to={`/characters/${voter.character_id}`}
+              style={{
+                flex: '1 1 auto',
+                minWidth: 0,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                fontFamily: READING,
+                fontWeight: 600,
+                fontSize: 'var(--text-content)',
+                color: INK,
+                textDecoration: 'none',
+              }}
+            >
+              {voter.display_name}
+            </Link>
+            <span
+              aria-hidden
+              style={{
+                width: 84,
+                height: 9,
+                borderRadius: 5,
+                background: PAGE,
+                border: `1px solid ${BORDER}`,
+                position: 'relative',
+                overflow: 'hidden',
+                flexShrink: 0,
+              }}
+            >
+              <span
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  width: `${(voter.value / 5) * 100}%`,
+                  background: `linear-gradient(90deg, ${PINK}, ${GOLD})`,
+                }}
+              />
+            </span>
+            <span
+              style={{
+                width: 20,
+                textAlign: 'right',
+                fontFamily: READING,
+                fontWeight: 600,
+                fontSize: 'var(--text-content)',
+                color: DEEP,
+              }}
+            >
+              {voter.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+
+  const asideRest = (
+    <>
+      {voteBlock}
+      {votersBlock}
+      {/* NOT dressed, by contract: the report card is the platform speaking. */}
+      <PraxisFlagBlock state={state} />
+    </>
+  )
+
+  // ── Proof · write-up · crew · charms ──────────────────────────────────────
+  const proof = praxis.media_items.length > 0 && (
+    <section style={{ marginBottom: sectionGap }}>
+      {sectionHead(t('detail.sections.proof'))}
+      {/* The slip's own gradient as a mat, the proof pressed onto it. */}
+      <div
+        style={{
+          borderRadius: 16,
+          padding: 'var(--space-sm)',
+          border: `2px solid ${BORDER}`,
+          background:
+            'linear-gradient(158deg, var(--faction-coven-slip-from), var(--faction-coven-slip-mid) 38%, var(--faction-coven-slip-lav) 76%, var(--faction-coven-slip-vio))',
+          boxShadow: 'var(--faction-coven-slip-shadow)',
+        }}
+      >
+        <div style={{ borderRadius: 10, background: CARD, padding: 'var(--space-md)' }}>
+          <MediaGallery media={praxis.media_items} layout={desktop ? 'grid' : 'column'} />
+        </div>
+      </div>
+    </section>
+  )
+
+  const writeUp = praxis.body_text && (
+    <section style={{ marginBottom: sectionGap }}>
+      {sectionHead(t('detail.coven.writeUp'))}
+      <MarkdownPreview
+        source={praxis.body_text}
+        className="markdown-preview content-text"
+        style={{ fontFamily: READING, lineHeight: 1.75, color: INK }}
+      />
+    </section>
+  )
+
+  const crew = isCollab && (
+    <section style={{ marginBottom: sectionGap }}>
+      {sectionHead(t('detail.coven.members'))}
+      <CollabRoster
+        members={praxis.members}
+        currentCharacterId={state.user?.character?.id ?? null}
+        factionSlug={praxis.task_faction_slug}
+        taskPointValue={praxis.task_point_value}
+        onKick={state.handleKickMember}
+      />
+    </section>
+  )
+
+  // READ-ONLY, by construction (#1093). `MetaTaskSeal` omits the peel control
+  // and the add slot when it gets neither `removable` nor `onAdd`, and each seal
+  // wears its ISSUING faction's dress (#927/#933). The design's add chips are
+  // deliberately absent: `apply_metatask` requires `status == in_progress`, so
+  // every chip would 422 on tap.
+  const metatasks = praxis.applied_metatasks.length > 0 && (
+    <section style={{ marginBottom: sectionGap }}>
+      {sectionHead(t('detail.coven.metatasks'))}
+      <MetaTaskSeal metatasks={praxis.applied_metatasks} />
+    </section>
+  )
+
+  return (
+    <div className="py-8" style={{ position: 'relative', color: INK, fontFamily: CHROME }}>
+      {desktop ? breadcrumb : mobileBar}
+
+      {/* The candlelight wash belongs to the COLUMN, not the viewport: the site
+          background still shows around the page (WORLD_ZERO_STYLE §5, the #1028
+          ruling). index.css owns the ground, its four blooms, their drift and
+          the light/dark flip; this only places and clips them. */}
+      <div
+        className="coven-candle-backdrop"
+        style={{
+          position: 'relative',
+          zIndex: 1,
+          maxWidth: 1200,
+          margin: '0 auto',
+          border: `2px solid ${BORDER}`,
+          borderRadius: 18,
+          padding: desktop ? 'var(--space-2xl)' : 'var(--space-lg)',
+          boxSizing: 'border-box',
+        }}
+      >
+        {/* The pentagram watermark, turning once every two minutes. `.cvn-wheel`
+            carries the motion and its reduced-motion guard (#911/#1023). */}
+        <svg
+          className="cvn-wheel"
+          width={size.wheel}
+          height={size.wheel}
+          viewBox="0 0 100 100"
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            right: desktop ? -170 : -140,
+            top: 140,
+            zIndex: 0,
+            pointerEvents: 'none',
+            opacity: 0.09,
+          }}
+        >
+          <circle cx="50" cy="50" r="44" fill="none" stroke={DEEP} strokeWidth="0.8" />
+          <path
+            d="M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z"
+            fill="none"
+            stroke={DEEP}
+            strokeWidth="1.1"
+            strokeLinejoin="round"
+          />
+        </svg>
+
+        <div style={{ position: 'relative', zIndex: 1 }}>
+          {banners}
+
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: desktop ? 'row' : 'column',
+              alignItems: 'stretch',
+              gap: desktop ? 'var(--space-2xl)' : 'var(--space-xl)',
+            }}
+          >
+            <div style={{ flex: '1 1 auto', minWidth: 0 }}>
+              {header}
+              {/* Mobile stacks the rail above the proof — one block each, moved,
+                  never a second copy hidden at the other breakpoint. */}
+              {!desktop && (
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 'var(--space-lg)',
+                    marginBottom: 'var(--space-xl)',
+                  }}
+                >
+                  {rail}
+                </div>
+              )}
+              {proof}
+              {writeUp}
+              {crew}
+              {metatasks}
+              {!desktop && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
+                  {asideRest}
+                </div>
+              )}
+            </div>
+
+            {desktop && (
+              <aside
+                style={{
+                  flex: `0 0 ${ASIDE_TRACK}px`,
+                  width: ASIDE_TRACK,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: 'var(--space-lg)',
+                }}
+              >
+                {rail}
+                {asideRest}
+              </aside>
+            )}
+          </div>
+
+          {/* The third layout region (ADR-0061, amending ADR-0006): comments sit
+              beneath both columns, inside the page's own sheet, and the layout
+              draws the heading so the thread does not draw a second one. */}
+          <PraxisDetailComments
+            state={state}
+            heading={sectionHead(t('detail.coven.comments'))}
+            style={{ marginTop: sectionGap }}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -282,13 +282,13 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
         {t('detail.breadcrumb.tasks')}
       </Link>
       <span aria-hidden style={{ ...CAPTION, color: SOFT }}>
-        ✿
+        ·
       </span>
       <Link to={`/tasks/${praxis.task_id}`} style={crumbLink}>
         {praxis.task_title}
       </Link>
       <span aria-hidden style={{ ...CAPTION, color: SOFT }}>
-        ✿
+        ·
       </span>
       <span style={CAPTION}>{t('detail.breadcrumb.current')}</span>
     </nav>

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -69,6 +69,10 @@
  * not re-narrated here · `CommentThread` via `PraxisDetailComments` with the
  * layout's own heading, so one list carries one heading (the #1029 trap).
  *
+ * The duel card and the comment thread are LAYOUT SLOTS of this page rather than
+ * chrome the dispatcher appends (ADR-0064) — which is why a skin mounts them at
+ * all, and why both take this file's panel and section head.
+ *
  * The score ARITHMETIC is not built either: the design invents its own, and
  * `scoreBreakdown()` (ADR-0053) is the single authority the mounted stamp reads.
  */


### PR DESCRIPTION
Closes #1117

The first faction skin over the shared praxis-detail layout: Cozy Coven's
candlelit ward, dressing `DefaultPraxisDetail`'s regions rather than rebuilding
them. One responsive component (ADR-0063) — `useFormFactor()` internally, no
mobile twin.

## What landed

- `pages/praxisDetail/archetypes/CovenPraxisDetail.tsx` — the skin.
- `factions/coven.ts` — one `praxisDetail` line; the `praxisDetail` registry has
  its first entry since #1089, so `archetypeSlots.test.tsx` now walks this page
  automatically (no test edit needed, which is why that loop stayed).
- `locales/en/praxis.json` — a `detail.coven.*` block, five keys, appended
  inside `detail`. Nothing reordered.
- `pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx` — the skin's own
  contract.

## Dress — and it adds no CSS

Grenze Gotisch (display) · Cormorant Garamond (reading) · Caveat (hand) ·
Quicksand (chrome), on the `--faction-coven-slip-*` / `--faction-coven-ward-*`
tokens the spell slip (#1023) and the candlelit task detail (#1031) already
shipped. All four motions are existing index.css rules this file only names —
the drifting haze (`.coven-candle-backdrop`), the candle flicker under the score
(`.cvn-candle`), the turning pentagram (`.cvn-wheel`) and the braided section
rules (`.cvn-braid`). Each is already gated on
`@media (prefers-reduced-motion: no-preference)`, so the skin writes no inline
`animation:` that could bypass the guard, and the light/dark flip runs entirely
through the `[data-theme="dark"]` cascade — no `dark ?` branch anywhere.
`index.css` is untouched, so none of the moved-block hazards apply.

The ward ground is painted on the 1200px COLUMN, not the viewport — the site
background still shows around the page (WORLD_ZERO_STYLE §5, the #1028 ruling).

## The contract, inherited not re-derived (#1129)

- 330px aside track on desktop, dropped (not hidden) on mobile.
- Score and duel are built ONCE and moved by where they are mounted — aside on
  desktop, above the proof on mobile. Never drawn twice and hidden.
- The crown renders at both form factors; it comes from the shared
  `PraxisStatusBanners`, keyed only on `is_top_for_task`.
- **The report card and the steward bar are not dressed.** `PraxisFlagBlock` and
  `PraxisAdminBar` are mounted bare on `.sidebar-card` + `--color-*`, wearing
  none of the ward's panel dress; the flagged/failed banners keep the shared
  neutral copy and warning tokens (ADR-0061 as amended, 2026-07-28).

## Voice — five slots of six

Content slots read `detail.coven.*`: write-up "What it looked like" · crew
"Cast together by" · metatasks "Charms added" · duel "A friendly duel" ·
comments "Comments". Proof, score, vote and voters keep the shared neutral heads.

**The sixth string, the composer's "post", is deliberately not built.** That
button lives inside `CommentThread`'s composer, which dispatches on the VIEWER's
faction rather than the page's — voicing it means editing `CovenComment` /
`comments.coven.*`, which ADR-0061 puts out of scope in both its Decision and
its Amendment ("the neutral rule stops at the speaker's voice"), and a Coven
viewer would then carry that word onto every other faction's page. Flagged here
rather than guessed; if the word is wanted, it is a `comments.*` change with its
own issue.

## Not built, per the grill

The score arithmetic (mounted `ScoreStamp` → `CovenScoreStamp` over
`scoreBreakdown()`, ADR-0053) · metatask add-chips (`apply_metatask` needs
`in_progress`; read-only `MetaTaskSeal`) · the duel verdict as drawn (`DuelCard`
already has all three readings and draws nothing on `declined`) · phone chrome ·
the left sidebar · comment rows.

The design's `WowVote` import is a bug: this mounts `VoteUI` on
`task_faction_slug`, which resolves Coven's own `CovenVote` **and** carries the
`viewer_can_vote` gate plus the `VoteFactionContext` the logged-out gate reads —
neither of which the widget owns itself, so mounting `CovenVote` bare would have
shown the caster to a praxis owner.

## Checks

`tsc --noEmit` clean · `eslint src` clean (net-new file takes `no-raw-style-values`
in full; one per-line ornament hatch, for the drawn ring stroke on the byline
disc) · `vitest run` 1877 passing, 127 files · `vite build` clean; the skin
code-splits into its own `CovenPraxisDetail-*.js`, entry chunk unchanged at
137 KB gzip.

**Visual QA is outstanding** — this environment cannot screenshot and has no dev
stack, so everything below is unverified by eye.

### What to eyeball

Desktop, light then dark:
1. Published solo, uncrowned, as a visitor — haze drift, turning pentagram
   behind the copy, braid rules, candle flicker under the score sticker.
2. Same praxis crowned — crown hero above the split, and only one score mark.
3. Published collab (3+ members) as a member — overlapping byline discs,
   "Cast together by" roster, the kick control.
4. Settled duel — "A friendly duel" card in the aside. **Known nit:** `DuelCard`
   paints its own `--faction-default-*` inks with no dress seam, so the names
   and totals inside the ward read cream/near-black rather than Coven pink. It
   is legible in both themes; every sibling skin will hit it identically, so it
   wants one shared fix, not seven.
5. Flagged, and failed-with-note, as a steward — banners + steward bar must read
   as the platform, not as the coven.
6. Any praxis with 5+ voters — the pink→gold rungs and the un-dressed report card
   directly beneath them.

Mobile (same six), light and dark:
7. Score and duel above the proof; no 330px track; the back link instead of the
   breadcrumb; the pentagram clipped at the column edge.
8. `prefers-reduced-motion: reduce` — haze, flicker and wheel all still, and the
   page still reads as the ward.

## Note for the wave

`factions/__tests__/surfaceDispatch.test.ts` has no `praxisDetail` BESPOKE row
(its comment says the row returns "with the first of them"). I left it out on
purpose: a row naming only `coven` would be false within hours and would fail
main the moment a sibling skin merges without a rebase. It should come back once
in a follow-up listing every faction that has landed, not four times in parallel.
