### PR TITLE
Fix red main: praxisDetail BESPOKE row lost two landed skins

### DIFF
--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -72,7 +72,7 @@ const CORE_SIX = ['coven', 'snide', 'ephemerists', 'singularity', 'everymen', 'u
 // neutral copy. Both are "registered"; only one is a skin.
 const BESPOKE: Record<string, string[]> = {
   taskDetail: [...CORE_SIX, 'wow', 'albescent'],
-  praxisDetail: ['coven', 'albescent'],
+  praxisDetail: ['coven', 'ephemerists', 'singularity', 'albescent'],
   mobileFactionPage: [...CORE_SIX, 'wow'],
   mobileFieldDesk: [...CORE_SIX, 'wow'],
   mobileEditPraxis: [...CORE_SIX, 'wow'],


### PR DESCRIPTION
`main` is red at 63057880.

`surfaceDispatch.test.ts` asserts **both** directions — every listed slug must be registered, and every *unlisted* slug must resolve to the Default. #1157 (Albescent) rewrote the row as `['coven','albescent']`, dropping `ephemerists` (#1156, already merged) and not anticipating `singularity` (#1158, merged after). Both are registered, so the `leaves %s to the surface Default` half failed.

Each PR was green on its own branch. The row is a shared registry, so a squash merge of a green branch can still red main — which is exactly what happened twice in a row here.

Row now matches the four skins actually registered on `main`: coven, ephemerists, singularity, albescent.

Three more skins (SNIDE #1159, WOW #1160, Everymen #1161) are open and each conflicts on this same line; they will each add their slug as they land.

## What to eyeball

- [ ] `main` goes green again
- [ ] No behaviour change — this is a test registry only