### PR TITLE
UA duel seal skins — the breath before the stroke (#725)

### DIFF
--- a/frontend/src/components/duel/UaDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/UaDuelSealConfirm.tsx
@@ -1,0 +1,337 @@
+/**
+ * University of Asthmatics DESKTOP duel seal-confirm (#725) — the breath before
+ * the stroke.
+ *
+ * UA is the last core faction to get a duel dialog, and it arrives in the
+ * practice's own register rather than the mock's. `UaDuel.dc.html` /
+ * `UaDuelDialog.dc.html` draw a GILT frame, and #788/#848–#853 removed gold from
+ * UA entirely (it went to Warriors of Whimsy, ADR-0050) — the issue's own audit
+ * comment says the mock "is no longer buildable as drawn". So the chrome is
+ * taken from the sibling seal skins' structure plus UA's shipped kit: a quiet,
+ * sun-bleached practice sheet served over the composer, one ensō at its head,
+ * hairline rules, Cormorant display over EB Garamond text.
+ *
+ * The metaphor is the mark itself. An ensō is made in one breath and left open;
+ * sealing your side of a duel is the moment the brush touches the paper. In
+ * forfeit mode the circle dims — the breath let go — the title drops a tier, and
+ * a vermilion rule runs down the body. Quiet, because UA is quiet; marked,
+ * because the consequence is permanent.
+ *
+ * BOTH MODES, ONE FILE (#751). `useDuelSealCopy` owns every string that differs
+ * (heading, body, the free-reopen note, the confirm label, the destructive
+ * tone); this skin re-derives none of it. What the mode changes here is chrome
+ * only.
+ *
+ * COPY IS FACTION-NEUTRAL (#718) — identity is visual. Every string comes
+ * through `t()` from the shipped `duelSeal.*` / `duelStakes.*` / `duelForfeit.*`
+ * keys, and this skin adds NO catalog keys and voices nothing. The one label it
+ * draws itself, the stakes rubric, is the shipped neutral `duelStakes.heading`,
+ * the same key `EphemeristsDuelSealConfirm` uses.
+ *
+ * Pure frame otherwise: `StakesTiles` computes the figures from the VIEWER's own
+ * faction config (Snide's 0.0× lose falls out by construction), `RaceRoster`
+ * reads `is_submitted`, and `SealActions` owns the global [Cancel] … [Submit]
+ * order (#646). None is dropped in either mode.
+ *
+ * THE OPPONENT'S HUE IS HELD AS A RING, AN EDGE AND A BAR — NEVER AS INK AND
+ * NEVER BEHIND TEXT (#310, #1115). It can be any colour in the palette, so this
+ * is what lets a hostile hue sit inside UA's cream without a contrast fix, and
+ * there is no text pair to measure. All three marks are DRAWN FILLS through
+ * `factionFill`, so an unaffiliated opponent gets the spectrum in the cut its
+ * geometry needs (conic ring / vertical rule / horizontal bar) instead of
+ * degrading to grey (ADR-0039). The structural guard for this rule died with the
+ * duel rail — nothing will catch a violation automatically.
+ *
+ * CONTRAST, measured with `utils/contrast.ts` on both themes. UA's paper and
+ * accent are both warm and light, which makes it the faction most prone to
+ * failing pairings (#1155). `--color-danger` reads 3.98:1 on `--faction-ua-card-bg`
+ * in light — below AA for 18px body copy — so the forfeit body is NOT painted in
+ * it. It takes `--faction-ua-card-notice` (5.85:1 light / 9.87:1 dark on the
+ * sheet), one of the two inks minted for exactly this, and the red survives only
+ * as a RULE beside the paragraph, where it carries no text. The reopen note
+ * takes `--faction-ua-card-credit` (7.51:1 / 9.46:1) for the same reason.
+ * Everything in the stakes well sits on `--faction-ua-panel`: card-text 11.32 /
+ * 12.28, card-muted 5.13 / 5.10, `--color-success` 7.07 / 8.56, and the Snide
+ * zero figure in `--color-danger` at 3.75 / 5.39 — 24px bold, so large text at a
+ * 3:1 floor.
+ *
+ * Both themes come from the `[data-theme="dark"]` cascade; there is no ternary
+ * on theme anywhere in this file.
+ */
+import { useTranslation } from 'react-i18next'
+import { factionCssVar, factionFill } from '../../utils/factions'
+import { UaSigil } from '../cards/UaSigil'
+import { UA_DISPLAY, UA_EYEBROW, UA_TEXT, uaShade } from '../cards/uaAtoms'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const SHEET = 'var(--faction-ua-card-bg)'
+const PANEL = 'var(--faction-ua-panel)'
+const LIFT = 'var(--faction-ua-lift)'
+const INK = 'var(--faction-ua-card-text)'
+const MUTED = 'var(--faction-ua-card-muted)'
+const RULE = 'var(--faction-ua-rule)'
+const HAIR = 'var(--faction-ua-hair)'
+const NOTICE = 'var(--faction-ua-card-notice)'
+const CREDIT = 'var(--faction-ua-card-credit)'
+
+export default function UaDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { t } = useTranslation('praxis')
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  // Opponent tokens, the same rule as the Default dialog and every sibling skin:
+  // the foreign duelist looks foreign even inside UA's own sheet (#310). This
+  // scalar reaches the shared slots' tile rings; the three marks this file draws
+  // itself go through `factionFill` instead, so `na` keeps its spectrum.
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: MUTED, bodyFont: UA_TEXT }
+
+  const relinquishing = copy.danger
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{
+        padding: 'var(--space-lg)',
+        background: 'radial-gradient(circle, rgba(0,0,0,0.55), rgba(0,0,0,0.75))',
+      }}
+    >
+      <div
+        className="w-full max-w-[460px]"
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          background: SHEET,
+          color: INK,
+          fontFamily: UA_TEXT,
+          border: `1px solid ${RULE}`,
+          borderRadius: 'var(--radius-md)',
+          boxShadow: `0 22px 54px -26px ${uaShade(60)}`,
+        }}
+      >
+        {/* ── OPPONENT EDGE ── the foreign hue down the sheet's spine, as a
+            drawn fill so an unaffiliated opponent gets the vertical ramp. */}
+        <span
+          aria-hidden
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            left: 0,
+            width: 4,
+            ...factionFill(foe.faction_slug, 'rule'),
+          }}
+        />
+
+        {/* ── Masthead: the mark, the beat, the foe ── */}
+        <div
+          style={{
+            padding: 'var(--space-lg) var(--space-xl)',
+            background: LIFT,
+            borderBottom: `1px solid ${HAIR}`,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-md)',
+              minWidth: 0,
+            }}
+          >
+            {/* The circle dims when the brush is being set down rather than
+                lifted. Ornament only — UaSigil is aria-hidden throughout. */}
+            <span style={{ display: 'flex', opacity: relinquishing ? 0.35 : 1 }}>
+              <UaSigil width={38} height={38} />
+            </span>
+            <h2
+              style={{
+                margin: 0,
+                minWidth: 0,
+                fontFamily: UA_DISPLAY,
+                fontWeight: 600,
+                // The costly dialog speaks a tier quieter than the routine one.
+                // Both rungs are Content tier (§4a).
+                fontSize: relinquishing ? 'var(--text-title)' : 'var(--text-heading)',
+                lineHeight: 1.05,
+                letterSpacing: '-0.01em',
+                color: INK,
+              }}
+            >
+              {copy.heading}
+            </h2>
+          </div>
+
+          {/* ── OPPONENT RING ── a drawn ring (outer fill, inner UA disc), so the
+              monogram sits on UA's own stock and never on the foreign hue. */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-sm)',
+              marginTop: 'var(--space-lg)',
+              minWidth: 0,
+            }}
+          >
+            <span
+              aria-hidden
+              style={{
+                flexShrink: 0,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 34,
+                height: 34,
+                borderRadius: '50%',
+                ...factionFill(foe.faction_slug, 'dot'),
+              }}
+            >
+              <span
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 26,
+                  height: 26,
+                  borderRadius: '50%',
+                  background: LIFT,
+                  color: INK,
+                  fontFamily: UA_DISPLAY,
+                  fontWeight: 600,
+                  fontSize: 'var(--text-content)',
+                  lineHeight: 1,
+                }}
+              >
+                {foe.display_name.slice(0, 1)}
+              </span>
+            </span>
+            <span
+              className="content-text"
+              style={{ fontFamily: UA_DISPLAY, fontWeight: 600, color: INK, minWidth: 0 }}
+            >
+              {foe.display_name}
+            </span>
+          </div>
+        </div>
+
+        {/* ── OPPONENT BAR ── the hue laid across the sheet under the masthead. */}
+        <span
+          aria-hidden
+          style={{ display: 'block', height: 3, ...factionFill(foe.faction_slug, 'bar') }}
+        />
+
+        <div style={{ padding: 'var(--space-xl)' }}>
+          {/* The body line. In forfeit mode the ink is UA's notice ink on UA's
+              sheet — `--color-danger` measures 3.98:1 on this cream and is body
+              copy here — and the red survives as the rule beside it. */}
+          <p
+            className="content-text"
+            style={{
+              lineHeight: 1.6,
+              color: relinquishing ? NOTICE : INK,
+              ...(relinquishing
+                ? {
+                    fontWeight: 600,
+                    paddingLeft: 'var(--space-md)',
+                    borderLeft: '3px solid var(--color-danger)',
+                  }
+                : {}),
+            }}
+          >
+            {copy.body}
+          </p>
+
+          {/* The free-reopen half of the truth — the shared condition, not a UA
+              one. A forfeit has no such note and `copy.note` is null there. */}
+          {copy.note && (
+            <p
+              className="content-text"
+              style={{ marginTop: 'var(--space-sm)', lineHeight: 1.6, color: CREDIT }}
+            >
+              {copy.note}
+            </p>
+          )}
+
+          {/* ── The stakes well: an inset panel inside a hairline, the idiom
+              `UaEditPraxis` already wears. ── */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-sm)',
+              marginTop: 'var(--space-xl)',
+            }}
+          >
+            <span style={{ ...UA_EYEBROW, whiteSpace: 'nowrap' }}>
+              {t('duelStakes.heading')}
+            </span>
+            <span aria-hidden style={{ height: 1, flex: 1, background: HAIR }} />
+          </div>
+
+          <div
+            style={{
+              marginTop: 'var(--space-md)',
+              padding: 'var(--space-md)',
+              background: PANEL,
+              color: INK,
+              border: `1px solid ${RULE}`,
+              borderRadius: 'var(--radius-sm)',
+            }}
+          >
+            <StakesTiles
+              viewerFactionSlug={me.faction_slug}
+              opponentFactionSlug={foe.faction_slug}
+              opponentName={foe.display_name}
+              taskPointValue={taskPointValue}
+              status={duel.status}
+              theme={theme}
+            />
+            <RaceRoster me={me} foe={foe} theme={theme} />
+          </div>
+        </div>
+
+        {/* ── Footer band ── */}
+        <div
+          style={{
+            padding: 'var(--space-md) var(--space-xl)',
+            background: LIFT,
+            borderTop: `1px solid ${HAIR}`,
+          }}
+        >
+          {/* ponytail: SealActions keeps its shared btn-outline / btn-primary
+              pair rather than growing a UA seal-button slot. The global
+              [Cancel] … [Submit] order (#646) and the shared `danger` tone are
+              worth more than a sienna button, and adding a skin prop to the
+              shared component would be foundation work, not a skin change. */}
+          <SealActions
+            onConfirm={onConfirm}
+            onCancel={onCancel}
+            busy={busy}
+            confirmLabel={copy.confirmLabel}
+            danger={copy.danger}
+            theme={theme}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/duel/UaMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/UaMobileDuelSealConfirm.tsx
@@ -1,0 +1,271 @@
+/**
+ * University of Asthmatics MOBILE duel seal-confirm (#725) — the same breath,
+ * on a phone.
+ *
+ * The desktop sheet unfolded to the full screen: UA's mesa-sand ground, a
+ * masthead band carrying the ensō and the foe, the practice sheet as one plate
+ * in a scrolling middle, and the actions pinned to the bottom so the thumb lands
+ * on them. Single-column throughout — SPEC-faction-ui-profile §1a forbids a
+ * fixed-px grid on the mobile path, and there is no grid here at all.
+ *
+ * Everything the desktop skin's docblock states holds verbatim and is not
+ * repeated: both modes through `useDuelSealCopy` (#751), faction-neutral copy
+ * through `t()` with no new catalog keys (#718), the shared slots owning every
+ * figure, and the opponent's hue held as a RING, an EDGE and a BAR — never as
+ * ink, never behind text (#310, #1115) — drawn as fills through `factionFill`
+ * so an unaffiliated opponent keeps the spectrum (ADR-0039).
+ *
+ * The contrast readings are the desktop skin's too, with one addition: the
+ * masthead band is `--faction-ua-lift`, where UA's body ink reads 12.99:1 light
+ * and 10.95:1 dark. Body copy and the reopen note stay on the `card-bg` plate,
+ * because `--faction-ua-card-notice` / `-card-credit` are measured against that
+ * sheet and nothing else (#694).
+ */
+import { useTranslation } from 'react-i18next'
+import { factionCssVar, factionFill } from '../../utils/factions'
+import { UaSigil } from '../cards/UaSigil'
+import { UA_DISPLAY, UA_EYEBROW, UA_TEXT } from '../cards/uaAtoms'
+import {
+  duelSides,
+  RaceRoster,
+  SealActions,
+  StakesTiles,
+  useDuelSealCopy,
+  type DuelSlotTheme,
+} from './shared'
+import type { DuelSealConfirmProps } from './DuelSealConfirm'
+
+const GROUND = 'var(--faction-ua-page)'
+const SHEET = 'var(--faction-ua-card-bg)'
+const PANEL = 'var(--faction-ua-panel)'
+const LIFT = 'var(--faction-ua-lift)'
+const INK = 'var(--faction-ua-card-text)'
+const MUTED = 'var(--faction-ua-card-muted)'
+const RULE = 'var(--faction-ua-rule)'
+const HAIR = 'var(--faction-ua-hair)'
+const NOTICE = 'var(--faction-ua-card-notice)'
+const CREDIT = 'var(--faction-ua-card-credit)'
+
+export default function UaMobileDuelSealConfirm({
+  duel,
+  viewerCharacterId,
+  taskPointValue,
+  onConfirm,
+  onCancel,
+  busy,
+  mode = 'submit',
+}: DuelSealConfirmProps) {
+  const { t } = useTranslation('praxis')
+  const { me, foe } = duelSides(duel, viewerCharacterId)
+  const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
+
+  const accent = factionCssVar(foe.faction_slug, 'card-accent')
+  const theme: DuelSlotTheme = { accent, muted: MUTED, bodyFont: UA_TEXT }
+
+  const relinquishing = copy.danger
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={copy.heading}
+      className="fixed inset-0 z-50 flex flex-col"
+      style={{ background: GROUND, color: INK, fontFamily: UA_TEXT }}
+    >
+      {/* ── Masthead band ── */}
+      <div
+        style={{
+          flexShrink: 0,
+          padding: 'var(--space-lg)',
+          background: LIFT,
+          borderBottom: `1px solid ${HAIR}`,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', minWidth: 0 }}>
+          <span style={{ display: 'flex', opacity: relinquishing ? 0.35 : 1 }}>
+            <UaSigil width={32} height={32} />
+          </span>
+          <h2
+            style={{
+              margin: 0,
+              minWidth: 0,
+              fontFamily: UA_DISPLAY,
+              fontWeight: 600,
+              fontSize: relinquishing ? 'var(--text-title)' : 'var(--text-heading)',
+              lineHeight: 1.05,
+              letterSpacing: '-0.01em',
+              color: INK,
+            }}
+          >
+            {copy.heading}
+          </h2>
+        </div>
+
+        {/* ── OPPONENT RING ── outer drawn fill, inner UA disc under the letter. */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+            marginTop: 'var(--space-md)',
+            minWidth: 0,
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 32,
+              height: 32,
+              borderRadius: '50%',
+              ...factionFill(foe.faction_slug, 'dot'),
+            }}
+          >
+            <span
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 24,
+                height: 24,
+                borderRadius: '50%',
+                background: LIFT,
+                color: INK,
+                fontFamily: UA_DISPLAY,
+                fontWeight: 600,
+                fontSize: 'var(--text-content)',
+                lineHeight: 1,
+              }}
+            >
+              {foe.display_name.slice(0, 1)}
+            </span>
+          </span>
+          <span
+            className="content-text"
+            style={{ fontFamily: UA_DISPLAY, fontWeight: 600, color: INK, minWidth: 0 }}
+          >
+            {foe.display_name}
+          </span>
+        </div>
+      </div>
+
+      {/* ── OPPONENT BAR ── across the full width, under the band. */}
+      <span
+        aria-hidden
+        style={{ flexShrink: 0, height: 3, ...factionFill(foe.faction_slug, 'bar') }}
+      />
+
+      {/* ── Scrolling middle: one practice sheet on the ground ── */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: 'var(--space-lg)' }}>
+        <div
+          style={{
+            position: 'relative',
+            overflow: 'hidden',
+            padding: 'var(--space-lg)',
+            paddingLeft: 'var(--space-xl)',
+            background: SHEET,
+            border: `1px solid ${RULE}`,
+            borderRadius: 'var(--radius-md)',
+          }}
+        >
+          {/* ── OPPONENT EDGE ── down the plate's spine. */}
+          <span
+            aria-hidden
+            style={{
+              position: 'absolute',
+              top: 0,
+              bottom: 0,
+              left: 0,
+              width: 4,
+              ...factionFill(foe.faction_slug, 'rule'),
+            }}
+          />
+
+          <p
+            className="content-text"
+            style={{
+              lineHeight: 1.6,
+              color: relinquishing ? NOTICE : INK,
+              ...(relinquishing
+                ? {
+                    fontWeight: 600,
+                    paddingLeft: 'var(--space-md)',
+                    borderLeft: '3px solid var(--color-danger)',
+                  }
+                : {}),
+            }}
+          >
+            {copy.body}
+          </p>
+
+          {copy.note && (
+            <p
+              className="content-text"
+              style={{ marginTop: 'var(--space-sm)', lineHeight: 1.6, color: CREDIT }}
+            >
+              {copy.note}
+            </p>
+          )}
+
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-sm)',
+              marginTop: 'var(--space-lg)',
+            }}
+          >
+            <span style={{ ...UA_EYEBROW, whiteSpace: 'nowrap' }}>{t('duelStakes.heading')}</span>
+            <span aria-hidden style={{ height: 1, flex: 1, background: HAIR }} />
+          </div>
+
+          <div
+            style={{
+              marginTop: 'var(--space-md)',
+              padding: 'var(--space-md)',
+              background: PANEL,
+              color: INK,
+              border: `1px solid ${RULE}`,
+              borderRadius: 'var(--radius-sm)',
+            }}
+          >
+            <StakesTiles
+              viewerFactionSlug={me.faction_slug}
+              opponentFactionSlug={foe.faction_slug}
+              opponentName={foe.display_name}
+              taskPointValue={taskPointValue}
+              status={duel.status}
+              theme={theme}
+            />
+            <RaceRoster me={me} foe={foe} theme={theme} />
+          </div>
+        </div>
+      </div>
+
+      {/* ── Pinned footer band ── */}
+      <div
+        style={{
+          flexShrink: 0,
+          padding: 'var(--space-md) var(--space-lg)',
+          background: LIFT,
+          borderTop: `1px solid ${HAIR}`,
+        }}
+      >
+        {/* ponytail: the shared SealActions pair again — thumb-sized styling
+            would need a skin slot on the shared component, which is foundation
+            work rather than a skin change. */}
+        <SealActions
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+          busy={busy}
+          confirmLabel={copy.confirmLabel}
+          danger={copy.danger}
+          theme={theme}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/factions/ua.ts
+++ b/frontend/src/factions/ua.ts
@@ -14,12 +14,14 @@ import { lazyArchetype } from './lazyArchetype'
 const UaAvatar = lazyArchetype(() => import('../components/avatar/UaAvatar'))
 const UaBackdrop = lazyArchetype(() => import('../components/backdrop/UaBackdrop'))
 const UaComment = lazyArchetype(() => import('../components/comments/voices/UaComment'))
+const UaDuelSealConfirm = lazyArchetype(() => import('../components/duel/UaDuelSealConfirm'))
 const UaEditPraxis = lazyArchetype(() => import('../pages/editPraxis/archetypes/UaEditPraxis'))
 const UaFactionBody = lazyArchetype(() => import('../pages/factionDetail/archetypes/UaFactionBody'))
 const UaFactionHero = lazyArchetype(() => import('../components/cards/UaFactionHero'))
 const UaFactionPage = lazyArchetype(() => import('../pages/factionDetail/mobileArchetypes/UaFactionPage'))
 const UaFeedFrame = lazyArchetype(() => import('../components/feed/UaFeedFrame'))
 const UaHome = lazyArchetype(() => import('../pages/fieldDesk/mobileArchetypes/UaHome'))
+const UaMobileDuelSealConfirm = lazyArchetype(() => import('../components/duel/UaMobileDuelSealConfirm'))
 const UaMobileEditPraxis = lazyArchetype(() => import('../pages/editPraxis/mobileArchetypes/UaComposer'))
 const UaMobilePraxisCard = lazyArchetype(() => import('../components/praxisCard/mobile/UaMobilePraxisCard'))
 const UaProfileBody = lazyArchetype(() => import('../pages/characterProfile/archetypes/UaProfileBody'))
@@ -49,6 +51,8 @@ export const UA_MANIFEST: FactionManifest = {
   comment: () => UaComment,
   feedFrame: () => UaFeedFrame,
   vote: () => UaVote,
+  duelSeal: () => UaDuelSealConfirm,
+  mobileDuelSeal: () => UaMobileDuelSealConfirm,
   taskDetail: () => UaTaskDetail,
   praxisDetail: () => UaPraxisDetail,
   editPraxis: () => UaEditPraxis,


### PR DESCRIPTION
University of Asthmatics was the only core faction with no duel dialog skin: `components/duel/` held desktop+mobile `DuelSealConfirm` pairs for Coven, Ephemerists, Everymen, Singularity, Snide and WOW, and `factions/ua.ts` registered no duel surface, so a UA-task duel wore the neutral Default chrome.

Built to the **rescoped** ask, not the issue body — two files, not three surfaces:

- `frontend/src/components/duel/UaDuelSealConfirm.tsx`
- `frontend/src/components/duel/UaMobileDuelSealConfirm.tsx`
- registered on `frontend/src/factions/ua.ts` as `duelSeal` / `mobileDuelSeal` (thunks, like every other entry)

No duel rail was built. `UaDuelRail.dc.html` mocks a surface #1090 deleted.

## The chrome, and why it is not the mock's

`UaDuel.dc.html` draws a gilt frame; #788/#848–853 removed gold from UA entirely (it went to WOW, ADR-0050), which is what the issue's own audit comment means by "no longer buildable as drawn". So the structure comes from the sibling seal skins and the dress from UA's shipped kit: a sun-bleached practice sheet over the composer, hairline rules, one ensō at the head, Cormorant display over EB Garamond text, the `Plate`/eyebrow idiom `UaEditPraxis` already wears.

The metaphor is the mark. An ensō is made in one breath and left open; sealing your side is the moment the brush touches the paper. **Forfeit mode** dims the circle to 0.35 (the breath let go), drops the title a Content-tier rung (`--text-heading` → `--text-title`), and runs a vermilion rule down the body.

## Copy — no new keys, nothing voiced

Every string goes through `t()` from the shipped `duelSeal.*` / `duelStakes.*` / `duelForfeit.*` catalog; `useDuelSealCopy` owns the whole mode branch and neither skin re-derives any of it. **Zero copy keys added.** The one label these skins draw themselves is the existing neutral `duelStakes.heading`, the same key `EphemeristsDuelSealConfirm` uses. No faction voice — #718's ruling, and the one #1165 had to re-enforce.

## Where the opponent's accent appears, and in what form

Three places, **all drawn fills, none of them ink and none of them behind text** (#310). Its structural guard died with the duel rail (#1115), so it is honoured by hand and verified by rendering:

| Form | Element | Fill |
|---|---|---|
| **Edge** | 4px spine down the left of the sheet (desktop) / of the plate (mobile) | `factionFill(foe, 'rule')` |
| **Bar** | 3px band across the sheet under the masthead | `factionFill(foe, 'bar')` |
| **Ring** | the opponent's monogram ring — an outer filled disc with an inner `--faction-ua-lift` disc, so the letter sits on UA's own stock | `factionFill(foe, 'dot')` |

Going through `factionFill` rather than `factionCssVar` means an **unaffiliated** opponent gets the spectrum in the cut its geometry needs (vertical ramp / horizontal ramp / conic) instead of degrading to grey — ADR-0039. The only other opponent-coloured thing in the dialog is the shared `StakesTiles` tile ring, which takes `card-accent` from `DuelSlotTheme` exactly as all six siblings pass it.

The ensō stays `--faction-ua-glow`. UA's reserved mark is not repainted in a foreign hue.

## Contrast (`utils/contrast.ts`, both themes)

UA's paper and accent are both warm and light, so every pairing was measured rather than assumed:

- **`--color-danger` is 3.98:1 on `--faction-ua-card-bg` in light** — below AA for 18px body copy. So the forfeit body is **not** painted in it. It takes `--faction-ua-card-notice` (**5.85:1** light / **9.87:1** dark on the sheet), one of the two inks minted for exactly this case, and the red survives only as the 3px rule beside the paragraph, where it carries no text.
- The reopen note takes `--faction-ua-card-credit` (**7.51** / **9.46**) rather than the global `--color-success`, same reasoning.
- Stakes well on `--faction-ua-panel`: card-text **11.32 / 12.28**, card-muted **5.13 / 5.10**, `--color-success` **7.07 / 8.56**, and the Snide zero figure in `--color-danger` at **3.75 / 5.39** — 24px bold, i.e. large text at a 3:1 floor.
- Masthead/footer bands on `--faction-ua-lift`: body ink **12.99 / 10.95**.
- Body copy and the note stay on the `card-bg` plate, because `-card-notice` / `-card-credit` are measured against that sheet and nothing else (#694).

No `index.css` change; no new tokens; no theme ternary anywhere.

## Checks

`tsc --noEmit` clean · `eslint` clean on all three files (net-new files take `no-raw-style-values` in full; the legacy list is untouched and still empty) · `vitest run` 2114/2114 · `vite build` green, entry chunk 137.38 KB gzip (both skins are lazy chunks, no entry growth).

`duelSkinSlots.test.tsx` now walks UA in both modes on both form factors — 76 tests — and passes: every slot present, no `<p>` below the content floor, forfeit copy distinct from submit copy. `duelForfeitWarning.test.tsx` is untouched.

**Visual QA is outstanding** — there is no dev stack here and I cannot screenshot.

## What to eyeball

1. **Desktop · submit · light** — UA task, Snide opponent (`active`): cream sheet, ensō at full strength, green edge/bar/ring, "Until Rax casts…" in the credit green.
2. **Desktop · forfeit · light** — same duel `settled`: ensō dimmed, title one rung smaller, body in the amber notice ink behind a red rule, red confirm button.
3. **Desktop · submit · dark** — check the masthead/footer `lift` bands still read as *raised* against the `card-bg` sheet, and that the ring's inner disc doesn't vanish into the ground.
4. **Desktop · forfeit · dark** — the notice ink goes bright amber (`#fbbf24`); confirm it reads as alarm rather than as decoration next to the red rule.
5. **Mobile · submit · light + dark** — full screen on `--faction-ua-page`, one plate in the scrolling middle, footer pinned; confirm the plate's left edge is not clipped by the rounded corner.
6. **Mobile · forfeit · light + dark** — long heading ("Forfeit") plus a long display name at 375px; check the opponent chip wraps rather than overflows.
7. **A second opponent faction — an unaffiliated (`na`) foe** in either mode: the edge must be a vertical rainbow, the bar a horizontal one, the ring a conic — not grey, and not seven stops squeezed across a 3px rule.
8. **A third, for hue clash** — a Singularity (blue) or Coven (pink) opponent against UA's cream: the point of the ring/edge/bar rule is that a hostile hue needs no contrast fix. Confirm nothing legible sits on any of the three.

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)