### PR TITLE
ADR-0061: carve out the vote's tier vocabulary alongside comments

### DIFF
--- a/docs/adr/0061-praxis-detail-is-one-shared-page-every-faction-dresses.md
+++ b/docs/adr/0061-praxis-detail-is-one-shared-page-every-faction-dresses.md
@@ -45,10 +45,25 @@ copy.**
 - The layout is the contract: main column + aside + comments region,
   collapsing to one stacked column on mobile.
 - **The neutral rule covers the page's own slots and stops at the speaker's
-  voice.** Comment rows dispatch on `comment.author.faction_slug`, not the
-  page's — a Snide player's comment reads Snide on a Coven praxis.
-  `comments.<faction>.*` and the seven `*Comment` skins are **out of scope**
-  and must not be swept later by inference from this ADR.
+  voice and the vote's vocabulary.** Comment rows dispatch on
+  `comment.author.faction_slug`, not the page's — a Snide player's comment
+  reads Snide on a Coven praxis. `comments.<faction>.*` and the seven
+  `*Comment` skins are **out of scope** and must not be swept later by
+  inference from this ADR.
+- The same test applies to vote tiers. `frontend/src/components/vote/voteReframes.ts`
+  defines a per-faction `VoteReframe` — Ephemerists' `apocryphal → canonical`,
+  rendered in roman numerals, the Everymen's `Fair → Legendary`, and five
+  more archetypes' own ladders — and a reframe is the **vote surface's**
+  vocabulary, not the page's: the same "whose voice is this?" test the
+  comment carve-out passes. A bare numeral tells the reader strictly less
+  than the tier word does, so flattening one to the other would be a loss of
+  meaning, not a gain in consistency. `voteReframes.ts` and the
+  `votes:<faction>.*` labels it resolves are **out of scope** and must not
+  be swept later by inference from this ADR. (This is a clarification of
+  the standing neutral rule, not a reopening of the amendment below — that
+  amendment proposed voice on content slots; this documents a boundary that
+  was always meant to sit outside the neutral rule, the way comments always
+  did.)
 
 ### Comments are the third region (amending ADR-0006)
 
@@ -137,3 +152,8 @@ Singularity and Everymen were built neutral and were untouched.
   seven `*Comment` skins are not touched by this ADR, by the withdrawn
   amendment, or by the correction that undid it, and must not be swept by
   inference from any of the three.
+- **The vote-tier boundary is the same shape and out of scope for the same
+  reason.** `voteReframes.ts` and the `votes:<faction>.*` labels it resolves
+  are not touched by this ADR, by the withdrawn amendment, or by the
+  correction that undid it, and must not be swept by inference from any of
+  the three.


### PR DESCRIPTION
Closes #1163

## Two of three asks were already satisfied

1. **Copy drift** — already fixed by PR #1165 (merged). Confirmed on `origin/main`: `frontend/src/locales/en/praxis.json`'s `detail` block has no `coven`/`ephemerists`/`snide`/`wow` keys — the neutral 20-key list only. No change made.
2. **Comment carve-out** — already in ADR-0061, twice (Decision bullet + "Relations, restated" section). No change made.
3. **Voter-tier carve-out** — genuinely missing. This PR adds it.

## What changed

`docs/adr/0061-praxis-detail-is-one-shared-page-every-faction-dresses.md` only — one file, no code, no praxis.json, no archetypes.

Added the vote-tier carve-out in the same shape and place as the existing comment carve-out, so the two read as one rule with two edges:

- **Decision section**: extended the "stops at the speaker's voice" bullet to also name "the vote's vocabulary," then added a parallel bullet citing `frontend/src/components/vote/voteReframes.ts` — Ephemerists' `apocryphal → canonical` (roman numerals) and the Everymen's `Fair → Legendary`, confirmed against the file. Reasoning recorded: a reframe is the vote surface's vocabulary, not the page's (same "whose voice is this?" test as comments), and a bare numeral tells the reader strictly less than the tier word does.
- **"Relations, restated" section**: added a matching bullet putting the vote-tier boundary on the same footing as the comments boundary — untouched by the ADR, the withdrawn amendment, or the correction that undid it.
- Added one explicit line noting this is a clarification of the standing neutral rule, not a reopening of the withdrawn amendment (which was about voice on *content* slots) — the vote-tier boundary was always meant to sit outside the neutral rule, the way comments always did.

Nothing else in the file touched — the withdrawn-amendment section's own text is untouched (no cross-reference added there; the clarifying line lives at the point of the new carve-out instead, which read cleaner than editing the historical section).

## What to eyeball

Docs-only change (one markdown file) — visual QA is N/A.

- [ ] The new Decision bullet reads as one continuous rule with the comment carve-out, not a bolt-on
- [ ] Ephemerists' and Everymen's tier words are quoted accurately against `voteReframes.ts`
- [ ] The non-reopening note is clear enough that a future reader won't mistake this for reviving the withdrawn amendment