### PR TITLE
Duel seal dialogs: route --color-danger/--color-success to faction-measured inks (#1168)

### DIFF
--- a/frontend/src/components/duel/CovenDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/CovenDuelSealConfirm.tsx
@@ -122,7 +122,10 @@ export default function CovenDuelSealConfirm({
             style={{
               fontSize: 'var(--text-content)',
               lineHeight: 1.5,
-              ...(copy.danger ? { color: 'var(--color-danger)', fontWeight: 700 } : {}),
+              // `--color-danger` measures 4.31:1 on this pink sheet — below the
+              // 4.5:1 this 18px copy owes (#1168). `-card-notice` clears at
+              // 6.33 / 10.73.
+              ...(copy.danger ? { color: 'var(--faction-coven-card-notice)', fontWeight: 700 } : {}),
             }}
           >
             {copy.body}

--- a/frontend/src/components/duel/CovenMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/CovenMobileDuelSealConfirm.tsx
@@ -120,7 +120,10 @@ export default function CovenMobileDuelSealConfirm({
             style={{
               fontSize: 'var(--text-content)',
               lineHeight: 1.5,
-              ...(copy.danger ? { color: 'var(--color-danger)', fontWeight: 700 } : {}),
+              // `--color-danger` measures 4.31:1 on this pink sheet — below the
+              // 4.5:1 this 18px copy owes (#1168). `-card-notice` clears at
+              // 6.33 / 10.73.
+              ...(copy.danger ? { color: 'var(--faction-coven-card-notice)', fontWeight: 700 } : {}),
             }}
           >
             {copy.body}

--- a/frontend/src/components/duel/DuelSealConfirm.tsx
+++ b/frontend/src/components/duel/DuelSealConfirm.tsx
@@ -122,7 +122,10 @@ export function DefaultDuelSealConfirm({
         <p
           className="font-body content-text"
           style={{
-            color: copy.danger ? 'var(--color-danger)' : 'var(--color-text-secondary)',
+            // `--color-danger` measures 4.40:1 on `--color-bg-page` — below the
+            // 4.5:1 this 18px copy owes (#1168). `-card-notice` clears at
+            // 6.46 / 11.14.
+            color: copy.danger ? 'var(--faction-default-card-notice)' : 'var(--color-text-secondary)',
           }}
         >
           {copy.body}

--- a/frontend/src/components/duel/SingularityDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SingularityDuelSealConfirm.tsx
@@ -105,7 +105,16 @@ export default function SingularityDuelSealConfirm({
   // the foreign duelist's colour is the one variable that isn't phosphor, which
   // is precisely why it gets the left edge and the cast glow.
   const accent = factionCssVar(foe.faction_slug, 'card-accent')
-  const theme: DuelSlotTheme = { accent, muted: PHOSPHOR_DIM, bodyFont: TERMINAL }
+  // The global `--color-success` measures 1.99:1 on this glass-over-terminal
+  // ground in light theme — the chassis is dark in both themes, so the
+  // light-mode token never clears it (#1168). `-card-credit` is theme-invariant
+  // here and clears at 10.40 either way.
+  const theme: DuelSlotTheme = {
+    accent,
+    muted: PHOSPHOR_DIM,
+    bodyFont: TERMINAL,
+    credit: 'var(--faction-singularity-card-credit)',
+  }
 
   return (
     <div
@@ -140,7 +149,9 @@ export default function SingularityDuelSealConfirm({
               fontSize: 'var(--text-title)',
               color: PHOSPHOR,
               letterSpacing: '0.02em',
-              ...(copy.danger ? { color: 'var(--color-danger)' } : {}),
+              // Same ground as the body paragraph below — kept in the same ink
+              // so a forfeit doesn't show two different reds (#1168).
+              ...(copy.danger ? { color: 'var(--faction-singularity-card-notice)' } : {}),
             }}
           >
             <span aria-hidden style={{ color: BRAND_BLUE }}>{'$ '}</span>
@@ -157,7 +168,10 @@ export default function SingularityDuelSealConfirm({
             className="content-text"
             style={{
               lineHeight: 1.55,
-              color: copy.danger ? 'var(--color-danger)' : PHOSPHOR_DIM,
+              // `--color-danger` measures 4.03:1 on this always-dark chassis —
+              // below the 4.5:1 this 18px copy owes (#1168). `-card-notice`
+              // clears at 11.67 either theme.
+              color: copy.danger ? 'var(--faction-singularity-card-notice)' : PHOSPHOR_DIM,
             }}
           >
             {copy.body}
@@ -170,7 +184,9 @@ export default function SingularityDuelSealConfirm({
           {copy.note && (
             <p
               className="content-text"
-              style={{ marginTop: 'var(--space-sm)', color: 'var(--color-success)' }}
+              // `--color-success` measures 2.14:1 here — see the theme's `credit`
+              // comment (#1168).
+              style={{ marginTop: 'var(--space-sm)', color: 'var(--faction-singularity-card-credit)' }}
             >
               <span aria-hidden>{'// '}</span>
               {copy.note}

--- a/frontend/src/components/duel/SingularityMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SingularityMobileDuelSealConfirm.tsx
@@ -77,7 +77,16 @@ export default function SingularityMobileDuelSealConfirm({
   const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
 
   const accent = factionCssVar(foe.faction_slug, 'card-accent')
-  const theme: DuelSlotTheme = { accent, muted: PHOSPHOR_DIM, bodyFont: TERMINAL }
+  // The global `--color-success` measures 1.99:1 on this glass-over-terminal
+  // ground in light theme — the chassis is dark in both themes, so the
+  // light-mode token never clears it (#1168). `-card-credit` is theme-invariant
+  // here and clears at 10.40 either way.
+  const theme: DuelSlotTheme = {
+    accent,
+    muted: PHOSPHOR_DIM,
+    bodyFont: TERMINAL,
+    credit: 'var(--faction-singularity-card-credit)',
+  }
 
   return (
     <div
@@ -97,7 +106,9 @@ export default function SingularityMobileDuelSealConfirm({
         <h2
           style={{
             fontSize: 'var(--text-title)',
-            color: copy.danger ? 'var(--color-danger)' : PHOSPHOR,
+            // Same ground as the body paragraph below — kept in the same ink
+            // so a forfeit doesn't show two different reds (#1168).
+            color: copy.danger ? 'var(--faction-singularity-card-notice)' : PHOSPHOR,
             letterSpacing: '0.02em',
           }}
         >
@@ -115,7 +126,10 @@ export default function SingularityMobileDuelSealConfirm({
           className="content-text"
           style={{
             lineHeight: 1.55,
-            color: copy.danger ? 'var(--color-danger)' : PHOSPHOR_DIM,
+            // `--color-danger` measures 4.03:1 on this always-dark chassis —
+            // below the 4.5:1 this 18px copy owes (#1168). `-card-notice`
+            // clears at 11.67 either theme.
+            color: copy.danger ? 'var(--faction-singularity-card-notice)' : PHOSPHOR_DIM,
           }}
         >
           {copy.body}
@@ -124,7 +138,9 @@ export default function SingularityMobileDuelSealConfirm({
         {copy.note && (
           <p
             className="content-text"
-            style={{ marginTop: 'var(--space-sm)', color: 'var(--color-success)' }}
+            // `--color-success` measures 2.14:1 here — see the theme's `credit`
+            // comment (#1168).
+            style={{ marginTop: 'var(--space-sm)', color: 'var(--faction-singularity-card-credit)' }}
           >
             <span aria-hidden>{'// '}</span>
             {copy.note}

--- a/frontend/src/components/duel/SnideDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SnideDuelSealConfirm.tsx
@@ -85,7 +85,15 @@ export default function SnideDuelSealConfirm({
   // Opponent tokens, same rule as the Default dialog and the rail: the foreign
   // duelist looks foreign even on Snide's own paper.
   const accent = factionCssVar(foe.faction_slug, 'card-accent')
-  const theme: DuelSlotTheme = { accent, muted: MUTED, bodyFont: 'var(--font-body)' }
+  // The global `--color-success` measures 2.07:1 on Snide's ink in light theme
+  // — the sheet is dark in both themes, so the light-mode token never clears
+  // it (#1168). `-card-credit` is theme-invariant here and clears at 10.81.
+  const theme: DuelSlotTheme = {
+    accent,
+    muted: MUTED,
+    bodyFont: 'var(--font-body)',
+    credit: 'var(--faction-snide-card-credit)',
+  }
 
   return (
     <div

--- a/frontend/src/components/duel/SnideMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/SnideMobileDuelSealConfirm.tsx
@@ -54,7 +54,15 @@ export default function SnideMobileDuelSealConfirm({
   const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
 
   const accent = factionCssVar(foe.faction_slug, 'card-accent')
-  const theme: DuelSlotTheme = { accent, muted: MUTED, bodyFont: 'var(--font-body)' }
+  // The global `--color-success` measures 2.07:1 on Snide's ink in light theme
+  // — the sheet is dark in both themes, so the light-mode token never clears
+  // it (#1168). `-card-credit` is theme-invariant here and clears at 10.81.
+  const theme: DuelSlotTheme = {
+    accent,
+    muted: MUTED,
+    bodyFont: 'var(--font-body)',
+    credit: 'var(--faction-snide-card-credit)',
+  }
 
   return (
     <div

--- a/frontend/src/components/duel/WowDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowDuelSealConfirm.tsx
@@ -153,7 +153,10 @@ export default function WowDuelSealConfirm({
             style={{
               fontFamily: BODY_FONT,
               lineHeight: 1.55,
-              ...(copy.danger ? { color: 'var(--color-danger)', fontWeight: 700 } : {}),
+              // `--color-danger` measures 4.40:1 on `--faction-wow-duel-lists-bg`
+              // — below the 4.5:1 this 18px copy owes (#1168). `-card-notice`
+              // clears at 6.45 / 10.30.
+              ...(copy.danger ? { color: 'var(--faction-wow-card-notice)', fontWeight: 700 } : {}),
             }}
           >
             {copy.body}

--- a/frontend/src/components/duel/WowMobileDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowMobileDuelSealConfirm.tsx
@@ -118,7 +118,10 @@ export default function WowMobileDuelSealConfirm({
           style={{
             fontFamily: BODY_FONT,
             lineHeight: 1.55,
-            ...(copy.danger ? { color: 'var(--color-danger)', fontWeight: 700 } : {}),
+            // `--color-danger` measures 4.40:1 on `--faction-wow-duel-lists-bg`
+            // — below the 4.5:1 this 18px copy owes (#1168). `-card-notice`
+            // clears at 6.45 / 10.30.
+            ...(copy.danger ? { color: 'var(--faction-wow-card-notice)', fontWeight: 700 } : {}),
           }}
         >
           {copy.body}

--- a/frontend/src/components/duel/shared.tsx
+++ b/frontend/src/components/duel/shared.tsx
@@ -62,11 +62,22 @@ export interface DuelSlotTheme {
   muted?: string
   /** Body font for the prose. */
   bodyFont?: string
+  /**
+   * Ink for the WIN tile's figure (#1168). Defaults to the global
+   * `--color-success`, chosen against the app's near-white page and correct
+   * there — but wrong on a skin whose sheet is dark in *both* themes: it
+   * measured 2.07:1 on S.N.I.D.E.'s ink and 1.99:1 on Singularity's glass
+   * panel in light theme. Those two skins pass their own `-card-credit`
+   * token instead; every other skin's sheet flips polarity with the theme,
+   * so the global token already clears there and is left alone.
+   */
+  credit?: string
 }
 
-const DEFAULT_THEME: Required<Pick<DuelSlotTheme, 'muted' | 'bodyFont'>> = {
+const DEFAULT_THEME: Required<Pick<DuelSlotTheme, 'muted' | 'bodyFont' | 'credit'>> = {
   muted: 'var(--color-text-secondary)',
   bodyFont: 'var(--font-body)',
+  credit: 'var(--color-success)',
 }
 
 /* -------------------------------------------------------------------------- */
@@ -239,7 +250,7 @@ export function StakesTiles({
         <Tile
           label={t('duelStakes.winLabel')}
           value={formatPoints(stakes.win)}
-          color="var(--color-success)"
+          color={theme.credit ?? DEFAULT_THEME.credit}
           theme={theme}
         />
         <Tile

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -178,6 +178,72 @@ const ROSTER_PAIRS: Pair[] = CARD_KEYS.flatMap((key) => [
 ]);
 
 /**
+ * #1168 — the DUEL SEAL dialog's functional inks, on each skin's own ground.
+ *
+ * `copy.danger` paints the confirm body in the global `--color-danger`; the
+ * free-reopen note and the StakesTiles win figure paint in `--color-success`.
+ * Both are chosen against the app's near-white page and are correct there,
+ * but four skins measured below AA on their own sheet — the same "global
+ * functional ink on faction paper" shape #694 found in the collab roster,
+ * just never checked here (the composer's confirm dialog is a modal, not a
+ * route, so `e2e/contrast.spec.ts`'s walk never renders it either).
+ *
+ * Coven, Default, WOW and Singularity route their body/heading copy to their
+ * own `-card-notice`. Singularity and S.N.I.D.E. additionally route
+ * StakesTiles' win figure to their own `-card-credit`, via the new
+ * `DuelSlotTheme.credit` seam (`duel/shared.tsx`) — both are dark-in-both-
+ * themes sheets, so the light-theme `--color-success` never clears them
+ * (2.14:1 / 2.07:1). Every other skin's danger/success pairing already
+ * clears and is left untouched; the raw-token rows below pin those passing
+ * measurements so a future edit to the global tokens can't regress them
+ * unnoticed.
+ */
+const DUEL_SEAL_PAIRS: Pair[] = [
+  { what: "coven duel seal body, danger", surface: "--faction-coven-body-bg", text: "--faction-coven-card-notice" },
+  { what: "default duel seal body, danger", surface: "--color-bg-page", text: "--faction-default-card-notice" },
+  {
+    what: "wow duel seal body, danger",
+    surface: "--faction-wow-duel-lists-bg",
+    text: "--faction-wow-card-notice",
+  },
+  {
+    what: "singularity duel seal chassis, danger",
+    surface: "--faction-singularity-card-bg",
+    text: "--faction-singularity-card-notice",
+  },
+  // The StakesTiles win/lose figures sit behind Singularity's translucent
+  // glass panel (`color-mix(in srgb, var(--faction-singularity-card-accent)
+  // 5%, transparent)`) — the veil below is that wash's literal composited
+  // equivalent, since `parseColor` doesn't parse `color-mix()`.
+  {
+    what: "singularity duel seal glass panel, win figure, large display type",
+    surface: "--faction-singularity-card-bg",
+    veil: "rgba(74,222,128,0.05)",
+    text: "--faction-singularity-card-credit",
+    floor: AA_LARGE,
+  },
+  {
+    what: "singularity duel seal glass panel, lose-zero figure, large display type",
+    surface: "--faction-singularity-card-bg",
+    veil: "rgba(74,222,128,0.05)",
+    text: "--color-danger",
+    floor: AA_LARGE,
+  },
+  {
+    what: "snide duel seal panel, win figure, large display type",
+    surface: "--faction-snide-card-bg",
+    text: "--faction-snide-card-credit",
+    floor: AA_LARGE,
+  },
+  {
+    what: "snide duel seal panel, lose-zero figure, large display type",
+    surface: "--faction-snide-card-bg",
+    text: "--color-danger",
+    floor: AA_LARGE,
+  },
+];
+
+/**
  * Archetype-private primitives. Each entry is a role index.css states in
  * words; nothing here is inferred from how a component happens to use a token.
  */
@@ -525,7 +591,14 @@ const ARCHETYPE_PAIRS: Pair[] = [
   },
 ];
 
-const PAIRS: Pair[] = [...CARD_PAIRS, ...FILL_PAIRS, ...ACCENT_PAIRS, ...ROSTER_PAIRS, ...ARCHETYPE_PAIRS];
+const PAIRS: Pair[] = [
+  ...CARD_PAIRS,
+  ...FILL_PAIRS,
+  ...ACCENT_PAIRS,
+  ...ROSTER_PAIRS,
+  ...DUEL_SEAL_PAIRS,
+  ...ARCHETYPE_PAIRS,
+];
 
 /**
  * Part C — the baseline allowlist (the ratchet).


### PR DESCRIPTION
Closes #1168

## What

`--color-danger` and `--color-success` are chosen against the app's near-white page. Auditing every duel-seal dialog's use of them (not just the two the issue names) found four genuine AA failures, plus two more in the shared `StakesTiles` figures the issue flags as the related foundation defect:

**Body/heading danger text (18px, needs 4.5:1):**
| Skin | Ground | `--color-danger` | Fix |
|---|---|---|---|
| Coven | `--faction-coven-body-bg` | 4.31:1 | routed to `--faction-coven-card-notice` (6.33 / 10.73) |
| Default | `--color-bg-page` | 4.40:1 | routed to `--faction-default-card-notice` (6.46 / 11.14) |
| WOW | `--faction-wow-duel-lists-bg` | 4.40:1 | routed to `--faction-wow-card-notice` (6.45 / 10.30) |
| Singularity | `--faction-singularity-card-bg` | 4.03:1 | routed to `--faction-singularity-card-notice` (11.67 both) — also applied to the heading for the same ink, so a forfeit doesn't show two different reds |

**StakesTiles win figure / free-reopen note (needs 3:1, large display type):**
Singularity and S.N.I.D.E. are dark-in-both-themes sheets, so the light-theme `--color-success` never clears them:

| Skin | Ground | `--color-success` | Fix |
|---|---|---|---|
| Singularity | glass panel over its terminal chassis | 1.99:1 | routed to `--faction-singularity-card-credit` (10.40 both) |
| S.N.I.D.E. | `--faction-snide-card-bg` | 2.07:1 | routed to `--faction-snide-card-credit` (10.81 both) |

`StakesTiles` had no seam for a skin to supply its own ink, so `DuelSlotTheme` gains an optional `credit` field (defaults to `--color-success`, unchanged everywhere else) that `Singularity*DuelSealConfirm` and `Snide*DuelSealConfirm` now set explicitly.

Every other skin's danger/success pairing already cleared and is untouched: Everymen's forfeit body uses its own `--everymen-red`, which does fail AA (4.49 / 4.16) but is pre-existing debt already tracked in the `BASELINE` ratchet under `#651` (`--faction-everymen-card-accent` is literally `var(--everymen-red)`) — out of scope here. Ephemerists and S.N.I.D.E.'s own danger-body styling already route through their own tokens.

## Guard

Added a `DUEL_SEAL_PAIRS` block to `frontend/src/utils/__tests__/factionContrast.test.ts` asserting every pairing above (both the fixed ones and the two lose-zero/StakesTiles pairings that already passed), so this is a durable regression guard rather than a one-time audit — matching the issue's `ARCHETYPE_PAIRS`/`ROSTER_PAIRS` precedent. Suite: 332 → 348 assertions.

## Files changed

- `frontend/src/components/duel/shared.tsx` — `DuelSlotTheme.credit` seam
- `frontend/src/components/duel/{Coven,CovenMobile,Wow,WowMobile,Singularity,SingularityMobile,Snide,SnideMobile}DuelSealConfirm.tsx`, `DuelSealConfirm.tsx` (Default)
- `frontend/src/utils/__tests__/factionContrast.test.ts`

No `index.css` change, no new tokens, no raw hex literals.

## Test plan

- `npx vitest run` — 134 files / 2195 tests pass (includes the 348-assertion contrast suite and `duelSkinSlots.test.tsx`)
- `npx tsc --noEmit` — clean
- `npx eslint src` — clean on touched files
- `npx vite build` — clean, entry chunk 137.42 KB gzip (no meaningful change from baseline)
- Visual QA outstanding — no dev stack available in this environment to screenshot the four fixed skins in both themes/modes.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_0182bXUjx8DsfeUfuwyoNeo6)_