### PR TITLE
Vendor the Ephemerists and Coven task-detail designs for the two identity sweeps

### DIFF
--- a/.design-sync/coven-slip-sweep/README.md
+++ b/.design-sync/coven-slip-sweep/README.md
@@ -1,0 +1,59 @@
+# Cozy Coven — the candlelit vocabulary (for the `coven.exe` sweep)
+
+Vendored for the Cozy Coven coherence sweep. **Delete this folder in that
+issue's last PR** (`docs/agents/design-fidelity.md`).
+
+The sweep dresses surfaces that have **no design of their own** — avatar, faction
+hero and body, duel seal confirms, metatask seal, praxis card and stamp, profile
+body, field desk, faction cards. This file is where their vocabulary comes from.
+
+## Source
+
+claude.ai design project `0711d3a7-0074-4a60-8907-270f44168261`, file
+`coven-task-detail.jsx` — verbatim, production-intent React
+(`React.createElement`, no JSX transform, `module.exports` at the foot).
+
+## What is NOT here, and why
+
+`coven-task-card.jsx` is already ported — `components/cards/CovenTaskCard.tsx` is
+the slip itself. Unlike the Ephemerists, Coven has **no shared kit module**: the
+marks live inside `CovenTaskCard.tsx` and `pages/taskDetail/archetypes/CovenTaskDetail.tsx`.
+That is exactly why this file is worth having open — it is the whole vocabulary
+in one compact place instead of spread across two large components.
+
+## What to lift
+
+- **The braid** — a repeating thread rule built as an inline data-URI SVG
+  (`threadUrl`), gold bead at the join. Heads every section. Shipped as
+  `.cvn-braid`; the generator here shows how the strand is drawn.
+- **The candle haze** — four blurred radial blooms, drifting, plus scattered
+  gold sparks and the slow-turning pentagram wheel. `mixBlendMode: screen` in
+  dark, normal in light. This is the page ground for any full-surface dress.
+- **The ward** — points inside a glowing pentagram: aura gradient, flicker,
+  inner disc gradient, five sparks at fixed anchors.
+- **The sigil mark** at three sizes (30 header, 34 empty-media, 24 mobile bar) —
+  the stand-in wherever a Coven surface needs a mark rather than a photo.
+- **Avatars** — a 2px gradient ring around a card-coloured disc. **Two kin
+  treatments:** pink→deep for Coven, lavender→violet for `guest`. The sweep's
+  list surfaces need both.
+- **Comment rows, submission cards, sort-tab pills, and the two button states**
+  (pink gradient for act, gold gradient for done).
+
+## Two things to know before you read it
+
+1. **The colours in `TOKENS` are raw hex. Do not copy them.** They are declared
+   as `--faction-coven-slip-*` and the ward family in `index.css`, light and
+   dark. Three were **deliberately walked down for AA** and the walked-down
+   value wins: `soft` #b8517f → #973660, `label` #b06a92 → #83466a, and the CTA
+   band's stops (#ec4f92/#c9327a → #d13a80/#b02a69). The reasons are written at
+   the declarations. Geometry and ornament from this file; colour from tokens.
+2. **There is no roster here.** The file says so in its own header — task detail
+   pages carry no in-progress roster, the header count is enough. So for the
+   sweep's list surfaces (profile body, faction body, field desk) the pattern to
+   reuse is the **submission card and the comment row**, not a roster row.
+
+## Copy
+
+The design's words are placeholder. Coven's own detail vocabulary was retired
+wholesale by #1031 (ADR-0057) — the shipped surfaces read the shared neutral
+`detail.*` keys. Take nothing but dress from this file.

--- a/.design-sync/coven-slip-sweep/coven-task-detail.jsx
+++ b/.design-sync/coven-slip-sweep/coven-task-detail.jsx
@@ -1,0 +1,348 @@
+// Cozy Coven Task Detail — candlelight and a pentagram ward holding your points. Coven DRESS only:
+// the copy is faction-agnostic (task pages don't get faction-specific language).
+// header (breadcrumb, title, level / in progress / completed) beside one action plate (worth + sign up)
+// → the task (brief) → submissions (praxis gallery) → comments.
+// NOTE: task detail pages carry NO in-progress roster section — the brewing count in the header is enough.
+// Props: theme ('light'|'dark'), platform ('desktop'|'mobile'), state ('open'|'in_progress'), data.
+const TOKENS = {
+  light: {
+    page:'#fdeef5', ink:'#8f2557', deep:'#c9327a', pk:'#ec4f92', soft:'#b8517f', label:'#b06a92',
+    lt:'#fbc4dd', lt2:'#fdd9e8', card:'#fff6fb', border:'#f4a9cc', hair:'rgba(201,50,122,.18)',
+    lav:'#e6dbf7', vio:'#e3d6f6', gold:'#f4c430', dim:'#d99ab9',
+    green:'#7cbf99', greenDk:'#5c8150', glow:'rgba(236,79,146,.30)',
+    shadow:'0 14px 32px -16px rgba(236,79,146,.42)', candle:.5
+  },
+  dark: {
+    page:'#1d0a15', ink:'#fbcfe4', deep:'#f9a8d4', pk:'#f472b6', soft:'#e58cb6', label:'#c78aa6',
+    lt:'#5e2a46', lt2:'#4a2038', card:'#2a0f1e', border:'#7a3358', hair:'rgba(249,168,212,.2)',
+    lav:'#2e2145', vio:'#2b1c42', gold:'#f4d472', dim:'#8d5f78',
+    green:'#5fa882', greenDk:'#3f7259', glow:'rgba(244,114,182,.42)',
+    shadow:'0 18px 44px -18px rgba(0,0,0,.75)', candle:.7
+  }
+};
+
+const CG = "'Cormorant Garamond',Georgia,serif";
+const QS = "'Quicksand','Trebuchet MS',sans-serif";
+const CAV = "'Caveat',cursive";
+const GG = "'Grenze Gotisch','Cormorant Garamond',Georgia,serif";
+
+const CVN_CSS = `
+@keyframes cvndWheel { to { transform:rotate(360deg); } }
+@keyframes cvndFlicker { 0%,100% { opacity:.62; transform:scale(1); } 38% { opacity:.9; transform:scale(1.06); } 71% { opacity:.7; transform:scale(.98); } }
+@keyframes cvndFloat { 0%,100% { transform:translate3d(-3%,-2%,0) scale(1.1); } 50% { transform:translate3d(3%,2%,0) scale(1.18); } }
+@media (prefers-reduced-motion:reduce) { .cvnd-wheel,.cvnd-candle,.cvnd-haze { animation:none !important; } }
+`;
+
+const DATA = {
+  author: { name: 'Wren Abalone', level: 4, href: '#/players/wren-abalone' },
+  num: 305, title: 'Brew comfort for a weary friend', level: 3, points: 120, multiplier: 1.5,
+  inProgress: 9, completed: 21, slotsOpen: 4, slotsMax: 13,
+  brief: [
+    "Put the kettle on for someone tired. Steep something warm, sit a while — the tea says what words can't.",
+    'No fixing, no advice unless it is asked for twice. Your whole task is the warmth and the staying.',
+    'When it is done, write down one thing they said that you want to keep. That line is the spell; the tea was only the vessel.'
+  ],
+  praxis: [
+    { title: 'Chamomile, and a very long silence', author: 'Maeve Thornbramble', score: '4.6', votes: 22, when: '3 days ago', pts: 180, rec: 902, top: true },
+    { title: 'Two mugs on the fire escape', author: 'Bramblewick', score: '4.3', votes: 17, when: '5 days ago', pts: 165, rec: 897 },
+    { title: 'I made the wrong tea and stayed anyway', author: 'Juniper Ash', score: '4.1', votes: 14, when: 'last week', pts: 150, rec: 884 },
+    { title: 'Honey from the back of the cupboard', author: 'the Kettle Keeper', score: '4.0', votes: 12, when: '2 weeks ago', pts: 144, rec: 871 },
+    { title: 'She talked for an hour about her mother', author: 'Ostrich Featherby', score: '3.9', votes: 9, when: 'last month', pts: 138, rec: 852 },
+    { title: 'A thermos, left on a doorstep', author: 'unsigned', score: '4.2', votes: 15, when: 'last month', pts: 158, rec: 840 }
+  ],
+  comments: [
+    { author: 'Bramblewick', when: '4 days ago', body: 'The staying is the hard part. I wanted to be useful and had to sit on my hands instead.' },
+    { author: 'the Kettle Keeper', when: '2 days ago', body: 'Sitting on your hands IS the useful part, love. Write that on the tin.' },
+    { author: 'Juniper Ash', when: '9 hours ago', body: 'Kept her line: "nobody has asked me that in a year." Still thinking about it.' }
+  ]
+};
+
+function CovenTaskDetail(props) {
+  const theme = props.theme === 'dark' ? 'dark' : 'light';
+  const desktop = props.platform === 'desktop';
+  const t = TOKENS[theme];
+  const d = Object.assign({}, DATA, props.data || {});
+  const el = React.createElement;
+
+  const [taken, setTaken] = React.useState(props.state === 'in_progress');
+  const [sort, setSort] = React.useState('loved');
+  const [showAll, setShowAll] = React.useState(false);
+  React.useEffect(() => { setTaken(props.state === 'in_progress'); }, [props.state]);
+
+  const yourPoints = Math.round(d.points * d.multiplier);
+  const showMult = Math.abs(d.multiplier - 1) > 1e-9;
+
+  const cap = { fontFamily:QS, fontWeight:700, letterSpacing:'.2em', textTransform:'uppercase' };
+  const eyebrow = { ...cap, fontSize:9.5, color:t.label };
+  const hand = (size) => ({ fontFamily:CAV, fontSize:size, lineHeight:.92, color:t.ink });
+  const display = (size) => ({ fontFamily:GG, fontWeight:600, fontSize:size, lineHeight:1.06, color:t.ink, letterSpacing:'.005em' });
+  const italic = (size, color) => ({ fontFamily:CG, fontStyle:'italic', fontSize:size, lineHeight:1.5, color:color || t.soft });
+  const panel = { background:t.card, border:`2px solid ${t.border}`, borderRadius:16, boxSizing:'border-box', boxShadow:t.shadow };
+
+  const sparkle = (size, color, op) => el('svg', { width:size, height:size, viewBox:'0 0 24 24', 'aria-hidden':true, style:{ display:'block', flex:'0 0 auto', opacity:op==null?1:op } },
+    el('path', { d:'M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z', fill:color })
+  );
+  const heartIcon = (size, color) => el('svg', { width:size, height:size, viewBox:'0 0 36 36', 'aria-hidden':true, style:{ display:'block', flex:'0 0 auto' } },
+    el('path', { d:'M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z', fill:color })
+  );
+
+  const threadUrl = (color, bead) => {
+    const strand = (dd) => "<path d='" + dd + "' fill='none' stroke='" + color + "' stroke-width='1.2' stroke-linecap='round'/>";
+    const svg = "<svg xmlns='http://www.w3.org/2000/svg' width='40' height='12' viewBox='0 0 40 12'>"
+      + strand('M0 3 C10 3, 10 9, 20 9 C24 9, 26 8.2, 28 7')
+      + strand('M32 5 C34 3.8, 36 3, 40 3')
+      + strand('M0 9 C4 9, 6 8.2, 8 7')
+      + strand('M12 5 C14 3.8, 16 3, 20 3 C30 3, 30 9, 40 9')
+      + "<circle cx='20' cy='6' r='1.2' fill='" + bead + "' opacity='0.9'/></svg>";
+    return "url(\"data:image/svg+xml," + encodeURIComponent(svg) + "\")";
+  };
+  const braid = (extra) => el('span', { 'aria-hidden':true, style:{ display:'block', height:12, minWidth:20,
+    backgroundImage:threadUrl(t.deep, t.gold), backgroundRepeat:'repeat-x', backgroundPosition:'left center', opacity:.8, ...(extra||{}) } });
+
+  // candlelight haze behind the page
+  const haze = el('div', { 'aria-hidden':true, style:{ position:'absolute', inset:0, overflow:'hidden', zIndex:0, pointerEvents:'none' } },
+    el('div', { className:'cvnd-haze', style:{ position:'absolute', inset:'-25%', opacity:t.candle, filter:'blur(70px)',
+      animation:'cvndFloat 34s ease-in-out infinite',
+      backgroundImage:[
+        'radial-gradient(50% 40% at 12% 8%, ' + t.pk + ', transparent 100%)',
+        'radial-gradient(46% 38% at 88% 14%, ' + t.lav + ', transparent 100%)',
+        'radial-gradient(42% 34% at 62% 84%, ' + t.gold + ', transparent 100%)',
+        'radial-gradient(46% 36% at 20% 92%, ' + t.vio + ', transparent 100%)'
+      ].join(','), mixBlendMode: theme === 'dark' ? 'screen' : 'normal' } }),
+    el('svg', { width:'100%', height:'100%', viewBox:'0 0 100 100', preserveAspectRatio:'none', 'aria-hidden':true, style:{ position:'absolute', inset:0 } },
+      [[13,31,.45,.5],[38,46,.5,.55],[5,62,.65,.7],[57,71,.45,.5],[29,83,.7,.75],[46,97,.6,.65]]
+        .map(([x,y,r,o],i)=>el('path', { key:i, transform:'scale(1,1)',
+          d:`M${x} ${y-r*2.6} l${r} ${r*2.6} ${r*2.6} ${r} -${r*2.6} ${r} -${r} ${r*2.6} -${r} -${r*2.6} -${r*2.6} -${r} ${r*2.6} -${r} z`,
+          fill:t.gold, opacity: o * (theme === 'dark' ? 1 : .72) }))
+    ),
+    el('svg', { className:'cvnd-wheel', width:640, height:640, viewBox:'0 0 100 100', 'aria-hidden':true,
+      style:{ position:'absolute', right:-180, top:120, opacity: theme === 'dark' ? .1 : .07, animation:'cvndWheel 150s linear infinite', transformOrigin:'50% 50%' } },
+      el('circle', { cx:50, cy:50, r:44, fill:'none', stroke:t.deep, strokeWidth:.8 }),
+      el('path', { d:'M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z', fill:'none', stroke:t.deep, strokeWidth:1.1, strokeLinejoin:'round' })
+    )
+  );
+
+  const sigilMark = (size) => el('svg', { width:size, height:size, viewBox:'0 0 44 44', 'aria-hidden':true, style:{ display:'block', flex:'0 0 auto' } },
+    el('circle', { cx:22, cy:22, r:19, fill:t.pk, opacity: theme === 'dark' ? .28 : .16 }),
+    el('circle', { cx:22, cy:22, r:15, fill:'none', stroke:t.gold, strokeWidth:1, strokeDasharray:'2 4' }),
+    el('path', { d:'M22 8 L30.2 33.3 L8.7 17.7 L35.3 17.7 L13.8 33.3 Z', fill:'none', stroke:t.deep, strokeWidth:1.5, strokeLinejoin:'round' }),
+    el('circle', { cx:22, cy:22, r:3, fill:t.gold })
+  );
+
+  const sectionHead = (label, gloss) => el('div', { style:{ display:'flex', alignItems:'center', gap:12, marginBottom:14 } },
+    el('span', { style:{ ...display(desktop ? 27 : 23), letterSpacing:'.02em' } }, label),
+    braid({ flex:1 }),
+    gloss ? el('span', { style:{ ...eyebrow, fontSize:9, flex:'0 0 auto' } }, gloss) : null
+  );
+
+  const avatar = (name, size, kin) => el('span', { style:{ width:size, height:size, borderRadius:'50%', flex:'0 0 auto', padding:2, boxSizing:'border-box',
+    background: kin === 'guest' ? `linear-gradient(150deg,${t.lav},${t.vio})` : `linear-gradient(150deg,${t.pk},${t.deep})` } },
+    el('span', { style:{ display:'flex', alignItems:'center', justifyContent:'center', width:'100%', height:'100%', borderRadius:'50%',
+      background:t.card, fontFamily:CG, fontWeight:600, fontSize:size * 0.42, color:t.deep } }, name[0].toUpperCase())
+  );
+
+  // ── the ward: points inside a glowing pentagram ────────────────────────
+  const wardId = 'cvnd-' + (desktop ? 'd' : 'm') + '-' + theme;
+  const ward = (size) => el('div', { style:{ position:'relative', flex:'0 0 auto', width:size, height:size, display:'flex', alignItems:'center', justifyContent:'center' } },
+    el('svg', { width:size, height:size, viewBox:'0 0 100 100', 'aria-hidden':true, style:{ position:'absolute', inset:0, overflow:'visible' } },
+      el('defs', null,
+        el('radialGradient', { id:wardId + '-in' },
+          el('stop', { offset:'0%', stopColor: theme === 'dark' ? '#1a0713' : '#ffffff', stopOpacity: theme === 'dark' ? .92 : .98 }),
+          el('stop', { offset:'64%', stopColor: theme === 'dark' ? '#1a0713' : '#ffffff', stopOpacity: theme === 'dark' ? .6 : .72 }),
+          el('stop', { offset:'100%', stopColor: theme === 'dark' ? '#1a0713' : '#ffffff', stopOpacity:0 })
+        ),
+        el('radialGradient', { id:wardId + '-aura' },
+          el('stop', { offset:'0%', stopColor:t.pk, stopOpacity: theme === 'dark' ? .58 : .4 }),
+          el('stop', { offset:'55%', stopColor:t.pk, stopOpacity: theme === 'dark' ? .22 : .15 }),
+          el('stop', { offset:'100%', stopColor:t.pk, stopOpacity:0 })
+        )
+      ),
+      el('circle', { className:'cvnd-candle', cx:50, cy:50, r:48, fill:'url(#' + wardId + '-aura)', style:{ animation:'cvndFlicker 5.5s ease-in-out infinite', transformOrigin:'50% 50%' } }),
+      el('path', { d:'M50 16 L69.8 78.5 L16.5 40.1 L83.5 40.1 L30.2 78.5 Z', fill:'none', stroke:t.gold, strokeWidth:1, strokeLinejoin:'round', opacity:.55 }),
+      el('circle', { cx:50, cy:50, r:33, fill:'none', stroke:t.pk, strokeWidth:1.8, opacity:.9 }),
+      el('circle', { cx:50, cy:50, r:32.1, fill:'url(#' + wardId + '-in)' }),
+      [[50,3,3.2],[90,26,2.3],[12,74,2.6],[86,80,1.8],[14,22,1.6]].map(([x,y,r],i)=>el('path', { key:i,
+        d:`M${x} ${y-r*2.6} l${r} ${r*2.6} ${r*2.6} ${r} -${r*2.6} ${r} -${r} ${r*2.6} -${r} -${r*2.6} -${r*2.6} -${r} ${r*2.6} -${r} z`,
+        fill:t.gold, opacity: theme === 'dark' ? .95 : .85 }))
+    ),
+    el('div', { style:{ position:'relative', display:'flex', flexDirection:'column', alignItems:'center', lineHeight:.85 } },
+      el('span', { style:{ fontFamily:CG, fontWeight:600, fontSize:size * 0.3, color:t.deep } }, yourPoints),
+      el('span', { style:{ ...cap, fontSize:7.5, letterSpacing:'.16em', color:t.label, marginTop:3 } }, 'points')
+    )
+  );
+
+  // ── header ─────────────────────────────────────────────────────────────
+  const header = el('div', { style:{ marginBottom: desktop ? 30 : 20 } },
+    el('div', { style:{ display:'flex', alignItems:'center', gap:8, marginBottom:12 } },
+      el('span', { style:{ ...eyebrow, color:t.deep } }, 'tasks'),
+      el('span', { style:{ ...eyebrow, color:t.dim } }, '/'),
+      el('span', { style:{ ...eyebrow } }, 'task no. ' + d.num)
+    ),
+    el('div', { style:{ display:'flex', alignItems:'center', gap:10, marginBottom:10 } },
+      sigilMark(30),
+      el('span', { style:{ ...hand(desktop ? 26 : 23), color:t.label } }, 'Task detail')
+    ),
+    el('h1', { style:{ ...display(desktop ? 46 : 31), margin:'0 0 16px', textWrap:'pretty' } }, d.title),
+    el('div', { style:{ display:'flex', alignItems:'center', gap:10, marginBottom:16 } },
+      el('a', { href:d.author.href, title:'View ' + d.author.name + "'s profile", style:{ display:'flex', alignItems:'center', gap:9, textDecoration:'none' } },
+        el('span', { style:{ display:'inline-flex', alignItems:'center', justifyContent:'center', flex:'0 0 auto', width:30, height:30, borderRadius:'50%', overflow:'hidden', background:t.card, border:`2px solid ${t.border}`, fontFamily:QS, fontWeight:700, fontSize:11, color:t.label } }, d.author.name.split(' ').map(function(w){return w[0];}).join('').slice(0,2).toUpperCase()),
+        el('span', { style:{ ...hand(25), borderBottom:`2px solid ${t.border}` } }, d.author.name)),
+      el('span', { style:{ ...eyebrow, fontSize:9 } }, 'author · lvl ' + d.author.level)),
+    el('div', { style:{ display:'flex', alignItems:'center', gap: desktop ? 22 : 16, flexWrap:'wrap' } },
+      el('div', { style:{ display:'flex', flexDirection:'column', gap:5 } },
+        el('span', { style:{ ...cap, fontSize:8.5, letterSpacing:'.16em', color:t.label } }, 'level'),
+        el('span', { style:{ fontFamily:CG, fontWeight:600, fontSize: desktop ? 32 : 27, lineHeight:.8, color:t.ink } }, d.level)
+      ),
+      el('span', { 'aria-hidden':true, style:{ width:1, alignSelf:'stretch', minHeight:34, background:t.hair } }),
+      el('div', { style:{ display:'flex', flexDirection:'column', gap:5 } },
+        el('span', { style:{ ...cap, fontSize:8.5, letterSpacing:'.16em', color:t.label } }, 'in progress'),
+        el('span', { style:{ fontFamily:CG, fontWeight:600, fontSize: desktop ? 28 : 24, lineHeight:.8, color:t.ink } }, d.inProgress)
+      ),
+      el('span', { 'aria-hidden':true, style:{ width:1, alignSelf:'stretch', minHeight:34, background:t.hair } }),
+      el('div', { style:{ display:'flex', flexDirection:'column', gap:5 } },
+        el('span', { style:{ ...cap, fontSize:8.5, letterSpacing:'.16em', color:t.label } }, 'completed'),
+        el('span', { style:{ fontFamily:CG, fontWeight:600, fontSize: desktop ? 28 : 24, lineHeight:.8, color:t.ink } }, d.completed)
+      )
+    )
+  );
+
+  // ── action plate ───────────────────────────────────────────────────────
+  const worth = el('div', { style:{ display:'flex', flexDirection:'column', alignItems:'center', gap:10 } },
+    el('div', { style:{ display:'flex', alignItems:'baseline', justifyContent:'center', gap:8, flexWrap:'wrap' } },
+      el('span', { style:{ ...cap, fontSize:8, letterSpacing:'.16em', color:t.label } }, 'base'),
+      el('span', { style:{ fontFamily:CG, fontWeight:600, fontSize: desktop ? 21 : 18, lineHeight:1, color:t.ink } }, d.points),
+      showMult ? el('span', { style:{ fontFamily:QS, fontWeight:700, fontSize:11, color:'#fff', background:`linear-gradient(180deg,${t.pk},${t.deep})`,
+        border:`1.5px solid ${t.deep}`, borderRadius:20, padding:'3px 9px', lineHeight:1.2, boxShadow:`0 3px 8px ${t.glow}` } }, '×' + d.multiplier.toFixed(2)) : null
+    ),
+    ward(desktop ? 104 : 84)
+  );
+
+  const bigButton = (label, onClick, done) => el('div', { onClick, style:{ cursor:'pointer', textAlign:'center',
+    background: done ? `linear-gradient(180deg,${t.gold},#d9a521)` : `linear-gradient(180deg,${t.pk},${t.deep})`,
+    color: done ? '#5c3a06' : '#fff', fontFamily:QS, fontWeight:700, fontSize: desktop ? 13 : 12, letterSpacing:'.12em', textTransform:'uppercase',
+    borderRadius:12, border:`1.5px solid ${done ? '#c08d14' : t.deep}`, padding: desktop ? '14px 18px' : '13px 12px',
+    boxShadow: done ? '0 8px 18px -8px rgba(217,165,33,.6)' : `0 8px 18px -8px ${t.glow}`, display:'flex', alignItems:'center', justifyContent:'center', gap:7 } },
+    sparkle(12, done ? '#5c3a06' : '#fff', .95), label);
+
+  const ctaBody = taken
+    ? el('div', null,
+        el('div', { style:{ ...hand(desktop ? 27 : 24), marginBottom:11 } }, "You're on this task"),
+        bigButton('continue', null, true),
+        el('div', { onClick:()=>setTaken(false), style:{ cursor:'pointer', textAlign:'center', marginTop:10, ...italic(13.5, t.label) } }, 'drop this task')
+      )
+    : el('div', null,
+        bigButton('sign up', ()=>setTaken(true)),
+        el('div', { style:{ textAlign:'center', marginTop:10, ...italic(13.5, t.label) } },
+          d.slotsOpen + ' of ' + d.slotsMax + ' spots open · level ' + d.level + ' and up')
+      );
+
+  const innerBox = { background:t.page, border:`1.5px solid ${t.border}`, borderRadius:12, padding: desktop ? '16px 18px' : '15px 14px', boxSizing:'border-box' };
+  const actionPlate = el('div', { style:{ position:'relative', overflow:'hidden', borderRadius:18, border:`2px solid ${t.border}`, boxShadow:t.shadow,
+    background:`linear-gradient(158deg,${t.lt2},${t.lt} 38%,${t.lav} 76%,${t.vio})`, padding:8, display:'flex', gap:8, alignItems:'stretch', boxSizing:'border-box' } },
+    el('div', { style:{ ...innerBox, flex:'0 0 auto', minWidth: desktop ? 166 : 124, display:'flex', alignItems:'center', justifyContent:'center' } }, worth),
+    el('div', { style:{ ...innerBox, flex:1, minWidth:0, display:'flex', flexDirection:'column', justifyContent:'center' } }, ctaBody)
+  );
+
+  // ── the asking ─────────────────────────────────────────────────────────
+  const brief = el('section', { style:{ marginBottom: desktop ? 32 : 22 } },
+    sectionHead('The task', 'full brief'),
+    el('div', { style:{ ...panel, padding: desktop ? '22px 26px 20px' : '17px 18px' } },
+      d.brief.map((p, i) => el('p', { key:i, style: i === 0
+        ? { ...display(desktop ? 22 : 19), fontWeight:600, lineHeight:1.35, margin:'0 0 14px', textWrap:'pretty' }
+        : { ...italic(desktop ? 15.5 : 14.5), margin: i === d.brief.length - 1 ? 0 : '0 0 12px', textWrap:'pretty' } }, p)),
+      braid({ marginTop:16 })
+    )
+  );
+
+  // ── spells cast ────────────────────────────────────────────────────────
+  const sortTab = (key, label) => el('span', { key, onClick:()=>setSort(key), style:{ cursor:'pointer', ...cap, fontSize:8.5, letterSpacing:'.14em',
+    padding:'5px 10px', borderRadius:8, color: sort === key ? '#fff' : t.label,
+    background: sort === key ? `linear-gradient(180deg,${t.pk},${t.deep})` : 'transparent' } }, label);
+
+  const list = (sort === 'loved' ? d.praxis : d.praxis.slice().reverse()).slice(0, showAll ? d.praxis.length : 3);
+
+  const gallery = el('section', { style:{ marginBottom: desktop ? 32 : 22 } },
+    el('div', { style:{ display:'flex', alignItems:'center', gap:12, marginBottom:14, flexWrap:'wrap' } },
+      el('span', { style:{ ...display(desktop ? 27 : 23), letterSpacing:'.02em' } }, d.completed + ' submissions'),
+      braid({ flex:1 }),
+      el('span', { style:{ display:'flex', gap:2, padding:2, border:`1.5px solid ${t.border}`, borderRadius:10, background:t.card } },
+        [sortTab('loved','most liked'), sortTab('recent','newest')])
+    ),
+    el('div', { style:{ display:'grid', gridTemplateColumns: desktop ? 'repeat(3,1fr)' : '1fr', gap:14 } },
+      list.map((p) => el('div', { key:p.title, style:{ ...panel, borderRadius:14, cursor:'pointer', padding:'14px 15px 13px', position:'relative', overflow:'hidden' } },
+        p.top ? el('span', { style:{ position:'absolute', right:12, top:12, display:'flex', alignItems:'center', gap:4, ...cap, fontSize:7.5, letterSpacing:'.14em',
+          color:'#fff', background:`linear-gradient(180deg,${t.pk},${t.deep})`, borderRadius:20, padding:'4px 9px' } }, sparkle(9,'#fff',.95), 'most liked') : null,
+        el('div', { style:{ ...cap, fontSize:8, letterSpacing:'.16em', color:t.label, marginBottom:7 } }, 'submission no. ' + p.rec),
+        el('div', { style:{ ...display(desktop ? 20 : 19), marginBottom:9, textWrap:'pretty', paddingRight: p.top ? 8 : 0 } }, p.title),
+        el('div', { style:{ display:'flex', alignItems:'center', gap:8, marginBottom:12 } },
+          avatar(p.author, 26, 'coven'),
+          el('span', { style:{ ...italic(13, t.label), overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' } }, p.author)
+        ),
+        el('div', { style:{ position:'relative', overflow:'hidden', height: desktop ? 118 : 108, borderRadius:10,
+          background:`linear-gradient(150deg,${t.lt2},${t.lav})`, border:`1.5px solid ${t.border}`,
+          display:'flex', alignItems:'center', justifyContent:'center' } },
+          sigilMark(34)
+        ),
+        braid({ margin:'12px 0 10px' }),
+        el('div', { style:{ display:'flex', alignItems:'center', gap:10 } },
+          el('span', { style:{ display:'flex', alignItems:'center', gap:5, ...italic(13, t.soft) } }, heartIcon(12, t.pk), p.votes),
+          el('span', { style:{ ...italic(13, t.label) } }, '♦ ' + p.score),
+          el('span', { style:{ marginLeft:'auto', display:'flex', alignItems:'baseline', gap:4 } },
+            el('span', { style:{ fontFamily:CG, fontWeight:600, fontSize:20, lineHeight:1, color:t.deep } }, p.pts),
+            el('span', { style:{ ...cap, fontSize:7.5, letterSpacing:'.14em', color:t.label } }, 'pts')
+          )
+        ),
+        el('div', { style:{ ...italic(12.5, t.dim), marginTop:8 } }, p.when)
+      ))
+    ),
+    d.praxis.length > 3 ? el('div', { onClick:()=>setShowAll(!showAll), style:{ marginTop:14, cursor:'pointer', ...display(20), color:t.deep } },
+      showAll ? 'fewer ↑' : 'all ' + d.completed + ' submissions →') : null
+  );
+
+  // ── whispers ───────────────────────────────────────────────────────────
+  const comments = el('section', null,
+    sectionHead('Comments', d.comments.length + ' notes'),
+    el('div', { style:{ display:'flex', flexDirection:'column', gap:12, marginBottom:14 } },
+      d.comments.map((c, i) => el('div', { key:i, style:{ ...panel, boxShadow:'none', padding:'13px 15px' } },
+        el('div', { style:{ display:'flex', alignItems:'center', gap:9, marginBottom:8 } },
+          avatar(c.author, 24, 'coven'),
+          el('span', { style:{ fontFamily:QS, fontWeight:600, fontSize:12.5, color:t.ink } }, c.author),
+          el('span', { style:{ marginLeft:'auto', ...cap, fontSize:8, letterSpacing:'.14em', color:t.dim } }, c.when)
+        ),
+        el('p', { style:{ margin:0, ...italic(14.5, t.soft), textWrap:'pretty' } }, c.body)
+      ))
+    ),
+    el('div', { style:{ ...panel, boxShadow:'none', padding:'12px 14px', display:'flex', alignItems:'center', gap:12 } },
+      el('span', { style:{ flex:1, ...italic(14, t.dim) } }, 'Add a comment…'),
+      el('span', { style:{ cursor:'pointer', ...cap, fontSize:9, color:'#fff', background:`linear-gradient(180deg,${t.pk},${t.deep})`,
+        border:`1.5px solid ${t.deep}`, borderRadius:9, padding:'7px 14px' } }, 'post')
+    )
+  );
+
+  const styleTag = el('style', null, CVN_CSS);
+
+  if (desktop) {
+    return el('div', { style:{ position:'relative', width:'100%', boxSizing:'border-box', background:t.page, color:t.ink, fontFamily:QS, padding:'34px 38px 46px' } },
+      styleTag, haze,
+      el('div', { style:{ position:'relative', zIndex:1, display:'flex', gap:28, alignItems:'flex-start' } },
+        el('div', { style:{ flex:1, minWidth:0 } }, header),
+        el('div', { style:{ flex:'0 0 452px', width:452, marginTop:8 } }, actionPlate)
+      ),
+      el('div', { style:{ position:'relative', zIndex:1, minWidth:0 } }, brief, gallery, comments)
+    );
+  }
+
+  return el('div', { style:{ position:'relative', width:'100%', boxSizing:'border-box', background:t.page, color:t.ink, fontFamily:QS, minHeight:'100%', display:'flex', flexDirection:'column' } },
+    styleTag, haze,
+    el('div', { style:{ display:'flex', alignItems:'center', gap:10, padding:'12px 16px', borderBottom:`1.5px solid ${t.border}`,
+      position:'sticky', top:0, background:t.page, zIndex:5 } },
+      el('span', { style:{ fontFamily:CG, fontSize:18, color:t.deep, cursor:'pointer' } }, '←'),
+      el('span', { style:{ ...display(19), color:t.label } }, 'task no. ' + d.num),
+      el('span', { style:{ marginLeft:'auto' } }, sigilMark(24))
+    ),
+    el('div', { style:{ position:'relative', zIndex:1, padding:'18px 16px 26px' } },
+      header, el('div', { style:{ marginBottom:24 } }, actionPlate), brief, gallery, el('div', { style:{ height:22 } }), comments)
+  );
+}
+
+module.exports = { CovenTaskDetail };

--- a/.design-sync/ephemerists-plate-sweep/README.md
+++ b/.design-sync/ephemerists-plate-sweep/README.md
@@ -1,0 +1,48 @@
+# Ephemerists — the Valley plate's full vocabulary (for the codex sweep)
+
+Vendored for the Ephemerists coherence sweep. **Delete this folder in that
+issue's last PR** (`docs/agents/design-fidelity.md`).
+
+The sweep dresses surfaces that have **no design of their own** — avatar, faction
+hero and body, duel seal confirms, profile body, field desk, faction cards. This
+file is where their vocabulary comes from: it is the only Valley-plate document
+that draws lists, avatars, panels, rules and buttons at page scale.
+
+## Source
+
+claude.ai design project `0711d3a7-0074-4a60-8907-270f44168261`, file
+`ephemerists-task-detail.jsx` — verbatim, production-intent React
+(`React.createElement`, no JSX transform, `module.exports` at the foot).
+
+## What is NOT here, and why
+
+The sibling `ephemerists-deco-egypt-task-card.jsx` is **already ported**:
+`components/cards/ephemeristsPlate.tsx` carries its token names, its `GLYPHS`
+library (byte-for-byte) and its `WingedDisc` / `Cornice` / `FlutedRule` /
+`GlyphRegister` / `Sign` / `Octagon` marks, and `components/cards/EphemeristsTaskCard.tsx`
+is the card itself. Read those rather than re-vendoring the card.
+
+## What this file has that the repo does not
+
+- **Roster rows** — octagon-clipped initial avatars, tally strokes for level,
+  Ally/Rival chips, the `+N more` foot. The shipped `EphemeristsTaskDetail.tsx`
+  deliberately dropped the roster (all nine task-detail designs did), so this is
+  the only drawing of an Ephemerists **list of players** anywhere. The profile
+  body, faction body and field desk all need one.
+- **The gravity-well panel** — a lattice bent toward a mass behind body copy,
+  masked to a corner. The plate's answer to "a block of prose on a panel".
+- **The alchemical squared-circle medallion** — ring, ticks, inscribed square,
+  triangle, inner disc. A second numeral holder beside the stepped octagon.
+- **Comment rows, ledger rows, sort tabs, and the two CTA band treatments**
+  (dark band with gold ink in light, brass band with dark ink in dark).
+
+## The one rule for reading it
+
+**The colours in `TOKENS` are raw hex. Do not copy them.** Every one is already
+declared as `--faction-ephemerists-plate-*` in `index.css`, light and dark. Where
+a token deliberately differs from the hex here, the **token wins** and the reason
+is written at its declaration — `-brass` is a rule colour that measures 2.97:1,
+so captions drawn in `brass` here take `-caption` in code. Same for any ink this
+file sets on a gradient.
+
+Geometry, ornament, rhythm and layout: take them from this file.

--- a/.design-sync/ephemerists-plate-sweep/ephemerists-task-detail.jsx
+++ b/.design-sync/ephemerists-plate-sweep/ephemerists-task-detail.jsx
@@ -1,0 +1,396 @@
+// Ephemerists Task Detail — DECO × EGYPT, the full rite of a fragment.
+// Same anatomy as DefaultTaskDetail (header → action panel → brief → roster →
+// praxis gallery → discussion), dressed as a field-journal plate out of the Valley:
+// cavetto-cornice masthead with a winged disc and two incised glyph registers,
+// fragment number in a cartouche, points in a stepped octagon, tally strokes for
+// the sphere, fluted rules between registers.
+// Props: theme ('light'|'dark'), platform ('desktop'|'mobile'), state ('open'|'in_progress'), data.
+const TOKENS = {
+  light: {
+    page:'#E4D5B0', ink:'#2A2418', muted:'#6B5F45', faint:'#9A8C6C',
+    brass:'#9A7A2E', brassL:'#C39B3D', gold:'#E3C56A',
+    ochre:'#A6432B', nile:'#1D4F6E', lapis:'#1D4F6E', edge:'#1D4F6E', deco:'rgba(29,79,110,0.16)',
+    plate:'#EADCB6', plate2:'#F2E7CB', band:'#1E2233', bandInk:'#EFE4C4', disc:'#F6EED6',
+    rule:'rgba(29,79,110,0.16)', line:'rgba(29,79,110,0.34)',
+    ctaBg:'#1E2233', ctaText:'#E9D79B',
+    shadow:'0 18px 44px -26px rgba(42,32,16,.45)'
+  },
+  dark: {
+    page:'#101320', ink:'#F0E6C8', muted:'#A2977A', faint:'#6A6144',
+    brass:'#C9A24B', brassL:'#E6C877', gold:'#F2D98A',
+    ochre:'#D9744C', nile:'#5FB3A6', lapis:'#5FB3A6', edge:'#E6C877', deco:'rgba(201,162,75,0.14)',
+    plate:'#171A26', plate2:'#1D2130', band:'#0A0C15', bandInk:'#F2D98A', disc:'#12151F',
+    rule:'rgba(201,162,75,0.12)', line:'rgba(201,162,75,0.28)',
+    ctaBg:'#C9A24B', ctaText:'#12151F',
+    shadow:'0 20px 50px -26px rgba(0,0,0,.8)'
+  }
+};
+
+const DECO = "'Poiret One','Cinzel',serif";
+const CAPS = "'Cinzel',serif";
+const BODY = "'Spectral','EB Garamond',Georgia,serif";
+
+const GLYPHS = {
+  ankh:'M12 22 V10 M6 15 H18 M12 10 a4 4 0 1 0 0.001 0 Z',
+  eye:'M3 12 C7 7 17 7 21 12 C17 16 7 16 3 12 M12 10.2 a1.8 1.8 0 1 0 .01 0 Z M15 15 L18 20 M8 15 L5 19',
+  feather:'M12 22 V4 M12 6 C15 7 17 10 17 13 M12 6 C9 7 7 10 7 13 M12 12 C14.6 12.8 16 14.6 16 17 M12 12 C9.4 12.8 8 14.6 8 17',
+  water:'M2 9 l4 3 4-3 4 3 4-3 4 3 M2 15 l4 3 4-3 4 3 4-3 4 3',
+  djed:'M12 22 V8 M6 8 H18 M6 12 H18 M7.5 4.6 H16.5 M9 2 H15',
+  reed:'M12 22 V7 C12 4 14 2.6 17 2.6 C17 6 15 7.4 12 7.4',
+  sun:'M12 12 a5 5 0 1 0 .01 0 Z M12 3 V6 M12 18 V21 M3 12 H6 M18 12 H21',
+  offering:'M4 8 H20 M6 8 V14 H18 V8 M9 14 V20 M15 14 V20 M4 20 H20',
+  scarab:'M12 4 C15.5 4 17.5 7 17.5 11 C17.5 16.6 15 20 12 20 C9 20 6.5 16.6 6.5 11 C6.5 7 8.5 4 12 4 M12 4 V20 M6.5 9 L2.5 6 M17.5 9 L21.5 6 M6.5 15 L2.5 18 M17.5 15 L21.5 18',
+  greekKey:'M2 20 V6 H16 V16 H8 V11 H12',
+  chevrons:'M3 8 L12 3 L21 8 M3 14 L12 9 L21 14 M3 20 L12 15 L21 20',
+  alchemy:'M12 3 L21 19 H3 Z M6.6 13.6 H17.4',
+  hourglass:'M5 3 H19 M5 21 H19 M6.5 3 L12 12 L6.5 21 M17.5 3 L12 12 L17.5 21',
+  openEye:'M2 12 C6 5.4 18 5.4 22 12 M2 12 C6 18.6 18 18.6 22 12 M8.4 12 a3.6 3.6 0 1 0 7.2 0 a3.6 3.6 0 1 0 -7.2 0 M10.7 12 a1.3 1.3 0 1 0 2.6 0 a1.3 1.3 0 1 0 -2.6 0 M12 2.8 V5 M5 4.6 L6.8 6.6 M19 4.6 L17.2 6.6',
+  planet:'M5.8 12 a6.2 6.2 0 1 0 12.4 0 a6.2 6.2 0 1 0 -12.4 0 M1.8 16.2 A10.8 3.7 -22 0 1 22.2 7.8 A10.8 3.7 -22 0 1 1.8 16.2'
+};
+
+const ROMAN = (n) => {
+  const map = [[1000,'M'],[900,'CM'],[500,'D'],[400,'CD'],[100,'C'],[90,'XC'],[50,'L'],[40,'XL'],[10,'X'],[9,'IX'],[5,'V'],[4,'IV'],[1,'I']];
+  let out = '', v = Math.max(0, Math.round(Number(n) || 0));
+  map.forEach(([k, s]) => { while (v >= k) { out += s; v -= k; } });
+  return out || '0';
+};
+
+const DATA = {
+  author: { name: 'Wren Abalone', level: 4, href: '#/players/wren-abalone' },
+  num: 305, title: 'Catalogue every bench along the river walk', level: 4,
+  points: 30, multiplier: 1.25, inProgress: 9, completed: 23, slotsOpen: 2, slotsMax: 3,
+  brief: [
+    'Walk the water from the lock to the last lamp and number every bench you pass. Photograph each one from standing height, and note which face the water and which have turned away from it.',
+    'Record the material, the damage, the initials cut into the arm. A bench is a measurement of how long a person expects to stay — the river walk is therefore an instrument, and no one has read it.',
+    'Submit the index as a single sequence, in the order you walked it. If you double back, say so. A false order is worse than a missing bench.'
+  ],
+  roster: [
+    { name: 'Thessaly Vane', level: 6, tag: 'Friend' },
+    { name: 'monochord', level: 3, tag: null },
+    { name: 'Io Sarris', level: 8, tag: 'Foe' },
+    { name: 'B. Aetheling', level: 4, tag: null },
+    { name: 'nine_ratios', level: 2, tag: null },
+    { name: 'Calder Wynn', level: 5, tag: null }
+  ],
+  praxis: [
+    { title: 'Forty-one benches, north bank, dawn to dusk', author: 'Thessaly Vane', votes: 34, when: 'jul 14', pts: 38, rec: 1187, top: true },
+    { title: 'Nine that face away from the water', author: 'Calder Wynn', votes: 27, when: 'jul 11', pts: 33, rec: 1174 },
+    { title: 'The initials, transcribed and dated', author: 'monochord', votes: 19, when: 'jul 9', pts: 29, rec: 1166 },
+    { title: 'Bench XVII, measured against the flood mark', author: 'Io Sarris', votes: 24, when: 'jul 6', pts: 31, rec: 1158 },
+    { title: 'A rubbing of every cast-iron leg', author: 'B. Aetheling', votes: 15, when: 'jul 2', pts: 26, rec: 1141 },
+    { title: 'Counted twice, and the counts disagree', author: 'nine_ratios', votes: 11, when: 'jun 28', pts: 22, rec: 1129 }
+  ],
+  comments: [
+    { author: 'Io Sarris', when: '4 days ago', body: 'Does a memorial bench count twice — once as furniture, once as a name? I have logged them as both and will accept the penalty.' },
+    { author: 'monochord', when: '2 days ago', body: 'Once. The name is an inscription, not a bench. Keep the index clean or it is not an index.' },
+    { author: 'Thessaly Vane', when: '15 hours ago', body: 'Two of mine were gone between the first walk and the second. The instrument is being edited while we read it.' }
+  ]
+};
+
+function EphemeristsTaskDetail(props) {
+  const theme = props.theme === 'dark' ? 'dark' : 'light';
+  const desktop = props.platform === 'desktop';
+  const t = TOKENS[theme];
+  const d = Object.assign({}, DATA, props.data || {});
+  const el = React.createElement;
+
+  const [signed, setSigned] = React.useState(props.state === 'in_progress');
+  const [sort, setSort] = React.useState('top');
+  const [showAll, setShowAll] = React.useState(false);
+  React.useEffect(() => { setSigned(props.state === 'in_progress'); }, [props.state]);
+
+  const yourPoints = Math.round(d.points * d.multiplier);
+  const showMult = Math.abs(d.multiplier - 1) > 1e-9;
+
+  const sc = { fontFamily:CAPS, fontWeight:500, letterSpacing:'.24em', textTransform:'uppercase' };
+  const eyebrow = { ...sc, fontSize:9.5, color:t.brass };
+  const body = (size) => ({ fontFamily:BODY, fontSize:size, lineHeight:1.7, color:t.muted });
+  const plate = { background:t.plate, border:`1px solid ${t.line}`, boxSizing:'border-box' };
+
+  const ico = (name, size, color, w) => el('svg', { width:size, height:size, viewBox:'0 0 24 24', 'aria-hidden':true, style:{ display:'block', flex:'0 0 auto' } },
+    el('path', { d:GLYPHS[name], fill:'none', stroke:color, strokeWidth:w || 1.5, strokeLinecap:'round', strokeLinejoin:'round' }));
+
+  // rule of symbol-only physics — big/small rhythm, no numerals
+  const EQ = '∇×Ψ≡∂Φ∕∂τ ∮⟨ψ‖Θ‖ψ⟩∝Σμν ⊗Δλ≥ϖ ∫ρ∂ν≈Ω ∴Γ⇌Θξ ∇²φ≡−κρ ⨍ση∝√Π ⊕ζ⊥∮Δς';
+  const fluted = (extra) => el('div', { 'aria-hidden':true, style:{ display:'flex', alignItems:'center', gap:2.5, height:15, overflow:'hidden',
+    fontFamily:BODY, whiteSpace:'nowrap', userSelect:'none', ...(extra||{}) } },
+    Array.from({ length: 56 }).map((_, i) => {
+      const ch = EQ[i % EQ.length];
+      const r1 = (i * 0.6180339887) % 1, r2 = (i * 0.7548776662) % 1;
+      const delay = (r1 * 12).toFixed(2);
+      const dur = (9 + r2 * 8).toFixed(2);
+      return el('span', { key:i, className:'epd-glyph', style:{ flex:'1 1 auto', textAlign:'center', color: i % 2 ? t.brass : t.lapis,
+        fontSize: i % 2 ? 14 : 10, lineHeight:1, '--epdOp': i % 2 ? .7 : .45,
+        animationDelay: delay + 's', animationDuration: dur + 's' } }, ch === ' ' ? '·' : ch);
+    }));
+
+  const sectionHead = (label, gloss) => el('div', { style:{ marginBottom:15 } },
+    el('div', { style:{ display:'flex', alignItems:'center', gap:12, marginBottom:7, flexWrap:'wrap' } },
+      el('span', { style:{ ...sc, fontSize:11, fontWeight:600, color:t.ink, flex:'0 0 auto', whiteSpace:'nowrap' } }, label),
+      el('span', { style:{ flex:1, minWidth:24, height:1, background:t.brass, opacity:.5 } }),
+      gloss ? el('span', { style:{ ...sc, fontSize:9, color:t.faint } }, gloss) : null),
+    fluted());
+
+  const cartouche = (label) => el('span', { style:{ ...sc, fontWeight:700, fontSize:9.5, color:t.ink, whiteSpace:'nowrap' } }, label);
+
+  const tally = (level) => el('span', { 'aria-hidden':true, style:{ display:'flex', alignItems:'flex-end', gap:2.5, height:11 } },
+    Array.from({ length: Math.min(9, Math.max(1, Math.round(level))) }).map((_, i) =>
+      el('span', { key:i, style:{ width:1.6, height: 11 - (i % 3) * 2, background: i === 4 ? t.ochre : t.brass, opacity:.85 } })));
+
+  // ── masthead: winged disc between two incised glyph registers, closed by a cornice
+  const wing = (dir) => el('g', { transform: dir === 'l' ? 'scale(-1,1)' : 'none' },
+    [0,1,2,3,4].map((i) => el('rect', { key:i, x:13 + i*11.4, y:-6 + i*1.5, width:9.6, height:8.4 - i*1.4, rx:1.4, fill:t.gold })),
+    [0,1,2,3].map((i) => el('rect', { key:'b'+i, x:15 + i*11.4, y:4.2 + i*1.6, width:8, height:3.4 - i*0.5, rx:1, fill:t.brass })));
+
+  const REG = ['ankh','water','feather','eye','djed','greekKey','reed','offering','alchemy','chevrons','scarab','sun','ankh','water','djed','eye'];
+  const register = (y, prefix, op) => REG.map((n, i) => el('g', { key:prefix+i, className:'epd-glyph',
+    transform:`translate(${18 + i*27.5} ${y}) scale(${13/24}) translate(-12 -12)`,
+    style:{ ['--epdOp']: op * (i % 3 === 0 ? 1 : 0.7), animationDelay: ((i*7) % 12) * 1.6 + 's' } },
+    el('path', { d:GLYPHS[n], fill:'none', stroke:t.gold, strokeWidth:1.6, strokeLinecap:'round', strokeLinejoin:'round' })));
+
+  const mastHeight = desktop ? 108 : 92;
+  const masthead = el('div', null,
+    el('div', { style:{ position:'relative', overflow:'hidden', height:mastHeight, background:t.band, color:t.bandInk } },
+      el('svg', { width:'100%', height:mastHeight, viewBox:'0 0 440 108', preserveAspectRatio:'xMidYMid slice', 'aria-hidden':true, style:{ position:'absolute', inset:0, zIndex:1 } },
+        el('path', { d:'M8 24 H432 M8 84 H432', stroke:t.brassL, strokeWidth:.6, opacity:.28 }),
+        register(13, 'a', .34), register(95, 'b', .3)),
+      el('div', { style:{ position:'relative', zIndex:2, height:'100%', display:'flex', flexDirection:'column', alignItems:'center', justifyContent:'center', gap:4 } },
+        el('svg', { width: desktop ? 176 : 150, height:38, viewBox:'-88 -20 176 40', 'aria-hidden':true, style:{ display:'block' } },
+          wing('r'), wing('l'),
+          el('circle', { r:10, fill:'none', stroke:t.gold, strokeWidth:1.5 }),
+          el('circle', { r:5, fill:t.gold, opacity:.8 }),
+          el('path', { d:'M-13 0 H-10.5 M10.5 0 H13', stroke:t.brassL, strokeWidth:1 })),
+        el('span', { style:{ fontFamily:DECO, fontSize: desktop ? 19 : 16, letterSpacing:'.3em', textTransform:'uppercase', color:t.bandInk, whiteSpace:'nowrap' } }, 'Ephemerists'))),
+    el('div', { 'aria-hidden':true, style:{ background:t.band } },
+      el('div', { style:{ display:'flex', height:7, alignItems:'flex-end', gap:3, padding:'0 10px', overflow:'hidden' } },
+        Array.from({ length: 52 }).map((_, i) => el('span', { key:i, style:{ flex:1, height: i % 2 ? 6 : 3.5, background:t.brassL, opacity: i % 2 ? .5 : .28 } }))),
+      el('div', { style:{ height:2, background:t.brass, opacity:.9 } }),
+      el('div', { style:{ height:1, marginTop:2, background:t.brassL, opacity:.55 } })));
+
+  // ── header ────────────────────────────────────────────────────────────
+  const header = el('div', { style:{ marginBottom: desktop ? 28 : 20 } },
+    el('div', { style:{ display:'flex', alignItems:'center', gap:9, marginBottom:14, flexWrap:'wrap' } },
+      el('span', { style:{ ...sc, fontSize:9.5, color:t.nile } }, 'Tasks'),
+      el('span', { style:{ ...sc, fontSize:9.5, color:t.faint } }, '/'),
+      cartouche('Task №' + d.num)),
+    el('div', { style:{ display:'flex', alignItems:'center', gap:9, marginBottom:12 } },
+      ico('ankh', 19, t.brass, 1.6),
+      el('span', { style:{ ...sc, fontSize:9.5, color:t.brass } }, 'Ephemerists')),
+    el('h1', { style:{ fontFamily:DECO, fontWeight:400, fontSize: desktop ? 44 : 28, lineHeight:1.16, letterSpacing:'.02em', margin:'0 0 16px', color:t.ink, textWrap:'pretty' } }, d.title),
+    el('div', { style:{ display:'flex', alignItems:'center', gap:10, marginBottom:16 } },
+      el('a', { href:d.author.href, title:'View ' + d.author.name + "'s profile", style:{ display:'flex', alignItems:'center', gap:9, textDecoration:'none' } },
+        el('span', { style:{ display:'inline-flex', alignItems:'center', justifyContent:'center', flex:'0 0 auto', width:30, height:30, borderRadius:'50%', overflow:'hidden', background:t.plate, border:`1px solid ${t.line}`, fontFamily:CAPS, fontWeight:500, fontSize:11, color:t.brass } }, d.author.name.split(' ').map(function(w){return w[0];}).join('').slice(0,2).toUpperCase()),
+        el('span', { style:{ fontFamily:BODY, fontSize:15, color:t.ink, borderBottom:`1px solid ${t.brass}` } }, d.author.name)),
+      el('span', { style:{ ...eyebrow, fontSize:9 } }, 'author · lvl ' + d.author.level)),
+    el('div', { style:{ display:'flex', alignItems:'flex-end', gap: desktop ? 26 : 18, flexWrap:'wrap' } },
+      el('div', { style:{ display:'flex', flexDirection:'column', gap:5, lineHeight:1 } },
+        el('span', { style:{ ...eyebrow, fontSize:8.5 } }, 'Level'),
+        el('span', { style:{ fontFamily:DECO, fontSize: desktop ? 38 : 30, lineHeight:.8, color:t.ink } }, d.level),
+        tally(d.level)),
+      el('span', { 'aria-hidden':true, style:{ width:1, alignSelf:'stretch', minHeight:38, background:t.line } }),
+      el('div', { style:{ display:'flex', alignItems:'center', gap:9, paddingBottom:4 } },
+        ico('hourglass', 15, t.brass),
+        el('span', { style:{ ...body(desktop ? 14.5 : 13), fontStyle:'italic' } }, d.inProgress + ' in progress'))));
+
+  // ── action panel: stepped octagon medallion + the summons ──────────────
+  // alchemical squared circle — outer ring, inscribed square, triangle, inner disc
+  const medSize = desktop ? 104 : 88;
+  const ticks = Array.from({ length: 24 }).map((_, i) => {
+    const a = (i / 24) * Math.PI * 2, long = i % 6 === 0;
+    const r1 = 48, r2 = long ? 42 : 45.5;
+    return el('path', { key:i, d:`M${(50 + Math.cos(a)*r1).toFixed(2)} ${(50 + Math.sin(a)*r1).toFixed(2)} L${(50 + Math.cos(a)*r2).toFixed(2)} ${(50 + Math.sin(a)*r2).toFixed(2)}`,
+      stroke: long ? t.brass : t.brassL, strokeWidth: long ? 1 : .6, opacity: long ? .9 : .5 });
+  });
+  const medallion = el('div', { style:{ flex:'0 0 auto', position:'relative', width:medSize, height:medSize, display:'flex', alignItems:'center', justifyContent:'center' } },
+    el('svg', { width:medSize, height:medSize, viewBox:'0 0 100 100', 'aria-hidden':true, style:{ position:'absolute', inset:0 } },
+      el('circle', { cx:50, cy:50, r:48, fill:t.disc, stroke:t.brass, strokeWidth:1.3 }),
+      ticks,
+      el('circle', { cx:50, cy:50, r:41, fill:'none', stroke:t.lapis, strokeWidth:.7, opacity:.75 }),
+      el('rect', { x:20.9, y:20.9, width:58.2, height:58.2, fill:'none', stroke:t.brassL, strokeWidth:.7, opacity:.7 }),
+      el('path', { d:'M50 9.9 L84.7 70 H15.3 Z', fill:'none', stroke:t.lapis, strokeWidth:.8, opacity:.55 }),
+      el('circle', { cx:50, cy:50, r:26, fill:'none', stroke:t.brass, strokeWidth:.8, opacity:.8 }),
+      el('path', { d:'M2 50 H14 M86 50 H98 M50 2 V10 M50 90 V98', stroke:t.brassL, strokeWidth:.6, opacity:.5 })),
+    el('div', { style:{ position:'relative', display:'flex', flexDirection:'column', alignItems:'center', lineHeight:.82 } },
+      el('span', { style:{ fontFamily:DECO, fontSize: desktop ? 34 : 29, color:t.ink } }, yourPoints),
+      el('span', { style:{ ...sc, fontSize:6.5, letterSpacing:'.2em', color:t.muted, marginTop:5 } }, 'points')));
+
+  const ledgerRow = (label, value) => el('div', { style:{ display:'flex', alignItems:'baseline', gap:10 } },
+    el('span', { style:{ ...sc, fontSize:8.5, color:t.faint } }, label),
+    el('span', { 'aria-hidden':true, style:{ flex:1, minWidth:10, height:1, background:t.line } }),
+    el('span', { style:{ fontFamily:DECO, fontSize:16, color:t.ink, whiteSpace:'nowrap' } }, value));
+
+  const summons = signed
+    ? el('div', { style:{ display:'flex', flexDirection:'column', gap:11 } },
+        el('div', { style:{ display:'flex', alignItems:'center', gap:8 } },
+          ico('openEye', 15, t.nile),
+          el('span', { style:{ ...body(13.5), fontStyle:'italic', color:t.nile } }, "You're on this task")),
+        el('div', { style:{ display:'flex', alignItems:'center', gap:14, flexWrap:'wrap' } },
+          el('span', { style:{ cursor:'pointer', flex:1, textAlign:'center', background:t.ctaBg, color:t.ctaText, border:`2px solid ${t.brass}`,
+            padding: desktop ? '14px 12px' : '12px 8px', fontFamily:CAPS, fontWeight:500, fontSize: desktop ? 12 : 11, letterSpacing:'.1em', textTransform:'uppercase', whiteSpace:'nowrap' } }, 'Continue'),
+          el('span', { onClick:()=>setSigned(false), style:{ cursor:'pointer', ...body(12.5), fontStyle:'italic', color:t.muted, borderBottom:`1px solid ${t.line}` } }, 'drop')))
+    : el('div', { style:{ display:'flex', flexDirection:'column', gap:11 } },
+        el('div', { onClick:()=>setSigned(true), style:{ cursor:'pointer', display:'flex', alignItems:'center', justifyContent:'center', gap:9,
+          background:t.ctaBg, color:t.ctaText, border:`2px solid ${t.brass}`, padding: desktop ? '14px 12px' : '12px 8px',
+          fontFamily:CAPS, fontWeight:500, fontSize: desktop ? 12 : 11, letterSpacing:'.1em', textTransform:'uppercase' } },
+          ico('openEye', 15, t.ctaText, 1.4),
+          el('span', { style:{ whiteSpace:'nowrap' } }, 'Sign up'),
+          ico('planet', 14, t.ctaText, 1.4)),
+        el('div', { style:{ ...body(12.5), fontStyle:'italic' } },
+          'You have ' + d.slotsOpen + ' of ' + d.slotsMax + ' task slots open · ',
+          el('span', { style:{ color:t.nile } }, 'Level ' + d.level + ' met')));
+
+  // one panel, two cells — the worth beside the summons, as the other factions lay it out
+  const innerBox = { background:t.plate2, border:`1px solid ${t.line}`, padding: desktop ? '16px 18px' : '14px 12px', boxSizing:'border-box' };
+  const crownedPanel = (panel) => panel;
+
+  const actionPanel = el('div', { style:{ ...plate, outline:`1px solid ${t.edge}`, outlineOffset:3, boxShadow:t.shadow, padding:7,
+    display:'flex', flexDirection:'row', gap:7, alignItems:'stretch' } },
+    el('div', { style:{ ...innerBox, flex:'0 0 auto', width: desktop ? 150 : 116, display:'flex', flexDirection:'column', alignItems:'center', gap:12 } },
+      el('div', { style:{ width:'100%', display:'flex', flexDirection:'column', gap:8 } },
+        ledgerRow('Base', String(d.points)),
+        ledgerRow('Bonus', showMult ? '×' + d.multiplier.toFixed(2) : '×1.00')),
+      medallion),
+    el('div', { style:{ ...innerBox, flex:1, minWidth:0, display:'flex', flexDirection:'column', justifyContent:'center' } }, summons));
+
+  // ── brief: text sitting in a gravity well — a lattice bent toward a mass
+  const gravityGrid = (() => {
+    const W = 200, H = 100, cx = 218, cy = 116, R = 60, S = 0.7;
+    const warp = (x, y) => {
+      const dx = cx - x, dy = cy - y, d = Math.hypot(dx, dy) || 1e-6;
+      const f = S / (1 + Math.pow(d / R, 2.1));
+      return [x + dx * f, y + dy * f];
+    };
+    const path = (pts) => pts.map((p, i) => (i ? 'L' : 'M') + p[0].toFixed(2) + ' ' + p[1].toFixed(2)).join(' ');
+    const lines = [];
+    for (let x = -30; x <= 230; x += 13) {
+      const pts = []; for (let y = -20; y <= 120; y += 3.5) pts.push(warp(x, y));
+      lines.push(path(pts));
+    }
+    for (let y = -20; y <= 120; y += 13) {
+      const pts = []; for (let x = -30; x <= 230; x += 3.5) pts.push(warp(x, y));
+      lines.push(path(pts));
+    }
+    return el('svg', { 'aria-hidden':true, viewBox:`0 0 ${W} ${H}`, preserveAspectRatio:'none',
+      style:{ position:'absolute', inset:0, width:'100%', height:'100%', pointerEvents:'none',
+        maskImage:'radial-gradient(125% 145% at 100% 100%, #000 30%, transparent 100%)',
+        WebkitMaskImage:'radial-gradient(125% 145% at 100% 100%, #000 30%, transparent 100%)' } },
+      lines.map((dstr, i) => el('path', { key:i, d:dstr, fill:'none', stroke:t.deco, strokeWidth:0.35, vectorEffect:'non-scaling-stroke' })),
+      null);
+  })();
+
+  const brief = el('section', { style:{ marginBottom: desktop ? 34 : 26 } },
+    sectionHead('Task description', 'in full'),
+    el('div', { style:{ ...plate, position:'relative', overflow:'hidden', padding: desktop ? '30px 34px' : '22px 20px' } },
+      gravityGrid,
+      el('div', { style:{ position:'relative' } },
+      d.brief.map((p, i) => el('p', { key:i, style:{ ...body(desktop ? 15.5 : 14), lineHeight:1.85, color:t.ink, margin: i === d.brief.length - 1 ? 0 : '0 0 22px', textWrap:'pretty' } }, p)))));
+
+  // ── roster ────────────────────────────────────────────────────────────
+  const rest = Math.max(0, d.inProgress - (desktop ? 5 : 4));
+  const roster = el('section', { style:{ marginBottom: desktop ? 34 : 26 } },
+    sectionHead('In progress', d.inProgress + ' players'),
+    el('div', { style:{ ...plate } },
+      d.roster.slice(0, desktop ? 5 : 4).map((p, i) => el('div', { key:p.name, style:{ display:'flex', alignItems:'center', gap:12, padding:'11px 14px',
+        borderTop: i === 0 ? 'none' : `1px solid ${t.rule}` } },
+        el('span', { style:{ width:28, height:28, flex:'0 0 auto', display:'flex', alignItems:'center', justifyContent:'center',
+          border:`1px solid ${t.brass}`, background:t.disc, clipPath:'polygon(30% 0,70% 0,100% 30%,100% 70%,70% 100%,30% 100%,0 70%,0 30%)',
+          fontFamily:DECO, fontSize:13, color:t.ink } }, p.name[0].toUpperCase()),
+        el('span', { style:{ ...body(14), color:t.ink, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' } }, p.name),
+        p.tag ? el('span', { style:{ ...sc, fontSize:8, color: p.tag === 'Foe' ? t.ochre : t.nile, border:`1px solid ${p.tag === 'Foe' ? t.ochre : t.nile}`, padding:'2px 6px' } },
+          p.tag === 'Foe' ? 'Rival' : 'Ally') : null,
+        el('span', { style:{ marginLeft:'auto', display:'flex', alignItems:'center', gap:8 } },
+          tally(p.level),
+          el('span', { style:{ ...sc, fontSize:8.5, color:t.faint } }, 'lvl ' + p.level)))),
+      rest > 0 ? el('div', { style:{ borderTop:`1px solid ${t.rule}`, padding:'11px 14px', ...body(13.5), fontStyle:'italic', color:t.nile, cursor:'pointer' } }, '+' + rest + ' more players →') : null));
+
+  // ── praxis gallery ────────────────────────────────────────────────────
+  const sortTab = (key, label) => el('span', { key, onClick:()=>setSort(key), style:{ cursor:'pointer', ...sc, fontSize:8.5, padding:'6px 11px',
+    color: sort === key ? (theme === 'dark' ? t.ctaText : t.ctaText) : t.muted,
+    background: sort === key ? t.ctaBg : 'transparent' } }, label);
+
+  const praxisCard = (p) => el('div', { key:p.title, style:{ ...plate, cursor:'pointer', boxShadow:t.shadow, display:'flex', flexDirection:'column' } },
+    el('div', { style:{ padding:'14px 15px 12px' } },
+      el('div', { style:{ display:'flex', alignItems:'flex-start', justifyContent:'space-between', gap:12, marginBottom:10 } },
+        el('span', { style:{ ...sc, fontSize:8, color:t.brass } }, 'Praxis №' + p.rec),
+        p.top ? el('span', { title:'top rated praxis', style:{ display:'flex', alignItems:'center', gap:5, ...sc, fontSize:7.5, color:t.gold } },
+          el('svg', { width:26, height:9, viewBox:'-88 -20 176 40', 'aria-hidden':true, style:{ display:'block' } }, wing('r'), wing('l'), el('circle', { r:9, fill:t.gold, opacity:.85 })),
+          'top rated') : null),
+      el('div', { style:{ fontFamily:DECO, fontSize:19, lineHeight:1.28, letterSpacing:'.02em', color:t.ink, marginBottom:11, textWrap:'pretty' } }, p.title),
+      el('div', { style:{ display:'flex', alignItems:'center', gap:12 } },
+        el('div', { style:{ flex:1, minWidth:0, display:'flex', alignItems:'center', gap:8 } },
+          el('span', { style:{ width:24, height:24, flex:'0 0 auto', display:'flex', alignItems:'center', justifyContent:'center', border:`1px solid ${t.brass}`,
+            background:t.disc, clipPath:'polygon(30% 0,70% 0,100% 30%,100% 70%,70% 100%,30% 100%,0 70%,0 30%)', fontFamily:DECO, fontSize:11, color:t.ink } }, p.author[0].toUpperCase()),
+          el('span', { style:{ ...body(12.5), overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' } }, p.author)),
+        el('span', { style:{ flex:'0 0 auto', display:'flex', alignItems:'baseline', gap:5 } },
+          el('span', { style:{ fontFamily:DECO, fontSize:22, lineHeight:1, color:t.ink } }, p.pts),
+          el('span', { style:{ ...sc, fontSize:7, color:t.muted } }, 'pts')))),
+    el('div', { style:{ position:'relative', height: desktop ? 116 : 104, background:t.plate2, borderTop:`1px solid ${t.rule}`, borderBottom:`1px solid ${t.rule}`, overflow:'hidden',
+      display:'flex', alignItems:'center', justifyContent:'center' } },
+      el('svg', { width:'100%', height:'100%', viewBox:'0 0 200 110', preserveAspectRatio:'xMidYMid slice', 'aria-hidden':true, style:{ position:'absolute', inset:0, opacity:.5 } },
+        el('path', { d:'M0 55 H200 M100 0 V110 M0 0 L200 110 M200 0 L0 110', stroke:t.brass, strokeWidth:.5, opacity:.35 }),
+        el('circle', { cx:100, cy:55, r:34, fill:'none', stroke:t.brass, strokeWidth:.6, opacity:.5 })),
+      ico('offering', 26, t.faint, 1.2)),
+    el('div', { style:{ display:'flex', alignItems:'center', gap:10, padding:'10px 15px 11px' } },
+      el('span', { style:{ ...sc, fontSize:8, color:t.faint } }, p.when),
+      el('span', { 'aria-hidden':true, style:{ flex:1, height:1, background:t.line, opacity:.7 } }),
+      el('span', { style:{ ...sc, fontSize:8, color:t.faint } }, p.votes + ' votes')));
+
+  const list = (sort === 'top' ? d.praxis : d.praxis.slice().reverse());
+  const gallery = el('section', { style:{ marginBottom: desktop ? 34 : 26 } },
+    el('div', { style:{ marginBottom:15 } },
+      el('div', { style:{ display:'flex', alignItems:'center', gap:12, marginBottom:7, flexWrap:'wrap' } },
+        el('span', { style:{ ...sc, fontSize:11, fontWeight:600, color:t.ink } }, d.completed + ' completed praxis'),
+        el('span', { style:{ flex:1, minWidth:24, height:1, background:t.brass, opacity:.5 } }),
+        el('span', { style:{ display:'flex', gap:2, border:`1px solid ${t.line}`, padding:2 } }, [sortTab('top','Top rated'), sortTab('recent','Recent')])),
+      fluted()),
+    el('div', { style:{ display:'grid', gridTemplateColumns: desktop ? 'repeat(3,1fr)' : '1fr', gap:16 } },
+      list.slice(0, showAll ? list.length : 3).map(praxisCard)),
+    el('div', { onClick:()=>setShowAll(!showAll), style:{ marginTop:16, ...body(13.5), fontStyle:'italic', color:t.nile, cursor:'pointer' } },
+      showAll ? 'Show fewer ↑' : 'Show all ' + d.completed + ' praxis →'));
+
+  // ── discussion ────────────────────────────────────────────────────────
+  const comments = el('section', null,
+    sectionHead('Discussion', d.comments.length + ' comments'),
+    el('div', { style:{ ...plate, marginBottom:14 } },
+      d.comments.map((c, i) => el('div', { key:i, style:{ padding:'14px 16px', borderTop: i === 0 ? 'none' : `1px solid ${t.rule}` } },
+        el('div', { style:{ display:'flex', alignItems:'center', gap:10, marginBottom:8 } },
+          el('span', { style:{ width:24, height:24, flex:'0 0 auto', display:'flex', alignItems:'center', justifyContent:'center', border:`1px solid ${t.brass}`,
+            background:t.disc, clipPath:'polygon(30% 0,70% 0,100% 30%,100% 70%,70% 100%,30% 100%,0 70%,0 30%)', fontFamily:DECO, fontSize:11, color:t.ink } }, c.author[0].toUpperCase()),
+          el('span', { style:{ ...body(13.5), color:t.ink } }, c.author),
+          el('span', { style:{ marginLeft:'auto', ...sc, fontSize:8, color:t.faint } }, c.when)),
+        el('p', { style:{ margin:0, ...body(desktop ? 14.5 : 13.5), fontStyle:'italic', textWrap:'pretty' } }, c.body)))),
+    el('div', { style:{ ...plate, padding:'12px 14px', display:'flex', alignItems:'center', gap:12 } },
+      el('span', { style:{ flex:1, ...body(13.5), fontStyle:'italic', color:t.faint } }, 'Say something about this task…'),
+      el('span', { style:{ cursor:'pointer', ...sc, fontSize:8.5, color:t.ctaText, background:t.ctaBg, border:`1px solid ${t.brass}`, padding:'8px 14px' } }, 'Post')));
+
+  const CSS = `
+@keyframes epdBreathe { 0%,100% { opacity:0; } 22%,72% { opacity:var(--epdOp,.3); } }
+.epd-glyph { opacity:0; animation:epdBreathe 19s ease-in-out infinite; }
+@media (prefers-reduced-motion:reduce) { .epd-glyph { animation:none; opacity:var(--epdOp,.3); } }
+`;
+
+  const shell = { width:'100%', boxSizing:'border-box', background:t.page, color:t.ink, fontFamily:BODY, minHeight:'100%' };
+
+  if (desktop) {
+    return el('div', { style:shell },
+      el('style', null, CSS),
+      el('div', { style:{ padding:'32px 38px 46px' } },
+        el('div', { style:{ display:'flex', gap:30, alignItems:'flex-start', marginBottom:30 } },
+          el('div', { style:{ flex:1, minWidth:0 } }, header),
+          el('div', { style:{ flex:'0 0 420px', width:420, marginTop:0 } }, crownedPanel(actionPanel))),
+        el('div', { style:{ minWidth:0 } }, brief, gallery, comments)));
+  }
+
+  return el('div', { style:{ ...shell, display:'flex', flexDirection:'column' } },
+    el('style', null, CSS),
+    el('div', { style:{ display:'flex', alignItems:'center', gap:10, padding:'11px 14px', background:t.band, color:t.bandInk, position:'sticky', top:0, zIndex:5, borderBottom:`2px solid ${t.brass}` } },
+      el('span', { style:{ fontFamily:DECO, fontSize:16, cursor:'pointer', color:t.bandInk } }, '←'),
+      el('span', { style:{ ...sc, fontSize:8.5, color:t.gold } }, 'Task №' + d.num),
+      el('span', { style:{ marginLeft:'auto' } }, ico('planet', 15, t.gold, 1.3))),
+    el('div', { style:{ padding:'18px 16px 28px' } },
+      header,
+      el('div', { style:{ marginBottom:26 } }, crownedPanel(actionPanel)),
+      brief, gallery, comments));
+}
+
+module.exports = { EphemeristsTaskDetail };


### PR DESCRIPTION
Design bundles only — no source changes, no runtime impact. These two commits
were pushed to #1206's branch after it merged, so they need their own PR.

- `.design-sync/ephemerists-plate-sweep/` — for #1208. The only Valley-plate
  document that draws lists, avatars, panels and buttons at page scale; the
  shipped task detail dropped the roster, so it is the sole drawing of an
  Ephemerists list of players.
- `.design-sync/coven-slip-sweep/` — for #1209. Coven has no shared kit module,
  so this is the slip vocabulary in one place instead of spread across two
  large components.

Each folder's README names the source, what is deliberately not vendored (both
task cards are already ported), and the raw-hex-vs-token rule. Each sweep's last
PR deletes its own folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)