### PR TITLE
Edit praxis v2 — The Everymen: the work order

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1142,6 +1142,18 @@
      for text. */
   --faction-everymen-dispatch-rule: rgba(100, 140, 200, 0.12);
 
+  /* ══ Everymen — THE WORK ORDER (edit-praxis composer, #1187) ══
+     One token, for the reason the two blocks above are short: the composer is
+     the bill's ray burst and the broadsheet's plates printed on the faction's
+     own card ground, and every colour it needs already has a home here. The
+     exception is the SHEET's frame, which the design's skin row takes from gold
+     by day and the deep accent by night — a poster frame rather than a printed
+     rule, so it is neither `--everymen-frame` (which is ink) nor a live accent.
+     It carries no text and never bounds a control: a 2px band at 1.87:1 on the
+     paper is a frame in the same sense WOW's gilt is (§3), so every field inside
+     the sheet keeps `--everymen-frame` and no form boundary rests on this. */
+  --faction-everymen-composer-frame: var(--everymen-gold);
+
   /* ── Gearworks vote widget (#821) — reached gears heat a cold→ember ramp with
      pale hubs; unreached gears are edge-only outlines; rank 5 throws sparks. The
      edge + rank-5 glow flip in the dark cascade (see the dark block). ── */
@@ -1807,6 +1819,10 @@
   /* The ledger rule inverts with the paper: a pale blue line ON the near-black
      newsprint instead of a dark one in it (#1123). */
   --faction-everymen-dispatch-rule: rgba(150, 185, 230, 0.09);
+  /* The work order's frame at night: the design's skin row swaps gold for the
+     deep accent, which is the one edge on the sheet that does NOT lift with the
+     paper — a printed poster frame stays the colour it was printed in (#1187). */
+  --faction-everymen-composer-frame: var(--everymen-red-deep);
   /* Gearworks: cooler edge for cold gears, a brighter single-halo rank-5 glow on
      the dark paper (the light double-drop-shadow would muddy against it). */
   --faction-everymen-vote-edge: #8a7856;

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -371,44 +371,7 @@
         "successHeading": "REPORT FILED",
         "successBody": "Every hand signed off. The job's on the board.",
         "successContinue": "See the filed report"
-      },
-      "masthead": "THE EVERYMEN · WORK REPORT {{number}}",
-      "pageTitle": "EDIT PRAXIS",
-      "savingStatus": "filing carbon copy…",
-      "autosaveSaved": "autosaved {{ago}}",
-      "autosaveUnsaved": "not yet filed",
-      "taskRefLabel": "Re: completion of",
-      "modeLabel": "THE CREW",
-      "mode": {
-        "solo": { "label": "SOLO", "desc": "one pair of hands" },
-        "collab": { "label": "COLLAB", "desc": "all hands" },
-        "duel": { "label": "DUEL", "desc": "head to head" }
-      },
-      "inviteLabel": "THE CREW ROSTER",
-      "inviteLabelDuel": "YOUR OPPONENT",
-      "invitePlaceholder": "search by name or @handle",
-      "titleLabel": "THE JOB",
-      "titleMeta": "{{length}}/200",
-      "titlePlaceholder": "name the work in one line",
-      "saveState": {
-        "saved": "↳ carbon copy on file",
-        "saving": "↳ filing…",
-        "idle": "↳ not yet filed"
-      },
-      "bodyLabel": "THE REPORT",
-      "bodyMeta": "{{words}} words · markdown ok",
-      "bodyPlaceholder": "Clocked in at…",
-      "previewLabel": "Foreman's preview",
-      "onFileLabel": "ON FILE",
-      "filesLabel": "PROOF OF WORK",
-      "filesMeta": "{{pinned}} pinned · images · video · audio · max 50mb each",
-      "fileButton": "Pin Proof",
-      "metatasksLabel": "SIDE WORK",
-      "metatasksMeta": "optional · extra credit",
-      "metatasksPoints": "+{{points}} PTS",
-      "publishIdle": "★ STAMP & FILE ★",
-      "publishBusy": "✓ FILING…",
-      "dropLabel": "VOID THE REPORT"
+      }
     },
     "snide": {
       "collab": {

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -663,7 +663,7 @@ export default function EverymenEditPraxis({ state }: Props) {
                   ) : (
                     <MediaArt
                       art={pickArtKey(filename, "audio")}
-                      width={132}
+                      width={128}
                       height={104}
                     />
                   )}

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -1,632 +1,799 @@
 /**
- * The Everymen — Edit Praxis form.
- * The praxis-filing form takes the task's faction treatment; the Everymen
- * frame it as a union WORK REPORT filed at the hall: a stamped red masthead,
- * a job-reference slip, the crew (mode) selector, the job headline, the
- * report body, proof-of-work attachments, and a "STAMP & FILE" action bar.
- * Theme-aware through the --everymen* / --faction-everymen* token cascade.
+ * The Everymen — edit praxis, composer v2 (#1187, epic #1179; design project
+ * c491945e, `Everymen Edit Praxis.dc.html`, the `everymen` row of `SKINS`).
+ *
+ * The union's WORK ORDER: a red masthead plate flanked by two counter-rotating
+ * cogs, poster rays fanning from behind it over a gold and an olive corner glow,
+ * dashed red rules between every region, a rubber-stamp points seal, and a
+ * full-width report bar for the cast. Bebas Neue carries every headline and
+ * label; Courier Prime carries everything read.
+ *
+ * ## The layout is not this file's (ADR-0065 §1)
+ *
+ * masthead → status row → the task slip → title → how it was done → the mode
+ * block → write-up → proof → footer, in that order, every region from
+ * `shared.tsx`, every control from `controls.tsx` through its `*Skin` prop. This
+ * file brings frame, type, ornament and motion and nothing else — no forked
+ * control, no re-ordered region, no word of its own.
+ *
+ * ## One responsive component, no mobile twin (ADR-0065 §2)
+ *
+ * `useComposerSizes()` picks the size set; there is one tree at two widths, and
+ * `pages/editPraxis/mobileArchetypes/EverymenEditPraxis` went with the
+ * `mobileEditPraxis` surface in #1181. Mobile stacks with flow — no fixed-px
+ * grid anywhere below (SPEC-faction-ui-profile §1a).
+ *
+ * ## Copy is the shared neutral set (ADR-0065 §3)
+ *
+ * The union voice this composer used to speak — `WORK REPORT №0055`, `THE CREW`,
+ * `THE JOB`, `PROOF OF WORK`, `★ STAMP & FILE ★`, `VOID THE REPORT` — is
+ * deleted with this issue, and the archetype reads `editPraxis.composer.*` like
+ * every other skin. `editPraxis.everymen.collab` SURVIVES: that block is
+ * `collabCopy`'s override table, a different resolver that also feeds
+ * `CollabRoster` on `/praxes/:id`, and it is pinned by `collabCopy.test.ts`.
+ *
+ * The masthead plate is the one place the design puts words on the dress, and
+ * the design's own word there is faction voice (`FILE YOUR REPORT`), which
+ * ADR-0065's rejected alternative names outright — "a deliberately designed set
+ * of near-synonyms is still the catalog the neutral rule exists to delete". So
+ * the plate carries what `EverymenTaskDetail`'s masthead carries under the
+ * identical neutral-copy rule (ADR-0057): the faction's NAME, a shared datum out
+ * of `factions:names.*` rather than a per-surface vocabulary. Dress kept, voice
+ * dropped.
+ *
+ * ## Colour
+ *
+ * Almost all of it is the `--everymen-*` family and the `-bill-` / `-sheet-`
+ * roles the v2 task card and task detail already minted; only the sheet's frame
+ * needed a name (`--faction-everymen-composer-frame`). Two pairings decide where
+ * red may be ink:
+ *
+ * - The SHEET is `--everymen-paper`, on which `--faction-everymen-sheet-accent`
+ *   pays only 4.49:1 (index.css says so where it is declared). So on the paper,
+ *   red is a rule, a fill and a stamp — never a label.
+ * - Every plate — the task slip, the fields, the tiles — is
+ *   `--faction-everymen-sheet-panel`, the stock that accent was MEASURED on
+ *   (4.95:1 light / 5.45:1 dark). The red labels and the stamped `pts` live
+ *   there and nowhere else (WORLD_ZERO_STYLE §3, "a new ground invalidates every
+ *   contrast claim").
+ *
+ * Light/dark flips through the `[data-theme="dark"]` cascade; there is no
+ * `dark ?` branch in this file.
+ *
+ * ## Motion
+ *
+ * Two cogs on the masthead, `ep-spin` against `ep-spin-rev` — the counter-turn
+ * is the whole gag, and it is the only motion here. Both are CLASSES: the
+ * keyframes live in `index.css` behind the shared `prefers-reduced-motion`
+ * guard, and an inline `animation:` would bypass it (#1003). `index.css` needed
+ * no motion edit for this skin.
+ *
+ * ## Not drawn as designed
+ *
+ * The design offers "Forfeit the duel" at the awaiting stage. It is not drawn
+ * here or anywhere: #1071 decision 3 rejected that framing against ADR-0011
+ * §Forfeit, and #718 had rejected it once before — at `active` (you cast, the
+ * rival has not) unsubmitting is a free neutral reopen. The duel CLOCK is cut on
+ * the same decision (#1071 §4: no expiry field exists to read). The awaiting
+ * stage itself belongs to `PraxisWaitingSurface` and to #1189.
  */
-import { useRef } from "react";
+import { useState, type CSSProperties, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
-import type { MediaItemOut } from "../../../api/praxis";
+import { factionName } from "../../../utils/factions";
 import MediaArt from "../blocks/MediaArt";
 import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
+  ComposerFooter,
+  ComposerGround,
+  ComposerMasthead,
+  ComposerRule,
+  ComposerSection,
+  ComposerSheet,
+  ComposerStatusRow,
   ErrorBanner,
-  TaskMetaInline,
+  RingMark,
+  TaskSlip,
+  TitleCounter,
+  composerLabelStyle,
   formatAutosave,
+  useComposerSizes,
 } from "./shared";
 import {
   BodyPreview,
   BodyTextarea,
   DropButton,
+  FilePicker,
   InviteSearch,
   ModePicker,
   PublishButton,
   SaveDraftButton,
   TitleField,
+  WriteUpTabs,
+  type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
 import type { EditPraxisState } from "../useEditPraxis";
-import { EverymenSigil } from "../../../components/cards/EverymenSigil";
 
 interface Props {
   state: EditPraxisState;
 }
 
-const INK = "var(--everymen-ink)";
-const RED = "var(--everymen-red)";
-const GOLD = "var(--everymen-gold)";
-const CREAM = "var(--everymen-cream)";
+/* ── The sheet's palette. Named for the ROLE each plays in the design's skin row.
+ *    See the header for which reds may be ink and on what. ── */
+/** The newsprint the order is printed on — the faction's own card ground. */
 const PAPER = "var(--everymen-paper)";
-const PAPER_TEXT = "var(--everymen-paper-text)";
+/** The pasted-on plate: the task slip, every field, every proof tile. */
+const PANEL = "var(--faction-everymen-sheet-panel)";
+/** Text ink. FLIPS with the paper — deliberately not `--everymen-ink`. */
+const INK = "var(--everymen-paper-text)";
 const MUTED = "var(--everymen-muted)";
-const OLIVE = "var(--everymen-olive)";
-const ACCENT_FONT = "var(--faction-everymen-card-font)";
-const BODY_FONT = "var(--font-body)";
+/** Red as a RULE or a FILL. For red as text see {@link ACCENT}. */
+const RED = "var(--everymen-red)";
+/** Red as INK. Only clears AA on {@link PANEL} — never set it on {@link PAPER}. */
+const ACCENT = "var(--faction-everymen-sheet-accent)";
+/** What is legible printed ON a red fill. */
+const ON_ACCENT = "var(--faction-everymen-on-accent)";
+/** The printed rule around a plate. NOT `--everymen-ink`, which vanishes dark. */
+const FRAME = "var(--everymen-frame)";
+/** The sheet's own frame: the design's `border`, gold by day, deep red by night. */
+const SHEET_FRAME = "var(--faction-everymen-composer-frame)";
+/** The masthead bar, theme-INVARIANT: an order filed at night is the same order. */
+const MAST = "var(--faction-everymen-bill-mast)";
+const MAST_INK = "var(--faction-everymen-bill-mast-ink)";
+/** The full-width report bar at the foot of the sheet. */
+const BAR = "var(--faction-everymen-bill-cta-bg)";
+const BAR_INK = "var(--faction-everymen-bill-cta-ink)";
+const PAPER_DEEP = "var(--everymen-paper-deep)";
+const SHADOW = "var(--faction-everymen-bill-shadow)";
 
-const RED_GOLD_RULE =
-  "repeating-linear-gradient(90deg, var(--everymen-red) 0 16px, var(--everymen-gold) 16px 26px)";
+const BEBAS = "var(--faction-everymen-card-font)"; /* Bebas Neue */
+const COURIER = "var(--font-body)"; /* Courier Prime */
 
-/** Union stencil field label with a red/gold tape underline. */
-function FieldLabel({
-  children,
-  meta,
+/* ── The cog, the union's one glyph on this surface. Eight teeth around a hub,
+ *    generated once at module load: the arithmetic is the design's own and a
+ *    hand-written path would drift from it silently. The same construction the
+ *    v2 task card and task detail draw — a THIRD caller now, which by
+ *    WORLD_ZERO_STYLE §6 ("the module is the enforcement") is the point at which
+ *    the three should collapse into one `everymenOrnament` module. That
+ *    extraction touches two shipped Everymen surfaces and is outside this
+ *    issue's footprint; it is raised in the PR rather than done here. ── */
+const GEAR_TEETH = 8;
+const GEAR_RADIUS = 9.5;
+const GEAR_TIP_LENGTH = 5;
+const GEAR_TIP_HALF = 1.6;
+const GEAR_ROOT_HALF = 2.6;
+
+function buildGearPath(): string {
+  const point = (radius: number, angle: number): string =>
+    `${12 + radius * Math.cos(angle)},${12 + radius * Math.sin(angle)}`;
+  const step = (Math.PI * 2) / GEAR_TEETH;
+  const tipRadius = GEAR_RADIUS + GEAR_TIP_LENGTH;
+  let path = "";
+  for (let tooth = 0; tooth < GEAR_TEETH; tooth++) {
+    const start = tooth * step;
+    const rootBefore = point(GEAR_RADIUS, start - GEAR_ROOT_HALF / GEAR_RADIUS);
+    const tipBefore = point(tipRadius, start - GEAR_TIP_HALF / tipRadius);
+    const tipAfter = point(tipRadius, start + GEAR_TIP_HALF / tipRadius);
+    const rootAfter = point(GEAR_RADIUS, start + GEAR_ROOT_HALF / GEAR_RADIUS);
+    const nextRoot = point(
+      GEAR_RADIUS,
+      start + step - GEAR_ROOT_HALF / GEAR_RADIUS,
+    );
+    path += `${tooth === 0 ? "M" : "L"}${rootBefore}L${tipBefore}L${tipAfter}L${rootAfter}`;
+    path += `A${GEAR_RADIUS},${GEAR_RADIUS} 0 0 1 ${nextRoot}`;
+  }
+  return `${path}Z`;
+}
+
+const GEAR_PATH = buildGearPath();
+
+/**
+ * The union cog. Ornament only — aria-hidden at every call site.
+ *
+ * `spin` reaches the shared `ep-spin` / `ep-spin-rev` classes rather than an
+ * inline `animation:`, so the pair stills itself under `prefers-reduced-motion`
+ * (#1003). `--ep-spin-dur` re-times both without a second keyframe.
+ */
+function Gear({
+  size,
+  fill,
+  hole,
+  spin,
+  duration,
 }: {
-  children: React.ReactNode;
-  meta?: string;
+  size: number;
+  fill: string;
+  hole: string;
+  spin?: "forward" | "reverse";
+  duration?: string;
 }) {
   return (
-    <div
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden
+      className={
+        spin === "forward" ? "ep-spin" : spin === "reverse" ? "ep-spin-rev" : undefined
+      }
       style={{
-        display: "flex",
-        alignItems: "baseline",
-        gap: "var(--space-lg)",
-        marginBottom: "var(--space-sm)",
+        display: "block",
+        flex: "0 0 auto",
+        ...(duration ? ({ "--ep-spin-dur": duration } as CSSProperties) : {}),
       }}
     >
-      <span
-        style={{
-          fontFamily: ACCENT_FONT,
-          fontSize: "var(--text-xl)",
-          letterSpacing: "0.12em",
-          color: RED,
-          whiteSpace: "nowrap",
-        }}
-      >
-        {children}
-      </span>
-      {meta && (
-        <span
-          style={{
-            fontFamily: BODY_FONT,
-            fontSize: "var(--text-sm)",
-            letterSpacing: "0.14em",
-            textTransform: "uppercase",
-            color: MUTED,
-            whiteSpace: "nowrap",
-          }}
-        >
-          {meta}
-        </span>
-      )}
-      <span
-        aria-hidden
-        style={{
-          flex: 1,
-          height: 2,
-          background:
-            "repeating-linear-gradient(90deg, var(--everymen-red) 0 12px, var(--everymen-gold) 12px 20px)",
-          opacity: 0.5,
-        }}
-      />
-    </div>
+      <path d={GEAR_PATH} fill={fill} />
+      <circle cx="12" cy="12" r="3" fill={hole} />
+    </svg>
   );
 }
 
 export default function EverymenEditPraxis({ state }: Props) {
   const { t } = useTranslation("forms");
-  const fileRef = useRef<HTMLInputElement>(null);
+  const sizes = useComposerSizes();
+  const [tab, setTab] = useState<ComposerTab>("write");
   const praxis = state.praxis!;
   const task = state.task;
+  const slug = task?.primary_faction_slug ?? praxis.task_faction_slug;
 
   const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
+  const modeOptions: Array<{ key: PraxisType; label: string }> = [
+    { key: "solo", label: t("editPraxis.composer.modeSolo") },
+    { key: "collab", label: t("editPraxis.composer.modeCollab") },
+    { key: "duel", label: t("editPraxis.composer.modeDuel") },
+  ];
 
-  const modeOptions: Array<{ key: PraxisType; name: string; sub: string }> = (
-    ["solo", "collab", "duel"] as const
-  ).map((key) => ({
-    key,
-    name: t(`editPraxis.everymen.mode.${key}.label`),
-    sub: t(`editPraxis.everymen.mode.${key}.desc`),
-  }));
-  const reportNo = String(praxis.id).padStart(4, "0");
-  const totalProof = state.media.length;
+  /** Bebas, struck in tracked caps — every label and headline on the order. */
+  const stencil = (overrides: CSSProperties = {}): CSSProperties =>
+    composerLabelStyle({
+      fontFamily: BEBAS,
+      letterSpacing: "0.16em",
+      ...overrides,
+    });
+
+  /** A plate: panel stock inside the printed frame rule. Radius 0 throughout. */
+  const fieldBox = {
+    width: "100%",
+    background: PANEL,
+    color: INK,
+    border: `2px solid ${FRAME}`,
+    borderRadius: 0,
+    padding: "var(--space-md)",
+    outline: "none",
+    boxSizing: "border-box",
+  } as const;
+
+  /** The broadsheet's divider — one element, drawn between every region. */
+  const dashRule = (
+    <ComposerRule
+      style={{ height: 0, background: "transparent", borderTop: `2px dashed ${RED}` }}
+    />
+  );
 
   return (
-    <div
-      style={
-        {
-          fontFamily: BODY_FONT,
-          color: PAPER_TEXT,
-          background: "var(--everymen-paper-deep)",
-          minHeight: "100vh",
-          padding: "var(--space-2xl) var(--space-xl) var(--space-5xl)",
-        } as React.CSSProperties
-      }
-    >
-      <div style={{ maxWidth: 720, margin: "0 auto" }}>
+    <div style={{ fontFamily: COURIER, color: INK }}>
+      <div
+        style={{
+          maxWidth: sizes.maxWidth,
+          margin: "0 auto",
+          padding: "var(--space-lg) var(--space-lg) 0",
+        }}
+      >
         <Breadcrumb
           praxisId={praxis.id}
           taskId={praxis.task_id}
           taskTitle={praxis.task_title}
           inkColor={MUTED}
         />
+      </div>
 
-        {/* Masthead ribbon */}
-        <div
-          style={{
-            position: "relative",
-            display: "inline-flex",
-            alignItems: "center",
-            gap: "var(--space-sm)",
-            background: RED,
-            color: CREAM,
-            padding: "var(--space-sm) var(--space-lg)",
-            boxShadow: `5px 5px 0 ${INK}`,
-          }}
-        >
-          <EverymenSigil size={17} color={CREAM} />
-          <span
+      <ComposerSheet
+        sizes={sizes}
+        style={{
+          background: PAPER,
+          border: `2px solid ${SHEET_FRAME}`,
+          borderRadius: 0,
+          boxShadow: SHADOW,
+        }}
+        masthead={
+          /* The nameplate: cog · the paper's name · cog, on the union's red bar,
+             under a 3px double rule and the printed-in shadow of its own ink. */
+          <ComposerMasthead
+            background={MAST}
             style={{
-              fontFamily: ACCENT_FONT,
-              fontSize: "var(--text-content)",
-              letterSpacing: "0.16em",
-              whiteSpace: "nowrap",
+              height: "auto",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: "var(--space-sm)",
+              padding: sizes.isMobile
+                ? "var(--space-sm) var(--space-lg)"
+                : "var(--space-md) var(--space-lg)",
+              borderBottom: `3px double ${BAR}`,
+              boxShadow: `inset 0 -6px 0 -4px ${PAPER_DEEP}`,
             }}
           >
-            {t("editPraxis.everymen.masthead", { number: reportNo })}
-          </span>
-        </div>
-
-        {/* Big title */}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "flex-end",
-            justifyContent: "space-between",
-            gap: "var(--space-lg)",
-            margin: "var(--space-lg) 0 var(--space-xs)",
-          }}
-        >
-          <div
+            <Gear size={16} fill={MAST_INK} hole={MAST} spin="forward" duration="26s" />
+            <span
+              style={{
+                fontFamily: BEBAS,
+                fontSize: "var(--text-content)",
+                letterSpacing: "0.16em",
+                textTransform: "uppercase",
+                lineHeight: 1,
+                color: MAST_INK,
+              }}
+            >
+              {factionName(slug)}
+            </span>
+            <Gear size={16} fill={MAST_INK} hole={MAST} spin="reverse" duration="26s" />
+          </ComposerMasthead>
+        }
+        ground={
+          /* Poster rays fanning from behind the masthead, a gold glow in one
+             corner and an olive one in the other, all masked away from the copy.
+             Anchored (inset 0, unanimated): the burst's origin is the masthead,
+             and a drifting layer would walk it off the plate. */
+          <ComposerGround
+            inset={0}
+            background={
+              "radial-gradient(40% 32% at 100% 0, var(--faction-everymen-bill-glow-gold), transparent 70%),"
+              + " radial-gradient(44% 38% at 0 100%, var(--faction-everymen-bill-glow-olive), transparent 70%),"
+              + " repeating-conic-gradient(from 0deg at 50% 8%, var(--faction-everymen-bill-ray) 0 5.2deg, transparent 5.2deg 10.4deg)"
+            }
             style={{
-              fontFamily: ACCENT_FONT,
-              fontSize: "var(--text-display)",
-              lineHeight: 0.9,
-              letterSpacing: "0.02em",
-              color: PAPER_TEXT,
+              /* Alpha, not colour: a mask reads only the channel, so black here
+                 is "keep" and transparent is "drop" (the same literal the v2
+                 task card's mask carries). */
+              WebkitMaskImage:
+                "radial-gradient(130% 70% at 50% 8%, #000 40%, transparent 92%)",
+              maskImage:
+                "radial-gradient(130% 70% at 50% 8%, #000 40%, transparent 92%)",
             }}
-          >
-            {t("editPraxis.everymen.pageTitle")}
-          </div>
-          <div
-            style={{
-              textAlign: "right",
-              fontFamily: BODY_FONT,
-              fontSize: "var(--text-sm)",
-              letterSpacing: "0.12em",
-              textTransform: "uppercase",
-              color: MUTED,
-              lineHeight: 1.4,
-              paddingBottom: "var(--space-xs)",
-            }}
-          >
-            <div>
-              {state.saveStatus === "saving"
-                ? t("editPraxis.everymen.savingStatus")
-                : ""}
-            </div>
-            <div>
-              {state.autosaveAt
-                ? t("editPraxis.everymen.autosaveSaved", {
-                    ago: formatAutosave(state.autosaveAt),
-                  })
-                : t("editPraxis.everymen.autosaveUnsaved")}
-            </div>
-          </div>
-        </div>
-        <div
-          style={{
-            height: 4,
-            width: 180,
-            background: RED_GOLD_RULE,
-            marginBottom: "var(--space-xl)",
-          }}
+          />
+        }
+      >
+        {/* Draft · saved just now, with a cog turning at the end of the row. */}
+        <ComposerStatusRow
+          status={t("editPraxis.composer.statusDraft")}
+          meta={
+            state.autosaveAt
+              ? t("editPraxis.composer.statusSaved", {
+                  ago: formatAutosave(state.autosaveAt),
+                })
+              : t("editPraxis.composer.statusUnsaved")
+          }
+          statusStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+          metaStyle={{ color: MUTED }}
+          mark={<Gear size={40} fill={RED} hole={PANEL} />}
         />
 
-        {/* Job reference slip */}
-        <div
+        {/* The job reference slip, on plate stock with the stamped points seal. */}
+        <TaskSlip
+          praxis={praxis}
+          task={task}
           style={{
-            position: "relative",
-            overflow: "hidden",
-            border: `1.5px solid ${INK}`,
-            background: PAPER,
-            marginBottom: "var(--space-2xl)",
-            display: "flex",
+            background: PANEL,
+            border: `2px solid ${FRAME}`,
+            borderRadius: 0,
+            padding: "var(--space-lg)",
           }}
-        >
-          <div
-            style={{
-              width: 8,
-              background: RED,
-              flexShrink: 0,
-              backgroundImage:
-                "repeating-linear-gradient(180deg, transparent 0 13px, color-mix(in srgb, var(--everymen-cream) 55%, transparent) 13px 15px)",
-            }}
-          />
-          <div style={{ flex: 1, padding: "var(--space-lg)" }}>
-            <div
+          labelStyle={stencil({ color: ACCENT, letterSpacing: "0.2em" })}
+          titleStyle={{
+            fontFamily: BEBAS,
+            textTransform: "uppercase",
+            letterSpacing: "0.01em",
+            lineHeight: 0.96,
+            color: INK,
+          }}
+          descriptionStyle={{ fontFamily: COURIER, color: MUTED }}
+          pillStyle={stencil({ color: ACCENT, borderRadius: 0 })}
+          mark={
+            <RingMark
+              size={76}
+              inset={4}
+              ring="transparent"
+              inner="transparent"
               style={{
-                fontFamily: BODY_FONT,
-                fontSize: "var(--text-xs)",
-                letterSpacing: "0.2em",
-                textTransform: "uppercase",
-                color: MUTED,
-                marginBottom: "var(--space-xs)",
-              }}
-            >
-              {t("editPraxis.everymen.taskRefLabel")}
-            </div>
-            <div
-              style={{
-                fontFamily: ACCENT_FONT,
-                fontSize: "var(--text-heading)",
-                lineHeight: 0.96,
-                color: PAPER_TEXT,
-                marginBottom: "var(--space-sm)",
-              }}
-            >
-              {praxis.task_title}
-            </div>
-            {task?.description && (
-              <div style={{ fontFamily: ACCENT_FONT, fontSize: "var(--text-content)", lineHeight: 1.5, color: MUTED, marginBottom: "var(--space-sm)" }}>
-                {task.description}
-              </div>
-            )}
-            <TaskMetaInline praxis={praxis} task={task} textColor={RED} />
-          </div>
-        </div>
-
-        {/* The crew (mode selector) */}
-        {!state.controlsLocked && (
-          <div style={{ marginBottom: "var(--space-xl)" }}>
-            <FieldLabel>{t("editPraxis.everymen.modeLabel")}</FieldLabel>
-            <ModePicker
-              state={state}
-              skin={{
-                containerStyle: {
-                  display: "grid",
-                  gridTemplateColumns: "repeat(3, 1fr)",
-                  gap: "var(--space-md)",
-                },
-                options: modeOptions,
-                allowedModes,
-                renderOption: (opt, { active, disabled, onSelect }) => (
-                  <button
-                    key={opt.key}
-                    type="button"
-                    aria-pressed={active}
-                    onClick={onSelect}
-                    disabled={disabled && !active}
-                    style={{
-                      position: "relative",
-                      cursor: disabled ? "not-allowed" : "pointer",
-                      textAlign: "left",
-                      padding: "var(--space-md) var(--space-lg)",
-                      background: active ? RED : PAPER,
-                      color: active ? CREAM : PAPER_TEXT,
-                      border: `2px solid ${INK}`,
-                      fontFamily: BODY_FONT,
-                      boxShadow: active ? `4px 4px 0 ${INK}` : "none",
-                      transform: active ? "translate(-1px,-1px)" : "none",
-                      transition: "all 110ms",
-                    }}
-                  >
-                    <div
-                      style={{
-                        fontFamily: ACCENT_FONT,
-                        fontSize: "var(--text-title)",
-                        lineHeight: 1,
-                        letterSpacing: "0.04em",
-                      }}
-                    >
-                      {opt.name}
-                    </div>
-                    <div
-                      style={{
-                        fontSize: "var(--text-sm)",
-                        letterSpacing: "0.04em",
-                        marginTop: "var(--space-xs)",
-                        opacity: active ? 0.9 : 0.7,
-                      }}
-                    >
-                      {opt.sub}
-                    </div>
-                    {active && (
-                      <div
-                        aria-hidden
-                        style={{
-                          position: "absolute",
-                          top: 8,
-                          right: 9,
-                          width: 9,
-                          height: 9,
-                          borderRadius: "50%",
-                          background: GOLD,
-                          boxShadow: `0 0 0 2px ${INK}`,
-                        }}
-                      />
-                    )}
-                  </button>
-                ),
-              }}
-            />
-          </div>
-        )}
-
-        {/* Collab invite / duel challenge */}
-        {state.showInviteBox && <InviteBlock state={state} />}
-
-        {/* Metatasks */}
-        {state.showSealStack && <MetatasksBlock state={state} />}
-
-        {/* The job (headline) */}
-        <div style={{ marginBottom: "var(--space-xl)" }}>
-          <FieldLabel
-            meta={t("editPraxis.everymen.titleMeta", {
-              length: state.title.length,
-            })}
-          >
-            {t("editPraxis.everymen.titleLabel")}
-          </FieldLabel>
-          <TitleField
-            state={state}
-            skin={{
-              placeholder: t("editPraxis.everymen.titlePlaceholder"),
-              inputStyle: {
-                width: "100%",
-                border: "none",
-                borderBottom: `2px solid ${INK}`,
-                background: "transparent",
-                fontFamily: ACCENT_FONT,
-                letterSpacing: "0.01em",
-                color: PAPER_TEXT,
-                padding: "var(--space-xs) var(--space-xs) var(--space-sm)",
-                outline: "none",
-              },
-            }}
-          />
-          <div
-            style={{
-              fontFamily: BODY_FONT,
-              fontSize: "var(--text-sm)",
-              letterSpacing: "0.12em",
-              textTransform: "uppercase",
-              color: MUTED,
-              marginTop: "var(--space-xs)",
-            }}
-          >
-            {state.saveStatus === "saved"
-              ? t("editPraxis.everymen.saveState.saved")
-              : state.saveStatus === "saving"
-                ? t("editPraxis.everymen.saveState.saving")
-                : t("editPraxis.everymen.saveState.idle")}
-          </div>
-        </div>
-
-        {/* The report (body) */}
-        <div style={{ marginBottom: "var(--space-xl)" }}>
-          <FieldLabel
-            meta={t("editPraxis.everymen.bodyMeta", {
-              words: state.wordCount,
-            })}
-          >
-            {t("editPraxis.everymen.bodyLabel")}
-          </FieldLabel>
-          <BodyTextarea
-            state={state}
-            skin={{
-              rows: 9,
-              placeholder: t("editPraxis.everymen.bodyPlaceholder"),
-              textareaStyle: {
-                width: "100%",
-                resize: "vertical",
-                border: `1.5px solid ${INK}`,
-                background: PAPER,
-                fontFamily: BODY_FONT,
-                lineHeight: 1.6,
-                color: PAPER_TEXT,
-                padding: "var(--space-md) var(--space-lg)",
-                outline: "none",
-                minHeight: 200,
-              },
-            }}
-          />
-          <BodyPreview
-            state={state}
-            skin={{
-              wrapperStyle: {
-                marginTop: "var(--space-md)",
-                borderLeft: `4px solid ${RED}`,
-                paddingLeft: "var(--space-md)",
-              },
-              label: (
-                <div
-                  style={{
-                    fontFamily: BODY_FONT,
-                    fontSize: "var(--text-sm)",
-                    letterSpacing: "0.2em",
-                    textTransform: "uppercase",
-                    color: MUTED,
-                    marginBottom: "var(--space-xs)",
-                  }}
-                >
-                  {t("editPraxis.everymen.previewLabel")}
-                </div>
-              ),
-              markdownStyle: {
-                fontFamily: BODY_FONT,
-                lineHeight: 1.6,
-                color: PAPER_TEXT,
-              },
-            }}
-          />
-        </div>
-
-        {/* Already pinned proof */}
-        {state.media.length > 0 && (
-          <ExistingProof state={state} />
-        )}
-
-        {/* Proof of work */}
-        <div style={{ marginBottom: "var(--space-2xl)" }}>
-          <FieldLabel
-            meta={t("editPraxis.everymen.filesMeta", { pinned: totalProof })}
-          >
-            {t("editPraxis.everymen.filesLabel")}
-          </FieldLabel>
-          <div
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "var(--space-md)",
-              alignItems: "flex-start",
-            }}
-          >
-            <button
-              type="button"
-              onClick={() => fileRef.current?.click()}
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: "var(--space-sm)",
-                cursor: "pointer",
-                border: `2px dashed ${INK}`,
-                background: "transparent",
-                color: PAPER_TEXT,
-                fontFamily: BODY_FONT,
-                fontSize: "var(--text-md)",
-                fontWeight: 700,
-                letterSpacing: "0.12em",
-                textTransform: "uppercase",
-                padding: "var(--space-md) var(--space-lg)",
+                boxSizing: "border-box",
+                borderRadius: "50%",
+                border: `2px solid ${RED}`,
+                boxShadow: `inset 0 0 0 3px ${PANEL}, inset 0 0 0 4px ${RED}`,
               }}
             >
               <span
                 style={{
-                  fontFamily: ACCENT_FONT,
-                  fontSize: "var(--text-content)",
-                  color: RED,
-                  lineHeight: 0.6,
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  gap: "var(--space-xs)",
                 }}
               >
-                +
-              </span>{" "}
-              {t("editPraxis.everymen.fileButton")}
-            </button>
-            <input
-              ref={fileRef}
-              type="file"
-              multiple
-              accept="image/*,video/*,audio/*"
-              onChange={state.handleFileChange}
-              style={{ display: "none" }}
-            />
-          </div>
-          {state.fileError && (
-            <p
-              style={{
-                fontSize: "var(--text-md)",
-                color: "var(--color-danger)",
-                marginTop: "var(--space-sm)",
+                <span
+                  style={{
+                    fontFamily: BEBAS,
+                    fontSize: "var(--text-title)",
+                    lineHeight: 0.8,
+                    color: ACCENT,
+                  }}
+                >
+                  {task?.point_value ?? 0}
+                </span>
+                <span style={stencil({ color: ACCENT, letterSpacing: "0.22em" })}>
+                  {t("editPraxis.composer.pointsUnit")}
+                </span>
+              </span>
+            </RingMark>
+          }
+        />
+
+        <ComposerSection
+          label={t("editPraxis.composer.titleLabel")}
+          htmlFor="composer-title"
+          rule={dashRule}
+          meta={<TitleCounter length={state.title.length} color={MUTED} />}
+          labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+        >
+          <TitleField
+            state={state}
+            skin={{
+              id: "composer-title",
+              placeholder: t("editPraxis.composer.titlePlaceholder"),
+              inputStyle: {
+                ...fieldBox,
+                fontFamily: BEBAS,
+                letterSpacing: "0.02em",
+              },
+            }}
+          />
+        </ComposerSection>
+
+        {/* How it was done — hidden once the mode can no longer change, per the
+            house rule that an unusable control is not drawn disabled. */}
+        {!state.controlsLocked && (
+          <ComposerSection
+            label={t("editPraxis.composer.modeLabel")}
+            rule={dashRule}
+            labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+          >
+            <ModePicker
+              state={state}
+              skin={{
+                containerStyle: {
+                  display: "flex",
+                  gap: "var(--space-sm)",
+                  flexWrap: "wrap",
+                },
+                options: modeOptions,
+                allowedModes,
+                renderOption: (option, { active, disabled, onSelect }) => (
+                  <button
+                    key={option.key}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={onSelect}
+                    disabled={disabled && !active}
+                    style={stencil({
+                      cursor: disabled ? "not-allowed" : "pointer",
+                      padding: "var(--space-sm) var(--space-lg)",
+                      borderRadius: 0,
+                      background: active ? RED : PANEL,
+                      color: active ? ON_ACCENT : INK,
+                      border: `2px solid ${FRAME}`,
+                      boxShadow: active ? `4px 4px 0 ${FRAME}` : "none",
+                    })}
+                  >
+                    {option.label}
+                  </button>
+                ),
               }}
-            >
-              {state.fileError}
-            </p>
+            />
+          </ComposerSection>
+        )}
+
+        {/* The mode block: the crew roster, or the duel pair. One control draws
+            both — `InviteSearch` switches on `state.duelMode`. */}
+        {state.showInviteBox && (
+          <ComposerSection
+            label={
+              state.duelMode
+                ? t("editPraxis.composer.opponentLabel")
+                : t("editPraxis.composer.collaboratorsLabel", {
+                    count: praxis.members.length,
+                  })
+            }
+            rule={dashRule}
+            labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+          >
+            <InviteSearch
+              state={state}
+              skin={{
+                fontFamily: COURIER,
+                inputBg: PANEL,
+                inputColor: INK,
+                inputBorder: `2px solid ${FRAME}`,
+                dropdownBg: PANEL,
+                dropdownBorder: `2px solid ${FRAME}`,
+                acceptedBg: RED,
+                acceptedColor: ON_ACCENT,
+                pendingColor: INK,
+                placeholder: t("editPraxis.composer.invitePlaceholder"),
+                leaveStyle: { color: MUTED },
+              }}
+            />
+          </ComposerSection>
+        )}
+
+        {state.showSealStack && (
+          <ComposerSection
+            label={t("editPraxis.composer.sealsLabel")}
+            rule={dashRule}
+            labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+          >
+            <MetataskSealStack state={state} />
+          </ComposerSection>
+        )}
+
+        {/* Write-up — the tabs sit in the section's meta slot, so the label row
+            reads `Write-up … [Write|Preview]` as the design draws it. */}
+        <ComposerSection
+          label={t("editPraxis.composer.writeUpLabel")}
+          htmlFor="composer-body"
+          rule={dashRule}
+          labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+          meta={
+            <WriteUpTabs
+              tab={tab}
+              setTab={setTab}
+              skin={{
+                containerStyle: { gap: "var(--space-xs)" },
+                buttonStyle: (active) =>
+                  stencil({
+                    padding: "var(--space-xs) var(--space-sm)",
+                    borderRadius: 0,
+                    border: `2px solid ${active ? FRAME : "transparent"}`,
+                    background: active ? PANEL : "transparent",
+                    color: active ? INK : MUTED,
+                  }),
+              }}
+            />
+          }
+        >
+          {/* Mounted one at a time: a hidden textarea is still a tab stop and
+              would put the body in the DOM twice. */}
+          {tab === "write" ? (
+            <>
+              <BodyTextarea
+                state={state}
+                skin={{
+                  id: "composer-body",
+                  rows: 9,
+                  placeholder: t("editPraxis.composer.bodyPlaceholder"),
+                  toolbarButtonStyle: {
+                    background: PANEL,
+                    color: INK,
+                    border: `2px solid ${FRAME}`,
+                    borderRadius: 0,
+                    fontFamily: BEBAS,
+                  },
+                  textareaStyle: {
+                    ...fieldBox,
+                    resize: "vertical",
+                    minHeight: 200,
+                    lineHeight: 1.6,
+                    fontFamily: COURIER,
+                    padding: "var(--space-md) var(--space-lg)",
+                  },
+                }}
+              />
+              <div
+                style={stencil({
+                  color: MUTED,
+                  fontFamily: COURIER,
+                  letterSpacing: "0.12em",
+                  marginTop: "var(--space-sm)",
+                })}
+              >
+                {t("editPraxis.composer.wordCount", { words: state.wordCount })}
+              </div>
+            </>
+          ) : (
+            <BodyPreview
+              state={state}
+              skin={{
+                wrapperStyle: {
+                  ...fieldBox,
+                  minHeight: 200,
+                  padding: "var(--space-md) var(--space-lg)",
+                },
+                markdownStyle: { fontFamily: COURIER, lineHeight: 1.6, color: INK },
+                emptyState: (
+                  <p
+                    style={{
+                      fontFamily: COURIER,
+                      fontSize: "var(--text-content)",
+                      color: MUTED,
+                      margin: 0,
+                    }}
+                  >
+                    {t("editPraxis.composer.bodyPlaceholder")}
+                  </p>
+                ),
+              }}
+            />
           )}
-        </div>
+        </ComposerSection>
+
+        <ComposerSection
+          label={t("editPraxis.composer.proofLabel")}
+          rule={dashRule}
+          labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: "var(--space-lg)",
+              alignItems: "flex-start",
+              flexWrap: "wrap",
+            }}
+          >
+            {state.media.map((item) => {
+              const filename = item.file_path.split("/").pop() ?? item.file_path;
+              const src = mediaUrl(item.file_path);
+              return (
+                <ProofSlip
+                  key={item.id}
+                  caption={filename}
+                  onRemove={() => void state.removeMedia(item)}
+                >
+                  {item.type === "image" ? (
+                    <img
+                      src={src}
+                      alt=""
+                      style={{ width: "100%", height: 104, objectFit: "cover" }}
+                    />
+                  ) : item.type === "video" ? (
+                    <video
+                      src={src}
+                      style={{ width: "100%", height: 104, objectFit: "cover" }}
+                    />
+                  ) : (
+                    <MediaArt
+                      art={pickArtKey(filename, "audio")}
+                      width={132}
+                      height={104}
+                    />
+                  )}
+                </ProofSlip>
+              );
+            })}
+            {!state.controlsLocked && (
+              <FilePicker
+                state={state}
+                skin={{
+                  buttonStyle: stencil({
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: "var(--space-sm)",
+                    cursor: "pointer",
+                    background: "transparent",
+                    border: `2px dashed ${RED}`,
+                    borderRadius: 0,
+                    padding: "var(--space-lg) var(--space-xl)",
+                    color: INK,
+                  }),
+                  buttonLabel: t("editPraxis.composer.proofButton"),
+                  helperText: t("editPraxis.composer.proofHelper"),
+                  helperStyle: {
+                    fontFamily: COURIER,
+                    fontSize: "var(--text-content)",
+                    color: MUTED,
+                    maxWidth: 280,
+                    lineHeight: 1.5,
+                    marginTop: "var(--space-sm)",
+                  },
+                }}
+              />
+            )}
+          </div>
+        </ComposerSection>
 
         <ErrorBanner message={state.error} />
 
-        {/* File bar */}
-        <div
+        {dashRule}
+
+        {/* [Cancel] … [Submit] — the global order from #646, stacked so the cast
+            reads as a BAR rather than an inline button (the design's
+            `barSubmit`). The exits keep their own row above it. */}
+        <ComposerFooter
           style={{
-            borderTop:
-              "1px solid color-mix(in srgb, var(--everymen-paper-text) 22%, transparent)",
-            paddingTop: "var(--space-xl)",
-            marginTop: "var(--space-xl)",
-            display: "flex",
-            alignItems: "center",
+            flexDirection: "column",
+            alignItems: "stretch",
             gap: "var(--space-lg)",
-            flexWrap: "wrap",
           }}
-        >
-          <SaveDraftButton state={state} />
-          <DropButton
-            state={state}
-            skin={{
-              label: t("editPraxis.everymen.dropLabel"),
-              style: {
-                background: "transparent",
-                border: "none",
-                color: MUTED,
-                fontFamily: BODY_FONT,
-                fontSize: "var(--text-md)",
-                fontStyle: "italic",
-                textDecoration: "underline",
-                cursor: "pointer",
-              },
-            }}
-          />
-          <PublishButton
-            state={state}
-            skin={{
-              idleLabel: t("editPraxis.everymen.publishIdle"),
-              busyLabel: t("editPraxis.everymen.publishBusy"),
-              style: {
-                marginLeft: "auto",
-                cursor: state.submitting ? "wait" : "pointer",
-                border: `2px solid ${INK}`,
-                background: state.submitting ? OLIVE : RED,
-                color: CREAM,
-                fontFamily: ACCENT_FONT,
-                fontSize: "var(--text-title)",
-                letterSpacing: "0.1em",
-                padding: "var(--space-md) var(--space-2xl)",
-                whiteSpace: "nowrap",
-                boxShadow: `5px 5px 0 ${INK}`,
-                transition: "background 150ms",
-              },
-            }}
-          />
-        </div>
-      </div>
+          start={
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-lg)",
+                flexWrap: "wrap",
+              }}
+            >
+              <SaveDraftButton state={state} skin={{ style: { color: MUTED } }} />
+              <DropButton
+                state={state}
+                skin={{
+                  style: stencil({
+                    background: "transparent",
+                    border: "none",
+                    padding: 0,
+                    color: MUTED,
+                    textDecoration: "underline",
+                    cursor: "pointer",
+                  }),
+                }}
+              />
+            </div>
+          }
+          end={
+            <PublishButton
+              state={state}
+              skin={{
+                idleLabel: t("editPraxis.composer.submit"),
+                busyLabel: t("editPraxis.composer.submitBusy"),
+                style: stencil({
+                  width: "100%",
+                  cursor: state.submitting ? "wait" : "pointer",
+                  background: BAR,
+                  color: BAR_INK,
+                  border: "none",
+                  borderTop: `2px solid ${FRAME}`,
+                  borderRadius: 0,
+                  padding: "var(--space-md) var(--space-lg)",
+                  letterSpacing: "0.22em",
+                  textAlign: "center",
+                }),
+              }}
+            />
+          }
+        />
+      </ComposerSheet>
     </div>
   );
 }
 
 interface ProofSlipProps {
-  children: React.ReactNode;
+  children: ReactNode;
   caption: string;
   onRemove: () => void;
 }
 
-/** A stamped proof slip — the Everymen take on a pinned attachment. */
+/** One filed proof, stamped onto a plate and pinned to the order. */
 function ProofSlip({ children, caption, onRemove }: ProofSlipProps) {
   const { t } = useTranslation("forms");
   return (
     <div
       style={{
         position: "relative",
-        width: 152,
-        background: PAPER,
-        border: `1.5px solid ${INK}`,
-        boxShadow: `3px 3px 0 ${INK}`,
+        width: 140,
+        background: PANEL,
+        border: `2px solid ${FRAME}`,
+        borderRadius: 0,
+        boxShadow: `3px 3px 0 ${FRAME}`,
         padding: "var(--space-xs)",
+        boxSizing: "border-box",
       }}
     >
-      <div style={{ width: "100%", height: 100, overflow: "hidden" }}>
-        {children}
-      </div>
+      <div style={{ width: "100%", height: 104, overflow: "hidden" }}>{children}</div>
       <div
         style={{
-          fontFamily: BODY_FONT,
-          fontSize: "var(--text-sm)",
-          letterSpacing: "0.04em",
-          color: PAPER_TEXT,
+          fontFamily: COURIER,
+          fontSize: "var(--text-md)",
+          color: INK,
           marginTop: "var(--space-xs)",
           overflow: "hidden",
           textOverflow: "ellipsis",
@@ -641,13 +808,14 @@ function ProofSlip({ children, caption, onRemove }: ProofSlipProps) {
         aria-label={t("media.removeAria", { name: caption })}
         style={{
           position: "absolute",
-          top: -8,
-          right: -8,
+          top: -9,
+          right: -9,
           width: 22,
           height: 22,
           background: RED,
-          border: `2px solid ${INK}`,
-          color: CREAM,
+          border: `2px solid ${FRAME}`,
+          borderRadius: 0,
+          color: ON_ACCENT,
           fontSize: "var(--text-lg)",
           fontWeight: 700,
           cursor: "pointer",
@@ -657,104 +825,6 @@ function ProofSlip({ children, caption, onRemove }: ProofSlipProps) {
       >
         ×
       </button>
-    </div>
-  );
-}
-
-function ExistingProof({ state }: { state: EditPraxisState }) {
-  const { t } = useTranslation("forms");
-  return (
-    <div style={{ marginBottom: "var(--space-xl)" }}>
-      <FieldLabel>{t("editPraxis.everymen.onFileLabel")}</FieldLabel>
-      <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-md)" }}>
-        {state.media.map((item: MediaItemOut) => {
-          const src = mediaUrl(item.file_path);
-          const filename =
-            item.file_path.split("/").pop() ?? item.file_path;
-          return (
-            <ProofSlip
-              key={item.id}
-              caption={filename}
-              onRemove={() => void state.removeMedia(item)}
-            >
-              {item.type === "image" ? (
-                <img
-                  src={src}
-                  alt=""
-                  style={{ width: "100%", height: 100, objectFit: "cover" }}
-                />
-              ) : item.type === "video" ? (
-                <video
-                  src={src}
-                  style={{ width: "100%", height: 100, objectFit: "cover" }}
-                />
-              ) : (
-                <div style={{ width: "100%", height: 100 }}>
-                  <MediaArt art={pickArtKey(filename, "audio")} />
-                </div>
-              )}
-            </ProofSlip>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function InviteBlock({ state }: { state: EditPraxisState }) {
-  const { t } = useTranslation("forms");
-  // Delegates to the shared InviteSearch so collab-invite and duel-challenge (#311)
-  // behaviour stay identical across archetypes; the crew-frame chrome stays bespoke.
-  return (
-    <div
-      style={{
-        marginBottom: "var(--space-xl)",
-        padding: "var(--space-md) var(--space-lg)",
-        background: PAPER,
-        border: `1.5px dashed ${INK}`,
-      }}
-    >
-      <FieldLabel>
-        {state.duelMode
-          ? t("editPraxis.everymen.inviteLabelDuel")
-          : t("editPraxis.everymen.inviteLabel")}
-      </FieldLabel>
-      <InviteSearch
-        state={state}
-        skin={{
-          fontFamily: BODY_FONT,
-          inputBg: CREAM,
-          inputColor: INK,
-          inputBorder: `1.5px solid ${INK}`,
-          dropdownBg: PAPER,
-          dropdownBorder: `1.5px solid ${INK}`,
-          acceptedBg: OLIVE,
-          acceptedColor: CREAM,
-          pendingColor: PAPER_TEXT,
-          placeholder: t("editPraxis.everymen.invitePlaceholder"),
-        }}
-      />
-    </div>
-  );
-}
-
-function MetatasksBlock({ state }: { state: EditPraxisState }) {
-  const { t } = useTranslation("forms");
-  return (
-    <div
-      style={{
-        marginBottom: "var(--space-xl)",
-        padding: "var(--space-lg)",
-        background: PAPER,
-        border: `1.5px solid ${INK}`,
-      }}
-    >
-      <FieldLabel meta={t("editPraxis.everymen.metatasksMeta")}>
-        {t("editPraxis.everymen.metatasksLabel")}
-      </FieldLabel>
-      {/* The seal stack + neutral picker (#933) replace the old hand-rolled
-          checklist; the Everymen paper-and-ink frame and label stay. */}
-      <MetataskSealStack state={state} />
     </div>
   );
 }

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/everymenComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/everymenComposer.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * The Everymen composer's dress (#1187, epic #1179, ADR-0065).
+ *
+ * Three claims, each of which was true of the skin this replaces and is the
+ * thing most likely to come back:
+ *
+ * 1. **The copy is the neutral shared set.** The union vocabulary
+ *    (`THE CREW`, `PROOF OF WORK`, `★ STAMP & FILE ★`, `VOID THE REPORT`) is
+ *    deleted from `forms.json`, so a re-introduction would have to re-add the
+ *    keys — but a hardcoded string in the archetype would not, and that is what
+ *    this asserts against.
+ * 2. **`editPraxis.everymen.collab` survives.** It is not composer copy: it is
+ *    `collabCopy`'s override table, read by `CollabRoster` on the read page.
+ *    Deleting the block alongside the page keys is the easy mistake.
+ * 3. **One component, both widths, and the ground stays in its column.** The
+ *    old build painted `minHeight: 100vh` on the page — the #1028 trap the
+ *    shared `ComposerSheet` now exists to make impossible.
+ *
+ * renderToStaticMarkup, no DOM, matching the rest of this suite.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../../i18n";
+import i18n from "../../../../i18n";
+import type { EditPraxisState } from "../../useEditPraxis";
+
+const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "mobile" | "desktop" }));
+
+vi.mock("../../../../hooks/useFormFactor", () => ({
+  useFormFactor: () => mocks.formFactor,
+}));
+
+// Imported after the mock is registered.
+import EverymenEditPraxis from "../EverymenEditPraxis";
+
+/**
+ * Only the state this archetype reads. The composer's full contract is ~70
+ * fields and is exercised by `composerDispatch.test.tsx`; a second copy of it
+ * here would be a fixture to maintain rather than a claim to make.
+ */
+function state(overrides: Record<string, unknown> = {}): EditPraxisState {
+  return {
+    praxis: {
+      id: 55,
+      task_id: 7,
+      task_title: "A Very Human Thing",
+      task_faction_slug: "everymen",
+      type: "solo",
+      created_by_id: 3,
+      members: [],
+      invites: [],
+      duel_id: null,
+    },
+    task: {
+      id: 7,
+      description: "Do a small honest thing.",
+      point_value: 20,
+      level_required: 1,
+      primary_faction_slug: "everymen",
+      allowed_modes: ["solo", "collab"],
+    },
+    title: "I helped a stranger",
+    setTitle: () => {},
+    body: "## What I did\n\nCaught the papers.",
+    setBody: () => {},
+    wordCount: 4,
+    media: [],
+    fileError: "",
+    error: "",
+    handleFileChange: () => {},
+    removeMedia: async () => {},
+    autosaveAt: null,
+    submitting: false,
+    switchingMode: null,
+    isPublished: false,
+    controlsLocked: false,
+    modeIsLocked: false,
+    showInviteBox: false,
+    showSealStack: false,
+    duelMode: false,
+    duelChipVisible: false,
+    duel: null,
+    currentCharacterId: 3,
+    ...overrides,
+  } as unknown as EditPraxisState;
+}
+
+function render(formFactor: "mobile" | "desktop"): string {
+  mocks.formFactor = formFactor;
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <EverymenEditPraxis state={state()} />
+    </MemoryRouter>,
+  );
+}
+
+const WIDTHS = ["desktop", "mobile"] as const;
+
+describe("Everymen composer copy is the neutral set (ADR-0065 §3)", () => {
+  it.each(WIDTHS)("draws the shared region labels on %s", (width) => {
+    const markup = render(width);
+    for (const key of [
+      "taskLabel",
+      "titleLabel",
+      "modeLabel",
+      "writeUpLabel",
+      "proofLabel",
+      "submit",
+    ]) {
+      expect(markup).toContain(i18n.t(`forms:editPraxis.composer.${key}` as never));
+    }
+  });
+
+  it.each(WIDTHS)("speaks none of the retired union vocabulary on %s", (width) => {
+    const markup = render(width);
+    for (const voice of [
+      "THE CREW",
+      "THE JOB",
+      "THE REPORT",
+      "PROOF OF WORK",
+      "STAMP &amp; FILE",
+      "VOID THE REPORT",
+      "WORK REPORT",
+      "FILE YOUR REPORT",
+      "SIDE WORK",
+      "ON FILE",
+    ]) {
+      expect(markup).not.toContain(voice);
+    }
+  });
+
+  it("names the paper on the masthead from the shared faction catalog", () => {
+    // The design's masthead word is faction voice, which ADR-0065's rejected
+    // alternative rules out; the plate carries the faction's NAME instead — the
+    // same substitution `EverymenTaskDetail` makes under ADR-0057.
+    expect(render("desktop")).toContain(i18n.t("factions:names.everymen"));
+  });
+
+  it("keeps editPraxis.everymen.collab, which is not composer copy", () => {
+    // collabCopy's override table, also read by CollabRoster on /praxes/:id.
+    expect(i18n.t("forms:editPraxis.everymen.collab.castAction")).toBe(
+      "Sign off on my part",
+    );
+  });
+});
+
+describe("Everymen composer dress", () => {
+  it("counter-rotates the two masthead cogs", () => {
+    // The pair is the design's one motion, and it is reached by CLASS: an
+    // inline `animation:` would bypass the shared reduced-motion guard (#1003).
+    const markup = render("desktop");
+    expect((markup.match(/class="ep-spin"/g) ?? []).length).toBe(1);
+    expect((markup.match(/class="ep-spin-rev"/g) ?? []).length).toBe(1);
+    expect(markup).not.toContain("animation:");
+  });
+
+  it.each(WIDTHS)("keeps its ground inside its own column on %s (#1028)", (width) => {
+    const markup = render(width);
+    expect(markup).not.toContain("100vh");
+    expect(markup).not.toContain("position:fixed");
+  });
+
+  it.each(WIDTHS)("draws exactly one breadcrumb on %s", (width) => {
+    expect((render(width).match(/<nav/g) ?? []).length).toBe(1);
+  });
+});


### PR DESCRIPTION
Rebuilds `EverymenEditPraxis` on the shared composer layout #1181 landed — one responsive component, the neutral copy set, and the Everymen dressed as a union **work order**: a red masthead plate between two counter-rotating cogs, poster rays fanning from behind it under a radial mask, dashed red rules, a rubber-stamp points seal and a full-width report bar for the cast.

Closes #1187

## What changed

- **`EverymenEditPraxis.tsx` rebuilt** over `ComposerSheet` / `ComposerMasthead` / `ComposerGround` / `ComposerStatusRow` / `TaskSlip` / `ComposerSection` / `ComposerRule` / `ComposerFooter` / `RingMark`, with every control composed through its `*Skin` prop. No control forked, no region re-ordered, no widening of `shared.tsx` or `controls.tsx` needed — see the two deviations below for the one place that was close.
- **One responsive component.** `useComposerSizes()` picks the size set; the mobile twin is already gone. No fixed-px layout grid.
- **Copy went neutral.** `editPraxis.everymen.*` page keys deleted from `forms.json`; the archetype reads `editPraxis.composer.*`. **`editPraxis.everymen.collab` is kept** — that is `collabCopy`'s override table, also read by `CollabRoster` on `/praxes/:id` and pinned by `collabCopy.test.ts`.
- **One new token,** `--faction-everymen-composer-frame` (light `--everymen-gold`, dark `--everymen-red-deep`), both halves declared in `index.css` and verified in the emitted stylesheet at `:root` and `[data-theme="dark"]` depth. Everything else is the existing `--everymen-*` / `-bill-` / `-sheet-` families. No hex in the component; no `dark ?` branch.
- **No `index.css` motion edit.** The cogs use the shipped `ep-spin` / `ep-spin-rev` pair with `--ep-spin-dur: 26s`.
- **New test** `__tests__/everymenComposer.test.tsx` (11 cases): the neutral labels render at both widths, none of the retired union vocabulary appears, `everymen.collab` still resolves, the cogs counter-rotate by class with no inline `animation:`, and the sheet paints no `100vh` / `position:fixed` ground (#1028).

## Where the design and the rulings disagreed — two calls, both flagged

**1. The masthead's words.** The design puts `FILE YOUR REPORT` on the plate. That is faction voice on a surface ADR-0065 §3 makes neutral, and the ADR's *Alternatives rejected* names this exact case ("a deliberately designed set of near-synonyms is still the catalog the neutral rule exists to delete"). The issue body asks for both the string and "no faction vocabulary in this surface", so it contradicts itself; I followed the ADR. The plate carries the **faction's name** from `factions:names.*` instead — the same substitution `EverymenTaskDetail`'s masthead already makes under the identical rule (ADR-0057). One string to flip if the intent was the design's words.

**2. "Full-bleed" submit bar.** `ComposerFooter` is the seam, and it supports a bar: the footer stacks (exits row above, bar below) and the cast is a full-**width** bar with the bill's CTA colours, `[Cancel] … [Submit]` order intact (#646). It is **not** edge-to-edge to the sheet, because the content column owns the padding and the only ways to escape it are negative margins that duplicate the shared padding values in the skin. True bleed wants an additive `footer` slot on `ComposerSheet`, drawn outside the padded column exactly as `masthead` is — worth adding once for whichever skins need it, rather than seven times.

## Also worth a decision, not done here

`buildGearPath()` / `Gear` now exists in **three** Everymen surfaces (task card, task detail, this). WORLD_ZERO_STYLE §6 says the third caller is when the vocabulary collapses into one `everymenOrnament` module. That touches two shipped surfaces and is outside this issue's footprint, so it is noted in the archetype's docstring and left for a follow-up.

Unrelated staleness spotted: WORLD_ZERO_STYLE §4's font table still lists Everymen's headline face as **Special Elite**; `--faction-everymen-card-font` has been Bebas Neue since the v2 cards.

## What to eyeball

- Masthead: the two cogs turning in **opposite** directions, the `3px double` bottom rule and the `inset 0 -6px 0 -4px` printed shadow under it.
- The ray burst: origin under the masthead at `50% 8%`, fading out through the radial mask before it reaches the footer — and staying **inside the sheet** at both widths.
- Light **and** dark: the sheet frame is gold by day and deep red by night; the plates (task slip, fields, tiles) should lift off the paper in both.
- Red as ink only on the plates — the stamped `20` / `pts` seal and the slip's labels. Nothing red is set on the paper itself.
- The footer at mobile width: exits row, then the bar spanning the column.
- Radius 0 everywhere, including the mode chips' offset shadow and the proof tiles' corner ×.

**Visual QA is outstanding.** I cannot screenshot in this environment and there is no dev stack here, so every claim above is from `tsc --noEmit`, `eslint`, `vite build`, the emitted stylesheet, and the full vitest suite (133 files / 2277 tests, green) — not from looking at the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
