### PR TITLE
Edit praxis v2 — S.N.I.D.E.: the flyposted xerox sheet

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -437,6 +437,42 @@
   --faction-snide-note-cta-ink: #14110b;
   --faction-snide-note-shadow: 0 12px 28px -14px rgba(20, 17, 11, 0.55);
 
+  /* ══ S.N.I.D.E. — THE FLYPOSTED SHEET (edit-praxis composer, #1184) ══
+     The composer is a xerox sheet taped to the wall: grain raster, two tape
+     strips, a near-black masthead bar with the wordmark in acid, censor stripes
+     for section rules, and a full-bleed acid submit bar at the foot.
+
+     THIS FAMILY FLIPS, for the same reason `-note-*` above does and NOT for the
+     reason `-card-*` doesn't: a sheet of paper is the whole conceit, so it goes
+     warm xerox stock by day and photocopier black by night. The theme-invariant
+     `-paper`/`-ink`/`-acid` pigments at the head of this faction's block are the
+     PRESS's constants — the ink that prints on an acid ground stays #14110b in
+     both themes, which is what the submit bar and the points numeral read. These
+     are the SHEET's tiers, they are not synonyms for those, and collapsing the
+     two puts paper-white type on acid green (1.2:1).
+
+     Declared rather than borrowed, on #1181's reasoning for the na composer: the
+     obvious borrows are `-note-paper`/`-note-bar`/`-note-grain`, which are the
+     PRAXIS CARD's clipping — same values today, a different surface's contract
+     tomorrow, and reading them here is the "tokenized-looking, not tokenized"
+     failure a var() at the wrong tier always passes lint with.
+
+     ONE INK IS WALKED DOWN from the design, the same way the clipping walked its
+     pink: the `PTS` caption under the points blob is drawn in acid, and acid is a
+     poster colour, not an ink — #b6ff2e measures 1.35:1 on the stock. It takes a
+     deep acid in the light half (4.8:1) and the bright one only where the ground
+     is dark. Acid stays bright everywhere it is a DRAWN THING: the masthead
+     rule, the blobs, the submit bar. */
+  --faction-snide-composer-sheet: #f4f1e8; /* the xerox stock (FLIPS) */
+  --faction-snide-composer-ink: #14110b; /* type on that stock (FLIPS) */
+  --faction-snide-composer-muted: #5f5c50; /* the task's prose, the pill */
+  --faction-snide-composer-faint: #6e6b5d; /* counter, autosave line — 4.8:1 */
+  --faction-snide-composer-field: #eae6d8; /* an input, a shade off the sheet */
+  --faction-snide-composer-rule: rgba(20, 17, 11, 0.5); /* a drawn hairline */
+  --faction-snide-composer-bar: #14110b; /* masthead bar + the censor stripe */
+  --faction-snide-composer-grain: rgba(20, 17, 11, 0.09); /* the raster */
+  --faction-snide-composer-acid-ink: #4a7500; /* acid that is TEXT, not a line */
+
   /* ── Singularity terminal border (blue brand) ── */
   --faction-singularity-border-hard: #2563eb;
 
@@ -1435,6 +1471,24 @@
   --faction-snide-note-bar-ink: #ff2d8b; /* the bar's ordinal goes pink — 5.75:1 */
   --faction-snide-note-pink-ink: #ff69ac;
   --faction-snide-note-shadow: 0 14px 34px -14px rgba(0, 0, 0, 0.85);
+
+  /* ── The flyposted sheet, lights out (#1184) ──
+     The stock and its type SWAP, exactly as the clipping's do: photocopier black
+     with xerox-white type. The masthead bar and the censor stripe go a shade
+     BELOW the sheet rather than above it — a redaction is always the darkest
+     thing on the page, and lifting it to white would turn every section rule
+     into a highlighter. Acid becomes text-safe on this ground, so
+     `-acid-ink` takes the bright pigment back. Measured on the dark stock:
+     muted 11.0:1, faint 5.7:1, acid-ink 15.6:1. */
+  --faction-snide-composer-sheet: #14110b;
+  --faction-snide-composer-ink: #f4f1e8;
+  --faction-snide-composer-muted: #cfcdbf;
+  --faction-snide-composer-faint: #94917f;
+  --faction-snide-composer-field: #1e1a12;
+  --faction-snide-composer-rule: rgba(244, 241, 232, 0.32);
+  --faction-snide-composer-bar: #080706;
+  --faction-snide-composer-grain: rgba(244, 241, 232, 0.07);
+  --faction-snide-composer-acid-ink: #b6ff2e;
   --faction-singularity-card-muted: #60a5fa; /* blue brand chrome */
 
   /* ── Singularity terminal session, lights out (#1023) ──

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -460,9 +460,11 @@
      ONE INK IS WALKED DOWN from the design, the same way the clipping walked its
      pink: the `PTS` caption under the points blob is drawn in acid, and acid is a
      poster colour, not an ink — #b6ff2e measures 1.35:1 on the stock. It takes a
-     deep acid in the light half (4.8:1) and the bright one only where the ground
-     is dark. Acid stays bright everywhere it is a DRAWN THING: the masthead
-     rule, the blobs, the submit bar. */
+     deep acid in the light half and the bright one only where the ground is
+     dark. Measured against the ground it actually sits on, which is the task
+     slip's field rather than the sheet (#1028: contrast is a pairing): 4.7:1 on
+     the field, 5.2:1 on the stock. Acid stays bright everywhere it is a DRAWN
+     THING: the masthead rule, the blobs, the submit bar. */
   --faction-snide-composer-sheet: #f4f1e8; /* the xerox stock (FLIPS) */
   --faction-snide-composer-ink: #14110b; /* type on that stock (FLIPS) */
   --faction-snide-composer-muted: #5f5c50; /* the task's prose, the pill */
@@ -471,7 +473,7 @@
   --faction-snide-composer-rule: rgba(20, 17, 11, 0.5); /* a drawn hairline */
   --faction-snide-composer-bar: #14110b; /* masthead bar + the censor stripe */
   --faction-snide-composer-grain: rgba(20, 17, 11, 0.09); /* the raster */
-  --faction-snide-composer-acid-ink: #4a7500; /* acid that is TEXT, not a line */
+  --faction-snide-composer-acid-ink: #457000; /* acid that is TEXT, not a line */
 
   /* ── Singularity terminal border (blue brand) ── */
   --faction-singularity-border-hard: #2563eb;

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -426,37 +426,7 @@
         "successHeading": "IT'S OUT THERE",
         "successBody": "whole gang's in. it hit the street.",
         "successContinue": "go see it"
-      },
-      "masthead": "ZINE #47 ·· S.N.I.D.E. ·· FREE / STEAL ME",
-      "pageTitle": "edit praxis",
-      "taskRefLabel": "Re: completion of",
-      "modeLabel": "how shall we DO this??",
-      "mode": {
-        "solo": { "label": "LONE WOLF", "desc": "just me" },
-        "collab": { "label": "THE GANG", "desc": "a gang of us" },
-        "duel": { "label": "BEEF", "desc": "me v. them" }
-      },
-      "inviteLabel": "WHO ELSE",
-      "inviteLabelDuel": "✗ THE OPPOSITION ✗",
-      "invitePlaceholder": "@ who else?",
-      "invitePlaceholderDuel": "@ who are you fighting?",
-      "titleLabel": "HEADLINE · cut from anywhere",
-      "titleEmptyHint": "(snip letters out of magazines · paste here)",
-      "titlePlaceholder": "type your headline · we'll cut the letters for you",
-      "bodyLabel": "↳ the manifesto · {{words}} words · markdown ok",
-      "bodyPlaceholder": "lead with the lie. bury the truth in paragraph five...",
-      "previewLabel": "Preview",
-      "mediaOnPageLabel": "↳ already glued in",
-      "figureCaption": "FIG. {{number}} · {{name}}",
-      "filesLabel": "↳ glue in proof · photos / audio / receipts",
-      "fileButton": "+ paste it in",
-      "fileHelper": "images · video · audio · max 50mb each",
-      "metatasksLabel": "★ optional bonus",
-      "publishIdle": "FILE IT & RUN",
-      "publishBusy": "running...",
-      "dropLabel": "burn it",
-      "autosaveSaved": "↳ photocopied & filed {{ago}}",
-      "autosaveUnsaved": "↳ unsaved · staple it before it walks off"
+      }
     },
     "singularity": {
       "collab": {

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -1,22 +1,90 @@
 /**
- * Punk Zine — S.N.I.D.E. faction.
- * Photocopier ink stock, ransom-note title, two-column markdown preview, xerox
- * photo tiles. Colours read from the faction tokens, so it tracks the punk palette.
+ * S.N.I.D.E. edit praxis — composer v2 (#1184, epic #1179; design project
+ * c491945e, `Snide Edit Praxis.dc.html`, the `snide` row of `SKINS`).
+ *
+ * The same page `DefaultEditPraxis` draws, wearing SNIDE's dress: a xerox sheet
+ * flyposted to the wall. Every region, every control and every word is shared
+ * (ADR-0065); what belongs to this file is the frame, the type, the ornament and
+ * the marks.
+ *
+ * ## The dress
+ *
+ * **Geometry — radius 0, borderW 0.** SNIDE is the one skin that draws no card
+ * border at all, so the sheet is a hard-cornered rectangle with nothing around
+ * it: what separates it from the page is the stock, the grain and the tape. The
+ * shared sheet's default 10px radius is overridden here rather than inherited.
+ *
+ * **Masthead** — a near-black bar carrying the wordmark in acid, a dashed acid
+ * rule that flexes to fill, and the stage word. All three are ornament: the bar
+ * is `aria-hidden`, because the stage is announced once, by the status row
+ * underneath it. The zine says DRAFT twice on purpose; a screen reader hears it
+ * once.
+ *
+ * **Ground** — the photocopier raster plus two tape strips, both running off the
+ * sheet's edge. They can only do that because `ComposerSheet` owns the
+ * `overflow: hidden` clip: the ground is the COLUMN's, never the viewport's
+ * (#1028, the trap six of eight task-detail skins fell into).
+ *
+ * **Section rule** — the censor stripe, a solid redaction bar rather than a
+ * hairline.
+ *
+ * **The two marks** are one hand-drawn blob at two sizes: the points blob with
+ * its numeral and `PTS` caption, and the status blob with a check struck through
+ * in pen. They are NOT `RingMark` — that block is a ring with its middle punched
+ * out, and this design's mark is a splat. They are passed through the same two
+ * mark SLOTS (`TaskSlip.mark`, `ComposerStatusRow.mark`), which is the seam that
+ * matters.
+ *
+ * **Submit** — a full-bleed acid bar, not an inline button. The shared
+ * `ComposerFooter` already expressed it: its `style` prop turns the row into a
+ * stretched column, and the sheet's bottom padding is dropped so the bar can
+ * land flush on the sheet's edge. No footer was forked and no bar helper added.
+ *
+ * ## Colour
+ *
+ * Every value is a `--faction-snide-*` token, so the sheet flips through the
+ * `[data-theme="dark"]` cascade with no `dark ?` branch anywhere below. Two
+ * families are deliberately kept apart: `-composer-*` is the SHEET (it flips),
+ * and `-acid`/`-ink`/`-pink` are the PRESS (they do not). Type printed on an
+ * acid ground reads the press's ink in both themes — paper-white on acid green
+ * measures 1.2:1.
+ *
+ * ## Type
+ *
+ * Anton for the title tier, Special Elite for body and labels, both read from
+ * the faction's font tokens. The label geometry (uppercase, 0.14em, the label
+ * tier) comes from `composerLabelStyle`; this file supplies only the face.
+ *
+ * ## Motion
+ *
+ * One: `ep-pulse`, slowed, on the masthead's dashed rule — the flicker of a
+ * tube light over the flyposting. The keyframe is in `index.css` behind the
+ * shared reduced-motion guard, reached by class; an inline `animation:` would
+ * bypass that guard (#1003).
  */
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { factionCssVar } from "../../../utils/factions";
+import type { CSSProperties, ReactNode } from "react";
 import { mediaUrl } from "../../../utils/media";
+import { factionName } from "../../../utils/factions";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
 import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
+  ComposerFooter,
+  ComposerGround,
+  ComposerMasthead,
+  ComposerRule,
+  ComposerSection,
+  ComposerSheet,
+  ComposerStatusRow,
   ErrorBanner,
-  RainbowTitle,
-  RainbowUnderline,
-  TaskMetaInline,
+  TaskSlip,
   TitleCounter,
+  composerLabelStyle,
   formatAutosave,
+  useComposerSizes,
 } from "./shared";
 import {
   BodyPreview,
@@ -28,6 +96,8 @@ import {
   PublishButton,
   SaveDraftButton,
   TitleField,
+  WriteUpTabs,
+  type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
 import type { EditPraxisState } from "../useEditPraxis";
@@ -36,622 +106,674 @@ interface Props {
   state: EditPraxisState;
 }
 
-const cutoutFonts = [
-  "'Permanent Marker', cursive",
-  "'Special Elite', serif",
-  "'Anton', sans-serif",
-  "'Archivo Black', sans-serif",
-  "'Lora', serif",
-  "'Courier Prime', monospace",
-  "'Bebas Neue', sans-serif",
-  "'IM Fell English', serif",
-];
+/* THE SHEET — flips with the theme (xerox stock by day, photocopier black by
+ * night), so nothing below branches on it. */
+const SHEET = "var(--faction-snide-composer-sheet)";
+const INK = "var(--faction-snide-composer-ink)";
+const MUTED = "var(--faction-snide-composer-muted)";
+const FAINT = "var(--faction-snide-composer-faint)";
+const FIELD = "var(--faction-snide-composer-field)";
+const RULE = "var(--faction-snide-composer-rule)";
+const BAR = "var(--faction-snide-composer-bar)";
+const GRAIN = "var(--faction-snide-composer-grain)";
+/* Acid as TEXT: deep in the light half, bright on the dark stock. */
+const ACID_INK = "var(--faction-snide-composer-acid-ink)";
 
-const MODE_FONTS: Record<PraxisType, string> = {
-  solo: "'Permanent Marker', cursive",
-  collab: "'UnifrakturCook', serif",
-  duel: "'Bebas Neue', sans-serif",
-};
+/* THE PRESS — theme-invariant pigments. `ACID` is acid as a DRAWN THING (the
+ * masthead rule, the blobs, the submit bar), and `PRESS_INK` is the near-black
+ * that prints on it in either theme. Pairing acid with the sheet's ink instead
+ * would put paper-white type on acid green under [data-theme="dark"]. */
+const ACID = "var(--faction-snide-acid)";
+const PRESS_INK = "var(--faction-snide-ink)";
+const PRESS_PAPER = "var(--faction-snide-paper)";
+const HOT_PINK = "var(--faction-snide-pink)";
 
-function RansomChar({ ch, index }: { ch: string; index: number }) {
-  if (ch === " ")
-    return <span style={{ display: "inline-block", width: "0.4em" }} />;
-  const palette = [
-    factionCssVar("snide"),
-    factionCssVar("snide", "card-accent"),
-    factionCssVar("snide", "card-bg"),
-    "var(--color-text-primary)",
-  ];
-  const bg = palette[(index * 3) % palette.length];
-  const font = cutoutFonts[(index * 2 + 1) % cutoutFonts.length];
-  const rot = ((index * 17) % 12) - 6;
-  const sz = 26 + ((index * 5) % 12);
+const TITLE_FACE = "var(--faction-snide-font-impact)"; /* Anton */
+const BODY_FACE = "var(--faction-snide-font-type)"; /* Special Elite */
+
+/** The label tier with SNIDE's face on it — geometry shared, face local. */
+function punkLabel(overrides: CSSProperties = {}): CSSProperties {
+  return composerLabelStyle({ fontFamily: BODY_FACE, ...overrides });
+}
+
+/** One spray-can splat, drawn once and cut at two sizes. */
+const BLOB_PATH =
+  "M6 28 C4 13 20 4 42 3 C62 2 88 6 89 24 C90 40 86 63 54 69 C28 74 9 52 6 28 Z";
+
+interface BlobProps {
+  width: number;
+  height: number;
+  /** Strike the blob through — the draft's unfinished check. */
+  struck?: boolean;
+  children?: ReactNode;
+}
+
+/**
+ * The blob behind both marks. The design draws it at 94×72 for the points and
+ * smaller for the status; the aspect is the same, so one path serves both.
+ */
+function SnideBlob({ width, height, struck = false, children }: BlobProps) {
   return (
     <span
       style={{
-        display: "inline-block",
-        background: bg,
-        color: "var(--color-text-on-accent)",
-        fontFamily: font,
-        fontSize: sz,
-        lineHeight: 1,
-        fontWeight: 700,
-        // eslint-disable-next-line local/no-raw-style-values -- ornament: ransom-note letter tile; the mat is cut tight around one glyph.
-        padding: "2px 6px",
-        // eslint-disable-next-line local/no-raw-style-values -- ornament: the scraps overlap into a word; a 4px gutter would space them out into a row of chips.
-        margin: "2px 1px",
-        transform: `rotate(${rot}deg)`,
-        boxShadow: "1px 1px 0 rgba(0,0,0,.2)",
-        textTransform: index % 2 ? "uppercase" : "none",
+        position: "relative",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        width,
+        height,
+        flexShrink: 0,
+        transform: "rotate(-5deg)",
       }}
     >
-      {ch}
+      <svg
+        aria-hidden
+        viewBox="0 0 94 72"
+        preserveAspectRatio="none"
+        style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
+      >
+        <path d={BLOB_PATH} fill={ACID} />
+        {struck && (
+          <>
+            <polyline
+              points="28,36 41,50 66,22"
+              fill="none"
+              stroke={PRESS_INK}
+              strokeWidth={8}
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <line
+              x1="10"
+              y1="58"
+              x2="84"
+              y2="15"
+              stroke={HOT_PINK}
+              strokeWidth={6}
+              strokeLinecap="round"
+            />
+          </>
+        )}
+      </svg>
+      {children}
     </span>
   );
 }
 
 export default function SnideEditPraxis({ state }: Props) {
   const { t } = useTranslation("forms");
+  const sizes = useComposerSizes();
+  const [tab, setTab] = useState<ComposerTab>("write");
   const praxis = state.praxis!;
   const task = state.task;
 
-  const modeOptions: Array<{
-    key: PraxisType;
-    label: string;
-    desc: string;
-    font: string;
-  }> = (["solo", "collab", "duel"] as const).map((key) => ({
-    key,
-    label: t(`editPraxis.snide.mode.${key}.label`),
-    desc: t(`editPraxis.snide.mode.${key}.desc`),
-    font: MODE_FONTS[key],
-  }));
-
-  const accent = factionCssVar("snide");
-  const accentDeep = factionCssVar("snide", "card-accent");
-  const surface = factionCssVar("snide", "card-bg");
-  const ink = factionCssVar("snide", "card-text");
-  const muted = factionCssVar("snide", "card-muted");
-  const lightBg = factionCssVar("snide", "light");
-  const hot = "var(--faction-snide-pink)";
-
   const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
+  const modeOptions: Array<{ key: PraxisType; label: string }> = [
+    { key: "solo", label: t("editPraxis.composer.modeSolo") },
+    { key: "collab", label: t("editPraxis.composer.modeCollab") },
+    { key: "duel", label: t("editPraxis.composer.modeDuel") },
+  ];
+
+  /* Every field is a block cut from the sheet: square corners, a drawn hairline,
+   * one shade off the stock so it reads inset rather than painted on. */
+  const fieldBox = {
+    width: "100%",
+    background: FIELD,
+    color: INK,
+    border: `1px solid ${RULE}`,
+    borderRadius: 0,
+    padding: "var(--space-md)",
+    outline: "none",
+    boxSizing: "border-box",
+  } as const;
+
+  /* The censor stripe, this skin's section divider. Every section gets its own
+   * (the shared block draws a hairline otherwise). */
+  const censorStripe = <ComposerRule style={{ height: 10, background: BAR }} />;
+
+  /* The submit bar's bleed: the sheet's own side padding, negated. Not a value
+   * off the scale — the same token, running the other way, which is the only
+   * way a child of a padded column reaches its parent's edge. */
+  const sidePad = sizes.isMobile ? "var(--space-lg)" : "var(--space-2xl)";
 
   return (
-    <div
-      style={{
-        background: surface,
-        color: ink,
-        fontFamily: "'Courier Prime', monospace",
-        position: "relative",
-        padding: "var(--space-3xl) var(--space-xl) var(--space-4xl)",
-        minHeight: "100vh",
-        backgroundImage: `repeating-linear-gradient(7deg, ${lightBg} 0, ${lightBg} 1px, transparent 1px, transparent 4px), repeating-linear-gradient(-93deg, rgba(0,0,0,.015) 0, rgba(0,0,0,.015) 1px, transparent 1px, transparent 5px)`,
-      }}
-    >
-      <div style={{ maxWidth: 760, margin: "0 auto" }}>
+    <div style={{ fontFamily: BODY_FACE, color: INK }}>
+      <div
+        style={{
+          maxWidth: sizes.maxWidth,
+          margin: "0 auto",
+          padding: "var(--space-lg) var(--space-lg) 0",
+        }}
+      >
         <Breadcrumb
           praxisId={praxis.id}
           taskId={praxis.task_id}
           taskTitle={praxis.task_title}
-          inkColor={muted}
         />
+      </div>
 
-        {/* Top punk header */}
-        <div style={{ marginBottom: "var(--space-lg)", position: "relative" }}>
-          <div
-            style={{
-              background: accentDeep,
-              color: "var(--color-text-on-accent)",
-              padding: "var(--space-sm) var(--space-md)",
-              transform: "rotate(-1.2deg)",
-              fontFamily: "'Bebas Neue', sans-serif",
-              letterSpacing: "0.2em",
-              fontSize: "var(--text-content)",
-              display: "inline-block",
-              boxShadow: `3px 3px 0 ${hot}`,
-            }}
+      <ComposerSheet
+        sizes={sizes}
+        /* radius 0, borderW 0 — the sheet has no edge but its own stock. */
+        style={{ background: SHEET, borderRadius: 0 }}
+        /* Bottom padding goes to the full-bleed submit bar below. */
+        contentStyle={{ paddingBottom: 0 }}
+        masthead={
+          <ComposerMasthead
+            background={BAR}
+            style={{ height: "auto", padding: "var(--space-sm) var(--space-lg)" }}
           >
-            {t("editPraxis.snide.masthead")}
-          </div>
-        </div>
-
-        <div style={{ marginBottom: "var(--space-lg)" }}>
-          <RainbowTitle
-            text={t("editPraxis.snide.pageTitle")}
-            size={40}
-            color={ink}
-          />
-        </div>
-
-        {/* Task slip */}
-        <div
-          style={{
-            position: "relative",
-            marginBottom: "var(--space-xl)",
-            background: surface,
-            color: ink,
-            padding: "var(--space-md) var(--space-lg)",
-            transform: "rotate(-1deg)",
-            fontFamily: "'Special Elite', serif",
-            borderTop: `3px solid ${accent}`,
-            borderBottom: `3px solid ${accent}`,
-          }}
-        >
-          <span
-            className="eyebrow"
-            style={{ color: accentDeep, display: "block" }}
-          >
-            {t("editPraxis.snide.taskRefLabel")}
-          </span>
-          <div style={{ fontSize: "var(--text-content)", lineHeight: 1.25, marginTop: "var(--space-xs)" }}>
-            {praxis.task_title}
-          </div>
-          {task?.description && (
-            <div style={{ fontSize: "var(--text-content)", lineHeight: 1.45, color: muted, marginTop: "var(--space-xs)" }}>
-              {task.description}
-            </div>
-          )}
-          <div style={{ marginTop: "var(--space-sm)" }}>
-            <TaskMetaInline
-              praxis={praxis}
-              task={task}
-              textColor={accentDeep}
-            />
-          </div>
-        </div>
-
-        {/* Mode */}
-        {!state.controlsLocked && (
-          <div style={{ marginBottom: "var(--space-xl)" }}>
-            <div
+            {/* Ornament, and hidden as such: the stage word is announced by the
+                status row, and a masthead that announced itself would put the
+                faction's chrome ahead of the page's first real content. */}
+            <span
+              aria-hidden
               style={{
-                display: "inline-block",
-                background: lightBg,
-                color: ink,
-                fontFamily: "'Permanent Marker', cursive",
-                fontSize: "var(--text-lg)",
-                padding: "var(--space-xs) var(--space-md)",
-                marginBottom: "var(--space-sm)",
-                transform: "rotate(-1.5deg)",
-              }}
-            >
-              {t("editPraxis.snide.modeLabel")}
-            </div>
-            <ModePicker
-              state={state}
-              skin={{
-                containerStyle: { display: "flex", gap: "var(--space-md)", flexWrap: "wrap" },
-                options: modeOptions,
-                allowedModes,
-                renderOption: (opt, { active, disabled, onSelect, index }) => {
-                  const bg = active
-                    ? opt.key === "duel"
-                      ? hot
-                      : accentDeep
-                    : surface;
-                  const fg = active ? "var(--color-text-on-accent)" : ink;
-                  return (
-                    <button
-                      key={opt.key}
-                      type="button"
-                      aria-pressed={active}
-                      onClick={onSelect}
-                      disabled={disabled && !active}
-                      style={{
-                        cursor: disabled ? "not-allowed" : "pointer",
-                        textAlign: "left",
-                        background: bg,
-                        color: fg,
-                        border: active
-                          ? `2.5px solid ${accentDeep}`
-                          : `2px dashed ${accentDeep}`,
-                        padding: "var(--space-md) var(--space-lg)",
-                        position: "relative",
-                        fontFamily: opt.font,
-                        transform: `rotate(${active ? (index % 2 ? 1.5 : -1.8) : index % 2 ? -0.5 : 0.5}deg)`,
-                        boxShadow: active ? `3px 3px 0 ${accentDeep}` : "none",
-                        minWidth: 130,
-                      }}
-                    >
-                      <div
-                        style={{ fontSize: "var(--text-title)", lineHeight: 1, marginBottom: "var(--space-xs)" }}
-                      >
-                        {opt.label}
-                      </div>
-                      <div
-                        style={{
-                          fontSize: "var(--text-base)",
-                          fontFamily: "'Courier Prime', monospace",
-                          opacity: 0.85,
-                        }}
-                      >
-                        {opt.desc}
-                      </div>
-                    </button>
-                  );
-                },
-              }}
-            />
-          </div>
-        )}
-
-        {/* Invite */}
-        {state.showInviteBox && (
-            <div
-              style={{
-                marginBottom: "var(--space-xl)",
-                padding: "var(--space-md) var(--space-lg)",
-                border: `2px solid ${accentDeep}`,
-                background: `repeating-linear-gradient(135deg, ${surface} 0, ${surface} 16px, ${lightBg} 16px, ${lightBg} 32px)`,
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-md)",
               }}
             >
               <span
-                className="eyebrow"
-                style={{ color: hot, display: "block", marginBottom: "var(--space-sm)" }}
+                style={{
+                  fontFamily: TITLE_FACE,
+                  // eslint-disable-next-line local/no-raw-style-values -- ornament: the wordmark is a poster face at its drawn optical size, not a tier of the text scale (§4a).
+                  fontSize: 20,
+                  lineHeight: 1,
+                  letterSpacing: "0.06em",
+                  color: ACID,
+                  whiteSpace: "nowrap",
+                }}
               >
-                {state.duelMode
-                  ? t("editPraxis.snide.inviteLabelDuel")
-                  : t("editPraxis.snide.inviteLabel")}
+                {factionName("snide")}
               </span>
-              <InviteSearch
-                state={state}
-                skin={{
-                  fontFamily: "'Special Elite', serif",
-                  inputBg: surface,
-                  inputColor: ink,
-                  inputBorder: `2px dashed ${accentDeep}`,
-                  placeholder: state.duelMode
-                    ? t("editPraxis.snide.invitePlaceholderDuel")
-                    : t("editPraxis.snide.invitePlaceholder"),
-                  pillBg: lightBg,
-                  acceptedBg: accentDeep,
-                  acceptedColor: "var(--color-text-on-accent)",
+              <span
+                className="ep-pulse"
+                style={{
+                  flex: 1,
+                  height: 6,
+                  background: `repeating-linear-gradient(90deg, ${ACID} 0 6px, transparent 6px 10px)`,
+                  ...({ "--ep-pulse-dur": "3.6s" } as CSSProperties),
                 }}
               />
-            </div>
-          )}
-
-        {/* Metatasks */}
-        {state.showSealStack && (
-          <div
-            style={{
-              marginBottom: "var(--space-xl)",
-              padding: "var(--space-md) var(--space-lg)",
-              border: `2px dashed ${accentDeep}`,
-              background: lightBg,
-            }}
+              <span
+                style={punkLabel({
+                  color: PRESS_PAPER,
+                  letterSpacing: "0.2em",
+                  whiteSpace: "nowrap",
+                })}
+              >
+                {t("editPraxis.composer.statusDraft")}
+              </span>
+            </span>
+          </ComposerMasthead>
+        }
+        ground={
+          <ComposerGround
+            background={`repeating-linear-gradient(0deg, ${GRAIN} 0 1px, transparent 1px 3px)`}
+            /* Flush, not overhanging: the raster is printed on the sheet, and
+               only the tape is allowed to run off it. */
+            inset={0}
           >
             <span
-              className="eyebrow"
-              style={{ display: "block", marginBottom: "var(--space-sm)", color: accentDeep }}
+              className="snide-tape"
+              style={{
+                width: 110,
+                height: 26,
+                right: -26,
+                top: 64,
+                transform: "rotate(-38deg)",
+                opacity: 0.75,
+              }}
+            />
+            <span
+              className="snide-tape"
+              style={{
+                width: 96,
+                height: 22,
+                left: -30,
+                bottom: 96,
+                transform: "rotate(34deg)",
+                opacity: 0.6,
+              }}
+            />
+          </ComposerGround>
+        }
+      >
+        <ComposerStatusRow
+          status={t("editPraxis.composer.statusDraft")}
+          meta={
+            state.autosaveAt
+              ? t("editPraxis.composer.statusSaved", {
+                  ago: formatAutosave(state.autosaveAt),
+                })
+              : t("editPraxis.composer.statusUnsaved")
+          }
+          statusStyle={{ color: INK, fontWeight: 700, letterSpacing: "0.2em" }}
+          metaStyle={{ color: FAINT }}
+          mark={<SnideBlob width={52} height={40} struck />}
+        />
+
+        <TaskSlip
+          praxis={praxis}
+          task={task}
+          style={{
+            background: FIELD,
+            border: `1px solid ${RULE}`,
+            borderRadius: 0,
+            padding: "var(--space-lg)",
+          }}
+          labelStyle={{ color: MUTED }}
+          titleStyle={{
+            fontFamily: TITLE_FACE,
+            color: INK,
+            letterSpacing: "0.02em",
+          }}
+          descriptionStyle={{ color: MUTED }}
+          pillStyle={{ color: MUTED, borderRadius: 0 }}
+          mark={
+            <span
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: "var(--space-xs)",
+                flexShrink: 0,
+              }}
             >
-              {t("editPraxis.snide.metatasksLabel")}
+              <SnideBlob width={94} height={72}>
+                <span
+                  style={{
+                    position: "relative",
+                    fontFamily: TITLE_FACE,
+                    fontSize: "var(--text-title)",
+                    lineHeight: 1,
+                    color: PRESS_INK,
+                  }}
+                >
+                  {task?.point_value ?? 0}
+                </span>
+              </SnideBlob>
+              <span style={punkLabel({ color: ACID_INK, letterSpacing: "0.2em" })}>
+                {t("editPraxis.composer.pointsUnit")}
+              </span>
             </span>
-            <MetataskSealStack state={state} />
-          </div>
+          }
+        />
+
+        <ComposerSection
+          label={t("editPraxis.composer.titleLabel")}
+          htmlFor="composer-title"
+          rule={censorStripe}
+          meta={<TitleCounter length={state.title.length} color={FAINT} />}
+          labelStyle={{ color: MUTED }}
+        >
+          <TitleField
+            state={state}
+            skin={{
+              id: "composer-title",
+              placeholder: t("editPraxis.composer.titlePlaceholder"),
+              inputStyle: { ...fieldBox, fontFamily: TITLE_FACE },
+            }}
+          />
+        </ComposerSection>
+
+        {/* Hidden once the mode can no longer change — an unusable control is
+            not drawn disabled. */}
+        {!state.controlsLocked && (
+          <ComposerSection
+            label={t("editPraxis.composer.modeLabel")}
+            rule={censorStripe}
+            labelStyle={{ color: MUTED }}
+          >
+            <ModePicker
+              state={state}
+              skin={{
+                containerStyle: {
+                  display: "flex",
+                  gap: "var(--space-sm)",
+                  flexWrap: "wrap",
+                },
+                options: modeOptions,
+                allowedModes,
+                renderOption: (option, { active, disabled, onSelect }) => (
+                  <button
+                    key={option.key}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={onSelect}
+                    disabled={disabled && !active}
+                    style={punkLabel({
+                      cursor: disabled ? "not-allowed" : "pointer",
+                      padding: "var(--space-sm) var(--space-lg)",
+                      borderRadius: 0,
+                      background: active ? ACID : FIELD,
+                      color: active ? PRESS_INK : MUTED,
+                      border: `1px solid ${active ? ACID : RULE}`,
+                      fontWeight: active ? 700 : 400,
+                    })}
+                  >
+                    {option.label}
+                  </button>
+                ),
+              }}
+            />
+          </ComposerSection>
         )}
 
-        {/* Title — ransom note + editable input */}
-        <div
-          style={{
-            marginBottom: "var(--space-xl)",
-            padding: "var(--space-lg) var(--space-md)",
-            background: lightBg,
-            border: `2px dashed ${accentDeep}`,
-          }}
+        {/* The mode block: the collaborator roster, or the duel pair. */}
+        {state.showInviteBox && (
+          <ComposerSection
+            rule={censorStripe}
+            label={
+              state.duelMode
+                ? t("editPraxis.composer.opponentLabel")
+                : t("editPraxis.composer.collaboratorsLabel", {
+                    count: praxis.members.length,
+                  })
+            }
+            labelStyle={{ color: MUTED }}
+          >
+            <InviteSearch
+              state={state}
+              skin={{
+                fontFamily: BODY_FACE,
+                inputBg: FIELD,
+                inputColor: INK,
+                inputBorder: `1px solid ${RULE}`,
+                dropdownBg: SHEET,
+                dropdownBorder: `1px solid ${RULE}`,
+                acceptedBg: ACID,
+                acceptedColor: PRESS_INK,
+                placeholder: t("editPraxis.composer.invitePlaceholder"),
+                leaveStyle: { color: FAINT, fontFamily: BODY_FACE },
+              }}
+            />
+          </ComposerSection>
+        )}
+
+        {state.showSealStack && (
+          <ComposerSection
+            label={t("editPraxis.composer.sealsLabel")}
+            rule={censorStripe}
+            labelStyle={{ color: MUTED }}
+          >
+            <MetataskSealStack state={state} />
+          </ComposerSection>
+        )}
+
+        <ComposerSection
+          label={t("editPraxis.composer.writeUpLabel")}
+          htmlFor="composer-body"
+          rule={censorStripe}
+          labelStyle={{ color: MUTED }}
+          meta={
+            <WriteUpTabs
+              tab={tab}
+              setTab={setTab}
+              skin={{
+                containerStyle: { gap: "var(--space-xs)" },
+                buttonStyle: (active) =>
+                  punkLabel({
+                    padding: "var(--space-xs) var(--space-sm)",
+                    borderRadius: 0,
+                    border: `1px solid ${active ? RULE : "transparent"}`,
+                    background: active ? FIELD : "transparent",
+                    color: active ? INK : FAINT,
+                  }),
+              }}
+            />
+          }
+        >
+          {/* One panel at a time: a hidden textarea is still a tab stop and
+              still submits, and drawing both puts the body in the DOM twice. */}
+          {tab === "write" ? (
+            <>
+              <BodyTextarea
+                state={state}
+                skin={{
+                  id: "composer-body",
+                  rows: 8,
+                  placeholder: t("editPraxis.composer.bodyPlaceholder"),
+                  toolbarButtonStyle: {
+                    background: FIELD,
+                    color: INK,
+                    border: `1px solid ${RULE}`,
+                    borderRadius: 0,
+                  },
+                  textareaStyle: {
+                    ...fieldBox,
+                    resize: "vertical",
+                    minHeight: 180,
+                    lineHeight: 1.7,
+                    fontFamily: BODY_FACE,
+                  },
+                }}
+              />
+              <div
+                style={punkLabel({
+                  color: FAINT,
+                  marginTop: "var(--space-sm)",
+                  letterSpacing: "0.06em",
+                })}
+              >
+                {t("editPraxis.composer.wordCount", { words: state.wordCount })}
+              </div>
+            </>
+          ) : (
+            <BodyPreview
+              state={state}
+              skin={{
+                wrapperStyle: { ...fieldBox, minHeight: 180 },
+                markdownStyle: {
+                  fontFamily: BODY_FACE,
+                  lineHeight: 1.7,
+                  color: INK,
+                },
+                emptyState: (
+                  <p
+                    style={{
+                      fontFamily: BODY_FACE,
+                      fontSize: "var(--text-content)",
+                      color: FAINT,
+                      margin: 0,
+                    }}
+                  >
+                    {t("editPraxis.composer.bodyPlaceholder")}
+                  </p>
+                ),
+              }}
+            />
+          )}
+        </ComposerSection>
+
+        <ComposerSection
+          label={t("editPraxis.composer.proofLabel")}
+          rule={censorStripe}
+          labelStyle={{ color: MUTED }}
         >
           <div
             style={{
               display: "flex",
-              justifyContent: "space-between",
-              marginBottom: "var(--space-sm)",
+              gap: "var(--space-lg)",
+              alignItems: "center",
+              flexWrap: "wrap",
             }}
           >
-            <span className="eyebrow" style={{ color: accentDeep }}>
-              {t("editPraxis.snide.titleLabel")}
-            </span>
-            <TitleCounter length={state.title.length} color={accentDeep} />
-          </div>
-          <div style={{ minHeight: 60, lineHeight: 1.4, marginBottom: "var(--space-sm)" }}>
-            {state.title.split("").map((ch, index) => (
-              <RansomChar key={index} ch={ch} index={index} />
-            ))}
-            {!state.title && (
-              <span style={{ color: muted, fontStyle: "italic", fontSize: "var(--text-xl)" }}>
-                {t("editPraxis.snide.titleEmptyHint")}
-              </span>
+            {state.media.map((item) => {
+              const filename = item.file_path.split("/").pop() ?? item.file_path;
+              const src = mediaUrl(item.file_path);
+              return (
+                <MediaTile
+                  key={item.id}
+                  caption={filename}
+                  onRemove={() => void state.removeMedia(item)}
+                >
+                  {item.type === "image" ? (
+                    <img
+                      src={src}
+                      alt=""
+                      style={{ width: 120, height: 120, objectFit: "cover" }}
+                    />
+                  ) : item.type === "video" ? (
+                    <video
+                      src={src}
+                      style={{ width: 120, height: 120, objectFit: "cover" }}
+                    />
+                  ) : (
+                    <MediaArt
+                      art={pickArtKey(filename, "audio")}
+                      width={120}
+                      height={120}
+                    />
+                  )}
+                </MediaTile>
+              );
+            })}
+            {!state.controlsLocked && (
+              <FilePicker
+                state={state}
+                skin={{
+                  buttonStyle: punkLabel({
+                    cursor: "pointer",
+                    background: "transparent",
+                    border: `1px dashed ${RULE}`,
+                    borderRadius: 0,
+                    padding: "var(--space-lg) var(--space-xl)",
+                    color: MUTED,
+                  }),
+                  buttonLabel: t("editPraxis.composer.proofButton"),
+                  helperText: t("editPraxis.composer.proofHelper"),
+                  helperStyle: {
+                    fontFamily: BODY_FACE,
+                    fontSize: "var(--text-content)",
+                    color: FAINT,
+                    maxWidth: 260,
+                    lineHeight: 1.5,
+                    marginTop: "var(--space-sm)",
+                  },
+                }}
+              />
             )}
           </div>
-          <TitleField
-            state={state}
-            skin={{
-              placeholder: t("editPraxis.snide.titlePlaceholder"),
-              inputStyle: {
-                width: "100%",
-                fontFamily: "'Courier Prime', monospace",
-                padding: "var(--space-xs) var(--space-sm)",
-                background: surface,
-                color: ink,
-                border: `1.5px dashed ${accentDeep}`,
-                outline: "none",
-              },
-            }}
-          />
-          <RainbowUnderline opacity={0.5} />
-        </div>
-
-        {/* Body */}
-        <div style={{ marginBottom: "var(--space-xl)" }}>
-          <span
-            className="eyebrow"
-            style={{ display: "block", marginBottom: "var(--space-sm)", color: accentDeep }}
-          >
-            {t("editPraxis.snide.bodyLabel", { words: state.wordCount })}
-          </span>
-          <div style={{ position: "relative", transform: "rotate(0.3deg)" }}>
-            <BodyTextarea
-              state={state}
-              skin={{
-                rows: 12,
-                placeholder: t("editPraxis.snide.bodyPlaceholder"),
-                textareaStyle: {
-                  width: "100%",
-                  fontFamily: "'Special Elite', serif",
-                  lineHeight: 1.7,
-                  color: ink,
-                  background: surface,
-                  border: `2px solid ${accentDeep}`,
-                  padding: "var(--space-lg) var(--space-xl)",
-                  outline: "none",
-                  resize: "vertical",
-                  minHeight: 220,
-                  boxShadow: `4px 4px 0 ${accentDeep}`,
-                },
-              }}
-            />
-          </div>
-          <BodyPreview
-            state={state}
-            skin={{
-              wrapperStyle: {
-                marginTop: "var(--space-md)",
-                background: surface,
-                border: `2px solid ${accentDeep}`,
-                padding: "var(--space-lg) var(--space-xl)",
-                columnCount: 2,
-                columnGap: "var(--space-xl)",
-                columnRule: `0.5px solid ${accentDeep}`,
-                boxShadow: `4px 4px 0 ${accentDeep}`,
-              },
-              label: (
-                <span
-                  className="eyebrow"
-                  style={{ color: accentDeep, display: "block", marginBottom: "var(--space-xs)" }}
-                >
-                  {t("editPraxis.snide.previewLabel")}
-                </span>
-              ),
-              markdownStyle: {
-                fontFamily: "'Special Elite', serif",
-                lineHeight: 1.6,
-                color: ink,
-              },
-            }}
-          />
-        </div>
-
-        {/* Existing media */}
-        {state.media.length > 0 && (
-          <div style={{ marginBottom: "var(--space-xl)" }}>
-            <span
-              className="eyebrow"
-              style={{ display: "block", marginBottom: "var(--space-sm)", color: accentDeep }}
-            >
-              {t("editPraxis.snide.mediaOnPageLabel")}
-            </span>
-            <div style={{ display: "flex", gap: "var(--space-md)", flexWrap: "wrap" }}>
-              {state.media.map((item, index) => {
-                const src = mediaUrl(item.file_path);
-                const filename =
-                  item.file_path.split("/").pop() ?? item.file_path;
-                return (
-                  <div
-                    key={item.id}
-                    style={{
-                      position: "relative",
-                      border: `2px solid ${accentDeep}`,
-                      padding: "var(--space-xs)",
-                      background: surface,
-                      transform: `rotate(${index % 2 ? 2 : -2.4}deg)`,
-                      boxShadow: `2px 2px 0 ${accentDeep}`,
-                    }}
-                  >
-                    <div
-                      style={{
-                        width: 140,
-                        height: 100,
-                        overflow: "hidden",
-                        filter: "contrast(1.15) saturate(0.9)",
-                      }}
-                    >
-                      {item.type === "image" ? (
-                        <img
-                          src={src}
-                          alt=""
-                          style={{
-                            width: 140,
-                            height: 100,
-                            objectFit: "cover",
-                          }}
-                        />
-                      ) : item.type === "video" ? (
-                        <video
-                          src={src}
-                          style={{
-                            width: 140,
-                            height: 100,
-                            objectFit: "cover",
-                          }}
-                        />
-                      ) : (
-                        <MediaArt art={pickArtKey(filename, "audio")} />
-                      )}
-                    </div>
-                    <div
-                      style={{
-                        fontSize: "var(--text-sm)",
-                        marginTop: "var(--space-xs)",
-                        fontStyle: "italic",
-                        fontFamily: "'Special Elite', serif",
-                        color: accentDeep,
-                      }}
-                    >
-                      {t("editPraxis.snide.figureCaption", { number: index + 1, name: filename })}
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => void state.removeMedia(item)}
-                      aria-label={`Remove ${filename}`}
-                      style={{
-                        position: "absolute",
-                        top: -8,
-                        right: -8,
-                        width: 22,
-                        height: 22,
-                        background: lightBg,
-                        border: `2px solid ${ink}`,
-                        color: ink,
-                        fontSize: "var(--text-lg)",
-                        fontWeight: 700,
-                        cursor: "pointer",
-                        lineHeight: 1,
-                        padding: 0,
-                        borderRadius: "50%",
-                      }}
-                    >
-                      ×
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        )}
-
-        {/* New files */}
-        <div style={{ marginBottom: "var(--space-xl)" }}>
-          <span
-            className="eyebrow"
-            style={{ display: "block", marginBottom: "var(--space-sm)", color: accentDeep }}
-          >
-            {t("editPraxis.snide.filesLabel")}
-          </span>
-          <FilePicker
-            state={state}
-            skin={{
-              buttonStyle: {
-                background: accentDeep,
-                color: "var(--color-text-on-accent)",
-                fontFamily: "'Permanent Marker', cursive",
-                fontSize: "var(--text-xl)",
-                padding: "var(--space-sm) var(--space-lg)",
-                border: `2px solid ${accentDeep}`,
-                cursor: "pointer",
-                transform: "rotate(-1deg)",
-              },
-              buttonLabel: "+ paste it in",
-              helperText: "images · video · audio · max 50mb each",
-              helperStyle: {
-                fontSize: "var(--text-sm)",
-                color: muted,
-                marginTop: "var(--space-xs)",
-                fontStyle: "italic",
-              },
-            }}
-          />
-        </div>
+        </ComposerSection>
 
         <ErrorBanner message={state.error} />
 
-        {/* CTAs */}
-        <div
+        {/* [Cancel] … [Submit] — the global order from #646, stacked rather than
+            ranged because SNIDE's cast is a bar and not a button. The exits keep
+            the start, the cast keeps the end. */}
+        <ComposerFooter
           style={{
-            display: "flex",
+            flexDirection: "column",
+            alignItems: "stretch",
             gap: "var(--space-lg)",
-            alignItems: "center",
-            marginTop: "var(--space-xl)",
-            paddingTop: "var(--space-lg)",
-            borderTop: `2px dashed ${accentDeep}`,
-            flexWrap: "wrap",
           }}
-        >
-          <SaveDraftButton state={state} />
-          <DropButton
-            state={state}
-            skin={{
-              label: t("editPraxis.snide.dropLabel"),
-              style: {
-                background: "transparent",
-                color: muted,
-                fontFamily: "'Special Elite', serif",
-                fontSize: "var(--text-md)",
-                border: "none",
-                cursor: "pointer",
-                textDecoration: "underline",
-              },
-            }}
-          />
-          <div style={{ flex: 1 }} />
-          <PublishButton
-            state={state}
-            skin={{
-              idleLabel: t("editPraxis.snide.publishIdle"),
-              busyLabel: t("editPraxis.snide.publishBusy"),
-              ornament: (
-                <span
-                  aria-hidden
-                  style={{
-                    position: "absolute",
-                    inset: 4,
-                    border: `1.5px dashed rgba(255,255,255,.6)`,
-                    pointerEvents: "none",
-                  }}
-                />
-              ),
-              style: {
-                background: accent,
-                color: "var(--color-text-on-accent)",
-                fontFamily: "'Permanent Marker', cursive",
-                fontSize: "var(--text-title)",
-                padding: "var(--space-md) var(--space-xl)",
-                border: `3px solid ${accentDeep}`,
-                borderRadius: 0,
-                cursor: state.submitting ? "wait" : "pointer",
-                position: "relative",
-                transform: "rotate(-1.8deg)",
-                boxShadow: `4px 4px 0 ${ink}`,
-              },
-            }}
-          />
-        </div>
+          start={
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-lg)",
+                flexWrap: "wrap",
+              }}
+            >
+              <SaveDraftButton
+                state={state}
+                skin={{ style: { color: FAINT, fontFamily: BODY_FACE } }}
+              />
+              <DropButton
+                state={state}
+                skin={{
+                  style: punkLabel({
+                    background: "transparent",
+                    border: "none",
+                    padding: 0,
+                    color: FAINT,
+                    textDecoration: "underline",
+                    cursor: "pointer",
+                  }),
+                }}
+              />
+            </div>
+          }
+          end={
+            <PublishButton
+              state={state}
+              skin={{
+                idleLabel: t("editPraxis.composer.submit"),
+                busyLabel: t("editPraxis.composer.submitBusy"),
+                style: punkLabel({
+                  display: "block",
+                  width: "auto",
+                  /* The bleed: the sheet's own side padding, negated, so the bar
+                     reaches both edges of a padded column. */
+                  marginLeft: `calc(-1 * ${sidePad})`,
+                  marginRight: `calc(-1 * ${sidePad})`,
+                  padding: "var(--space-lg) var(--space-xl)",
+                  border: "none",
+                  borderRadius: 0,
+                  background: ACID,
+                  color: PRESS_INK,
+                  fontFamily: TITLE_FACE,
+                  /* A bar the width of the sheet set at the label tier reads as
+                     a rule rather than as the page's one irreversible action. */
+                  fontSize: "var(--text-content)",
+                  letterSpacing: "0.24em",
+                  cursor: state.submitting ? "wait" : "pointer",
+                }),
+              }}
+            />
+          }
+        />
+      </ComposerSheet>
+    </div>
+  );
+}
 
-        <div
-          style={{
-            marginTop: "var(--space-md)",
-            fontSize: "var(--text-base)",
-            color: muted,
-            fontFamily: "'Special Elite', serif",
-            fontStyle: "italic",
-          }}
-        >
-          {state.autosaveAt
-            ? t("editPraxis.snide.autosaveSaved", {
-                ago: formatAutosave(state.autosaveAt),
-              })
-            : t("editPraxis.snide.autosaveUnsaved")}
-        </div>
-      </div>
+interface MediaTileProps {
+  children: ReactNode;
+  caption: string;
+  onRemove: () => void;
+}
+
+/** One already-uploaded proof item, glued to the sheet square-cornered. */
+function MediaTile({ children, caption, onRemove }: MediaTileProps) {
+  const { t } = useTranslation("forms");
+  return (
+    <div
+      style={{
+        position: "relative",
+        background: FIELD,
+        border: `1px solid ${RULE}`,
+        borderRadius: 0,
+        overflow: "hidden",
+      }}
+    >
+      <div style={{ width: 120, height: 120, overflow: "hidden" }}>{children}</div>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label={t("media.removeAria", { name: caption })}
+        style={{
+          position: "absolute",
+          top: 4,
+          right: 4,
+          width: 22,
+          height: 22,
+          borderRadius: 0,
+          background: ACID,
+          border: "none",
+          color: PRESS_INK,
+          fontSize: "var(--text-md)",
+          fontWeight: 700,
+          cursor: "pointer",
+          lineHeight: 1,
+          padding: 0,
+        }}
+      >
+        ×
+      </button>
     </div>
   );
 }

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/snideComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/snideComposer.test.tsx
@@ -105,11 +105,21 @@ function render(formFactor: "mobile" | "desktop"): string {
 
 const WIDTHS = ["desktop", "mobile"] as const;
 
+/* Spelled out rather than built from a suffix: the catalog's key type is a
+ * literal union, so an interpolated key is not a key at all to tsc. */
+const NEUTRAL_KEYS = [
+  "forms:editPraxis.composer.taskLabel",
+  "forms:editPraxis.composer.titleLabel",
+  "forms:editPraxis.composer.writeUpLabel",
+  "forms:editPraxis.composer.proofLabel",
+  "forms:editPraxis.composer.submit",
+] as const;
+
 describe("SNIDE composer copy is the shared neutral set (ADR-0065 §3)", () => {
   it.each(WIDTHS)("reads the composer.* keys on %s", (width) => {
     const markup = render(width);
-    for (const key of ["taskLabel", "titleLabel", "writeUpLabel", "proofLabel", "submit"]) {
-      expect(markup).toContain(i18n.t(`forms:editPraxis.composer.${key}`));
+    for (const key of NEUTRAL_KEYS) {
+      expect(markup).toContain(i18n.t(key));
     }
   });
 

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/snideComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/snideComposer.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * S.N.I.D.E.'s composer dress (#1184, epic #1179, ADR-0065).
+ *
+ * The layout, the controls and the copy are shared and are proved once by
+ * `composerDispatch.test.tsx`. What is only true of THIS file is the dress, and
+ * three parts of it are claims a build can silently reverse:
+ *
+ *  1. **The copy went neutral.** The page block was deleted and the collab
+ *     override table was not — two halves of one edit that a later sweep could
+ *     take either too far or not far enough.
+ *  2. **radius 0 / borderW 0.** SNIDE is the only skin that draws no card border
+ *     at all, and both of those are overrides of a shared default, so an
+ *     inherited value is the failure mode rather than a missing one.
+ *  3. **The submit is a full-bleed bar.** It reaches the sheet's edges by
+ *     negating the sheet's own side padding, which is form-factor dependent —
+ *     the desktop rung on a phone would overhang by 16px.
+ *
+ * Plus the #1028 trap, asserted the way the task-detail epic learned to: the
+ * faction ground belongs to the column, so nothing here may reach for the
+ * viewport.
+ *
+ * renderToStaticMarkup, no DOM, matching the rest of this suite.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../../i18n";
+import i18n from "../../../../i18n";
+import type { EditPraxisState } from "../../useEditPraxis";
+import type { PraxisOut } from "../../../../api/praxis";
+import type { TaskOut } from "../../../../api/tasks";
+
+const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "mobile" | "desktop" }));
+
+vi.mock("../../../../hooks/useFormFactor", () => ({
+  useFormFactor: () => mocks.formFactor,
+}));
+
+// Imported after the mock is registered.
+import SnideEditPraxis from "../SnideEditPraxis";
+
+const task = {
+  id: 7,
+  title: "A Very Human Thing",
+  description: "Do a small honest thing.",
+  point_value: 20,
+  level_required: 1,
+  primary_faction_slug: "snide",
+  allowed_modes: ["solo", "collab", "duel"],
+} as unknown as TaskOut;
+
+const praxis = {
+  id: 55,
+  task_id: 7,
+  task_title: "A Very Human Thing",
+  task_faction_slug: "snide",
+  type: "solo",
+  status: "in_progress",
+  title: "I helped a stranger",
+  body_text: "Caught the papers.",
+  members: [],
+  invites: [],
+  media_items: [],
+} as unknown as PraxisOut;
+
+const state = {
+  praxis,
+  task,
+  error: "",
+  title: "I helped a stranger",
+  setTitle: () => {},
+  body: "Caught the papers.",
+  setBody: () => {},
+  wordCount: 3,
+  media: [],
+  fileError: "",
+  handleFileChange: () => {},
+  removeMedia: async () => {},
+  inviteQuery: "",
+  setInviteQuery: () => {},
+  inviteResults: [],
+  inviteOpen: false,
+  setInviteOpen: () => {},
+  submitting: false,
+  switchingMode: null,
+  autosaveAt: null,
+  isPublished: false,
+  controlsLocked: false,
+  modeIsLocked: false,
+  showInviteBox: false,
+  showSealStack: false,
+  duelMode: false,
+  duelChipVisible: true,
+  currentCharacterId: 3,
+} as unknown as EditPraxisState;
+
+function render(formFactor: "mobile" | "desktop"): string {
+  mocks.formFactor = formFactor;
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <SnideEditPraxis state={state} />
+    </MemoryRouter>,
+  );
+}
+
+const WIDTHS = ["desktop", "mobile"] as const;
+
+describe("SNIDE composer copy is the shared neutral set (ADR-0065 §3)", () => {
+  it.each(WIDTHS)("reads the composer.* keys on %s", (width) => {
+    const markup = render(width);
+    for (const key of ["taskLabel", "titleLabel", "writeUpLabel", "proofLabel", "submit"]) {
+      expect(markup).toContain(i18n.t(`forms:editPraxis.composer.${key}`));
+    }
+  });
+
+  it("deleted the faction's page copy", () => {
+    for (const key of ["masthead", "publishIdle", "titleLabel", "bodyLabel", "dropLabel"]) {
+      expect(i18n.exists(`forms:editPraxis.snide.${key}`)).toBe(false);
+    }
+  });
+
+  it("kept editPraxis.snide.collab — collabCopy's table, not page copy", () => {
+    // Also read by CollabRoster on /praxes/:id, a surface this epic is not
+    // touching. `collabCopy.test.ts` is the other half of this guard.
+    expect(i18n.exists("forms:editPraxis.snide.collab.castAction")).toBe(true);
+    expect(i18n.exists("forms:editPraxis.snide.collab.successHeading")).toBe(true);
+  });
+});
+
+describe("SNIDE's dress", () => {
+  it.each(WIDTHS)("draws no card border and no radius on %s", (width) => {
+    const markup = render(width);
+    expect(markup).toContain("border-radius:0");
+    // The shared sheet's own 10px radius, inherited instead of overridden.
+    expect(markup).not.toContain("border-radius:10px");
+    // The generic card edge every other skin outlines its sheet with.
+    expect(markup).not.toContain("--faction-snide-border");
+  });
+
+  it.each(WIDTHS)("paints on the composer's own token family on %s", (width) => {
+    const markup = render(width);
+    expect(markup).toContain("--faction-snide-composer-sheet");
+    expect(markup).toContain("--faction-snide-composer-grain");
+    // The clipping's family belongs to the praxis card, not to this surface.
+    expect(markup).not.toContain("--faction-snide-note-");
+  });
+
+  it("bleeds the submit bar to the sheet's edge at each width", () => {
+    expect(render("desktop")).toContain("margin-left:calc(-1 * var(--space-2xl))");
+    expect(render("mobile")).toContain("margin-left:calc(-1 * var(--space-lg))");
+  });
+
+  it.each(WIDTHS)("keeps its ground on the column, not the viewport on %s", (width) => {
+    // #1028: six of eight task-detail skins painted the faction ground
+    // full-bleed. `ComposerSheet` owns the clip; nothing here may opt out of it.
+    const markup = render(width);
+    expect(markup).not.toContain("100vh");
+    expect(markup).not.toContain("position:fixed");
+  });
+});


### PR DESCRIPTION
Rebuilds `SnideEditPraxis` to its v2 design over the shared composer layout
#1181 landed: one responsive component (`useComposerSizes()` internally, no
mobile twin), every region and every control from `shared.tsx` / `controls.tsx`,
and dress that is SNIDE's alone.

Closes #1184

## The dress, against the spec

| Spec | Built as |
| --- | --- |
| Anton (title) / Special Elite (body + label) | `--faction-snide-font-impact` / `-font-type` |
| radius 0, borderW 0 | the sheet overrides `ComposerSheet`'s 10px and carries no `border` at all |
| Masthead: bar token, wordmark in acid, flexing dashed acid rule, `DRAFT` | `ComposerMasthead` with `height: auto`; the wordmark is `factionName("snide")`, the rule flexes to fill and carries `ep-pulse` slowed to 3.6s |
| Ground: 0deg grain + two tape strips (110×26 right −26 / top 64 at −38°, .75; 96×22 left −30 / bottom 96 at 34°, .6) | `ComposerGround` at `inset: 0`, tape via the existing `.snide-tape` utility (it brings the torn edges) |
| Section rule: the censor stripe | a 10px solid redaction bar passed to every section's `rule` |
| Points mark: 94×72 blob at −5°, numeral over it, `PTS` in acid beneath | one SVG splat in `TaskSlip`'s `mark` slot |
| Status mark: the blob with a check struck through | the same splat at 52×40, check in press ink, strike in hot pink |
| Submit: full-bleed bar, acid ground, ink text | `ComposerFooter`'s own `style` seam — see below |

## The submit bar needed no new seam

The shared footer already expressed it. `ComposerFooter` takes `style`, so the
row becomes a stretched column (exits keep the start, the cast keeps the end —
#646 order intact), and `ComposerSheet`'s `contentStyle={{ paddingBottom: 0 }}`
plus a negated side-padding margin on the button lands the bar flush on the
sheet's edges at both widths. **No control was forked and no skin interface was
widened** — `controls.tsx` and `shared.tsx` are untouched by this PR.

## Colour: a new `--faction-snide-composer-*` family (9 tokens × 2 themes)

`index.css` is the one shared file this PR edits, in SNIDE's own block only.
The composer is a xerox sheet **flyposted**, so its stock flips with the theme —
and none of the existing families say that:

- `-card-*` is ink-dark in **both** themes by its own stated contract, which
  would put a near-black masthead bar on a near-black sheet.
- `-note-*` has the right values but is the **praxis card's clipping** — same
  numbers today, a different surface's contract tomorrow. Reading it here is
  the "tokenized-looking, not tokenized" failure.

So the sheet's tiers are declared (`sheet · ink · muted · faint · field · rule ·
bar · grain · acid-ink`), exactly as #1181 declared na's `field/faint/hair`
rather than borrowing the score plate. The theme-invariant press pigments
(`-acid`, `-ink`, `-paper`, `-pink`, `-tape`) are reused as-is: type printed on
an acid ground reads `#14110b` in **both** themes, because paper-white on acid
green is 1.2:1.

One ink is walked down from the design, the way the clipping walked its pink:
the `PTS` caption is drawn in acid, and acid is a poster colour — 1.35:1 on the
stock. It takes a deep acid in the light half, measured against the ground it
actually sits on (the task slip's **field**, not the sheet): 4.7:1 there, 5.2:1
on the stock. Acid stays bright everywhere it is a drawn thing.

**No `index.css` motion changes** — `ep-pulse` was already there, and it is
reached by class so the shared `prefers-reduced-motion` guard still applies.

## Copy

`editPraxis.snide.*` page keys deleted (30 lines); the archetype reads the
neutral `editPraxis.composer.*` set. **`editPraxis.snide.collab` kept** — that
is `collabCopy`'s override table, which also feeds `CollabRoster` on
`/praxes/:id`. A test pins both halves of that split.

## Two judgement calls worth a look

1. **`RingMark` is not used.** It is a ring with its middle punched out; SNIDE's
   design draws a hand-drawn blob. The shared *slots* (`TaskSlip.mark`,
   `ComposerStatusRow.mark`) are used, which is the seam that matters.
2. **`DRAFT` appears twice** — once in the masthead (ornament, `aria-hidden`)
   and once in the status row (the region the layout contract requires). A
   screen reader hears it once. If that reads as duplication on screen, the
   masthead word is the one to drop.

## What to eyeball

- **Light and dark, desktop and phone** — all four surfaces the design renders.
  The sheet inverts (xerox stock ↔ photocopier black); the masthead bar and the
  censor stripes must stay the darkest things on the page in **both**.
- The masthead: wordmark in acid, dashed rule filling the gap, stage word at the
  end, all on one line at 360px wide.
- The two tape strips running **off** the sheet's edges and clipped there — and
  the site background still showing around the column (#1028).
- The censor stripes as section rules: heavy redaction bars, not hairlines.
- The submit bar reaching both edges at both widths (this is the negated-padding
  trick; a padding change in `useComposerSizes` would leave a gap).
- The points blob: numeral legible on acid, `PTS` legible on the field beneath.
- Anton in the title input and the task title; Special Elite everywhere else.

## Verification

`tsc --noEmit` clean · `eslint .` clean · `vite build` clean · **full** vitest
suite 2277 passed / 133 files (11 of them new here). Rebased onto `origin/main`
after #1211 and re-run green.

**Visual QA is outstanding.** There is no dev stack in this worktree and the
Browser pane renderer times out, so nothing in this PR has been looked at — the
"what to eyeball" list above is the whole of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
