### PR TITLE
Edit praxis v2 — Cozy Coven: the candlelit spell slip replaces the wow.exe window

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4048,11 +4048,31 @@
   --faction-coven-ward-hold-to: #d9a521;
   --faction-coven-ward-hold-ink: #5c3a06;
   --faction-coven-ward-hold-border: #c08d14;
+
+  /* ── The composer's cast band (#1188) ──
+     The edit-praxis submit bar runs pink while you are still composing and
+     flips GREEN once your part is in. The green had to be its own pair rather
+     than `--color-success` or `--faction-coven-card-credit`: both of those are
+     INKS measured as text on a sheet, and reading an ink as a fill is the "var()
+     at the wrong tier" failure — it passes every lint gate and still ends up
+     with a colour nobody measured for the job it is doing.
+     Polarity follows --faction-coven-slip-cta-*: a dark band under white by day,
+     a bright band under near-black by night. Measured against
+     --faction-coven-cast-ink at BOTH gradient stops (the lower stop is the
+     tighter reading in light, the upper in dark):
+       light  #ffffff on #2f7d4f  5.04:1  ·  on #1c5a37  7.4:1
+       dark   #14110b on #4ade80 10.69:1  ·  on #22c55e  8.27:1 */
+  --faction-coven-cast-from: #2f7d4f;
+  --faction-coven-cast-to: #1c5a37;
+  --faction-coven-cast-ink: #ffffff;
 }
 [data-theme="dark"] {
   --faction-coven-ward-page: #1d0a15;
   --faction-coven-ward-card: #2a0f1e;
   --faction-coven-ward-hair: rgba(249, 168, 212, 0.2);
+  --faction-coven-cast-from: #4ade80;
+  --faction-coven-cast-to: #22c55e;
+  --faction-coven-cast-ink: #14110b;
   /* The night slip carries more candle, exactly as the design's own dark half
      does (.5 → .7 there; both walked down here for the contrast floor above). */
   --faction-coven-ward-haze: 0.28;

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -542,33 +542,7 @@
         "successHeading": "The circle is closed",
         "successBody": "Every part is cast. It's out in the world now.",
         "successContinue": "See where it landed"
-      },
-      "windowTitle": "wow.exe — edit praxis",
-      "pageTitle": "edit praxis",
-      "taskRefLabel": "re: completion of",
-      "modeLabel": "how are you walking?",
-      "mode": {
-        "solo": { "label": "solo", "desc": "one set of footprints" },
-        "collab": { "label": "w/ friends", "desc": "in step with others" },
-        "duel": { "label": "witch duel", "desc": "two paths, one prize" }
-      },
-      "inviteLabel": "↳ walking together",
-      "inviteLabelDuel": "↳ racing",
-      "invitePlaceholder": "@ invite another walker…",
-      "titleLabel": "title · what whimsy arose?",
-      "titlePlaceholder": "What whimsy arose?",
-      "autosaveSaved": "saved {{ago}}",
-      "autosaveUnsaved": "unsaved",
-      "bodyLabel": "field notes · {{words}} words · markdown ok",
-      "bodyPlaceholder": "Tonight I walked...",
-      "previewLabel": "preview",
-      "filesLabel": "scraps & specimens · {{pasted}} pasted",
-      "fileButton": "+ paste in a scrap",
-      "fileHelper": "images · video · audio · max 50mb each",
-      "metatasksLabel": "★ optional bonus",
-      "publishIdle": "cast it into the world",
-      "publishBusy": "casting...",
-      "dropLabel": "let it go"
+      }
     },
     "wow": {
       "pageTitle": "The Squire's Writ",

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -123,7 +123,6 @@ const DEEP = "var(--faction-coven-slip-deep)"; /* the design's accentDeep */
 const PINK = "var(--faction-coven-slip-pk)"; /* the design's accent */
 const GOLD = "var(--faction-coven-slip-gold)";
 const BORDER = "var(--faction-coven-slip-border)";
-const HAIR = "var(--faction-coven-ward-hair)";
 const CTA_INK = "var(--faction-coven-slip-cta-ink)";
 const CTA_BAND =
   "linear-gradient(180deg, var(--faction-coven-slip-cta-from), var(--faction-coven-slip-cta-to))";
@@ -374,25 +373,35 @@ function PointsWard({ size, points }: { size: number; points: number }) {
         </g>
       </svg>
       {WARD_STARS.map(([x, y, delay]) => (
+        // Two nodes, not one: the outer span is CENTRED on the point by
+        // transform (a negative half-pixel margin would be spacing wearing
+        // ornament's clothes, and the ratchet's Literal-only check waves a
+        // unary minus through), and `epTwinkle` animates `transform` — so the
+        // keyframe would overwrite that centring if they shared an element.
         <span
           key={`${x}-${y}`}
           aria-hidden
-          className="ep-twinkle"
-          style={
-            {
-              position: "absolute",
-              left: `${x}%`,
-              top: `${y}%`,
-              width: 7,
-              height: 7,
-              marginLeft: -3.5,
-              marginTop: -3.5,
-              borderRadius: "50%",
-              background: GOLD,
-              "--ep-delay": delay,
-            } as CSSProperties
-          }
-        />
+          style={{
+            position: "absolute",
+            left: `${x}%`,
+            top: `${y}%`,
+            transform: "translate(-50%, -50%)",
+          }}
+        >
+          <span
+            className="ep-twinkle"
+            style={
+              {
+                display: "block",
+                width: 7,
+                height: 7,
+                borderRadius: "50%",
+                background: GOLD,
+                "--ep-delay": delay,
+              } as CSSProperties
+            }
+          />
+        </span>
       ))}
       <span
         style={{

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -1,27 +1,90 @@
 /**
- * Cozy Coven's faction edit-praxis form — the `wow.exe` window.
+ * Cozy Coven — THE CANDLELIT SPELL SLIP, as a composer (edit praxis v2, #1188,
+ * epic #1179; design project c491945e, `Coven Edit Praxis.dc.html`,
+ * `faction="coven"`).
  *
- * The WINDOW TITLE really is the literal string `wow.exe`: this skin predates
- * #784, which split Coven off Warriors of Whimsy and handed it the pink
- * computer-witch identity, chrome string included. The FACTION is `coven`; only
- * the drawn window caption still says wow. Do not read that label as a slug —
- * ADR-0050.
+ * The shared composer layout (`shared.tsx`) wearing Coven's dress: a centred
+ * masthead of a turning pentacle disc under a twinkle field, a glow-and-lavender
+ * ground carrying the coven wheel and a scatter of arcane glyphs, braided thread
+ * for every section rule, an 88px haloed ward for the points, a 40px pentacle
+ * for the stage mark, and a full-bleed band for the cast.
  *
- * Lo-fi computer-witch desktop window: pastel pink chrome, dotted grid body,
- * notepad panels, window-tab mode chips, lo-fi pink buttons, ivy + sticker charms.
+ * ## This REPLACES the `wow.exe` window wholesale
+ *
+ * The file this one replaces drew a literal desktop-window caption reading
+ * `wow.exe` — a chrome string left over from before #784 split Coven off
+ * Warriors of Whimsy (ADR-0050). It was never a slug and never a dispatch bug;
+ * the window metaphor was simply the old design, and #1023 / #1031 had already
+ * retired it on the task card and the task detail page. The composer is the last
+ * surface still carrying it, so the whole metaphor goes, caption included.
+ *
+ * ## Copy is neutral (ADR-0065 §3)
+ *
+ * Every word comes from the shared `editPraxis.composer.*` set — the same
+ * strings an unaffiliated player reads. Coven's own composer vocabulary
+ * (`windowTitle`, `pageTitle` "edit praxis", `modeLabel` "how are you walking?",
+ * `bodyLabel` "field notes", `publishIdle` "cast it into the world", …) is
+ * deleted with this issue. `editPraxis.coven.collab` STAYS: that block is
+ * `collabCopy`'s override table, a different resolver, and it also feeds
+ * `CollabRoster` on the read page — deleting it would restyle a surface this
+ * epic is not touching.
+ *
+ * The one word this page draws that is not from the neutral set is the
+ * MASTHEAD WORDMARK, and it is not composer copy: it is Coven's own wordmark,
+ * already owned by `feed:taskCard.coven.masthead` for the v2 task card. Read
+ * from there rather than re-keyed here, so the coven is lettered identically on
+ * both surfaces and this page introduces no faction copy of its own.
+ *
+ * ## One responsive component, no mobile twin (ADR-0065 §2)
+ *
+ * `useComposerSizes()` picks the size set; there is one tree at two widths and
+ * no fixed-px grid anywhere below (SPEC-faction-ui-profile §1a). The
+ * `mobileEditPraxis` twin and its manifest surface were retired in #1181.
+ *
+ * ## Colour and motion
+ *
+ * All colour via `--faction-coven-slip-*` (shared with the v2 task card and task
+ * detail) plus `--faction-coven-ward-*` for the sheet and its fields, and the
+ * three `--faction-coven-cast-*` tokens this issue adds for the band's
+ * submitted state. Light/dark flips entirely through the `[data-theme="dark"]`
+ * cascade — there is no `dark ? a : b` anywhere in this file.
+ *
+ * Motion is reached by CLASS only: `.ep-spin` (the masthead disc at 42s, the
+ * ward's spokes at 30s, both re-timed through `--ep-spin-dur`), `.ep-twinkle`
+ * (the ward's five stars, staggered through `--ep-delay`) and `.cvn-wheel` (the
+ * ground's pentagram, Coven's own 120s turn). Every keyframe already lives in
+ * `index.css` behind the shared `prefers-reduced-motion` guard; an inline
+ * `animation:` would bypass that guard (#1003).
+ *
+ * ## Not drawn as designed
+ *
+ * No forfeit at the awaiting stage and no duel clock: #1071 decisions 3 and 4
+ * (unsubmitting before a duel settles is a free neutral reopen, and no expiry
+ * field exists to read). The awaiting stage itself belongs to
+ * `PraxisWaitingSurface` and to #1189.
  */
+import { useState, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
-import { factionCssVar } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
 import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
+  ComposerFooter,
+  ComposerGround,
+  ComposerMasthead,
+  ComposerRule,
+  ComposerSection,
+  ComposerSheet,
+  ComposerStatusRow,
   ErrorBanner,
-  TaskMetaInline,
+  RingMark,
+  TaskSlip,
   TitleCounter,
+  composerLabelStyle,
   formatAutosave,
+  useComposerSizes,
 } from "./shared";
 import {
   BodyPreview,
@@ -33,6 +96,8 @@ import {
   PublishButton,
   SaveDraftButton,
   TitleField,
+  WriteUpTabs,
+  type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
 import type { EditPraxisState } from "../useEditPraxis";
@@ -41,796 +106,886 @@ interface Props {
   state: EditPraxisState;
 }
 
-/* ───────── sticker + ivy atoms (inlined from the redesign kit) ───────── */
+/* The two faces the design names. Both are SURFACE faces on shared
+ * `--font-faction-*` tokens rather than Coven's `card-font` (still Caveat), for
+ * the reason WORLD_ZERO_STYLE §4 gives: repointing a faction's card-font to
+ * satisfy one design restyles a dozen other surfaces. */
+const DISPLAY = "var(--font-faction-witch)"; /* Grenze Gotisch — title */
+const CHROME = "var(--font-faction-rounded)"; /* Quicksand — body + label */
 
-function Sparkle({
-  size = 16,
+/* The slip's pigments, named for the ROLE each plays in the design's skin row. */
+const SHEET = "var(--faction-coven-ward-card)";
+const FIELD = "var(--faction-coven-ward-page)";
+const INK = "var(--faction-coven-slip-ink)";
+const SOFT = "var(--faction-coven-slip-soft)";
+const LABEL = "var(--faction-coven-slip-label)";
+const DEEP = "var(--faction-coven-slip-deep)"; /* the design's accentDeep */
+const PINK = "var(--faction-coven-slip-pk)"; /* the design's accent */
+const GOLD = "var(--faction-coven-slip-gold)";
+const BORDER = "var(--faction-coven-slip-border)";
+const HAIR = "var(--faction-coven-ward-hair)";
+const CTA_INK = "var(--faction-coven-slip-cta-ink)";
+const CTA_BAND =
+  "linear-gradient(180deg, var(--faction-coven-slip-cta-from), var(--faction-coven-slip-cta-to))";
+/** Once your part is in, the band goes green. Polarity matches the cast ink. */
+const CAST_BAND =
+  "linear-gradient(180deg, var(--faction-coven-cast-from), var(--faction-coven-cast-to))";
+const CAST_INK = "var(--faction-coven-cast-ink)";
+
+/** The skin's geometry: radius 14, borders 1.5, and the border takes gold. */
+const RADIUS = 14;
+const FIELD_RADIUS = 10;
+const EDGE = `1.5px solid ${GOLD}`;
+const RULE = `1.5px solid ${BORDER}`;
+
+/** A four-point star, centred on (x, y) with arm length r. */
+function starPath(x: number, y: number, r: number): string {
+  const long = r * 2.6;
+  return `M${x} ${y - long} l${r} ${long} ${long} ${r} -${long} ${r} -${r} ${long} -${r} -${long} -${long} -${r} ${long} -${r} z`;
+}
+
+/** The braided thread rule. `.cvn-braid` owns the strands' pigments (index.css). */
+function Braid({ style }: { style?: CSSProperties }) {
+  return (
+    <span aria-hidden className="cvn-braid" style={{ minWidth: 20, ...style }} />
+  );
+}
+
+/**
+ * The coven's pentagram, alone. The status mark IS this at 40px in accentDeep;
+ * the masthead badge is this inside a disc.
+ */
+function Pentacle({
+  size,
   color,
-  style,
+  strokeWidth = 1.5,
+  opacity,
 }: {
-  size?: number;
+  size: number;
   color: string;
-  style?: React.CSSProperties;
+  strokeWidth?: number;
+  opacity?: number;
 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" style={style}>
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 44 44"
+      aria-hidden="true"
+      style={{ display: "block", flex: "0 0 auto" }}
+    >
       <path
-        d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z"
-        fill={color}
+        d="M22 8 L30.2 33.3 L8.7 17.7 L35.3 17.7 L13.8 33.3 Z"
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinejoin="round"
+        opacity={opacity}
       />
     </svg>
   );
 }
 
-function Heart({
-  size = 34,
-  style,
-}: {
-  size?: number;
-  style?: React.CSSProperties;
-}) {
+/**
+ * The masthead badge: accent field, a dashed gold ring, the pentagram in
+ * accentDeep and a gold centre — turning once every 42 seconds. `.ep-spin` owns
+ * the motion and its reduced-motion guard; `--ep-spin-dur` re-times it without
+ * a second keyframe.
+ */
+function SigilDisc({ size }: { size: number }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 36 36" style={style}>
+    <svg
+      className="ep-spin"
+      width={size}
+      height={size}
+      viewBox="0 0 44 44"
+      aria-hidden="true"
+      style={
+        {
+          display: "block",
+          flex: "0 0 auto",
+          "--ep-spin-dur": "42s",
+        } as CSSProperties
+      }
+    >
+      <circle cx="22" cy="22" r="19" fill={PINK} opacity="0.18" />
+      <circle
+        cx="22"
+        cy="22"
+        r="15"
+        fill="none"
+        stroke={GOLD}
+        strokeWidth="1"
+        strokeDasharray="2 4"
+      />
       <path
-        d="M18 31C7 23 3 17 6.5 11 9 6.8 14 6.5 16 10c.9 1.5 1.6 2.7 2 3.4.4-.7 1.1-1.9 2-3.4 2-3.5 7-3.2 9.5 1C33 17 29 23 18 31Z"
-        fill="#fb7aa8"
-        stroke="#fff"
-        strokeWidth="2.4"
+        d="M22 8 L30.2 33.3 L8.7 17.7 L35.3 17.7 L13.8 33.3 Z"
+        fill="none"
+        stroke={DEEP}
+        strokeWidth="1.5"
         strokeLinejoin="round"
       />
+      <circle cx="22" cy="22" r="3" fill={GOLD} />
     </svg>
   );
 }
 
-function StarSticker({
-  size = 26,
-  color = "#f6c75e",
-  style,
-}: {
-  size?: number;
-  color?: string;
-  style?: React.CSSProperties;
-}) {
+/** Gold twinkles behind the masthead row, stretched across the band. */
+function TwinkleField() {
+  const stars: [number, number, number][] = [
+    [34, 22, 2.4],
+    [118, 52, 1.4],
+    [206, 18, 1.8],
+    [292, 46, 2],
+    [366, 24, 1.4],
+    [452, 50, 1.7],
+  ];
   return (
-    <svg width={size} height={size} viewBox="0 0 28 28" style={style}>
-      <path
-        d="M14 2l3 7.3L24.5 10l-5.5 4.6L20.7 23 14 18.6 7.3 23l1.7-8.4L3.5 10 11 9.3Z"
-        fill={color}
-        stroke="#fff"
-        strokeWidth="2"
-        strokeLinejoin="round"
-      />
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 480 72"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        inset: 0,
+        zIndex: 0,
+        pointerEvents: "none",
+      }}
+    >
+      {stars.map(([x, y, r]) => (
+        <path
+          key={`${x}-${y}`}
+          d={starPath(x, y, r)}
+          fill={GOLD}
+          opacity={0.75}
+        />
+      ))}
     </svg>
   );
 }
 
-function IvyLeaf({
-  x,
-  y,
-  rot,
-  scale,
-  c,
-  leaf,
-}: {
-  x: number;
-  y: number;
-  rot: number;
-  scale: number;
-  c: string;
-  leaf: string;
-}) {
+/**
+ * The ground's scatter of arcane marks. Positioned in percentages so it reflows
+ * with the column instead of pinning to a canvas width — the same reason the
+ * layout carries no fixed-px grid.
+ */
+const GLYPHS: { left: string; top: string; size: number; turn: number }[] = [
+  { left: "8%", top: "14%", size: 15, turn: -12 },
+  { left: "78%", top: "9%", size: 11, turn: 18 },
+  { left: "26%", top: "38%", size: 9, turn: 6 },
+  { left: "91%", top: "44%", size: 14, turn: -24 },
+  { left: "14%", top: "63%", size: 12, turn: 15 },
+  { left: "64%", top: "72%", size: 10, turn: -8 },
+  { left: "38%", top: "88%", size: 13, turn: 22 },
+  { left: "86%", top: "82%", size: 9, turn: -16 },
+];
+
+function GlyphScatter() {
   return (
-    <g transform={`translate(${x} ${y}) rotate(${rot}) scale(${scale})`}>
-      <path
-        d="M0 0 C -9 -3 -11 -13 -6 -20 C -2 -25 2 -25 6 -20 C 11 -13 9 -3 0 0 Z"
-        fill={leaf}
-        stroke={c}
-        strokeWidth="1.1"
-      />
-      <path d="M0 -1 L0 -19" stroke={c} strokeWidth="1" opacity="0.55" />
-      <path
-        d="M0 -8 L-4 -12 M0 -8 L4 -12"
-        stroke={c}
-        strokeWidth="0.8"
-        opacity="0.45"
-        fill="none"
-      />
-    </g>
+    <>
+      {GLYPHS.map((glyph) => (
+        <span
+          key={`${glyph.left}-${glyph.top}`}
+          aria-hidden
+          style={{
+            position: "absolute",
+            left: glyph.left,
+            top: glyph.top,
+            transform: `rotate(${glyph.turn}deg)`,
+            opacity: 0.22,
+          }}
+        >
+          <Pentacle size={glyph.size} color={DEEP} strokeWidth={1.1} />
+        </span>
+      ))}
+    </>
   );
 }
 
-function Ivy({
-  height = 250,
-  c,
-  leaf,
-}: {
-  height?: number;
-  c: string;
-  leaf: string;
-}) {
-  const width = 76;
-  const segments = 60;
-  const xAt = (t: number) => 40 + 20 * Math.sin(t * Math.PI * 2.3);
-  const yAt = (t: number) => 6 + t * (height - 12);
-  let path = "";
-  for (let i = 0; i <= segments; i++) {
-    const t = i / segments;
-    path +=
-      (i === 0 ? "M" : "L") + xAt(t).toFixed(1) + " " + yAt(t).toFixed(1) + " ";
-  }
-  const leafTs = [0.07, 0.17, 0.28, 0.39, 0.5, 0.61, 0.72, 0.83, 0.93];
+/**
+ * The points, held in a glowing ward: a halo in accent, an accent ring, four
+ * gold spokes turning once every 30 seconds, and five gold stars twinkling out
+ * of step with each other.
+ *
+ * Built on `RingMark` — the shared geometry the layout contract offers for both
+ * marks — with the punch-out collapsed (`inset={0}`, transparent centre) because
+ * Coven's ward is a drawn sigil rather than a ring with a hole in it. The size,
+ * the centring and the content slot are still the shared ones.
+ *
+ * The stars are HTML spans rather than SVG nodes on purpose: `epTwinkle`
+ * animates `transform: scale()`, and on an SVG child that scales about the
+ * viewBox origin instead of the star, which throws them across the disc.
+ */
+const WARD_STARS: [number, number, string][] = [
+  [50, 4, "0s"],
+  [88, 26, "0.3s"],
+  [14, 74, "0.6s"],
+  [84, 78, "0.9s"],
+  [16, 24, "1.2s"],
+];
+
+function PointsWard({ size, points }: { size: number; points: number }) {
   return (
-    <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
-      <path
-        d={path}
-        fill="none"
-        stroke={c}
-        strokeWidth="2.6"
-        strokeLinecap="round"
-      />
-      <path
-        d={`M${xAt(0.02)} ${yAt(0.02)} q -10 -6 -4 -13 q 4 -4 8 0`}
-        fill="none"
-        stroke={c}
-        strokeWidth="1.8"
-        strokeLinecap="round"
-      />
-      {leafTs.map((t, i) => {
-        const side = i % 2 === 0 ? 1 : -1;
-        return (
-          <IvyLeaf
-            key={i}
-            x={xAt(t) + side * 7}
-            y={yAt(t)}
-            rot={side > 0 ? 38 : -38}
-            scale={i % 3 === 0 ? 1.15 : 0.95}
-            c={c}
-            leaf={leaf}
-          />
-        );
-      })}
-    </svg>
+    <RingMark
+      size={size}
+      inset={0}
+      ring="var(--faction-coven-slip-sigil-halo)"
+      inner="transparent"
+    >
+      {/* The still layer: the accent ring the numeral sits inside. */}
+      <svg
+        viewBox="0 0 100 100"
+        aria-hidden="true"
+        style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
+      >
+        <circle
+          cx="50"
+          cy="50"
+          r="32"
+          fill="none"
+          stroke={PINK}
+          strokeWidth="1.8"
+          opacity="0.9"
+        />
+      </svg>
+      {/* The turning layer: four gold spokes outside the ring. */}
+      <svg
+        className="ep-spin"
+        viewBox="0 0 100 100"
+        aria-hidden="true"
+        style={
+          {
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            transformOrigin: "50% 50%",
+            "--ep-spin-dur": "30s",
+          } as CSSProperties
+        }
+      >
+        <g stroke={GOLD} strokeWidth="1.4" strokeLinecap="round" opacity="0.85">
+          <path d="M50 50 L74.7 25.3" />
+          <path d="M50 50 L74.7 74.7" />
+          <path d="M50 50 L25.3 74.7" />
+          <path d="M50 50 L25.3 25.3" />
+        </g>
+      </svg>
+      {WARD_STARS.map(([x, y, delay]) => (
+        <span
+          key={`${x}-${y}`}
+          aria-hidden
+          className="ep-twinkle"
+          style={
+            {
+              position: "absolute",
+              left: `${x}%`,
+              top: `${y}%`,
+              width: 7,
+              height: 7,
+              marginLeft: -3.5,
+              marginTop: -3.5,
+              borderRadius: "50%",
+              background: GOLD,
+              "--ep-delay": delay,
+            } as CSSProperties
+          }
+        />
+      ))}
+      <span
+        style={{
+          position: "relative",
+          fontFamily: DISPLAY,
+          fontSize: "var(--text-title)",
+          lineHeight: 1,
+          color: DEEP,
+        }}
+      >
+        {points}
+      </span>
+    </RingMark>
   );
 }
 
 export default function CovenEditPraxis({ state }: Props) {
   const { t } = useTranslation("forms");
+  /* The wordmark is Coven's own, already lettered for the v2 task card. Read
+     from `feed` rather than re-keyed under `editPraxis.coven`, which this issue
+     deletes — the composer introduces no faction copy of its own. */
+  const { t: tFeed } = useTranslation("feed");
+  const sizes = useComposerSizes();
+  const [tab, setTab] = useState<ComposerTab>("write");
   const praxis = state.praxis!;
   const task = state.task;
 
-  const modeOptions: Array<{ key: PraxisType; label: string; desc: string }> = (
-    ["solo", "collab", "duel"] as const
-  ).map((key) => ({
-    key,
-    label: t(`editPraxis.coven.mode.${key}.label`),
-    desc: t(`editPraxis.coven.mode.${key}.desc`),
-  }));
-
-  const pink = factionCssVar("coven");
-  const pinkDeep = factionCssVar("coven", "card-accent");
-  const ink = factionCssVar("coven", "card-text");
-  const muted = factionCssVar("coven", "card-muted");
-  const lightBg = factionCssVar("coven", "light");
-  const cardFont = factionCssVar("coven", "card-font");
-
-  const winBorder = factionCssVar("coven", "win-border");
-  const titleFrom = factionCssVar("coven", "title-from");
-  const titleTo = factionCssVar("coven", "title-to");
-  const titleText = factionCssVar("coven", "title-text");
-  const bodyBg = factionCssVar("coven", "body-bg");
-  const notepadBg = factionCssVar("coven", "notepad-bg");
-  const notepadBorder = factionCssVar("coven", "notepad-border");
-  const dot = factionCssVar("coven", "dot");
-  const ivy = factionCssVar("coven", "ivy");
-  const ivyLeaf = factionCssVar("coven", "ivy-leaf");
-
   const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
+  const modeOptions: Array<{ key: PraxisType; label: string }> = [
+    { key: "solo", label: t("editPraxis.composer.modeSolo") },
+    { key: "collab", label: t("editPraxis.composer.modeCollab") },
+    { key: "duel", label: t("editPraxis.composer.modeDuel") },
+  ];
 
-  const eyebrowStyle: React.CSSProperties = {
-    display: "block",
-    fontFamily: "var(--font-body)",
-    fontSize: "var(--text-sm)",
-    textTransform: "uppercase",
-    letterSpacing: "0.18em",
-    color: pinkDeep,
-  };
+  /* The sheet's own inset, declared here rather than inherited, so the submit
+     band's full bleed is arithmetic the reader can check against one place.
+     Same values `useComposerSizes` would have given. */
+  const padX = sizes.isMobile ? "var(--space-lg)" : "var(--space-2xl)";
+  const padTop = sizes.isMobile ? "var(--space-lg)" : "var(--space-xl)";
+  const padBottom = sizes.isMobile ? "var(--space-xl)" : "var(--space-2xl)";
 
-  const notepadPanel: React.CSSProperties = {
-    background: notepadBg,
-    border: `1.5px solid ${notepadBorder}`,
-    borderRadius: 8,
-    padding: "var(--space-md) var(--space-lg)",
-    position: "relative",
-    zIndex: 9,
-  };
+  /* Cast, not merely composing: a duel side that has sealed, or a collab member
+     whose part is in. The band goes green for both — the only two states where
+     the footer still draws a button after publishing (`PublishButton`). */
+  const hasCast =
+    state.isPublished ||
+    praxis.members.some(
+      (member) =>
+        member.character_id === state.currentCharacterId && member.has_submitted,
+    );
+
+  const labelStyle: CSSProperties = { fontFamily: CHROME, color: LABEL };
+  const fieldBox = {
+    width: "100%",
+    background: FIELD,
+    color: INK,
+    border: RULE,
+    borderRadius: FIELD_RADIUS,
+    padding: "var(--space-md)",
+    outline: "none",
+    boxSizing: "border-box",
+  } as const;
+  /* Every section is headed by the braid. */
+  const braidRule = (
+    <ComposerRule>
+      <Braid />
+    </ComposerRule>
+  );
 
   return (
-    <div
-      style={
-        {
-          fontFamily: "var(--font-body)",
-          color: ink,
-          padding: "var(--space-2xl) var(--space-lg) var(--space-5xl)",
-          minHeight: "100vh",
-          background: lightBg,
-        } as React.CSSProperties
-      }
-    >
-      <div style={{ maxWidth: 760, margin: "0 auto", position: "relative" }}>
-        {/* ivy down the left edge, behind the window */}
-        <div
-          aria-hidden
-          style={{
-            position: "absolute",
-            left: -54,
-            top: 70,
-            zIndex: 0,
-            pointerEvents: "none",
-          }}
-        >
-          <Ivy height={420} c={ivy} leaf={ivyLeaf} />
-        </div>
-
+    <div style={{ fontFamily: CHROME, color: INK }}>
+      <div
+        style={{
+          maxWidth: sizes.maxWidth,
+          margin: "0 auto",
+          padding: "var(--space-lg) var(--space-lg) 0",
+        }}
+      >
         <Breadcrumb
           praxisId={praxis.id}
           taskId={praxis.task_id}
           taskTitle={praxis.task_title}
-          inkColor={muted}
+          inkColor={LABEL}
         />
+      </div>
 
-        {/* ── the .exe window ── */}
-        <div
-          style={{
-            position: "relative",
-            zIndex: 5,
-            borderRadius: 12,
-            overflow: "hidden",
-            border: `2px solid ${winBorder}`,
-            boxShadow: "0 12px 30px rgba(190,60,120,.22)",
-          }}
-        >
-          {/* title bar */}
-          <div
+      <ComposerSheet
+        sizes={sizes}
+        style={{
+          background: SHEET,
+          border: EDGE,
+          borderRadius: RADIUS,
+          boxShadow: "var(--faction-coven-slip-shadow)",
+        }}
+        contentStyle={{ padding: `${padTop} ${padX} ${padBottom}` }}
+        masthead={
+          <ComposerMasthead
             style={{
-              display: "flex",
-              alignItems: "center",
-              gap: "var(--space-sm)",
-              padding: "var(--space-sm) var(--space-md)",
-              background: `linear-gradient(180deg, ${titleFrom}, ${titleTo})`,
-              borderBottom: `2px solid ${winBorder}`,
+              height: "auto",
+              padding: "var(--space-lg) var(--space-lg) var(--space-md)",
+              overflow: "hidden",
             }}
           >
-            <div style={{ display: "flex", gap: "var(--space-xs)" }}>
-              <span
-                style={{
-                  width: 11,
-                  height: 11,
-                  borderRadius: "50%",
-                  background: "#fb7aa8",
-                  border: "1.5px solid rgba(255,255,255,0.7)",
-                }}
-              />
-              <span
-                style={{
-                  width: 11,
-                  height: 11,
-                  borderRadius: "50%",
-                  background: "#f6c75e",
-                  border: "1.5px solid rgba(255,255,255,0.7)",
-                }}
-              />
-              <span
-                style={{
-                  width: 11,
-                  height: 11,
-                  borderRadius: "50%",
-                  background: "#86cfa6",
-                  border: "1.5px solid rgba(255,255,255,0.7)",
-                }}
-              />
-            </div>
-            <span
-              style={{
-                fontSize: "var(--text-md)",
-                color: titleText,
-                letterSpacing: "0.03em",
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-xs)",
-              }}
-            >
-              <Sparkle size={11} color={titleText} />{" "}
-              {t("editPraxis.coven.windowTitle")}
-            </span>
-            <span
-              style={{
-                marginLeft: "auto",
-                fontSize: "var(--text-md)",
-                color: titleText,
-                opacity: 0.75,
-                letterSpacing: "1.5px",
-              }}
-            >
-              ▭ ✕
-            </span>
-          </div>
-
-          {/* dotted body */}
-          <div
-            style={{
-              position: "relative",
-              padding: "var(--space-xl)",
-              background: bodyBg,
-              backgroundImage: `radial-gradient(${dot} 1.4px, transparent 1.4px)`,
-              backgroundSize: "13px 13px",
-            }}
-          >
-            {/* headline */}
-            <div
-              style={{
-                fontFamily: cardFont,
-                fontSize: "var(--text-display)",
-                fontWeight: 700,
-                lineHeight: 1,
-                color: ink,
-                marginBottom: "var(--space-lg)",
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-sm)",
-              }}
-            >
-              {t("editPraxis.coven.pageTitle")}
-              <StarSticker size={26} color="#f47aa6" />
-            </div>
-
-            {/* Task — notepad scrap */}
-            <div style={{ ...notepadPanel, marginBottom: "var(--space-xl)" }}>
-              <span style={{ ...eyebrowStyle, marginBottom: "var(--space-xs)" }}>
-                {t("editPraxis.coven.taskRefLabel")}
-              </span>
+            <div aria-hidden style={{ position: "relative" }}>
+              <TwinkleField />
               <div
                 style={{
-                  fontFamily: cardFont,
-                  fontSize: "var(--text-title)",
-                  fontWeight: 700,
-                  lineHeight: 1.1,
-                  color: ink,
-                  marginTop: "var(--space-xs)",
-                  marginBottom: "var(--space-sm)",
+                  position: "relative",
+                  zIndex: 1,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "var(--space-sm)",
                 }}
               >
-                {praxis.task_title}
-              </div>
-              {task?.description && (
-                <div style={{ fontFamily: cardFont, fontSize: "var(--text-content)", lineHeight: 1.5, color: muted, marginBottom: "var(--space-sm)" }}>
-                  {task.description}
-                </div>
-              )}
-              <TaskMetaInline praxis={praxis} task={task} textColor={pinkDeep} />
-            </div>
-
-            {/* Mode — window tab chips */}
-            {!state.controlsLocked && (
-              <div style={{ marginBottom: "var(--space-xl)" }}>
-                <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                  {t("editPraxis.coven.modeLabel")}
-                </span>
-                <ModePicker
-                  state={state}
-                  skin={{
-                    containerStyle: { display: "flex", gap: "var(--space-sm)", flexWrap: "wrap" },
-                    options: modeOptions,
-                    allowedModes,
-                    renderOption: (opt, { active, disabled, onSelect }) => (
-                      <button
-                        key={opt.key}
-                        type="button"
-                        aria-pressed={active}
-                        onClick={onSelect}
-                        disabled={disabled && !active}
-                        style={{
-                          flex: "1 1 180px",
-                          cursor: disabled ? "not-allowed" : "pointer",
-                          textAlign: "left",
-                          background: active
-                            ? `linear-gradient(180deg, ${pink}, ${pinkDeep})`
-                            : notepadBg,
-                          color: active ? "var(--color-text-on-accent)" : ink,
-                          border: `1.5px solid ${active ? pinkDeep : notepadBorder}`,
-                          borderRadius: 9,
-                          padding: "var(--space-md)",
-                          fontFamily: "var(--font-body)",
-                          boxShadow: active
-                            ? "0 4px 10px rgba(236,95,153,.32)"
-                            : "none",
-                        }}
-                      >
-                        <div
-                          style={{
-                            fontFamily: cardFont,
-                            fontSize: "var(--text-title)",
-                            fontWeight: 700,
-                            marginBottom: "var(--space-xs)",
-                          }}
-                        >
-                          {opt.label}
-                        </div>
-                        <div style={{ fontSize: "var(--text-base)", opacity: 0.85 }}>
-                          {opt.desc}
-                        </div>
-                      </button>
-                    ),
-                  }}
-                />
-              </div>
-            )}
-
-            {/* Invite */}
-            {state.showInviteBox && (
-                <div
+                <SigilDisc size={30} />
+                <span
                   style={{
-                    ...notepadPanel,
-                    marginBottom: "var(--space-xl)",
-                    borderStyle: "dashed",
+                    fontFamily: DISPLAY,
+                    // eslint-disable-next-line local/no-raw-style-values -- ornament: the coven's wordmark, lettered in Grenze Gotisch.
+                    fontSize: 22,
+                    lineHeight: 1,
+                    letterSpacing: "0.02em",
+                    color: INK,
                   }}
                 >
-                  <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                    {state.duelMode
-                      ? t("editPraxis.coven.inviteLabelDuel")
-                      : t("editPraxis.coven.inviteLabel")}
-                  </span>
-                  <InviteSearch
-                    state={state}
-                    skin={{
-                      fontFamily: "var(--font-body)",
-                      inputBg: bodyBg,
-                      inputColor: ink,
-                      inputBorder: `1.5px solid ${notepadBorder}`,
-                      pillBg: lightBg,
-                      acceptedBg: pink,
-                      acceptedColor: "var(--color-text-on-accent)",
-                      placeholder: t("editPraxis.coven.invitePlaceholder"),
-                    }}
-                  />
-                </div>
-              )}
-
-            {/* Metatasks */}
-            {state.showSealStack && (
-              <div
-                style={{
-                  ...notepadPanel,
-                  marginBottom: "var(--space-lg)",
-                  borderStyle: "dashed",
-                }}
-              >
-                <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                  {t("editPraxis.coven.metatasksLabel")}
-                </span>
-                <MetataskSealStack state={state} />
-              </div>
-            )}
-
-            {/* Title — notepad panel */}
-            <div style={{ ...notepadPanel, marginBottom: "var(--space-lg)" }}>
-              <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                {t("editPraxis.coven.titleLabel")}
-              </span>
-              <TitleField
-                state={state}
-                skin={{
-                  placeholder: t("editPraxis.coven.titlePlaceholder"),
-                  inputStyle: {
-                    width: "100%",
-                    fontFamily: cardFont,
-                    fontWeight: 700,
-                    color: ink,
-                    background: "transparent",
-                    border: "none",
-                    outline: "none",
-                    borderBottom: `2px solid ${notepadBorder}`,
-                    padding: "var(--space-xs) 0 var(--space-sm)",
-                  },
-                }}
-              />
-              <div
-                style={{
-                  marginTop: "var(--space-xs)",
-                  display: "flex",
-                  justifyContent: "space-between",
-                }}
-              >
-                <TitleCounter length={state.title.length} color={muted} />
-                <span style={{ ...eyebrowStyle, color: muted, fontSize: "var(--text-xs)" }}>
-                  {state.autosaveAt
-                    ? t("editPraxis.coven.autosaveSaved", {
-                        ago: formatAutosave(state.autosaveAt),
-                      })
-                    : t("editPraxis.coven.autosaveUnsaved")}
+                  {tFeed("taskCard.coven.masthead")}
                 </span>
               </div>
+              <Braid style={{ marginTop: "var(--space-sm)" }} />
             </div>
+          </ComposerMasthead>
+        }
+        ground={
+          <>
+            {/* The glow and the lavender wash, at the design's two anchors. */}
+            <ComposerGround
+              inset={0}
+              opacity={0.7}
+              background={`radial-gradient(62% 48% at 12% 0%, ${PINK}, transparent 70%), radial-gradient(58% 46% at 100% 100%, var(--faction-coven-slip-lav), transparent 72%)`}
+            />
+            {/* The wheel and the glyphs, on their own layer so each keeps its
+                own strength instead of inheriting the wash's. */}
+            <ComposerGround inset={0}>
+              <svg
+                className="cvn-wheel"
+                width={520}
+                height={520}
+                viewBox="0 0 100 100"
+                aria-hidden="true"
+                style={{
+                  position: "absolute",
+                  right: -150,
+                  bottom: -110,
+                  opacity: 0.1,
+                }}
+              >
+                <path
+                  d="M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z"
+                  fill="none"
+                  stroke={DEEP}
+                  strokeWidth="1.2"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <GlyphScatter />
+            </ComposerGround>
+          </>
+        }
+      >
+        {/* Draft · Saved just now, closed by the pentacle. */}
+        <ComposerStatusRow
+          status={t("editPraxis.composer.statusDraft")}
+          meta={
+            state.autosaveAt
+              ? t("editPraxis.composer.statusSaved", {
+                  ago: formatAutosave(state.autosaveAt),
+                })
+              : t("editPraxis.composer.statusUnsaved")
+          }
+          statusStyle={{ fontFamily: CHROME, color: INK, fontWeight: 700 }}
+          metaStyle={{ fontFamily: CHROME, color: LABEL }}
+          mark={<Pentacle size={40} color={DEEP} />}
+        />
 
-            {/* Body — notepad panel */}
-            <div style={{ ...notepadPanel, marginBottom: "var(--space-lg)" }}>
-              <span style={{ ...eyebrowStyle, marginBottom: "var(--space-sm)" }}>
-                {t("editPraxis.coven.bodyLabel", { words: state.wordCount })}
-              </span>
+        {/* The task reference slip, with the ward. */}
+        <TaskSlip
+          praxis={praxis}
+          task={task}
+          style={{
+            background: FIELD,
+            border: RULE,
+            borderRadius: FIELD_RADIUS,
+            padding: "var(--space-lg)",
+          }}
+          labelStyle={labelStyle}
+          titleStyle={{ fontFamily: DISPLAY, color: INK }}
+          descriptionStyle={{ fontFamily: CHROME, color: SOFT }}
+          pillStyle={{ fontFamily: CHROME, color: LABEL }}
+          mark={<PointsWard size={88} points={task?.point_value ?? 0} />}
+        />
+
+        <ComposerSection
+          label={t("editPraxis.composer.titleLabel")}
+          htmlFor="composer-title"
+          rule={braidRule}
+          meta={<TitleCounter length={state.title.length} color={LABEL} />}
+          labelStyle={labelStyle}
+        >
+          <TitleField
+            state={state}
+            skin={{
+              id: "composer-title",
+              placeholder: t("editPraxis.composer.titlePlaceholder"),
+              inputStyle: { ...fieldBox, fontFamily: DISPLAY },
+            }}
+          />
+        </ComposerSection>
+
+        {/* How it was done — hidden once the mode can no longer change, per the
+            house rule that an unusable control is not drawn disabled. */}
+        {!state.controlsLocked && (
+          <ComposerSection
+            label={t("editPraxis.composer.modeLabel")}
+            rule={braidRule}
+            labelStyle={labelStyle}
+          >
+            <ModePicker
+              state={state}
+              skin={{
+                containerStyle: {
+                  display: "flex",
+                  gap: "var(--space-sm)",
+                  flexWrap: "wrap",
+                },
+                options: modeOptions,
+                allowedModes,
+                renderOption: (option, { active, disabled, onSelect }) => (
+                  <button
+                    key={option.key}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={onSelect}
+                    disabled={disabled && !active}
+                    style={composerLabelStyle({
+                      fontFamily: CHROME,
+                      fontWeight: 700,
+                      cursor: disabled ? "not-allowed" : "pointer",
+                      padding: "var(--space-sm) var(--space-lg)",
+                      borderRadius: 999,
+                      background: active ? CTA_BAND : FIELD,
+                      color: active ? CTA_INK : LABEL,
+                      border: active
+                        ? "1.5px solid var(--faction-coven-slip-cta-to)"
+                        : RULE,
+                    })}
+                  >
+                    {option.label}
+                  </button>
+                ),
+              }}
+            />
+          </ComposerSection>
+        )}
+
+        {/* The mode block: the collaborator roster, or the duel pair. One
+            control draws both — `InviteSearch` switches on `state.duelMode`. */}
+        {state.showInviteBox && (
+          <ComposerSection
+            label={
+              state.duelMode
+                ? t("editPraxis.composer.opponentLabel")
+                : t("editPraxis.composer.collaboratorsLabel", {
+                    count: praxis.members.length,
+                  })
+            }
+            rule={braidRule}
+            labelStyle={labelStyle}
+          >
+            <InviteSearch
+              state={state}
+              skin={{
+                fontFamily: CHROME,
+                inputBg: FIELD,
+                inputColor: INK,
+                inputBorder: RULE,
+                dropdownBg: SHEET,
+                dropdownBorder: RULE,
+                acceptedBg: "var(--faction-coven-slip-cta-from)",
+                acceptedColor: CTA_INK,
+                pendingColor: SOFT,
+                placeholder: t("editPraxis.composer.invitePlaceholder"),
+                leaveStyle: { color: LABEL },
+              }}
+            />
+          </ComposerSection>
+        )}
+
+        {state.showSealStack && (
+          <ComposerSection
+            label={t("editPraxis.composer.sealsLabel")}
+            rule={braidRule}
+            labelStyle={labelStyle}
+          >
+            <MetataskSealStack state={state} />
+          </ComposerSection>
+        )}
+
+        {/* Write-up — the tabs sit in the section's meta slot, so the label row
+            reads `Write-up … [Write|Preview]` exactly as the design draws it. */}
+        <ComposerSection
+          label={t("editPraxis.composer.writeUpLabel")}
+          htmlFor="composer-body"
+          rule={braidRule}
+          labelStyle={labelStyle}
+          meta={
+            <WriteUpTabs
+              tab={tab}
+              setTab={setTab}
+              skin={{
+                containerStyle: { gap: "var(--space-xs)" },
+                buttonStyle: (active) =>
+                  composerLabelStyle({
+                    fontFamily: CHROME,
+                    fontWeight: 700,
+                    padding: "var(--space-xs) var(--space-sm)",
+                    borderRadius: 999,
+                    border: active ? RULE : "1.5px solid transparent",
+                    background: active ? FIELD : "transparent",
+                    color: active ? DEEP : LABEL,
+                  }),
+              }}
+            />
+          }
+        >
+          {/* Both panels are mounted only one at a time: a hidden textarea would
+              still be a tab stop and still be submitted by a form. */}
+          {tab === "write" ? (
+            <>
               <BodyTextarea
                 state={state}
                 skin={{
-                  rows: 12,
-                  placeholder: t("editPraxis.coven.bodyPlaceholder"),
+                  id: "composer-body",
+                  rows: 8,
+                  placeholder: t("editPraxis.composer.bodyPlaceholder"),
                   textareaStyle: {
-                    width: "100%",
-                    fontFamily: "var(--font-body)",
-                    lineHeight: "24px",
-                    color: ink,
-                    background: bodyBg,
-                    border: `1.5px solid ${notepadBorder}`,
-                    borderRadius: 7,
-                    padding: "var(--space-lg)",
-                    outline: "none",
+                    ...fieldBox,
                     resize: "vertical",
-                    minHeight: 220,
+                    minHeight: 180,
+                    lineHeight: 1.7,
+                    fontFamily: CHROME,
+                  },
+                  toolbarButtonStyle: {
+                    background: FIELD,
+                    color: DEEP,
+                    border: RULE,
+                    borderRadius: 8,
                   },
                 }}
               />
-              <BodyPreview
+              <div
+                style={composerLabelStyle({
+                  fontFamily: CHROME,
+                  color: LABEL,
+                  marginTop: "var(--space-sm)",
+                  letterSpacing: "0.06em",
+                })}
+              >
+                {t("editPraxis.composer.wordCount", { words: state.wordCount })}
+              </div>
+            </>
+          ) : (
+            <BodyPreview
+              state={state}
+              skin={{
+                wrapperStyle: { ...fieldBox, minHeight: 180 },
+                markdownStyle: {
+                  fontFamily: CHROME,
+                  lineHeight: 1.7,
+                  color: INK,
+                },
+                emptyState: (
+                  <p
+                    style={{
+                      fontFamily: CHROME,
+                      fontSize: "var(--text-content)",
+                      color: LABEL,
+                      margin: 0,
+                    }}
+                  >
+                    {t("editPraxis.composer.bodyPlaceholder")}
+                  </p>
+                ),
+              }}
+            />
+          )}
+        </ComposerSection>
+
+        <ComposerSection
+          label={t("editPraxis.composer.proofLabel")}
+          rule={braidRule}
+          labelStyle={labelStyle}
+        >
+          <div
+            style={{
+              display: "flex",
+              gap: "var(--space-lg)",
+              alignItems: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            {state.media.map((item) => {
+              const filename = item.file_path.split("/").pop() ?? item.file_path;
+              const src = mediaUrl(item.file_path);
+              return (
+                <MediaTile
+                  key={item.id}
+                  caption={filename}
+                  onRemove={() => void state.removeMedia(item)}
+                >
+                  {item.type === "image" ? (
+                    <img
+                      src={src}
+                      alt=""
+                      style={{ width: 120, height: 120, objectFit: "cover" }}
+                    />
+                  ) : item.type === "video" ? (
+                    <video
+                      src={src}
+                      style={{ width: 120, height: 120, objectFit: "cover" }}
+                    />
+                  ) : (
+                    <MediaArt
+                      art={pickArtKey(filename, "audio")}
+                      width={120}
+                      height={120}
+                    />
+                  )}
+                </MediaTile>
+              );
+            })}
+            {!state.controlsLocked && (
+              <FilePicker
                 state={state}
                 skin={{
-                  wrapperStyle: {
-                    marginTop: "var(--space-md)",
-                    background: bodyBg,
-                    border: `1.5px solid ${notepadBorder}`,
-                    borderRadius: 7,
-                    padding: "var(--space-lg)",
-                  },
-                  label: (
-                    <span style={{ ...eyebrowStyle, marginBottom: "var(--space-xs)" }}>
-                      {t("editPraxis.coven.previewLabel")}
-                    </span>
-                  ),
-                  markdownStyle: {
-                    fontFamily: "var(--font-body)",
-                    lineHeight: 1.65,
-                    color: ink,
+                  buttonStyle: composerLabelStyle({
+                    fontFamily: CHROME,
+                    fontWeight: 700,
+                    cursor: "pointer",
+                    background: "transparent",
+                    border: `1.5px dashed ${BORDER}`,
+                    borderRadius: FIELD_RADIUS,
+                    padding: "var(--space-lg) var(--space-xl)",
+                    color: DEEP,
+                  }),
+                  buttonLabel: t("editPraxis.composer.proofButton"),
+                  helperText: t("editPraxis.composer.proofHelper"),
+                  helperStyle: {
+                    fontFamily: CHROME,
+                    fontSize: "var(--text-content)",
+                    color: LABEL,
+                    maxWidth: 260,
+                    lineHeight: 1.5,
+                    marginTop: "var(--space-sm)",
                   },
                 }}
               />
-            </div>
+            )}
+          </div>
+        </ComposerSection>
 
-            {/* Media — notepad panel */}
-            <div style={{ ...notepadPanel, marginBottom: "var(--space-lg)" }}>
-              <span style={{ ...eyebrowStyle, marginBottom: "var(--space-md)" }}>
-                {t("editPraxis.coven.filesLabel", {
-                  pasted: state.media.length,
-                })}
-              </span>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-md)" }}>
-                {state.media.map((item) => {
-                  const filename =
-                    item.file_path.split("/").pop() ?? item.file_path;
-                  const src = mediaUrl(item.file_path);
-                  return (
-                    <MediaTile
-                      key={item.id}
-                      caption={filename}
-                      borderColor={notepadBorder}
-                      tileBg={notepadBg}
-                      removeColor={pink}
-                      onRemove={() => void state.removeMedia(item)}
-                    >
-                      {item.type === "image" ? (
-                        <img
-                          src={src}
-                          alt=""
-                          style={{
-                            width: 140,
-                            height: 100,
-                            objectFit: "cover",
-                          }}
-                        />
-                      ) : item.type === "video" ? (
-                        <video
-                          src={src}
-                          style={{
-                            width: 140,
-                            height: 100,
-                            objectFit: "cover",
-                          }}
-                        />
-                      ) : (
-                        <MediaArt art={pickArtKey(filename, "audio")} />
-                      )}
-                    </MediaTile>
-                  );
-                })}
-              </div>
-              <div style={{ marginTop: "var(--space-md)" }}>
-                <FilePicker
+        <ErrorBanner message={state.error} />
+
+        {/* [Cancel] … [Submit] — the global order from #646, stacked here
+            because Coven's cast is a full-bleed band rather than an inline
+            button: the exits read first, the band closes the sheet. */}
+        <ComposerFooter
+          style={{
+            flexDirection: "column",
+            alignItems: "stretch",
+            gap: "var(--space-lg)",
+          }}
+          start={
+            <>
+              <Braid />
+              <div
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--space-lg)",
+                  flexWrap: "wrap",
+                }}
+              >
+                <SaveDraftButton
+                  state={state}
+                  skin={{ style: { color: LABEL, fontFamily: CHROME } }}
+                />
+                <DropButton
                   state={state}
                   skin={{
-                    buttonStyle: {
-                      width: 152,
-                      height: 110,
-                      background: bodyBg,
-                      border: `2px dashed ${notepadBorder}`,
-                      borderRadius: 9,
+                    style: composerLabelStyle({
+                      fontFamily: CHROME,
+                      background: "transparent",
+                      border: "none",
+                      padding: 0,
+                      color: LABEL,
+                      textDecoration: "underline",
                       cursor: "pointer",
-                      fontFamily: cardFont,
-                      fontSize: "var(--text-content)",
-                      fontWeight: 700,
-                      color: pink,
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                      flexDirection: "column",
-                      gap: "var(--space-xs)",
-                    },
-                    buttonLabel: t("editPraxis.coven.fileButton"),
-                    helperText: t("editPraxis.coven.fileHelper"),
-                    helperStyle: {
-                      fontSize: "var(--text-sm)",
-                      color: muted,
-                      marginTop: "var(--space-xs)",
-                    },
+                    }),
                   }}
                 />
               </div>
-            </div>
-
-            <ErrorBanner message={state.error} />
-
-            {/* CTAs — lo-fi pink buttons */}
-            <div
-              style={{
-                display: "flex",
-                gap: "var(--space-md)",
-                alignItems: "center",
-                marginTop: "var(--space-xl)",
-                paddingTop: "var(--space-lg)",
-                borderTop: `1.5px dashed ${notepadBorder}`,
-                flexWrap: "wrap",
+            </>
+          }
+          end={
+            <PublishButton
+              state={state}
+              skin={{
+                idleLabel: t("editPraxis.composer.submit"),
+                busyLabel: t("editPraxis.composer.submitBusy"),
+                ornament: <Sparkle size={12} />,
+                style: composerLabelStyle({
+                  // The one place Coven speaks in the LABEL face rather than
+                  // the title one. 13px in the design; the label ramp's top
+                  // rung is 14, and button chrome is label tier (§4a — a token
+                  // names a tier, so the number lands where it lands).
+                  fontFamily: CHROME,
+                  fontSize: "var(--text-xl)",
+                  fontWeight: 700,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "var(--space-sm)",
+                  cursor: state.submitting ? "wait" : "pointer",
+                  border: "none",
+                  borderTop: EDGE,
+                  borderRadius: 0,
+                  padding: "var(--space-lg) var(--space-xl)",
+                  color: hasCast ? CAST_INK : CTA_INK,
+                  background: hasCast ? CAST_BAND : CTA_BAND,
+                  // Full bleed: back out the sheet's own inset so the band runs
+                  // edge to edge and sits flush on the bottom. The sheet's
+                  // `overflow: hidden` rounds its corners for us.
+                  margin: `0 calc(-1 * ${padX}) calc(-1 * ${padBottom})`,
+                }),
               }}
-            >
-              <SaveDraftButton state={state} />
-              <DropButton
-                state={state}
-                skin={{
-                  label: t("editPraxis.coven.dropLabel"),
-                  style: {
-                    background: "transparent",
-                    color: muted,
-                    fontFamily: cardFont,
-                    fontSize: "var(--text-content)",
-                    fontWeight: 700,
-                    border: "none",
-                    cursor: "pointer",
-                  },
-                }}
-              />
-              <div style={{ flex: 1 }} />
-              <PublishButton
-                state={state}
-                skin={{
-                  ornament: (
-                    <Sparkle size={12} color="var(--color-text-on-accent)" />
-                  ),
-                  idleLabel: t("editPraxis.coven.publishIdle"),
-                  busyLabel: t("editPraxis.coven.publishBusy"),
-                  style: {
-                    display: "inline-flex",
-                    alignItems: "center",
-                    gap: "var(--space-xs)",
-                    background: `linear-gradient(180deg, ${pink}, ${pinkDeep})`,
-                    color: "var(--color-text-on-accent)",
-                    fontFamily: "var(--font-body)",
-                    fontSize: "var(--text-lg)",
-                    fontWeight: 600,
-                    textTransform: "uppercase",
-                    letterSpacing: "0.1em",
-                    padding: "var(--space-md) var(--space-xl)",
-                    border: `1.5px solid ${pinkDeep}`,
-                    borderRadius: 9,
-                    cursor: state.submitting ? "wait" : "pointer",
-                    boxShadow: "0 4px 12px rgba(236,95,153,.32)",
-                  },
-                }}
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* sticker charms peeking off the window edges */}
-        <div
-          aria-hidden
-          style={{
-            position: "absolute",
-            top: 4,
-            right: 6,
-            transform: "rotate(14deg)",
-            filter: "drop-shadow(0 2px 2.5px rgba(120,40,80,0.28))",
-            zIndex: 12,
-            pointerEvents: "none",
-          }}
-        >
-          <Heart size={34} />
-        </div>
-        <div
-          aria-hidden
-          style={{
-            position: "absolute",
-            bottom: -6,
-            left: 30,
-            transform: "rotate(-9deg)",
-            filter: "drop-shadow(0 2px 2.5px rgba(120,40,80,0.28))",
-            zIndex: 12,
-            pointerEvents: "none",
-          }}
-        >
-          <StarSticker size={30} color="#f6c75e" />
-        </div>
-      </div>
+            />
+          }
+        />
+      </ComposerSheet>
     </div>
+  );
+}
+
+/** The band's leading sparkle, in the cast ink it sits on. */
+function Sparkle({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      style={{ display: "block", flex: "0 0 auto" }}
+    >
+      <path
+        d="M12 1c.6 5.2 2.8 7.4 8 8-5.2.6-7.4 2.8-8 8-.6-5.2-2.8-7.4-8-8 5.2-.6 7.4-2.8 8-8z"
+        fill="currentColor"
+      />
+    </svg>
   );
 }
 
 interface MediaTileProps {
   children: React.ReactNode;
   caption: string;
-  borderColor: string;
-  tileBg: string;
-  removeColor: string;
   onRemove: () => void;
 }
 
-function MediaTile({
-  children,
-  caption,
-  borderColor,
-  tileBg,
-  removeColor,
-  onRemove,
-}: MediaTileProps) {
+/** One already-uploaded proof item, on the slip's field ground. */
+function MediaTile({ children, caption, onRemove }: MediaTileProps) {
   const { t } = useTranslation("forms");
   return (
     <div
       style={{
         position: "relative",
-        background: tileBg,
-        padding: "var(--space-xs) var(--space-xs) var(--space-xl)",
-        borderRadius: 9,
-        border: `1.5px solid ${borderColor}`,
-        boxShadow: "0 3px 7px rgba(190,60,120,.16)",
+        background: FIELD,
+        border: RULE,
+        borderRadius: FIELD_RADIUS,
+        overflow: "hidden",
       }}
     >
-      <div
-        style={{
-          width: 140,
-          height: 100,
-          overflow: "hidden",
-          borderRadius: 5,
-        }}
-      >
+      <div style={{ width: 120, height: 120, overflow: "hidden" }}>
         {children}
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          bottom: 4,
-          left: 8,
-          right: 8,
-          fontSize: "var(--text-base)",
-          fontFamily: "var(--font-body)",
-          color: borderColor,
-          textAlign: "center",
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-        }}
-      >
-        {caption}
       </div>
       <button
         type="button"
@@ -838,14 +993,14 @@ function MediaTile({
         aria-label={t("media.removeAria", { name: caption })}
         style={{
           position: "absolute",
-          top: -8,
-          right: -8,
+          top: 4,
+          right: 4,
           width: 22,
           height: 22,
           borderRadius: "50%",
-          background: tileBg,
-          border: `1.5px solid ${removeColor}`,
-          color: removeColor,
+          background: SHEET,
+          border: `1.5px solid ${BORDER}`,
+          color: DEEP,
           fontSize: "var(--text-md)",
           fontWeight: 700,
           cursor: "pointer",

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/covenComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/covenComposer.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * Cozy Coven's composer, rebuilt to the v2 design (#1188, epic #1179).
+ *
+ * Two claims, both regressions this issue is the fix for.
+ *
+ * 1. **The `wow.exe` caption is gone.** The file this replaces drew a literal
+ *    desktop-window caption reading `wow.exe` — a chrome string left from before
+ *    #784 split Coven off Warriors of Whimsy (ADR-0050). It was never a slug and
+ *    never a dispatch bug, which is exactly why nothing failed while it shipped:
+ *    the only check that can see a wrong WORD is one that looks for it.
+ *
+ * 2. **The page speaks the neutral composer set** (ADR-0065 §3) and carries no
+ *    Coven page copy of its own — asserted at the catalog as well as at the
+ *    render, because a deleted key that some other archetype still reads is a
+ *    compile error, while a key left behind that nobody reads is silent.
+ *
+ * `editPraxis.coven.collab` is deliberately exempt: that block is `collabCopy`'s
+ * override table, a different resolver, and it also feeds `CollabRoster` on the
+ * read page `/praxes/:id`. `collabCopy.test.ts` pins it from the other side.
+ *
+ * renderToStaticMarkup needs no DOM, matching the rest of this suite. Effects
+ * never run, so nothing here can assert on state that arrives after mount.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../../i18n";
+import i18n from "../../../../i18n";
+import forms from "../../../../locales/en/forms.json";
+import type { EditPraxisState } from "../../useEditPraxis";
+import type { PraxisOut } from "../../../../api/praxis";
+import type { TaskOut } from "../../../../api/tasks";
+
+const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "mobile" | "desktop" }));
+vi.mock("../../../../hooks/useFormFactor", () => ({
+  useFormFactor: () => mocks.formFactor,
+}));
+
+import CovenEditPraxis from "../CovenEditPraxis";
+
+const task = {
+  id: 7,
+  title: "Bless the work",
+  description: "Do a small honest thing.",
+  point_value: 20,
+  level_required: 1,
+  status: "active",
+  task_type: "standard",
+  primary_faction_slug: "coven",
+  allowed_modes: ["solo", "collab", "duel"],
+} as unknown as TaskOut;
+
+const praxis = {
+  id: 55,
+  task_id: 7,
+  task_title: "Bless the work",
+  task_faction_slug: "coven",
+  type: "solo",
+  status: "in_progress",
+  title: "I helped a stranger",
+  body_text: "## What I did\n\nCaught the papers.",
+  moderation_status: "visible",
+  duel_id: null,
+  created_by_id: 3,
+  members: [],
+  invites: [],
+  media_items: [],
+} as unknown as PraxisOut;
+
+function baseState(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
+  return {
+    loading: false,
+    phase: "composing",
+    praxis,
+    task,
+    error: "",
+    title: praxis.title,
+    setTitle: () => {},
+    body: "Caught the papers.",
+    setBody: () => {},
+    wordCount: 3,
+    media: [],
+    fileError: "",
+    handleFileChange: () => {},
+    removeMedia: async () => {},
+    switchingMode: null,
+    changeMode: async () => {},
+    inviteQuery: "",
+    setInviteQuery: () => {},
+    inviteResults: [],
+    inviteOpen: false,
+    setInviteOpen: () => {},
+    inviting: false,
+    submitting: false,
+    publish: async () => {},
+    saveDraft: async () => {},
+    pullBack: async () => {},
+    cancel: async () => {},
+    autosaveAt: null,
+    autoSubmitDays: 10,
+    isPublished: false,
+    controlsLocked: false,
+    modeIsLocked: false,
+    showInviteBox: false,
+    showSealStack: false,
+    duelMode: false,
+    duelChipVisible: true,
+    currentCharacterId: 3,
+    ...overrides,
+  } as unknown as EditPraxisState;
+}
+
+function render(
+  formFactor: "mobile" | "desktop",
+  state: EditPraxisState = baseState(),
+): string {
+  mocks.formFactor = formFactor;
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <CovenEditPraxis state={state} />
+    </MemoryRouter>,
+  );
+}
+
+const WIDTHS = ["desktop", "mobile"] as const;
+
+describe("Coven composer — the window is gone (ADR-0050, #1188)", () => {
+  it.each(WIDTHS)("draws no wow.exe caption on %s", (width) => {
+    expect(render(width)).not.toContain("wow.exe");
+  });
+
+  it("keeps no page copy of its own, only the collab override table", () => {
+    expect(Object.keys(forms.editPraxis.coven)).toEqual(["collab"]);
+  });
+
+  it.each(WIDTHS)("letters the coven's own wordmark on %s", (width) => {
+    // Read from `feed`, where the v2 task card already owns it — the composer
+    // introduces no faction copy key of its own.
+    expect(render(width)).toContain(i18n.t("feed:taskCard.coven.masthead"));
+  });
+});
+
+describe("Coven composer — the shared layout, neutrally worded (ADR-0065)", () => {
+  // Spelled out rather than built from a `${key}` template: the catalog's keys
+  // are a literal union, so a template-literal key does not typecheck — and a
+  // key assembled at runtime is also invisible to the i18n sweep's grep.
+  const REGIONS = [
+    i18n.t("forms:editPraxis.composer.taskLabel"),
+    i18n.t("forms:editPraxis.composer.titleLabel"),
+    i18n.t("forms:editPraxis.composer.modeLabel"),
+    i18n.t("forms:editPraxis.composer.writeUpLabel"),
+    i18n.t("forms:editPraxis.composer.proofLabel"),
+    i18n.t("forms:editPraxis.composer.submit"),
+  ];
+
+  it.each(WIDTHS)("draws every region on %s from the neutral set", (width) => {
+    const markup = render(width);
+    for (const region of REGIONS) {
+      expect(markup).toContain(region);
+    }
+  });
+
+  it.each(WIDTHS)("draws exactly one breadcrumb on %s", (width) => {
+    expect((render(width).match(/<nav/g) ?? []).length).toBe(1);
+  });
+
+  it("hides the mode picker once the controls lock, rather than disabling it", () => {
+    const markup = render("desktop", baseState({ controlsLocked: true }));
+    expect(markup).not.toContain(i18n.t("forms:editPraxis.composer.modeLabel"));
+  });
+});


### PR DESCRIPTION
Closes #1188

Part of epic #1179. Rebuilds `CovenEditPraxis.tsx` over the shared composer
layout (ADR-0065) as **one responsive component** — the mobile twin is gone,
`useComposerSizes()` picks the size set.

## What changed

**The `wow.exe` window is gone.** This file drew a literal desktop-window
caption reading `wow.exe` — a chrome string left over from before #784 split
Coven off Warriors of Whimsy (ADR-0050). Never a slug, never a dispatch bug;
the whole window metaphor was simply the old design, already retired on the
task card (#1023) and the task detail page (#1031). The composer was the last
surface carrying it.

In its place, the candlelit spell slip:

- **Masthead** — gold twinkles behind a centred row: the 30px pentacle disc
  (accent field r=19, dashed gold ring r=15 `2 4`, the pentagram in accentDeep,
  gold centre r=3) turning on `.ep-spin` at `--ep-spin-dur: 42s`, then the
  coven's wordmark in Grenze Gotisch. A braid closes the block.
- **Ground** — a glow at `12% 0%` and a lavender wash at `100% 100%` at
  opacity .7, on one layer; the turning `.cvn-wheel` pentagram and an
  eight-mark glyph scatter on a second, so each keeps its own strength.
- **Section rule** — the braid (`.cvn-braid`), on every section.
- **Points mark** — an 88px ward on the shared `RingMark`: a radial-gradient
  halo in accent, an r=32 accent ring, four gold spokes turning at 30s, and
  five gold stars twinkling on staggered `--ep-delay`. Numeral at
  `--text-title` (24px, the design's number exactly).
- **Status mark** — the pentacle at 40px in accentDeep.
- **Submit** — a full-bleed band, leading white sparkle, that flips to a green
  gradient once your part is in.

Geometry: radius 14, borders 1.5, the border takes gold. Grenze Gotisch for
title, Quicksand for body and label.

**Copy went neutral** (ADR-0065 §3): `editPraxis.coven.*` page keys are
deleted and the page reads the shared `editPraxis.composer.*` set.
**`editPraxis.coven.collab` is kept** — that block is `collabCopy`'s override
table, a different resolver that also feeds `CollabRoster` on `/praxes/:id`.

## Decisions worth a second look

1. **The masthead wordmark reads `feed:taskCard.coven.masthead`.** The design
   letters "the cozy coven" across the top. That is not composer copy — it is
   Coven's own wordmark, already owned by that key for the v2 task card. Read
   from there rather than re-keyed under `editPraxis.coven`, which this issue
   deletes, so the composer introduces no faction copy key of its own and the
   two surfaces cannot drift apart.

2. **`index.css` gained three tokens** — `--faction-coven-cast-{from,to,ink}`,
   for the submit band's green state. It could not reuse `--color-success` or
   `--faction-coven-card-credit`: both are **inks** measured as text on a
   sheet, and reading an ink as a fill is the "var() at the wrong tier" failure
   that passes every lint gate. Polarity follows `--faction-coven-slip-cta-*`
   (dark band under white by day, bright band under near-black by night);
   contrast measured at both gradient stops in both themes and recorded in the
   comment — 5.04:1 worst case.

   This is the only `index.css` edit: **no motion was added.** All seven `ep*`
   keyframes and Coven's three `cvn-*` motions already existed.

3. **No skin interface was widened.** Every control is composed through its
   existing `*Skin` prop. `ComposerMasthead`'s fixed `height` is overridden
   through its own `style` prop rather than by widening the type to
   `number | string` — seven agents are in this file's neighbours right now,
   and the escape hatch was already there.

4. **The submit band's label is `--text-xl` (14px), not the design's 13.**
   Button chrome is Label tier and 13 is off the ramp; §4a's rule is that a
   token names a tier and the number lands where it lands. The masthead
   wordmark keeps a raw 22px behind a per-line ornament hatch — it is
   display-face lettering, not typeset copy.

5. **The ward's twinkles are two nested spans.** `epTwinkle` animates
   `transform`, so the centring `translate(-50%,-50%)` had to live on a
   separate element or the keyframe would overwrite it — and a negative
   half-pixel margin (the obvious alternative) is spacing wearing ornament's
   clothes that the ratchet's Literal-only check waves straight through.

6. **Nothing drawn that #1071 ruled out.** No forfeit at the awaiting stage
   (decision 3), no duel clock (decision 4). The awaiting stage itself belongs
   to #1189.

## What to eyeball

- **The masthead** at both widths — disc/wordmark alignment, and whether the
  twinkle field reads at all behind them (it is stretched with
  `preserveAspectRatio="none"`, the same as the task card's).
- **The full-bleed submit band.** It bleeds by backing out the sheet's own
  inset with negative margins, so it should sit flush to the sheet's left,
  right and bottom edges with the corners rounded by the sheet's clip. A
  mis-flush band is the most likely visual defect in this PR.
- **The green flip.** Cast a collab part (or seal a duel) and the band should
  go green with the sparkle still legible on it.
- **The ground.** The wheel is anchored bottom-right at `-150/-110`; confirm it
  is clipped to the SHEET and never paints the viewport, and that the glyph
  scatter sits under the copy rather than through it.
- **Dark theme** on all of the above, and the ward's halo against the night
  card.
- **Mobile.** One column, no fixed grid; the band still full-bleeds at the
  narrower inset (`--space-lg` rather than `--space-2xl`).

## Verification

`tsc --noEmit` clean · `eslint src` clean · **full** vitest suite 2276 passed
(133 files, including 10 new) · `vite build` clean · new
`--faction-coven-cast-*` tokens confirmed present in **both** theme blocks of
the built stylesheet.

**Visual QA is outstanding.** I cannot screenshot in this environment and
there is no dev stack here, so nothing above has been seen rendered. Every
claim about layout is a claim about the code, not about pixels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
