### PR TITLE
Edit praxis v2 — the waiting surface takes each faction's dress

### DIFF
--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -255,6 +255,8 @@
       "statusDraft": "Draft",
       "statusSaved": "Saved {{ago}}",
       "statusUnsaved": "Not saved yet",
+      "statusSubmitted": "Submitted",
+      "statusSealed": "Sealed",
       "taskLabel": "The task",
       "pointsUnit": "pts",
       "levelLabel": "Level {{level}}",

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -18,10 +18,8 @@ import {
   useEditPraxis,
 } from "./editPraxis/useEditPraxis";
 import DefaultEditPraxis from "./editPraxis/archetypes/DefaultEditPraxis";
-import { Breadcrumb } from "./editPraxis/archetypes/shared";
 import MetataskPicker from "./editPraxis/MetataskPicker";
 import MetataskRemoveConfirm from "./editPraxis/MetataskRemoveConfirm";
-import PraxisWaitingSurface from "./editPraxis/waiting/PraxisWaitingSurface";
 
 export default function EditPraxis() {
   const { t } = useTranslation("forms");
@@ -63,39 +61,27 @@ export default function EditPraxis() {
   // and its eight files were retired in #1181: each archetype calls
   // `useFormFactor()` internally for its own size set, so the dispatcher has no
   // form factor to branch on.
+  // ONE component per slug, drawing whichever stage the praxis is in.
+  //
+  // Once your part of a multi-party praxis is submitted the composer stops being
+  // a composer (ADR-0059) and becomes `PraxisWaitingSurface` — but that swap is
+  // the ARCHETYPE's to make, not the dispatcher's (#1189). The archetype hands
+  // that shared surface its own `ComposerDress`, so the page keeps its faction's
+  // masthead, ground, rule and status mark at the moment you press Submit; a
+  // dispatcher-level swap could only ever hand over an undressed one, which is
+  // what #1071 shipped and deferred. It is also how the design is authored: one
+  // component taking a `stage` prop, not two components taking turns.
+  //
+  // The breadcrumb went with it. It used to be drawn here, gated on the waiting
+  // phase, because that surface painted none of its own; now every path draws
+  // exactly one — the archetype's, at both widths — and this dispatcher draws
+  // none. Nothing may draw two and nothing may draw zero (#567, #1181).
   const Archetype = pickVariant(surfaceMap('editPraxis'), slug, DefaultEditPraxis);
-  // Once your part of a multi-party praxis is submitted, the composer stops
-  // being a composer (ADR-0059) and this one shared surface takes the
-  // archetype's place — first while the praxis waits on somebody else, and then
-  // (#1164) in its completed reading once everybody is in. The second case is
-  // what used to be a locked composer.
-  const waiting = state.phase === "waiting" || state.phase === "completed";
 
   return (
     <>
       <PageTitle title="Edit Praxis" />
-      {/* The waiting surface paints no breadcrumb of its own, so it takes the
-          shared one — otherwise the post-cast screen is a dead end (#567).
-          Every ARCHETYPE paints its own, at both widths since #1181 collapsed
-          the form-factor split, so this is gated to the waiting surface alone.
-          The gate used to read `formFactor === "mobile" || waiting`, which was
-          the phone half of the same #567 argument: mobile skins painted none.
-          Those skins are gone and the desktop archetype now serves the phone,
-          so the phone half is already covered and keeping it would draw a
-          SECOND breadcrumb above every mobile composer. Exactly one of the two
-          paths draws one, in every state and at every width. */}
-      {waiting && (
-        <Breadcrumb
-          praxisId={state.praxis.id}
-          taskId={state.praxis.task_id}
-          taskTitle={state.praxis.task_title}
-        />
-      )}
-      {waiting ? (
-        <PraxisWaitingSurface state={state} />
-      ) : (
-        <Archetype state={state} />
-      )}
+      <Archetype state={state} />
       {/* The cast that closes a collab's consensus gate earns a standalone beat
           rather than a silent redirect (#591). Rendered here, over whichever
           archetype is mounted, so it's one shared screen for every faction and

--- a/frontend/src/pages/__tests__/EditPraxisBackAffordance.test.tsx
+++ b/frontend/src/pages/__tests__/EditPraxisBackAffordance.test.tsx
@@ -1,33 +1,34 @@
 /**
- * The edit-praxis back affordance (#567, reworked by #1181).
+ * The edit-praxis back affordance (#567, reworked by #1181 and again by #1189).
  *
  * #567's defect: after publish the phone composer was a dead end, because the
  * mobile skins painted no breadcrumb. The fix was a breadcrumb rendered by the
  * DISPATCHER on the mobile path, and this file pinned it — present on mobile in
  * every state, absent on desktop so the archetype's own was not doubled.
  *
- * ADR-0065 retired the mobile twin, and the desktop archetype now serves the
- * phone and paints its own breadcrumb at both widths. So the mobile half of that
- * gate is not merely unnecessary, it is WRONG: keeping it would draw two
- * breadcrumbs above every phone composer. The gate is now `waiting` alone.
+ * ADR-0065 retired the mobile twin, so #1181 narrowed that gate to the waiting
+ * surface, which was faction-neutral chrome and painted none of its own. #1189
+ * dressed that surface: the archetype draws it now, through the same
+ * `ComposerPage` the composer uses, so it paints its own breadcrumb like every
+ * other stage. The dispatcher draws NONE.
  *
- * The invariant #567 actually bought is unchanged, and is what this file pins
- * now: **from every state of `/praxes/:id/edit`, at every width, there is
- * exactly one way back and never zero.** Three states, three owners:
+ * The invariant #567 actually bought is unchanged, and is what this file pins:
+ * **from every state of `/praxes/:id/edit`, at every width, there is exactly one
+ * way back and never zero.** Two halves, two files:
  *
- *   composing → the ARCHETYPE draws it. Proved with the real archetype mounted,
- *               and COUNTED, in `editPraxis/archetypes/__tests__/
- *               composerDispatch.test.tsx`; the skins are mocked to null here,
- *               so this file proves only that the dispatcher adds none.
- *   waiting /
- *   completed → the DISPATCHER draws it — `PraxisWaitingSurface` is faction-
- *               neutral and paints none of its own.
- *   handoff   → neither: a published solo praxis has nothing left to compose and
- *               redirects to the read page (#1164), which is a way out by
- *               construction rather than a dead end.
+ *   never TWO  → this file. Every skin is mocked to null, so a breadcrumb in the
+ *                markup could only be the dispatcher's own. There is none, in
+ *                any state, at either width.
+ *   never ZERO → `editPraxis/archetypes/__tests__/composerDispatch.test.tsx`,
+ *                which mounts the REAL archetype and COUNTS `<nav>` at both
+ *                widths, while composing and while waiting.
+ *
+ * `handoff` is the one state with neither: a published solo praxis has nothing
+ * left to compose and redirects to the read page (#1164), which is a way out by
+ * construction rather than a dead end.
  *
  * Runs headless (node env): renderToStaticMarkup, skins mocked to null so the
- * test isolates the dispatcher's own breadcrumb.
+ * test isolates the dispatcher's own output.
  */
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
@@ -88,29 +89,23 @@ function render(
 const WIDTHS = ["mobile", "desktop"] as const;
 const BACK_LINK = 'href="/praxes/55"';
 
+const DRAWN_STATES = ["composing", "waiting", "completed"] as const;
+
 describe("EditPraxis back affordance (#567)", () => {
-  it.each(WIDTHS)(
-    "draws the shared breadcrumb over the waiting surface on %s",
-    (width) => {
-      expect(render(width, "waiting")).toContain(BACK_LINK);
-    },
-  );
-
-  it.each(WIDTHS)(
-    "draws it over the completed reading on %s too (#1164)",
-    (width) => {
-      expect(render(width, "completed")).toContain(BACK_LINK);
-    },
-  );
-
-  it.each(WIDTHS)(
-    "adds none of its own while composing on %s — the archetype owns it",
-    (width) => {
+  it.each(
+    WIDTHS.flatMap((width) =>
+      DRAWN_STATES.map((phase) => [width, phase] as const),
+    ),
+  )(
+    "adds no breadcrumb of its own on %s while %s — the archetype owns it",
+    (width, phase) => {
       // Before #1181 this passed on desktop and failed on mobile BY DESIGN: the
       // dispatcher drew the phone's breadcrumb because the mobile skins drew
-      // none. One archetype now serves both widths and draws its own, so a
-      // dispatcher breadcrumb here would be the second one.
-      expect(render(width, "composing")).not.toContain(BACK_LINK);
+      // none. Before #1189 it drew the waiting surface's, because that surface
+      // was undressed chrome. One archetype now serves both widths AND both
+      // stages and draws its own, so a dispatcher breadcrumb here would be the
+      // second one.
+      expect(render(width, phase)).not.toContain(BACK_LINK);
     },
   );
 

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -74,6 +74,7 @@ import {
   ComposerFooter,
   ComposerGround,
   ComposerMasthead,
+  ComposerPage,
   ComposerRule,
   ComposerSection,
   ComposerSheet,
@@ -85,7 +86,9 @@ import {
   composerLabelStyle,
   formatAutosave,
   useComposerSizes,
+  type ComposerDress,
 } from "./shared";
+import PraxisWaitingSurface from "../waiting/PraxisWaitingSurface";
 import {
   BodyPreview,
   BodyTextarea,
@@ -100,7 +103,7 @@ import {
   type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
-import type { EditPraxisState } from "../useEditPraxis";
+import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
   state: EditPraxisState;
@@ -471,33 +474,44 @@ export default function CovenEditPraxis({ state }: Props) {
     </ComposerRule>
   );
 
-  return (
-    <div style={{ fontFamily: CHROME, color: INK }}>
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: "0 auto",
-          padding: "var(--space-lg) var(--space-lg) 0",
-        }}
-      >
-        <Breadcrumb
-          praxisId={praxis.id}
-          taskId={praxis.task_id}
-          taskTitle={praxis.task_title}
-          inkColor={LABEL}
-        />
-      </div>
-
-      <ComposerSheet
-        sizes={sizes}
-        style={{
-          background: SHEET,
-          border: EDGE,
-          borderRadius: RADIUS,
-          boxShadow: "var(--faction-coven-slip-shadow)",
-        }}
-        contentStyle={{ padding: `${padTop} ${padX} ${padBottom}` }}
-        masthead={
+  /* The chrome, named once and mounted twice: the composer below, and the
+     waiting surface once your part is in (#1189). The same ELEMENTS both
+     times, so the twinkling wordmark, the braid, the wheel and the glyph
+     scatter cannot drift between the two stages. */
+  const sheetStyle = {
+    background: SHEET,
+    border: EDGE,
+    borderRadius: RADIUS,
+    boxShadow: "var(--faction-coven-slip-shadow)",
+  };
+  const contentStyle = { padding: `${padTop} ${padX} ${padBottom}` };
+  const statusMark = <Pentacle size={40} color={DEEP} />;
+  const slip = {
+    style: {
+      background: FIELD,
+      border: RULE,
+      borderRadius: FIELD_RADIUS,
+      padding: "var(--space-lg)",
+    },
+    labelStyle,
+    titleStyle: { fontFamily: DISPLAY, color: INK },
+    descriptionStyle: { fontFamily: CHROME, color: SOFT },
+    pillStyle: { fontFamily: CHROME, color: LABEL },
+  } as const;
+  /* The waiting footer's affirmative control is a BUTTON, not the composer's
+     full-bleed band: the band is the slip's one irreversible act, and taking
+     your own part back out is neither irreversible nor the page's subject. */
+  const primaryStyle = composerLabelStyle({
+    fontFamily: CHROME,
+    fontSize: "var(--text-xl)",
+    fontWeight: 700,
+    border: "none",
+    borderRadius: FIELD_RADIUS,
+    padding: "var(--space-md) var(--space-xl)",
+    color: CTA_INK,
+    background: CTA_BAND,
+  });
+  const masthead = (
           <ComposerMasthead
             style={{
               height: "auto",
@@ -534,8 +548,8 @@ export default function CovenEditPraxis({ state }: Props) {
               <Braid style={{ marginTop: "var(--space-sm)" }} />
             </div>
           </ComposerMasthead>
-        }
-        ground={
+  );
+  const ground = (
           <>
             {/* The glow and the lavender wash, at the design's two anchors. */}
             <ComposerGround
@@ -570,7 +584,59 @@ export default function CovenEditPraxis({ state }: Props) {
               <GlyphScatter />
             </ComposerGround>
           </>
-        }
+  );
+
+  const dress: ComposerDress = {
+    accent: DEEP,
+    pageStyle: { fontFamily: CHROME, color: INK },
+    breadcrumbInk: LABEL,
+    sheetStyle,
+    contentStyle,
+    masthead,
+    ground,
+    rule: () => braidRule,
+    mark: statusMark,
+    statusStyle: { fontFamily: CHROME, color: INK, fontWeight: 700 },
+    metaStyle: { fontFamily: CHROME, color: LABEL },
+    labelStyle,
+    slip,
+    panelStyle: {
+      background: FIELD,
+      border: RULE,
+      borderRadius: FIELD_RADIUS,
+    },
+    headingStyle: { fontFamily: DISPLAY, color: INK },
+    bodyStyle: { fontFamily: CHROME, color: SOFT },
+    quietStyle: { fontFamily: CHROME, color: LABEL },
+    primaryStyle,
+    quietButtonStyle: { fontFamily: CHROME, color: LABEL },
+  };
+
+  /* Your part is in, so the composer is not a composer any more (ADR-0059).
+     Same page, same sheet, same ornament — a different stage. */
+  if (isWaitingStage(state.phase)) {
+    return <PraxisWaitingSurface state={state} dress={dress} />;
+  }
+
+  return (
+    <ComposerPage
+      sizes={sizes}
+      style={dress.pageStyle}
+      breadcrumb={
+        <Breadcrumb
+          praxisId={praxis.id}
+          taskId={praxis.task_id}
+          taskTitle={praxis.task_title}
+          inkColor={LABEL}
+        />
+      }
+    >
+      <ComposerSheet
+        sizes={sizes}
+        style={sheetStyle}
+        contentStyle={contentStyle}
+        masthead={masthead}
+        ground={ground}
       >
         {/* Draft · Saved just now, closed by the pentacle. */}
         <ComposerStatusRow
@@ -582,25 +648,16 @@ export default function CovenEditPraxis({ state }: Props) {
                 })
               : t("editPraxis.composer.statusUnsaved")
           }
-          statusStyle={{ fontFamily: CHROME, color: INK, fontWeight: 700 }}
-          metaStyle={{ fontFamily: CHROME, color: LABEL }}
-          mark={<Pentacle size={40} color={DEEP} />}
+          statusStyle={dress.statusStyle}
+          metaStyle={dress.metaStyle}
+          mark={statusMark}
         />
 
         {/* The task reference slip, with the ward. */}
         <TaskSlip
           praxis={praxis}
           task={task}
-          style={{
-            background: FIELD,
-            border: RULE,
-            borderRadius: FIELD_RADIUS,
-            padding: "var(--space-lg)",
-          }}
-          labelStyle={labelStyle}
-          titleStyle={{ fontFamily: DISPLAY, color: INK }}
-          descriptionStyle={{ fontFamily: CHROME, color: SOFT }}
-          pillStyle={{ fontFamily: CHROME, color: LABEL }}
+          {...slip}
           mark={<PointsWard size={88} points={task?.point_value ?? 0} />}
         />
 
@@ -952,7 +1009,7 @@ export default function CovenEditPraxis({ state }: Props) {
           }
         />
       </ComposerSheet>
-    </div>
+    </ComposerPage>
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -78,6 +78,7 @@ import {
   ComposerFooter,
   ComposerGround,
   ComposerMasthead,
+  ComposerPage,
   ComposerRule,
   ComposerSection,
   ComposerSheet,
@@ -89,7 +90,9 @@ import {
   composerLabelStyle,
   formatAutosave,
   useComposerSizes,
+  type ComposerDress,
 } from "./shared";
+import PraxisWaitingSurface from "../waiting/PraxisWaitingSurface";
 import {
   BodyPreview,
   BodyTextarea,
@@ -104,7 +107,7 @@ import {
   type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
-import type { EditPraxisState } from "../useEditPraxis";
+import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
   state: EditPraxisState;
@@ -137,6 +140,83 @@ const BAND = "var(--faction-default-rainbow-loop)";
  * --font-body is the site's Courier Prime. */
 const TITLE_FACE = "var(--font-display)";
 
+const labelStyle = { color: MUTED };
+const panelStyle = {
+  background: FIELD,
+  border: `1px solid ${BORDER}`,
+  borderRadius: 10,
+};
+/* The submit button's paint, minus the busy cursor the composer adds. */
+const primaryStyle = composerLabelStyle({
+  border: "none",
+  borderRadius: 10,
+  padding: "var(--space-md) var(--space-xl)",
+  color: ON_ACCENT,
+  background: INK,
+  fontWeight: 700,
+});
+
+/* The chrome, named once and mounted twice: the composer below, and the
+   waiting surface once your part is in (#1189). These are the same ELEMENTS
+   both times, not two constructions of the same idea, so na's spectrum band
+   and drifting aurora cannot drift apart between the two stages. */
+const masthead = <ComposerMasthead background={BAND} animated />;
+const ground = (
+  <ComposerGround
+    background="var(--faction-default-aurora)"
+    opacity="var(--faction-default-aurora-opacity)"
+    filter="var(--faction-default-aurora-filter)"
+    mixBlendMode="var(--faction-default-aurora-blend)"
+    animated
+  />
+);
+const sheetStyle = {
+  background: SHEET,
+  border: `1px solid ${BORDER}`,
+  boxShadow: "0 16px 40px -24px rgba(0,0,0,0.5)",
+};
+const statusMark = (
+  <RingMark size={44} inset={5} ring={RING} inner={FIELD} spin />
+);
+const slip = {
+  style: {
+    background: FIELD,
+    border: `1px solid ${BORDER}`,
+    borderRadius: 10,
+    padding: "var(--space-lg)",
+  },
+  labelStyle: { color: FAINT },
+  titleStyle: { fontFamily: TITLE_FACE, fontStyle: "italic", color: INK },
+  descriptionStyle: { color: MUTED },
+  pillStyle: { color: MUTED },
+} as const;
+
+/**
+ * The na kit's dress, handed to `PraxisWaitingSurface` once your part is in
+ * (#1189). Exported because it is also the fall-through every unregistered slug
+ * renders, so a test that asserts on the shared surface asserts on a REAL dress
+ * rather than a fixture invented for the occasion.
+ */
+export const DEFAULT_COMPOSER_DRESS: ComposerDress = {
+  accent: INK,
+  pageStyle: { fontFamily: TITLE_FACE, color: INK },
+  sheetStyle,
+  masthead,
+  ground,
+  rule: <ComposerRule style={{ background: HAIR }} />,
+  mark: statusMark,
+  statusStyle: { color: INK, fontWeight: 700 },
+  metaStyle: { color: FAINT },
+  labelStyle,
+  slip,
+  panelStyle,
+  headingStyle: { fontFamily: TITLE_FACE, color: INK },
+  bodyStyle: { color: MUTED },
+  quietStyle: { color: FAINT },
+  primaryStyle,
+  quietButtonStyle: { color: FAINT },
+};
+
 export default function DefaultEditPraxis({ state }: Props) {
   const { t } = useTranslation("forms");
   const sizes = useComposerSizes();
@@ -161,40 +241,29 @@ export default function DefaultEditPraxis({ state }: Props) {
     outline: "none",
     boxSizing: "border-box",
   } as const;
+  /* Your part is in, so the composer is not a composer any more (ADR-0059).
+     Same page, same sheet, same ornament — a different stage. */
+  if (isWaitingStage(state.phase)) {
+    return <PraxisWaitingSurface state={state} dress={DEFAULT_COMPOSER_DRESS} />;
+  }
 
   return (
-    <div style={{ fontFamily: TITLE_FACE, color: INK }}>
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: "0 auto",
-          padding: "var(--space-lg) var(--space-lg) 0",
-        }}
-      >
+    <ComposerPage
+      sizes={sizes}
+      style={DEFAULT_COMPOSER_DRESS.pageStyle}
+      breadcrumb={
         <Breadcrumb
           praxisId={praxis.id}
           taskId={praxis.task_id}
           taskTitle={praxis.task_title}
         />
-      </div>
-
+      }
+    >
       <ComposerSheet
         sizes={sizes}
-        style={{
-          background: SHEET,
-          border: `1px solid ${BORDER}`,
-          boxShadow: "0 16px 40px -24px rgba(0,0,0,0.5)",
-        }}
-        masthead={<ComposerMasthead background={BAND} animated />}
-        ground={
-          <ComposerGround
-            background="var(--faction-default-aurora)"
-            opacity="var(--faction-default-aurora-opacity)"
-            filter="var(--faction-default-aurora-filter)"
-            mixBlendMode="var(--faction-default-aurora-blend)"
-            animated
-          />
-        }
+        style={sheetStyle}
+        masthead={masthead}
+        ground={ground}
       >
         {/* Draft · Saved just now, with the spectrum status mark. */}
         <ComposerStatusRow
@@ -206,25 +275,16 @@ export default function DefaultEditPraxis({ state }: Props) {
                 })
               : t("editPraxis.composer.statusUnsaved")
           }
-          statusStyle={{ color: INK, fontWeight: 700 }}
-          metaStyle={{ color: FAINT }}
-          mark={<RingMark size={44} inset={5} ring={RING} inner={FIELD} spin />}
+          statusStyle={DEFAULT_COMPOSER_DRESS.statusStyle}
+          metaStyle={DEFAULT_COMPOSER_DRESS.metaStyle}
+          mark={statusMark}
         />
 
         {/* The task reference slip, on the field ground with the points mark. */}
         <TaskSlip
           praxis={praxis}
           task={task}
-          style={{
-            background: FIELD,
-            border: `1px solid ${BORDER}`,
-            borderRadius: 10,
-            padding: "var(--space-lg)",
-          }}
-          labelStyle={{ color: FAINT }}
-          titleStyle={{ fontFamily: TITLE_FACE, fontStyle: "italic", color: INK }}
-          descriptionStyle={{ color: MUTED }}
-          pillStyle={{ color: MUTED }}
+          {...slip}
           mark={
             <RingMark
               size={84}
@@ -252,7 +312,7 @@ export default function DefaultEditPraxis({ state }: Props) {
           label={t("editPraxis.composer.titleLabel")}
           htmlFor="composer-title"
           meta={<TitleCounter length={state.title.length} color={FAINT} />}
-          labelStyle={{ color: MUTED }}
+          labelStyle={labelStyle}
         >
           <TitleField
             state={state}
@@ -273,7 +333,7 @@ export default function DefaultEditPraxis({ state }: Props) {
         {!state.controlsLocked && (
           <ComposerSection
             label={t("editPraxis.composer.modeLabel")}
-            labelStyle={{ color: MUTED }}
+            labelStyle={labelStyle}
           >
             <ModePicker
               state={state}
@@ -320,7 +380,7 @@ export default function DefaultEditPraxis({ state }: Props) {
                     count: praxis.members.length,
                   })
             }
-            labelStyle={{ color: MUTED }}
+            labelStyle={labelStyle}
           >
             <InviteSearch
               state={state}
@@ -343,7 +403,7 @@ export default function DefaultEditPraxis({ state }: Props) {
         {state.showSealStack && (
           <ComposerSection
             label={t("editPraxis.composer.sealsLabel")}
-            labelStyle={{ color: MUTED }}
+            labelStyle={labelStyle}
           >
             <MetataskSealStack state={state} />
           </ComposerSection>
@@ -354,7 +414,7 @@ export default function DefaultEditPraxis({ state }: Props) {
         <ComposerSection
           label={t("editPraxis.composer.writeUpLabel")}
           htmlFor="composer-body"
-          labelStyle={{ color: MUTED }}
+          labelStyle={labelStyle}
           meta={
             <WriteUpTabs
               tab={tab}
@@ -432,7 +492,7 @@ export default function DefaultEditPraxis({ state }: Props) {
 
         <ComposerSection
           label={t("editPraxis.composer.proofLabel")}
-          labelStyle={{ color: MUTED }}
+          labelStyle={labelStyle}
         >
           <div
             style={{
@@ -533,21 +593,16 @@ export default function DefaultEditPraxis({ state }: Props) {
               skin={{
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),
-                style: composerLabelStyle({
+                style: {
+                  ...primaryStyle,
                   cursor: state.submitting ? "wait" : "pointer",
-                  border: "none",
-                  borderRadius: 10,
-                  padding: "var(--space-md) var(--space-xl)",
-                  color: ON_ACCENT,
-                  background: INK,
-                  fontWeight: 700,
-                }),
+                },
               }}
             />
           }
         />
       </ComposerSheet>
-    </div>
+    </ComposerPage>
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -203,7 +203,7 @@ export const DEFAULT_COMPOSER_DRESS: ComposerDress = {
   sheetStyle,
   masthead,
   ground,
-  rule: <ComposerRule style={{ background: HAIR }} />,
+  rule: () => <ComposerRule style={{ background: HAIR }} />,
   mark: statusMark,
   statusStyle: { color: INK, fontWeight: 700 },
   metaStyle: { color: FAINT },

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -88,6 +88,7 @@ import {
   ComposerFooter,
   ComposerGround,
   ComposerMasthead,
+  ComposerPage,
   ComposerRule,
   ComposerSection,
   ComposerSheet,
@@ -98,7 +99,9 @@ import {
   composerLabelStyle,
   formatAutosave,
   useComposerSizes,
+  type ComposerDress,
 } from "./shared";
+import PraxisWaitingSurface from "../waiting/PraxisWaitingSurface";
 import {
   BodyPreview,
   BodyTextarea,
@@ -138,7 +141,7 @@ import {
   Sign,
   WingedDisc,
 } from "../../../components/cards/ephemeristsPlate";
-import type { EditPraxisState } from "../useEditPraxis";
+import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
   state: EditPraxisState;
@@ -322,32 +325,41 @@ export default function EphemeristsEditPraxis({ state }: Props) {
     boxSizing: "border-box",
   } as const;
 
-  return (
-    <div style={{ fontFamily: DECO, color: INK }}>
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: "0 auto",
-          padding: "var(--space-lg) var(--space-lg) 0",
-        }}
-      >
-        <Breadcrumb
-          praxisId={praxis.id}
-          taskId={praxis.task_id}
-          taskTitle={praxis.task_title}
-          inkColor={QUIET}
-        />
-      </div>
-
-      <ComposerSheet
-        sizes={sizes}
-        style={{
-          background: PLATE,
-          border: `1.5px solid ${LINE}`,
-          borderRadius: 0,
-          boxShadow: SHADOW,
-        }}
-        masthead={
+  /* The chrome, named once and mounted twice: the composer below, and the
+     waiting surface once your part is in (#1189). The same ELEMENTS both
+     times, so the sky band, the cornice and the ruled ground cannot drift
+     between the two stages. */
+  const sheetStyle = {
+    background: PLATE,
+    border: `1.5px solid ${LINE}`,
+    borderRadius: 0,
+    boxShadow: SHADOW,
+  };
+  const statusMark = <StatusMark />;
+  const slip = {
+    style: {
+      background: INNER,
+      border: `1.5px solid ${LINE}`,
+      borderRadius: 0,
+      padding: "var(--space-lg)",
+    },
+    labelStyle: { ...label, color: QUIET },
+    titleStyle: { fontFamily: CAPS, color: INK, lineHeight: 1.2 },
+    descriptionStyle: { fontFamily: READING, color: QUIET },
+    pillStyle: { ...label, color: QUIET, borderRadius: 0 },
+  } as const;
+  const primaryStyle = composerLabelStyle({
+    ...label,
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "var(--space-sm)",
+    border: `1.5px solid ${BRASS}`,
+    borderRadius: 0,
+    padding: "var(--space-md) var(--space-xl)",
+    color: CTA_INK,
+    background: CTA,
+  });
+  const masthead = (
           <>
             {/* The sky band. A wash rather than a flat fill: the night blue
                 lifts toward the nile at the horizon and settles back into the
@@ -391,8 +403,8 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             {/* The cavetto cornice, beneath the band, carrying the one motion. */}
             <Cornice glow />
           </>
-        }
-        ground={
+  );
+  const ground = (
           <ComposerGround
             inset={0}
             background={`repeating-linear-gradient(0deg, transparent 0 ${RULING}px, ${RULE} ${RULING}px ${RULING + 1}px)`}
@@ -411,7 +423,57 @@ export default function EphemeristsEditPraxis({ state }: Props) {
               }}
             />
           </ComposerGround>
-        }
+  );
+
+  const dress: ComposerDress = {
+    accent: BRASS,
+    pageStyle: { fontFamily: DECO, color: INK },
+    breadcrumbInk: QUIET,
+    sheetStyle,
+    masthead,
+    ground,
+    rule: () => flute,
+    mark: statusMark,
+    statusStyle: { ...label, color: INK },
+    metaStyle: { fontFamily: READING, color: QUIET },
+    labelStyle: sectionLabel,
+    slip,
+    panelStyle: {
+      background: INNER,
+      border: `1.5px solid ${LINE}`,
+      borderRadius: 0,
+    },
+    headingStyle: { fontFamily: CAPS, color: INK, lineHeight: 1.2 },
+    bodyStyle: { fontFamily: READING, color: QUIET },
+    quietStyle: { fontFamily: READING, color: QUIET },
+    primaryStyle,
+    quietButtonStyle: { ...label, color: QUIET },
+  };
+
+  /* Your part is in, so the composer is not a composer any more (ADR-0059).
+     Same page, same sheet, same ornament — a different stage. */
+  if (isWaitingStage(state.phase)) {
+    return <PraxisWaitingSurface state={state} dress={dress} />;
+  }
+
+  return (
+    <ComposerPage
+      sizes={sizes}
+      style={dress.pageStyle}
+      breadcrumb={
+        <Breadcrumb
+          praxisId={praxis.id}
+          taskId={praxis.task_id}
+          taskTitle={praxis.task_title}
+          inkColor={QUIET}
+        />
+      }
+    >
+      <ComposerSheet
+        sizes={sizes}
+        style={sheetStyle}
+        masthead={masthead}
+        ground={ground}
       >
         {/* Draft · Saved just now, with the ankh cartouche at the row's end. */}
         <ComposerStatusRow
@@ -423,25 +485,16 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                 })
               : t("editPraxis.composer.statusUnsaved")
           }
-          statusStyle={{ ...label, color: INK }}
-          metaStyle={{ fontFamily: READING, color: QUIET }}
-          mark={<StatusMark />}
+          statusStyle={dress.statusStyle}
+          metaStyle={dress.metaStyle}
+          mark={statusMark}
         />
 
         {/* The task reference slip, on an inner cell with the points mark. */}
         <TaskSlip
           praxis={praxis}
           task={task}
-          style={{
-            background: INNER,
-            border: `1.5px solid ${LINE}`,
-            borderRadius: 0,
-            padding: "var(--space-lg)",
-          }}
-          labelStyle={{ ...label, color: QUIET }}
-          titleStyle={{ fontFamily: CAPS, color: INK, lineHeight: 1.2 }}
-          descriptionStyle={{ fontFamily: READING, color: QUIET }}
-          pillStyle={{ ...label, color: QUIET, borderRadius: 0 }}
+          {...slip}
           mark={
             <PointsMark
               points={task?.point_value ?? praxis.task_point_value ?? 0}
@@ -765,24 +818,16 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                     weight={1.4}
                   />
                 ),
-                style: composerLabelStyle({
-                  ...label,
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: "var(--space-sm)",
+                style: {
+                  ...primaryStyle,
                   cursor: state.submitting ? "wait" : "pointer",
-                  border: `1.5px solid ${BRASS}`,
-                  borderRadius: 0,
-                  padding: "var(--space-md) var(--space-xl)",
-                  color: CTA_INK,
-                  background: CTA,
-                }),
+                },
               }}
             />
           }
         />
       </ComposerSheet>
-    </div>
+    </ComposerPage>
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -89,6 +89,7 @@ import {
   ComposerFooter,
   ComposerGround,
   ComposerMasthead,
+  ComposerPage,
   ComposerRule,
   ComposerSection,
   ComposerSheet,
@@ -100,7 +101,9 @@ import {
   composerLabelStyle,
   formatAutosave,
   useComposerSizes,
+  type ComposerDress,
 } from "./shared";
+import PraxisWaitingSurface from "../waiting/PraxisWaitingSurface";
 import {
   BodyPreview,
   BodyTextarea,
@@ -115,7 +118,7 @@ import {
   type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
-import type { EditPraxisState } from "../useEditPraxis";
+import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
   state: EditPraxisState;
@@ -273,32 +276,48 @@ export default function EverymenEditPraxis({ state }: Props) {
     />
   );
 
-  return (
-    <div style={{ fontFamily: COURIER, color: INK }}>
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: "0 auto",
-          padding: "var(--space-lg) var(--space-lg) 0",
-        }}
-      >
-        <Breadcrumb
-          praxisId={praxis.id}
-          taskId={praxis.task_id}
-          taskTitle={praxis.task_title}
-          inkColor={MUTED}
-        />
-      </div>
-
-      <ComposerSheet
-        sizes={sizes}
-        style={{
-          background: PAPER,
-          border: `2px solid ${SHEET_FRAME}`,
-          borderRadius: 0,
-          boxShadow: SHADOW,
-        }}
-        masthead={
+  /* The chrome, named once and mounted twice: the composer below, and the
+     waiting surface once your part is in (#1189). The same ELEMENTS both
+     times, so the nameplate's counter-turning cogs and the ray burst cannot
+     drift between the two stages. */
+  const sheetStyle = {
+    background: PAPER,
+    border: `2px solid ${SHEET_FRAME}`,
+    borderRadius: 0,
+    boxShadow: SHADOW,
+  };
+  const statusMark = <Gear size={40} fill={RED} hole={PANEL} />;
+  const slip = {
+    style: {
+      background: PANEL,
+      border: `2px solid ${FRAME}`,
+      borderRadius: 0,
+      padding: "var(--space-lg)",
+    },
+    labelStyle: stencil({ color: ACCENT, letterSpacing: "0.2em" }),
+    titleStyle: {
+      fontFamily: BEBAS,
+      textTransform: "uppercase" as const,
+      letterSpacing: "0.01em",
+      lineHeight: 0.96,
+      color: INK,
+    },
+    descriptionStyle: { fontFamily: COURIER, color: MUTED },
+    pillStyle: stencil({ color: ACCENT, borderRadius: 0 }),
+  };
+  /* The waiting footer's affirmative control is a BUTTON, not the composer's
+     full-bleed bar: the bar is the order's one irreversible act, and taking
+     your own part back out is neither irreversible nor the page's subject. */
+  const primaryStyle = stencil({
+    background: BAR,
+    color: BAR_INK,
+    border: "none",
+    borderRadius: 0,
+    padding: "var(--space-md) var(--space-xl)",
+    letterSpacing: "0.22em",
+    textAlign: "center",
+  });
+  const masthead = (
           /* The nameplate: cog · the paper's name · cog, on the union's red bar,
              under a 3px double rule and the printed-in shadow of its own ink. */
           <ComposerMasthead
@@ -331,8 +350,8 @@ export default function EverymenEditPraxis({ state }: Props) {
             </span>
             <Gear size={16} fill={MAST_INK} hole={MAST} spin="reverse" duration="26s" />
           </ComposerMasthead>
-        }
-        ground={
+  );
+  const ground = (
           /* Poster rays fanning from behind the masthead, a gold glow in one
              corner and an olive one in the other, all masked away from the copy.
              Anchored (inset 0, unanimated): the burst's origin is the masthead,
@@ -354,7 +373,62 @@ export default function EverymenEditPraxis({ state }: Props) {
                 "radial-gradient(130% 70% at 50% 8%, #000 40%, transparent 92%)",
             }}
           />
-        }
+  );
+
+  const dress: ComposerDress = {
+    accent: ACCENT,
+    pageStyle: { fontFamily: COURIER, color: INK },
+    breadcrumbInk: MUTED,
+    sheetStyle,
+    masthead,
+    ground,
+    rule: () => dashRule,
+    mark: statusMark,
+    statusStyle: stencil({ color: INK, letterSpacing: "0.2em" }),
+    metaStyle: { color: MUTED },
+    labelStyle: stencil({ color: INK, letterSpacing: "0.2em" }),
+    slip,
+    panelStyle: {
+      background: PANEL,
+      border: `2px solid ${FRAME}`,
+      borderRadius: 0,
+    },
+    headingStyle: {
+      fontFamily: BEBAS,
+      textTransform: "uppercase",
+      letterSpacing: "0.01em",
+      color: INK,
+    },
+    bodyStyle: { fontFamily: COURIER, color: MUTED },
+    quietStyle: { fontFamily: COURIER, color: MUTED },
+    primaryStyle,
+    quietButtonStyle: stencil({ color: MUTED }),
+  };
+
+  /* Your part is in, so the composer is not a composer any more (ADR-0059).
+     Same page, same sheet, same ornament — a different stage. */
+  if (isWaitingStage(state.phase)) {
+    return <PraxisWaitingSurface state={state} dress={dress} />;
+  }
+
+  return (
+    <ComposerPage
+      sizes={sizes}
+      style={dress.pageStyle}
+      breadcrumb={
+        <Breadcrumb
+          praxisId={praxis.id}
+          taskId={praxis.task_id}
+          taskTitle={praxis.task_title}
+          inkColor={MUTED}
+        />
+      }
+    >
+      <ComposerSheet
+        sizes={sizes}
+        style={sheetStyle}
+        masthead={masthead}
+        ground={ground}
       >
         {/* Draft · saved just now, with a cog turning at the end of the row. */}
         <ComposerStatusRow
@@ -366,31 +440,16 @@ export default function EverymenEditPraxis({ state }: Props) {
                 })
               : t("editPraxis.composer.statusUnsaved")
           }
-          statusStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
-          metaStyle={{ color: MUTED }}
-          mark={<Gear size={40} fill={RED} hole={PANEL} />}
+          statusStyle={dress.statusStyle}
+          metaStyle={dress.metaStyle}
+          mark={statusMark}
         />
 
         {/* The job reference slip, on plate stock with the stamped points seal. */}
         <TaskSlip
           praxis={praxis}
           task={task}
-          style={{
-            background: PANEL,
-            border: `2px solid ${FRAME}`,
-            borderRadius: 0,
-            padding: "var(--space-lg)",
-          }}
-          labelStyle={stencil({ color: ACCENT, letterSpacing: "0.2em" })}
-          titleStyle={{
-            fontFamily: BEBAS,
-            textTransform: "uppercase",
-            letterSpacing: "0.01em",
-            lineHeight: 0.96,
-            color: INK,
-          }}
-          descriptionStyle={{ fontFamily: COURIER, color: MUTED }}
-          pillStyle={stencil({ color: ACCENT, borderRadius: 0 })}
+          {...slip}
           mark={
             <RingMark
               size={76}
@@ -745,24 +804,19 @@ export default function EverymenEditPraxis({ state }: Props) {
               skin={{
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),
-                style: stencil({
+                style: {
+                  ...primaryStyle,
                   width: "100%",
                   cursor: state.submitting ? "wait" : "pointer",
-                  background: BAR,
-                  color: BAR_INK,
-                  border: "none",
                   borderTop: `2px solid ${FRAME}`,
-                  borderRadius: 0,
                   padding: "var(--space-md) var(--space-lg)",
-                  letterSpacing: "0.22em",
-                  textAlign: "center",
-                }),
+                },
               }}
             />
           }
         />
       </ComposerSheet>
-    </div>
+    </ComposerPage>
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -113,6 +113,7 @@ import {
   ComposerFooter,
   ComposerGround,
   ComposerMasthead,
+  ComposerPage,
   ComposerRule,
   ComposerSection,
   ComposerSheet,
@@ -123,7 +124,9 @@ import {
   composerLabelStyle,
   formatAutosave,
   useComposerSizes,
+  type ComposerDress,
 } from "./shared";
+import PraxisWaitingSurface from "../waiting/PraxisWaitingSurface";
 import {
   BodyPreview,
   BodyTextarea,
@@ -138,7 +141,7 @@ import {
   type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
-import type { EditPraxisState } from "../useEditPraxis";
+import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
   state: EditPraxisState;
@@ -230,33 +233,59 @@ export default function SingularityEditPraxis({ state }: Props) {
     />
   );
 
-  return (
-    <div style={{ fontFamily: FACE, color: INK }}>
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: "0 auto",
-          padding: "var(--space-lg) var(--space-lg) 0",
-        }}
-      >
-        {/* No inkColor: the breadcrumb is on the page's ground, not the
-            terminal's, so it keeps the ink that ground was measured with. */}
-        <Breadcrumb
-          praxisId={praxis.id}
-          taskId={praxis.task_id}
-          taskTitle={praxis.task_title}
-        />
-      </div>
-
-      <ComposerSheet
-        sizes={sizes}
-        style={{
-          background: CHASSIS,
-          border: `1px solid ${BORDER}`,
-          borderRadius: RADIUS,
-          boxShadow: SHADOW,
-        }}
-        masthead={
+  /* The chrome, named once and mounted twice: the composer below, and the
+     waiting surface once your part is in (#1189). The same ELEMENTS both
+     times, so the window bar, its breathing lamp and the travelling scanline
+     cannot drift between the two stages. */
+  const sheetStyle = {
+    background: CHASSIS,
+    border: `1px solid ${BORDER}`,
+    borderRadius: RADIUS,
+    boxShadow: SHADOW,
+  };
+  const statusMark = (
+    <span
+      aria-hidden
+      style={{
+        fontFamily: FACE,
+        // 19 in the design → the 18px content rung (§4a).
+        fontSize: "var(--text-content)",
+        lineHeight: 1,
+        color: ACCENT,
+      }}
+    >
+      {STATUS_MARK}
+    </span>
+  );
+  const slip = {
+    style: {
+      background: PANEL,
+      border: `1px solid ${BORDER}`,
+      borderRadius: RADIUS,
+      padding: "var(--space-lg)",
+      flexDirection: sizes.isMobile ? ("column" as const) : ("row" as const),
+    },
+    labelStyle: { fontFamily: FACE, color: MUTED },
+    titleStyle: {
+      fontFamily: FACE,
+      color: ACCENT,
+      textShadow: HALO_GREEN,
+    },
+    descriptionStyle: { fontFamily: FACE, color: INK },
+    pillStyle: { fontFamily: FACE, color: BLUE, borderRadius: RADIUS },
+  };
+  const primaryStyle = termLabel({
+    display: "inline-flex",
+    alignItems: "center",
+    border: `1px solid ${CTA_BG}`,
+    borderRadius: RADIUS,
+    padding: "var(--space-md) var(--space-xl)",
+    color: CTA_INK,
+    background: CTA_BG,
+    boxShadow: CTA_GLOW,
+    letterSpacing: "0.1em",
+  });
+  const masthead = (
           /* The window bar. `ComposerMasthead` is a 3px band by default; the
              skin gives it its own height and padding through `style`, which is
              spread last. Its whole content is aria-hidden chrome. */
@@ -315,8 +344,8 @@ export default function SingularityEditPraxis({ state }: Props) {
               />
             </div>
           </ComposerMasthead>
-        }
-        ground={
+  );
+  const ground = (
           /* The standing raster, at inset 0 — a fixed scrim, so unlike the
              spectrum's aurora it neither drifts nor overhangs. The travelling
              band rides inside it and overhangs horizontally instead, so its
@@ -337,7 +366,57 @@ export default function SingularityEditPraxis({ state }: Props) {
               }}
             />
           </ComposerGround>
-        }
+  );
+
+  const dress: ComposerDress = {
+    accent: ACCENT,
+    pageStyle: { fontFamily: FACE, color: INK },
+    sheetStyle,
+    masthead,
+    ground,
+    rule: () => hairRule,
+    mark: statusMark,
+    statusStyle: { fontFamily: FACE, color: ACCENT },
+    metaStyle: { fontFamily: FACE, color: MUTED },
+    labelStyle: { fontFamily: FACE, color: MUTED },
+    slip,
+    panelStyle: {
+      background: PANEL,
+      border: `1px solid ${BORDER}`,
+      borderRadius: RADIUS,
+    },
+    headingStyle: { fontFamily: FACE, color: ACCENT, textShadow: HALO_GREEN },
+    bodyStyle: { fontFamily: FACE, color: INK },
+    quietStyle: { fontFamily: FACE, color: MUTED },
+    primaryStyle,
+    quietButtonStyle: { fontFamily: FACE, color: MUTED },
+  };
+
+  /* Your part is in, so the composer is not a composer any more (ADR-0059).
+     Same page, same sheet, same ornament — a different stage. */
+  if (isWaitingStage(state.phase)) {
+    return <PraxisWaitingSurface state={state} dress={dress} />;
+  }
+
+  return (
+    <ComposerPage
+      sizes={sizes}
+      style={dress.pageStyle}
+      breadcrumb={
+        /* No inkColor: the breadcrumb is on the page's ground, not the
+           terminal's, so it keeps the ink that ground was measured with. */
+        <Breadcrumb
+          praxisId={praxis.id}
+          taskId={praxis.task_id}
+          taskTitle={praxis.task_title}
+        />
+      }
+    >
+      <ComposerSheet
+        sizes={sizes}
+        style={sheetStyle}
+        masthead={masthead}
+        ground={ground}
       >
         <ComposerStatusRow
           status={t("editPraxis.composer.statusDraft")}
@@ -348,22 +427,9 @@ export default function SingularityEditPraxis({ state }: Props) {
                 })
               : t("editPraxis.composer.statusUnsaved")
           }
-          statusStyle={{ fontFamily: FACE, color: ACCENT }}
-          metaStyle={{ fontFamily: FACE, color: MUTED }}
-          mark={
-            <span
-              aria-hidden
-              style={{
-                fontFamily: FACE,
-                // 19 in the design → the 18px content rung (§4a).
-                fontSize: "var(--text-content)",
-                lineHeight: 1,
-                color: ACCENT,
-              }}
-            >
-              {STATUS_MARK}
-            </span>
-          }
+          statusStyle={dress.statusStyle}
+          metaStyle={dress.metaStyle}
+          mark={statusMark}
         />
 
         {/* The task reference slip, on a raised panel, with the points readout
@@ -372,21 +438,7 @@ export default function SingularityEditPraxis({ state }: Props) {
         <TaskSlip
           praxis={praxis}
           task={task}
-          style={{
-            background: PANEL,
-            border: `1px solid ${BORDER}`,
-            borderRadius: RADIUS,
-            padding: "var(--space-lg)",
-            flexDirection: sizes.isMobile ? "column" : "row",
-          }}
-          labelStyle={{ fontFamily: FACE, color: MUTED }}
-          titleStyle={{
-            fontFamily: FACE,
-            color: ACCENT,
-            textShadow: HALO_GREEN,
-          }}
-          descriptionStyle={{ fontFamily: FACE, color: INK }}
-          pillStyle={{ fontFamily: FACE, color: BLUE, borderRadius: RADIUS }}
+          {...slip}
           mark={
             <div
               style={{
@@ -742,24 +794,16 @@ export default function SingularityEditPraxis({ state }: Props) {
                     }}
                   />
                 ),
-                style: termLabel({
-                  display: "inline-flex",
-                  alignItems: "center",
+                style: {
+                  ...primaryStyle,
                   cursor: state.submitting ? "wait" : "pointer",
-                  border: `1px solid ${CTA_BG}`,
-                  borderRadius: RADIUS,
-                  padding: "var(--space-md) var(--space-xl)",
-                  color: CTA_INK,
-                  background: CTA_BG,
-                  boxShadow: CTA_GLOW,
-                  letterSpacing: "0.1em",
-                }),
+                },
               }}
             />
           }
         />
       </ComposerSheet>
-    </div>
+    </ComposerPage>
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -75,6 +75,7 @@ import {
   ComposerFooter,
   ComposerGround,
   ComposerMasthead,
+  ComposerPage,
   ComposerRule,
   ComposerSection,
   ComposerSheet,
@@ -85,7 +86,10 @@ import {
   composerLabelStyle,
   formatAutosave,
   useComposerSizes,
+  composerStageWord,
+  type ComposerDress,
 } from "./shared";
+import PraxisWaitingSurface from "../waiting/PraxisWaitingSurface";
 import {
   BodyPreview,
   BodyTextarea,
@@ -100,7 +104,7 @@ import {
   type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
-import type { EditPraxisState } from "../useEditPraxis";
+import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
   state: EditPraxisState;
@@ -236,29 +240,43 @@ export default function SnideEditPraxis({ state }: Props) {
    * way a child of a padded column reaches its parent's edge. */
   const sidePad = sizes.isMobile ? "var(--space-lg)" : "var(--space-2xl)";
 
-  return (
-    <div style={{ fontFamily: BODY_FACE, color: INK }}>
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: "0 auto",
-          padding: "var(--space-lg) var(--space-lg) 0",
-        }}
-      >
-        <Breadcrumb
-          praxisId={praxis.id}
-          taskId={praxis.task_id}
-          taskTitle={praxis.task_title}
-        />
-      </div>
-
-      <ComposerSheet
-        sizes={sizes}
-        /* radius 0, borderW 0 — the sheet has no edge but its own stock. */
-        style={{ background: SHEET, borderRadius: 0 }}
-        /* Bottom padding goes to the full-bleed submit bar below. */
-        contentStyle={{ paddingBottom: 0 }}
-        masthead={
+  /* The chrome, named once and mounted twice: the composer below, and the
+     waiting surface once your part is in (#1189). The same ELEMENTS both
+     times, so the acid bar, the raster and the tape cannot drift between the
+     two stages. The masthead's stage word travels with them — it reads
+     SUBMITTED, not DRAFT, once your part is filed. */
+  /* radius 0, borderW 0 — the sheet has no edge but its own stock. */
+  const sheetStyle = { background: SHEET, borderRadius: 0 };
+  const statusMark = <SnideBlob width={52} height={40} struck />;
+  const slip = {
+    style: {
+      background: FIELD,
+      border: `1px solid ${RULE}`,
+      borderRadius: 0,
+      padding: "var(--space-lg)",
+    },
+    labelStyle: { color: MUTED },
+    titleStyle: {
+      fontFamily: TITLE_FACE,
+      color: INK,
+      letterSpacing: "0.02em",
+    },
+    descriptionStyle: { color: MUTED },
+    pillStyle: { color: MUTED, borderRadius: 0 },
+  } as const;
+  /* The waiting footer's affirmative control is a BUTTON, not the composer's
+     full-bleed bar: the bar is the sheet's one irreversible act, and taking
+     your own part back out is neither irreversible nor the page's subject. */
+  const primaryStyle = punkLabel({
+    padding: "var(--space-md) var(--space-xl)",
+    border: "none",
+    borderRadius: 0,
+    background: ACID,
+    color: PRESS_INK,
+    fontFamily: TITLE_FACE,
+    letterSpacing: "0.2em",
+  });
+  const masthead = (
           <ComposerMasthead
             background={BAR}
             style={{ height: "auto", padding: "var(--space-sm) var(--space-lg)" }}
@@ -303,12 +321,12 @@ export default function SnideEditPraxis({ state }: Props) {
                   whiteSpace: "nowrap",
                 })}
               >
-                {t("editPraxis.composer.statusDraft")}
+                {composerStageWord(state)}
               </span>
             </span>
           </ComposerMasthead>
-        }
-        ground={
+  );
+  const ground = (
           <ComposerGround
             background={`repeating-linear-gradient(0deg, ${GRAIN} 0 1px, transparent 1px 3px)`}
             /* Flush, not overhanging: the raster is printed on the sheet, and
@@ -338,10 +356,60 @@ export default function SnideEditPraxis({ state }: Props) {
               }}
             />
           </ComposerGround>
-        }
+  );
+
+  const dress: ComposerDress = {
+    accent: ACID_INK,
+    pageStyle: { fontFamily: BODY_FACE, color: INK },
+    sheetStyle,
+    masthead,
+    ground,
+    rule: () => censorStripe,
+    mark: statusMark,
+    statusStyle: { color: INK, fontWeight: 700, letterSpacing: "0.2em" },
+    metaStyle: { color: FAINT },
+    labelStyle: { color: MUTED },
+    slip,
+    panelStyle: {
+      background: FIELD,
+      border: `1px solid ${RULE}`,
+      borderRadius: 0,
+    },
+    headingStyle: { fontFamily: TITLE_FACE, color: INK, letterSpacing: "0.02em" },
+    bodyStyle: { color: MUTED },
+    quietStyle: { color: FAINT },
+    primaryStyle,
+    quietButtonStyle: { color: FAINT },
+  };
+
+  /* Your part is in, so the composer is not a composer any more (ADR-0059).
+     Same page, same sheet, same ornament — a different stage. */
+  if (isWaitingStage(state.phase)) {
+    return <PraxisWaitingSurface state={state} dress={dress} />;
+  }
+
+  return (
+    <ComposerPage
+      sizes={sizes}
+      style={dress.pageStyle}
+      breadcrumb={
+        <Breadcrumb
+          praxisId={praxis.id}
+          taskId={praxis.task_id}
+          taskTitle={praxis.task_title}
+        />
+      }
+    >
+      <ComposerSheet
+        sizes={sizes}
+        style={sheetStyle}
+        /* Bottom padding goes to the full-bleed submit bar below. */
+        contentStyle={{ paddingBottom: 0 }}
+        masthead={masthead}
+        ground={ground}
       >
         <ComposerStatusRow
-          status={t("editPraxis.composer.statusDraft")}
+          status={composerStageWord(state)}
           meta={
             state.autosaveAt
               ? t("editPraxis.composer.statusSaved", {
@@ -349,28 +417,15 @@ export default function SnideEditPraxis({ state }: Props) {
                 })
               : t("editPraxis.composer.statusUnsaved")
           }
-          statusStyle={{ color: INK, fontWeight: 700, letterSpacing: "0.2em" }}
-          metaStyle={{ color: FAINT }}
-          mark={<SnideBlob width={52} height={40} struck />}
+          statusStyle={dress.statusStyle}
+          metaStyle={dress.metaStyle}
+          mark={statusMark}
         />
 
         <TaskSlip
           praxis={praxis}
           task={task}
-          style={{
-            background: FIELD,
-            border: `1px solid ${RULE}`,
-            borderRadius: 0,
-            padding: "var(--space-lg)",
-          }}
-          labelStyle={{ color: MUTED }}
-          titleStyle={{
-            fontFamily: TITLE_FACE,
-            color: INK,
-            letterSpacing: "0.02em",
-          }}
-          descriptionStyle={{ color: MUTED }}
-          pillStyle={{ color: MUTED, borderRadius: 0 }}
+          {...slip}
           mark={
             <span
               style={{
@@ -727,7 +782,7 @@ export default function SnideEditPraxis({ state }: Props) {
           }
         />
       </ComposerSheet>
-    </div>
+    </ComposerPage>
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -97,6 +97,7 @@ import {
   Breadcrumb,
   ComposerFooter,
   ComposerGround,
+  ComposerPage,
   ComposerRule,
   ComposerSection,
   ComposerSheet,
@@ -107,7 +108,9 @@ import {
   composerLabelStyle,
   formatAutosave,
   useComposerSizes,
+  type ComposerDress,
 } from "./shared";
+import PraxisWaitingSurface from "../waiting/PraxisWaitingSurface";
 import {
   BodyPreview,
   BodyTextarea,
@@ -125,7 +128,7 @@ import { Lotus } from "../../../components/factionMarks";
 import { UaSigil } from "../../../components/cards/UaSigil";
 import { UA_DISPLAY, UA_TEXT, UaEnsoScore } from "../../../components/cards/uaAtoms";
 import { MetataskSealStack } from "../MetataskSealStack";
-import type { EditPraxisState } from "../useEditPraxis";
+import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
   state: EditPraxisState;
@@ -168,7 +171,7 @@ export default function UaEditPraxis({ state }: Props) {
   /* Ornament geometry, in raw px because a drawn figure is neither type nor
    * spacing (WORLD_ZERO_STYLE §4a). The phone gets the same two marks, smaller
    * and pulled in — conditional ornament, not a second layout. */
-  const ground = sizes.isMobile
+  const groundGeometry = sizes.isMobile
     ? { lotus: 300, lotusLeft: -122, lotusTop: -94, enso: 208, ensoRight: -66, ensoBottom: -58 }
     : { lotus: 420, lotusLeft: -170, lotusTop: -130, enso: 300, ensoRight: -96, ensoBottom: -84 };
 
@@ -192,43 +195,45 @@ export default function UaEditPraxis({ state }: Props) {
     boxSizing: "border-box",
   } as const;
 
-  return (
-    <div style={{ fontFamily: UA_TEXT, color: INK }}>
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: "0 auto",
-          padding: "var(--space-lg) var(--space-lg) 0",
-        }}
-      >
-        {/* No `inkColor`: the breadcrumb sits ABOVE the sheet, on the site
-            background, so it takes the global tertiary ink like every other
-            page's. A `--faction-ua-*` ink here would be a colour measured on
-            UA's paper and then painted on the app's (#651, #694). */}
-        <Breadcrumb
-          praxisId={praxis.id}
-          taskId={praxis.task_id}
-          taskTitle={praxis.task_title}
-        />
-      </div>
-
-      <ComposerSheet
-        sizes={sizes}
-        style={{
-          background: SHEET,
-          border: `${BORDER_WIDTH}px solid ${ACCENT}`,
-          borderRadius: RADIUS,
-        }}
-        /* NO masthead. UA is the one faction that draws no top band. */
-        ground={
+  /* The chrome, named once and mounted twice: the composer below, and the
+     waiting surface once your part is in (#1189). The same ELEMENTS both
+     times, so the lotus and the turning ensō cannot drift between stages. */
+  const sheetStyle = {
+    background: SHEET,
+    border: `${BORDER_WIDTH}px solid ${ACCENT}`,
+    borderRadius: RADIUS,
+  };
+  const statusMark = <UaSigil width={44} height={44} />;
+  const slip = {
+    style: {
+      background: FIELD,
+      border: `1px solid ${RULE}`,
+      borderRadius: RADIUS,
+      padding: "var(--space-lg)",
+    },
+    labelStyle,
+    titleStyle: { fontFamily: UA_DISPLAY, fontWeight: 600, color: INK },
+    descriptionStyle: { color: BODY },
+    pillStyle: { fontFamily: UA_TEXT, color: MUTED },
+  } as const;
+  const primaryStyle = composerLabelStyle({
+    fontFamily: UA_TEXT,
+    border: "none",
+    borderRadius: RADIUS,
+    padding: "var(--space-md) var(--space-xl)",
+    color: ON_FILL,
+    background: FILL,
+  });
+  /* NO masthead. UA is the one faction that draws no top band. */
+  const groundLayer = (
           <ComposerGround inset={0} opacity="var(--faction-ua-card-lotus-opacity)">
             <Lotus
-              size={ground.lotus}
+              size={groundGeometry.lotus}
               color="var(--faction-ua-card-lotus)"
               style={{
                 position: "absolute",
-                left: ground.lotusLeft,
-                top: ground.lotusTop,
+                left: groundGeometry.lotusLeft,
+                top: groundGeometry.lotusTop,
               }}
             />
             {/* The ensō turns once every 200s — re-timed through the shared
@@ -238,17 +243,63 @@ export default function UaEditPraxis({ state }: Props) {
               style={
                 {
                   position: "absolute",
-                  right: ground.ensoRight,
-                  bottom: ground.ensoBottom,
+                  right: groundGeometry.ensoRight,
+                  bottom: groundGeometry.ensoBottom,
                   "--ep-spin-dur": GROUND_SPIN,
                 } as CSSProperties
               }
             >
-              <UaSigil width={ground.enso} height={ground.enso} />
+              <UaSigil width={groundGeometry.enso} height={groundGeometry.enso} />
             </span>
           </ComposerGround>
-        }
-      >
+  );
+
+  const dress: ComposerDress = {
+    accent: ACCENT,
+    pageStyle: { fontFamily: UA_TEXT, color: INK },
+    sheetStyle,
+    ground: groundLayer,
+    rule: () => rule,
+    mark: statusMark,
+    statusStyle: { fontFamily: UA_TEXT, color: INK, fontWeight: 600 },
+    metaStyle: { fontFamily: UA_TEXT, color: MUTED },
+    labelStyle,
+    slip,
+    panelStyle: {
+      background: FIELD,
+      border: `1px solid ${RULE}`,
+      borderRadius: RADIUS,
+    },
+    headingStyle: { fontFamily: UA_DISPLAY, fontWeight: 600, color: INK },
+    bodyStyle: { color: BODY },
+    quietStyle: { fontFamily: UA_TEXT, color: MUTED },
+    primaryStyle,
+    quietButtonStyle: { fontFamily: UA_TEXT, color: MUTED },
+  };
+
+  /* Your part is in, so the composer is not a composer any more (ADR-0059).
+     Same page, same sheet, same ornament — a different stage. */
+  if (isWaitingStage(state.phase)) {
+    return <PraxisWaitingSurface state={state} dress={dress} />;
+  }
+
+  return (
+    <ComposerPage
+      sizes={sizes}
+      style={dress.pageStyle}
+      breadcrumb={
+        /* No `inkColor`: the breadcrumb sits ABOVE the sheet, on the site
+           background, so it takes the global tertiary ink like every other
+           page's. A `--faction-ua-*` ink here would be a colour measured on
+           UA's paper and then painted on the app's (#651, #694). */
+        <Breadcrumb
+          praxisId={praxis.id}
+          taskId={praxis.task_id}
+          taskTitle={praxis.task_title}
+        />
+      }
+    >
+      <ComposerSheet sizes={sizes} style={sheetStyle} ground={groundLayer}>
         {/* Draft · Saved just now, with the ensō as the status mark. */}
         <ComposerStatusRow
           status={t("editPraxis.composer.statusDraft")}
@@ -259,25 +310,16 @@ export default function UaEditPraxis({ state }: Props) {
                 })
               : t("editPraxis.composer.statusUnsaved")
           }
-          statusStyle={{ fontFamily: UA_TEXT, color: INK, fontWeight: 600 }}
-          metaStyle={{ fontFamily: UA_TEXT, color: MUTED }}
-          mark={<UaSigil width={44} height={44} />}
+          statusStyle={dress.statusStyle}
+          metaStyle={dress.metaStyle}
+          mark={statusMark}
         />
 
         {/* The task reference slip, on the inset panel with the points mark. */}
         <TaskSlip
           praxis={praxis}
           task={task}
-          style={{
-            background: FIELD,
-            border: `1px solid ${RULE}`,
-            borderRadius: RADIUS,
-            padding: "var(--space-lg)",
-          }}
-          labelStyle={labelStyle}
-          titleStyle={{ fontFamily: UA_DISPLAY, fontWeight: 600, color: INK }}
-          descriptionStyle={{ color: BODY }}
-          pillStyle={{ fontFamily: UA_TEXT, color: MUTED }}
+          {...slip}
           mark={
             <UaEnsoScore
               size={88}
@@ -594,21 +636,16 @@ export default function UaEditPraxis({ state }: Props) {
               skin={{
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),
-                style: composerLabelStyle({
-                  fontFamily: UA_TEXT,
+                style: {
+                  ...primaryStyle,
                   cursor: state.submitting ? "wait" : "pointer",
-                  border: "none",
-                  borderRadius: RADIUS,
-                  padding: "var(--space-md) var(--space-xl)",
-                  color: ON_FILL,
-                  background: FILL,
-                }),
+                },
               }}
             />
           }
         />
       </ComposerSheet>
-    </div>
+    </ComposerPage>
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -115,6 +115,7 @@ import {
   ComposerFooter,
   ComposerGround,
   ComposerMasthead,
+  ComposerPage,
   ComposerSection,
   ComposerSheet,
   ComposerStatusRow,
@@ -124,7 +125,9 @@ import {
   composerLabelStyle,
   formatAutosave,
   useComposerSizes,
+  type ComposerDress,
 } from "./shared";
+import PraxisWaitingSurface from "../waiting/PraxisWaitingSurface";
 import {
   BodyPreview,
   BodyTextarea,
@@ -139,7 +142,7 @@ import {
   type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../MetataskSealStack";
-import type { EditPraxisState } from "../useEditPraxis";
+import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
   state: EditPraxisState;
@@ -233,33 +236,59 @@ export default function WowEditPraxis({ state }: Props) {
     boxSizing: "border-box",
   } as const;
 
-  return (
-    <div style={{ fontFamily: LORA, color: INK }}>
-      <div
-        style={{
-          maxWidth: sizes.maxWidth,
-          margin: "0 auto",
-          padding: "var(--space-lg) var(--space-lg) 0",
-        }}
-      >
-        <Breadcrumb
-          praxisId={praxis.id}
-          taskId={praxis.task_id}
-          taskTitle={praxis.task_title}
-          inkColor={LABEL}
-        />
-      </div>
-
-      <ComposerSheet
-        sizes={sizes}
-        style={{
-          background: SHEET,
-          border: `1.5px solid ${GOLD}`,
-          borderRadius: 6,
-          boxShadow: SHEET_SHADOW,
-        }}
-        masthead={<ComposerMasthead background={RIBBON} height={7} />}
-        ground={
+  /* The chrome, named once and mounted twice: the composer below, and the
+     waiting surface once your part is in (#1189). The same ELEMENTS both
+     times, so the ribbon, the turning ring and the balloons cannot drift
+     between the two stages. */
+  const sheetStyle = {
+    background: SHEET,
+    border: `1.5px solid ${GOLD}`,
+    borderRadius: 6,
+    boxShadow: SHEET_SHADOW,
+  };
+  const masthead = <ComposerMasthead background={RIBBON} height={7} />;
+  const statusMark = (
+    <span
+      aria-hidden
+      style={{
+        fontFamily: MED,
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: the writ's ✦ device at the design's own optical size, not a type tier (§4a).
+        fontSize: 34,
+        lineHeight: 1,
+        color: GOLD,
+      }}
+    >
+      ✦
+    </span>
+  );
+  const slip = {
+    style: {
+      background: SHEET,
+      border: `1.5px solid ${GOLD}`,
+      borderRadius: 6,
+      padding: "var(--space-lg)",
+    },
+    labelStyle: LABEL_STYLE,
+    titleStyle: { fontFamily: MED, color: INK },
+    descriptionStyle: {
+      fontFamily: LORA,
+      fontStyle: "italic",
+      color: MUTED,
+    },
+    pillStyle: LABEL_STYLE,
+  } as const;
+  const primaryStyle = composerLabelStyle({
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "var(--space-sm)",
+    fontFamily: MED,
+    border: `1.5px solid ${GOLD_INK}`,
+    borderRadius: 6,
+    padding: "var(--space-md) var(--space-xl)",
+    color: ON_GOLD,
+    background: GOLD,
+  });
+  const ground = (
           <ComposerGround inset={0}>
             {/* The turning ring. `.ep-spin` reads --ep-spin-dur, whose default
                 is the design's own 90s, so no re-time is needed. */}
@@ -288,7 +317,57 @@ export default function WowEditPraxis({ state }: Props) {
               }}
             />
           </ComposerGround>
-        }
+  );
+
+  const dress: ComposerDress = {
+    accent: PLUM,
+    pageStyle: { fontFamily: LORA, color: INK },
+    breadcrumbInk: LABEL,
+    sheetStyle,
+    masthead,
+    ground,
+    rule: (key) => <Zig id={key} />,
+    mark: statusMark,
+    statusStyle: { fontFamily: MED, color: INK },
+    metaStyle: QUIET_STYLE,
+    labelStyle: LABEL_STYLE,
+    slip,
+    panelStyle: {
+      background: FIELD,
+      border: `1.5px solid ${GOLD}`,
+      borderRadius: 6,
+    },
+    headingStyle: { fontFamily: MED, color: INK },
+    bodyStyle: { fontFamily: LORA, color: MUTED },
+    quietStyle: QUIET_STYLE,
+    primaryStyle,
+    quietButtonStyle: QUIET_STYLE,
+  };
+
+  /* Your part is in, so the composer is not a composer any more (ADR-0059).
+     Same page, same sheet, same ornament — a different stage. */
+  if (isWaitingStage(state.phase)) {
+    return <PraxisWaitingSurface state={state} dress={dress} />;
+  }
+
+  return (
+    <ComposerPage
+      sizes={sizes}
+      style={dress.pageStyle}
+      breadcrumb={
+        <Breadcrumb
+          praxisId={praxis.id}
+          taskId={praxis.task_id}
+          taskTitle={praxis.task_title}
+          inkColor={LABEL}
+        />
+      }
+    >
+      <ComposerSheet
+        sizes={sizes}
+        style={sheetStyle}
+        masthead={masthead}
+        ground={ground}
       >
         <ComposerStatusRow
           status={t("editPraxis.composer.statusDraft")}
@@ -299,22 +378,9 @@ export default function WowEditPraxis({ state }: Props) {
                 })
               : t("editPraxis.composer.statusUnsaved")
           }
-          statusStyle={{ fontFamily: MED, color: INK }}
-          metaStyle={QUIET_STYLE}
-          mark={
-            <span
-              aria-hidden
-              style={{
-                fontFamily: MED,
-                // eslint-disable-next-line local/no-raw-style-values -- ornament: the writ's ✦ device at the design's own optical size, not a type tier (§4a).
-                fontSize: 34,
-                lineHeight: 1,
-                color: GOLD,
-              }}
-            >
-              ✦
-            </span>
-          }
+          statusStyle={dress.statusStyle}
+          metaStyle={dress.metaStyle}
+          mark={statusMark}
         />
 
         {/* The task slip, on the sheet's cream inside a gold frame — the ground
@@ -322,20 +388,7 @@ export default function WowEditPraxis({ state }: Props) {
         <TaskSlip
           praxis={praxis}
           task={task}
-          style={{
-            background: SHEET,
-            border: `1.5px solid ${GOLD}`,
-            borderRadius: 6,
-            padding: "var(--space-lg)",
-          }}
-          labelStyle={LABEL_STYLE}
-          titleStyle={{ fontFamily: MED, color: INK }}
-          descriptionStyle={{
-            fontFamily: LORA,
-            fontStyle: "italic",
-            color: MUTED,
-          }}
-          pillStyle={LABEL_STYLE}
+          {...slip}
           mark={<PointsPlaque points={task?.point_value ?? 0} />}
         />
 
@@ -649,24 +702,16 @@ export default function WowEditPraxis({ state }: Props) {
                 idleLabel: t("editPraxis.composer.submit"),
                 busyLabel: t("editPraxis.composer.submitBusy"),
                 trailingOrnament: <span aria-hidden>✦</span>,
-                style: composerLabelStyle({
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: "var(--space-sm)",
-                  fontFamily: MED,
+                style: {
+                  ...primaryStyle,
                   cursor: state.submitting ? "wait" : "pointer",
-                  border: `1.5px solid ${GOLD_INK}`,
-                  borderRadius: 6,
-                  padding: "var(--space-md) var(--space-xl)",
-                  color: ON_GOLD,
-                  background: GOLD,
-                }),
+                },
               }}
             />
           }
         />
       </ComposerSheet>
-    </div>
+    </ComposerPage>
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -36,7 +36,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock("../../../../hooks/useFormFactor", () => ({
   useFormFactor: () => mocks.formFactor,
 }));
-vi.mock("../../useEditPraxis", () => ({
+// Partial: `isWaitingStage` stays REAL. It is the predicate every archetype
+// asks before swapping in the waiting surface (#1189), and a stubbed one would
+// let the dispatcher assertions below pass against a stage that never happens.
+vi.mock("../../useEditPraxis", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../useEditPraxis")>()),
   useEditPraxis: () => mocks.state,
 }));
 

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -50,6 +50,7 @@ import DefaultEditPraxis from "../DefaultEditPraxis";
 import { surfaceMap } from "../../../../factions";
 import { pickVariant } from "../../../../utils/factionDispatch";
 import { resolvedArchetype } from "../../../../factions/lazyArchetype";
+import { collabCopy } from "../../../../components/collab/collabCopy";
 
 const SOLO = i18n.t("forms:editPraxis.composer.modeSolo");
 const COLLAB = i18n.t("forms:editPraxis.composer.modeCollab");
@@ -225,6 +226,90 @@ describe("editPraxis dispatch (ADR-0065: one component, both widths)", () => {
     const markup = render(width, baseState());
     expect((markup.match(/<nav/g) ?? []).length).toBe(1);
   });
+});
+
+/**
+ * The stage swap (#1189).
+ *
+ * Once your part is in, the composer stops being a composer (ADR-0059) and the
+ * archetype hands `PraxisWaitingSurface` its own dress. That swap is the
+ * ARCHETYPE's, not the dispatcher's, so it has to hold for every skin — a
+ * faction that forgot the branch would draw a live composer over a submitted
+ * praxis, and a faction that forgot the breadcrumb would strand the player.
+ *
+ * Rendered per skin rather than through `<EditPraxis />` so the slug under test
+ * is the one being asserted on, and unwrapped through `resolvedArchetype`
+ * because a manifest entry is a lazy loader (#1045).
+ */
+describe("every skin swaps in the waiting surface (#1189)", () => {
+  const SUBMITTED = "2026-02-01T00:00:00Z";
+  const waitingState = (slug: string | null) =>
+    baseState({
+      phase: "waiting",
+      task: task(["solo", "collab", "duel"], slug),
+      praxis: {
+        ...praxis,
+        type: "collab",
+        task_faction_slug: slug,
+        task_point_value: 20,
+        created_by_id: 3,
+        submitted_at: SUBMITTED,
+        updated_at: SUBMITTED,
+        submit_proposed_at: SUBMITTED,
+        members: [],
+        score: 20,
+        metatask_points: 0,
+        display_multiplier: 1,
+        points_from_votes: 0,
+      } as unknown as PraxisOut,
+    });
+
+  // Every slug that registers `editPraxis`, plus the two that fall through to
+  // the na kit (ADR-0065 §4).
+  const SLUGS = [
+    null,
+    "albescent",
+    "coven",
+    "ephemerists",
+    "everymen",
+    "singularity",
+    "snide",
+    "ua",
+    "wow",
+  ];
+
+  it.each(SLUGS)("%s draws the waiting reading, not its composer", (slug) => {
+    const Archetype = resolvedArchetype(
+      pickVariant(surfaceMap("editPraxis"), slug, DefaultEditPraxis),
+    )!;
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <Archetype state={waitingState(slug)} />
+      </MemoryRouter>,
+    );
+    expect(markup).toContain(collabCopy(slug, "awaitingHeading"));
+    // `Proof` is a composer-only region, and unlike `Submit` it is not a
+    // prefix of anything the waiting surface says.
+    expect(markup).not.toContain(i18n.t("forms:editPraxis.composer.proofLabel"));
+  });
+
+  it.each(
+    WIDTHS.flatMap((width) => SLUGS.map((slug) => [width, slug] as const)),
+  )(
+    "draws exactly one breadcrumb on %s while %s waits",
+    (width, slug) => {
+      mocks.formFactor = width;
+      const Archetype = resolvedArchetype(
+        pickVariant(surfaceMap("editPraxis"), slug, DefaultEditPraxis),
+      )!;
+      const markup = renderToStaticMarkup(
+        <MemoryRouter>
+          <Archetype state={waitingState(slug)} />
+        </MemoryRouter>,
+      );
+      expect((markup.match(/<nav/g) ?? []).length).toBe(1);
+    },
+  );
 });
 
 describe("mode picker gates, unchanged by the collapse (#311, #877)", () => {

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -293,6 +293,46 @@ describe("every skin swaps in the waiting surface (#1189)", () => {
     expect(markup).not.toContain(i18n.t("forms:editPraxis.composer.proofLabel"));
   });
 
+  /**
+   * One token per skin, taken from its MASTHEAD or its GROUND — the two parts
+   * #1071 left neutral. If the surface were still drawing the page's own chrome
+   * these would all be absent, and the test would still find the heading above,
+   * which is exactly the flat reading this issue was filed to end.
+   */
+  const ORNAMENT: Record<string, string> = {
+    coven: "--faction-coven-slip-shadow",
+    ephemerists: "--faction-ephemerists-plate-band",
+    everymen: "--faction-everymen-bill-mast",
+    singularity: "--faction-singularity-term-chrome",
+    snide: "--faction-snide-composer-bar",
+    ua: "--faction-ua-card-lotus",
+    wow: "--faction-wow-quest-ribbon",
+  };
+
+  it.each(Object.keys(ORNAMENT))(
+    "%s wears its own ornament on the waiting surface, not the page's chrome",
+    (slug) => {
+      const Archetype = resolvedArchetype(
+        pickVariant(surfaceMap("editPraxis"), slug, DefaultEditPraxis),
+      )!;
+      const markup = renderToStaticMarkup(
+        <MemoryRouter>
+          <Archetype state={waitingState(slug)} />
+        </MemoryRouter>,
+      );
+      expect(markup).toContain(ORNAMENT[slug]);
+    },
+  );
+
+  it("na falls through to the spectrum kit's own band (ADR-0065 §4)", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <DefaultEditPraxis state={waitingState(null)} />
+      </MemoryRouter>,
+    );
+    expect(markup).toContain("--faction-default-rainbow-loop");
+  });
+
   it.each(
     WIDTHS.flatMap((width) => SLUGS.map((slug) => [width, slug] as const)),
   )(

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -1,82 +1,24 @@
 /**
  * The composer's shared presentational layer.
  *
- * Two generations live here. The helpers at the top predate the v2 composer and
- * are still read by the seven archetypes that have not been rebuilt yet. Below
- * the banner comment sits THE COMPOSER LAYOUT CONTRACT (#1181, ADR-0065) — the
- * blocks every v2 skin assembles, factored out so a skin brings dress and
- * nothing else.
+ * One generation now. A pre-v2 set (`RainbowTitle`, `RainbowUnderline`,
+ * `TaskMetaInline`, `ArchetypeFrame`, `formatClock`) lived above the banner
+ * comment for as long as an un-rebuilt archetype still read it; the last reader
+ * was the undressed waiting surface, and #1189 dressed it. They are deleted
+ * rather than kept warm — a helper with no caller is paid for by every sweep
+ * that has to decide whether it is load-bearing.
+ *
+ * What is left is THE COMPOSER LAYOUT CONTRACT (#1181, ADR-0065) — the blocks
+ * every v2 skin assembles, plus the {@link ComposerDress} that hands a skin's
+ * ornament to the one surface that is shared rather than per-faction (#1189).
  */
 import type { CSSProperties, ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import i18n from "../../../i18n";
-import LevelGem from "../../../components/ui/LevelGem";
-import { factionCssVar, factionName } from "../../../utils/factions";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import type { TaskOut } from "../../../api/tasks";
 import type { PraxisOut } from "../../../api/praxis";
-
-const RAINBOW_VARS = [
-  "var(--underline-1)",
-  "var(--underline-2)",
-  "var(--underline-3)",
-  "var(--underline-4)",
-  "var(--underline-5)",
-  "var(--underline-6)",
-];
-
-interface RainbowTitleProps {
-  text: string;
-  size?: number;
-  fontFamily?: string;
-  color?: string;
-}
-
-/**
- * The page title rendered as the brand's signature six-color underline. Each
- * character gets its own underline tile so the cycle works regardless of
- * justification or wrapping. Callers pass the (localized) text.
- */
-export function RainbowTitle({
-  text,
-  size = 38,
-  fontFamily = "'Lora', serif",
-  color = "var(--color-text-primary)",
-}: RainbowTitleProps) {
-  return (
-    <span
-      style={{
-        fontFamily,
-        fontStyle: "italic",
-        fontWeight: 500,
-        fontSize: size,
-        lineHeight: 1.05,
-        color,
-        display: "inline-block",
-      }}
-    >
-      {text.split("").map((character, index) =>
-        character === " " ? (
-          <span
-            key={index}
-            style={{ display: "inline-block", width: "0.3em" }}
-          />
-        ) : (
-          <span
-            key={index}
-            style={{
-              borderBottom: `4px solid ${RAINBOW_VARS[index % RAINBOW_VARS.length]}`,
-              paddingBottom: "var(--space-xs)",
-            }}
-          >
-            {character}
-          </span>
-        ),
-      )}
-    </span>
-  );
-}
 
 interface BreadcrumbProps {
   praxisId: number | string;
@@ -131,54 +73,6 @@ export function Breadcrumb({
   );
 }
 
-interface TaskHeaderInfoProps {
-  praxis: PraxisOut;
-  task: TaskOut | null;
-  textColor?: string;
-}
-
-/**
- * Re-usable inline meta line for any archetype that wants a compact
- * faction · pts · level summary next to the proven task title.
- */
-export function TaskMetaInline({
-  praxis,
-  task,
-  textColor,
-}: TaskHeaderInfoProps) {
-  const { t } = useTranslation("forms");
-  const slug = task?.primary_faction_slug ?? null;
-  return (
-    <span
-      style={{
-        display: "inline-flex",
-        gap: "var(--space-md)",
-        alignItems: "center",
-        flexWrap: "wrap",
-        fontFamily: "'Courier Prime', monospace",
-        fontSize: "var(--text-sm)",
-        textTransform: "uppercase",
-        letterSpacing: "0.12em",
-        color: textColor ?? factionCssVar(slug),
-      }}
-    >
-      <span>{factionName(slug)}</span>
-      {task && (
-        <span>· {t("taskMeta.points", { points: task.point_value })}</span>
-      )}
-      {task && <LevelGem level={task.level_required} factionSlug={slug} />}
-      {(praxis.type === "collab" || praxis.duel_id != null) && (
-        <span>
-          ·{" "}
-          {praxis.duel_id != null
-            ? t("taskMeta.duel")
-            : t("taskMeta.collab")}
-        </span>
-      )}
-    </span>
-  );
-}
-
 interface TitleCounterProps {
   length: number;
   color?: string;
@@ -197,24 +91,6 @@ export function TitleCounter({ length, color }: TitleCounterProps) {
     >
       {length}/200
     </span>
-  );
-}
-
-interface RainbowUnderlineProps {
-  height?: number;
-  opacity?: number;
-}
-
-export function RainbowUnderline({
-  height = 3,
-  opacity = 0.6,
-}: RainbowUnderlineProps) {
-  return (
-    <div style={{ display: "flex", height, marginTop: "var(--space-xs)", opacity }}>
-      {RAINBOW_VARS.map((color, index) => (
-        <div key={index} style={{ flex: 1, background: color }} />
-      ))}
-    </div>
   );
 }
 
@@ -241,26 +117,6 @@ export function ErrorBanner({ message }: ErrorBannerProps) {
   );
 }
 
-interface SectionProps {
-  children: ReactNode;
-  style?: CSSProperties;
-}
-
-export function ArchetypeFrame({ children, style }: SectionProps) {
-  return (
-    <div
-      style={{
-        maxWidth: 760,
-        margin: "0 auto",
-        padding: "var(--space-xl) var(--space-lg)",
-        ...style,
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
 export function formatAutosave(date: Date | null): string {
   if (!date) return "";
   const now = Date.now();
@@ -271,22 +127,12 @@ export function formatAutosave(date: Date | null): string {
   return i18n.t("forms:autosaveAgo.minutes", { minutes });
 }
 
-export function formatClock(date: Date | null): string {
-  if (!date) return "--:--:--";
-  const hh = String(date.getHours()).padStart(2, "0");
-  const mm = String(date.getMinutes()).padStart(2, "0");
-  const ss = String(date.getSeconds()).padStart(2, "0");
-  return `${hh}:${mm}:${ss}`;
-}
-
 /* ========================================================================== *
  * THE COMPOSER LAYOUT CONTRACT (#1181, epic #1179, ADR-0065)
  *
- * Everything above this line predates the v2 composer and is still read by the
- * seven archetypes that have not been rebuilt yet. Everything below is the
- * shared layout the v2 designs draw, factored out ONCE so the seven skin issues
- * (#1182-#1188) inherit it instead of each re-deriving it — and so a change to
- * the layout is one edit rather than eight.
+ * The shared layout the v2 designs draw, factored out ONCE so the seven skin
+ * issues (#1182-#1188) inherit it instead of each re-deriving it — and so a
+ * change to the layout is one edit rather than eight.
  *
  * The split of responsibilities is ADR-0065's: the LAYOUT and the API are
  * shared; only DRESS changes. A skin brings frame, type, ornament and motion. It
@@ -787,11 +633,17 @@ export function RingMark({
   );
 }
 
-interface TaskSlipProps {
+export interface TaskSlipProps {
   praxis: PraxisOut;
   task: TaskOut | null;
   /** The faction's points mark, drawn at the slip's end. */
   mark?: ReactNode;
+  /**
+   * The slip's eyebrow. Defaults to the composer's neutral `The task`; the
+   * waiting surface passes `The duel` when the slip is fronting a duel, which
+   * is the one place the same slip refers to something other than a task.
+   */
+  label?: ReactNode;
   style?: CSSProperties;
   labelStyle?: CSSProperties;
   titleStyle?: CSSProperties;
@@ -811,6 +663,7 @@ export function TaskSlip({
   praxis,
   task,
   mark,
+  label,
   style,
   labelStyle,
   titleStyle,
@@ -829,7 +682,7 @@ export function TaskSlip({
     >
       <div style={{ flex: 1, minWidth: 0 }}>
         <div style={composerLabelStyle(labelStyle)}>
-          {t("editPraxis.composer.taskLabel")}
+          {label ?? t("editPraxis.composer.taskLabel")}
         </div>
         <div
           style={{
@@ -942,4 +795,117 @@ export function ComposerStickyFooter({
       {children}
     </div>
   );
+}
+
+interface ComposerPageProps {
+  sizes: ComposerSizes;
+  /** The skin's root: its body face and its ink. */
+  style?: CSSProperties;
+  /** Drawn in a column of the sheet's own width, above the sheet. */
+  breadcrumb?: ReactNode;
+  children: ReactNode;
+}
+
+/**
+ * The page around the sheet: the skin's face and ink, and a breadcrumb sitting
+ * in the sheet's own column above it.
+ *
+ * All eight archetypes had spelled this block out identically, and #1189 needed
+ * a ninth copy for the waiting surface — so it is one block now. The geometry is
+ * shared and the paint is the skin's, which is the same split every other block
+ * on this page makes.
+ *
+ * The breadcrumb belongs to the PAGE rather than to a stage: the composer and
+ * the waiting surface each draw exactly one, which is what keeps the dispatcher
+ * out of the business of drawing a second (#567, #1181).
+ */
+export function ComposerPage({
+  sizes,
+  style,
+  breadcrumb,
+  children,
+}: ComposerPageProps) {
+  return (
+    <div style={style}>
+      {breadcrumb != null && (
+        <div
+          style={{
+            maxWidth: sizes.maxWidth,
+            margin: "0 auto",
+            padding: "var(--space-lg) var(--space-lg) 0",
+          }}
+        >
+          {breadcrumb}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+/* ========================================================================== *
+ * THE DRESS (#1189, epic #1179, ADR-0065)
+ *
+ * The composer holds after you submit (ADR-0059), and what it becomes is
+ * `PraxisWaitingSurface` — ONE shared surface holding all of the post-cast
+ * logic. #1071 shipped it faction-neutral and deferred the frames by name; this
+ * is the seam that closes that.
+ *
+ * A dress is the faction's own ornament, handed to that shared surface by the
+ * archetype that is already mounted. It is deliberately NOT a registry:
+ *
+ *  - Nothing new dispatches. `EditPraxis.tsx` resolves ONE component per slug
+ *    (`surfaceMap('editPraxis')`), and that component decides which stage it is
+ *    drawing — which is exactly how the design is authored, as one component
+ *    taking a `stage` prop.
+ *  - Nothing new is imported eagerly. Archetypes are lazy (#1045); a slug-keyed
+ *    map of eight dresses would be a barrel, and a barrel over the archetypes is
+ *    the 420 KB entry chunk that issue existed to delete.
+ *  - Nothing can drift. The `masthead`, `ground` and `rule` a dress carries are
+ *    the SAME ELEMENTS the archetype mounts in its composer — named once and
+ *    passed to both — so the page cannot change dress the moment you submit.
+ *
+ * Every field is optional except the accent, and the surface degrades to the
+ * page's own tokens for anything a skin leaves out.
+ * ========================================================================== */
+
+export interface ComposerDress {
+  /** The one colour the surface leans on for marks, rings and headings. */
+  accent: string;
+  /** The skin's root style — its body face and ink. */
+  pageStyle?: CSSProperties;
+  /** The breadcrumb's ink, where the skin tints it. */
+  breadcrumbInk?: string;
+  /** The sheet's paint, border, radius and shadow. */
+  sheetStyle?: CSSProperties;
+  /** The sheet's content column, where a skin overrides its inset. */
+  contentStyle?: CSSProperties;
+  /** The masthead ELEMENT the composer mounts, not a copy of it. */
+  masthead?: ReactNode;
+  /** The ground ELEMENT the composer mounts, not a copy of it. */
+  ground?: ReactNode;
+  /** The section divider, as this skin draws it. */
+  rule?: ReactNode;
+  /** The status mark, exactly as the composer draws it in its status row. */
+  mark?: ReactNode;
+  /** The status row's stage word. */
+  statusStyle?: CSSProperties;
+  /** The status row's second line. */
+  metaStyle?: CSSProperties;
+  /** Section labels. */
+  labelStyle?: CSSProperties;
+  /** The task slip's dress, minus what the slip is about. */
+  slip?: Omit<TaskSlipProps, "praxis" | "task" | "mark" | "label">;
+  /** An inset panel: the skin's field ground, border and radius. */
+  panelStyle?: CSSProperties;
+  /** The confirmation beat's heading. */
+  headingStyle?: CSSProperties;
+  /** The surface's own sentences. */
+  bodyStyle?: CSSProperties;
+  /** Captions and the quieter half of a line. */
+  quietStyle?: CSSProperties;
+  /** The affirmative control — the way back into your own text. */
+  primaryStyle?: CSSProperties;
+  /** A quiet text button: leave, and the nudge. */
+  quietButtonStyle?: CSSProperties;
 }

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -17,8 +17,10 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import i18n from "../../../i18n";
 import { useFormFactor } from "../../../hooks/useFormFactor";
+import { collabCopy } from "../../../components/collab/collabCopy";
 import type { TaskOut } from "../../../api/tasks";
 import type { PraxisOut } from "../../../api/praxis";
+import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface BreadcrumbProps {
   praxisId: number | string;
@@ -125,6 +127,35 @@ export function formatAutosave(date: Date | null): string {
   if (ago < 60) return i18n.t("forms:autosaveAgo.seconds", { seconds: ago });
   const minutes = Math.round(ago / 60);
   return i18n.t("forms:autosaveAgo.minutes", { minutes });
+}
+
+/**
+ * The stage word in the status row's first slot.
+ *
+ * `Draft` while you are writing; `Sealed` on a duel side you have filed;
+ * `Submitted` on anything else that is in. Shared rather than inlined at the one
+ * call site because SNIDE draws the same word in its MASTHEAD, and a masthead
+ * still shouting DRAFT over a submitted praxis would be the page contradicting
+ * itself — the exact failure the dress exists to prevent.
+ *
+ * The completed reading takes the collab block's own word, which says
+ * `Submitted` rather than `Submitted by you`: a lapsed window publishes over a
+ * holdout (ADR-0012), and that holdout reads this same line.
+ */
+export function composerStageWord(state: EditPraxisState): string {
+  if (!isWaitingStage(state.phase)) {
+    return i18n.t("forms:editPraxis.composer.statusDraft");
+  }
+  if (state.phase === "completed") {
+    return collabCopy(state.praxis?.task_faction_slug, "completedStatusMeta");
+  }
+  // A duel side is `type='solo'` + a duel_id (ADR-0011) — never `type`.
+  const isDuel = state.praxis?.duel_id != null && state.duel != null;
+  return i18n.t(
+    isDuel
+      ? "forms:editPraxis.composer.statusSealed"
+      : "forms:editPraxis.composer.statusSubmitted",
+  );
 }
 
 /* ========================================================================== *
@@ -884,8 +915,14 @@ export interface ComposerDress {
   masthead?: ReactNode;
   /** The ground ELEMENT the composer mounts, not a copy of it. */
   ground?: ReactNode;
-  /** The section divider, as this skin draws it. */
-  rule?: ReactNode;
+  /**
+   * The section divider, as this skin draws it.
+   *
+   * A factory rather than an element because a divider can be a drawn thing
+   * with its own SVG defs — WOW's zigzag carries a per-instance gradient id —
+   * and the surface draws three of them. The `key` is that instance name.
+   */
+  rule?: (key: string) => ReactNode;
   /** The status mark, exactly as the composer draws it in its status row. */
   mark?: ReactNode;
   /** The status row's stage word. */

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -88,6 +88,20 @@ export type SaveStatus = "idle" | "saving" | "saved" | "error";
 export type EditPraxisPhase = "composing" | "waiting" | "completed" | "handoff";
 
 /**
+ * The two phases that draw `PraxisWaitingSurface` instead of the composer's own
+ * regions — while the praxis waits on somebody else, and (#1164) once everybody
+ * is in.
+ *
+ * Every archetype asks this, because since #1189 the stage swap is the
+ * archetype's: it is the one that holds the faction's dress, and the dispatcher
+ * could only hand the shared surface an undressed one. One predicate so eight
+ * skins cannot disagree about when the composer stops being a composer.
+ */
+export function isWaitingStage(phase: EditPraxisPhase): boolean {
+  return phase === "waiting" || phase === "completed";
+}
+
+/**
  * The phase, derived from data alone — no transient flag (ADR-0059).
  *
  * Deriving rather than latching means re-entry behaves the same as the cast

--- a/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
+++ b/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
@@ -3,17 +3,48 @@
  * have filed your part of a multi-party praxis.
  *
  * Submitting a collab part or a duel side no longer navigates. `publish()`
- * holds, `EditPraxis.tsx` swaps this in for the faction archetype, and the
- * player stays somewhere that can still let them back into their own text. The
- * public read view could show roster state but offers no authoring exit, and
+ * holds, the faction's archetype swaps this in for its own composer regions, and
+ * the player stays somewhere that can still let them back into their own text.
+ * The public read view could show roster state but offers no authoring exit, and
  * putting author-only controls on a public page is exactly what #646 undid.
  *
- * ONE shared, responsive, token-themed surface (epic #1071, decisions 7 and 8),
- * the way `CollabSuccess` is one screen for every faction and both form factors.
- * No mobile twin: a single stacked column at both widths, and `ScoreStamp` is
- * already size-agnostic. The design draws a per-faction device in the hero and a
- * per-faction masthead; those are a follow-up wave if this reads flat once live,
- * not a debt taken on here.
+ * ## Dressed, not neutral (#1189, closing #1071 decision 7)
+ *
+ * #1071 shipped this as one shared TOKEN-THEMED surface and deferred the frames
+ * by name — "per-faction frames are a follow-up wave if it reads flat once
+ * live". It read flat. This is the wave, and the seam it takes is the one
+ * ADR-0065 §2 describes for the whole composer: **one shared layout, dressed per
+ * faction.**
+ *
+ * So the LOGIC below is still one file for every faction — which reading to
+ * draw, which exits apply, who may be nudged, whether a clock has anything to
+ * count. What changed is that the ORNAMENT arrives as a {@link ComposerDress}
+ * from the archetype that is already mounted, and the surface assembles itself
+ * from the same `shared.tsx` blocks the composer does: the same page, the same
+ * sheet, the same masthead, the same ground, the same section rule, the same
+ * status mark. The design draws this as `edit-praxis.jsx` with `stage="awaiting"`
+ * for exactly this reason — pressing Submit must not change the page's dress.
+ *
+ * The `masthead`, `ground` and `rule` in a dress are the SAME ELEMENTS the
+ * composer mounts, named once in the archetype and handed to both, so there is
+ * no second copy of a faction's ornament to drift. See the dress's own note in
+ * `archetypes/shared.tsx` for why this is a prop rather than a registry.
+ *
+ * The breadcrumb comes with the dress too. It used to be drawn by
+ * `EditPraxis.tsx`, gated on `waiting`, because this surface painted none of its
+ * own; now it draws one exactly as every archetype does, and the dispatcher
+ * draws none. Exactly one, in every state and at every width.
+ *
+ * ## Copy is neutral, and already was
+ *
+ * Every key this surface reads resolves to the shared `editPraxis.collab.*`
+ * block: no faction overrides a single `awaiting*`, `completed*` or `duel*` key.
+ * `collabCopy(slug, …)` is kept rather than swapped for a bare `t()` because the
+ * resolver is the contract the roster and the footer share — the neutrality is a
+ * fact about the catalog, not a thing this file enforces. ADR-0065 §3 is
+ * therefore already satisfied here, and the stage words the status row gained
+ * (`Submitted` / `Sealed`) are neutral `editPraxis.composer.*` keys, sitting
+ * beside `Draft` in the same slot the composer's status row uses.
  *
  * Nudge (#1083) landed after this surface and is drawn here now — but not as the
  * design drew it. The design's `setNudged({...})` was local React state: the
@@ -48,9 +79,6 @@
  * refused by the backend once the praxis is `submitted`, and the one thing left
  * to do with a published praxis is read it.
  *
- * Copy resolves through `collabCopy(slug, key)` — shared `editPraxis.collab.*`
- * defaults with faction overrides where a faction has authored them.
- *
  * TESTABILITY. The harness is `renderToStaticMarkup`: no DOM, no effects, so a
  * component that fetches its own data cannot be asserted on. Everything here
  * renders from `EditPraxisState` plus two injectable scalars (`autoSubmitDays`,
@@ -58,6 +86,7 @@
  * function. `useGameConfig` is still the production source of the window
  * length; the prop only overrides it.
  */
+import type { CSSProperties, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import type { DuelSideOut } from "../../../api/duel";
@@ -69,7 +98,20 @@ import { useGameConfig } from "../../../hooks/useGameConfig";
 import { factionCssVar } from "../../../utils/factions";
 import { relativeTime } from "../../../utils/dates";
 import MarkdownPreview from "../blocks/MarkdownPreview";
-import { ArchetypeFrame, ErrorBanner, TaskMetaInline } from "../archetypes/shared";
+import {
+  Breadcrumb,
+  ComposerFooter,
+  ComposerPage,
+  ComposerRule,
+  ComposerSection,
+  ComposerSheet,
+  ComposerStatusRow,
+  ErrorBanner,
+  TaskSlip,
+  composerLabelStyle,
+  useComposerSizes,
+  type ComposerDress,
+} from "../archetypes/shared";
 import type { EditPraxisState } from "../useEditPraxis";
 import { collabPublishWindow } from "./waitingClock";
 
@@ -90,21 +132,33 @@ const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
  * Renders nothing at all when the window is unknowable — no `submit_proposed_at`
  * on the praxis, or `/game-config` not yet in hand. The duration is an
  * `EraConfig` value and is never assumed; a blank slot beats a wrong number.
+ *
+ * The dial is the one countdown on this surface with real data behind it, so it
+ * takes the skin's accent and panel rather than the page's neutral chrome. Both
+ * fall back to the token defaults when a dress leaves them out.
  */
 export function CollabPublishClock({
   submitProposedAt,
   autoSubmitDays,
   factionSlug,
   now,
+  accent,
+  panelStyle,
+  labelStyle,
+  bodyStyle,
 }: {
   submitProposedAt: string | null | undefined;
   autoSubmitDays: number | null | undefined;
   factionSlug: string | null | undefined;
   now?: number;
+  accent?: string;
+  panelStyle?: CSSProperties;
+  labelStyle?: CSSProperties;
+  bodyStyle?: CSSProperties;
 }) {
   const publishWindow = collabPublishWindow(submitProposedAt, autoSubmitDays, now);
   if (!publishWindow) return null;
-  const accent = factionCssVar(factionSlug, "card-accent");
+  const ink = accent ?? factionCssVar(factionSlug, "card-accent");
 
   return (
     <section
@@ -114,6 +168,7 @@ export function CollabPublishClock({
         borderRadius: 8,
         padding: "var(--space-md) var(--space-lg)",
         background: "var(--color-bg-surface)",
+        ...panelStyle,
       }}
     >
       <div
@@ -152,7 +207,7 @@ export function CollabPublishClock({
             strokeLinecap="round"
             strokeDasharray={RING_CIRCUMFERENCE}
             strokeDashoffset={RING_CIRCUMFERENCE * (1 - publishWindow.fraction)}
-            style={{ stroke: accent }}
+            style={{ stroke: ink }}
           />
         </svg>
         <span
@@ -160,8 +215,12 @@ export function CollabPublishClock({
           style={{ position: "absolute", inset: 0, lineHeight: 1.1 }}
         >
           <span
-            className="font-body"
-            style={{ fontSize: "var(--text-xl)", fontWeight: 700, color: accent }}
+            style={{
+              fontSize: "var(--text-xl)",
+              fontWeight: 700,
+              color: ink,
+              ...bodyStyle,
+            }}
           >
             {publishWindow.lapsed
               ? collabCopy(factionSlug, "awaitingClockLapsed")
@@ -170,7 +229,7 @@ export function CollabPublishClock({
                 })}
           </span>
           {!publishWindow.lapsed && (
-            <span className="eyebrow">
+            <span style={composerLabelStyle(labelStyle)}>
               {collabCopy(factionSlug, "awaitingClockHours", {
                 hours: publishWindow.hoursLeft,
               })}
@@ -179,14 +238,14 @@ export function CollabPublishClock({
         </span>
       </div>
       <div className="flex flex-col gap-1">
-        <span className="eyebrow" style={{ color: accent }}>
+        <span style={composerLabelStyle({ color: ink, ...labelStyle })}>
           {collabCopy(factionSlug, "awaitingClockLabel")}
         </span>
         {/* The rule the dial is counting down to, said in words — a ring alone
             never explains that nobody has to do anything for it to fire. */}
         <p
-          className="font-body content-text"
-          style={{ color: "var(--color-text-secondary)" }}
+          className="content-text"
+          style={{ color: "var(--color-text-secondary)", ...bodyStyle }}
         >
           {collabCopy(factionSlug, "awaitingClockCaption", {
             days: autoSubmitDays ?? 0,
@@ -210,6 +269,8 @@ function SideAvatar({ side }: { side: DuelSideOut }) {
         height: 28,
         borderRadius: "50%",
         flexShrink: 0,
+        // The SIDE's own faction, never the page's: a duel is the one place two
+        // factions share a surface, and the avatar is who is speaking.
         background: factionCssVar(side.faction_slug, "light"),
         border: `1px solid ${factionCssVar(side.faction_slug, "border")}`,
         fontSize: "var(--text-md)",
@@ -234,6 +295,7 @@ function DuelSidePanel({
   side,
   mine,
   factionSlug,
+  dress,
   title,
   body,
   completed,
@@ -242,6 +304,7 @@ function DuelSidePanel({
   side: DuelSideOut;
   mine: boolean;
   factionSlug: string | null | undefined;
+  dress: ComposerDress;
   title?: string;
   body?: string;
   /**
@@ -258,7 +321,7 @@ function DuelSidePanel({
    */
   onNudge?: () => void | Promise<void>;
 }) {
-  const accent = factionCssVar(factionSlug, "card-accent");
+  const accent = dress.accent;
   const nudged = side.nudged_at != null;
   return (
     <div
@@ -267,29 +330,34 @@ function DuelSidePanel({
         flex: "1 1 260px",
         minWidth: 0,
         borderRadius: 8,
+        background: "var(--color-bg-surface)",
+        ...dress.panelStyle,
+        // Your own side is the one the skin's accent claims; the rival's stays
+        // dashed and un-owned, which is the whole read of a sealed duel.
         border: mine
           ? `1.5px solid ${accent}`
           : "1.5px dashed var(--color-border-strong)",
         padding: "var(--space-md)",
-        background: "var(--color-bg-surface)",
       }}
     >
       <div className="flex items-center gap-2">
         <SideAvatar side={side} />
-        <span className="font-body content-text" style={{ flex: 1, minWidth: 0 }}>
+        <span className="content-text" style={{ flex: 1, minWidth: 0 }}>
           {side.display_name}
           {mine && (
-            <span style={{ color: "var(--color-text-tertiary)" }}>
+            <span style={dress.quietStyle ?? { color: "var(--color-text-tertiary)" }}>
               {" · "}
               {collabCopy(factionSlug, "you")}
             </span>
           )}
         </span>
         <span
-          className="eyebrow"
-          style={{
-            color: side.is_submitted ? accent : "var(--color-text-tertiary)",
-          }}
+          style={composerLabelStyle({
+            ...dress.labelStyle,
+            color: side.is_submitted
+              ? accent
+              : (dress.quietStyle?.color ?? "var(--color-text-tertiary)"),
+          })}
         >
           {side.is_submitted
             ? collabCopy(factionSlug, "duelPillSealed")
@@ -307,21 +375,27 @@ function DuelSidePanel({
             nudged ? "nudgeSentAria" : "duelNudgeAria",
             { name: side.display_name },
           )}
-          className="eyebrow self-start px-2 py-1"
-          style={{
+          className="self-start px-2 py-1"
+          style={composerLabelStyle({
+            ...dress.quietButtonStyle,
             borderRadius: 4,
             border: `1px solid ${nudged ? "var(--color-border)" : accent}`,
             background: "transparent",
-            color: nudged ? "var(--color-text-tertiary)" : accent,
+            color: nudged
+              ? (dress.quietStyle?.color ?? "var(--color-text-tertiary)")
+              : accent,
             cursor: nudged ? "default" : "pointer",
-          }}
+          })}
         >
           {collabCopy(factionSlug, nudged ? "nudgeSentAction" : "nudgeAction")}
         </button>
       )}
       {mine ? (
         <>
-          <span className="font-body content-title" style={{ fontWeight: 700 }}>
+          <span
+            className="content-title"
+            style={{ fontWeight: 700, ...dress.headingStyle }}
+          >
             {title}
           </span>
           {body?.trim() ? (
@@ -330,18 +404,15 @@ function DuelSidePanel({
               className="content-text markdown-preview"
             />
           ) : (
-            <p
-              className="font-body content-text"
-              style={{ color: "var(--color-text-tertiary)" }}
-            >
+            <p className="content-text" style={dress.quietStyle}>
               {collabCopy(factionSlug, "awaitingWriteUpEmpty")}
             </p>
           )}
         </>
       ) : (
         <p
-          className="font-body content-text"
-          style={{ color: "var(--color-text-tertiary)", fontStyle: "italic" }}
+          className="content-text"
+          style={{ fontStyle: "italic", ...dress.quietStyle }}
         >
           {collabCopy(
             factionSlug,
@@ -360,6 +431,12 @@ function DuelSidePanel({
 export interface PraxisWaitingSurfaceProps {
   state: EditPraxisState;
   /**
+   * The mounted archetype's ornament. Required: there is no undressed caller —
+   * every path here goes through a faction's own composer, which is what stops
+   * the page changing dress at the moment you submit.
+   */
+  dress: ComposerDress;
+  /**
    * The ADR-0012 window length, in days. Production leaves this undefined and
    * the game config supplies it; the prop exists so the clock is renderable in
    * a harness where effects never run.
@@ -371,17 +448,19 @@ export interface PraxisWaitingSurfaceProps {
 
 export default function PraxisWaitingSurface({
   state,
+  dress,
   autoSubmitDays,
   now,
 }: PraxisWaitingSurfaceProps) {
   const { t } = useTranslation("forms");
+  const sizes = useComposerSizes();
   const config = useGameConfig();
   const praxis = state.praxis;
   const duel = state.duel;
   if (!praxis) return null;
 
   const slug = praxis.task_faction_slug;
-  const accent = factionCssVar(slug, "card-accent");
+  const accent = dress.accent;
   // A duel side is `type='solo'` + a duel_id (ADR-0011) — never `type`.
   const isDuel = praxis.duel_id != null && duel != null;
   const sides = isDuel && duel ? duelSides(duel, state.currentCharacterId) : null;
@@ -403,306 +482,348 @@ export default function PraxisWaitingSurface({
   // everyone's, the creator included (ADR-0013, #1074).
   const isCreator = praxis.created_by_id === state.currentCharacterId;
   const busy = state.submitting;
+  const rule: ReactNode = dress.rule ?? <ComposerRule />;
+
+  /* The stage word, in the slot the composer's `Draft` occupies. Neutral keys
+     (ADR-0065 §3): a duel side is SEALED, everything else is SUBMITTED. On the
+     completed reading the word is the collab block's own, which says `Submitted`
+     rather than `Submitted by you` — a lapsed window publishes over a holdout,
+     and that holdout opens this same surface. */
+  const statusWord = completed
+    ? collabCopy(slug, "completedStatusMeta")
+    : isDuel
+      ? t("editPraxis.composer.statusSealed")
+      : t("editPraxis.composer.statusSubmitted");
+
+  const stamped = relativeTime(praxis.submitted_at ?? praxis.updated_at);
+  const statusMeta: ReactNode = completed ? (
+    stamped
+  ) : (
+    <>
+      {collabCopy(slug, "awaitingStatusMeta")}
+      {" · "}
+      {stamped}
+    </>
+  );
+
+  const primaryClass = dress.primaryStyle ? undefined : "btn-primary";
+  const quietButton = composerLabelStyle({
+    background: "none",
+    border: "none",
+    padding: 0,
+    cursor: "pointer",
+    color: "var(--color-text-tertiary)",
+    ...dress.quietButtonStyle,
+  });
 
   return (
-    <ArchetypeFrame>
-      {/* Status row — what is submitted, in the surface's own quiet voice. On
-          the completed reading it drops the "by you": a lapsed window publishes
-          a collab with a holdout still outstanding (ADR-0012), and that holdout
-          opens this same surface. */}
-      <div className="flex items-center justify-between gap-2 mb-4">
-        <span className="eyebrow" style={{ color: accent }}>
-          {collabCopy(slug, completed ? "completedStatusMeta" : "awaitingStatusMeta")}
-        </span>
-        <span className="eyebrow">
-          {relativeTime(praxis.submitted_at ?? praxis.updated_at)}
-        </span>
-      </div>
-
-      {/* The task this is all for. The design draws it and the issue's block
-          list omits it; without it the surface never says what was proven.
-          Reuses the composer's own `TaskMetaInline` rather than inventing a
-          second task-context component. */}
-      <section
-        className="flex flex-wrap items-start gap-4 mb-6"
-        style={{
-          borderLeft: `3px solid ${accent}`,
-          paddingLeft: "var(--space-lg)",
-        }}
+    <ComposerPage
+      sizes={sizes}
+      style={dress.pageStyle}
+      breadcrumb={
+        <Breadcrumb
+          praxisId={praxis.id}
+          taskId={praxis.task_id}
+          taskTitle={praxis.task_title}
+          inkColor={dress.breadcrumbInk}
+        />
+      }
+    >
+      <ComposerSheet
+        sizes={sizes}
+        style={dress.sheetStyle}
+        contentStyle={dress.contentStyle}
+        masthead={dress.masthead}
+        ground={dress.ground}
       >
-        <div className="flex flex-col gap-2" style={{ flex: "1 1 320px", minWidth: 0 }}>
-          <span className="eyebrow" style={{ color: accent }}>
-            {collabCopy(slug, isDuel ? "duelAwaitingTaskLabel" : "awaitingTaskLabel")}
-          </span>
-          <span className="font-display content-title">{praxis.task_title}</span>
-          <TaskMetaInline praxis={praxis} task={state.task} />
-          {state.task?.description && (
-            <p
-              className="font-body content-text"
-              style={{ color: "var(--color-text-secondary)" }}
-            >
-              {state.task.description}
-            </p>
-          )}
-        </div>
-        {/* The points, mounted rather than hand-drawn: `scoreBreakdown()` is the
-            single row-selection authority (ADR-0053) and already applies the
-            conditional rules the design's inline strip spelled out by hand — a
-            multiplier row only when it is not ×1.0, a votes row always. Both are
-            genuinely reachable here: unsubmitting preserves votes, and a duel
-            side carries a live, provisional modifier (ADR-0052). */}
-        <ScoreStamp praxis={praxis} />
-      </section>
+        {/* The status row, in the composer's own slot and carrying the skin's
+            own mark — the pentacle, the ankh, the gear, `[ok]`. The mark does
+            not move or change size when you submit; the WORD beside it does,
+            and that is the whole confirmation beat. */}
+        <ComposerStatusRow
+          status={statusWord}
+          meta={statusMeta}
+          mark={dress.mark}
+          statusStyle={dress.statusStyle}
+          metaStyle={dress.metaStyle}
+        />
 
-      {/* The confirmation beat. Shared and token-themed: the design's
-          per-faction device (pentacle, ensō, gear, ✦, swoosh, [ok], spectrum
-          ring) is a later wave, not this one. */}
-      <section
-        className="flex flex-col gap-2 mb-6"
-        style={{
-          border: `1.5px solid ${accent}`,
-          borderRadius: 8,
-          padding: "var(--space-lg)",
-          background: "var(--color-bg-surface)",
-        }}
-      >
-        <h2 className="font-display content-title" style={{ color: accent }}>
-          {collabCopy(
-            slug,
-            completed
-              ? isDuel
-                ? "duelCompletedHeading"
-                : "completedHeading"
-              : isDuel
-                ? "duelAwaitingHeading"
-                : "awaitingHeading",
-          )}
-        </h2>
-        {completed ? (
-          /* Nothing is outstanding, so neither clock has anything to say — not
-             the collab's countdown and not the duel's elapsed line. */
-          <p
-            className="font-body content-text"
-            style={{ color: "var(--color-text-secondary)" }}
-          >
-            {collabCopy(slug, isDuel ? "duelCompletedBody" : "completedBody")}
-          </p>
-        ) : isDuel && sides ? (
-          /* The duel's clock is an ELAPSED line, not a countdown. No deadline
-             exists to count down to: `Duel` has no expiry, `EraConfig` has no
-             duel duration, there is no scheduler, and ADR-0011 rejects per-duel
-             windows by name (epic #1071, decision 4). */
-          <p
-            className="font-body content-text"
-            style={{ color: "var(--color-text-secondary)" }}
-          >
+        {/* The task this is all for, on the composer's own reference slip.
+            Without it the surface never says what was proven.
+
+            The mark is `ScoreStamp` rather than the composer's points ring:
+            `scoreBreakdown()` is the single row-selection authority (ADR-0053),
+            it is already dressed per faction, and it applies the conditional
+            rules the design's inline strip spelled out by hand — a multiplier
+            row only when it is not ×1.0, a votes row always. Both are genuinely
+            reachable here: unsubmitting preserves votes, and a duel side carries
+            a live, provisional modifier (ADR-0052). A static task point value
+            would be the less true number in the same place. */}
+        <TaskSlip
+          praxis={praxis}
+          task={state.task}
+          label={collabCopy(slug, isDuel ? "duelAwaitingTaskLabel" : "awaitingTaskLabel")}
+          {...dress.slip}
+          mark={<ScoreStamp praxis={praxis} />}
+        />
+
+        {/* The confirmation beat. */}
+        <section
+          className="flex flex-col gap-2"
+          style={{
+            border: `1.5px solid ${accent}`,
+            borderRadius: 8,
+            padding: "var(--space-lg)",
+            background: "var(--color-bg-surface)",
+            ...dress.panelStyle,
+          }}
+        >
+          <h2 className="content-title" style={{ color: accent, ...dress.headingStyle }}>
             {collabCopy(
               slug,
-              duel?.status === "pending" ? "duelPendingLine" : "duelElapsedLine",
-              {
-                elapsed: relativeTime(praxis.submitted_at ?? praxis.updated_at),
-                name: sides.foe.display_name,
-              },
+              completed
+                ? isDuel
+                  ? "duelCompletedHeading"
+                  : "completedHeading"
+                : isDuel
+                  ? "duelAwaitingHeading"
+                  : "awaitingHeading",
             )}
-          </p>
-        ) : (
-          <p
-            className="font-body content-text"
-            style={{ color: "var(--color-text-secondary)" }}
-          >
-            {collabCopy(slug, "awaitingBody")}
-          </p>
-        )}
-      </section>
+          </h2>
+          {completed ? (
+            /* Nothing is outstanding, so neither clock has anything to say — not
+               the collab's countdown and not the duel's elapsed line. */
+            <p className="content-text" style={dress.bodyStyle}>
+              {collabCopy(slug, isDuel ? "duelCompletedBody" : "completedBody")}
+            </p>
+          ) : isDuel && sides ? (
+            /* The duel's clock is an ELAPSED line, not a countdown. No deadline
+               exists to count down to: `Duel` has no expiry, `EraConfig` has no
+               duel duration, there is no scheduler, and ADR-0011 rejects per-duel
+               windows by name (epic #1071, decision 4). */
+            <p className="content-text" style={dress.bodyStyle}>
+              {collabCopy(
+                slug,
+                duel?.status === "pending" ? "duelPendingLine" : "duelElapsedLine",
+                {
+                  elapsed: stamped,
+                  name: sides.foe.display_name,
+                },
+              )}
+            </p>
+          ) : (
+            <p className="content-text" style={dress.bodyStyle}>
+              {collabCopy(slug, "awaitingBody")}
+            </p>
+          )}
+        </section>
 
-      {/* Who else is outstanding. The collab reuses the roster unchanged — the
-          same component the composer and the read page already mount. */}
-      <section className="mb-6">
-        {isDuel && sides ? (
-          <div className="flex flex-wrap gap-4">
-            <DuelSidePanel
-              side={sides.me}
-              mine
+        {/* Who else is outstanding, under the composer's own section label —
+            `Collaborators · N` or `Opponent`, the same words the composer used
+            for the same block a moment ago. The collab reuses the roster
+            unchanged: it is the same component the composer and the read page
+            already mount, and it takes the faction slug itself. */}
+        <ComposerSection
+          label={
+            isDuel
+              ? t("editPraxis.composer.opponentLabel")
+              : t("editPraxis.composer.collaboratorsLabel", {
+                  count: praxis.members.length,
+                })
+          }
+          rule={rule}
+          labelStyle={dress.labelStyle}
+        >
+          {isDuel && sides ? (
+            <div className="flex flex-wrap gap-4">
+              <DuelSidePanel
+                side={sides.me}
+                mine
+                factionSlug={slug}
+                dress={dress}
+                title={state.title}
+                body={state.body}
+                completed={completed}
+              />
+              {/* The rival's nudge, gated on `active` exactly as the backend is:
+                  at `pending` they have not accepted yet and the outstanding
+                  thing is a decision (already in their requests tab as a
+                  challenge), and once the duel settles there is nothing left to
+                  hurry. */}
+              <DuelSidePanel
+                side={sides.foe}
+                mine={false}
+                factionSlug={slug}
+                dress={dress}
+                completed={completed}
+                onNudge={
+                  duel?.status === "active"
+                    ? () => state.nudge(sides.foe.character_id)
+                    : undefined
+                }
+              />
+            </div>
+          ) : (
+            /* Completed drops both author controls rather than drawing them to
+               be refused. The backend allows a kick only while the praxis is
+               still open, and there is nobody left to nudge — except after a
+               lapsed window, where the roster would otherwise offer to hurry a
+               member whose part is no longer wanted. */
+            <CollabRoster
+              members={praxis.members}
+              currentCharacterId={state.currentCharacterId}
               factionSlug={slug}
-              title={state.title}
-              body={state.body}
-              completed={completed}
+              taskPointValue={praxis.task_point_value}
+              onKick={completed ? undefined : state.kickMember}
+              onNudge={completed ? undefined : state.nudge}
             />
-            {/* The rival's nudge, gated on `active` exactly as the backend is:
-                at `pending` they have not accepted yet and the outstanding thing
-                is a decision (already in their requests tab as a challenge), and
-                once the duel settles there is nothing left to hurry. */}
-            <DuelSidePanel
-              side={sides.foe}
-              mine={false}
-              factionSlug={slug}
-              completed={completed}
-              onNudge={
-                duel?.status === "active"
-                  ? () => state.nudge(sides.foe.character_id)
-                  : undefined
-              }
-            />
-          </div>
-        ) : (
-          /* Completed drops both author controls rather than drawing them to be
-             refused. The backend allows a kick only while the praxis is still
-             open, and there is nobody left to nudge — except after a lapsed
-             window, where the roster would otherwise offer to hurry a member
-             whose part is no longer wanted. */
-          <CollabRoster
-            members={praxis.members}
-            currentCharacterId={state.currentCharacterId}
-            factionSlug={slug}
-            taskPointValue={praxis.task_point_value}
-            onKick={completed ? undefined : state.kickMember}
-            onNudge={completed ? undefined : state.nudge}
-          />
-        )}
-      </section>
+          )}
+        </ComposerSection>
 
-      {/* The clock — collab only, and only while there is still a window to
-          count. See the elapsed line above for the duel. */}
-      {isCollab && !completed && (
-        <div className="mb-6">
+        {/* The clock — collab only, and only while there is still a window to
+            count. See the elapsed line above for the duel. */}
+        {isCollab && !completed && (
           <CollabPublishClock
             submitProposedAt={praxis.submit_proposed_at}
             autoSubmitDays={windowDays}
             factionSlug={slug}
             now={now}
+            accent={accent}
+            panelStyle={dress.panelStyle}
+            labelStyle={dress.labelStyle}
+            bodyStyle={dress.bodyStyle}
           />
-        </div>
-      )}
+        )}
 
-      {/* Your write-up, read-only. The duel already showed it inside your own
-          side panel, so it is not repeated here. */}
-      {isCollab && (
-        <section className="flex flex-col gap-2 mb-6">
-          <span className="eyebrow" style={{ color: accent }}>
-            {collabCopy(slug, "awaitingWriteUpLabel")}
-          </span>
-          <div
-            style={{
-              border: "1px solid var(--color-border-strong)",
-              borderRadius: 8,
-              padding: "var(--space-lg)",
-              background: "var(--color-bg-surface)",
-            }}
+        {/* Your write-up, read-only. The duel already showed it inside your own
+            side panel, so it is not repeated here. */}
+        {isCollab && (
+          <ComposerSection
+            label={collabCopy(slug, "awaitingWriteUpLabel")}
+            rule={rule}
+            labelStyle={dress.labelStyle}
           >
-            <span className="font-display content-title" style={{ fontWeight: 700 }}>
-              {state.title}
-            </span>
-            {state.body.trim() ? (
-              <MarkdownPreview
-                source={state.body}
-                className="content-text markdown-preview mt-2"
-              />
-            ) : (
-              <p
-                className="font-body content-text mt-2"
-                style={{ color: "var(--color-text-tertiary)" }}
+            <div
+              style={{
+                border: "1px solid var(--color-border-strong)",
+                borderRadius: 8,
+                padding: "var(--space-lg)",
+                background: "var(--color-bg-surface)",
+                ...dress.panelStyle,
+              }}
+            >
+              <span
+                className="content-title"
+                style={{ fontWeight: 700, ...dress.headingStyle }}
               >
-                {collabCopy(slug, "awaitingWriteUpEmpty")}
-              </p>
-            )}
-          </div>
-        </section>
-      )}
+                {state.title}
+              </span>
+              {state.body.trim() ? (
+                <MarkdownPreview
+                  source={state.body}
+                  className="content-text markdown-preview mt-2"
+                />
+              ) : (
+                <p className="content-text mt-2" style={dress.quietStyle}>
+                  {collabCopy(slug, "awaitingWriteUpEmpty")}
+                </p>
+              )}
+            </div>
+          </ComposerSection>
+        )}
 
-      <ErrorBanner message={state.error} />
+        <ErrorBanner message={state.error} />
 
-      {/* Footer. Global order is [destructive/neutral] … [affirmative] (#646),
-          so the way back into your own text sits on the right on every surface.
-          Exactly one exit is drawn, the one that applies to this viewer.
+        {rule}
 
-          The completed reading keeps the position and changes the act: the one
-          thing left to do with a published praxis is read it, and the link is
-          the whole reason this beats the redirect the ruling turned down. */}
-      {completed ? (
-        <div
-          className="flex flex-wrap items-center justify-end gap-4 pt-4"
-          style={{ borderTop: "1px dashed var(--color-border-strong)" }}
-        >
-          <Link to={`/praxes/${praxis.id}`} className="btn-primary">
-            {collabCopy(slug, "completedReadAction")}
-          </Link>
-        </div>
-      ) : (
-      <div
-        className="flex flex-wrap items-center justify-between gap-4 pt-4"
-        style={{ borderTop: "1px dashed var(--color-border-strong)" }}
-      >
-        <div className="flex flex-wrap items-center gap-4">
-          {isCollab && (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => void state.leaveCollab()}
-              title={collabCopy(slug, "leaveDescription")}
-              className="font-body eyebrow hover:underline"
-              style={{
-                background: "none",
-                border: "none",
-                padding: 0,
-                cursor: "pointer",
-                color: "var(--color-text-tertiary)",
-              }}
-            >
-              {t("editPraxis.leaveAction")}
-            </button>
-          )}
-          {isCollab && isCreator && (
-            <button
-              type="button"
-              disabled={busy}
-              onClick={() => void state.cancel()}
-              title={collabCopy(slug, "deleteDescription")}
-              className="font-body eyebrow hover:underline"
-              style={{
-                background: "none",
-                border: "none",
-                padding: 0,
-                cursor: "pointer",
-                color: "var(--color-danger)",
-              }}
-            >
-              {collabCopy(slug, "deleteAction")}
-            </button>
-          )}
-        </div>
+        {/* Footer. Global order is [destructive/neutral] … [affirmative] (#646),
+            so the way back into your own text sits on the right on every
+            surface. Exactly one exit is drawn, the one that applies to this
+            viewer.
 
-        <div className="flex flex-col items-end gap-1">
-          <button
-            type="button"
-            disabled={busy}
-            onClick={() => void state.reopenForEdit()}
-            className="btn-primary"
-          >
-            {/* One button, not two. For a duel, "edit my entry" and "pull my
-                entry back" are the same call — `unsubmit` re-opens the praxis
-                for editing — so drawing both would be two labels for one act.
-                The neutral pull-back wording is the honest one (#1077). */}
-            {collabCopy(
-              slug,
-              isDuel ? "duelPullBackAction" : "awaitingEditAction",
-            )}
-          </button>
-          {/* The cost, before the click, not after it. On a collab the edit this
-              re-entry exists for cancels the pending-publish window and clears
-              every member's cast (`cancel_pending_publish_on_edit`, ADR-0012) —
-              the countdown drawn a few blocks up. */}
-          <span
-            className="font-body eyebrow-sentence"
-            style={{ textAlign: "right", maxWidth: 420 }}
-          >
-            {collabCopy(
-              slug,
-              isDuel ? "duelPullBackDescription" : "awaitingEditDescription",
-            )}
-          </span>
-        </div>
-      </div>
-      )}
-    </ArchetypeFrame>
+            The completed reading keeps the position and changes the act: the one
+            thing left to do with a published praxis is read it, and the link is
+            the whole reason this beats the redirect the ruling turned down. */}
+        {completed ? (
+          <ComposerFooter
+            end={
+              <Link
+                to={`/praxes/${praxis.id}`}
+                className={primaryClass}
+                style={dress.primaryStyle}
+              >
+                {collabCopy(slug, "completedReadAction")}
+              </Link>
+            }
+          />
+        ) : (
+          <ComposerFooter
+            start={
+              <>
+                {isCollab && (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void state.leaveCollab()}
+                    title={collabCopy(slug, "leaveDescription")}
+                    className="hover:underline"
+                    style={quietButton}
+                  >
+                    {t("editPraxis.leaveAction")}
+                  </button>
+                )}
+                {isCollab && isCreator && (
+                  <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void state.cancel()}
+                    title={collabCopy(slug, "deleteDescription")}
+                    className="hover:underline"
+                    style={{ ...quietButton, color: "var(--color-danger)" }}
+                  >
+                    {collabCopy(slug, "deleteAction")}
+                  </button>
+                )}
+              </>
+            }
+            end={
+              <div className="flex flex-col items-end gap-1">
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => void state.reopenForEdit()}
+                  className={primaryClass}
+                  style={dress.primaryStyle}
+                >
+                  {/* One button, not two. For a duel, "edit my entry" and "pull
+                      my entry back" are the same call — `unsubmit` re-opens the
+                      praxis for editing — so drawing both would be two labels
+                      for one act. The neutral pull-back wording is the honest
+                      one (#1077). */}
+                  {collabCopy(
+                    slug,
+                    isDuel ? "duelPullBackAction" : "awaitingEditAction",
+                  )}
+                </button>
+                {/* The cost, before the click, not after it. On a collab the
+                    edit this re-entry exists for cancels the pending-publish
+                    window and clears every member's cast
+                    (`cancel_pending_publish_on_edit`, ADR-0012) — the countdown
+                    drawn a few blocks up. */}
+                <span
+                  className="eyebrow-sentence"
+                  style={{ textAlign: "right", maxWidth: 420, ...dress.quietStyle }}
+                >
+                  {collabCopy(
+                    slug,
+                    isDuel ? "duelPullBackDescription" : "awaitingEditDescription",
+                  )}
+                </span>
+              </div>
+            }
+          />
+        )}
+      </ComposerSheet>
+    </ComposerPage>
   );
 }

--- a/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
+++ b/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
@@ -109,6 +109,7 @@ import {
   ErrorBanner,
   TaskSlip,
   composerLabelStyle,
+  composerStageWord,
   useComposerSizes,
   type ComposerDress,
 } from "../archetypes/shared";
@@ -482,18 +483,8 @@ export default function PraxisWaitingSurface({
   // everyone's, the creator included (ADR-0013, #1074).
   const isCreator = praxis.created_by_id === state.currentCharacterId;
   const busy = state.submitting;
-  const rule: ReactNode = dress.rule ?? <ComposerRule />;
-
-  /* The stage word, in the slot the composer's `Draft` occupies. Neutral keys
-     (ADR-0065 §3): a duel side is SEALED, everything else is SUBMITTED. On the
-     completed reading the word is the collab block's own, which says `Submitted`
-     rather than `Submitted by you` — a lapsed window publishes over a holdout,
-     and that holdout opens this same surface. */
-  const statusWord = completed
-    ? collabCopy(slug, "completedStatusMeta")
-    : isDuel
-      ? t("editPraxis.composer.statusSealed")
-      : t("editPraxis.composer.statusSubmitted");
+  /** The skin's divider, one instance per place it is drawn. */
+  const rule = (key: string): ReactNode => dress.rule?.(key) ?? <ComposerRule />;
 
   const stamped = relativeTime(praxis.submitted_at ?? praxis.updated_at);
   const statusMeta: ReactNode = completed ? (
@@ -541,7 +532,7 @@ export default function PraxisWaitingSurface({
             not move or change size when you submit; the WORD beside it does,
             and that is the whole confirmation beat. */}
         <ComposerStatusRow
-          status={statusWord}
+          status={composerStageWord(state)}
           meta={statusMeta}
           mark={dress.mark}
           statusStyle={dress.statusStyle}
@@ -631,7 +622,7 @@ export default function PraxisWaitingSurface({
                   count: praxis.members.length,
                 })
           }
-          rule={rule}
+          rule={rule("roster")}
           labelStyle={dress.labelStyle}
         >
           {isDuel && sides ? (
@@ -700,7 +691,7 @@ export default function PraxisWaitingSurface({
         {isCollab && (
           <ComposerSection
             label={collabCopy(slug, "awaitingWriteUpLabel")}
-            rule={rule}
+            rule={rule("writeup")}
             labelStyle={dress.labelStyle}
           >
             <div
@@ -734,7 +725,7 @@ export default function PraxisWaitingSurface({
 
         <ErrorBanner message={state.error} />
 
-        {rule}
+        {rule("footer")}
 
         {/* Footer. Global order is [destructive/neutral] … [affirmative] (#646),
             so the way back into your own text sits on the right on every

--- a/frontend/src/pages/editPraxis/waiting/__tests__/praxisWaitingSurface.test.tsx
+++ b/frontend/src/pages/editPraxis/waiting/__tests__/praxisWaitingSurface.test.tsx
@@ -16,7 +16,10 @@ import type { PraxisMemberOut, PraxisOut } from "../../../../api/praxis";
 import type { TaskOut } from "../../../../api/tasks";
 import { collabCopy } from "../../../../components/collab/collabCopy";
 import type { EditPraxisState } from "../../useEditPraxis";
-import PraxisWaitingSurface from "../PraxisWaitingSurface";
+import { DEFAULT_COMPOSER_DRESS } from "../../archetypes/DefaultEditPraxis";
+import PraxisWaitingSurface, {
+  type PraxisWaitingSurfaceProps,
+} from "../PraxisWaitingSurface";
 
 const ME = 1;
 const THEM = 2;
@@ -133,10 +136,19 @@ function state(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
   } as unknown as EditPraxisState;
 }
 
-function render(props: Parameters<typeof PraxisWaitingSurface>[0]) {
+/**
+ * Rendered in na's REAL dress (#1189), not a fixture invented here.
+ *
+ * The surface no longer dresses itself — an archetype hands it that faction's
+ * masthead, ground, rule and status mark, and `DEFAULT_COMPOSER_DRESS` is the
+ * one every unregistered slug falls through to. Using it keeps these assertions
+ * about the surface's READING (which control applies to whom) while still
+ * putting the dress seam every skin passes through in the path.
+ */
+function render(props: Omit<PraxisWaitingSurfaceProps, "dress">) {
   return renderToStaticMarkup(
     <MemoryRouter>
-      <PraxisWaitingSurface {...props} />
+      <PraxisWaitingSurface {...props} dress={DEFAULT_COMPOSER_DRESS} />
     </MemoryRouter>,
   );
 }


### PR DESCRIPTION
Closes #1189

The last issue in epic #1179, and the one #1071 deferred by name: *"per-faction frames are a follow-up wave if it reads flat once live."*

## The seam

`PraxisWaitingSurface` is still ONE file. All the post-cast logic — which reading to draw, which exits apply, who may be nudged, whether a clock has anything to count — is unchanged and unduplicated. What changed is where the ornament comes from.

Each archetype now names its chrome once and mounts the **same elements twice**: its own composer, and the waiting surface once your part is in.

```tsx
const masthead = <ComposerMasthead … />;   // named once
const ground   = <ComposerGround … />;
const dress: ComposerDress = { masthead, ground, sheetStyle, rule, mark, slip, … };

if (isWaitingStage(state.phase)) {
  return <PraxisWaitingSurface state={state} dress={dress} />;
}
return <ComposerPage …><ComposerSheet masthead={masthead} ground={ground} …>
```

There is no second copy of a faction's ornament, so the page cannot change dress at the moment you press Submit.

### Why the archetype owns the stage swap, not the dispatcher

I considered the three options in the issue and took a fourth.

- **A dress registry each archetype exports** was my starting point, but archetypes are **lazy** (`lazyArchetype`, #1045). A slug-keyed map of eight dresses is a barrel over the archetypes, which is the 420 KB entry chunk that issue existed to delete.
- **A new `waitingSurface` manifest surface with 8 skins** means a faction can register one and not the other — the composer dressed Coven, the waiting surface Default. That is the drift the epic is about, made registrable.
- **The archetype branching internally** was called "biggest blast radius, scatters the shared waiting logic across eight files" — but only if the logic moves. It doesn't. The shared surface keeps every line of it and takes dress, exactly as `ComposerSheet` / `TaskSlip` / `RingMark` already do. What the archetype gains is one predicate and one `return`.

That fourth option is also the design's own shape (one component, a `stage` prop) and ADR-0065's sentence read literally: *"who draws the surface, not when it is drawn."* No ADR change needed — but a reviewer may want to add one line to ADR-0065's consequences saying the dispatcher resolves one component that draws both stages. I did not amend an accepted ADR unasked.

### The breadcrumb

The surface paints its own now, through the same `ComposerPage` the composer uses, so `EditPraxis.tsx` draws **none**. The either/or is resolved in favour of "the surface paints its own", which the old comment anticipated. The two halves of #567's invariant are pinned in two files: *never two* in `EditPraxisBackAffordance.test.tsx` (every skin mocked to null — the dispatcher adds nothing in any state at either width), *never zero* in `composerDispatch.test.tsx` (real archetype mounted, `<nav>` counted per skin at both widths, composing **and** waiting).

## What the awaiting stage draws

Status row `Submitted` / `Sealed` + `Submitted by you` · the task slip · the confirmation beat with the faction's heading · `Collaborators · N` or `Opponent` · the `collab_auto_submit_days` ring · `Your write-up` read-only · `Edit my write-up` / `Pull my entry back`.

- **The status mark stays where the composer put it** — same mark, same size, same slot. The word beside it changes and that is the confirmation beat. Moving it would itself be a dress change, which is what this issue exists to stop.
- **The points mark is `ScoreStamp`**, as it already was: it is per-faction dressed, and `scoreBreakdown()` is the ADR-0053 authority for rows that are genuinely reachable here. It now sits *inside* the composer's own task slip rather than beside a hand-drawn block, so it occupies the same place the points ring did.
- **`composerStageWord`** is shared because SNIDE prints the stage word in its **masthead** — a masthead still shouting DRAFT over a submitted praxis would be the page contradicting itself.
- **Coven / SNIDE / Everymen** get an inline button in their CTA colours rather than their full-bleed submit band: the band is the sheet's one irreversible act, and taking your own part back out is neither irreversible nor this page's subject.

## Prior rulings, held

No forfeit (#1071 d3 / ADR-0011 §Forfeit / #718). No duel countdown — elapsed line only (#1071 d4); the collab ring stays because it has real data. No `sealed` / out-for-votes stage (#1084). No hex, no `dark ? a : b`, no component-injected keyframes; two new copy keys (`statusSubmitted`, `statusSealed`) sit beside `statusDraft` in the neutral `editPraxis.composer.*` block.

**Copy was already neutral.** I checked every `awaiting*` / `completed*` / `duel*` key against all nine faction blocks in `forms.json`: **not one is overridden.** `collabCopy(slug, …)` resolves to the shared block for every slug, so ADR-0065 §3 needed no sweep here — only a note saying so.

## Also in this PR

The pre-v2 half of `archetypes/shared.tsx` is deleted — `RainbowTitle`, `RainbowUnderline`, `TaskMetaInline`, `ArchetypeFrame`, `formatClock`. Its banner said those survive "for the archetypes that have not been rebuilt yet"; all eight are rebuilt, and the undressed waiting surface was their last reader.

## Visual QA is outstanding

**I could not look at this.** No dev stack, and the Browser pane renderer times out. Everything below is tests, types and lint — `tsc --noEmit` clean, `eslint` clean, `vite build` clean (entry 134.47 KB gzip, unchanged), **2352 frontend tests passing**. No backend change, so `pytest` is untouched.

### What to eyeball

1. **Submit a collab part on each of the eight skins.** The page must not visibly change frame — same masthead, same ground, same sheet, same type. That is the entire claim of this PR and the one thing a test cannot make.
2. **`CollabRoster` and the publish ring inside a dark faction sheet.** Both still carry `--color-bg-surface` / `--color-border-strong` in places. The roster is shared with the read page and I did not restyle it; on Singularity's terminal ground and Coven's ward it may read as a foreign panel. If it does, it is a follow-up.
3. **`ScoreStamp` in the task slip.** It has no `flex-shrink: 0` of its own; check it does not squeeze the borrowed task title on a phone.
4. **The confirmation panel's accent border** against each faction's sheet — it takes `dress.accent`, which is `DEEP` on Coven, `ACID_INK` on SNIDE, `BRASS` on Ephemerists.
5. **Coven's sheet inset on the waiting stage.** It passes its own `contentStyle` padding; the full-bleed submit band is gone there, so check the bottom edge.
6. **SNIDE's masthead now reads `SUBMITTED`** where it read `DRAFT`, in tracked caps on the acid bar — check it still fits without wrapping.
7. **Duel side panels** — the rival's dashed panel takes the skin's panel ground now; make sure "mine" still reads as clearly claimed.

### Known, deliberately not fixed here

- `ErrorBanner` still hardcodes `rgba(220,38,38,…)` and `--color-danger` measures ~4.03:1 on the Singularity ground. Flagged by three agents, getting its own issue.
- `ARCHETYPE_PAIRS` in `factionContrast.test.ts` still has no composer rows — deferred to one follow-up covering all factions.
- `epSweep` in `index.css` remains unused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)