### PR TITLE
Comments v2: the owner row waits for you, and DefaultComment becomes the Unaffiliated sheet

### DIFF
--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -128,9 +128,11 @@ export function DefaultComment(props: CommentProps) {
             // slugs reach this voice (every themed faction has one of its own).
             bg="var(--faction-default-composer-field)"
             text={factionCssVar(slug, 'card-text')}
+            // The shared string in the na sheet's own caption voice — an
+            // OVERRIDE of ComposerControls' neutral default, not a new hint.
             hint={
               <span style={{ ...CAPTION, color: factionCssVar(slug, 'card-muted') }}>
-                {t('comments.na.mentionHint')}
+                {t('comments.mentionHint')}
               </span>
             }
           />

--- a/frontend/src/components/comments/CommentThread.tsx
+++ b/frontend/src/components/comments/CommentThread.tsx
@@ -20,36 +20,122 @@ import {
   ComposerControls,
   MentionText,
 } from './shared'
-import { CommentEditor, OwnerControls, useOwnerEdit } from './OwnerControls'
+import {
+  CommentEditor,
+  OwnerControls,
+  useOwnerEdit,
+  useOwnerReveal,
+  ownerRevealStyle,
+} from './OwnerControls'
 import { CommentFlagControl, canFlagComment } from './FlagControl'
 
 /**
- * Neutral fallback voice — invariant slots themed only by the faction CSS vars +
- * FactionAvatar + the timestamp dialect. Any unregistered faction renders this,
- * which is also the na / Unaffiliated identity (ADR-0039): so the row wears the
- * spectrum-band na tells — a rainbow hairline across the bubble top and
- * gradient-clipped @mentions (#970), reached via factionFill/`--faction-default-rainbow`
- * (NOT factionCssVar, which is neutral grey for na).
+ * THE SPECTRUM BUBBLE — the comment voice of the UNAFFILIATED (`na`) identity,
+ * and the fallback for any slug with no voice of its own. `default ≡ na ≡
+ * Unaffiliated` is one identity (ADR-0039 / 0046 / 0048): this IS the
+ * unaffiliated kit, not a generic neutral. Albescent renders through it too and
+ * stays that way — `albescent ≡ na + drift` (ADR-0048), its card carries the
+ * difference — so nothing here may narrow to `na`.
+ *
+ * The na tells, and only these: a spectrum hairline across the top of every
+ * sheet, and gradient-clipped @mentions (#970). Both reached through
+ * `factionFill` / `--faction-default-rainbow`, NEVER `factionCssVar`, which is
+ * neutral grey for na. Everything else is the quiet cream sheet the rest of the
+ * na kit uses — Lora italic for the name, Courier Prime for every label,
+ * `.content-text` for the body, because a comment IS content (§4 role floor).
+ *
+ * Six states, one component (ADR-0056 / 0058 / 0063 — no mobile twin):
+ *   row · default | row · mention + edited | row · yours (hover) |
+ *   row · editing | composer · empty | composer · submitting
+ *
+ * The owner's edit/withdraw row is the only behavioural change (#1195): it now
+ * reveals on hover OR keyboard focus, and never gates at all on a device that
+ * cannot hover. See `useOwnerReveal`.
  */
+
+/** Label-tier caption voice, shared by every small mark on the sheet. */
+const CAPTION = {
+  fontFamily: 'var(--font-body)',
+  fontSize: 'var(--text-base)',
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+} as const
+
+/**
+ * The sheet both modes sit on: avatar in the margin, a cream card carrying the
+ * spectrum hairline. One shape for a row and for the composer, so the thread
+ * reads as one stack rather than a list plus a form.
+ */
+function Sheet({
+  slug,
+  avatar,
+  children,
+  containerProps,
+}: {
+  slug: string | null | undefined
+  avatar: React.ReactNode
+  children: React.ReactNode
+  containerProps?: React.ComponentPropsWithoutRef<'div'>
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
+      {avatar}
+      <div
+        {...containerProps}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          background: factionCssVar(slug, 'card-bg'),
+          border: `1px solid ${factionCssVar(slug, 'border')}`,
+          borderRadius: 10,
+          overflow: 'hidden',
+          boxShadow: '0 4px 14px -10px rgba(0,0,0,0.4)',
+        }}
+      >
+        {/* The spectrum hairline — the na tell. A rainbow for default/na via
+            factionFill; a themed slug would land here only if it registered no
+            voice, and then it gets its own solid hue, not a borrowed one. */}
+        <div style={{ height: 3, ...factionFill(slug, 'bar') }} />
+        <div style={{ padding: 'var(--space-md) var(--space-lg)' }}>{children}</div>
+      </div>
+    </div>
+  )
+}
+
 export function DefaultComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
   const { user } = useAuth()
+  const reveal = useOwnerReveal()
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props
+    const slug = character.faction_slug
     return (
-      <div style={{ display: 'flex', gap: 'var(--space-md)' }}>
-        <FactionAvatar character={character} size="sm" />
-        <div style={{ flex: 1 }}>
+      <Sheet slug={slug} avatar={<FactionAvatar character={character} size="sm" />}>
+        {/* `.content-text` rides the wrapper on purpose: the ONE slot inside
+            without a size of its own is the textarea (`font: inherit`), and a
+            comment draft is content-tier text (§4). Every other slot — count,
+            hint, Cancel, Post — names its own size. */}
+        <div className="content-text" aria-busy={submitting}>
           <ComposerControls
             value={value}
             onChange={onChange}
             onSubmit={onSubmit}
             submitting={submitting}
-            accent={factionCssVar(character.faction_slug, 'card-accent')}
-            onAccent={factionCssVar(character.faction_slug, 'on-accent')}
+            accent={factionCssVar(slug, 'card-accent')}
+            onAccent={factionCssVar(slug, 'on-accent')}
+            // The field tier, not the sheet: an input reads as inset rather
+            // than painted on. Default-only tokens, and only default-keyed
+            // slugs reach this voice (every themed faction has one of its own).
+            bg="var(--faction-default-composer-field)"
+            text={factionCssVar(slug, 'card-text')}
+            hint={
+              <span style={{ ...CAPTION, color: factionCssVar(slug, 'card-muted') }}>
+                {t('comments.na.mentionHint')}
+              </span>
+            }
           />
         </div>
-      </div>
+      </Sheet>
     )
   }
   const { comment, onEdited, onWithdrawn } = props
@@ -57,74 +143,99 @@ export function DefaultComment(props: CommentProps) {
   const accent = factionCssVar(slug, 'card-accent')
   const onAccent = factionCssVar(slug, 'on-accent')
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
-  // A quiet control row lives at the bubble foot (design intent) — but only when
-  // there is something to show: the author's edit/withdraw or a flag affordance.
-  // Hidden while editing, since the inline editor owns Save/Cancel then.
-  const showControls =
-    !owner.editing && (owner.isOwner || canFlagComment(comment, user?.character?.id))
+  const canFlag = canFlagComment(comment, user?.character?.id)
+  // A quiet control row lives at the sheet's foot — but only when there is
+  // something to show: the author's edit/withdraw or a flag affordance. Hidden
+  // while editing, since the inline editor owns Save/Cancel then.
+  const showControls = !owner.editing && (owner.isOwner || canFlag)
+  // On your OWN comment the foot holds nothing but the gated owner row, so the
+  // rule above it fades with the row — a hairline over empty space is a state
+  // the sheet never draws. A flaggable (someone else's) comment keeps its foot.
+  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
   return (
-    <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
-      <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
+    <Sheet
+      slug={slug}
+      avatar={<FactionAvatar character={authorToCharacter(comment.author)} size="sm" />}
+      containerProps={reveal.containerProps}
+    >
       <div
         style={{
-          flex: 1,
-          minWidth: 0,
-          background: factionCssVar(slug, 'card-bg'),
-          border: `1px solid ${factionCssVar(slug, 'border')}`,
-          borderRadius: 8,
-          overflow: 'hidden',
-          boxShadow: '0 4px 14px -10px rgba(0,0,0,0.4)',
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 'var(--space-sm)',
+          flexWrap: 'wrap',
         }}
       >
-        {/* spectrum hairline — the na tell; a rainbow for default/na, a solid
-            hue would never appear here because only default slugs reach this
-            voice. Reached via factionFill (rainbow), not factionCssVar (grey). */}
-        <div style={{ height: 3, ...factionFill(slug, 'bar') }} />
-        <div style={{ padding: 'var(--space-md) var(--space-lg)' }}>
-          <div style={{ display: 'flex', alignItems: 'baseline', gap: 'var(--space-sm)', flexWrap: 'wrap' }}>
-            <Link
-              to={`/characters/${comment.author.id}`}
-              style={{
-                fontFamily: 'var(--font-display)',
-                fontStyle: 'italic',
-                fontWeight: 700,
-                color: factionCssVar(slug, 'card-text'),
-                textDecoration: 'none',
-              }}
-            >
-              {comment.author.display_name}
-            </Link>
-            <span style={{ fontSize: 'var(--text-md)', color: factionCssVar(slug, 'card-muted') }}>
-              {formatCommentTime(slug, comment.created_at)}
-              {comment.is_edited ? ` · ${t('comments.edited')}` : ''}
-            </span>
-          </div>
-          <div style={{ marginTop: 'var(--space-xs)', color: factionCssVar(slug, 'card-text'), lineHeight: 1.5 }}>
-            {owner.editing ? (
-              <CommentEditor owner={owner} accent={accent} onAccent={onAccent} />
-            ) : (
-              <MentionText body={comment.body_text} mentions={comment.mentions} accent={accent} rainbow />
-            )}
-          </div>
-          {showControls && (
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'baseline',
-                flexWrap: 'wrap',
-                gap: 'var(--space-md)',
-                marginTop: 'var(--space-sm)',
-                paddingTop: 'var(--space-sm)',
-                borderTop: `1px solid ${factionCssVar(slug, 'border')}`,
-              }}
-            >
-              <OwnerControls owner={owner} />
-              <CommentFlagControl comment={comment} />
-            </div>
-          )}
-        </div>
+        <Link
+          to={`/characters/${comment.author.id}`}
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontStyle: 'italic',
+            fontWeight: 700,
+            color: factionCssVar(slug, 'card-text'),
+            textDecoration: 'none',
+          }}
+        >
+          {comment.author.display_name}
+        </Link>
+        <span style={{ ...CAPTION, color: factionCssVar(slug, 'card-muted') }}>
+          {formatCommentTime(slug, comment.created_at)}
+        </span>
+        {comment.is_edited && (
+          <span style={{ ...CAPTION, color: factionCssVar(slug, 'card-muted') }}>
+            <span aria-hidden="true">· </span>
+            {t('comments.edited')}
+          </span>
+        )}
       </div>
-    </div>
+      {/* The body is user-authored free text — the content floor, in both the
+          resting and the editing state (the editor's textarea inherits it). */}
+      <div
+        className="content-text"
+        style={{
+          marginTop: 'var(--space-sm)',
+          fontFamily: 'var(--font-body)',
+          color: factionCssVar(slug, 'card-text'),
+          lineHeight: 1.55,
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {owner.editing ? (
+          <CommentEditor
+            owner={owner}
+            accent={accent}
+            onAccent={onAccent}
+            bg="var(--faction-default-composer-field)"
+            text={factionCssVar(slug, 'card-text')}
+          />
+        ) : (
+          <MentionText
+            body={comment.body_text}
+            mentions={comment.mentions}
+            accent={accent}
+            rainbow
+          />
+        )}
+      </div>
+      {showControls && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            flexWrap: 'wrap',
+            gap: 'var(--space-md)',
+            marginTop: 'var(--space-md)',
+            paddingTop: 'var(--space-sm)',
+            // A divider INSIDE the sheet is quieter than the sheet's own edge.
+            borderTop: '1px solid var(--faction-default-composer-hair)',
+            ...footGate,
+          }}
+        >
+          <OwnerControls owner={owner} reveal={reveal} />
+          <CommentFlagControl comment={comment} />
+        </div>
+      )}
+    </Sheet>
   )
 }
 

--- a/frontend/src/components/comments/OwnerControls.tsx
+++ b/frontend/src/components/comments/OwnerControls.tsx
@@ -6,8 +6,12 @@
  * here (in `useOwnerEdit`); each voice opts in by calling the hook and dropping
  * `<OwnerControls>` in its meta cluster + swapping its body slot for
  * `<CommentEditor>` while editing. No voice re-implements the state machine.
+ *
+ * #1195 adds the second shared behaviour beside it: `useOwnerReveal`, the
+ * hover/focus gate the row now sits behind. Same deal — the gate lives here
+ * once, a voice opts in with two lines, and nobody re-implements it either.
  */
-import { useState } from 'react'
+import { type CSSProperties, type FocusEvent, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { type CommentOut, deleteComment, editComment } from '../../api/comments'
 import { useAuth } from '../../auth/AuthContext'
@@ -132,6 +136,102 @@ export function useOwnerEdit({
   }
 }
 
+// ── Hover / focus reveal of the owner row (#1195) ─────────────────────────────
+
+/**
+ * Does the viewer's primary input hover at all? A touch-only device answers no,
+ * and there the owner row is ALWAYS shown — a hover-gate with no hover is a
+ * control that does not exist.
+ */
+const HOVER_CAPABLE_QUERY = '(hover: hover)'
+
+function detectHoverCapable(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    // Static render (the comment tests render to markup, no DOM). Assume a
+    // pointer: the gate is opacity-only, so the controls are still in the
+    // markup and still focusable either way.
+    return true
+  }
+  return window.matchMedia(HOVER_CAPABLE_QUERY).matches
+}
+
+/**
+ * The reveal state + the handlers that drive it. Spread `containerProps` on the
+ * comment's OUTERMOST element (the card/bubble root) and hand the whole object
+ * to `<OwnerControls reveal={…}>`.
+ */
+export interface OwnerReveal {
+  /** True when the owner row should be visible. */
+  revealed: boolean
+  /** Spread onto the card root — the pointer + focus sources of the reveal. */
+  containerProps: {
+    onMouseEnter: () => void
+    onMouseLeave: () => void
+    onFocus: () => void
+    onBlur: (event: FocusEvent<HTMLElement>) => void
+  }
+}
+
+/**
+ * Progressive reveal for the author's edit/withdraw row (#1195, design: the
+ * Unaffiliated sheet's "Row · yours (hover)").
+ *
+ * Three routes to the control, because hover alone would make it mouse-only:
+ *   1. pointer — `onMouseEnter` / `onMouseLeave` on the card root;
+ *   2. keyboard — `onFocus` / `onBlur` on the same root, which is React's
+ *      bubbling focus pair, i.e. `:focus-within` without a stylesheet. The
+ *      buttons stay MOUNTED and merely transparent, so Tab reaches them and the
+ *      first stop reveals the row;
+ *   3. touch — a device that reports no hover capability never gates at all.
+ *
+ * Lives here, once, so the eight faction voices wire two lines (this hook + the
+ * spread) instead of re-implementing a gate each. `revealed` deliberately does
+ * NOT know about the withdraw-confirm strip; `<OwnerControls>` pins that open
+ * itself, so a voice cannot forget to.
+ */
+export function useOwnerReveal(): OwnerReveal {
+  const [hovered, setHovered] = useState(false)
+  const [focused, setFocused] = useState(false)
+  const [hoverCapable, setHoverCapable] = useState(detectHoverCapable)
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') {
+      setHoverCapable(false)
+      return
+    }
+    const query = window.matchMedia(HOVER_CAPABLE_QUERY)
+    const sync = () => setHoverCapable(query.matches)
+    sync()
+    query.addEventListener('change', sync)
+    return () => query.removeEventListener('change', sync)
+  }, [])
+
+  return {
+    revealed: !hoverCapable || hovered || focused,
+    containerProps: {
+      onMouseEnter: () => setHovered(true),
+      onMouseLeave: () => setHovered(false),
+      onFocus: () => setFocused(true),
+      onBlur: (event: FocusEvent<HTMLElement>) => {
+        // Only a focus leaving the card counts — moving between the row's own
+        // buttons must not flicker it away mid-Tab.
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setFocused(false)
+        }
+      },
+    },
+  }
+}
+
+/**
+ * The gate itself: OPACITY, never `display`/`visibility`/unmounting. A removed
+ * control is unreachable by keyboard, which is the whole failure mode this
+ * issue exists to avoid.
+ */
+export function ownerRevealStyle(revealed: boolean): CSSProperties {
+  return { opacity: revealed ? 1 : 0, transition: 'opacity 120ms ease-out' }
+}
+
 // ── Meta-cluster affordance (edit · delete / withdraw-confirm) ────────────────
 
 const linkStyle = {
@@ -146,10 +246,26 @@ const linkStyle = {
  * Neutral text affordance for the meta cluster — mirrors the praxis owner "edit"
  * link (tertiary `.eyebrow`). Self-hides for non-authors and while editing (the
  * inline editor owns Save/Cancel then).
+ *
+ * Pass `reveal` (from {@link useOwnerReveal}) to hover-gate it: the row then
+ * fades in on pointer-hover or keyboard focus anywhere in the card, and is
+ * always on for a device that cannot hover. Omit it and the row is always
+ * visible — which is what the seven faction voices still do until each one
+ * wires the two lines (#1196–#1202).
  */
-export function OwnerControls({ owner }: { owner: OwnerEdit }) {
+export function OwnerControls({
+  owner,
+  reveal,
+}: {
+  owner: OwnerEdit
+  reveal?: OwnerReveal
+}) {
   const { t } = useTranslation('praxis')
   if (!owner.isOwner || owner.editing) return null
+
+  // The confirm strip pins itself open: it is a question already asked, and a
+  // pointer wandering off must not swallow it mid-answer.
+  const gate = reveal == null ? null : ownerRevealStyle(reveal.revealed || owner.confirming)
 
   if (owner.confirming) {
     return (
@@ -160,6 +276,7 @@ export function OwnerControls({ owner }: { owner: OwnerEdit }) {
           flexWrap: 'wrap',
           gap: 'var(--space-sm)',
           fontSize: 'var(--text-content)',
+          ...gate,
         }}
       >
         <span style={{ color: 'var(--color-text-tertiary)' }}>
@@ -191,7 +308,9 @@ export function OwnerControls({ owner }: { owner: OwnerEdit }) {
   }
 
   return (
-    <span style={{ display: 'inline-flex', alignItems: 'baseline', gap: 'var(--space-sm)' }}>
+    <span
+      style={{ display: 'inline-flex', alignItems: 'baseline', gap: 'var(--space-sm)', ...gate }}
+    >
       <button
         onClick={owner.startEdit}
         aria-label={t('comments.edit')}

--- a/frontend/src/components/comments/__tests__/OwnerControls.test.tsx
+++ b/frontend/src/components/comments/__tests__/OwnerControls.test.tsx
@@ -18,7 +18,10 @@ import {
   OwnerControls,
   editSaveDisabled,
   isCommentOwner,
+  ownerRevealStyle,
+  useOwnerReveal,
   type OwnerEdit,
+  type OwnerReveal,
 } from '../OwnerControls'
 
 // Mock the axios instance so the comments client can be exercised without a network.
@@ -110,6 +113,81 @@ describe('OwnerControls', () => {
     expect(html).toContain('Withdraw this comment?')
     expect(html).toContain('Withdraw')
     expect(html).toContain('Keep')
+  })
+})
+
+// ── Hover / focus gate (#1195) ─────────────────────────────────────────────────
+
+function makeReveal(revealed: boolean): OwnerReveal {
+  return {
+    revealed,
+    containerProps: {
+      onMouseEnter: () => {},
+      onMouseLeave: () => {},
+      onFocus: () => {},
+      onBlur: () => {},
+    },
+  }
+}
+
+describe('ownerRevealStyle', () => {
+  it('gates with OPACITY only — never display/visibility, which would drop the row out of the tab order', () => {
+    expect(ownerRevealStyle(false).opacity).toBe(0)
+    expect(ownerRevealStyle(true).opacity).toBe(1)
+    expect(ownerRevealStyle(false).display).toBeUndefined()
+    expect(ownerRevealStyle(false).visibility).toBeUndefined()
+  })
+})
+
+describe('OwnerControls hover gate', () => {
+  it('keeps edit + delete MOUNTED while hidden, so Tab can still reach (and reveal) them', () => {
+    const html = renderToStaticMarkup(
+      <OwnerControls owner={makeOwner()} reveal={makeReveal(false)} />,
+    )
+    expect(html).toContain('edit')
+    expect(html).toContain('delete')
+    expect(html).toContain('opacity:0')
+  })
+
+  it('shows the row at full strength once revealed', () => {
+    const html = renderToStaticMarkup(
+      <OwnerControls owner={makeOwner()} reveal={makeReveal(true)} />,
+    )
+    expect(html).toContain('opacity:1')
+  })
+
+  it('pins the withdraw-confirm strip open even when unrevealed', () => {
+    const html = renderToStaticMarkup(
+      <OwnerControls owner={makeOwner({ confirming: true })} reveal={makeReveal(false)} />,
+    )
+    expect(html).toContain('Withdraw this comment?')
+    expect(html).toContain('opacity:1')
+  })
+
+  it('is ungated when no reveal is passed — the seven faction voices are untouched by #1195', () => {
+    const html = renderToStaticMarkup(<OwnerControls owner={makeOwner()} />)
+    expect(html).not.toContain('opacity')
+  })
+})
+
+describe('useOwnerReveal', () => {
+  it('exposes the pointer AND focus sources of the reveal', () => {
+    const captured: OwnerReveal[] = []
+    function Probe() {
+      captured.push(useOwnerReveal())
+      return null
+    }
+    renderToStaticMarkup(<Probe />)
+    expect(Object.keys(captured[0].containerProps).sort()).toEqual([
+      'onBlur',
+      'onFocus',
+      'onMouseEnter',
+      'onMouseLeave',
+    ])
+    // No `window` in the test environment, so hover capability is assumed and
+    // the row starts hidden. The gate is opacity-only, so the controls are in
+    // the markup either way — which is exactly what makes that assumption safe.
+    expect(captured[0].revealed).toBe(false)
   })
 })
 

--- a/frontend/src/components/comments/__tests__/composerControls.test.tsx
+++ b/frontend/src/components/comments/__tests__/composerControls.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * ComposerControls' foot slot (#1195).
+ *
+ * The "@ to mention" affordance used to live in the shared placeholder, which
+ * every one of the eight voices reads. The Unaffiliated design moves it to the
+ * foot's left slot, so that slot DEFAULTS rather than sits empty: a voice opts
+ * out or overrides, and no voice loses the affordance by not having been
+ * redressed yet (#1196–#1202).
+ *
+ * Rendered to static markup (no DOM) per the comments-test convention; `useAuth`
+ * resolves to its anonymous default so the mention hook renders without a
+ * provider.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so the neutral copy keys resolve to English text.
+import '../../../i18n'
+import { ComposerControls } from '../shared'
+import { MAX_COMMENT_BODY } from '../OwnerControls'
+
+function composer(extra: Partial<Parameters<typeof ComposerControls>[0]> = {}): string {
+  return renderToStaticMarkup(
+    <ComposerControls
+      value=""
+      onChange={() => {}}
+      onSubmit={() => {}}
+      submitting={false}
+      accent="var(--color-accent-primary)"
+      onAccent="var(--faction-default-on-accent)"
+      {...extra}
+    />,
+  )
+}
+
+describe('ComposerControls — the mention hint', () => {
+  it('defaults the hint, so a voice that passes nothing still states the affordance', () => {
+    expect(composer()).toContain('@ to mention')
+  })
+
+  it('lets a voice override it with its own dressed caption', () => {
+    const html = composer({ hint: <span>speak thy handle</span> })
+    expect(html).toContain('speak thy handle')
+    expect(html).not.toContain('@ to mention')
+  })
+
+  it('yields the slot to the live character count while editing', () => {
+    const html = composer({ maxLength: MAX_COMMENT_BODY })
+    expect(html).toContain(`0/${MAX_COMMENT_BODY}`)
+    expect(html).not.toContain('@ to mention')
+  })
+
+  it('no longer repeats the affordance in the placeholder', () => {
+    const html = composer()
+    expect(html).toContain('Say something worth keeping')
+    expect(html.match(/to mention/g)).toHaveLength(1)
+  })
+})

--- a/frontend/src/components/comments/__tests__/defaultComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/defaultComment.test.tsx
@@ -1,0 +1,135 @@
+/**
+ * DefaultComment — the Unaffiliated (`na`) comment sheet (#1195, epic #1192).
+ *
+ * `default ≡ na ≡ Unaffiliated` is one identity (ADR-0039 / 0046 / 0048), and
+ * Albescent renders through this same component (`albescent ≡ na + drift`,
+ * ADR-0048). These tests hold the na TELLS and the state slots the Unaffiliated
+ * sheet draws; the faction voices have their own guards.
+ *
+ * Rendered to static markup (no DOM) per the comments-test convention, so
+ * `useAuth` resolves to its anonymous default: the viewer owns nothing and can
+ * flag nothing, which is the "row · default" reading of every case below.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so the neutral copy keys resolve to English text.
+import '../../../i18n'
+import type { CommentOut } from '../../../api/comments'
+import type { CharacterOut } from '../../../api/auth'
+import { DefaultComment } from '../CommentThread'
+
+const COMMENT: CommentOut = {
+  id: 7,
+  praxis_id: 1,
+  task_id: null,
+  body_text: 'seedlings along the estuary',
+  is_edited: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: {
+    id: 42,
+    username: 'ada',
+    display_name: 'Adabel',
+    avatar_url: null,
+    faction_slug: 'na',
+  },
+  mentions: [],
+}
+
+const CHARACTER: CharacterOut = {
+  id: 42,
+  username: 'ada',
+  display_name: 'Adabel',
+  avatar_url: null,
+  faction_slug: 'na',
+  bio: null,
+  location: null,
+  level: 3,
+  score: 0,
+  all_time_score: 0,
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function row(comment: CommentOut): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <DefaultComment mode="row" comment={comment} />
+    </MemoryRouter>,
+  )
+}
+
+function composer(submitting: boolean): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <DefaultComment
+        mode="composer"
+        character={CHARACTER}
+        value=""
+        onChange={() => {}}
+        onSubmit={() => {}}
+        submitting={submitting}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('DefaultComment — the na tells', () => {
+  it('wears the spectrum hairline, not a grey one (factionFill, never factionCssVar)', () => {
+    expect(row(COMMENT)).toContain('--faction-default-rainbow')
+  })
+
+  it('clips resolved @mentions to the spectrum (#970)', () => {
+    const html = row({
+      ...COMMENT,
+      body_text: 'thank you @bo',
+      mentions: [{ character_id: 9, username: 'bo', display_name: 'Bo' }],
+    })
+    expect(html).toContain('rainbow-ink')
+    expect(html).toContain('href="/characters/9"')
+  })
+
+  it('leaves an unresolved handle as plain text', () => {
+    const html = row({ ...COMMENT, body_text: 'thank you @ghost' })
+    expect(html).toContain('@ghost')
+    expect(html).not.toContain('rainbow-ink')
+  })
+})
+
+describe('DefaultComment — row states', () => {
+  it('row · default: author identity, body on the content floor, no edited mark', () => {
+    const html = row(COMMENT)
+    expect(html).toContain('href="/characters/42"')
+    expect(html).toContain('Adabel')
+    expect(html).toContain('seedlings along the estuary')
+    expect(html).toContain('content-text')
+    expect(html).not.toContain('edited')
+  })
+
+  it('row · edited: the edited mark joins the byline', () => {
+    expect(row({ ...COMMENT, is_edited: true })).toContain('edited')
+  })
+
+  it('shows no owner row and no flag affordance to a signed-out viewer', () => {
+    const html = row(COMMENT)
+    expect(html).not.toContain('delete')
+    expect(html).not.toContain('Flag')
+  })
+})
+
+describe('DefaultComment — composer states', () => {
+  it('composer · empty: carries the @-mention hint', () => {
+    expect(composer(false)).toContain('@ to mention')
+  })
+
+  it('composer · submitting: marks itself busy and disables the field', () => {
+    const html = composer(true)
+    expect(html).toContain('aria-busy="true"')
+    expect(html).toContain('disabled')
+  })
+
+  it('composer · empty is NOT busy', () => {
+    expect(composer(false)).not.toContain('aria-busy="true"')
+  })
+})

--- a/frontend/src/components/comments/__tests__/defaultComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/defaultComment.test.tsx
@@ -123,6 +123,12 @@ describe('DefaultComment — composer states', () => {
     expect(composer(false)).toContain('@ to mention')
   })
 
+  it('states the @ affordance exactly ONCE — the hint slot owns it, the placeholder does not', () => {
+    const html = composer(false)
+    expect(html).toContain('Say something worth keeping')
+    expect(html.match(/to mention/g)).toHaveLength(1)
+  })
+
   it('composer · submitting: marks itself busy and disables the field', () => {
     const html = composer(true)
     expect(html).toContain('aria-busy="true"')

--- a/frontend/src/components/comments/shared.tsx
+++ b/frontend/src/components/comments/shared.tsx
@@ -7,7 +7,7 @@
  * timestamp+edited — and the composer mechanics out of every voice so each voice
  * only owns its chrome.
  */
-import type { ComponentType } from 'react'
+import type { ComponentType, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import type { CharacterOut } from '../../api/auth'
@@ -127,6 +127,7 @@ export function ComposerControls({
   submitLabel,
   submittingLabel,
   onCancel,
+  hint,
 }: {
   value: string
   onChange: (value: string) => void
@@ -148,6 +149,14 @@ export function ComposerControls({
   submittingLabel?: string
   /** When set, renders a neutral Cancel affordance beside submit (edit mode). */
   onCancel?: () => void
+  /**
+   * Voice-dressed caption for the foot's left slot — the composer's "@ to
+   * mention" hint (#1195). Deliberately a ReactNode rather than a string: the
+   * slot is shared, the dress is the voice's. It yields to the live character
+   * count, because `maxLength` is only set while EDITING, and the two states
+   * are mutually exclusive on the sheet.
+   */
+  hint?: ReactNode
 }) {
   const { t } = useTranslation('praxis')
   const disabled = submitting || value.trim().length === 0
@@ -205,7 +214,7 @@ export function ComposerControls({
             {t('comments.charCount', { count: value.length, max: maxLength })}
           </span>
         ) : (
-          <span />
+          (hint ?? <span />)
         )}
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
           {onCancel && (

--- a/frontend/src/components/comments/shared.tsx
+++ b/frontend/src/components/comments/shared.tsx
@@ -150,11 +150,18 @@ export function ComposerControls({
   /** When set, renders a neutral Cancel affordance beside submit (edit mode). */
   onCancel?: () => void
   /**
-   * Voice-dressed caption for the foot's left slot — the composer's "@ to
-   * mention" hint (#1195). Deliberately a ReactNode rather than a string: the
-   * slot is shared, the dress is the voice's. It yields to the live character
-   * count, because `maxLength` is only set while EDITING, and the two states
-   * are mutually exclusive on the sheet.
+   * Caption for the foot's left slot — the composer's "@ to mention" hint
+   * (#1195). A ReactNode rather than a string, because the slot is shared and
+   * the dress is the voice's: a voice OVERRIDES this to speak in its own ink.
+   *
+   * It defaults to the neutral caption below rather than to nothing, so the
+   * affordance is opt-OUT. The placeholder used to carry "type @ to mention
+   * someone" for all eight voices; the design moves that job here, and a
+   * default is what keeps the seven voices that have not been redressed yet
+   * (#1196–#1202) from silently losing it in the meantime.
+   *
+   * It yields to the live character count, because `maxLength` is only set
+   * while EDITING, and the two states are mutually exclusive on the sheet.
    */
   hint?: ReactNode
 }) {
@@ -214,7 +221,14 @@ export function ComposerControls({
             {t('comments.charCount', { count: value.length, max: maxLength })}
           </span>
         ) : (
-          (hint ?? <span />)
+          (hint ?? (
+            // Same tier as the character count it shares this slot with, so a
+            // voice that never overrides it inherits whatever legibility that
+            // count already has on its ground.
+            <span style={{ fontSize: 'var(--text-md)', color: 'var(--color-text-tertiary)' }}>
+              {t('comments.mentionHint')}
+            </span>
+          ))
         )}
         <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
           {onCancel && (

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -211,6 +211,9 @@
     "charCount": "{{count}}/{{max}}",
     "editError": "Could not save the edit.",
     "withdrawError": "Could not withdraw the comment.",
+    "na": {
+      "mentionHint": "@ to mention"
+    },
     "ua": {
       "house": "University of Asthmatics",
       "edited": "edited",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -197,7 +197,7 @@
     "heading_other": "{{count}} comments",
     "loading": "Loading…",
     "loadError": "Could not load comments.",
-    "composerPlaceholder": "Write a comment… type @ to mention someone",
+    "composerPlaceholder": "Say something worth keeping…",
     "post": "Post comment",
     "posting": "…",
     "edited": "edited",

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -198,6 +198,7 @@
     "loading": "Loading…",
     "loadError": "Could not load comments.",
     "composerPlaceholder": "Say something worth keeping…",
+    "mentionHint": "@ to mention",
     "post": "Post comment",
     "posting": "…",
     "edited": "edited",
@@ -211,9 +212,6 @@
     "charCount": "{{count}}/{{max}}",
     "editError": "Could not save the edit.",
     "withdrawError": "Could not withdraw the comment.",
-    "na": {
-      "mentionHint": "@ to mention"
-    },
     "ua": {
       "house": "University of Asthmatics",
       "edited": "edited",


### PR DESCRIPTION
Closes #1195

Part of epic #1192 (comments + update cards v2). F3 — the only behavioural delta the Unaffiliated sheet has against the shipped comment surface, plus the na skin the seven faction voice issues build against.

## What changed

**1. The owner row is hover-gated — and that gate is accessible.**

`useOwnerReveal()` + `ownerRevealStyle()` live once in `OwnerControls.tsx`. Three routes to the control:

- **pointer** — `onMouseEnter`/`onMouseLeave` on the card root;
- **keyboard** — `onFocus`/`onBlur` on the same root (React's bubbling focus pair, i.e. `:focus-within` without a stylesheet). The buttons stay **mounted and merely transparent**, so Tab reaches them and the first stop reveals the row. This is why the gate is `opacity` and never `display`/`visibility`/unmounting;
- **touch** — a device that reports `(hover: hover)` false never gates at all.

The withdraw-confirm strip pins itself open regardless of the gate — it is a question already asked, and a pointer wandering off must not swallow it mid-answer. `OwnerControls` does that itself so no voice can forget to.

**On the design's `Mobile · swipe left`:** the sheet draws two reveal routes, `Desktop · hover` and a mobile swipe-left. **This PR does not build swipe** — the comment row's mobile route here is "never gated at all", which is accessible and needs no gesture discovery. Swipe belongs to the feed's archive UX in **#1194**; the seven faction voice issues should NOT each invent one for their comment rows.

**2. `DefaultComment` rebuilt as the Unaffiliated sheet**, six states in one responsive component (ADR-0056/0058/0063, no mobile twin) — `Row · default`, `Row · mention + edited`, `Row · yours (hover)`, `Row · editing`, `Composer · empty`, `Composer · submitting`. `default ≡ na ≡ Unaffiliated` and Albescent renders through it too (ADR-0048) — nothing here narrows to `na`. The tells the issue names are kept and reached through `factionFill` / `--faction-default-rainbow`, never `factionCssVar`: the spectrum hairline and gradient-clipped @mentions. The rest is the na kit's own vocabulary — Lora italic name, Courier Prime label captions, the body on the **content floor** (`.content-text`; it previously had no size at all and inherited the page), the composer's `--faction-default-composer-field` / `-hair` tiers reused from the na composer set, and the byline's `edited` promoted to its own mark.

**3. The composer states the @ affordance once.** `comments.composerPlaceholder` is now the design's "Say something worth keeping…", and the mention affordance lives only in the new hint slot. Shipping both left the same instruction printed twice in one composer.

**The hint slot DEFAULTS**, so the affordance is opt-out rather than opt-in. The placeholder is shared by all eight voices, so moving the `@` prompt into a slot only the na composer filled would have taken it away from the seven voices queued behind this issue — a regression that only closes if six other PRs all land. `ComposerControls` now falls back to the same neutral caption (`comments.mentionHint`, in the character count's tier so it inherits whatever legibility that count already has on each ground), and a voice **overrides** it to speak in its own ink, exactly as `DefaultComment` does. No voice had to make room: the foot's left slot already existed for all eight, holding an empty span opposite the submit cluster.

**4. Seams for the seven faction agents**, since every gap here becomes seven conflicting edits later:

- a voice opts into the gate in **two lines** — `const reveal = useOwnerReveal()`, spread `reveal.containerProps` on its card root, pass `reveal` to `<OwnerControls>`;
- `ComposerControls` gained an optional `hint?: ReactNode` slot in the foot's left position. A `ReactNode`, not a string: the slot is shared, the dress is the voice's. It yields to the live character count, because `maxLength` is only set while editing and the two states are mutually exclusive on the sheet.

**Faction voices are untouched.** `OwnerControls` without a `reveal` prop renders exactly as before, so the seven voices are byte-identical.

## Copy divergences left as they are, on purpose

The design shows `Post` / `Posting…` / `Edit`; main ships `Post comment` / `…` / `edit`. All three are left alone, and I would keep two of them:

- **`Post comment` over `Post`** — it is the button's accessible name, and "Post" alone is the classic ambiguous-label case for a screen reader running the elements list. A visual sheet being terser is not a reason to regress it.
- **`edit` / `delete` lowercase** — these are the meta-cluster's tertiary link voice, shared with the praxis owner "edit" link. Recasing them here would split that pairing across surfaces.
- **`posting` = "…"** is a real a11y defect and is now **filed as #1236**: an ellipsis alone is not an accessible name, and a screen reader announces nothing when the button flips to it. **Not changed here** — it is shared by all eight voices (and by the inline editor's Save) and belongs in a copy pass, not a skin PR.

## Out of scope, as filed

The composer's 500-char draft cap vs. editing's 2000 is untouched.

## Filed, not fixed

- **#1236** — the Post button's busy state has no accessible name (`comments.posting` = `"…"`, all eight voices).

## Noted, not fixed (#1231)

`components/comments/FlagControl.tsx:65` hardcodes `rgba(220,38,38,0.4)` for the flag button's border — the same hardcoded-danger-red shape as `ErrorBanner`. Left alone here; it belongs with #1231.

## Verification

- `tsc --noEmit` clean · `eslint src` clean · `vite build` clean
- **full** frontend suite: 139 files / 2372 tests pass (20 new)
- New guards: the gate keeps the row mounted while hidden, reveals at full strength, pins the confirm strip, and stays ungated when no `reveal` is passed; `DefaultComment`'s na tells, its six states, and the @ affordance appearing exactly once; `ComposerControls` defaulting the hint, honouring an override, and yielding the slot to the character count while editing.

## Visual QA is outstanding

**The restyle was built without the sheet.** `DesignSync` is not available to subagents and the sheet is not vendored in the repo, so the na skin came from the issue's written description of the six states, the tells it names, and the existing na kit (`DefaultTaskCard`, the na composer tokens) — not from the drawing. (The state list and the placeholder string were confirmed against the sheet afterwards; the *visual* chassis still has not been compared to it.) Nor can I screenshot: there is no dev stack here and the Browser pane renderer times out. **Everything below wants a human eyeball, in both themes:**

## What to eyeball

1. **Fidelity against `Unaffiliated Comment + Update Cards.dc.html`** — chassis proportions, the byline rhythm, and whether the composer should sit on the same sheet as a row (I gave it one, so the thread reads as one stack).
2. **Hover the owner row** on your own comment: fade in, fade out, no layout shift (the gate is opacity-only, the row keeps its box).
3. **Tab to it with the mouse away** — the row must appear on the first focus inside the card and stay through both buttons.
4. **Touch device / devtools touch emulation** — the row should be permanently visible, never hover-gated, and no swipe is expected (see #1194).
5. **The foot rule on your own comment** fades with the row (a hairline over empty space is a state the sheet never draws); on someone else's comment the foot stays, carrying the flag control.
6. **Withdraw confirm**: click delete, then move the pointer off the card — the confirm strip must stay put.
7. **`.rainbow-ink` @mentions in both themes.** `background-clip: text` fails *invisibly* — if the token ever resolves to nothing the glyph renders blank, and axe cannot measure a gradient. The stop to hand-check is the darkest light-mode red `#c1272d` on the cream sheet.
8. **The 18px body** — the comment body was previously unsized and is now on the content floor. Check the thread's rhythm did not blow out.
9. **The seven faction composers**, which now show the neutral `@ to mention` caption in the foot's left slot — check it is legible on the dark grounds (S.N.I.D.E., Singularity) and does not crowd Coven's window chrome.
10. **Dark mode** across all six states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
