### PR TITLE
F1: feed items get stable identity and an archive (backend)

### DIFF
--- a/backend/alembic/versions/0010_feed_dismissal.py
+++ b/backend/alembic/versions/0010_feed_dismissal.py
@@ -52,13 +52,24 @@ def upgrade() -> None:
     )
 
     # Doubles as the read index: every query is "this character's archive".
+    #
+    # Not the `EXCEPTION WHEN duplicate_object` shape the FK above uses: adding
+    # a UNIQUE constraint also builds an index, and a pre-existing one raises
+    # `duplicate_table`, which that handler does not catch. On a fresh DB
+    # `0001_squashed` has already built both from the model, so this ran
+    # straight into an unhandled error. Ask pg_constraint instead.
     op.execute(
         """
         DO $$ BEGIN
-            ALTER TABLE feed_dismissal
-                ADD CONSTRAINT uq_feed_dismissal_character_item_key
-                UNIQUE (character_id, item_key);
-        EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'uq_feed_dismissal_character_item_key'
+            ) THEN
+                ALTER TABLE feed_dismissal
+                    ADD CONSTRAINT uq_feed_dismissal_character_item_key
+                    UNIQUE (character_id, item_key);
+            END IF;
+        END $$;
         """
     )
 

--- a/backend/alembic/versions/0010_feed_dismissal.py
+++ b/backend/alembic/versions/0010_feed_dismissal.py
@@ -1,0 +1,67 @@
+"""Add the `feed_dismissal` table (#1193).
+
+One row per activity-feed item a character has archived. See
+``models/feed_dismissal.py`` for why the archive is a table rather than
+per-device storage, and ``services/activity_feed.py::build_item_key`` for the
+shape of ``item_key``.
+
+``0001_squashed`` builds a *fresh* DB with ``Base.metadata.create_all``, so CI
+and a local reset land on this shape the moment the model exists. A deployed DB
+is stamped further down the chain and never re-runs the baseline — hence this
+revision. Idempotent on both: ``IF NOT EXISTS`` throughout, and the FK is
+created inside a DO block because Postgres has no
+``ADD CONSTRAINT IF NOT EXISTS`` (the 0008 / 0009 pattern).
+
+No enum, no backfill: the table starts empty everywhere, and an empty archive
+is exactly the pre-feature behaviour.
+
+Revision ID: 0010_feed_dismissal
+Revises: 0009_nudge_table
+Create Date: 2026-07-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0010_feed_dismissal"
+down_revision: Union[str, None] = "0009_nudge_table"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS feed_dismissal (
+            id SERIAL PRIMARY KEY,
+            character_id INTEGER NOT NULL,
+            item_key VARCHAR(128) NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+        """
+    )
+
+    op.execute(
+        """
+        DO $$ BEGIN
+            ALTER TABLE feed_dismissal
+                ADD CONSTRAINT feed_dismissal_character_id_fkey
+                FOREIGN KEY (character_id) REFERENCES character (id);
+        EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+        """
+    )
+
+    # Doubles as the read index: every query is "this character's archive".
+    op.execute(
+        """
+        DO $$ BEGIN
+            ALTER TABLE feed_dismissal
+                ADD CONSTRAINT uq_feed_dismissal_character_item_key
+                UNIQUE (character_id, item_key);
+        EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS feed_dismissal")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -29,6 +29,7 @@ from models.taunt_message import TauntMessage
 from models.faction_defection_history import FactionDefectionHistory
 from models.invitation_letter import InvitationLetter
 from models.nudge import Nudge
+from models.feed_dismissal import FeedDismissal
 
 __all__ = [
     "Faction",
@@ -65,4 +66,5 @@ __all__ = [
     "FactionDefectionHistory",
     "InvitationLetter",
     "Nudge",
+    "FeedDismissal",
 ]

--- a/backend/models/feed_dismissal.py
+++ b/backend/models/feed_dismissal.py
@@ -1,0 +1,56 @@
+"""One row per activity-feed item a character has archived (#1193).
+
+The activity feed is a **derived** read-model: it is a UNION over 15 source
+tables (``vote``, ``praxis``, ``duel``, ``nudge``, …) and owns no rows of its
+own, so there is nothing on a feed item to mark as dismissed. This table is
+that mark, and it is the only durable state the archive has.
+
+**Why a table and not localStorage.** "Nothing is destroyed, everything lands
+in Archived" is a durability promise made to the player, so it has to survive a
+device change, a reinstall, and a second browser. A per-device key/value store
+cannot make that promise.
+
+**What ``item_key`` is.** ``"{feed_item_type}:{source_row_pk}"`` — see
+``services.activity_feed.build_item_key``. The type prefix is load-bearing:
+three feed types are built from ``praxis_member`` rows and two from ``praxis``
+rows, so the source PK alone is not unique across the feed. Storing the key as
+one opaque string (rather than a type column + an id column) keeps the value
+the client sends, the value stored, and the value compared byte-identical.
+
+**Archiving is a view state, never a decision** (ADR-0065, epic #1192). An
+archived ``duel_challenge`` or ``collab_invite`` is still open and still
+unanswered — this table is written, and nothing else is. Nothing here touches
+``Duel.status`` or ``PraxisInvite.status``.
+
+``awaiting_submission`` can never appear here: it is state rather than an
+event (it exists exactly while ``PraxisMember.has_submitted`` is false), so a
+row would silence a standing obligation permanently. The refusal is enforced
+in the service, not by a constraint — see ``ARCHIVABLE_ITEM_TYPES``.
+
+Orphaned rows (the source row is later deleted) are harmless: the key simply
+matches nothing. There is deliberately no cleanup job.
+"""
+
+from sqlalchemy import ForeignKey, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from models.base import Base
+from models.mixins import CreatedAtMixin
+
+
+class FeedDismissal(CreatedAtMixin, Base):
+    __tablename__ = "feed_dismissal"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    character_id: Mapped[int] = mapped_column(
+        ForeignKey("character.id"), nullable=False
+    )
+    item_key: Mapped[str] = mapped_column(String(128), nullable=False)
+
+    __table_args__ = (
+        # Also the read index: every query here is "this character's archive",
+        # and character_id leads the constraint's implicit unique index.
+        UniqueConstraint(
+            "character_id", "item_key", name="uq_feed_dismissal_character_item_key"
+        ),
+    )

--- a/backend/routers/activity_feed.py
+++ b/backend/routers/activity_feed.py
@@ -9,8 +9,20 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db import get_db, get_session_factory
 from dependencies import get_current_character
 from models.character import Character
-from schemas.activity_feed import ActivityFeedResponse
-from services.activity_feed import get_activity_feed
+from schemas.activity_feed import (
+    ActivityFeedResponse,
+    FeedBulkArchiveRequest,
+    FeedBulkArchiveResponse,
+    FeedItemArchiveRequest,
+    FeedItemArchiveResponse,
+)
+from services.activity_feed import (
+    dismiss_feed_item,
+    dismiss_feed_items_for_filter,
+    get_activity_feed,
+    restore_feed_item,
+    restore_feed_items_for_filter,
+)
 
 router = APIRouter()
 
@@ -20,11 +32,17 @@ async def activity_feed(
     filter: Optional[str] = Query(None, alias="filter"),
     before: Optional[str] = Query(None),
     limit: int = Query(20, ge=1, le=100),
+    archived: bool = Query(False),
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
     session_factory: Callable = Depends(get_session_factory),
 ) -> ActivityFeedResponse:
-    """Return a unified, paginated activity feed for the current character."""
+    """Return a unified, paginated activity feed for the current character.
+
+    ``archived=true`` returns the archive instead — same cursor, same page size,
+    but it ignores the friend/foe/global type slicing and returns everything the
+    character has put away.
+    """
     # Unknown filters fall back to "all" in the service (FILTER_QUERIES.get default).
     before_cursor: Optional[datetime] = None
     if before:
@@ -37,5 +55,64 @@ async def activity_feed(
         feed_filter=filter,
         before_cursor=before_cursor,
         limit=limit,
+        archived=archived,
     )
     return ActivityFeedResponse.model_validate(asdict(dc_response))
+
+
+@router.post("/dismiss", response_model=FeedItemArchiveResponse)
+async def dismiss_item(
+    body: FeedItemArchiveRequest,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+) -> FeedItemArchiveResponse:
+    """Archive one feed item. 400 if the key is unknown or unarchivable."""
+    changed = await dismiss_feed_item(character.id, body.item_key, session)
+    return FeedItemArchiveResponse(
+        item_key=body.item_key, archived=True, changed=changed
+    )
+
+
+@router.post("/restore", response_model=FeedItemArchiveResponse)
+async def restore_item(
+    body: FeedItemArchiveRequest,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+) -> FeedItemArchiveResponse:
+    """Take one feed item back out of the archive."""
+    changed = await restore_feed_item(character.id, body.item_key, session)
+    return FeedItemArchiveResponse(
+        item_key=body.item_key, archived=False, changed=changed
+    )
+
+
+@router.post("/dismiss-all", response_model=FeedBulkArchiveResponse)
+async def dismiss_all_items(
+    body: FeedBulkArchiveRequest,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+    session_factory: Callable = Depends(get_session_factory),
+) -> FeedBulkArchiveResponse:
+    """Archive everything the given filter would currently return."""
+    count = await dismiss_feed_items_for_filter(
+        character_id=character.id,
+        session=session,
+        session_factory=session_factory,
+        feed_filter=body.filter,
+    )
+    return FeedBulkArchiveResponse(count=count, archived=True)
+
+
+@router.post("/restore-all", response_model=FeedBulkArchiveResponse)
+async def restore_all_items(
+    body: FeedBulkArchiveRequest,
+    character: Character = Depends(get_current_character),
+    session: AsyncSession = Depends(get_db),
+) -> FeedBulkArchiveResponse:
+    """Empty the archive, or the part of it belonging to one filter."""
+    count = await restore_feed_items_for_filter(
+        character_id=character.id,
+        session=session,
+        feed_filter=body.filter,
+    )
+    return FeedBulkArchiveResponse(count=count, archived=False)

--- a/backend/schemas/activity_feed.py
+++ b/backend/schemas/activity_feed.py
@@ -18,9 +18,16 @@ class ActivityFeedItem(BaseModel):
     - duel_challenge: someone challenged you to a duel
     - friend_signup: a friend signed up for a task you're doing
     - nudge: a collaborator or duel rival poked you to file your part
+
+    ``item_key`` is the item's stable identity, ``"{type}:{source row PK}"``.
+    A feed item is derived from a UNION over 15 source tables and owns no row
+    of its own, so this is the only handle a client can archive, restore, or
+    de-duplicate against. It is stable across requests and across devices —
+    see ``services.activity_feed.build_item_key``.
     """
 
     type: str
+    item_key: str
     timestamp: datetime
     actor_display_name: Optional[str] = None
     actor_faction_slug: Optional[str] = None
@@ -56,3 +63,42 @@ class ActivityFeedResponse(BaseModel):
     items: list[ActivityFeedItem]
     counts: FeedCounts
     next_cursor: Optional[str] = None
+
+
+class FeedItemArchiveRequest(BaseModel):
+    """Archive or restore exactly one feed item, named by its stable key."""
+
+    item_key: str
+
+
+class FeedItemArchiveResponse(BaseModel):
+    """The item's resulting archive state.
+
+    ``archived`` is the state *after* the call, not whether the call changed
+    anything: both endpoints are idempotent, so an undo strip that fires twice
+    gets the same answer twice. ``changed`` reports whether a row moved, for
+    clients that want to suppress a redundant toast.
+    """
+
+    item_key: str
+    archived: bool
+    changed: bool
+
+
+class FeedBulkArchiveRequest(BaseModel):
+    """Archive or restore in bulk, scoped to one filter tab.
+
+    ``filter`` names the tab the player is looking at — the same values the
+    feed's own ``filter`` query param takes. Omitted means every type: on
+    restore that empties the whole archive, which is what the Archived tab's
+    "Restore all" means.
+    """
+
+    filter: Optional[str] = None
+
+
+class FeedBulkArchiveResponse(BaseModel):
+    """How many items the bulk call moved."""
+
+    count: int
+    archived: bool

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -14,18 +14,20 @@ counts are ``COUNT`` over the *same* windowed query, so a source's ``WHERE`` is
 authored exactly once and the counts can never drift from the fan-out.
 """
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from typing import Any, Callable, Coroutine, Optional
 
-from sqlalchemy import Select, func, select
+from fastapi import HTTPException
+from sqlalchemy import Select, delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import InstrumentedAttribute, aliased
 
 from models.character import Character
 from models.comment import Comment, CommentMention
 from models.era import Era
 from models.faction_defection_history import FactionDefectionHistory
+from models.feed_dismissal import FeedDismissal
 from models.invitation_letter import InvitationLetter
 from models.nudge import Nudge
 from models.relationship import Relationship, RelationshipStatus, RelationshipType
@@ -39,8 +41,12 @@ from services.era import get_current_era_row
 
 @dataclass(frozen=True)
 class ActivityFeedItemDC:
-    """Frozen dataclass mirror of schemas.activity_feed.ActivityFeedItem."""
+    """Frozen dataclass mirror of schemas.activity_feed.ActivityFeedItem.
+
+    ``item_key`` is the item's stable identity — see ``build_item_key``.
+    """
     type: str
+    item_key: str
     timestamp: datetime
     payload: dict[str, Any]
     actor_display_name: Optional[str] = None
@@ -83,6 +89,34 @@ FEED_ITEM_TYPE_COMMENT_MENTION = "comment_mention"
 FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED = "collaborator_submitted"
 FEED_ITEM_TYPE_AWAITING_SUBMISSION = "awaiting_submission"
 FEED_ITEM_TYPE_NUDGE = "nudge"
+
+# --- Item identity ----------------------------------------------------------
+# A feed item is derived, never stored: the feed is a UNION read-model over 15
+# source tables and owns no rows. Its identity is therefore borrowed from the
+# row it was built out of — ``"{feed type}:{source row PK}"``.
+#
+# The type prefix is load-bearing, not decoration. Three types are built from
+# ``praxis_member`` rows (friend_signup / collaborator_submitted /
+# awaiting_submission) and two from ``praxis`` rows (friend_completion /
+# foe_completion), so a bare PK is not unique across the feed.
+#
+# Every source's ``to_item`` reads that PK out of a column its query already
+# selects — nothing here is derived from row position, offset, or timestamp,
+# so the key of a given item is identical on every request until the source row
+# is deleted. A dismissal keyed on it can never drift onto a different item.
+ITEM_KEY_SEPARATOR = ":"
+
+
+def build_item_key(item_type: str, source_id: int) -> str:
+    """The stable identity of one feed item: its type plus its source row's PK."""
+    return f"{item_type}{ITEM_KEY_SEPARATOR}{source_id}"
+
+
+# ``awaiting_submission`` is *state*, not an event: it exists exactly while the
+# viewer's ``PraxisMember.has_submitted`` is false, and clears itself the moment
+# they file. A dismissal row would therefore silence a standing obligation
+# permanently, so this one type is refused (epic #1192, decision 3).
+NON_ARCHIVABLE_ITEM_TYPES: frozenset[str] = frozenset({FEED_ITEM_TYPE_AWAITING_SUBMISSION})
 
 # --- Filter tabs ------------------------------------------------------------
 FILTER_ALL = "all"
@@ -129,12 +163,41 @@ class FeedSource:
     The fan-out runs it and maps rows via ``to_item``; the badge count is
     ``COUNT`` over the very same (windowed) query. Adding a feed type is one
     entry in ``FEED_SOURCES`` — not six scattered edits.
+
+    ``source_id_column`` is the PK column ``to_item`` builds the item key from.
+    Naming it on the registry lets the archive filter be applied *in SQL*, once,
+    for every source — so a dismissed row never eats a slot in the
+    ``SUB_QUERY_LIMIT`` window (filtering after the fetch would silently shrink
+    the page) and the badge count, which wraps the same query, drops with it.
     """
     item_type: str
     filters: frozenset[str]
     needs: frozenset[str]
     query: Callable[[FeedContext], Select]
     to_item: Callable[[Any], ActivityFeedItemDC]
+    source_id_column: InstrumentedAttribute[int]
+
+
+@dataclass(frozen=True, eq=False)
+class FeedArchiveView:
+    """The viewer's archive, resolved once per request.
+
+    ``dismissed_source_ids`` maps a feed type to the source-row PKs this
+    character has archived, pre-split by type so each source's query can filter
+    on its own integer PK rather than on a string key.
+
+    ``archived_only`` flips the whole feed over: ``False`` hides archived items
+    (the live feed), ``True`` shows *only* them (the Archived tab). It is state,
+    not a type-set, which is why it cannot ride ``FILTER_QUERIES``.
+
+    ``eq=False`` so the dict field doesn't have to be hashable; this is a
+    per-request carrier, never a key.
+    """
+    dismissed_source_ids: dict[str, frozenset[int]]
+    archived_only: bool = False
+
+
+EMPTY_ARCHIVE_VIEW = FeedArchiveView(dismissed_source_ids={}, archived_only=False)
 
 
 # ---------------------------------------------------------------------------
@@ -209,6 +272,7 @@ def _vote_on_mine_query(ctx: FeedContext) -> Select:
 def _vote_on_mine_item(row: Any) -> ActivityFeedItemDC:
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_VOTE_ON_MINE,
+        item_key=build_item_key(FEED_ITEM_TYPE_VOTE_ON_MINE, row.id),
         timestamp=row.created_at,
         actor_display_name=row.voter_display_name,
         actor_faction_slug=row.voter_faction_slug,
@@ -258,6 +322,7 @@ def _completion_item_factory(item_type: str) -> Callable[[Any], ActivityFeedItem
     def to_item(row: Any) -> ActivityFeedItemDC:
         return ActivityFeedItemDC(
             type=item_type,
+            item_key=build_item_key(item_type, row.id),
             timestamp=row.created_at,
             actor_display_name=row.author_display_name,
             actor_faction_slug=row.author_faction_slug,
@@ -303,6 +368,7 @@ def _foe_taunt_item(row: Any) -> ActivityFeedItemDC:
     taunt: TauntMessage = row[0]
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_FOE_TAUNT,
+        item_key=build_item_key(FEED_ITEM_TYPE_FOE_TAUNT, taunt.id),
         timestamp=taunt.created_at,
         actor_display_name=row.from_display_name,
         actor_faction_slug=row.from_faction_slug,
@@ -336,6 +402,7 @@ def _global_tasks_query(ctx: FeedContext) -> Select:
 def _global_task_item(row: Any) -> ActivityFeedItemDC:
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_GLOBAL_TASK,
+        item_key=build_item_key(FEED_ITEM_TYPE_GLOBAL_TASK, row.id),
         timestamp=row.created_at,
         actor_display_name=ADMIN_ACTOR_NAME,
         actor_faction_slug=None,
@@ -362,6 +429,7 @@ def _era_announcement_item(row: Any) -> ActivityFeedItemDC:
     era: Era = row[0]
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_ERA_ANNOUNCEMENT,
+        item_key=build_item_key(FEED_ITEM_TYPE_ERA_ANNOUNCEMENT, era.id),
         timestamp=era.started_at,
         actor_display_name=ADMIN_ACTOR_NAME,
         actor_faction_slug=None,
@@ -410,6 +478,7 @@ def _collab_invites_query(ctx: FeedContext) -> Select:
 def _collab_invite_item(row: Any) -> ActivityFeedItemDC:
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_COLLAB_INVITE,
+        item_key=build_item_key(FEED_ITEM_TYPE_COLLAB_INVITE, row.id),
         timestamp=row.created_at,
         actor_display_name=row.actor_display_name,
         actor_faction_slug=row.actor_faction_slug,
@@ -459,6 +528,7 @@ def _duel_challenges_query(ctx: FeedContext) -> Select:
 def _duel_challenge_item(row: Any) -> ActivityFeedItemDC:
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_DUEL_CHALLENGE,
+        item_key=build_item_key(FEED_ITEM_TYPE_DUEL_CHALLENGE, row.id),
         timestamp=row.created_at,
         actor_display_name=row.actor_display_name,
         actor_faction_slug=row.actor_faction_slug,
@@ -506,6 +576,7 @@ def _friend_signups_query(ctx: FeedContext) -> Select:
 def _friend_signup_item(row: Any) -> ActivityFeedItemDC:
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_FRIEND_SIGNUP,
+        item_key=build_item_key(FEED_ITEM_TYPE_FRIEND_SIGNUP, row.id),
         timestamp=row.joined_at,
         actor_display_name=row.display_name,
         actor_faction_slug=row.faction_slug,
@@ -538,6 +609,7 @@ def _invitation_letter_item(row: Any) -> ActivityFeedItemDC:
     letter: InvitationLetter = row[0]
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_INVITATION_LETTER,
+        item_key=build_item_key(FEED_ITEM_TYPE_INVITATION_LETTER, letter.id),
         timestamp=letter.delivered_at,
         actor_display_name=letter.faction_slug,
         actor_faction_slug=letter.faction_slug,
@@ -577,6 +649,9 @@ def _friend_defection_item(row: Any) -> ActivityFeedItemDC:
     # names from factions.json (factionName(<slug>)).
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_FRIEND_DEFECTION,
+        # The only source whose PK the payload does not already carry — the
+        # query selects it, so the key is as stable as the other fourteen.
+        item_key=build_item_key(FEED_ITEM_TYPE_FRIEND_DEFECTION, row.id),
         timestamp=row.defected_at,
         actor_display_name=row.display_name,
         actor_faction_slug=row.current_faction_slug,
@@ -618,6 +693,7 @@ def _comment_mentions_query(ctx: FeedContext) -> Select:
 def _comment_mention_item(row: Any) -> ActivityFeedItemDC:
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_COMMENT_MENTION,
+        item_key=build_item_key(FEED_ITEM_TYPE_COMMENT_MENTION, row.id),
         timestamp=row.created_at,
         actor_display_name=row.author_display_name,
         actor_faction_slug=row.author_faction_slug,
@@ -675,6 +751,7 @@ def _collaborator_submitted_query(ctx: FeedContext) -> Select:
 def _collaborator_submitted_item(row: Any) -> ActivityFeedItemDC:
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED,
+        item_key=build_item_key(FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED, row.id),
         timestamp=row.submitted_at,
         actor_display_name=row.display_name,
         actor_faction_slug=row.faction_slug,
@@ -731,6 +808,9 @@ def _awaiting_submission_item(row: Any) -> ActivityFeedItemDC:
     # the card frames to the task's faction (schema context_faction_slug fallback).
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_AWAITING_SUBMISSION,
+        # Carries a key like every other type — the refusal to archive it is a
+        # rule (NON_ARCHIVABLE_ITEM_TYPES), not an absence of identity.
+        item_key=build_item_key(FEED_ITEM_TYPE_AWAITING_SUBMISSION, row.id),
         timestamp=row.joined_at,
         actor_display_name=None,
         actor_faction_slug=None,
@@ -788,6 +868,7 @@ def _nudge_query(ctx: FeedContext) -> Select:
 def _nudge_item(row: Any) -> ActivityFeedItemDC:
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_NUDGE,
+        item_key=build_item_key(FEED_ITEM_TYPE_NUDGE, row.id),
         timestamp=row.created_at,
         actor_display_name=row.from_display_name,
         actor_faction_slug=row.from_faction_slug,
@@ -820,6 +901,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_vote_on_mine_query,
         to_item=_vote_on_mine_item,
+        source_id_column=Vote.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_FRIEND_COMPLETION,
@@ -827,6 +909,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset({NEEDS_FRIEND_IDS}),
         query=_completions_query_factory(NEEDS_FRIEND_IDS),
         to_item=_completion_item_factory(FEED_ITEM_TYPE_FRIEND_COMPLETION),
+        source_id_column=Praxis.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_FOE_TAUNT,
@@ -834,6 +917,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_foe_taunts_query,
         to_item=_foe_taunt_item,
+        source_id_column=TauntMessage.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_GLOBAL_TASK,
@@ -841,6 +925,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_global_tasks_query,
         to_item=_global_task_item,
+        source_id_column=Task.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_ERA_ANNOUNCEMENT,
@@ -848,6 +933,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_era_announcements_query,
         to_item=_era_announcement_item,
+        source_id_column=Era.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_COLLAB_INVITE,
@@ -855,6 +941,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_collab_invites_query,
         to_item=_collab_invite_item,
+        source_id_column=PraxisInvite.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_DUEL_CHALLENGE,
@@ -862,6 +949,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_duel_challenges_query,
         to_item=_duel_challenge_item,
+        source_id_column=Duel.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_FRIEND_SIGNUP,
@@ -869,6 +957,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset({NEEDS_FRIEND_IDS, NEEDS_MY_TASK_IDS}),
         query=_friend_signups_query,
         to_item=_friend_signup_item,
+        source_id_column=PraxisMember.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED,
@@ -876,6 +965,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_collaborator_submitted_query,
         to_item=_collaborator_submitted_item,
+        source_id_column=PraxisMember.id,
     ),
     FeedSource(
         # "Waiting on you to submit" — collab/duel praxes in the viewer's court.
@@ -886,6 +976,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_awaiting_submission_query,
         to_item=_awaiting_submission_item,
+        source_id_column=PraxisMember.id,
     ),
     FeedSource(
         # A nudge received (#1083). ALL + YOUR_STUFF, deliberately NOT REQUESTS:
@@ -899,6 +990,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_nudge_query,
         to_item=_nudge_item,
+        source_id_column=Nudge.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_INVITATION_LETTER,
@@ -906,6 +998,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_invitation_letters_query,
         to_item=_invitation_letter_item,
+        source_id_column=InvitationLetter.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_FRIEND_DEFECTION,
@@ -913,6 +1006,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset({NEEDS_FRIEND_IDS}),
         query=_friend_defections_query,
         to_item=_friend_defection_item,
+        source_id_column=FactionDefectionHistory.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_FOE_COMPLETION,
@@ -920,6 +1014,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset({NEEDS_FOE_IDS}),
         query=_completions_query_factory(NEEDS_FOE_IDS),
         to_item=_completion_item_factory(FEED_ITEM_TYPE_FOE_COMPLETION),
+        source_id_column=Praxis.id,
     ),
     FeedSource(
         item_type=FEED_ITEM_TYPE_COMMENT_MENTION,
@@ -927,6 +1022,7 @@ FEED_SOURCES: tuple[FeedSource, ...] = (
         needs=frozenset(),
         query=_comment_mentions_query,
         to_item=_comment_mention_item,
+        source_id_column=Comment.id,
     ),
 )
 
@@ -945,6 +1041,49 @@ FILTER_QUERIES: dict[str, set[str]] = {
     )
 }
 
+# Every feed type the registry knows, and the subset a player may archive.
+# Derived from FEED_SOURCES so neither can drift from the registry.
+FEED_ITEM_TYPES: frozenset[str] = frozenset(source.item_type for source in FEED_SOURCES)
+ARCHIVABLE_ITEM_TYPES: frozenset[str] = FEED_ITEM_TYPES - NON_ARCHIVABLE_ITEM_TYPES
+
+
+def parse_item_key(item_key: str) -> tuple[str, int]:
+    """Split an item key into ``(feed type, source row PK)``.
+
+    Raises ``HTTPException(400)`` on anything the registry does not recognise —
+    a malformed key, an unknown type, or a non-integer id. Callers that need the
+    "may this be archived?" rule as well should use ``parse_archivable_item_key``.
+    """
+    item_type, separator, raw_id = item_key.partition(ITEM_KEY_SEPARATOR)
+    if not separator or item_type not in FEED_ITEM_TYPES:
+        raise HTTPException(status_code=400, detail=f"Unknown feed item key: {item_key}")
+    try:
+        source_id = int(raw_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Malformed feed item key: {item_key}")
+    return item_type, source_id
+
+
+def parse_archivable_item_key(item_key: str) -> tuple[str, int]:
+    """``parse_item_key`` plus the one type that may never be archived.
+
+    ``awaiting_submission`` is refused rather than silently accepted: it is the
+    viewer's own standing obligation and it clears itself the moment they file,
+    so a dismissal row would hide it forever (epic #1192, decision 3). 400 —
+    the key names a thing that exists, but archiving it is not a request the
+    domain accepts.
+    """
+    item_type, source_id = parse_item_key(item_key)
+    if item_type in NON_ARCHIVABLE_ITEM_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Feed items of type '{item_type}' cannot be archived: they track "
+                "work still waiting on you and clear themselves once you file."
+            ),
+        )
+    return item_type, source_id
+
 
 # ---------------------------------------------------------------------------
 # Registry runner — one own-session-per-source pattern for fetch and count
@@ -961,34 +1100,69 @@ def _needs_satisfied(source: FeedSource, ctx: FeedContext) -> bool:
     return True
 
 
+def _scoped_query(
+    source: FeedSource,
+    ctx: FeedContext,
+    archive_view: FeedArchiveView,
+) -> Optional[Select]:
+    """The source's own query, narrowed to one side of the archive.
+
+    ``None`` means "this source cannot contribute anything" — either its
+    pre-fetch context is empty, or the Archived view is asking for a type this
+    character has archived nothing of. Both are answered without a round trip.
+
+    The archive predicate is applied *inside* the source's Select, before its
+    ``LIMIT``: filtering the mapped items afterwards would let dismissed rows
+    consume slots in the ``SUB_QUERY_LIMIT`` window, and would leave the badge
+    counts — which wrap this same Select in a COUNT — reading the unfiltered
+    number.
+    """
+    if not _needs_satisfied(source, ctx):
+        return None
+    dismissed_ids = archive_view.dismissed_source_ids.get(source.item_type, frozenset())
+    query = source.query(ctx)
+    if archive_view.archived_only:
+        if not dismissed_ids:
+            return None
+        return query.where(source.source_id_column.in_(dismissed_ids))
+    if not dismissed_ids:
+        return query
+    return query.where(source.source_id_column.notin_(dismissed_ids))
+
+
 async def _run_source_fetch(
     source: FeedSource,
     ctx: FeedContext,
+    archive_view: FeedArchiveView,
     session_factory: Callable,
 ) -> list[ActivityFeedItemDC]:
     """Run a source's query in its own session and map rows → items."""
-    if not _needs_satisfied(source, ctx):
+    query = _scoped_query(source, ctx, archive_view)
+    if query is None:
         return []
     async with session_factory() as session:
-        result = await session.execute(source.query(ctx))
+        result = await session.execute(query)
         return [source.to_item(row) for row in result.all()]
 
 
 async def _run_source_count(
     source: FeedSource,
     ctx: FeedContext,
+    archive_view: FeedArchiveView,
     session_factory: Callable,
 ) -> int:
     """COUNT over the source's OWN windowed query (ADR-0036).
 
     The count wraps the identical Select in a subquery, so it respects the same
-    WHERE, the ``before`` cursor, and the SUB_QUERY_LIMIT window as the fetch —
-    the badge can never disagree with what the fan-out would return.
+    WHERE, the ``before`` cursor, the ``SUB_QUERY_LIMIT`` window *and the
+    archive filter* as the fetch — the badge can never disagree with what the
+    fan-out would return. An archive that doesn't move the numbers is a bug.
     """
-    if not _needs_satisfied(source, ctx):
+    query = _scoped_query(source, ctx, archive_view)
+    if query is None:
         return 0
     async with session_factory() as session:
-        windowed = source.query(ctx).subquery()
+        windowed = query.subquery()
         result = await session.execute(select(func.count()).select_from(windowed))
         return int(result.scalar_one())
 
@@ -1005,6 +1179,7 @@ def _sum_counts_for_tab(tab: str, counts_by_type: dict[str, int]) -> int:
 async def _compute_counts(
     count_ctx: FeedContext,
     count_ctx_requests: FeedContext,
+    archive_view: FeedArchiveView,
     session_factory: Callable,
 ) -> FeedCountsDC:
     """Badge counts, each derived from its source's own query (ADR-0036).
@@ -1012,16 +1187,23 @@ async def _compute_counts(
     Every tab but ``requests`` sees all statuses (``count_ctx``); the
     ``requests`` tab windows collab invites / duel challenges to pending only
     (``count_ctx_requests``) — matching what that tab's fan-out returns.
+
+    The six badges always count the **live** feed, never the archive: they are
+    the sidebar's "what's waiting for you" numbers, and they stay truthful while
+    the player is reading the Archived tab. Hence the forced
+    ``archived_only=False`` — the caller's view flips the item fan-out, not the
+    badges.
     """
+    live_view = replace(archive_view, archived_only=False)
     requests_sources = [s for s in FEED_SOURCES if FILTER_REQUESTS in s.filters]
 
     normal_results, requests_results = await asyncio.gather(
         asyncio.gather(*(
-            _run_source_count(source, count_ctx, session_factory)
+            _run_source_count(source, count_ctx, live_view, session_factory)
             for source in FEED_SOURCES
         )),
         asyncio.gather(*(
-            _run_source_count(source, count_ctx_requests, session_factory)
+            _run_source_count(source, count_ctx_requests, live_view, session_factory)
             for source in requests_sources
         )),
     )
@@ -1052,6 +1234,7 @@ async def get_activity_feed(
     feed_filter: Optional[str] = None,
     before_cursor: Optional[datetime] = None,
     limit: int = 20,
+    archived: bool = False,
 ) -> ActivityFeedResponseDC:
     """Fetch a unified activity feed for the given character.
 
@@ -1066,13 +1249,27 @@ async def get_activity_feed(
         feed_filter: One of "all", "friends", "foes", "your_stuff", "global", "requests".
         before_cursor: ISO datetime cursor for pagination (items before this time).
         limit: Max items to return.
+        archived: Return the character's archive instead of their live feed.
+            Archived-ness is *state*, not type, so it cannot ride
+            ``FILTER_QUERIES`` — it is a separate axis crossed with the filter.
+            The archive deliberately ignores the friend/foe/global type slicing
+            and returns everything archived: a player looking for something they
+            put away should not have to remember which tab they put it away from.
     """
     active_filter = feed_filter or FILTER_ALL
-    allowed_types = FILTER_QUERIES.get(active_filter, FILTER_QUERIES[FILTER_ALL])
-    is_requests_filter = active_filter == FILTER_REQUESTS
+    allowed_types = (
+        FILTER_QUERIES[FILTER_ALL]
+        if archived
+        else FILTER_QUERIES.get(active_filter, FILTER_QUERIES[FILTER_ALL])
+    )
+    # The ``requests`` window (pending invites/duels only) is a live-feed rule.
+    # An archived invite that was since declined is still archived, and hiding it
+    # would strand it: nothing else lists it.
+    is_requests_filter = active_filter == FILTER_REQUESTS and not archived
 
     # Pre-fetch relationship / task / era context. Badge counts span every tab
     # regardless of the active filter, so all context is loaded up front.
+    archive_view = await get_archive_view(character_id, session, archived_only=archived)
     friend_ids = tuple(await _get_related_ids(character_id, RelationshipType.friend, session))
     foe_ids = tuple(await _get_related_ids(character_id, RelationshipType.foe, session))
     my_task_ids = tuple(await _get_my_task_ids(character_id, session))
@@ -1112,12 +1309,12 @@ async def get_activity_feed(
 
     # Run fan-out and badge counts concurrently; each sub-query owns its session.
     fetch_coros: list[Coroutine[Any, Any, list[ActivityFeedItemDC]]] = [
-        _run_source_fetch(source, fetch_ctx, session_factory)
+        _run_source_fetch(source, fetch_ctx, archive_view, session_factory)
         for source in allowed_sources
     ]
     gather_results = await asyncio.gather(
         *fetch_coros,
-        _compute_counts(count_ctx, count_ctx_requests, session_factory),
+        _compute_counts(count_ctx, count_ctx_requests, archive_view, session_factory),
     )
     counts: FeedCountsDC = gather_results[-1]
 
@@ -1139,3 +1336,182 @@ async def get_activity_feed(
         counts=counts,
         next_cursor=next_cursor,
     )
+
+
+# ---------------------------------------------------------------------------
+# The archive — reading and writing dismissals
+#
+# ADR-0065 / epic #1192: archiving is a *view state* and never a decision. Every
+# function below writes exactly one thing, ``feed_dismissal``. An archived duel
+# challenge is still open; an archived collab invite is still unanswered. If a
+# change here ever needs to touch ``Duel.status`` or ``PraxisInvite.status``,
+# the change is wrong.
+# ---------------------------------------------------------------------------
+
+# One "Archive all" covers everything the current filter would return, which is
+# bounded by the same window the feed itself reads: SUB_QUERY_LIMIT rows per
+# source. Beyond that window the tab's own badge count is already capped, so
+# archiving exactly the window is what makes the tab read empty and the badge
+# read zero.
+ARCHIVE_ALL_LIMIT = len(FEED_SOURCES) * SUB_QUERY_LIMIT
+
+
+async def get_archive_view(
+    character_id: int,
+    session: AsyncSession,
+    archived_only: bool = False,
+) -> FeedArchiveView:
+    """Load this character's dismissals, pre-split by feed type.
+
+    Keys that no longer parse — a type retired from the registry, or a row from
+    an older key format — are skipped rather than raised on. A stale dismissal
+    must never be able to break somebody's feed.
+    """
+    result = await session.execute(
+        select(FeedDismissal.item_key).where(
+            FeedDismissal.character_id == character_id
+        )
+    )
+    source_ids_by_type: dict[str, set[int]] = {}
+    for item_key in result.scalars():
+        item_type, separator, raw_id = item_key.partition(ITEM_KEY_SEPARATOR)
+        if not separator or item_type not in FEED_ITEM_TYPES:
+            continue
+        try:
+            source_id = int(raw_id)
+        except ValueError:
+            continue
+        source_ids_by_type.setdefault(item_type, set()).add(source_id)
+
+    return FeedArchiveView(
+        dismissed_source_ids={
+            item_type: frozenset(source_ids)
+            for item_type, source_ids in source_ids_by_type.items()
+        },
+        archived_only=archived_only,
+    )
+
+
+async def _existing_dismissed_keys(
+    character_id: int,
+    item_keys: list[str],
+    session: AsyncSession,
+) -> set[str]:
+    """Which of ``item_keys`` this character has already archived."""
+    if not item_keys:
+        return set()
+    result = await session.execute(
+        select(FeedDismissal.item_key).where(
+            FeedDismissal.character_id == character_id,
+            FeedDismissal.item_key.in_(item_keys),
+        )
+    )
+    return set(result.scalars())
+
+
+async def dismiss_feed_item(
+    character_id: int,
+    item_key: str,
+    session: AsyncSession,
+) -> bool:
+    """Archive one feed item. Returns True if this call is what archived it.
+
+    Idempotent: archiving an already-archived item is a no-op returning False,
+    not a 409. The client's undo strip can fire twice without consequence.
+    """
+    parse_archivable_item_key(item_key)
+    already = await _existing_dismissed_keys(character_id, [item_key], session)
+    if already:
+        return False
+    session.add(FeedDismissal(character_id=character_id, item_key=item_key))
+    await session.flush()
+    return True
+
+
+async def restore_feed_item(
+    character_id: int,
+    item_key: str,
+    session: AsyncSession,
+) -> bool:
+    """Take one feed item back out of the archive.
+
+    Returns True if a dismissal row was actually removed. Restoring puts the
+    item back at its own position in the ordering for free: position comes from
+    the source row's timestamp, which archiving never touched.
+    """
+    parse_item_key(item_key)
+    result = await session.execute(
+        delete(FeedDismissal)
+        .where(
+            FeedDismissal.character_id == character_id,
+            FeedDismissal.item_key == item_key,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    await session.flush()
+    return bool(result.rowcount)
+
+
+async def dismiss_feed_items_for_filter(
+    character_id: int,
+    session: AsyncSession,
+    session_factory: Callable,
+    feed_filter: Optional[str] = None,
+) -> int:
+    """Archive everything the given filter would currently return. One call.
+
+    Scope is defined by re-running the very feed the player is looking at, so
+    "Archive all" can never drift from what the tab shows. ``awaiting_submission``
+    rows are skipped, not refused: a bulk action that 400s because one
+    unarchivable row happened to be on screen would be unusable.
+    """
+    feed = await get_activity_feed(
+        character_id=character_id,
+        session=session,
+        session_factory=session_factory,
+        feed_filter=feed_filter,
+        limit=ARCHIVE_ALL_LIMIT,
+    )
+    item_keys = [
+        item.item_key for item in feed.items if item.type in ARCHIVABLE_ITEM_TYPES
+    ]
+    already = await _existing_dismissed_keys(character_id, item_keys, session)
+    new_keys = [item_key for item_key in item_keys if item_key not in already]
+    for item_key in new_keys:
+        session.add(FeedDismissal(character_id=character_id, item_key=item_key))
+    await session.flush()
+    return len(new_keys)
+
+
+async def restore_feed_items_for_filter(
+    character_id: int,
+    session: AsyncSession,
+    feed_filter: Optional[str] = None,
+) -> int:
+    """Empty the archive, or the part of it belonging to one filter. One call.
+
+    No filter restores everything, which is what the Archived tab wants: that
+    tab ignores type slicing, so "Restore all" there means all of it.
+    """
+    allowed_types = FILTER_QUERIES.get(
+        feed_filter or FILTER_ALL, FILTER_QUERIES[FILTER_ALL]
+    )
+    statement = delete(FeedDismissal).where(FeedDismissal.character_id == character_id)
+
+    if allowed_types != FILTER_QUERIES[FILTER_ALL]:
+        archive_view = await get_archive_view(character_id, session)
+        item_keys = [
+            build_item_key(item_type, source_id)
+            for item_type, source_ids in archive_view.dismissed_source_ids.items()
+            if item_type in allowed_types
+            for source_id in source_ids
+        ]
+        if not item_keys:
+            return 0
+        statement = statement.where(FeedDismissal.item_key.in_(item_keys))
+
+    result = await session.execute(
+        statement.execution_options(synchronize_session=False)
+    )
+    await session.flush()
+    return int(result.rowcount or 0)

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -20,6 +20,7 @@ from typing import Any, Callable, Coroutine, Optional
 
 from fastapi import HTTPException
 from sqlalchemy import Select, delete, func, select
+from sqlalchemy.dialects.postgresql import insert as postgres_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute, aliased
 
@@ -1392,21 +1393,33 @@ async def get_archive_view(
     )
 
 
-async def _existing_dismissed_keys(
+async def _insert_dismissals(
     character_id: int,
     item_keys: list[str],
     session: AsyncSession,
-) -> set[str]:
-    """Which of ``item_keys`` this character has already archived."""
+) -> int:
+    """Archive these keys; return how many rows were actually new.
+
+    ``ON CONFLICT DO NOTHING`` rather than read-then-write. Archiving is
+    idempotent by contract — the undo strip can fire twice — and a check-then-
+    insert leaves a window where two clicks race the unique constraint into a
+    500. This is Postgres-specific, which the rest of the schema already is.
+    """
     if not item_keys:
-        return set()
-    result = await session.execute(
-        select(FeedDismissal.item_key).where(
-            FeedDismissal.character_id == character_id,
-            FeedDismissal.item_key.in_(item_keys),
+        return 0
+    statement = (
+        postgres_insert(FeedDismissal)
+        .values(
+            [
+                {"character_id": character_id, "item_key": item_key}
+                for item_key in item_keys
+            ]
         )
+        .on_conflict_do_nothing(index_elements=["character_id", "item_key"])
     )
-    return set(result.scalars())
+    result = await session.execute(statement)
+    await session.flush()
+    return int(result.rowcount or 0)
 
 
 async def dismiss_feed_item(
@@ -1417,15 +1430,10 @@ async def dismiss_feed_item(
     """Archive one feed item. Returns True if this call is what archived it.
 
     Idempotent: archiving an already-archived item is a no-op returning False,
-    not a 409. The client's undo strip can fire twice without consequence.
+    not a 409.
     """
     parse_archivable_item_key(item_key)
-    already = await _existing_dismissed_keys(character_id, [item_key], session)
-    if already:
-        return False
-    session.add(FeedDismissal(character_id=character_id, item_key=item_key))
-    await session.flush()
-    return True
+    return await _insert_dismissals(character_id, [item_key], session) > 0
 
 
 async def restore_feed_item(
@@ -1475,12 +1483,7 @@ async def dismiss_feed_items_for_filter(
     item_keys = [
         item.item_key for item in feed.items if item.type in ARCHIVABLE_ITEM_TYPES
     ]
-    already = await _existing_dismissed_keys(character_id, item_keys, session)
-    new_keys = [item_key for item_key in item_keys if item_key not in already]
-    for item_key in new_keys:
-        session.add(FeedDismissal(character_id=character_id, item_key=item_key))
-    await session.flush()
-    return len(new_keys)
+    return await _insert_dismissals(character_id, item_keys, session)
 
 
 async def restore_feed_items_for_filter(

--- a/backend/tests/integration/test_activity_feed_archive.py
+++ b/backend/tests/integration/test_activity_feed_archive.py
@@ -1,0 +1,633 @@
+"""Integration tests for feed item identity and the archive (#1193).
+
+Everything here runs against the real feed service and the real routes — the
+whole point of the issue is that item identity is *derived*, so a mocked feed
+would prove nothing about it.
+
+``full_feed`` seeds one item of all fifteen feed types for ``character``. It is
+deliberately heavy: the acceptance criterion is "every one of the 15 types
+yields a stable ``item_key``", and there is no way to check that without all
+fifteen actually present.
+"""
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.comment import Comment, CommentMention
+from models.duel import Duel, DuelStatus
+from models.era import Era
+from models.faction_defection_history import FactionDefectionHistory
+from models.feed_dismissal import FeedDismissal
+from models.invitation_letter import InvitationLetter
+from models.nudge import Nudge
+from models.praxis import (
+    ModerationStatus,
+    Praxis,
+    PraxisInvite,
+    PraxisInviteStatus,
+    PraxisMember,
+    PraxisStatus,
+    PraxisType,
+)
+from models.relationship import Relationship, RelationshipStatus, RelationshipType
+from models.task import Task
+from models.taunt_message import TauntMessage, TauntTriggerType
+from services.activity_feed import (
+    FEED_ITEM_TYPE_AWAITING_SUBMISSION,
+    FEED_ITEM_TYPE_COLLAB_INVITE,
+    FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED,
+    FEED_ITEM_TYPE_FRIEND_COMPLETION,
+    FEED_ITEM_TYPE_FRIEND_SIGNUP,
+    FEED_ITEM_TYPE_GLOBAL_TASK,
+    FEED_ITEM_TYPES,
+    ITEM_KEY_SEPARATOR,
+)
+
+ALL_FILTER = "all"
+FRIENDS_FILTER = "friends"
+FOES_FILTER = "foes"
+REQUESTS_FILTER = "requests"
+
+# Item counts per tab for the ``full_feed`` seed, derived by hand from the
+# registry's filter membership. Asserting the numbers (not just "non-empty")
+# is what makes "the counts drop" a real check.
+SEEDED_ITEM_COUNTS = {
+    ALL_FILTER: 15,
+    FRIENDS_FILTER: 3,
+    FOES_FILTER: 2,
+    "your_stuff": 8,
+    "global": 2,
+    REQUESTS_FILTER: 3,
+}
+
+
+@pytest_asyncio.fixture
+async def full_feed(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    era: Era,
+    active_task: Task,
+) -> dict:
+    """Seed exactly one feed item of every one of the 15 types for ``character``.
+
+    Returns a handful of the seeded rows the tests need to assert against.
+    """
+    now = datetime.now(timezone.utc)
+
+    # character2 is a friend, character3 a foe — this is what makes the
+    # friend_* / foe_* sources contribute at all.
+    db_session.add_all(
+        [
+            Relationship(
+                from_character_id=character.id,
+                to_character_id=character2.id,
+                type=RelationshipType.friend,
+                status=RelationshipStatus.active,
+            ),
+            Relationship(
+                from_character_id=character.id,
+                to_character_id=character3.id,
+                type=RelationshipType.foe,
+                status=RelationshipStatus.active,
+            ),
+        ]
+    )
+
+    # --- vote_on_mine + comment_mention: the viewer's own submitted praxis ---
+    my_praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.submitted,
+        title="Mine",
+        body_text="proof",
+    )
+    db_session.add(my_praxis)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=my_praxis.id, character_id=character.id))
+    from models.vote import Vote
+
+    db_session.add(
+        Vote(
+            praxis_id=my_praxis.id,
+            voter_character_id=character2.id,
+            voter_account_id=character2.account_id,
+            value=3,
+        )
+    )
+    mention_comment = Comment(
+        praxis_id=my_praxis.id,
+        created_by_id=character2.id,
+        body_text="Look at this, @testcharacter",
+        moderation_status=ModerationStatus.visible,
+    )
+    db_session.add(mention_comment)
+    await db_session.flush()
+    db_session.add(
+        CommentMention(
+            comment_id=mention_comment.id, mentioned_character_id=character.id
+        )
+    )
+
+    # --- friend_completion / foe_completion ---------------------------------
+    db_session.add_all(
+        [
+            Praxis(
+                task_id=active_task.id,
+                created_by_id=character2.id,
+                type=PraxisType.solo,
+                status=PraxisStatus.submitted,
+                title="Friend did it",
+                body_text="proof",
+            ),
+            Praxis(
+                task_id=active_task.id,
+                created_by_id=character3.id,
+                type=PraxisType.solo,
+                status=PraxisStatus.submitted,
+                title="Foe did it",
+                body_text="proof",
+            ),
+        ]
+    )
+
+    # --- foe_taunt ----------------------------------------------------------
+    db_session.add(
+        TauntMessage(
+            from_character_id=character3.id,
+            to_character_id=character.id,
+            faction_slug="ua",
+            trigger_type=TauntTriggerType.score_overtake,
+        )
+    )
+
+    # --- the collab praxis: four types come off this one row -----------------
+    # collab_invite (the invite), awaiting_submission (viewer's unfiled member
+    # row), collaborator_submitted + friend_signup (character2's member row —
+    # ONE praxis_member PK feeding two feed types, which is exactly why the key
+    # carries a type prefix).
+    collab_praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character2.id,
+        type=PraxisType.collab,
+        status=PraxisStatus.in_progress,
+        title="Team",
+        body_text="proof",
+    )
+    db_session.add(collab_praxis)
+    await db_session.flush()
+    viewer_member = PraxisMember(
+        praxis_id=collab_praxis.id, character_id=character.id, has_submitted=False
+    )
+    friend_member = PraxisMember(
+        praxis_id=collab_praxis.id,
+        character_id=character2.id,
+        has_submitted=True,
+        submitted_at=now,
+    )
+    collab_invite = PraxisInvite(
+        praxis_id=collab_praxis.id,
+        inviter_id=character2.id,
+        invitee_id=character.id,
+        status=PraxisInviteStatus.pending,
+    )
+    db_session.add_all([viewer_member, friend_member, collab_invite])
+
+    # --- nudge --------------------------------------------------------------
+    db_session.add(
+        Nudge(
+            from_character_id=character2.id,
+            to_character_id=character.id,
+            praxis_id=collab_praxis.id,
+        )
+    )
+
+    # --- duel_challenge -----------------------------------------------------
+    challenger_praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character2.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        title="Fight me",
+        body_text="proof",
+    )
+    db_session.add(challenger_praxis)
+    await db_session.flush()
+    db_session.add(
+        Duel(
+            task_id=active_task.id,
+            challenger_praxis_id=challenger_praxis.id,
+            opponent_character_id=character.id,
+            status=DuelStatus.pending,
+        )
+    )
+
+    # --- invitation_letter + friend_defection --------------------------------
+    db_session.add_all(
+        [
+            InvitationLetter(
+                character_id=character.id, faction_slug="ua", era_id=era.id
+            ),
+            FactionDefectionHistory(
+                character_id=character2.id, faction_slug="na", era_id=era.id
+            ),
+        ]
+    )
+
+    # global_task (active_task) and era_announcement (era) need no seeding.
+    await db_session.commit()
+
+    return {
+        "collab_invite_id": collab_invite.id,
+        "friend_member_id": friend_member.id,
+        "task_id": active_task.id,
+    }
+
+
+async def _feed(
+    client: AsyncClient,
+    auth_headers: dict,
+    feed_filter: str = ALL_FILTER,
+    archived: bool = False,
+) -> dict:
+    params: dict = {"filter": feed_filter, "limit": 100}
+    if archived:
+        params["archived"] = "true"
+    response = await client.get("/activity-feed", params=params, headers=auth_headers)
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _key_of(feed: dict, item_type: str) -> str:
+    matches = [item["item_key"] for item in feed["items"] if item["type"] == item_type]
+    assert len(matches) == 1, f"expected exactly one {item_type}: {matches}"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# 1. Identity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_every_feed_type_yields_a_stable_item_key(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    """All 15 types are present, keyed, and identical across two requests."""
+    first = await _feed(client, auth_headers)
+    second = await _feed(client, auth_headers)
+
+    assert {item["type"] for item in first["items"]} == FEED_ITEM_TYPES
+    assert len(first["items"]) == SEEDED_ITEM_COUNTS[ALL_FILTER]
+
+    first_keys = [item["item_key"] for item in first["items"]]
+    second_keys = [item["item_key"] for item in second["items"]]
+    # Same keys, same order — nothing about identity is derived from position.
+    assert first_keys == second_keys
+    assert len(set(first_keys)) == len(first_keys), "item keys must be unique"
+
+    for item in first["items"]:
+        item_type, separator, raw_id = item["item_key"].partition(ITEM_KEY_SEPARATOR)
+        assert separator, item["item_key"]
+        assert item_type == item["type"]
+        assert int(raw_id) > 0, item["item_key"]
+
+
+@pytest.mark.asyncio
+async def test_one_source_row_two_types_get_distinct_keys(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    """The type prefix is load-bearing, not decoration.
+
+    ``friend_signup`` and ``collaborator_submitted`` are both built from the
+    *same* ``praxis_member`` row. Without the type prefix they would share a key
+    and archiving one would silently archive the other.
+    """
+    feed = await _feed(client, auth_headers)
+    signup_key = _key_of(feed, FEED_ITEM_TYPE_FRIEND_SIGNUP)
+    submitted_key = _key_of(feed, FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED)
+
+    member_id = str(full_feed["friend_member_id"])
+    assert signup_key.endswith(ITEM_KEY_SEPARATOR + member_id)
+    assert submitted_key.endswith(ITEM_KEY_SEPARATOR + member_id)
+    assert signup_key != submitted_key
+
+
+# ---------------------------------------------------------------------------
+# 2. Dismiss / restore
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dismiss_removes_the_item_and_drops_the_counts(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    before = await _feed(client, auth_headers)
+    target = _key_of(before, FEED_ITEM_TYPE_FRIEND_COMPLETION)
+
+    response = await client.post(
+        "/activity-feed/dismiss", json={"item_key": target}, headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"item_key": target, "archived": True, "changed": True}
+
+    after = await _feed(client, auth_headers)
+    assert target not in [item["item_key"] for item in after["items"]]
+    assert after["counts"]["all"] == before["counts"]["all"] - 1
+    # The badge is computed on a separate path (_sum_counts_for_tab) — an
+    # archive that doesn't move the numbers is a bug.
+    assert after["counts"]["friends"] == before["counts"]["friends"] - 1
+    assert after["counts"]["foes"] == before["counts"]["foes"]
+
+    friends = await _feed(client, auth_headers, FRIENDS_FILTER)
+    assert len(friends["items"]) == SEEDED_ITEM_COUNTS[FRIENDS_FILTER] - 1
+    assert friends["counts"]["friends"] == len(friends["items"])
+
+
+@pytest.mark.asyncio
+async def test_restore_puts_the_item_back_in_its_original_position(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    before = await _feed(client, auth_headers)
+    original_order = [item["item_key"] for item in before["items"]]
+    target = _key_of(before, FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED)
+
+    await client.post(
+        "/activity-feed/dismiss", json={"item_key": target}, headers=auth_headers
+    )
+    response = await client.post(
+        "/activity-feed/restore", json={"item_key": target}, headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"item_key": target, "archived": False, "changed": True}
+
+    after = await _feed(client, auth_headers)
+    assert [item["item_key"] for item in after["items"]] == original_order
+    assert after["counts"] == before["counts"]
+
+
+@pytest.mark.asyncio
+async def test_dismiss_and_restore_are_idempotent(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    """The undo strip can fire twice; neither call is an error."""
+    feed = await _feed(client, auth_headers)
+    target = _key_of(feed, FEED_ITEM_TYPE_GLOBAL_TASK)
+
+    first = await client.post(
+        "/activity-feed/dismiss", json={"item_key": target}, headers=auth_headers
+    )
+    second = await client.post(
+        "/activity-feed/dismiss", json={"item_key": target}, headers=auth_headers
+    )
+    assert first.json()["changed"] is True
+    assert second.status_code == 200
+    assert second.json()["changed"] is False
+
+    await client.post(
+        "/activity-feed/restore", json={"item_key": target}, headers=auth_headers
+    )
+    again = await client.post(
+        "/activity-feed/restore", json={"item_key": target}, headers=auth_headers
+    )
+    assert again.status_code == 200
+    assert again.json()["changed"] is False
+
+
+@pytest.mark.asyncio
+async def test_the_archive_is_per_character(
+    client: AsyncClient,
+    full_feed: dict,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """One player archiving a global event cannot hide it from anyone else."""
+    feed = await _feed(client, auth_headers)
+    target = _key_of(feed, FEED_ITEM_TYPE_GLOBAL_TASK)
+    await client.post(
+        "/activity-feed/dismiss", json={"item_key": target}, headers=auth_headers
+    )
+
+    other = await _feed(client, auth_headers2, "global")
+    assert target in [item["item_key"] for item in other["items"]]
+
+
+# ---------------------------------------------------------------------------
+# 3. awaiting_submission is not archivable
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dismissing_awaiting_submission_is_rejected(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    """It is state, not an event: archiving it would silence a standing
+    obligation forever. It clears itself the moment the player files."""
+    requests_feed = await _feed(client, auth_headers, REQUESTS_FILTER)
+    target = _key_of(requests_feed, FEED_ITEM_TYPE_AWAITING_SUBMISSION)
+
+    response = await client.post(
+        "/activity-feed/dismiss", json={"item_key": target}, headers=auth_headers
+    )
+    assert response.status_code == 400, response.text
+    assert "cannot be archived" in response.json()["detail"]
+
+    still_there = await _feed(client, auth_headers, REQUESTS_FILTER)
+    assert target in [item["item_key"] for item in still_there["items"]]
+
+
+@pytest.mark.asyncio
+async def test_dismiss_all_skips_awaiting_submission(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    """A bulk archive must not 400 because one unarchivable row is on screen —
+    and must not archive it either."""
+    response = await client.post(
+        "/activity-feed/dismiss-all",
+        json={"filter": REQUESTS_FILTER},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    # collab_invite + duel_challenge archived; awaiting_submission left alone.
+    assert response.json() == {"count": 2, "archived": True}
+
+    after = await _feed(client, auth_headers, REQUESTS_FILTER)
+    assert [item["type"] for item in after["items"]] == [
+        FEED_ITEM_TYPE_AWAITING_SUBMISSION
+    ]
+    assert after["counts"]["requests"] == 1
+
+
+@pytest.mark.asyncio
+async def test_unknown_and_malformed_keys_are_rejected(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    for bad_key in ("", "nonsense", "vote_on_mine", "no_such_type:1", "nudge:abc"):
+        response = await client.post(
+            "/activity-feed/dismiss", json={"item_key": bad_key}, headers=auth_headers
+        )
+        assert response.status_code == 400, f"{bad_key} -> {response.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Archiving never answers anything
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_archiving_a_collab_invite_leaves_it_pending(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    full_feed: dict,
+    auth_headers: dict,
+):
+    """ADR-0065: the archive is a view state, never a decision. The invite is
+    still open and still unanswered — F2 tags it 'still waiting'."""
+    feed = await _feed(client, auth_headers)
+    target = _key_of(feed, FEED_ITEM_TYPE_COLLAB_INVITE)
+
+    response = await client.post(
+        "/activity-feed/dismiss", json={"item_key": target}, headers=auth_headers
+    )
+    assert response.status_code == 200
+
+    invite = (
+        await db_session.execute(
+            select(PraxisInvite).where(PraxisInvite.id == full_feed["collab_invite_id"])
+        )
+    ).scalar_one()
+    assert invite.status == PraxisInviteStatus.pending
+
+    # ...and it is still answerable: the invite id in the archived item's key is
+    # the one the respond endpoint takes.
+    assert target.endswith(ITEM_KEY_SEPARATOR + str(invite.id))
+
+
+# ---------------------------------------------------------------------------
+# 5. Bulk + the archived view
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dismiss_all_scopes_to_the_current_filter(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    response = await client.post(
+        "/activity-feed/dismiss-all",
+        json={"filter": FRIENDS_FILTER},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["count"] == SEEDED_ITEM_COUNTS[FRIENDS_FILTER]
+
+    friends = await _feed(client, auth_headers, FRIENDS_FILTER)
+    assert friends["items"] == []
+    assert friends["counts"]["friends"] == 0
+
+    # Other filters keep whatever they didn't share with `friends`.
+    foes = await _feed(client, auth_headers, FOES_FILTER)
+    assert len(foes["items"]) == SEEDED_ITEM_COUNTS[FOES_FILTER]
+
+    everything = await _feed(client, auth_headers)
+    assert len(everything["items"]) == (
+        SEEDED_ITEM_COUNTS[ALL_FILTER] - SEEDED_ITEM_COUNTS[FRIENDS_FILTER]
+    )
+
+
+@pytest.mark.asyncio
+async def test_archived_view_ignores_the_type_slicing(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    """The Archived tab returns everything archived, whatever tab it came from —
+    a player looking for something they put away should not have to remember
+    which tab they put it away from."""
+    await client.post(
+        "/activity-feed/dismiss-all",
+        json={"filter": FRIENDS_FILTER},
+        headers=auth_headers,
+    )
+    await client.post(
+        "/activity-feed/dismiss-all",
+        json={"filter": FOES_FILTER},
+        headers=auth_headers,
+    )
+
+    # Asking with a `friends` filter still returns the foes items too.
+    archived = await _feed(client, auth_headers, FRIENDS_FILTER, archived=True)
+    archived_types = {item["type"] for item in archived["items"]}
+    assert len(archived["items"]) == (
+        SEEDED_ITEM_COUNTS[FRIENDS_FILTER] + SEEDED_ITEM_COUNTS[FOES_FILTER]
+    )
+    assert "foe_taunt" in archived_types
+    assert FEED_ITEM_TYPE_FRIEND_COMPLETION in archived_types
+
+    # The badges keep counting the live feed while the archive is on screen.
+    assert archived["counts"]["friends"] == 0
+    assert archived["counts"]["all"] == (
+        SEEDED_ITEM_COUNTS[ALL_FILTER]
+        - SEEDED_ITEM_COUNTS[FRIENDS_FILTER]
+        - SEEDED_ITEM_COUNTS[FOES_FILTER]
+    )
+
+    # An empty archive is an empty list, not an error.
+    await client.post("/activity-feed/restore-all", json={}, headers=auth_headers)
+    assert (await _feed(client, auth_headers, ALL_FILTER, archived=True))["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_restore_all_empties_the_archive(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    full_feed: dict,
+    auth_headers: dict,
+):
+    before = await _feed(client, auth_headers)
+
+    dismissed = await client.post(
+        "/activity-feed/dismiss-all", json={}, headers=auth_headers
+    )
+    # Everything except the one unarchivable type.
+    assert dismissed.json()["count"] == SEEDED_ITEM_COUNTS[ALL_FILTER] - 1
+
+    emptied = await client.post(
+        "/activity-feed/restore-all", json={}, headers=auth_headers
+    )
+    assert emptied.status_code == 200, emptied.text
+    assert emptied.json() == {
+        "count": SEEDED_ITEM_COUNTS[ALL_FILTER] - 1,
+        "archived": False,
+    }
+
+    after = await _feed(client, auth_headers)
+    assert [item["item_key"] for item in after["items"]] == [
+        item["item_key"] for item in before["items"]
+    ]
+    remaining = (
+        await db_session.execute(
+            select(FeedDismissal).where(FeedDismissal.character_id == character.id)
+        )
+    ).scalars().all()
+    assert remaining == []
+
+
+@pytest.mark.asyncio
+async def test_restore_all_can_be_scoped_to_one_filter(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    await client.post("/activity-feed/dismiss-all", json={}, headers=auth_headers)
+
+    restored = await client.post(
+        "/activity-feed/restore-all",
+        json={"filter": FOES_FILTER},
+        headers=auth_headers,
+    )
+    assert restored.json()["count"] == SEEDED_ITEM_COUNTS[FOES_FILTER]
+
+    foes = await _feed(client, auth_headers, FOES_FILTER)
+    assert len(foes["items"]) == SEEDED_ITEM_COUNTS[FOES_FILTER]
+
+    friends = await _feed(client, auth_headers, FRIENDS_FILTER)
+    assert friends["items"] == []


### PR DESCRIPTION
Backend only. Nothing here is visible to a player — F2 (#1194) consumes it.

Closes #1193

## The identity scheme (read this first, #1194)

**`item_key = "{feed_item_type}:{source_row_pk}"`** — e.g. `collab_invite:42`, `nudge:7`, `era_announcement:1`.

Built in each source's row mapper via `services/activity_feed.py::build_item_key`, from a PK the source's query already selects. Nothing is derived from row position, page offset, or timestamp, so the key of a given item is byte-identical on every request until its source row is deleted.

**The type prefix is load-bearing, not decoration.** Three types are built from the *same* `praxis_member` table and two from the *same* `praxis` table:

| Source table | Feed types built from it |
|---|---|
| `praxis_member` | `friend_signup`, `collaborator_submitted`, `awaiting_submission` |
| `praxis` | `friend_completion`, `foe_completion` |

In the seeded test fixture one single `praxis_member` row produces **both** a `friend_signup` and a `collaborator_submitted` card. A bare PK would give them one key, and archiving one would silently archive the other. `test_one_source_row_two_types_get_distinct_keys` pins this.

**All 15 verified, as the issue asked — not assumed.** Every source query already selects its source PK; 14 of the 15 also already carried it in the payload. The one that did not:

- **`friend_defection`** — `FactionDefectionHistory.id` is selected by the query but was never put in the payload. No query change was needed; the mapper reads `row.id`.

Entity-selecting queries (`foe_taunt`, `era_announcement`, `invitation_letter` select the whole ORM object) read `.id` off the entity rather than a labelled column. No synthesised keys anywhere.

`awaiting_submission` **does** get a key like everything else — refusing to archive it is a rule, not an absence of identity.

## What changed

**`feed_dismissal` table** (`models/feed_dismissal.py`, migration `0010_feed_dismissal`) — `character_id` → `character.id`, `item_key`, `created_at`, unique on `(character_id, item_key)`. No enum, so nothing to add to `0001_squashed`'s `ENUMS` list. A table rather than localStorage because "nothing is destroyed, everything lands in Archived" is a durability promise that has to survive a device change.

**Filtering happens in SQL, inside each source's `Select`, before its `LIMIT`.** `FeedSource` gained one field, `source_id_column`, so the archive predicate can be applied generically for all 15. This matters twice:

- filtering the *mapped items* afterwards would let dismissed rows eat slots in the 50-per-source window, silently shrinking pages;
- **`FeedCounts` drops with the feed** for free, because counts wrap the very same `Select` in a `COUNT` (ADR-0036). The separate `_sum_counts_for_tab` path the issue warns about needed no special case.

**Endpoints**

| Route | Body | Notes |
|---|---|---|
| `GET /activity-feed?archived=true` | — | The archive. Same cursor, same page size. Ignores friend/foe/global type slicing and returns everything archived. Also ignores the `requests` tab's pending-only window — an archived invite that was since declined is still archived, and nothing else would list it. |
| `POST /activity-feed/dismiss` | `{item_key}` | 400 on unknown / malformed / unarchivable |
| `POST /activity-feed/restore` | `{item_key}` | |
| `POST /activity-feed/dismiss-all` | `{filter?}` | One call. Scope = re-runs the feed for that filter, so it can never drift from what the tab shows |
| `POST /activity-feed/restore-all` | `{filter?}` | One call. No filter = empty the whole archive, which is what the Archived tab's "Restore all" means |

`archived` is a separate parameter crossed with the existing filter, never a member of `FILTER_QUERIES` — archived-ness is state, and `FILTER_QUERIES` is a type-set map.

**Response shape:** `ActivityFeedItem` gains `item_key: str`. `FeedCounts` is unchanged.

**`awaiting_submission` is refused server-side** with a 400 that says why. It is state, not an event — it exists exactly while `PraxisMember.has_submitted` is false, and clears itself the moment the player files, so a dismissal row would silence a standing obligation forever. Bulk archive *skips* it rather than refusing: an "Archive all" that 400s because one unarchivable row is on screen would be unusable.

**Archiving never answers anything.** Every write in the archive path writes exactly one table, `feed_dismissal`. A test archives a `collab_invite` and asserts the `PraxisInvite` is still `pending`.

## What to eyeball

1. **The identity scheme itself.** `services/activity_feed.py`, the `# --- Item identity ---` block. This is the load-bearing decision of the epic.
2. **`_scoped_query`** — the one place the archive predicate is applied, for fetch and count alike. Returning `None` means "this source cannot contribute", which also absorbs the pre-existing `_needs_satisfied` guard.
3. **Counts always count the live feed, never the archive** (`_compute_counts` forces `archived_only=False`). The sidebar badges stay truthful while the player is reading the Archived tab. Deliberate — say so if you disagree.
4. **Bulk scope is the standard 50-per-source window** (`ARCHIVE_ALL_LIMIT`). Anything past it is beyond what that tab's own badge counts, so "Archive all" leaves the tab reading empty *and* the badge reading zero. It is not a retroactive sweep of all history.
5. **`restore-all` with a `filter` restores by type-set**, not by "what that tab would show" — the archived view has no tabs.
6. **The migration's UNIQUE guard** does not use the `EXCEPTION WHEN duplicate_object` shape 0008/0009 use. See below.
7. **`ON CONFLICT DO NOTHING`** on the insert — Postgres-specific, as the rest of the schema already is.

## A real bug the verification caught

The migration originally copied 0009's `DO $$ ... EXCEPTION WHEN duplicate_object` pattern for the unique constraint. On a fresh DB (`0001_squashed` = `create_all` from the models) the constraint already exists, and `ADD CONSTRAINT ... UNIQUE` also builds an index, so the re-add raises **`duplicate_table`** — which that handler does not catch. `alembic upgrade head` died. It is now guarded by a `pg_constraint` lookup. This would have passed pytest and failed CI.

## Verified / not verified

**Verified**

- `pytest -q --cov=. --cov-fail-under=80` from `backend/` against a dedicated `wz1193_test` DB: **832 passed, 89.85% coverage**. 14 of those are new, all integration tests over the real feed service and real routes — no mocks.
- The new fixture seeds one item of **all 15 feed types** and asserts the set is exactly the registry's, which is the only honest way to test "every one of the 15".
- `alembic upgrade head` on a fresh empty DB, plus a `downgrade` → `upgrade` round-trip, plus `alembic check` (no drift).
- Acceptance criteria, each with a named test: stable keys across two requests · dismiss removes the item *and* drops the `all` + `friends` counts · restore returns it at its original position (full ordered key list compared) · dismiss-all on `friends` empties that tab while `foes` keeps its items · `awaiting_submission` rejected with 400 · archiving a `collab_invite` leaves `PraxisInvite.status == pending`.

**Not verified**

- **No visual QA** — this PR renders nothing, and the environment cannot screenshot.
- **No frontend change.** `frontend/src/api/activityFeed.ts::ActivityFeedItem` does not yet declare `item_key`; the extra JSON field is harmless to TS. Declaring it is F2's job.
- **Not exercised under real concurrency.** `ON CONFLICT DO NOTHING` is the argument, not a test.
- **`FeedCounts` has no `archived` count.** Adding one would mean a second full 15-query count fan-out on every feed request. If the Archived tab wants a badge, that is a deliberate follow-up decision, not an oversight.
- **ADR-0065 / ADR-0066 / CONTEXT.md / SPEC-faction-ui-profile.md §12 are unwritten** — the epic lists them, they live outside `backend/`, and this agent is scoped to `backend/` only.

## Skipped by owner ruling

Per the epic's 2026-07-29 amendment: no `expired` enum value, no duel deadline column, no duel duration in `EraConfig`, no member counts, no re-request endpoint. None were added. A drawn state with no API behind it is not built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
