### PR TITLE
The score panel hears the vote it was already rendering (#1142)

### DIFF
--- a/frontend/src/components/vote/__tests__/applyVoteDelta.test.ts
+++ b/frontend/src/components/vote/__tests__/applyVoteDelta.test.ts
@@ -1,0 +1,172 @@
+/**
+ * The merge arithmetic, exercised on BOTH payload shapes (#1142).
+ *
+ * The bug was a detail page merging the viewer's cast into its `VoteSummary`
+ * while its score panel read the praxis object — so the guard has to be that one
+ * delta reaches both, and that the praxis arm is read back through
+ * `scoreBreakdown()`, the single row-selection authority (ADR-0053). Asserting
+ * the merged fields alone would pass even if the resolver stopped reading them.
+ *
+ * Deliberately not a click test: the harness is `renderToStaticMarkup` with no
+ * jsdom, effects never run, and `useSyncExternalStore`'s server snapshot is
+ * always null (see voteOverrides.ts), so a rendered component can never observe
+ * an active override. The resolver is what's testable, and it's what broke.
+ */
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { PraxisCardOut, PraxisOut } from '../../../api/praxis'
+import type { VoteSummary } from '../../../api/votes'
+import { scoreBreakdown } from '../../praxisCard/scoreStamp/scoreBreakdown'
+import { applyVoteDelta, applyVoteSummaryDelta } from '../useVotedPraxis'
+import { __resetVoteOverrides, recordVote, tallyDelta } from '../voteOverrides'
+
+const PRAXIS_ID = 7
+
+/** A detail payload: `PraxisOut` carries no voter count. (base 12 + meta 0) × 1.0 + 4. */
+const DETAIL: PraxisOut = {
+  id: PRAXIS_ID,
+  task_id: 2,
+  task_title: 'Walk the ridge',
+  task_point_value: 12,
+  task_level_required: 1,
+  task_faction_slug: null,
+  type: 'solo',
+  status: 'submitted',
+  title: 'The Long Way Round',
+  body_text: 'Walked the whole ridge before dark.',
+  moderation_status: 'visible',
+  admin_note: null,
+  flagged_at: null,
+  submitted_at: '2026-01-03T00:00:00Z',
+  submit_proposed_at: null,
+  created_by_id: 3,
+  created_by_display_name: 'Ada',
+  created_by_faction_slug: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-03T00:00:00Z',
+  members: [],
+  invites: [],
+  media_items: [],
+  score: 16,
+  metatask_points: 0,
+  display_multiplier: 1.0,
+  points_from_votes: 4,
+  is_top_for_task: false,
+  duel_id: null,
+  can_flag: true,
+  applied_metatasks: [],
+}
+
+/** A card payload: same numbers, plus the voter count only cards carry. */
+const CARD: PraxisCardOut = {
+  id: PRAXIS_ID,
+  task_id: 2,
+  task_title: 'Walk the ridge',
+  task_point_value: 12,
+  task_level_required: 1,
+  type: 'solo',
+  status: 'submitted',
+  title: 'The Long Way Round',
+  moderation_status: 'visible',
+  created_by_id: 3,
+  created_by_display_name: 'Ada',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-03T00:00:00Z',
+  submitted_at: '2026-01-03T00:00:00Z',
+  member_count: 1,
+  score: 16,
+  voter_count: 2,
+  metatask_points: 0,
+  display_multiplier: 1.0,
+  points_from_votes: 4,
+  is_top_for_task: false,
+  task_faction_slug: null,
+}
+
+const SUMMARY: VoteSummary = { praxis_id: PRAXIS_ID, total_votes: 2, total_score: 4 }
+
+/** The delta a first cast of 5 publishes: +5 points, +1 voter. */
+function firstCastOfFive() {
+  recordVote(PRAXIS_ID, 5, null)
+  const delta = tallyDelta(PRAXIS_ID)
+  if (!delta) throw new Error('expected an active override')
+  return delta
+}
+
+describe('applyVoteDelta on a detail payload (#1142)', () => {
+  beforeEach(() => {
+    __resetVoteOverrides()
+  })
+
+  it('moves the score panel the archetypes render, not just the vote line', () => {
+    // The regression: every praxis-detail archetype mounts ScoreStamp, which
+    // resolves its rows from the praxis object. Before the fix this stayed at
+    // "+ 4 from votes" / total 16 until a refresh.
+    const voted = applyVoteDelta(DETAIL, firstCastOfFive())
+    expect(scoreBreakdown(voted)).toEqual({
+      base: 12,
+      mult: null,
+      meta: null,
+      votes: 9,
+      total: 21,
+    })
+  })
+
+  it('leaves the server payload untouched, so a re-render cannot compound it', () => {
+    applyVoteDelta(DETAIL, firstCastOfFive())
+    expect(scoreBreakdown(DETAIL)).toEqual(
+      expect.objectContaining({ votes: 4, total: 16 }),
+    )
+  })
+
+  it('invents no voter count on a payload that has none', () => {
+    const voted = applyVoteDelta(DETAIL, firstCastOfFive())
+    expect('voter_count' in voted).toBe(false)
+  })
+
+  it('reads the same numbers off a card as off a detail payload', () => {
+    // One arithmetic for both shapes is the point: the card's stamp and the
+    // detail page's stamp must never disagree about the same cast.
+    const delta = firstCastOfFive()
+    expect(scoreBreakdown(applyVoteDelta(CARD, delta))).toEqual(
+      scoreBreakdown(applyVoteDelta(DETAIL, delta)),
+    )
+    expect(applyVoteDelta(CARD, delta).voter_count).toBe(3)
+  })
+})
+
+describe('applyVoteSummaryDelta (#1142)', () => {
+  beforeEach(() => {
+    __resetVoteOverrides()
+  })
+
+  it('moves the votes-only summary by the same delta', () => {
+    expect(applyVoteSummaryDelta(SUMMARY, firstCastOfFive())).toEqual({
+      praxis_id: PRAXIS_ID,
+      total_votes: 3,
+      total_score: 9,
+    })
+  })
+
+  it('agrees with the praxis merge about the vote points', () => {
+    // Different baselines (a summary is votes-only, a praxis total is the lot),
+    // so the check is that the MOVEMENT matches, not the absolute numbers.
+    const delta = firstCastOfFive()
+    const summaryMoved =
+      applyVoteSummaryDelta(SUMMARY, delta).total_score - SUMMARY.total_score
+    const praxisMoved =
+      scoreBreakdown(applyVoteDelta(DETAIL, delta)).votes - scoreBreakdown(DETAIL).votes
+    expect(summaryMoved).toBe(praxisMoved)
+  })
+
+  it('re-vote: moves the score with no new voter', () => {
+    recordVote(PRAXIS_ID, 5, 3)
+    const delta = tallyDelta(PRAXIS_ID)
+    if (!delta) throw new Error('expected an active override')
+    expect(applyVoteSummaryDelta(SUMMARY, delta)).toEqual({
+      praxis_id: PRAXIS_ID,
+      total_votes: 2,
+      total_score: 6,
+    })
+    expect(scoreBreakdown(applyVoteDelta(DETAIL, delta)).total).toBe(18)
+  })
+})

--- a/frontend/src/components/vote/useVotedPraxis.ts
+++ b/frontend/src/components/vote/useVotedPraxis.ts
@@ -1,18 +1,61 @@
 import type { PraxisCardOut } from '../../api/praxis'
+import type { VoteSummary } from '../../api/votes'
+import type { ScoredPraxis } from '../praxisCard/scoreStamp/scoreBreakdown'
 import { useVoteOverride, type VoteDelta } from './voteOverrides'
+
+/**
+ * The praxis shape a pending vote can be merged into: the score terms
+ * `scoreBreakdown()` resolves (ADR-0053), plus the card-only voter count.
+ *
+ * Deliberately the resolver's OWN input set. The panel that reads a score is
+ * `scoreBreakdown()`'s and nothing else's, so pinning the merge to those fields
+ * makes "which numbers a cast moves" and "which numbers a stamp shows" one
+ * decision instead of two that can drift. `voter_count` is optional because only
+ * `PraxisCardOut` carries one — a detail page counts voters from its voters list.
+ */
+export type VoteScoredPraxis = ScoredPraxis & { voter_count?: number }
 
 /**
  * The arithmetic half of the merge, pulled out so it's testable without the
  * hook: `useSyncExternalStore`'s server snapshot is always null under
  * `renderToStaticMarkup` (see voteOverrides.ts), so a component-rendered test
  * can never observe an active override. `tallyDelta` + this function can.
+ *
+ * Generic over the payload (#1142) so the card's `PraxisCardOut` and the detail
+ * page's `PraxisOut` share ONE copy of "how a pending vote adjusts a score".
+ * Two copies is how the card and the detail page start disagreeing.
+ *
+ * `score` and `points_from_votes` both move by the same points: a praxis total
+ * is `(base + meta) × mult + votes`, and a vote's points enter that sum
+ * unmultiplied, so the total moves by exactly what the votes row moves by.
  */
-export function applyVoteDelta(praxis: PraxisCardOut, delta: VoteDelta): PraxisCardOut {
+export function applyVoteDelta<T extends VoteScoredPraxis>(praxis: T, delta: VoteDelta): T {
   return {
     ...praxis,
+    // Absent stays absent: a payload with no voter count never had one, and
+    // inventing `NaN` there would print through a card's footer.
+    ...(typeof praxis.voter_count === 'number'
+      ? { voter_count: praxis.voter_count + delta.voters }
+      : {}),
     score: praxis.score + delta.score,
-    voter_count: praxis.voter_count + delta.voters,
     points_from_votes: praxis.points_from_votes + delta.score,
+  }
+}
+
+/**
+ * The same delta on the votes-only summary a detail page fetches (#1142).
+ *
+ * A separate function, not a separate arithmetic: `VoteSummary.total_score` is a
+ * votes-only baseline while a praxis `score` is the whole total (see
+ * voteOverrides.ts on why no baseline is shared), so the two shapes cannot share
+ * one signature — but both take their numbers from the same {@link VoteDelta},
+ * and they live side by side here so a change to one is visibly a change to both.
+ */
+export function applyVoteSummaryDelta(votes: VoteSummary, delta: VoteDelta): VoteSummary {
+  return {
+    ...votes,
+    total_score: votes.total_score + delta.score,
+    total_votes: votes.total_votes + delta.voters,
   }
 }
 
@@ -21,8 +64,8 @@ export function applyVoteDelta(praxis: PraxisCardOut, delta: VoteDelta): PraxisC
  *
  * Both card dispatchers (desktop PraxisCard, mobile MobilePraxisCard) call this
  * before picking a faction skin, so every slot below them — the score stamp's
- * breakdown, PraxisFooterMeta's score, and the VoteUI tally — reads one
- * already-correct object instead of each learning about the cast separately.
+ * breakdown and the VoteUI tally — reads one already-correct object instead of
+ * each learning about the cast separately.
  *
  * Returns the praxis unchanged when there's no override, so the common case
  * keeps its identity and skins don't re-render for nothing.

--- a/frontend/src/components/vote/voteOverrides.ts
+++ b/frontend/src/components/vote/voteOverrides.ts
@@ -3,13 +3,18 @@ import { useSyncExternalStore } from 'react'
 /**
  * Client-side vote overrides (#626) — "the tally moved because I just voted".
  *
- * A card renders its tally in three sibling components (VoteSummary, the
- * faction score stamp, PraxisFooterMeta) that all read the praxis object, which
- * useVote has no way to reach. Rather than drill an onVoted callback through
- * eight faction variants that only draw stamps and hearts, a cast publishes
- * here and the two card dispatchers + usePraxisDetail merge it back in.
+ * A surface renders its tally in sibling components (the faction score stamp,
+ * the vote line) that all read the praxis object, which useVote has no way to
+ * reach. Rather than drill an onVoted callback through eight faction variants
+ * that only draw stamps and hearts, a cast publishes here and the two card
+ * dispatchers + usePraxisDetail merge it back in.
  *
- * One writer (useVote), three read points. Keep it that way.
+ * ONE writer (useVote), and every reader merges through useVotedPraxis.ts —
+ * `applyVoteDelta` for a praxis payload, `applyVoteSummaryDelta` for a
+ * VoteSummary. Keep it that way. This docblock used to enumerate the three
+ * COMPONENTS that read a tally, and #1142 was that list going stale: one of them
+ * had been replaced by a panel reading the praxis object, which the detail page
+ * merged nothing into. Name the merge points, not what renders below them.
  *
  * An override lives only until the server catches up: every fetch that returns
  * fresh truth for a praxis clears it (see clearVoteOverrides' callers in the

--- a/frontend/src/pages/praxisDetail/usePraxisDetail.ts
+++ b/frontend/src/pages/praxisDetail/usePraxisDetail.ts
@@ -25,6 +25,10 @@ import { useAdminMode } from "../../auth/AdminModeContext";
 import { moderatePraxis } from "../../api/admin";
 import { extractError } from "../../utils/errors";
 import { seedViewerVote, useVoteOverride } from "../../components/vote/voteOverrides";
+import {
+  applyVoteDelta,
+  applyVoteSummaryDelta,
+} from "../../components/vote/useVotedPraxis";
 import type { CurrentUser } from "../../api/auth";
 import { FLAG_REASON_OTHER, type FlagReason } from "../../utils/flagReasons";
 
@@ -265,23 +269,22 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
     if (own) seedViewerVote(praxis.id, own.value);
   }, [voters, viewerCharacterId, praxis?.id]);
 
-  // Merge the viewer's own just-cast vote into the tally the archetypes render
-  // (#626) — every bespoke "standing" panel reads this, not just the vote line.
+  // Merge the viewer's own just-cast vote into everything this page renders
+  // (#626). It has to land on the PRAXIS, not only on the vote summary (#1142):
+  // every archetype's score panel is the mounted `ScoreStamp`, which resolves
+  // its rows from `scoreBreakdown(praxis)` (ADR-0053) — so a delta that stops at
+  // `votes` leaves the panel reading "+ 0 from votes" until a refresh, which is
+  // exactly the bug. `votes` gets the same delta through its own sibling helper;
+  // both are one `VoteDelta`, and neither recomputes a total here.
   const voteDelta = useVoteOverride(praxis?.id ?? -1);
-  const displayVotes =
-    votes && voteDelta
-      ? {
-          ...votes,
-          total_score: votes.total_score + voteDelta.score,
-          total_votes: votes.total_votes + voteDelta.voters,
-        }
-      : votes;
+  const displayPraxis = praxis && voteDelta ? applyVoteDelta(praxis, voteDelta) : praxis;
+  const displayVotes = votes && voteDelta ? applyVoteSummaryDelta(votes, voteDelta) : votes;
 
   const isOwner = isViewerMember(praxis, user?.character?.id);
 
   return {
     loading,
-    praxis,
+    praxis: displayPraxis,
     fetchError,
 
     votes: displayVotes,


### PR DESCRIPTION
Casting a vote moved the vote line but left the score panel reading `+ 0 from
votes` until a refresh.

Closes #1142

## Root cause

`usePraxisDetail` merged the override into the **`VoteSummary`** and handed the
**praxis** through untouched. Every praxis-detail archetype draws its score panel
by mounting `ScoreStamp`, which resolves rows from `scoreBreakdown(praxis)`
(ADR-0053) — so the delta landed on an object the panel doesn't read.

Worse, it landed on an object *nothing* reads: since #1091 gave the whole score
rail to `ScoreStamp`, no archetype destructures `state.votes` at all. The merge
was dead code, and the comment above it ("every bespoke 'standing' panel reads
this") was the assumption that made it look done.

## Every `useVoteOverride` consumer, as asked

| Read point | What it does | Before |
|---|---|---|
| `useVotedPraxis` → `PraxisCard` (desktop) | merges into `PraxisCardOut` before faction dispatch; skins' `ScoreStamp` reads it | correct |
| `useVotedPraxis` → `MobilePraxisCard` | same merge for the mobile dispatcher | correct |
| `usePraxisDetail` → `votes` | merges into `VoteSummary` | correct arithmetic, **no consumer** |
| `usePraxisDetail` → `praxis` | what every archetype's `ScoreStamp` reads | **missing — the bug** |
| `useVote` → `viewerVote()` | pre-highlights the viewer's own stars (not a tally read) | correct |

So the hole was one-sided, not systemic: the cards were already right. The
docblock's third named read point, `PraxisFooterMeta`, no longer exists — that
stale enumeration is what hid the gap, so the docblock now names the two **merge
helpers** instead of the components downstream of them.

## The fix

- `applyVoteDelta` goes generic over `ScoredPraxis & { voter_count?: number }` —
  deliberately `scoreBreakdown()`'s own input set, so "which numbers a cast
  moves" and "which numbers a stamp shows" are one decision. `PraxisOut` and
  `PraxisCardOut` now share one copy of the arithmetic; `voter_count` stays
  absent on payloads that never had one rather than becoming `NaN`.
- `applyVoteSummaryDelta` moves the `VoteSummary` merge next to it. Separate
  signature (a summary is votes-only, a praxis `score` is the whole total — the
  store's docblock is explicit that no baseline is shared), same single
  `VoteDelta`.
- `usePraxisDetail` applies both from one delta and returns the merged praxis.
  No total is recomputed here; the resolver stays the only place a breakdown is
  resolved.

No double-count: `getPraxis`/`getVotes` still `clearVoteOverrides` on fresh
truth, and the merge is a pure derivation of the server payload — the fixture is
asserted unmutated so a re-render can't compound.

## Tests

New `src/components/vote/__tests__/applyVoteDelta.test.ts` (7 tests) asserts the
merged detail payload **through `scoreBreakdown()`**, not through the merged
fields — a check that would have failed before this PR and that survives a
resolver change. Also: card and detail agree on the same cast, re-vote adds no
voter, no invented `voter_count`, and the summary's movement equals the praxis's.

Testing the resolver, not the click, is forced: the harness is
`renderToStaticMarkup` with no jsdom, effects never run, and
`useSyncExternalStore`'s server snapshot is always `null`, so a rendered
component can never observe an active override.

Full frontend suite: **140 files / 2379 tests pass**. `tsc --noEmit` clean,
`vite build` clean, eslint clean on the touched paths.

## What to eyeball

**Visual QA is outstanding — I cannot screenshot and there is no dev stack here.**

1. Open any submitted praxis detail page as a non-owner and cast a vote. **Without
   refreshing**, watch the score panel above the vote widget: the votes row must
   move from `+ N` to `+ N + stars` and the total must move by the same amount, at
   the same moment the widget flips to "YOUR VOTE".
2. Change the vote (e.g. 4 → 2) before refreshing: the panel must move to the
   *difference*, not compound off your own last guess.
3. Refresh: the numbers must be identical to what you just saw — not doubled.
4. Same on a praxis **card** in a list (regression check — cards were already
   correct and must stay so).
5. Worth a glance on a duel praxis: the duel cross-link card reads
   `duel.<side>.points_from_votes` from a **separate** `DuelDetailOut` payload,
   which no override touches, so a spectator's cast leaves that live tally stale
   until refetch. Out of scope here (different payload, different fetch) — say the
   word and I'll file it.
