### PR TITLE
PublishButton's duel pull-back is not dead code — it moved to the moderated composer

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx
@@ -5,6 +5,14 @@
  * label. PublishButton uses no hooks, so it's invoked directly: we read the
  * returned <button>'s onClick to fire the action headlessly and
  * renderToStaticMarkup for the visible label.
+ *
+ * #1177 re-aimed the pull-back cases at the state a player can still be in. Both
+ * pull-back routes — the duel's `duelPullBack` and the collab's `iCast` — were
+ * written for the ordinary cast, which now derives a waiting stage and gets
+ * `PraxisWaitingSurface` instead of this footer (#1080/ADR-0059, #1189). Each one
+ * survives only on the MODERATED composer, so each is asserted there, alongside
+ * a case pinning the ordinary path to `waiting` so the difference is on the
+ * record rather than rediscovered.
  */
 import type { ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
@@ -13,6 +21,7 @@ import "../../../../i18n";
 import type { PraxisMemberOut, PraxisOut } from "../../../../api/praxis";
 import type { DuelDetailOut, DuelStatus } from "../../../../api/duel";
 import type { EditPraxisState } from "../../useEditPraxis";
+import { deriveEditPraxisPhase } from "../../useEditPraxis";
 import { collabCopy } from "../../../../components/collab/collabCopy";
 import { PublishButton, type PublishButtonSkin } from "../controls";
 
@@ -38,6 +47,7 @@ function collabState(
   overrides: {
     currentCharacterId?: number;
     factionSlug?: string | null;
+    moderationStatus?: string;
     publish?: () => Promise<void>;
     pullBack?: () => Promise<void>;
   } = {},
@@ -45,12 +55,19 @@ function collabState(
   const praxis = {
     id: 1,
     type: "collab",
+    // A collab mid-consensus is `pending`, never `submitted` — one member having
+    // cast is a member fact (`has_submitted`), not a praxis status. Carried for
+    // the same reason as the duel fixture's: so the phase can be derived (#1177).
+    status: "pending",
+    moderation_status: overrides.moderationStatus ?? "visible",
+    duel_id: null,
     members,
     task_faction_slug: overrides.factionSlug ?? null,
     task_point_value: 20,
   } as unknown as PraxisOut;
   return {
     praxis,
+    duel: null,
     submitting: false,
     switchingMode: null,
     isPublished: false,
@@ -96,14 +113,20 @@ function duelState(
     isPublished?: boolean;
     rivalCast?: boolean;
     factionSlug?: string | null;
+    moderationStatus?: string;
     publish?: () => Promise<void>;
     pullBack?: () => Promise<void>;
     requestDuelSeal?: () => void;
   } = {},
 ): EditPraxisState {
+  const published = overrides.isPublished ?? true;
   const praxis = {
     id: 1,
     type: "solo",
+    // Carried so `deriveEditPraxisPhase` can be run over the SAME fixture — the
+    // phase is what decides whether this button is mounted at all (#1177).
+    status: published ? "submitted" : "in_progress",
+    moderation_status: overrides.moderationStatus ?? "visible",
     duel_id: 7,
     members: [],
     task_faction_slug: overrides.factionSlug ?? null,
@@ -127,12 +150,24 @@ function duelState(
     duelMode: true,
     submitting: false,
     switchingMode: null,
-    isPublished: overrides.isPublished ?? true,
+    isPublished: published,
     currentCharacterId: 1,
     publish: overrides.publish ?? (async () => {}),
     pullBack: overrides.pullBack ?? (async () => {}),
     requestDuelSeal: overrides.requestDuelSeal ?? (() => {}),
   } as unknown as EditPraxisState;
+}
+
+/**
+ * Assert the fixture is a state the composer actually mounts in.
+ *
+ * This button lives in the archetype's footer, and every archetype returns
+ * `PraxisWaitingSurface` instead at `isWaitingStage(phase)`. So a case asserting
+ * what the button draws is only meaningful if the same data derives `composing`
+ * — otherwise it is testing a screen no player reaches (#1177).
+ */
+function expectComposerMounts(state: EditPraxisState): void {
+  expect(deriveEditPraxisPhase(state.praxis, state.duel, 1)).toBe("composing");
 }
 
 describe("PublishButton — collab cast/pull-back gate (#646)", () => {
@@ -151,13 +186,21 @@ describe("PublishButton — collab cast/pull-back gate (#646)", () => {
     expect(pullBack).not.toHaveBeenCalled();
   });
 
-  it("once I have cast it shows the pull-back label and calls pullBack", () => {
+  // Re-described by #1177, exactly like the duel cases below. An unmoderated
+  // collab member who has cast derives `waiting`, so the archetype shows
+  // `PraxisWaitingSurface` and never builds this footer; the `iCast` route
+  // survives on the MODERATED composer, reached by the identical short-circuit
+  // (`deriveEditPraxisPhase` tests moderation before the collab branch). The two
+  // halves of the condition live or die together, so both are asserted.
+  it("once I have cast on a failed collab it shows the pull-back label and calls pullBack", () => {
     const publish = vi.fn(async () => {});
     const pullBack = vi.fn(async () => {});
     const state = collabState([member(1, true), member(2, false)], {
+      moderationStatus: "failed",
       publish,
       pullBack,
     });
+    expectComposerMounts(state);
     const el = renderButton(state);
 
     expect(renderToStaticMarkup(el)).toContain(
@@ -166,6 +209,13 @@ describe("PublishButton — collab cast/pull-back gate (#646)", () => {
     el.props.onClick();
     expect(pullBack).toHaveBeenCalledTimes(1);
     expect(publish).not.toHaveBeenCalled();
+  });
+
+  it("is not the ordinary cast member's surface — that one derives a waiting stage", () => {
+    const ordinary = collabState([member(1, true), member(2, false)]);
+    expect(deriveEditPraxisPhase(ordinary.praxis, ordinary.duel, 1)).toBe(
+      "waiting",
+    );
   });
 
   it("resolves the idle label through collabCopy in the task faction's voice", () => {
@@ -193,14 +243,35 @@ describe("PublishButton — collab cast/pull-back gate (#646)", () => {
   });
 });
 
-describe("PublishButton — duel pull-back before the duel settles (#1077)", () => {
-  it("offers a neutral pull-back once I have cast and the rival has not", () => {
+/**
+ * The duel pull-back (#1077), re-described by #1177.
+ *
+ * #1077 wrote these cases for the ordinary cast, and the ordinary cast no longer
+ * reaches this button: since #1080/ADR-0059 a cast duel side derives `waiting`
+ * and the archetype swaps in `PraxisWaitingSurface` (#1189), which carries the
+ * pull-back itself. The rule did not move — the *surface* did.
+ *
+ * What still reaches this button is the MODERATED composer.
+ * `deriveEditPraxisPhase` tests `moderation_status` before its duel branch and
+ * returns `composing` for `failed`, and moderation never touches `status`, so a
+ * duel side whose entry a moderator failed is still `submitted` with a live duel
+ * and no waiting surface. These cases now assert that state, because it is the
+ * one a player can actually be in. `expectComposerMounts` is what keeps them
+ * honest about it.
+ */
+describe("PublishButton — duel pull-back on the moderated composer (#1077, #1177)", () => {
+  it("offers a neutral pull-back on a failed entry while the rival has not cast", () => {
     const publish = vi.fn(async () => {});
     const pullBack = vi.fn(async () => {});
     const requestDuelSeal = vi.fn();
-    const el = renderButton(
-      duelState("active", { publish, pullBack, requestDuelSeal }),
-    );
+    const state = duelState("active", {
+      moderationStatus: "failed",
+      publish,
+      pullBack,
+      requestDuelSeal,
+    });
+    expectComposerMounts(state);
+    const el = renderButton(state);
 
     expect(renderToStaticMarkup(el)).toContain(
       collabCopy(null, "duelPullBackAction"),
@@ -212,21 +283,39 @@ describe("PublishButton — duel pull-back before the duel settles (#1077)", () 
   });
 
   it("says nothing about forfeit — that only begins at settled (ADR-0011)", () => {
-    const html = renderToStaticMarkup(renderButton(duelState("active")));
+    const html = renderToStaticMarkup(
+      renderButton(duelState("active", { moderationStatus: "failed" })),
+    );
     expect(html).not.toMatch(/forfeit|discard|wins/i);
   });
 
-  // Cast before the rival even accepted: the same trap (author-only entry, no
-  // way back in) and the same free reopen, since the duel has not settled.
+  // Failed before the rival even accepted: the same free reopen, since the duel
+  // still has not settled.
   it("offers the same pull-back on a duel still awaiting acceptance", () => {
     const pullBack = vi.fn(async () => {});
-    const el = renderButton(duelState("pending", { pullBack }));
+    const state = duelState("pending", {
+      moderationStatus: "failed",
+      pullBack,
+    });
+    expectComposerMounts(state);
+    const el = renderButton(state);
 
     expect(renderToStaticMarkup(el)).toContain(
       collabCopy(null, "duelPullBackAction"),
     );
     el.props.onClick();
     expect(pullBack).toHaveBeenCalledTimes(1);
+  });
+
+  // The other half of #1177's answer: the branch is not dead, but it is not the
+  // ordinary path either. An unmoderated cast derives a waiting stage, so the
+  // archetype never builds this footer — delete the branch and THIS is the case
+  // that keeps working, which is why the deletion looked safe.
+  it("is not the ordinary cast's surface — that one derives a waiting stage", () => {
+    const ordinary = duelState("active");
+    expect(deriveEditPraxisPhase(ordinary.praxis, ordinary.duel, 1)).toBe(
+      "waiting",
+    );
   });
 
   // Both sides cast → the duel settles, and from there unsubmitting IS a

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -912,20 +912,41 @@ export function PublishButton({
   skin: PublishButtonSkin;
 }) {
   const praxis = state.praxis;
-  // The one published state that keeps its footer button (#1077). A duel side
-  // that casts goes straight to `submitted` while the duel is still unsettled —
-  // `active` (accepted, and the rival has not answered, because a second cast
-  // settles it: `maybe_settle_duel`) or `pending` (cast before the rival even
-  // accepted). Both are the same trap: the entry is author-only until the duel
-  // completes (#999), the composer is locked, and there is no way back into it.
+  // The one published state that keeps its footer button (#1077) — but NOT for
+  // the reason #1077 wrote it, and #1177 is the record of that. DO NOT DELETE
+  // THIS BRANCH as unreachable; read the next three paragraphs first.
   //
-  // Pulling back from either is a free, neutral reopen. `unsubmit_praxis` marks
-  // a forfeit only for a *settled* duel (ADR-0011 §Forfeit), so the praxis just
-  // returns to `in_progress` with `forfeited_by_character_id` still NULL and the
-  // duel untouched — the promise the seal dialog already made on the way in
-  // (`duelSeal.reopenNote`). Listed, not negated: `settled`/`resolved` are where
-  // forfeit begins and belong to the detail page, and a `declined` challenge
-  // leaves an ordinary published solo praxis, which stays unpublishable-back.
+  // What no longer reaches here: the ORDINARY cast. A duel side that casts goes
+  // to `submitted` while the duel is still unsettled, and since #1080/ADR-0059
+  // that derives `waiting`, so every archetype swaps in `PraxisWaitingSurface`
+  // (#1189 moved that swap into the archetypes) before this footer is built. The
+  // waiting surface carries the pull-back itself, through the same
+  // `duelPullBackAction` key and the same `pullBack()`.
+  //
+  // What DOES reach here: the MODERATED composer. `deriveEditPraxisPhase` tests
+  // `moderation_status` BEFORE its duel and collab branches and returns
+  // `composing` for `hidden`/`failed` — deliberately, because a cheerful "your
+  // part is submitted" over a failed praxis would be a lie. Moderation never
+  // touches `status` (`update_praxis_moderation` sets only the moderation
+  // fields), so such a praxis is still `submitted` and `isPublished` is still
+  // true. `hidden` never mounts at all — `can_view_praxis` 404s it for everyone
+  // including the author — which leaves `failed` as the live case: a duel side
+  // whose entry a moderator failed while the duel is `active` or `pending`.
+  //
+  // That is the case most worth serving, not least. The waiting surface refuses
+  // to render, the composer is locked, and this button is the way back into the
+  // text the author was just told to fix. Pulling back stays free and neutral:
+  // `unsubmit_praxis` marks a forfeit only for a *settled* duel (ADR-0011
+  // §Forfeit), so the praxis returns to `in_progress` with
+  // `forfeited_by_character_id` still NULL and the duel untouched — the promise
+  // the seal dialog made on the way in (`duelSeal.reopenNote`). Listed, not
+  // negated: `settled`/`resolved` are where forfeit begins and belong to the
+  // detail page, and a `declined` challenge leaves an ordinary published solo
+  // praxis, which stays unpublishable-back.
+  //
+  // The `collab?.iCast` route below survives by the identical mechanism — a
+  // `failed` multi-member collab also short-circuits to `composing` — so the two
+  // halves live or die together. Both are covered in `PublishButton.test.tsx`.
   const duelPullBack =
     state.isPublished &&
     state.duelMode &&


### PR DESCRIPTION
Closes #1177

**The issue's own conclusion was wrong, and this PR corrects it rather than silently contradicting it.** #1177 says `PublishButton`'s duel pull-back branch is dead code and asks for its deletion. The branch is reachable. So this ships the documentation and test changes that make the branch's *actual* remaining job legible, and deletes nothing.

## Why not delete

#1177's premise holds for the path it describes. Since #1080/ADR-0059 an ordinary cast duel side derives `waiting`, and #1189 moved the stage swap into each archetype, so `PraxisWaitingSurface` replaces the composer before the footer is ever built — and it carries the pull-back itself, via the same `duelPullBackAction` key and the same `pullBack()`. That path is genuinely gone.

But `deriveEditPraxisPhase` tests `moderation_status` **before** its duel and collab branches and returns `composing` for `hidden`/`failed` — deliberately, per its own docstring, because a cheerful "your part is submitted" over a failed praxis would be a lie. `update_praxis_moderation` sets only the moderation fields, so `status` stays `submitted` and `isPublished` stays true. `hidden` never mounts (`can_view_praxis` 404s it for everyone, author included), which leaves the live case:

> **a duel side whose entry a moderator marked `failed` while the duel is still `active`/`pending`.**

That state gets the locked composer, no waiting surface, and this button as its way back into the text it was just told to fix. Deleting the branch would remove the reopen from the surface the player actually lands on when they open `/edit` — a real, if small, behaviour change shipped under a cleanup framing. That is the wrong call regardless of whether the change is defensible on its own merits; if we later decide the detail page should be the only reopen for a failed duel side, that is its own issue with its own framing.

The finding also makes the branch *more* worth keeping than #1177 assumed: the moderated composer is exactly the case where a waiting surface would lie, and exactly the case where the player needs a way out.

**The collab half answers the same way, separately.** `collab?.iCast` was also written for the ordinary cast (which now derives `waiting`) and also survives on the moderated composer, by the identical short-circuit. The two halves live or die together.

## What changed

- `frontend/src/pages/editPraxis/archetypes/controls.tsx` — the comment above `duelPullBack` rewritten. It now names `moderation_status = 'failed'`, the moderation short-circuit that causes it, and what took the ordinary phase, with a "DO NOT DELETE" pointing at #1177. Comment only; no logic touched.
- `frontend/src/pages/editPraxis/archetypes/__tests__/PublishButton.test.tsx` — the `active`/`pending` pull-back cases re-aimed at the moderated composer, for the duel and the collab alike. New `expectComposerMounts` helper derives the phase from the same fixture, so a case can no longer assert what the button draws in a state no player can reach. Two new cases pin the ordinary paths to `waiting`, putting the difference on the record. The `settled` / `resolved` / plain-published-solo "renders nothing" cases are untouched — they stay valid either way.

## Verified vs. assumed

**Verified by execution:**
- `deriveEditPraxisPhase` → `composing` for a `failed` duel side with a live duel, and → `waiting` for the same fixture unmoderated. Both are now assertions in the suite, not a one-off probe.
- `PublishButton` renders `duelPullBackAction` when fed the hook's own derived `isPublished`/`duelMode` for that data.
- Same for the collab `iCast` route.
- `tsc --noEmit` clean · full vitest **139 files / 2374 tests passed** · `eslint` clean on both files · `vite build` succeeds. (`tsc --version` confirmed at 5.9.3 first, so this is not the absent-binary false pass.)

**Verified by reading, not running:** `update_praxis_moderation` leaves `status` alone; `can_view_praxis` 404s `hidden`; `unsubmit_praxis` forfeits only at `settled`, so the reopen really is free here; all 8 archetypes early-return the waiting surface before their footer and none gates the footer on moderation; `flagged` is not in the composing set, so a flagged duel side does reach the waiting surface.

**Assumed, deliberately not chased** (verifying either is scope creep on a documentation fix): that an admin can in practice set `failed` on a duel side — I read the moderation service, not the route guard end-to-end; and that the praxis detail page renders end-to-end for a `failed` praxis, which is what makes `PraxisSubmitControls`' `duelLive` unsubmit a genuine second path rather than a theoretical one.

## What to eyeball

- The rewritten comment in `controls.tsx` — it is the whole point of the PR. It is what stops the next reader deleting the branch in three months, so it should read as convincing to someone who has not seen this thread.
- Whether "keep + re-document" is the call you want, versus deleting the branch under a separate behaviour-change issue. The reasoning above is the argument for keeping; the counter-argument is that `PraxisSubmitControls` already offers the same neutral reopen on the detail page (`unsubmitCase` → `duelLive`), so a failed duel side is not stranded site-wide.
- Test naming — I renamed the duel `describe` to "duel pull-back on the moderated composer (#1077, #1177)". If you would rather the issue numbers stayed out of test names, say so.

**Visual QA is outstanding.** There is no dev stack here and I cannot screenshot, so nothing was checked in a browser. Being a comment-and-test change with no logic or style touched, there should be nothing to see — but that is an argument, not an observation.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
