### PR TITLE
F2: the faction feed frame becomes a chassis — archive UX, Archived tab, neutral copy

### DIFF
--- a/frontend/src/api/activityFeed.ts
+++ b/frontend/src/api/activityFeed.ts
@@ -2,6 +2,16 @@ import api from './axios'
 
 export interface ActivityFeedItem {
   type: string
+  /**
+   * Stable identity for the archive (#1193): `"{type}:{source row PK}"`, e.g.
+   * `collab_invite:42`. A feed item is a UNION over 15 source tables and owns no
+   * row of its own, so this is the ONLY handle the archive can name.
+   *
+   * The type prefix is load-bearing, not decoration: three types are built from
+   * the same `praxis_member` row and two from the same `praxis` row, so a bare
+   * PK would collide and archiving one card would silently archive another.
+   */
+  item_key: string
   timestamp: string
   actor_display_name: string | null
   actor_faction_slug: string | null
@@ -27,11 +37,70 @@ export interface ActivityFeedResponse {
   next_cursor: string | null
 }
 
+/** Result of archiving/restoring one item. `archived` is the state AFTER the
+ *  call (both endpoints are idempotent); `changed` says whether a row moved. */
+export interface FeedItemArchiveResult {
+  item_key: string
+  archived: boolean
+  changed: boolean
+}
+
+/** Result of a bulk archive/restore — how many items moved. */
+export interface FeedBulkArchiveResult {
+  count: number
+  archived: boolean
+}
+
 export async function getActivityFeed(params?: {
   filter?: string
   before?: string
   limit?: number
+  /** Read the archive instead of the live feed. Crossed WITH `filter`, never a
+   *  member of it: archived-ness is state, the filter is a type-set. */
+  archived?: boolean
 }): Promise<ActivityFeedResponse> {
   const { data } = await api.get<ActivityFeedResponse>('/activity-feed', { params })
+  return data
+}
+
+/**
+ * Put one feed item in the archive. 400 when the key is unknown, malformed, or
+ * names an `awaiting_submission` row — that type is state, not an event, and the
+ * backend refuses it. The UI must therefore not offer the control on that card
+ * at all (hide unusable controls; never render them disabled).
+ */
+export async function dismissFeedItem(itemKey: string): Promise<FeedItemArchiveResult> {
+  const { data } = await api.post<FeedItemArchiveResult>('/activity-feed/dismiss', {
+    item_key: itemKey,
+  })
+  return data
+}
+
+/** Take one feed item back out of the archive. */
+export async function restoreFeedItem(itemKey: string): Promise<FeedItemArchiveResult> {
+  const { data } = await api.post<FeedItemArchiveResult>('/activity-feed/restore', {
+    item_key: itemKey,
+  })
+  return data
+}
+
+/**
+ * Archive everything the given filter currently returns. One call — the server
+ * re-runs the feed for that filter, so the scope can never drift from what the
+ * tab shows. `awaiting_submission` rows are SKIPPED, not refused.
+ */
+export async function dismissAllFeedItems(filter?: string): Promise<FeedBulkArchiveResult> {
+  const { data } = await api.post<FeedBulkArchiveResult>('/activity-feed/dismiss-all', {
+    filter: filter ?? null,
+  })
+  return data
+}
+
+/** Empty the archive (no filter = everything, which is what "Restore all" means
+ *  on the Archived tab — the archived view has no tabs of its own). */
+export async function restoreAllFeedItems(filter?: string): Promise<FeedBulkArchiveResult> {
+  const { data } = await api.post<FeedBulkArchiveResult>('/activity-feed/restore-all', {
+    filter: filter ?? null,
+  })
   return data
 }

--- a/frontend/src/components/__tests__/factionFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/factionFeedFrame.test.tsx
@@ -28,9 +28,18 @@ const DESIGNED_FACTIONS = [
   "ua",
 ];
 
-function frameFor(slug: string | null): string {
+/** The widened chassis contract (#1194): every frame draws these four. */
+function frameFor(slug: string | null, tag: string | null = null): string {
   return renderToStaticMarkup(
-    <FactionFeedFrame slug={slug}>{CARD}</FactionFeedFrame>,
+    <FactionFeedFrame
+      slug={slug}
+      kicker="Task completed"
+      time="2h ago"
+      tag={tag}
+      archive={<button type="button">archive-node</button>}
+    >
+      {CARD}
+    </FactionFeedFrame>,
   );
 }
 
@@ -58,10 +67,16 @@ describe("FactionFeedFrame dispatch", () => {
     expect(frameFor("albescent")).toBe(frameFor("no-such-faction"));
   });
 
-  it("passes a null/neutral slug straight through", () => {
-    // era_announcement and friends bring their own chrome — a null slug must be
-    // a true passthrough, adding no wrapper at all.
-    expect(frameFor(null)).toBe("<span>card-body</span>");
+  it("gives a null/neutral slug the Unaffiliated chassis, NOT a passthrough (#1194)", () => {
+    // The reverse of what this used to assert, deliberately. A null slug used to
+    // pass straight through because the only card carrying one was
+    // era_announcement, which brings its own chrome — and that card no longer
+    // routes through here at all (epic #1192 decision 6). A passthrough now would
+    // mean a card with no kicker, no time and no way to be dismissed.
+    const html = frameFor(null);
+    expect(html).not.toBe("<span>card-body</span>");
+    expect(html).toContain("<span>card-body</span>");
+    expect(html).toContain("card-bg");
   });
 
   it("tints an unregistered slug with the default frame, keeping the card", () => {
@@ -71,5 +86,19 @@ describe("FactionFeedFrame dispatch", () => {
     expect(html).not.toBe("<span>card-body</span>");
     expect(html).toContain("<span>card-body</span>");
     expect(html).toContain("card-bg");
+  });
+
+  it("draws all four chrome slots on EVERY frame, default included (#1194)", () => {
+    // A frame that swallows one of these loses a feature, not a decoration: the
+    // kicker is the card's only kind label, the time is its only timestamp (the
+    // row stopped drawing one), and the archive node is the entire keyboard and
+    // screen-reader route to the archive.
+    for (const slug of [...DESIGNED_FACTIONS, "wow", "albescent", null]) {
+      const html = frameFor(slug, "Still waiting");
+      expect(html, `${slug} draws the kicker`).toContain("Task completed");
+      expect(html, `${slug} draws the time`).toContain("2h ago");
+      expect(html, `${slug} draws the tag`).toContain("Still waiting");
+      expect(html, `${slug} places the archive node`).toContain("archive-node");
+    }
   });
 });

--- a/frontend/src/components/__tests__/feedChassis.test.tsx
+++ b/frontend/src/components/__tests__/feedChassis.test.tsx
@@ -1,0 +1,314 @@
+/**
+ * THE CHASSIS AND THE ARCHIVE (F2, #1194).
+ *
+ * The acceptance criteria of the load-bearing frontend issue of epic #1192,
+ * each pinned by name. The harness is `renderToStaticMarkup` — no DOM, so no
+ * effect runs and no pointer event fires. What that can prove is exactly what
+ * matters most here and cannot be checked any other way: WHICH CONTROLS EXIST on
+ * which card. The six-second timer and the swipe gesture are asserted at their
+ * seams (the strip's two label phases, the commit fraction) rather than driven.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../i18n'
+import i18n from '../../i18n'
+import FeedCardRouter from '../feed/FeedCardRouter'
+import FeedUndoStrip from '../feed/FeedUndoStrip'
+import FeedBulkArchiveButton from '../feed/FeedBulkArchiveButton'
+import { feedKicker, isArchivable, NON_ARCHIVABLE_TYPES } from '../feed/feedItemLabels'
+import { normalizeFeedItem } from '../feed/normalizeFeedItem'
+import feedCatalog from '../../locales/en/feed.json'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+
+/** Every type the backend emits (#1193 seeds one of each in its fixture). */
+const ALL_FEED_TYPES = [
+  'friend_completion',
+  'foe_completion',
+  'vote_on_mine',
+  'foe_taunt',
+  'friend_signup',
+  'friend_defection',
+  'global_task',
+  'collaborator_submitted',
+  'awaiting_submission',
+  'nudge',
+  'era_announcement',
+  'invitation_letter',
+  'duel_challenge',
+  'collab_invite',
+  'comment_mention',
+]
+
+function item(
+  type: string,
+  payload: Record<string, unknown> = {},
+  slug: string | null = 'coven',
+): ActivityFeedItem {
+  return {
+    type,
+    item_key: `${type}:1`,
+    timestamp: '2026-01-01T00:00:00Z',
+    actor_display_name: 'Ada',
+    actor_faction_slug: slug,
+    actor_avatar_url: null,
+    payload,
+    context_faction_slug: slug,
+  }
+}
+
+function render(feedItem: ActivityFeedItem, archivedView = false): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <FeedCardRouter item={feedItem} archivedView={archivedView} />
+    </MemoryRouter>,
+  )
+}
+
+const ARCHIVE_LABEL = i18n.t('feed:archive.dismissLabel')
+const RESTORE_LABEL = i18n.t('feed:archive.restoreLabel')
+
+/** A payload rich enough for whichever type is asking. */
+const FAT_PAYLOAD = {
+  character_id: 3,
+  praxis_id: 7,
+  task_id: 9,
+  task_title: 'Reforest the verge',
+  task_point_value: 40,
+  task_level_required: 2,
+  points_earned: 12,
+  praxis_title: 'A returned proof',
+  praxis_type: 'collab',
+  from_character_id: 4,
+  from_name: 'Ada',
+  to_name: 'Bo',
+  faction_slug: 'coven',
+  old_faction_slug: 'coven',
+  new_faction_slug: 'snide',
+  era_name: 'Era One',
+  duel_id: 5,
+  challenger_praxis_id: 6,
+  challenger_character_id: 3,
+  invite_id: 8,
+  inviter_character_id: 3,
+  task_faction_slug: 'coven',
+}
+
+describe('the archive control: which cards offer one', () => {
+  it('draws an archive control on every archivable type', () => {
+    for (const type of ALL_FEED_TYPES) {
+      if (NON_ARCHIVABLE_TYPES.has(type)) continue
+      // comment_mention has no body until #1196 and renders nothing at all; it
+      // is not a card that lost its control.
+      if (type === 'comment_mention') continue
+      expect(render(item(type, FAT_PAYLOAD)), `${type} offers the ✕`).toContain(
+        ARCHIVE_LABEL,
+      )
+    }
+  })
+
+  it('draws NO archive control on awaiting_submission, and none disabled', () => {
+    // It is state, not an event: it exists exactly while `has_submitted` is
+    // false and clears itself the moment you file, so a dismissal would silence
+    // a standing obligation forever. The backend 400s on it. Repo convention is
+    // to hide a control the player cannot use — never to draw it disabled.
+    const html = render(item('awaiting_submission', FAT_PAYLOAD))
+    expect(html).not.toContain(ARCHIVE_LABEL)
+    expect(html).not.toContain(RESTORE_LABEL)
+    expect(html).not.toContain('disabled')
+    expect(isArchivable(item('awaiting_submission'))).toBe(false)
+  })
+
+  it('offers RESTORE, not archive, in the archived view', () => {
+    const html = render(item('friend_completion', FAT_PAYLOAD), true)
+    expect(html).toContain(RESTORE_LABEL)
+    expect(html).not.toContain(ARCHIVE_LABEL)
+  })
+})
+
+describe('the chassis', () => {
+  it('names every one of the 15 types with a real label, never a raw key', () => {
+    for (const type of ALL_FEED_TYPES) {
+      const kicker = feedKicker(type)
+      expect(kicker, type).not.toContain('feed:')
+      expect(kicker, type).not.toContain('kicker.')
+      expect(kicker.length, type).toBeGreaterThan(0)
+    }
+  })
+
+  it('draws the kicker and the timestamp once each, on the chassis', () => {
+    const html = render(item('friend_completion', FAT_PAYLOAD))
+    const kicker = feedKicker('friend_completion')
+    expect(html.split(kicker).length - 1, 'kicker drawn exactly once').toBe(1)
+    // The row stopped drawing its own time in #1194 — two timestamps on one card
+    // is what that removal fixed.
+    expect(html.split('ago').length - 1).toBeLessThanOrEqual(1)
+  })
+
+  it('puts the three interactive companions INSIDE the chassis, handlers intact', () => {
+    // Epic decision 9. `FeedCardRouter` used to warn that these own real
+    // accept/decline handlers that "must NOT collapse into slots"; the chassis
+    // takes arbitrary children, so this was a strip-the-wrapper refactor.
+    const duel = render(item('duel_challenge', FAT_PAYLOAD))
+    expect(duel, 'chassis kicker').toContain(feedKicker('duel_challenge'))
+    expect(duel, 'accept survives').toContain(i18n.t('feed:duelChallenge.accept'))
+    expect(duel, 'decline survives').toContain(i18n.t('feed:duelChallenge.decline'))
+
+    const collab = render(item('collab_invite', FAT_PAYLOAD))
+    expect(collab).toContain(feedKicker('collab_invite'))
+    expect(collab, 'accept survives').toContain(i18n.t('feed:collabInvite.accept'))
+    expect(collab, 'decline survives').toContain(i18n.t('feed:collabInvite.decline'))
+
+    const letter = render(item('invitation_letter', FAT_PAYLOAD))
+    expect(letter).toContain(feedKicker('invitation_letter'))
+    expect(letter, 'the letter keeps its way out').toContain(
+      i18n.t('feed:invitationLetter.viewFactions'),
+    )
+  })
+
+  it('leaves era_announcement OUTSIDE the chassis, with only the ✕ added', () => {
+    // Epic decision 6: it is the one factionless type and must stay that way. An
+    // era turn can strip a player of their faction, so speaking that card in
+    // their faction's voice is exactly backwards.
+    const html = render(item('era_announcement', FAT_PAYLOAD, null))
+    expect(html, 'keeps its own always-dark chrome').toContain('--badge-admin-bg')
+    // The chassis's own tint and accent rule. Asserted on the tokens rather than
+    // on the kicker's WORD, because the card's own copy says "Era Announcement"
+    // and "Era Archive" — the word proves nothing here, the chrome does.
+    expect(html, 'no chassis tint').not.toContain('card-bg')
+    expect(html, 'no chassis accent rule').not.toContain('card-accent')
+    expect(html, 'gains the ✕').toContain(ARCHIVE_LABEL)
+  })
+
+  it('renders nothing for a type with no body yet (comment_mention, until #1196)', () => {
+    expect(render(item('comment_mention', FAT_PAYLOAD))).toBe('')
+  })
+})
+
+describe('archiving never answers anything (ADR-0066)', () => {
+  const stillWaiting = i18n.t('feed:archive.stillWaiting')
+
+  it('tags an archived duel challenge and collab invite "still waiting"', () => {
+    expect(render(item('duel_challenge', FAT_PAYLOAD), true)).toContain(stillWaiting)
+    expect(render(item('collab_invite', FAT_PAYLOAD), true)).toContain(stillWaiting)
+  })
+
+  it('does not tag them in the live feed — their own buttons say it there', () => {
+    expect(render(item('duel_challenge', FAT_PAYLOAD))).not.toContain(stillWaiting)
+  })
+
+  it('does not tag a plain event, archived or not', () => {
+    expect(render(item('friend_completion', FAT_PAYLOAD), true)).not.toContain(
+      stillWaiting,
+    )
+  })
+})
+
+describe('the undo strip degrades rather than vanishing', () => {
+  const strip = (phase: 'undo' | 'expired', actionLabel: string) =>
+    renderToStaticMarkup(
+      <FeedUndoStrip
+        message={i18n.t('feed:archive.archived', { title: 'Reforest the verge' })}
+        actionLabel={actionLabel}
+        phase={phase}
+        onAct={() => {}}
+        error={null}
+      />,
+    )
+
+  it('reads Archived "{title}" with Undo inside the window', () => {
+    const html = strip('undo', i18n.t('feed:archive.undo'))
+    expect(html).toContain('Reforest the verge')
+    expect(html).toContain(i18n.t('feed:archive.undo'))
+  })
+
+  it('offers Restore once the window has lapsed, still standing in the slot', () => {
+    // The sheet degrades the slot instead of collapsing it, which keeps the list
+    // stable for a reader who looked away.
+    const html = strip('expired', i18n.t('feed:archive.restore'))
+    expect(html).toContain('Reforest the verge')
+    expect(html).toContain(i18n.t('feed:archive.restore'))
+    expect(html).toContain('data-feed-undo-strip="expired"')
+  })
+
+  it('shows an error in place of the message when the reversal fails', () => {
+    const html = renderToStaticMarkup(
+      <FeedUndoStrip
+        message="Archived “x”"
+        actionLabel="Undo"
+        phase="undo"
+        onAct={() => {}}
+        error="Couldn't restore that update."
+      />,
+    )
+    // The apostrophe comes back HTML-escaped, so match the unambiguous tail.
+    expect(html).toContain('restore that update.')
+    expect(html).not.toContain('Archived')
+  })
+})
+
+describe('the bulk controls', () => {
+  const bulk = (archivedView: boolean) =>
+    renderToStaticMarkup(
+      <FeedBulkArchiveButton archivedView={archivedView} onAct={() => {}} pending={false} />,
+    )
+
+  it('is Archive all on the feed and Restore all in the archive', () => {
+    expect(bulk(false)).toContain(i18n.t('feed:archive.archiveAll'))
+    expect(bulk(true)).toContain(i18n.t('feed:archive.restoreAll'))
+  })
+
+  it('draws them at different weights — a pill vs an underlined text button', () => {
+    expect(bulk(false)).toContain('border-radius:999px')
+    expect(bulk(true)).toContain('text-decoration:underline')
+  })
+})
+
+describe('the row action slot (epic §2b)', () => {
+  it('offers File it AND Drop out on a collab awaiting submission', () => {
+    const row = normalizeFeedItem(
+      item('awaiting_submission', { praxis_id: 7, praxis_type: 'collab', task_title: 'x' }),
+    )!
+    expect(row.actions.map((action) => action.id)).toEqual(['fileIt', 'dropOut'])
+  })
+
+  it('offers only File it on a DUEL side — leave_praxis refuses any other type', () => {
+    // `leave_praxis` opens with "Only collab memberships can be left.", so on a
+    // duel side "Drop out" could only ever 400. Hide it there.
+    const row = normalizeFeedItem(
+      item('awaiting_submission', { praxis_id: 7, praxis_type: 'duel', task_title: 'x' }),
+    )!
+    expect(row.actions.map((action) => action.id)).toEqual(['fileIt'])
+  })
+
+  it('renders the CTAs inside the card', () => {
+    const html = render(
+      item('awaiting_submission', { praxis_id: 7, praxis_type: 'collab', task_title: 'x' }),
+    )
+    expect(html).toContain(i18n.t('feed:rowAction.fileIt'))
+    expect(html).toContain(i18n.t('feed:rowAction.dropOut'))
+  })
+
+  it('builds no action a payload cannot address', () => {
+    const row = normalizeFeedItem(item('awaiting_submission', { task_title: 'x' }))!
+    expect(row.actions).toEqual([])
+  })
+})
+
+describe('the copy is neutral: no faction sheet dialect ships', () => {
+  it('carries none of the eight sheets\' archive verbs', () => {
+    // The sheets are written in gorgeous per-faction dialect and NONE of it
+    // ships (epic #1192, the rule governing every child issue). Faction identity
+    // is carried by the skin, not the words.
+    const catalog = JSON.stringify(feedCatalog)
+    for (const dialect of ['Tuck away', 'Bin it', 'Spike it', 'rm --event', 'Shelve']) {
+      expect(catalog, `${dialect} must not ship`).not.toContain(dialect)
+    }
+  })
+
+  it('says Archive, Restore and Undo in the domain\'s own plain nouns', () => {
+    expect(i18n.t('feed:archive.dismiss')).toBe('Archive')
+    expect(i18n.t('feed:archive.restore')).toBe('Restore')
+    expect(i18n.t('feed:archive.undo')).toBe('Undo')
+  })
+})

--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -16,6 +16,8 @@ import { collabCopy } from '../collab/collabCopy'
 function item(type: string, payload: Record<string, unknown>): ActivityFeedItem {
   return {
     type,
+    // `"{type}:{source row PK}"` (#1193) — the archive's only handle on an item.
+    item_key: `${type}:1`,
     timestamp: '2026-01-01T00:00:00Z',
     actor_display_name: 'Ada',
     actor_faction_slug: 'coven',

--- a/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
+++ b/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
@@ -101,7 +101,14 @@ const taskCard = () =>
       onSignup={() => {}}
     />,
   )
-const feedRow = () => routed(<UaFeedFrame><span>card-body</span></UaFeedFrame>)
+// #1194 widened the chassis contract: a frame carries the kicker, the time, an
+// optional tag and the archive node alongside its children.
+const feedRow = () =>
+  routed(
+    <UaFeedFrame kicker="Task completed" time="2h ago" tag={null} archive={null}>
+      <span>card-body</span>
+    </UaFeedFrame>,
+  )
 const comment = () =>
   routed(<UaComment mode="row" comment={COMMENT} />)
 const composer = () =>

--- a/frontend/src/components/feed/CovenFeedFrame.tsx
+++ b/frontend/src/components/feed/CovenFeedFrame.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react'
-
 import i18n from '../../i18n'
+import FeedChassisBand from './FeedChassisBand'
+import type { FeedFrameProps } from './feedFrameProps'
 
 /**
  * Cozy Coven feed frame — the neutral feed card dressed as a tiny
@@ -8,6 +8,11 @@ import i18n from '../../i18n'
  * window name + a sparkle charm) sits above a notepad/paper body that holds the
  * untouched card `{children}`. Frame-level chrome only: this is a thin wrapper,
  * not a reimplementation of the card. Flips with the theme via the Coven tokens.
+ *
+ * #1194: the title bar is now also the CHASSIS BAND — the window name keeps its
+ * place and the kicker, the tag, the time and the dismiss control ride the same
+ * strip, tinted by the bar's own title ink. The look is unchanged otherwise;
+ * Coven's dress issue restyles it.
  */
 
 const WIN_BORDER = 'var(--faction-coven-win-border)'
@@ -31,7 +36,7 @@ function Sparkle({ size }: { size: number }) {
   )
 }
 
-export default function CovenFeedFrame({ children }: { children: ReactNode }) {
+export default function CovenFeedFrame({ kicker, time, tag, archive, children }: FeedFrameProps) {
   return (
     <div
       style={{
@@ -72,9 +77,9 @@ export default function CovenFeedFrame({ children }: { children: ReactNode }) {
         ))}
         <span
           style={{
-            marginLeft: 'auto',
             display: 'inline-flex',
             alignItems: 'center',
+            flexShrink: 0,
             // eslint-disable-next-line local/no-raw-style-values -- ornament: lead between the hand-lettered window title and its sparkle.
             gap: 6,
             fontFamily: SCRIPT,
@@ -86,6 +91,11 @@ export default function CovenFeedFrame({ children }: { children: ReactNode }) {
           {i18n.t('feed:identity.coven.windowTitle')}
           <Sparkle size={12} />
         </span>
+
+        {/* chassis band — rides the title bar, inked with the window title */}
+        <div style={{ flex: 1, minWidth: 0, color: TITLE_TEXT }}>
+          <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
+        </div>
       </div>
 
       {/* notepad/paper body — holds the neutral card, untouched */}

--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react'
-
 import { EphemeristsSigil, Foxing } from '../cards/ephemeristsAtoms'
+import FeedChassisBand from './FeedChassisBand'
+import type { FeedFrameProps } from './feedFrameProps'
 
 /**
  * Ephemerists feed-card FRAME (surface #12, SPEC-faction-ui-profile.md).
@@ -8,12 +8,22 @@ import { EphemeristsSigil, Foxing } from '../cards/ephemeristsAtoms'
  * A thin presentational wrapper that dresses the neutral feed card (`children`)
  * as a leaf torn from the faction's ephemeris: foxed-vellum stock, an iron-gall
  * ink hairline, a gold-ruled running edge, and a rubric marginal sigil. The card
- * internals (avatar / actor / badge / time) are untouched — they arrive via
+ * internals (avatar / actor / badge) are untouched — they arrive via
  * `{children}` and render in the content area.
+ *
+ * #1194: the leaf gains a CHASSIS BAND above the content — a ruled running head
+ * carrying the kicker, the tag, the time and the dismiss control in iron-gall
+ * ink. The stock is otherwise unchanged; Ephemerists' dress issue restyles it.
  *
  * Theme-aware through the --eph-* cascade; no document-theme mutation, no hex.
  */
-export default function EphemeristsFeedFrame({ children }: { children: ReactNode }) {
+export default function EphemeristsFeedFrame({
+  kicker,
+  time,
+  tag,
+  archive,
+  children,
+}: FeedFrameProps) {
   return (
     <div
       style={{
@@ -45,6 +55,21 @@ export default function EphemeristsFeedFrame({ children }: { children: ReactNode
         }}
       >
         <EphemeristsSigil size={12} color="var(--eph-rubric)" stroke={1.2} />
+      </div>
+
+      {/* chassis band — the leaf's running head, ruled off the content */}
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 2,
+          color: 'var(--eph-vellum-text)',
+          borderBottom:
+            '1px solid color-mix(in srgb, var(--eph-vellum-text) 22%, transparent)',
+          paddingBottom: 'var(--space-xs)',
+          marginBottom: 'var(--space-sm)',
+        }}
+      >
+        <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
       </div>
 
       {/* the neutral feed card, rendered in the content area */}

--- a/frontend/src/components/feed/EverymenFeedFrame.tsx
+++ b/frontend/src/components/feed/EverymenFeedFrame.tsx
@@ -5,15 +5,26 @@
  * skins the neutral feed card (`children`) in the Everymen physical archetype —
  * a red masthead spine on the left edge, manila paper stock with a screen-print
  * halftone wash, and an inked border with gold trim. It does NOT reimplement the
- * card internals (avatar/actor/badge/time/task-ref) — those arrive via
- * `{children}` and render untouched in the content area.
+ * card internals (avatar/actor/badge/task-ref) — those arrive via `{children}`
+ * and render untouched in the content area.
+ *
+ * #1194: the slip gains a CHASSIS BAND at the head of the content area — a ruled
+ * dispatch line carrying the kicker, the tag, the time and the dismiss control in
+ * paper ink. The stock is otherwise unchanged; Everymen's dress issue restyles it.
  *
  * Theme-aware via everymen.css tokens (light + dark both defined); no document
  * theme mutation. Visual intent from design-system/templates/everymen.
  */
-import type { ReactNode } from 'react'
+import FeedChassisBand from './FeedChassisBand'
+import type { FeedFrameProps } from './feedFrameProps'
 
-export default function EverymenFeedFrame({ children }: { children: ReactNode }) {
+export default function EverymenFeedFrame({
+  kicker,
+  time,
+  tag,
+  archive,
+  children,
+}: FeedFrameProps) {
   return (
     <article
       style={{
@@ -91,6 +102,20 @@ export default function EverymenFeedFrame({ children }: { children: ReactNode })
             backgroundSize: '5px 5px',
           }}
         />
+
+        {/* chassis band — the dispatch line at the head of the slip */}
+        <div
+          style={{
+            position: 'relative',
+            zIndex: 2,
+            color: 'var(--everymen-paper-text)',
+            padding: 'var(--space-xs) var(--space-md) var(--space-xs) var(--space-lg)',
+            borderBottom:
+              '1px solid color-mix(in srgb, var(--everymen-paper-text) 22%, transparent)',
+          }}
+        >
+          <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
+        </div>
 
         {/* the neutral feed card, rendered above the chrome */}
         <div style={{ position: 'relative', zIndex: 2 }}>{children}</div>

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -15,6 +15,7 @@
 import { pickVariant } from '../../utils/factionDispatch'
 import { surfaceMap } from '../../factions'
 import { factionCssVar } from '../../utils/factions'
+import FeedChassisBand from './FeedChassisBand'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
@@ -49,33 +50,12 @@ function DefaultFeedFrame({ slug, kicker, time, tag, archive, children }: FeedFr
     >
       <div
         style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 'var(--space-sm)',
           padding: 'var(--space-xs) var(--space-md) var(--space-xs) var(--space-lg)',
           borderBottom: '1px solid var(--color-border)',
-          color: 'var(--color-text-tertiary)',
+          color: 'var(--color-text-secondary)',
         }}
       >
-        <span className="eyebrow" style={{ color: 'var(--color-text-secondary)' }}>
-          {kicker}
-        </span>
-        {tag && (
-          <span
-            className="eyebrow"
-            style={{
-              color: 'var(--color-text-tertiary)',
-              border: '1px solid var(--color-border-strong)',
-              padding: '0 var(--space-xs)',
-            }}
-          >
-            {tag}
-          </span>
-        )}
-        <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--color-text-tertiary)' }}>
-          {time}
-        </span>
-        {archive}
+        <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
       </div>
       {children}
     </div>

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -1,27 +1,43 @@
 /**
- * Per-faction feed-card frame dispatch (surface #12, SPEC-faction-ui-profile.md).
+ * Per-faction feed-card CHASSIS dispatch (surface #12, SPEC-faction-ui-profile.md).
  *
- * The activity feed itself is neutral; each *card* themes to its faction. This is
- * the single seam where a faction's bespoke feed skin plugs in — wrap the
- * event-type card (FeedCardRouter) in the frame for `item.context_faction_slug`,
- * falling back to a neutral passthrough until design delivers an archetype.
+ * The activity feed itself is neutral; each *card* is drawn on its faction's own
+ * chassis. This is the single seam where a faction's bespoke feed skin plugs in:
+ * claim `feedFrame` in the faction's manifest and every card whose
+ * `context_faction_slug` is that faction adopts the skin with no other change.
  *
- * Wiring is ready ahead of the components: claim `feedFrame` in the faction's manifest
- * (e.g. `everymen: EverymenFeedFrame`) and that faction's feed cards adopt its
- * skin with no other change. Mirrors the `taskCard` / `backdrop` surfaces.
+ * #1194 WIDENED THE SEAM. A frame used to own only `{ children }`, so it could
+ * not draw the kicker band, the timestamp or the dismiss control — all three of
+ * which every design sheet puts on the chassis. The contract is now
+ * {@link FeedFrameProps}; read its docblock before writing a faction skin.
+ * Nothing may be written against the old `{ children }` shape.
  */
-import type { ReactNode } from 'react'
-
 import { pickVariant } from '../../utils/factionDispatch'
 import { surfaceMap } from '../../factions'
 import { factionCssVar } from '../../utils/factions'
+import type { FeedFrameProps } from './feedFrameProps'
 
-/** Neutral fallback. Owns the per-faction tint that the event cards used to
- *  hand-roll (card-bg fill + accent border), so a faction with a bespoke frame
- *  never double-skins. A null/neutral slug (e.g. era_announcement, which brings
- *  its own dark chrome) stays a true passthrough. */
-function DefaultFeedFrame({ slug, children }: { slug?: string | null; children: ReactNode }) {
-  if (!slug) return <>{children}</>
+/**
+ * The Unaffiliated chassis — and the default every unclaimed slug takes.
+ *
+ * `default ≡ na ≡ Unaffiliated` is ONE identity (ADR-0039 / 0046 / 0048), so
+ * this is not a placeholder standing in for a design: it IS the Unaffiliated
+ * skin, built to `Unaffiliated Comment + Update Cards`, and it is what every
+ * player sees until their faction's dress issue lands.
+ *
+ * A kicker band across the top — neutral kind label, optional status tag, the
+ * relative time, then the dismiss control — over a faction-tinted body. The tint
+ * is the generic `card-bg` fill + accent rule that the event cards used to
+ * hand-roll, so a faction with a bespoke frame never double-skins.
+ *
+ * A null / unaffiliated slug resolves to the `default` token family and gets the
+ * SAME chassis, not a passthrough. Before #1194 a null slug passed straight
+ * through, because the only card that carried one was `era_announcement`, which
+ * brings its own chrome. That card no longer routes through here at all — it
+ * keeps its neutral chrome deliberately (epic decision 6) — so a passthrough now
+ * would mean a card with no kicker, no time and no way to be dismissed.
+ */
+function DefaultFeedFrame({ slug, kicker, time, tag, archive, children }: FeedFrameProps & { slug?: string | null }) {
   return (
     <div
       className="sidebar-card"
@@ -31,21 +47,51 @@ function DefaultFeedFrame({ slug, children }: { slug?: string | null; children: 
         borderLeft: `4px solid ${factionCssVar(slug, 'card-accent')}`,
       }}
     >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-sm)',
+          padding: 'var(--space-xs) var(--space-md) var(--space-xs) var(--space-lg)',
+          borderBottom: '1px solid var(--color-border)',
+          color: 'var(--color-text-tertiary)',
+        }}
+      >
+        <span className="eyebrow" style={{ color: 'var(--color-text-secondary)' }}>
+          {kicker}
+        </span>
+        {tag && (
+          <span
+            className="eyebrow"
+            style={{
+              color: 'var(--color-text-tertiary)',
+              border: '1px solid var(--color-border-strong)',
+              padding: '0 var(--space-xs)',
+            }}
+          >
+            {tag}
+          </span>
+        )}
+        <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--color-text-tertiary)' }}>
+          {time}
+        </span>
+        {archive}
+      </div>
       {children}
     </div>
   )
 }
 
-interface Props {
+interface Props extends FeedFrameProps {
   slug: string | null | undefined
-  children: ReactNode
 }
 
-export default function FactionFeedFrame({ slug, children }: Props) {
+export default function FactionFeedFrame({ slug, ...frame }: Props) {
   const Frame = pickVariant(surfaceMap('feedFrame'), slug, DefaultFeedFrame)
-  // Only the default frame needs the slug (to tint); bespoke frames are slug-blind.
-  if (Frame === DefaultFeedFrame) return <DefaultFeedFrame slug={slug}>{children}</DefaultFeedFrame>
-  return <Frame>{children}</Frame>
+  // Only the default chassis needs the slug (to tint); bespoke skins are
+  // slug-blind — they ARE the faction, so there is nothing to dispatch on.
+  if (Frame === DefaultFeedFrame) return <DefaultFeedFrame slug={slug} {...frame} />
+  return <Frame {...frame} />
 }
 
 export { DefaultFeedFrame }

--- a/frontend/src/components/feed/FeedArchiveButton.tsx
+++ b/frontend/src/components/feed/FeedArchiveButton.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react'
+import i18n from '../../i18n'
+
+/**
+ * The chassis's dismiss / restore control (Unaffiliated sheet §2a).
+ *
+ * "Dismissing is a one-tap, no-confirm action" — so this is a plain button with
+ * no dialog behind it. It sits DORMANT at 40% opacity and comes up to full on
+ * hover **or focus**: the focus half is not decoration, it is the keyboard and
+ * screen-reader route to the archive, which swipe alone would not provide.
+ *
+ * Built once, centrally, and handed to every faction frame as a ready node
+ * (`FeedFrameProps.archive`) so eight skins share one accessible control instead
+ * of writing eight. It paints in `currentColor`; a frame tints it by setting
+ * `color` on whatever it places the node inside.
+ */
+export default function FeedArchiveButton({
+  onAct,
+  variant = 'archive',
+}: {
+  onAct: () => void
+  /** `archive` draws the ✕; `restore` draws the archive's take-it-back arrow. */
+  variant?: 'archive' | 'restore'
+}) {
+  const [lit, setLit] = useState(false)
+  const label = i18n.t(
+    variant === 'restore' ? 'feed:archive.restoreLabel' : 'feed:archive.dismissLabel',
+  )
+
+  return (
+    <button
+      type="button"
+      onClick={onAct}
+      onMouseEnter={() => setLit(true)}
+      onMouseLeave={() => setLit(false)}
+      onFocus={() => setLit(true)}
+      onBlur={() => setLit(false)}
+      aria-label={label}
+      title={label}
+      data-feed-archive={variant}
+      style={{
+        flexShrink: 0,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'transparent',
+        border: 'none',
+        padding: 'var(--space-xs)',
+        cursor: 'pointer',
+        color: 'currentColor',
+        fontFamily: "'Courier Prime', monospace",
+        fontSize: 'var(--text-base)',
+        lineHeight: 1,
+        opacity: lit ? 1 : 0.4,
+        transition: 'opacity 120ms',
+      }}
+    >
+      <span aria-hidden>{variant === 'restore' ? '↺' : '✕'}</span>
+    </button>
+  )
+}

--- a/frontend/src/components/feed/FeedBulkArchiveButton.tsx
+++ b/frontend/src/components/feed/FeedBulkArchiveButton.tsx
@@ -1,0 +1,48 @@
+import i18n from '../../i18n'
+
+/**
+ * `Archive all` and `Restore all` (Unaffiliated sheet §2a).
+ *
+ * Deliberately two different WEIGHTS, because the sheet draws them that way and
+ * they are not the same kind of act. Archiving is the thing the header offers, so
+ * it is a pill. Restoring everything undoes work the player chose to do, so it is
+ * an underlined text button that does not compete with the archive it sits above.
+ *
+ * Both are hidden when there is nothing to act on: an empty feed offers no
+ * "Archive all", an empty archive offers no "Restore all". Repo convention is to
+ * hide a control the player cannot use rather than render it disabled.
+ */
+export default function FeedBulkArchiveButton({
+  archivedView,
+  onAct,
+  pending,
+}: {
+  archivedView: boolean
+  onAct: () => void
+  pending: boolean
+}) {
+  const label = i18n.t(archivedView ? 'feed:archive.restoreAll' : 'feed:archive.archiveAll')
+
+  return (
+    <button
+      type="button"
+      onClick={onAct}
+      className="eyebrow"
+      data-feed-bulk={archivedView ? 'restore-all' : 'archive-all'}
+      style={{
+        cursor: pending ? 'progress' : 'pointer',
+        background: 'transparent',
+        color: 'var(--color-text-secondary)',
+        ...(archivedView
+          ? { border: 'none', padding: 0, textDecoration: 'underline' }
+          : {
+              border: '1px solid var(--color-border-strong)',
+              borderRadius: 999,
+              padding: 'var(--space-xs) var(--space-md)',
+            }),
+      }}
+    >
+      {label}
+    </button>
+  )
+}

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -14,7 +14,6 @@ import {
 } from "../../api/praxis";
 import { extractError } from "../../utils/errors";
 import { factionColor, factionFill, isKnownFaction } from "../../utils/factions";
-import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
 
 interface Props {
@@ -23,6 +22,16 @@ interface Props {
 
 const DEFAULT_MAX_TASK_SLOTS = 20;
 
+/**
+ * The collaboration invite — a PAYLOAD BODY inside the faction chassis as of
+ * #1194 (epic #1192 decision 9). A strip-the-wrapper refactor: the accept /
+ * decline handlers, the bank-full drop-and-retry flow and the accepted
+ * "✓ Joined / open the praxis" state variant all survive untouched, because the
+ * chassis takes arbitrary children rather than a fixed slot bag.
+ *
+ * The one removal is its own timestamp — the chassis band draws that for every
+ * card now, and a body that drew it too printed it twice.
+ */
 export default function FeedCardCollabInvite({ item }: Props) {
   const {
     praxis_id,
@@ -165,16 +174,6 @@ export default function FeedCardCollabInvite({ item }: Props) {
               </span>
               <FeedBadge type="your_stuff" label={i18n.t("feed:badge.yourStuff")} />
             </div>
-            <span
-              className="eyebrow"
-              style={{
-                color: "var(--color-text-tertiary)",
-                display: "block",
-                marginTop: "var(--space-xs)",
-              }}
-            >
-              {relativeTime(item.timestamp)}
-            </span>
           </div>
         </div>
 

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -10,7 +10,6 @@ import { useAuth } from "../../auth/AuthContext";
 import { deletePraxis, leavePraxis } from "../../api/praxis";
 import { cancelChallenge, respondToChallenge } from "../../api/duel";
 import { factionColor, factionFill, isKnownFaction } from "../../utils/factions";
-import { relativeTime } from "../../utils/dates";
 import { extractError } from "../../utils/errors";
 import FeedBadge from "./FeedBadge";
 
@@ -25,6 +24,18 @@ const BANK_FULL_MARKER = "Task bank is full";
 
 const DEFAULT_MAX_TASK_SLOTS = 20;
 
+/**
+ * The duel challenge — a PAYLOAD BODY inside the faction chassis as of #1194
+ * (epic #1192 decision 9). `FeedCardRouter` used to warn that this card owns real
+ * accept/decline handlers that "must NOT collapse into slots"; that objection was
+ * about `FeedRowContent`'s fixed slot bag, and the chassis takes arbitrary
+ * children. So this was a strip-the-wrapper refactor and nothing else: every
+ * handler, the bank-full drop-and-retry flow, the withdraw path and each state
+ * variant are untouched.
+ *
+ * The one removal is its own timestamp — the chassis band draws that for every
+ * card now, and a body that drew it too printed it twice.
+ */
 export default function FeedCardDuelChallenge({ item }: Props) {
   // Duel payload carries duel_id / challenger_praxis_id / duel_status — NOT
   // the collab invite_id / praxis_id / invite_status fields. The shared hook
@@ -194,16 +205,6 @@ export default function FeedCardDuelChallenge({ item }: Props) {
               </span>
               <FeedBadge type="duel" label={i18n.t("feed:badge.duel")} />
             </div>
-            <span
-              className="eyebrow"
-              style={{
-                color: "var(--color-text-tertiary)",
-                display: "block",
-                marginTop: "var(--space-xs)",
-              }}
-            >
-              {relativeTime(item.timestamp)}
-            </span>
           </div>
         </div>
 

--- a/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
+++ b/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import type { ActivityFeedItem } from '../../api/activityFeed'
 import i18n from '../../i18n'
@@ -5,9 +6,17 @@ import FeedBadge from './FeedBadge'
 
 interface Props {
   item: ActivityFeedItem
+  /**
+   * The dismiss control, dropped into the existing header. #1194's ONE change to
+   * this card: it is the single factionless feed type and stays that way (epic
+   * #1192 decision 6). An era turn can strip a player of their faction, so
+   * speaking that specific card in their faction's voice is exactly backwards —
+   * it keeps its neutral always-dark chrome and gains the ✕, nothing else.
+   */
+  archive?: ReactNode
 }
 
-export default function FeedCardEraAnnouncement({ item }: Props) {
+export default function FeedCardEraAnnouncement({ item, archive }: Props) {
   const { era_name, era_notes } = item.payload
 
   /* Era announcement is intentionally always-dark (Style Guide §8).
@@ -30,6 +39,7 @@ export default function FeedCardEraAnnouncement({ item }: Props) {
         <span style={{ marginLeft: 'auto' }}>
           <FeedBadge type="admin" label={i18n.t('feed:badge.admin')} />
         </span>
+        {archive}
       </div>
 
       <h3

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -3,13 +3,20 @@ import { Trans } from "react-i18next";
 import type { ActivityFeedItem } from "../../api/activityFeed";
 import i18n from "../../i18n";
 import { factionColor, factionName } from "../../utils/factions";
-import { relativeTime } from "../../utils/dates";
 import FeedBadge from "./FeedBadge";
 
 interface Props {
   item: ActivityFeedItem;
 }
 
+/**
+ * The faction invitation letter — a PAYLOAD BODY inside the faction chassis as of
+ * #1194 (epic #1192 decision 9), not a card that brings its own chrome.
+ *
+ * It lost its own kicker and its own timestamp: the chassis band draws both for
+ * every card now, and a body that drew them too printed each twice. Its content
+ * and its link are untouched.
+ */
 export default function FeedCardInvitationLetter({ item }: Props) {
   const { faction_slug } = item.payload;
   const color = factionColor(faction_slug);
@@ -26,19 +33,7 @@ export default function FeedCardInvitationLetter({ item }: Props) {
       >
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: envelope emoji used as an icon */}
         <span style={{ fontSize: 16 }}>&#x2709;&#xFE0F;</span>
-        <span className="eyebrow" style={{ color }}>
-          {i18n.t("feed:invitationLetter.kicker")}
-        </span>
         <FeedBadge type="your_stuff" label={i18n.t("feed:badge.yourStuff")} />
-        <span
-          className="eyebrow"
-          style={{
-            marginLeft: "auto",
-            color: "var(--color-text-tertiary)",
-          }}
-        >
-          {relativeTime(item.timestamp)}
-        </span>
       </div>
 
       <p

--- a/frontend/src/components/feed/FeedCardRouter.tsx
+++ b/frontend/src/components/feed/FeedCardRouter.tsx
@@ -1,22 +1,50 @@
+import type { ReactNode } from 'react'
 import type { ActivityFeedItem } from '../../api/activityFeed'
+import i18n from '../../i18n'
+import { relativeTime } from '../../utils/dates'
 import FactionFeedFrame from './FactionFeedFrame'
+import FeedItemSlot from './FeedItemSlot'
 import FeedRowContent from './FeedRowContent'
 import { normalizeFeedItem } from './normalizeFeedItem'
+import { feedKicker, STILL_WAITING_TYPES } from './feedItemLabels'
 import FeedCardEraAnnouncement from './FeedCardEraAnnouncement'
 import FeedCardCollabInvite from './FeedCardCollabInvite'
 import FeedCardDuelChallenge from './FeedCardDuelChallenge'
 import FeedCardInvitationLetter from './FeedCardInvitationLetter'
 
 /**
- * Full adoption (#376): the faction owns every "someone did X" row. Those types
- * normalize into one slot-driven `FeedRowContent` inside the faction frame — no
- * per-event-type card. The remaining four are structural / interactive and keep
- * their bespoke companion cards (the design's factionless announcement + the
- * interactive challenge cards); the interactive ones own real accept/decline
- * handlers that must NOT collapse into slots.
+ * THE CHASSIS SEAM, assembled. Read this and {@link FeedFrameProps} before
+ * building a faction feed skin (#1194).
+ *
+ * Every feed item is three layers, and each one owns exactly one thing:
+ *
+ *   FeedItemSlot   the archive — the control, the swipe, the write, the undo
+ *                  strip that stands in the slot. Faction-blind. Nothing in a
+ *                  skin touches this.
+ *   FactionFeedFrame  the CHASSIS — one per faction, dispatched on
+ *                  `context_faction_slug`. It draws the kicker band, the tag,
+ *                  the time and places the archive node. THIS is what a dress
+ *                  issue rewrites.
+ *   the body       shared payload — either the slot-driven `FeedRowContent` or
+ *                  one of the three interactive companions. Faction-blind.
+ *
+ * So the whole of "give this faction its own feed card" is: claim `feedFrame` in
+ * the faction's manifest. Nothing else changes, and no body needs touching.
+ *
+ * THE ONE EXCEPTION is `era_announcement` (epic #1192 decision 6). It is the
+ * single factionless type and must stay that way — an era turn can strip a
+ * player of their faction, so speaking that card in their faction's voice is
+ * exactly backwards. It keeps its own neutral always-dark chrome, is NOT wrapped
+ * in a chassis, and gains only the ✕.
+ *
+ * `comment_mention` is #1196's job. It reaches this router already: give it a
+ * body in `normalizeFeedItem` and it inherits the chassis, the kicker and the
+ * archive with no change here.
  */
-const COMPANION_MAP: Record<string, React.ComponentType<{ item: ActivityFeedItem }>> = {
-  era_announcement: FeedCardEraAnnouncement,
+
+/** The three interactive companions — payload BODIES inside the chassis since
+ *  #1194, keeping their own accept/decline handlers (epic decision 9). */
+const COMPANION_BODIES: Record<string, React.ComponentType<{ item: ActivityFeedItem }>> = {
   invitation_letter: FeedCardInvitationLetter,
   duel_challenge: FeedCardDuelChallenge,
   collab_invite: FeedCardCollabInvite,
@@ -24,25 +52,54 @@ const COMPANION_MAP: Record<string, React.ComponentType<{ item: ActivityFeedItem
 
 interface Props {
   item: ActivityFeedItem
+  /** Drawn in the Archived tab: the control restores instead of archiving, and
+   *  an unanswered challenge or invite carries the "still waiting" tag. */
+  archivedView?: boolean
+  /** Fired after a successful archive write so the surrounding feed can refresh
+   *  its counts. */
+  onArchiveChange?: () => void
 }
 
-export default function FeedCardRouter({ item }: Props) {
+export default function FeedCardRouter({ item, archivedView = false, onArchiveChange }: Props) {
   const row = normalizeFeedItem(item)
-  if (row) {
-    return (
-      <FactionFeedFrame slug={row.slug}>
-        <FeedRowContent row={row} avatarUrl={item.actor_avatar_url} />
-      </FactionFeedFrame>
-    )
+  const Companion = COMPANION_BODIES[item.type]
+  const isEraAnnouncement = item.type === 'era_announcement'
+
+  // A type with no body yet (today: comment_mention, until #1196) renders
+  // nothing rather than an empty chassis.
+  if (!row && !Companion && !isEraAnnouncement) return null
+
+  // "Still waiting" only in the archive, and only where there is something to
+  // wait for: archiving never answers anything (ADR-0066), so an archived duel
+  // challenge or collab invite is still open and says so. In the live feed the
+  // card's own buttons already make that plain.
+  const tag =
+    archivedView && STILL_WAITING_TYPES.has(item.type)
+      ? i18n.t('feed:archive.stillWaiting')
+      : null
+
+  const renderBody = (): ReactNode => {
+    if (row) return <FeedRowContent row={row} avatarUrl={item.actor_avatar_url} />
+    return <Companion item={item} />
   }
 
-  const Companion = COMPANION_MAP[item.type]
-  if (!Companion) return null
-  // Companions bring their own chrome (announcement is dark; the interactive
-  // cards are neutral) — still framed by faction context where one exists.
   return (
-    <FactionFeedFrame slug={item.context_faction_slug}>
-      <Companion item={item} />
-    </FactionFeedFrame>
+    <FeedItemSlot item={item} archivedView={archivedView} onArchiveChange={onArchiveChange}>
+      {(archive) =>
+        isEraAnnouncement ? (
+          <FeedCardEraAnnouncement item={item} archive={archive} />
+        ) : (
+          <FactionFeedFrame
+            slug={row ? row.slug : item.context_faction_slug}
+            kicker={feedKicker(item.type)}
+            time={relativeTime(item.timestamp)}
+            tag={tag}
+            archive={archive}
+          >
+            {renderBody()}
+          </FactionFeedFrame>
+        )
+      }
+    </FeedItemSlot>
   )
 }

--- a/frontend/src/components/feed/FeedChassisBand.tsx
+++ b/frontend/src/components/feed/FeedChassisBand.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react'
+
+/**
+ * The chassis band's DEFAULT ARRANGEMENT: kicker · tag → time · archive.
+ *
+ * A convenience, not part of the contract. `FeedFrameProps` says a frame must
+ * draw all four chrome slots; it does not say where. This is the arrangement
+ * every sheet in the epic happens to draw (kind on the left, time and the
+ * dismiss control on the right), factored out so eight frames do not each
+ * re-derive the ellipsis, the wrap and the auto-margin.
+ *
+ * A faction dress issue is free to throw it away and place the four slots by
+ * hand — that is the whole point of the seam. What it must not do is DROP one:
+ * a swallowed slot loses a feature, not a decoration.
+ *
+ * Everything here paints in `color: inherit` / `currentColor`, so a frame tints
+ * the whole band (the archive control included) by setting `color` on whatever
+ * it places this inside.
+ */
+export default function FeedChassisBand({
+  kicker,
+  time,
+  tag,
+  archive,
+}: {
+  kicker: string
+  time: string
+  tag: string | null
+  archive: ReactNode
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-sm)',
+        minWidth: 0,
+        color: 'inherit',
+      }}
+    >
+      <span
+        className="eyebrow"
+        style={{
+          color: 'inherit',
+          minWidth: 0,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {kicker}
+      </span>
+      {tag && (
+        <span
+          className="eyebrow"
+          style={{
+            color: 'inherit',
+            opacity: 0.8,
+            border: '1px solid currentColor',
+            padding: '0 var(--space-xs)',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {tag}
+        </span>
+      )}
+      <span
+        className="eyebrow"
+        style={{
+          marginLeft: 'auto',
+          color: 'inherit',
+          opacity: 0.7,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {time}
+      </span>
+      {archive}
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedEmptyState.tsx
+++ b/frontend/src/components/feed/FeedEmptyState.tsx
@@ -1,0 +1,42 @@
+import i18n from '../../i18n'
+
+/**
+ * The feed's two empty states (Unaffiliated sheet §2a), which are NOT the same
+ * message and are never collapsed into one:
+ *
+ *   feed    "Nothing left to read." / "The city is quiet. Go do something."
+ *   archive "The archive is empty."  / "Dismissed updates rest here"
+ *
+ * They say different things. An empty feed is an invitation to go and do
+ * something; an empty archive is a statement that you have thrown nothing away.
+ * The single message this replaced ("No updates yet…") was neither, and in the
+ * Archived tab it would have been actively wrong.
+ */
+export default function FeedEmptyState({ archivedView }: { archivedView: boolean }) {
+  return (
+    <div className="sidebar-card" style={{ padding: 'var(--space-xl)', textAlign: 'center' }}>
+      <p
+        className="font-body"
+        style={{
+          margin: 0,
+          fontSize: 'var(--text-content)',
+          fontWeight: 700,
+          color: 'var(--color-text-secondary)',
+        }}
+      >
+        {i18n.t(archivedView ? 'feed:archive.emptyTitle' : 'feed:archive.feedEmptyTitle')}
+      </p>
+      <p
+        className="font-body"
+        style={{
+          margin: 0,
+          marginTop: 'var(--space-xs)',
+          fontSize: 'var(--text-content)',
+          color: 'var(--color-text-tertiary)',
+        }}
+      >
+        {i18n.t(archivedView ? 'feed:archive.emptyBody' : 'feed:archive.feedEmptyBody')}
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedItemSlot.tsx
+++ b/frontend/src/components/feed/FeedItemSlot.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import {
+  dismissFeedItem,
+  restoreFeedItem,
+  type ActivityFeedItem,
+} from '../../api/activityFeed'
+import i18n from '../../i18n'
+import { extractError } from '../../utils/errors'
+import FeedArchiveButton from './FeedArchiveButton'
+import FeedUndoStrip, { UNDO_WINDOW_MS, type FeedUndoPhase } from './FeedUndoStrip'
+import { feedItemTitle, isArchivable } from './feedItemLabels'
+
+/**
+ * ONE SLOT IN THE FEED — and the whole of the archive interaction (#1194,
+ * Unaffiliated sheet §2a).
+ *
+ * Everything about dismissing lives here, OUTSIDE the faction frames, so eight
+ * skins inherit it and none of them reimplements it:
+ *
+ *  - the ✕ / ↺ control, handed to the card as a finished node;
+ *  - swipe-left-to-archive on touch;
+ *  - the write, issued IMMEDIATELY;
+ *  - the undo strip, which replaces the card in THIS slot rather than floating
+ *    somewhere else, so the list never jumps;
+ *  - the six-second window, after which the strip degrades to the plain reverse
+ *    verb instead of collapsing.
+ *
+ * WHY THE WRITE IS IMMEDIATE. The obvious implementation waits out the six
+ * seconds and only then calls the server. That loses the dismissal the moment
+ * the player navigates away, which is most of the time — you archive something
+ * and keep reading, or leave. So the dismissal is written on the tap and undo
+ * issues the reverse write. The strip offers a reversal; it does not delay an
+ * action.
+ *
+ * WHY IT IS A RENDER PROP. The archive control has to sit wherever the card puts
+ * its chrome, and the two kinds of card put it in different places: a chassis
+ * card takes it as `FeedFrameProps.archive` on the band, while `era_announcement`
+ * keeps its own neutral chrome deliberately (epic #1192 decision 6) and just
+ * needs the ✕ dropped into its header. Handing the finished node to a callback
+ * serves both without this component knowing which it is looking at.
+ *
+ * BOTH DIRECTIONS RUN THROUGH ONE PATH. In the feed the act is dismiss and the
+ * reverse is restore; in the Archived tab it is the other way round. Only the
+ * vocabulary differs, so `archivedView` picks the words and the same state
+ * machine does the rest.
+ */
+
+/** A swipe commits past this fraction of the card's width on release; a shorter
+ *  drag springs back (design §2a). */
+const SWIPE_COMMIT_FRACTION = 0.4
+
+type Phase = 'card' | 'acted'
+
+export default function FeedItemSlot({
+  item,
+  archivedView = false,
+  onArchiveChange,
+  children,
+}: {
+  item: ActivityFeedItem
+  /** True when this slot is being drawn in the Archived tab. Flips the act from
+   *  dismiss to restore, and turns on the "still waiting" tag. */
+  archivedView?: boolean
+  /** Fired after any successful write, so the surrounding feed can refresh its
+   *  counts. It must NOT drop the item from the list: that would delete the slot
+   *  the undo strip is standing in. */
+  onArchiveChange?: () => void
+  /** Draws the card, given the finished archive control (or `null` when this
+   *  item offers none). */
+  children: (archive: ReactNode) => ReactNode
+}) {
+  const [phase, setPhase] = useState<Phase>('card')
+  const [undoPhase, setUndoPhase] = useState<FeedUndoPhase>('undo')
+  const [error, setError] = useState<string | null>(null)
+  const [stripError, setStripError] = useState<string | null>(null)
+  const [dragX, setDragX] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const slotRef = useRef<HTMLDivElement | null>(null)
+  const dragStartX = useRef<number | null>(null)
+  const slotWidth = useRef(0)
+
+  // `awaiting_submission` offers no control at all — the backend refuses to
+  // archive it (it is state, not an event) and a control that can only fail must
+  // not be drawn, not even disabled. Nothing in the archive can be that type, so
+  // the archived view always offers its restore control.
+  const offersControl = archivedView || isArchivable(item)
+
+  // The six-second window. When it lapses the strip stays put and its action
+  // becomes the plain reverse verb, so a reader who looked away still finds the
+  // slot where they left it.
+  useEffect(() => {
+    if (phase !== 'acted' || undoPhase === 'expired') return
+    const timer = window.setTimeout(() => setUndoPhase('expired'), UNDO_WINDOW_MS)
+    return () => window.clearTimeout(timer)
+  }, [phase, undoPhase])
+
+  /** Archive (feed) or restore (archive) — written straight away. */
+  const act = async () => {
+    if (busy) return
+    setBusy(true)
+    setError(null)
+    setDragX(0)
+    try {
+      if (archivedView) await restoreFeedItem(item.item_key)
+      else await dismissFeedItem(item.item_key)
+      setPhase('acted')
+      setUndoPhase('undo')
+      setStripError(null)
+      onArchiveChange?.()
+    } catch (err) {
+      // The card comes back. A slot showing an undo strip for a dismissal that
+      // never happened would be a lie about durable state.
+      setError(
+        extractError(
+          err,
+          i18n.t(archivedView ? 'feed:archive.restoreError' : 'feed:archive.error'),
+        ),
+      )
+    }
+    setBusy(false)
+  }
+
+  /** The reverse write — `Undo` inside the window, the plain verb after it. */
+  const reverse = async () => {
+    if (busy) return
+    setBusy(true)
+    setStripError(null)
+    try {
+      if (archivedView) await dismissFeedItem(item.item_key)
+      else await restoreFeedItem(item.item_key)
+      setPhase('card')
+      onArchiveChange?.()
+    } catch (err) {
+      setStripError(
+        extractError(
+          err,
+          i18n.t(archivedView ? 'feed:archive.error' : 'feed:archive.restoreError'),
+        ),
+      )
+    }
+    setBusy(false)
+  }
+
+  // ─── The undo strip, standing in this slot ────────────────────────────────
+  if (phase === 'acted') {
+    const title = feedItemTitle(item)
+    return (
+      <FeedUndoStrip
+        message={i18n.t(
+          archivedView ? 'feed:archive.restored' : 'feed:archive.archived',
+          { title },
+        )}
+        actionLabel={i18n.t(
+          undoPhase === 'undo'
+            ? 'feed:archive.undo'
+            : archivedView
+              ? 'feed:archive.dismiss'
+              : 'feed:archive.restore',
+        )}
+        phase={undoPhase}
+        onAct={reverse}
+        error={stripError}
+      />
+    )
+  }
+
+  // ─── Swipe-left to archive ────────────────────────────────────────────────
+  //
+  // Touch only. A mouse gets the ✕, which is both the pointer route and the
+  // keyboard/screen-reader one; turning drag on for a mouse would fight text
+  // selection and the links inside every card. Swipe is never the ONLY route to
+  // the archive — that is the whole reason `FeedArchiveButton` exists.
+  const canSwipe = offersControl && !busy
+
+  const onPointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!canSwipe || event.pointerType !== 'touch') return
+    dragStartX.current = event.clientX
+    slotWidth.current = slotRef.current?.offsetWidth ?? 0
+  }
+
+  const onPointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (dragStartX.current === null) return
+    // Left only: a rightward drag is not a gesture this surface has.
+    setDragX(Math.min(0, event.clientX - dragStartX.current))
+  }
+
+  const endDrag = () => {
+    if (dragStartX.current === null) return
+    const travelled = -dragX
+    dragStartX.current = null
+    if (slotWidth.current > 0 && travelled >= slotWidth.current * SWIPE_COMMIT_FRACTION) {
+      void act()
+      return
+    }
+    setDragX(0) // spring back
+  }
+
+  return (
+    <div
+      ref={slotRef}
+      data-feed-slot={item.item_key}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      style={{
+        // `pan-y` so the gesture can be claimed horizontally without stealing
+        // the vertical scroll the feed is read with.
+        touchAction: canSwipe ? 'pan-y' : undefined,
+        transform: dragX ? `translateX(${dragX}px)` : undefined,
+        transition: dragX ? undefined : 'transform 160ms',
+      }}
+    >
+      {error && (
+        <p
+          className="font-body"
+          style={{
+            margin: 0,
+            fontSize: 'var(--text-content)',
+            color: 'var(--color-danger)',
+            padding: 'var(--space-xs) var(--space-lg)',
+          }}
+        >
+          {error}
+        </p>
+      )}
+      {children(
+        offersControl ? (
+          <FeedArchiveButton onAct={act} variant={archivedView ? 'restore' : 'archive'} />
+        ) : null,
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/feed/FeedRowActions.tsx
+++ b/frontend/src/components/feed/FeedRowActions.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import i18n from '../../i18n'
+import { leavePraxis } from '../../api/praxis'
+import { extractError } from '../../utils/errors'
+import { notifyRequestsChanged } from '../../utils/requestsBus'
+import type { FeedRowAction } from './normalizeFeedItem'
+
+/**
+ * The row's ACTION SLOT (epic #1192 amendment §2b).
+ *
+ * The rewritten sheets put buttons on ordinary rows, not only on the three
+ * interactive companions, so the slot is a general payload affordance: any type
+ * that normalizes with `actions` gets them, and a type with none renders
+ * nothing at all.
+ *
+ * Only two shapes exist, deliberately. An action either NAVIGATES to a route
+ * that already exists (`href`) or CALLS an endpoint that already exists
+ * (`call`). Anything a sheet drew without an API behind it is not built — see
+ * the note on `buildAwaitingActions` in `normalizeFeedItem.ts` for the two
+ * (Nudge back, and the sheets' answer buttons) that were struck on that ground.
+ *
+ * A `call` action is one-shot: once it has fired, the row it belonged to no
+ * longer describes reality (you have left the collab), so the button is replaced
+ * by nothing rather than left clickable. `notifyRequestsChanged()` makes the
+ * surrounding feed refetch, which is what actually removes the row.
+ */
+export default function FeedRowActions({ actions }: { actions: FeedRowAction[] }) {
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [doneIds, setDoneIds] = useState<string[]>([])
+  const [error, setError] = useState<string | null>(null)
+
+  const visible = actions.filter((action) => !doneIds.includes(action.id))
+  if (visible.length === 0 && !error) return null
+
+  const runCall = async (action: FeedRowAction) => {
+    if (!action.call || pendingId) return
+    setPendingId(action.id)
+    setError(null)
+    try {
+      await leavePraxis(action.call.praxisId)
+      setDoneIds((prev) => [...prev, action.id])
+      notifyRequestsChanged()
+    } catch (err) {
+      setError(extractError(err, i18n.t('feed:rowAction.failed')))
+    }
+    setPendingId(null)
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        alignItems: 'center',
+        gap: 'var(--space-sm)',
+        marginTop: 'var(--space-md)',
+      }}
+    >
+      {visible.map((action) =>
+        action.href ? (
+          <Link key={action.id} to={action.href} className="eyebrow" style={buttonStyle(action.tone)}>
+            {action.label}
+          </Link>
+        ) : (
+          <button
+            key={action.id}
+            type="button"
+            className="eyebrow"
+            onClick={() => runCall(action)}
+            style={{
+              ...buttonStyle(action.tone),
+              cursor: pendingId === action.id ? 'progress' : 'pointer',
+            }}
+          >
+            {action.label}
+          </button>
+        ),
+      )}
+      {error && (
+        <span className="eyebrow" style={{ color: 'var(--color-danger)' }}>
+          {error}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Two tones, both neutral. `primary` is the thing the card is asking for;
+ * `quiet` is the way out. Nothing here is faction-tinted: the chassis around it
+ * carries the faction (epic decision 5), and a button that repainted itself per
+ * faction would fight the skin that already surrounds it.
+ */
+function buttonStyle(tone: FeedRowAction['tone']): React.CSSProperties {
+  const primary = tone === 'primary'
+  return {
+    display: 'inline-flex',
+    alignItems: 'center',
+    padding: 'var(--space-xs) var(--space-md)',
+    textDecoration: 'none',
+    background: primary ? 'var(--color-text-primary)' : 'transparent',
+    color: primary ? 'var(--color-bg-page)' : 'var(--color-text-secondary)',
+    border: `1px solid ${primary ? 'var(--color-text-primary)' : 'var(--color-border-strong)'}`,
+    borderRadius: 0,
+  }
+}

--- a/frontend/src/components/feed/FeedRowContent.tsx
+++ b/frontend/src/components/feed/FeedRowContent.tsx
@@ -3,14 +3,20 @@ import i18n from '../../i18n'
 import { factionColor, factionFill, isKnownFaction } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import FeedBadge from './FeedBadge'
+import FeedRowActions from './FeedRowActions'
 import type { FeedRow } from './normalizeFeedItem'
 
 /**
  * The faction-owned activity row (#376 full adoption). One slot-driven body —
- * avatar · actor + action + badge · time · headline · points/level — rendered
- * inside the faction's frame (FactionFeedFrame). The faction's accent colors the
- * actor, avatar, and headline rule so the row reads in the faction's voice; the
- * frame supplies the physical chrome. No per-event-type card.
+ * avatar · actor + action + badge · headline · points/level · actions — rendered
+ * inside the faction's chassis (FactionFeedFrame). The faction's accent colors
+ * the actor, avatar, and headline rule so the row reads in the faction's voice;
+ * the chassis supplies the physical chrome. No per-event-type card.
+ *
+ * #1194 changed the slot bag twice. It LOST `time`: the chassis draws the
+ * timestamp for every card now, so a row that also drew one printed it twice.
+ * It GAINED `actions`, because the rewritten sheets put CTAs on ordinary rows
+ * and not only on the three interactive companions (epic #1192 §2b).
  *
  * Two of those three accents are FILLS and one is ink, which is the whole of
  * ADR-0039 on this surface (#983). The monogram disc and the headline rule are
@@ -128,9 +134,6 @@ export default function FeedRowContent({
             </span>
             {row.badge && <FeedBadge type={row.badge.type} label={row.badge.label} />}
           </div>
-          <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)', display: 'block', marginTop: 'var(--space-xs)' }}>
-            {row.time}
-          </span>
         </div>
       </div>
 
@@ -186,6 +189,14 @@ export default function FeedRowContent({
               </span>
             )}
           </div>
+        </div>
+      )}
+
+      {/* The action slot. Indented to the text column exactly as the headline
+          is, so a row with an avatar reads as one block rather than two. */}
+      {row.actions.length > 0 && (
+        <div style={{ marginLeft: row.actor ? 'var(--space-3xl)' : 0 }}>
+          <FeedRowActions actions={row.actions} />
         </div>
       )}
     </div>

--- a/frontend/src/components/feed/FeedUndoStrip.tsx
+++ b/frontend/src/components/feed/FeedUndoStrip.tsx
@@ -1,11 +1,9 @@
-import i18n from '../../i18n'
-
-/** How long the strip offers UNDO before it degrades to RESTORE (design §2a:
- *  the sheet's own `setTimeout(..., 6000)`). */
+/** How long the strip offers UNDO before it degrades to the plain reverse verb
+ *  (design §2a: the sheet's own `setTimeout(..., 6000)`). */
 export const UNDO_WINDOW_MS = 6000
 
-/** Which word the strip's action currently carries. */
-export type FeedArchivePhase = 'undo' | 'restore'
+/** Whether the strip is still inside its window. */
+export type FeedUndoPhase = 'undo' | 'expired'
 
 /**
  * The undo strip (Unaffiliated sheet §2a).
@@ -18,19 +16,26 @@ export type FeedArchivePhase = 'undo' | 'restore'
  * write for six seconds would lose it the moment the player navigates away, so
  * the strip's job is to offer the reversal, not to delay the action.
  *
- * When the window expires the action becomes **Restore** rather than the strip
- * vanishing — the sheet degrades the slot instead of collapsing it, which keeps
- * the list stable for a reader who looked away. The slot clears on the next
- * fetch, when the server no longer returns the item.
+ * When the window expires the action becomes the plain reverse verb — **Restore**
+ * in the feed, **Archive** in the archive — rather than the strip vanishing. The
+ * sheet degrades the slot instead of collapsing it, which keeps the list stable
+ * for a reader who looked away. The slot clears on the next fetch, when the
+ * server no longer returns the item.
+ *
+ * It takes finished strings rather than a direction: both directions of the
+ * archive use one strip, and the vocabulary decision belongs to `FeedItemSlot`,
+ * which knows whether it is looking at the feed or the archive.
  */
 export default function FeedUndoStrip({
-  title,
+  message,
+  actionLabel,
   phase,
   onAct,
   error,
 }: {
-  title: string
-  phase: FeedArchivePhase
+  message: string
+  actionLabel: string
+  phase: FeedUndoPhase
   onAct: () => void
   error: string | null
 }) {
@@ -53,13 +58,13 @@ export default function FeedUndoStrip({
           flex: 1,
           minWidth: 0,
           fontSize: 'var(--text-content)',
-          color: 'var(--color-text-secondary)',
+          color: error ? 'var(--color-danger)' : 'var(--color-text-secondary)',
           overflow: 'hidden',
           textOverflow: 'ellipsis',
           whiteSpace: 'nowrap',
         }}
       >
-        {error ?? i18n.t('feed:archive.archived', { title })}
+        {error ?? message}
       </span>
       <button
         type="button"
@@ -75,7 +80,7 @@ export default function FeedUndoStrip({
           textDecoration: 'underline',
         }}
       >
-        {i18n.t(phase === 'undo' ? 'feed:archive.undo' : 'feed:archive.restore')}
+        {actionLabel}
       </button>
     </div>
   )

--- a/frontend/src/components/feed/FeedUndoStrip.tsx
+++ b/frontend/src/components/feed/FeedUndoStrip.tsx
@@ -1,0 +1,82 @@
+import i18n from '../../i18n'
+
+/** How long the strip offers UNDO before it degrades to RESTORE (design §2a:
+ *  the sheet's own `setTimeout(..., 6000)`). */
+export const UNDO_WINDOW_MS = 6000
+
+/** Which word the strip's action currently carries. */
+export type FeedArchivePhase = 'undo' | 'restore'
+
+/**
+ * The undo strip (Unaffiliated sheet §2a).
+ *
+ * "the card leaves the feed and its slot becomes an undo strip" — so this
+ * replaces the card IN ITS OWN SLOT. Not a toast, not a corner snackbar: the
+ * list must not jump under the reader's cursor.
+ *
+ * The dismissal is already written by the time this renders. Deferring the
+ * write for six seconds would lose it the moment the player navigates away, so
+ * the strip's job is to offer the reversal, not to delay the action.
+ *
+ * When the window expires the action becomes **Restore** rather than the strip
+ * vanishing — the sheet degrades the slot instead of collapsing it, which keeps
+ * the list stable for a reader who looked away. The slot clears on the next
+ * fetch, when the server no longer returns the item.
+ */
+export default function FeedUndoStrip({
+  title,
+  phase,
+  onAct,
+  error,
+}: {
+  title: string
+  phase: FeedArchivePhase
+  onAct: () => void
+  error: string | null
+}) {
+  return (
+    <div
+      role="status"
+      data-feed-undo-strip={phase}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 'var(--space-md)',
+        padding: 'var(--space-md) var(--space-lg)',
+        background: 'var(--color-bg-surface-alt)',
+        border: '1px dashed var(--color-border-strong)',
+      }}
+    >
+      <span
+        className="font-body"
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: 'var(--text-content)',
+          color: 'var(--color-text-secondary)',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {error ?? i18n.t('feed:archive.archived', { title })}
+      </span>
+      <button
+        type="button"
+        onClick={onAct}
+        className="eyebrow"
+        style={{
+          flexShrink: 0,
+          background: 'transparent',
+          border: 'none',
+          padding: 0,
+          cursor: 'pointer',
+          color: 'var(--color-text-primary)',
+          textDecoration: 'underline',
+        }}
+      >
+        {i18n.t(phase === 'undo' ? 'feed:archive.undo' : 'feed:archive.restore')}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/feed/SingularityFeedFrame.tsx
+++ b/frontend/src/components/feed/SingularityFeedFrame.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react'
-
 import i18n from '../../i18n'
+import FeedChassisBand from './FeedChassisBand'
+import type { FeedFrameProps } from './feedFrameProps'
 
 /**
  * Singularity per-faction feed frame (surface #12, SPEC-faction-ui-profile.md).
@@ -10,6 +10,13 @@ import i18n from '../../i18n'
  * terminal-black slab with a signal-blue inset border, scanline overlay, and a
  * `>` boot/prompt strip header — and renders the unchanged card as the printout
  * body. It must NOT reimplement the card internals; those arrive via `children`.
+ *
+ * #1194: the boot strip is now also the CHASSIS BAND. It used to be
+ * `aria-hidden` in one piece, which cannot hold the dismiss control — the
+ * keyboard and screen-reader route to the archive is the whole reason that
+ * control exists (swipe alone would not provide one). The two ornamental spans
+ * carry `aria-hidden` individually instead, so the strip's chrome stays silent
+ * while the kicker, the time and the ✕ are announced.
  *
  * Singularity is ALWAYS DARK: its --faction-singularity-* tokens are identical in
  * both themes, so the container styles itself with them and reads as a terminal
@@ -27,7 +34,13 @@ const FONT = 'var(--font-faction-terminal)'
 const signal = (pct: number): string =>
   `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
 
-export default function SingularityFeedFrame({ children }: { children: ReactNode }) {
+export default function SingularityFeedFrame({
+  kicker,
+  time,
+  tag,
+  archive,
+  children,
+}: FeedFrameProps) {
   return (
     <div
       style={{
@@ -63,9 +76,8 @@ export default function SingularityFeedFrame({ children }: { children: ReactNode
         }}
       />
 
-      {/* boot/prompt strip header */}
+      {/* boot/prompt strip header — also the chassis band */}
       <div
-        aria-hidden="true"
         style={{
           position: 'relative',
           zIndex: 2,
@@ -82,8 +94,15 @@ export default function SingularityFeedFrame({ children }: { children: ReactNode
           textTransform: 'uppercase',
         }}
       >
-        <span style={{ color: PHOSPHOR }}>{'>'}</span>
-        <span>{i18n.t('feed:frame.singularity.masthead')}</span>
+        <span aria-hidden="true" style={{ color: PHOSPHOR, flexShrink: 0 }}>
+          {'>'}
+        </span>
+        <span aria-hidden="true" style={{ flexShrink: 0 }}>
+          {i18n.t('feed:frame.singularity.masthead')}
+        </span>
+        <div style={{ flex: 1, minWidth: 0, color: signal(75) }}>
+          <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
+        </div>
       </div>
 
       {/* printout body — the neutral card, unchanged */}

--- a/frontend/src/components/feed/SnideFeedFrame.tsx
+++ b/frontend/src/components/feed/SnideFeedFrame.tsx
@@ -1,4 +1,5 @@
-import type { ReactNode } from 'react'
+import FeedChassisBand from './FeedChassisBand'
+import type { FeedFrameProps } from './feedFrameProps'
 
 /**
  * S.N.I.D.E. activity-feed FRAME (surface #12, SPEC-faction-ui-profile.md).
@@ -10,12 +11,22 @@ import type { ReactNode } from 'react'
  * stripe running its left edge. The card body itself stays exactly as passed in
  * — this only adds the skin around `{children}`.
  *
+ * #1194: the slip gains a CHASSIS BAND above the body — a typed intake line
+ * carrying the kicker, the tag, the time and the dismiss control in photocopier
+ * ink. The skin is otherwise unchanged; SNIDE's dress issue restyles it.
+ *
  * Always-dark by intent: SNIDE is the ransom/xerox dossier. We scope the
  * theme-stable --faction-snide-card-* / -paper / -ink / -acid tokens to this
  * frame's own container only; we never mutate the document theme, and we avoid
  * the --faction-snide-*-wall-text tokens that flip between light/dark.
  */
-export default function SnideFeedFrame({ children }: { children: ReactNode }) {
+export default function SnideFeedFrame({
+  kicker,
+  time,
+  tag,
+  archive,
+  children,
+}: FeedFrameProps) {
   const ink = 'var(--faction-snide-ink)'
   const paper = 'var(--faction-snide-paper)'
   const acid = 'var(--faction-snide-acid)'
@@ -59,6 +70,19 @@ export default function SnideFeedFrame({ children }: { children: ReactNode }) {
         aria-hidden="true"
         style={{ top: -9, right: 40, width: 64, height: 20, transform: 'rotate(5deg)' }}
       />
+      {/* chassis band — the intake line typed across the head of the slip */}
+      <div
+        style={{
+          position: 'relative',
+          color: ink,
+          borderBottom: `1px solid color-mix(in srgb, ${ink} 35%, transparent)`,
+          paddingBottom: 'var(--space-xs)',
+          marginBottom: 'var(--space-sm)',
+        }}
+      >
+        <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
+      </div>
+
       {/* the slip body — the neutral feed card, untouched */}
       <div style={{ position: 'relative' }}>{children}</div>
     </div>

--- a/frontend/src/components/feed/UaFeedFrame.tsx
+++ b/frontend/src/components/feed/UaFeedFrame.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react'
-
 import { UaSigil } from '../cards/UaSigil'
+import FeedChassisBand from './FeedChassisBand'
+import type { FeedFrameProps } from './feedFrameProps'
 
 /**
  * UA feed frame (per-faction surface #12, kit §12, #851).
@@ -15,9 +15,20 @@ import { UaSigil } from '../cards/UaSigil'
  * no engraved masthead: the salon is dead, and a feed row was the worst place
  * it lived.
  *
+ * #1194: a CHASSIS BAND sits above the row, carrying the kicker, the tag, the
+ * time and the dismiss control. It is inset on the right so it clears the ensō
+ * rather than moving the faction mark: a functional control must not land under
+ * an ornament. The dress is otherwise unchanged; UA's dress issue restyles it.
+ *
  * Both themes come from the `[data-theme="dark"]` cascade.
  */
-export default function UaFeedFrame({ children }: { children: ReactNode }) {
+export default function UaFeedFrame({
+  kicker,
+  time,
+  tag,
+  archive,
+  children,
+}: FeedFrameProps) {
   return (
     <div
       style={{
@@ -44,6 +55,20 @@ export default function UaFeedFrame({ children }: { children: ReactNode }) {
       >
         <UaSigil width={18} height={18} />
       </span>
+
+      {/* chassis band — inset on the right so the ✕ clears the ensō */}
+      <div
+        style={{
+          color: 'var(--faction-ua-card-text)',
+          paddingRight: 'var(--space-xl)',
+          borderBottom: '1px solid var(--faction-ua-rule)',
+          paddingBottom: 'var(--space-xs)',
+          marginBottom: 'var(--space-sm)',
+        }}
+      >
+        <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
+      </div>
+
       {children}
     </div>
   )

--- a/frontend/src/components/feed/WowFeedFrame.tsx
+++ b/frontend/src/components/feed/WowFeedFrame.tsx
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react'
-
 import i18n from '../../i18n'
+import FeedChassisBand from './FeedChassisBand'
+import type { FeedFrameProps } from './feedFrameProps'
 
 /**
  * Warriors of Whimsy — THE HERALD'S DISPATCH (kit §07, #899).
@@ -17,10 +17,14 @@ import i18n from '../../i18n'
  *    portrait; in the app the card already renders one, and for a WOW actor that
  *    portrait IS the crest (`WowAvatar`, #897). Adding a second seal here would
  *    put two crests on one row;
- *  • the DATE on the right of the band, and the "+140 points" pill under the
- *    sentence. Both are card content, not frame chrome — the neutral row already
- *    owns the timestamp and the points, and re-drawing them in the wrapper would
- *    print each twice.
+ *  • the "+140 points" pill under the sentence. That is card content, not frame
+ *    chrome — the neutral row owns the points, and re-drawing them in the wrapper
+ *    would print them twice.
+ *
+ * THE DATE ON THE RIGHT OF THE BAND, which this file previously called card
+ * content for the same reason, is now chrome and the kit was right: #1194 moved
+ * the timestamp onto the chassis for every faction, and the row no longer draws
+ * one. The band carries it, with the kicker, the tag and the dismiss control.
  *
  * `feed:row.wow.*` (#898) belongs to the row SENTENCE, which `FeedRowContent`
  * composes generically; it is not readable from a frame that only sees
@@ -28,7 +32,13 @@ import i18n from '../../i18n'
  *
  * Both themes come from the `[data-theme="dark"]` cascade.
  */
-export default function WowFeedFrame({ children }: { children: ReactNode }) {
+export default function WowFeedFrame({
+  kicker,
+  time,
+  tag,
+  archive,
+  children,
+}: FeedFrameProps) {
   return (
     <article
       style={{
@@ -62,6 +72,7 @@ export default function WowFeedFrame({ children }: { children: ReactNode }) {
         <span
           className="eyebrow"
           style={{
+            flexShrink: 0,
             fontFamily: 'var(--faction-wow-card-font)',
             letterSpacing: '0.14em',
             color: 'var(--faction-wow-card-accent)',
@@ -69,6 +80,11 @@ export default function WowFeedFrame({ children }: { children: ReactNode }) {
         >
           {i18n.t('feed:identity.wow.dispatch')}
         </span>
+
+        {/* chassis band — rides the dispatch band in the herald's own accent */}
+        <div style={{ flex: 1, minWidth: 0, color: 'var(--faction-wow-card-accent)' }}>
+          <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
+        </div>
       </div>
 
       <div style={{ padding: 'var(--space-md)' }}>{children}</div>

--- a/frontend/src/components/feed/feedFrameProps.ts
+++ b/frontend/src/components/feed/feedFrameProps.ts
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react'
+
+/**
+ * THE CHASSIS SEAM (epic #1192, F2 #1194).
+ *
+ * A faction's feed card is ONE chassis × shared payload bodies — not a bespoke
+ * card per faction × per feed type. This is the whole contract between the two:
+ * the frame owns the physical chrome and the three things every design sheet
+ * draws on it (kicker band, timestamp, dismiss control); the body arrives as
+ * `children` and is faction-blind.
+ *
+ * Before #1194 a frame owned only `{ children }`, which is why every card drew
+ * its own timestamp inside the body and no card could be dismissed at all.
+ *
+ * RULES FOR A FACTION FRAME
+ * -------------------------
+ * 1. **Draw all four slots.** `kicker`, `time` and `archive` are chrome; a frame
+ *    that swallows one loses a feature, not a decoration. `tag` is nullable.
+ * 2. **Never print a faction name.** The skin is the identification (epic
+ *    decision 5). `kicker` is a neutral domain noun — "Duel challenge", "Vote".
+ * 3. **`archive` is a pre-composed node.** Place it; do not rebuild it. It is
+ *    already dormant-at-40%-until-hover-or-focus, already keyboard reachable,
+ *    already labelled, and already ABSENT when the card cannot be archived
+ *    (`awaiting_submission`) — a frame must never render a disabled stand-in.
+ *    It paints in `currentColor`, so a frame tints it by setting `color` on the
+ *    element it sits in.
+ * 4. **One responsive component per faction** — no mobile twin (ADR-0056 /
+ *    0058 / 0063). Size from `useFormFactor()` inside the component if needed.
+ * 5. **Nothing else changes.** Swipe-to-archive, the undo strip and the archived
+ *    list live OUTSIDE the frame, in `FeedItemSlot` — a faction skin inherits
+ *    all three for free and must not reimplement them.
+ */
+export interface FeedFrameProps {
+  /**
+   * The neutral name for this card's kind, drawn as the kicker band's label.
+   * Comes from `feed:kicker.<feed type>`. Never a faction name.
+   */
+  kicker: string
+  /** Relative timestamp, already formatted ("2h ago"). */
+  time: string
+  /**
+   * A neutral status tag for the band, or null. Today the only one is
+   * "Still waiting" — the tag an archived duel challenge / collab invite
+   * carries, because archiving never answers anything (ADR-0066).
+   */
+  tag: string | null
+  /**
+   * The dismiss (or, in the archived view, restore) control — already built.
+   * `null` when the card offers neither, which is `awaiting_submission`: it is
+   * state, not an event, and the backend refuses to archive it.
+   */
+  archive: ReactNode
+  /** The payload body — a shared row or a companion card. Faction-blind. */
+  children: ReactNode
+}

--- a/frontend/src/components/feed/feedItemLabels.ts
+++ b/frontend/src/components/feed/feedItemLabels.ts
@@ -1,0 +1,53 @@
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import i18n from '../../i18n'
+
+/**
+ * The chassis's neutral vocabulary (epic #1192 decision 7).
+ *
+ * Every string here comes from the `feed` catalog, authored once in #1194. The
+ * faction sheets are written in dialect ("Tuck away" / "Bin it" / "Spike it" /
+ * "rm --event") and NONE of it ships: faction identity is carried by the skin,
+ * not the words. Faction issues must not append to or edit these keys.
+ */
+
+/** Feed types the archive tags "still waiting" — archiving never answers
+ *  anything, so an archived challenge or invite is still open (ADR-0066). */
+export const STILL_WAITING_TYPES = new Set(['duel_challenge', 'collab_invite'])
+
+/**
+ * The one feed type that cannot be archived. It is *state*, not an event: it
+ * exists exactly while `PraxisMember.has_submitted` is false and clears itself
+ * the moment you file, so a dismissal would silence a standing obligation
+ * forever. The backend refuses it with a 400; the UI must not offer the control
+ * at all rather than render it disabled.
+ */
+export const NON_ARCHIVABLE_TYPES = new Set(['awaiting_submission'])
+
+export function isArchivable(item: ActivityFeedItem): boolean {
+  return !NON_ARCHIVABLE_TYPES.has(item.type)
+}
+
+/** The neutral name for a card's kind — the chassis kicker band's label. */
+export function feedKicker(type: string): string {
+  const key = `feed:kicker.${type}`
+  const label = i18n.t(key)
+  // i18next returns the key itself when it is missing; a type we have not named
+  // must still draw a band rather than print a raw key at the player.
+  return label === key ? i18n.t('feed:kicker.fallback') : label
+}
+
+/**
+ * A short human handle for the card, used by the undo strip's
+ * `Archived "{title}"`. Falls back to the kicker so the strip never reads
+ * `Archived ""`.
+ */
+export function feedItemTitle(item: ActivityFeedItem): string {
+  const payload = item.payload ?? {}
+  return (
+    payload.task_title ??
+    payload.praxis_title ??
+    payload.era_name ??
+    item.actor_display_name ??
+    feedKicker(item.type)
+  )
+}

--- a/frontend/src/components/feed/feedItemLabels.ts
+++ b/frontend/src/components/feed/feedItemLabels.ts
@@ -10,9 +10,37 @@ import i18n from '../../i18n'
  * not the words. Faction issues must not append to or edit these keys.
  */
 
+/**
+ * The kicker key for each of the 15 backend feed types, written out rather than
+ * interpolated. The catalog is a TYPED resource here, so `` i18n.t(`feed:kicker.
+ * ${type}`) `` on an unconstrained string does not compile — and a literal map
+ * is the better shape anyway: it is the checklist of the 15, and an unnamed type
+ * lands on the fallback instead of printing a raw key at the player.
+ */
+const KICKER_KEY = {
+  friend_completion: 'feed:kicker.friend_completion',
+  foe_completion: 'feed:kicker.foe_completion',
+  vote_on_mine: 'feed:kicker.vote_on_mine',
+  foe_taunt: 'feed:kicker.foe_taunt',
+  friend_signup: 'feed:kicker.friend_signup',
+  friend_defection: 'feed:kicker.friend_defection',
+  global_task: 'feed:kicker.global_task',
+  collaborator_submitted: 'feed:kicker.collaborator_submitted',
+  awaiting_submission: 'feed:kicker.awaiting_submission',
+  nudge: 'feed:kicker.nudge',
+  era_announcement: 'feed:kicker.era_announcement',
+  invitation_letter: 'feed:kicker.invitation_letter',
+  duel_challenge: 'feed:kicker.duel_challenge',
+  collab_invite: 'feed:kicker.collab_invite',
+  comment_mention: 'feed:kicker.comment_mention',
+} as const
+
 /** Feed types the archive tags "still waiting" — archiving never answers
  *  anything, so an archived challenge or invite is still open (ADR-0066). */
-export const STILL_WAITING_TYPES = new Set(['duel_challenge', 'collab_invite'])
+export const STILL_WAITING_TYPES: ReadonlySet<string> = new Set([
+  'duel_challenge',
+  'collab_invite',
+])
 
 /**
  * The one feed type that cannot be archived. It is *state*, not an event: it
@@ -21,7 +49,9 @@ export const STILL_WAITING_TYPES = new Set(['duel_challenge', 'collab_invite'])
  * forever. The backend refuses it with a 400; the UI must not offer the control
  * at all rather than render it disabled.
  */
-export const NON_ARCHIVABLE_TYPES = new Set(['awaiting_submission'])
+export const NON_ARCHIVABLE_TYPES: ReadonlySet<string> = new Set([
+  'awaiting_submission',
+])
 
 export function isArchivable(item: ActivityFeedItem): boolean {
   return !NON_ARCHIVABLE_TYPES.has(item.type)
@@ -29,11 +59,8 @@ export function isArchivable(item: ActivityFeedItem): boolean {
 
 /** The neutral name for a card's kind — the chassis kicker band's label. */
 export function feedKicker(type: string): string {
-  const key = `feed:kicker.${type}`
-  const label = i18n.t(key)
-  // i18next returns the key itself when it is missing; a type we have not named
-  // must still draw a band rather than print a raw key at the player.
-  return label === key ? i18n.t('feed:kicker.fallback') : label
+  const key = KICKER_KEY[type as keyof typeof KICKER_KEY]
+  return i18n.t(key ?? 'feed:kicker.fallback')
 }
 
 /**

--- a/frontend/src/components/feed/normalizeFeedItem.ts
+++ b/frontend/src/components/feed/normalizeFeedItem.ts
@@ -1,18 +1,20 @@
 import type { ActivityFeedItem } from '../../api/activityFeed'
 import i18n from '../../i18n'
 import { factionName } from '../../utils/factions'
-import { relativeTime } from '../../utils/dates'
 import { resolveTaunt } from '../../utils/taunts'
 import { collabCopy } from '../collab/collabCopy'
 
 /**
  * Full-adoption activity feed (#376): the faction owns the whole "someone did X"
  * row. Every faction-owned event type is normalized into ONE slot bag rendered by
- * `FeedRowContent` inside the faction's frame — there is no per-event-type card.
- * The four structural / interactive events (era announcement, invitation letter,
- * duel challenge, collab invite) keep their bespoke companion cards (the design's
- * factionless announcement + interactive challenge cards), routed in
- * FeedCardRouter — so accept/decline handlers are never collapsed into slots.
+ * `FeedRowContent` inside the faction's chassis — there is no per-event-type
+ * card. The three interactive companions (invitation letter, duel challenge,
+ * collab invite) moved INSIDE the chassis in #1194 as payload bodies, keeping
+ * their own accept/decline handlers; `era_announcement` stays outside it
+ * deliberately (epic #1192 decision 6).
+ *
+ * The row no longer carries a `time` slot: the chassis draws the timestamp for
+ * every card, so a row that also drew one printed it twice.
  *
  * Copy comes from the `feed` catalog (#447). This module is plain TS (no hook
  * context), so it reads the singleton `i18n.t` directly — importing the
@@ -34,8 +36,32 @@ export const FACTION_ROW_TYPES = new Set([
   'nudge',
 ])
 
+/**
+ * A mutating CTA on an ordinary row. Only endpoints that ALREADY exist appear
+ * here — a state drawn on a sheet with no API behind it is not built (epic
+ * #1192 amendment, owner ruling 2026-07-29).
+ */
+export type FeedRowCall = { endpoint: 'leavePraxis'; praxisId: number }
+
+/**
+ * A CTA in the row's action slot (epic #1192 amendment §3). The slot is a
+ * GENERAL payload affordance, not a companion-only one: the rewritten sheets
+ * put buttons on ordinary rows too.
+ *
+ * An action is either a navigation to a route that already exists (`href`) or a
+ * call to an endpoint that already exists (`call`). Never both.
+ */
+export interface FeedRowAction {
+  /** Stable id — also the `feed:rowAction.<id>` copy key. */
+  id: string
+  label: string
+  tone: 'primary' | 'quiet'
+  href?: string
+  call?: FeedRowCall
+}
+
 export interface FeedRow {
-  /** Faction whose voice styles the row (frame + accent). */
+  /** Faction whose voice styles the row (chassis + accent). */
   slug: string | null
   actor: string | null
   actorHref: string | null
@@ -48,16 +74,59 @@ export interface FeedRow {
   /** Pre-formatted points string, e.g. "40 pts" / "+12 pts", or null. */
   points: string | null
   level: number | null
-  time: string
+  /** CTAs for the row's action slot. Empty for most types. */
+  actions: FeedRowAction[]
+}
+
+/**
+ * The `awaiting_submission` row's CTAs: "File it" always, "Drop out" on a
+ * collab only.
+ *
+ * `leave_praxis` opens with `if praxis.type != PraxisType.collab: 400 "Only
+ * collab memberships can be left."` — so on a duel side the control could only
+ * ever fail. Repo convention: hide a control the player cannot use rather than
+ * render it disabled (or, worse, render it live and let it 400).
+ *
+ * WHAT IS DELIBERATELY NOT HERE: **"Nudge back"**. The endpoint
+ * (`POST /praxes/{id}/nudge/{character_id}`) exists, but nothing on either the
+ * `nudge` or the `awaiting_submission` payload can satisfy its authorization:
+ *
+ *  - on a **collab**, `services/nudge.py` rule 1 requires the SENDER to have
+ *    already filed. The recipient of a nudge is by construction someone who has
+ *    not — that is why they were nudged — so the call 403s;
+ *  - on a **duel**, `praxis_id` is the side the VIEWER owes (ADR-0011: a duel is
+ *    two linked solo praxes). The rival's own praxis id, which is what the
+ *    endpoint wants, is not in the payload and must not be invented.
+ *
+ * Per the epic's owner ruling: a drawn state with no API behind it is not built.
+ */
+function buildAwaitingActions(payload: Record<string, any>): FeedRowAction[] {
+  if (payload.praxis_id == null) return []
+  const actions: FeedRowAction[] = [
+    {
+      id: 'fileIt',
+      label: i18n.t('feed:rowAction.fileIt'),
+      tone: 'primary',
+      href: `/praxes/${payload.praxis_id}/edit`,
+    },
+  ]
+  if (payload.praxis_type === 'collab') {
+    actions.push({
+      id: 'dropOut',
+      label: i18n.t('feed:rowAction.dropOut'),
+      tone: 'quiet',
+      call: { endpoint: 'leavePraxis', praxisId: payload.praxis_id },
+    })
+  }
+  return actions
 }
 
 /** Map a faction-owned feed item to its row slots. Returns null for the
- *  structural/interactive types that keep bespoke companion cards. */
+ *  structural/interactive types that render a companion body instead. */
 export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
   if (!FACTION_ROW_TYPES.has(item.type)) return null
   const p = item.payload ?? {}
   const actor = item.actor_display_name
-  const time = relativeTime(item.timestamp)
   const slug = item.context_faction_slug
 
   switch (item.type) {
@@ -80,7 +149,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.points', { points: p.task_point_value })
             : null,
         level: null,
-        time,
+        actions: [],
       }
     }
     case 'friend_signup':
@@ -98,7 +167,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.points', { points: p.task_point_value })
             : null,
         level: p.task_level_required ?? null,
-        time,
+        actions: [],
       }
     case 'collaborator_submitted':
       // A co-member submitted their part of a collab you're in (#571). Reuses the
@@ -117,7 +186,19 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.points', { points: p.task_point_value })
             : null,
         level: null,
-        time,
+        // "File yours" — a plain navigation to the shared editor, which every
+        // member of the collab can already open. No new endpoint.
+        actions:
+          p.praxis_id != null
+            ? [
+                {
+                  id: 'fileYours',
+                  label: i18n.t('feed:rowAction.fileYours'),
+                  tone: 'primary',
+                  href: `/praxes/${p.praxis_id}/edit`,
+                },
+              ]
+            : [],
       }
     case 'awaiting_submission':
       // Your turn: a collab/duel praxis waiting on your submission (#updates-
@@ -140,7 +221,12 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.points', { points: p.task_point_value })
             : null,
         level: p.task_level_required ?? null,
-        time,
+        // "File it" is a navigation to the editor. "Drop out" is `leavePraxis`
+        // — and it is offered ONLY on a collab: the service refuses any other
+        // praxis type outright ("Only collab memberships can be left."), so on
+        // a duel side the control would 400 every time. Hide it there rather
+        // than draw one that cannot work.
+        actions: buildAwaitingActions(p),
       }
     case 'nudge':
       // Someone poked you to file (#1083). It lands BESIDE the
@@ -171,7 +257,20 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.points', { points: p.task_point_value })
             : null,
         level: null,
-        time,
+        // "Answer" — the nudge's whole point, a navigation into your own
+        // editor. The sheet also draws "Nudge back"; it is NOT built. See the
+        // note on `buildAwaitingActions` below.
+        actions:
+          p.praxis_id != null
+            ? [
+                {
+                  id: 'answer',
+                  label: i18n.t('feed:rowAction.answer'),
+                  tone: 'primary',
+                  href: `/praxes/${p.praxis_id}/edit`,
+                },
+              ]
+            : [],
       }
     case 'vote_on_mine':
       return {
@@ -188,7 +287,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.pointsEarned', { points: p.points_earned })
             : null,
         level: null,
-        time,
+        actions: [],
       }
     case 'foe_taunt': {
       // ADR-0031: the payload is a structured reference; resolve the copy from
@@ -214,7 +313,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         headlineQuoted: true,
         points: null,
         level: null,
-        time,
+        actions: [],
       }
     }
     case 'friend_defection':
@@ -232,7 +331,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         headlineQuoted: false,
         points: null,
         level: null,
-        time,
+        actions: [],
       }
     case 'global_task':
       return {
@@ -249,7 +348,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? i18n.t('feed:row.points', { points: p.task_point_value })
             : null,
         level: p.task_level_required ?? null,
-        time,
+        actions: [],
       }
     default:
       return null

--- a/frontend/src/factions/manifest.ts
+++ b/frontend/src/factions/manifest.ts
@@ -47,6 +47,7 @@ import type { MobilePraxisCardProps } from '../components/praxisCard/mobile/Mobi
 import type { FactionAvatarProps } from '../components/avatar/FactionAvatar'
 import type { SigilVariantProps } from '../components/cards/FactionSigil'
 import type { CommentComponent } from '../components/comments/shared'
+import type { FeedFrameProps } from '../components/feed/feedFrameProps'
 import type { VoteUIProps } from '../components/vote/VoteUI'
 import type { ScoreStampProps } from '../components/praxisCard/scoreStamp/ScoreStamp'
 import type { FactionCardProps } from '../components/cards/FactionCard'
@@ -95,7 +96,15 @@ export interface FactionManifest {
   readonly backdrop?: Lazy<ComponentType>
   readonly sigil?: Lazy<ComponentType<SigilVariantProps>>
   readonly comment?: Lazy<CommentComponent>
-  readonly feedFrame?: Lazy<ComponentType<{ children: React.ReactNode }>>
+  /**
+   * The faction's activity-feed CHASSIS (surface #12). #1194 widened this from
+   * `{ children }` to {@link FeedFrameProps}: a frame that owned only children
+   * could not draw the kicker band, the timestamp or the archive control, all
+   * three of which every design sheet puts on the chassis. Read that interface's
+   * docblock before writing a faction skin — nothing may be written against the
+   * old shape.
+   */
+  readonly feedFrame?: Lazy<ComponentType<FeedFrameProps>>
   readonly vote?: Lazy<ComponentType<VoteUIProps>>
   /**
    * The praxis-card score stamp (ADR-0049). Size-agnostic — the same component

--- a/frontend/src/hooks/__tests__/useRespondToRequest.test.ts
+++ b/frontend/src/hooks/__tests__/useRespondToRequest.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../api/duel', () => ({ respondToChallenge: vi.fn() }))
 
 const feedItem = (type: string, payload: Record<string, unknown>): ActivityFeedItem => ({
   type,
+  item_key: `${type}:1`,
   timestamp: '2026-07-03T00:00:00Z',
   actor_display_name: 'Rival',
   actor_faction_slug: 'snide',

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -1,8 +1,7 @@
 {
   "page": {
     "show": "show",
-    "loading": "Loading...",
-    "empty": "No updates yet. Activity from friends, foes, and the community will appear here."
+    "loading": "Loading..."
   },
   "mobile": {
     "title": "Updates",
@@ -19,9 +18,6 @@
       "requests": "Requests",
       "archived": "Archived"
     }
-  },
-  "filter": {
-    "archived": "Archived"
   },
   "kicker": {
     "friend_completion": "Task completed",

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -48,6 +48,7 @@
     "restore": "Restore",
     "restoreLabel": "Restore this update",
     "archived": "Archived “{{title}}”",
+    "restored": "Restored “{{title}}”",
     "archiveAll": "Archive all",
     "restoreAll": "Restore all",
     "stillWaiting": "Still waiting",

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -59,7 +59,6 @@
     "fileIt": "File it",
     "dropOut": "Drop out",
     "answer": "Answer",
-    "nudgeBack": "Nudge back",
     "fileYours": "File yours",
     "failed": "That didn't go through."
   },

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -16,8 +16,55 @@
       "foes": "Foes",
       "yourStuff": "Yours",
       "global": "Global",
-      "requests": "Requests"
+      "requests": "Requests",
+      "archived": "Archived"
     }
+  },
+  "filter": {
+    "archived": "Archived"
+  },
+  "kicker": {
+    "friend_completion": "Task completed",
+    "foe_completion": "Task completed",
+    "vote_on_mine": "Vote",
+    "foe_taunt": "Taunt",
+    "friend_signup": "Signup",
+    "friend_defection": "Defection",
+    "global_task": "New task",
+    "collaborator_submitted": "Collaborator filed",
+    "awaiting_submission": "Your turn",
+    "nudge": "Nudge",
+    "era_announcement": "Era",
+    "invitation_letter": "Faction invitation",
+    "duel_challenge": "Duel challenge",
+    "collab_invite": "Collaboration invite",
+    "comment_mention": "Mention",
+    "fallback": "Update"
+  },
+  "archive": {
+    "dismiss": "Archive",
+    "dismissLabel": "Archive this update",
+    "undo": "Undo",
+    "restore": "Restore",
+    "restoreLabel": "Restore this update",
+    "archived": "Archived “{{title}}”",
+    "archiveAll": "Archive all",
+    "restoreAll": "Restore all",
+    "stillWaiting": "Still waiting",
+    "error": "Couldn't archive that update.",
+    "restoreError": "Couldn't restore that update.",
+    "emptyTitle": "The archive is empty.",
+    "emptyBody": "Dismissed updates rest here",
+    "feedEmptyTitle": "Nothing left to read.",
+    "feedEmptyBody": "The city is quiet. Go do something."
+  },
+  "rowAction": {
+    "fileIt": "File it",
+    "dropOut": "Drop out",
+    "answer": "Answer",
+    "nudgeBack": "Nudge back",
+    "fileYours": "File yours",
+    "failed": "That didn't go through."
   },
   "badge": {
     "friend": "Friend",

--- a/frontend/src/pages/Updates.tsx
+++ b/frontend/src/pages/Updates.tsx
@@ -2,6 +2,8 @@ import { useTranslation } from 'react-i18next'
 import PageTitle from '../components/ui/PageTitle'
 import FeedCardRouter from '../components/feed/FeedCardRouter'
 import FeedDateDivider, { getDateLabel } from '../components/feed/FeedDateDivider'
+import FeedEmptyState from '../components/feed/FeedEmptyState'
+import FeedBulkArchiveButton from '../components/feed/FeedBulkArchiveButton'
 import { useFormFactor } from '../hooks/useFormFactor'
 import {
   useUpdates,
@@ -43,6 +45,12 @@ function DesktopUpdates({ state }: { state: UpdatesState }) {
     fetchError,
     loadMoreError,
     loadMore,
+    archivedView,
+    refreshCounts,
+    archiveAll,
+    restoreAll,
+    bulkPending,
+    bulkError,
   } = state
 
   /** Insert date dividers between items when the date changes. */
@@ -50,16 +58,25 @@ function DesktopUpdates({ state }: { state: UpdatesState }) {
     const elements: React.ReactNode[] = []
     let lastDateLabel = ''
 
-    for (let index = 0; index < items.length; index++) {
-      const item = items[index]
+    for (const item of items) {
       const dateLabel = getDateLabel(item.timestamp)
 
       if (dateLabel !== lastDateLabel) {
-        elements.push(<FeedDateDivider key={`divider-${dateLabel}-${index}`} label={dateLabel} />)
+        elements.push(<FeedDateDivider key={`divider-${dateLabel}-${item.item_key}`} label={dateLabel} />)
         lastDateLabel = dateLabel
       }
 
-      elements.push(<FeedCardRouter key={`${item.type}-${item.timestamp}-${index}`} item={item} />)
+      // Keyed on `item_key` since #1194: it is stable for the life of the source
+      // row, so a slot showing an undo strip is not remounted (and its six-second
+      // window not restarted) by anything happening around it.
+      elements.push(
+        <FeedCardRouter
+          key={item.item_key}
+          item={item}
+          archivedView={archivedView}
+          onArchiveChange={refreshCounts}
+        />,
+      )
     }
 
     return elements
@@ -114,10 +131,26 @@ function DesktopUpdates({ state }: { state: UpdatesState }) {
           <span className="eyebrow">{t('page.show')}</span>
           {ROW_1_FILTERS.map(renderFilterButton)}
         </div>
-        {/* Row 2 */}
+        {/* Row 2 — Global · Requests · Archived (#1194) */}
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-sm)', alignItems: 'center', paddingLeft: 'var(--space-3xl)' }}>
           {ROW_2_FILTERS.map(renderFilterButton)}
+          {/* Bulk archive lives with the tabs, and only when it has something to
+              act on — hide an unusable control, never draw it disabled. */}
+          {items.length > 0 && !loading && !fetchError && (
+            <span style={{ marginLeft: 'auto' }}>
+              <FeedBulkArchiveButton
+                archivedView={archivedView}
+                onAct={archivedView ? restoreAll : archiveAll}
+                pending={bulkPending}
+              />
+            </span>
+          )}
         </div>
+        {bulkError && (
+          <p className="font-body content-text" style={{ color: 'var(--color-danger)', marginTop: 'var(--space-sm)' }}>
+            {bulkError}
+          </p>
+        )}
       </div>
 
       {/* ── Feed ── */}
@@ -129,11 +162,7 @@ function DesktopUpdates({ state }: { state: UpdatesState }) {
           <button onClick={() => window.location.reload()} className="underline">{tc('states.tryRefreshing')}</button>
         </p>
       ) : items.length === 0 ? (
-        <div className="sidebar-card" style={{ padding: 'var(--space-xl)', textAlign: 'center' }}>
-          <p className="font-body content-text" style={{ color: 'var(--color-text-tertiary)' }}>
-            {t('page.empty')}
-          </p>
-        </div>
+        <FeedEmptyState archivedView={archivedView} />
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
           {renderFeedWithDividers()}

--- a/frontend/src/pages/updates/MobileUpdates.tsx
+++ b/frontend/src/pages/updates/MobileUpdates.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next'
 import FeedCardRouter from '../../components/feed/FeedCardRouter'
 import FeedDateDivider, { getDateLabel } from '../../components/feed/FeedDateDivider'
+import FeedEmptyState from '../../components/feed/FeedEmptyState'
+import FeedBulkArchiveButton from '../../components/feed/FeedBulkArchiveButton'
 import {
   ALL_FILTERS,
   getCount,
@@ -15,6 +17,11 @@ import {
  * reuses the shared `useUpdates()` fetch and the per-item FeedCardRouter (which
  * already wraps every row in the acting faction's frame via
  * `context_faction_slug`), touch-tuned for a 375px viewport.
+ *
+ * #1194 reaches the phone for free, exactly as that split intends: the Archived
+ * tab is one more chip, and swipe-left-to-archive and the undo strip live in
+ * `FeedItemSlot`, inside the shared `FeedCardRouter`. Nothing about the archive
+ * is implemented twice.
  */
 
 /** Full `feed` catalog key for each filter's chip label (spaces aren't keys). */
@@ -25,6 +32,7 @@ const FILTER_LABEL_KEY = {
   'Your Stuff': 'mobile.filter.yourStuff',
   'Global': 'mobile.filter.global',
   'Requests': 'mobile.filter.requests',
+  'Archived': 'mobile.filter.archived',
 } as const satisfies Record<FeedFilter, string>
 
 export default function MobileUpdates({ state }: { state: UpdatesState }) {
@@ -41,6 +49,12 @@ export default function MobileUpdates({ state }: { state: UpdatesState }) {
     fetchError,
     loadMoreError,
     loadMore,
+    archivedView,
+    refreshCounts,
+    archiveAll,
+    restoreAll,
+    bulkPending,
+    bulkError,
   } = state
 
   return (
@@ -114,6 +128,22 @@ export default function MobileUpdates({ state }: { state: UpdatesState }) {
         })}
       </div>
 
+      {/* Bulk archive — only when there is something to act on. */}
+      {items.length > 0 && !loading && !fetchError && (
+        <div className="mb-3" style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <FeedBulkArchiveButton
+            archivedView={archivedView}
+            onAct={archivedView ? restoreAll : archiveAll}
+            pending={bulkPending}
+          />
+        </div>
+      )}
+      {bulkError && (
+        <p className="font-body content-text mb-3" style={{ color: 'var(--color-danger)' }}>
+          {bulkError}
+        </p>
+      )}
+
       {/* Stream — single column; every card keeps its own faction frame. */}
       {loading ? (
         <p className="font-body text-muted">{t('page.loading')}</p>
@@ -125,14 +155,10 @@ export default function MobileUpdates({ state }: { state: UpdatesState }) {
           </button>
         </p>
       ) : items.length === 0 ? (
-        <div className="sidebar-card" style={{ padding: 'var(--space-xl)', textAlign: 'center' }}>
-          <p className="font-body content-text" style={{ color: 'var(--color-text-tertiary)' }}>
-            {t('page.empty')}
-          </p>
-        </div>
+        <FeedEmptyState archivedView={archivedView} />
       ) : (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-md)' }}>
-          {renderStream(items)}
+          {renderStream(items, archivedView, refreshCounts)}
         </div>
       )}
 
@@ -172,21 +198,32 @@ export default function MobileUpdates({ state }: { state: UpdatesState }) {
   )
 }
 
-/** Single-column list with date dividers, one FeedCardRouter per item. */
-function renderStream(items: UpdatesState['items']): React.ReactNode[] {
+/** Single-column list with date dividers, one FeedCardRouter per item. Keyed on
+ *  `item_key` since #1194 so a slot mid-undo is never remounted. */
+function renderStream(
+  items: UpdatesState['items'],
+  archivedView: boolean,
+  onArchiveChange: () => void,
+): React.ReactNode[] {
   const elements: React.ReactNode[] = []
   let lastDateLabel = ''
 
-  for (let index = 0; index < items.length; index++) {
-    const item = items[index]
+  for (const item of items) {
     const dateLabel = getDateLabel(item.timestamp)
 
     if (dateLabel !== lastDateLabel) {
-      elements.push(<FeedDateDivider key={`divider-${dateLabel}-${index}`} label={dateLabel} />)
+      elements.push(<FeedDateDivider key={`divider-${dateLabel}-${item.item_key}`} label={dateLabel} />)
       lastDateLabel = dateLabel
     }
 
-    elements.push(<FeedCardRouter key={`${item.type}-${item.timestamp}-${index}`} item={item} />)
+    elements.push(
+      <FeedCardRouter
+        key={item.item_key}
+        item={item}
+        archivedView={archivedView}
+        onArchiveChange={onArchiveChange}
+      />,
+    )
   }
 
   return elements

--- a/frontend/src/pages/updates/__tests__/archivedTab.test.ts
+++ b/frontend/src/pages/updates/__tests__/archivedTab.test.ts
@@ -1,0 +1,83 @@
+/**
+ * The Archived tab's wiring (#1194) — the pure parts of `useUpdates`.
+ *
+ * The hook itself self-fetches, and this harness has no DOM, so what is pinned
+ * here is the tab vocabulary: the seventh entry, the two maps that must not be
+ * confused, and the deliberate absence of a badge.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  ALL_FILTERS,
+  ARCHIVED_FILTER,
+  FILTER_API_MAP,
+  FILTER_URL_MAP,
+  ROW_1_FILTERS,
+  ROW_2_FILTERS,
+  getCount,
+} from '../useUpdates'
+import type { FeedCounts } from '../../../api/activityFeed'
+
+const COUNTS: FeedCounts = {
+  all: 9,
+  friends: 4,
+  foes: 2,
+  your_stuff: 1,
+  global_count: 1,
+  requests: 1,
+}
+
+describe('Archived is the seventh tab', () => {
+  it('sits alongside the existing six, not instead of any', () => {
+    expect(ALL_FILTERS).toEqual([
+      'All',
+      'Friends',
+      'Foes',
+      'Your Stuff',
+      'Global',
+      'Requests',
+      'Archived',
+    ])
+    expect(ROW_1_FILTERS).toHaveLength(4)
+    expect(ROW_2_FILTERS).toContain('Archived')
+  })
+
+  it('every tab has both an API filter and a deep-link token', () => {
+    for (const filter of ALL_FILTERS) {
+      expect(FILTER_API_MAP[filter], filter).toBeTruthy()
+      expect(FILTER_URL_MAP[filter], filter).toBeTruthy()
+    }
+  })
+
+  it('sends the `all` type-set, because archived-ness is state not a type-set', () => {
+    // `archived=true` is crossed WITH a filter and is never a member of one. The
+    // archive ignores the friend/foe/global slicing entirely, so the filter it
+    // crosses with is `all`.
+    expect(FILTER_API_MAP[ARCHIVED_FILTER]).toBe('all')
+  })
+
+  it('keeps a deep-link token of its OWN, distinct from every other', () => {
+    // The reason FILTER_URL_MAP exists: Archived and All send the same API
+    // filter, so resolving `?filter=` through FILTER_API_MAP would have made
+    // `?filter=archived` unreachable and `?filter=all` ambiguous.
+    expect(FILTER_URL_MAP[ARCHIVED_FILTER]).toBe('archived')
+    const tokens = ALL_FILTERS.map((filter) => FILTER_URL_MAP[filter])
+    expect(new Set(tokens).size, 'every token unique').toBe(tokens.length)
+  })
+
+  it('leaves the six existing deep links exactly as they were', () => {
+    // Links already in the wild (Sidebar → Requests) must keep working.
+    expect(FILTER_URL_MAP['Requests']).toBe('requests')
+    expect(FILTER_URL_MAP['Your Stuff']).toBe('your_stuff')
+    expect(FILTER_URL_MAP['Global']).toBe('global')
+    expect(FILTER_URL_MAP['All']).toBe('all')
+  })
+
+  it('draws no badge — FeedCounts has no archived count, by design', () => {
+    // Counts describe the LIVE feed and stay truthful while the archive is on
+    // screen (#1193). `0` means "no badge", not "the archive is empty".
+    expect(getCount('Archived', COUNTS)).toBe(0)
+    // …and the other six still read their own count.
+    expect(getCount('All', COUNTS)).toBe(9)
+    expect(getCount('Requests', COUNTS)).toBe(1)
+  })
+})

--- a/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
+++ b/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
@@ -16,6 +16,7 @@ import type { ActivityFeedItem } from '../../../api/activityFeed'
 function completion(slug: string, id: number, title: string): ActivityFeedItem {
   return {
     type: 'friend_completion',
+    item_key: `friend_completion:${id}`,
     timestamp: '2026-01-01T00:00:00Z',
     actor_display_name: 'Ada',
     actor_faction_slug: slug,
@@ -37,6 +38,12 @@ function baseState(overrides: Partial<UpdatesState>): UpdatesState {
     fetchError: null,
     loadMoreError: null,
     loadMore: async () => {},
+    archivedView: false,
+    refreshCounts: () => {},
+    archiveAll: async () => {},
+    restoreAll: async () => {},
+    bulkPending: false,
+    bulkError: null,
     ...overrides,
   }
 }
@@ -81,8 +88,20 @@ describe('mobile Updates mixed multi-faction stream', () => {
     expect(text).toContain('Map the boring')
   })
 
-  it('shows the empty state when the stream is empty', () => {
+  it('shows the FEED empty state when the stream is empty (#1194)', () => {
     const { text } = render(baseState({ items: [] }))
-    expect(text).toContain('No updates yet')
+    expect(text).toContain('Nothing left to read.')
+    expect(text).toContain('The city is quiet.')
+  })
+
+  it('shows the ARCHIVE empty state on the Archived tab, never the feed one', () => {
+    // Two empty states, never collapsed into one: an empty feed is an invitation
+    // to go and do something, an empty archive is a statement that you have
+    // thrown nothing away.
+    const { text } = render(
+      baseState({ items: [], filter: 'Archived', archivedView: true }),
+    )
+    expect(text).toContain('The archive is empty.')
+    expect(text).not.toContain('Nothing left to read.')
   })
 })

--- a/frontend/src/pages/updates/useUpdates.ts
+++ b/frontend/src/pages/updates/useUpdates.ts
@@ -1,14 +1,41 @@
 import { useEffect, useState, useCallback } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { getActivityFeed, type ActivityFeedItem, type FeedCounts } from '../../api/activityFeed'
+import {
+  dismissAllFeedItems,
+  getActivityFeed,
+  restoreAllFeedItems,
+  type ActivityFeedItem,
+  type FeedCounts,
+} from '../../api/activityFeed'
+import i18n from '../../i18n'
 import { extractError } from '../../utils/errors'
 import { onRequestsChanged } from '../../utils/requestsBus'
 
-export type FeedFilter = 'All' | 'Friends' | 'Foes' | 'Your Stuff' | 'Global' | 'Requests'
+export type FeedFilter =
+  | 'All'
+  | 'Friends'
+  | 'Foes'
+  | 'Your Stuff'
+  | 'Global'
+  | 'Requests'
+  | 'Archived'
 
 export const ROW_1_FILTERS: FeedFilter[] = ['All', 'Friends', 'Foes', 'Your Stuff']
-export const ROW_2_FILTERS: FeedFilter[] = ['Global', 'Requests']
+export const ROW_2_FILTERS: FeedFilter[] = ['Global', 'Requests', 'Archived']
 export const ALL_FILTERS: FeedFilter[] = [...ROW_1_FILTERS, ...ROW_2_FILTERS]
+
+/**
+ * The seventh tab (#1194). Archived is a FILTER TAB rather than a stacked section
+ * below the feed (epic #1192 decision 8): the design sheet stacks it because a
+ * sheet has a fixed height, but a real feed is infinite-scroll and would push the
+ * archive permanently below the horizon.
+ *
+ * It is not a member of the API's filter set. Archived-ness is *state* and
+ * `?filter=` is a type-set, so the request is `archived=true` crossed with a
+ * filter — and the archive ignores the friend/foe/global slicing entirely, so the
+ * filter it crosses with is always `all`.
+ */
+export const ARCHIVED_FILTER: FeedFilter = 'Archived'
 
 /** Map UI filter name to API filter param. */
 export const FILTER_API_MAP: Record<FeedFilter, string> = {
@@ -18,9 +45,31 @@ export const FILTER_API_MAP: Record<FeedFilter, string> = {
   'Your Stuff': 'your_stuff',
   'Global': 'global',
   'Requests': 'requests',
+  // The archive shows everything archived; the type-set is not what selects it.
+  'Archived': 'all',
 }
 
-/** Map filter name to the key in FeedCounts. */
+/**
+ * Deep-link token per tab, kept SEPARATE from the API map. `Archived` and `All`
+ * send the same API filter, so resolving `?filter=` through `FILTER_API_MAP`
+ * would make `?filter=archived` unreachable and `?filter=all` ambiguous. Every
+ * other token is unchanged, so links already in the wild (Sidebar → Requests)
+ * keep working.
+ */
+export const FILTER_URL_MAP: Record<FeedFilter, string> = {
+  ...FILTER_API_MAP,
+  'Archived': 'archived',
+}
+
+/**
+ * Map filter name to the key in FeedCounts.
+ *
+ * Archived has NO count, deliberately (#1193). `FeedCounts` would need a second
+ * full 15-query count fan-out on every request to carry one, and the counts are
+ * defined to describe the LIVE feed — they stay truthful while the player reads
+ * the archive rather than going quiet. `0` here means the tab draws no badge; it
+ * does not claim the archive is empty.
+ */
 export function getCount(filter: FeedFilter, counts: FeedCounts): number {
   switch (filter) {
     case 'All': return counts.all
@@ -29,7 +78,17 @@ export function getCount(filter: FeedFilter, counts: FeedCounts): number {
     case 'Your Stuff': return counts.your_stuff
     case 'Global': return counts.global_count
     case 'Requests': return counts.requests
+    case 'Archived': return 0
   }
+}
+
+const EMPTY_COUNTS: FeedCounts = {
+  all: 0,
+  friends: 0,
+  foes: 0,
+  your_stuff: 0,
+  global_count: 0,
+  requests: 0,
 }
 
 export interface UpdatesState {
@@ -43,37 +102,56 @@ export interface UpdatesState {
   fetchError: string | null
   loadMoreError: string | null
   loadMore: () => Promise<void>
+  /** True while the Archived tab is on screen. Drives the restore-shaped
+   *  controls, the "still waiting" tag, and which empty state is drawn. */
+  archivedView: boolean
+  /** Refresh the tab counts WITHOUT touching `items`. Called after a single
+   *  archive write: dropping the item would delete the slot its undo strip is
+   *  standing in, so the row stays and only the badges catch up. */
+  refreshCounts: () => void
+  /** Archive everything the current tab shows / empty the whole archive. */
+  archiveAll: () => Promise<void>
+  restoreAll: () => Promise<void>
+  bulkPending: boolean
+  bulkError: string | null
 }
 
 /**
  * Shared Updates state — the one activity-feed fetch (filter tabs + cursor
  * pagination) consumed by both the desktop page and the mobile stream (#532).
  * Presentation-only split: the mobile branch renders the SAME items through the
- * SAME per-faction FeedCardRouter frames, so no data/API change is needed.
+ * SAME per-faction chassis, so no data/API change is needed — which is also why
+ * the Archived tab reaches the phone for free (#1194).
  */
 export function useUpdates(): UpdatesState {
   const [searchParams] = useSearchParams()
   const [items, setItems] = useState<ActivityFeedItem[]>([])
-  const [counts, setCounts] = useState<FeedCounts>({ all: 0, friends: 0, foes: 0, your_stuff: 0, global_count: 0, requests: 0 })
-  // Deep-link the initial tab from ?filter=<api value> (e.g. Sidebar → Requests).
+  const [counts, setCounts] = useState<FeedCounts>(EMPTY_COUNTS)
+  // Deep-link the initial tab from ?filter=<url token> (e.g. Sidebar → Requests).
   const [filter, setFilter] = useState<FeedFilter>(() => {
-    const apiFilter = searchParams.get('filter')
-    return ALL_FILTERS.find((name) => FILTER_API_MAP[name] === apiFilter) ?? 'All'
+    const urlFilter = searchParams.get('filter')
+    return ALL_FILTERS.find((name) => FILTER_URL_MAP[name] === urlFilter) ?? 'All'
   })
   const [loading, setLoading] = useState(true)
   const [loadingMore, setLoadingMore] = useState(false)
   const [nextCursor, setNextCursor] = useState<string | null>(null)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [loadMoreError, setLoadMoreError] = useState<string | null>(null)
-  // Bumped when a request is accepted/declined/submitted anywhere; re-runs the
-  // load effect so the tab counts (esp. Requests) resolve without a reload.
+  const [bulkPending, setBulkPending] = useState(false)
+  const [bulkError, setBulkError] = useState<string | null>(null)
+  // Bumped when a request is accepted/declined/submitted anywhere, or after a
+  // bulk archive; re-runs the load effect so the tab counts (esp. Requests)
+  // resolve without a reload.
   const [refreshKey, setRefreshKey] = useState(0)
+
+  const archivedView = filter === ARCHIVED_FILTER
 
   const fetchFeed = useCallback(async (feedFilter: FeedFilter, cursor?: string) => {
     return getActivityFeed({
       filter: FILTER_API_MAP[feedFilter],
       before: cursor,
       limit: 20,
+      archived: feedFilter === ARCHIVED_FILTER,
     })
   }, [])
 
@@ -114,6 +192,49 @@ export function useUpdates(): UpdatesState {
     setLoadingMore(false)
   }
 
+  /**
+   * Counts only. Archiving one card must not reload `items`: the card's slot is
+   * standing there showing an undo strip, and refetching would pull the item out
+   * from under it and jump the list — exactly what the design's
+   * strip-in-its-own-slot rule exists to prevent. The badges are worth one small
+   * request; the ordering is not worth breaking.
+   */
+  const refreshCounts = useCallback(() => {
+    getActivityFeed({ filter: FILTER_API_MAP[filter], limit: 1 })
+      .then((response) => setCounts(response.counts))
+      .catch(() => { /* a stale badge is not worth an error surface */ })
+  }, [filter])
+
+  /** Archive everything this tab currently shows. The server re-runs the feed
+   *  for the same filter, so the scope can never drift from what is on screen. */
+  const archiveAll = async () => {
+    if (bulkPending) return
+    setBulkPending(true)
+    setBulkError(null)
+    try {
+      await dismissAllFeedItems(FILTER_API_MAP[filter])
+      setRefreshKey((key) => key + 1)
+    } catch (err) {
+      setBulkError(extractError(err, i18n.t('feed:archive.error')))
+    }
+    setBulkPending(false)
+  }
+
+  /** Empty the archive. No filter — "Restore all" on the Archived tab means
+   *  everything, and the archived view has no tabs of its own. */
+  const restoreAll = async () => {
+    if (bulkPending) return
+    setBulkPending(true)
+    setBulkError(null)
+    try {
+      await restoreAllFeedItems()
+      setRefreshKey((key) => key + 1)
+    } catch (err) {
+      setBulkError(extractError(err, i18n.t('feed:archive.restoreError')))
+    }
+    setBulkPending(false)
+  }
+
   return {
     items,
     counts,
@@ -125,5 +246,11 @@ export function useUpdates(): UpdatesState {
     fetchError,
     loadMoreError,
     loadMore,
+    archivedView,
+    refreshCounts,
+    archiveAll,
+    restoreAll,
+    bulkPending,
+    bulkError,
   }
 }


### PR DESCRIPTION
Frontend only. The load-bearing issue of epic #1192: after this the archive **works end to end in the `na` skin for every player**, and the eight faction issues become pure dress.

Closes #1194

Consumes the contract merged in #1235. No backend change.

---

## THE CHASSIS SEAM — read this first, all nine of you

Every feed item is **three layers**, each owning exactly one thing. A dress issue rewrites exactly one of them.

```
FeedItemSlot          the ARCHIVE — the ✕, the swipe, the write, the undo strip.
                      Faction-blind. A skin must not touch or reimplement any of it.
  └ FactionFeedFrame  the CHASSIS — one per faction, dispatched on `context_faction_slug`.
                      Draws the kicker band, the tag, the time; PLACES the archive node.
                      *** THIS IS WHAT A DRESS ISSUE REWRITES. Nothing else. ***
      └ the body      shared PAYLOAD — `FeedRowContent` or one of three companions.
                      Faction-blind. No body needs touching, ever.
```

So the whole of "give this faction its own feed card" is: **claim `feedFrame` in the faction's manifest.** That is it.

### The contract you build against

`FactionManifest.feedFrame` was `Lazy<ComponentType<{ children: ReactNode }>>`. It is now `Lazy<ComponentType<FeedFrameProps>>`:

```ts
interface FeedFrameProps {
  kicker: string        // the neutral name for this card's KIND. Never a faction name.
  time: string          // relative timestamp, already formatted ("2h ago")
  tag: string | null    // today only "Still waiting". Nullable.
  archive: ReactNode    // pre-composed. PLACE IT; do not rebuild it.
  children: ReactNode   // the payload body
}
```

**Nothing may be written against the old `{ children }` shape.** All eight existing frames are converted in this PR (#782's lesson: a widened seam invalidates anything queued against the old one).

### Five rules for a faction frame

1. **Draw all four slots.** `kicker`, `time` and `archive` are chrome, not decoration. `kicker` is a card's only kind label; `time` is its only timestamp (the row stopped drawing one — see below); `archive` is the **entire** keyboard and screen-reader route to the archive. A frame that swallows one loses a feature. `tag` is nullable. A test loops every frame and asserts all four survive.
2. **Never print a faction name.** The skin is the identification (epic decision 5).
3. **`archive` is a finished node — place it, don't rebuild it.** It is already dormant-at-40%-until-hover-**or-focus**, already keyboard reachable, already labelled, and already **`null`** when the card cannot be archived. It paints in `currentColor`, so **tint it by setting `color` on whatever you place it inside.**
4. **One responsive component per faction**, no mobile twin (ADR-0056 / 0058 / 0063).
5. **Swipe, the undo strip and the archived list are NOT yours.** They live in `FeedItemSlot`. You inherit all three free.

### The convenience you may throw away

`FeedChassisBand` renders `kicker · tag → time · archive` — the arrangement every sheet happens to draw, factored out so eight frames don't each re-derive the ellipsis, the wrap and the auto-margin. It is **not** part of the contract. Place the four slots by hand if your sheet wants them elsewhere. Just don't drop one.

### Two things that moved, so you don't re-add them

- **The row no longer draws a timestamp.** `FeedRow` lost its `time` slot; the chassis draws it. If your sheet puts a date on the band, that is now correct — and `WowFeedFrame`'s docblock, which called it card content, has been corrected.
- **`FeedRow` gained `actions`** — CTAs on ordinary rows, not just companions (epic §2b).

### Where `comment_mention` plugs in (#1196)

It already reaches `FeedCardRouter` and currently returns `''`. Give it a body in `normalizeFeedItem` and it inherits the chassis, the kicker, the archive and the swipe with **no change to the router**. Its kicker key (`feed:kicker.comment_mention` = "Mention") is already authored. Its row-action copy is not — that is #1196's, and it is the only issue permitted to add to this catalog.

---

## What to eyeball

1. **The seam itself** — `components/feed/feedFrameProps.ts` and `FeedCardRouter.tsx`'s docblock. Nine agents build against these. If either is vague, say so now, not after eight PRs.
2. **`FeedItemSlot` writes the dismissal on the tap, not after six seconds.** The obvious implementation defers the write until the window closes. That loses the dismissal the moment the player navigates away — which is most of the time. So the write is immediate and *undo issues the reverse write*. The strip offers a reversal; it does not delay an action.
3. **The strip stands in the card's own slot and DEGRADES rather than vanishing.** At 6s its action becomes `Restore` (or `Archive`, in the archive) instead of the slot collapsing — the list must not jump under a reader who looked away. It clears on the next fetch.
4. **Cards are keyed on `item_key`** (was type+timestamp+index). That is what the backend's stable identity is *for*: a slot mid-undo must not be remounted, and its six-second window restarted, by anything happening around it.
5. **`refreshCounts` refreshes badges without reloading `items`.** One extra small request after each archive write. Reloading items would pull the archived item out from under the strip standing in its slot — exactly what §2a's strip-in-its-own-slot rule exists to prevent. Deliberate trade; say so if you disagree.
6. **Archived has no badge.** `FeedCounts` has no archived count by design (#1193), so `getCount('Archived')` returns `0`. That means *no badge*, not *the archive is empty*. Counts keep describing the live feed while the archive is on screen.
7. **`FILTER_URL_MAP` is new and separate from `FILTER_API_MAP`.** Archived and All send the same API filter (`all` — the archive ignores type slicing), so resolving `?filter=` through the API map would have made `?filter=archived` unreachable and `?filter=all` ambiguous. Existing tokens are byte-identical, so `Sidebar → Requests` still works.
8. **`awaiting_submission` gets no control at all** — not a disabled one. It is state, not an event; the backend 400s. Verified by a test that also asserts the string `disabled` is absent from its markup.
9. **Swipe is touch-only.** `event.pointerType !== 'touch'` returns early. A mouse-drag would fight text selection and the links inside every card, and the ✕ is already both the pointer route and the a11y route. Swipe is never the only way in.
10. **Singularity's boot strip lost its blanket `aria-hidden`.** It was `aria-hidden` in one piece, which cannot hold the dismiss control — and that control is the whole keyboard/SR route to the archive. The two ornamental spans carry it individually now.
11. **UA's band is inset on the right** rather than the ensō being moved: a functional control must not land under an ornament.
12. **`era_announcement` is the deliberate exception** — not wrapped, keeps its own always-dark chrome, gains the ✕ in its existing header and nothing else. An era turn can strip a player of their faction, so speaking that card in their voice is backwards (epic decision 6).
13. **The two big companions kept every handler.** `FeedCardRouter` used to warn they "must NOT collapse into slots"; that objection was about `FeedRowContent`'s fixed slot bag, and a chassis takes arbitrary children. Accept, decline, withdraw, bank-full drop-and-retry and the accepted state variants are all untouched — a test asserts accept + decline still render inside the chassis for both.
14. **`Nudge back` is still not built, and its copy key is now deleted.** The endpoint exists but nothing on either payload can satisfy its authorization (collab: the sender must have already filed, and a nudge recipient by construction has not; duel: the rival's praxis id is not in the payload). Dead copy for an unbuilt state is worse than an absent key.
15. **Two empty states, never collapsed.** "Nothing left to read." / "The city is quiet." vs "The archive is empty." / "Dismissed updates rest here". `page.empty` ("No updates yet…") is deleted — it was neither, and in the Archived tab it would have been actively wrong.

## Verified

- **`tsc --noEmit`: clean.**
- **`eslint src --max-warnings=0`: clean.** No new `no-raw-style-values` suppressions; the existing ornament exemptions were carried, not added to.
- **`vite build`: clean.** Entry chunk 135.00 KB gzip, unmoved.
- **`vitest run`: 142 files, 2434 passed, 0 failed.** 34 of those are new here.
- Rebased onto `origin/main` @ `a32e8fa7` and re-verified after the rebase. No file overlap with anything that landed since.

**Two existing assertions were REVERSED on purpose, each flagged in its own commit:**

- *"passes a null/neutral slug straight through"* → now asserts the Unaffiliated chassis. That test was right when the only card carrying a null slug was `era_announcement`, which brings its own chrome — and that card no longer routes through the frame at all. A passthrough today would mean a card with no kicker, no time and no way to be dismissed.
- The mobile empty-state assertion, which pinned the deleted `page.empty`. It now pins **both** states, and that the archive's never shows the feed's.

## NOT verified

- **No visual QA.** This environment cannot screenshot and there is no dev stack. **Every layout claim in this PR is inference from the code, not observation.** The bands are placed to preserve each frame's existing look, but nobody has looked. Worth a pass on: Coven's title bar (the kicker now rides beside `coven.exe`), Singularity's boot strip, WOW's dispatch band, and UA's ✕/ensō clearance.
- **The 6s timer and the swipe are untested end to end.** The frontend harness is `renderToStaticMarkup` only — no jsdom, so no effect runs and no pointer event fires. They are asserted at their seams (the strip's two label phases, the commit fraction, the `pointerType` gate) rather than driven. Real verification is a human on a phone.
- **`FeedRowActions`' `leavePraxis` call is not exercised.** Same reason.
- **Not verified against a live server.** No request in this PR has been issued for real; the client contract is read off #1235's routes and its Pydantic response models.

## Outside this agent's scope, still open

- **`docs/spec/SPEC-faction-ui-profile.md` §12 is now STALE, and eight agents will read it.** It still describes the frame + `FeedRowContent` split and names all four companions as chassis-exempt; three of them moved inside, and the frame's props changed. This agent is scoped to `frontend/`. **Please amend §12 before dispatching the dress issues** — a stale spec at that exact seam is how #782 went wrong. The authoritative description meanwhile is `feedFrameProps.ts` + `FeedCardRouter.tsx`, both written to be read first.
- **ADR-0066 (archive) / ADR-0067 (chassis) unwritten** — epic-level docs, outside `frontend/`. `0065` is taken by #1179; do not reuse.

## No faction sheet's wording appears anywhere in the diff

Copy is faction-neutral throughout, in the domain's own plain nouns per the Unaffiliated sheet: Archive · Restore · Undo · Still waiting · File it · Drop out · Answer. A test asserts none of `Tuck away` / `Bin it` / `Spike it` / `rm --event` / `Shelve` appears anywhere in the catalog.

The catalog is authored **once, here**. The eight faction issues append nothing to it and must never edit it — eight agents editing one JSON namespace in parallel has taken `main` red in this repo before. The ~10 per-faction flavour keys under `praxis.json` → `comments.<slug>.*` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
