### PR TITLE
B1: comment_mention gets a body — every @mention card has been blank (#1196)

### DIFF
--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -138,6 +138,11 @@ SUB_QUERY_LIMIT = 50
 ERA_ANNOUNCEMENT_LIMIT = 5
 ADMIN_ACTOR_NAME = "Admin"
 
+# How much of a mentioning comment the feed card quotes. The card shows the
+# excerpt verbatim and does not re-truncate, so this number is the whole of what
+# a reader sees before they open the thread.
+COMMENT_EXCERPT_LENGTH = 140
+
 
 @dataclass(frozen=True)
 class FeedContext:
@@ -674,6 +679,7 @@ def _comment_mentions_query(ctx: FeedContext) -> Select:
             Comment.created_at,
             Comment.praxis_id,
             Comment.task_id,
+            Character.id.label("author_character_id"),
             Character.display_name.label("author_display_name"),
             Character.faction_slug.label("author_faction_slug"),
             Character.avatar_url.label("author_avatar_url"),
@@ -701,9 +707,18 @@ def _comment_mention_item(row: Any) -> ActivityFeedItemDC:
         actor_avatar_url=row.author_avatar_url,
         payload={
             "comment_id": row.id,
+            # The commenter, so the card's actor can link to their character page
+            # like every other actor-bearing type (#1196). Keyed "character_id"
+            # to match friend_completion / friend_signup / friend_defection /
+            # collaborator_submitted — the frontend reads one payload key for
+            # "whose name is this", not a per-type spelling.
+            "character_id": row.author_character_id,
+            # Exactly one of these is set: num_nonnulls(praxis_id, task_id) = 1 is
+            # a DB CHECK (migration 0005), so the client can read them in order
+            # without a tie-break.
             "praxis_id": row.praxis_id,
             "task_id": row.task_id,
-            "excerpt": row.body_text[:140],
+            "excerpt": row.body_text[:COMMENT_EXCERPT_LENGTH],
         },
     )
 

--- a/backend/tests/integration/test_activity_feed_archive.py
+++ b/backend/tests/integration/test_activity_feed_archive.py
@@ -41,6 +41,7 @@ from services.activity_feed import (
     FEED_ITEM_TYPE_AWAITING_SUBMISSION,
     FEED_ITEM_TYPE_COLLAB_INVITE,
     FEED_ITEM_TYPE_COLLABORATOR_SUBMITTED,
+    FEED_ITEM_TYPE_COMMENT_MENTION,
     FEED_ITEM_TYPE_FRIEND_COMPLETION,
     FEED_ITEM_TYPE_FRIEND_SIGNUP,
     FEED_ITEM_TYPE_GLOBAL_TASK,
@@ -415,6 +416,32 @@ async def test_the_archive_is_per_character(
 
     other = await _feed(client, auth_headers2, "global")
     assert target in [item["item_key"] for item in other["items"]]
+
+
+@pytest.mark.asyncio
+async def test_a_mention_is_archivable_like_any_other_event(
+    client: AsyncClient, full_feed: dict, auth_headers: dict
+):
+    """``comment_mention`` is an EVENT, not a standing obligation (#1196).
+
+    Someone said your name; there is nothing to answer and nothing clears itself,
+    so it takes the general archive rule. ``awaiting_submission`` is the sole
+    exemption, and this pins that the mention had not quietly joined it during the
+    long stretch when its card rendered as nothing and nobody could have noticed.
+    """
+    before = await _feed(client, auth_headers)
+    target = _key_of(before, FEED_ITEM_TYPE_COMMENT_MENTION)
+
+    response = await client.post(
+        "/activity-feed/dismiss", json={"item_key": target}, headers=auth_headers
+    )
+    assert response.status_code == 200, response.text
+    assert response.json() == {"item_key": target, "archived": True, "changed": True}
+
+    after = await _feed(client, auth_headers)
+    assert target not in [item["item_key"] for item in after["items"]]
+    archived = await _feed(client, auth_headers, ALL_FILTER, archived=True)
+    assert target in [item["item_key"] for item in archived["items"]]
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_comments.py
+++ b/backend/tests/integration/test_comments.py
@@ -274,6 +274,152 @@ async def test_mention_notifies_via_activity_feed(
     assert mention_items[0]["actor_display_name"] == character2.display_name
 
 
+# ── The mention CARD (#1196) ──────────────────────────────────────────────────
+#
+# `comment_mention` had a correct query and a complete payload from the day it
+# shipped and no frontend case, so every mention ever sent rendered as nothing.
+# The fix is frontend, but it leans on three backend facts. These pin them, so a
+# change here fails loudly instead of quietly blanking the card again.
+
+
+@pytest.mark.asyncio
+async def test_mention_payload_carries_what_the_card_draws(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    praxis_solo: Praxis,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Actor link, exactly one target, and the quoted excerpt."""
+    await client.post(
+        f"/praxes/{praxis_solo.id}/comments",
+        json={"body_text": "this bit is yours @testcharacter"},
+        headers=auth_headers2,
+    )
+    feed = await client.get(
+        "/activity-feed", params={"filter": "your_stuff"}, headers=auth_headers
+    )
+    payload = [i for i in feed.json()["items"] if i["type"] == "comment_mention"][0][
+        "payload"
+    ]
+    # The commenter, so the card's actor can link to their character page.
+    assert payload["character_id"] == character2.id
+    # Exactly one target — the CHECK constraint, seen from the client's side. The
+    # card reads praxis_id then task_id and needs no tie-break.
+    assert payload["praxis_id"] == praxis_solo.id
+    assert payload["task_id"] is None
+    # The card quotes this verbatim and does not re-truncate.
+    assert payload["excerpt"] == "this bit is yours @testcharacter"
+
+
+@pytest.mark.asyncio
+async def test_mention_counts_under_your_stuff_not_requests(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    praxis_solo: Praxis,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A mention is news about you, not a request of you.
+
+    Nothing is being asked — there is no accept, decline or answer — so it counts
+    under Your stuff and must NOT inflate the Requests badge, which exists to say
+    "someone is waiting on a decision from you".
+    """
+    await client.post(
+        f"/praxes/{praxis_solo.id}/comments",
+        json={"body_text": "over to you @testcharacter"},
+        headers=auth_headers2,
+    )
+
+    def mentions(body: dict) -> list[dict]:
+        return [i for i in body["items"] if i["type"] == "comment_mention"]
+
+    for tab in ("all", "your_stuff"):
+        feed = await client.get(
+            "/activity-feed", params={"filter": tab}, headers=auth_headers
+        )
+        assert len(mentions(feed.json())) == 1, (tab, feed.json()["items"])
+    assert feed.json()["counts"]["your_stuff"] >= 1
+
+    requests_feed = await client.get(
+        "/activity-feed", params={"filter": "requests"}, headers=auth_headers
+    )
+    assert mentions(requests_feed.json()) == []
+
+
+@pytest.mark.asyncio
+async def test_withdrawn_mention_leaves_no_card(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    praxis_solo: Praxis,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Withdrawing the comment withdraws the mention card with it.
+
+    The card quotes the comment's own words, so a withdrawn comment that still had
+    a feed card would keep publishing text its author had retracted — to the one
+    person it named.
+    """
+    create = await client.post(
+        f"/praxes/{praxis_solo.id}/comments",
+        json={"body_text": "ignore this @testcharacter"},
+        headers=auth_headers2,
+    )
+    comment_id = create.json()["id"]
+    delete = await client.delete(f"/comments/{comment_id}", headers=auth_headers2)
+    assert delete.status_code == 204
+
+    feed = await client.get(
+        "/activity-feed", params={"filter": "your_stuff"}, headers=auth_headers
+    )
+    assert [i for i in feed.json()["items"] if i["type"] == "comment_mention"] == []
+
+
+@pytest.mark.asyncio
+async def test_hidden_mention_leaves_no_card(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    praxis_solo: Praxis,
+    era: Era,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """A comment hidden by moderation loses its card too.
+
+    The mention query asks for ``moderation_status == visible``, so the card and
+    the public thread hide the same comment at the same moment. A card that
+    outlived the hiding would republish flagged text straight into the feed of the
+    person it was aimed at.
+    """
+    create = await client.post(
+        f"/praxes/{praxis_solo.id}/comments",
+        json={"body_text": "rude thing @testcharacter"},
+        headers=auth_headers2,
+    )
+    comment_id = create.json()["id"]
+    # comment_flag_review_threshold is 1, so one flag from an eligible flagger
+    # (flag_level_required=4) moves it out of `visible`.
+    await _set_level(db_session, character, era, 5)
+    flag = await client.post(
+        f"/comments/{comment_id}/flag",
+        json={"reason": "spam"},
+        headers=auth_headers,
+    )
+    assert flag.status_code == 200, flag.text
+
+    feed = await client.get(
+        "/activity-feed", params={"filter": "your_stuff"}, headers=auth_headers
+    )
+    assert [i for i in feed.json()["items"] if i["type"] == "comment_mention"] == []
+
+
 # Exactly-one-target is a DB CHECK (num_nonnulls(praxis_id, task_id) = 1, in
 # migration 0005). The service guards it first with a clean 422; testing the guard
 # here keeps us clear of the conftest's SAVEPOINT machinery, which an IntegrityError

--- a/frontend/src/components/__tests__/feedChassis.test.tsx
+++ b/frontend/src/components/__tests__/feedChassis.test.tsx
@@ -92,15 +92,14 @@ const FAT_PAYLOAD = {
   invite_id: 8,
   inviter_character_id: 3,
   task_faction_slug: 'coven',
+  comment_id: 11,
+  excerpt: 'your name came up',
 }
 
 describe('the archive control: which cards offer one', () => {
   it('draws an archive control on every archivable type', () => {
     for (const type of ALL_FEED_TYPES) {
       if (NON_ARCHIVABLE_TYPES.has(type)) continue
-      // comment_mention has no body until #1196 and renders nothing at all; it
-      // is not a card that lost its control.
-      if (type === 'comment_mention') continue
       expect(render(item(type, FAT_PAYLOAD)), `${type} offers the ✕`).toContain(
         ARCHIVE_LABEL,
       )
@@ -180,8 +179,24 @@ describe('the chassis', () => {
     expect(html, 'gains the ✕').toContain(ARCHIVE_LABEL)
   })
 
-  it('renders nothing for a type with no body yet (comment_mention, until #1196)', () => {
-    expect(render(item('comment_mention', FAT_PAYLOAD))).toBe('')
+  // REVERSED in #1196, deliberately. This asserted `render(comment_mention) ===
+  // ''` — a true description of a bug, pinned as if it were a rule. Every
+  // @mention anyone had ever received drew a blank card, and this is the
+  // assertion that would have caught it on day one had it been written the other
+  // way round. There is now no feed type the backend emits that renders nothing.
+  it('draws a real card for every one of the 15 types the backend emits', () => {
+    for (const type of ALL_FEED_TYPES) {
+      expect(render(item(type, FAT_PAYLOAD)), `${type} renders`).not.toBe('')
+    }
+  })
+
+  it('gives comment_mention the chassis with no change to the router (#1196)', () => {
+    // The seam's first customer: a body in `normalizeFeedItem` and the card
+    // inherits the kicker, the timestamp and the ✕ for free.
+    const html = render(item('comment_mention', FAT_PAYLOAD))
+    expect(html, 'the kicker band').toContain(feedKicker('comment_mention'))
+    expect(html, 'the archive route').toContain(ARCHIVE_LABEL)
+    expect(html, 'the coven chassis').toContain('--faction-coven')
   })
 })
 

--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -150,6 +150,71 @@ describe('normalizeFeedItem', () => {
     expect(row.headline).not.toContain('napping')
   })
 
+  // ── comment_mention (#1196) ────────────────────────────────────────────────
+  //
+  // The type shipped with a correct query, a complete payload and NO case here,
+  // so the normalizer returned null, `FeedCardRouter` fell through to `return
+  // null`, and every @mention anyone ever received rendered as nothing at all.
+
+  it('maps a mention to a quoted excerpt over the praxis it sits on', () => {
+    const row = normalizeFeedItem(
+      item('comment_mention', {
+        comment_id: 11,
+        character_id: 8,
+        praxis_id: 12,
+        task_id: null,
+        excerpt: 'the second half is yours @ada',
+      }),
+    )!
+    expect(row.actor).toBe('Ada')
+    expect(row.actorHref).toBe('/characters/8')
+    expect(row.action).toBe('mentioned you in a comment')
+    // News about you, not a request of you — nothing is being asked.
+    expect(row.badge?.label).toBe('Your Stuff')
+    expect(row.headline).toBe('the second half is yours @ada')
+    // Speech, so it is quoted like a taunt rather than titled like a task.
+    expect(row.headlineQuoted).toBe(true)
+    expect(row.headlineHref).toBe('/praxes/12')
+    expect(row.points).toBeNull()
+    expect(row.level).toBeNull()
+  })
+
+  it('sends a mention on a TASK comment to the task instead', () => {
+    // Exactly one of the two ids is ever set — `num_nonnulls(praxis_id, task_id)
+    // = 1` is a DB CHECK — so reading them in order cannot pick the wrong target.
+    const row = normalizeFeedItem(
+      item('comment_mention', {
+        comment_id: 12,
+        character_id: 8,
+        praxis_id: null,
+        task_id: 5,
+        excerpt: 'thought of you for this one',
+      }),
+    )!
+    expect(row.headlineHref).toBe('/tasks/5')
+  })
+
+  it('offers exactly one CTA on a mention, into the page holding the thread', () => {
+    // The Snide sheet draws two — "open the composer" and "open the thread" — and
+    // in this app those are the SAME navigation: `CommentThread` mounts the
+    // composer directly under the list, and no route, hash or query parameter
+    // opens one without the other. Two buttons with identical hrefs is not two
+    // affordances, so the quoted excerpt opens the thread and this is the
+    // invitation to answer it. Same ground on which #1194 struck "Nudge back".
+    const row = normalizeFeedItem(
+      item('comment_mention', { comment_id: 11, praxis_id: 12, excerpt: 'hi' }),
+    )!
+    expect(row.actions.map((action) => action.id)).toEqual(['reply'])
+    expect(row.actions[0].href).toBe('/praxes/12')
+    expect(row.actions[0].call).toBeUndefined()
+  })
+
+  it('builds no mention CTA when the payload names no target', () => {
+    const row = normalizeFeedItem(item('comment_mention', { comment_id: 11 }))!
+    expect(row.actions).toEqual([])
+    expect(row.headlineHref).toBeNull()
+  })
+
   it('has an actorless system row for a global task', () => {
     const row = normalizeFeedItem(item('global_task', { task_id: 5, task_title: 'New job', task_point_value: 10, task_level_required: 2 }))!
     expect(row.actor).toBeNull()
@@ -218,6 +283,49 @@ describe('FeedRowContent', () => {
     const naHtml = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={completionRow('na')} avatarUrl={null} /></MemoryRouter>)
     const albHtml = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={completionRow('albescent')} avatarUrl={null} /></MemoryRouter>)
     expect(albHtml).toBe(naHtml)
+  })
+
+  // A quoted headline used to be unconditionally inert, which was right while
+  // `foe_taunt` was the only quoted row (ADR-0031: no taunt page to link to) and
+  // wrong the moment a second one arrived carrying a target — the mention's href
+  // would have been silently dropped.
+  it('links a quoted excerpt to its target, and leaves a taunt inert', () => {
+    const mention = normalizeFeedItem(
+      item('comment_mention', {
+        comment_id: 11,
+        character_id: 8,
+        praxis_id: 12,
+        excerpt: 'over to you',
+      }),
+    )!
+    const mentionHtml = renderToStaticMarkup(
+      <MemoryRouter><FeedRowContent row={mention} avatarUrl={null} /></MemoryRouter>,
+    )
+    // Quoted (curly quotes from the catalog) AND clickable.
+    expect(mentionHtml).toContain('“over to you”')
+    expect(mentionHtml).toContain('href="/praxes/12"')
+    // The CTA is the second route to the same page, not a second destination.
+    expect(mentionHtml).toContain('Reply')
+
+    const taunt = normalizeFeedItem(
+      item('foe_taunt', {
+        from_character_id: 9,
+        taunt_id: 2,
+        faction_slug: 'coven',
+        trigger_type: 'level_up',
+        from_name: 'Ada',
+        to_name: 'Bo',
+      }),
+    )!
+    const tauntHtml = renderToStaticMarkup(
+      <MemoryRouter><FeedRowContent row={taunt} avatarUrl={null} /></MemoryRouter>,
+    )
+    // Its only destination is the actor — the quote itself goes nowhere.
+    expect(tauntHtml).toContain('href="/characters/9"')
+    expect(tauntHtml, 'the quote is a paragraph, not a link').toContain('<p class="font-body"')
+    for (const route of ['href="/praxes', 'href="/tasks']) {
+      expect(tauntHtml, `${route} must not appear on a taunt`).not.toContain(route)
+    }
   })
 
   // The other half of ADR-0039, and the half that looks like a bug: an actor's

--- a/frontend/src/components/feed/FeedCardRouter.tsx
+++ b/frontend/src/components/feed/FeedCardRouter.tsx
@@ -37,9 +37,10 @@ import FeedCardInvitationLetter from './FeedCardInvitationLetter'
  * exactly backwards. It keeps its own neutral always-dark chrome, is NOT wrapped
  * in a chassis, and gains only the ✕.
  *
- * `comment_mention` is #1196's job. It reaches this router already: give it a
- * body in `normalizeFeedItem` and it inherits the chassis, the kicker and the
- * archive with no change here.
+ * `comment_mention` was the seam's first customer and its proof: #1196 gave it a
+ * body in `normalizeFeedItem` and it picked up the chassis, the kicker, the
+ * timestamp, the ✕ and the swipe with NOT ONE LINE changed here. All fifteen
+ * backend types now render.
  */
 
 /** The three interactive companions — payload BODIES inside the chassis since
@@ -65,8 +66,10 @@ export default function FeedCardRouter({ item, archivedView = false, onArchiveCh
   const Companion = COMPANION_BODIES[item.type]
   const isEraAnnouncement = item.type === 'era_announcement'
 
-  // A type with no body yet (today: comment_mention, until #1196) renders
-  // nothing rather than an empty chassis.
+  // A type with no body renders nothing rather than an empty chassis. Every one
+  // of the fifteen the backend emits has a body as of #1196, so this guards a
+  // type added to the backend registry ahead of its frontend case — the exact
+  // fault that hid every @mention ever sent.
   if (!row && !Companion && !isEraAnnouncement) return null
 
   // "Still waiting" only in the archive, and only where there is something to

--- a/frontend/src/components/feed/FeedRowContent.tsx
+++ b/frontend/src/components/feed/FeedRowContent.tsx
@@ -162,12 +162,7 @@ export default function FeedRowContent({
           />
           <div style={{ flex: 1, minWidth: 0 }}>
             {row.headlineQuoted ? (
-              <p
-                className="font-body"
-                style={{ margin: 0, fontSize: 'var(--text-content)', fontStyle: 'italic', color: 'var(--color-text-primary)', lineHeight: 1.4 }}
-              >
-                {i18n.t('feed:row.quotedHeadline', { headline: row.headline })}
-              </p>
+              <QuotedHeadline headline={row.headline} href={row.headlineHref} />
             ) : row.headlineHref ? (
               <Link
                 to={row.headlineHref}
@@ -200,6 +195,43 @@ export default function FeedRowContent({
         </div>
       )}
     </div>
+  )
+}
+
+/**
+ * A quoted headline: somebody's actual words, not a title.
+ *
+ * Two row types use it. A taunt has nowhere to go — ADR-0031 means the catalog
+ * owns the words and there is no taunt page, so `headlineHref` is null. A comment
+ * mention's excerpt DOES have a home: the praxis or task the comment sits on
+ * (#1196). So the quote becomes a link exactly when the row handed it one.
+ *
+ * It was unconditionally inert before, which was right while `foe_taunt` was the
+ * only quoted row and wrong the moment a second one arrived carrying a target —
+ * the href would have been silently dropped. The type, size and italic are
+ * identical either way: the quote is speech, and dressing it as a bold title link
+ * would undo the distinction the quoting exists to draw.
+ */
+function QuotedHeadline({ headline, href }: { headline: string; href: string | null }) {
+  const quoted = i18n.t('feed:row.quotedHeadline', { headline })
+  const style: React.CSSProperties = {
+    margin: 0,
+    fontSize: 'var(--text-content)',
+    fontStyle: 'italic',
+    color: 'var(--color-text-primary)',
+    lineHeight: 1.4,
+  }
+  if (!href) {
+    return (
+      <p className="font-body" style={style}>
+        {quoted}
+      </p>
+    )
+  }
+  return (
+    <Link to={href} className="font-body" style={{ ...style, display: 'block', textDecoration: 'none' }}>
+      {quoted}
+    </Link>
   )
 }
 

--- a/frontend/src/components/feed/normalizeFeedItem.ts
+++ b/frontend/src/components/feed/normalizeFeedItem.ts
@@ -34,6 +34,7 @@ export const FACTION_ROW_TYPES = new Set([
   'collaborator_submitted',
   'awaiting_submission',
   'nudge',
+  'comment_mention',
 ])
 
 /**
@@ -119,6 +120,45 @@ function buildAwaitingActions(payload: Record<string, any>): FeedRowAction[] {
     })
   }
   return actions
+}
+
+/**
+ * Where a comment lives: `/praxes/{id}` or `/tasks/{id}`, never both.
+ *
+ * A comment hangs off EXACTLY ONE target — `num_nonnulls(praxis_id, task_id) = 1`
+ * is a DB CHECK (migration 0005) and the service guards it with a 422 first — so
+ * reading the two ids in order can never pick the wrong one.
+ *
+ * There is deliberately NO per-comment anchor. The thread is a plain list on the
+ * target page with no id on any row and no hash handling anywhere, so a
+ * `#comment-{id}` link would resolve to nothing at all. The page the comment sits
+ * on IS the deep link; landing there and reading the thread is the behaviour.
+ */
+function commentTargetHref(payload: Record<string, any>): string | null {
+  if (payload.praxis_id != null) return `/praxes/${payload.praxis_id}`
+  if (payload.task_id != null) return `/tasks/${payload.task_id}`
+  return null
+}
+
+/**
+ * The mention row's CTA: "Reply", a navigation to the page the comment sits on —
+ * which is where its thread and the composer both are.
+ *
+ * ONE control, not the two the Snide sheet draws. The sheet's pair is "open the
+ * composer on the target page" and "open the thread", and in this app those are
+ * the *same navigation*: `CommentThread` mounts the composer directly beneath the
+ * list on the praxis/task page, and there is no route, hash or query parameter
+ * that opens one without the other. Two buttons with identical `href`s is not two
+ * affordances. So the pair is served by the two link surfaces the row actually
+ * has — the quoted excerpt opens the thread, this CTA is the invitation to answer
+ * it — and no third control is invented for a route that does not exist. Same
+ * ground on which #1194 struck "Nudge back" and the sheets' answer buttons: a
+ * drawn state with nothing behind it is not built.
+ */
+function buildMentionActions(payload: Record<string, any>): FeedRowAction[] {
+  const href = commentTargetHref(payload)
+  if (href == null) return []
+  return [{ id: 'reply', label: i18n.t('feed:rowAction.reply'), tone: 'primary', href }]
 }
 
 /** Map a faction-owned feed item to its row slots. Returns null for the
@@ -271,6 +311,37 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
                 },
               ]
             : [],
+      }
+    case 'comment_mention':
+      // Someone @mentioned you in a comment (#1196). This case is the whole of
+      // that fix: the backend has emitted the type with a complete payload since
+      // it shipped, and the router already reaches it — but there was no case
+      // here, so `normalizeFeedItem` returned null, the router fell through to
+      // `return null`, and EVERY mention anyone ever received rendered as
+      // nothing at all.
+      //
+      // Badged `your_stuff`, matching where the backend files it
+      // (`FILTER_ALL | FILTER_YOUR_STUFF`): a mention is news about you, not a
+      // request of you — nothing is being asked, so it is not a Request.
+      //
+      // Framed in the COMMENTER's voice: `context_faction_slug` resolves to the
+      // actor's faction, and a mention is something a named person did to you
+      // (the same reasoning as `nudge`).
+      return {
+        slug,
+        actor,
+        actorHref: p.character_id != null ? `/characters/${p.character_id}` : null,
+        action: i18n.t('feed:row.action.mentionedYou'),
+        badge: { type: 'your_stuff', label: i18n.t('feed:badge.yourStuff') },
+        // The comment's own words, quoted rather than titled — the excerpt is
+        // speech, so it borrows `foe_taunt`'s quoted headline. The backend caps
+        // it at 140 characters; nothing is re-truncated here.
+        headline: p.excerpt ?? null,
+        headlineHref: commentTargetHref(p),
+        headlineQuoted: true,
+        points: null,
+        level: null,
+        actions: buildMentionActions(p),
       }
     case 'vote_on_mine':
       return {

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -60,6 +60,7 @@
     "dropOut": "Drop out",
     "answer": "Answer",
     "fileYours": "File yours",
+    "reply": "Reply",
     "failed": "That didn't go through."
   },
   "badge": {
@@ -80,7 +81,8 @@
       "tauntsYou": "taunts you",
       "defected": "defected from {{oldFaction}} to {{newFaction}}",
       "globalTaskActivated": "A new task has been activated",
-      "awaitingSubmission": "Waiting on your submission"
+      "awaitingSubmission": "Waiting on your submission",
+      "mentionedYou": "mentioned you in a comment"
     },
     "points": "{{points}} pts",
     "pointsEarned": "+{{points}} pts",


### PR DESCRIPTION
Fixes the oldest invisible bug in the feed. `comment_mention` has been emitted by the backend since it shipped — correct query, complete payload, reachable router — and had no case in `normalizeFeedItem`, so it returned null, `FeedCardRouter` fell through to `return null`, and **every @mention anyone has ever received rendered as nothing at all.**

Closes #1196

Consumes the chassis merged in #1243. Rebased onto `origin/main` @ `12ffb6e5` (after #1244's spec correction).

---

## The seam held

The whole of the card is a `case` in `normalizeFeedItem` and two copy keys. **`FeedCardRouter` is unchanged apart from its docblock** — the mention picked up the chassis, the kicker band, the timestamp, the ✕, the swipe, the undo strip and the Archived tab for free, in all nine skins. That was #1194's claim about the three-layer seam and this is its first outside test of it.

The row, as #1196 specified it: the commenter as actor linking to their character page · "mentioned you in a comment" · the excerpt **quoted** via `foe_taunt`'s `headlineQuoted` · `headlineHref` to `/praxes/{id}` or `/tasks/{id}` · badge `your_stuff` · no points, no level.

## Both "verify, don't assume" items came back clean

- **Counts.** `FILTER_QUERIES` needed no fix. It is *derived* from `FEED_SOURCES`, and the mention's source already declares `frozenset({FILTER_ALL, FILTER_YOUR_STUFF})` — matching ADR-0006. Pinned by a new test that also asserts the **Requests tab is empty of it**: nothing is being asked of the player, so it must not inflate the badge that means "someone is waiting on a decision from you".
- **Archivability.** Archivable, and it draws the control. `NON_ARCHIVABLE_ITEM_TYPES` is `{awaiting_submission}` alone and `ARCHIVABLE_ITEM_TYPES` is derived by subtraction, so the mention was always archivable — but no test could have noticed the affordance was missing from a card that rendered as nothing. Now pinned on both sides: a frontend loop over all fifteen types demanding the ✕, and a backend dismiss/restore round trip.

## Three judgement calls — please read these

**1. One CTA, not the Snide sheet's two.** The sheet draws "open the composer on the target page" and "open the thread". In this app those are the **same navigation**: `CommentThread` mounts the composer directly beneath the list on the praxis/task page, and there is no route, hash or query parameter that opens one without the other. Two buttons with identical `href`s is not two affordances. So the pair is served by the two link surfaces the row actually has — the quoted excerpt opens the thread, one primary `Reply` CTA is the invitation to answer it — and no third control is invented for a route that does not exist. Same ground on which #1194 struck `Nudge back` and the sheets' answer buttons. **If you want the second button anyway, it needs a scroll-to/focus target on the thread first, which is a separate change to a shared component.**

**2. A quoted headline is now a link when the row gives it an href.** It was unconditionally inert. That was right while `foe_taunt` was the only quoted row — ADR-0031 means the catalog owns the words and there is no taunt page — and it would have **silently swallowed** `headlineHref` on the mention, leaving the issue's acceptance criterion ("the link opens the praxis or task") unmeetable. Same type, size and italic either way: the quote is speech, and dressing it as a bold title link would undo the distinction the quoting exists to draw. `foe_taunt`'s markup is byte-identical (its href is null).

**3. One small backend change, which the issue said might be needed.** The payload carried the commenter's display name, faction and avatar but **not their id**, so "actor links to their character page" was unbuildable. The query already joins `Character`; it now selects the id, keyed `character_id` to match `friend_completion` / `friend_signup` / `friend_defection` / `collaborator_submitted` rather than inventing a per-type spelling. The bare `140` became `COMMENT_EXCERPT_LENGTH`. Nothing else in the backend moved.

## What to eyeball

1. **The two CTAs question above.** It is the one place I did not do what the issue's words said, and the reasoning is in the code as well as here.
2. **A quoted excerpt that is a link.** Nothing signals clickability on it — no underline, no colour shift, no weight change — because it must not start reading as a title. The `Reply` button below it is the obvious affordance. Is the silent link fine, or should the quote be inert and the button carry the whole job?
3. **Two routes to one page** — the excerpt and `Reply` both land on `/praxes/{id}`. Deliberate (a reader who wants the context taps the words; one who wants to answer taps the button), but it is worth a look on a real card.
4. **A long excerpt.** 140 characters of italic, quoted, indented text is the tallest headline any row draws, and the mention is the only type that can fill it. Nothing re-truncates it. Check it does not swamp Coven's title bar or Singularity's boot strip.
5. **The commenter's voice, not yours.** `context_faction_slug` resolves to the actor's faction, so a Snide player quoting you draws a Snide card in your feed — same rule as `nudge`. Correct by the epic, but the mention is the first card whose *body is someone else's words inside their own chassis*.
6. **`Archived "Ada"`.** `feedItemTitle` falls through `task_title → praxis_title → era_name → actor_display_name`, and a mention payload has only the last, so the undo strip names the commenter rather than the comment. Left alone — it is #1194's function and it never reads `Archived ""` — but `Archived "your name came up…"` would be better. Say the word and it is two lines.

## Verified

- **`tsc --noEmit`: clean.** (`tsc --version` → 5.9.3 confirmed running, not an absent-binary false pass.)
- **`eslint src --max-warnings=0`: clean.** No new `no-raw-style-values` suppressions.
- **`vite build`: clean.** Entry chunk 135.01 KB gzip — unmoved from #1243's 135.00.
- **`vitest run`: 142 files, 2440 passed, 0 failed.** (#1243 left 2434; six new here.)
- **`pytest`: 839 passed, 0 failed**, on the dedicated DB `wz1196_test`.

**One existing assertion was REVERSED on purpose.** `feedChassis.test.tsx` asserted `render(comment_mention) === ''` — a true description of a blank card, pinned as though it were a rule. It is the assertion that would have caught this on day one had it been written the other way round. It now loops all fifteen types and demands each render something.

## NOT verified

- **No visual QA. Every layout claim above is inference from the code, not observation.** This environment cannot screenshot and there is no dev stack. Nobody has looked at a mention card in any of the nine skins.
- **The `Reply` navigation has not been clicked.** The harness is `renderToStaticMarkup` — no jsdom, so no effect runs and no click fires. The `href` is asserted as a string; that the praxis page then scrolls anywhere useful is untested and, per judgement call 1, it does not scroll at all.
- **Not run against a live server.** The payload assertions are integration tests against the real route and the real query, but no browser has fetched a real mention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
