### PR TITLE
Albescent: the feed chassis is the na chassis, with light washed over it (#1203)

### DIFF
--- a/frontend/src/components/__tests__/albescentFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/albescentFeedFrame.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * Albescent's feed chassis (#1203, epic #1192 decision 13).
+ *
+ * The dress issue's acceptance criteria, pinned. Two of them can only be checked
+ * here rather than in `feedChassis.test.tsx`, whose fixtures are all Coven: that
+ * ALL FIFTEEN backend types survive inside this particular chassis, and that the
+ * nine the design sheet never drew are not a special case.
+ *
+ * What this file does NOT re-prove: the archive control, the swipe and the
+ * six-second undo. They live in `FeedItemSlot`, outside every frame, and
+ * `feedChassis.test.tsx` owns them. What is asserted here is that this chassis
+ * still PLACES the control it is handed — the one way a frame can silently lose
+ * the whole keyboard and screen-reader route into the archive.
+ *
+ * The harness is `renderToStaticMarkup`: no DOM, so no effect runs and no pointer
+ * event fires. The ornament layers' inertness is asserted as `aria-hidden` here;
+ * their `pointer-events: none` is index.css's and cannot be read without a DOM.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../i18n'
+import i18n from '../../i18n'
+import FeedCardRouter from '../feed/FeedCardRouter'
+import { feedKicker, NON_ARCHIVABLE_TYPES } from '../feed/feedItemLabels'
+import { surfaceMap } from '../../factions'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+
+/** Every type the backend emits. */
+const ALL_FEED_TYPES = [
+  'friend_completion',
+  'foe_completion',
+  'vote_on_mine',
+  'foe_taunt',
+  'friend_signup',
+  'friend_defection',
+  'global_task',
+  'collaborator_submitted',
+  'awaiting_submission',
+  'nudge',
+  'era_announcement',
+  'invitation_letter',
+  'duel_challenge',
+  'collab_invite',
+  'comment_mention',
+]
+
+/** The eleven rows plus the three companions — every type the chassis wraps.
+ *  `era_announcement` is exempt by TYPE (epic decision 6), not by slug. */
+const CHASSIS_TYPES = ALL_FEED_TYPES.filter((type) => type !== 'era_announcement')
+
+/** A payload rich enough for whichever type is asking. The faction slugs in it
+ *  are OTHER factions on purpose: an Albescent actor completing a Coven task is
+ *  an ordinary item, and the actor's slug is the only thing that skins the card
+ *  (SPEC-faction-ui-profile.md §2). */
+const FAT_PAYLOAD = {
+  character_id: 3,
+  praxis_id: 7,
+  task_id: 9,
+  task_title: 'Reforest the verge',
+  task_point_value: 40,
+  task_level_required: 2,
+  points_earned: 12,
+  praxis_title: 'A returned proof',
+  praxis_type: 'collab',
+  from_character_id: 4,
+  from_name: 'Ada',
+  to_name: 'Bo',
+  faction_slug: 'coven',
+  old_faction_slug: 'coven',
+  new_faction_slug: 'snide',
+  era_name: 'Era One',
+  duel_id: 5,
+  challenger_praxis_id: 6,
+  challenger_character_id: 3,
+  invite_id: 8,
+  inviter_character_id: 3,
+  task_faction_slug: 'coven',
+  comment_id: 11,
+  excerpt: 'your name came up',
+}
+
+function item(type: string, slug: string | null = 'albescent'): ActivityFeedItem {
+  return {
+    type,
+    item_key: `${type}:1`,
+    timestamp: '2026-01-01T00:00:00Z',
+    actor_display_name: 'Ada',
+    actor_faction_slug: slug,
+    actor_avatar_url: null,
+    payload: FAT_PAYLOAD,
+    context_faction_slug: slug,
+  }
+}
+
+function render(feedItem: ActivityFeedItem, archivedView = false): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <FeedCardRouter item={feedItem} archivedView={archivedView} />
+    </MemoryRouter>,
+  )
+}
+
+const ARCHIVE_LABEL = i18n.t('feed:archive.dismissLabel')
+const RESTORE_LABEL = i18n.t('feed:archive.restoreLabel')
+
+describe('every type this chassis carries', () => {
+  it('wraps all fourteen chassis types, including the nine the sheet never drew', () => {
+    // The sheet drew collab_invite, duel_challenge, collaborator_submitted,
+    // awaiting_submission, nudge and comment_mention. It never drew the six
+    // plain social rows, global_task or the invitation letter — and a payload
+    // shape a design never saw is a CHASSIS problem if it looks wrong, never a
+    // per-type special case. There is no branch in this frame to special-case
+    // with.
+    for (const type of CHASSIS_TYPES) {
+      const html = render(item(type))
+      expect(html, `${type} is dressed`).toContain('class="alb-feed"')
+      expect(html, `${type} keeps its kicker`).toContain(feedKicker(type))
+      expect(html, `${type} carries the wash`).toContain('class="alb-feed-aurora"')
+      expect(html, `${type} carries the edge`).toContain('class="alb-feed-edge"')
+    }
+  })
+
+  it('leaves era_announcement alone even when its slug says albescent', () => {
+    // Chassis-exempt by TYPE, not by a null slug (epic decision 6): an era turn
+    // can strip a player of their faction, so speaking that one card in their
+    // voice is exactly backwards. Forced to 'albescent' here precisely because
+    // the real item carries null — a frame that exempted it by slug would look
+    // correct in production and be wrong.
+    const html = render(item('era_announcement'))
+    expect(html).not.toContain('alb-feed')
+    expect(html, 'keeps its own always-dark chrome').toContain('--badge-admin-bg')
+    expect(html, 'still gains the ✕').toContain(ARCHIVE_LABEL)
+  })
+
+  it('places the archive control it is handed, on every archivable type', () => {
+    // The one way a frame silently loses a feature. The control itself is
+    // `FeedItemSlot`'s; all this chassis can do is fail to draw it.
+    for (const type of CHASSIS_TYPES) {
+      if (NON_ARCHIVABLE_TYPES.has(type)) continue
+      expect(render(item(type)), `${type} offers the ✕`).toContain(ARCHIVE_LABEL)
+    }
+  })
+
+  it('draws no archive control on awaiting_submission, and none disabled', () => {
+    // It is state, not an event, and the backend 400s on it. The chassis still
+    // draws — a card with no dismiss control is not a card with no chrome.
+    const html = render(item('awaiting_submission'))
+    expect(html).toContain('class="alb-feed"')
+    expect(html).not.toContain(ARCHIVE_LABEL)
+    expect(html).not.toContain(RESTORE_LABEL)
+    expect(html).not.toContain('disabled')
+  })
+
+  it('keeps the two companions answerable inside the chassis', () => {
+    // Epic decision 9 held for this skin too: the handlers did not move, so
+    // accepting a duel or a collab from inside this card still works.
+    const duel = render(item('duel_challenge'))
+    expect(duel).toContain('class="alb-feed"')
+    expect(duel).toContain(i18n.t('feed:duelChallenge.accept'))
+    expect(duel).toContain(i18n.t('feed:duelChallenge.decline'))
+
+    const collab = render(item('collab_invite'))
+    expect(collab).toContain('class="alb-feed"')
+    expect(collab).toContain(i18n.t('feed:collabInvite.accept'))
+    expect(collab).toContain(i18n.t('feed:collabInvite.decline'))
+  })
+
+  it('forwards the tag slot — an archived challenge still says still waiting', () => {
+    expect(render(item('duel_challenge'), true)).toContain(
+      i18n.t('feed:archive.stillWaiting'),
+    )
+  })
+
+  it('draws the kicker and the timestamp once each', () => {
+    const html = render(item('friend_completion'))
+    expect(html.split(feedKicker('friend_completion')).length - 1).toBe(1)
+    expect(html.split('ago').length - 1).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('the society stays hidden', () => {
+  it('never prints the faction name on the card', () => {
+    // Epic decision 5 for every faction; ADR-0027 twice over for this one, whose
+    // whole design constraint is that a member is indistinguishable from an
+    // unaffiliated player. The types below are the ones whose payload names no
+    // faction of its own — friend_defection and invitation_letter legitimately
+    // print the factions their CONTENT is about.
+    for (const type of ['friend_completion', 'vote_on_mine', 'comment_mention', 'duel_challenge', 'collab_invite']) {
+      expect(render(item(type)), `${type} names no faction`).not.toContain('Albescent')
+    }
+  })
+
+  it('hides both ornament layers from assistive tech', () => {
+    const html = render(item('friend_completion'))
+    expect(html).toContain('aria-hidden="true" class="alb-feed-aurora"')
+    expect(html).toContain('aria-hidden="true" class="alb-feed-edge"')
+  })
+})
+
+describe('epic decision 13, both halves', () => {
+  it('claims the chassis', () => {
+    expect(surfaceMap('feedFrame')['albescent']).toBeDefined()
+  })
+
+  it('claims NO comment voice — Albescent keeps DefaultComment', () => {
+    // `albescent ≡ na + drift` (ADR-0048): the comment voice does not need to
+    // differ, because the card is sufficiently distinct on its own once the light
+    // is on it. Owner's call at grill, and the title of the issue that built
+    // this. An AlbescentComment appearing here would be the drift ADR-0027 is
+    // about — a per-faction WORD is as identifying as a per-faction hue.
+    expect(surfaceMap('comment')['albescent']).toBeUndefined()
+  })
+})

--- a/frontend/src/components/__tests__/factionFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/factionFeedFrame.test.tsx
@@ -59,12 +59,43 @@ describe("FactionFeedFrame dispatch", () => {
     }
   });
 
-  it("frames an albescent row exactly like an unaffiliated one (#783)", () => {
-    // The inverse of what this file used to assert. Albescent had its own
-    // Record frame (#232); it now takes the same default chrome as any
-    // unthemed slug, because a member reading the feed must be
-    // indistinguishable from an unaffiliated player.
-    expect(frameFor("albescent")).toBe(frameFor("no-such-faction"));
+  it("frames an albescent row as the unaffiliated card PLUS light (#1203)", () => {
+    // THE SECOND REVERSAL OF THIS ASSERTION, and each one narrowed it rather
+    // than flipping a verdict. It first demanded Albescent's own Record frame
+    // (#232). #783 demanded byte equality with an unthemed slug, because a
+    // member reading the feed must be indistinguishable from an unaffiliated
+    // player. ADR-0048 then made "frozen" mean "frozen UNTIL DESIGNED", and
+    // #1203 is that design: still the unaffiliated card, still not one colour of
+    // its own, with two ornament layers washed over it.
+    //
+    // Containment is the whole statement, and it is stronger than the equality
+    // it replaces: the unaffiliated chassis appears INSIDE the Albescent one,
+    // untouched and contiguous, so strip the wrapper and the two spans and the
+    // card is Default byte for byte. A skin that hand-copied the chrome — the
+    // failure this file exists to catch — would drift out of this the first time
+    // the shared chassis changed, without anyone editing this test.
+    const neutral = frameFor("no-such-faction");
+    const albescent = frameFor("albescent");
+
+    expect(albescent).toContain(neutral);
+    expect(albescent).not.toBe(neutral);
+    // Both flourishes present, and both inert: they are decoration over a card
+    // full of links and controls, so they are hidden from assistive tech here
+    // and `pointer-events: none` in index.css.
+    expect(albescent).toContain('aria-hidden="true" class="alb-feed-aurora"');
+    expect(albescent).toContain('aria-hidden="true" class="alb-feed-edge"');
+  });
+
+  it("tints albescent from na's token family, never one of its own (#783)", () => {
+    // The half of #783 that survives #1203 intact. `CSS_KEY` maps the slug to
+    // `default`, so the chassis paints --faction-default-*. Asserted against
+    // `na`'s OWN render rather than against a token name, so the two move
+    // together forever — the same discipline
+    // utils/__tests__/factionAlbescentHidesInPlainSight.test.ts applies to every
+    // other surface, and the reason a --faction-albescent-* block cannot creep
+    // back in through this one.
+    expect(frameFor("albescent")).toContain(frameFor(null));
+    expect(frameFor("albescent")).not.toContain("--faction-albescent");
   });
 
   it("gives a null/neutral slug the Unaffiliated chassis, NOT a passthrough (#1194)", () => {

--- a/frontend/src/components/feed/AlbescentFeedFrame.tsx
+++ b/frontend/src/components/feed/AlbescentFeedFrame.tsx
@@ -1,0 +1,83 @@
+import { DefaultFeedFrame } from './FactionFeedFrame'
+import type { FeedFrameProps } from './feedFrameProps'
+
+/**
+ * Albescent — the feed card's tell (#1203, epic #1192, ADR-0048). The FIFTH
+ * Albescent surface to unfreeze, after the praxis card (#821), the task card
+ * (#1023), the task detail (#1038) and the praxis detail (#1140), and built to
+ * the same rule as all four: **this is not a ninth chassis.**
+ *
+ * It renders the exact {@link DefaultFeedFrame} an unaffiliated player sees and
+ * washes light over it. Strip the two ornament spans and the card is `Default`
+ * byte for byte — the property a hand-copied skin could never keep, and the
+ * reason a change to the chassis seam or to the Unaffiliated card reaches
+ * Albescent with no edit here.
+ *
+ * ### Why a wrapper and not a skin
+ *
+ * `albescent ≡ na + drift` (ADR-0048). Albescent is a secret society hiding in
+ * plain sight (ADR-0027), so it has no `--faction-albescent-*` token block and
+ * `isKnownFaction('albescent')` is false on purpose (WORLD_ZERO_STYLE §3). A
+ * bespoke chassis — its own band, its own ground, its own chrome — would be a
+ * ninth identity, and identity is the one thing this faction may not have. The
+ * epic settled it as decision 13 before a line was written.
+ *
+ * The four slots therefore arrive drawn. `kicker`, `time`, `tag` and `archive`
+ * are forwarded whole to the chassis that already places them, so none of the
+ * three ways a dress issue loses a feature (swallowing the kind label, dropping
+ * the only timestamp, rebuilding the archive control) is even reachable from
+ * here. That includes `awaiting_submission`, whose `archive` is `null`: the na
+ * chassis renders nothing for it, and this file has no branch that could
+ * accidentally draw a disabled stand-in.
+ *
+ * ### The slug it hands down
+ *
+ * `'albescent'`, not `null` — and the two are identical by construction.
+ * `CSS_KEY` maps this slug to `default` (#783), so `factionCssVar('albescent',
+ * 'card-bg')` and its accent resolve to the same `--faction-default-*` pair an
+ * unaffiliated card paints with, and a test compares the two slugs rather than
+ * pinning a literal so they can never drift apart. Passing the real slug says
+ * what is happening; passing `null` would say the card has no faction, which is
+ * `era_announcement`'s claim (epic decision 6), not this one's.
+ *
+ * ### Where the light sits
+ *
+ * On top, blended, clipped to the card. The chassis paints an OPAQUE sheet, so
+ * an ornament behind it is invisible and `z-index: -1` is not a position
+ * available here (§5). Both layers are `pointer-events: none` and sit inside an
+ * `isolation: isolate` wrapper, so the blend cannot reach the page around the
+ * card and the ✕, the links and the companions' accept / decline buttons all
+ * stay clickable — the archive interaction lives in `FeedItemSlot` and is
+ * untouched by anything in this file.
+ *
+ * index.css owns both classes, both theme halves and the reduced-motion guard; a
+ * component may not inject a stylesheet (#911). It declares no new colour value:
+ * the wash reads `--faction-default-aurora` and the travelling hairline reads
+ * `--faction-default-rainbow-loop`, both na's own spectrum. Stilled, the card is
+ * a static wash and a static edge.
+ *
+ * ### Two things this file deliberately does not do
+ *
+ * There is **no `AlbescentComment`** and the `comment` manifest key stays
+ * unclaimed (epic decision 13): the card is distinct enough on its own, so
+ * Albescent comments keep rendering through the shared default voice.
+ *
+ * And **no word of the design sheet ships.** The sheet is written in Albescent's
+ * own dialect; the copy comes from the neutral `feed` catalog authored in F2
+ * (#1194), the same ruling the task detail (#1038) and the praxis detail (#1140)
+ * took, and for the same reason: a per-faction WORD is as identifying as a
+ * per-faction hue, and it renders to every viewer.
+ *
+ * No `useFormFactor()` call and no mobile twin (ADR-0056 / 0058 / 0063): the
+ * responsive half lives in the chassis this forwards to whole, and the light is
+ * the same light at both widths.
+ */
+export default function AlbescentFeedFrame(props: FeedFrameProps) {
+  return (
+    <div className="alb-feed">
+      <DefaultFeedFrame slug="albescent" {...props} />
+      <span aria-hidden="true" className="alb-feed-aurora" />
+      <span aria-hidden="true" className="alb-feed-edge" />
+    </div>
+  )
+}

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -44,6 +44,9 @@ const AlbescentSeal = lazyArchetype(() => import('../components/metaTaskSeal/ski
 const AlbescentTaskDetail = lazyArchetype(() => import('../pages/taskDetail/archetypes/AlbescentTaskDetail'))
 // #1140 — the praxis-detail unfreeze, lazy for the same reason as its sibling.
 const AlbescentPraxisDetail = lazyArchetype(() => import('../pages/praxisDetail/archetypes/AlbescentPraxisDetail'))
+// #1203 — the feed-card unfreeze. Lazy like every wrapper above: it pulls in the
+// na chassis, which is exactly the weight route-splitting keeps off first load.
+const AlbescentFeedFrame = lazyArchetype(() => import('../components/feed/AlbescentFeedFrame'))
 
 export const ALBESCENT_MANIFEST: FactionManifest = {
   slug: 'albescent',
@@ -119,6 +122,26 @@ export const ALBESCENT_MANIFEST: FactionManifest = {
    * factors.
    */
   praxisDetail: () => AlbescentPraxisDetail,
+
+  /**
+   * The feed-card tell (#1203, epic #1192, ADR-0048) — the FIFTH surface to
+   * unfreeze and the same "Default + light" shape as the four above.
+   * `AlbescentFeedFrame` is a WRAPPER: it renders the shared `DefaultFeedFrame`
+   * chassis whole, forwarding all four chrome slots (kicker, time, tag and the
+   * pre-composed archive node) untouched, and layers two ornament spans over it —
+   * a drifting spectrum wash and a travelling hairline. It has NO structural
+   * delta: the archive control, the swipe and the six-second undo live in
+   * `FeedItemSlot` outside every frame, and nothing here reimplements them.
+   *
+   * This row exists because the epic settled it as decision 13, which is also the
+   * decision NOT to claim `comment`: Albescent keeps `DefaultComment`, because
+   * the card is sufficiently distinct on its own once the light is on it. So the
+   * faction's feed presence is one manifest line and no voice of its own.
+   *
+   * `era_announcement` never reaches this frame — it is chassis-exempt by type
+   * for every faction (epic decision 6), so no exclusion is needed here.
+   */
+  feedFrame: () => AlbescentFeedFrame,
 
   /**
    * The ferrofluid vote widget (#843, the eighth of #821's eight). Same rule as

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3601,6 +3601,102 @@
   .alb-praxis-edge { animation: alb-praxis-edge 16s linear infinite; }
 }
 
+/* Albescent — the FEED CARD's tell (#1203, epic #1192, ADR-0048). The fifth
+   surface to unfreeze, and the same rule as the four before it: the shared
+   chassis an unaffiliated player sees, with light washed over it. Strip these two
+   spans and the card is `DefaultFeedFrame`, byte for byte.
+
+   NOT ONE NEW COLOUR VALUE IS DECLARED HERE, and that is the point. Both layers
+   read na's own spectrum tokens — `--faction-default-aurora` (with its opacity
+   and blur, both of which already flip with the theme) and
+   `--faction-default-rainbow-loop`. A hue of Albescent's own would put the
+   society back in the spectrum and un-hide it (#783 / WORLD_ZERO_STYLE §3), so
+   the whole delta is MOTION: a wash that drifts and a hairline that travels.
+
+   WHAT THIS BLOCK DECIDES:
+
+   • THE BLEND IS NOT READ FROM `--faction-default-aurora-blend`, deliberately.
+     That token says `normal` in light because it describes the composer's
+     GROUND, painted behind the copy. Here the same wash is an OVERLAY — a
+     component's inline sheet is not markup this file can reach behind, and
+     `z-index: -1` is not a position available (§5). At `normal` a 20% coloured
+     film would sit on top of the ink; `multiply` on the light sheet and `screen`
+     on the dark one is what keeps it legible. Reading the token here would be a
+     var() at the wrong tier: it passes every lint gate and means the wrong
+     thing. Same call `.alb-task-aurora` and `.alb-praxis-aurora` already make.
+
+   • THE EDGE IS A 1px MASKED RING, not a border, for the same reason
+     `.alb-task-edge` and `.alb-praxis-edge` are. It lands on `.sidebar-card`'s
+     own hairline so the effect reads as that border coming alive, and it is a
+     hairline rather than the task card's 3px so the chassis's 4px `card-accent`
+     rule down the left edge still reads as the near-black rule it is.
+
+   • THE RADIUS IS THE TOKEN, not a literal. `.sidebar-card` corners with
+     `--radius-xl`, so this follows it for free — unlike the three earlier
+     Albescent blocks, which had to hardcode 14 / 18px to track a component's
+     inline style.
+
+   • MOTION IS OPT-IN, gated on `no-preference`. Stilled, the card is a static
+     wash and a static edge; nothing carries meaning through motion alone. */
+@keyframes alb-feed-drift {
+  0%, 100% { transform: translate3d(-5%, -4%, 0) scale(1.14) rotate(0deg); }
+  50% { transform: translate3d(5%, 4%, 0) scale(1.22) rotate(-5deg); }
+}
+@keyframes alb-feed-edge { from { background-position: 0% 50%; } to { background-position: 300% 50%; } }
+
+.alb-feed {
+  position: relative;
+  isolation: isolate;
+}
+.alb-feed-aurora,
+.alb-feed-edge {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  border-radius: var(--radius-xl);
+}
+
+/* The wash. Seven blooms blurred past recognition, so a short wide card reads it
+   as coloured light travelling across the sheet rather than as seven shapes. */
+.alb-feed-aurora {
+  overflow: hidden;
+}
+.alb-feed-aurora::before {
+  content: "";
+  position: absolute;
+  inset: -30%;
+  background-image: var(--faction-default-aurora);
+  filter: var(--faction-default-aurora-filter);
+  opacity: var(--faction-default-aurora-opacity);
+  mix-blend-mode: multiply;
+  transform: translate3d(-5%, -4%, 0) scale(1.14);
+}
+[data-theme="dark"] .alb-feed-aurora::before {
+  mix-blend-mode: screen;
+}
+
+/* The hairline, travelling. The loop cut is the seamless one, so the ring scrolls
+   forever without a red-meets-magenta seam passing through every cycle. */
+.alb-feed-edge {
+  padding: 1px;
+  background-image: var(--faction-default-rainbow-loop);
+  background-size: 300% 100%;
+  opacity: 0.6;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box exclude,
+    linear-gradient(#000 0 0);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .alb-feed-aurora::before { animation: alb-feed-drift 46s ease-in-out infinite; }
+  .alb-feed-edge { animation: alb-feed-edge 16s linear infinite; }
+}
+
 /* UA — growing mandala: each rank blooms a fuller mandala; the emphasized cell
    pops (bloom), rank-5 breathes (twist), rings turn (spin) and a halo pulses out
    on selection. Every motion is class-gated on reduced-motion so the widget


### PR DESCRIPTION
Frontend only. The smallest of the eight dress issues, and deliberately so.

Closes #1203

---

## The whole change

`AlbescentFeedFrame` is **11 lines of JSX**: it renders `DefaultFeedFrame` whole and hangs two ornament spans off it.

```
<div className="alb-feed">
  <DefaultFeedFrame slug="albescent" {...props} />
  <span aria-hidden="true" className="alb-feed-aurora" />
  <span aria-hidden="true" className="alb-feed-edge" />
</div>
```

That is the answer to the issue's own question. Albescent is not a ninth identity — `albescent ≡ na + drift` (ADR-0048) — so the sheet is not transcribed into a parallel chassis. This is the `AlbescentPraxisDetail` (#1140) shape exactly: forward the shared component whole, wash light over it, and **strip the two spans and the card is Default byte for byte**. A test asserts that as containment rather than as a claim.

**No design sheet was read for this PR** (I have no design access), and per the vendored spec on the issue, none was needed. If you look at the sheet and it disagrees, the disagreement will be in the two CSS layers and nowhere else — nothing structural was invented to hide a mismatch in.

## Not one new colour value is declared

Both layers read na's own spectrum tokens:

- the wash reads `--faction-default-aurora`, **plus its `-opacity` and `-filter`** — which already flip with the theme, so dark mode came free;
- the travelling hairline reads `--faction-default-rainbow-loop`, the seamless cut, so it scrolls forever without a red-meets-magenta seam passing through each cycle;
- the radius reads `--radius-xl`, `.sidebar-card`'s own corner — so unlike the three earlier Albescent blocks, which hardcode 14 / 18px to track a component's inline style, this one follows the card for free.

A hue of Albescent's own would put the society back in the spectrum and un-hide it (#783). The entire delta from the unaffiliated card is **motion**.

## What to eyeball

1. **`--faction-default-aurora-blend` is deliberately NOT read.** That token says `normal` in light because it describes the composer's **ground**, painted *behind* the copy. Here the same wash is an **overlay** — the chassis paints an opaque sheet and `z-index: -1` is not a position available (§5). At `normal` a 20% coloured film would sit on top of the ink, which is a contrast risk this repo has paid for before (#651, #669/#677); `multiply` on the light sheet and `screen` on the dark one is what keeps it legible. Reading the token here would be a var() at the wrong tier — passing every lint gate while meaning the wrong thing. Same call `.alb-task-aurora` and `.alb-praxis-aurora` already make. **If you would rather it read the token, say so and I will flip it — but the ink gets a film over it.**
2. **The travelling hairline is the layer I would cut first if you want less.** The aurora is unambiguously the "na + drift" tell. The edge is a judgement call: `.sidebar-card`'s hairline is plain `--color-border`, not the spectrum border the task card's edge lands on, so this one gives the feed card a **coloured** hairline it did not have. I kept it at `1px` and `opacity: .6` — a hairline rather than the task card's 3px — precisely so the chassis's 4px near-black `card-accent` rule down the left edge still reads as the near-black rule it is. Two layers is also the minimum in this family (task card 2, praxis detail 3, task detail 3). Veto it and the diff loses six lines.
3. **The frame hands down `slug="albescent"`, not `null`.** `CSS_KEY` maps the slug to `default` (#783), so the two are byte-identical today — but the real slug says what is happening, where `null` would claim the card has no faction at all, which is `era_announcement`'s claim (epic decision 6) and not this one's. A test compares the Albescent render against `frameFor(null)` rather than pinning a token name, so the two move together forever — the same discipline `factionAlbescentHidesInPlainSight.test.ts` applies to every other surface.
4. **The four chrome slots arrive drawn.** `kicker`, `time`, `tag` and the pre-composed `archive` are forwarded whole to the chassis that already places them, so none of the three ways a dress issue loses a feature is reachable from this file. That includes `awaiting_submission`, whose `archive` is `null`: there is no branch here that could draw a disabled stand-in. The archive control, the swipe, the 6s undo and the Archived list are `FeedItemSlot`'s and are untouched — **nothing in the sheets' archive mechanics was re-implemented.**
5. **`era_announcement` is asserted exempt by TYPE, with its slug forced to `albescent`.** The real item carries `null`, so a frame that exempted it by *slug* would look correct in production and be wrong. This is the one assertion in the file that could not be written with a realistic fixture.
6. **All fifteen types are looped through this chassis**, including the nine the sheet never drew and `comment_mention`, whose body landed in #1245 while this was in flight (I rebased onto it). The issue asks for state variants; **none of the unbacked ones were built** — no expiry for invites or duels, no duel countdown, no pre-submission deadline, no filed/total counts on `collaborator_submitted`. There is no field to read for any of them, and this frame has no per-type branch to put one in.
7. **`comment` stays unclaimed** (epic decision 13, and the issue's title). There is no `AlbescentComment`; Albescent comments keep rendering through the shared default voice. Pinned as its own test so a later "completeness" sweep cannot quietly add one.
8. **One existing assertion is REVERSED, and it is the second narrowing of the same line.** `factionFeedFrame.test.tsx` demanded Albescent's own Record frame under #232, then byte equality with an unthemed slug under #783. ADR-0048 made "frozen" mean "frozen UNTIL DESIGNED", and this is that design — so it now asserts **containment**, which is strictly stronger than the equality it replaces: a hand-copied chassis would drift out of it the first time the shared one changed, with nobody editing the test. The tint half of #783 survives intact as its own test.
9. **No string from the design sheet appears in the diff** — the copy is the neutral `feed` catalog authored in F2, untouched. Nothing was added to or edited in that catalog, and no `--faction-albescent-*` token was created.
10. **`surfaceDispatch.test.ts` has no `feedFrame` row and I did not add one.** Adding it would be correct in the abstract, but that file's own header records that it red-mained `main` twice because parallel PRs *restated* a shared row instead of appending, and seven siblings are dressing other factions right now. My own test file pins `surfaceMap('feedFrame')['albescent']` instead. **Worth adding the row once the wave has landed** — it would be a nine-slug line with only `na` falling through.

## Verified

- **`tsc --noEmit`: clean.**
- **`eslint src --max-warnings=0`: clean.** No `no-raw-style-values` suppression added — the component carries no inline style at all.
- **`vite build`: clean.** Entry chunk **135.07 KB gzip**, unmoved from #1243's 135.00. `AlbescentFeedFrame` splits to its own **381-byte** chunk — a true wrapper; it hoists nothing.
- **`vitest run`: 143 files, 2452 passed, 0 failed.** 11 of those are new here.
- **Built CSS grepped, not brace-counted** (the #1162 lesson): `[data-theme=dark] .alb-feed-aurora:before` survives with its prefix intact, and both animations land *inside* `@media (prefers-reduced-motion:no-preference)`.
- Rebased onto `origin/main` @ `273c39a7` (#1245) mid-build and re-verified after.

## NOT verified

- **No visual QA. This environment cannot screenshot and there is no dev stack, so every appearance claim above is inference from the code — nobody has looked at this card.** In particular: whether a 56px blur over a ~452×110 card reads as travelling coloured light or as a uniform smudge, whether `opacity: .6` on the hairline is a shimmer or a stripe, and whether the wash sits acceptably behind the ✕'s focus ring.
- **The drift and the swipe are untested end to end.** The harness is `renderToStaticMarkup` — no jsdom, so no effect runs, no pointer event fires, and no animation exists. Real verification is a human on a phone.
- **Nothing was rendered against a live server.** No Albescent-actored feed item has been fetched for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
