### PR TITLE
UA: comment voice + feed chassis v2 (#1201)

### DIFF
--- a/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
+++ b/frontend/src/components/cards/__tests__/uaDesktopSkin.test.tsx
@@ -224,6 +224,71 @@ describe('the ensō is reserved for the score and the faction mark', () => {
   })
 })
 
+describe('the feed chassis and the comment note (#1201)', () => {
+  /** The chassis with all four chrome slots filled, as `FeedItemSlot` hands them. */
+  const chassis = () =>
+    routed(
+      <UaFeedFrame
+        kicker="Task completed"
+        time="2h ago"
+        tag="Still waiting"
+        archive={<button type="button">archive-node</button>}
+      >
+        <span>card-body</span>
+      </UaFeedFrame>,
+    )
+
+  it('draws all four chrome slots and swallows none of them', () => {
+    // A frame that drops one loses a FEATURE, not a decoration: the kicker is the
+    // card's only kind label, the time its only timestamp, and the archive node
+    // the entire keyboard/screen-reader route to the archive (#1194).
+    const html = chassis()
+    expect(html, 'kicker').toContain('Task completed')
+    expect(html, 'time').toContain('2h ago')
+    expect(html, 'tag').toContain('Still waiting')
+    expect(html, 'archive node placed, not rebuilt').toContain('archive-node')
+    expect(html, 'body intact').toContain('<span>card-body</span>')
+  })
+
+  it('grounds the card in the three-stop paper stock, not a flat fill', () => {
+    // The design sheet's `--cardGrad`. A flat `card-bg` is what this replaced.
+    expect(chassis()).toContain('var(--faction-ua-parchment)')
+  })
+
+  it('reads NO token from the praxis-card-only exception block (#857)', () => {
+    // `--faction-ua-card-parchment` is the same gradient under a name scoped to
+    // the praxis card, whose block asks in writing not to be widened. The stock
+    // is named once in UA's primitives instead; reading the exception's copy here
+    // would quietly make the exception the rule.
+    const html = chassis()
+    expect(html).not.toContain('--faction-ua-card-parchment')
+    expect(html).not.toContain('--faction-ua-card-frame')
+  })
+
+  it('puts no archive affordance on a comment', () => {
+    // The epic's load-bearing structural fact: comments are NEVER archivable,
+    // only update cards are. Every design sheet says it in its own dialect.
+    const html = comment()
+    expect(html).not.toContain('data-feed-archive')
+    expect(html).not.toContain('data-feed-slot')
+  })
+
+  it('gates the owner row through the SHARED reveal, not a gate of its own', () => {
+    // F3 (#1195) owns the hover/focus gate. A voice wires two lines; it does not
+    // re-implement hover state, and a `display:none` gate would put the control
+    // out of reach of the keyboard entirely.
+    const source = readFileSync(
+      join(SRC_DIR, 'components/comments/voices/UaComment.tsx'),
+      'utf-8',
+    )
+    expect(source, 'uses the shared hook').toContain('useOwnerReveal')
+    expect(source, 'hands the reveal to the shared control').toMatch(
+      /reveal=\{reveal\}/,
+    )
+    expect(source, 'rolls its own hover state').not.toMatch(/useState/)
+  })
+})
+
 describe('the eleven rebuilt surfaces carry no salon left-overs', () => {
   const REBUILT = [
     'components/cards/UaTaskCard.tsx',

--- a/frontend/src/components/comments/voices/UaComment.tsx
+++ b/frontend/src/components/comments/voices/UaComment.tsx
@@ -3,24 +3,48 @@ import type { CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { UaSigil } from '../../cards/UaSigil'
-import { UA_DISPLAY, UA_TEXT } from '../../cards/uaAtoms'
+import { UA_DISPLAY, UA_EYEBROW, UA_TEXT } from '../../cards/uaAtoms'
+import { useAuth } from '../../../auth/AuthContext'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
-import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
-import { CommentFlagControl } from '../FlagControl'
+import {
+  CommentEditor,
+  OwnerControls,
+  ownerRevealStyle,
+  useOwnerEdit,
+  useOwnerReveal,
+} from '../OwnerControls'
+import { CommentFlagControl, canFlagComment } from '../FlagControl'
 
 /**
- * UA comment — THE MARGINAL NOTE (kit §14, #851).
+ * UA comment — THE MARGINAL NOTE (kit §14, #851; redressed by #1201).
  *
- * SUPERSEDES ADR-0026's gilt salon. A UA comment is now a note written in the
- * margin of the work: rag paper, one dashed orange rule down the left edge, an
- * ensō on the composer, and nothing else. No gold-leaf frame, no house line, no
- * ornament. The mandala is ABSENT — a comment thread is the densest text
- * surface in the app (brief §5).
+ * SUPERSEDES ADR-0026's gilt salon. A UA comment is a note written in the margin
+ * of the work: the practice's own paper stock, one dashed orange rule down the
+ * left edge, an ensō on the composer, and nothing else. No gold-leaf frame, no
+ * house line, no ornament. The mandala is ABSENT — a comment thread is the
+ * densest text surface in the app (brief §5).
  *
  * The three invariant slots are unchanged (ADR-0016): author identity · body ·
  * timestamp+edited. A posted row takes the AUTHOR's faction; the composer takes
  * the current character's.
+ *
+ * #1201 changes three things, all dress:
+ *
+ *  - the sheet is `--faction-ua-parchment`, the three-stop stock the design draws
+ *    (`--cardGrad`), rather than the flat `card-bg` fill;
+ *  - the metadata speaks in the kit's one label shape (`UA_EYEBROW`) instead of a
+ *    hand-rolled small serif, and the composer's mention hint is overridden into
+ *    that same voice rather than inheriting the neutral caption;
+ *  - the owner's edit/withdraw row leaves the header for a FOOT row under a
+ *    hairline, and is hover/focus-gated with F3's shared `useOwnerReveal` — not a
+ *    gate of this file's own. The move is what makes the gate usable: revealing a
+ *    control inside the baseline header reflowed the timestamp every time the
+ *    pointer crossed the note.
+ *
+ * Seven states, one component (ADR-0056 / 0058 / 0063 — no mobile twin):
+ *   row · default | row · mention | row · edited | row · yours (hover) |
+ *   row · editing | composer · empty | composer · submitting
  *
  * Both themes come from the `[data-theme="dark"]` cascade. The salon that never
  * dimmed is gone.
@@ -38,19 +62,27 @@ function note(active: boolean): CSSProperties {
       ? '1px solid var(--faction-ua)'
       : '1px solid var(--faction-ua-rule)',
     borderLeft: '2px dashed var(--faction-ua)',
-    background: active
-      ? 'var(--faction-ua-lift)'
-      : 'var(--faction-ua-card-bg)',
+    // The practice's paper stock, both modes: a note and the pad it is written
+    // on are the same sheet. Composed from the surface primitives, so it dims
+    // with the faction and needs no ternary.
+    background: 'var(--faction-ua-parchment)',
     color: 'var(--faction-ua-card-text)',
   }
 }
 
+/** Metadata voice — the kit's one label shape, quiet on the stock. */
+function meta(extra?: CSSProperties): CSSProperties {
+  return { ...UA_EYEBROW, ...extra }
+}
+
 export default function UaComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
+  const { user } = useAuth()
+  const reveal = useOwnerReveal()
   if (props.mode === 'composer') {
     const { value, onChange, onSubmit, submitting } = props
     return (
-      <div style={note(true)}>
+      <div style={note(true)} aria-busy={submitting}>
         {/* The mark stands in for the portrait on the composer, as the kit
             draws it: you are writing in the practice's margin, not signing.
             The three invariant slots (ADR-0016) belong to the posted row. */}
@@ -78,6 +110,9 @@ export default function UaComment(props: CommentProps) {
             onAccent="var(--faction-ua-on-accent)"
             bg="var(--faction-ua-panel)"
             text="var(--faction-ua-card-text)"
+            // The shared string in the practice's own label voice — an OVERRIDE
+            // of ComposerControls' neutral caption, not a new hint (#1195).
+            hint={<span style={meta()}>{t('comments.mentionHint')}</span>}
           />
         </div>
       </div>
@@ -87,8 +122,16 @@ export default function UaComment(props: CommentProps) {
   const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
+  const canFlag = canFlagComment(comment, user?.character?.id)
+  // The foot exists only when it has something to hold: the author's own row, or
+  // a flag affordance on somebody else's note. Hidden while editing — the inline
+  // editor owns Save/Cancel then.
+  const showFoot = !owner.editing && (owner.isOwner || canFlag)
+  // On your OWN note the foot holds nothing but the gated row, so its hairline
+  // fades with the row: a rule over empty space is a state the sheet never draws.
+  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
   return (
-    <div style={note(false)}>
+    <div style={note(false)} {...reveal.containerProps}>
       <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
       <div style={{ flex: 1, minWidth: 0 }}>
         <div
@@ -111,21 +154,9 @@ export default function UaComment(props: CommentProps) {
           >
             {comment.author.display_name}
           </Link>
-          <span
-            style={{
-              fontFamily: UA_TEXT,
-              fontSize: 'var(--text-lg)',
-              color: 'var(--faction-ua-card-muted)',
-              whiteSpace: 'nowrap',
-              display: 'inline-flex',
-              alignItems: 'baseline',
-              gap: 'var(--space-sm)',
-            }}
-          >
+          <span style={meta({ whiteSpace: 'nowrap' })}>
             {formatCommentTime(slug, comment.created_at)}
             {comment.is_edited ? ` · ${t('comments.ua.edited')}` : ''}
-            <OwnerControls owner={owner} />
-            <CommentFlagControl comment={comment} />
           </span>
         </div>
         <div
@@ -135,6 +166,7 @@ export default function UaComment(props: CommentProps) {
             lineHeight: 1.55,
             color: 'var(--faction-ua-card-body)',
             marginTop: 'var(--space-sm)',
+            overflowWrap: 'anywhere',
           }}
         >
           {owner.editing ? (
@@ -153,6 +185,25 @@ export default function UaComment(props: CommentProps) {
             />
           )}
         </div>
+        {showFoot && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              flexWrap: 'wrap',
+              gap: 'var(--space-md)',
+              marginTop: 'var(--space-md)',
+              paddingTop: 'var(--space-sm)',
+              // The faintest divider UA has: a rule inside the note is quieter
+              // than the note's own edge.
+              borderTop: '1px solid var(--faction-ua-hair)',
+              ...footGate,
+            }}
+          >
+            <OwnerControls owner={owner} reveal={reveal} />
+            <CommentFlagControl comment={comment} />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/components/feed/UaFeedFrame.tsx
+++ b/frontend/src/components/feed/UaFeedFrame.tsx
@@ -1,26 +1,50 @@
+import { useFormFactor } from '../../hooks/useFormFactor'
 import { UaSigil } from '../cards/UaSigil'
-import FeedChassisBand from './FeedChassisBand'
+import { UA_DISPLAY, UA_EYEBROW, UaInkColumn } from '../cards/uaAtoms'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
- * UA feed frame (per-faction surface #12, kit §12, #851).
+ * UA feed CHASSIS — the practice's day-book leaf (surface #12, kit §12, #1201).
  *
- * A thin presentational WRAPPER: it dresses the neutral feed card (`children`)
- * as a UA row and reimplements none of the card's internals, which arrive as
- * children and keep their slot order (ADR-0016).
+ * Not a row wrapper any more (#1194): the frame owns the outside of the card and
+ * the body arrives as `children`, faction-blind. See {@link FeedFrameProps} for
+ * the four chrome slots this must draw, and `FeedItemSlot` for the archive
+ * interaction it must NOT reimplement — the ✕ handed in as `archive` is already
+ * hover/focus-gated, keyboard reachable, labelled, and `null` on the one type
+ * that cannot be archived (`awaiting_submission`). This file places it and adds
+ * nothing to it.
  *
- * The dress is two things: a 3px orange rule down the left edge and one small
- * ensō as the faction mark. No mandala — a feed is a dense, text-heavy surface
- * and the pattern is ABSENT there (brief §5). No gilt sandwich, no gold liner,
- * no engraved masthead: the salon is dead, and a feed row was the worst place
- * it lived.
+ * THE DRESS is parchment and one ensō, and that is deliberately the whole of it:
  *
- * #1194: a CHASSIS BAND sits above the row, carrying the kicker, the tag, the
- * time and the dismiss control. It is inset on the right so it clears the ensō
- * rather than moving the faction mark: a functional control must not land under
- * an ornament. The dress is otherwise unchanged; UA's dress issue restyles it.
+ *  - The ground is UA's three-stop paper stock (`--faction-ua-parchment`), the
+ *    design sheet's `--cardGrad`, rather than a flat fill. It is composed from
+ *    the surface primitives, so both themes come from the `[data-theme="dark"]`
+ *    cascade with no second declaration and no ternary.
+ *  - The ink column down the left edge (`UaInkColumn`) is the faction's declared
+ *    chrome for a surface too dense for the mandala. It replaces the old flat
+ *    3px border: same reading, drawn with the kit's own primitive. The mandala is
+ *    ABSENT here — a strength, not an omission (brief §5).
+ *  - ONE ensō, at the head of the kicker band. This is the faction-mark half of
+ *    the mark's reservation (brief §4); it is never a container border.
  *
- * Both themes come from the `[data-theme="dark"]` cascade.
+ * WHY THE MARK MOVED INTO THE BAND. It used to sit in the card's top-right
+ * corner, which is exactly where the dismiss control has to go; #1194 answered
+ * that by insetting the band's right edge to clear the ornament. Making the mark
+ * the band's leading glyph removes the collision instead of routing around it —
+ * the ✕ gets the corner it wants, the mark reads as the leaf's seal, and no
+ * functional control sits under an ornament.
+ *
+ * TYPE. Kicker in Cormorant Garamond (the display cut), uppercase and widely
+ * tracked; the time in the EB Garamond eyebrow, the pairing the sheet draws.
+ * Both are label tier — a kind label and a timestamp are scanned, not read (§4).
+ *
+ * NO COPY. Every string on this card arrives as a prop from the neutral `feed`
+ * catalog; the sheet's own dialect is discarded (epic #1192), and there is no
+ * faction-name label anywhere.
+ *
+ * One responsive component, no mobile twin (ADR-0056 / 0058 / 0063): the layout
+ * is fluid, and `useFormFactor` only trims the gutter where a phone column has
+ * none to spare.
  */
 export default function UaFeedFrame({
   kicker,
@@ -29,44 +53,85 @@ export default function UaFeedFrame({
   archive,
   children,
 }: FeedFrameProps) {
+  const gutter = useFormFactor() === 'mobile' ? 'var(--space-md)' : 'var(--space-xl)'
   return (
     <div
       style={{
         position: 'relative',
         overflow: 'hidden',
-        background: 'var(--faction-ua-card-bg)',
+        background: 'var(--faction-ua-parchment)',
         color: 'var(--faction-ua-card-text)',
         border: '1px solid var(--faction-ua-rule)',
-        borderLeft: '3px solid var(--faction-ua)',
         borderRadius: 'var(--radius-md)',
-        padding: 'var(--space-lg) var(--space-xl)',
+        padding: `var(--space-lg) ${gutter}`,
       }}
     >
-      {/* the faction mark — one of the ensō's two sanctioned uses (brief §4) */}
-      <span
-        aria-hidden="true"
-        style={{
-          position: 'absolute',
-          right: 10,
-          top: 10,
-          opacity: 0.5,
-          pointerEvents: 'none',
-        }}
-      >
-        <UaSigil width={18} height={18} />
-      </span>
+      {/* The ink column — UA's signature on a dense surface. Absolutely
+          positioned, so the padding above is what it sits inside. */}
+      <UaInkColumn
+        style={{ left: 0, top: 'var(--space-md)', bottom: 'var(--space-md)' }}
+      />
 
-      {/* chassis band — inset on the right so the ✕ clears the ensō */}
+      {/* The chassis band, placed by hand rather than via `FeedChassisBand`: the
+          mark leads it. Its `color` is the muted ink, and that is what tints the
+          archive control, which paints in `currentColor` (#1194). Muted clears AA
+          on all three stops of the stock, in both themes. */}
       <div
         style={{
-          color: 'var(--faction-ua-card-text)',
-          paddingRight: 'var(--space-xl)',
-          borderBottom: '1px solid var(--faction-ua-rule)',
+          display: 'flex',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+          gap: 'var(--space-sm)',
+          minWidth: 0,
+          color: 'var(--faction-ua-card-muted)',
+          borderBottom: '1px solid var(--faction-ua-hair)',
           paddingBottom: 'var(--space-xs)',
           marginBottom: 'var(--space-sm)',
         }}
       >
-        <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
+        {/* the faction mark — the band's seal (brief §4) */}
+        <span
+          aria-hidden="true"
+          style={{ display: 'inline-flex', flexShrink: 0, opacity: 0.8 }}
+        >
+          <UaSigil width={15} height={15} />
+        </span>
+        <span
+          style={{
+            fontFamily: UA_DISPLAY,
+            fontSize: 'var(--text-lg)',
+            fontWeight: 600,
+            letterSpacing: '0.18em',
+            textTransform: 'uppercase',
+            color: 'var(--faction-ua-card-accent)',
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {kicker}
+        </span>
+        {tag && (
+          /* The status tag, filled: the sheet's chip is solid with warm-white
+             lettering, which is the accent / on-accent pair exactly (#924). */
+          <span
+            style={{
+              ...UA_EYEBROW,
+              color: 'var(--faction-ua-on-accent)',
+              background: 'var(--faction-ua-card-accent)',
+              borderRadius: 999,
+              padding: '0 var(--space-sm)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {tag}
+          </span>
+        )}
+        <span style={{ ...UA_EYEBROW, marginLeft: 'auto', whiteSpace: 'nowrap' }}>
+          {time}
+        </span>
+        {archive}
       </div>
 
       {children}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -642,6 +642,28 @@
   --faction-ua-card-body: #544a3c; /* running prose, a step above muted — 7.15:1 */
   --faction-ua-rule: #dbcbb3; /* neutral hairline / divider (cf. -border, orange) */
   --faction-ua-hair: #e4d8c3; /* faintest divider, below -rule */
+  /* THE PAPER STOCK — the three-stop sheet UA's design sheets draw as
+     `--cardGrad`, never a flat fill: lift at the top edge, the sheet through the
+     middle, panel at the foot. Composed from the three surface primitives above
+     instead of repeating their hex, so it needs NO dark half — the var()s
+     re-resolve under [data-theme="dark"] and the stock dims with the faction.
+
+     WHY NOT `--faction-ua-card-parchment`, which is the same gradient. That name
+     lives inside the PRAXIS-CARD-ONLY exception block below (#857), which asks
+     in writing not to be widened; a second surface reading it would quietly turn
+     the exception into the rule. So the stock is named once out here, where any
+     UA surface may take it — #1201's feed chassis and comment note are the first
+     two — and the exception keeps its own private copy.
+
+     Every ink UA already measures is measured on all three stops (see
+     --faction-ua-card-muted's note: 4.87/5.13/5.45 light, 4.55/5.10/5.64 dark),
+     so painting on the ramp introduces no new pairing. */
+  --faction-ua-parchment: linear-gradient(
+    158deg,
+    var(--faction-ua-lift),
+    var(--faction-ua-card-bg) 46%,
+    var(--faction-ua-panel)
+  );
   --faction-ua-glow: #dd5a1e; /* ORNAMENT ONLY — ensō, mandala. 3.12:1. Never text. */
   --faction-ua-vermil: #b5361a; /* the ensō score numeral — large display type only */
 

--- a/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
+++ b/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
@@ -74,9 +74,11 @@ describe('mobile Updates mixed multi-faction stream', () => {
     // Distinct per-faction frame markers appearing TOGETHER in one render
     // prove a mixed stream, not one uniform tint.
     expect(text, 'COVEN window chrome').toContain('coven.exe')
-    // UA's frame is dress only now (#851): a 3px orange rule and the ensō, no
-    // engraved masthead, so the marker is the token rather than a house line.
-    expect(html, 'UA ink-rule frame').toContain('3px solid var(--faction-ua)')
+    // UA's frame is dress only (#851), and #1201 restated that dress: the flat
+    // 3px orange border became the kit's own ink column and the ground became
+    // the three-stop paper stock. The stock is the marker — unique to the UA
+    // chassis, and still a token rather than a house line.
+    expect(html, 'UA parchment chassis').toContain('var(--faction-ua-parchment)')
     expect(html, 'SNIDE dossier tokens').toContain('--faction-snide')
     expect(html, 'COVEN scrapbook tokens').toContain('--faction-coven')
   })


### PR DESCRIPTION
Dress only. Every behaviour on both surfaces already worked before this; F2 (#1243) built the chassis seam and F3 (#1195) built the hover gate, and this claims both rather than re-implementing either.

Closes #1201

Part of epic #1192.

---

## What changed

**`UaFeedFrame` is a chassis now, not a `{ children }` wrapper.** It takes `FeedFrameProps` and draws all four chrome slots by hand — `FeedChassisBand` is thrown away (which the contract permits) because the mark leads the band.

The dress, and the whole of it:

- **The ground is the three-stop paper stock**, the sheet's `--cardGrad`, not a flat `card-bg`. New token `--faction-ua-parchment`.
- **The ink column replaces the flat 3px orange border.** `UaInkColumn` is the kit's declared chrome for a surface too dense for the mandala; the border was the same reading, hand-drawn. The mandala stays ABSENT as a strength (brief §5).
- **Kicker in Cormorant Garamond**, uppercase and tracked; **time in the EB Garamond eyebrow** — the pairing the sheet draws. Both label tier.
- **The tag is a filled chip** in `card-accent` / `on-accent`. The sheet's `--chipText: #FCF7EF` is exactly the light value of `--faction-ua-on-accent`, so the literal maps onto the #924 pair rather than becoming a new token.

**The ensō moved from the card's corner into the band, as its leading glyph.** #1194 had to inset the band's right edge so the dismiss control would not land under the ornament (its own eyeball item 11). Leading with the mark removes the collision instead of routing around it: the ✕ gets the corner it wants and the mark reads as the leaf's seal. Still one of the mark's two sanctioned uses; never a container border.

**`UaComment`** takes the same stock under both modes, moves its metadata into the kit's one label shape, overrides the mention hint into that voice, and — the only structural change — **moves the owner's edit/withdraw row out of the header into a gated foot row** under `--faction-ua-hair`, wired to F3's `useOwnerReveal`. Revealing a control inside the baseline header reflowed the timestamp on every pointer crossing; the na sheet puts it at the foot for that reason and UA now follows. The hairline fades with the row on your own note, so a rule never stands over empty space.

**No copy from the sheet ships.** Every string on the chassis arrives as a prop from the neutral `feed` catalog; the comment's three keys are the pre-existing `praxis.json → comments.ua.*` flavour keys. `feed.json` is untouched.

**`factions/ua.ts` needed no edit** — UA already claims `comment` and `feedFrame`. Registration was never the gap.

## Decisions worth arguing with

**1. A new token rather than reading the praxis card's.** `--faction-ua-card-parchment` is byte-for-byte the gradient this card wants, and it sits inside the praxis-card-only block whose own comment asks not to be widened (#857). So the stock is named once out in UA's primitives, where any UA surface may take it, and the exception keeps its private copy. A test pins that the chassis reads neither `--faction-ua-card-parchment` nor `--faction-ua-card-frame`.

It is composed from `lift` / `card-bg` / `panel` instead of their hex, so it needs **no dark half**: the `var()`s re-resolve under `[data-theme="dark"]`. Verified in the **built** stylesheet, not by reading the source — one `--faction-ua-parchment` declaration, both `--faction-ua-lift` declarations present.

**2. No new contrast pairing was introduced.** Painting on a ramp means three grounds instead of one, and every ink used here is already measured on all three: `factionContrast.test.ts` gates `ua panel/lift × ink · prose · muted · accent`, and `index.css` records muted at 4.87/5.13/5.45 light and 4.55/5.10/5.64 dark. The two ends I re-measured by hand for this dress: `card-accent` on the darkest light stop (panel) = **4.88:1**, and on the lightest dark stop (lift) = **5.31:1**. Both clear AA for label-tier text. The band's `color` is muted, which is what tints the archive ✕ (it paints in `currentColor`).

**3. `useFormFactor` trims the gutter and nothing else.** One responsive component, no mobile twin (ADR-0056 / 0058 / 0063). The layout is fluid — flex, `auto` margins, `%` — so the only thing a phone column genuinely needs is narrower side padding. No fixed-px grid anywhere.

**4. `mixedStream.test.tsx` pinned the border I deleted.** Its UA marker was the literal `3px solid var(--faction-ua)`; it now pins `var(--faction-ua-parchment)`, which is unique to this chassis. One line, in a file three faction dress issues will each want to touch — kept deliberately minimal for that reason.

**5. No state variant was invented.** The chassis is type-blind dress, so all fifteen types plus their variants inherit it with nothing per-type here. Nothing draws an expiry, a duel countdown, a pre-submission deadline or a filed/total count — none has a backend (epic's gap table). `awaiting_submission` gets no ✕ and no swipe because `FeedItemSlot` hands it `archive={null}`; this frame renders no disabled stand-in for it. `era_announcement` never reaches here. `comment_mention` gained a body in #1196 and lands in this chassis with no change on either side.

**6. The sheet's `--ensoF` filter is not ported.** Our ensō is a `public/` asset painted through a CSS mask and tinted from `--faction-ua-glow` (ADR-0049 / #908) — the token already does the filter's job and stacking both would double-tint. Same conclusion #1217 reached.

## What to eyeball

1. **The band with the mark leading it.** This is the one place I departed from the previous arrangement, and the reason is a functional control clearing an ornament. Does the 15px ensō read as a seal at that size, or as debris beside a tracked kicker?
2. **The gradient's direction on a short card.** 158° across a two-line row shows much less of the ramp than across a praxis card. If the stock reads as a flat fill on the shortest cards, the angle is the thing to change, not the stops.
3. **The kicker's ellipsis.** `Collaborator submitted` at `--text-lg` with 0.18em tracking is the longest label in the catalog; the band wraps, but the kicker itself truncates. Check the wrap point on a phone.
4. **The filled tag chip against the accent kicker** — two accents on one band, one filled and one as ink. Only `Still waiting` exists today, so this is only ever seen in the Archived tab on a duel or collab invite.
5. **The comment's foot row appearing.** It only shows for your own note or a flaggable one, and it is opacity-gated, so it reserves its height at rest. Worth confirming that reads as intentional whitespace rather than a gap.
6. **Dark mode on both surfaces.** The stock inverts its ordering (lift is the *shallowest* surface in dark), so the ramp runs the other way visually. That is what the primitives say; nobody has seen it.

## Verified

- `tsc --noEmit`: clean.
- `eslint src --max-warnings=0`: clean. No new `no-raw-style-values` suppressions; no file added to the legacy list.
- `vitest run`: **142 files, 2445 passed, 0 failed** (5 new here).
- `vite build`: clean. Entry chunk **135.01 KB gzip**, unmoved.
- Rebased onto `origin/main` @ `273c39a7` (#1196) and re-verified all four gates after the rebase.
- No hex in either component; no `dark ? a : b` anywhere; no faction name printed.

## NOT verified — visual QA is outstanding

**Nobody has looked at either surface.** This environment cannot screenshot and there is no dev stack, so **every layout and legibility claim above is inference from code and hand arithmetic, not observation.** The six eyeball items are where I would look first.

Specifically untested by construction: the harness is `renderToStaticMarkup` with no jsdom, so no effect runs and no pointer event fires. The hover gate's three routes, the 6s undo window and the swipe are asserted at their seams by F2's tests and driven by nobody. `useFormFactor` returns `'desktop'` in every test in this repo, so the mobile gutter is unexercised.

## Noticed, not fixed — for the dispatcher

- **`index.css`'s "PRAXIS CARD ONLY" scope claim (#857) is stale.** Six non-praxis surfaces already read that namespace today: `UaTaskCard`, `UaSeal`, `UaTaskDetail`, `UaPraxisDetail` and both praxis cards read `--faction-ua-card-frame` / `-card-parchment`. I did not widen it further and did not edit the comment — the fix is either a rename or a narrowing, and that is an owner call, not a dress issue's.
- **`praxis.json → comments.ua.house` is dead copy** — `"University of Asthmatics"`, a faction-name label, which epic decision 5 forbids. Grep finds no reader anywhere in `src`; nothing has used it since #851. Left in place deliberately: eight dress agents editing one JSON file in parallel is how `main` goes red.
- **No inline-style cleanup to hand off.** Both files were already fully tokenised and stay that way; nothing in the feature components around them (`FeedItemSlot`, `CommentThread`, `ComposerControls`) needed a raw value routed out for this dress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
