### PR TITLE
Everymen: the dispatch slip — feed chassis v2 + comment voice

### DIFF
--- a/frontend/src/components/comments/voices/EverymenComment.tsx
+++ b/frontend/src/components/comments/voices/EverymenComment.tsx
@@ -1,81 +1,310 @@
+/**
+ * THE EVERYMEN COMMENT — the same dispatch slip as the faction's feed chassis,
+ * at comment scale (ADR-0006 / ADR-0018; epic #1192, dress issue #1200).
+ *
+ * The card and the comment are one sheet in the design, so they are one object
+ * here: `--everymen-paper` stock inside the DOUBLE FRAME (a 2px ink rule, a 4px
+ * pad, a 1px hairline), headed by a red band. On the feed card that band carries
+ * the event's kind; on a comment it carries the BYLINE — who filed it and on what
+ * shift — because that is the comment's masthead. The two read as the same press.
+ *
+ * NO FACTION NAME. The band used to print `comments.everymen.masthead`
+ * ("EVERYMEN · DISPATCH FROM THE FLOOR"). Epic #1192 decision 5 is unqualified —
+ * *no faction-name label anywhere, the skin is the identification* — and the
+ * author's faction is already carried by the avatar badge and by the whole slip.
+ * The byline took the band's place; the key is now unused (see the PR).
+ *
+ * COMMENTS ARE NEVER ARCHIVABLE. There is no ✕, no swipe and no undo strip on
+ * this surface, deliberately: the archive is the FEED's affordance and lives in
+ * `FeedItemSlot`, and every sheet in the epic says in its own dialect that a
+ * comment is never rolled up.
+ *
+ * WHY THE BODY SITS ON A PANEL RATHER THAN ON THE PAPER. `MentionText` paints a
+ * resolved @mention in the voice's accent, and #1223 measured red at 4.49:1 as
+ * TYPE on `--everymen-paper` — below AA. On `--faction-everymen-sheet-panel` the
+ * same hue pays 4.95:1 light / 5.45:1 dark via `--faction-everymen-sheet-accent`,
+ * so the typed area is the panel and the mention ink is legible on it. On the
+ * paper red stays a fill (the band) and never type. This is §3's rule taken the
+ * other way round: rather than walk the ink down, give it the ground it was
+ * measured on.
+ *
+ * BEHAVIOUR IS NOT OURS. Edit, withdraw, flag, @mention autocomplete, the live
+ * character count, the submitting state and the hover/focus gate on the author's
+ * own controls all live in the shared helpers (`useOwnerEdit`, `useOwnerReveal`,
+ * `ComposerControls`, `CommentEditor`, `CommentFlagControl`). #1195 built the
+ * gate once; this voice wires the two lines and reimplements none of it.
+ *
+ * Seven states, one component, no mobile twin (ADR-0056 / 0058 / 0063):
+ *   row · default | row · mention | row · edited | row · yours (hover) |
+ *   row · editing | composer · empty | composer · submitting
+ */
+import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
+import { useAuth } from '../../../auth/AuthContext'
+import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
-import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
-import { CommentFlagControl } from '../FlagControl'
+import {
+  CommentEditor,
+  OwnerControls,
+  ownerRevealStyle,
+  useOwnerEdit,
+  useOwnerReveal,
+} from '../OwnerControls'
+import { CommentFlagControl, canFlagComment } from '../FlagControl'
+
+/** The composer's accent: red as a RULE (the field's edge) and a FILL (the
+ *  Post button), never as type. Its AA ink is the one #924 measured on it. */
+const ACCENT = 'var(--everymen-red)'
+const ON_ACCENT = 'var(--faction-everymen-on-accent)'
+/** The typed area — see the docblock on why this is the panel, not the paper. */
+const PANEL = 'var(--faction-everymen-sheet-panel)'
+/** The field inset INTO the panel. Deeper than the panel in both themes
+ *  (#ece1c6 under #f4ecd6 by day; #221a16 under #2c231c by night). */
+const FIELD = 'var(--everymen-paper)'
+const BODY_INK = 'var(--everymen-paper-text)'
+
+/** Label voice for the marks on the band: the body face, tracked, uppercase. */
+const DATELINE = {
+  fontFamily: 'var(--font-body)',
+  fontSize: 'var(--text-sm)',
+  letterSpacing: '0.15em',
+  textTransform: 'uppercase',
+  whiteSpace: 'nowrap',
+  color: 'inherit',
+} as const
+
+/** The author's name, set as the slip's byline: the poster face, on the band. */
+const BYLINE = {
+  fontFamily: 'var(--faction-everymen-card-font)',
+  // Content tier, not the label tier the kind label on the feed card uses: a
+  // person's name is identity, and Bebas is narrow enough that 18px reads about
+  // as large as 14 of a normal face.
+  fontSize: 'var(--text-content)',
+  letterSpacing: '0.08em',
+  textTransform: 'uppercase',
+  lineHeight: 1.15,
+  color: 'inherit',
+  textDecoration: 'none',
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+} as const
 
 /**
- * Everymen — dispatch from the floor (ADR-0018). Union-poster register: red
- * masthead bar, Bebas display name over a condensed body, paper stock. Timestamp
- * counts shifts ("Shift N").
+ * The slip both modes sit on: avatar in the margin, then the double-framed sheet
+ * with its red byline band. One shape for a row and for the composer, so a
+ * thread reads as one run of slips rather than a list plus a form.
  */
-function frame(): React.CSSProperties {
-  return {
-    background: 'var(--faction-everymen-card-bg)',
-    color: 'var(--faction-everymen-card-text)',
-    border: '1px solid rgba(193,39,45,0.3)',
-  }
+function Slip({
+  avatar,
+  byline,
+  dateline,
+  children,
+  containerProps,
+}: {
+  avatar: ReactNode
+  byline: ReactNode
+  dateline: ReactNode
+  children: ReactNode
+  containerProps?: React.ComponentPropsWithoutRef<'div'>
+}) {
+  const mobile = useFormFactor() === 'mobile'
+  return (
+    <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
+      {avatar}
+      <div
+        {...containerProps}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          background: 'var(--everymen-paper)',
+          color: BODY_INK,
+          // The double frame, exactly as the feed slip rules it: the plate edge…
+          border: '2px solid var(--everymen-frame)',
+          // …the 4px pad (--space-xs IS 4px)…
+          padding: 'var(--space-xs)',
+          boxShadow: 'var(--faction-everymen-slip-shadow)',
+        }}
+      >
+        {/* …and the form's own rule inside it. */}
+        <div style={{ border: '1px solid var(--faction-everymen-sheet-hair)' }}>
+          {/* The byline band. Red as a FILL, inked in the masthead's own ink —
+              the pairing the broadsheet chrome measured (5.24:1 / 4.59:1). */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              justifyContent: 'space-between',
+              gap: 'var(--space-md)',
+              flexWrap: 'wrap',
+              background: 'var(--everymen-red)',
+              color: 'var(--everymen-masthead-text)',
+              // The ground shows through the band's bottom edge, as on the card.
+              borderBottom: '3px double var(--everymen-paper)',
+              padding: mobile
+                ? 'var(--space-xs) var(--space-sm)'
+                : 'var(--space-xs) var(--space-md)',
+            }}
+          >
+            {byline}
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'baseline',
+                gap: 'var(--space-sm)',
+                color: 'inherit',
+              }}
+            >
+              {dateline}
+            </span>
+          </div>
+          {/* The typed area. */}
+          <div
+            style={{
+              background: PANEL,
+              padding: mobile ? 'var(--space-sm)' : 'var(--space-md)',
+            }}
+          >
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
 }
 
 export default function EverymenComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
-  const masthead = (
-    <div style={{
-      background: 'var(--faction-everymen-card-accent)', color: 'var(--faction-everymen-card-bg)',
-      fontFamily: 'var(--faction-everymen-card-font)', letterSpacing: '0.14em',
-      padding: 'var(--space-xs) var(--space-lg)',
-      // eslint-disable-next-line local/no-raw-style-values -- ornament: newsprint masthead bar
-      fontSize: 13,
-    }}>
-      {t('comments.everymen.masthead')}
-    </div>
-  )
+  const { user } = useAuth()
+  const reveal = useOwnerReveal()
 
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props
     return (
-      <div style={frame()}>
-        {masthead}
-        <div style={{ padding: 'var(--space-md) var(--space-lg)', display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
-          <FactionAvatar character={character} size="sm" />
-          <div style={{ flex: 1 }}>
-            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-everymen-card-accent)" onAccent="var(--faction-everymen-on-accent)" bg="rgba(0,0,0,0.03)" text="var(--faction-everymen-card-text)" />
-          </div>
+      <Slip
+        avatar={<FactionAvatar character={character} size="sm" />}
+        byline={<span style={BYLINE}>{character.display_name}</span>}
+        dateline={null}
+      >
+        {/* `.content-text` rides the wrapper because the one slot inside without
+            a size of its own is the textarea (`font: inherit`), and a draft is
+            content-tier text. Every other slot names its own size. */}
+        <div className="content-text" aria-busy={submitting}>
+          <ComposerControls
+            value={value}
+            onChange={onChange}
+            onSubmit={onSubmit}
+            submitting={submitting}
+            accent={ACCENT}
+            onAccent={ON_ACCENT}
+            bg={FIELD}
+            text={BODY_INK}
+            // The shared hint in this sheet's own caption voice — an OVERRIDE of
+            // the neutral default, not a new string.
+            hint={
+              <span
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 'var(--text-sm)',
+                  letterSpacing: '0.15em',
+                  textTransform: 'uppercase',
+                  color: 'var(--everymen-muted)',
+                }}
+              >
+                {t('comments.mentionHint')}
+              </span>
+            }
+          />
         </div>
-      </div>
+      </Slip>
     )
   }
+
   const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
+  const canFlag = canFlagComment(comment, user?.character?.id)
+  // The foot only exists when it holds something: the author's edit/withdraw or
+  // a flag affordance. Hidden while editing — the inline editor owns Save/Cancel.
+  const showControls = !owner.editing && (owner.isOwner || canFlag)
+  // On your OWN comment the foot holds nothing but the gated owner row, so the
+  // rule above it fades with the row: a hairline over empty space is a state the
+  // sheet never draws. Someone else's (flaggable) comment keeps its foot.
+  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+
   return (
-    <div style={frame()}>
-      {masthead}
-      <div style={{ padding: 'var(--space-md) var(--space-lg)', display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
-        <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 'var(--space-md)' }}>
-            <Link to={`/characters/${comment.author.id}`} style={{ fontFamily: 'var(--faction-everymen-card-font)', fontSize: 'var(--text-content)', letterSpacing: '0.04em', color: 'var(--faction-everymen-card-text)', textDecoration: 'none' }}>
-              {comment.author.display_name}
-            </Link>
-            <span style={{ fontSize: 'var(--text-md)', color: 'var(--faction-everymen-card-muted)', textTransform: 'uppercase', letterSpacing: '0.06em', whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 'var(--space-sm)' }}>
-              {formatCommentTime(slug, comment.created_at)}
-              {comment.is_edited ? ` · ${t('comments.everymen.edited')}` : ''}
-              <OwnerControls owner={owner} />
-              <CommentFlagControl comment={comment} />
+    <Slip
+      avatar={<FactionAvatar character={authorToCharacter(comment.author)} size="sm" />}
+      containerProps={reveal.containerProps}
+      byline={
+        <Link to={`/characters/${comment.author.id}`} style={BYLINE}>
+          {comment.author.display_name}
+        </Link>
+      }
+      dateline={
+        <>
+          {/* "Shift N" — the faction's timestamp dialect (ADR-0018), at FULL
+              masthead ink. The band's 4.59:1 dark pairing has no headroom for
+              the customary 0.7 opacity, so face and size do the separating. */}
+          <span style={DATELINE}>{formatCommentTime(slug, comment.created_at)}</span>
+          {comment.is_edited && (
+            <span style={DATELINE}>
+              <span aria-hidden="true">· </span>
+              {t('comments.everymen.edited')}
             </span>
-          </div>
-          <div style={{ fontSize: 'var(--text-content)', lineHeight: 1.4, marginTop: 'var(--space-xs)' }}>
-            {owner.editing ? (
-              <CommentEditor owner={owner} accent="var(--faction-everymen-card-accent)" onAccent="var(--faction-everymen-on-accent)" bg="rgba(0,0,0,0.03)" text="var(--faction-everymen-card-text)" />
-            ) : (
-              <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-everymen-card-accent)" />
-            )}
-          </div>
-        </div>
+          )}
+        </>
+      }
+    >
+      {/* The filed copy: user-authored free text, so the content floor — in the
+          resting state and in the editor alike (its textarea inherits this). */}
+      <div
+        className="content-text"
+        style={{
+          fontFamily: 'var(--font-body)',
+          color: BODY_INK,
+          lineHeight: 1.55,
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {owner.editing ? (
+          <CommentEditor
+            owner={owner}
+            accent={ACCENT}
+            onAccent={ON_ACCENT}
+            bg={FIELD}
+            text={BODY_INK}
+          />
+        ) : (
+          <MentionText
+            body={comment.body_text}
+            mentions={comment.mentions}
+            // Red as ink, which is only legible on this panel — see the docblock.
+            accent="var(--faction-everymen-sheet-accent)"
+          />
+        )}
       </div>
-    </div>
+      {showControls && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            flexWrap: 'wrap',
+            gap: 'var(--space-md)',
+            marginTop: 'var(--space-md)',
+            paddingTop: 'var(--space-sm)',
+            // A rule INSIDE the panel is quieter than the form's own edge.
+            borderTop: '1px solid var(--faction-everymen-sheet-hair)',
+            ...footGate,
+          }}
+        >
+          <OwnerControls owner={owner} reveal={reveal} />
+          <CommentFlagControl comment={comment} />
+        </div>
+      )}
+    </Slip>
   )
 }

--- a/frontend/src/components/feed/EverymenFeedFrame.tsx
+++ b/frontend/src/components/feed/EverymenFeedFrame.tsx
@@ -1,21 +1,50 @@
 /**
- * Everymen feed frame — the "printed union dispatch slip" chrome.
+ * THE EVERYMEN DISPATCH SLIP — the faction's feed-card CHASSIS (surface #12,
+ * SPEC-faction-ui-profile.md; epic #1192, dress issue #1200).
  *
- * A thin presentational wrapper (surface #12, SPEC-faction-ui-profile.md): it
- * skins the neutral feed card (`children`) in the Everymen physical archetype —
- * a red masthead spine on the left edge, manila paper stock with a screen-print
- * halftone wash, and an inked border with gold trim. It does NOT reimplement the
- * card internals (avatar/actor/badge/task-ref) — those arrive via `{children}`
- * and render untouched in the content area.
+ * A press slip run off in the union shop. Two things make it that slip and
+ * nothing else on the site is either of them:
  *
- * #1194: the slip gains a CHASSIS BAND at the head of the content area — a ruled
- * dispatch line carrying the kicker, the tag, the time and the dismiss control in
- * paper ink. The stock is otherwise unchanged; Everymen's dress issue restyles it.
+ *   1. A DOUBLE FRAME. Not one border — a 2px rule in the faction's ink, a 4px
+ *      pad, then a 1px hairline inside it. That is how a printed form is ruled:
+ *      the outer rule is the plate edge and the inner one is the form itself.
+ *   2. A CENTRED RED MASTHEAD BAND at the head, whose bottom edge is a `3px
+ *      double` rule the paper shows through. The band is the KICKER'S HOME — the
+ *      card's kind is the slip's masthead, not a label sitting above it — and it
+ *      carries the whole of the chassis chrome: the status tag on the left, the
+ *      kind centred, the dateline and the dismiss control on the right.
  *
- * Theme-aware via everymen.css tokens (light + dark both defined); no document
- * theme mutation. Visual intent from design-system/templates/everymen.
+ * WHAT THIS FILE OWNS, AND WHAT IT DOES NOT (the three-layer seam, #1194):
+ * `FeedItemSlot` above owns the ARCHIVE — the swipe, the write, the six-second
+ * undo strip — and hands the finished control down as `archive`. The body arrives
+ * as `children` and is faction-blind (`FeedRowContent` or one of the three
+ * interactive companions: `invitation_letter`, `duel_challenge`, `collab_invite`,
+ * whose accept/decline handlers live in the bodies and did not move). This frame
+ * is dress. It reimplements none of that, and it carries all fifteen backend feed
+ * types because it never looks at the type — only at the four chrome slots.
+ *
+ * `archive` is `null` on `awaiting_submission`, which is state rather than an
+ * event, so that card simply has nothing in the band's right slot past the
+ * dateline. The frame does not need to know why, and must not draw a stand-in.
+ *
+ * COPY: every word on this card comes from the neutral `feed` catalog (epic
+ * decision 7). The design sheet is written in a gorgeous union dialect and NONE
+ * of it ships; the skin is the identification, and there is no faction name
+ * anywhere on the slip (decision 5).
+ *
+ * INK. The band is `--everymen-red` as a FILL, inked in
+ * `--everymen-masthead-text` — the pairing the broadsheet chrome already
+ * measured (5.24:1 light / 4.59:1 dark). #1223 established that red is only
+ * 4.49:1 as TYPE on `--everymen-paper`, so no red label is set on the stock:
+ * on the paper red is a fill, and the ink on it is the masthead's. The dateline
+ * and the tag chip therefore print at FULL masthead ink and separate themselves
+ * by face and size — the shared band's 0.7 opacity would have walked the dark
+ * pairing down to roughly 3.2:1.
+ *
+ * One responsive component, no mobile twin (ADR-0056 / 0058 / 0063): the slip
+ * tightens its band and drops the masthead a size on a phone.
  */
-import FeedChassisBand from './FeedChassisBand'
+import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
 
 export default function EverymenFeedFrame({
@@ -25,53 +54,33 @@ export default function EverymenFeedFrame({
   archive,
   children,
 }: FeedFrameProps) {
+  const mobile = useFormFactor() === 'mobile'
+
   return (
     <article
       style={{
         position: 'relative',
-        display: 'flex',
-        overflow: 'hidden',
         background: 'var(--everymen-paper)',
         color: 'var(--everymen-paper-text)',
-        border:
-          '1px solid color-mix(in srgb, var(--everymen-paper-text) 26%, transparent)',
-        borderLeft: 'none',
-        boxShadow:
-          '0 1px 0 rgba(0,0,0,0.04), 0 6px 16px -12px rgba(0,0,0,0.5)',
+        // The double frame, half one: the plate edge, in the faction's ink
+        // rather than --color-border (a printed rule is part of the printing).
+        border: '2px solid var(--everymen-frame)',
+        // …and the 4px pad the second rule sits inside. --space-xs IS 4px, so
+        // the design's gutter comes off the scale rather than beside it.
+        padding: 'var(--space-xs)',
+        boxShadow: 'var(--faction-everymen-slip-shadow)',
       }}
     >
-      {/* red masthead spine with cream notches (union ribbon) */}
+      {/* Half two: the form's own rule, inside the pad. */}
       <div
-        aria-hidden
         style={{
-          flexShrink: 0,
-          width: 8,
-          background: 'var(--everymen-red)',
-          backgroundImage:
-            'repeating-linear-gradient(180deg, transparent 0 13px, color-mix(in srgb, var(--everymen-cream) 55%, transparent) 13px 15px)',
-          boxShadow:
-            'inset -1px 0 0 color-mix(in srgb, var(--everymen-red-deep) 70%, transparent)',
+          position: 'relative',
+          border: '1px solid var(--faction-everymen-sheet-hair)',
+          overflow: 'hidden',
         }}
-      />
-
-      {/* content area: paper texture + halftone wash behind the card body */}
-      <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
-        {/* gold trim rule hugging the spine */}
-        <div
-          aria-hidden
-          style={{
-            position: 'absolute',
-            insetBlock: 0,
-            left: 0,
-            width: 2,
-            background: 'var(--everymen-gold)',
-            opacity: 0.55,
-            pointerEvents: 'none',
-            zIndex: 1,
-          }}
-        />
-
-        {/* woven paper texture (burlap crosshatch + warm mottle) */}
+      >
+        {/* Newsprint stock — a burlap crosshatch, a warm mottle and a screen-print
+            halftone, all struck in the paper's own ink at ornament alphas. */}
         <div
           aria-hidden
           style={{
@@ -80,44 +89,105 @@ export default function EverymenFeedFrame({
             zIndex: 1,
             pointerEvents: 'none',
             backgroundImage: [
-              'repeating-linear-gradient(45deg, color-mix(in srgb, var(--everymen-paper-text) 7%, transparent) 0 1px, transparent 1px 4px)',
-              'repeating-linear-gradient(-45deg, color-mix(in srgb, var(--everymen-paper-text) 5%, transparent) 0 1px, transparent 1px 4px)',
-              'radial-gradient(130% 90% at 5% 0%, color-mix(in srgb, var(--everymen-cream) 18%, transparent), transparent 55%)',
-              'radial-gradient(120% 85% at 100% 100%, color-mix(in srgb, var(--everymen-paper-deep) 65%, transparent), transparent 52%)',
+              'repeating-linear-gradient(45deg, color-mix(in srgb, var(--everymen-paper-text) 6%, transparent) 0 1px, transparent 1px 4px)',
+              'repeating-linear-gradient(-45deg, color-mix(in srgb, var(--everymen-paper-text) 4%, transparent) 0 1px, transparent 1px 4px)',
+              'radial-gradient(130% 90% at 5% 0%, color-mix(in srgb, var(--everymen-cream) 16%, transparent), transparent 55%)',
+              'radial-gradient(120% 85% at 100% 100%, color-mix(in srgb, var(--everymen-paper-deep) 60%, transparent), transparent 52%)',
+              'radial-gradient(color-mix(in srgb, var(--everymen-ink) 45%, transparent) 0.7px, transparent 0.9px)',
             ].join(', '),
+            backgroundSize: 'auto, auto, auto, auto, 5px 5px',
           }}
         />
 
-        {/* screen-print halftone wash */}
-        <div
-          aria-hidden
-          style={{
-            position: 'absolute',
-            inset: 0,
-            zIndex: 1,
-            pointerEvents: 'none',
-            opacity: 0.06,
-            backgroundImage:
-              'radial-gradient(color-mix(in srgb, var(--everymen-ink) 100%, transparent) 0.7px, transparent 0.9px)',
-            backgroundSize: '5px 5px',
-          }}
-        />
-
-        {/* chassis band — the dispatch line at the head of the slip */}
+        {/* ── The masthead band ──────────────────────────────────────────────
+            Three tracks so the kind stays optically CENTRED on the slip rather
+            than centred in whatever the dateline leaves over: `1fr auto 1fr`
+            with equal flanks. The middle item carries minWidth 0, which is what
+            lets an auto track shrink past its content and ellipsise instead of
+            shoving the flanks to nothing. */}
         <div
           style={{
             position: 'relative',
             zIndex: 2,
-            color: 'var(--everymen-paper-text)',
-            padding: 'var(--space-xs) var(--space-md) var(--space-xs) var(--space-lg)',
-            borderBottom:
-              '1px solid color-mix(in srgb, var(--everymen-paper-text) 22%, transparent)',
+            display: 'grid',
+            gridTemplateColumns: '1fr auto 1fr',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+            background: 'var(--everymen-red)',
+            color: 'var(--everymen-masthead-text)',
+            // The band's bottom edge: two thin rules with the slip's own ground
+            // between them. It flips with the paper, because it IS the paper.
+            borderBottom: '3px double var(--everymen-paper)',
+            padding: mobile
+              ? 'var(--space-xs) var(--space-sm)'
+              : 'var(--space-xs) var(--space-md)',
           }}
         >
-          <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
+          {/* Left flank — the status tag ("Still waiting"), or nothing. Drawn as
+              an overprinted chip: a currentColor hairline box, so it reads as a
+              stamp struck onto the band rather than a second colour on it. */}
+          <span style={{ justifySelf: 'start', minWidth: 0, display: 'inline-flex' }}>
+            {tag && (
+              <span
+                className="eyebrow"
+                style={{
+                  color: 'inherit',
+                  border: '1px solid currentColor',
+                  padding: '0 var(--space-xs)',
+                  whiteSpace: 'nowrap',
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {tag}
+              </span>
+            )}
+          </span>
+
+          {/* The masthead itself — the card's kind, in the poster face. */}
+          <span
+            style={{
+              justifySelf: 'center',
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              fontFamily: 'var(--faction-everymen-card-font)',
+              fontSize: mobile ? 'var(--text-lg)' : 'var(--text-xl)',
+              letterSpacing: mobile ? '0.12em' : '0.18em',
+              textTransform: 'uppercase',
+              lineHeight: 1.15,
+              color: 'inherit',
+            }}
+          >
+            {kicker}
+          </span>
+
+          {/* Right flank — the dateline, then the spike. `color: inherit` is
+              load-bearing: the archive control paints in currentColor, so this
+              is what tints it to the masthead's ink. */}
+          <span
+            style={{
+              justifySelf: 'end',
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 'var(--space-xs)',
+              minWidth: 0,
+              color: 'inherit',
+            }}
+          >
+            <span
+              className="eyebrow"
+              style={{ color: 'inherit', whiteSpace: 'nowrap', minWidth: 0 }}
+            >
+              {time}
+            </span>
+            {archive}
+          </span>
         </div>
 
-        {/* the neutral feed card, rendered above the chrome */}
+        {/* The shared payload body, printed on the stock. */}
         <div style={{ position: 'relative', zIndex: 2 }}>{children}</div>
       </div>
     </article>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1192,6 +1192,31 @@
      the sheet keeps `--everymen-frame` and no form boundary rests on this. */
   --faction-everymen-composer-frame: var(--everymen-gold);
 
+  /* ══ Everymen — THE DISPATCH SLIP (feed card + comment voice v2, #1200) ══
+     A press slip run off in the union shop: `--everymen-paper` stock inside a
+     DOUBLE FRAME (a 2px `--everymen-frame` rule, a 4px pad, then a 1px hairline),
+     with the card's kind set in a centred red masthead band whose bottom edge is
+     a 3px double rule the ground shows through.
+
+     ONE token, for the reason the three blocks above are short — every colour
+     this surface needs already has a home in the `--everymen-*` family, and a
+     second name for the same value is a second place for it to drift:
+       · the band is `--everymen-red` as a FILL, inked in
+         `--everymen-masthead-text` (5.24:1 light / 4.59:1 dark) — the pairing
+         the broadsheet chrome already measured;
+       · the 1px inner rule and the panel hairlines reuse
+         `--faction-everymen-sheet-hair`, which is exactly this role (the ink at
+         22%, flipping to cream in dark) under a name minted for the broadsheet;
+       · the comment's typed area is `--faction-everymen-sheet-panel`, chosen
+         rather than the paper deliberately: §3 records that
+         `--faction-everymen-sheet-accent` pays 4.95:1 on that stock and only
+         4.49:1 on `--everymen-paper`, so red as @mention INK is legible on the
+         panel and is not on the paper. On the paper red stays a rule or a fill.
+
+     What had no home is the slip's shadow, which the frame was carrying as raw
+     rgba inline. */
+  --faction-everymen-slip-shadow: 0 1px 0 rgba(34, 26, 18, 0.05), 0 6px 16px -12px rgba(34, 26, 18, 0.5);
+
   /* ── Gearworks vote widget (#821) — reached gears heat a cold→ember ramp with
      pale hubs; unreached gears are edge-only outlines; rank 5 throws sparks. The
      edge + rank-5 glow flip in the dark cascade (see the dark block). ── */
@@ -1879,6 +1904,10 @@
      deep accent, which is the one edge on the sheet that does NOT lift with the
      paper — a printed poster frame stays the colour it was printed in (#1187). */
   --faction-everymen-composer-frame: var(--everymen-red-deep);
+  /* The dispatch slip at night (#1200): the drop shadow goes to the near-black
+     of the dark ground rather than the ink brown, and deepens — a slip on a dark
+     press bench lifts off it more than one on a lit paper page. */
+  --faction-everymen-slip-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 6px 16px -10px rgba(0, 0, 0, 0.8);
   /* Gearworks: cooler edge for cold gears, a brighter single-halo rank-5 glow on
      the dark paper (the light double-drop-shadow would muddy against it). */
   --faction-everymen-vote-edge: #8a7856;


### PR DESCRIPTION
Frontend only, dress only. Every behaviour on both surfaces worked before this and works identically after it.

Closes #1200

Part of epic #1192. Built against the seam merged in #1243 and the SPEC §12 correction in #1244.

---

## What changed, in three commits

**1. `index.css` — one new token.** `--faction-everymen-slip-shadow`, light and dark. That is the whole colour diff. Everything else the two surfaces need already had a home in the `--everymen-*` family, and the block says out loud which role reaches for which — including the two decisions below, so the next editor finds them at the token rather than in a component.

**2. `EverymenFeedFrame` — the dispatch slip.** Rewritten from the left-edge red spine to the design's press slip:

- a **double frame**: a 2px `--everymen-frame` rule (the plate edge), a 4px pad, then a 1px hairline (the form's own rule). `--space-xs` *is* 4px, so the design's gutter comes off the scale rather than beside it;
- a **centred red masthead band** whose bottom edge is `3px double var(--everymen-paper)` — the card's own ground showing through two thin rules;
- **all four chrome slots on that band**: tag chip left, kind centred, dateline + the archive node right. Three grid tracks (`1fr auto 1fr`) so the kind is centred on the *slip*, not on whatever the dateline leaves over.

**3. `EverymenComment` — the same slip, bylined.** Paper stock, the same double frame, the same red band — except the band carries the **byline** (who filed it, on what shift) instead of the event's kind, and the filed copy sits on a typed panel below it.

`frontend/src/factions/everymen.ts` needed **no change**: it already claims both `comment` and `feedFrame`. The manifest line is the whole registration, as #1243 says.

---

## Two judgement calls, both flagged rather than buried

**1. The comment band no longer prints "EVERYMEN · DISPATCH FROM THE FLOOR".** Epic decision 5 is unqualified — *no faction-name label anywhere, the skin is the identification* — and the author's faction is already carried by the avatar badge and by the whole slip. The byline took the band's place. **`praxis.json` → `comments.everymen.masthead` is now an orphan key**; I left it alone rather than edit a catalog eight agents are working beside. (`fieldDesk.home.everymen.masthead` is a different key and still live.) Say the word and it comes back.

**2. The comment's typed area is `--faction-everymen-sheet-panel`, not the paper.** `MentionText` paints a resolved @mention in the voice's accent, and #1223 measured red at **4.49:1 as type on `--everymen-paper`** — below AA. The same hue pays 4.95:1 light / 5.45:1 dark on the panel. So rather than walk the ink down, this gives the ink the ground it was measured on: the body is the panel, and on the paper red stays a fill (the band) and never type. It also earns the sheet its structure — a slip with a typed area pasted into it.

---

## The design element I could NOT build, and why

**The points seal.** The sheet draws points as a 66px circular seal at `rotate(-4deg)` with a 2px red ring. **Points are not reachable from the chassis.** They live in `FeedRowContent` (`row.points` / `row.level`), which is the shared, faction-blind payload body — the layer #1243 says no body needs touching, ever, and which is outside this issue's three-file footprint. A seal with no number in it is decoration, so I did not draw one.

This is a real gap between the sheet and the seam, not an oversight. If you want it, it is either a new optional slot on `FeedFrameProps` (nine frames, one PR) or a per-type override via the manifest escape hatch epic decision 2 reserves. Everymen already owns the mark — `PointsRoundel` + `.everymen-stamp-print`, used by `EverymenScoreStamp` — so it is dress, not new drawing, once the value can reach the frame.

## Other spec lines I deviated from, deliberately

- **The dateline and the tag chip print at FULL masthead ink, not `FeedChassisBand`'s 0.7 opacity.** `--everymen-masthead-text` on `--everymen-red` is 5.24:1 light and **4.59:1 dark**; at 0.7 the dark pairing lands near 3.2:1. Face and size do the separating instead. I threw `FeedChassisBand` away for this and for the centred masthead — it is explicitly a convenience, not the contract.
- **The tag chip lives on the band, not on a second dateline strip.** A strip that exists only to hold a `null`-most-of-the-time chip adds a row of bulk to every card in the feed.
- **No gold.** The old frame had a gold trim rule hugging the spine. The design's note places the band's edge as a 3px double paper rule and nothing else, and a gold hairline immediately under it competes. `--faction-everymen-composer-frame` (gold) is untouched and still the work order's.
- **`buildGearPath()` / `Gear` still has three callers.** Neither surface needed a fourth.

---

## What to eyeball

1. **The double frame reads as two rules, not as a fat one.** 2px ink + 4px paper gutter + 1px hairline. If the gutter disappears optically the pad wants `--space-sm`, not `--space-xs` — but 4px is what the sheet specifies.
2. **The `3px double` bottom border on the band.** It needs all three pixels to render as two lines; check it has not collapsed to a solid rule, in both themes. In dark the "paper" showing through is `#221a16`, so the rule reads dark-on-red rather than cream-on-red — deliberate (it *is* the ground), but it is the one place the light and dark sheets diverge in character.
3. **The kind actually centred.** The grid's flanks are `1fr` each, but a `1fr` track cannot shrink below its content's min-content, so a long time string plus the ✕ will pull the kind left. Worst case is the widest kicker beside `about 1 month ago` at the 452px grid minimum.
4. **The ✕ on the red band.** Its dormant 40% opacity is `FeedArchiveButton`'s own and faction-blind, so I could not change it — but on a saturated red fill, 40% of a 4.59:1 ink is faint. It is hover/focus-lit, and swipe and the ✕ are never the only route, so this is a legibility question rather than an access one. If it reads as absent, the answer is a change in `FeedArchiveButton` for all nine.
5. **`awaiting_submission` has nothing in the band's right slot past the dateline** — no ✕, not a disabled one. The band should not look broken with the slot empty.
6. **The three companions inside the slip** — `duel_challenge`, `collab_invite`, `invitation_letter`. Their own headers now sit under a masthead band that also names the kind. Check it does not read as two titles.
7. **The comment byline at 18px Bebas.** The feed card's kind label is 14px; the byline is content tier because a person's name is identity, not chrome. Bebas is narrow enough that this should read about like 14 of a normal face — but it is the one size on either surface I chose rather than inherited.
8. **A comment with a long display name.** The band wraps (`flexWrap`), so byline and dateline drop to two lines rather than the name ellipsising into nothing.
9. **The comment foot's hairline fading with the owner row.** On your own comment (nothing to flag) the rule fades with the controls, per #1195's Unaffiliated sheet. On someone else's it stays.
10. **The mention ink on the panel** — light and dark. This is the whole reason the panel exists.

## Verified

- `tsc --noEmit`: **clean.**
- `eslint src --max-warnings=0`: **clean.** No new `no-raw-style-values` suppressions — neither file carries one, and the frame's old raw `rgba(0,0,0,…)` shadow and the comment's old `rgba(0,0,0,0.03)` field are both gone to tokens.
- `vite build`: **clean.** Entry chunk 134.97 KB gzip (135.00 before).
- `vitest run`: **142 files, 2434 passed, 0 failed** — the #1243 baseline exactly. Includes `factionFeedFrame.test.tsx`'s all-four-slots loop and `factionTokensDeclared.test.ts`, which is what would catch the new token being referenced but undeclared.
- Branched off `origin/main` @ `12ffb6e5` and never diverged.

## NOT verified — visual QA is outstanding

**No screenshot exists of either surface.** This environment cannot render and there is no dev stack, so **every layout and every colour claim above is inference from the code, not observation.** The eyeball list is where I think it is most likely to be wrong. The contrast figures are read off the measurements already recorded in `index.css` (`--everymen-masthead-text` 5.24 / 4.59; `--faction-everymen-sheet-accent` 4.95 / 5.45) and re-derived by hand, not measured against a rendered pixel.

Also not exercised: the 6s undo timer and the swipe, for the usual reason — the harness is `renderToStaticMarkup` only, no jsdom, so no effect runs and no pointer event fires. Both live in `FeedItemSlot` and are untouched here.

## Things for someone else

- **`OwnerControls` hardcodes `--color-danger` on the Withdraw button and the error line.** In the light theme that is **4.10:1 on the Everymen panel and 3.72:1 on the paper** — below AA, in a shared slot with no prop, so no skin can route around it however carefully it measures. This is `DuelCardInk` / `DuelSlotTheme` again (WORLD_ZERO_STYLE.md, "where a shared slot hardcodes the ink"): the fix is a `danger` field on the control defaulting to today's value, not a per-voice patch, and it touches all nine voices. Out of this footprint.
- **`FlagControl.tsx:66` carries a raw `rgba(220,38,38,0.4)` border literal** in a shared component — a colour living outside `index.css`. Also out of footprint.
- **`WORLD_ZERO_STYLE.md`'s per-faction font table says Everymen's headline face is `Special Elite`.** The code has said `--faction-everymen-card-font: var(--font-accent)` (Bebas Neue) for a long time, and the design sheet agrees with the code. The doc row is stale. I left it: eight agents are in flight and that file is a conflict magnet.
- **Neither pairing this dress leans on is in `factionContrast.test.ts`'s `PAIRINGS` list** — `--everymen-masthead-text` on `--everymen-red`, and `--faction-everymen-sheet-accent` on `--faction-everymen-sheet-panel`. Both are documented with figures in `index.css`, but the automated guard does not check them. Appending two rows is the right fix and the wrong PR to do it in: eight parallel branches appending to one shared array is exactly the shape that took `main` red on the #1168 registry.

## No sheet wording appears in the diff

The chassis takes every string from the neutral `feed` catalog through `feedKicker` / `archive.stillWaiting` — this PR appends nothing to it and edits nothing in it. The comment's only faction-flavour strings are the two pre-existing ones (`praxis.json` → `comments.everymen.edited` = "revised", and the "Shift N" dialect in `commentTime.ts`), both untouched. The sheet's union dialect is discarded entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
