### PR TITLE
Warriors of Whimsy: the chronicle proclamation — feed chassis v2 + comment voice

### DIFF
--- a/frontend/src/components/__tests__/wowFeedChassis.test.tsx
+++ b/frontend/src/components/__tests__/wowFeedChassis.test.tsx
@@ -200,8 +200,13 @@ describe('every type the backend emits, inside this chassis', () => {
     }
   })
 
-  it('leaves the two exempt types alone', () => {
-    expect(card('comment_mention'), 'no body yet (#1196)').toBe('')
+  it('dresses the mention and leaves the one exempt type alone', () => {
+    // #1196 landed while this branch was open and gave `comment_mention` a body,
+    // so the old assertion here (`toBe('')`) had pinned a BUG as a rule. The
+    // mention is an ordinary row now: it takes the chassis like any other.
+    // `era_announcement` is the only genuinely exempt type — deliberately, since
+    // an era turn can strip a player of their faction (epic #1192 decision 6).
+    expect(card('comment_mention'), 'the mention is proclaimed like any row').toContain(RIBBON)
     expect(card('era_announcement'), 'keeps its own neutral chrome').not.toContain(RIBBON)
   })
 

--- a/frontend/src/components/__tests__/wowFeedChassis.test.tsx
+++ b/frontend/src/components/__tests__/wowFeedChassis.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * WOW's feed chassis — THE CHRONICLE PROCLAMATION (#1204, epic #1192).
+ *
+ * A dress issue's guards, so they hold the two things a dress can break and
+ * nothing the shared layers already own: the four chrome slots survive, and the
+ * skin is the only identification (no faction name, no second kind label).
+ *
+ * `renderToStaticMarkup`, per the frontend harness — no DOM, so no effect runs
+ * and no pointer event fires. The swipe, the 6s undo and the archive write live
+ * in `FeedItemSlot` and are pinned by `feedChassis.test.tsx`; nothing here
+ * re-asserts them. `useFormFactor` resolves to its no-matchMedia default
+ * (desktop), which is the size set every expectation below reads.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../i18n'
+import i18n from '../../i18n'
+import FactionFeedFrame from '../feed/FactionFeedFrame'
+import FeedCardRouter from '../feed/FeedCardRouter'
+import { feedKicker } from '../feed/feedItemLabels'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+
+/** The chassis, exercised through the dispatcher the way the feed reaches it. */
+function frame(tag: string | null = null): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <FactionFeedFrame
+        slug="wow"
+        kicker="Task completed"
+        time="2h ago"
+        tag={tag}
+        archive={<button type="button">archive-node</button>}
+      >
+        <span>card-body</span>
+      </FactionFeedFrame>
+    </MemoryRouter>,
+  )
+}
+
+/** Rich enough for whichever of the fifteen types is asking. */
+const FAT_PAYLOAD = {
+  character_id: 3,
+  praxis_id: 7,
+  task_id: 9,
+  task_title: 'Reforest the verge',
+  task_point_value: 40,
+  task_level_required: 2,
+  points_earned: 12,
+  praxis_title: 'A returned proof',
+  praxis_type: 'collab',
+  from_character_id: 4,
+  from_name: 'Ada',
+  to_name: 'Bo',
+  faction_slug: 'wow',
+  old_faction_slug: 'wow',
+  new_faction_slug: 'snide',
+  era_name: 'Era One',
+  duel_id: 5,
+  challenger_praxis_id: 6,
+  challenger_character_id: 3,
+  invite_id: 8,
+  inviter_character_id: 3,
+  task_faction_slug: 'wow',
+}
+
+function card(type: string, archivedView = false): string {
+  const item: ActivityFeedItem = {
+    type,
+    item_key: `${type}:1`,
+    timestamp: '2026-01-01T00:00:00Z',
+    actor_display_name: 'Ada',
+    actor_faction_slug: 'wow',
+    actor_avatar_url: null,
+    payload: FAT_PAYLOAD,
+    context_faction_slug: 'wow',
+  }
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <FeedCardRouter item={item} archivedView={archivedView} />
+    </MemoryRouter>,
+  )
+}
+
+/** The crown, and the same ribbon again as the section rule. */
+const RIBBON = '--faction-wow-quest-ribbon'
+
+describe('the four chrome slots (the contract every frame owes)', () => {
+  it('draws the kicker, the time, the tag and the archive node', () => {
+    const html = frame('Still waiting')
+    expect(html, 'kicker').toContain('Task completed')
+    expect(html, 'time').toContain('2h ago')
+    expect(html, 'tag').toContain('Still waiting')
+    expect(html, 'the archive node is PLACED, not rebuilt').toContain('archive-node')
+  })
+
+  it('keeps the payload body intact', () => {
+    expect(frame()).toContain('<span>card-body</span>')
+  })
+
+  it('omits the tag entirely when there is none', () => {
+    expect(frame()).not.toContain('Still waiting')
+  })
+
+  it('tints the archive by INHERITANCE — the head is plum, the ✕ paints in currentColor', () => {
+    // Rule 3 of the seam: the control arrives finished and is tinted by setting
+    // `color` on what it sits in, never by rebuilding it.
+    expect(frame()).toContain('color:var(--faction-wow-card-accent)')
+  })
+})
+
+describe('the skin is the identification (epic decision 5)', () => {
+  it('prints no faction name', () => {
+    const html = frame('Still waiting')
+    expect(html).not.toContain('Warriors of Whimsy')
+    expect(html).not.toContain('Whimsy')
+  })
+
+  it('carries no second kind label beside the kicker', () => {
+    // v1 headed every card "HERALD'S DISPATCH" as well as its kicker. #1194 made
+    // `kicker` a card's ONLY kind label; two labels naming one kind is exactly
+    // what that rule exists to stop.
+    const html = frame()
+    expect(html).not.toContain(i18n.t('feed:identity.wow.dispatch'))
+    expect(html.split('Task completed').length - 1, 'the kind is named once').toBe(1)
+  })
+})
+
+describe('the proclamation chrome', () => {
+  it('crowns the card with the barber ribbon and repeats it as the section rule', () => {
+    const html = frame()
+    expect(html.split(RIBBON).length - 1, 'the ribbon is drawn twice').toBe(2)
+    expect(html, 'the 6px crown').toContain('height:6px')
+    expect(html, 'the 3px rule, held back').toContain('height:3px')
+    expect(html).toContain('opacity:0.75')
+  })
+
+  it('binds the sheet in a 2px gold frame at radius 9 on the cream ground', () => {
+    const html = frame()
+    expect(html).toContain('border-radius:9px')
+    expect(html).toContain('2px solid var(--faction-wow-chronicle-gold)')
+    expect(html).toContain('background:var(--faction-wow-card-bg)')
+  })
+
+  it('never lays the muted date ink on the parchment plate (#1221)', () => {
+    // `--faction-wow-card-muted` is 4.77:1 on the cream card but only 4.25:1 on
+    // `--faction-wow-chronicle-panel` — a CREAM-ONLY ink. v1's head was that
+    // plate. The head is now the cream sheet, so the plate is absent entirely.
+    const html = frame()
+    expect(html).toContain('var(--faction-wow-card-muted)')
+    expect(html).not.toContain('--faction-wow-chronicle-panel')
+  })
+
+  it('strikes the tag as the measured plum lozenge, not the failing chip pair', () => {
+    // `-stamp-chip-text` on `-chip-bg` is 4.14:1 in dark (#1221 measured that
+    // pair against the duel ribbon, not against each other). `-plum-surface` /
+    // `-on-plum` is 5.16:1 in BOTH themes.
+    const html = frame('Still waiting')
+    expect(html).toContain('var(--faction-wow-plum-surface)')
+    expect(html).toContain('var(--faction-wow-on-plum)')
+    expect(html).not.toContain('--faction-wow-stamp-chip-text')
+  })
+
+  it('adds no padding of its own around the body — the payload pads itself', () => {
+    // v1 wrapped `{children}` in another `var(--space-md)`, double-padding every
+    // card. The head's own padding is `--space-sm --space-lg`, so a lone
+    // `--space-md` in this markup could only be that wrapper coming back.
+    expect(frame()).not.toContain('padding:var(--space-md)"')
+  })
+})
+
+describe('every type the backend emits, inside this chassis', () => {
+  /**
+   * Thirteen of the fifteen. The two the chassis deliberately does not dress are
+   * asserted below: `era_announcement`, neutral by design because an era turn can
+   * strip a player of their faction (epic decision 6), and `comment_mention`,
+   * which has no body until #1196.
+   */
+  const TYPES = [
+    'friend_completion',
+    'foe_completion',
+    'friend_signup',
+    'friend_defection',
+    'vote_on_mine',
+    'foe_taunt',
+    'global_task',
+    'collaborator_submitted',
+    'awaiting_submission',
+    'nudge',
+    'invitation_letter',
+    'duel_challenge',
+    'collab_invite',
+  ]
+
+  it('dresses all thirteen in the proclamation, kicker and all', () => {
+    for (const type of TYPES) {
+      const html = card(type)
+      expect(html, `${type} is proclaimed`).toContain(RIBBON)
+      expect(html, `${type} is named`).toContain(feedKicker(type))
+    }
+  })
+
+  it('leaves the two exempt types alone', () => {
+    expect(card('comment_mention'), 'no body yet (#1196)').toBe('')
+    expect(card('era_announcement'), 'keeps its own neutral chrome').not.toContain(RIBBON)
+  })
+
+  it('keeps the companions answerable inside the chassis', () => {
+    const duel = card('duel_challenge')
+    expect(duel).toContain(i18n.t('feed:duelChallenge.accept'))
+    expect(duel).toContain(i18n.t('feed:duelChallenge.decline'))
+
+    const collab = card('collab_invite')
+    expect(collab).toContain(i18n.t('feed:collabInvite.accept'))
+    expect(collab).toContain(i18n.t('feed:collabInvite.decline'))
+
+    expect(card('invitation_letter')).toContain(i18n.t('feed:invitationLetter.viewFactions'))
+  })
+
+  it('offers no archive control on awaiting_submission, and none disabled', () => {
+    // It is state, not an event. `archive` arrives as `null` and a chassis must
+    // never draw a disabled stand-in.
+    const html = card('awaiting_submission')
+    expect(html).toContain(RIBBON)
+    expect(html).not.toContain(i18n.t('feed:archive.dismissLabel'))
+    expect(html).not.toContain('disabled')
+  })
+
+  it('tags an archived challenge "still waiting" (ADR-0066)', () => {
+    expect(card('duel_challenge', true)).toContain(i18n.t('feed:archive.stillWaiting'))
+    expect(card('friend_completion', true)).not.toContain(i18n.t('feed:archive.stillWaiting'))
+  })
+})

--- a/frontend/src/components/comments/__tests__/wowComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/wowComment.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * WowComment — counsel on the proclamation (#1204, epic #1192).
+ *
+ * The states the sheet draws, plus the two things this dress must not get wrong:
+ * the comment card wears the SAME chrome as WOW's feed card (one sheet drew
+ * both), and no muted ink lands on the parchment plate (#1221 measured
+ * `--faction-wow-card-muted` at 4.25:1 there — it is a cream-only ink).
+ *
+ * `renderToStaticMarkup` per the comments-test convention, so `useAuth` resolves
+ * to its anonymous default: the viewer owns nothing and can flag nothing, which
+ * is the "row · default" reading of every case below. The owner states (yours ·
+ * hover, editing) run on `useOwnerEdit` / `useOwnerReveal`, which are pinned in
+ * `OwnerControls.test.tsx`; this voice only wires them.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import type { CommentOut } from '../../../api/comments'
+import type { CharacterOut } from '../../../api/auth'
+import WowComment from '../voices/WowComment'
+
+const COMMENT: CommentOut = {
+  id: 7,
+  praxis_id: 1,
+  task_id: null,
+  body_text: 'the verge is planted, and the horn was sounded',
+  is_edited: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: {
+    id: 42,
+    username: 'ada',
+    display_name: 'Adabel',
+    avatar_url: null,
+    faction_slug: 'wow',
+  },
+  mentions: [],
+}
+
+const CHARACTER: CharacterOut = {
+  id: 42,
+  username: 'ada',
+  display_name: 'Adabel',
+  avatar_url: null,
+  faction_slug: 'wow',
+  bio: null,
+  location: null,
+  level: 3,
+  score: 0,
+  all_time_score: 0,
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function row(comment: CommentOut = COMMENT): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <WowComment mode="row" comment={comment} />
+    </MemoryRouter>,
+  )
+}
+
+function composer(submitting: boolean): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <WowComment
+        mode="composer"
+        character={CHARACTER}
+        value=""
+        onChange={() => {}}
+        onSubmit={() => {}}
+        submitting={submitting}
+      />
+    </MemoryRouter>,
+  )
+}
+
+const RIBBON = '--faction-wow-quest-ribbon'
+
+describe('the comment wears the proclamation chrome', () => {
+  it('is crowned by the barber ribbon, in a 2px gold frame at radius 9', () => {
+    const html = row()
+    expect(html).toContain(RIBBON)
+    expect(html).toContain('height:6px')
+    expect(html).toContain('border-radius:9px')
+    expect(html).toContain('2px solid var(--faction-wow-chronicle-gold)')
+    expect(html).toContain('background:var(--faction-wow-card-bg)')
+  })
+
+  it('letters the name in MedievalSharp and the quiet register in Lora italic', () => {
+    const html = row()
+    expect(html).toContain('var(--faction-wow-card-font)')
+    expect(html).toContain('var(--faction-wow-body-font)')
+    expect(html).toContain('font-style:italic')
+  })
+
+  it('never lays a muted mark on the parchment plate (#1221)', () => {
+    // The plate is legible under `-card-text` (13:1) and NOT under `-card-muted`
+    // (4.25:1), so a resting row — every mark on which is ink or muted — must not
+    // reach for it at all.
+    const html = row()
+    expect(html).toContain('var(--faction-wow-card-muted)')
+    expect(html).not.toContain('--faction-wow-chronicle-panel')
+  })
+
+  it('uses the plate only for the composer FIELD, whose ink is card-text', () => {
+    expect(composer(false)).toContain('--faction-wow-chronicle-panel')
+  })
+})
+
+describe('row states', () => {
+  it('row · default: author identity, body on the content floor, no edited mark', () => {
+    const html = row()
+    expect(html).toContain('href="/characters/42"')
+    expect(html).toContain('Adabel')
+    expect(html).toContain('the verge is planted')
+    expect(html).toContain('content-text')
+    expect(html).not.toContain(i18n.t('praxis:comments.wow.edited'))
+  })
+
+  it('row · with a mention: a resolved handle links to the character', () => {
+    const html = row({
+      ...COMMENT,
+      body_text: 'well fought @bo',
+      mentions: [{ character_id: 9, username: 'bo', display_name: 'Bo' }],
+    })
+    expect(html).toContain('href="/characters/9"')
+    expect(html).toContain('@bo')
+    // Plum is the mention's ink, not the spectrum: that clip is the na tell.
+    expect(html).toContain('var(--faction-wow-card-accent)')
+    expect(html).not.toContain('rainbow-ink')
+  })
+
+  it('leaves an unresolved handle as plain text', () => {
+    const html = row({ ...COMMENT, body_text: 'well fought @ghost' })
+    expect(html).toContain('@ghost')
+    expect(html).not.toContain('href="/characters/9"')
+  })
+
+  it('row · edited: the amended mark joins the byline', () => {
+    expect(row({ ...COMMENT, is_edited: true })).toContain(i18n.t('praxis:comments.wow.edited'))
+  })
+
+  it('shows no owner row and no flag affordance to a signed-out viewer', () => {
+    const html = row()
+    expect(html).not.toContain(i18n.t('praxis:comments.delete'))
+    expect(html).not.toContain('Flag')
+    // No foot means no section rule over empty space either.
+    expect(html.split(RIBBON).length - 1, 'the crown only').toBe(1)
+  })
+
+  it('draws no reaction pill — nothing in the product can answer one', () => {
+    // The kit draws "✦ Huzzah · 12" and #898 shipped the word, but there is no
+    // reaction endpoint, column or count. A control that no-ops is forbidden.
+    expect(row()).not.toContain(i18n.t('praxis:comments.wow.react'))
+  })
+})
+
+describe('composer states', () => {
+  it('composer · empty: the prompt, the section rule and the @-mention hint', () => {
+    const html = composer(false)
+    expect(html).toContain(i18n.t('praxis:comments.wow.prompt'))
+    expect(html).toContain('@ to mention')
+    expect(html.split(RIBBON).length - 1, 'crown + section rule').toBe(2)
+  })
+
+  it('states the @ affordance exactly ONCE — the hint owns it, not the placeholder', () => {
+    expect(composer(false).match(/to mention/g)).toHaveLength(1)
+  })
+
+  it('composer · submitting: marks itself busy and disables the field', () => {
+    const html = composer(true)
+    expect(html).toContain('aria-busy="true"')
+    expect(html).toContain('disabled')
+  })
+
+  it('composer · empty is NOT busy', () => {
+    expect(composer(false)).not.toContain('aria-busy="true"')
+  })
+})

--- a/frontend/src/components/comments/voices/WowComment.tsx
+++ b/frontend/src/components/comments/voices/WowComment.tsx
@@ -1,163 +1,281 @@
-import type { CSSProperties } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
+import { useAuth } from '../../../auth/AuthContext'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
-import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
-import { CommentFlagControl } from '../FlagControl'
+import {
+  CommentEditor,
+  OwnerControls,
+  ownerRevealStyle,
+  useOwnerEdit,
+  useOwnerReveal,
+} from '../OwnerControls'
+import { CommentFlagControl, canFlagComment } from '../FlagControl'
 
 /**
- * Warriors of Whimsy — COUNSEL IN THE MARGIN (kit §06, #899).
+ * Warriors of Whimsy — COUNSEL IN THE PROCLAMATION (comment voice v2, #1204).
  *
- * A knight speaks beside the chronicle, not on it: a slip of the same cream
- * parchment, ruled down its left edge in plum, with the crest avatar set at the
- * head and the name lettered in MedievalSharp. It follows the decree's chrome
- * (the task card is the archetype the other surfaces mirror) — same parchment,
- * same gold hairline, same plum ink — and adds no ornament of its own.
+ * A knight speaks on the same instrument the Court proclaims on: the comment
+ * card is the update card's chrome exactly (`WowFeedFrame`, this issue's other
+ * half) — a 6px gold/plum barber ribbon crowning a cream sheet in a 2px gold
+ * frame at radius 9, the crest set in the margin, the name lettered in
+ * MedievalSharp, the quiet register in Lora italic, and the ribbon repeating as
+ * a 3px section rule where the sheet divides. One sheet draws both halves and
+ * they now match; v1's plum-ruled slip at radius 12 predated it.
  *
  * The three invariant slots are unchanged (ADR-0016): author identity · body ·
  * timestamp+edited. A posted row takes the AUTHOR's faction; the composer takes
  * the current character's, which is why both ends carry the crest avatar rather
  * than the bare sigil — `WowAvatar` (#897) is already the crest in a gilt ring.
  *
- * THE HUZZAH IS NOT BUILT. The kit draws a "✦ Huzzah · 12" reaction pill on this
- * row, and #898 shipped the word for it (`comments.wow.react`). There is no
- * reaction anywhere in the product — no endpoint, no column, no count on
- * `CommentOut` — so rendering the pill would be a control that no-ops, which UX
- * principle 5 forbids outright ("no dead buttons"). The copy key is left in
- * place for whoever builds reactions; the pill arrives with the feature, not
- * before it. The kit's "Reply" affordance is absent for the same reason:
- * comments are flat (ADR-0006).
+ * SEVEN STATES, ONE COMPONENT (ADR-0056 / 0058 / 0063 — no mobile twin):
+ *   row · default | row · with a mention | row · edited | row · yours (hover) |
+ *   row · editing | composer · empty | composer · submitting
  *
- * Both themes come from the `[data-theme="dark"]` cascade.
+ * BEHAVIOUR IS INHERITED, NOT REBUILT. Edit, withdraw, flag, @mention
+ * autocomplete, the live character count and the submitting state all live in
+ * the shared helpers, and #1195 put the owner's edit/withdraw row behind a
+ * hover-OR-focus gate: this voice opts into that gate with the two lines it was
+ * designed for (`useOwnerReveal` + spreading `containerProps` on the card root)
+ * and re-implements none of it. The foot, its rule and the gate's exact
+ * conditions follow `DefaultComment`, which is the copy and behaviour spec for
+ * every voice (epic #1192) — including the detail that on your OWN comment the
+ * rule fades with the row, since a hairline over empty space is a state the
+ * sheet never draws.
+ *
+ * NO STRING FROM THE SHEET SHIPS. Its dialect is discarded (epic #1192); the
+ * words here are the ones already in `praxis.json`. `comments.wow.*` (#898) is
+ * pre-existing per-voice copy from WOW's own kit, not lifted off this design —
+ * the epic's neutral-copy rule governs the FEED catalog, and whether the nine
+ * comment voices should also be neutralised is a call for the owner, not for a
+ * dress issue holding a shared locale file eight agents are queued on.
+ *
+ * THE HUZZAH IS STILL NOT BUILT. The kit draws a "✦ Huzzah · 12" reaction pill
+ * and #898 shipped the word (`comments.wow.react`), but there is no reaction
+ * anywhere in the product — no endpoint, no column, no count on `CommentOut` —
+ * so the pill would be a control that no-ops, which UX principle 5 forbids. The
+ * key waits for the feature. "Reply" is absent for the same reason: comments are
+ * flat (ADR-0006).
+ *
+ * Every colour is a shipped `--faction-wow-*` token and both themes come from
+ * the `[data-theme="dark"]` cascade. The one AA trap on this palette is avoided
+ * rather than re-measured: `--faction-wow-card-muted` is a CREAM-only ink
+ * (4.77:1 on `-card-bg`, 4.25:1 on `-chronicle-panel`, #1221), so every muted
+ * mark here sits on the cream sheet, and only the composer's inset FIELD — whose
+ * ink is `-card-text` at 13:1 — uses the parchment plate.
  */
+
+const MED = 'var(--faction-wow-card-font)' /* MedievalSharp */
+const LORA = 'var(--faction-wow-body-font)' /* Lora */
+const GOLD = 'var(--faction-wow-chronicle-gold)'
+const GILT = 'var(--faction-wow-stamp-total)'
+const INK = 'var(--faction-wow-card-text)'
+const MUTED = 'var(--faction-wow-card-muted)'
+const PLUM = 'var(--faction-wow-card-accent)'
+const RIBBON = 'var(--faction-wow-quest-ribbon)'
 
 /**
  * The kit sets the crest beside the counsel at 44px, wider than the shared
  * `sm` (24px) — a seal that small stops reading as a seal. Below #897's 56px
  * motto floor, so the band drops its lettering and keeps its ring, which is
- * exactly what the kit draws here.
+ * exactly what the kit draws here. Ornament geometry, so a raw number (§4a).
  */
 const CREST_AVATAR = 44
 
-/** The parchment slip: gold hairline all round, plum rule down the margin. */
-const SLIP: CSSProperties = {
-  display: 'flex',
-  gap: 'var(--space-md)',
-  alignItems: 'flex-start',
-  padding: 'var(--space-lg) var(--space-xl)',
-  borderRadius: 12,
-  background: 'var(--faction-wow-chronicle-bg)',
-  color: 'var(--faction-wow-card-text)',
-  border: '1px solid var(--faction-wow-chronicle-rule)',
-  borderLeft: '4px solid var(--faction-wow-card-accent)',
-  fontFamily: 'var(--faction-wow-body-font)',
+/** The barber ribbon's two weights — the crown and the section rule (§4a). */
+const CROWN_HEIGHT = 6
+const RULE_HEIGHT = 3
+const RULE_OPACITY = 0.75
+
+/** The quiet register: Lora italic, the face WOW says everything small in. */
+const QUIET: CSSProperties = {
+  fontFamily: LORA,
+  fontStyle: 'italic',
+  fontSize: 'var(--text-lg)',
+  color: MUTED,
+}
+
+/**
+ * The sheet both modes sit on — the proclamation card, crest in the margin.
+ * One shape for a row and for the composer, so a thread reads as one stack
+ * rather than a list plus a form.
+ */
+function Sheet({
+  avatar,
+  children,
+  containerProps,
+}: {
+  avatar: ReactNode
+  children: ReactNode
+  containerProps?: React.ComponentPropsWithoutRef<'div'>
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
+      {avatar}
+      <div
+        {...containerProps}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          borderRadius: 9,
+          overflow: 'hidden',
+          background: 'var(--faction-wow-card-bg)',
+          color: INK,
+          border: `2px solid ${GOLD}`,
+          boxShadow: 'var(--faction-wow-quest-shadow)',
+          fontFamily: LORA,
+        }}
+      >
+        {/* The crown — a stripe carrying NO text, which is the only reason the
+            undimmed gold/plum ships as drawn (§3, #840). */}
+        <div aria-hidden style={{ height: CROWN_HEIGHT, background: RIBBON }} />
+        <div style={{ padding: 'var(--space-md) var(--space-lg)' }}>{children}</div>
+      </div>
+    </div>
+  )
+}
+
+/** The ribbon again, thinner and held back: the sheet's section divider. */
+function RibbonRule({ style }: { style?: CSSProperties }) {
+  return (
+    <div
+      aria-hidden
+      style={{ height: RULE_HEIGHT, background: RIBBON, opacity: RULE_OPACITY, ...style }}
+    />
+  )
 }
 
 export default function WowComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
+  const { user } = useAuth()
+  const reveal = useOwnerReveal()
 
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props
     return (
-      <div style={SLIP}>
-        <FactionAvatar character={character} size={CREST_AVATAR} />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div
-            style={{
-              fontStyle: 'italic',
-              fontSize: 'var(--text-content)',
-              color: 'var(--faction-wow-card-muted)',
-              marginBottom: 'var(--space-md)',
-            }}
-          >
+      <Sheet avatar={<FactionAvatar character={character} size={CREST_AVATAR} />}>
+        {/* `.content-text` rides the wrapper: the one slot inside without a size
+            of its own is the textarea (`font: inherit`), and a comment draft is
+            content-tier text (§4). Every other slot names its own size. */}
+        <div className="content-text" aria-busy={submitting}>
+          <div style={{ ...QUIET, marginBottom: 'var(--space-sm)' }}>
+            <span className="wow-tw" aria-hidden style={{ color: GILT, marginRight: 'var(--space-xs)' }}>
+              ✦
+            </span>
             {t('comments.wow.prompt')}
           </div>
+          <RibbonRule style={{ marginBottom: 'var(--space-md)' }} />
           <ComposerControls
             value={value}
             onChange={onChange}
             onSubmit={onSubmit}
             submitting={submitting}
-            accent="var(--faction-wow-card-accent)"
+            accent={PLUM}
             onAccent="var(--faction-wow-on-accent)"
+            // The field tier, not the sheet: an inset plate reads as written ON
+            // rather than painted over. Its ink is `-card-text` at 13:1 — the
+            // one WOW ink measured against the parchment plate.
             bg="var(--faction-wow-chronicle-panel)"
-            text="var(--faction-wow-card-text)"
+            text={INK}
             submitLabel={t('comments.wow.post')}
+            // The shared string in the decree's own quiet register — an OVERRIDE
+            // of ComposerControls' neutral default, not a new hint.
+            hint={<span style={QUIET}>{t('comments.mentionHint')}</span>}
           />
         </div>
-      </div>
+      </Sheet>
     )
   }
 
   const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
+  const canFlag = canFlagComment(comment, user?.character?.id)
+  // The foot exists only when it holds something: the author's edit/withdraw or
+  // a flag affordance. Hidden while editing — the inline editor owns Save/Cancel.
+  const showControls = !owner.editing && (owner.isOwner || canFlag)
+  // On your OWN comment the foot holds nothing but the gated owner row, so the
+  // rule above it fades with the row. A flaggable (someone else's) comment keeps
+  // its foot always. Same condition as `DefaultComment`, the behaviour spec.
+  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
 
   return (
-    <div style={SLIP}>
-      <FactionAvatar character={authorToCharacter(comment.author)} size={CREST_AVATAR} />
-      <div style={{ flex: 1, minWidth: 0 }}>
-        <div
+    <Sheet
+      avatar={<FactionAvatar character={authorToCharacter(comment.author)} size={CREST_AVATAR} />}
+      containerProps={reveal.containerProps}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          flexWrap: 'wrap',
+          gap: 'var(--space-sm)',
+        }}
+      >
+        <Link
+          to={`/characters/${comment.author.id}`}
           style={{
-            display: 'flex',
-            alignItems: 'baseline',
-            flexWrap: 'wrap',
-            gap: 'var(--space-sm)',
-          }}
-        >
-          <Link
-            to={`/characters/${comment.author.id}`}
-            style={{
-              fontFamily: 'var(--faction-wow-card-font)',
-              fontSize: 'var(--text-content)',
-              color: 'var(--faction-wow-card-text)',
-              textDecoration: 'none',
-            }}
-          >
-            {comment.author.display_name}
-          </Link>
-          <span
-            style={{
-              fontStyle: 'italic',
-              fontSize: 'var(--text-lg)',
-              color: 'var(--faction-wow-card-muted)',
-              display: 'inline-flex',
-              alignItems: 'baseline',
-              gap: 'var(--space-sm)',
-            }}
-          >
-            {formatCommentTime(slug, comment.created_at)}
-            {comment.is_edited ? ` · ${t('comments.wow.edited')}` : ''}
-            <OwnerControls owner={owner} />
-            <CommentFlagControl comment={comment} />
-          </span>
-        </div>
-        <div
-          style={{
+            fontFamily: MED,
             fontSize: 'var(--text-content)',
-            lineHeight: 1.55,
-            color: 'var(--faction-wow-card-text)',
-            marginTop: 'var(--space-sm)',
+            color: INK,
+            textDecoration: 'none',
           }}
         >
-          {owner.editing ? (
-            <CommentEditor
-              owner={owner}
-              accent="var(--faction-wow-card-accent)"
-              onAccent="var(--faction-wow-on-accent)"
-              bg="var(--faction-wow-chronicle-panel)"
-              text="var(--faction-wow-card-text)"
-            />
-          ) : (
-            <MentionText
-              body={comment.body_text}
-              mentions={comment.mentions}
-              accent="var(--faction-wow-card-accent)"
-            />
-          )}
-        </div>
+          {comment.author.display_name}
+        </Link>
+        <span style={QUIET}>{formatCommentTime(slug, comment.created_at)}</span>
+        {comment.is_edited && (
+          <span style={QUIET}>
+            <span aria-hidden="true">· </span>
+            {t('comments.wow.edited')}
+          </span>
+        )}
       </div>
-    </div>
+
+      {/* The body is user-authored free text — the content floor, resting and
+          editing alike (the editor's textarea inherits it). */}
+      <div
+        className="content-text"
+        style={{
+          marginTop: 'var(--space-sm)',
+          fontFamily: LORA,
+          color: INK,
+          lineHeight: 1.55,
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {owner.editing ? (
+          <CommentEditor
+            owner={owner}
+            accent={PLUM}
+            onAccent="var(--faction-wow-on-accent)"
+            bg="var(--faction-wow-chronicle-panel)"
+            text={INK}
+          />
+        ) : (
+          <MentionText body={comment.body_text} mentions={comment.mentions} accent={PLUM} />
+        )}
+      </div>
+
+      {showControls && (
+        <div style={footGate ?? undefined}>
+          <RibbonRule style={{ marginTop: 'var(--space-md)' }} />
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              flexWrap: 'wrap',
+              gap: 'var(--space-md)',
+              marginTop: 'var(--space-sm)',
+            }}
+          >
+            <OwnerControls owner={owner} reveal={reveal} />
+            <CommentFlagControl comment={comment} />
+          </div>
+        </div>
+      )}
+    </Sheet>
   )
 }

--- a/frontend/src/components/feed/WowFeedFrame.tsx
+++ b/frontend/src/components/feed/WowFeedFrame.tsx
@@ -1,37 +1,101 @@
-import i18n from '../../i18n'
-import FeedChassisBand from './FeedChassisBand'
+import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
- * Warriors of Whimsy — THE HERALD'S DISPATCH (kit §07, #899).
+ * Warriors of Whimsy — THE CHRONICLE PROCLAMATION (feed chassis v2, #1204).
  *
- * The decree's chrome, folded down to a feed row: a gold-framed sheet of cream
- * parchment headed by a parchment-plate band that carries a twinkling ✦ and the
- * words HERALD'S DISPATCH. Frame-level chrome only (surface #12,
- * SPEC-faction-ui-profile.md) — the neutral card arrives as `{children}` and
- * renders untouched, exactly as in `CovenFeedFrame` / `EverymenFeedFrame`.
+ * The card every WOW-actor update is proclaimed on: a 6px gold/plum barber
+ * ribbon crowning a cream sheet bound in a 2px gold frame at radius 9, the
+ * herald's ✦ leading a MedievalSharp kicker, the date set in Lora italic at the
+ * far end, and the ribbon repeating as a 3px section rule between the head and
+ * the body. It is the quest decree's own chrome (`WowTaskCard`, #1023) folded
+ * down to a feed card — a WOW surface must look like the decree (§6).
  *
- * WHAT THE KIT DRAWS THAT THIS DOES NOT:
+ * WHAT THIS IS, AND WHAT IT IS NOT (the three-layer seam, #1194):
  *
- *  • the WAX SEAL beside the dispatch text. In the kit that seal is the actor's
- *    portrait; in the app the card already renders one, and for a WOW actor that
- *    portrait IS the crest (`WowAvatar`, #897). Adding a second seal here would
- *    put two crests on one row;
- *  • the "+140 points" pill under the sentence. That is card content, not frame
- *    chrome — the neutral row owns the points, and re-drawing them in the wrapper
- *    would print them twice.
+ *   FeedItemSlot      the ARCHIVE — the ✕, the swipe, the write, the 6s undo.
+ *   └ THIS FILE       the CHASSIS — kicker · tag · time, and it PLACES the ✕.
+ *       └ children    the shared PAYLOAD. Faction-blind. Never touched here.
  *
- * THE DATE ON THE RIGHT OF THE BAND, which this file previously called card
- * content for the same reason, is now chrome and the kit was right: #1194 moved
- * the timestamp onto the chassis for every faction, and the row no longer draws
- * one. The band carries it, with the kicker, the tag and the dismiss control.
+ * So this file is dress and nothing else. It draws all four chrome slots
+ * ({@link FeedFrameProps}) and rebuilds none of them: `archive` arrives finished
+ * — hover/focus-gated, keyboard reachable, labelled, and `null` on
+ * `awaiting_submission`, which is state rather than an event and offers no
+ * control at all. It paints in `currentColor`, so the head tints it plum simply
+ * by being plum. Swipe, the undo strip and the archived list are inherited whole.
  *
- * `feed:row.wow.*` (#898) belongs to the row SENTENCE, which `FeedRowContent`
- * composes generically; it is not readable from a frame that only sees
- * `children`. Those three keys stay unclaimed until the row copy is dispatched.
+ * NOT A WORD OF THE SHEET'S OWN DIALECT SHIPS (epic #1192). The design is
+ * written in the Court's voice and every string on this card is the neutral one
+ * from the `feed` catalog: the kicker is `feed:kicker.<type>`, the tag is
+ * "Still waiting". The skin is the identification — no faction name appears
+ * anywhere on it, and the old HERALD'S DISPATCH masthead is gone with #1194's
+ * rule that `kicker` is a card's ONLY kind label. Two labels naming one card's
+ * kind is what that rule exists to stop. `feed:identity.wow.dispatch` therefore
+ * has no reader left; the key stays in the catalog untouched, because a dress
+ * issue may not edit the shared `feed` catalog while the other seven faction
+ * agents are in flight, and sweeping it belongs to whoever tidies the catalog
+ * once the epic lands. `feed:row.wow.*` (#898) is still unclaimed for the same
+ * reason it always was: it belongs to the row SENTENCE, which the shared body
+ * composes generically and a chassis cannot see.
+ *
+ * THE SHEET'S CROOKED POINTS PLAQUE IS NOT DRAWN HERE, and cannot be from this
+ * seam. Points live on the shared, faction-blind body (`FeedRowContent` sets
+ * them beside the level), and the chassis only ever sees `children` — it has no
+ * points value to strike a plaque with, and reaching into the body's markup to
+ * restyle one would be the chassis special-casing a payload, which the seam
+ * forbids. Drawing its own plaque would print the figure twice, exactly as
+ * re-drawing the kit's wax seal would have put two crests on one row (the actor's
+ * portrait already IS the crest, `WowAvatar` #897). It stays undrawn until the
+ * shared body grows a slot for it.
+ *
+ * WHERE THE SHEET'S LITERALS LANDED. Every one maps onto a shipped
+ * `--faction-wow-*` token; nothing is ported and nothing new is minted:
+ *   ribbon   → `--faction-wow-quest-ribbon` (the composed gold/plum 11px stripe)
+ *   cardBg   → `--faction-wow-card-bg`     · gold  → `--faction-wow-chronicle-gold`
+ *   ink      → `--faction-wow-card-text`   · muted → `--faction-wow-card-muted`
+ *   ctaBg    → `--faction-wow-plum-surface` under `--faction-wow-on-plum`
+ *   goldDeep → `--faction-wow-stamp-total` (the herald's ✦)
+ *
+ * TWO AA FINDINGS FROM #1221 ARE HONOURED BY AVOIDANCE, not by re-measuring:
+ * `--faction-wow-card-muted` is a CREAM-ONLY ink (4.77:1 on `-card-bg`, but
+ * 4.25:1 on `-chronicle-panel`), so the date sits on the cream sheet and this
+ * card grows no parchment head plate for it to fail on — the v1 dispatch band
+ * was exactly such a plate; and `-stamp-chip-text` on `-chip-bg` is 4.14:1 in
+ * dark, so the tag chip takes the theme-invariant `-plum-surface` / `-on-plum`
+ * pair (5.16:1 in both themes) that every other measured WOW chip uses.
+ *
+ * ONE RESPONSIVE COMPONENT, no mobile twin (ADR-0056 / 0058 / 0063):
+ * `useFormFactor` picks the padding and the kicker's tier, and the head wraps
+ * with the date and the ✕ held together as one cluster, so a narrow card breaks
+ * between the label and the controls rather than orphaning the ✕.
  *
  * Both themes come from the `[data-theme="dark"]` cascade.
  */
+
+const MED = 'var(--faction-wow-card-font)' /* MedievalSharp */
+const LORA = 'var(--faction-wow-body-font)' /* Lora */
+const GOLD = 'var(--faction-wow-chronicle-gold)'
+const GILT = 'var(--faction-wow-stamp-total)'
+const PLUM = 'var(--faction-wow-card-accent)'
+const RIBBON = 'var(--faction-wow-quest-ribbon)'
+
+/** The barber ribbon's two weights: the 6px crown and the 3px section rule.
+ *  Ornament geometry — the drawn stripe itself, not layout spacing (§4a). */
+const CROWN_HEIGHT = 6
+const RULE_HEIGHT = 3
+/** The rule is the same ribbon held back so it divides without competing. */
+const RULE_OPACITY = 0.75
+
+interface SizeSet {
+  head: string
+  kicker: string
+}
+
+const SIZES: Record<'desktop' | 'mobile', SizeSet> = {
+  desktop: { head: 'var(--space-sm) var(--space-lg)', kicker: 'var(--text-lg)' },
+  mobile: { head: 'var(--space-xs) var(--space-md)', kicker: 'var(--text-md)' },
+}
+
 export default function WowFeedFrame({
   kicker,
   time,
@@ -39,55 +103,117 @@ export default function WowFeedFrame({
   archive,
   children,
 }: FeedFrameProps) {
+  const formFactor = useFormFactor()
+  const size = SIZES[formFactor]
+
   return (
     <article
+      data-form-factor={formFactor}
       style={{
-        borderRadius: 11,
+        borderRadius: 9,
         overflow: 'hidden',
-        background: 'var(--faction-wow-chronicle-bg)',
+        background: 'var(--faction-wow-card-bg)',
         color: 'var(--faction-wow-card-text)',
-        border: '2px solid var(--faction-wow-chronicle-border)',
-        boxShadow: '0 12px 28px -16px var(--faction-wow-chronicle-shadow)',
-        fontFamily: 'var(--faction-wow-body-font)',
+        border: `2px solid ${GOLD}`,
+        boxShadow: 'var(--faction-wow-quest-shadow)',
+        fontFamily: LORA,
       }}
     >
-      {/* the dispatch band — a strip of the inset parchment plate */}
+      {/* The crown. A stripe carrying NO text, which is the only reason the
+          undimmed gold/plum ships as drawn (§3, #840). */}
+      <div aria-hidden style={{ height: CROWN_HEIGHT, background: RIBBON }} />
+
+      {/* The proclamation head. Plum is the head's ink, so the pre-composed
+          archive node inherits it — that is how a chassis tints a control it
+          must not rebuild. */}
       <div
         style={{
           display: 'flex',
           alignItems: 'center',
+          flexWrap: 'wrap',
           gap: 'var(--space-sm)',
-          padding: 'var(--space-xs) var(--space-md)',
-          background: 'var(--faction-wow-chronicle-panel)',
-          borderBottom: '1px solid var(--faction-wow-chronicle-rule)',
+          padding: size.head,
+          color: PLUM,
         }}
       >
-        <span
-          className="wow-tw"
-          aria-hidden
-          style={{ color: 'var(--faction-wow-stamp-total)' }}
-        >
+        <span className="wow-tw" aria-hidden style={{ color: GILT }}>
           ✦
         </span>
+
         <span
           className="eyebrow"
           style={{
-            flexShrink: 0,
-            fontFamily: 'var(--faction-wow-card-font)',
+            fontFamily: MED,
+            fontSize: size.kicker,
             letterSpacing: '0.14em',
-            color: 'var(--faction-wow-card-accent)',
+            color: 'inherit',
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
           }}
         >
-          {i18n.t('feed:identity.wow.dispatch')}
+          {kicker}
         </span>
 
-        {/* chassis band — rides the dispatch band in the herald's own accent */}
-        <div style={{ flex: 1, minWidth: 0, color: 'var(--faction-wow-card-accent)' }}>
-          <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
-        </div>
+        {/* "Still waiting" — an archived challenge or invite is still open, since
+            archiving never answers anything (ADR-0066). Struck as the decree's
+            own plum lozenge, the one WOW chip pairing measured in both themes. */}
+        {tag && (
+          <span
+            className="eyebrow"
+            style={{
+              fontFamily: MED,
+              fontSize: 'var(--text-md)',
+              letterSpacing: '0.1em',
+              color: 'var(--faction-wow-on-plum)',
+              background: 'var(--faction-wow-plum-surface)',
+              borderRadius: 4,
+              padding: '0 var(--space-sm)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {tag}
+          </span>
+        )}
+
+        {/* The date and the ✕ travel together: when the head wraps it must break
+            before this cluster, never inside it. */}
+        <span
+          style={{
+            marginLeft: 'auto',
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+          }}
+        >
+          <span
+            style={{
+              fontFamily: LORA,
+              fontStyle: 'italic',
+              fontSize: 'var(--text-lg)',
+              // The cream-only ink, on the cream sheet it was measured against.
+              color: 'var(--faction-wow-card-muted)',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {time}
+          </span>
+          {archive}
+        </span>
       </div>
 
-      <div style={{ padding: 'var(--space-md)' }}>{children}</div>
+      {/* The section rule — the crown again, thinner and held back. */}
+      <div
+        aria-hidden
+        style={{ height: RULE_HEIGHT, background: RIBBON, opacity: RULE_OPACITY }}
+      />
+
+      {/* The payload pads itself — every shared body and all three companions set
+          their own `var(--space-md) var(--space-lg)` — so the chassis adds none.
+          The v1 frame wrapped children in another `--space-md` and double-padded
+          every card. */}
+      {children}
     </article>
   )
 }

--- a/frontend/src/factions/wow.ts
+++ b/frontend/src/factions/wow.ts
@@ -32,6 +32,17 @@
  * chronicle: two chromes on one palette, deliberately unalike (#785's "the
  * praxis card mirrors the task card" clause is retired for WOW).
  *
+ * #1204 REDRESSES those last two on one sheet — "Warrior of Whimsy Comment +
+ * Update Cards" (epic #1192). Both rows are unchanged; the components behind
+ * them are not. `feedFrame` stopped being a `{ children }` wrapper and became
+ * THE CHRONICLE PROCLAMATION, a chassis drawing the kicker, the tag, the time
+ * and the archive control (`FeedFrameProps`, #1194); `comment` follows the same
+ * sheet, so the counsel now wears the proclamation's own chrome — barber ribbon,
+ * 2px gold frame, radius 9 — instead of v1's plum-ruled slip. The herald's-
+ * dispatch masthead is gone with it: `kicker` is a card's only kind label. Not a
+ * word of that sheet's dialect ships; the epic's copy spec is the Unaffiliated
+ * sheet and the faction carries identity in dress alone.
+ *
  * #1037 adds the desktop `taskDetail` — THE PARCHMENT FIELD: gold-and-plum
  * parchment under a dot texture, bunting across the head, a struck points
  * plaque, wavy gold→plum rules and a bunch of googly balloons. It is the first


### PR DESCRIPTION
Frontend only. Dress: every behaviour on this card already worked before it.

Closes #1204

Part of epic #1192. Built on the chassis seam from #1243 and the shared comment controls from #1195.

---

## What it does

WOW's two surfaces off one sheet (`Warrior of Whimsy Comment + Update Cards`), so they now match:

**`WowFeedFrame` — the chronicle proclamation.** Rewritten from the v1 herald's-dispatch band onto its own dress: a 6px gold/plum barber ribbon crowns the card, a 2px gold frame at radius 9 binds it, the herald's ✦ leads a MedievalSharp kicker, the date is set in Lora italic, and the ribbon returns as a 3px section rule at 0.75 above the body. It draws all four chrome slots and rebuilds none of them — `archive` arrives finished and is tinted by inheritance, because the head's ink is plum and the control paints in `currentColor`.

**`WowComment` — counsel on the same instrument.** The same chrome (v1 was a plum-ruled slip at radius 12, which predated this sheet), plus the two lines that opt into #1195's hover-OR-focus gate for the owner row. The foot, its rule and the gate's exact conditions follow `DefaultComment`, which the epic makes the behaviour spec for every voice — including that on your own comment the rule fades with the row, since a hairline over empty space is a state the sheet never draws.

**`factions/wow.ts`** — docstring only. `comment` and `feedFrame` were already claimed by #899; what changed is what they point at.

**No `index.css` change, and no new token.** Every literal on the sheet already ships as a `--faction-wow-*` name, and `--ribbon` is `--faction-wow-quest-ribbon` verbatim (the composed gold/plum 11px stripe #1023 minted). Minting a near-duplicate here would be the "tokenized-looking, not tokenized" trap.

## Three things I removed, each for a stated reason

1. **The HERALD'S DISPATCH masthead.** #1194's rule 1 says `kicker` is a card's *only* kind label; the masthead was a second one naming the same thing. `feed:identity.wow.dispatch` now has no reader. **I did not delete the key** — a dress issue may not edit the shared `feed` catalog while seven sibling agents are in it (a union conflict there is guaranteed), so the sweep belongs to whoever tidies the catalog after the epic. Flagging it rather than orphaning it silently.
2. **The parchment head plate.** #1221 measured `--faction-wow-card-muted` at 4.25:1 on `--faction-wow-chronicle-panel` — it is a cream-only ink, and the v1 band was exactly that plate under exactly that ink. The head is the cream sheet now (4.77:1), and the plate survives only as the composer's inset FIELD, whose ink is `-card-text` at ~13:1.
3. **The frame's `padding: var(--space-md)` around `{children}`.** Every shared body and all three companions already pad themselves, so v1 double-padded every WOW card. `DefaultFeedFrame` adds none either.

The tag chip takes `-plum-surface` / `-on-plum` (5.16:1 both themes) rather than `-stamp-chip-text` on `-chip-bg`, which #1221 measured at 4.14:1 in dark — that pair was measured against the duel ribbon, not against each other.

## The sheet draws one thing this seam cannot reach

**The crooked points plaque is not drawn.** Points live on the shared, faction-blind body (`FeedRowContent` sets them beside the level); the chassis only ever sees `children`, so it has no figure to strike a plaque with, and reaching into the body's markup to restyle one would be the chassis special-casing a payload — which the seam forbids. Drawing its own would print the figure twice, the same reason #899 declined to re-draw the kit's wax seal (the actor's portrait already *is* the crest). It stays undrawn until the shared body grows a slot for it. **Say if you would rather the body grew that slot** — that is a `FeedRowContent` change and therefore a different issue.

No unbacked state was invented: nothing here needs expiry, a countdown, a deadline or filed/total counts.

## What to eyeball

1. **The ribbon on the dark card.** It is theme-invariant by construction (gold and plum-surface are both invariant on purpose), which is what `WowTaskCard` already ships — but a 6px undimmed gold/plum stripe on `#1b1508` is worth a look at feed density, where you see eight of them at once rather than one card.
2. **The head at feed width, and where it wraps.** ✦ · kicker · tag → date · ✕, with the date and the ✕ bound into one cluster so a narrow card breaks *before* them and never orphans the ✕. Worth checking against a long kicker ("Collaboration invite") plus the "Still waiting" tag on a phone.
3. **The ✕ against the ribbon and the ✦.** #1243 flagged UA's ✕/ensō clearance as exactly the kind of thing nobody had looked at; the equivalent risk here is the twinkling ✦ at the other end of the same line and the crown directly above the control.
4. **The section rule under the head.** Two ribbons twenty-odd pixels apart is the sheet's own idea; at 3px and 0.75 it should read as a divider, not a second crown. If it competes, the rule is the thing to lose.
5. **The comment and the update card side by side**, on a praxis page and in the feed. They are meant to read as one instrument now.
6. **The composer's prompt + rule + field stack**, and the hint in Lora italic where the neutral caption voice used to be (the STRING is unchanged).
7. **`awaiting_submission`** — no ✕, no swipe, and nothing disabled. Pinned by a test, but worth one look.

## Verified

- `tsc --noEmit`: clean.
- `eslint src --max-warnings=0`: clean. No new `no-raw-style-values` suppressions — none were needed.
- `vitest run`: **144 files, 2464 passed, 0 failed.** 30 of those are new here, in two NEW files (`wowFeedChassis.test.tsx`, `wowComment.test.tsx`). **No shared test registry was touched** — a shared row restated by parallel PRs is how `main` went red twice this week.
- `vite build`: clean. Entry chunk 134.96 KB gzip, unmoved from #1243's 135.00.
- All thirteen dressable feed types render in this chassis with their kicker; `era_announcement` and `comment_mention` stay out of it; both big companions keep accept + decline inside it.

## NOT verified

- **No visual QA. This environment cannot screenshot and there is no dev stack, so every layout and colour-balance claim above is inference from the code, not observation.** Nobody has looked at this card.
- **Dark mode is reasoned, not seen.** The sheet has a `- Dark` companion file, but no dark-side literals reached me; every token used here has an audited dark value and flips through the `[data-theme="dark"]` cascade, with no ternary anywhere. That is an argument, not a screenshot.
- **The swipe, the 6s undo and the archive write are untouched and untested end to end** — they live in `FeedItemSlot`, and the harness is `renderToStaticMarkup` with no jsdom, so no effect runs and no pointer event fires. Real verification is a human on a phone.
- **The hover gate's reveal cannot be exercised** for the same reason; the row's owner states are pinned at `OwnerControls.test.tsx`'s seam rather than driven.
- **Contrast ratios are quoted from #1221 and `index.css`, not re-measured here.**

## One judgement call left open

`comments.wow.*` ("Add thy counsel to the chronicle…", "Proclaim", "amended") **still ships**. Those are #898's pre-existing per-voice comment strings from WOW's own kit, not lifted off this sheet — and the epic's neutral-copy rule is written about the FEED catalog and the sheets' archive verbs. Whether the nine *comment* voices should also be neutralised is a call for you, not for a dress issue holding a locale file eight agents are queued on. Nothing from this design sheet appears anywhere in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
