### PR TITLE
Ephemerists: the feed card and the comment card move onto the Valley plate

### DIFF
--- a/frontend/src/components/comments/__tests__/ephemeristsComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/ephemeristsComment.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * The Ephemerists' comment VOICE (#1199, epic #1192).
+ *
+ * `defaultComment.test.tsx` beside this file holds the Unaffiliated sheet, which
+ * is the copy and behaviour spec. Guarded here is only what this voice owns:
+ *
+ *  - the plate ground, not the retired illuminated-codex one (ADR-0055);
+ *  - **the body is rendered WHOLE.** The old dress lifted the first character out
+ *    into a rubric drop cap, so a note opening with a mention lost the mention:
+ *    `MentionText` was handed the body minus its `@`. That is the regression this
+ *    file exists to pin.
+ *  - no raw hex, in a file whose whole job is colour.
+ *
+ * Static markup only (no DOM), the comments-test convention — so `useAuth`
+ * resolves to its anonymous default: the viewer owns nothing and can flag
+ * nothing, which is the "row · default" reading of every case below. The owner
+ * and editing states are driven by state a static render cannot reach; they are
+ * asserted at their seam instead (`OwnerControls.test.tsx`).
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so the neutral copy keys resolve to English text.
+import '../../../i18n'
+import type { CommentOut } from '../../../api/comments'
+import type { CharacterOut } from '../../../api/auth'
+import EphemeristsComment from '../voices/EphemeristsComment'
+
+const COMMENT: CommentOut = {
+  id: 7,
+  praxis_id: 1,
+  task_id: null,
+  body_text: 'the river read three cubits at dawn',
+  is_edited: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: {
+    id: 42,
+    username: 'ada',
+    display_name: 'Adabel',
+    avatar_url: null,
+    faction_slug: 'ephemerists',
+  },
+  mentions: [],
+}
+
+const CHARACTER: CharacterOut = {
+  id: 42,
+  username: 'ada',
+  display_name: 'Adabel',
+  avatar_url: null,
+  faction_slug: 'ephemerists',
+  bio: null,
+  location: null,
+  level: 3,
+  score: 0,
+  all_time_score: 0,
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function row(comment: CommentOut = COMMENT): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <EphemeristsComment mode="row" comment={comment} />
+    </MemoryRouter>,
+  )
+}
+
+function composer(submitting: boolean): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <EphemeristsComment
+        mode="composer"
+        character={CHARACTER}
+        value=""
+        onChange={() => {}}
+        onSubmit={() => {}}
+        submitting={submitting}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('EphemeristsComment — row states', () => {
+  it('row · default: byline links the author, body sits on the content floor', () => {
+    const html = row()
+    expect(html).toContain('href="/characters/42"')
+    expect(html).toContain('Adabel')
+    expect(html).toContain('the river read three cubits at dawn')
+    expect(html).toContain('content-text')
+  })
+
+  it('row · edited: the faction mark joins the byline', () => {
+    // `comments.ephemerists.edited` — a pre-existing flavour key, not new copy.
+    expect(row({ ...COMMENT, is_edited: true })).toContain('emended')
+    expect(row()).not.toContain('emended')
+  })
+
+  it('row · mention: a resolved handle links in the plate Nile ink', () => {
+    const html = row({
+      ...COMMENT,
+      body_text: 'as @bo recorded',
+      mentions: [{ character_id: 9, username: 'bo', display_name: 'Bo' }],
+    })
+    expect(html).toContain('href="/characters/9"')
+    expect(html).toContain('--faction-ephemerists-plate-nile')
+  })
+
+  it('links a mention that OPENS the note — the drop cap used to eat its @', () => {
+    // The regression. The rubric cap was built as `body[0]` + `body.slice(1)`, so
+    // this body reached MentionText as "molly filed it first" with no handle to
+    // match, and the '@' was set 34px high in its place.
+    const html = row({
+      ...COMMENT,
+      body_text: '@molly filed it first',
+      mentions: [{ character_id: 11, username: 'molly', display_name: 'Molly' }],
+    })
+    expect(html).toContain('href="/characters/11"')
+    expect(html).toContain('@molly')
+  })
+
+  it('shows no owner row and no flag affordance to a signed-out viewer', () => {
+    const html = row()
+    expect(html).not.toContain('delete')
+    expect(html).not.toContain('Flag')
+  })
+})
+
+describe('EphemeristsComment — composer states', () => {
+  it('composer · empty: the faction prompt and the shared @-mention hint', () => {
+    const html = composer(false)
+    expect(html).toContain('inscribe a note in the margin')
+    expect(html).toContain('@ to mention')
+    expect(html).not.toContain('aria-busy="true"')
+  })
+
+  it('composer · submitting: marks itself busy and disables the field', () => {
+    const html = composer(true)
+    expect(html).toContain('aria-busy="true"')
+    expect(html).toContain('disabled')
+  })
+
+  it('sets the submit button on the CTA pair, never on brass', () => {
+    // `-brass` is a rule colour the plate module forbids putting text on.
+    const html = composer(false)
+    expect(html).toContain('--faction-ephemerists-plate-cta-bg')
+    expect(html).toContain('--faction-ephemerists-plate-cta-ink')
+  })
+})
+
+describe('EphemeristsComment — the Valley plate ground', () => {
+  it('paints on the plate tokens', () => {
+    const html = row()
+    for (const token of [
+      '--faction-ephemerists-plate-bg',
+      '--faction-ephemerists-plate-ink',
+      '--faction-ephemerists-plate-ochre',
+      '--faction-ephemerists-plate-line',
+    ]) {
+      expect(html, `carries ${token}`).toContain(token)
+    }
+  })
+
+  it('carries no illuminated-codex ink of its own (ADR-0055)', () => {
+    // `--faction-ephemerists-card-*` is the codex family this voice used to be
+    // painted in, and nothing else on the sheet emits it — so its absence is
+    // exactly the metaphor swap.
+    //
+    // Deliberately NOT a blanket ban on `--eph-`: the avatar in the margin is a
+    // DIFFERENT per-faction surface (#11, `EphemeristsAvatar`) and still wears
+    // the codex atoms. Migrating it is not this issue's footprint, and asserting
+    // it here would pin someone else's file through this test.
+    const html = row() + composer(false)
+    expect(html).not.toContain('--faction-ephemerists-card-')
+  })
+
+  it('names no colour in hex', () => {
+    expect(row() + composer(false)).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
+  })
+})

--- a/frontend/src/components/comments/voices/EphemeristsComment.tsx
+++ b/frontend/src/components/comments/voices/EphemeristsComment.tsx
@@ -1,77 +1,304 @@
+/**
+ * THE EPHEMERISTS' COMMENT VOICE — a note filed on the Valley plate (#1199,
+ * epic #1192; design `Ephemerists Comment + Update Cards.dc.html`, whose comment
+ * half this is).
+ *
+ * `DefaultComment` (the Unaffiliated sheet, #1195) is the copy and behaviour
+ * spec; read it there. This file owns the dress and nothing else. All seven
+ * behaviours are the shared helpers' — edit, withdraw, flag, @mentions, the live
+ * character count, the submitting state, and the hover/focus gate on the owner
+ * row (`useOwnerReveal`, F3). None of them is re-implemented here.
+ *
+ * Seven states, ONE component (ADR-0056 / 0058 / 0063 — no mobile twin):
+ *   row · default | row · mention | row · edited | row · yours (hover) |
+ *   row · editing | composer · empty | composer · submitting
+ *
+ * ## What changed in the dress
+ *
+ * The voice moves from the ILLUMINATED CODEX (`--faction-ephemerists-card-*`,
+ * foxed vellum, Cinzel-only) to the v2 VALLEY PLATE the sheet is drawn on and
+ * every other v2 Ephemerists surface already wears — papyrus stock, a fluted
+ * brass rule at the head, incised small caps for every label, Spectral for the
+ * note itself, and an ochre margin rule beside the body, marginalia's own mark.
+ * The plate is a full metaphor swap (ADR-0055): the two grounds must not mix, so
+ * no `--eph-*` atom survives here.
+ *
+ * **The rubric drop cap is gone, and it was a bug as well as a metaphor.** It was
+ * built by slicing the first character off the body and setting it large — so a
+ * note that OPENED with a mention (`@molly …`) had its `@` lifted into the drop
+ * cap and the remainder handed to `MentionText`, which then found no handle to
+ * link. The plate's own answer to "this is a note in the margin" is the ochre
+ * rule, which needs no surgery on the text.
+ *
+ * The last raw hex in this file (`RUBRIC = '#9a3b2e'`) goes with it: the ochre is
+ * `--faction-ephemerists-plate-ochre`, which flips in the dark cascade as a
+ * literal never did.
+ *
+ * ## Copy
+ *
+ * No string from the design sheet appears here. The two faction flavour keys are
+ * pre-existing `praxis.json` → `comments.ephemerists.*` entries (the composer
+ * prompt and the edited mark); every other word comes from the shared neutral
+ * `comments.*` block. Nothing in this file adds or edits a catalog key.
+ *
+ * Every colour is a `--faction-ephemerists-plate-*` token; light/dark flips
+ * through the `[data-theme="dark"]` cascade, never a ternary. `-brass` is a rule
+ * colour and never an ink; labels take `-caption` and quiet type `-quiet`, both
+ * measured on this ground.
+ */
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
-import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
-import { CommentFlagControl } from '../FlagControl'
+import {
+  CommentEditor,
+  OwnerControls,
+  ownerRevealStyle,
+  useOwnerEdit,
+  useOwnerReveal,
+} from '../OwnerControls'
+import { CommentFlagControl, canFlagComment } from '../FlagControl'
+import { useAuth } from '../../../auth/AuthContext'
+import {
+  CAPS,
+  CAPTION,
+  FlutedRule,
+  INK,
+  INNER,
+  LINE,
+  NILE,
+  OCHRE,
+  PLATE,
+  QUIET,
+  READING,
+  SHADOW,
+  SMALL_CAPS,
+  WASH,
+} from '../../cards/ephemeristsPlate'
 
 /**
- * The Ephemerists — marginalia (ADR-0018). Vellum leaf, engraved Cinzel byline,
- * a double left margin-rule and a rubric drop-cap on the body. Timestamp counts
- * days ("the Nth day").
+ * The plate's affirmative button pair. Declared here rather than beside its
+ * siblings in `ephemeristsPlate` only because this issue's footprint is the
+ * chassis, the voice and the faction's own token block; a follow-up whose whole
+ * diff is a move can hoist both.
+ *
+ * NOT `-brass`, which is a rule colour the module forbids putting text on, and
+ * NOT `-band`, which the dark cascade drives to near-black while the CTA lifts to
+ * brass. The pair is measured as a pair.
  */
-const RUBRIC = '#9a3b2e'
+const CTA_BG = 'var(--faction-ephemerists-plate-cta-bg)'
+const CTA_INK = 'var(--faction-ephemerists-plate-cta-ink)'
 
-function frame(): React.CSSProperties {
-  return {
-    background: 'var(--faction-ephemerists-card-bg)',
-    color: 'var(--faction-ephemerists-card-text)',
-    border: '1px solid rgba(29,110,114,0.3)',
-    borderLeft: '4px double var(--faction-ephemerists-card-accent)',
-    // the wider left inset clears the 4px double margin-rule; the other three sides land on --space-lg.
-    padding: 'var(--space-lg) var(--space-lg) var(--space-lg) var(--space-xl)',
-    fontFamily: 'var(--faction-ephemerists-card-font)',
-  }
+/** Incised small caps at label tier — every mark on the sheet that is not prose. */
+const LABEL = {
+  ...SMALL_CAPS,
+  fontSize: 'var(--text-sm)',
+  color: CAPTION,
+} as const
+
+/**
+ * The leaf both modes sit on: avatar in the margin, a papyrus plate headed by a
+ * fluted brass rule. One shape for a row and for the composer, so a thread reads
+ * as one stack of filed notes rather than a list plus a form.
+ */
+function Leaf({
+  avatar,
+  children,
+  containerProps,
+}: {
+  avatar: React.ReactNode
+  children: React.ReactNode
+  containerProps?: React.ComponentPropsWithoutRef<'div'>
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
+      {avatar}
+      <div
+        {...containerProps}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          background: PLATE,
+          border: `1px solid ${LINE}`,
+          boxShadow: SHADOW,
+          color: INK,
+        }}
+      >
+        {/* The cavetto flute at the head of the leaf — this sheet's answer to the
+            na sheet's spectrum hairline, and the same mark the feed chassis wears
+            under its masthead. Reused from `ephemeristsPlate`, not redrawn. */}
+        <FlutedRule />
+        {/* The gold wash rides the leaf's own background: the dark plate takes no
+            wash at all (`--plate-wash: none`), so there is nothing for a ternary
+            or a positioned overlay to decide. NO `overflow: hidden` anywhere on
+            this leaf — the composer's @mention listbox is an absolutely
+            positioned child, and a clipping ancestor would cut it off. */}
+        <div style={{ padding: 'var(--space-md) var(--space-lg)', background: WASH }}>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The note itself, struck beside an ochre margin rule. Drawn as a flex sibling
+ * rather than a border so it stretches to the note's own height, and so the same
+ * block carries the inline editor while editing.
+ */
+function Marginalia({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'flex', gap: 'var(--space-md)', marginTop: 'var(--space-sm)' }}>
+      <span
+        aria-hidden="true"
+        style={{
+          width: 1,
+          flexShrink: 0,
+          alignSelf: 'stretch',
+          background: OCHRE,
+          opacity: 0.55,
+        }}
+      />
+      {/* A comment IS content — the §4 role floor, in the resting state and in the
+          editing one (the editor's textarea inherits this). */}
+      <div
+        className="content-text"
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: READING,
+          color: INK,
+          lineHeight: 1.6,
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  )
 }
 
 export default function EphemeristsComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
+  const { user } = useAuth()
+  const reveal = useOwnerReveal()
+
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props
     return (
-      <div style={{ ...frame(), display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
-        <FactionAvatar character={character} size="sm" />
-        <div style={{ flex: 1 }}>
-          <div style={{ fontSize: 'var(--text-base)', letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--faction-ephemerists-card-accent)', marginBottom: 'var(--space-sm)' }}>
+      <Leaf avatar={<FactionAvatar character={character} size="sm" />}>
+        <div aria-busy={submitting}>
+          <div style={{ ...LABEL, marginBottom: 'var(--space-sm)' }}>
             {t('comments.ephemerists.prompt')}
           </div>
-          <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-ephemerists-card-accent)" onAccent="var(--faction-ephemerists-on-accent)" bg="rgba(255,255,255,0.35)" text="var(--faction-ephemerists-card-text)" />
+          <Marginalia>
+            <ComposerControls
+              value={value}
+              onChange={onChange}
+              onSubmit={onSubmit}
+              submitting={submitting}
+              accent={CTA_BG}
+              onAccent={CTA_INK}
+              // The panel cell, not the plate: a field reads as inset into the
+              // sheet rather than painted on it.
+              bg={INNER}
+              text={INK}
+              // The shared string in this sheet's incised label voice — an
+              // OVERRIDE of ComposerControls' neutral default, not a new hint.
+              hint={<span style={LABEL}>{t('comments.mentionHint')}</span>}
+            />
+          </Marginalia>
         </div>
-      </div>
+      </Leaf>
     )
   }
+
   const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
-  const body = comment.body_text
-  const drop = body[0] ?? ''
+  const canFlag = canFlagComment(comment, user?.character?.id)
+  // The foot holds the author's edit/withdraw row and the flag affordance, and is
+  // drawn only when one of them has something to show — hidden while editing,
+  // since the inline editor owns Save/Cancel then.
+  const showControls = !owner.editing && (owner.isOwner || canFlag)
+  // On your OWN note the foot holds nothing but the gated owner row, so its rule
+  // fades with the row: a brass hairline over empty space is a state this sheet
+  // never draws. Someone else's (flaggable) note keeps its foot lit.
+  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+
   return (
-    <div style={frame()}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', borderBottom: '1px solid rgba(29,110,114,0.25)', paddingBottom: 'var(--space-sm)', marginBottom: 'var(--space-md)' }}>
-        <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
-        <Link to={`/characters/${comment.author.id}`} style={{ fontSize: 'var(--text-content)', fontWeight: 600, letterSpacing: '0.05em', color: 'var(--faction-ephemerists-card-text)', textDecoration: 'none' }}>
+    <Leaf
+      avatar={<FactionAvatar character={authorToCharacter(comment.author)} size="sm" />}
+      containerProps={reveal.containerProps}
+    >
+      {/* The byline: the hand that wrote the note, then when. */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 'var(--space-sm)',
+          flexWrap: 'wrap',
+        }}
+      >
+        <Link
+          to={`/characters/${comment.author.id}`}
+          style={{
+            fontFamily: CAPS,
+            fontSize: 'var(--text-content)',
+            fontWeight: 600,
+            letterSpacing: '0.06em',
+            color: INK,
+            textDecoration: 'none',
+          }}
+        >
           {comment.author.display_name}
         </Link>
-        <span style={{ marginLeft: 'auto', fontSize: 'var(--text-md)', fontStyle: 'italic', color: 'var(--faction-ephemerists-card-muted)', whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 'var(--space-sm)' }}>
+        <span style={{ ...LABEL, color: QUIET }}>
           {formatCommentTime(slug, comment.created_at)}
-          {comment.is_edited ? ` · ${t('comments.ephemerists.edited')}` : ''}
-          <OwnerControls owner={owner} />
-          <CommentFlagControl comment={comment} />
         </span>
+        {comment.is_edited && (
+          <span style={{ ...LABEL, color: QUIET }}>
+            <span aria-hidden="true">· </span>
+            {t('comments.ephemerists.edited')}
+          </span>
+        )}
       </div>
-      {owner.editing ? (
-        <CommentEditor owner={owner} accent="var(--faction-ephemerists-card-accent)" onAccent="var(--faction-ephemerists-on-accent)" bg="rgba(255,255,255,0.35)" text="var(--faction-ephemerists-card-text)" />
-      ) : (
-        <div style={{ fontSize: 'var(--text-content)', lineHeight: 1.55 }}>
-          <span style={{
-            float: 'left', lineHeight: 0.72, color: RUBRIC, padding: 'var(--space-xs) var(--space-sm) 0 0', fontWeight: 600,
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: illuminated drop cap
-            fontSize: 34,
-          }}>{drop}</span>
-          <MentionText body={body.slice(1)} mentions={comment.mentions} accent="var(--faction-ephemerists-card-accent)" />
+
+      <Marginalia>
+        {owner.editing ? (
+          <CommentEditor
+            owner={owner}
+            accent={CTA_BG}
+            onAccent={CTA_INK}
+            bg={INNER}
+            text={INK}
+          />
+        ) : (
+          // Resolved @mentions in the plate's Nile ink — the token whose whole job
+          // is links and affirmations on this ground.
+          <MentionText body={comment.body_text} mentions={comment.mentions} accent={NILE} />
+        )}
+      </Marginalia>
+
+      {showControls && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            flexWrap: 'wrap',
+            gap: 'var(--space-md)',
+            marginTop: 'var(--space-md)',
+            paddingTop: 'var(--space-sm)',
+            // A hairline INSIDE the leaf is quieter than the leaf's own edge.
+            borderTop: `1px solid ${LINE}`,
+            ...footGate,
+          }}
+        >
+          <OwnerControls owner={owner} reveal={reveal} />
+          <CommentFlagControl comment={comment} />
         </div>
       )}
-    </div>
+    </Leaf>
   )
 }

--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -151,7 +151,9 @@ export default function EphemeristsFeedFrame({
         <svg
           width="100%"
           height={size.height}
-          viewBox={`0 0 ${size.view} 30`}
+          // The viewBox tracks the band's own height so `slice` crops the
+          // register at the edges rather than through the middle of every sign.
+          viewBox={`0 0 ${size.view} ${size.height}`}
           preserveAspectRatio="xMidYMid slice"
           aria-hidden="true"
           style={{ position: 'absolute', inset: 0, zIndex: 1 }}
@@ -164,7 +166,7 @@ export default function EphemeristsFeedFrame({
           />
           <GlyphRegister
             width={size.view}
-            y={23}
+            y={size.height - 7}
             strength={size.register}
             keyPrefix="feed"
           />

--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -1,22 +1,119 @@
-import { EphemeristsSigil, Foxing } from '../cards/ephemeristsAtoms'
-import FeedChassisBand from './FeedChassisBand'
+/**
+ * THE EPHEMERISTS' FEED CHASSIS — a Valley plate at card size (#1199, epic
+ * #1192; design `Ephemerists Comment + Update Cards.dc.html`, light + Dark in
+ * one document).
+ *
+ * The CHASSIS layer and nothing else. Read {@link FeedFrameProps} and
+ * `FeedCardRouter`'s docblock first: `FeedItemSlot` owns the whole archive
+ * interaction (the ✕, the touch swipe, the immediate write, the six-second undo
+ * strip) and the body is the shared faction-blind payload. This file draws the
+ * physical card and places the four chrome slots on it — kicker, tag, time,
+ * archive — and it neither reimplements nor gates any of the archive.
+ *
+ * ## The metaphor
+ *
+ * The v2 VALLEY PLATE, the same Deco × Egypt vocabulary as the task card
+ * (#1023), task detail (#1032) and the praxis record (#1120): a night-sky
+ * masthead over a fluted cavetto cornice, a winged sun disc crowning it, and the
+ * event itself filed on papyrus below with an ochre margin rule struck down the
+ * gutter. Cinzel small caps label it; Spectral dates it.
+ *
+ * This REPLACES the illuminated-codex leaf the frame wore before (foxed vellum,
+ * rubric sigil, `--eph-*`). The plate is a full metaphor swap (ADR-0055) and
+ * `ephemeristsPlate.tsx` is explicit that the two grounds must not be mixed on
+ * one surface — so the codex atoms leave the file rather than sit under the new
+ * band.
+ *
+ * Every mark is REUSED from `ephemeristsPlate`, never redrawn: `WingedDisc`,
+ * `Cornice`, `GlyphRegister`. No new SVG.
+ *
+ * ## Two things the sheet draws that this card deliberately does not
+ *
+ * 1. **The 22px ruled grid.** On the sheet that texture is the PAGE the plate
+ *    lies on, and the plate is opaque over it. The activity feed has no
+ *    Ephemerists page: it is one shared, mixed, multi-faction stream, and a
+ *    faction skin owns its own card and never the viewport (WORLD_ZERO_STYLE §5,
+ *    the #1028 ruling). Painting a page texture onto the plate instead would be
+ *    a thing the sheet itself never does. The ruled character is carried by the
+ *    marks the sheet DOES strike on the plate — the cornice flutes, the brass
+ *    hairline and the ochre margin rule.
+ * 2. **The cornice's slow gold bloom** (`.eph-cornice-glow`). That is the praxis
+ *    record's one piece of motion, on a page-long surface showing a single deed.
+ *    A feed is twenty cards tall, so twenty independent 16s blooms would be the
+ *    loudest thing on the page. `<Cornice />` without `glow`.
+ *
+ * Every colour is a `--faction-ephemerists-plate-*` token and flips through the
+ * `[data-theme="dark"]` cascade — no ternary, no hex. `-brass` is a rule colour
+ * and never an ink; the band's two ink tiers are `-band-ink` and the measured
+ * `-band-quiet` (see index.css) rather than one ink at two opacities.
+ *
+ * ONE responsive component, no mobile twin (ADR-0056 / 0058 / 0063): the band's
+ * geometry comes from `useFormFactor()`.
+ */
+import {
+  BAND,
+  BAND_INK,
+  BRASS,
+  BRASS_LIGHT,
+  Cornice,
+  GlyphRegister,
+  INK,
+  LINE,
+  OCHRE,
+  PLATE,
+  READING,
+  SHADOW,
+  SMALL_CAPS,
+  WASH,
+  WingedDisc,
+} from '../cards/ephemeristsPlate'
+import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
- * Ephemerists feed-card FRAME (surface #12, SPEC-faction-ui-profile.md).
- *
- * A thin presentational wrapper that dresses the neutral feed card (`children`)
- * as a leaf torn from the faction's ephemeris: foxed-vellum stock, an iron-gall
- * ink hairline, a gold-ruled running edge, and a rubric marginal sigil. The card
- * internals (avatar / actor / badge) are untouched — they arrive via
- * `{children}` and render in the content area.
- *
- * #1194: the leaf gains a CHASSIS BAND above the content — a ruled running head
- * carrying the kicker, the tag, the time and the dismiss control in iron-gall
- * ink. The stock is otherwise unchanged; Ephemerists' dress issue restyles it.
- *
- * Theme-aware through the --eph-* cascade; no document-theme mutation, no hex.
+ * The masthead's second ink tier. Declared here rather than beside its siblings
+ * in `ephemeristsPlate` only because this issue's footprint is the chassis, the
+ * voice and the faction's own token block; a follow-up whose whole diff is a
+ * move can hoist it.
  */
+const BAND_QUIET = 'var(--faction-ephemerists-plate-band-quiet)'
+
+interface BandSize {
+  /** Masthead height, and the width its register is drawn to fill. Geometry. */
+  height: number
+  view: number
+  /** The winged disc crowning the band. Geometry. */
+  disc: number
+  discHeight: number
+  /** Strength of the incised register behind the label. */
+  register: number
+  bandPadding: string
+  labelSize: string
+}
+
+const SIZES: Record<'desktop' | 'mobile', BandSize> = {
+  // 452 is the feed column's own basis (the sheet's `minmax(452px, 1fr)`), so
+  // the register's signs land at their drawn pitch instead of being sliced short.
+  desktop: {
+    height: 30,
+    view: 452,
+    disc: 58,
+    discHeight: 14,
+    register: 0.24,
+    bandPadding: 'var(--space-xs) var(--space-md)',
+    labelSize: 'var(--text-md)',
+  },
+  mobile: {
+    height: 26,
+    view: 360,
+    disc: 42,
+    discHeight: 10,
+    register: 0.2,
+    bandPadding: 'var(--space-xs) var(--space-sm)',
+    labelSize: 'var(--text-base)',
+  },
+}
+
 export default function EphemeristsFeedFrame({
   kicker,
   time,
@@ -24,56 +121,154 @@ export default function EphemeristsFeedFrame({
   archive,
   children,
 }: FeedFrameProps) {
+  const size = SIZES[useFormFactor() === 'mobile' ? 'mobile' : 'desktop']
+
   return (
     <div
       style={{
         position: 'relative',
-        marginBottom: 'var(--space-lg)',
-        padding: 'var(--space-md) var(--space-md) var(--space-md) var(--space-lg)',
-        background:
-          'linear-gradient(170deg, var(--eph-vellum), var(--eph-vellum-deep))',
-        border: '1px solid color-mix(in srgb, var(--eph-vellum-text) 30%, transparent)',
-        boxShadow:
-          'inset 3px 0 0 -1px color-mix(in srgb, var(--eph-gold) 70%, transparent), 0 8px 20px -16px rgba(0, 0, 0, 0.6)',
-        overflow: 'hidden',
+        // The ornament z-indexes (the register behind the label, the cornice's
+        // own layer) stay inside this card. Without it they order against
+        // whatever stacking context the feed column happens to establish, which
+        // is how a positioned ornament ends up over unrelated copy (§5).
+        isolation: 'isolate',
+        background: PLATE,
+        border: `1px solid ${LINE}`,
+        boxShadow: SHADOW,
+        color: INK,
       }}
     >
-      {/* age-foxing stains over the vellum stock */}
-      <Foxing opacity={0.35} />
-
-      {/* rubric marginal ornament — the watching-wanderer sigil in the gutter */}
-      <div
-        aria-hidden="true"
-        style={{
-          position: 'absolute',
-          left: 3,
-          top: 9,
-          zIndex: 1,
-          opacity: 0.5,
-          color: 'var(--eph-rubric)',
-          pointerEvents: 'none',
-        }}
-      >
-        <EphemeristsSigil size={12} color="var(--eph-rubric)" stroke={1.2} />
-      </div>
-
-      {/* chassis band — the leaf's running head, ruled off the content */}
+      {/* ── The masthead: night sky, one incised register, the winged disc ── */}
       <div
         style={{
           position: 'relative',
-          zIndex: 2,
-          color: 'var(--eph-vellum-text)',
-          borderBottom:
-            '1px solid color-mix(in srgb, var(--eph-vellum-text) 22%, transparent)',
-          paddingBottom: 'var(--space-xs)',
-          marginBottom: 'var(--space-sm)',
+          overflow: 'hidden',
+          height: size.height,
+          background: BAND,
+          color: BAND_INK,
         }}
       >
-        <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
+        <svg
+          width="100%"
+          height={size.height}
+          viewBox={`0 0 ${size.view} 30`}
+          preserveAspectRatio="xMidYMid slice"
+          aria-hidden="true"
+          style={{ position: 'absolute', inset: 0, zIndex: 1 }}
+        >
+          <path
+            d={`M6 4 H${size.view - 6}`}
+            stroke={BRASS_LIGHT}
+            strokeWidth="0.6"
+            opacity="0.24"
+          />
+          <GlyphRegister
+            width={size.view}
+            y={23}
+            strength={size.register}
+            keyPrefix="feed"
+          />
+        </svg>
+
+        {/* The four chrome slots, placed by hand rather than through
+            `FeedChassisBand`: this band sets the kicker in incised small caps and
+            the time in the reading face, which the shared arrangement's uniform
+            `.eyebrow` would flatten. All four are still drawn — a swallowed slot
+            loses a feature, not a decoration. */}
+        <div
+          style={{
+            position: 'relative',
+            zIndex: 2,
+            height: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+            padding: size.bandPadding,
+            boxSizing: 'border-box',
+            minWidth: 0,
+          }}
+        >
+          <WingedDisc width={size.disc} height={size.discHeight} />
+          <span
+            style={{
+              ...SMALL_CAPS,
+              fontSize: size.labelSize,
+              color: BAND_INK,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {kicker}
+          </span>
+          {tag && (
+            <span
+              style={{
+                ...SMALL_CAPS,
+                fontSize: 'var(--text-sm)',
+                color: BAND_INK,
+                border: `1px solid ${BRASS}`,
+                padding: '0 var(--space-xs)',
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+              }}
+            >
+              {tag}
+            </span>
+          )}
+          <span
+            style={{
+              marginLeft: 'auto',
+              fontFamily: READING,
+              fontStyle: 'italic',
+              fontSize: size.labelSize,
+              color: BAND_QUIET,
+              whiteSpace: 'nowrap',
+              flexShrink: 0,
+            }}
+          >
+            {time}
+          </span>
+          {/* The dismiss control, tinted by the band's own `color` — it paints in
+              `currentColor` and arrives finished (dormant until hover OR focus,
+              labelled, keyboard reachable, and `null` on a card that cannot be
+              archived, which is `awaiting_submission`). Placed, never rebuilt. */}
+          {archive}
+        </div>
       </div>
 
-      {/* the neutral feed card, rendered in the content area */}
-      <div style={{ position: 'relative', zIndex: 2 }}>{children}</div>
+      {/* The cavetto cornice, carrying the band's night ground out beneath it so
+          masthead and cornice read as one architectural element. No `glow`. */}
+      <Cornice />
+
+      {/* ── The leaf: the event filed on papyrus ──
+          The gold wash rides the leaf's own `background` rather than an absolute
+          overlay: the dark plate takes no wash at all (`--plate-wash: none`), and
+          a positioned layer here would need a stacking context of its own to stay
+          off the copy. */}
+      <div style={{ position: 'relative', background: WASH }}>
+        {/* The margin rule, struck in the gutter at --space-sm so it clears the
+            body's own --space-lg text inset on every payload shape — the shared
+            row, and all three companions. */}
+        <span
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            left: 'var(--space-sm)',
+            top: 'var(--space-sm)',
+            bottom: 'var(--space-sm)',
+            width: 1,
+            background: OCHRE,
+            opacity: 0.5,
+            pointerEvents: 'none',
+          }}
+        />
+        {/* The shared payload — the slot-driven row or one of the three
+            companions. Its inks are the global text tokens, which follow the
+            theme exactly as the plate ground does, so nothing is set on it. */}
+        {children}
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
+++ b/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * The Ephemerists' feed CHASSIS (#1199, epic #1192).
+ *
+ * The shared `factionFeedFrame` test already loops every faction and asserts the
+ * four chrome slots survive dispatch; it is a SHARED registry and this file adds
+ * nothing to it. What is guarded here is what only this skin can get wrong:
+ *
+ *  - the plate ground, not the retired illuminated-codex one (`--eph-*`), which
+ *    `ephemeristsPlate` forbids mixing onto the same surface (ADR-0055);
+ *  - the archive slot placed and never rebuilt — including the `null` case,
+ *    where a disabled stand-in must not appear (`awaiting_submission`);
+ *  - no raw hex, in a file whose whole job is colour.
+ *
+ * Static markup only (no DOM), the repo's frontend-test convention:
+ * `useFormFactor` answers its SSR default, `desktop`.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import EphemeristsFeedFrame from '../EphemeristsFeedFrame'
+
+function frame({
+  tag = null,
+  archive = <button type="button">archive-node</button>,
+}: {
+  tag?: string | null
+  archive?: React.ReactNode
+} = {}): string {
+  return renderToStaticMarkup(
+    <EphemeristsFeedFrame
+      kicker="Task completed"
+      time="2h ago"
+      tag={tag}
+      archive={archive}
+    >
+      <span>card-body</span>
+    </EphemeristsFeedFrame>,
+  )
+}
+
+describe('EphemeristsFeedFrame — the four chrome slots', () => {
+  it('draws kicker, tag, time and the archive node, and keeps the payload', () => {
+    const html = frame({ tag: 'Still waiting' })
+    expect(html).toContain('Task completed')
+    expect(html).toContain('Still waiting')
+    expect(html).toContain('2h ago')
+    expect(html).toContain('archive-node')
+    expect(html).toContain('<span>card-body</span>')
+  })
+
+  it('draws NO stand-in when the card offers no archive control', () => {
+    // `awaiting_submission` is state, not an event: the backend refuses to
+    // archive it, so the slot arrives `null` and a disabled control must not be
+    // invented to fill the gap.
+    const html = frame({ archive: null })
+    expect(html).not.toContain('disabled')
+    expect(html).not.toContain('✕')
+    // The rest of the band is unaffected.
+    expect(html).toContain('Task completed')
+    expect(html).toContain('2h ago')
+  })
+
+  it('omits the tag entirely when there is none', () => {
+    expect(frame({ tag: null })).not.toContain('Still waiting')
+  })
+})
+
+describe('EphemeristsFeedFrame — the Valley plate ground', () => {
+  it('paints on the plate tokens: papyrus, night band, brass, ochre', () => {
+    const html = frame()
+    for (const token of [
+      '--faction-ephemerists-plate-bg',
+      '--faction-ephemerists-plate-band)',
+      '--faction-ephemerists-plate-band-ink',
+      '--faction-ephemerists-plate-band-quiet',
+      '--faction-ephemerists-plate-brass',
+      '--faction-ephemerists-plate-ochre',
+    ]) {
+      expect(html, `carries ${token}`).toContain(token)
+    }
+  })
+
+  it('carries no illuminated-codex atom — the two grounds never mix (ADR-0055)', () => {
+    expect(frame()).not.toContain('--eph-')
+  })
+
+  it('names no colour in hex', () => {
+    // A dark-mode ternary cannot exist if there is no literal to switch between.
+    expect(frame()).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
+  })
+
+  it('reuses the plate ornament rather than drawing new marks', () => {
+    const html = frame()
+    // The winged disc's medallion (a `plate-disc` fill) and the incised register
+    // (`epg-glyph`, whose breathe cycle + reduced-motion gate live in index.css).
+    expect(html).toContain('--faction-ephemerists-plate-disc')
+    expect(html).toContain('epg-glyph')
+  })
+
+  it('keeps its ornament stacking inside the card', () => {
+    // A positioned ornament at a z-index above 0 orders against the nearest
+    // stacking context; without `isolation` that is whatever the feed column
+    // established, which is how an ornament lands over unrelated copy (§5).
+    expect(frame()).toContain('isolation:isolate')
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1036,6 +1036,13 @@
   --faction-ephemerists-plate-gold: #e3c56a; /* glyphs + the winged disc */
   --faction-ephemerists-plate-band: #1e2233; /* the cornice masthead */
   --faction-ephemerists-plate-band-ink: #efe4c4;
+  /* Quiet ink ON THE NIGHT BAND (feed chassis v2, #1199) — the masthead's
+     second tier, for a timestamp beside the kicker. A measured token rather
+     than `band-ink` at an opacity: a translucent ink takes its tint from the
+     band under it, which is exactly the failure #669/#677 chased down, and the
+     dark cascade repoints `band-ink` to the GOLD, so an opacity there would
+     have collapsed both tiers onto one colour. 8.6:1 light, 8.9:1 dark. */
+  --faction-ephemerists-plate-band-quiet: #c9bfa4;
   --faction-ephemerists-plate-disc: #f6eed6; /* the medallion's field */
   --faction-ephemerists-plate-ochre: #a6432b; /* the fifth tally stroke */
   --faction-ephemerists-plate-cta-bg: #1e2233;
@@ -1680,6 +1687,10 @@
   --faction-ephemerists-plate-gold: #f2d98a;
   --faction-ephemerists-plate-band: #0a0c15;
   --faction-ephemerists-plate-band-ink: #f2d98a;
+  /* Muted gold, not the parchment grey of the light band: the dark band is
+     nearly black and its primary ink is already the gold, so the second tier
+     steps DOWN the same hue instead of introducing a cool one. */
+  --faction-ephemerists-plate-band-quiet: #c2ae7e;
   --faction-ephemerists-plate-disc: #12151f;
   --faction-ephemerists-plate-ochre: #d9744c;
   --faction-ephemerists-plate-cta-bg: #c9a24b;


### PR DESCRIPTION
Frontend only, dress only. Every behaviour already worked before this landed.

Closes #1199

Part of epic #1192. Built on the three-layer seam from #1243 — `FeedItemSlot` (archive) → `FactionFeedFrame` (chassis) → shared payload. **Only the chassis layer is rewritten**, plus this faction's comment voice.

---

## What this is

The Ephemerists' feed card and comment card move onto the **v2 Valley plate** — the Deco × Egypt vocabulary the task card (#1023), task detail (#1032) and praxis record (#1120) already wear, which is what the design sheet draws.

**Feed chassis.** A night-sky masthead carrying kicker · tag → time · ✕, a fluted cavetto cornice beneath it, and the shared payload filed on papyrus with an ochre margin rule struck down the gutter. All four chrome slots are placed by hand rather than through `FeedChassisBand`, because the sheet sets the kicker in incised Cinzel small caps and the time in Spectral — the shared arrangement's uniform `.eyebrow` would flatten both. **All four are still drawn.**

**Comment voice.** The same plate: papyrus headed by the cavetto flute, incised small caps for every label, Spectral for the note, an ochre margin rule beside the body. The owner's edit/withdraw row now inherits F3's hover/focus gate (`useOwnerReveal`) and sits in a foot that fades with it; the flag control joins it there.

**Every ornament is reused from `components/cards/ephemeristsPlate` (#1216) — `WingedDisc`, `Cornice`, `FlutedRule`, `GlyphRegister`. No new SVG.**

The chassis was already on the widened `FeedFrameProps` signature: #1243 converted all eight frames when it widened the seam. So this is not a `{ children }` → chassis conversion — it is the dress that conversion left for this issue.

## Two things the sheet draws that this deliberately does not — and why

**1. The 22px ruled grid. Skipped entirely.** On the sheet that texture is the **page** the plate lies on, and the plate is opaque over it. The activity feed has no Ephemerists page: it is one shared, mixed, multi-faction stream, and a faction skin owns its own card and never the viewport (WORLD_ZERO_STYLE §5, the #1028 ruling). Moving it onto the plate instead would be a thing the sheet itself never does — the plate's surface is flat papyrus. The ruled character is carried by the marks the sheet *does* strike on the plate: the cornice flutes, the brass hairline and the ochre margin rule.

**2. The cornice's slow gold bloom** (`.eph-cornice-glow`). That is the praxis record's one piece of motion, on a page-long surface showing a single deed. A feed is twenty cards tall; twenty independent 16s blooms would be the loudest thing on the page. `<Cornice />` without `glow`.

## No unbacked state was invented

The chassis is **type-blind** — it takes `kicker`/`tag`/`time`/`archive`/`children` and draws no state-specific anything. So there was no gap-table state (invite/duel expiry, a duel countdown, a pre-submission deadline, filed/total counts) for it to draw, and none was built. All 15 types minus `era_announcement` (chassis-exempt by design) inherit the plate with no per-type branch, including the nine the sheet never drew.

## Two bugs fixed on the way

1. **The rubric drop cap ate a leading mention.** It was built as `body[0]` + `body.slice(1)`, so a note opening with a mention (`@molly …`) had its `@` lifted into the cap and the remainder handed to `MentionText`, which then found no handle to link — the mention rendered as plain text with a giant ochre `@` beside it. The cap is gone (the plate's own marginalia mark is the ochre rule, which needs no surgery on the text) and there is a test pinning the case.
2. **The voice's last raw hex** (`RUBRIC = '#9a3b2e'`) went with it. The ochre is `--faction-ephemerists-plate-ochre`, which flips in the dark cascade as the literal never did.

## Colour

One new token pair, in the faction's own block:

```
--faction-ephemerists-plate-band-quiet   #c9bfa4 light (8.6:1 on the band)
                                         #c2ae7e dark  (8.9:1)
```

The masthead's second ink tier, for the timestamp beside the kicker. `band-ink` at an opacity would take its tint from the band under it — the exact failure #669/#677 chased down — and the dark cascade repoints `band-ink` to the **gold**, so an opacity there would have collapsed both tiers onto one colour. Verified at `:root` and `[data-theme="dark"]` depth in the **built** stylesheet, not by reading the source.

Everything else maps onto existing `--faction-ephemerists-plate-*` tokens. The whole vendored palette was already tokenized; **no design-side hex was ported**. Two deliberate near-misses: the sheet's `--nile #2E6E6A` and `--page #DCCBA2` are kept at their existing token values (`#276460`, `#e4d5b0`), which were walked down for AA and are what every other v2 Ephemerists surface reads. The sheet's `--faint #9A8C6C` is **not** adopted — it is ~2.3:1 on papyrus, so quiet type takes `-quiet` and rules take `-line`.

`--eph-*` (illuminated codex) is gone from both files. `ephemeristsPlate` is explicit that the two grounds must not mix on one surface (ADR-0055).

## What to eyeball

1. **The band's proportions.** 30px desktop / 26px mobile, plus a ~12px cornice, over a card whose body is often ~80px. That is a lot of chrome for a feed card, and it is deliberate (it is the faction's signature), but it is the first thing to reject if it reads top-heavy in a stream.
2. **The winged disc at 58×14 / 42×10.** It is drawn for a 150px masthead in the praxis record. At feed size the wing steps may mush together.
3. **The incised register under live text.** Strength 0.24, gold on night, behind an 11px label. Fine on a page-sized masthead; worth a look at 30px.
4. **The longest kicker plus a tag on a narrow card.** `Collaboration invite` + `Still waiting` overflows a 360px band and the kicker ellipsises. That is the designed degradation, not a bug — but check that what remains still reads.
5. **The ochre margin rule against each payload.** Struck at `--space-sm` (8px) so it clears the body's own inset; the smallest left padding across the shared row and all three companions is `--space-lg` (16px). Verified by reading, not by looking.
6. **The comment card next to its avatar.** `FactionAvatar` → `EphemeristsAvatar` is a *different* per-faction surface (#11) and still wears the codex atoms (`--eph-vellum`, `--eph-lapis`), so a codex avatar now sits beside a plate leaf. Out of this footprint; flagged below.
7. **Dark mode on both files.** The plate flips ground *and* ink, and the shared payload's global text tokens flip with it; nobody has looked at the two together.
8. **Cards spaced by the list, not the card.** The old frame carried `marginBottom: var(--space-lg)` on top of the feed column's own `gap: var(--space-sm)`, which made Ephemerists cards sit further apart than Coven/Everymen/Singularity/WOW ones in the same stream. Dropped. (`SnideFeedFrame` still has one — #1200's call, not touched here.)

## Verified

- **`tsc --noEmit`: clean.**
- **`eslint src --max-warnings=0`: clean.** No new `no-raw-style-values` suppressions and no per-line hatches — both files are token-clean on both axes.
- **`vite build`: clean.** Entry chunk **134.99 KB** gzip (135.00 before — unmoved).
- **`vitest run`: 144 files, 2453 passed, 0 failed.** 19 of those are new here, in two new files named for this faction (`feed/__tests__/ephemeristsFeedFrame.test.tsx`, `comments/__tests__/ephemeristsComment.test.tsx`).
- **No shared registry was restated.** `components/__tests__/factionFeedFrame.test.tsx` already loops `ephemerists` and asserts the four slots survive dispatch; it is untouched. Same for the copy catalog — see below.
- `factions/ephemerists.ts` needed **no change**: it already claims both `comment` and `feedFrame`. It is in the stated footprint and is deliberately not in the diff.
- Branched off `origin/main` @ `12ffb6e5` and pushed incrementally, one commit per file.

## NOT verified

- **No visual QA. This environment cannot screenshot and there is no dev stack, so every layout claim above is inference from the code, not observation.** Items 1–7 in *What to eyeball* all need a human.
- **The swipe, the 6s undo and the archive write are untested end to end** — the harness is `renderToStaticMarkup` with no jsdom, so no effect runs and no pointer event fires. They are also **not this PR's code**: they live in `FeedItemSlot` and are inherited untouched. The chassis is opaque and squared, so a mid-swipe card reveals the page behind it rather than an under-layer of its own; the sheet's *Mobile — mid-swipe* state needed nothing built.
- **The hover/focus reveal on the comment's owner row** is likewise asserted at its seam (`OwnerControls.test.tsx`), not driven — `useOwnerReveal`'s `matchMedia` never runs in a static render, so the row renders revealed there.

## No string from this design sheet is in the diff

The chassis prints only what F2 hands it. The voice's two faction words (`comments.ephemerists.prompt` = "inscribe a note in the margin", `.edited` = "emended") are **pre-existing** `praxis.json` → `comments.<slug>.*` flavour keys, the ~10 that #1243 explicitly left untouched. **Nothing in this PR adds, edits or deletes a catalog key** — not `feed.json`, not `praxis.json`.

## Outside this footprint, worth someone's queue

1. **`utils/__tests__/factionContrast.test.ts` has two gaps this PR opens, and I did not edit it on purpose** — it is a shared registry, and eight faction dress issues are in flight; today's two `main`-red incidents were both parallel PRs editing one shared assertion table. Both pairs are hand-measured, so the follow-up is two lines:
   - `--faction-ephemerists-plate-band` + `-band-quiet` — the new token. **8.62:1 light, 8.90:1 dark.**
   - `--faction-ephemerists-plate-bg` + `-plate-nile` — mention links on the plate. **5.02:1 light, 7.0:1 dark.** (`-nile` is measured on `-page` and `-inner`, not on the plate itself.)

   Every other pair this PR paints is already in that table (rows 419 / 421 / 422 / 425 / 437 / 438).
2. **`ACCENT_PAIRS` row 120 is now dead coverage.** It asserts "the exact var each voice hands `ComposerControls` as `accent`", and for ephemerists that is now `plate-cta-bg`/`plate-cta-ink` (already measured at row 425), not `card-accent`/`on-accent`. Not corrected here for the same shared-registry reason, and because `--faction-ephemerists-on-accent` **lost its last live consumer in this PR** — it is now reachable only as `factionCssVar('ephemerists', 'on-accent')` from `DefaultComment`, which this faction never renders. Deciding that token's fate belongs to one pass over all eight voices, not to eight PRs.
3. **`DefaultComment`'s sheet sets `overflow: hidden`** (`CommentThread.tsx`, the `Sheet` helper) and the composer's `@`-mention listbox is an absolutely positioned child of it — so the na dropdown looks clipped. This voice avoids `overflow` entirely for that reason. `CommentThread.tsx` carries the thread's fetch/state, so it is `frontend-feature`'s, not a style change.
4. **`EphemeristsAvatar` (surface #11) is still on the codex family** — see eyeball item 6. A metaphor mismatch beside every plate surface, not only this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
