### PR TITLE
SNIDE: the intercepted slip — feed chassis v2 + comment voice

### DIFF
--- a/frontend/src/components/comments/__tests__/snideComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/snideComment.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * S.N.I.D.E. comment voice — the intercepted slip (#1198, epic #1192).
+ *
+ * Rendered to static markup (no DOM) per the comments-test convention, so
+ * `useAuth` resolves to its anonymous default — the viewer owns nothing and can
+ * flag nothing, which is the "row · default" reading of every case below — and
+ * `useFormFactor` falls to `getServerSnapshot`, i.e. desktop.
+ *
+ * These hold the SNIDE tells and the three inks the move to a paper stock forced
+ * down. `defaultComment.test.tsx` holds the na tells; the shared behaviours
+ * (`useOwnerEdit`, `useOwnerReveal`, `ComposerControls`, `CommentFlagControl`)
+ * have their own suites and are not re-tested here.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so the copy keys resolve to English text.
+import '../../../i18n'
+import type { CommentOut } from '../../../api/comments'
+import type { CharacterOut } from '../../../api/auth'
+import SnideComment from '../voices/SnideComment'
+
+const COMMENT: CommentOut = {
+  id: 7,
+  praxis_id: 1,
+  task_id: null,
+  body_text: 'the sign was already crooked when we got there',
+  is_edited: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: {
+    id: 42,
+    username: 'vex',
+    display_name: 'Vexline',
+    avatar_url: null,
+    faction_slug: 'snide',
+  },
+  mentions: [],
+}
+
+const CHARACTER: CharacterOut = {
+  id: 42,
+  username: 'vex',
+  display_name: 'Vexline',
+  avatar_url: null,
+  faction_slug: 'snide',
+  bio: null,
+  location: null,
+  level: 4,
+  score: 0,
+  all_time_score: 0,
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function row(comment: CommentOut = COMMENT): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <SnideComment mode="row" comment={comment} />
+    </MemoryRouter>,
+  )
+}
+
+function composer(submitting: boolean): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <SnideComment
+        mode="composer"
+        character={CHARACTER}
+        value=""
+        onChange={() => {}}
+        onSubmit={() => {}}
+        submitting={submitting}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('SnideComment — the slip tells', () => {
+  it('cuts the author name from ransom scraps and links it to the character', () => {
+    const html = row()
+    expect(html).toContain('href="/characters/42"')
+    // Letter-by-letter: the name never appears as one string.
+    expect(html).not.toContain('>Vexline<')
+    expect(html).toContain('--faction-snide-font-impact')
+    expect(html).toContain('--faction-snide-font-black')
+  })
+
+  it('tapes the slip down and rasters the stock', () => {
+    const html = row()
+    expect(html).toContain('snide-tape')
+    expect(html).toContain('--faction-snide-slip-grain')
+  })
+
+  it('sits on the FLIPPING stock, not the theme-invariant photocopier card', () => {
+    // The slots this voice does not write — OwnerControls, CommentFlagControl,
+    // the shared editor — paint the app's global inks, which flip. §3 (#1118).
+    const html = row()
+    expect(html).toContain('--faction-snide-slip-paper')
+    expect(html).not.toContain('--faction-snide-card-bg')
+  })
+})
+
+describe('SnideComment — acid and pink are drawn things, not inks (#1224)', () => {
+  it('paints a resolved @mention in the WALKED-DOWN acid, never the poster acid', () => {
+    const html = row({
+      ...COMMENT,
+      body_text: 'ask @bo',
+      mentions: [{ character_id: 9, username: 'bo', display_name: 'Bo' }],
+    })
+    expect(html).toContain('href="/characters/9"')
+    expect(html).toContain('--faction-snide-slip-acid-ink')
+  })
+
+  it('leaves an unresolved handle as plain text', () => {
+    const html = row({ ...COMMENT, body_text: 'ask @ghost' })
+    expect(html).toContain('@ghost')
+    expect(html).not.toContain('--faction-snide-slip-acid-ink')
+  })
+
+  it('scrawls the composer prompt in the walked-down pink', () => {
+    const html = composer(false)
+    expect(html).toContain('--faction-snide-slip-pink-ink')
+    expect(html).not.toContain('color:var(--faction-snide-pink)')
+  })
+
+  it('carries no hardcoded colour literal — every pigment is a token', () => {
+    const html = row() + composer(false)
+    expect(html).not.toContain('#fff')
+    expect(html).not.toContain('rgba(255,255,255')
+  })
+})
+
+describe('SnideComment — row states', () => {
+  it('row · default: identity, the typed body on the content floor, no edited mark', () => {
+    const html = row()
+    expect(html).toContain('the sign was already crooked when we got there')
+    expect(html).toContain('content-text')
+    // The sheet's body face is Special Elite, and somebody else's prose is not
+    // shouted: no forced uppercase on the body slot.
+    expect(html).toContain('--faction-snide-font-type')
+    expect(html).not.toContain('EDITED')
+  })
+
+  it('row · edited: the typed edited mark joins the byline', () => {
+    expect(row({ ...COMMENT, is_edited: true })).toContain('EDITED')
+  })
+
+  it('shows no owner row and no flag affordance to a signed-out viewer', () => {
+    // Nothing to put in the foot means no foot, and so no censor rule over
+    // empty space.
+    const html = row()
+    expect(html).not.toContain('delete')
+    expect(html).not.toContain('Flag')
+    expect(html).not.toContain('--faction-snide-slip-rule')
+  })
+})
+
+describe('SnideComment — composer states', () => {
+  it('composer · empty: carries the @-mention hint exactly once', () => {
+    const html = composer(false)
+    expect(html).toContain('@ to mention')
+    expect(html.match(/to mention/g)).toHaveLength(1)
+  })
+
+  it('composer · submitting: marks the slip busy and disables the field', () => {
+    const html = composer(true)
+    expect(html).toContain('aria-busy="true"')
+    expect(html).toContain('disabled')
+  })
+
+  it('composer · empty is NOT busy', () => {
+    expect(composer(false)).not.toContain('aria-busy="true"')
+  })
+
+  it('prints the press ink on the acid submit fill, not the sheet ink', () => {
+    // The sheet's ink SWAPS with the theme; pairing it with acid would put
+    // paper-white type on acid green under [data-theme="dark"].
+    const html = composer(false)
+    expect(html).toContain('background:var(--faction-snide-acid)')
+    expect(html).toContain('color:var(--faction-snide-ink)')
+  })
+})

--- a/frontend/src/components/comments/voices/SnideComment.tsx
+++ b/frontend/src/components/comments/voices/SnideComment.tsx
@@ -1,22 +1,103 @@
+import type { CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
+import { useAuth } from '../../../auth/AuthContext'
+import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
-import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
-import { CommentFlagControl } from '../FlagControl'
+import {
+  CommentEditor,
+  OwnerControls,
+  useOwnerEdit,
+  useOwnerReveal,
+  ownerRevealStyle,
+} from '../OwnerControls'
+import { CommentFlagControl, canFlagComment } from '../FlagControl'
 
 /**
- * S.N.I.D.E. — ransom dispatch (ADR-0018). Reuses the task-card ransom vocabulary:
- * photocopier-black card, cut-out author name, scotch tape, acid highlight. Body
- * stays legible in the condensed face (the card's own rule — only the name is cut).
+ * S.N.I.D.E. comment voice — THE INTERCEPTED SLIP (ADR-0018, redressed for
+ * epic #1192 / #1198 against `Snide Comment + Update Cards.dc.html`).
+ *
+ * The comment half of the same sheet that draws the feed chassis, and it is the
+ * same object: a xerox photocopy taped to the wall, half a degree off true,
+ * dusted with the halftone raster, the author's name cut letter-by-letter out of
+ * five different scraps. Rows and the composer share one shape so a thread reads
+ * as a run of flyposted slips rather than a list plus a form.
+ *
+ * Six states, one responsive component (ADR-0056 / 0058 / 0063 — no mobile
+ * twin): row · default | row · mention | row · edited | row · yours (hover) |
+ * row · editing | composer · empty | composer · submitting.
+ *
+ * ── WHAT THIS FILE DOES NOT OWN ─────────────────────────────────────────────
+ * Every behaviour is shared and stays shared: `useOwnerEdit` runs the
+ * edit/withdraw state machine, `useOwnerReveal` runs F3's hover-OR-focus gate on
+ * the owner row (never `display`, so Tab still reaches it, and never gated at
+ * all on a device that cannot hover), `ComposerControls` owns the textarea, the
+ * @-mention autocomplete, the 500-character cap and its live count, and
+ * `CommentFlagControl` owns flagging. This file passes them a skin.
+ *
+ * ── THREE INKS ARE WALKED DOWN, AND THE STOCK NOW FLIPS ─────────────────────
+ * The sheet's card is `--paper`, so this moved off the theme-invariant
+ * `--faction-snide-card-bg` (photocopier black in both themes) onto the flipping
+ * `--faction-snide-slip-*` stock. That is what §3's #1118 rule requires of it:
+ * the slots this voice does not write — `OwnerControls`, `CommentFlagControl`,
+ * the shared editor — all paint the app's global inks, and on the invariant
+ * black card in the LIGHT theme `--color-text-tertiary` was 3.20:1 on the owner
+ * row and `--color-danger` 3.90:1 on Withdraw. On the flipping stock they land
+ * at 5.22:1 and 6.82:1 respectively, the same pairings the na sheet has.
+ *
+ * Moving to paper is also what forces the three walk-downs, and this is the
+ * #1224 trap the design notes name outright: acid is a DRAWN thing, not an ink.
+ *   • resolved @mentions: `--faction-snide-acid` → `-slip-acid-ink` (1.35 → 5.20)
+ *   • the composer's marker prompt: `-pink` → `-slip-pink-ink` (3.10 → 5.35)
+ *   • the pink ransom tile's letter: paper-white → `-on-accent` (3.50 → 5.38)
+ * Acid keeps its bright pigment wherever it is drawn rather than read — the
+ * ransom scraps, the submit button's fill, the field's rule.
+ *
+ * The BODY face is Special Elite (`-font-type`), per the sheet's own type line
+ * (Anton headline · Archivo Black · Special Elite body). It used to be condensed
+ * Bebas forced to uppercase, which is a poster treatment applied to somebody
+ * else's prose; only the cut-out NAME is a poster now.
+ */
+
+/**
+ * The five scraps the author's name is cut from. Only the first FLIPS — it is a
+ * paler patch of the sheet itself, so on a dark stock it has to be a darker one
+ * or the letter loses its edge. The other four are the PRESS's theme-invariant
+ * pigments: over-inked black, hot pink, acid. A scrap is a drawn thing.
  */
 const RANSOM = [
-  { bg: 'var(--faction-snide-paper)', col: 'var(--faction-snide-ink)', font: 'var(--faction-snide-font-impact)', rot: -5 },
-  { bg: 'var(--faction-snide-ink)', col: 'var(--faction-snide-acid)', font: 'var(--faction-snide-font-cond)', rot: 4 },
-  { bg: 'var(--faction-snide-pink)', col: '#fff', font: 'var(--faction-snide-font-black)', rot: -3 },
-  { bg: 'var(--faction-snide-acid)', col: 'var(--faction-snide-ink)', font: 'var(--faction-snide-font-impact)', rot: 6 },
-  { bg: 'var(--faction-snide-ink)', col: '#fff', font: 'var(--faction-snide-font-cond)', rot: -6 },
+  {
+    bg: 'var(--faction-snide-slip-field)',
+    col: 'var(--faction-snide-slip-ink)',
+    font: 'var(--faction-snide-font-impact)',
+    rot: -5,
+  },
+  {
+    bg: 'var(--faction-snide-ink)',
+    col: 'var(--faction-snide-acid)',
+    font: 'var(--faction-snide-font-cond)',
+    rot: 4,
+  },
+  {
+    bg: 'var(--faction-snide-pink)',
+    col: 'var(--faction-snide-on-accent)',
+    font: 'var(--faction-snide-font-black)',
+    rot: -3,
+  },
+  {
+    bg: 'var(--faction-snide-acid)',
+    col: 'var(--faction-snide-ink)',
+    font: 'var(--faction-snide-font-impact)',
+    rot: 6,
+  },
+  {
+    bg: 'var(--faction-snide-ink)',
+    col: 'var(--faction-snide-paper)',
+    font: 'var(--faction-snide-font-cond)',
+    rot: -6,
+  },
 ]
 
 function Ransom({ text, size = 16 }: { text: string; size?: number }) {
@@ -33,7 +114,7 @@ function Ransom({ text, size = 16 }: { text: string; size?: number }) {
           <span key={index} style={{ display: 'inline-block', background: s.bg, color: s.col, fontFamily: s.font, fontSize: size, lineHeight: 0.92,
             // eslint-disable-next-line local/no-raw-style-values -- ornament: inset of a single cut-out letter tile inside its scrap of paper
             padding: '2px 5px 0',
-            transform: `rotate(${s.rot}deg)`, boxShadow: '1.5px 2.5px 0 rgba(0,0,0,0.4)', textTransform: 'uppercase' }}>
+            transform: `rotate(${s.rot}deg)`, boxShadow: '1.5px 2.5px 0 var(--faction-snide-slip-scrap-shadow)', textTransform: 'uppercase' }}>
             {char}
           </span>
         )
@@ -42,78 +123,189 @@ function Ransom({ text, size = 16 }: { text: string; size?: number }) {
   )
 }
 
-function frame(): React.CSSProperties {
+/**
+ * The slip itself — the same stock, raster, border and hard printed shadow the
+ * feed chassis paints, so the two halves of the sheet read as one object.
+ *
+ * The tilt and the offset shadow are desktop-only: in a narrow single column a
+ * rotated card fouls its neighbours' edges and the shadow eats the gutter.
+ */
+function slip(mobile: boolean): CSSProperties {
   return {
     position: 'relative',
-    background: 'var(--faction-snide-card-bg)',
-    color: 'var(--faction-snide-card-text)',
-    // eslint-disable-next-line local/no-raw-style-values -- ornament: the ransom card's graded 20/18/16 inset. The scale has no rung between 16 and 24, so every tokenization collapses top/sides/bottom to one value and regularizes the archetype (§4a asymmetric-inset exception).
+    background: 'var(--faction-snide-slip-paper)',
+    color: 'var(--faction-snide-slip-ink)',
+    border: '1.5px solid var(--faction-snide-slip-ink)',
+    backgroundImage:
+      'radial-gradient(var(--faction-snide-slip-grain) 1px, transparent 1px),' +
+      'radial-gradient(var(--faction-snide-slip-grain) 1px, transparent 1px)',
+    backgroundSize: '3px 3px, 4px 4px',
+    backgroundPosition: '0 0, 2px 1px',
+    boxShadow: mobile ? undefined : 'var(--faction-snide-slip-shadow)',
+    transform: mobile ? undefined : 'rotate(-0.6deg)',
+    // eslint-disable-next-line local/no-raw-style-values -- ornament: the ransom slip's graded 20/18/16 inset. The scale has no rung between 16 and 24, so every tokenization collapses top/sides/bottom to one value and regularizes the archetype (§4a asymmetric-inset exception).
     padding: '20px 18px 16px',
-    boxShadow: '6px 8px 0 rgba(0,0,0,0.28)',
-    transform: 'rotate(-0.6deg)',
   }
 }
 
 function Tape() {
   return (
     <>
-      <div className="snide-tape" style={{ top: -8, left: 28, transform: 'rotate(-8deg)' }} />
-      <div className="snide-tape" style={{ top: -8, right: 22, transform: 'rotate(7deg)' }} />
+      <div className="snide-tape" aria-hidden="true" style={{ top: -8, left: 28, transform: 'rotate(-8deg)' }} />
+      <div className="snide-tape" aria-hidden="true" style={{ top: -8, right: 22, transform: 'rotate(7deg)' }} />
     </>
   )
 }
 
+/** Typewriter label voice — the timestamp, the edited mark, the composer hint. */
+const TYPED: CSSProperties = {
+  fontFamily: 'var(--faction-snide-font-type)',
+  fontSize: 'var(--text-lg)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.1em',
+}
+
+/** The field tier: an input reads as inset on the stock, not painted onto it. */
+const FIELD = {
+  // Acid is a DRAWN thing here — the box's rule and the submit fill — and the
+  // press's near-black is the type that prints on it, in both themes.
+  accent: 'var(--faction-snide-acid)',
+  onAccent: 'var(--faction-snide-ink)',
+  bg: 'var(--faction-snide-slip-field)',
+  text: 'var(--faction-snide-slip-ink)',
+} as const
+
 export default function SnideComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
+  const { user } = useAuth()
+  const mobile = useFormFactor() === 'mobile'
+  const reveal = useOwnerReveal()
+
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props
     return (
-      <div style={frame()}>
+      <div style={slip(mobile)} aria-busy={submitting}>
         <Tape />
         <div style={{ position: 'relative', display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
           <FactionAvatar character={character} size="sm" />
-          <div style={{ flex: 1 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {/* The marker scrawl across the head of the slip. Pink as TEXT, so
+                the walked-down ink rather than the poster pigment. */}
             <div style={{
-              fontFamily: 'var(--faction-snide-font-marker)', color: 'var(--faction-snide-pink)',
+              fontFamily: 'var(--faction-snide-font-marker)',
+              color: 'var(--faction-snide-slip-pink-ink)',
               transform: 'rotate(-1deg)', marginBottom: 'var(--space-sm)',
-              // eslint-disable-next-line local/no-raw-style-values -- ornament: rotated marker scrawl
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: rotated marker scrawl, an optical size the type scale has no rung for
               fontSize: 11,
             }}>
               {t('comments.snide.prompt')}
             </div>
-            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-snide-pink)" onAccent="var(--faction-snide-on-accent)" bg="rgba(255,255,255,0.04)" text="var(--faction-snide-card-text)" />
+            {/* The draft is content-tier free text; the textarea inherits the
+                size from this wrapper (`font: inherit`), which is why the class
+                rides here rather than on any slot inside. */}
+            <div className="content-text" style={{ fontFamily: 'var(--faction-snide-font-type)' }}>
+              <ComposerControls
+                value={value}
+                onChange={onChange}
+                onSubmit={onSubmit}
+                submitting={submitting}
+                accent={FIELD.accent}
+                onAccent={FIELD.onAccent}
+                bg={FIELD.bg}
+                text={FIELD.text}
+                // The shared string, typed in this sheet's own label voice — an
+                // OVERRIDE of the neutral default, not a new affordance.
+                hint={
+                  <span style={{ ...TYPED, color: 'var(--faction-snide-slip-faint)' }}>
+                    {t('comments.mentionHint')}
+                  </span>
+                }
+              />
+            </div>
           </div>
         </div>
       </div>
     )
   }
+
   const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
+  const canFlag = canFlagComment(comment, user?.character?.id)
+  // The foot only exists when it holds something: the author's own row, or a
+  // flag affordance for everyone else. The inline editor owns Save/Cancel while
+  // editing, so the foot stands down then.
+  const showControls = !owner.editing && (owner.isOwner || canFlag)
+  // On your OWN slip the foot holds nothing but the gated owner row, so the
+  // censor rule above it fades with the row — a hairline over empty space is a
+  // state the sheet never draws.
+  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+
   return (
-    <div style={frame()}>
+    <div style={slip(mobile)} {...reveal.containerProps}>
       <Tape />
       <div style={{ position: 'relative', display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
         <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
         <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 'var(--space-md)', marginBottom: 'var(--space-sm)' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 'var(--space-md)', marginBottom: 'var(--space-sm)', flexWrap: 'wrap' }}>
             <Link to={`/characters/${comment.author.id}`} style={{ textDecoration: 'none' }}>
               <Ransom text={comment.author.display_name} size={16} />
             </Link>
-            <span style={{ fontFamily: 'var(--font-body)', fontSize: 'var(--text-base)', color: 'var(--faction-snide-card-muted)', whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 'var(--space-sm)' }}>
+            <span style={{ ...TYPED, color: 'var(--faction-snide-slip-muted)', whiteSpace: 'nowrap' }}>
               {formatCommentTime(slug, comment.created_at)}
-              {comment.is_edited ? ` · ${t('comments.snide.edited')}` : ''}
-              <OwnerControls owner={owner} />
-              <CommentFlagControl comment={comment} />
+              {comment.is_edited && (
+                <>
+                  <span aria-hidden="true"> · </span>
+                  {t('comments.snide.edited')}
+                </>
+              )}
             </span>
           </div>
-          <div style={{ fontFamily: 'var(--faction-snide-font-cond)', textTransform: 'uppercase', fontSize: 'var(--text-content)', lineHeight: 1.4, letterSpacing: '0.02em' }}>
+          {/* Somebody else's prose: the content floor, typed rather than set in
+              the condensed poster face, and not forced to uppercase. */}
+          <div
+            className="content-text"
+            style={{
+              fontFamily: 'var(--faction-snide-font-type)',
+              lineHeight: 1.5,
+              letterSpacing: '0.01em',
+              overflowWrap: 'anywhere',
+            }}
+          >
             {owner.editing ? (
-              <CommentEditor owner={owner} accent="var(--faction-snide-pink)" onAccent="var(--faction-snide-on-accent)" bg="rgba(255,255,255,0.04)" text="var(--faction-snide-card-text)" />
+              <CommentEditor
+                owner={owner}
+                accent={FIELD.accent}
+                onAccent={FIELD.onAccent}
+                bg={FIELD.bg}
+                text={FIELD.text}
+              />
             ) : (
-              <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-snide-acid)" />
+              <MentionText
+                body={comment.body_text}
+                mentions={comment.mentions}
+                accent="var(--faction-snide-slip-acid-ink)"
+              />
             )}
           </div>
+          {showControls && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'baseline',
+                flexWrap: 'wrap',
+                gap: 'var(--space-md)',
+                marginTop: 'var(--space-md)',
+                paddingTop: 'var(--space-sm)',
+                // A censor rule inside the slip, quieter than its cut edge.
+                borderTop: '1px solid var(--faction-snide-slip-rule)',
+                ...footGate,
+              }}
+            >
+              <OwnerControls owner={owner} reveal={reveal} />
+              <CommentFlagControl comment={comment} />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/components/comments/voices/SnideComment.tsx
+++ b/frontend/src/components/comments/voices/SnideComment.tsx
@@ -44,8 +44,10 @@ import { CommentFlagControl, canFlagComment } from '../FlagControl'
  * the slots this voice does not write — `OwnerControls`, `CommentFlagControl`,
  * the shared editor — all paint the app's global inks, and on the invariant
  * black card in the LIGHT theme `--color-text-tertiary` was 3.20:1 on the owner
- * row and `--color-danger` 3.90:1 on Withdraw. On the flipping stock they land
- * at 5.22:1 and 6.82:1 respectively, the same pairings the na sheet has.
+ * row. On the flipping stock it lands at 5.22:1. `--color-danger` moves 3.90 →
+ * 4.28:1, which is better and still under AA — it is painted by three shared
+ * controls that take no ink prop, so it is §3's #1153 missing-seam case rather
+ * than something this voice can route. See the token block's note.
  *
  * Moving to paper is also what forces the three walk-downs, and this is the
  * #1224 trap the design notes name outright: acid is a DRAWN thing, not an ink.

--- a/frontend/src/components/feed/SnideFeedFrame.tsx
+++ b/frontend/src/components/feed/SnideFeedFrame.tsx
@@ -1,24 +1,55 @@
-import FeedChassisBand from './FeedChassisBand'
+import type { CSSProperties } from 'react'
+import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
- * S.N.I.D.E. activity-feed FRAME (surface #12, SPEC-faction-ui-profile.md).
+ * S.N.I.D.E. activity-feed CHASSIS (surface #12, SPEC-faction-ui-profile.md §12).
  *
- * A thin presentational WRAPPER — not a card. It dresses the neutral feed card
- * (`children`) in SNIDE's outer chrome: an "intercepted ransom-note slip" cut
- * from warm xerox paper, bound in a photocopier-ink border, taped down at the
- * top, tilted on the wall, dusted with halftone, with an acid-green margin
- * stripe running its left edge. The card body itself stays exactly as passed in
- * — this only adds the skin around `{children}`.
+ * Design: `Snide Comment + Update Cards.dc.html` (+ its `- Dark` companion),
+ * epic #1192 / #1198. An INTERCEPTED SLIP: a xerox photocopy flyposted on the
+ * wall, taped down at the head, half a degree off true, dusted with the halftone
+ * raster, with an acid sprocket stripe ruled down its left edge and a near-black
+ * intake bar typed across its top.
  *
- * #1194: the slip gains a CHASSIS BAND above the body — a typed intake line
- * carrying the kicker, the tag, the time and the dismiss control in photocopier
- * ink. The skin is otherwise unchanged; SNIDE's dress issue restyles it.
+ * ── WHAT THIS LAYER OWNS ────────────────────────────────────────────────────
+ * The outside of the card and the four chrome slots of {@link FeedFrameProps},
+ * and nothing else. The archive itself — the ✕'s behaviour, swipe-to-archive,
+ * the immediate write, the six-second undo strip — lives OUTSIDE in
+ * `FeedItemSlot` and is inherited free; `archive` arrives here as a finished
+ * node and is PLACED, never rebuilt. The payload (`FeedRowContent` or one of the
+ * three companions) arrives as `children` and is faction-blind: it self-pads and
+ * paints its own inks, so this frame gives it a stock and stays out of its way.
  *
- * Always-dark by intent: SNIDE is the ransom/xerox dossier. We scope the
- * theme-stable --faction-snide-card-* / -paper / -ink / -acid tokens to this
- * frame's own container only; we never mutate the document theme, and we avoid
- * the --faction-snide-*-wall-text tokens that flip between light/dark.
+ * All fifteen feed types therefore ride this one chassis unchanged, including
+ * the nine the design sheet never drew — the drawing is a style sheet, not a
+ * screenshot. `era_announcement` is the deliberate exception and never reaches
+ * here (epic decision 6). `awaiting_submission` arrives with `archive === null`,
+ * which is the whole of "not archivable" on this side of the seam: the slot
+ * refuses to hand out a control the backend would 400, and the bar simply has
+ * one fewer thing in it. Nothing here draws a disabled stand-in.
+ *
+ * ── WHY THE STOCK FLIPS ─────────────────────────────────────────────────────
+ * `--faction-snide-slip-*` is a FLIPPING family, unlike the theme-invariant
+ * `--faction-snide-paper`/`-ink` this frame used to paint. That is a contrast
+ * fix, not a taste call: the body is shared payload written in the app's global
+ * inks (`--color-text-primary`/`-secondary`/`-tertiary`), those flip with the
+ * theme, and §3's #1118 rule — a block whose ink you do not control gets the
+ * stock that ink was measured on — makes a flipping stock mandatory. The old
+ * invariant paper put `#f0e6d0` headline copy on `#f4f1e8` at night: 1.10:1.
+ *
+ * ── ACID IS A DRAWN THING, NOT AN INK ───────────────────────────────────────
+ * The sprocket stripe, the rule under the bar and the tag chip's edge take the
+ * bright `--faction-snide-acid`, which measures 1.35:1 as type on the light
+ * stock (#1224). The kicker is TYPE, so on the near-black bar it reads the
+ * PRESS's paper — and the bar exists partly so that it can: a kicker typed
+ * straight onto the stock would have to be walked down to
+ * `--faction-snide-slip-acid-ink`, which is quieter than this card's loudest
+ * line should be.
+ *
+ * One responsive component, no mobile twin (ADR-0056 / 0058 / 0063): the tilt
+ * and the hard offset shadow are desktop-only — in a single narrow column a
+ * rotated card fouls its neighbours' edges and the shadow eats the gutter — and
+ * the stripe narrows. Everything else is identical.
  */
 export default function SnideFeedFrame({
   kicker,
@@ -27,64 +58,134 @@ export default function SnideFeedFrame({
   archive,
   children,
 }: FeedFrameProps) {
-  const ink = 'var(--faction-snide-ink)'
-  const paper = 'var(--faction-snide-paper)'
-  const acid = 'var(--faction-snide-acid)'
+  const mobile = useFormFactor() === 'mobile'
+
+  const slip: CSSProperties = {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'stretch',
+    marginBottom: 'var(--space-lg)',
+    background: 'var(--faction-snide-slip-paper)',
+    color: 'var(--faction-snide-slip-ink)',
+    border: '1.5px solid var(--faction-snide-slip-ink)',
+    // The xerox raster: two offset dot screens in the stock's own ink, so the
+    // grain inverts with the sheet instead of staying a light-mode smudge.
+    backgroundImage:
+      'radial-gradient(var(--faction-snide-slip-grain) 1px, transparent 1px),' +
+      'radial-gradient(var(--faction-snide-slip-grain) 1px, transparent 1px)',
+    backgroundSize: '3px 3px, 4px 4px',
+    backgroundPosition: '0 0, 2px 1px',
+    // Printed, not floating — a hard offset with no blur.
+    boxShadow: mobile ? undefined : 'var(--faction-snide-slip-shadow)',
+    transform: mobile ? undefined : 'rotate(-0.6deg)',
+    // Clips the tape to a half-strip, as if it were applied from behind.
+    overflow: 'hidden',
+  }
 
   return (
-    <div
-      style={{
-        position: 'relative',
-        background: paper,
-        border: `1.5px solid ${ink}`,
-        // halftone dust over the xerox slab — ink at low opacity, theme-stable.
-        backgroundImage:
-          'radial-gradient(color-mix(in srgb, var(--faction-snide-ink) 6%, transparent) 1px, transparent 1px),' +
-          'radial-gradient(color-mix(in srgb, var(--faction-snide-ink) 4%, transparent) 1px, transparent 1px)',
-        backgroundSize: '3px 3px, 4px 4px',
-        backgroundPosition: '0 0, 2px 1px',
-        boxShadow: '3px 4px 0 rgba(0,0,0,0.22)',
-        transform: 'rotate(-0.6deg)',
-        padding: 'var(--space-lg) var(--space-lg) var(--space-lg) var(--space-xl)',
-        marginBottom: 'var(--space-lg)',
-        overflow: 'hidden',
-      }}
-    >
-      {/* acid margin stripe — sprocket-ruled, hugging the left edge */}
-      <div
+    <div style={slip}>
+      {/* The acid sprocket stripe ruled down the left edge. A drawn thing, so it
+          keeps the bright pigment; a flex child rather than an absolute overlay
+          so the column beside it needs no inset to keep clear of it. */}
+      <span
         aria-hidden="true"
         style={{
-          position: 'absolute',
-          left: 0,
-          top: 0,
-          bottom: 0,
-          width: 8,
-          background: acid,
+          // Ornament geometry — the drawn stripe's own width, not layout spacing.
+          width: mobile ? 5 : 8,
+          flexShrink: 0,
+          background: 'var(--faction-snide-acid)',
           backgroundImage:
-            'repeating-linear-gradient(180deg, transparent 0 13px, rgba(0,0,0,0.25) 13px 14px)',
+            'repeating-linear-gradient(180deg, transparent 0 13px, var(--faction-snide-slip-bar) 13px 14px)',
         }}
       />
-      {/* a strip of tape pinning the slip to the wall */}
-      <div
-        className="snide-tape"
-        aria-hidden="true"
-        style={{ top: -9, right: 40, width: 64, height: 20, transform: 'rotate(5deg)' }}
-      />
-      {/* chassis band — the intake line typed across the head of the slip */}
-      <div
-        style={{
-          position: 'relative',
-          color: ink,
-          borderBottom: `1px solid color-mix(in srgb, ${ink} 35%, transparent)`,
-          paddingBottom: 'var(--space-xs)',
-          marginBottom: 'var(--space-sm)',
-        }}
-      >
-        <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
-      </div>
 
-      {/* the slip body — the neutral feed card, untouched */}
-      <div style={{ position: 'relative' }}>{children}</div>
+      <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
+        {/* A strip of tape pinning the slip to the wall. */}
+        <div
+          className="snide-tape"
+          aria-hidden="true"
+          style={{ top: -9, right: 40, width: 64, height: 20, transform: 'rotate(5deg)' }}
+        />
+
+        {/* ── THE INTAKE BAR ── the kicker band, over-inked across the head of
+            the slip. It carries three of the four chrome slots and tints the
+            fourth: `archive` paints in `currentColor`, so setting `color` here
+            is what makes the ✕ read paper-white on the bar in both themes. */}
+        <div
+          style={{
+            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-sm)',
+            minWidth: 0,
+            padding: mobile
+              ? 'var(--space-xs) var(--space-sm)'
+              : 'var(--space-xs) var(--space-md)',
+            background: 'var(--faction-snide-slip-bar)',
+            color: 'var(--faction-snide-paper)',
+            // The bar is only 1.4:1 against the dark stock, so this rule is what
+            // draws the band's foot at night. Structure, not garnish.
+            borderBottom: '2px solid var(--faction-snide-acid)',
+          }}
+        >
+          {/* The card's kind, cut in the condensed poster face. */}
+          <span
+            style={{
+              fontFamily: 'var(--faction-snide-font-cond)',
+              fontSize: 'var(--text-xl)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              lineHeight: 1.1,
+              minWidth: 0,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {kicker}
+          </span>
+
+          {/* The status chip — nullable, and today only ever "Still waiting". */}
+          {tag && (
+            <span
+              style={{
+                flexShrink: 0,
+                fontFamily: 'var(--faction-snide-font-type)',
+                fontSize: 'var(--text-base)',
+                textTransform: 'uppercase',
+                letterSpacing: '0.1em',
+                lineHeight: 1.2,
+                color: 'var(--faction-snide-acid)',
+                border: '1px solid var(--faction-snide-acid)',
+                padding: '0 var(--space-xs)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {tag}
+            </span>
+          )}
+
+          {/* The timestamp, typed. Right-aligned on the bar's own line. */}
+          <span
+            style={{
+              marginLeft: 'auto',
+              flexShrink: 0,
+              fontFamily: 'var(--faction-snide-font-type)',
+              fontSize: 'var(--text-lg)',
+              letterSpacing: '0.04em',
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {time}
+          </span>
+
+          {archive}
+        </div>
+
+        {/* The slip's body — the shared payload, which self-pads and paints its
+            own inks. It gets a stock and nothing else. */}
+        <div style={{ position: 'relative' }}>{children}</div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/feed/__tests__/snideFeedFrame.test.tsx
+++ b/frontend/src/components/feed/__tests__/snideFeedFrame.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * S.N.I.D.E. feed CHASSIS — the intercepted slip (#1198, epic #1192).
+ *
+ * The shared dispatch guard (`components/__tests__/factionFeedFrame.test.tsx`)
+ * already loops every frame and asserts the four chrome slots survive. It is
+ * shared by eight parallel dress issues, so nothing SNIDE-specific is added
+ * there — a row in a shared registry asserted from eight branches is how `main`
+ * has gone red in this repo before. This file holds what is only this skin's.
+ *
+ * Rendered to static markup (no DOM, per the frontend harness): `useFormFactor`
+ * falls to its `getServerSnapshot`, i.e. the desktop reading.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import SnideFeedFrame from '../SnideFeedFrame'
+
+function frame({
+  tag = null,
+  archive = <button type="button">archive-node</button>,
+}: {
+  tag?: string | null
+  archive?: React.ReactNode
+} = {}): string {
+  return renderToStaticMarkup(
+    <SnideFeedFrame kicker="Duel challenge" time="2h ago" tag={tag} archive={archive}>
+      <span>card-body</span>
+    </SnideFeedFrame>,
+  )
+}
+
+describe('SnideFeedFrame — the four chrome slots', () => {
+  it('draws kicker, time, tag and the archive node, and keeps the body intact', () => {
+    const html = frame({ tag: 'Still waiting' })
+    expect(html).toContain('Duel challenge')
+    expect(html).toContain('2h ago')
+    expect(html).toContain('Still waiting')
+    expect(html).toContain('archive-node')
+    expect(html).toContain('<span>card-body</span>')
+  })
+
+  it('drops the tag chip when the tag is null, and nothing else', () => {
+    const html = frame()
+    expect(html).toContain('Duel challenge')
+    expect(html).toContain('2h ago')
+    expect(html).toContain('archive-node')
+  })
+
+  it('renders no archive affordance at all when the item offers none', () => {
+    // `awaiting_submission` arrives with `archive === null`: it is state, not an
+    // event, and the backend refuses to archive it. A frame must never draw a
+    // disabled stand-in — assert the WORD is absent, not merely the node.
+    const html = frame({ archive: null })
+    expect(html).not.toContain('archive-node')
+    expect(html).not.toContain('disabled')
+    // The rest of the chrome is unaffected.
+    expect(html).toContain('Duel challenge')
+    expect(html).toContain('2h ago')
+  })
+})
+
+describe('SnideFeedFrame — the stock flips, and acid stays a drawn thing', () => {
+  it('paints the FLIPPING slip stock, never the theme-invariant press paper', () => {
+    // The body is faction-blind payload painted in the app's global inks, which
+    // flip; §3 (#1118) therefore requires a stock that flips with them. The
+    // invariant `--faction-snide-paper` put #f0e6d0 copy on #f4f1e8 at 1.10:1.
+    const html = frame()
+    expect(html).toContain('--faction-snide-slip-paper')
+    expect(html).toContain('--faction-snide-slip-ink')
+    expect(html).not.toContain('background:var(--faction-snide-paper)')
+  })
+
+  it('tints the archive node by setting a colour on the bar it sits in', () => {
+    // FeedArchiveButton paints in `currentColor`, so the bar's `color` is the
+    // whole of how the ✕ reads paper-white on the over-inked band.
+    expect(frame()).toContain('--faction-snide-slip-bar')
+    expect(frame()).toContain('color:var(--faction-snide-paper)')
+  })
+
+  it('reads acid only where it is DRAWN, never as the kicker ink (#1224)', () => {
+    // Bright acid measures 1.35:1 as type on the light stock. It appears here as
+    // the sprocket stripe, the bar's foot rule and the tag chip's edge — all
+    // drawn — and the kicker is type on the near-black bar instead.
+    const html = frame({ tag: 'Still waiting' })
+    expect(html).toContain('--faction-snide-acid')
+    expect(html).not.toContain('--faction-snide-slip-acid-ink')
+  })
+
+  it('prints no faction name (epic decision 5 — the skin is the identification)', () => {
+    // TEXT nodes only: token names and the `.snide-tape` class carry the slug by
+    // necessity, and neither is copy. What must not appear is a visible label.
+    const text = frame({ tag: 'Still waiting' })
+      .replace(/<[^>]*>/g, ' ')
+      .toLowerCase()
+    expect(text).not.toContain('snide')
+    expect(text).not.toContain('s.n.i.d.e')
+    // …and the neutral chrome the catalog authored is all that is left.
+    expect(text).toContain('duel challenge')
+    expect(text).toContain('still waiting')
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -524,6 +524,9 @@
   --faction-snide-slip-acid-ink: #457000; /* acid that is TEXT — 5.20:1 */
   --faction-snide-slip-pink-ink: #be185d; /* pink that is TEXT — 5.35:1 */
   --faction-snide-slip-shadow: 3px 4px 0 rgba(20, 17, 11, 0.3); /* printed, no blur */
+  /* The drop under a single cut-out ransom scrap — a colour, not a whole shadow,
+     because the scrap's offset is its own (1.5/2.5) and not the slip's. */
+  --faction-snide-slip-scrap-shadow: rgba(20, 17, 11, 0.4);
 
   /* ── Singularity terminal border (blue brand) ── */
   --faction-singularity-border-hard: #2563eb;
@@ -1577,6 +1580,7 @@
   --faction-snide-slip-acid-ink: #b6ff2e;
   --faction-snide-slip-pink-ink: #ff69ac;
   --faction-snide-slip-shadow: 3px 4px 0 rgba(0, 0, 0, 0.6);
+  --faction-snide-slip-scrap-shadow: rgba(0, 0, 0, 0.6);
   --faction-singularity-card-muted: #60a5fa; /* blue brand chrome */
 
   /* ── Singularity terminal session, lights out (#1023) ──

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -475,6 +475,56 @@
   --faction-snide-composer-grain: rgba(20, 17, 11, 0.09); /* the raster */
   --faction-snide-composer-acid-ink: #457000; /* acid that is TEXT, not a line */
 
+  /* ══ S.N.I.D.E. — THE INTERCEPTED SLIP (feed chassis + comment sheet, #1198) ══
+     Design: `Snide Comment + Update Cards.dc.html` — a flyposted xerox slip
+     taped to the wall at half a degree off true, with a near-black intake bar
+     typed across its head, an acid sprocket stripe down its left edge, and the
+     halftone raster over the whole stock.
+
+     THIS FAMILY FLIPS, and here that is a bug fix rather than only a dress
+     choice. §3's "a block whose ink you do not control gets the stock that ink
+     was measured on" (#1118) decides it: the chassis's BODY is faction-blind
+     shared payload (`FeedRowContent`, three companions, the comment editor) and
+     every one of them paints the app's global inks — `--color-text-primary`,
+     `-secondary`, `-tertiary`, `--color-border-strong`. Those flip with the
+     theme, so the stock under them has to flip too. The frame previously painted
+     the theme-INVARIANT `--faction-snide-paper`, which put `#f0e6d0` body copy
+     on `#f4f1e8` paper under [data-theme="dark"] — 1.10:1, the headline of every
+     S.N.I.D.E. feed card invisible at night, with the actor line at 2.92:1.
+
+     So this is a THIRD flipping S.N.I.D.E. stock beside `-note-*` (the task
+     card's clipping) and `-composer-*` (the edit-praxis sheet), declared rather
+     than borrowed for #1181's reason: same values today, a different surface's
+     contract tomorrow, and reading another surface's token here is the
+     "tokenized-looking, not tokenized" failure that passes every lint gate.
+
+     WHAT IS NOT HERE, deliberately. Type on the intake bar and type on an acid
+     ground both read THE PRESS's theme-invariant constants at the head of this
+     faction's block — `--faction-snide-paper` on the bar (16.7:1 in both
+     themes) and `--faction-snide-ink` on acid (15.5:1) — exactly as
+     SnideEditPraxis's PRESS_PAPER / PRESS_INK do. Minting slip-local synonyms
+     for those would be a second name for one pigment.
+
+     TWO INKS ARE WALKED DOWN, both for the same reason the composer walked its
+     acid: acid and hot pink are POSTER COLOURS, not inks. On the light stock
+     `#b6ff2e` measures 1.35:1 and `#ff2d8b` 3.10:1. Both keep their bright
+     value everywhere they are a DRAWN THING — the sprocket stripe, the rule
+     under the bar, the filled submit button, the ransom letter tiles. */
+  --faction-snide-slip-paper: #f4f1e8; /* the slip's stock (FLIPS) */
+  --faction-snide-slip-ink: #14110b; /* type on that stock (FLIPS) — 16.7:1 */
+  --faction-snide-slip-muted: #5f5c50; /* byline, timestamp, meta — 5.94:1 */
+  --faction-snide-slip-faint: #6e6b5d; /* character count, hint — 4.80:1 */
+  --faction-snide-slip-field: #eae6d8; /* an input, a shade off the stock */
+  --faction-snide-slip-rule: rgba(20, 17, 11, 0.28); /* a drawn hairline */
+  --faction-snide-slip-grain: rgba(20, 17, 11, 0.06); /* the xerox raster */
+  /* The intake bar. Near-black in BOTH themes — it is over-inked, not a shade of
+     the stock — which is why it needs the acid rule at its foot to read as a
+     band at all once the stock goes dark too. */
+  --faction-snide-slip-bar: #14110b;
+  --faction-snide-slip-acid-ink: #457000; /* acid that is TEXT — 5.20:1 */
+  --faction-snide-slip-pink-ink: #be185d; /* pink that is TEXT — 5.35:1 */
+  --faction-snide-slip-shadow: 3px 4px 0 rgba(20, 17, 11, 0.3); /* printed, no blur */
+
   /* ── Singularity terminal border (blue brand) ── */
   --faction-singularity-border-hard: #2563eb;
 
@@ -1503,6 +1553,30 @@
   --faction-snide-composer-bar: #080706;
   --faction-snide-composer-grain: rgba(244, 241, 232, 0.07);
   --faction-snide-composer-acid-ink: #b6ff2e;
+
+  /* ── The intercepted slip, lights out (#1198) ──
+     The stock and its type SWAP, as the clipping's and the sheet's do. The intake
+     bar goes a shade BELOW the stock rather than above it, for the same reason
+     the composer's redaction does — an over-inked band is the darkest thing on
+     the sheet, and lifting it to white would turn the card's own header into a
+     highlighter. That leaves the bar only 1.4:1 against the stock, so the acid
+     rule at its foot is what draws the band here; it is structure, not garnish.
+     Acid and pink become text-safe on this ground and both take their bright
+     pigment back. Measured on the dark stock: ink 15.2:1, muted 11.8:1,
+     faint 5.96:1, acid-ink 15.5:1, pink-ink 7.06:1. The shared body's global
+     inks land at primary 15.2:1, secondary 5.70:1, tertiary 6.31:1 — the
+     pairings the previous invariant stock broke. */
+  --faction-snide-slip-paper: #14110b;
+  --faction-snide-slip-ink: #f4f1e8;
+  --faction-snide-slip-muted: #cfcdbf;
+  --faction-snide-slip-faint: #94917f;
+  --faction-snide-slip-field: #1e1a12;
+  --faction-snide-slip-rule: rgba(244, 241, 232, 0.32);
+  --faction-snide-slip-grain: rgba(244, 241, 232, 0.07);
+  --faction-snide-slip-bar: #080706;
+  --faction-snide-slip-acid-ink: #b6ff2e;
+  --faction-snide-slip-pink-ink: #ff69ac;
+  --faction-snide-slip-shadow: 3px 4px 0 rgba(0, 0, 0, 0.6);
   --faction-singularity-card-muted: #60a5fa; /* blue brand chrome */
 
   /* ── Singularity terminal session, lights out (#1023) ──

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -492,6 +492,15 @@
      on `#f4f1e8` paper under [data-theme="dark"] — 1.10:1, the headline of every
      S.N.I.D.E. feed card invisible at night, with the actor line at 2.92:1.
 
+     ONE PAIRING STILL DOES NOT CLEAR AA, and it is not reachable from here:
+     `--color-danger` measures 4.28:1 on this stock (it is 4.75 on the na sheet,
+     3.98 on UA's cream, and was 3.90 on the invariant black card this replaces,
+     so the move is an improvement rather than a regression). It is painted by
+     `OwnerControls`, `ComposerControls` and `CommentFlagControl`, none of which
+     takes an ink prop — §3's #1153 case: a missing seam, not a missing
+     measurement. If that seam is ever added, the slip needs its own
+     `-slip-alarm`; `-card-notice`/`-card-credit` are measured on `-card-bg`.
+
      So this is a THIRD flipping S.N.I.D.E. stock beside `-note-*` (the task
      card's clipping) and `-composer-*` (the edit-praxis sheet), declared rather
      than borrowed for #1181's reason: same values today, a different surface's
@@ -500,8 +509,8 @@
 
      WHAT IS NOT HERE, deliberately. Type on the intake bar and type on an acid
      ground both read THE PRESS's theme-invariant constants at the head of this
-     faction's block — `--faction-snide-paper` on the bar (16.7:1 in both
-     themes) and `--faction-snide-ink` on acid (15.5:1) — exactly as
+     faction's block — `--faction-snide-paper` on the bar (16.68:1 light,
+     17.82:1 dark) and `--faction-snide-ink` on acid (15.55:1) — exactly as
      SnideEditPraxis's PRESS_PAPER / PRESS_INK do. Minting slip-local synonyms
      for those would be a second name for one pigment.
 
@@ -511,9 +520,9 @@
      value everywhere they are a DRAWN THING — the sprocket stripe, the rule
      under the bar, the filled submit button, the ransom letter tiles. */
   --faction-snide-slip-paper: #f4f1e8; /* the slip's stock (FLIPS) */
-  --faction-snide-slip-ink: #14110b; /* type on that stock (FLIPS) — 16.7:1 */
-  --faction-snide-slip-muted: #5f5c50; /* byline, timestamp, meta — 5.94:1 */
-  --faction-snide-slip-faint: #6e6b5d; /* character count, hint — 4.80:1 */
+  --faction-snide-slip-ink: #14110b; /* type on that stock (FLIPS) — 16.68:1 */
+  --faction-snide-slip-muted: #5f5c50; /* byline, timestamp, meta — 5.93:1 */
+  --faction-snide-slip-faint: #6e6b5d; /* character count, hint — 4.74:1 */
   --faction-snide-slip-field: #eae6d8; /* an input, a shade off the stock */
   --faction-snide-slip-rule: rgba(20, 17, 11, 0.28); /* a drawn hairline */
   --faction-snide-slip-grain: rgba(20, 17, 11, 0.06); /* the xerox raster */
@@ -521,7 +530,7 @@
      the stock — which is why it needs the acid rule at its foot to read as a
      band at all once the stock goes dark too. */
   --faction-snide-slip-bar: #14110b;
-  --faction-snide-slip-acid-ink: #457000; /* acid that is TEXT — 5.20:1 */
+  --faction-snide-slip-acid-ink: #457000; /* acid that is TEXT — 5.21:1 */
   --faction-snide-slip-pink-ink: #be185d; /* pink that is TEXT — 5.35:1 */
   --faction-snide-slip-shadow: 3px 4px 0 rgba(20, 17, 11, 0.3); /* printed, no blur */
   /* The drop under a single cut-out ransom scrap — a colour, not a whole shadow,
@@ -1565,10 +1574,10 @@
      highlighter. That leaves the bar only 1.4:1 against the stock, so the acid
      rule at its foot is what draws the band here; it is structure, not garnish.
      Acid and pink become text-safe on this ground and both take their bright
-     pigment back. Measured on the dark stock: ink 15.2:1, muted 11.8:1,
-     faint 5.96:1, acid-ink 15.5:1, pink-ink 7.06:1. The shared body's global
-     inks land at primary 15.2:1, secondary 5.70:1, tertiary 6.31:1 — the
-     pairings the previous invariant stock broke. */
+     pigment back. Measured on the dark stock: ink 16.68:1, muted 11.79:1,
+     faint 5.93:1, acid-ink 15.55:1, pink-ink 7.06:1. The shared body's global
+     inks land at primary 15.19:1, secondary 5.70:1, tertiary 6.29:1 — the
+     pairings the previous invariant stock broke (1.10:1 and 2.92:1). */
   --faction-snide-slip-paper: #14110b;
   --faction-snide-slip-ink: #f4f1e8;
   --faction-snide-slip-muted: #cfcdbf;


### PR DESCRIPTION
Frontend only. Dress. Every behaviour in this diff already worked before it landed.

Closes #1198

Built on the seam merged in #1243 and the §12 correction in #1244. No copy added, no shared file touched.

---

## What changed, and where

| File | What |
|---|---|
| `frontend/src/index.css` | +12 SNIDE-only tokens, declared twice (`:root` + `[data-theme="dark"]`) — the `--faction-snide-slip-*` family |
| `frontend/src/components/feed/SnideFeedFrame.tsx` | the chassis, rebuilt: an intercepted xerox slip with the kicker typed into a near-black intake bar |
| `frontend/src/components/comments/voices/SnideComment.tsx` | the same slip as a comment sheet, plus the two F3 behaviours this voice had never inherited |
| `frontend/src/components/feed/__tests__/snideFeedFrame.test.tsx` | new — 7 tests |
| `frontend/src/components/comments/__tests__/snideComment.test.tsx` | new — 14 tests |

**`frontend/src/factions/snide.ts` needed no change.** It has claimed both `comment` and `feedFrame` since before this issue, so the manifest line the epic describes was already there. The issue's footprint lists the file; I read it, and editing it would have been a no-op.

**Nothing shared was touched.** Not the `feed` catalog, not `normalizeFeedItem.ts`, not `FeedCardRouter.tsx`, not the manifest type, not `FeedChassisBand`, not `factions.ts` — `--faction-snide-slip-*` is a faction-namespaced extension (the sanctioned `-note-*` / `-composer-*` / `-amp-*` pattern), not a new entry in `factionCssVar`'s cross-faction suffix contract, so adding it there would have implied eight factions owe a `slip` family.

---

## THE FINDING: this frame's headline was invisible in dark mode on `main`

Not a dress note. `SnideFeedFrame` painted the theme-**invariant** `--faction-snide-paper` (`#f4f1e8`), and the body inside a chassis is faction-blind shared payload — `FeedRowContent`, the three companions, `FeedRowActions` — which paints the app's **global** inks. Those flip. So under `[data-theme="dark"]`:

| pairing | on `main` |
|---|---|
| `--color-text-primary` on the card (the headline, the actor name) | **1.10:1** |
| `--color-text-secondary` (the action line) | **2.92:1** |

`WORLD_ZERO_STYLE.md` §3 already decides this — *"a block whose ink you do not control gets the stock that ink was measured on"* (#1118) — and the two most recent S.N.I.D.E. surfaces already applied it: the task card's clipping (`-note-*`, #1023) and the edit-praxis sheet (`-composer-*`, #1184) both left the invariant pigments for a stock that flips, for the same stated reason. This is the third. On the flipping stock the same three pairings land at 15.19 / 5.70 / 6.29.

The comment voice carried the mirror-image version of it: on the invariant photocopier-black card, in the **light** theme, `--color-text-tertiary` was **3.20:1** on the owner row and `--color-danger` **3.90:1** on Withdraw.

**Every ratio in this PR was produced by the repo's own contrast helper, not by hand.** I wrote nine of them out by arithmetic first and nine were wrong by a rounding step, one (the dark stock's ink) by a point and a half — the last commit is the correction, and I mention it because a hand-measured ratio in a comment reads exactly like a measured one.

---

## What to eyeball

1. **The intake bar is the biggest departure from the previous frame, and it is load-bearing three ways.** The vendored palette gives `--bar:#14110b` / `--barText:#f4f1e8`; I read it as the kicker band. It (a) lets the kicker be **paper** rather than a walked-down acid — bright acid is 1.35:1 as type on the light stock, the #1224 trap — (b) tints the archive node, which paints in `currentColor`, and (c) gives the tag chip a ground its acid edge reads on. If the sheet actually puts the kicker on the stock rather than in a band, that is the one thing to send back.
2. **In dark mode the bar is 1.4:1 against the stock** (`#080706` on `#14110b`) — deliberately below it, on the composer's redaction reasoning: an over-inked band is the darkest thing on the sheet, and lifting it to white turns a card header into a highlighter. **The 2px acid rule at the bar's foot is therefore structure, not garnish** — it is what draws the band's edge at night. Delete it and the dark card loses its header.
3. **The comment card moved from photocopier black to paper.** The vendored spec is explicit (`--wall` is the page, `--paper` the card) and the sheet has a Dark companion, so the card flips. This is the single biggest visual change in the diff and the one most worth a look — the S.N.I.D.E. comment has been a dark slab since ADR-0018.
4. **The comment body lost its forced uppercase and its condensed face.** The vendored type line reads *Anton (headline) · Archivo Black · Special Elite (body)*, so the body is Special Elite, sentence case, on `.content-text`. It was Bebas Neue at `textTransform: uppercase` — a poster treatment applied to somebody else's prose. Only the cut-out **name** is a poster now. If the sheet really does shout the body, say so and I will put it back.
5. **Ransom scrap #1 changed ground.** It was `--faction-snide-paper` on a black card; on a paper card a paper scrap has no edge. It takes `-slip-field` (a shade off the stock, flipping) so the letter still reads as a cut patch in both themes. Scraps 2–5 keep the press's invariant pigments.
6. **The pink scrap's letter went from `#fff` to `--faction-snide-on-accent`** (3.50 → 5.38:1). That deleted one of two hardcoded colour literals the file carried; the other was `rgba(255,255,255,0.04)` as the field ground, now `-slip-field`.
7. **Mobile drops the tilt and the offset shadow, and narrows the sprocket stripe.** One responsive component via `useFormFactor()`, no twin (ADR-0056 / 0058 / 0063). In a single narrow column a `rotate(-0.6deg)` card fouls its neighbours' edges and a hard offset shadow eats the gutter. **`renderToStaticMarkup` has no `window`, so every test here exercises the desktop branch only** — the mobile reading is unverified by anything but reading.
8. **`awaiting_submission` gets nothing, not a disabled anything.** `archive` arrives `null` and the bar simply holds one fewer item; the swipe is gated off in `FeedItemSlot`, above me. A test asserts the string `disabled` is absent from that render.
9. **Comments have no archive affordance anywhere in the diff** — they are never archivable, and `CommentProps` has no `archive` slot to accidentally honour.
10. **The tape is clipped to a half-strip** by `overflow: hidden` on the slip, as it was before. That is the existing "taped from behind" reading, kept on purpose, not a clipping bug.

## The one pairing that still does not clear AA, and why it is not fixed here

`--color-danger` measures **4.28:1** on the new stock. Context, because the number alone is misleading: it is 4.75 on the na sheet, **3.98 on UA's cream** (a documented failure UA routed around in #1168), and it was **3.90 on the invariant black card this replaces** — so the move is an improvement, and short of AA either way.

It is painted by `OwnerControls` (Withdraw, and its error), `ComposerControls` (the over-limit count) and `CommentFlagControl`, **none of which takes an ink prop.** That makes it §3's #1153 case — a missing seam, not a missing measurement — and adding a seam to three shared comment files while seven sibling dress issues are in flight is exactly the shape that has taken `main` red here. It is written down in the token block instead. If that seam ever lands, the slip needs its own `-slip-alarm`: `-card-notice` / `-card-credit` are measured against `-card-bg`, which is the wrong stock now.

## Unbacked states: none skipped, because a chassis cannot draw one

The sheet's expired invite/duel, the duel countdown, the pre-submission deadline and `collaborator_submitted`'s filed/total counts all live in the **body**, which is faction-blind and outside this footprint. The chassis's whole surface is `kicker` / `time` / `tag` / `archive`, and `tag` is handed to it by `FeedCardRouter` — today only ever `"Still waiting"`. So there was no unbacked state available to invent, and I invented none.

## Verified

- **`tsc --noEmit`** clean.
- **`eslint src --max-warnings=0`** clean. No new `no-raw-style-values` suppressions; the two ornament hatches in `SnideComment` were carried, not added to.
- **`vite build`** clean. Entry chunk **135.05 KB** gzip (135.00 before — noise).
- **`vitest run`: 145 files, 2473 passed, 0 failed.** 21 of those are new here.
- **Both token blocks verified in the BUILT stylesheet**, not by counting braces: all 12 names appear exactly twice, once under `:root` and once under `[data-theme="dark"]`, with no `@media` reparenting.
- Rebased onto `origin/main` @ `c3159bda` (after #1246 landed) and re-verified end to end. `index.css` is two hunks, both inside S.N.I.D.E.'s own regions.

## NOT verified

- **No visual QA. This environment cannot screenshot and there is no dev stack, so every layout claim above is inference from code — nobody has looked at this card.** The four worth a human eye: the intake bar in dark mode (item 2), the paper comment card (item 3), the un-shouted body (item 4), and the mobile no-tilt reading (item 7).
- **The mobile branch is untested.** No `window` under `renderToStaticMarkup`, so `useFormFactor` returns `desktop` in every test.
- **Swipe, the 6s undo and the archive write are untested end to end here** — they are `FeedItemSlot`'s, unchanged by this PR, and the harness has no jsdom to fire a pointer event with.
- **The design sheets themselves were not opened by this agent.** `DesignSync` is orchestrator-only; I built against the vendored spec in the issue body and cross-checked it against the code, the epic and §3 rather than taking it on faith. Where it and the code agreed I followed both; nothing in it contradicted either.

## No wording from the S.N.I.D.E. sheet appears in this diff

Every visible string is either a prop from the neutral `feed` catalog (`kicker`, `time`, `tag`) or one of the two pre-existing `praxis.json` → `comments.snide.*` flavour keys (`prompt`, `edited`) that #1243 explicitly left untouched. A test strips the markup and asserts no faction name reaches a text node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
