### PR TITLE
Singularity: comment voice + feed chassis v2

### DIFF
--- a/frontend/src/components/__tests__/singularityFeedFrame.test.tsx
+++ b/frontend/src/components/__tests__/singularityFeedFrame.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Singularity feed chassis — the session window (#1202, epic #1192).
+ *
+ * Scoped to this ONE faction on purpose. `factionFeedFrame.test.tsx` already
+ * loops every frame and asserts the four chrome slots survive; restating that
+ * row here would be the pattern that has taken `main` red before — eight
+ * parallel dress agents each rewriting one shared assertion. These are the
+ * decisions specific to the Singularity sheet.
+ *
+ * Rendered to static markup (no DOM), per the frame-test convention.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so the masthead key resolves to English text.
+import '../../i18n'
+import SingularityFeedFrame from '../feed/SingularityFeedFrame'
+
+function frame({
+  kicker = 'Task completed',
+  time = '2h ago',
+  tag = null as string | null,
+  archive = <button type="button">archive-node</button> as React.ReactNode,
+} = {}): string {
+  return renderToStaticMarkup(
+    <SingularityFeedFrame kicker={kicker} time={time} tag={tag} archive={archive}>
+      <span>card-body</span>
+    </SingularityFeedFrame>,
+  )
+}
+
+describe('SingularityFeedFrame — the window bar is ornament, the prompt line is not', () => {
+  it('hides the masthead and the process handle from assistive tech individually', () => {
+    // #1243 §10: the boot strip used to be `aria-hidden` in ONE piece, which
+    // cannot hold the dismiss control. Each ornament carries the attribute now.
+    const html = frame()
+    expect(html).toMatch(/<span aria-hidden="true"[^>]*>DISPATCH/)
+    expect(html).toMatch(/<span aria-hidden="true"[^>]*>0x[0-9A-F]{4}</)
+  })
+
+  it('places the archive node outside every aria-hidden subtree', () => {
+    // The ✕ is the entire keyboard and screen-reader route to the archive
+    // (swipe is touch-only), so an ornament must never contain it.
+    const html = frame()
+    const before = html.slice(0, html.indexOf('archive-node'))
+    // Every aria-hidden element opened before the control is also closed before
+    // it: the ornaments are all leaf spans on the bar above.
+    const opened = (before.match(/aria-hidden="true"/g) ?? []).length
+    const closed = (before.match(/<\/span>/g) ?? []).length
+    expect(opened).toBeGreaterThan(0)
+    expect(closed).toBeGreaterThanOrEqual(opened)
+  })
+
+  it('draws the kicker, the time and the archive on the same functional row', () => {
+    const html = frame({ tag: 'Still waiting' })
+    expect(html).toContain('Task completed')
+    expect(html).toContain('2h ago')
+    expect(html).toContain('Still waiting')
+    expect(html).toContain('archive-node')
+    expect(html).toContain('<span>card-body</span>')
+  })
+
+  it('prints the tag verbatim and lowercases it in CSS, never in the string', () => {
+    // Copy is neutral and shared (epic #1192). The costume may not mutilate a
+    // translator's word, so the transform is `text-transform`, not `.toLowerCase()`.
+    const html = frame({ tag: 'Still waiting' })
+    expect(html).toContain('Still waiting')
+    expect(html).toContain('text-transform:lowercase')
+  })
+})
+
+describe('SingularityFeedFrame — the process handle identifies a KIND, not an item', () => {
+  it('is stable while the relative time ticks over', () => {
+    // An identifier that mutates under the reader is a lie the sheet never told,
+    // so the handle is derived from the kicker alone.
+    const handle = (html: string) => /0x[0-9A-F]{4}/.exec(html)?.[0]
+    expect(handle(frame({ time: '2h ago' }))).toBe(handle(frame({ time: '3h ago' })))
+  })
+
+  it('differs between two kinds of card', () => {
+    const handle = (html: string) => /0x[0-9A-F]{4}/.exec(html)?.[0]
+    expect(handle(frame({ kicker: 'Task completed' }))).not.toBe(
+      handle(frame({ kicker: 'Duel challenge' })),
+    )
+  })
+})
+
+describe('SingularityFeedFrame — always dark, and the shared body repointed onto it', () => {
+  it('repoints the global ink the shared body paints from', () => {
+    // Singularity is near-black in BOTH themes while the global `--color-*` set
+    // was measured on the app's near-white page, so the body's light-theme halves
+    // land at roughly 1:1 here. Dropping this repoint makes the card unreadable
+    // in light mode without failing anything else.
+    const html = frame()
+    expect(html).toContain('--color-text-primary:var(--faction-singularity-term-bright)')
+    expect(html).toContain('--color-danger:var(--faction-singularity-card-notice)')
+  })
+
+  it('carries no hardcoded colour and no theme ternary', () => {
+    // Every colour is a --faction-singularity-* token; the `[data-theme="dark"]`
+    // cascade flips the phosphor underneath and the chassis never flips at all.
+    const html = frame()
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
+  })
+})

--- a/frontend/src/components/comments/__tests__/singularityComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/singularityComment.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * Singularity comment voice — the session transcript (#1202, epic #1192).
+ *
+ * Rendered to static markup (no DOM) per the comments-test convention, so
+ * `useAuth` resolves to its anonymous default and `useOwnerReveal` takes its
+ * static-render branch (hover assumed capable; the gate is opacity-only, so the
+ * controls stay in the markup either way). That makes every case below the
+ * "row · default" reading.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, it, expect, vi } from 'vitest'
+// Initialize the i18n catalog so the neutral copy keys resolve to English text.
+import '../../../i18n'
+import type { CommentOut } from '../../../api/comments'
+import type { CharacterOut } from '../../../api/auth'
+
+// Control the signed-in viewer: the owner row only exists for the author, and
+// the flag control only for anyone else.
+const authState = vi.hoisted(() => ({ user: null as unknown }))
+vi.mock('../../../auth/AuthContext', () => ({ useAuth: () => authState }))
+
+import SingularityComment from '../voices/SingularityComment'
+
+afterEach(() => {
+  authState.user = null
+})
+
+const COMMENT: CommentOut = {
+  id: 7,
+  praxis_id: 1,
+  task_id: null,
+  body_text: 'signal acquired on the estuary relay',
+  is_edited: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  author: {
+    id: 42,
+    username: 'ada',
+    display_name: 'Adabel',
+    avatar_url: null,
+    faction_slug: 'singularity',
+  },
+  mentions: [],
+}
+
+const CHARACTER: CharacterOut = {
+  id: 42,
+  username: 'ada',
+  display_name: 'Adabel',
+  avatar_url: null,
+  faction_slug: 'singularity',
+  bio: null,
+  location: null,
+  level: 3,
+  score: 0,
+  all_time_score: 0,
+  status: 'active',
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function row(comment: CommentOut = COMMENT): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <SingularityComment mode="row" comment={comment} />
+    </MemoryRouter>,
+  )
+}
+
+function composer(submitting: boolean): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <SingularityComment
+        mode="composer"
+        character={CHARACTER}
+        value=""
+        onChange={() => {}}
+        onSubmit={() => {}}
+        submitting={submitting}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('SingularityComment — a comment is never archivable', () => {
+  it('offers no dismiss control, in either mode', () => {
+    // The sheet's single most important structural fact (epic #1192): only update
+    // cards are archivable. The archive belongs to `FeedItemSlot`, and a comment
+    // never passes through one.
+    for (const html of [row(), composer(false)]) {
+      expect(html).not.toContain('data-feed-archive')
+      expect(html).not.toContain('✕')
+      expect(html).not.toContain('↺')
+    }
+  })
+})
+
+describe('SingularityComment — the shared behaviours are wired, not rebuilt', () => {
+  it('gates the owner row on the shared hover/focus reveal', () => {
+    // `useOwnerReveal` (#1195) fades the row in on pointer OR keyboard, and never
+    // gates at all on a touch device. This voice used to show it always. The gate
+    // is OPACITY, never unmounting — a removed control is unreachable by keyboard
+    // — so the observable half in a static render is the transition it installs.
+    authState.user = { character: { id: COMMENT.author.id } }
+    const html = row()
+    expect(html).toContain('transition:opacity')
+    // The affordance is the shared neutral one, in the shared neutral words.
+    expect(html).toContain('aria-label="edit"')
+    expect(html).toContain('aria-label="delete"')
+  })
+
+  it('shows no foot at all to a viewer who owns nothing and cannot flag', () => {
+    // A hairline over empty space is a state the sheet never draws.
+    expect(row()).not.toContain('transition:opacity')
+    expect(row()).not.toContain('border-top:1px dashed')
+  })
+
+  it('speaks the mention hint in the voice, not the neutral default grey', () => {
+    const html = composer(false)
+    expect(html).toContain('@')
+    // The hint override rides the terminal caption ink, not --color-text-tertiary.
+    expect(html).toContain('var(--faction-singularity-term-dim)')
+  })
+
+  it('marks the composer busy while a post is inflight', () => {
+    expect(composer(true)).toContain('aria-busy="true"')
+    expect(composer(false)).not.toContain('aria-busy="true"')
+  })
+
+  it('draws the blink through the shared reduced-motion-guarded class', () => {
+    // #1003: keyframes live in index.css. An inline `animation:` would bypass the
+    // `prefers-reduced-motion` guard `.sg-cursor` sits behind.
+    const html = composer(false)
+    expect(html).toContain('sg-cursor')
+    expect(html).not.toContain('animation:')
+  })
+})
+
+describe('SingularityComment — the states the sheet draws', () => {
+  it('marks an edited comment', () => {
+    expect(row()).not.toContain('[edited]')
+    expect(row({ ...COMMENT, is_edited: true })).toContain('[edited]')
+  })
+
+  it('links a resolved @mention and leaves an unresolved handle as text', () => {
+    const html = row({
+      ...COMMENT,
+      body_text: 'ping @bex and @ghost',
+      mentions: [{ username: 'bex', display_name: 'Bex', character_id: 99 }],
+    })
+    expect(html).toContain('/characters/99')
+    expect(html).toContain('@ghost')
+  })
+
+  it('draws the comment its own process handle', () => {
+    // Ornament on a real referent (the comment id), never copy.
+    expect(row()).toMatch(/aria-hidden="true"[^>]*>0x007</)
+  })
+})
+
+describe('SingularityComment — always dark, no hardcoded colour', () => {
+  it('carries no hex literal in either mode', () => {
+    // The composer field used to be a hardcoded `#0a1f12`. Every colour is now a
+    // --faction-singularity-* token, so the `[data-theme="dark"]` cascade flips
+    // the phosphor and no `dark ? a : b` ternary is possible.
+    for (const html of [row(), composer(false)]) {
+      expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
+    }
+  })
+})

--- a/frontend/src/components/comments/voices/SingularityComment.tsx
+++ b/frontend/src/components/comments/voices/SingularityComment.tsx
@@ -1,95 +1,335 @@
+import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { factionCssVar } from '../../../utils/factions'
 import FactionAvatar from '../../avatar/FactionAvatar'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
-import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
-import { CommentFlagControl } from '../FlagControl'
+import {
+  CommentEditor,
+  OwnerControls,
+  ownerRevealStyle,
+  useOwnerEdit,
+  useOwnerReveal,
+} from '../OwnerControls'
+import { CommentFlagControl, canFlagComment } from '../FlagControl'
+import { useAuth } from '../../../auth/AuthContext'
 
 /**
- * Singularity — terminal printout (ADR-0018). Dark, green mono, corner brackets,
- * a `>` prompt and (composer) a blinking cursor. Same in light + dark mode, like
- * the task card. Timestamp is a plain relative in terminal type (no T-#### fluff).
+ * Singularity comment voice — THE SESSION TRANSCRIPT (ADR-0006 / ADR-0018;
+ * epic #1192 / #1202, design project 19d52c65,
+ * `Singularity Comment + Update Cards.dc.html`).
+ *
+ * Restyled onto the same terminal the feed chassis wears, so the two halves of
+ * the sheet read as one window: near-black chassis, a standing raster, four blue
+ * corner brackets, Share Tech Mono throughout, a `>` prompt before every line
+ * and a blinking block cursor on the composer.
+ *
+ * **Comments are never archivable** — every sheet in the epic says so in its own
+ * dialect, and it is the sheet's single most important structural fact. There is
+ * no ✕, no swipe and no undo strip anywhere in this file; the archive belongs to
+ * `FeedItemSlot` and to update cards only.
+ *
+ * ## What is inherited rather than built
+ *
+ * All seven states the issue names are states of shared machinery, not of this
+ * file: edit / withdraw / confirm (`useOwnerEdit`), the hover-and-focus gate on
+ * the owner row (`useOwnerReveal`, #1195), @mention autocomplete +
+ * linkification, the live character count and the 500-char cap (#1205), and
+ * flagging. This voice wires them and dresses them. Two were missing here before
+ * #1202: the hover gate (the owner row was always on) and an in-voice `hint`.
+ *
+ * ## Repoints, and why they are three narrow ones rather than one wide one
+ *
+ * Singularity is dark in BOTH themes (WORLD_ZERO_STYLE §6) while the shared
+ * control primitives paint from the global `--color-*` set, which was measured
+ * against the app's near-white page. So `--color-text-tertiary` (the character
+ * count, Cancel, the owner row) and `--color-success` (the "reported" mark) were
+ * dark ink on near-black in light theme.
+ *
+ * The obvious fix — one repoint on the card root, as `SingularityFeedFrame` does
+ * for the shared body — is WRONG here, and each exception is load-bearing:
+ *
+ *  - **`--color-text-primary` / `-secondary` stay put.** Inside this card their
+ *    only reader is the @mention dropdown, a floating popover painting its own
+ *    near-white `--color-surface-scrim` panel. Repointing them would put bright
+ *    phosphor on near-white at about 1.9:1.
+ *  - **`--color-danger` moves only around `OwnerControls`.** There it is ink
+ *    (#dc2626 is 4.02:1 on the terminal — a 3:1 heading floor passes, 9px text
+ *    does not), so it takes the sheet-measured NOTICE exactly as #1168 routed the
+ *    duel seal's forfeit body. `CommentFlagControl` paints the same token as a
+ *    FILL on its selected reason and its submit, and amber under
+ *    `--color-bg-surface` ink would be 1.67:1 — so the flag control keeps the red.
+ *  - **`--color-bg-surface` stays put**, for that same fill.
+ *
+ * That leaves the flag *link* at a pre-existing 4.02:1 which cannot be fixed from
+ * here: the token is both ink and fill inside one shared component, which is a
+ * missing seam rather than a missing measurement (WORLD_ZERO_STYLE, "the seam
+ * beats the ground"). Recorded on the PR, not papered over.
+ *
+ * ## Always dark, in both themes
+ *
+ * No `dark ?` branch. Every value is an existing `--faction-singularity-*` token;
+ * `-term-*` is a two-theme contract whose halves are both near-black, so the
+ * cascade flips the phosphor and never the chassis. Nothing was added to
+ * `index.css` — including the composer field, which used to be a hardcoded
+ * `#0a1f12` and is now the chassis's own `-term-panel`.
  */
-const FONT = factionCssVar('singularity', 'card-font')
 
-function frame(): React.CSSProperties {
-  return {
-    position: 'relative',
-    background: 'var(--faction-singularity-card-bg)',
-    color: 'var(--faction-singularity-card-text)',
-    border: '1px solid var(--faction-singularity-border-hard)',
-    fontFamily: FONT,
-    padding: 'var(--space-md) var(--space-lg)',
-    overflow: 'hidden',
-  }
+const MONO = 'var(--faction-singularity-card-font)' /* Share Tech Mono */
+
+const BG = 'var(--faction-singularity-term-bg)'
+const PANEL = 'var(--faction-singularity-term-panel)' /* the field, inset on the chassis */
+const INK = 'var(--faction-singularity-term-ink)' /* the transcript's prose */
+const BRIGHT = 'var(--faction-singularity-term-bright)' /* the author, the caret */
+const DIM = 'var(--faction-singularity-term-dim)' /* captions */
+const BLUE = 'var(--faction-singularity-term-blue)' /* brackets, prompts, mentions */
+const BORDER = 'var(--faction-singularity-term-border)'
+const HAIR = 'var(--faction-singularity-term-hair)'
+const NOTICE = 'var(--faction-singularity-card-notice)'
+const CREDIT = 'var(--faction-singularity-card-credit)'
+const ON_ACCENT = 'var(--faction-singularity-on-accent)'
+
+/** Terminal caption voice — every small mark on the transcript speaks in it. */
+const LABEL: CSSProperties = {
+  fontFamily: MONO,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.14em',
+  textTransform: 'uppercase',
 }
 
+/**
+ * Ink-only repoint. Safe around any subtree that reads `--color-danger` as TEXT
+ * — `OwnerControls` and `ComposerControls` both do. See the docblock for why it
+ * is not applied to the card root.
+ */
+const INK_REPOINT = {
+  '--color-text-tertiary': DIM,
+  '--color-danger': NOTICE,
+} as CSSProperties
+
+/**
+ * The flag control keeps its red (it fills with the token as well as inking with
+ * it); only the post-report acknowledgement moves, and it has to — the global
+ * success green is #14532d in light theme, about 1.5:1 here.
+ */
+const FLAG_REPOINT = { '--color-success': CREDIT } as CSSProperties
+
+/** The comment's process handle. Ornament on a real referent, never copy. */
+function handleOf(id: number): string {
+  return `0x${id.toString(16).toUpperCase().padStart(3, '0')}`
+}
+
+/** Four corner brackets — the sheet's window tell. Ornament geometry, raw px. */
 function Brackets() {
-  const c = 'var(--faction-singularity-card-text)'
   return (
     <>
-      <span style={{ position: 'absolute', top: 3, left: 3, width: 9, height: 9, borderTop: `1px solid ${c}`, borderLeft: `1px solid ${c}` }} />
-      <span style={{ position: 'absolute', top: 3, right: 3, width: 9, height: 9, borderTop: `1px solid ${c}`, borderRight: `1px solid ${c}` }} />
-      <span style={{ position: 'absolute', bottom: 3, left: 3, width: 9, height: 9, borderBottom: `1px solid ${c}`, borderLeft: `1px solid ${c}` }} />
-      <span style={{ position: 'absolute', bottom: 3, right: 3, width: 9, height: 9, borderBottom: `1px solid ${c}`, borderRight: `1px solid ${c}` }} />
+      <span aria-hidden="true" style={{ position: 'absolute', top: 3, left: 3, width: 9, height: 9, borderTop: `1px solid ${BLUE}`, borderLeft: `1px solid ${BLUE}` }} />
+      <span aria-hidden="true" style={{ position: 'absolute', top: 3, right: 3, width: 9, height: 9, borderTop: `1px solid ${BLUE}`, borderRight: `1px solid ${BLUE}` }} />
+      <span aria-hidden="true" style={{ position: 'absolute', bottom: 3, left: 3, width: 9, height: 9, borderBottom: `1px solid ${BLUE}`, borderLeft: `1px solid ${BLUE}` }} />
+      <span aria-hidden="true" style={{ position: 'absolute', bottom: 3, right: 3, width: 9, height: 9, borderBottom: `1px solid ${BLUE}`, borderRight: `1px solid ${BLUE}` }} />
     </>
+  )
+}
+
+/**
+ * The window both modes sit in: avatar in the margin, a bracketed terminal pane
+ * carrying the standing raster. One shape for a row and for the composer, so a
+ * thread reads as one session rather than a list plus a form.
+ */
+function Pane({
+  avatar,
+  children,
+  containerProps,
+}: {
+  avatar: ReactNode
+  children: ReactNode
+  containerProps?: React.ComponentPropsWithoutRef<'div'>
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
+      {avatar}
+      <div
+        {...containerProps}
+        style={{
+          position: 'relative',
+          flex: 1,
+          minWidth: 0,
+          overflow: 'hidden',
+          background: BG,
+          border: `1px solid ${BORDER}`,
+          color: INK,
+          fontFamily: MONO,
+          padding: 'var(--space-md) var(--space-lg)',
+        }}
+      >
+        {/* The standing raster — a fixed scrim, no motion. Matches the feed
+            chassis; the travelling sweep stays off a list surface. */}
+        <div
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            inset: 0,
+            pointerEvents: 'none',
+            background:
+              'repeating-linear-gradient(0deg, var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)',
+          }}
+        />
+        <Brackets />
+        <div style={{ position: 'relative' }}>{children}</div>
+      </div>
+    </div>
   )
 }
 
 export default function SingularityComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
+  const { user } = useAuth()
+  const reveal = useOwnerReveal()
+
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props
     return (
-      <div style={frame()}>
-        <Brackets />
-        <div style={{ position: 'relative', display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
-          <FactionAvatar character={character} size="sm" />
-          <div style={{ flex: 1 }}>
-            <div style={{ fontSize: 'var(--text-sm)', color: 'var(--faction-singularity-card-muted)', textTransform: 'uppercase', letterSpacing: '0.14em', marginBottom: 'var(--space-sm)' }}>
-              {t('comments.singularity.protocol')}
-              <span aria-hidden className="sg-cursor" style={{ display: 'inline-block', width: 5, height: 9, background: 'var(--faction-singularity-card-text)', marginLeft: 'var(--space-xs)', verticalAlign: 'middle' }} />
-            </div>
-            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-singularity-card-text)" onAccent="var(--faction-singularity-on-accent)" bg="#0a1f12" text="var(--faction-singularity-card-text)" />
+      <Pane avatar={<FactionAvatar character={character} size="sm" />}>
+        <div aria-busy={submitting}>
+          <div style={{ ...LABEL, color: BLUE, marginBottom: 'var(--space-sm)' }}>
+            <span aria-hidden="true">{'> '}</span>
+            {t('comments.singularity.protocol')}
+            {/* `.sg-cursor` owns the blink AND its reduced-motion guard (#1003:
+                keyframes never live in a component). The caret is punctuation on
+                the prompt, so it stays drawn when the blink is stilled. */}
+            <span
+              aria-hidden="true"
+              className="sg-cursor"
+              style={{
+                display: 'inline-block',
+                width: 5,
+                height: 9,
+                background: BRIGHT,
+                marginLeft: 'var(--space-xs)',
+                verticalAlign: 'middle',
+              }}
+            />
+          </div>
+          <div style={INK_REPOINT}>
+            <ComposerControls
+              value={value}
+              onChange={onChange}
+              onSubmit={onSubmit}
+              submitting={submitting}
+              accent={BRIGHT}
+              onAccent={ON_ACCENT}
+              bg={PANEL}
+              text={INK}
+              hint={<span style={{ ...LABEL, color: DIM }}>{t('comments.mentionHint')}</span>}
+            />
           </div>
         </div>
-      </div>
+      </Pane>
     )
   }
+
   const { comment, onEdited, onWithdrawn } = props
-  const slug = comment.author.faction_slug
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
+  const canFlag = canFlagComment(comment, user?.character?.id)
+  // The foot exists only when it holds something. Hidden while editing — the
+  // inline editor owns Save/Cancel then.
+  const showFoot = !owner.editing && (owner.isOwner || canFlag)
+  // On your own comment the foot holds nothing but the gated owner row, so the
+  // rule above it fades with the row: a hairline over empty space is a state the
+  // sheet never draws. A flaggable (someone else's) comment keeps its foot.
+  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+
   return (
-    <div style={frame()}>
-      <Brackets />
-      <div style={{ position: 'relative', display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
-        <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 'var(--space-md)' }}>
-            <Link to={`/characters/${comment.author.id}`} style={{ fontSize: 'var(--text-content)', color: 'var(--faction-singularity-card-text)', textDecoration: 'none' }}>
-              {comment.author.username}
-            </Link>
-            <span style={{ fontSize: 'var(--text-md)', color: 'var(--faction-singularity-card-muted)', whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'baseline', gap: 'var(--space-sm)' }}>
-              {formatCommentTime(slug, comment.created_at)}
-              {comment.is_edited ? ` [${t('comments.singularity.edited')}]` : ''}
-              <OwnerControls owner={owner} />
-              <CommentFlagControl comment={comment} />
-            </span>
-          </div>
-          <div style={{ fontSize: 'var(--text-content)', lineHeight: 1.55, marginTop: 'var(--space-xs)' }}>
-            {owner.editing ? (
-              <CommentEditor owner={owner} accent="var(--faction-singularity-card-text)" onAccent="var(--faction-singularity-on-accent)" bg="#0a1f12" text="var(--faction-singularity-card-text)" />
-            ) : (
-              <>
-                <span style={{ color: 'var(--faction-singularity-card-muted)' }}>&gt; </span>
-                <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-singularity-card-muted)" />
-              </>
-            )}
-          </div>
-        </div>
+    <Pane
+      avatar={<FactionAvatar character={authorToCharacter(comment.author)} size="sm" />}
+      containerProps={reveal.containerProps}
+    >
+      {/* The session header: prompt, the author as the acting process, its
+          handle, then the timestamp. */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 'var(--space-sm)',
+          flexWrap: 'wrap',
+        }}
+      >
+        <span aria-hidden="true" style={{ color: BLUE }}>
+          {'>'}
+        </span>
+        <Link
+          to={`/characters/${comment.author.id}`}
+          style={{
+            fontFamily: MONO,
+            fontSize: 'var(--text-content)',
+            color: BRIGHT,
+            textDecoration: 'none',
+          }}
+        >
+          {comment.author.username}
+        </Link>
+        <span aria-hidden="true" style={{ ...LABEL, color: BLUE }}>
+          {handleOf(comment.id)}
+        </span>
+        <span style={{ ...LABEL, color: DIM, marginLeft: 'auto', whiteSpace: 'nowrap' }}>
+          {formatCommentTime(comment.author.faction_slug, comment.created_at)}
+          {comment.is_edited && (
+            <>
+              {' '}
+              {`[${t('comments.singularity.edited')}]`}
+            </>
+          )}
+        </span>
       </div>
-    </div>
+
+      {/* The transcript line. User-authored free text, so the content floor (§4)
+          in both the resting and the editing state — the editor's textarea
+          inherits the size through `font: inherit`. */}
+      <div
+        style={{
+          fontSize: 'var(--text-content)',
+          lineHeight: 1.55,
+          marginTop: 'var(--space-sm)',
+          color: INK,
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {owner.editing ? (
+          <div style={INK_REPOINT}>
+            <CommentEditor owner={owner} accent={BRIGHT} onAccent={ON_ACCENT} bg={PANEL} text={INK} />
+          </div>
+        ) : (
+          <>
+            <span aria-hidden="true" style={{ color: BLUE }}>
+              {'> '}
+            </span>
+            <MentionText body={comment.body_text} mentions={comment.mentions} accent={BLUE} />
+          </>
+        )}
+      </div>
+
+      {showFoot && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'baseline',
+            flexWrap: 'wrap',
+            gap: 'var(--space-md)',
+            marginTop: 'var(--space-md)',
+            paddingTop: 'var(--space-sm)',
+            borderTop: `1px dashed ${HAIR}`,
+            ...footGate,
+          }}
+        >
+          {/* Two repoints, deliberately not one — see the docblock. */}
+          <span style={INK_REPOINT}>
+            <OwnerControls owner={owner} reveal={reveal} />
+          </span>
+          <span style={FLAG_REPOINT}>
+            <CommentFlagControl comment={comment} />
+          </span>
+        </div>
+      )}
+    </Pane>
   )
 }

--- a/frontend/src/components/feed/SingularityFeedFrame.tsx
+++ b/frontend/src/components/feed/SingularityFeedFrame.tsx
@@ -1,38 +1,152 @@
+import type { CSSProperties } from 'react'
 import i18n from '../../i18n'
-import FeedChassisBand from './FeedChassisBand'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
- * Singularity per-faction feed frame (surface #12, SPEC-faction-ui-profile.md).
+ * Singularity activity-feed CHASSIS — the session window (surface #12,
+ * SPEC-faction-ui-profile.md; epic #1192 / #1202, design project 19d52c65,
+ * `Singularity Comment + Update Cards.dc.html`).
  *
- * A thin presentational WRAPPER: it skins the neutral feed card (`children`) as a
- * terminal dispatch/printout. The frame supplies only the OUTER chrome — a
- * terminal-black slab with a signal-blue inset border, scanline overlay, and a
- * `>` boot/prompt strip header — and renders the unchanged card as the printout
- * body. It must NOT reimplement the card internals; those arrive via `children`.
+ * ## What this layer is, and what it is not
  *
- * #1194: the boot strip is now also the CHASSIS BAND. It used to be
- * `aria-hidden` in one piece, which cannot hold the dismiss control — the
- * keyboard and screen-reader route to the archive is the whole reason that
- * control exists (swipe alone would not provide one). The two ornamental spans
- * carry `aria-hidden` individually instead, so the strip's chrome stays silent
- * while the kicker, the time and the ✕ are announced.
+ * The middle of the three layers #1194 split apart. `FeedItemSlot` above owns
+ * the ARCHIVE — the ✕, the touch swipe, the immediate write, the six-second
+ * undo strip — and is faction-blind; the body below (`FeedRowContent` or one of
+ * the three companions) is faction-blind too. This file owns the physical
+ * chrome and nothing else, and it is the only layer the dress issue rewrote.
+ * Nothing here re-implements a behaviour: `archive` arrives as a finished node
+ * and is PLACED.
  *
- * Singularity is ALWAYS DARK: its --faction-singularity-* tokens are identical in
- * both themes, so the container styles itself with them and reads as a terminal
- * regardless of the global theme — it never mutates data-theme.
+ * ## The window
+ *
+ * Two tiers, which is how the sheet draws it:
+ *
+ *   1. the WINDOW BAR — three lamps, the process name, a right-aligned hex
+ *      handle. Pure ornament, `aria-hidden` piece by piece.
+ *   2. the PROMPT LINE — `>` then the kicker, the tag as a boxed readout, the
+ *      time, and the dismiss control. Every functional slot lives here.
+ *
+ * The split is deliberate and not merely decorative. #1243 §10/§11 record the
+ * two mistakes available at this seam: the boot strip used to be `aria-hidden`
+ * **in one piece**, which cannot hold the dismiss control (that control is the
+ * whole keyboard and screen-reader route to the archive — swipe is touch-only),
+ * and a functional control must never land under an ornament. So the ornament
+ * tier holds no control and the control tier holds no ornament.
+ *
+ * ## Why the shared body's ink is repointed for the subtree
+ *
+ * WORLD_ZERO_STYLE §6: Singularity is dark in BOTH themes. The shared body
+ * paints itself from the global `--color-*` set, which was measured against the
+ * app's near-white page, so on this chassis its light-theme halves land at
+ * roughly 1:1 — the headline, the action clause and every companion's decline
+ * button were dark ink on near-black. This is the case the style doc names
+ * ("Singularity had to, being near-black in both themes where the shared
+ * component assumed light-in-light"), and the same repoint `ON_CHASSIS_INK`
+ * makes on `SingularityPraxisDetail`. Every value is an existing Singularity
+ * token, so the `[data-theme="dark"]` cascade still flips the phosphor
+ * underneath and no `dark ?` branch appears anywhere.
+ *
+ * A repoint rather than a fork, because the body is shared and faction-blind by
+ * contract — and rather than a bag of ink props, because none of the four slots
+ * is "the one that was meant": the whole body is on the wrong ground here.
+ *
+ * ## Copy: none of the sheet's words ship
+ *
+ * Epic #1192 — the Unaffiliated sheet is the copy spec and the other eight are
+ * visual chassis only. `kicker`, `tag` and `time` arrive already resolved from
+ * the neutral `feed` catalog and are printed verbatim. The one string this file
+ * names is `feed:frame.singularity.masthead`, which F2 authored for exactly this
+ * slot. The costume lowercases the tag and letter-spaces the kicker; it
+ * mutilates no word, the same call `SingularityPraxisDetail`'s `LABEL` makes in
+ * the other direction.
+ *
+ * ## Always dark, in both themes
+ *
+ * No `dark ?` branch. `--faction-singularity-term-*` is a two-theme contract
+ * whose halves are BOTH near-black — the cascade flips the phosphor, never the
+ * chassis (WORLD_ZERO_STYLE §6). The sheet ships no light inversion and none is
+ * invented here. Nothing new was declared in `index.css`: every value below is a
+ * Singularity token that already shipped with the v2 task card.
  */
 
-// Token shorthands — every color resolves to a --faction-singularity-* var.
-const VOID = 'var(--faction-singularity-card-bg)' // terminal black
-const PHOSPHOR = 'var(--faction-singularity-card-accent)' // green
-const SIGNAL = 'var(--faction-singularity-card-muted)' // blue chrome
-const BORDER_HARD = 'var(--faction-singularity-border-hard)'
-const FONT = 'var(--font-faction-terminal)'
+const MONO = 'var(--faction-singularity-card-font)' /* Share Tech Mono */
 
-// color-mix helper for the blue chrome at reduced opacity.
-const signal = (pct: number): string =>
-  `color-mix(in srgb, ${SIGNAL} ${pct}%, transparent)`
+const BG = 'var(--faction-singularity-term-bg)' /* the chassis */
+const CHROME = 'var(--faction-singularity-term-chrome)' /* the window bar */
+const PANEL = 'var(--faction-singularity-term-panel)'
+const READOUT = 'var(--faction-singularity-term-readout)' /* a boxed well */
+const INK = 'var(--faction-singularity-term-ink)'
+const BRIGHT = 'var(--faction-singularity-term-bright)'
+const DIM = 'var(--faction-singularity-term-dim)'
+const BLUE = 'var(--faction-singularity-term-blue)'
+const BORDER = 'var(--faction-singularity-term-border)'
+const HAIR = 'var(--faction-singularity-term-hair)'
+const NOTICE = 'var(--faction-singularity-card-notice)'
+
+/**
+ * The repoint the shared body gets. See the docblock — the global inks were
+ * chosen against a near-white page and this chassis is near-black in both
+ * themes, so their light halves are unreadable here.
+ *
+ * `--color-danger` goes to the sheet-measured NOTICE for the same reason #1168
+ * routed the duel seal's forfeit BODY there: `#dc2626` measures 4.02:1 on the
+ * terminal, which clears a 3:1 heading floor and fails a 4.5:1 text one, and
+ * every danger-inked string in a feed companion (the withdraw affordance, the
+ * error line) is text at label tier.
+ *
+ * `--color-text-on-accent` is deliberately NOT repointed. The companions' accept
+ * buttons paint it on `--badge-duel` (#dc2626), where white is 4.83:1 and the
+ * near-black `-on-accent` would be 3.92:1 — repointing it to fix one pairing
+ * would break the other. The one place it is genuinely wrong on this chassis is
+ * `FeedRowContent`'s monogram disc (white on the phosphor fill, 1.74:1), and
+ * that needs an ink seam on the shared body, which is outside this footprint.
+ */
+const ON_CHASSIS_INK = {
+  '--color-text-primary': BRIGHT,
+  '--color-text-secondary': INK,
+  '--color-text-tertiary': DIM,
+  '--color-border': HAIR,
+  '--color-danger': NOTICE,
+  '--color-bg-surface': PANEL,
+  '--color-bg-surface-alt': READOUT,
+} as CSSProperties
+
+/** Terminal label voice — every small mark on the chrome speaks in it. */
+const LABEL: CSSProperties = {
+  fontFamily: MONO,
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  whiteSpace: 'nowrap',
+}
+
+/** One of the window bar's three lamps. Ornament geometry, so raw px. */
+function Lamp({ fill }: { fill: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      style={{ width: 8, height: 8, borderRadius: '50%', background: fill, display: 'block' }}
+    />
+  )
+}
+
+/**
+ * The card KIND's process handle, drawn right-aligned on the window bar as the
+ * sheet draws it. Ornament, never copy and never an item identifier: it is a
+ * stable hash of the kind label, so every "Task completed" card prints the same
+ * handle — which is what a terminal would do, one process per kind.
+ *
+ * It is NOT derived from the timestamp, on purpose. A relative time ticks over
+ * ("2h ago" → "3h ago"), so a handle mixed with it would mutate under the
+ * reader — an identifier that changes while identifying nothing is a lie the
+ * sheet never told.
+ */
+function processHandle(kicker: string): string {
+  let hash = 0x9e37
+  for (let index = 0; index < kicker.length; index += 1) {
+    hash = (hash * 31 + kicker.charCodeAt(index)) & 0xffff
+  }
+  return `0x${hash.toString(16).toUpperCase().padStart(4, '0')}`
+}
 
 export default function SingularityFeedFrame({
   kicker,
@@ -42,28 +156,26 @@ export default function SingularityFeedFrame({
   children,
 }: FeedFrameProps) {
   return (
-    <div
+    <article
       style={{
         position: 'relative',
         overflow: 'hidden',
-        border: `1px solid ${BORDER_HARD}`,
-        background: VOID,
-        color: PHOSPHOR,
-        fontFamily: FONT,
+        boxSizing: 'border-box',
+        borderRadius: 8,
+        border: `1px solid ${BORDER}`,
+        background: BG,
+        color: INK,
+        fontFamily: MONO,
+        boxShadow: 'var(--faction-singularity-term-shadow)',
       }}
     >
-      {/* inset signal border */}
-      <div
-        aria-hidden="true"
-        style={{
-          position: 'absolute',
-          inset: 4,
-          border: `1px solid ${signal(18)}`,
-          pointerEvents: 'none',
-          zIndex: 3,
-        }}
-      />
-      {/* scanline overlay */}
+      {/*
+        The standing raster — a fixed scrim, no motion. The travelling `.sg-scan`
+        sweep the task card and the detail page carry is deliberately ABSENT
+        here: it animates `top`, a layout property, and a feed is a long list
+        where twenty simultaneous copies is a per-frame cost a single card never
+        pays. The sheet draws one card; the feed draws a page of them.
+      */}
       <div
         aria-hidden="true"
         style={{
@@ -72,11 +184,11 @@ export default function SingularityFeedFrame({
           pointerEvents: 'none',
           zIndex: 3,
           background:
-            'repeating-linear-gradient(to bottom,transparent,transparent 2px,rgba(255,255,255,0.018) 2px,rgba(255,255,255,0.018) 4px)',
+            'repeating-linear-gradient(0deg, var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)',
         }}
       />
 
-      {/* boot/prompt strip header — also the chassis band */}
+      {/* TIER 1 — the window bar. Ornament only; it holds no control. */}
       <div
         style={{
           position: 'relative',
@@ -84,29 +196,102 @@ export default function SingularityFeedFrame({
           display: 'flex',
           alignItems: 'center',
           gap: 'var(--space-sm)',
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: boot/prompt chrome strip, sized around its raw 7px terminal type.
-          padding: '6px 12px',
-          borderBottom: `1px solid ${signal(20)}`,
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: terminal chrome strip, part of the frame illustration
-          fontSize: 7,
-          letterSpacing: '0.18em',
-          color: signal(55),
-          textTransform: 'uppercase',
+          padding: 'var(--space-xs) var(--space-md)',
+          background: CHROME,
+          borderBottom: `1px solid ${HAIR}`,
         }}
       >
-        <span aria-hidden="true" style={{ color: PHOSPHOR, flexShrink: 0 }}>
-          {'>'}
+        <span aria-hidden="true" style={{ display: 'flex', gap: 'var(--space-xs)', flexShrink: 0 }}>
+          <Lamp fill={DIM} />
+          <Lamp fill={BLUE} />
+          <Lamp fill={BRIGHT} />
         </span>
-        <span aria-hidden="true" style={{ flexShrink: 0 }}>
+        <span
+          aria-hidden="true"
+          style={{
+            ...LABEL,
+            fontSize: 'var(--text-base)',
+            color: DIM,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
           {i18n.t('feed:frame.singularity.masthead')}
         </span>
-        <div style={{ flex: 1, minWidth: 0, color: signal(75) }}>
-          <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
-        </div>
+        <span
+          aria-hidden="true"
+          style={{ ...LABEL, fontSize: 'var(--text-base)', color: BLUE, marginLeft: 'auto' }}
+        >
+          {processHandle(kicker)}
+        </span>
       </div>
 
-      {/* printout body — the neutral card, unchanged */}
-      <div style={{ position: 'relative', zIndex: 2 }}>{children}</div>
-    </div>
+      {/*
+        TIER 2 — the prompt line. All four chrome slots the contract names live
+        here (`kicker`, `tag`, `time`, `archive`); `color: BRIGHT` on the row is
+        what tints the archive node, which paints in `currentColor`.
+      */}
+      <div
+        style={{
+          position: 'relative',
+          zIndex: 2,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--space-sm)',
+          flexWrap: 'wrap',
+          padding: 'var(--space-xs) var(--space-md)',
+          borderBottom: `1px dashed ${HAIR}`,
+          color: BRIGHT,
+        }}
+      >
+        <span aria-hidden="true" style={{ color: BLUE, flexShrink: 0 }}>
+          {'>'}
+        </span>
+        <span
+          style={{
+            ...LABEL,
+            fontSize: 'var(--text-md)',
+            color: BRIGHT,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+          }}
+        >
+          {kicker}
+        </span>
+        {tag && (
+          /*
+            The sheet draws its status marks as boxed lowercase readouts on the
+            blue well. The catalog's word is printed unchanged — `lowercase` is
+            CSS costume, not a rewrite — and the only tag that exists today is
+            "Still waiting": an archived invite or challenge stays unanswered
+            (ADR-0066).
+          */
+          <span
+            style={{
+              ...LABEL,
+              fontSize: 'var(--text-base)',
+              textTransform: 'lowercase',
+              letterSpacing: '0.08em',
+              color: BLUE,
+              background: READOUT,
+              border: `1px solid ${BORDER}`,
+              padding: '0 var(--space-xs)',
+              flexShrink: 0,
+            }}
+          >
+            {tag}
+          </span>
+        )}
+        <span style={{ ...LABEL, fontSize: 'var(--text-base)', color: DIM, marginLeft: 'auto' }}>
+          {time}
+        </span>
+        {archive}
+      </div>
+
+      {/* The printout — the shared body, unchanged, on repointed ink. */}
+      <div style={{ position: 'relative', zIndex: 2, ...ON_CHASSIS_INK }}>{children}</div>
+    </article>
   )
 }


### PR DESCRIPTION
Frontend only. **Dress only** — every behaviour already worked before this landed.

Closes #1202

Part of epic #1192, consuming the chassis seam from #1243. Footprint is 4 files: the chassis, the voice, and one guard file for each.

---

## Two premises in the brief were already satisfied, and one instruction was impossible

1. **"Rewrite `SingularityFeedFrame.tsx` from a `{ children }` wrapper into a chassis taking `FeedFrameProps`."** #1243 already did this — it converted all eight frames, deliberately ("a widened seam invalidates anything queued against the old one"). So this PR is the sheet, not the seam.
2. **"a new faction-linked variable goes in BOTH `index.css` and `factions.ts`"** — **no new variable was needed.** `--faction-singularity-term-*` **is** this sheet's palette already, minted for the v2 task card (#1023): `term-bg` = the sheet's `--bg` `#07130C`, `term-chrome` = `--chrome` `#0C2016`, `term-ink` = `--ink`, `term-bright` = `--bright`, `term-border`/`-hair`/`-cta-*` byte-identical. The two the repo *walked up* for AA (`--blue` `#2563EB` → `#4c7fef`, `--dim` `#3D8B5E` → `#409363`) are the shipped values and the sheet's annotations were measured on the sheet's own plate, so the walked-up pair wins. **`index.css` is untouched**, and `factions/singularity.ts` already claimed both `comment` and `feedFrame`. Zero conflict surface with the seven sibling branches.
3. **The `<pre>` key/value readout (`agent :` / `task :` / `points :`) and the boxed vote-delta readout are NOT built, and cannot be from here.** Those are the *body*, and the body (`FeedRowContent`) is faction-blind by contract — decision 2 of the epic and rule 5 of the seam. Building them would mean editing a shared file the issue explicitly forbids. The body does inherit Share Tech Mono and the phosphor ink from the chassis, so it reads as a printout; it is not keyed.

## What the chassis is

Two tiers, and the split is load-bearing rather than decorative:

| tier | holds | a11y |
|---|---|---|
| **window bar** | three 8px lamps (dim · blue · bright), the process name, a right-aligned hex handle | ornament, `aria-hidden` **piece by piece** |
| **prompt line** | `>` · `kicker` · the `tag` as a boxed readout · `time` · `archive` | every functional slot |

#1243 §10/§11 record both mistakes available at this seam: the old boot strip was `aria-hidden` **in one piece** (which cannot hold the dismiss control — the whole keyboard and screen-reader route to the archive, since swipe is touch-only), and a functional control must not land under an ornament. So the ornament tier holds no control and the control tier holds no ornament.

`color: BRIGHT` on the prompt line is what tints the archive node — it paints in `currentColor` and is placed, never rebuilt. No swipe, no undo strip, no 6s timer in this diff.

## The real defect this dress fixes

**The shared body was dark-on-dark in light theme.** Singularity is near-black in *both* themes (WORLD_ZERO_STYLE §6) while `FeedRowContent` and all three companions paint from the global `--color-*` set, which was measured against the app's near-white page. So in light mode the headline, the action clause and every companion's decline button were roughly 1:1 on the chassis.

Fixed with the same subtree repoint `SingularityPraxisDetail`'s `ON_CHASSIS_INK` makes, same values: `text-primary`→`term-bright`, `-secondary`→`term-ink`, `-tertiary`→`term-dim`, `border`→`term-hair`, `bg-surface`→`term-panel`, `bg-surface-alt`→`term-readout`, and `danger`→`card-notice` (the #1168 call: `#dc2626` is **4.02:1** here, which clears a 3:1 heading floor and fails a 4.5:1 text one). Every value is an existing Singularity token, so the `[data-theme="dark"]` cascade still flips the phosphor and there is no `dark ?` branch anywhere.

**`--color-text-on-accent` is deliberately NOT repointed**, and this is the interesting one: the companions' accept buttons paint it on `--badge-duel` (`#dc2626`), where white is 4.83:1 and the near-black `-on-accent` would be 3.92:1 — a repoint fixing one pairing breaks the other.

## The comment voice

Restyled onto the same terminal so both halves of the sheet read as one window. **Comments are never archivable** — the sheet's single most important structural fact — so there is no ✕, no swipe and no undo strip in that file, and a test asserts it.

Two shared behaviours were **missing** here and are now wired (not reimplemented):

- **`useOwnerReveal` (#1195).** The owner's edit/withdraw row was always-on in this voice. It now reveals on hover **or** keyboard focus and never gates on a touch device, and it moved to a hairline foot beside the flag control — the arrangement `DefaultComment` ships. The foot only exists when it holds something, and on your own comment the rule fades with the row.
- **An in-voice `hint`**, so "@ to mention" speaks in terminal dim instead of the neutral grey default (which was near-invisible here).

Plus: **the last hardcoded hex in the file is gone.** The composer/editor field was `bg="#0a1f12"`, twice; it is now `--faction-singularity-term-panel`.

**Three narrow repoints in the voice rather than one wide one — each exception is load-bearing:**

- `--color-text-primary` / `-secondary` **stay put.** Inside a comment card their only reader is the @mention dropdown, a floating popover painting its own near-white `--color-surface-scrim`. Repointing them would put bright phosphor on near-white at ~1.9:1.
- `--color-danger` moves **only around `OwnerControls`**, where it is ink. `CommentFlagControl` paints the same token as a **fill** on its selected reason and submit, and amber under `--color-bg-surface` ink would be 1.67:1.
- `--color-success` moves **only around the flag control** — the global success green is `#14532d` in light theme, ~1.5:1 here.

## Decisions worth challenging

1. **The travelling `.sg-scan` sweep is deliberately absent** from both surfaces; the standing raster stays. `sg-scan-sweep` animates `top`, a layout property, and a feed is a long list — twenty simultaneous copies is a per-frame cost a single task card never pays. The sheet draws one card. Say the word and it goes back on.
2. **The window name is `feed:frame.singularity.masthead`** ("DISPATCH — SIGNAL ONLINE"), the key F2 authored for exactly this slot. The sheet draws a `*.log` filename; a `<kind>.log` would mean either minting copy into the shared catalog (forbidden — F2 authored it once, and eight agents editing one namespace has taken `main` red) or printing an untranslated backend type key. So the `.log` flavour is carried by the lamps and the handle instead.
3. **The hex handle identifies a KIND, not an item.** It is a stable hash of the kicker, so every "Task completed" card prints the same handle — one process per kind, which is what a terminal would do. It is **not** mixed with the timestamp on purpose: a relative time ticks over, and an identifier that mutates under the reader while identifying nothing is a lie the sheet never told. The comment's handle *does* have a real referent (`comment.id`), same idiom as `SingularityPraxisDetail`'s `hexOf`.
4. **The tag chip is lowercased in CSS, never in the string.** The sheet draws `friend` / `your_stuff` / `foe` / `system` / `invite` / `collab` literally, and it is the clearest statement of the `tag` slot's intent of any sheet — but those are a *taxonomy* and `tag` is one nullable status string whose only value today is "Still waiting". The catalog's word is printed verbatim; `text-transform: lowercase` is costume. No value was renamed and nothing was added to `feed.json`.
5. **No `useFormFactor()` branch**, matching all eight sibling frames. There is literally one component (ADR-0056 / 0058 / 0063) and the chassis has no fixed dimension: it fills its grid cell, the masthead ellipsises at `min-width: 0`, and the prompt line wraps. A form-factor branch would have nothing to decide.
6. **Unbacked states**: none were built, and this sheet drew none that the API cannot produce. Expiry, duel countdowns and filed/total counts are absent because the backend has no such fields (epic gap table).

## What to eyeball

1. **Light mode on the Updates page.** This is the change with the most behind it and none of it has been seen. The body repoint is what makes a Singularity card readable at all in light theme; if a slot still comes out dark-on-dark, it reads from a token not in `ON_CHASSIS_INK`.
2. **The prompt line at narrow widths.** `kicker` · chip · `time` · ✕ all wrap; the ✕ must not end up alone on its own line beneath the timestamp, and it must stay reachable.
3. **A `duel_challenge` and a `collab_invite` inside the chassis** — accept, decline and the accepted variants. Handlers did not move, but those are the tallest bodies and the busiest ink.
4. **The flag control on a Singularity comment.** Its red is intact by choice (see above), so the report *link* is still **4.02:1** on the terminal. That is a pre-existing sub-AA pairing I could not fix from here without breaking two fills — `FlagControl` reads `--color-danger` as both ink and fill inside one shared component, which is a missing seam rather than a missing measurement. **Worth its own issue.**
5. **`FeedRowContent`'s monogram disc** for a Singularity actor with no avatar: white on the phosphor fill, **1.74:1**. Same shape of problem — it needs an ink seam on the shared body, which is outside this footprint. **Also worth an issue.**
6. **The three lamps are dim / blue / bright**, per this sheet — *not* the red/amber/green traffic light `SingularityTaskCard` uses. Two Singularity surfaces now disagree about lamp colour. Deliberate (each follows its own sheet), but somebody should decide whether it stays that way.
7. **The comment's `>` prompt sits inline before the body**, so a wrapped second line does not hang under it. Check a long comment.

## Verified

- `tsc --noEmit`: clean.
- `eslint src --max-warnings=0`: clean. **No new `no-raw-style-values` suppressions** — the old frame carried two (a raw `6px 12px` padding and a raw `fontSize: 7`) and both are gone; everything is on `--space-*` / `--text-*` now.
- `vite build`: clean. Entry chunk **135.06 KB** gzip, unmoved.
- `vitest run`: **145 files, 2470 passed, 0 failed.** 18 of those are new here.
- Rebased onto `origin/main` @ `c3159bda` (after #1246 landed, which touched `FeedRowContent`) and re-verified end to end after the rebase. No file overlap with anything that has landed.
- No string from the design sheet appears in the diff. `feed.json` and `praxis.json` are untouched.

## NOT verified — visual QA is outstanding

**No screenshot exists of any of this.** This environment cannot render a page and there is no dev stack, so **every layout and legibility claim above is inference from code plus hand-computed contrast, not observation.** The contrast figures are arithmetic on the token values; the wrapping, the lamp sizes, the raster density and the foot's rule are unlooked-at. A human on the Updates page in **both themes** is the real check, and the seven items above are where to start.

The hover gate and the reveal transition are asserted at their seams, not driven: the frontend harness is `renderToStaticMarkup` only — no jsdom, so no effect runs and no pointer event fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
