### PR TITLE
Coven: the candlelit slip takes the feed chassis and the comment voice

### DIFF
--- a/frontend/src/components/comments/voices/CovenComment.tsx
+++ b/frontend/src/components/comments/voices/CovenComment.tsx
@@ -132,7 +132,9 @@ export default function CovenComment(props: CommentProps) {
         <div
           className="content-text"
           aria-busy={submitting}
-          style={{ fontFamily: READING, color: INK }}
+          // 500, not the default 400: index.html loads Cormorant Garamond at
+          // 500/600/700 only, so an unspecified weight would be synthesised.
+          style={{ fontFamily: READING, fontWeight: 500, color: INK }}
         >
           <ComposerControls
             value={value}
@@ -214,6 +216,8 @@ export default function CovenComment(props: CommentProps) {
         style={{
           marginTop: 'var(--space-sm)',
           fontFamily: READING,
+          // See the composer: Cormorant's 400 is not among the loaded weights.
+          fontWeight: 500,
           color: INK,
           lineHeight: 1.55,
           overflowWrap: 'anywhere',

--- a/frontend/src/components/comments/voices/CovenComment.tsx
+++ b/frontend/src/components/comments/voices/CovenComment.tsx
@@ -1,34 +1,117 @@
+import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import FactionAvatar from '../../avatar/FactionAvatar'
+import { useAuth } from '../../../auth/AuthContext'
 import { formatCommentTime } from '../../../utils/commentTime'
 import { type CommentProps, authorToCharacter, ComposerControls, MentionText } from '../shared'
-import { CommentEditor, OwnerControls, useOwnerEdit } from '../OwnerControls'
-import { CommentFlagControl } from '../FlagControl'
+import {
+  CommentEditor,
+  OwnerControls,
+  ownerRevealStyle,
+  useOwnerEdit,
+  useOwnerReveal,
+} from '../OwnerControls'
+import { CommentFlagControl, canFlagComment } from '../FlagControl'
 
 /**
- * Cozy Coven — `{handle}.exe` (ADR-0018). Reuses the task-card window
- * chrome verbatim (--faction-coven-win-border / title gradient / dotted body),
- * retitled to the author's handle. Handwritten Caveat body.
+ * Cozy Coven — THE CANDLELIT SLIP, as a comment (dress issue #1197, epic #1192).
+ *
+ * A slip of the coven's own paper: a candle-glow gradient along its top edge, a
+ * near-white sheet under it, the byline hand-set in Grenze Gotisch and the
+ * reading copy in Cormorant Garamond. The braided thread rules the foot off the
+ * body, and Caveat survives as the one hand-written mark — the "edited"
+ * marginalia, which is what a pencilled amendment on a slip looks like.
+ *
+ * THIS REPLACES the `{handle}.exe` window (ADR-0018's original Coven voice). The
+ * window metaphor was retired for this faction wholesale by ADR-0055 / ADR-0056
+ * (task card) and #1031 (task detail); the comment and the feed card were the
+ * last two surfaces wearing it, and #1197 dresses both.
+ *
+ * THE FOUR FACES, and why the body moved off Caveat. The sheet names Grenze
+ * Gotisch (display), Quicksand (chrome), Cormorant Garamond (reading) and Caveat
+ * (hand) — four ROLES, not four decorations. A comment body is user-authored
+ * content, so it takes the reading face at the content floor (§4 role floor);
+ * hand-lettering a stranger's paragraph is the one place Caveat costs
+ * legibility. The hand keeps the marginalia, which is the job it is named for.
+ *
+ * BEHAVIOUR IS NOT MINE. Edit, withdraw, flag, @mentions, the live character
+ * count and the submitting state all live in the shared helpers, and the owner
+ * row's hover/focus gate is F3's `useOwnerReveal` (#1195) — wired here in two
+ * lines, never re-implemented. This file owns chrome and ink only.
+ *
+ * Seven states, one responsive component (ADR-0056 / 0058 / 0063 — no mobile
+ * twin): row · default | row + mention | row · edited | row · yours (hover) |
+ * row · editing | composer · empty | composer · submitting.
+ *
+ * Colour is entirely `--faction-coven-slip-*` / `-ward-*` — both themes already
+ * declared, both already measured (#1023 / #1031). No hex, no ternary; the theme
+ * flips through the `[data-theme="dark"]` cascade.
  */
-function Dot({ color }: { color: string }) {
-  return <span style={{ width: 9, height: 9, borderRadius: '50%', background: color, border: '1.2px solid rgba(255,255,255,0.7)' }} />
+
+const CHROME = 'var(--font-faction-rounded)' /* Quicksand */
+const READING = 'var(--font-faction-serif)' /* Cormorant Garamond */
+const HAND = 'var(--font-faction-script)' /* Caveat */
+const DISPLAY = 'var(--font-faction-witch)' /* Grenze Gotisch */
+
+const INK = 'var(--faction-coven-slip-ink)'
+const LABEL = 'var(--faction-coven-slip-label)'
+/** The CTA pair, measured at both ends in both themes (#1023). */
+const ACCENT = 'var(--faction-coven-slip-cta-from)'
+const ON_ACCENT = 'var(--faction-coven-slip-cta-ink)'
+/** The inset field: a tinted stop of the slip's own gradient, so a textarea
+ *  reads as pressed into the paper rather than painted on top of it. */
+const FIELD = 'var(--faction-coven-slip-from)'
+
+/** Small-caps chrome voice — the byline's quiet marks speak in it. */
+const CAPTION: CSSProperties = {
+  fontFamily: CHROME,
+  fontWeight: 700,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  color: LABEL,
 }
 
-function Window({ title, children }: { title: string; children: React.ReactNode }) {
+/**
+ * The slip both modes sit on: avatar in the margin, a near-white sheet under a
+ * candle-glow edge. One shape for a row and for the composer, so the thread
+ * reads as one stack of slips rather than a list plus a form.
+ */
+function Slip({
+  avatar,
+  children,
+  containerProps,
+}: {
+  avatar: ReactNode
+  children: ReactNode
+  containerProps?: React.ComponentPropsWithoutRef<'div'>
+}) {
   return (
-    <div style={{ border: '2px solid var(--faction-coven-win-border)', borderRadius: 11, overflow: 'hidden' }}>
-      <div style={{ display: 'flex', alignItems: 'center', padding: 'var(--space-sm) var(--space-md)', background: 'linear-gradient(180deg, var(--faction-coven-title-from), var(--faction-coven-title-to))', borderBottom: '2px solid var(--faction-coven-win-border)',
-        // eslint-disable-next-line local/no-raw-style-values -- ornament: rhythm of the three drawn traffic-light dots, not layout spacing
-        gap: 7 }}>
-        <Dot color="#fb7aa8" /><Dot color="#f6c75e" /><Dot color="#86cfa6" />
-        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: window title bar + close glyphs, part of the desktop-window illustration */}
-        <span style={{ fontSize: 10, letterSpacing: '0.03em', color: 'var(--faction-coven-title-text)', marginLeft: 2 }}>✦ {title}</span>
-        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the ▭ ✕ window glyphs are drawn chrome, not typeset copy */}
-        <span style={{ marginLeft: 'auto', fontSize: 10, opacity: 0.8, letterSpacing: '1.5px', color: 'var(--faction-coven-title-text)' }}>▭ ✕</span>
-      </div>
-      <div style={{ padding: 'var(--space-md) var(--space-lg)', background: 'var(--faction-coven-body-bg)', backgroundImage: 'radial-gradient(var(--faction-coven-dot) 1.4px, transparent 1.4px)', backgroundSize: '13px 13px' }}>
-        {children}
+    <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
+      {avatar}
+      <div
+        {...containerProps}
+        style={{
+          flex: 1,
+          minWidth: 0,
+          background: 'var(--faction-coven-ward-card)',
+          border: '1.5px solid var(--faction-coven-slip-border)',
+          borderRadius: 14,
+          overflow: 'hidden',
+          boxShadow: 'var(--faction-coven-slip-shadow)',
+        }}
+      >
+        {/* the candle glow along the top edge — the slip's gradient, at 4px */}
+        <div
+          aria-hidden="true"
+          style={{
+            height: 4,
+            background:
+              'linear-gradient(90deg, var(--faction-coven-slip-from), var(--faction-coven-slip-mid) 38%, var(--faction-coven-slip-lav) 78%, var(--faction-coven-slip-vio))',
+          }}
+        />
+        <div style={{ padding: 'var(--space-md) var(--space-lg)' }}>{children}</div>
       </div>
     </div>
   )
@@ -36,48 +119,141 @@ function Window({ title, children }: { title: string; children: React.ReactNode 
 
 export default function CovenComment(props: CommentProps) {
   const { t } = useTranslation('praxis')
+  const { user } = useAuth()
+  const reveal = useOwnerReveal()
+
   if (props.mode === 'composer') {
     const { character, value, onChange, onSubmit, submitting } = props
     return (
-      <Window title={`${character.username}.exe`}>
-        <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
-          <FactionAvatar character={character} size="sm" />
-          <div style={{ flex: 1 }}>
-            <ComposerControls value={value} onChange={onChange} onSubmit={onSubmit} submitting={submitting} accent="var(--faction-coven-card-accent)" onAccent="var(--faction-coven-on-accent)" bg="var(--faction-coven-notepad-bg)" text="var(--faction-coven-card-text)" />
-          </div>
+      <Slip avatar={<FactionAvatar character={character} size="sm" />}>
+        {/* `.content-text` rides the wrapper because the one slot inside without
+            a size of its own is the textarea (`font: inherit`), and a comment
+            draft is content-tier text. Every other slot names its own size. */}
+        <div
+          className="content-text"
+          aria-busy={submitting}
+          style={{ fontFamily: READING, color: INK }}
+        >
+          <ComposerControls
+            value={value}
+            onChange={onChange}
+            onSubmit={onSubmit}
+            submitting={submitting}
+            accent={ACCENT}
+            onAccent={ON_ACCENT}
+            bg={FIELD}
+            text={INK}
+            // The shared string in this sheet's own caption voice — an OVERRIDE
+            // of ComposerControls' neutral default, not a new hint.
+            hint={<span style={CAPTION}>{t('comments.mentionHint')}</span>}
+          />
         </div>
-      </Window>
+      </Slip>
     )
   }
+
   const { comment, onEdited, onWithdrawn } = props
   const slug = comment.author.faction_slug
   const owner = useOwnerEdit({ comment, onEdited, onWithdrawn })
+  const canFlag = canFlagComment(comment, user?.character?.id)
+  // The foot exists only when it holds something: the author's edit/withdraw row
+  // or a flag affordance. Hidden while editing — the inline editor owns
+  // Save/Cancel then.
+  const showFoot = !owner.editing && (owner.isOwner || canFlag)
+  // On your OWN comment the foot holds nothing but the gated owner row, so the
+  // braid above it fades with the row: a thread ruling off empty space is a state
+  // this sheet never draws. Someone else's (flaggable) comment keeps its foot.
+  const footGate = owner.isOwner && !canFlag ? ownerRevealStyle(reveal.revealed) : null
+
   return (
-    <Window title={`${comment.author.username}.exe`}>
-      <div style={{ display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
-        <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontFamily: 'var(--faction-coven-card-font)', fontSize: 'var(--text-content)', lineHeight: 1.25, color: 'var(--faction-coven-card-text)' }}>
-            {owner.editing ? (
-              <CommentEditor owner={owner} accent="var(--faction-coven-card-accent)" onAccent="var(--faction-coven-on-accent)" bg="var(--faction-coven-notepad-bg)" text="var(--faction-coven-card-text)" />
-            ) : (
-              <MentionText body={comment.body_text} mentions={comment.mentions} accent="var(--faction-coven-card-accent)" />
-            )}
-          </div>
-          <div style={{ marginTop: 'var(--space-sm)', fontSize: 'var(--text-md)', color: 'var(--faction-coven-card-accent)', letterSpacing: '0.04em', display: 'inline-flex', alignItems: 'baseline', flexWrap: 'wrap', gap: 'var(--space-sm)' }}>
-            <Link to={`/characters/${comment.author.id}`} style={{ color: 'inherit', textDecoration: 'none' }}>
-              @{comment.author.username}
-            </Link>
-            <span>
-              {' · '}
-              {formatCommentTime(slug, comment.created_at)}
-              {comment.is_edited ? ` · ${t('comments.coven.edited')}` : ''}
-            </span>
-            <OwnerControls owner={owner} />
+    <Slip
+      avatar={<FactionAvatar character={authorToCharacter(comment.author)} size="sm" />}
+      containerProps={reveal.containerProps}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'baseline',
+          gap: 'var(--space-sm)',
+          flexWrap: 'wrap',
+        }}
+      >
+        <Link
+          to={`/characters/${comment.author.id}`}
+          style={{
+            fontFamily: DISPLAY,
+            fontSize: 'var(--text-xl)',
+            letterSpacing: '0.04em',
+            color: INK,
+            textDecoration: 'none',
+          }}
+        >
+          {comment.author.display_name}
+        </Link>
+        <span style={CAPTION}>{formatCommentTime(slug, comment.created_at)}</span>
+        {comment.is_edited && (
+          // The hand's one mark on the slip: a pencilled amendment, lowercase in
+          // Caveat rather than set in the chrome's small caps.
+          <span
+            style={{
+              fontFamily: HAND,
+              fontSize: 'var(--text-lg)',
+              color: LABEL,
+            }}
+          >
+            <span aria-hidden="true">· </span>
+            {t('comments.coven.edited')}
+          </span>
+        )}
+      </div>
+
+      {/* The body is user-authored free text — the content floor, resting and
+          editing alike (the editor's textarea inherits from here). */}
+      <div
+        className="content-text"
+        style={{
+          marginTop: 'var(--space-sm)',
+          fontFamily: READING,
+          color: INK,
+          lineHeight: 1.55,
+          overflowWrap: 'anywhere',
+        }}
+      >
+        {owner.editing ? (
+          <CommentEditor owner={owner} accent={ACCENT} onAccent={ON_ACCENT} bg={FIELD} text={INK} />
+        ) : (
+          <MentionText
+            body={comment.body_text}
+            mentions={comment.mentions}
+            accent="var(--faction-coven-slip-deep)"
+          />
+        )}
+      </div>
+
+      {showFoot && (
+        <div style={{ marginTop: 'var(--space-md)', ...footGate }}>
+          {/* the braided thread rules the foot off the body. `.cvn-braid` owns
+              both its pigments and its dark override — a data-URI SVG is a
+              separate document, so `var(--…)` inside one never resolves. */}
+          <span
+            className="cvn-braid"
+            aria-hidden="true"
+            style={{ display: 'block', width: '100%' }}
+          />
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'baseline',
+              flexWrap: 'wrap',
+              gap: 'var(--space-md)',
+              marginTop: 'var(--space-sm)',
+            }}
+          >
+            <OwnerControls owner={owner} reveal={reveal} />
             <CommentFlagControl comment={comment} />
           </div>
         </div>
-      </div>
-    </Window>
+      )}
+    </Slip>
   )
 }

--- a/frontend/src/components/feed/CovenFeedFrame.tsx
+++ b/frontend/src/components/feed/CovenFeedFrame.tsx
@@ -83,31 +83,52 @@ const CAPTION: CSSProperties = {
   flexShrink: 0,
 }
 
-/** A four-point twinkle centred on (x, y), arms `r` wide and 2.6r long. */
+/**
+ * A four-point twinkle, arms `r` wide and 2.6r long. `(x, y)` is the TOP point,
+ * not the centre — the same construction the spell slip's stars use, so the two
+ * marks are the same shape.
+ */
 function twinkle(x: number, y: number, r: number): string {
   const arm = r * 2.6
   return `M${x} ${y - arm} l${r} ${arm} ${arm} ${r} -${arm} ${r} -${r} ${arm} -${r} -${arm} -${arm} -${r} ${arm} -${r} z`
 }
 
 /**
- * The gold candle-spark field, clipped to the head band so no spark ever lands
+ * The gold candle-spark field, confined to the head band so no spark ever lands
  * in copy. Three sparks, not the task card's six: this card is drawn dozens of
  * times down one scroll, and the slip's masthead field is a once-per-page mark.
+ *
+ * Each spark is its OWN square-viewBox svg placed by percentage, rather than one
+ * stretched sheet across the band. The task card can afford
+ * `preserveAspectRatio="none"` because its viewBox matches its fixed 340px width;
+ * a feed card takes whatever width the column gives it, and a stretched
+ * four-point star flattens into a dash.
  */
+const SPARKS: { left: string; top: number; size: number; opacity: number }[] = [
+  { left: '7%', top: 5, size: 9, opacity: 0.85 },
+  { left: '58%', top: 19, size: 6, opacity: 0.7 },
+  { left: '86%', top: 8, size: 10, opacity: 0.8 },
+]
+
 function SparkField() {
   return (
-    <svg
-      width="100%"
-      height="100%"
-      viewBox="0 0 320 34"
-      preserveAspectRatio="none"
+    <span
       aria-hidden="true"
-      style={{ position: 'absolute', inset: 0, zIndex: 0, pointerEvents: 'none' }}
+      style={{ position: 'absolute', inset: 0, zIndex: 0, overflow: 'hidden', pointerEvents: 'none' }}
     >
-      <path d={twinkle(28, 9, 1.5)} fill="var(--faction-coven-slip-gold)" opacity={0.85} />
-      <path d={twinkle(196, 25, 1.1)} fill="var(--faction-coven-slip-gold)" opacity={0.7} />
-      <path d={twinkle(288, 12, 1.7)} fill="var(--faction-coven-slip-gold)" opacity={0.8} />
-    </svg>
+      {SPARKS.map((spark) => (
+        <svg
+          key={spark.left}
+          width={spark.size}
+          height={spark.size}
+          viewBox="0 0 20 20"
+          style={{ position: 'absolute', left: spark.left, top: spark.top, opacity: spark.opacity }}
+        >
+          {/* top point at y = 20/2 − arm, so the star sits centred in its box */}
+          <path d={twinkle(10, 8.4, 1.6)} fill="var(--faction-coven-slip-gold)" />
+        </svg>
+      ))}
+    </span>
   )
 }
 

--- a/frontend/src/components/feed/CovenFeedFrame.tsx
+++ b/frontend/src/components/feed/CovenFeedFrame.tsx
@@ -1,113 +1,255 @@
-import i18n from '../../i18n'
-import FeedChassisBand from './FeedChassisBand'
+import type { CSSProperties } from 'react'
+import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
- * Cozy Coven feed frame — the neutral feed card dressed as a tiny
- * "whimsy.exe" desktop window. A pink title bar (traffic-light dots + a script
- * window name + a sparkle charm) sits above a notepad/paper body that holds the
- * untouched card `{children}`. Frame-level chrome only: this is a thin wrapper,
- * not a reimplementation of the card. Flips with the theme via the Coven tokens.
+ * Cozy Coven — THE CANDLELIT SLIP, as a feed card (dress issue #1197, epic
+ * #1192).
  *
- * #1194: the title bar is now also the CHASSIS BAND — the window name keeps its
- * place and the kicker, the tag, the time and the dismiss control ride the same
- * strip, tinted by the bar's own title ink. The look is unchanged otherwise;
- * Coven's dress issue restyles it.
+ * The chassis is a leaf torn off the same stock as the v2 task card (#1023) and
+ * the candlelit ward (#1031): a pink→lavender gradient head under a gold twinkle
+ * field, a braided thread seam, and a near-white slip below it carrying the
+ * shared payload. Grenze Gotisch names the card's kind, Quicksand speaks the
+ * chrome, gold is the only non-pink note.
+ *
+ * THIS REPLACES the lo-fi `coven.exe` window this frame used to draw. That
+ * metaphor was retired for Coven wholesale by ADR-0055 / ADR-0056 (task cards)
+ * and again by #1031 (task detail); the feed card was the last surface still
+ * wearing it. Two things follow, and both are deliberate:
+ *   - the `--faction-coven-win-*` / `-notepad-*` tokens are NOT deleted — other
+ *     surfaces still paint with them (index.css says so at the family's head);
+ *   - `feed:identity.coven.windowTitle` ("coven.exe") is no longer read here. It
+ *     is still read by `FactionCard` and `FactionSelectCard`, so nothing is
+ *     orphaned — and epic #1192 decision 5 forbids a faction-name label on this
+ *     surface anyway. The skin is the identification.
+ *
+ * WHAT THIS OWNS, AND ONLY THIS (the three-layer seam, #1194):
+ *   FeedItemSlot      the archive — the ✕, the swipe, the write, the 6s undo
+ *                     strip. Inherited whole; nothing here touches it.
+ *   → this file       the CHASSIS: the four chrome slots and the stock they sit
+ *                     on. It PLACES `archive`; it does not rebuild it.
+ *   → children        the shared payload body (a row or one of the three
+ *                     companions). Faction-blind, pads itself, and is NOT
+ *                     re-inked here — hence no padding on the body wrapper.
+ *
+ * The four slots are placed by hand rather than through `FeedChassisBand`,
+ * because the band's `.eyebrow` sets the kicker at the label ramp's floor and
+ * this sheet wants it in the display face. Nothing is dropped: kicker · tag ·
+ * time · archive all ride the head, and the head is tinted `--faction-coven-
+ * slip-ink` so the archive control — which paints in `currentColor` — comes out
+ * in the slip's own ink.
+ *
+ * ONE RESPONSIVE COMPONENT (ADR-0056 / 0058 / 0063): `useFormFactor` picks a
+ * size set, never a second file, and the card takes the width it is given.
+ *
+ * Colour is entirely `--faction-coven-slip-*` / `-ward-*`, which both themes
+ * already declare; light/dark flips through the `[data-theme="dark"]` cascade,
+ * never a ternary. Every ink on the head is already measured against the
+ * gradient's worst stop — see the slip block in index.css (#1023) and the ward
+ * block (#1031).
  */
 
-const WIN_BORDER = 'var(--faction-coven-win-border)'
-const TITLE_FROM = 'var(--faction-coven-title-from)'
-const TITLE_TO = 'var(--faction-coven-title-to)'
-const TITLE_TEXT = 'var(--faction-coven-title-text)'
-const NOTEPAD_BG = 'var(--faction-coven-notepad-bg)'
-const NOTEPAD_BORDER = 'var(--faction-coven-notepad-border)'
-const SCRIPT = 'var(--faction-coven-card-font)'
-const PINK = 'var(--faction-coven)'
+const CHROME = 'var(--font-faction-rounded)' /* Quicksand */
+const DISPLAY = 'var(--font-faction-witch)' /* Grenze Gotisch */
 
-/** The four-point sparkle charm — Coven's signature window flourish. */
-function Sparkle({ size }: { size: number }) {
+interface SizeSet {
+  headPad: string
+  kickerSize: string
+  /** The pentacle charm's box. Ornament geometry, so a raw px number (§4a). */
+  charm: number
+}
+
+const SIZES: Record<'desktop' | 'mobile', SizeSet> = {
+  desktop: {
+    headPad: 'var(--space-sm) var(--space-lg)',
+    kickerSize: 'var(--text-xl)',
+    charm: 20,
+  },
+  mobile: {
+    headPad: 'var(--space-sm) var(--space-md)',
+    kickerSize: 'var(--text-lg)',
+    charm: 18,
+  },
+}
+
+/** Small-caps chrome voice — every small mark on the head speaks in it. */
+const CAPTION: CSSProperties = {
+  fontFamily: CHROME,
+  fontWeight: 700,
+  fontSize: 'var(--text-md)',
+  letterSpacing: '0.16em',
+  textTransform: 'uppercase',
+  whiteSpace: 'nowrap',
+  flexShrink: 0,
+}
+
+/** A four-point twinkle centred on (x, y), arms `r` wide and 2.6r long. */
+function twinkle(x: number, y: number, r: number): string {
+  const arm = r * 2.6
+  return `M${x} ${y - arm} l${r} ${arm} ${arm} ${r} -${arm} ${r} -${r} ${arm} -${r} -${arm} -${arm} -${r} ${arm} -${r} z`
+}
+
+/**
+ * The gold candle-spark field, clipped to the head band so no spark ever lands
+ * in copy. Three sparks, not the task card's six: this card is drawn dozens of
+ * times down one scroll, and the slip's masthead field is a once-per-page mark.
+ */
+function SparkField() {
   return (
-    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true">
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 320 34"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      style={{ position: 'absolute', inset: 0, zIndex: 0, pointerEvents: 'none' }}
+    >
+      <path d={twinkle(28, 9, 1.5)} fill="var(--faction-coven-slip-gold)" opacity={0.85} />
+      <path d={twinkle(196, 25, 1.1)} fill="var(--faction-coven-slip-gold)" opacity={0.7} />
+      <path d={twinkle(288, 12, 1.7)} fill="var(--faction-coven-slip-gold)" opacity={0.8} />
+    </svg>
+  )
+}
+
+/** The pentacle charm that heads the card — a pink disc, a dashed gold ring. */
+function Pentacle({ size }: { size: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 44 44"
+      aria-hidden="true"
+      style={{ display: 'block', flexShrink: 0 }}
+    >
+      <circle cx="22" cy="22" r="19" fill="var(--faction-coven-slip-pk)" opacity="0.18" />
+      <circle
+        cx="22"
+        cy="22"
+        r="15"
+        fill="none"
+        stroke="var(--faction-coven-slip-gold)"
+        strokeWidth="1.2"
+        strokeDasharray="2 4"
+      />
       <path
-        d="M12 0c.9 7 4.1 10.2 11 11-6.9.8-10.1 4-11 11-.9-7-4.1-10.2-11-11C7.9 10.2 11.1 7 12 0Z"
-        fill={PINK}
+        d="M22 8 L30.2 33.3 L8.7 17.7 L35.3 17.7 L13.8 33.3 Z"
+        fill="none"
+        stroke="var(--faction-coven-slip-deep)"
+        strokeWidth="1.6"
+        strokeLinejoin="round"
       />
     </svg>
   )
 }
 
 export default function CovenFeedFrame({ kicker, time, tag, archive, children }: FeedFrameProps) {
+  const formFactor = useFormFactor()
+  const size = SIZES[formFactor]
+
   return (
-    <div
+    <article
+      data-form-factor={formFactor}
       style={{
-        borderRadius: 13,
+        position: 'relative',
         overflow: 'hidden',
-        border: `2px solid ${WIN_BORDER}`,
-        boxShadow: `0 6px 18px color-mix(in srgb, ${PINK} 22%, transparent)`,
+        boxSizing: 'border-box',
+        borderRadius: 16,
+        border: '1.5px solid var(--faction-coven-slip-border)',
+        background: 'var(--faction-coven-ward-card)',
+        boxShadow: 'var(--faction-coven-slip-shadow)',
       }}
     >
-      {/* title bar — traffic-light dots + window name + sparkle */}
+      {/* THE HEAD — the slip's gradient band, and all four chrome slots. Tinted
+          slip-ink so the archive node (currentColor) inks itself from here. */}
       <div
         style={{
+          position: 'relative',
           display: 'flex',
           alignItems: 'center',
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: window title bar, sized around its 9px traffic-light dots and raw script type.
-          gap: 7,
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: window title bar, sized around its 9px traffic-light dots and raw script type.
-          padding: '7px 12px',
-          background: `linear-gradient(180deg, ${TITLE_FROM}, ${TITLE_TO})`,
-          borderBottom: `2px solid ${WIN_BORDER}`,
+          gap: 'var(--space-sm)',
+          minWidth: 0,
+          padding: size.headPad,
+          background:
+            'linear-gradient(112deg, var(--faction-coven-slip-from), var(--faction-coven-slip-mid) 38%, var(--faction-coven-slip-lav) 78%, var(--faction-coven-slip-vio))',
+          color: 'var(--faction-coven-slip-ink)',
         }}
       >
-        {[
-          'var(--faction-coven-scrap-deep)',
-          'var(--faction-coven-tape)',
-          'var(--faction-coven-ivy-leaf)',
-        ].map((lightColor) => (
-          <span
-            key={lightColor}
-            style={{
-              width: 9,
-              height: 9,
-              borderRadius: '50%',
-              background: lightColor,
-              border: '1.2px solid rgba(255,255,255,0.7)',
-            }}
-          />
-        ))}
-        <span
-          style={{
-            display: 'inline-flex',
-            alignItems: 'center',
-            flexShrink: 0,
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: lead between the hand-lettered window title and its sparkle.
-            gap: 6,
-            fontFamily: SCRIPT,
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: hand-lettered window title on the frame chrome
-            fontSize: 17,
-            color: TITLE_TEXT,
-          }}
-        >
-          {i18n.t('feed:identity.coven.windowTitle')}
-          <Sparkle size={12} />
+        <SparkField />
+
+        <span style={{ position: 'relative', zIndex: 1, display: 'flex', flexShrink: 0 }}>
+          <Pentacle size={size.charm} />
         </span>
 
-        {/* chassis band — rides the title bar, inked with the window title */}
-        <div style={{ flex: 1, minWidth: 0, color: TITLE_TEXT }}>
-          <FeedChassisBand kicker={kicker} time={time} tag={tag} archive={archive} />
-        </div>
+        {/* kicker — the card's only kind label, in the coven's display face */}
+        <span
+          style={{
+            position: 'relative',
+            zIndex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            fontFamily: DISPLAY,
+            fontSize: size.kickerSize,
+            lineHeight: 1.1,
+            letterSpacing: '0.08em',
+            textTransform: 'uppercase',
+            color: 'inherit',
+          }}
+        >
+          {kicker}
+        </span>
+
+        {/* tag — nullable; today only "Still waiting", pinned in a gold hairline */}
+        {tag && (
+          <span
+            style={{
+              ...CAPTION,
+              position: 'relative',
+              zIndex: 1,
+              fontSize: 'var(--text-base)',
+              padding: '0 var(--space-xs)',
+              borderRadius: 999,
+              border: '1px solid var(--faction-coven-slip-gold)',
+              color: 'inherit',
+            }}
+          >
+            {tag}
+          </span>
+        )}
+
+        {/* time — the card's only timestamp since #1194 (the row stopped drawing one) */}
+        <span
+          style={{
+            ...CAPTION,
+            position: 'relative',
+            zIndex: 1,
+            marginLeft: 'auto',
+            color: 'var(--faction-coven-slip-label)',
+          }}
+        >
+          {time}
+        </span>
+
+        {/* archive — a finished node; placed, never rebuilt. `null` on
+            awaiting_submission, which is why nothing here draws a stand-in. */}
+        <span style={{ position: 'relative', zIndex: 1, display: 'flex', flexShrink: 0 }}>
+          {archive}
+        </span>
       </div>
 
-      {/* notepad/paper body — holds the neutral card, untouched */}
-      <div
-        style={{
-          background: NOTEPAD_BG,
-          borderTop: `1px solid ${NOTEPAD_BORDER}`,
-          padding: 'var(--space-md)',
-        }}
-      >
-        {children}
-      </div>
-    </div>
+      {/* the braided thread seam. `.cvn-braid` owns both its pigments and its
+          dark override — a data-URI SVG is a separate document, so `var(--…)`
+          inside one never resolves (index.css says so at the class). */}
+      <span
+        className="cvn-braid"
+        aria-hidden="true"
+        style={{ display: 'block', width: '100%' }}
+      />
+
+      {/* THE SLIP — the shared payload body. No padding and no ink of ours: every
+          body already pads itself, and the body is faction-blind by contract. */}
+      <div style={{ position: 'relative' }}>{children}</div>
+    </article>
   )
 }

--- a/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
+++ b/frontend/src/pages/updates/__tests__/mixedStream.test.tsx
@@ -73,7 +73,12 @@ describe('mobile Updates mixed multi-faction stream', () => {
     const { text, html } = render(baseState({ items }))
     // Distinct per-faction frame markers appearing TOGETHER in one render
     // prove a mixed stream, not one uniform tint.
-    expect(text, 'COVEN window chrome').toContain('coven.exe')
+    // COVEN's frame prints no house line any more (#1197): the `coven.exe`
+    // window is retired and epic #1192 decision 5 forbids a faction-name label
+    // on this surface, so its marker is the candlelit slip's own gradient token
+    // — the same move #851 made for UA one line down.
+    expect(html, 'COVEN candlelit-slip chrome').toContain('--faction-coven-slip-mid')
+    expect(text, 'and no faction name survives on the card').not.toContain('coven.exe')
     // UA's frame is dress only now (#851): a 3px orange rule and the ensō, no
     // engraved masthead, so the marker is the token rather than a house line.
     expect(html, 'UA ink-rule frame').toContain('3px solid var(--faction-ua)')


### PR DESCRIPTION
Frontend only, dress only. Every behaviour in this diff already worked before it — F1/F2/F3 built the archive, the chassis seam and the shared comment controls, and this PR moves no logic.

Closes #1197

---

## What changed

Two Coven surfaces, both of which were still wearing a metaphor this faction retired months ago.

**`CovenFeedFrame`** was the lo-fi `coven.exe` desktop window — traffic-light dots, a script window title, a notepad body. That window was retired for Coven's task card by ADR-0055/ADR-0056 and for its task detail by #1031; the feed card and the comment were the last two surfaces still drawing it. It is now a leaf off the same stock as the spell slip: a pink→lavender gradient head under a gold spark field, a `.cvn-braid` thread seam, and the near-white slip (`--faction-coven-ward-card`) carrying the shared payload. Grenze Gotisch names the card's kind, Quicksand speaks the chrome, gold is the only non-pink note.

**`CovenComment`** was `{handle}.exe` — the same window, retitled. It is now the same slip: a candle-glow edge, a Grenze Gotisch byline, Cormorant Garamond reading copy, and a braid ruling the foot off the body.

**`mixedStream.test.tsx`** — one assertion repointed. See "One shared file" below.

## Four faces, four roles

The sheet names Grenze Gotisch (display), Quicksand (chrome), Cormorant Garamond (reading) and Caveat (hand). Those are four **roles**, so:

| face | job |
|---|---|
| Grenze Gotisch | the kicker, the byline |
| Quicksand | timestamp, tag, mention hint |
| Cormorant Garamond | the comment body, at the content floor |
| Caveat | the "edited" marginalia, and nothing else |

**The comment body moved off Caveat on purpose.** It was Caveat before. A comment body is user-authored content and owes the content floor (WORLD_ZERO_STYLE §4 role floor); hand-lettering a stranger's paragraph at 18px is the one place the script face costs legibility. The hand keeps the pencilled amendment, which is the job it is named for.

All four faces are **already** in the single Google Fonts link. No new font request; both surfaces are free on load.

## No new tokens, no new copy keys, no new measurements

Every value is an existing `--faction-coven-slip-*` / `--faction-coven-ward-*`, and the vendored palette maps onto that family essentially one-for-one — `--card:#fff6fb` **is** `--faction-coven-ward-card`, and `--lt`/`--lt2`/`--lav`/`--vio`/`--border`/`--gold`/`--glow`/`--shadow` are the slip's stops verbatim. Where the sheet and the shipped tokens disagree the tokens win, and the disagreement was already settled: the sheet's `soft #b8517f` / `label #b06a92` are the two inks #1023 walked down to `#973660` / `#83466a` for AA against the gradient's darkest stop.

**Every ink/ground pair this PR introduces is already pinned in `factionContrast.test.ts`** and passes there:

- head band, kicker + tag → `coven slip, ink` / `coven slip lavender, ink` (both gradient ends)
- head band, time → `coven slip, caption` / `coven slip lavender, caption`
- card + comment body → `coven ward panel, ink`
- byline captions, mention hint → `coven ward panel, caption`
- composer submit → `coven slip CTA band top` / `band foot`

The one pair **not** pinned is the composer textarea's ground, `--faction-coven-slip-from` × `slip-ink`. It needs no row: `slip-from` is *lighter* than the pinned `slip-mid` in light and *darker* in dark, so the reading is strictly better than an already-measured pair in both themes. I did not append a row to that shared registry — seven siblings are live in it and a restated row there has taken `main` red before.

## What to eyeball

1. **The head band's height vs. the pentacle charm.** The charm is 20px desktop / 18px mobile and the band is padded `--space-sm`; the kicker rides beside it. If the band reads tall or the charm crowds the kicker, that is the number to move.
2. **The kicker at `--text-xl` (14px) in Grenze Gotisch.** I threw `FeedChassisBand` away for exactly this: the band sets the kicker in `.eyebrow`, at the label ramp's 9px floor, and a blackletter display face is unreadable there. 14px is the ramp's top label rung. Nothing was dropped — kicker, tag, time and archive all ride the head.
3. **The archive ✕ on a pink gradient.** It is dormant at 40% opacity (shared behaviour in `FeedArchiveButton`, not mine) and inherits `--faction-coven-slip-ink` from the head. 40% of a 5.5:1 ink on a light gradient is the thing most likely to read faint. If it does, that is a #1243-wide observation, not a Coven one.
4. **The three gold sparks.** Each is its own square-viewBox svg placed by percentage, *not* one stretched sheet — the slip can use `preserveAspectRatio="none"` because its card is a fixed 340px and a feed card is not. Check they land clear of the kicker at both form factors.
5. **The braid seam at narrow widths.** `.cvn-braid` tiles a 40px thread; it now runs under the head on the feed card and above the foot on the comment.
6. **Dark mode on both.** `--faction-coven-ward-card` is `#2a0f1e` in dark — *darker* than the `#39152a` notepad it replaces, so the shared body's global inks read better, not worse. But nobody has looked.
7. **The comment foot's gate.** On your own comment the braid fades with the gated owner row (a thread ruling off empty space is a state the sheet never draws); on someone else's the foot stays for the flag control. Same shape as `DefaultComment`.

## Three things deliberately NOT built

- **No `feed:identity.coven.windowTitle` ("coven.exe").** Epic #1192 decision 5 forbids a faction-name label on this surface, and that string is one. The key is still read by `FactionCard` and `FactionSelectCard`, so nothing is orphaned and `feed.json` is untouched.
- **No turning pentagram watermark.** The slip draws one because a slip is drawn once; a feed draws fifty cards down one scroll.
- **No green "blessed" state, and this one is a seam limit rather than a taste call.** My sheet carries a green pair for a completed state, and `--faction-coven-cast-*` (#1225) is the right token for it. But `FeedFrameProps` is `{ kicker, time, tag, archive, children }` — **the chassis has no type discriminator.** The only way to tint a completion green from in here would be to compare `kicker` against a translated string, which is copy laundering, and the only `tag` that exists today is "Still waiting", which is not a completed state. If a completed/blessed tint is wanted, the chassis needs the item's type (or a semantic `tone`) as a prop, once, for all nine frames — a `frontend-feature` change on the shared seam, not something to take inside a dress issue.

## State variants

The vendored spec for my sheet carries its palette, its type and the shared card anatomy — not a per-state drawing list — so I built the chassis **type-agnostically**, which is what the seam is for: it draws four chrome slots and knows nothing about the fifteen types passing through it. **No state was invented and none skipped.** The unbacked states named on epic #1192 (invite/duel expiry, a duel countdown, a pre-submission deadline, filed/total counts) live on the companion *bodies*, which this PR does not touch, and none of them appears here.

`awaiting_submission` gets no ✕ and no swipe: `archive` arrives as `null` and the head simply has nothing to place. The chassis draws no stand-in and the word `disabled` appears nowhere in it (asserted).

## One shared file, and a merge warning for the orchestrator

`frontend/src/pages/updates/__tests__/mixedStream.test.tsx` went red on my change: it proved Coven's card was in Coven chrome by looking for the literal string `coven.exe`. I repointed that one assertion to the slip's gradient token — the same move #851 already made for UA one line below ("the marker is the token rather than a house line") — and added a second line asserting the retired house line is *gone*, which is the decision-5 guard nothing else holds.

**That block also holds the UA and S.N.I.D.E. markers, and both of those dress issues are live right now.** I touched one assertion plus its comment and left every other line alone, including the now stale-sounding `'COVEN scrapbook tokens'` label, precisely so a sibling's edit conflicts visibly instead of silently reverting mine. Expect a conflict there and resolve by keeping *all three* faction lines.

`frontend/src/factions/coven.ts` and `frontend/src/index.css` needed **no change** — `comment` and `feedFrame` were already registered, and no token was added, retired or repointed. I also checked that every `--faction-coven-win-*` / `-notepad-*` / `-scrap-*` token these two files stopped reading still has 6–10 other readers, so index.css's "other surfaces still paint with them" comment stays true and nothing is left dead.

## Verified

Rebased onto `origin/main` @ `c3159bda` (after #1245 and #1246 landed) and re-verified everything below on the rebased tree.

- **`tsc --noEmit`: clean.**
- **`eslint src --max-warnings=0`: clean.** No new `no-raw-style-values` suppressions — the two files between them shed the four the old window chrome needed.
- **`vite build`: clean.** Entry chunk 135.03 KB gzip; the `Updates` route chunk is unmoved at 9.3 KB gzip.
- **`vitest run`: 143 files, 2452 passed, 0 failed.** Including the three suites that render *through* this chassis, which is where the risk was: `feedChassis.test.tsx` seeds `context_faction_slug: 'coven'` for **every one of the 15 backend types** and asserts each renders, each names its kind, the three companions keep accept/decline, an archived duel/collab carries "still waiting", and `awaiting_submission` draws no control and no `disabled`. `factionFeedFrame.test.tsx` asserts all four chrome slots survive. `factionContrast.test.ts` covers the pairs listed above.

## NOT verified

- **No visual QA. This is outstanding and someone has to look.** This environment cannot screenshot and there is no dev stack, so **every layout and legibility claim above is inference from the code and from arithmetic on the token values, not observation.** The seven "what to eyeball" items are where I would look first.
- **The 6s undo window and the swipe are untested end to end**, for the reason #1243 gives: the harness is `renderToStaticMarkup`, so no effect runs and no pointer event fires. They live in `FeedItemSlot`, are untouched here, and are inherited whole.
- **The comment voice has no test of its own** — none of the eight voices does; only `DefaultComment` is covered. Its states (mention, edited, yours-on-hover, editing, composer empty/submitting) are asserted only by inspection.
- **Not verified against a live server.** No request in this diff is new.

## No string from the design sheet appears in the diff

The Coven sheet is written in a gorgeous dialect and none of it ships (epic #1192, the rule governing every child issue). This PR adds **no copy at all**: it reads `comments.mentionHint` and `comments.coven.edited`, both of which already existed, and it deletes one read of a faction-name label. `feed.json` and `praxis.json` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
