### PR TITLE
An account cannot duel its own alt — the self-duel guard resolves through the account (#1237)

### DIFF
--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -38,6 +38,37 @@ from services.praxis import (
 )
 
 
+# One account may never hold both sides of a duel (ADR-0041, #1237). Shared by
+# the challenge and the acceptance guard so the two read alike and cannot drift.
+SELF_DUEL_DETAIL = "You cannot duel your own character."
+
+
+async def _characters_share_account(
+    first_character_id: int,
+    second_character_id: int,
+    session: AsyncSession,
+) -> bool:
+    """Whether two characters belong to the same ACCOUNT (ADR-0041).
+
+    Anti-abuse is an account-level rule: one account owns many characters, so a
+    duel between two of a player's own lives is self-dealing even though the two
+    character ids differ. Same rule family — and the same shape — as
+    ``services.vote._voter_account_owns_praxis`` / ``_voter_in_praxis_duel``,
+    which both resolve through ``Character.account_id``.
+
+    A missing character is *not* treated as a shared account: the callers each
+    raise their own 404 for that case, and returning True here would answer with
+    the wrong error.
+    """
+    if first_character_id == second_character_id:
+        return True
+    first = await session.get(Character, first_character_id)
+    second = await session.get(Character, second_character_id)
+    if first is None or second is None:
+        return False
+    return first.account_id == second.account_id
+
+
 def _build_duel_out(duel: Duel) -> DuelOut:
     return DuelOut(
         id=duel.id,
@@ -185,10 +216,13 @@ async def issue_duel_challenge(
     This does NOT create a praxis — it loads the challenger's existing one and
     creates only the pending Duel row pointing at it. The opponent must not
     already have an active praxis for this task (Everymen exempt); challenger
-    and opponent cannot be the same.
+    and opponent cannot belong to the same ACCOUNT (ADR-0041) — comparing
+    character ids alone let an account duel its own alt (#1237).
     """
-    if challenger_character_id == opponent_character_id:
-        raise HTTPException(status_code=400, detail="Cannot challenge yourself.")
+    if await _characters_share_account(
+        challenger_character_id, opponent_character_id, session
+    ):
+        raise HTTPException(status_code=400, detail=SELF_DUEL_DETAIL)
 
     challenger_praxis = await get_praxis(challenger_praxis_id, session)
     if challenger_praxis.created_by_id != challenger_character_id:
@@ -281,6 +315,21 @@ async def respond_to_duel_challenge(
     opponent = await session.get(Character, character_id)
     if opponent is None:
         raise HTTPException(status_code=404, detail="Character not found.")
+
+    # Account-level self-duel guard (ADR-0041, #1237). The invitation check above
+    # only proves the responder is the invited *character*; it says nothing about
+    # whose account that character sits on. Without this, an account that had a
+    # pending challenge against its own alt could accept it and then forfeit one
+    # side for a deterministic win (ADR-0052 decides a forfeit ahead of points).
+    #
+    # Deliberately on the ACCEPT path only: declining stays open — as does
+    # :func:`cancel_duel_challenge` — so a same-account challenge that predates
+    # this guard can still be dissolved rather than being stuck pending forever.
+    challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
+    if challenger_praxis is not None and await _characters_share_account(
+        challenger_praxis.created_by_id, character_id, session
+    ):
+        raise HTTPException(status_code=400, detail=SELF_DUEL_DETAIL)
 
     task = await session.get(Task, duel.task_id)
     if task is None:

--- a/backend/tests/integration/test_duel_self_duel.py
+++ b/backend/tests/integration/test_duel_self_duel.py
@@ -1,0 +1,299 @@
+"""One ACCOUNT may not hold both sides of a duel (#1237, ADR-0041).
+
+The guard used to compare *character* ids, so two characters on one account read
+as two different players: the main could challenge a throwaway alt, the alt could
+accept (acceptance has no task-level gate, ADR-0051), and a forfeit would then
+hand the main a deterministic duel-win multiplier ahead of any votes (ADR-0052).
+
+Both entry points are pinned here. The single-character case is deliberately NOT
+the interesting one — it passed before the fix and proves nothing — so every test
+below uses *two distinct characters on one account*, plus a cross-account control
+so a failure can't be explained away by some unrelated precondition.
+"""
+from typing import Optional
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.account import Account
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.duel import Duel, DuelStatus
+from models.era import Era
+from models.praxis import (
+    ModerationStatus,
+    Praxis,
+    PraxisMember,
+    PraxisStatus,
+    PraxisType,
+)
+from models.task import Task
+from services.duel import (
+    SELF_DUEL_DETAIL,
+    issue_duel_challenge,
+    respond_to_duel_challenge,
+)
+
+from fastapi import HTTPException
+
+
+async def _make_character(
+    session: AsyncSession,
+    account: Account,
+    era: Era,
+    username: str,
+    level: int,
+) -> Character:
+    """A character on ``account`` seated at ``level`` in the current era."""
+    character = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username,
+        faction_slug="ua",
+    )
+    session.add(character)
+    await session.flush()
+    session.add(
+        CharacterStats(
+            character_id=character.id,
+            era_id=era.id,
+            score=0,
+            all_time_score=0,
+            level=level,
+            votes_spent_this_era=0,
+        )
+    )
+    await session.flush()
+    return character
+
+
+async def _make_in_progress_praxis(
+    session: AsyncSession, task: Task, author: Character
+) -> Praxis:
+    """The challenger's solo praxis — a duel is attached to an existing one (ADR-0011)."""
+    praxis = Praxis(
+        task_id=task.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        moderation_status=ModerationStatus.visible,
+        created_by_id=author.id,
+    )
+    session.add(praxis)
+    await session.flush()
+    session.add(
+        PraxisMember(praxis_id=praxis.id, character_id=author.id, has_submitted=False)
+    )
+    await session.flush()
+    return praxis
+
+
+async def _set_level(session: AsyncSession, character: Character, era: Era, level: int) -> None:
+    result = await session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats = result.scalar_one()
+    stats.level = level
+    await session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Entry point 1 — issuing the challenge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_challenging_an_alt_on_the_same_account_is_rejected(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    active_task: Task,
+) -> None:
+    """Two DIFFERENT character ids, one account — the case that used to slip through."""
+    await _set_level(db_session, character, era, CURRENT_ERA.duel_level_required)
+    alt = await _make_character(
+        db_session, account, era, "sockpuppet", CURRENT_ERA.duel_level_required
+    )
+    challenger_praxis = await _make_in_progress_praxis(db_session, active_task, character)
+    assert alt.id != character.id
+    assert alt.account_id == character.account_id
+
+    with pytest.raises(HTTPException) as exception_info:
+        await issue_duel_challenge(
+            challenger_character_id=character.id,
+            challenger_praxis_id=challenger_praxis.id,
+            opponent_character_id=alt.id,
+            session=db_session,
+        )
+
+    assert exception_info.value.status_code == 400
+    assert exception_info.value.detail == SELF_DUEL_DETAIL
+
+    # No Duel row was created.
+    result = await db_session.execute(
+        select(Duel).where(Duel.challenger_praxis_id == challenger_praxis.id)
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_challenging_your_own_character_is_still_rejected(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+    active_task: Task,
+) -> None:
+    """The pre-existing same-id case keeps working — the account lookup didn't lose it."""
+    await _set_level(db_session, character, era, CURRENT_ERA.duel_level_required)
+    challenger_praxis = await _make_in_progress_praxis(db_session, active_task, character)
+
+    with pytest.raises(HTTPException) as exception_info:
+        await issue_duel_challenge(
+            challenger_character_id=character.id,
+            challenger_praxis_id=challenger_praxis.id,
+            opponent_character_id=character.id,
+            session=db_session,
+        )
+
+    assert exception_info.value.status_code == 400
+    assert exception_info.value.detail == SELF_DUEL_DETAIL
+
+
+@pytest.mark.asyncio
+async def test_challenging_a_character_on_another_account_still_succeeds(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    era: Era,
+    active_task: Task,
+) -> None:
+    """Control for the two tests above: identical setup, a different account."""
+    await _set_level(db_session, character, era, CURRENT_ERA.duel_level_required)
+    challenger_praxis = await _make_in_progress_praxis(db_session, active_task, character)
+    assert character2.account_id != character.account_id
+
+    _praxis, duel = await issue_duel_challenge(
+        challenger_character_id=character.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_character_id=character2.id,
+        session=db_session,
+    )
+
+    assert duel.status == DuelStatus.pending
+    assert duel.opponent_character_id == character2.id
+
+
+# ---------------------------------------------------------------------------
+# Entry point 2 — responding to the challenge
+# ---------------------------------------------------------------------------
+
+
+async def _pending_same_account_duel(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    task: Task,
+) -> tuple[Duel, Character]:
+    """A pending same-account duel written straight to the DB.
+
+    Deliberately bypasses ``issue_duel_challenge``, which now rejects it: this is
+    the shape a row created before the guard existed would have, and the only way
+    to reach the responder path independently of the challenge path.
+    """
+    await _set_level(db_session, character, era, CURRENT_ERA.duel_level_required)
+    alt = await _make_character(
+        db_session, account, era, "sockpuppet", CURRENT_ERA.duel_level_required
+    )
+    challenger_praxis = await _make_in_progress_praxis(db_session, task, character)
+    duel = Duel(
+        task_id=task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_character_id=alt.id,
+        status=DuelStatus.pending,
+    )
+    db_session.add(duel)
+    await db_session.flush()
+    return duel, alt
+
+
+@pytest.mark.asyncio
+async def test_accepting_a_challenge_from_your_own_character_is_rejected(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    active_task: Task,
+) -> None:
+    """The invited character IS the responder, so the invitation check passes —
+    only the account comparison stops this."""
+    duel, alt = await _pending_same_account_duel(
+        db_session, account, character, era, active_task
+    )
+
+    with pytest.raises(HTTPException) as exception_info:
+        await respond_to_duel_challenge(duel.id, alt.id, True, db_session)
+
+    assert exception_info.value.status_code == 400
+    assert exception_info.value.detail == SELF_DUEL_DETAIL
+    assert duel.status == DuelStatus.pending
+    assert duel.opponent_praxis_id is None
+
+
+@pytest.mark.asyncio
+async def test_declining_a_challenge_from_your_own_character_is_allowed(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    active_task: Task,
+) -> None:
+    """The guard is on the ACCEPT path only, so a same-account challenge that
+    predates it can still be dissolved rather than stranded as pending."""
+    duel, alt = await _pending_same_account_duel(
+        db_session, account, character, era, active_task
+    )
+
+    opponent_praxis: Optional[Praxis]
+    opponent_praxis, updated_duel = await respond_to_duel_challenge(
+        duel.id, alt.id, False, db_session
+    )
+
+    assert opponent_praxis is None
+    assert updated_duel.status == DuelStatus.declined
+    assert updated_duel.declined_at is not None
+
+
+@pytest.mark.asyncio
+async def test_accepting_a_challenge_from_another_account_still_succeeds(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    era: Era,
+    active_task: Task,
+) -> None:
+    """Control for the responder guard: the ordinary two-account duel still accepts."""
+    await _set_level(db_session, character, era, CURRENT_ERA.duel_level_required)
+    await _set_level(db_session, character2, era, CURRENT_ERA.duel_level_required)
+    challenger_praxis = await _make_in_progress_praxis(db_session, active_task, character)
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=challenger_praxis.id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.pending,
+    )
+    db_session.add(duel)
+    await db_session.flush()
+
+    opponent_praxis, updated_duel = await respond_to_duel_challenge(
+        duel.id, character2.id, True, db_session
+    )
+
+    assert opponent_praxis is not None
+    assert updated_duel.status == DuelStatus.active
+    assert updated_duel.opponent_praxis_id == opponent_praxis.id


### PR DESCRIPTION
The self-duel guard compared **character** ids, so two characters on one account
read as two different players. Both duel entry points now resolve through
`Character.account_id` (ADR-0041), following the shape `services/vote.py` already
uses for `_voter_account_owns_praxis` / `_voter_in_praxis_duel`.

Closes #1237

## What changed

`backend/services/duel.py` only — no model, no schema, no migration, no route change.

- New `_characters_share_account(first_character_id, second_character_id, session)`
  helper + a shared `SELF_DUEL_DETAIL` constant, so the two call sites cannot drift.
  A missing character returns `False` rather than `True`: each caller already raises
  its own 404 for that, and answering "self-duel" there would be the wrong error.
- `issue_duel_challenge` — the `challenger_character_id == opponent_character_id`
  check became an account comparison. Same 400, honest message: *"You cannot duel
  your own character."*
- `respond_to_duel_challenge` — **accept** now also rejects a challenge whose
  challenger sits on the responder's account. The pre-existing
  `duel.opponent_character_id != character_id` check only proves the responder is
  the invited *character*; it says nothing about whose account that character is on.

### Deliberate carve-out: the guard is on accept, not decline

Declining a same-account challenge is still allowed, as is `cancel_duel_challenge`.
That is the escape hatch for a row created before this guard existed: it can be
dissolved (both sides revert to plain solo, stats recalculated) instead of being
stranded as `pending` forever. Guarding decline would have been the "fail at an
awkward moment" outcome the issue warns about.

## Existing data

**No same-account duels exist in the local dev database — there are no `duel` rows
at all** (`SELECT count(*) FROM duel` → 0), so nothing is invalidated there and no
owner decision is needed on this side. The check was run as:

```sql
SELECT d.id, d.status, c1.account_id, c2.account_id
FROM duel d
JOIN praxis p ON p.id = d.challenger_praxis_id
JOIN character c1 ON c1.id = p.created_by_id
JOIN character c2 ON c2.id = d.opponent_character_id
WHERE c1.account_id = c2.account_id;   -- 0 rows
```

Note the issue's SQL used `d.challenger_character_id`, which does not exist — the
challenger is reached through `challenger_praxis.created_by_id`. The query above is
the working version; **run it against production before deploying**, which I cannot
reach from here. If it returns rows: a `pending` one can be declined or cancelled
normally, an `active` one can be cancelled, and a `settled`/`resolved` one is
untouched by this PR (frozen outcomes are not unwound here — that stays an owner call).

## Tests

New `backend/tests/integration/test_duel_self_duel.py`, 6 tests. Every same-account
case uses **two distinct character ids on one account** — the single-character case
passed before the fix and proves nothing, so it is present only as a regression pin.

- challenge an alt on the same account → 400, and no `Duel` row is written
- challenge your own character (same id) → still 400
- challenge a character on another account → still succeeds (control)
- accept a challenge from your own alt → 400, duel stays `pending`, no opponent praxis
- decline a challenge from your own alt → allowed, duel goes `declined`
- accept a challenge from another account → still succeeds (control)

I verified these fail for the right reason: with the two guards reverted to the old
character-id comparison, exactly the two same-account tests fail (`DID NOT RAISE`)
and the other four still pass.

```
pytest --cov=. --cov-fail-under=80
# 845 passed in 77.94s — coverage 90.13% (floor 80%)
# run from /backend with TEST_DATABASE_URL -> wz1237_test (dedicated DB, per batch convention)
```

## What to eyeball

1. **The accept-vs-decline asymmetry.** Intentional (see above), but it is the one
   judgement call in this PR. If you would rather decline be blocked too, it is one
   line moved.
2. **Status code 400** on both paths, matching the old self-challenge behaviour.
   403 would also be defensible; I kept it consistent rather than "improving" one.
3. **Error copy** — "You cannot duel your own character." Leaks nothing: both paths
   are authenticated as one of the two same-account characters, so the only person
   who can see this message already owns both. `account_id` / `email` stay private.
4. **The opponent picker is unfixed, on purpose (issue item 4).** The duel picker in
   `frontend/src/pages/editPraxis/archetypes/controls.tsx` searches
   `GET /characters` (`listCharacters`, params `search` / `faction` /
   `exclude_active_task_id`) — an unauthenticated public list that does **not** filter
   the caller's own account. So a player can still *select* their own alt and get the
   400. That is a comprehensible refusal rather than a mystery error, and it is
   frontend scope; adding an account filter to that shared endpoint would change the
   public browse/invite semantics too. Worth a follow-up issue if you want the name
   hidden from the picker.
5. **`backend/scripts/seed_demo_praxes.py` writes a `Duel` row directly**, bypassing
   the service. It pairs two different demo players, so it is fine today — but it is
   the one place that can still construct a same-account duel if the fixture ever
   changes.

## Verified vs assumed

**Verified:** the two guards fire and only for same-account pairs (tests, plus the
reverted-guard run); the full backend suite passes; the local dev DB has zero duel
rows; `issue_duel_challenge` is the only service path that creates a `Duel`
(`seed_demo_praxes.py` is the sole other constructor); no test or frontend string
depended on the old `"Cannot challenge yourself."` copy.

**Assumed / not verified:** production data (unreachable — see the SQL above); no
browser check of the picker (no dev stack, and I cannot screenshot); I did not touch
`backend/services/vote.py` or `backend/models/vote.py`, which #1150 is editing in
parallel — this PR only *reads* `vote.py`'s helpers as a pattern, so the two should
not conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
