### PR TITLE
One vote per praxis per account: uniqueness and the vote lookup move to the account (#1150)

### DIFF
--- a/backend/alembic/versions/0011_vote_unique_per_account.py
+++ b/backend/alembic/versions/0011_vote_unique_per_account.py
@@ -1,0 +1,116 @@
+"""Move vote uniqueness from the character to the account (#1150).
+
+``uq_vote_praxis (praxis_id, voter_character_id)`` -> ``uq_vote_praxis_account
+(praxis_id, voter_account_id)``. Anti-abuse is enforced one layer up from the
+action (ADR-0041), so the uniqueness anchor is the account: alt characters on
+one account can no longer stack several votes onto the same praxis. See
+``models/vote.py`` and ``services/vote.py::cast_or_update_vote``.
+
+``0001_squashed`` builds a *fresh* DB with ``Base.metadata.create_all``, so CI
+and a local reset land on the account-scoped constraint the moment the model
+says so — the squash needs no edit. A deployed DB is stamped further down the
+chain and never re-runs the baseline, hence this revision. It is idempotent on
+both: the DROP is ``IF EXISTS`` and the ADD asks ``pg_constraint`` first.
+
+Not the 0008 / 0009 ``EXCEPTION WHEN duplicate_object`` pattern: adding a
+UNIQUE also builds an index, and a pre-existing one raises ``duplicate_table``,
+which that handler does not catch (#1193 hit exactly this and died on a fresh
+DB). Any migration adding a UNIQUE constraint or index needs the
+``pg_constraint`` lookup instead.
+
+**Pre-existing duplicates are NOT resolved here.** If some account already
+holds two votes on one praxis via alts, this migration RAISES with the count
+and changes nothing. Which of a player's real votes survives — earliest,
+latest, highest — is an owner call about someone's actual rating, not a
+builder's, and a migration is the worst place to guess it. Nothing is deleted:
+re-run once the owner has ruled and the surplus rows have been resolved by
+hand. The dev database had zero such pairs when this landed.
+
+Revision ID: 0011_vote_unique_per_account
+Revises: 0010_feed_dismissal
+Create Date: 2026-07-29
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0011_vote_unique_per_account"
+down_revision: Union[str, None] = "0010_feed_dismissal"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+OLD_CONSTRAINT: str = "uq_vote_praxis"
+NEW_CONSTRAINT: str = "uq_vote_praxis_account"
+
+# Refuse rather than pick a survivor. Raised before either DDL statement so a
+# deployed DB with duplicates is left exactly as it was found.
+#
+# ``RAISE ... USING MESSAGE`` rather than ``RAISE '...%', n``: the statement runs
+# through the DBAPI, where a literal ``%`` is only safe while SQLAlchemy happens
+# to take its no-parameters path. Concatenation keeps the SQL ``%``-free.
+_GUARD_AGAINST_DUPLICATES: str = """
+DO $$
+DECLARE duplicate_pairs INTEGER;
+BEGIN
+    SELECT count(*) INTO duplicate_pairs FROM (
+        SELECT 1 FROM vote
+        GROUP BY praxis_id, voter_account_id
+        HAVING count(*) > 1
+    ) AS duplicates;
+    IF duplicate_pairs > 0 THEN
+        RAISE EXCEPTION USING
+            MESSAGE = '#1150: ' || duplicate_pairs || ' (praxis, account) pair(s)'
+                || ' hold more than one vote, so UNIQUE (praxis_id,'
+                || ' voter_account_id) cannot be added.',
+            DETAIL = 'This migration deliberately does not choose which real'
+                || ' vote survives (earliest? latest? highest?) - that is an'
+                || ' owner decision, not a builder''s. Nothing was changed.',
+            HINT = 'List them with: SELECT praxis_id, voter_account_id,'
+                || ' count(*) FROM vote GROUP BY praxis_id, voter_account_id'
+                || ' HAVING count(*) > 1;';
+    END IF;
+END $$;
+"""
+
+
+def upgrade() -> None:
+    op.execute(_GUARD_AGAINST_DUPLICATES)
+
+    # Fresh DB: never existed (the model no longer declares it) -> no-op.
+    op.execute(f"ALTER TABLE vote DROP CONSTRAINT IF EXISTS {OLD_CONSTRAINT}")
+
+    op.execute(
+        f"""
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint WHERE conname = '{NEW_CONSTRAINT}'
+            ) THEN
+                ALTER TABLE vote
+                    ADD CONSTRAINT {NEW_CONSTRAINT}
+                    UNIQUE (praxis_id, voter_account_id);
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Restore the character-scoped constraint.
+
+    Widening is always safe: one vote per account per praxis already satisfies
+    one vote per character per praxis, so no duplicate guard is needed here.
+    """
+    op.execute(f"ALTER TABLE vote DROP CONSTRAINT IF EXISTS {NEW_CONSTRAINT}")
+    op.execute(
+        f"""
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint WHERE conname = '{OLD_CONSTRAINT}'
+            ) THEN
+                ALTER TABLE vote
+                    ADD CONSTRAINT {OLD_CONSTRAINT}
+                    UNIQUE (praxis_id, voter_character_id);
+            END IF;
+        END $$;
+        """
+    )

--- a/backend/models/vote.py
+++ b/backend/models/vote.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Index, Integer, UniqueConstraint, func
+from sqlalchemy import DateTime, ForeignKey, Integer, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
@@ -13,9 +13,15 @@ if TYPE_CHECKING:
 class Vote(Base):
     __tablename__ = "vote"
     __table_args__ = (
-        # One vote per voter per praxis. Duel sides are separate praxes, so
-        # this naturally enforces one vote per voter per duel side.
-        UniqueConstraint("praxis_id", "voter_character_id", name="uq_vote_praxis"),
+        # One vote per ACCOUNT per praxis (#1150). Anti-abuse is enforced one
+        # layer up from where the action happens (ADR-0041), so the uniqueness
+        # anchor is the account, not the character: alt characters on one
+        # account cannot stack several votes onto the same praxis. Duel sides
+        # are separate praxes, so this also gives one vote per account per duel
+        # side. ``voter_character_id`` stays on the row as attribution — it
+        # records which life set the value that stands — and is deliberately
+        # not part of the key.
+        UniqueConstraint("praxis_id", "voter_account_id", name="uq_vote_praxis_account"),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -41,8 +41,16 @@ async def cast_or_update_vote(
 ) -> Vote:
     """Cast or update a vote on a solo or collab praxis.
 
-    Enforces account-level anti-self-vote so alt characters on the same account
-    cannot vote on each other's praxes.
+    Every rule here is account-level (ADR-0041): alt characters on one account
+    cannot vote on each other's praxes, cannot rate a duel any of them is in,
+    and — since #1150 — cannot hold more than one vote on the same praxis. The
+    third is not an extra rejection: an alt's second rating *updates* the
+    account's existing vote, which is free (no budget deduction).
+
+    The vote *budget* stays per character by owner ruling (#1150) — one
+    ``CharacterStats`` row per (character, era). An account with several
+    characters deliberately carries several budgets; it just cannot spend them
+    twice on one praxis.
     """
     if not 1 <= value <= 5:
         raise HTTPException(status_code=422, detail="Vote value must be between 1 and 5.")
@@ -52,6 +60,8 @@ async def cast_or_update_vote(
     # enforcement path and the ``viewer_can_vote`` predicate that drives the UI
     # share one source of truth (#998). Budget (below) is deliberately NOT part
     # of that predicate — it is temporary and re-rating an existing vote is free.
+    # Nor is one-vote-per-account (C, below) part of it: it never denies a vote,
+    # it routes the second one into an update, so ``viewer_can_vote`` stays True.
     if await _voter_account_owns_praxis(voter, praxis, session):
         raise HTTPException(status_code=403, detail="Cannot vote on your own praxis.")
     if await _voter_in_praxis_duel(voter, praxis, session):
@@ -60,16 +70,24 @@ async def cast_or_update_vote(
             detail="Cannot vote on a duel you're a participant in.",
         )
 
+    # C. One vote per praxis per ACCOUNT (#1150) — matched on the account, not
+    # the character, so an alt life re-rates the account's existing vote instead
+    # of falling through as a brand-new one. This is the lookup half of the
+    # ``uq_vote_praxis_account`` constraint; the constraint is the backstop.
     result = await session.execute(
         select(Vote).where(
             Vote.praxis_id == praxis.id,
-            Vote.voter_character_id == voter.id,
+            Vote.voter_account_id == voter.account_id,
         )
     )
     existing = result.scalar_one_or_none()
 
     if existing is not None:
-        # Update is free — no budget deduction
+        # Update is free — no budget deduction, whichever life re-rates. The
+        # account holds one vote; ``voter_character_id`` follows the life that
+        # set the value that stands, so the voter list, the activity feed and
+        # the character-scoped ``viewer_vote`` star all name the same character.
+        existing.voter_character_id = voter.id
         existing.value = value
         await session.flush()
         await recalculate_character_stats(praxis.created_by_id, session, era)
@@ -168,8 +186,11 @@ async def viewer_can_vote(
     participation (B) applies — the same two blocks ``cast_or_update_vote``
     enforces. Budget exhaustion is NOT considered: it is temporary and
     re-rating an existing vote is free, so the module stays visible for
-    out-of-budget viewers. Anonymous viewers (``voter is None``) get ``True`` —
-    the client shows its own login gate regardless.
+    out-of-budget viewers. One-vote-per-account (#1150) is not considered
+    either, for the same reason: an account that has already voted may still
+    re-rate, so an existing vote never turns this ``False``. Anonymous viewers
+    (``voter is None``) get ``True`` — the client shows its own login gate
+    regardless.
     """
     if voter is None:
         return True

--- a/backend/services/vote_tally.py
+++ b/backend/services/vote_tally.py
@@ -71,6 +71,12 @@ class ViewerVote:
     character who voted when the carried character did not: the account-scoped
     "voted by Alice" marker. The two are mutually exclusive by construction — the
     marker only fires when the carried character's own star is absent.
+
+    Since #1150 an account holds at most ONE vote per praxis, so the marker means
+    "your account's vote on this praxis was set by another of your lives"; rating
+    it as the carried character re-rates that row and moves the attribution to it,
+    retiring the marker. The two fields could not co-occur before either; now the
+    data cannot even represent it.
     """
 
     value: Optional[int]
@@ -112,7 +118,9 @@ async def viewer_votes_for(
         if voter_character_id == viewer_character_id:
             carried_value[praxis_id] = value
         else:
-            # First account-mate wins; a deterministic single name for the marker.
+            # One row per (praxis, account) since #1150, so there is only ever one
+            # mate to name. setdefault stays as defence for pre-#1150 rows: first
+            # account-mate wins, a deterministic single name for the marker.
             account_mate_name.setdefault(praxis_id, display_name)
 
     votes: dict[int, ViewerVote] = {}

--- a/backend/tests/integration/test_character_stats.py
+++ b/backend/tests/integration/test_character_stats.py
@@ -45,9 +45,10 @@ async def _seed_solo_praxes_with_votes(
         db_session.add(praxis)
         await db_session.flush()
 
-        # Fresh voter per praxis — avoids UNIQUE(praxis_id, voter_character_id)
-        # collisions and also keeps voter identity distinct from the author
-        # (anti-self-vote is enforced at account_id level).
+        # Fresh voter ACCOUNT per praxis — avoids
+        # UNIQUE(praxis_id, voter_account_id) collisions (#1150) and also keeps
+        # voter identity distinct from the author (anti-self-vote is enforced at
+        # account_id level).
         voter_account = Account(email=f"voter_{tag}_{praxis_index}_{author.id}@example.com")
         db_session.add(voter_account)
         await db_session.flush()

--- a/backend/tests/integration/test_praxis_voted_filter.py
+++ b/backend/tests/integration/test_praxis_voted_filter.py
@@ -13,6 +13,7 @@ praxis when the carried character did not.
 from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.account import Account
@@ -24,6 +25,7 @@ from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
 from models.task import Task
 from models.vote import Vote
 from services.praxis import build_praxis_card_out, list_praxes, VotedFilter
+from services.vote import cast_or_update_vote
 from services.vote_tally import viewer_votes_for
 
 
@@ -243,7 +245,7 @@ async def test_voted_by_name_fires_for_account_mate_only(
 
 
 @pytest.mark.asyncio
-async def test_voted_by_name_suppressed_when_both_carried_and_mate_voted(
+async def test_carried_character_re_rating_a_mates_vote_takes_over_the_marker(
     db_session: AsyncSession,
     account: Account,
     character: Character,
@@ -251,12 +253,21 @@ async def test_voted_by_name_suppressed_when_both_carried_and_mate_voted(
     _make_character,
     _make_submitted_praxis,
 ):
-    """If both the carried character and an account-mate voted, the own star wins
-    and the marker is suppressed."""
+    """One vote per praxis per account (#1150): the carried character rating a
+    praxis an account-mate already voted RE-RATES that single vote.
+
+    Replaces the old "both of us voted" case, which asserted the marker was
+    suppressed when the carried character and a mate each held a row. Two rows
+    for one account on one praxis are now impossible — ``uq_vote_praxis_account``
+    rejects the second — so the state under test no longer exists. What is left
+    to pin down is the takeover: the row's value and its attribution both move to
+    the life that re-rated it, so the own star appears and the mate marker
+    retires. The ``own is not None`` suppression branch in ``viewer_votes_for``
+    stays covered as defensive code by ``tests/unit/test_vote_tally.py``.
+    """
     mate = await _make_character(account, "matecharacter", "Account Mate")
-    p_both = await _make_submitted_praxis(character3, "Both of us voted")
-    await _cast(db_session, p_both, character, 4)
-    await _cast(db_session, p_both, mate, 2)
+    p_shared = await _make_submitted_praxis(character3, "Mate voted first")
+    await _cast(db_session, p_shared, mate, 2)
 
     praxes = await list_praxes(
         session=db_session,
@@ -264,13 +275,22 @@ async def test_voted_by_name_suppressed_when_both_carried_and_mate_voted(
         viewer_id=character.id,
         viewer_account_id=character.account_id,
     )
+    target = next(p for p in praxes if p.id == p_shared.id)
+
+    await cast_or_update_vote(character, target, 4, db_session)
+
+    rows = (
+        (await db_session.execute(select(Vote).where(Vote.praxis_id == p_shared.id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].value == 4
+    assert rows[0].voter_character_id == character.id
+
     viewer_votes = await viewer_votes_for(
         {p.id for p in praxes}, character.id, character.account_id, db_session
     )
-    card = await build_praxis_card_out(
-        next(p for p in praxes if p.id == p_both.id),
-        db_session,
-        viewer_votes=viewer_votes,
-    )
+    card = await build_praxis_card_out(target, db_session, viewer_votes=viewer_votes)
     assert card.viewer_vote == 4
     assert card.voted_by_name is None

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -182,6 +182,226 @@ async def test_update_vote_is_free(
     assert compute_votes_available(stats) == budget_after_first  # unchanged
 
 
+# ---------------------------------------------------------------------------
+# One vote per praxis per ACCOUNT (#1150) — the alt-character gap.
+#
+# Before this, uniqueness was (praxis_id, voter_character_id) and the
+# existing-vote lookup matched the character, so switching life let one account
+# stack several votes onto one praxis. The budget stays per character by owner
+# ruling; only the concentrated case is closed.
+# ---------------------------------------------------------------------------
+
+
+async def _add_second_life(
+    db_session: AsyncSession,
+    account: Account,
+    era: Era,
+    *,
+    username: str,
+) -> Character:
+    """Seed a second character (with current-era stats) on ``account``."""
+    alt = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username.title(),
+        faction_slug="ua",
+    )
+    db_session.add(alt)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(
+            character_id=alt.id,
+            era_id=era.id,
+            score=0,
+            all_time_score=0,
+            level=0,
+            votes_spent_this_era=0,
+        )
+    )
+    await db_session.commit()
+    await db_session.refresh(alt)
+    return alt
+
+
+@pytest.mark.asyncio
+async def test_alt_life_re_rates_the_accounts_vote_instead_of_adding_one(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Switching life and voting again UPDATES the account's one vote (#1150).
+
+    The regression: two rows, two lots of vote points on one praxis. Now the
+    single row's value moves, and its ``voter_character_id`` follows the life
+    that set the value that stands.
+    """
+    from models.vote import Vote
+
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Alt vote test"},
+        headers=auth_headers2,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    first = await client.post(
+        f"/praxes/{praxis_id}/vote", json={"value": 5}, headers=auth_headers
+    )
+    assert first.status_code == 200
+    assert first.json()["voter_character_id"] == character.id
+
+    alt = await _add_second_life(db_session, account, era, username="altlife")
+    switch = await client.post(
+        "/me/active-character", json={"character_id": alt.id}, headers=auth_headers
+    )
+    assert switch.status_code == 200, switch.text
+    assert switch.json()["character"]["id"] == alt.id
+
+    # Same account, different life, same praxis — accepted, but as an update.
+    second = await client.post(
+        f"/praxes/{praxis_id}/vote", json={"value": 1}, headers=auth_headers
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["value"] == 1
+    assert second.json()["voter_character_id"] == alt.id
+    assert second.json()["id"] == first.json()["id"]  # the same row, re-rated
+
+    rows = (
+        (await db_session.execute(select(Vote).where(Vote.praxis_id == praxis_id)))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    assert rows[0].value == 1
+    assert rows[0].voter_account_id == account.id
+
+
+@pytest.mark.asyncio
+async def test_alt_re_rating_is_free_and_leaves_both_budgets_alone(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """Re-rating across lives spends nothing, and the budget stays per character.
+
+    The owner ruling on #1150 keeps ``votes_spent_this_era`` on
+    ``CharacterStats`` per (character, era). So the first life keeps the one
+    point it spent and the alt spends none — it updated an existing vote, which
+    is free for any life.
+    """
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Alt budget test"},
+        headers=auth_headers2,
+    )
+    assert create_resp.status_code == 201
+    praxis_id = create_resp.json()["id"]
+
+    assert (
+        await client.post(
+            f"/praxes/{praxis_id}/vote", json={"value": 4}, headers=auth_headers
+        )
+    ).status_code == 200
+
+    alt = await _add_second_life(db_session, account, era, username="altbudget")
+    assert (
+        await client.post(
+            "/me/active-character", json={"character_id": alt.id}, headers=auth_headers
+        )
+    ).status_code == 200
+    assert (
+        await client.post(
+            f"/praxes/{praxis_id}/vote", json={"value": 2}, headers=auth_headers
+        )
+    ).status_code == 200
+
+    spent = {
+        stats.character_id: stats.votes_spent_this_era
+        for stats in (
+            await db_session.execute(
+                select(CharacterStats).where(
+                    CharacterStats.character_id.in_([character.id, alt.id]),
+                    CharacterStats.era_id == era.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    }
+    assert spent[character.id] == 1
+    assert spent[alt.id] == 0
+
+
+@pytest.mark.asyncio
+async def test_unique_constraint_rejects_a_second_vote_from_one_account(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua,
+    praxis_solo,
+    character3: Character,
+):
+    """``uq_vote_praxis_account`` is the backstop under the service's lookup.
+
+    The lookup in ``cast_or_update_vote`` routes a second rating into an update,
+    so this state is unreachable through the API. Asserted directly at the DB so
+    the constraint cannot be dropped without a failing test — a raw insert path
+    (a script, a future service) still cannot stack two votes on one account.
+    """
+    from sqlalchemy.exc import IntegrityError
+
+    from models.vote import Vote
+
+    # praxis_solo is authored by ``character``; ``character3`` (its own account)
+    # votes on it, then a second life on character3's account tries to add one.
+    db_session.add(
+        Vote(
+            praxis_id=praxis_solo.id,
+            voter_character_id=character3.id,
+            voter_account_id=character3.account_id,
+            value=4,
+        )
+    )
+    await db_session.flush()
+
+    alt = Character(
+        account_id=character3.account_id,
+        username="constraintalt",
+        display_name="Constraint Alt",
+        faction_slug="ua",
+    )
+    db_session.add(alt)
+    await db_session.flush()
+
+    db_session.add(
+        Vote(
+            praxis_id=praxis_solo.id,
+            voter_character_id=alt.id,
+            voter_account_id=character3.account_id,
+            value=1,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
 @pytest.mark.asyncio
 async def test_invalid_stars_returns_422(
     client: AsyncClient,

--- a/backend/tests/unit/test_vote_tally.py
+++ b/backend/tests/unit/test_vote_tally.py
@@ -45,6 +45,12 @@ async def test_viewer_votes_for_splits_own_and_account_mate():
     Row shape is (praxis_id, voter_character_id, value, display_name). The carried
     character (id 7) yields ``value``; a different character on the account yields
     ``voted_by_name`` only when the carried character did not vote that praxis.
+
+    Praxis 12 (carried character AND a mate) is unreachable from the database
+    since #1150 — ``uq_vote_praxis_account`` allows one row per (praxis, account).
+    The stubbed rows keep the suppression branch covered as defence for pre-#1150
+    data; this is the reason the integration test for that case was replaced with
+    a re-rate test rather than deleted outright.
     """
 
     class _FakeResult:


### PR DESCRIPTION
One vote per praxis per **account**. `vote` was unique on `(praxis_id, voter_character_id)` and
`cast_or_update_vote` looked the existing vote up by character, so switching life let one account
stack several votes onto the same praxis. Uniqueness and the lookup both move to the account —
the third rule in the `_voter_account_owns_praxis` / `_voter_in_praxis_duel` family (ADR-0041:
anti-abuse is enforced one layer up from the action).

The vote **budget** is untouched, per the owner ruling on the issue: `compute_votes_available`
keeps its shape and `votes_spent_this_era` stays per `(character, era)`. An account with several
lives still carries several budgets — it just cannot spend them twice on one praxis.

Closes #1150

## What happens to pre-existing duplicate votes

**Nothing is deleted, and the migration refuses to run rather than pick a survivor.**

`0011` opens with a pre-flight `DO` block: if any `(praxis_id, voter_account_id)` pair holds more
than one vote it `RAISE`s with the count, a `DETAIL` saying the choice is an owner decision, and a
`HINT` containing the listing query — before either DDL statement, so the database is left exactly
as it was found. Which of a player's real ratings survives (earliest? latest? highest?) is not a
builder's call, so it is not guessed at here.

Verified both ways on a scratch DB: seeded two votes from two lives of one account onto one
praxis, ran `upgrade head`, got

```
asyncpg.exceptions.RaiseError: #1150: 1 (praxis, account) pair(s) hold more than one vote, so UNIQUE (praxis_id, voter_account_id) cannot be added.
DETAIL:  This migration deliberately does not choose which real vote survives (earliest? latest? highest?) - that is an owner decision, not a builder's. Nothing was changed.
HINT:  List them with: SELECT praxis_id, voter_account_id, count(*) FROM vote GROUP BY praxis_id, voter_account_id HAVING count(*) > 1;
```

and confirmed afterwards that the table still carried the **old** constraint and **both** vote
rows. Removing the surplus row let `upgrade head` proceed.

**The dev database has zero such pairs** (`SELECT praxis_id, voter_account_id, count(*) FROM vote
GROUP BY praxis_id, voter_account_id HAVING count(*) > 1` → 0 rows), so no owner decision is
needed to deploy this as things stand. Production is unknown from here; if it has any, the
migration will say so by count and stop.

## The migration

`0011_vote_unique_per_account`: drop `uq_vote_praxis`, add `uq_vote_praxis_account
(praxis_id, voter_account_id)`.

- **Uses the `pg_constraint` lookup, not the 0008/0009 `EXCEPTION WHEN duplicate_object`
  pattern.** Adding a `UNIQUE` also builds an index; a pre-existing one raises `duplicate_table`,
  which that handler does not catch — the lesson #1193 (PR #1235) paid for.
- **`0001_squashed` needs no edit.** It builds tables with `Base.metadata.create_all`, so a fresh
  DB gets the account-scoped constraint straight from the model. The rename (`uq_vote_praxis` →
  `uq_vote_praxis_account`) is what makes both paths idempotent: on a fresh DB the DROP is a
  no-op and the ADD is skipped by the `pg_constraint` check; on a deployed DB both fire.
- The guard uses `RAISE ... USING MESSAGE = ... || ...` rather than `RAISE '%', n`, so the SQL
  contains no literal `%` for a DBAPI to interpret.

## Behaviour change to eyeball

When an alt re-rates the account's existing vote, the row's `voter_character_id` moves to the life
that set the value that stands (`services/vote.py`, one line). This is the one judgement call in
the PR and it is reversible by deleting that line.

Why: `viewer_votes_for` splits the account's rows into the *carried character's* own star and an
*account-mate* marker (#644 §7). Without the re-attribution, a life that re-rates a mate's vote
would still see "voted by Alice" and no star of its own — the click would look like it did
nothing, which is exactly the "UI predicates must agree with the API" failure the issue's step 4
warns about. With it, the voter list, the activity feed and the star all name the same character.
Cost: `/praxes/{id}/voters` and the feed attribute the vote to the last life that rated it, not
the first. `created_at` is left on the original cast.

## What to eyeball

1. **The duplicate-vote policy above** — that "refuse and report, delete nothing" is the wanted
   posture, and that it is fine for a deploy to abort on it.
2. **Re-attribution of `voter_character_id` on re-rate** — the one behaviour choice not dictated
   by the issue (see above).
3. **`viewer_can_vote` is deliberately unchanged.** One-vote-per-account never *denies* a vote, it
   routes the second into an update, so an existing vote must not turn the predicate `False` — the
   module has to stay open so the account can re-rate. Budget is excluded for the same reason
   (#998).
4. **`viewer_votes_for` needed no behaviour change** — it already matched on `voter_account_id`
   (#644). Only its docstring moved, to say what the marker means now.
5. **`list_praxes(voted=...)`** was already account-scoped (#644 §6) — untouched.
6. **The replaced test.** `test_voted_by_name_suppressed_when_both_carried_and_mate_voted` asserted
   a state the constraint now rejects (two rows, one account). It is replaced by
   `test_carried_character_re_rating_a_mates_vote_takes_over_the_marker`, and the defensive
   suppression branch in `viewer_votes_for` stays covered by the stubbed-row unit test in
   `tests/unit/test_vote_tally.py` (which is now labelled as pre-#1150 defence).
7. **`scripts/seed_demo_praxes.py` was checked and needs no change** — every demo player has its
   own account, so no `players.values()` loop can produce two votes for one account.

## Tests

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz1150_test \
  python -m pytest --cov=. --cov-fail-under=80 -q
```
→ **842 passed, coverage 89.97%** (floor 80%).

New: three tests in `tests/integration/test_votes.py` — an alt life re-rating through the API
updates the single row and takes over its attribution; re-rating costs nothing and leaves both
per-character budgets alone; and the constraint itself rejects a second row for one account, so it
cannot be dropped without a failing test.

Migration verified on a **fresh** database (`alembic upgrade head` from scratch, since that is how
CI builds), plus `downgrade -1` → `upgrade head` round trip (the constraint flips back to
`(praxis_id, voter_character_id)` and forward again) and `alembic check` → "No new upgrade
operations detected".

**Unverified:** nothing was exercised in a browser (no dev stack, and the screenshot renderer is
unavailable) — the star module's behaviour after an alt re-rates is argued from `viewer_votes_for`
plus the tests, not observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
