### PR TITLE
GET /tasks/{id}/signups returns TaskSignupOut, and the schema names what the route emits (#1051)

### DIFF
--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -13,13 +13,14 @@ from dependencies import (
 from models.account import Account
 from models.character import Character
 from models.task import Task
-from schemas.task import TaskCreate, TaskOut
+from schemas.task import TaskCreate, TaskOut, TaskSignupOut
 from services.auth import get_current_account
 from services.task import (
     UNKNOWN_TASK_AUTHOR,
     authors_for_tasks,
     build_task_out,
     build_task_out_for_viewer,
+    build_task_signup_out,
     in_progress_counts_for_tasks,
     list_signups_for_task,
     list_tasks as service_list_tasks,
@@ -89,28 +90,19 @@ async def list_tasks(
     ]
 
 
-def _build_signup_dict(member, character, praxis, level: int) -> dict:
-    return {
-        "character_id": character.id,
-        "display_name": character.display_name,
-        "avatar_url": character.avatar_url,
-        "faction_slug": character.faction_slug,
-        # Current-era level for the roster row's "lvl N" (#1029); joined in
-        # list_signups_for_task, so the roster is still one query.
-        "level": level,
-        "praxis_type": praxis.type.value,
-        "joined_at": member.joined_at,
-    }
-
-
-@router.get("/{task_id}/signups", response_model=list[dict])
+@router.get("/{task_id}/signups", response_model=list[TaskSignupOut])
 async def list_task_signups(
     task_id: int,
     session: AsyncSession = Depends(get_db),
-):
-    """List characters currently working on a task via praxis membership."""
+) -> list[TaskSignupOut]:
+    """List characters currently working on a task via praxis membership.
+
+    ``response_model`` is the real schema, not ``list[dict]`` (#1051): the rows
+    are now validated and the shape appears in the OpenAPI document, so the schema
+    can no longer drift away from the route unnoticed.
+    """
     rows = await list_signups_for_task(task_id, session)
-    return [_build_signup_dict(*row) for row in rows]
+    return [build_task_signup_out(*row) for row in rows]
 
 
 @router.get("/{task_id}", response_model=TaskOut)

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from models.praxis import PraxisType
 from models.task import TaskStatus, TaskType
 
 
@@ -85,7 +86,23 @@ class CharacterTaskOut(BaseModel):
 
 
 class TaskSignupOut(BaseModel):
-    """One row of a task's in-progress roster (GET /tasks/{id}/signups)."""
+    """One row of a task's in-progress roster (GET /tasks/{id}/signups).
+
+    This is the route's real response model (``response_model=list[TaskSignupOut]``).
+    It previously was not: the route declared ``list[dict]`` and hand-built rows,
+    so FastAPI validated nothing and the two drifted (#1051). The reconciliation
+    kept the names the *route* emitted, because those are the accurate ones:
+
+    * ``praxis_type`` is the praxis's :class:`PraxisType` (solo/collab/duel). The
+      schema used to call this ``status``, which was simply the wrong fact — a
+      praxis type is not a status, and the route never emitted a status.
+    * ``joined_at`` is ``PraxisMember.joined_at``, matching both the source column
+      and the ``joined_at`` already on praxis-member payloads. The schema used to
+      call it ``signed_up_at``; same fact, inconsistent name.
+
+    Neither of the schema's old names was consumed by anything (see #1051), so no
+    live reader depended on the drift.
+    """
 
     character_id: int
     display_name: str
@@ -95,5 +112,9 @@ class TaskSignupOut(BaseModel):
     # ADR-0042), for the roster row's "lvl N" (#1029). 0 when the character has
     # no stats row for the current era.
     level: int = 0
-    status: str
-    signed_up_at: datetime
+    # Which kind of praxis the character is working the task through. Typed as the
+    # enum rather than ``str`` so the domain values are not bare string literals;
+    # Pydantic serialises it to its value ("solo"/"collab"/"duel") on the wire,
+    # exactly as PraxisOut.type does.
+    praxis_type: PraxisType
+    joined_at: datetime

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -10,7 +10,7 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.praxis import Praxis, PraxisMember, PraxisStatus
 from models.task import Task, TaskStatus, TaskType
-from schemas.task import TaskCreate, TaskOut
+from schemas.task import TaskCreate, TaskOut, TaskSignupOut
 from services.era import (
     get_current_era_row,
     get_current_era_row_safe,
@@ -328,6 +328,34 @@ async def list_signups_for_task(
         (member, character, praxis, int(level or 0))
         for member, character, praxis, level in result.all()
     ]
+
+
+def build_task_signup_out(
+    member: PraxisMember,
+    character: Character,
+    praxis: Praxis,
+    level: int,
+) -> TaskSignupOut:
+    """Assemble one roster row from a :func:`list_signups_for_task` tuple.
+
+    Mirrors :func:`build_task_out` — the row is composed here in the service, not
+    in the route, and the route simply maps this over the query result (#1051).
+
+    Deliberately projects a *chosen* set of columns off ``character`` rather than
+    validating the ORM object wholesale: ``Character`` carries ``account_id``,
+    which must never reach a public response.
+    """
+    return TaskSignupOut(
+        character_id=character.id,
+        display_name=character.display_name,
+        avatar_url=character.avatar_url,
+        faction_slug=character.faction_slug,
+        # Current-era level for the roster row's "lvl N" (#1029); joined in
+        # list_signups_for_task, so the roster is still one query.
+        level=level,
+        praxis_type=praxis.type,
+        joined_at=member.joined_at,
+    )
 
 
 async def in_progress_counts_for_tasks(

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -16,6 +16,7 @@ from models.era import Era
 from models.faction import Faction, FactionStatus
 from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
 from models.task import Task, TaskStatus
+from schemas.task import TaskSignupOut
 from services.faction_service import UNAFFILIATED_FACTION_SLUG
 
 
@@ -2240,3 +2241,100 @@ async def test_task_signups_carry_current_era_level(
     assert len(rows) == 1
     assert rows[0]["character_id"] == character2.id
     assert rows[0]["level"] == 5  # character2 fixture is level 5
+
+
+# ---------------------------------------------------------------------------
+# #1051 — the signups route's wire format IS TaskSignupOut
+#
+# The route used to declare response_model=list[dict] and hand-build its rows, so
+# FastAPI validated nothing and the schema drifted (it said status/signed_up_at
+# while the route emitted praxis_type/joined_at) with no test able to notice.
+# These tests pin the response to the schema so the two cannot separate again.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_task_signups_response_keys_are_exactly_the_schema(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    active_task: Task,
+    character2: Character,
+):
+    """Every roster row carries exactly TaskSignupOut's fields — no more, no less.
+
+    Derived from the schema rather than a hand-written literal: a field added to
+    TaskSignupOut without the builder populating it (or vice versa) fails here,
+    which is the drift #1051 was about.
+    """
+    await _add_praxis_member(
+        db_session, active_task.id, character2.id, PraxisStatus.in_progress
+    )
+
+    resp = await client.get(f"/tasks/{active_task.id}/signups")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert set(rows[0]) == set(TaskSignupOut.model_fields)
+
+
+@pytest.mark.asyncio
+async def test_task_signups_row_reports_praxis_type_and_joined_at(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    active_task: Task,
+    character2: Character,
+):
+    """The praxis fields use the route's (accurate) names and serialise as values.
+
+    ``praxis_type`` is the PraxisType enum's *value* on the wire, not "PraxisType.solo";
+    ``joined_at`` is a timestamp. The schema's former ``status``/``signed_up_at``
+    must not reappear.
+    """
+    await _add_praxis_member(
+        db_session, active_task.id, character2.id, PraxisStatus.in_progress
+    )
+
+    resp = await client.get(f"/tasks/{active_task.id}/signups")
+    row = resp.json()[0]
+    assert row["praxis_type"] == PraxisType.solo.value
+    assert row["joined_at"]
+    assert "status" not in row
+    assert "signed_up_at" not in row
+
+
+@pytest.mark.asyncio
+async def test_task_signups_never_expose_account_id_or_email(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    active_task: Task,
+    character2: Character,
+):
+    """The roster row projects chosen Character columns — never account identity.
+
+    ``Character`` carries ``account_id``; the builder must not hand the ORM object
+    to the schema wholesale.
+    """
+    await _add_praxis_member(
+        db_session, active_task.id, character2.id, PraxisStatus.in_progress
+    )
+
+    resp = await client.get(f"/tasks/{active_task.id}/signups")
+    body = resp.text
+    assert "account_id" not in body
+    assert "email" not in body
+
+
+def test_task_signups_openapi_documents_the_schema():
+    """The route's shape reaches the OpenAPI document.
+
+    ``list[dict]`` published an untyped object, so a client generator learned
+    nothing about the roster. Guards the half of #1051 that no request can show.
+    """
+    from main import app
+
+    schema = app.openapi()
+    response = schema["paths"]["/tasks/{task_id}/signups"]["get"]["responses"]["200"]
+    items = response["content"]["application/json"]["schema"]["items"]
+    assert items["$ref"].endswith("/TaskSignupOut")
+    documented = schema["components"]["schemas"]["TaskSignupOut"]["properties"]
+    assert set(documented) == set(TaskSignupOut.model_fields)

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -1,4 +1,5 @@
 import api from './axios'
+import type { PraxisType } from './praxis'
 
 export type TaskType = 'standard' | 'metatask'
 
@@ -88,6 +89,15 @@ export async function proposeTask(body: TaskCreate): Promise<TaskOut> {
   return data
 }
 
+/**
+ * One row of GET /tasks/{id}/signups.
+ *
+ * This mirrors the backend `TaskSignupOut`, which is now the route's real
+ * `response_model` — it was `list[dict]`, so this type described a schema the
+ * route did not actually return (#1051). The two fields that were wrong:
+ * `status` was never emitted (the route sends the praxis's *type*), and
+ * `signed_up_at` is really `joined_at`.
+ */
 export interface TaskSignupOut {
   character_id: number
   display_name: string
@@ -96,8 +106,10 @@ export interface TaskSignupOut {
   // Current-era level, for the roster row's "lvl N" (#1029). Always present on
   // a live backend response; optional here so pre-#1029 mocks stay valid.
   level?: number
-  status: string
-  signed_up_at: string
+  /** Which kind of praxis the character is working the task through. */
+  praxis_type: PraxisType
+  /** When the character joined the praxis (`PraxisMember.joined_at`). */
+  joined_at: string
 }
 
 export async function getTaskSignups(taskId: number): Promise<TaskSignupOut[]> {

--- a/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
@@ -82,8 +82,8 @@ const SIGNUP: TaskSignupOut = {
   avatar_url: "",
   faction_slug: "albescent",
   level: 7,
-  status: "in_progress",
-  signed_up_at: "2026-01-03T00:00:00Z",
+  praxis_type: "solo",
+  joined_at: "2026-01-03T00:00:00Z",
 };
 
 function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {

--- a/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
@@ -58,8 +58,8 @@ const SIGNUP: TaskSignupOut = {
   avatar_url: "",
   faction_slug: "coven",
   level: 5,
-  status: "in_progress",
-  signed_up_at: "2026-01-03T00:00:00Z",
+  praxis_type: "solo",
+  joined_at: "2026-01-03T00:00:00Z",
 };
 
 function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {

--- a/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
@@ -61,8 +61,8 @@ const SIGNUP: TaskSignupOut = {
   avatar_url: "",
   faction_slug: "snide",
   level: 7,
-  status: "in_progress",
-  signed_up_at: "2026-01-03T00:00:00Z",
+  praxis_type: "solo",
+  joined_at: "2026-01-03T00:00:00Z",
 };
 
 function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -68,8 +68,8 @@ const SIGNUP: TaskSignupOut = {
   avatar_url: "",
   faction_slug: "ephemerists",
   level: 6,
-  status: "in_progress",
-  signed_up_at: "2026-01-03T00:00:00Z",
+  praxis_type: "solo",
+  joined_at: "2026-01-03T00:00:00Z",
 };
 
 function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {

--- a/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
@@ -62,8 +62,8 @@ const SIGNUP: TaskSignupOut = {
   avatar_url: "",
   faction_slug: "everymen",
   level: 7,
-  status: "in_progress",
-  signed_up_at: "2026-01-03T00:00:00Z",
+  praxis_type: "solo",
+  joined_at: "2026-01-03T00:00:00Z",
 };
 
 /** Four filed praxis — one more than the gallery preview, so "view all" shows. */

--- a/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
@@ -61,8 +61,8 @@ const SIGNUP: TaskSignupOut = {
   avatar_url: "",
   faction_slug: "snide",
   level: 7,
-  status: "in_progress",
-  signed_up_at: "2026-01-03T00:00:00Z",
+  praxis_type: "solo",
+  joined_at: "2026-01-03T00:00:00Z",
 };
 
 function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {

--- a/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
@@ -66,8 +66,8 @@ const SIGNUP: TaskSignupOut = {
   avatar_url: "",
   faction_slug: "snide",
   level: 7,
-  status: "in_progress",
-  signed_up_at: "2026-01-03T00:00:00Z",
+  praxis_type: "solo",
+  joined_at: "2026-01-03T00:00:00Z",
 };
 
 function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {

--- a/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
@@ -64,8 +64,8 @@ const SIGNUP: TaskSignupOut = {
   avatar_url: "",
   faction_slug: "ua",
   level: 6,
-  status: "in_progress",
-  signed_up_at: "2026-01-03T00:00:00Z",
+  praxis_type: "solo",
+  joined_at: "2026-01-03T00:00:00Z",
 };
 
 function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {

--- a/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
@@ -56,8 +56,8 @@ const SIGNUP: TaskSignupOut = {
   avatar_url: "",
   faction_slug: "snide",
   level: 7,
-  status: "in_progress",
-  signed_up_at: "2026-01-03T00:00:00Z",
+  praxis_type: "solo",
+  joined_at: "2026-01-03T00:00:00Z",
 };
 
 function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {


### PR DESCRIPTION
`GET /tasks/{id}/signups` declared `response_model=list[dict]` and hand-built its
rows, so FastAPI validated nothing, the OpenAPI document published an untyped
object, and `TaskSignupOut` was decorative — it had already drifted to two names
the route never emitted.

Took the issue's first option (make it real): the route now declares
`list[TaskSignupOut]`, the row builder moved into `services/task.py` beside
`build_task_out`, and the schema names the facts the route actually sends.

Closes #1051

## Which keys are genuinely consumed, and which were fiction

I grepped both sides before picking a direction, because whichever side wins
could break a live consumer that tsc never protected. It turns out **nothing**
was at risk — the drifted fields were fiction on *both* sides:

| key | consumed by | verdict |
|---|---|---|
| `character_id` | `test_tasks.py` (3 tests) | real |
| `level` | `test_task_signups_carry_current_era_level` | real, backend-only |
| `display_name`, `avatar_url`, `faction_slug` | nothing at runtime | real fields, no reader |
| `praxis_type` / `joined_at` (route) | **nothing** | emitted, never read |
| `status` / `signed_up_at` (schema + FE type) | **nothing** | never emitted, never read |

No component reads *any* field of a signup. `useTaskDetail` fetches the route,
stores it in `signups`, and exposes it on the state object — and every one of the
nine task-detail skins deliberately draws no roster (each has a test asserting
`not.toContain("Ossuary Pete")`, per epic #1028 decision 3 being reversed). The
only appearances of `status`/`signed_up_at` in the frontend were **test fixtures**.

So "the route's names are the ones in the wild" is true in a weaker sense than the
issue assumed: nothing is in the wild. That freed the choice to be made on
accuracy, and the route's names win on accuracy too:

- `praxis_type` is `praxis.type` — solo/collab/duel. The schema called this
  `status`, which is not a rename but **a different fact**; a praxis type is not a
  status, and the route never emitted a status at all. The nine fixtures all set
  `status: "in_progress"` — not a valid `PraxisType` — which is the clearest proof
  no reader existed.
- `joined_at` is `PraxisMember.joined_at`, matching the source column and the
  `joined_at` already on praxis-member payloads (`api/praxis.ts`). `signed_up_at`
  was the same fact under an inconsistent name.

`CharacterTaskOut.status` / `.signed_up_at` in the same module are a **different
schema for a different route** and are untouched.

## `level` earns its place

The issue asked. Keeping it: it has no *rendering* consumer, but it is asserted by
a backend test, `list_signups_for_task` does the `CharacterStats` outer join for
it, and it is no more orphaned than `display_name`. Since no field of this route is
rendered today, singling out `level` would be arbitrary — dropping the roster
payload is a separate product call.

## Other things this fixes

- **`account_id` hardening.** The builder projects chosen `Character` columns
  rather than validating the ORM object, which carries `account_id`. The old dict
  did not leak it either, but the response model now *enforces* the field set.
- **`praxis_type` is `PraxisType`, not `str`** — no bare string literals for domain
  values. Pydantic serialises it to its value, so the wire format is unchanged
  from the old `praxis.type.value`.
- Route got its return annotation; row construction left the router.

## What to eyeball

1. **The naming call is the whole judgement here.** I kept the route's
   `praxis_type`/`joined_at` and deleted the schema's `status`/`signed_up_at`.
   Reasoning above; if you would rather the roster expose a real praxis *status*,
   that is a new field, not this rename.
2. **`level` kept** — say so if you would rather it go with the unrendered roster.
3. **Out of scope, left alone: `.design-sync/previews/_state.tsx`** builds
   `TaskSignupOut[]` with `status: 'active'` (not even a valid praxis status) and
   `signed_up_at`. It is outside `tsconfig`'s `include: ["src"]`, so **CI will not
   flag it**, and it is outside this issue's footprint — but it is now type-stale
   and wants a one-line fix by whoever owns design-sync previews.
4. **`praxis_type` is required** in the TS type (`level` stayed optional, per its
   existing pre-#1029-mock comment). That is why all nine fixtures changed.
5. Nothing visual changed and no route response any consumer reads changed, so
   there is nothing to click through. Unverified by browser — no dev stack, and
   the Browser pane renderer times out.

## Tests

Four new tests pin the contract so it cannot silently drift again:

- key set is **derived from `TaskSignupOut.model_fields`**, not a hand-written
  literal, so adding a schema field the builder ignores fails
- `praxis_type` serialises as its value and `status`/`signed_up_at` do not reappear
- no `account_id`/`email` in the body
- the OpenAPI document `$ref`s `TaskSignupOut` — this guards the half of the bug
  no request could reveal (with `list[dict]` there was no `$ref` at all)

```
# backend, dedicated DB wz1051_test
TEST_DATABASE_URL=postgresql+asyncpg://.../wz1051_test \
  python -m pytest --cov=. --cov-fail-under=80 -q
852 passed — coverage 90.22% (gate 80%)

# frontend (api/tasks.ts touched)
tsc --noEmit          -> 0 errors (tsc 5.9.3 confirmed running, not a false pass)
npx vitest run        -> 151 files, 2545 tests, all passed
npx eslint <touched>  -> clean
```

No migration: this is a response-shape change only, no DB schema touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
