### PR TITLE
Character creation stops saying No File Chosen over a photo you already chose (#1149)

### DIFF
--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -88,6 +88,13 @@
   "media": {
     "removeAria": "Remove {{name}}"
   },
+  "portrait": {
+    "chooseAction": "Choose a photo",
+    "changeAction": "Change photo",
+    "noneChosen": "No photo chosen yet",
+    "chosen": "Chosen: {{name}}",
+    "keepingCurrent": "Keeping your current photo"
+  },
   "editPraxis": {
     "loadingPageTitle": "Edit Praxis",
     "loading": "Loading...",

--- a/frontend/src/pages/CreateCharacter.tsx
+++ b/frontend/src/pages/CreateCharacter.tsx
@@ -14,6 +14,7 @@ import {
   BIO_MAX,
   type CreateCharacterState,
 } from './characterPaths/useCreateCharacter'
+import PortraitPicker from './characterPaths/PortraitPicker'
 import DefaultCreateCharacter from './characterPaths/mobileArchetypes/DefaultCreateCharacter'
 
 /**
@@ -50,6 +51,7 @@ function DesktopCreateCharacter({ state }: { state: CreateCharacterState }) {
     factionSlug,
     setFactionSlug,
     invited,
+    avatarFile,
     avatarPreview,
     avatarSource,
     setAvatarSource,
@@ -105,17 +107,17 @@ function DesktopCreateCharacter({ state }: { state: CreateCharacterState }) {
             <span style={{ color: 'var(--color-text-tertiary)' }}>{t('createCharacter.charsLeft', { count: BIO_MAX - bio.length })}</span>
           </div>
 
-          {/* Portrait — reuses the existing avatar uploader (POST /characters/{id}/avatar) */}
+          {/* Portrait — reuses the existing avatar uploader (POST /characters/{id}/avatar).
+              The picker owns the hidden input and the "what's chosen" readout (#1149);
+              the credential card on the right opens the same input through fileInputRef. */}
           <label style={{ ...eyebrow, marginTop: 'var(--space-xl)' }}>{t('createCharacter.portraitLabel')} <span style={{ textTransform: 'none', letterSpacing: 0 }}>{t('createCharacter.optional')}</span></label>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept="image/*"
+          <PortraitPicker
+            inputRef={fileInputRef}
             onChange={handleAvatarChange}
-            className="font-body text-sm"
+            chosenFile={avatarFile}
+            error={avatarError}
             style={{ marginTop: 'var(--space-sm)' }}
           />
-          {avatarError && <p className="font-body content-text text-red-600 mt-1">{avatarError}</p>}
 
           {/* Faction picker — only when the account holds invitations (ADR-0019) */}
           {showPicker && (

--- a/frontend/src/pages/EditCharacter.tsx
+++ b/frontend/src/pages/EditCharacter.tsx
@@ -9,6 +9,7 @@ import { useFormFactor } from '../hooks/useFormFactor'
 import { pickVariant } from '../utils/factionDispatch'
 import { surfaceMap } from '../factions'
 import { useEditCharacter, type EditCharacterState } from './characterPaths/useEditCharacter'
+import PortraitPicker from './characterPaths/PortraitPicker'
 import DefaultEditCharacter from './characterPaths/mobileArchetypes/DefaultEditCharacter'
 
 /**
@@ -103,6 +104,7 @@ function DesktopEditCharacter({ state }: { state: EditCharacterState }) {
     setBio,
     location,
     setLocation,
+    avatarFile,
     avatarPreview,
     avatarSource,
     setAvatarSource,
@@ -222,14 +224,16 @@ function DesktopEditCharacter({ state }: { state: EditCharacterState }) {
               <label className="font-body text-sm font-bold" style={{ display: 'block', marginBottom: 'var(--space-sm)' }}>
                 {t('editCharacter.avatarLabel')}
               </label>
-              <input
-                ref={fileRef}
-                type="file"
-                accept="image/*"
+              {/* The picker owns the hidden input and the readout (#1149). On this
+                  screen there may already be a saved portrait, so "nothing new
+                  chosen" reads as keeping it rather than as having none. */}
+              <PortraitPicker
+                inputRef={fileRef}
                 onChange={handleAvatarChange}
-                className="font-body text-sm"
+                chosenFile={avatarFile}
+                hasCurrentPortrait={Boolean(character.avatar_url)}
+                error={avatarError}
               />
-              {avatarError && <p className="font-body content-text text-red-600 mt-1">{avatarError}</p>}
               <p style={avatarHintStyle}>{t('editCharacter.avatarHint', { initial })}</p>
             </div>
           </div>

--- a/frontend/src/pages/characterPaths/PortraitPicker.tsx
+++ b/frontend/src/pages/characterPaths/PortraitPicker.tsx
@@ -1,0 +1,140 @@
+import { useId, useRef, type ChangeEvent, type CSSProperties, type RefObject } from 'react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * The portrait file control for the character screens (#1149).
+ *
+ * Both desktop screens used to render a naked `<input type="file">`, which draws
+ * the browser's own "No file chosen" text beside it. That text is a report on the
+ * INPUT's `files` list, and {@link useAvatarPicker}'s `handleAvatarChange`
+ * deliberately clears it (`event.target.value = ''`) the instant a file arrives —
+ * it has to, or re-picking the same path would fire no `change` event and the
+ * crop modal would never reopen. So the chrome went on saying "No file chosen"
+ * over a portrait that was plainly sitting in the preview: the label was telling
+ * the truth about an input we had emptied on purpose, and lying about the state
+ * the player cares about.
+ *
+ * That is an accessibility defect before it is a cosmetic one — a screen reader
+ * got told nothing was chosen. So the fix is not to hide the chrome and stop
+ * there: the native input goes `display: none` (removing it from the
+ * accessibility tree along with its stale label), and a real button plus a live
+ * status line take over. The button's accessible name IS its visible text, and
+ * the status line — a `role="status"` region the button points at through
+ * `aria-describedby` — reads the picker's React state, never `input.files`. What
+ * is announced and what is on screen are the same two strings.
+ *
+ * The mobile skins were never wrong here: they already hid the input behind a
+ * photo ring with its own caption. They keep their bespoke ring (each faction
+ * owns its archetype) and only gained the accessible name the ring was missing.
+ */
+
+export interface PortraitPickerProps {
+  /** The picker hook's input handler — validates size, then opens the cropper. */
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+  /**
+   * The cropped file awaiting upload, from React state. Null while nothing has
+   * been confirmed — including after a pick whose crop was cancelled, which is a
+   * genuine "nothing chosen" and reads as one.
+   */
+  chosenFile: File | null
+  /** True on the edit screen when the character already has a saved portrait. */
+  hasCurrentPortrait?: boolean
+  /** Avatar-scoped error (over-size, upload failure) — rendered under the row. */
+  error?: string
+  /**
+   * Share the hidden input so the surface can open it from elsewhere too — the
+   * create screen's credential-card portrait is a second trigger for it. Omit and
+   * the control keeps its own.
+   */
+  inputRef?: RefObject<HTMLInputElement | null>
+  /** Wrapper override, for a surface that owns the surrounding spacing. */
+  style?: CSSProperties
+  buttonStyle?: CSSProperties
+  statusStyle?: CSSProperties
+}
+
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--space-md)',
+  flexWrap: 'wrap',
+}
+
+const defaultStatusStyle: CSSProperties = {
+  fontFamily: 'var(--font-body)',
+  color: 'var(--color-text-secondary)',
+  // Long filenames wrap rather than push the button off the row.
+  minWidth: 0,
+  wordBreak: 'break-word',
+}
+
+const errorStyle: CSSProperties = {
+  fontFamily: 'var(--font-body)',
+  color: 'var(--color-danger)',
+  margin: 'var(--space-sm) 0 0',
+}
+
+export default function PortraitPicker({
+  onChange,
+  chosenFile,
+  hasCurrentPortrait = false,
+  error,
+  inputRef,
+  style,
+  buttonStyle,
+  statusStyle,
+}: PortraitPickerProps) {
+  const { t } = useTranslation('forms')
+  // Always called, then discarded when the caller supplied its own (hooks order).
+  const ownRef = useRef<HTMLInputElement>(null)
+  const ref = inputRef ?? ownRef
+  const statusId = `portrait-status-${useId()}`
+
+  // One expression, two consumers: the visible line and the button's description.
+  const statusText = chosenFile
+    ? t('portrait.chosen', { name: chosenFile.name })
+    : hasCurrentPortrait
+      ? t('portrait.keepingCurrent')
+      : t('portrait.noneChosen')
+
+  return (
+    <div style={style}>
+      <div style={rowStyle}>
+        <button
+          type="button"
+          onClick={() => ref.current?.click()}
+          aria-describedby={statusId}
+          className="btn-outline"
+          style={buttonStyle}
+        >
+          {chosenFile || hasCurrentPortrait ? t('portrait.changeAction') : t('portrait.chooseAction')}
+        </button>
+        {/* The state of record. `role="status"` so a confirmed crop is announced
+            without stealing focus; the text comes from React, not input.files. */}
+        <span
+          id={statusId}
+          role="status"
+          data-testid="portrait-status"
+          className="content-text"
+          style={{ ...defaultStatusStyle, ...statusStyle }}
+        >
+          {statusText}
+        </span>
+      </div>
+      {/* Hidden, so the browser's stale "no file chosen" chrome is gone from the
+          page AND from the accessibility tree. The button above is the control. */}
+      <input
+        ref={ref}
+        type="file"
+        accept="image/*"
+        onChange={onChange}
+        style={{ display: 'none' }}
+      />
+      {error && (
+        <p className="content-text" style={errorStyle}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/characterPaths/PortraitPicker.tsx
+++ b/frontend/src/pages/characterPaths/PortraitPicker.tsx
@@ -46,7 +46,7 @@ export interface PortraitPickerProps {
    * create screen's credential-card portrait is a second trigger for it. Omit and
    * the control keeps its own.
    */
-  inputRef?: RefObject<HTMLInputElement | null>
+  inputRef?: RefObject<HTMLInputElement>
   /** Wrapper override, for a surface that owns the surrounding spacing. */
   style?: CSSProperties
   buttonStyle?: CSSProperties

--- a/frontend/src/pages/characterPaths/PortraitPicker.tsx
+++ b/frontend/src/pages/characterPaths/PortraitPicker.tsx
@@ -88,7 +88,10 @@ export default function PortraitPicker({
   // Always called, then discarded when the caller supplied its own (hooks order).
   const ownRef = useRef<HTMLInputElement>(null)
   const ref = inputRef ?? ownRef
-  const statusId = `portrait-status-${useId()}`
+  // The button's aria-describedby has to point at the status line by id, and two
+  // pickers could in principle share a page, so the id is generated.
+  const generatedId = useId()
+  const statusId = `portrait-status-${generatedId}`
 
   // One expression, two consumers: the visible line and the button's description.
   const statusText = chosenFile
@@ -114,7 +117,6 @@ export default function PortraitPicker({
         <span
           id={statusId}
           role="status"
-          data-testid="portrait-status"
           className="content-text"
           style={{ ...defaultStatusStyle, ...statusStyle }}
         >

--- a/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
@@ -123,6 +123,19 @@ describe('DefaultCreateCharacter mobile skin', () => {
     expect(text, 'sticky create').toContain('Create character')
     expect(text, 'born-unaffiliated explainer').toContain('Unaffiliated')
   })
+
+  // #1149: the ring's accessible name used to fall through to the "+" glyph or,
+  // once a portrait existed, to its alt text. It now matches the caption drawn
+  // right beneath it, in both states.
+  it('names the photo ring with its own caption', () => {
+    const empty = render(<DefaultCreateCharacter state={createState({})} />)
+    expect(empty.html, 'empty ring').toContain('aria-label="Add photo"')
+    expect(empty.text, 'and the caption agrees').toContain('Add photo')
+
+    const picked = render(<DefaultCreateCharacter state={createState({ avatarPreview: 'blob:p-1' })} />)
+    expect(picked.html, 'ring holding a portrait').toContain('aria-label="Change photo"')
+    expect(picked.text, 'and the caption agrees').toContain('Change photo')
+  })
 })
 
 describe('DefaultEditCharacter mobile skin', () => {
@@ -141,6 +154,12 @@ describe('DefaultEditCharacter mobile skin', () => {
   it('links out to a joined faction detail page', () => {
     const { html } = render(<DefaultEditCharacter state={editState({ character: character({ faction_slug: 'wow' }) })} />)
     expect(html).toContain('href="/factions/wow"')
+  })
+
+  it('names the photo ring with its own caption (#1149)', () => {
+    const { html, text } = render(<DefaultEditCharacter state={editState({})} />)
+    expect(html).toContain('aria-label="Change photo"')
+    expect(text).toContain('Change photo')
   })
 
   it('shows a freshly cropped portrait (preview) over the persisted avatar (#985)', () => {

--- a/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/characterPaths.test.tsx
@@ -52,6 +52,7 @@ function createState(overrides: Partial<CreateCharacterState>): CreateCharacterS
     factionSlug: '',
     setFactionSlug: () => {},
     invited: [],
+    avatarFile: null,
     avatarPreview: null,
     avatarSource: null,
     setAvatarSource: () => {},

--- a/frontend/src/pages/characterPaths/__tests__/portraitPicker.test.tsx
+++ b/frontend/src/pages/characterPaths/__tests__/portraitPicker.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * PortraitPicker — the character screens' photo control (#1149).
+ *
+ * The bug was a naked `<input type="file">`: its browser chrome reports on
+ * `input.files`, which `useAvatarPicker.handleAvatarChange` clears on purpose, so
+ * it said "No file chosen" over a portrait that was already picked — and told a
+ * screen reader the same thing.
+ *
+ * WHAT THESE TESTS COVER: the rendered markup for each state — which is exactly
+ * the surface that was wrong. The visible readout, the button's label, the
+ * `aria-describedby` → status wiring, and the fact that the native input is
+ * hidden (out of the page and out of the accessibility tree, taking its stale
+ * label with it).
+ *
+ * WHAT THEY CANNOT COVER: the act of choosing. There is no jsdom in this repo
+ * (renderToStaticMarkup only) and no way to dispatch a file-selection event or
+ * run the crop modal, so the transition itself — pick → crop → confirm → readout
+ * updates — is only verified by driving the component with the state that
+ * transition produces. The `role="status"` announcement likewise needs a real AT
+ * to observe.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so the copy keys resolve to English text.
+import '../../../i18n'
+import PortraitPicker from '../PortraitPicker'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(element)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+const chosen = new File(['x'], 'blossom-in-the-rain.jpg', { type: 'image/jpeg' })
+
+describe('PortraitPicker — the readout agrees with the state, not with input.files', () => {
+  it('names the chosen file once a crop is confirmed', () => {
+    const { text } = render(<PortraitPicker onChange={() => {}} chosenFile={chosen} />)
+    expect(text, 'the filename is on screen').toContain('blossom-in-the-rain.jpg')
+    // The whole point of the issue: nothing anywhere claims no file was chosen.
+    expect(text.toLowerCase(), 'no stale "no file chosen"').not.toContain('no photo chosen')
+    expect(text, 'the action reads as a replacement now').toContain('Change photo')
+  })
+
+  it('says so plainly when nothing has been chosen', () => {
+    const { text } = render(<PortraitPicker onChange={() => {}} chosenFile={null} />)
+    expect(text).toContain('No photo chosen yet')
+    expect(text).toContain('Choose a photo')
+  })
+
+  it('reads a saved portrait as kept, not as missing (the edit screen)', () => {
+    const { text } = render(
+      <PortraitPicker onChange={() => {}} chosenFile={null} hasCurrentPortrait />,
+    )
+    expect(text, 'not "none chosen" — there IS one').toContain('Keeping your current photo')
+    expect(text).not.toContain('No photo chosen yet')
+    expect(text).toContain('Change photo')
+  })
+
+  it('hides the native input, so its stale label cannot render', () => {
+    const { html } = render(<PortraitPicker onChange={() => {}} chosenFile={chosen} />)
+    expect(html, 'there is still a real file input to drive').toContain('type="file"')
+    expect(html, 'but it is display:none — no browser chrome, no a11y node').toMatch(
+      /type="file"[^>]*style="display:none"|style="display:none"[^>]*type="file"/,
+    )
+  })
+
+  it('wires the button to the status line, so the accessible description carries the state', () => {
+    const { html } = render(<PortraitPicker onChange={() => {}} chosenFile={chosen} />)
+    const described = /aria-describedby="([^"]+)"/.exec(html)?.[1]
+    const statusId = /id="([^"]+)"[^>]*role="status"/.exec(html)?.[1]
+    expect(described, 'the button points at a description').toBeTruthy()
+    expect(statusId, 'the status line has an id to point at').toBeTruthy()
+    expect(described).toBe(statusId)
+  })
+
+  it('carries an avatar-scoped error under the row', () => {
+    const { text } = render(
+      <PortraitPicker onChange={() => {}} chosenFile={null} error="Portrait must be under 10 MB." />,
+    )
+    expect(text).toContain('Portrait must be under 10 MB.')
+  })
+})

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
@@ -40,6 +40,15 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
     showPicker,
   } = state
 
+  // One string for the ring's accessible name and its visible caption (#1149).
+  // The ring never showed the browser's "No file chosen" — its input has always
+  // been hidden — but it had no accessible name either: the name fell through to
+  // the "+" glyph, or to the portrait's alt text once one was picked. Naming it
+  // with the caption is what makes what is announced and what is on screen agree.
+  const photoAction = avatarPreview
+    ? t('createCharacter.mobile.changePhoto')
+    : t('createCharacter.mobile.addPhoto')
+
   return (
     <form data-skin="default" data-testid="mobile-create-character" onSubmit={handleSubmit} style={page}>
       {/* Top row — back + title */}
@@ -53,12 +62,13 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
 
       {/* Photo add */}
       <div style={{ textAlign: 'center' }}>
-        <button type="button" onClick={() => fileRef.current?.click()} style={ringBtn}>
+        <button type="button" onClick={() => fileRef.current?.click()} aria-label={photoAction} style={ringBtn}>
           <span style={ringInner}>
             {avatarPreview ? (
               <img src={avatarPreview} alt={handle} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
             ) : (
               <span
+                aria-hidden
                 style={{
                   // eslint-disable-next-line local/no-raw-style-values -- ornament: "+" is a glyph-as-icon, sized to the 104px photo ring, not text
                   fontSize: 26,
@@ -71,7 +81,7 @@ export default function DefaultCreateCharacter({ state }: { state: CreateCharact
           </span>
         </button>
         <div className="eyebrow" style={{ marginTop: 'var(--space-md)', color: 'var(--faction-default-card-muted)' }}>
-          {avatarPreview ? t('createCharacter.mobile.changePhoto') : t('createCharacter.mobile.addPhoto')}
+          {photoAction}
         </div>
         <div className="eyebrow" style={{ marginTop: 'var(--space-sm)', color: 'var(--color-text-tertiary)' }}>
           {t('createCharacter.mobile.step')}

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
@@ -68,12 +68,21 @@ export default function DefaultEditCharacter({ state }: { state: EditCharacterSt
 
       {/* Photo */}
       <div style={{ textAlign: 'center' }}>
-        <button type="button" onClick={() => fileRef.current?.click()} style={ringBtn}>
+        {/* The ring's accessible name is the caption right below it (#1149) —
+            without it the name fell through to the portrait's alt text or to the
+            monogram letter, neither of which says this opens a file picker. */}
+        <button
+          type="button"
+          onClick={() => fileRef.current?.click()}
+          aria-label={t('editCharacter.mobile.changePhoto')}
+          style={ringBtn}
+        >
           <span style={ringInner}>
             {portraitSrc ? (
               <img src={portraitSrc} alt={character.username} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
             ) : (
               <span
+                aria-hidden
                 style={{
                   fontFamily: 'var(--faction-default-card-font)',
                   fontStyle: 'italic',

--- a/frontend/src/pages/characterPaths/useCreateCharacter.ts
+++ b/frontend/src/pages/characterPaths/useCreateCharacter.ts
@@ -48,6 +48,12 @@ export interface CreateCharacterState {
   factionSlug: string
   setFactionSlug: (value: string) => void
   invited: string[]
+  /**
+   * The cropped portrait awaiting upload. Exposed (#1149) because it is the only
+   * honest answer to "has a photo been chosen?" — the file input is cleared as
+   * soon as it hands the file over, so its own `files` list always says no.
+   */
+  avatarFile: File | null
   avatarPreview: string | null
   avatarSource: File | null
   setAvatarSource: (file: File | null) => void
@@ -118,6 +124,7 @@ export function useCreateCharacter(): CreateCharacterState {
     factionSlug,
     setFactionSlug,
     invited,
+    avatarFile,
     avatarPreview,
     avatarSource,
     setAvatarSource,


### PR DESCRIPTION
Closes #1149

## Diagnosis (confirmed, not assumed)

The screenshot's "No File Chosen" is the browser's own chrome on a naked
`<input type="file">`, and it was telling the truth about an input we empty on
purpose.

`useAvatarPicker.handleAvatarChange` (`frontend/src/pages/characterPaths/useAvatarPicker.ts:90`)
does `event.target.value = ''` the moment it takes the file. That line has to
stay: without it, re-picking the same path fires no `change` event, so the crop
modal would never reopen for a file you had already tried once. But the native
label is a report on `input.files`, so a cleared input reads "No file chosen"
forever — over a portrait sitting right there in the preview.

The hook's own docstring already said `handleAvatarChange` was a "**Hidden**
file-input onChange" (line 67). Both mobile skins honoured that; the two desktop
screens rendered the input bare and visible. That's the whole bug.

**Where it was drawn — all four surfaces checked:**

| Surface | Before | Verdict |
|---|---|---|
| `pages/CreateCharacter.tsx` (desktop) | bare visible input, line 110 | **the bug** |
| `pages/EditCharacter.tsx` (desktop) | bare visible input, line 225 | **the bug** |
| `characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx` | input already `display:none`, ring + caption | not the bug — but the ring had **no accessible name** |
| `characterPaths/mobileArchetypes/DefaultEditCharacter.tsx` | same | same |

Character creation *is* a desktop/mobile pair (`useFormFactor()` → `pickVariant(surfaceMap('mobileCreateCharacter'), …)`), and `na`/Default is the only registered skin for both mobile surfaces, so those two files are the whole mobile side.

## The fix

New shared control `frontend/src/pages/characterPaths/PortraitPicker.tsx`, built on the
`FilePicker` pattern from `editPraxis/archetypes/controls.tsx` — **not** by reusing
`FilePicker` itself, which is bound to `EditPraxisState` (multi-file, praxis media,
`state.handleFileChange`) and shares no state with the avatar flow. Same shape,
different domain; the two surfaces stay separate, as the issue asked.

- native input goes `display: none` — out of the page **and** out of the accessibility tree, taking its stale label with it;
- a real `<button class="btn-outline">` opens it. Its **accessible name is its visible text** ("Choose a photo" / "Change photo");
- a `role="status"` line beside it names the state, read from **React state (`avatarFile`)**, never `input.files`: `Chosen: blossom.jpg` / `No photo chosen yet` / `Keeping your current photo` (edit screen with a saved avatar);
- the button carries `aria-describedby` → that status line, so the state is part of what a screen reader hears on the button, and a confirmed crop is announced without stealing focus. One expression feeds both the visible text and the description — they cannot drift.

`useCreateCharacter` now returns `avatarFile` (`useEditCharacter` already did) — it is
the only honest answer to "has a photo been chosen?".

The create screen's credential-card portrait ring keeps working as a second
trigger: it shares the same `fileInputRef`, now passed into the picker.

Mobile: each ring button gains `aria-label` equal to the caption printed directly
beneath it, and the decorative `+` / monogram glyph inside is `aria-hidden`.
Nothing visual changes on mobile; the bespoke rings are untouched.

**Copy** (new shared `portrait.*` block in `forms.json`): `chooseAction`,
`changeAction`, `noneChosen`, `chosen`, `keepingCurrent`.

## What to eyeball

1. **Create character (desktop)** — the "No file chosen" text is gone. Before picking: `[ CHOOSE A PHOTO ]  No photo chosen yet`.
2. Pick a photo, confirm the crop → the line becomes `Chosen: <your filename>` and the button reads `CHANGE PHOTO`. **This is the reported bug; this is the line to check.**
3. Pick a photo and **cancel** the crop → back to `No photo chosen yet`. Correct: nothing was confirmed.
4. Pick the **same file twice** → the crop modal must reopen. This is what the `value = ''` reset buys, and it must still work.
5. Click the **credential-card portrait ring** on the right → same picker opens; the status line in the left column updates.
6. **Edit character (desktop)**, character with a saved avatar → `[ CHANGE PHOTO ]  Keeping your current photo`. Pick a new one → `Chosen: …`. Character with no avatar → `Choose a photo` / `No photo chosen yet`.
7. Over-size file (>10 MB) → "Portrait must be under 10 MB." under the row, and the status line still says nothing was chosen.
8. **Screen reader** on the button: it should read as "Choose a photo, button, No photo chosen yet" and, after a crop, "Change photo, button, Chosen: blossom.jpg".
9. **Mobile create/edit** — visually identical to before. Only the ring's accessible name changed.
10. Button style: `btn-outline` (existing shared class, `--text-sm` uppercase). If the portrait row wants its own treatment on either screen, that's a `frontend-style` call, not one I made.

## Verified vs inferred

**Verified locally:**
- `tsc --noEmit` — clean.
- `npm run lint` (full `eslint src`, what CI's `frontend` job runs) — clean, including the `no-raw-style-values` ratchet on the new file.
- `npx vite build` — built in 3.22s.
- **Full frontend suite: 152 files, 2553 tests, all passing** (18 in `characterPaths/`, of which 6 are the new `portraitPicker.test.tsx`).
- Read the four surfaces and `useAvatarPicker` on disk and confirmed the `value = ''` reset and the two bare inputs. `grep -rn 'type="file"' src/` shows exactly five inputs in the repo; the two remaining are `PortraitPicker`'s and `FilePicker`'s, both hidden.

**Inferred / NOT verified:**
- **No visual QA.** No dev stack in this worktree and the Browser pane renderer times out here. Every pixel claim above is inferred from the markup.
- **No screen-reader run.** The a11y claims are structural (accessible name = visible text; `aria-describedby` resolves to a `role="status"` element carrying the state text) and asserted in markup, not observed in AT.
- **The act of choosing is untestable here.** The harness is `renderToStaticMarkup` only — no jsdom, effects never run, and there is no way to dispatch a file-selection event or drive `ImageEditModal`. The tests render the component with the state each transition *produces*; they do not perform the transition. Eyeball items 2-4 are the only real check on that path. This is stated in the test file's header too.
- Item 4 (re-picking the same file) is behaviour I *preserved* by leaving `handleAvatarChange` alone — I did not exercise it.

## Adjacent finding, deliberately NOT fixed

`components/CredentialCard.tsx` (the clickable portrait ring, ~line 172) — its
`title` is `common.credential.uploadTitle` = *"Drag a photo here, or click to
upload"*, but no drop handler is wired anywhere on that ring. That `title` is also
its only accessible name (via the accname `title` fallback). Giving it an explicit
`aria-label` would have meant codifying "drag a photo here" as an accessible name
for something that doesn't accept a drag — the same class of defect as this issue.
Either the drop target should be built or the copy corrected; both are someone
else's call. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
