### PR TITLE
The score stamp stops saying the base twice

### DIFF
--- a/docs/adr/0047-praxis-card-shows-computed-total-not-merit.md
+++ b/docs/adr/0047-praxis-card-shows-computed-total-not-merit.md
@@ -34,7 +34,20 @@ well-defined and non-identity.
 total**, not Merit — but **only where the total is well-defined**. The card
 renders a **conditional stamp** with these rules, per praxis type:
 
+The rows are one policy, not four accidents: **a row exists when it tells the
+viewer something the total mark does not already say** — with the votes row as
+the single declared exception below.
+
 - **Solo** — full Contribution total: `(base + meta) × faction_mult + votes`.
+  - The **base** row shows only when some other term has moved the figure.
+    **Added 2026-07-29 (#1131).** With no multiplier, no metatask and no vote
+    points, the stamp printed `10.0 POINTS` and then restated it as `BASE 10` —
+    the same number twice. So the base row is hidden when it would only repeat
+    the total. The total **mark** stays: under ADR-0049 it is the faction's
+    signature device (UA's ensō, Everymen's roundel, the Ephemerists' rubric),
+    and dropping it would cost identity, not redundancy. The owner was offered
+    "hide base *and* `+0 from votes`" and declined the second half, so the empty
+    state is the mark plus the tally.
   - The **multiplier** row shows only when `faction_mult ≠ 1.0`.
   - The **metatask** row shows only when `metatask_points > 0`.
   - The **votes** row always shows (`+0` is valid). **Re-affirmed 2026-07-20**
@@ -71,6 +84,17 @@ stylistically (e.g. Singularity's terminal `13.60` / `×0.80` / `+04`) — the
 underlying value is identical. Applies on both desktop (corner stamp) and mobile
 (horizontal `BASE | MULT | VOTES | TOT` strip; the MULT cell collapses out when
 not shown).
+
+### Where the rules live
+
+All of them live in `scoreBreakdown(praxis)` and nowhere else — ADR-0049 made
+that function the single row-selection authority for all nine stamps, and
+ADR-0053 made it the only place the breakdown is resolved. A hidden row is a
+`null` term (`base`, `mult`, `meta`); each skin decides only what a row *looks*
+like. `base` is null exactly when no other term is in play, so a skin that hangs
+its multiplier chip off the base row can drop the whole row as one unit without
+orphaning the chip. A row rule added to a component instead of the resolver is a
+bug in nine places.
 
 ## Consequences
 

--- a/docs/adr/0049-the-score-stamp-is-a-manifest-surface.md
+++ b/docs/adr/0049-the-score-stamp-is-a-manifest-surface.md
@@ -46,8 +46,11 @@ The split between shared and bespoke is drawn at **logic vs. presentation**:
 
 - **Shared, unchanged:** `scoreBreakdown(praxis)` — the pure function that
   decides *which rows exist* under ADR-0047 (mult hidden at `×1.0` or collab,
-  meta hidden at `≤ 0`, votes always, total to one decimal). One function, one
+  meta hidden at `≤ 0`, base hidden when it would restate the total — added
+  2026-07-29 by #1131 — votes always, total to one decimal). One function, one
   test, nine consumers. This is the invariant and it stays exactly where it is.
+  The **total mark never drops out**: it is the faction's device, so it is the
+  one thing a row rule may make redundant rather than remove.
 - **Bespoke, per faction:** everything about *what those rows look like* — the
   numerals' face and size, the chip, the rule, the rotation, the blend mode, and
   above all the **total mark**, which is frequently not a box at all.

--- a/frontend/src/components/praxisCard/scoreStamp/CovenScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/CovenScoreStamp.tsx
@@ -21,7 +21,9 @@ import type { ScoreStampProps } from "./ScoreStamp";
  *
  * Rows and their selection are the shared box's (ADR-0047 via `scoreBreakdown`);
  * the design files Coven under "the remaining box-pattern factions … follow the
- * Unaffiliated mechanism exactly". Only the presentation is Coven's.
+ * Unaffiliated mechanism exactly". Only the presentation is Coven's. That
+ * includes the base line dropping out when it would only repeat the sticker's
+ * bottom-line total (#1131).
  */
 export default function CovenScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
@@ -63,56 +65,62 @@ export default function CovenScoreStamp({ praxis, showCrown }: ScoreStampProps) 
         />
       )}
 
-      {/* Base, with the highlighter chip pinned right and counter-rotated. */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "var(--space-xs)",
-          whiteSpace: "nowrap",
-        }}
-      >
-        <span
+      {/* Base, with the highlighter chip pinned right and counter-rotated. The
+          line is only written when something moved the figure (#1131) — the
+          sticker's bottom line already carries it otherwise — and the chip rides
+          this line, which is safe: a live multiplier is one of the things that
+          keeps the line. */}
+      {base !== null && (
+        <div
           style={{
-            fontFamily: "var(--faction-coven-card-font)",
-            fontWeight: 700,
-            fontSize: "var(--text-xl)",
-            color: "var(--faction-coven-sticker-muted)",
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-xs)",
+            whiteSpace: "nowrap",
           }}
         >
-          {t("card.stamp.base")}
-        </span>
-        <span
-          style={{
-            fontFamily: "var(--faction-coven-card-font)",
-            fontWeight: 700,
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: the sticker's base numeral, the design's 28 (§4a)
-            fontSize: 28,
-            lineHeight: 0.7,
-            color: "var(--faction-coven-card-text)",
-          }}
-        >
-          {base}
-        </span>
-        {mult !== null && (
           <span
             style={{
-              marginLeft: "auto",
               fontFamily: "var(--faction-coven-card-font)",
               fontWeight: 700,
               fontSize: "var(--text-xl)",
-              // Counter-rotation, so the chip reads level on the crooked sticker.
-              transform: "rotate(3deg)",
-              color: "var(--faction-coven-stamp-chip-text)",
-              background: "var(--faction-coven-stamp-chip-bg)",
-              borderRadius: 10,
-              padding: "0 var(--space-sm)",
+              color: "var(--faction-coven-sticker-muted)",
             }}
           >
-            {formatMult(mult)}
+            {t("card.stamp.base")}
           </span>
-        )}
-      </div>
+          <span
+            style={{
+              fontFamily: "var(--faction-coven-card-font)",
+              fontWeight: 700,
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the sticker's base numeral, the design's 28 (§4a)
+              fontSize: 28,
+              lineHeight: 0.7,
+              color: "var(--faction-coven-card-text)",
+            }}
+          >
+            {base}
+          </span>
+          {mult !== null && (
+            <span
+              style={{
+                marginLeft: "auto",
+                fontFamily: "var(--faction-coven-card-font)",
+                fontWeight: 700,
+                fontSize: "var(--text-xl)",
+                // Counter-rotation, so the chip reads level on the crooked sticker.
+                transform: "rotate(3deg)",
+                color: "var(--faction-coven-stamp-chip-text)",
+                background: "var(--faction-coven-stamp-chip-bg)",
+                borderRadius: 10,
+                padding: "0 var(--space-sm)",
+              }}
+            >
+              {formatMult(mult)}
+            </span>
+          )}
+        </div>
+      )}
 
       {meta !== null && (
         <div style={workingStyle}>
@@ -120,7 +128,16 @@ export default function CovenScoreStamp({ praxis, showCrown }: ScoreStampProps) 
         </div>
       )}
 
-      <div style={workingStyle}>{t("card.stamp.fromVotes", { votes })}</div>
+      {/* The tally, always. Its lead belongs to the line above it, so it goes
+          when the base line does (#1131) and the sticker keeps its own padding. */}
+      <div
+        style={{
+          ...workingStyle,
+          marginTop: base !== null ? workingStyle.marginTop : undefined,
+        }}
+      >
+        {t("card.stamp.fromVotes", { votes })}
+      </div>
 
       {/* The dashed rule — the sticker's own edge, run across the middle. */}
       <div

--- a/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
@@ -30,6 +30,10 @@ import type { ScoreStampProps } from "./ScoreStamp";
  *
  * `scoreBreakdown()` is the single row-selection authority (ADR-0053) and every
  * rule below is its call, not this file's:
+ *   - the BASE row appears only when some other term has moved the figure. With
+ *     no multiplier, no metatask and no votes the disc already states it, so the
+ *     row would print the same number twice (#1131) — the working out drops to
+ *     nothing and the tally keeps the sheet honest on its own.
  *   - the MULT row appears only when the multiplier is not ×1.0. `era_1`
  *     neutralises it to 1.0 for every faction, so the row is dark today and
  *     lights up on its own if an era ever configures one.
@@ -69,9 +73,10 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   /** The working out, in reading order. Selection belongs to scoreBreakdown. */
-  const rows: { key: string; label: string; value: string }[] = [
-    { key: "base", label: t("card.stamp.base"), value: `${base}` },
-  ];
+  const rows: { key: string; label: string; value: string }[] = [];
+  if (base !== null) {
+    rows.push({ key: "base", label: t("card.stamp.base"), value: `${base}` });
+  }
   if (mult !== null) {
     rows.push({ key: "mult", label: t("card.stamp.mult"), value: formatMult(mult) });
   }
@@ -232,12 +237,14 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
       ))}
 
       {/* The tally, under a rule of its own. Always drawn: `+ 0 from votes` is a
-          fact about this praxis, not a missing row. */}
+          fact about this praxis, not a missing row. Its rule separates it from
+          the working above — with no working (the #1131 empty state) there is
+          nothing to separate, and the rule would hang under the disc alone. */}
       <div
         style={{
-          borderTop: "1px solid var(--faction-default-card-line)",
+          borderTop: rows.length > 0 ? "1px solid var(--faction-default-card-line)" : undefined,
           marginTop: "var(--space-xs)",
-          paddingTop: "var(--space-sm)",
+          paddingTop: rows.length > 0 ? "var(--space-sm)" : undefined,
           fontFamily: "var(--font-body)",
           fontSize: "var(--text-base)",
           letterSpacing: "0.06em",

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -19,6 +19,8 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * Row selection stays in `scoreBreakdown` (ADR-0047); this file is presentation
  * only. Each optional row is its own line, so the box reads as a shorter or
  * longer entry in all five conditional states rather than as a form with gaps.
+ * The BASE line is optional too since #1131 — when nothing has moved the figure
+ * the rubric already carries it, and the entry shortens to the tally alone.
  */
 export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
@@ -51,46 +53,51 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
         />
       )}
 
-      {/* Base, with the multiplier chip pinned to the right rail. */}
-      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)", whiteSpace: "nowrap" }}>
-        <span
-          style={{
-            fontFamily: "var(--eph-serif)",
-            fontSize: "var(--text-sm)",
-            letterSpacing: "0.12em",
-            textTransform: "uppercase",
-            color: "var(--eph-muted)",
-          }}
-        >
-          {t("card.stamp.base")}
-        </span>
-        <span
-          style={{
-            fontFamily: "var(--eph-display)",
-            fontWeight: 600,
-            fontSize: "var(--text-title)",
-            lineHeight: 0.8,
-            color: "var(--eph-vellum-text)",
-          }}
-        >
-          {base}
-        </span>
-        {mult !== null && (
+      {/* Base, with the multiplier chip pinned to the right rail. The chip rides
+          this row, and it may: `scoreBreakdown` only nulls `base` when no other
+          term exists (#1131), so the whole line leaves together and the chip is
+          never orphaned. */}
+      {base !== null && (
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)", whiteSpace: "nowrap" }}>
           <span
             style={{
-              marginLeft: "auto",
-              fontFamily: "var(--eph-display)",
-              fontSize: "var(--text-md)",
-              color: "var(--faction-ephemerists-on-fill)",
-              background: "var(--faction-ephemerists)",
-              borderRadius: 3,
-              padding: "0 var(--space-xs)",
+              fontFamily: "var(--eph-serif)",
+              fontSize: "var(--text-sm)",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "var(--eph-muted)",
             }}
           >
-            {formatMult(mult)}
+            {t("card.stamp.base")}
           </span>
-        )}
-      </div>
+          <span
+            style={{
+              fontFamily: "var(--eph-display)",
+              fontWeight: 600,
+              fontSize: "var(--text-title)",
+              lineHeight: 0.8,
+              color: "var(--eph-vellum-text)",
+            }}
+          >
+            {base}
+          </span>
+          {mult !== null && (
+            <span
+              style={{
+                marginLeft: "auto",
+                fontFamily: "var(--eph-display)",
+                fontSize: "var(--text-md)",
+                color: "var(--faction-ephemerists-on-fill)",
+                background: "var(--faction-ephemerists)",
+                borderRadius: 3,
+                padding: "0 var(--space-xs)",
+              }}
+            >
+              {formatMult(mult)}
+            </span>
+          )}
+        </div>
+      )}
 
       {meta !== null && (
         <div
@@ -132,13 +139,15 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
         </div>
       )}
 
+      {/* The lead above the tally belongs to the working it follows; with no
+          working (the #1131 empty state) it would read as stray top padding. */}
       <div
         style={{
           fontFamily: "var(--eph-serif)",
           fontStyle: "italic",
           fontSize: "var(--text-md)",
           color: "var(--eph-muted)",
-          marginTop: "var(--space-xs)",
+          marginTop: base !== null ? "var(--space-xs)" : undefined,
         }}
       >
         {t("card.stamp.fromVotes", { votes })}

--- a/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
@@ -15,7 +15,9 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * total. #821 had neither — one upright rectangle stood in for both.
  *
  * ROW SELECTION IS NOT OURS. `scoreBreakdown` decides which rows exist
- * (ADR-0047); this file only decides what a row looks like. The one row this
+ * (ADR-0047) — including the BASE row, which drops out when the roundel already
+ * states that figure (#1131); the tally then holds `VOTES +0` alone, which is
+ * still a completed form. This file only decides what a row looks like. The one row this
  * stamp adds on its own is GROUP — `(base + meta)`, drawn under a rule — and it
  * appears only when a metatask AND a multiplier are both in play, which is
  * exactly the design's "full formula" column. Without a multiplier the subtotal
@@ -37,12 +39,16 @@ export default function EverymenScoreStamp({ praxis, showCrown }: ScoreStampProp
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   /** Rows in working order. `ruled` draws the subtotal rule above the row. */
-  const rows: { key: string; label: string; value: string; gold?: boolean; ruled?: boolean }[] = [
-    { key: "base", label: t("card.stamp.base"), value: `${base}` },
-  ];
+  const rows: { key: string; label: string; value: string; gold?: boolean; ruled?: boolean }[] = [];
+  if (base !== null) {
+    rows.push({ key: "base", label: t("card.stamp.base"), value: `${base}` });
+  }
   if (meta !== null) {
     rows.push({ key: "meta", label: t("card.stamp.meta"), value: `+${meta}` });
-    if (mult !== null) {
+    // `base` is non-null whenever a metatask is in play (the #1131 rule hides it
+    // only when nothing else exists), so the subtotal always has both terms;
+    // the guard is what tells the compiler so.
+    if (mult !== null && base !== null) {
       rows.push({ key: "group", label: t("card.stamp.group"), value: `${base + meta}`, ruled: true });
     }
   }

--- a/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
@@ -18,6 +18,9 @@ import type { ScoreStampProps } from "./ScoreStamp";
  *  - the votes row zero-pads to two digits (`+04`), for the same reason.
  * Row SELECTION stays in `scoreBreakdown` — a hidden row leaves the register
  * shorter, never gappy, so all five conditional states read as one read-out.
+ * That now includes `BASE`, which the resolver drops when the figure would only
+ * restate `TOT` (#1131): the read-out prints `VOTES +00` and the total, and the
+ * machine is not made to echo itself.
  */
 export default function SingularityScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
@@ -34,6 +37,46 @@ export default function SingularityScoreStamp({ praxis, showCrown }: ScoreStampP
     color: "var(--faction-singularity-phosphor-dim)",
     marginTop: "var(--space-xs)",
   } as const;
+
+  /**
+   * The register, as lines rather than fixed JSX, because since #1131 EVERY line
+   * above the tally is optional — including `base` — and the read-out's first
+   * line is the one that must not carry a leading gap. Whichever line comes
+   * first gets `marginTop: 0`; the machine never prints a blank line at the top.
+   */
+  const lines: { key: string; label: string; value: string; valueColor: string }[] = [];
+  if (base !== null) {
+    lines.push({
+      key: "base",
+      label: t("card.stamp.base"),
+      value: `${base}`,
+      valueColor: "var(--faction-singularity-terminal-ink)",
+    });
+  }
+  if (mult !== null) {
+    lines.push({
+      key: "mult",
+      label: t("card.stamp.mult"),
+      value: formatMult(mult),
+      valueColor: "var(--faction-singularity-led-amber)",
+    });
+  }
+  if (meta !== null) {
+    lines.push({
+      key: "meta",
+      label: t("card.stamp.meta"),
+      value: `+${meta}`,
+      valueColor: "var(--faction-singularity-terminal-ink)",
+    });
+  }
+  lines.push({
+    key: "votes",
+    label: t("card.stamp.votes"),
+    // The terminal pads its output — `+04`. Notation is this file's, not the
+    // resolver's (ADR-0047 fixes which rows exist, not how they read).
+    value: `+${String(votes).padStart(2, "0")}`,
+    valueColor: "var(--faction-singularity-terminal-ink)",
+  });
 
   return (
     <div
@@ -60,31 +103,12 @@ export default function SingularityScoreStamp({ praxis, showCrown }: ScoreStampP
         />
       )}
 
-      <div style={{ ...rowStyle, marginTop: 0 }}>
-        <span>{t("card.stamp.base")}</span>
-        <span style={{ color: "var(--faction-singularity-terminal-ink)" }}>{base}</span>
-      </div>
-
-      {mult !== null && (
-        <div style={rowStyle}>
-          <span>{t("card.stamp.mult")}</span>
-          <span style={{ color: "var(--faction-singularity-led-amber)" }}>{formatMult(mult)}</span>
+      {lines.map((line, index) => (
+        <div key={line.key} style={{ ...rowStyle, marginTop: index === 0 ? 0 : rowStyle.marginTop }}>
+          <span>{line.label}</span>
+          <span style={{ color: line.valueColor }}>{line.value}</span>
         </div>
-      )}
-
-      {meta !== null && (
-        <div style={rowStyle}>
-          <span>{t("card.stamp.meta")}</span>
-          <span style={{ color: "var(--faction-singularity-terminal-ink)" }}>+{meta}</span>
-        </div>
-      )}
-
-      <div style={rowStyle}>
-        <span>{t("card.stamp.votes")}</span>
-        <span style={{ color: "var(--faction-singularity-terminal-ink)" }}>
-          {`+${String(votes).padStart(2, "0")}`}
-        </span>
-      </div>
+      ))}
 
       <div
         aria-hidden

--- a/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
@@ -17,7 +17,8 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * Row SELECTION stays in `scoreBreakdown` (ADR-0047) — this file is presentation
  * only. Each optional row is its own line so the tag stays legible across all
  * five conditional states; nothing here is positioned relative to a row that
- * may not exist.
+ * may not exist. Since #1131 the BASE line is optional too: with nothing to
+ * multiply, add or vote, the tag types the tally and the numeral says the rest.
  */
 export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
@@ -50,49 +51,54 @@ export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) 
         />
       )}
 
-      {/* Base, with the pink multiplier chip stuck on at the right. */}
-      <div style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)", whiteSpace: "nowrap" }}>
-        <span
-          style={{
-            fontFamily: "var(--font-body)",
-            fontSize: "var(--text-sm)",
-            letterSpacing: "0.1em",
-            textTransform: "uppercase",
-            color: "var(--faction-snide-vote-off)",
-          }}
-        >
-          {t("card.stamp.base")}
-        </span>
-        <span
-          style={{
-            fontFamily: "var(--faction-snide-font-impact)",
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: Anton figure struck at the design's 27, a poster face rather than text (§4a)
-            fontSize: 27,
-            lineHeight: 0.8,
-            color: "var(--faction-snide-acid)",
-          }}
-        >
-          {base}
-        </span>
-        {mult !== null && (
+      {/* Base, with the pink multiplier chip stuck on at the right. The line is
+          typed only when something moved the figure (#1131) — the Anton total
+          below the perforation is already saying it — and the chip leaves with
+          the line, which is safe: a live multiplier keeps the line. */}
+      {base !== null && (
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)", whiteSpace: "nowrap" }}>
           <span
             style={{
-              marginLeft: "auto",
-              fontFamily: "var(--faction-snide-font-black)",
-              // eslint-disable-next-line local/no-raw-style-values -- ornament: the stuck-on multiplier chip, the design's 11 (§4a)
-              fontSize: 11,
-              color: "var(--faction-snide-ink)",
-              background: "var(--faction-snide-pink)",
-              // eslint-disable-next-line local/no-raw-style-values -- ornament: the chip's drawn inset; rounding to a rung swells a sticker into a button (§4a)
-              padding: "2px 5px",
-              transform: "rotate(3deg)",
-              whiteSpace: "nowrap",
+              fontFamily: "var(--font-body)",
+              fontSize: "var(--text-sm)",
+              letterSpacing: "0.1em",
+              textTransform: "uppercase",
+              color: "var(--faction-snide-vote-off)",
             }}
           >
-            {formatMult(mult)}
+            {t("card.stamp.base")}
           </span>
-        )}
-      </div>
+          <span
+            style={{
+              fontFamily: "var(--faction-snide-font-impact)",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: Anton figure struck at the design's 27, a poster face rather than text (§4a)
+              fontSize: 27,
+              lineHeight: 0.8,
+              color: "var(--faction-snide-acid)",
+            }}
+          >
+            {base}
+          </span>
+          {mult !== null && (
+            <span
+              style={{
+                marginLeft: "auto",
+                fontFamily: "var(--faction-snide-font-black)",
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: the stuck-on multiplier chip, the design's 11 (§4a)
+                fontSize: 11,
+                color: "var(--faction-snide-ink)",
+                background: "var(--faction-snide-pink)",
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: the chip's drawn inset; rounding to a rung swells a sticker into a button (§4a)
+                padding: "2px 5px",
+                transform: "rotate(3deg)",
+                whiteSpace: "nowrap",
+              }}
+            >
+              {formatMult(mult)}
+            </span>
+          )}
+        </div>
+      )}
 
       {meta !== null && (
         <div
@@ -120,7 +126,9 @@ export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) 
           letterSpacing: "0.06em",
           textTransform: "uppercase",
           color: "var(--faction-snide-acid)",
-          marginTop: "var(--space-xs)",
+          // The lead is between typed LINES: none when the tally is the first
+          // one on the tag (#1131).
+          marginTop: base !== null ? "var(--space-xs)" : undefined,
         }}
       >
         {t("card.stamp.fromVotes", { votes })}

--- a/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
@@ -27,7 +27,9 @@ import type { ScoreStampProps } from "./ScoreStamp";
  *
  * ROW SELECTION IS NOT OURS. `scoreBreakdown` decides which rows exist
  * (ADR-0047); this file only decides what a row looks like. The votes row
- * survives at `+0` — a declared deviation from the design, which drops it.
+ * survives at `+0` — a declared deviation from the design, which drops it. The
+ * base row does NOT survive a total it merely repeats (#1131): with nothing to
+ * multiply, add or vote, the plate keeps the tally and the ensō holds the figure.
  *
  * Every raw number below is ornament: the plate's own insets and leads, and
  * display type sized to the drawing rather than to the text scale (§4a).
@@ -117,37 +119,45 @@ export default function UaScoreStamp({ praxis, showCrown }: ScoreStampProps) {
           padding: "7px 11px",
         }}
       >
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: lead between the cap label and its figure.
-            gap: 7,
-            whiteSpace: "nowrap",
-          }}
-        >
-          <span style={labelStyle}>{t("card.stamp.base")}</span>
-          <span
+        {/*
+         * The base row. It goes when `scoreBreakdown` nulls the figure (#1131) —
+         * the ensō below is already saying it — and the chip goes with it, which
+         * is safe because a live multiplier is one of the things that keeps the
+         * base row alive in the first place.
+         */}
+        {base !== null && (
+          <div
             style={{
-              fontFamily: "var(--faction-ua-card-font)",
-              fontWeight: 600,
-              // eslint-disable-next-line local/no-raw-style-values -- ornament: the plate's engraved figure.
-              fontSize: 25,
-              lineHeight: 0.8,
-              color: "var(--faction-ua-card-text)",
+              display: "flex",
+              alignItems: "center",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: lead between the cap label and its figure.
+              gap: 7,
+              whiteSpace: "nowrap",
             }}
           >
-            {base}
-          </span>
-          {/*
-           * The chip stays on the base row in EVERY state. The design's
-           * "full formula" column moves it onto a `× mult` row of its own; the
-           * other four keep it here, and a plate that rearranges itself stops
-           * reading as the same object when a row drops out (§6 — the archetype
-           * is the identity). Declared deviation.
-           */}
-          {mult !== null && <MultChip>{formatMult(mult)}</MultChip>}
-        </div>
+            <span style={labelStyle}>{t("card.stamp.base")}</span>
+            <span
+              style={{
+                fontFamily: "var(--faction-ua-card-font)",
+                fontWeight: 600,
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: the plate's engraved figure.
+                fontSize: 25,
+                lineHeight: 0.8,
+                color: "var(--faction-ua-card-text)",
+              }}
+            >
+              {base}
+            </span>
+            {/*
+             * The chip stays on the base row in EVERY state. The design's
+             * "full formula" column moves it onto a `× mult` row of its own; the
+             * other four keep it here, and a plate that rearranges itself stops
+             * reading as the same object when a row drops out (§6 — the archetype
+             * is the identity). Declared deviation.
+             */}
+            {mult !== null && <MultChip>{formatMult(mult)}</MultChip>}
+          </div>
+        )}
 
         {meta !== null && (
           <div
@@ -166,9 +176,11 @@ export default function UaScoreStamp({ praxis, showCrown }: ScoreStampProps) {
          * The grouped subtotal, drawn under a hairline. It exists only when a
          * metatask AND a multiplier are both live — the design's "full formula"
          * column — because without a multiplier `(base + meta)` explains
-         * nothing and the plate reads as a form with a hole in it.
+         * nothing and the plate reads as a form with a hole in it. Either of
+         * those keeps the base row alive too (#1131), so the `base !== null`
+         * clause is the compiler's proof, not a fourth state.
          */}
-        {meta !== null && mult !== null && (
+        {meta !== null && mult !== null && base !== null && (
           <div
             style={{
               display: "flex",
@@ -205,8 +217,10 @@ export default function UaScoreStamp({ praxis, showCrown }: ScoreStampProps) {
         <div
           style={{
             ...workingStyle,
+            // A lead between working LINES — so none when the tally is the only
+            // line left standing (#1131).
             // eslint-disable-next-line local/no-raw-style-values -- ornament: the plate's lead between working lines.
-            marginTop: 3,
+            marginTop: base !== null ? 3 : undefined,
           }}
         >
           {t("card.stamp.fromVotes", { votes })}

--- a/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
@@ -20,7 +20,8 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * The design files WOW under the shared box pattern ("the remaining box-pattern
  * factions … follow the Unaffiliated mechanism exactly"), so the ROWS match
  * {@link DefaultScoreStamp} and row selection stays in `scoreBreakdown`
- * (ADR-0047). Everything else is the chronicle: MedievalSharp figures, Lora
+ * (ADR-0047) — base included, which drops out when it would only repeat the
+ * total under the rule (#1131). Everything else is the chronicle: MedievalSharp figures, Lora
  * italic for the working, the plum chip, the gold rule.
  */
 export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
@@ -63,52 +64,57 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
         />
       )}
 
-      {/* Base, with the plum multiplier chip pinned to the right rail. */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "var(--space-xs)",
-          whiteSpace: "nowrap",
-        }}
-      >
-        <span
+      {/* Base, with the plum multiplier chip pinned to the right rail. The entry
+          is only written when something moved the figure (#1131); the total under
+          the gold rule already states it otherwise. The chip rides this line and
+          may: a live multiplier is one of the things that keeps the line. */}
+      {base !== null && (
+        <div
           style={{
-            fontFamily: "var(--faction-wow-body-font)",
-            fontStyle: "italic",
-            fontSize: "var(--text-base)",
-            color: "var(--faction-wow-card-muted)",
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-xs)",
+            whiteSpace: "nowrap",
           }}
         >
-          {t("card.stamp.base")}
-        </span>
-        <span
-          style={{
-            fontFamily: "var(--faction-wow-card-font)",
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: the chronicle's base numeral, the design's 25 (§4a)
-            fontSize: 25,
-            lineHeight: 0.8,
-            color: "var(--faction-wow-card-text)",
-          }}
-        >
-          {base}
-        </span>
-        {mult !== null && (
           <span
             style={{
-              marginLeft: "auto",
-              fontFamily: "var(--faction-wow-card-font)",
-              fontSize: "var(--text-lg)",
-              color: "var(--faction-wow-stamp-chip-text)",
-              background: "var(--faction-wow-stamp-chip-bg)",
-              borderRadius: 4,
-              padding: "0 var(--space-xs)",
+              fontFamily: "var(--faction-wow-body-font)",
+              fontStyle: "italic",
+              fontSize: "var(--text-base)",
+              color: "var(--faction-wow-card-muted)",
             }}
           >
-            {formatMult(mult)}
+            {t("card.stamp.base")}
           </span>
-        )}
-      </div>
+          <span
+            style={{
+              fontFamily: "var(--faction-wow-card-font)",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the chronicle's base numeral, the design's 25 (§4a)
+              fontSize: 25,
+              lineHeight: 0.8,
+              color: "var(--faction-wow-card-text)",
+            }}
+          >
+            {base}
+          </span>
+          {mult !== null && (
+            <span
+              style={{
+                marginLeft: "auto",
+                fontFamily: "var(--faction-wow-card-font)",
+                fontSize: "var(--text-lg)",
+                color: "var(--faction-wow-stamp-chip-text)",
+                background: "var(--faction-wow-stamp-chip-bg)",
+                borderRadius: 4,
+                padding: "0 var(--space-xs)",
+              }}
+            >
+              {formatMult(mult)}
+            </span>
+          )}
+        </div>
+      )}
 
       {meta !== null && (
         <div style={workingStyle}>
@@ -116,7 +122,16 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
         </div>
       )}
 
-      <div style={workingStyle}>{t("card.stamp.fromVotes", { votes })}</div>
+      {/* The tally, always. Its lead belongs to the line above, so it goes when
+          the base entry does (#1131) and the leaf keeps its own inset. */}
+      <div
+        style={{
+          ...workingStyle,
+          marginTop: base !== null ? workingStyle.marginTop : undefined,
+        }}
+      >
+        {t("card.stamp.fromVotes", { votes })}
+      </div>
 
       {/* The gold→plum hairline, then the total and its star. */}
       <div

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -82,6 +82,52 @@ describe('scoreBreakdown row selection (ADR-0053)', () => {
     expect(scoreBreakdown(praxis({ points_from_votes: 0 })).votes).toBe(0)
   })
 
+  /**
+   * #1131. The base row is the one row whose content can be entirely implied by
+   * the total mark: with no multiplier, no metatask and no votes the stamp said
+   * `10.0 POINTS` and then `BASE 10`. The votes row is NOT part of this — the
+   * owner was offered "hide base and `+0 from votes`" and declined it, so the
+   * empty state is the mark plus the tally.
+   */
+  it('hides the base row when it would only restate the total', () => {
+    const bare = praxis({
+      task_point_value: 10,
+      display_multiplier: 1,
+      metatask_points: 0,
+      points_from_votes: 0,
+      score: 10,
+    })
+    expect(scoreBreakdown(bare)).toEqual({
+      base: null,
+      mult: null,
+      meta: null,
+      votes: 0,
+      total: 10,
+    })
+  })
+
+  it('brings the base row back the moment any term moves the figure', () => {
+    const bare = { task_point_value: 10, display_multiplier: 1, metatask_points: 0, points_from_votes: 0 }
+    // Each of the three terms, alone, is enough to make the base row explain
+    // something — which is why a stamp may hang its multiplier chip off it.
+    expect(scoreBreakdown(praxis({ ...bare, points_from_votes: 4, score: 14 })).base).toBe(10)
+    expect(scoreBreakdown(praxis({ ...bare, metatask_points: 3, score: 13 })).base).toBe(10)
+    expect(scoreBreakdown(praxis({ ...bare, display_multiplier: 1.1, score: 11 })).base).toBe(10)
+  })
+
+  it('keeps the base row when the score disagrees with its own terms', () => {
+    // A `score` that has drifted from the terms behind it must stay legible.
+    // Hiding the row here would collapse two different numbers into one mark.
+    const drifted = praxis({
+      task_point_value: 10,
+      display_multiplier: 1,
+      metatask_points: 0,
+      points_from_votes: 0,
+      score: 99,
+    })
+    expect(scoreBreakdown(drifted).base).toBe(10)
+  })
+
   it('never derives vote points by subtraction (the old Merit assumption)', () => {
     // score is authoritative and unrelated to base/votes arithmetic here.
     const rows = scoreBreakdown(praxis({ task_point_value: 12, points_from_votes: 4, score: 99 }))
@@ -160,6 +206,50 @@ describe('scoreStamp surface dispatch (ADR-0049)', () => {
 })
 
 /**
+ * The five conditional states of design v2, shared by both stamp waves below.
+ *
+ * `showsBase` is part of the state, not a detail of one skin: 'base only' is the
+ * #1131 empty state, where the figure equals the total and the row would print it
+ * twice, so every stamp must OMIT it there and print it in the other four.
+ */
+const STATES = [
+  {
+    name: 'base only',
+    fields: { display_multiplier: 1, metatask_points: 0, points_from_votes: 0, score: 12 },
+    showsBase: false,
+  },
+  {
+    name: '+ votes',
+    fields: { display_multiplier: 1, metatask_points: 0, points_from_votes: 4, score: 16 },
+    showsBase: true,
+  },
+  {
+    name: '× mult',
+    fields: { display_multiplier: 0.8, metatask_points: 0, points_from_votes: 0, score: 9.6 },
+    showsBase: true,
+  },
+  {
+    name: '+ metatask',
+    fields: { display_multiplier: 1, metatask_points: 20, points_from_votes: 0, score: 32 },
+    showsBase: true,
+  },
+  {
+    name: 'full formula',
+    fields: { display_multiplier: 0.8, metatask_points: 20, points_from_votes: 4, score: 29.6 },
+    showsBase: true,
+  },
+] as const
+
+/**
+ * Every stamp labels the row from the same key, so one assertion covers all
+ * eight: the label is present exactly when the resolver kept the figure.
+ */
+function expectBaseRow(html: string, showsBase: boolean) {
+  if (showsBase) expect(html).toContain('base')
+  else expect(html).not.toContain('base')
+}
+
+/**
  * The five conditional states of design v2, on both #841 stamps. The failure
  * mode this guards is not a missing row — `scoreBreakdown` is tested above —
  * but a stamp that stops READING as itself when a row drops out: a tally whose
@@ -167,15 +257,7 @@ describe('scoreStamp surface dispatch (ADR-0049)', () => {
  * it. Each state must still print the total and its own device.
  */
 describe('#841 stamps across the conditional states (ADR-0047)', () => {
-  const STATES = [
-    ['base only', { display_multiplier: 1, metatask_points: 0, points_from_votes: 0, score: 12 }],
-    ['+ votes', { display_multiplier: 1, metatask_points: 0, points_from_votes: 4, score: 16 }],
-    ['× mult', { display_multiplier: 0.8, metatask_points: 0, points_from_votes: 0, score: 9.6 }],
-    ['+ metatask', { display_multiplier: 1, metatask_points: 20, points_from_votes: 0, score: 32 }],
-    ['full formula', { display_multiplier: 0.8, metatask_points: 20, points_from_votes: 4, score: 29.6 }],
-  ] as const
-
-  for (const [name, fields] of STATES) {
+  for (const { name, fields, showsBase } of STATES) {
     it(`Everymen prints the tally and the roundel — ${name}`, () => {
       const html = text(renderToStaticMarkup(<EverymenScoreStamp praxis={praxis({ ...fields })} />))
       expect(html).toContain('TALLY')
@@ -184,6 +266,7 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
       expect(html).toContain(fields.score.toFixed(1))
       // The votes row survives at 0 — the deliberate ADR-0047 deviation.
       expect(html).toContain('votes')
+      expectBaseRow(html, showsBase)
       expect(html).not.toMatch(HEX)
     })
 
@@ -191,7 +274,7 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
       const html = text(
         renderToStaticMarkup(<EphemeristsScoreStamp praxis={praxis({ ...fields })} />),
       )
-      expect(html).toContain('base')
+      expectBaseRow(html, showsBase)
       expect(html).toContain('from votes')
       expect(html).toContain(fields.score.toFixed(1))
       expect(html).not.toMatch(HEX)
@@ -200,7 +283,7 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
     it(`UA prints the score box and the ensō — ${name}`, () => {
       const markup = renderToStaticMarkup(<UaScoreStamp praxis={praxis({ ...fields })} />)
       const html = text(markup)
-      expect(html).toContain('base')
+      expectBaseRow(html, showsBase)
       // The votes row survives at 0 — the deliberate ADR-0047 deviation.
       expect(html).toContain('from votes')
       expect(html).toContain(fields.score.toFixed(1))
@@ -212,10 +295,10 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
     })
   }
 
-  for (const [name, fields] of STATES) {
+  for (const { name, fields, showsBase } of STATES) {
     it(`WOW prints the working and keeps the star — ${name}`, () => {
       const html = text(renderToStaticMarkup(<WowScoreStamp praxis={praxis({ ...fields })} />))
-      expect(html).toContain('base')
+      expectBaseRow(html, showsBase)
       expect(html).toContain('from votes')
       expect(html).toContain(fields.score.toFixed(1))
       // The retired ✦ survives here and only here — see ADR-0050 / the design
@@ -226,7 +309,7 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
 
     it(`Coven prints the working and keeps the sparkle — ${name}`, () => {
       const html = text(renderToStaticMarkup(<CovenScoreStamp praxis={praxis({ ...fields })} />))
-      expect(html).toContain('base')
+      expectBaseRow(html, showsBase)
       expect(html).toContain('from votes')
       expect(html).toContain(fields.score.toFixed(1))
       expect(html).toContain('✨')
@@ -300,18 +383,10 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
  * assertions below are deliberately notation-aware.
  */
 describe('#842 stamps across the conditional states (ADR-0047)', () => {
-  const STATES = [
-    ['base only', { display_multiplier: 1, metatask_points: 0, points_from_votes: 0, score: 12 }],
-    ['+ votes', { display_multiplier: 1, metatask_points: 0, points_from_votes: 4, score: 16 }],
-    ['× mult', { display_multiplier: 0.8, metatask_points: 0, points_from_votes: 0, score: 9.6 }],
-    ['+ metatask', { display_multiplier: 1, metatask_points: 20, points_from_votes: 0, score: 32 }],
-    ['full formula', { display_multiplier: 0.8, metatask_points: 20, points_from_votes: 4, score: 29.6 }],
-  ] as const
-
-  for (const [name, fields] of STATES) {
+  for (const { name, fields, showsBase } of STATES) {
     it(`S.N.I.D.E. prints the working and the total in pts — ${name}`, () => {
       const html = text(renderToStaticMarkup(<SnideScoreStamp praxis={praxis({ ...fields })} />))
-      expect(html).toContain('base')
+      expectBaseRow(html, showsBase)
       expect(html).toContain('from votes')
       expect(html).toContain(fields.score.toFixed(1))
       expect(html).toContain('pts')
@@ -322,7 +397,7 @@ describe('#842 stamps across the conditional states (ADR-0047)', () => {
       const html = text(
         renderToStaticMarkup(<SingularityScoreStamp praxis={praxis({ ...fields })} />),
       )
-      expect(html).toContain('base')
+      expectBaseRow(html, showsBase)
       expect(html).toContain('tot')
       // The terminal pads its output: two decimals, and a zero-padded votes row.
       expect(html).toContain(fields.score.toFixed(2))
@@ -332,11 +407,60 @@ describe('#842 stamps across the conditional states (ADR-0047)', () => {
 
     it(`the unaffiliated sheet prints the working and the total — ${name}`, () => {
       const html = text(renderToStaticMarkup(<DefaultScoreStamp praxis={praxis({ ...fields })} />))
-      expect(html).toContain('base')
+      expectBaseRow(html, showsBase)
       expect(html).toContain('from votes')
       expect(html).toContain(fields.score.toFixed(1))
       expect(html).toContain('points')
       expect(html).not.toMatch(HEX)
+    })
+  }
+})
+
+/**
+ * #1131 on every registered stamp at once. The rule lives in `scoreBreakdown`,
+ * but each skin still has to ACT on the null — nine files built their own row
+ * arrays from the resolver's nulls, and a skin that interpolates `base` straight
+ * into JSX would render an empty label instead of dropping the row. So this
+ * asserts the state on all eight rather than trusting the resolver test.
+ *
+ * The state is the commonest one on the site: a freshly submitted praxis, before
+ * anyone votes, under `era_1`'s neutral ×1.0 — which is also what the composer's
+ * waiting surface shows the moment you submit.
+ */
+describe('the base row leaves every stamp when it restates the total (#1131)', () => {
+  const STAMPS = [
+    ['the unaffiliated sheet', DefaultScoreStamp],
+    ['Everymen', EverymenScoreStamp],
+    ['the Ephemerists', EphemeristsScoreStamp],
+    ['S.N.I.D.E.', SnideScoreStamp],
+    ['Singularity', SingularityScoreStamp],
+    ['WOW', WowScoreStamp],
+    ['Coven', CovenScoreStamp],
+    ['UA', UaScoreStamp],
+  ] as const
+
+  /** No multiplier, no metatask, no votes: base IS the total. */
+  const bare = praxis({
+    task_point_value: 10,
+    display_multiplier: 1,
+    metatask_points: 0,
+    points_from_votes: 0,
+    score: 10,
+  })
+
+  for (const [name, Stamp] of STAMPS) {
+    it(`${name} states the figure once, and still says nobody has voted`, () => {
+      const html = text(renderToStaticMarkup(<Stamp praxis={bare} />))
+      expect(html).not.toContain('base')
+      // The total mark stays — under ADR-0049 it is the faction's signature
+      // device, so it is the one number that never drops out. Singularity's
+      // two-decimal `10.00` contains this too.
+      expect(html).toContain('10.0')
+      // And the votes row stays at +0: ADR-0047's declared exception, which the
+      // owner re-affirmed against hiding it alongside base.
+      expect(html).toMatch(/votes/)
+      // The label is gone, not blanked: no orphaned figure left behind.
+      expect(html).not.toMatch(/\b10\b(?!\.)/)
     })
   }
 })

--- a/frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts
+++ b/frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts
@@ -25,7 +25,16 @@ export interface ScoredPraxis {
 }
 
 export interface ScoreBreakdown {
-  base: number;
+  /**
+   * The task's base points, or null when the base row is hidden because it
+   * would only restate the total (#1131).
+   *
+   * A null `base` always coincides with `mult === null`, `meta === null` and
+   * `votes === 0` — it is hidden precisely when no other term is in play — so a
+   * skin that hangs its multiplier chip off the base row may drop the whole row
+   * as one unit without orphaning the chip.
+   */
+  base: number | null;
   /** The display multiplier, or null when the mult row is hidden (×1.0). */
   mult: number | null;
   /** Metatask points, or null when the meta row is hidden (`≤ 0`). */
@@ -35,24 +44,48 @@ export interface ScoreBreakdown {
 }
 
 /**
- * Resolve the rows a stamp should show (ADR-0053):
- *  - mult row only when `display_multiplier !== 1`
- *  - meta row only when `metatask_points > 0`
- *  - votes row always (`+0` is valid)
+ * Resolve the rows a stamp should show (ADR-0053).
+ *
+ * One policy, four clauses: a row exists when it tells the viewer something the
+ * total mark does not already say, with the votes row as the single declared
+ * exception.
+ *  - base row only when some other term has moved it — hidden when it would
+ *    print the total a second time (#1131)
+ *  - mult row only when `display_multiplier !== 1` (×1.0 moves nothing)
+ *  - meta row only when `metatask_points > 0` (`+0` moves nothing)
+ *  - votes row ALWAYS, `+0` included — the exception, re-affirmed in ADR-0047:
+ *    an absent row cannot say "nobody has voted yet"
  *  - total to 1 decimal at the render sites
  *
  * A duel side's multiplier is live and provisional (ADR-0052) — a side that is
  * currently behind legitimately shows a loss modifier, ×0.0 for Snide.
  */
 export function scoreBreakdown(praxis: ScoredPraxis): ScoreBreakdown {
+  const rawBase = praxis.task_point_value ?? 0;
   const rawMult = praxis.display_multiplier ?? 1;
   const rawMeta = praxis.metatask_points ?? 0;
+  const mult = rawMult !== 1 ? rawMult : null;
+  const meta = rawMeta > 0 ? rawMeta : null;
+  const votes = praxis.points_from_votes ?? 0;
+  const total = praxis.score ?? 0;
+
+  /**
+   * #1131 — the empty state said `10.0 POINTS` and then `BASE 10`. Both halves
+   * of this test are load-bearing: the three terms decide whether any row could
+   * explain a difference between base and total, and `total === rawBase` refuses
+   * to hide a figure the payload itself disagrees with — a `score` that has
+   * drifted from its terms must stay legible, not collapse silently into the
+   * faction's total mark.
+   */
+  const baseRestatesTotal =
+    mult === null && meta === null && votes === 0 && total === rawBase;
+
   return {
-    base: praxis.task_point_value ?? 0,
-    mult: rawMult !== 1 ? rawMult : null,
-    meta: rawMeta > 0 ? rawMeta : null,
-    votes: praxis.points_from_votes ?? 0,
-    total: praxis.score ?? 0,
+    base: baseRestatesTotal ? null : rawBase,
+    mult,
+    meta,
+    votes,
+    total,
   };
 }
 


### PR DESCRIPTION
`scoreBreakdown()` gains one rule: **`base` is null when the base row would only
restate the total.** The fix is in the resolver, not in nine components — ADR-0049
gives row selection to that one function and calls it the invariant.

Closes #1131

## The rule, and why it reads as one policy with the other three

The resolver now hides the base row when **no other term is in play** (`mult ===
null && meta === null && votes === 0`) **and** the figure equals the total. Both
halves are load-bearing: the terms decide whether any row could explain a
difference between base and total, and `total === base` refuses to hide a figure
the payload itself disagrees with — a `score` that has drifted from its terms
stays legible rather than collapsing silently into the faction's mark.

That makes the four rules one sentence, now written at the top of ADR-0047's
Decision: **a row exists when it tells the viewer something the total mark does
not already say** — with the votes row as the single declared exception, because
an absent row cannot say "nobody has voted yet". The owner was offered "hide base
*and* `+0 from votes`" and declined the second half, so the empty state is the
total mark plus the tally.

The **total mark never drops out**. Under ADR-0049 it is the faction's signature
device (UA's ensō, Everymen's roundel, the Ephemerists' rubric), so it is the one
thing a row rule may make redundant rather than remove. ADR-0049's own summary of
the row rules is amended alongside 0047 so the two cannot disagree.

No new ADR: #1131 amends ADR-0047's Decision section (dated, attributed) and the
one-line rule summary in ADR-0049. `0066`/`0067` are still free for epic #1192.

## What each consumer now renders

`scoreBreakdown()` has one direct consumer family — the eight stamps — and
everything else reaches it by mounting `ScoreStamp`. Verified by grep; no surface
computes a breakdown of its own.

| Consumer | Before | Now (empty state) |
|---|---|---|
| `DefaultScoreStamp` (also `na`/albescent fall-through) | disc `10.0 POINTS`, `BASE … 10`, rule, `+ 0 from votes` | disc, then `+ 0 from votes`. The **rule above the tally goes too** — it separates the tally from the working, and there is no working |
| `EverymenScoreStamp` | `TALLY` header, `BASE 10`, `VOTES +0`, roundel | `TALLY` header, `VOTES +0`, roundel. Still a completed form |
| `EphemeristsScoreStamp` | `BASE 10` line, tally, rubric | tally, rubric — the line **and the lead above the tally** both go |
| `SnideScoreStamp` | `BASE 10` + chip line, tally, perforation, Anton total | tally, perforation, total |
| `SingularityScoreStamp` | `BASE 10` / `VOTES +00` register | `VOTES +00` register. Its rows became a **line list** so whichever line prints first carries no leading gap — the base row used to own that job (`marginTop: 0`) |
| `WowScoreStamp` | `base 10` + plum chip, tally, gold rule, `29.6 ✦` | tally, rule, total, star |
| `CovenScoreStamp` | `base 10` + highlighter chip, tally, dashed rule, `10.0 ✨` | tally, rule, total, sparkle |
| `UaScoreStamp` | plate: `BASE 10` + chip, tally; ensō below | plate: tally only; ensō unchanged |
| `ScoreStamp` (dispatcher) | — | unchanged; it reads no score terms |
| praxis **cards** (desktop + mobile), all nine praxis **detail** archetypes, the composer's **waiting surface** | — | unchanged code; they mount `ScoreStamp`, so they inherit the rule |

Three skins hang the multiplier chip off the base row (UA, Coven, WOW — Snide and
the Ephemerists too). Dropping the whole line is safe **because** a live
multiplier is one of the things that keeps the base row alive; that guarantee is
now written into `ScoreBreakdown.base`'s doc comment, and UA's and Everymen's
`base + meta` subtotals carry a `base !== null` clause as the compiler's proof of
it rather than as a fourth state.

The task-reference line on the detail pages (`detail.taskRef.points`) is a
different object — the task's own value, not a stamp row — and is untouched.

`#1147` (the ensō ring's layout) is deliberately not in scope; no geometry changed.

## Verification

- `tsc --noEmit` — clean.
- `vite build` — clean (entry 417.99 kB / 134.97 kB gzip, unchanged).
- `eslint src --max-warnings=0` — clean.
- **Full** frontend suite: **151 files, 2556 tests, all passing.** Only
  `scoreStamp.test.tsx` needed changing: its five conditional states now carry a
  `showsBase` expectation (`'base only'` is precisely the state where the row must
  be ABSENT), plus a new cross-stamp case asserting the empty state on all eight
  skins, and three resolver cases (hidden when it restates; back the moment any
  one term moves the figure; kept when `score` disagrees with its terms).
- No praxis-detail or waiting-surface test exercised the empty state before this
  PR — they all use `points_from_votes: 4`. That is why the new case renders all
  eight stamps directly rather than trusting the resolver test.

**Visual QA is outstanding.** I cannot screenshot (no dev stack in the worktree,
and the harness is `renderToStaticMarkup` with no DOM), so a green suite does not
prove the layout closed up.

## What to eyeball

Both themes, on a praxis card, on the praxis detail page, and on the composer's
waiting surface (the last is the commonest sighting — a praxis you just submitted
has no votes yet, and `era_1` neutralises every multiplier to ×1.0):

1. **No multiplier, no metatask, no votes** — one figure only. Check for a stray
   rule, an orphaned label, or a gap where the row was: the Unaffiliated disc's
   hairline, the Ephemerists' lead above the tally, Singularity's first register
   line, UA's plate collapsing to a single italic line under the ensō, and
   Everymen's `TALLY` header with only `VOTES +0` under it.
2. **Votes only** (`+4`) — base row **back**, in every skin.
3. **Metatask only** — base row back, meta row present, no grouped subtotal (UA
   and Everymen draw that only with a multiplier as well).
4. **Multiplier only** (a duel side, or an era that configures one) — base row
   back with the chip on it; check Snide at ×0.0.
5. **Full formula** — unchanged from today: base, chip, meta, group, votes, total.
6. **The live transition:** cast a vote on an unvoted praxis. `points_from_votes`
   goes non-zero, so the base row **appears** and the stamp grows a line without a
   refetch (`useVotedPraxis`). Worth watching for layout jump in a card gutter.
