### PR TITLE
Foundation: retire the brand palette into the na spectrum, and give it scalar stops (#1220)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -64,6 +64,7 @@ All color values are CSS custom properties defined in `index.css`. See that file
 - **Faction cards:** `--faction-{slug}-card-bg`, `--faction-{slug}-card-text`, `--faction-{slug}-card-accent`, `--faction-{slug}-card-font`
 - **Functional:** `--color-success`, `--color-danger`, `--color-warning` (each with `-light` and `-border` variants)
 - **Votes:** `--vote-1` through `--vote-5` (orange → yellow → green → blue → magenta, increasing intensity)
+- **The rainbow:** `--faction-default-stop-1` through `-stop-7` (red → orange → yellow → green → teal → blue → magenta) as scalars, plus the nine gradient cuts composed from them. This is the site's only rainbow — see below.
 
 **Dark mode** is handled by `[data-theme="dark"]` overrides in `index.css`. Components should use `var(--faction-everymen-card-bg)` — never `dark ? '#1e1a10' : '#fffef5'`.
 
@@ -100,6 +101,24 @@ The second is a **global functional ink on faction paper**. `--color-warning` an
 **And where a shared slot hardcodes the ink, "route it per skin" is not available — that is a missing seam, not a missing measurement.** `StakesTiles` and `RaceRoster` painted the win figure and the "sealed" mark in `--color-success` with no prop, so no skin could reach them however carefully it measured: 2.07:1 on S.N.I.D.E.'s photocopier ink, 1.99:1 on Singularity's terminal glass, 1.88:1 on Everymen's *forfeit* panel — the last of which is the sharpest version of the rule, because that panel inverts to ink on a **mode** branch while the token flips on the **theme**, so the two polarities disagree inside one render. `DuelSlotTheme` now takes `credit` and `alarm`, defaulting to exactly what the slots painted before. This is `DuelCardInk` (#1153) again, and the same two details carry over: **default every field to today's value** so a skin passing nothing is byte-identical, and **resolve field-by-field rather than by spread**, which Everymen relies on directly — it passes `credit` only on the ink branch and `undefined` otherwise, and a spread would let that `undefined` erase the default. Nothing new was minted; `-card-notice` and `-card-credit` already existed for all eight, and Everymen's inverted panel took the faction's own gold.
 
 Two calibrations worth keeping. **Check the size before the threshold**: the roster's "sealed" mark is 18px regular and owes 4.5:1, while the win figure beside it is 24px bold and owes 3:1 — the *smaller* text is what gates a shared ink, and the zero figure in `--color-danger` clears 3:1 on all nine grounds and is therefore left red on every one of them. And **a pairing that passes is left alone and written down anyway**: Ephemerists needed no change at all, and its zero figure at 3.01:1 is now a row precisely because that margin would vanish under any darkening of its ledger band.
+
+### There is one rainbow, and `na` is it (#1219, ADR-0066)
+
+> **The brand and N/A should be the same rainbow. N/A is essentially the neutral site look.** — owner, 2026-07-29
+
+The site ran **two** rainbows for a long time without either knowing about the other: the na spectrum (`--faction-default-*`, seven hues, nine cuts, both themes) and a six-hue brand palette (`--underline-1…6`, a resequenced near-copy, **no dark form at all**) that dressed the nav wordmark, every page title, the Home hero, the field desk and the level-up popup. A census turned up nineteen multi-hue definitions across six hue sets; two of the six were this one duplication, and a third copy of the same hexes sat in `--fdl-rainbow`. The brand palette is retired; the na spectrum is the site's rainbow, and the unaffiliated player's identity is one *use* of it rather than the whole of it.
+
+**The spectrum is now scalars first and gradients second, because a gradient token cannot be indexed.** `--faction-default-stop-1…7` are the source; every cut composes from them with `var()`. That inversion is what the duplication was hiding: the surfaces that reached for a second palette were all cycling stops *by position* — a per-letter title bar, an ability row's dingbat, a confetti flake, a hard-wedge seal — and a `linear-gradient()` cannot answer "give me stop 3". If you find yourself copying hues out of a ramp, you want the stops.
+
+**Retiring a palette is three migrations, not a find-and-replace.** Its consumers were three different shapes wearing one set of hues, and each shape lands somewhere different: index-cycling consumers take the seven stops; narrow marks (a 2px wordmark rule, a 6px progress fill) take the **short cuts that already exist** — `--faction-default-total-rainbow` (4 stops) and `-eyebrow-rainbow` (3) — because a mark that narrow cannot spend seven stops legibly; and a surface using one stop alone as a gold was never a rainbow use at all and takes `--faction-default-gold`. Nothing new was minted for the second and third shapes. **Before replacing a rainbow reference, ask what it was drawing.**
+
+**The cycle length is not a constant.** Going six stops to seven broke the one place that had written the number down: the level-up seal's wedges were `idx * 60deg`. They are `360 / stops` now. A cycling consumer that hardcodes its count is a bug waiting for the next re-cut.
+
+**Brand chrome flips with the theme — one palette, one behaviour, no exceptions.** This is the owner's ruling and it is the part that changed rendered output rather than moving values around: the nav wordmark, the page titles and the level-up popup rendered identical hexes in both themes, and now inherit the brightened dark stops. Those stops were tuned to sit on a **dark faction card**, not behind nav text, so the chrome that inherited them is the pairing to re-check whenever a stop moves. It amends ADR-0054, which called the Task Crown ring a fixed brand constant in both themes.
+
+**Three hues are still restated on purpose, and each says so at its own declaration.** `--badge-victor-stop-*` and `--spectrum-glow-*` are theme-invariant *identities*; `--faction-default-chip` is a fixed green→blue pill whose white ink is measured on its two exact values, so composing it from stops 4 and 6 would flip it and put white on a brightened green. That is the shape of a legitimate exception: **a hue restated deliberately carries its reason at the declaration**, or the next sweep tokenizes it and breaks something.
+
+And one thing the merge cost, worth knowing before the next re-cut: **a stop is load-bearing across surfaces that never used to share one.** Moving the dark yellow now moves the na card's POINTS caption, the Singularity credits accent, every page title's third letter and the level-up rule together. That is the point of one source, and it is also the new blast radius.
 
 ### Unaffiliated grey is usually a FILL written as a border (#983, #805)
 
@@ -428,13 +447,13 @@ Where a mark ships as an inline SVG and where as a masked `public/` asset is a *
 ### Nav Bar
 
 - Frosted glass: `var(--color-nav-bg)` with backdrop blur
-- Wordmark: Lora italic with rainbow gradient underline
+- Wordmark: Lora italic over a 2px rule in `var(--faction-default-total-rainbow)` — the spectrum's four-stop cut, drawn as the second layer of a two-layer `backgroundImage` that the page ground masks down to the bottom 2px
 - Links: Courier Prime, `--text-base`, uppercase
 
 ### Page Title
 
 - Lora italic, `--text-display`
-- Per-letter colored underline bars cycling through `--underline-1` to `--underline-6`
+- Per-letter colored underline bars cycling through `--faction-default-stop-1` to `--faction-default-stop-7` — the site's one rainbow, **seven** long (#1220, ADR-0066)
 
 ### Filter Controls
 

--- a/docs/adr/0054-one-theme-aware-task-crown.md
+++ b/docs/adr/0054-one-theme-aware-task-crown.md
@@ -1,6 +1,6 @@
 # ADR-0054 — One theme-aware Task Crown (the flur is one mark)
 
-**Status:** Accepted
+**Status:** Accepted (amended 2026-07-29 by [ADR-0066](0066-one-rainbow-the-brand-palette-retires-into-the-na-spectrum.md) — the ring's theme behaviour only)
 **Date:** 2026-07-24
 **Amends:** [ADR-0028](0028-task-crown-replaces-faction-distinction-laurel.md) — the per-card recolour of the crown's inner disc + glyph
 **Relates to:** #826
@@ -25,6 +25,12 @@ job: a viewer scanning the feed cannot learn one emblem and recognise it everywh
 and glyph no longer follow the card — they follow the global light/dark theme.
 
 - The rainbow ring (`--fdl-rainbow`) stays a fixed brand constant, unchanged.
+  **Amended by ADR-0066 (2026-07-29):** "a fixed brand constant in both themes" no
+  longer holds. There is one rainbow now, the brand palette retired into the na
+  spectrum, and brand chrome flips with the theme — so the ring flips too. The rest
+  of this decision is untouched: one canonical crown, theme-aware only, with no
+  per-faction recolour. Only the *ring's* theme behaviour changed, and the token
+  itself is re-pointed by #1213 rather than here.
 - Two new theme-aware tokens in `index.css` carry the inner look, and are the ONLY
   thing that varies:
   - `--fdl-disc` — the disc fill: ivory/paper in light, near-black in dark.

--- a/docs/adr/0066-one-rainbow-the-brand-palette-retires-into-the-na-spectrum.md
+++ b/docs/adr/0066-one-rainbow-the-brand-palette-retires-into-the-na-spectrum.md
@@ -1,0 +1,101 @@
+# ADR-0066 — One rainbow: the brand palette retires into the na spectrum
+
+**Status:** Accepted
+**Date:** 2026-07-29
+**Relates to:** #1219 (epic), #1220 (this ADR's issue)
+**Amends:** [ADR-0054](0054-one-theme-aware-task-crown.md) — its "the rainbow ring
+stays a fixed brand constant" clause. The brand palette is not a constant any more;
+it flips with the theme like everything else in the spectrum.
+**Builds on:** [ADR-0039](0039-unaffiliated-fill-is-a-gradient-not-a-hue.md) — the na
+spectrum, which this ADR promotes from "the unaffiliated player's identity" to
+"the site's rainbow, of which the unaffiliated player's identity is one use"
+
+## Context
+
+The site had **two rainbows pretending to be one**, and neither knew about the
+other.
+
+`--faction-default-*` held the **na spectrum** (ADR-0039): seven hues, nine
+gradient cuts, present in both themes with a brightened dark twin. It is the
+unaffiliated player's identity and the most-consumed colour construct in the app.
+
+`--underline-1…6` held a **six-hue brand palette**: a resequenced near-copy of the
+same idea, with **no dark override at all**. It dressed the site's top-level
+chrome — the nav wordmark's rule, every page title's per-letter bars, the Home
+hero, the field desk, the level-up popup — plus three Singularity credit accents
+that were only ever using its first stop as a gold. `--fdl-rainbow`, the Task
+Crown's ring, is a third copy of that same hex set (retired separately, #1213).
+
+A census of every multi-hue spectrum in `frontend/` found nineteen definitions
+across six distinct hue sets. Two of the six were this duplication.
+
+> **The brand and N/A should be the same rainbow. N/A is essentially the neutral
+> site look.** — owner, 2026-07-29
+
+## Decision
+
+**One rainbow. The na spectrum is it, and the brand palette retires into it.**
+
+Three parts, in the order they matter:
+
+**1. The spectrum gains scalar stops, and every ramp composes from them.**
+`--faction-default-stop-1…7` are declared in both theme blocks, in spectrum order
+(red · orange · yellow · green · teal · blue · magenta). Every na gradient — the
+bar ramp, the wedge ring, the vertical rule, the seamless loop, the smooth conic,
+the aurora wash, and the four- and three-stop short cuts — is rebuilt from them.
+The stops exist because **a gradient token cannot be indexed**: the consumers
+being migrated cycle stops *by position* (a per-letter bar, an ability row's
+dingbat, a confetti flake, a hard-wedge seal), which is exactly why they reached
+for a second palette instead of this one. Nine gradient cuts survive unreduced —
+each has a geometry argument the others cannot serve, and that stays true.
+
+**2. `--underline-1…6` is deleted, and its consumers move by SHAPE.** They were
+three different uses wearing one palette, and a find-and-replace would have been
+wrong three times over:
+
+| Shape | Consumers | Lands on |
+|---|---|---|
+| Index-cycled, full palette | `PageTitle`, `LevelUpPopup` | the seven stops |
+| Four- and three-stop narrow marks | `NavBar` wordmark, `Home` hero, `FieldDesk` title rule + progress fill | `--faction-default-total-rainbow` / `-eyebrow-rainbow`, which already existed |
+| A single stop used as a gold | three Singularity credits accents | `--faction-default-gold` |
+
+Nothing was minted for the second and third rows. A mark narrow enough to need
+fewer stops reads one of the short cuts that exist; a surface that wants a gold
+asks for the gold.
+
+**3. Brand chrome flips with the theme.** One palette, one behaviour, no
+exceptions. This is the part that changes rendered output rather than moving
+values around: the nav wordmark, every page title and the level-up popup showed
+identical hexes in light and dark, and now take the brightened dark stops.
+
+## Consequences
+
+- **The cycle length changed from six to seven.** Anything that hardcoded
+  `60deg` a wedge is wrong: `LevelUpPopup`'s seal derives `360 / stops` now. A
+  cycling consumer must never write the count down.
+- **ADR-0054's "fixed brand constant in both themes" no longer holds.** The Task
+  Crown's ring is brand chrome and brand chrome flips. ADR-0054's actual subject
+  — one canonical crown, theme-aware only, no per-faction recolour — is untouched
+  and still correct; only its claim about the *ring's* theme behaviour is amended.
+  The ring token itself is #1213's work.
+- **Three deliberate exceptions remain, and they are exceptions on the record.**
+  `--badge-victor-stop-*` and `--spectrum-glow-*` are theme-INVARIANT identities;
+  `--faction-default-chip` is a fixed green→blue pill whose white ink is measured
+  on its two exact hues, so composing it from stops 4 and 6 would flip it and put
+  white on a brightened green. Each says so at its own declaration. **A hue
+  restated on purpose has to say why, at the declaration.**
+- **A stop is now load-bearing across surfaces that never used to share one.** A
+  re-cut of the dark yellow moves the na card's POINTS caption, the Singularity
+  credits accent, every page title's third letter and the level-up rule together.
+  That is the point of one source, and it is also the new blast radius.
+- **Dark overrides that only restated the light composition are gone rather than
+  kept.** The gold, both short ramps and the aurora's hue list compose from stops
+  the dark block rebinds, so the `:root` declarations re-resolve on their own.
+  Restating them would be lines that have to be remembered when the light cut
+  changes.
+- **This is a real visual change to top-level chrome that no automated check can
+  see.** These are gradients and per-letter bars: axe cannot measure a gradient
+  (#651) and the test harness has no DOM. The guard used here was resolving every
+  token out of the **built** stylesheet in both themes and diffing against the
+  previous build — which proves the *values* moved as intended and proves nothing
+  at all about legibility. Both themes owe a human eyeball.

--- a/frontend/src/components/LevelUpPopup.tsx
+++ b/frontend/src/components/LevelUpPopup.tsx
@@ -19,14 +19,38 @@ function tKey(t: TFunction<'progression'>, key: string): string {
  * Self-contained inline-styled modal, matching EverymenVote / the feed modals.
  */
 
+/**
+ * The site's one rainbow, as scalars — the na spectrum's seven stops (#1220,
+ * ADR-0066). Five surfaces in this file index it: the rank text's per-letter
+ * bars, the rule, the seal's hard wedges, the ability-row dingbats and the
+ * confetti. A gradient token cannot be indexed, which is why these are stops
+ * and not `--faction-default-rainbow`.
+ *
+ * It cycled `underline-1…6` — a separate six-hue brand palette — until #1219
+ * collapsed the two. Two things changed with the move: the cycle is SEVEN long
+ * (the seal's wedge is `360 / RAINBOW.length`, not a hardcoded 60deg), and the
+ * popup now flips with the theme, where the brand palette had no dark form. The
+ * comments below are the hues as declared; the old set's were wrong — it
+ * labelled its last stop "red" over `#f97316` orange.
+ */
 const RAINBOW = [
-  'var(--underline-1)', // amber
-  'var(--underline-2)', // magenta
-  'var(--underline-3)', // indigo
-  'var(--underline-4)', // teal
-  'var(--underline-5)', // green
-  'var(--underline-6)', // red
+  'var(--faction-default-stop-1)', // red
+  'var(--faction-default-stop-2)', // orange
+  'var(--faction-default-stop-3)', // yellow
+  'var(--faction-default-stop-4)', // green
+  'var(--faction-default-stop-5)', // teal
+  'var(--faction-default-stop-6)', // blue
+  'var(--faction-default-stop-7)', // magenta
 ]
+
+/**
+ * One wedge of the seal's ring, in degrees. Derived rather than written down:
+ * the ring is a hard-wedge conic with one wedge per stop, so a stop added or
+ * removed must not leave a gap. This is deliberately NOT
+ * `--faction-default-ring` — that token is the same seven wedges, but #1127 is
+ * collapsing it into the smooth conic, and the seal wants edges.
+ */
+const SEAL_WEDGE_DEGREES = 360 / RAINBOW.length
 
 const INK = 'var(--color-text-primary)'
 const PAPER = 'var(--color-bg-page)'
@@ -84,7 +108,10 @@ function SealStamp({ level, sealRing = 'rainbow' }: { level: number; sealRing?: 
     sealRing === 'ink'
       ? INK
       : 'conic-gradient(from -60deg,' +
-        RAINBOW.map((c, idx) => `${c} ${idx * 60}deg ${(idx + 1) * 60}deg`).join(',') +
+        RAINBOW.map(
+          (c, idx) =>
+            `${c} ${(idx * SEAL_WEDGE_DEGREES).toFixed(2)}deg ${((idx + 1) * SEAL_WEDGE_DEGREES).toFixed(2)}deg`,
+        ).join(',') +
         ')'
   return (
     <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 'var(--space-lg)' }}>

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -47,7 +47,12 @@ export default function NavBar() {
               color: 'var(--color-text-primary)',
               display: 'inline-block',
               borderBottom: '2px solid transparent',
-              backgroundImage: 'linear-gradient(var(--color-bg-page), var(--color-bg-page)), linear-gradient(90deg, var(--underline-3), var(--underline-2), var(--underline-6), var(--underline-5))',
+              // The page ground masks all but the bottom 2px, so the second
+              // layer IS the wordmark's rule. It reads the spectrum's four-stop
+              // cut (#1220, ADR-0066) rather than a ramp of its own: a 2px band
+              // under a short word cannot spend seven stops legibly, which is
+              // what --faction-default-total-rainbow exists for.
+              backgroundImage: 'linear-gradient(var(--color-bg-page), var(--color-bg-page)), var(--faction-default-total-rainbow)',
               backgroundSize: '100% calc(100% - 2px), 100% 2px',
               backgroundPosition: 'top, bottom',
               backgroundRepeat: 'no-repeat',

--- a/frontend/src/components/ui/PageTitle.tsx
+++ b/frontend/src/components/ui/PageTitle.tsx
@@ -1,11 +1,25 @@
 /**
- * Page title with per-letter colored underline bars (Style Guide §5.2).
+ * Page title with per-letter colored underline bars (Style Guide §7).
  *
- * Each letter gets a border-bottom cycling through the faction-inspired palette.
- * Spaces render as gaps with no underline.
+ * Each letter gets a border-bottom cycling through the site's one rainbow —
+ * the na spectrum's seven scalar stops (#1220, ADR-0066). It cycled a separate
+ * six-hue brand palette (`underline-1…6`) until that palette was retired into
+ * the spectrum; the cycle is SEVEN long now, and it flips with the theme, which
+ * the brand palette never did. Spaces render as gaps with no underline.
+ *
+ * Scalars rather than `--faction-default-rainbow`: a per-letter bar needs stop
+ * N by index, and a gradient token cannot be indexed.
  */
 
-const UNDERLINE_COLORS = ['var(--underline-1)', 'var(--underline-2)', 'var(--underline-3)', 'var(--underline-4)', 'var(--underline-5)', 'var(--underline-6)']
+const SPECTRUM_STOPS = [
+  'var(--faction-default-stop-1)',
+  'var(--faction-default-stop-2)',
+  'var(--faction-default-stop-3)',
+  'var(--faction-default-stop-4)',
+  'var(--faction-default-stop-5)',
+  'var(--faction-default-stop-6)',
+  'var(--faction-default-stop-7)',
+]
 
 interface Props {
   title: string
@@ -29,7 +43,7 @@ export default function PageTitle({ title, eyebrow }: Props) {
               <span key={index} style={{ display: 'inline-block', width: '0.3em' }} />
             )
           }
-          const color = UNDERLINE_COLORS[colorIndex % UNDERLINE_COLORS.length]
+          const color = SPECTRUM_STOPS[colorIndex % SPECTRUM_STOPS.length]
           colorIndex++
           return (
             <span

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -209,27 +209,60 @@
   --faction-default: #6b6a7a;
   --faction-default-light: rgba(107, 106, 122, 0.1);
   --faction-default-border: rgba(0, 0, 0, 0.12);
-  --faction-default-rainbow: linear-gradient(90deg, #c1272d 0%, #c2541f 17%, #ca8a04 33%, #16a34a 50%, #1d6e72 67%, #2563eb 83%, #be185d 100%);
-  --faction-default-ring: conic-gradient(#c1272d 0 51deg, #c2541f 0 103deg, #ca8a04 0 154deg, #16a34a 0 206deg, #1d6e72 0 257deg, #2563eb 0 309deg, #be185d 0 360deg);
+  /* ── THE SEVEN STOPS · the site's one rainbow (#1220, ADR-0066) ──
+     The spectrum as SCALARS, and the single source every ramp below composes
+     from. Two things arrive with them.
+
+     They exist because a gradient token cannot be INDEXED. The spectrum was
+     gradients only, so every surface that wanted stop N — a per-letter title
+     bar, an ability row's dingbat, a confetti flake, a hard-wedge seal — reached
+     instead for the retired `underline-1…6` family — a SECOND six-hue brand
+     palette carrying its own near-copy of these hues. #1219 collapsed the two:
+     the brand six are deleted and their consumers cycle these. A cycling
+     consumer therefore has SEVEN stops now, not six — anything that hardcoded
+     `60deg` a wedge wants `360 / 7`.
+
+     And they FLIP with the theme, which is the part that changed behaviour
+     rather than merely moving it. That family had no dark override at all, so
+     the nav wordmark, the page titles and the level-up popup rendered identical
+     hexes in both themes; on these stops they take the brightened dark twin.
+     That is the #1219 ruling — one palette, one behaviour, no exceptions — and
+     it amends ADR-0054's "fixed brand constant in both themes" clause.
+
+     Not every spectrum in this file is one of these, and the exceptions are
+     exceptions on purpose: `--badge-victor-stop-*` and `--spectrum-glow-*` are
+     theme-INVARIANT identities (each says so at its own declaration), and
+     `--faction-default-chip` is a fixed green→blue pill whose white ink is
+     measured on these two exact hues. Those three restate a hue deliberately.
+     Everything else cut from the spectrum reads a stop. */
+  --faction-default-stop-1: #c1272d; /* red */
+  --faction-default-stop-2: #c2541f; /* orange */
+  --faction-default-stop-3: #ca8a04; /* yellow */
+  --faction-default-stop-4: #16a34a; /* green */
+  --faction-default-stop-5: #1d6e72; /* teal */
+  --faction-default-stop-6: #2563eb; /* blue */
+  --faction-default-stop-7: #be185d; /* magenta */
+  --faction-default-rainbow: linear-gradient(90deg, var(--faction-default-stop-1) 0%, var(--faction-default-stop-2) 17%, var(--faction-default-stop-3) 33%, var(--faction-default-stop-4) 50%, var(--faction-default-stop-5) 67%, var(--faction-default-stop-6) 83%, var(--faction-default-stop-7) 100%);
+  --faction-default-ring: conic-gradient(var(--faction-default-stop-1) 0 51deg, var(--faction-default-stop-2) 0 103deg, var(--faction-default-stop-3) 0 154deg, var(--faction-default-stop-4) 0 206deg, var(--faction-default-stop-5) 0 257deg, var(--faction-default-stop-6) 0 309deg, var(--faction-default-stop-7) 0 360deg);
   /* The bar ramp stood on end (#983), for a vertical RULE — the left-edge
      accent a feed row, a quoted block or a callout draws. Same seven stops,
      same cut, 180deg: a rule is ~3px wide and tens of px tall, so the 90deg
      ramp above would spend the whole spectrum across those 3px (≈0.4px a
      stop) and read as one muddy smear, exactly the failure --faction-default-ring
      exists to avoid on a 10px dot. Ramps are cut for their geometry. */
-  --faction-default-rainbow-vertical: linear-gradient(180deg, #c1272d 0%, #c2541f 17%, #ca8a04 33%, #16a34a 50%, #1d6e72 67%, #2563eb 83%, #be185d 100%);
+  --faction-default-rainbow-vertical: linear-gradient(180deg, var(--faction-default-stop-1) 0%, var(--faction-default-stop-2) 17%, var(--faction-default-stop-3) 33%, var(--faction-default-stop-4) 50%, var(--faction-default-stop-5) 67%, var(--faction-default-stop-6) 83%, var(--faction-default-stop-7) 100%);
   /* The same spectrum cut to TILE (#1023). Its last stop is its first, so a
      surface that scrolls its background-position loops without a seam — which
      the bar ramp above cannot do: red at 0% meets magenta at 100% and shows a
      hard edge every cycle. Same argument as the two shorter ramps below; the
      spectrum comes in ramps cut for their geometry. Only Albescent's drifting
      card edge reads it today. */
-  --faction-default-rainbow-loop: linear-gradient(90deg, #c1272d 0%, #c2541f 14%, #ca8a04 28%, #16a34a 43%, #1d6e72 57%, #2563eb 72%, #be185d 86%, #c1272d 100%);
+  --faction-default-rainbow-loop: linear-gradient(90deg, var(--faction-default-stop-1) 0%, var(--faction-default-stop-2) 14%, var(--faction-default-stop-3) 28%, var(--faction-default-stop-4) 43%, var(--faction-default-stop-5) 57%, var(--faction-default-stop-6) 72%, var(--faction-default-stop-7) 86%, var(--faction-default-stop-1) 100%);
   /* The loop bent into a circle (#1038): the same seamless cut, swept as a
      SMOOTH conic. Deliberately not --faction-default-ring above, which is the
      vote widget's seven HARD wedges — a pinwheel, not a prism. Anything that
      turns wants this one; anything that counts wants the wedges. */
-  --faction-default-rainbow-conic: conic-gradient(#c1272d 0%, #c2541f 14%, #ca8a04 28%, #16a34a 43%, #1d6e72 57%, #2563eb 72%, #be185d 86%, #c1272d 100%);
+  --faction-default-rainbow-conic: conic-gradient(var(--faction-default-stop-1) 0%, var(--faction-default-stop-2) 14%, var(--faction-default-stop-3) 28%, var(--faction-default-stop-4) 43%, var(--faction-default-stop-5) 57%, var(--faction-default-stop-6) 72%, var(--faction-default-stop-7) 86%, var(--faction-default-stop-1) 100%);
   --faction-default-card-bg: #fffdf9;
   --faction-default-card-text: #1a1209;
   --faction-default-card-accent: #1a1209;
@@ -254,16 +287,35 @@
      `gold` the POINTS caption. The last two gradients are deliberately NOT the
      seven-stop spectrum: the design draws the chip and the total with their own
      shorter ramps, and substituting --faction-default-rainbow would flatten a
-     green→blue chip into a full spectrum smear at 40px wide. */
+     green→blue chip into a full spectrum smear at 40px wide.
+
+     They are SHORT CUTS of the same spectrum, not a palette of their own —
+     `-total-rainbow` is stops 1·3·4·6 and `-eyebrow-rainbow` is 4·6·7, which is
+     why #1220 could land the retired brand palette's narrow marks (the nav
+     wordmark rule, the Home hero rule, the field-desk title rule and its
+     progress fill) on these two rather than mint a third short ramp. A mark
+     narrow enough to need fewer stops reads one of these; the count is a
+     geometry decision, the hues are not. */
   --faction-default-card-line: #e6ddc8;
   --faction-default-stamp-bg: #ffffff;
-  --faction-default-gold: #ca8a04;
+  /* Stop 3 as an INK. Same value as the yellow stop in light, and it tracks the
+     stop through the theme, but it is named for the caption it paints (and for
+     the Singularity credits accent that #1220 pointed here) rather than for a
+     position in a ramp — a gradient must not read it back, or a ramp ends up
+     composed from a text colour. */
+  --faction-default-gold: var(--faction-default-stop-3);
+  /* The chip restates its two hues, and this is the one place in the family
+     where that is correct. It has NO dark override: the pill is a saturated
+     green→blue in either theme, and --faction-default-chip-text is white
+     measured on these two exact values. Composing it from stops 4 and 6 would
+     make it flip with them and put white on the brightened #4ade80/#60a5fa,
+     which fails. Theme-invariance is the design, so the hues are literal. */
   --faction-default-chip: linear-gradient(90deg, #16a34a, #2563eb);
   /* White in BOTH themes: the chip is a saturated green→blue pill in either,
      and the ink has to answer to the pill, not to the page. */
   --faction-default-chip-text: #ffffff;
-  --faction-default-total-rainbow: linear-gradient(90deg, #c1272d, #ca8a04 40%, #16a34a 60%, #2563eb);
-  --faction-default-eyebrow-rainbow: linear-gradient(90deg, #16a34a, #2563eb, #be185d);
+  --faction-default-total-rainbow: linear-gradient(90deg, var(--faction-default-stop-1), var(--faction-default-stop-3) 40%, var(--faction-default-stop-4) 60%, var(--faction-default-stop-6));
+  --faction-default-eyebrow-rainbow: linear-gradient(90deg, var(--faction-default-stop-4), var(--faction-default-stop-6), var(--faction-default-stop-7));
   /* ── The edit-praxis COMPOSER's own tiers (#1181, epic #1179, ADR-0065) ──
      The card set above gives the composer its SHEET (--faction-default-card-bg),
      its ink and its muted ink. Three tiers it does not give, all of which the v2
@@ -299,13 +351,13 @@
      are tokens for the same reason the hues are — so the component reads a
      var() and never branches on a `dark` boolean (WORLD_ZERO_STYLE §2). */
   --faction-default-aurora:
-    radial-gradient(62% 78% at 8% 16%, #c1272d, transparent 70%),
-    radial-gradient(58% 72% at 34% 4%, #c2541f, transparent 70%),
-    radial-gradient(60% 74% at 56% 18%, #ca8a04, transparent 70%),
-    radial-gradient(64% 78% at 84% 12%, #16a34a, transparent 70%),
-    radial-gradient(66% 80% at 98% 62%, #2563eb, transparent 70%),
-    radial-gradient(64% 78% at 62% 96%, #be185d, transparent 70%),
-    radial-gradient(60% 74% at 22% 92%, #1d6e72, transparent 70%);
+    radial-gradient(62% 78% at 8% 16%, var(--faction-default-stop-1), transparent 70%),
+    radial-gradient(58% 72% at 34% 4%, var(--faction-default-stop-2), transparent 70%),
+    radial-gradient(60% 74% at 56% 18%, var(--faction-default-stop-3), transparent 70%),
+    radial-gradient(64% 78% at 84% 12%, var(--faction-default-stop-4), transparent 70%),
+    radial-gradient(66% 80% at 98% 62%, var(--faction-default-stop-6), transparent 70%),
+    radial-gradient(64% 78% at 62% 96%, var(--faction-default-stop-7), transparent 70%),
+    radial-gradient(60% 74% at 22% 92%, var(--faction-default-stop-5), transparent 70%);
   --faction-default-aurora-opacity: 0.2;
   --faction-default-aurora-filter: blur(56px) saturate(0.5);
   --faction-default-aurora-blend: normal;
@@ -1337,13 +1389,15 @@
   --vote-4: #2563eb;
   --vote-5: #be185d;
 
-  /* ── Title underline colors (cycling) ── */
-  --underline-1: #fbbf24;
-  --underline-2: #be185d;
-  --underline-3: #4f46e5;
-  --underline-4: #0e7490;
-  --underline-5: #16a34a;
-  --underline-6: #f97316;
+  /* The `underline-1…6` cycling title/wordmark palette lived here. It was a
+     SECOND six-hue rainbow — a resequenced near-copy of the na spectrum, with no
+     dark override — and #1220 retired it into --faction-default-stop-1…7
+     (ADR-0066). Its consumers moved by shape, not by find-and-replace: the two
+     index-cycling ones (PageTitle's per-letter bars, LevelUpPopup's rank text /
+     rule / ability rows / confetti / seal) took the seven stops; the four narrow
+     marks took --faction-default-total-rainbow / -eyebrow-rainbow, which are cut
+     for exactly that width; and the three Singularity credit accents took
+     --faction-default-gold, which is what they were actually asking for. */
 
   /* ── Watercolor splash opacities ── */
   --wc-opacity-blob: 0.3;
@@ -1727,11 +1781,25 @@
   --faction-default: #8b8aa0;
   --faction-default-light: rgba(255, 255, 255, 0.06);
   --faction-default-border: rgba(255, 255, 255, 0.12);
-  --faction-default-rainbow: linear-gradient(90deg, #e2433f 0%, #e07a3a 17%, #e6b94f 33%, #4ade80 50%, #3aa0a4 67%, #60a5fa 83%, #f472b6 100%);
-  --faction-default-ring: conic-gradient(#e2433f 0 51deg, #e07a3a 0 103deg, #e6b94f 0 154deg, #4ade80 0 206deg, #3aa0a4 0 257deg, #60a5fa 0 309deg, #f472b6 0 360deg);
-  --faction-default-rainbow-vertical: linear-gradient(180deg, #e2433f 0%, #e07a3a 17%, #e6b94f 33%, #4ade80 50%, #3aa0a4 67%, #60a5fa 83%, #f472b6 100%);
-  --faction-default-rainbow-loop: linear-gradient(90deg, #e2433f 0%, #e07a3a 14%, #e6b94f 28%, #4ade80 43%, #3aa0a4 57%, #60a5fa 72%, #f472b6 86%, #e2433f 100%);
-  --faction-default-rainbow-conic: conic-gradient(#e2433f 0%, #e07a3a 14%, #e6b94f 28%, #4ade80 43%, #3aa0a4 57%, #60a5fa 72%, #f472b6 86%, #e2433f 100%);
+  /* The seven stops, brightened — the twin the light block's docstring points
+     at. Every ramp below is the same composition as its light counterpart, so
+     re-cutting the spectrum for dark means editing these seven lines and
+     nothing else. Since #1220 these also carry the retired brand chrome (nav
+     wordmark, page titles, the level-up popup), which had no dark form at all
+     before; they were tuned for a dark faction CARD, so that chrome is the
+     pairing to re-check when a stop moves. */
+  --faction-default-stop-1: #e2433f; /* red */
+  --faction-default-stop-2: #e07a3a; /* orange */
+  --faction-default-stop-3: #e6b94f; /* yellow */
+  --faction-default-stop-4: #4ade80; /* green */
+  --faction-default-stop-5: #3aa0a4; /* teal */
+  --faction-default-stop-6: #60a5fa; /* blue */
+  --faction-default-stop-7: #f472b6; /* magenta */
+  --faction-default-rainbow: linear-gradient(90deg, var(--faction-default-stop-1) 0%, var(--faction-default-stop-2) 17%, var(--faction-default-stop-3) 33%, var(--faction-default-stop-4) 50%, var(--faction-default-stop-5) 67%, var(--faction-default-stop-6) 83%, var(--faction-default-stop-7) 100%);
+  --faction-default-ring: conic-gradient(var(--faction-default-stop-1) 0 51deg, var(--faction-default-stop-2) 0 103deg, var(--faction-default-stop-3) 0 154deg, var(--faction-default-stop-4) 0 206deg, var(--faction-default-stop-5) 0 257deg, var(--faction-default-stop-6) 0 309deg, var(--faction-default-stop-7) 0 360deg);
+  --faction-default-rainbow-vertical: linear-gradient(180deg, var(--faction-default-stop-1) 0%, var(--faction-default-stop-2) 17%, var(--faction-default-stop-3) 33%, var(--faction-default-stop-4) 50%, var(--faction-default-stop-5) 67%, var(--faction-default-stop-6) 83%, var(--faction-default-stop-7) 100%);
+  --faction-default-rainbow-loop: linear-gradient(90deg, var(--faction-default-stop-1) 0%, var(--faction-default-stop-2) 14%, var(--faction-default-stop-3) 28%, var(--faction-default-stop-4) 43%, var(--faction-default-stop-5) 57%, var(--faction-default-stop-6) 72%, var(--faction-default-stop-7) 86%, var(--faction-default-stop-1) 100%);
+  --faction-default-rainbow-conic: conic-gradient(var(--faction-default-stop-1) 0%, var(--faction-default-stop-2) 14%, var(--faction-default-stop-3) 28%, var(--faction-default-stop-4) 43%, var(--faction-default-stop-5) 57%, var(--faction-default-stop-6) 72%, var(--faction-default-stop-7) 86%, var(--faction-default-stop-1) 100%);
   --faction-default-card-bg: #1c1b24;
   --faction-default-card-text: #f0e6d0;
   --faction-default-card-accent: #f0e6d0;
@@ -1741,14 +1809,24 @@
   --faction-default-vote-on: #e07a3a;
   --faction-default-vote-off: #b0925f;
   /* The cream sheet, lights out (#842) — the design's own dark card, not an
-     inversion: the hairline becomes a white scrim, the stamp plate lifts off
-     the sheet rather than sinking into it, and both narrow rainbows swap their
-     stops for the brightened spectrum's. */
+     inversion: the hairline becomes a white scrim and the stamp plate lifts off
+     the sheet rather than sinking into it. Both narrow rainbows still swap their
+     stops for the brightened spectrum's; since #1220 they do it by composition
+     rather than by a second declaration (see below). */
   --faction-default-card-line: rgba(255, 255, 255, 0.14);
   --faction-default-stamp-bg: #26252f;
-  --faction-default-gold: #e6b34a;
-  --faction-default-total-rainbow: linear-gradient(90deg, #e2433f, #e6b34a 40%, #4ade80 60%, #60a5fa);
-  --faction-default-eyebrow-rainbow: linear-gradient(90deg, #4ade80, #60a5fa, #f472b6);
+  /* --faction-default-gold, -total-rainbow and -eyebrow-rainbow need no dark
+     entry any more: since #1220 all three compose from --faction-default-stop-*,
+     which this block rebinds above, so the `:root` declarations re-resolve to
+     the brightened spectrum on their own. Same argument the UA parchment
+     gradient makes further up. Restating them here would be three lines that
+     have to be remembered whenever the light cut changes.
+
+     #1220 corrected one drift on the way: the dark gold and the dark total's
+     yellow were both #e6b34a, a hair off the dark yellow STOP (#e6b94f) the
+     comment above claimed they took. One hue, one source — the delta is ~6/255
+     on one channel and lifts the POINTS caption's contrast on the dark sheet
+     rather than lowering it. */
   /* The composer's three tiers, lights out (#1181). The field LIFTS off the
      sheet here rather than sinking into it — the same inversion --faction-
      default-stamp-bg already makes one block up — and both hairlines become
@@ -1756,17 +1834,11 @@
   --faction-default-composer-field: #1f1e2b;
   --faction-default-composer-faint: #4a4860;
   --faction-default-composer-hair: rgba(255, 255, 255, 0.06);
-  /* The aurora on the brightened spectrum, screen-blended so it lifts off the
-     dark sheet instead of muddying into it, and blurred less hard because a lit
-     wash spreads further on a dark ground than a dark one does on a light. */
-  --faction-default-aurora:
-    radial-gradient(62% 78% at 8% 16%, #e2433f, transparent 70%),
-    radial-gradient(58% 72% at 34% 4%, #e07a3a, transparent 70%),
-    radial-gradient(60% 74% at 56% 18%, #e6b94f, transparent 70%),
-    radial-gradient(64% 78% at 84% 12%, #4ade80, transparent 70%),
-    radial-gradient(66% 80% at 98% 62%, #60a5fa, transparent 70%),
-    radial-gradient(64% 78% at 62% 96%, #f472b6, transparent 70%),
-    radial-gradient(60% 74% at 22% 92%, #3aa0a4, transparent 70%);
+  /* The aurora needs no dark hue list either — the `:root` wash reads the seven
+     stops, so it arrives on the brightened spectrum by itself. What still flips
+     is the wash's COMPOSITING: screen-blended so it lifts off the dark sheet
+     instead of muddying into it, and blurred less hard because a lit wash
+     spreads further on a dark ground than a dark one does on a light. */
   --faction-default-aurora-opacity: 0.22;
   --faction-default-aurora-filter: blur(48px) saturate(0.8);
   --faction-default-aurora-blend: screen;

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -260,12 +260,15 @@ const headingStyle: CSSProperties = {
   color: 'var(--color-text-primary)',
   margin: 0,
 }
+// The title's rule takes the spectrum's four-stop cut (#1220, ADR-0066) — a
+// 4px × 220px band, which is the geometry --faction-default-total-rainbow is
+// cut for; the seven-stop ramp smears at this size.
 const rainbowUnderline: CSSProperties = {
   height: 4,
   width: 220,
   marginTop: 'var(--space-sm)',
   borderRadius: 2,
-  background: 'linear-gradient(90deg, var(--underline-3), var(--underline-2), var(--underline-6), var(--underline-5))',
+  background: 'var(--faction-default-total-rainbow)',
 }
 const rosterRow: CSSProperties = {
   display: 'flex',
@@ -346,8 +349,10 @@ const progressTrack: CSSProperties = {
   background: 'var(--color-bg-surface)',
   border: '1px solid var(--color-border-strong)',
 }
+// Narrower still — a 6px fill inside a 160px track, and only 45% of it drawn.
+// Three stops, which is --faction-default-eyebrow-rainbow (#1220, ADR-0066).
 const progressFill: CSSProperties = {
   height: '100%',
   width: '45%',
-  background: 'linear-gradient(90deg, var(--underline-3), var(--underline-2), var(--underline-6))',
+  background: 'var(--faction-default-eyebrow-rainbow)',
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -132,8 +132,11 @@ export default function Home() {
               color: 'var(--color-text-primary)',
               display: 'inline-block',
               paddingBottom: 'var(--space-sm)',
+              // Same two-layer rule as the nav wordmark, 6px instead of 2px:
+              // the spectrum's four-stop cut (#1220, ADR-0066), not a ramp of
+              // its own.
               backgroundImage:
-                'linear-gradient(var(--color-bg-page), var(--color-bg-page)), linear-gradient(90deg, var(--underline-3), var(--underline-2), var(--underline-6), var(--underline-5))',
+                'linear-gradient(var(--color-bg-page), var(--color-bg-page)), var(--faction-default-total-rainbow)',
               backgroundSize: '100% calc(100% - 6px), 100% 6px',
               backgroundPosition: 'top, bottom',
               backgroundRepeat: 'no-repeat',

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -33,7 +33,14 @@ const PHOSPHOR = "var(--faction-singularity-card-accent)"; // green
 const SIGNAL = "var(--faction-singularity-card-muted)"; // blue
 const BORDER_HARD = "var(--faction-singularity-border-hard)"; // blue brand
 const SIGNAL_FILL = "var(--faction-singularity)"; // blue brand fill
-const AMBER = "var(--underline-1)"; // credits accent (shared brand gold)
+// The credits accent: a GOLD SCALAR, not a rainbow. It read the retired brand
+// palette's first stop until #1220 (ADR-0066) pointed it at the token that
+// actually means "the spectrum's yellow as an ink". Consequence to know: the
+// brand palette was theme-invariant and this one is not, so the accent now
+// deepens in light (7.0:1 on the terminal black) and lifts in dark (10.0:1).
+// If Singularity's credits panel ever wants its own gold, that is a
+// --faction-singularity-* token, not a brand one.
+const AMBER = "var(--faction-default-gold)";
 const FONT = "var(--font-faction-terminal)";
 
 // color-mix helpers for shades that have no dedicated token.

--- a/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
@@ -26,7 +26,14 @@ const VOID = 'var(--faction-singularity-card-bg)'
 const PHOSPHOR = 'var(--faction-singularity-card-accent)'
 const SIGNAL = 'var(--faction-singularity-card-muted)'
 const BORDER_HARD = 'var(--faction-singularity-border-hard)'
-const AMBER = 'var(--underline-1)'
+// The credits accent: a GOLD SCALAR, not a rainbow. It read the retired brand
+// palette's first stop until #1220 (ADR-0066) pointed it at the token that
+// actually means "the spectrum's yellow as an ink". Consequence to know: the
+// brand palette was theme-invariant and this one is not, so the accent now
+// deepens in light (7.0:1 on the terminal black) and lifts in dark (10.0:1).
+// If Singularity's credits panel ever wants its own gold, that is a
+// --faction-singularity-* token, not a brand one.
+const AMBER = 'var(--faction-default-gold)'
 const FONT = 'var(--font-faction-terminal)'
 
 const phosphor = (pct: number): string => `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
@@ -24,7 +24,14 @@ const VOID = 'var(--faction-singularity-card-bg)'
 const PHOSPHOR = 'var(--faction-singularity-card-accent)'
 const SIGNAL = 'var(--faction-singularity-card-muted)'
 const BORDER_HARD = 'var(--faction-singularity-border-hard)'
-const AMBER = 'var(--underline-1)'
+// The credits accent: a GOLD SCALAR, not a rainbow. It read the retired brand
+// palette's first stop until #1220 (ADR-0066) pointed it at the token that
+// actually means "the spectrum's yellow as an ink". Consequence to know: the
+// brand palette was theme-invariant and this one is not, so the accent now
+// deepens in light (7.0:1 on the terminal black) and lifts in dark (10.0:1).
+// If Singularity's credits panel ever wants its own gold, that is a
+// --faction-singularity-* token, not a brand one.
+const AMBER = 'var(--faction-default-gold)'
 const FONT = 'var(--font-faction-terminal)'
 
 const phosphor = (pct: number): string => `color-mix(in srgb, ${PHOSPHOR} ${pct}%, transparent)`


### PR DESCRIPTION
Closes #1220

Foundation for epic #1219. The site had two rainbows; it has one now.

## What changed

**`index.css` — the spectrum becomes scalars first, gradients second.**
`--faction-default-stop-1…7` in both theme blocks, in spectrum order
(red · orange · yellow · green · teal · blue · magenta). Every na gradient is
rebuilt from them with `var()`: the bar ramp, the wedge ring, the vertical rule,
the seamless loop, the smooth conic, the aurora wash, and the four- and
three-stop short cuts. The retired brand palette is deleted.

**The three consumer shapes landed separately**, per the issue:

| Shape | Files | Now reads |
|---|---|---|
| Index-cycled | `PageTitle`, `LevelUpPopup` | the seven stops |
| Narrow marks | `NavBar`, `Home`, `FieldDesk` ×2 | `--faction-default-total-rainbow` / `-eyebrow-rainbow` |
| A stop used as a gold | 3 Singularity credit accents | `--faction-default-gold` |

No short-ramp or gold token was minted. The retired family's grep over
`frontend` returns nothing, and no reference to it survives in the built bundle.

**Docs.** ADR-0066 records the merge. ADR-0054 is **amended in place** — its
"the rainbow ring stays a fixed brand constant" clause is annotated and its
actual subject (one canonical crown, theme-aware only) left standing.
`WORLD_ZERO_STYLE.md` §7 no longer names the retired palette; §3 gains the
doctrine and a key-groups row.

## How the CSS was verified

Not by counting braces. I resolved **every** `--faction-default-*`, `--fdl-*`,
`--badge-victor-*`, `--spectrum-glow-*` and `--vote-*` token out of the **built**
stylesheet, in both themes, before and after, and diffed. Every pre-existing
gradient resolves **byte-identically** in both themes. A second pass confirms all
39 `--faction-default-*` declarations sit at nesting depth **0** under `:root`
and `[data-theme=dark]` — nothing reparented.

**Two values moved, both in dark, both deliberate.** `--faction-default-gold` and
`--faction-default-total-rainbow`'s yellow were `#e6b34a`, a hair off the dark
yellow **stop** `#e6b94f` that the comment above them claimed they took. They are
one hue now. The delta is ~6/255 on one channel and *lifts* the POINTS caption's
contrast on the dark sheet.

**Four dark declarations were deleted rather than restated.** `-gold`,
`-total-rainbow`, `-eyebrow-rainbow` and the `-aurora` hue list compose from stops
the dark block rebinds, so the `:root` declarations re-resolve to the brightened
spectrum on their own (the resolved-value diff proves this). Same argument the UA
parchment gradient already makes. Restating them would be four lines that have to
be remembered whenever the light cut changes.

## Decisions worth challenging

1. **`--faction-default-chip` keeps its literal hexes**, and this is the one
   acceptance bullet I did not satisfy to the letter. `#16a34a`/`#2563eb` *are*
   light stops 4 and 6 — but the chip has **no dark override** and
   `--faction-default-chip-text` is white *measured on those two exact values*.
   Composing it from the stops would make it flip and put white on the brightened
   `#4ade80`/`#60a5fa`, which fails. Theme-invariance is the design there, so the
   hues stay literal with a comment saying why. Flagging rather than silently
   deviating.
2. **`--faction-default-gold` is now `var(--faction-default-stop-3)`.** The issue
   quotes it as `#ca8a04`; pointing it at the stop is what removed the drift in
   (2) above. Its docstring says a gradient must not read it *back* — an ink
   inside a ramp is the wrong tier.
3. **`--faction-default-vote-on` / `-vote-off` were left alone.** `vote-on` equals
   stop 2 in *both* themes, so it is another coincidence — but it is a scalar ink,
   outside this issue's gradient-only acceptance, and coupling the vote widget's
   caption to the spectrum is a judgement call that belongs with #1127.
4. **`LevelUpPopup`'s seal composes its own conic rather than reading
   `--faction-default-ring`**, which is the same seven hard wedges. Deliberate:
   #1127 is collapsing that token into the smooth conic (or deleting it), and the
   seal wants edges. Its wedge is `360 / RAINBOW.length` now, not `60deg`.

## One issue premise was stale

`pages/editPraxis/archetypes/shared.tsx:21-26` is listed as a third full-cycle
consumer. That code no longer exists — #1189 deleted the pre-v2 helper set
(`RainbowTitle`, `RainbowUnderline`, …) along with it. So it is **eight** converted
files, not nine, and there are two index-cycling consumers, not three. Nothing
else in the issue disagreed with the code.

## The seam #1213 and the other rainbow issues build on

- **`--faction-default-stop-1…7`, both themes, spectrum order, 1-indexed.** This is
  the only source of a spectrum hue. #1213 should compose `--fdl-rainbow` and
  `.alb-rainbow` from these rather than adding stops of its own — but note the
  issue's own warning: `--fdl-rainbow` is a **conic** and `ep-edge` walks
  `background-position` across a 300% band, so neither is interchangeable with the
  bar ramp. The stops serve them; the *ramps* do not.
- **The seamless cut already exists.** Anything that scrolls its
  `background-position` wants `--faction-default-rainbow-loop` /
  `-rainbow-conic` (last stop == first stop). The ordinary ramp seams where red
  meets magenta — that is #1179's bug, and it is already solved by a token.
- **A composed token needs no dark twin.** If your value is
  `var(--faction-default-stop-N)` all the way down, declare it in `:root` only; the
  dark block's stop rebind does the rest. Four tokens already work this way. Adding
  a dark restatement re-introduces the drift this PR removed.
- **`--faction-default-ring` is still the seven hard wedges** and is now
  stop-composed. #1127 collapses it into `--faction-default-rainbow-conic`; both
  are already stop-composed, so that becomes a one-line alias rather than a
  re-transcription.
- **Three theme-invariant exceptions are documented at their declarations** —
  `--badge-victor-stop-*`, `--spectrum-glow-*`, `--faction-default-chip`. Do not
  tokenize them into the stops without re-measuring their inks. #1214 is
  comment-only over `--spectrum-glow-*` and does not conflict.
- **The cycle is seven long.** Any consumer that hardcodes a count or a wedge
  angle is now wrong.

## What to eyeball — visual QA is OUTSTANDING

I cannot screenshot (the renderer times out) and there is no dev stack here, so
**nothing below has been looked at**. Everything is gradients, `background-clip`
and per-letter bars: axe cannot measure a gradient (#651) and the harness has no
DOM. `tsc`, `eslint`, `vite build` and all **2545** tests pass, and that proves
only that the values moved as intended.

**In BOTH themes, and dark first — these surfaces had no dark form at all before:**

1. **`NavBar` wordmark** — the 2px rule went from indigo/magenta/orange/green to
   red/yellow/green/blue, and now flips. It is the most-seen 2px in the app.
2. **`PageTitle`** on any list page — per-letter bars, six hues to seven, and
   brightened in dark. The issue calls this and the nav out specifically: the dark
   stops were tuned for a dark faction **card**, not behind nav text.
3. **`LevelUpPopup`** — rank text, the rule, the seal's wedges (7 × 51.43° now,
   `from -60deg` unchanged), the ability-row dingbats and the confetti. Check the
   seal has no gap or double-drawn wedge.
4. **`Home` hero** — the 6px rule under the wordmark.
5. **`FieldDesk`** — the 220px title rule (4 stops) and the 160px progress fill
   (3 stops).
6. **Singularity credits accents** ×3 (faction body, mobile faction page, mobile
   home) — these sit on a terminal black that does **not** flip while the gold now
   does: `#fbbf24` (11.5:1) → `#ca8a04` in light (7.0:1) and `#e6b94f` in dark
   (10.0:1). Measured, not guessed; both clear AA at these small sizes, but the
   *look* is duller in light and that is a design call worth a glance.
7. **The na card's POINTS caption** in dark — the `#e6b34a` → `#e6b94f` nudge.
8. **Any na surface at all** — feed rows, the vote widget, the avatar ring, the
   composer aurora, Albescent's drift. All of these resolve byte-identically to
   before, so they are a regression check on the recomposition rather than a review
   of a change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
