### PR TITLE
The task id leaves the cards and the detail breadcrumb (#1124)

### DIFF
--- a/frontend/src/components/cards/CovenTaskCard.tsx
+++ b/frontend/src/components/cards/CovenTaskCard.tsx
@@ -277,20 +277,9 @@ export default function CovenTaskCard({
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
           <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
-            <div
-              style={{
-                fontFamily: HAND,
-                // eslint-disable-next-line local/no-raw-style-values -- ornament: the ordinal is pencilled on the slip in Caveat.
-                fontSize: 19,
-                lineHeight: 1,
-                color: "var(--faction-coven-slip-label)",
-                textAlign: "center",
-                padding: "var(--space-md) 0",
-              }}
-            >
-              {i18n.t("feed:taskCard.ordinal", { id: task.id })}
-            </div>
-
+            {/* The slip's pencilled ordinal ("Task {id}", hand-lettered under the
+                masthead) is gone with #1124 — the id no longer shows on any card,
+                and it was the whole line. */}
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)", marginBottom: "var(--space-md)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", gap: "var(--space-xs)" }}>
                 <span style={{ fontFamily: READING, fontWeight: 600, fontSize: size.levelSize, lineHeight: 0.8 }}>

--- a/frontend/src/components/cards/DefaultTaskCard.tsx
+++ b/frontend/src/components/cards/DefaultTaskCard.tsx
@@ -113,19 +113,10 @@ export default function DefaultTaskCard({
           to={`/tasks/${task.id}`}
           style={{ display: "block", textDecoration: "none", color: "inherit" }}
         >
-          {/* Eyebrow — the uniform ordinal every faction card carries (#1020). */}
-          <div
-            style={{
-              ...CAPTION,
-              fontSize: "var(--text-base)",
-              letterSpacing: "0.22em",
-              marginBottom: "var(--space-lg)",
-            }}
-          >
-            {i18n.t("feed:taskCard.ordinal", { id: task.id })}
-          </div>
-
-          {/* Hero — level, a hairline, the marks in their ring, the modifier. */}
+          {/* Hero — level, a hairline, the marks in their ring, the modifier.
+              #1020's uniform "Task {id}" eyebrow sat above this row until #1124
+              retired the id from every card, taking the whole eyebrow with it:
+              the ordinal was the only thing in it. */}
           <div
             style={{
               display: "flex",

--- a/frontend/src/components/cards/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/cards/EphemeristsTaskCard.tsx
@@ -372,35 +372,9 @@ export default function EphemeristsTaskCard({
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
           <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
-            {/* The cartouche, carrying the uniform ordinal (#1020). */}
-            <div style={{ display: "flex", justifyContent: "center", padding: "var(--space-md) 0 var(--space-xs)" }}>
-              <span
-                style={{
-                  display: "inline-flex",
-                  alignItems: "center",
-                  gap: "var(--space-sm)",
-                  padding: "var(--space-xs) var(--space-md)",
-                  border: "1.5px solid var(--faction-ephemerists-plate-brass)",
-                  borderRadius: 12,
-                  background: "var(--faction-ephemerists-plate-wash)",
-                }}
-              >
-                <span aria-hidden="true" style={{ width: 1.5, height: 12, background: "var(--faction-ephemerists-plate-brass)" }} />
-                <span
-                  style={{
-                    ...SMALL_CAPS,
-                    fontWeight: 700,
-                    fontSize: "var(--text-base)",
-                    letterSpacing: "0.24em",
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {i18n.t("feed:taskCard.ordinal", { id: task.id })}
-                </span>
-                <span aria-hidden="true" style={{ width: 1.5, height: 12, background: "var(--faction-ephemerists-plate-brass)" }} />
-              </span>
-            </div>
-
+            {/* #1020's brass cartouche stood here, ruling off the uniform "Task
+                {id}" ordinal at both ends. #1124 retired the id from every card
+                and the cartouche held nothing else, so both are gone. */}
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", padding: "var(--space-md) 0 var(--space-lg)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", gap: "var(--space-xs)", lineHeight: 1 }}>
                 <span style={{ ...SMALL_CAPS, fontSize: "var(--text-sm)", color: "var(--faction-ephemerists-plate-caption)" }}>

--- a/frontend/src/components/cards/EverymenTaskCard.tsx
+++ b/frontend/src/components/cards/EverymenTaskCard.tsx
@@ -206,20 +206,8 @@ export default function EverymenTaskCard({
             {/* Everything but the CTA reads the full call — a card-sized target
                 that stays valid HTML (no <button> nested in an <a>). */}
             <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
-              {/* Dateline — the uniform ordinal every faction card carries. */}
-              <div
-                style={{
-                  fontFamily: TYPED,
-                  fontSize: "var(--text-sm)",
-                  letterSpacing: "0.2em",
-                  textTransform: "uppercase",
-                  color: "var(--everymen-muted)",
-                  marginBottom: "var(--space-md)",
-                }}
-              >
-                {i18n.t("feed:taskCard.ordinal", { id: task.id })}
-              </div>
-
+              {/* The dateline carried the uniform "Task {id}" ordinal and nothing
+                  else, so #1124's retirement of the id takes the whole line. */}
               <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginBottom: "var(--space-md)" }}>
                 <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1 }}>
                   <span style={{ ...LABEL, fontSize: "var(--text-base)", color: "var(--everymen-olive)", marginBottom: "var(--space-xs)" }}>

--- a/frontend/src/components/cards/SingularityTaskCard.tsx
+++ b/frontend/src/components/cards/SingularityTaskCard.tsx
@@ -8,12 +8,17 @@ import { useFormFactor } from "../../hooks/useFormFactor";
 /**
  * Singularity — THE TERMINAL SESSION (task card v2, #1023).
  *
- * A windowed terminal: a chrome bar carrying three LEDs, the process name and
- * the task's ordinal; a boot line echoing the query; a LEVEL + POINTS readout
- * with the total in a lit blue well; a standing raster over the whole chassis
- * and a slow scan sweep travelling down it. Share Tech Mono throughout — the
- * faction has one face and this card uses it for everything, chrome and copy
- * alike.
+ * A windowed terminal: a chrome bar carrying three LEDs and the process name; a
+ * LEVEL + POINTS readout with the total in a lit blue well; a standing raster
+ * over the whole chassis and a slow scan sweep travelling down it. Share Tech
+ * Mono throughout — the faction has one face and this card uses it for
+ * everything, chrome and copy alike.
+ *
+ * The chrome bar's right-hand slug and the boot line beneath it both read the
+ * task's id ("Task {id}", and in the design a hex twin of it). #1124 retired the
+ * id from every card, and neither element carried anything else — the boot line
+ * was a `> query` with only the ordinal to query — so both are gone and the bar
+ * is LEDs plus process name.
  *
  * This replaces the sprocket-holed "Terminal Printout" wholesale (ADR-0055 /
  * ADR-0056 — a metaphor swap, not a tweak): the perforated fanfold paper is
@@ -104,7 +109,6 @@ export default function SingularityTaskCard({
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
   const showMultiplier = !isNeutralMultiplier(multiplier);
-  const ordinal = i18n.t("feed:taskCard.ordinal", { id: task.id });
 
   return (
     <div
@@ -154,7 +158,7 @@ export default function SingularityTaskCard({
           }}
         />
 
-        {/* Window chrome — lamps, the process name, the task's ordinal. */}
+        {/* Window chrome — lamps and the process name. */}
         <div
           style={{
             position: "relative",
@@ -176,26 +180,12 @@ export default function SingularityTaskCard({
           <span style={{ ...LABEL, fontSize: 10.5 }}>
             {i18n.t("feed:taskCard.singularity.windowTitle")}
           </span>
-          {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the window bar's right-hand slug, set to its neighbour. */}
-          <span style={{ ...LABEL, fontSize: 10.5, color: BLUE, marginLeft: "auto" }}>
-            {ordinal}
-          </span>
         </div>
 
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
           <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
-            {/* The boot line — the terminal's echo of the query, and this card's
-                eyebrow. The design put a hex id here and in the window bar; the
-                ordinal is uniform across all nine cards (#1020), so the hex is
-                gone and both slots read the same "Task {id}" the rest do. */}
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: command echo, set to the window bar it answers. */}
-            <div style={{ ...LABEL, fontSize: 10.5, color: BLUE, marginBottom: "var(--space-md)" }}>
-              {i18n.t("feed:taskCard.singularity.bootPrefix")}{" "}
-              <span style={{ color: BRIGHT }}>{ordinal}</span>
-            </div>
-
             <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-md)", marginBottom: "var(--space-lg)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1 }}>
                 <span style={{ ...LABEL, fontSize: "var(--text-sm)", marginBottom: "var(--space-xs)" }}>

--- a/frontend/src/components/cards/SnideTaskCard.tsx
+++ b/frontend/src/components/cards/SnideTaskCard.tsx
@@ -216,7 +216,9 @@ export default function SnideTaskCard({
           transform: "rotate(-0.4deg)",
         }}
       >
-        {/* The header bar — wordmark, a broken acid rule, the ordinal. */}
+        {/* The header bar — wordmark and a broken acid rule. The bar's right end
+            carried the uniform "Task {id}" ordinal until #1124 retired the id
+            from every card; the rule takes the freed width. */}
         <div
           style={{
             position: "relative",
@@ -242,9 +244,6 @@ export default function SnideTaskCard({
                 "repeating-linear-gradient(90deg, var(--faction-snide-acid) 0 6px, transparent 6px 10px)",
             }}
           />
-          <span style={{ fontFamily: TYPE, fontSize: "var(--text-base)", letterSpacing: "0.12em" }}>
-            {i18n.t("feed:taskCard.ordinal", { id: task.id })}
-          </span>
         </div>
 
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>

--- a/frontend/src/components/cards/UaTaskCard.tsx
+++ b/frontend/src/components/cards/UaTaskCard.tsx
@@ -23,10 +23,11 @@ import { UA_DISPLAY, UA_EYEBROW, UA_TEXT, UaEnsoScore } from "./uaAtoms";
  * `mobileTaskCard` surface retired, so this file serves both form factors.
  *
  * TWO MARKS, AND THE COUNT IS THE POINT (WORLD_ZERO_STYLE §6). The design draws
- * the ensō three times — beside the ordinal, behind the score, and again on the
+ * the ensō three times — in the eyebrow, behind the score, and again on the
  * sign-up button. The third is the mark spent as decoration, so it is dropped:
  * the ensō is reserved for the SCORE and the FACTION MARK, and a seal on a
- * button is neither.
+ * button is neither. The eyebrow mark stood beside the uniform "Task {id}"
+ * ordinal until #1124 retired the id; it keeps its line alone.
  *
  * THE LOTUS COMES BACK, and that reverses a line in this file's old docstring.
  * #851 read the kit's corner-bleed as something "the brief's strength ruling
@@ -123,12 +124,11 @@ export default function UaTaskCard({
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
           <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
-            {/* The eyebrow — the faction mark, then the uniform ordinal. */}
+            {/* The eyebrow — the faction mark alone. The uniform "Task {id}"
+                ordinal sat beside it until #1124 retired the id from every card;
+                the mark stays because it is the ensō, not the number. */}
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)", marginBottom: "var(--space-md)" }}>
               <UaSigil width={16} height={16} />
-              <span style={{ ...UA_EYEBROW, fontSize: "var(--text-base)" }}>
-                {i18n.t("feed:taskCard.ordinal", { id: task.id })}
-              </span>
             </div>
 
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginBottom: "var(--space-md)" }}>

--- a/frontend/src/components/cards/WowTaskCard.tsx
+++ b/frontend/src/components/cards/WowTaskCard.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "../TaskCard";
 import i18n from "../../i18n";
@@ -91,13 +90,9 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   },
 };
 
-/** The decree's label voice — MedievalSharp small caps, in plum. */
-const EYEBROW: CSSProperties = {
-  fontFamily: MED,
-  letterSpacing: "0.14em",
-  textTransform: "uppercase",
-  color: PLUM,
-};
+/* The decree's label voice (MedievalSharp small caps in plum) lived here. Its one
+   reader was the eyebrow carrying the uniform "Task {id}" ordinal, which #1124
+   retired, so the voice went with it. */
 
 /** The sword-and-shield that marks the muster. */
 function SwordAndShield({ size }: { size: number }) {
@@ -163,11 +158,9 @@ export default function WowTaskCard({
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
           <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: decree lettering, set to the ribbon above it rather than the label ramp (§4a). */}
-            <div style={{ ...EYEBROW, fontSize: 10, marginBottom: "var(--space-md)" }}>
-              {i18n.t("feed:taskCard.ordinal", { id: task.id })}
-            </div>
-
+            {/* The decree-lettered eyebrow held the uniform "Task {id}" ordinal and
+              nothing else, so #1124's retirement of the id takes the line with
+              it. The barber ribbon above is now the card's top note. */}
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginBottom: "var(--space-lg)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1 }}>
                 <span

--- a/frontend/src/components/cards/__tests__/defaultTaskCard.test.tsx
+++ b/frontend/src/components/cards/__tests__/defaultTaskCard.test.tsx
@@ -74,9 +74,13 @@ function card(props: Partial<{
 const SIGNUP = i18n.t('feed:taskCard.na.signup')
 
 describe('na task card — content slots', () => {
-  it('carries the uniform "Task {id}" ordinal, not a faction ordinal', () => {
+  // #1020 gave every card a uniform "Task {id}" eyebrow; #1124 retired the id
+  // from cards altogether. Both halves of this assertion are now negative: no
+  // shared ordinal, and still no faction ordinal — the design canvas's "Task No."
+  // ornament was never ours to draw either.
+  it('draws no task id, in the uniform voice or a faction one', () => {
     const { text } = card()
-    expect(text).toContain(i18n.t('feed:taskCard.ordinal', { id: 7 }))
+    expect(text, 'no uniform ordinal').not.toContain('Task 7')
     expect(text, 'no Task No. ornament from the design canvas').not.toContain('№')
   })
 

--- a/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/cards/__tests__/factionTaskCardsV2.test.tsx
@@ -138,9 +138,13 @@ function render(
 }
 
 describe.each(SKINS)('$slug task card v2 — content slots', (skin) => {
-  it('carries the uniform "Task {id}" ordinal, no faction ordinal', () => {
+  // #1020 gave every card a uniform "Task {id}" eyebrow; #1124 retired the id
+  // from cards altogether. Both halves are negative now: no shared ordinal, and
+  // still none of the design canvases' per-faction ordinals — which is why the
+  // regex survives the change that deleted the string it was guarding.
+  it('draws no task id, in the uniform voice or a faction one', () => {
     const { text } = render(skin)
-    expect(text).toContain(i18n.t('feed:taskCard.ordinal', { id: 7 }))
+    expect(text, 'no uniform ordinal').not.toContain('Task 7')
     expect(text, 'no folio/fragment/dispatch ornament from the design canvas')
       .not.toMatch(/№|Nº|Fragment|Folio|Dispatch/)
   })

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -181,7 +181,6 @@
     "title": "Task Crown — top praxis for this task"
   },
   "taskCard": {
-    "ordinal": "Task {{id}}",
     "inProgress": "{{count}} in progress",
     "multiplier": "×{{value}}",
     "modifierCaption": "modifier",
@@ -231,7 +230,6 @@
       "signup": "sign up",
       "levelPill": "lvl {{level}}",
       "windowTitle": "task.proc — singularity",
-      "bootPrefix": "> query",
       "levelCaption": "lvl",
       "pointsUnit": "pts"
     },

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -30,8 +30,7 @@
       "note": "Requires level {{level}}, one rung above you — your faction's once-a-level leap covers it."
     },
     "breadcrumb": {
-      "tasks": "Tasks",
-      "current": "Task №{{number}}"
+      "tasks": "Tasks"
     },
     "meta": "META",
     "metataskFor": "Metatask for {{faction}}",

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -118,7 +118,11 @@ describe("Ephemerists task detail — the Valley plate", () => {
     const { text } = render(<EphemeristsTaskDetail state={baseState()} />);
     expect(text).toContain("Task Description");
     expect(text).toContain("Discussion");
-    expect(text).toContain("Task №305");
+    // The breadcrumb is the shared "Tasks" crumb and nothing after it: #1124
+    // retired `Task №{id}`, which was the trail's whole second crumb here (a
+    // brass cartouche framing it).
+    expect(text).toContain("Tasks");
+    expect(text, "no task id in the breadcrumb").not.toContain("№");
     // ADR-0057: the retired Discordant Map voice.
     for (const retired of [
       "credence",

--- a/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
@@ -189,7 +189,10 @@ describe("Everymen task detail — the broadsheet", () => {
     const { html, text } = render(<EverymenTaskDetail state={baseState()} />);
     expect(html).toContain("em-broadsheet");
     expect(text).toContain("Everymen");
-    expect(text).toContain("Task №207");
+    // The breadcrumb is the shared "Tasks" crumb and nothing after it: #1124
+    // retired `Task №{id}`, which was the trail's whole second crumb.
+    expect(text).toContain("Tasks");
+    expect(text, "no task id in the breadcrumb").not.toContain("№");
   });
 
   it("renders the author byline from the task's denormalised fields", () => {

--- a/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
@@ -138,9 +138,15 @@ describe("Singularity task detail — the terminal dress", () => {
     expect(html).toContain("var(--faction-singularity-term-cta-glow)");
   });
 
-  it("titles the window with the task's ordinal in hex", () => {
+  // The window bar used to slug the task's id in hex (`0x0D0` for 208) as a
+  // process id. #1124 retired the task id from this page, and a base-16 id is
+  // still the id, so the slug went with the `Task №{id}` crumb beside it. The
+  // assertion inverts rather than disappears: hex is exactly the shape this
+  // number would come back in.
+  it("slugs no process id — the task id is gone from the window bar, hex included", () => {
     const { text } = render(<SingularityTaskDetail state={baseState()} />);
-    expect(text).toContain("0x0D0"); // 208
+    expect(text).not.toContain("0x");
+    expect(text).not.toContain("№");
   });
 });
 

--- a/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
@@ -30,6 +30,12 @@ import type { TaskDetailState } from "../useTaskDetail";
  * per-faction WORD is as identifying as a per-faction hue (WORLD_ZERO_STYLE §3).
  * Albescent keeps the light and loses the words; the copy is inherited whole.
  *
+ * The one number in that list outlived the words it travelled with: `№207` came
+ * back neutrally as the inherited breadcrumb's `Task №{id}` crumb. #1124 retired
+ * the task id from cards and this breadcrumb alike, so the trail this skin
+ * inherits is a single `Tasks` crumb and the design's ordinal is gone in both
+ * voices.
+ *
  * ### Why the light sits ON TOP
  *
  * `DefaultTaskDetail` paints an OPAQUE sheet on its own 1200 column, so an

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -597,13 +597,12 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
           flexWrap: "wrap",
         }}
       >
+        {/* One crumb, not two: the trail read `TASKS / Task №{id}` until #1124
+            retired the task id, and the id WAS the second crumb, so the
+            separator went with it rather than dangling. */}
         <Link to="/tasks" style={{ ...eyebrow, color: DEEP, textDecoration: "none" }}>
           {t("detail.breadcrumb.tasks")}
         </Link>
-        <span aria-hidden style={eyebrow}>
-          /
-        </span>
-        <span style={eyebrow}>{t("detail.breadcrumb.current", { number: task.id })}</span>
       </nav>
 
       <div

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -428,6 +428,11 @@ export default function DefaultTaskDetail({
   );
 
   // ── Header: breadcrumb, faction line, title, author, stats ──
+  //
+  // The breadcrumb is one crumb, not two. It read `TASKS / Task №{id}` until
+  // #1124 retired the task id from this page; the trail's second crumb WAS the
+  // id, so the separator went with it rather than being left to dangle. The
+  // title sits two rows below and names the page.
   const header = (
     <div>
       <nav
@@ -450,12 +455,6 @@ export default function DefaultTaskDetail({
         >
           {t("detail.breadcrumb.tasks")}
         </Link>
-        <span aria-hidden className="eyebrow">
-          /
-        </span>
-        <span className="eyebrow" style={{ letterSpacing: "0.2em" }}>
-          {t("detail.breadcrumb.current", { number: task.id })}
-        </span>
       </nav>
 
       <div

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -85,7 +85,8 @@ const CTA_INK = "var(--faction-ephemerists-plate-cta-ink)";
 const RULE = "var(--faction-ephemerists-plate-rule)";
 const LINE = "var(--faction-ephemerists-plate-line)";
 const SHADOW = "var(--faction-ephemerists-plate-shadow)";
-const WASH = "var(--faction-ephemerists-plate-wash)";
+/* `--faction-ephemerists-plate-wash` filled the breadcrumb cartouche and nothing
+   else on this page; #1124 retired the cartouche with the task id it framed. */
 
 /**
  * Praxis cards shown before the gallery expands. `PraxisCard` carries
@@ -651,7 +652,7 @@ export default function EphemeristsTaskDetail({
     </div>
   );
 
-  // ── Header: breadcrumb cartouche, faction line, title, author, stats ──
+  // ── Header: breadcrumb, faction line, title, author, stats ──
   const header = (
     <div>
       <nav
@@ -663,30 +664,13 @@ export default function EphemeristsTaskDetail({
           flexWrap: "wrap",
         }}
       >
+        {/* One crumb, not two. A brass cartouche ruled the second crumb off at
+            both ends, and that crumb was the task's ordinal — #1124 retired the
+            id, so the cartouche and the separator before it went with it rather
+            than framing nothing. */}
         <Link to="/tasks" style={{ ...eyebrow, color: NILE, textDecoration: "none" }}>
           {t("detail.breadcrumb.tasks")}
         </Link>
-        <span aria-hidden style={{ ...eyebrow, color: QUIET }}>
-          /
-        </span>
-        {/* The cartouche — the task's ordinal, ruled off at both ends. */}
-        <span
-          style={{
-            display: "inline-flex",
-            alignItems: "center",
-            gap: "var(--space-sm)",
-            padding: "var(--space-xs) var(--space-md)",
-            border: `1.5px solid ${BRASS}`,
-            borderRadius: 12,
-            background: WASH,
-          }}
-        >
-          <span aria-hidden style={{ width: 1.5, height: 12, background: BRASS }} />
-          <span style={{ ...SMALL_CAPS, fontWeight: 700, fontSize: "var(--text-base)", color: INK, whiteSpace: "nowrap" }}>
-            {t("detail.breadcrumb.current", { number: task.id })}
-          </span>
-          <span aria-hidden style={{ width: 1.5, height: 12, background: BRASS }} />
-        </span>
       </nav>
 
       <div

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -274,6 +274,10 @@ export default function EverymenTaskDetail({
   );
 
   // ── Header: breadcrumb, masthead, title, byline, stats ──
+  //
+  // One crumb, not two: the trail read `TASKS / Task №{id}` until #1124 retired
+  // the task id, and the id WAS the second crumb, so the separator went with it
+  // rather than dangling.
   const header = (
     <div>
       <nav
@@ -296,15 +300,6 @@ export default function EverymenTaskDetail({
         >
           {t("detail.breadcrumb.tasks")}
         </Link>
-        <span aria-hidden className="eyebrow" style={{ color: MUTED }}>
-          /
-        </span>
-        <span
-          className="eyebrow"
-          style={{ letterSpacing: "0.2em", color: MUTED }}
-        >
-          {t("detail.breadcrumb.current", { number: task.id })}
-        </span>
       </nav>
 
       {/* The masthead — the faction line, set as the paper's nameplate. */}

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -94,10 +94,10 @@ const LABEL: CSSProperties = {
   color: DIM,
 };
 
-/** The task's ordinal in hex — the window's process id. Ornament, never copy. */
-function hexOf(id: number): string {
-  return `0x${id.toString(16).toUpperCase().padStart(3, "0")}`;
-}
+/* `hexOf` rendered the task's id as a `0x131` process slug at the right end of
+   the window bar. It read as ornament, but the number it drew was the task id in
+   another base, and #1124 retired that id from this page — so the slug and the
+   helper are gone rather than the id surviving in hex. */
 
 /** Initials fallback for an author with no uploaded avatar. */
 function initialsOf(name: string): string {
@@ -257,9 +257,15 @@ export default function SingularityTaskDetail({
     </div>
   );
 
-  // ── Window chrome: lamps (desktop) or a back arrow (mobile), the breadcrumb,
-  //    and the process id. The design drew a second breadcrumb row inside the
-  //    header; one window title bar is enough, so the breadcrumb lives here.
+  // ── Window chrome: lamps (desktop) or a back arrow (mobile) and the
+  //    breadcrumb. The design drew a second breadcrumb row inside the header; one
+  //    window title bar is enough, so the breadcrumb lives here.
+  //
+  //    The bar used to carry the task id twice — `Task №{id}` as the trail's
+  //    second crumb and a `0x131` process slug at the far right. #1124 retired
+  //    the id, and both were it, so the bar is the back affordance plus the one
+  //    crumb: on desktop a TASKS link, on mobile the arrow alone (the crumb text
+  //    was always desktop-only).
   const chrome = (
     <div
       style={{
@@ -297,28 +303,10 @@ export default function SingularityTaskDetail({
       )}
 
       {desktop && (
-        <>
-          <Link to="/tasks" style={{ ...LABEL, color: BLUE, textDecoration: "none" }}>
-            {t("detail.breadcrumb.tasks")}
-          </Link>
-          <span aria-hidden style={LABEL}>
-            /
-          </span>
-        </>
+        <Link to="/tasks" style={{ ...LABEL, color: BLUE, textDecoration: "none" }}>
+          {t("detail.breadcrumb.tasks")}
+        </Link>
       )}
-      <span
-        style={{
-          ...LABEL,
-          overflow: "hidden",
-          whiteSpace: "nowrap",
-          textOverflow: "ellipsis",
-        }}
-      >
-        {t("detail.breadcrumb.current", { number: task.id })}
-      </span>
-      <span aria-hidden style={{ ...LABEL, marginLeft: "auto", color: BLUE, flex: "none" }}>
-        {hexOf(task.id)}
-      </span>
     </div>
   );
 

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -592,6 +592,10 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
   );
 
   // ── Header: breadcrumb, the bar, the cut-up headline, author, stats ──
+  //
+  // One crumb, not two: the trail read `TASKS / Task №{id}` until #1124 retired
+  // the task id, and the id WAS the second crumb, so the separator went with it
+  // rather than dangling.
   const header = (
     <div>
       <nav
@@ -614,12 +618,6 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
         >
           {t("detail.breadcrumb.tasks")}
         </Link>
-        <span aria-hidden="true" style={eyebrow}>
-          /
-        </span>
-        <span style={eyebrow}>
-          {t("detail.breadcrumb.current", { number: task.id })}
-        </span>
       </nav>
 
       {/* The masthead bar — the faction line, a broken acid rule, and (only on

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -465,6 +465,10 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
   );
 
   // ── Header: breadcrumb, faction line, title, author, the two counts ──
+  //
+  // One crumb, not two: the trail read `TASKS / Task №{id}` until #1124 retired
+  // the task id, and the id WAS the second crumb, so the separator went with it
+  // rather than dangling.
   const header = (
     <div>
       <nav
@@ -486,12 +490,6 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
         >
           {t("detail.breadcrumb.tasks")}
         </Link>
-        <span aria-hidden style={UA_EYEBROW}>
-          /
-        </span>
-        <span style={UA_EYEBROW}>
-          {t("detail.breadcrumb.current", { number: task.id })}
-        </span>
       </nav>
 
       {/* The faction line — the mark, then the name resolved from the catalog by

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -554,15 +554,12 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
           flexWrap: "wrap",
         }}
       >
+        {/* One crumb, not two: the trail read `TASKS / Task №{id}` until #1124
+            retired the task id, and the id WAS the second crumb, so the
+            separator went with it rather than dangling. */}
         <Link to="/tasks" style={{ ...EYEBROW, color: PLUM, textDecoration: "none" }}>
           {t("detail.breadcrumb.tasks")}
         </Link>
-        <span aria-hidden style={{ ...EYEBROW, color: LABEL }}>
-          /
-        </span>
-        <span style={{ ...EYEBROW, color: LABEL }}>
-          {t("detail.breadcrumb.current", { number: task.id })}
-        </span>
       </nav>
 
       <div


### PR DESCRIPTION
The task's id number no longer renders anywhere on a task card or a task-detail
breadcrumb, and both catalog keys are gone.

Closes #1124

## What I found — nine card surfaces, eight breadcrumbs

The issue's table was right about the cards and one off about the details, and
the sibling check found a **third** place the id was drawn that the issue did not
name.

- **Cards: nine surfaces, eight files.** `AlbescentTaskCard` renders
  `<DefaultTaskCard {...props} />` and adds light, so it never drew its own
  ordinal — fixing na fixed Albescent. The other eight each drew
  `feed:taskCard.ordinal` themselves. Singularity drew it **twice**: the window
  bar's right-hand slug *and* the boot line under it.
- **Breadcrumbs: nine surfaces, eight files.** Same reason —
  `AlbescentTaskDetail` renders `<DefaultTaskDetail>`. The eight bespoke skins
  each draw their own `<nav>`; nothing is shared, so this was eight edits, not
  one. (`pages/taskDetail/archetypes/shared.tsx` owns the level-jump banner, the
  comments slot and the action-column geometry — no breadcrumb.)
- **Not in the issue: `SingularityTaskDetail` drew the id a second time in hex.**
  A `hexOf(task.id)` helper slugged `0x0D0` at the far right of the window bar,
  docblocked as "Ornament, never copy". It is the same number in base 16, so it
  went with the crumb beside it, helper included. Left alone it would have been
  the one page still showing you a task id.

## The two shapes the removal took

Nothing was replaced with invented copy. Where the id was an element's whole
content, the element went; where it shared a row, only the id went.

- **Element deleted** (the id was all it held): na's eyebrow, Coven's pencilled
  slip line, the Ephemerists brass cartouche (card **and** breadcrumb), the
  Everymen dateline, WOW's decree eyebrow, and Singularity's boot line — that one
  was `> query` plus the ordinal, so keeping it would have left a prompt with
  nothing to query. `feed:taskCard.singularity.bootPrefix` is deleted with it.
- **Element kept, id removed**: the SNIDE header bar keeps its wordmark and acid
  rule; UA's eyebrow keeps the ensō (a mark, not a number — and the docblock's
  "three ensō" count depends on it).
- **The breadcrumb is one crumb now: `TASKS`.** No dangling separator — the
  `/` went with the crumb it separated, in all eight skins. I took the issue's
  second option rather than `TASKS / <task title>`, because every v2 skin's
  header draws the title a row or two below the trail (#1030's anatomy is
  breadcrumb · faction line · title), so a title crumb would restate it. On
  Singularity's mobile chrome the crumb text was always desktop-only, so mobile
  is the back arrow alone.

## Nothing keys off the id

Checked before deleting: no `aria-label`, anchor target, `data-` attribute or
test selector read the ordinal or the hex. `e2e/` mentions neither (its only
"breadcrumb" hits are prose in `contrastBaseline.ts`), so the nightly suite is
unaffected. `href="/tasks/{id}"` links are untouched — every card still links to
its task, which `archetypeSlots.test.tsx` and the card tests still assert.
`praxis:detail.breadcrumb.current` is a different namespace and is the literal
word "Praxis" with no id; untouched.

## Tests updated, not deleted

Each assertion inverted in place, keeping the sibling assertion it travelled with:

- `defaultTaskCard.test.tsx` / `factionTaskCardsV2.test.tsx` — the positive
  ordinal assertion becomes `not.toContain('Task 7')`; the
  `№|Nº|Fragment|Folio|Dispatch` guard against per-faction ordinals **survives**,
  as the issue asked.
- `ephemeristsDetail.test.tsx`, `everymenDetail.test.tsx` — `Task №305` /
  `Task №207` become "the trail is `Tasks` and carries no `№`".
- `singularityDetail.test.tsx` — "titles the window with the task's ordinal in
  hex" becomes "slugs no process id, hex included". Kept as an inverted test
  rather than deleted: hex is exactly the shape this number would come back in.

## What to eyeball — visual QA is outstanding

**I could not render any of this.** No screenshots (the browser pane's renderer
times out) and no dev stack, so everything below is verified by tsc, eslint,
vitest and `vite build` only. Every one of these surfaces lost an element from
the top of its layout, so the vertical rhythm above the hero row is the thing to
look at.

Task cards (feed, `/tasks`, faction pages — desktop **and** mobile, one
responsive component each):

1. **na / Unaffiliated** — eyebrow gone; card now opens on the level+marks row.
2. **Albescent** — inherits na's card. Confirm the light still sits right.
3. **Coven** — the hand-lettered slip line under the masthead is gone.
4. **Ephemerists** — the brass cartouche is gone; the plate opens on the level row.
5. **Everymen** — the dateline above the hero row is gone.
6. **Singularity** — window bar is LEDs + `task.proc — singularity`, nothing at
   the right end; the `> query` boot line is gone entirely. **The most changed
   card.**
7. **SNIDE** — header bar right end is empty; the dashed acid rule takes the width.
8. **UA** — the eyebrow is a lone 16px ensō. Judgement call; say if it should go.
9. **WOW** — decree eyebrow gone; the barber ribbon is now the top note.

Task detail breadcrumbs (`/tasks/:id`):

10. **na** and 11. **Albescent** (inherited) — `TASKS`, no separator.
12. **Coven**, 13. **Everymen**, 14. **SNIDE**, 15. **UA**, 16. **WOW** — same.
17. **Ephemerists** — the cartouche is out of the trail too.
18. **Singularity** — desktop: lamps + `TASKS`. **Mobile: the back arrow alone**,
    since the crumb was desktop-gated. Worth a look on a phone width.

## Two follow-ups for `frontend-style` (I did not touch `index.css` — #1220 owns it)

1. **`--faction-snide-note-bar-ink` now paints nothing.** The SNIDE card bar's
   `color:` declaration is still there but the ordinal was its only text. Its
   `index.css` comments (`the ordinal on that bar`, `the bar's ordinal goes pink`)
   are now stale, and so is the `snide clipping bar, ordinal` row in
   `factionContrast.test.ts`. Same story for `singularity window bar, ordinal`
   (`--faction-singularity-term-blue` on `-chrome`): the token is still used
   widely elsewhere, but nothing draws it on the chrome any more. I left all of
   it alone rather than edit a contrast baseline in the same batch as the
   index.css owner — it wants one pass over the tokens and the rows together.
2. **`feed:taskCard.*` has pre-existing orphans**, none created here, offered as
   a candidate list and not a delete order (a leaf-name grep over-reports —
   template-literal keys do not match): `snide.dispatchNumber`
   (`dispatch №{{number}}` — id-shaped, so the next id sweep will flag it),
   `ephemerists.coordXPrefix`, `ephemerists.coordPolar`,
   `ephemerists.vanishingLabel`, `singularity.levelPill`, `ua.estLine`,
   `ua.pointsLine`, `coven.questMeta`, `wow.byOrder`.

## One thing the issue asked for that I did not do

`AlbescentTaskDetail.tsx:24`'s `№207` sits inside a list of the *vendored
design's* voiced strings, under "**Every one of those is gone**" — a true
statement about copy that was never built, which #1124 does not falsify.
Rewriting it would have made it less accurate, so I added a sentence instead: the
design's one number did briefly survive neutrally, as the inherited breadcrumb's
`Task №{id}`, and now does not.

## Verification

`tsc --noEmit` clean · `eslint src --max-warnings=0` clean · `vitest run` 151
files / 2545 tests passing (same count as the pre-change baseline) · `vite build`
succeeds. Rebased onto `origin/main` at 2eea213c (#1051 landed mid-run) and
re-run green after the rebase. **Visual QA is outstanding on all 18 surfaces
above.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
