### PR TITLE
The favicon paints the na spectrum, and a test keeps it there

### DIFF
--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -2,19 +2,49 @@
   <!--
     World Zero site icon: the "Rainbow WoZero" mark (design ca218fc4,
     "Rainbow W0 Icon"). A rounded tile carrying the WO-stroke wordmark
-    glyph in Lora italic, filled with the unaffiliated rainbow spectrum.
+    glyph in Lora italic, filled with the unaffiliated (na) rainbow spectrum.
     Primary is the dark tile; the light tile (a design alternate) shows
     under a dark color scheme so the icon always contrasts the tab bar.
+
+    EVERY COLOUR IN THIS FILE IS A HAND-COPY OF THE LIGHT (`:root`) BLOCK OF
+    frontend/src/index.css:
+
+      glyph ramp  --faction-default-stop-1 .. -stop-7  (the na spectrum,
+                  ADR-0039), at the offsets --faction-default-rainbow uses
+      .tile       --color-text-primary   (the light theme's ink)
+      dark .tile  --color-bg-page        (the light theme's paper)
+
+    The copy is not laziness and not drift: this file is served from `public/`,
+    outside the bundle and outside the cascade. A favicon is a standalone
+    document fetched by browser chrome, so it cannot reach a CSS custom
+    property. Hardcoding is correct here. Hardcoding something *adjacent* to
+    the palette is what let three of these seven stops drift for months
+    (#1215) behind a comment that merely claimed they were the spectrum.
+
+    It tracks the LIGHT stops on BOTH tiles, deliberately. Browser chrome
+    gives us no theme signal -- the `prefers-color-scheme` query below reads
+    the OS scheme, not the site's `[data-theme]` -- and this asset's flip runs
+    *opposite* to the site's, since an OS dark scheme swaps in the LIGHT tile.
+    Borrowing the `[data-theme="dark"]` stops would therefore lay colours
+    brightened for dark grounds onto the pale tile. The dark block is a
+    per-ground override, and this asset carries its own ground.
+
+    KEPT HONEST BY A TEST, not by this comment:
+    frontend/src/__tests__/faviconSpectrum.test.ts parses this file and
+    index.css and fails CI the moment a hex or an offset here stops matching
+    the token it copies. Repoint the na spectrum and that test sends you back
+    to this file. The x1/y1 -> x2/y2 diagonal is a design choice about the
+    glyph rather than a palette question, so the test leaves it alone.
   -->
   <defs>
     <linearGradient id="wzRainbow" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#c1272d" />
-      <stop offset="0.16" stop-color="#ea580c" />
+      <stop offset="0.17" stop-color="#c2541f" />
       <stop offset="0.33" stop-color="#ca8a04" />
       <stop offset="0.5" stop-color="#16a34a" />
-      <stop offset="0.66" stop-color="#2563eb" />
-      <stop offset="0.83" stop-color="#6d28d9" />
-      <stop offset="1" stop-color="#a21caf" />
+      <stop offset="0.67" stop-color="#1d6e72" />
+      <stop offset="0.83" stop-color="#2563eb" />
+      <stop offset="1" stop-color="#be185d" />
     </linearGradient>
   </defs>
   <style>

--- a/frontend/src/__tests__/faviconSpectrum.test.ts
+++ b/frontend/src/__tests__/faviconSpectrum.test.ts
@@ -1,0 +1,110 @@
+/**
+ * #1215 — the favicon's hand-copied palette must equal the tokens it copies.
+ *
+ * WHY THIS EXISTS. `public/favicon.svg` is the one rainbow in the repo that
+ * can never read a custom property: it is a standalone document fetched by
+ * browser chrome, served from `public/`, outside the bundle and outside the
+ * cascade. So its colours are literals, and literals drift. Three of its seven
+ * stops were off the na spectrum — an orange found nowhere else in the repo, a
+ * violet the palette does not contain, a purple endpoint where the spectrum
+ * ends magenta, and no teal at all — for as long as anyone can remember,
+ * because the only thing asserting they were the spectrum was a comment
+ * *saying* they were the spectrum. A claim is not a check. This is the check.
+ *
+ * WHAT IT CATCHES. Repointing `--faction-default-stop-N`, resequencing the
+ * spectrum, or editing a stop in the SVG by hand. Any of those turns this red
+ * with the token name and both values, which is the signal the comment cannot
+ * give: come back to the asset, the palette moved without you.
+ *
+ * WHAT IT DELIBERATELY DOES NOT POLICE. The gradient's `x1/y1 -> x2/y2`
+ * diagonal — direction is a design decision about the glyph, not a palette
+ * question (#1215 says so explicitly) — and the geometry of the mark.
+ *
+ * WHY THE LIGHT THEME. Browser chrome hands us no site-theme signal; the SVG's
+ * own `prefers-color-scheme` query reads the OS scheme, and its flip runs
+ * *opposite* to the site's (an OS dark scheme swaps in the pale tile). So the
+ * asset copies one theme on both tiles, and the canonical one is `:root`; the
+ * `[data-theme="dark"]` block is a brightening for dark page grounds, and this
+ * asset brings its own ground. Both tile fills come from the light theme too,
+ * so the whole file follows a single rule this test can state.
+ *
+ * NOTE ON LEGIBILITY. Whether seven true stops read at 16px is an eyeball
+ * question no node test can answer (#1219: "each one owes a human eyeball").
+ * This test proves the values are right, not that the mark is clear.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { readThemes, resolveVar } from "../utils/__tests__/cssVars";
+
+const FAVICON = readFileSync(fileURLToPath(new URL("../../public/favicon.svg", import.meta.url)), "utf8");
+const THEMES = readThemes(readFileSync(fileURLToPath(new URL("../index.css", import.meta.url)), "utf8"));
+
+/** Resolve a light-theme token, failing loudly rather than comparing against null. */
+function lightValue(token: string): string {
+  const value = resolveVar(token, "light", THEMES);
+  expect(value, `${token} is not declared in the :root block of index.css`).not.toBeNull();
+  return (value as string).trim().toLowerCase();
+}
+
+/** The `<stop>` elements of `#wzRainbow`, in document order. */
+function faviconStops(): { offset: string; color: string }[] {
+  const gradient = /<linearGradient id="wzRainbow"[^>]*>([\s\S]*?)<\/linearGradient>/.exec(FAVICON);
+  expect(gradient, "favicon.svg no longer declares a #wzRainbow linearGradient").not.toBeNull();
+  return [...(gradient as RegExpExecArray)[1].matchAll(/<stop\s+offset="([^"]+)"\s+stop-color="([^"]+)"/g)].map(
+    (match) => ({ offset: match[1], color: match[2].trim().toLowerCase() }),
+  );
+}
+
+/**
+ * The `(colour, position)` pairs of a `linear-gradient(...)` token, so the
+ * favicon's offsets are measured against the ramp rather than a copied number.
+ */
+function rampStops(token: string): { percent: number; color: string }[] {
+  const value = lightValue(token);
+  return [...value.matchAll(/(#[0-9a-f]{6})\s+([\d.]+)%/g)].map((match) => ({
+    color: match[1],
+    percent: Number(match[2]),
+  }));
+}
+
+/** A fractional SVG offset as the percentage the CSS ramp states it in. */
+const asPercent = (offset: string) => Number(offset) * 100;
+
+describe("favicon.svg hand-copies the na spectrum exactly (#1215)", () => {
+  it("paints the seven --faction-default-stop-N hues, in spectrum order", () => {
+    const expected = [1, 2, 3, 4, 5, 6, 7].map((index) => lightValue(`--faction-default-stop-${index}`));
+    expect(faviconStops().map((stop) => stop.color)).toEqual(expected);
+  });
+
+  it("places them at the offsets --faction-default-rainbow uses", () => {
+    const ramp = rampStops("--faction-default-rainbow");
+    expect(ramp, "--faction-default-rainbow no longer parses as a 7-stop percentage ramp").toHaveLength(7);
+    expect(faviconStops().map((stop) => asPercent(stop.offset))).toEqual(ramp.map((stop) => stop.percent));
+  });
+
+  it("has no stop that is absent from the spectrum, so a hue cannot be added quietly", () => {
+    const spectrum = [1, 2, 3, 4, 5, 6, 7].map((index) => lightValue(`--faction-default-stop-${index}`));
+    const strangers = faviconStops()
+      .map((stop) => stop.color)
+      .filter((color) => !spectrum.includes(color));
+    expect(strangers).toEqual([]);
+  });
+
+  it("draws both tiles from the light theme's ink and paper", () => {
+    // Default tile = the site's ink; the `prefers-color-scheme: dark` alternate
+    // = the site's paper. Inverted against the site on purpose, so the mark
+    // always contrasts the tab bar rather than matching it.
+    const fills = [...FAVICON.matchAll(/\.tile\s*\{\s*fill:\s*(#[0-9a-fA-F]{6});/g)].map((match) =>
+      match[1].toLowerCase(),
+    );
+    expect(fills, "favicon.svg no longer declares exactly two .tile fills").toHaveLength(2);
+    expect(fills).toEqual([lightValue("--color-text-primary"), lightValue("--color-bg-page")]);
+  });
+
+  it("reads a non-empty gradient, so the guard cannot pass by finding nothing", () => {
+    expect(faviconStops()).toHaveLength(7);
+  });
+});


### PR DESCRIPTION
Closes #1215

Child of #1219 (the rainbow consolidation epic). This is the only rainbow that
ships outside the bundle.

## The three drifted stops

`frontend/public/favicon.svg` filled the WØ wordmark from a gradient its own
comment called "the unaffiliated rainbow spectrum". Three of the seven stops
were not on it: an orange (`#ea580c`) used nowhere else in the repo, a violet
the palette does not contain, and a purple endpoint where the spectrum ends
magenta. Teal was missing entirely.

Now the seven `na` hues in spectrum order, at the offsets
`--faction-default-rainbow` uses (`0/17/33/50/67/83/100%` — two of the old
offsets were `0.16`/`0.66`):

`#c1272d` `#c2541f` `#ca8a04` `#16a34a` `#1d6e72` `#2563eb` `#be185d`

The `x1/y1 -> x2/y2` diagonal is untouched: direction is a design choice about
the glyph, not a palette question.

**These values were re-derived from `frontend/src/index.css` on disk, not from
the issue's table.** #1220 landed after #1215 was written and moved two *dark*
values; the light stops the issue lists are exactly what `--faction-default-stop-1…7`
declares in `:root`. No contradiction to report.

## Which theme it tracks, and why

The light (`:root`) stops, on **both** tiles. Browser chrome hands us no
site-theme signal — the SVG's `prefers-color-scheme` query reads the *OS*
scheme, not our `[data-theme]` — and this asset's own flip runs *opposite* to
the site's, since an OS dark scheme swaps in the pale tile. Borrowing the
`[data-theme="dark"]` stops would therefore lay colours brightened for dark
grounds onto the light tile. The dark block is a per-ground override; this asset
brings its own ground.

That turns out to be the rule the whole file already followed: both `.tile`
fills are the light theme's `--color-text-primary` and `--color-bg-page`.

## How the next spectrum change gets caught

The issue asks for a hand-copy, and a hand-copy is correct — a favicon is a
standalone document fetched by browser chrome and cannot read a custom
property. But **a comment claiming these were the spectrum is exactly what let
three stops drift for months.** A claim is not a check, so this PR adds one.

`frontend/src/__tests__/faviconSpectrum.test.ts` parses `favicon.svg` and
`index.css` in the node environment (reusing the existing `cssVars` resolver
from the #651 contrast work) and asserts the asset's literals equal the tokens
they copy:

| assertion | against |
|---|---|
| seven stop hues, in order | `--faction-default-stop-1…7` |
| their offsets | the percentages in `--faction-default-rainbow` |
| no stop outside the spectrum | the same seven |
| both `.tile` fills | `--color-text-primary` / `--color-bg-page` |

It holds no palette of its own — every expected value is read out of
`index.css` — so it cannot drift in turn. Repoint the na spectrum and CI names
the token and both values.

**Verified by mutation, not just by passing:** a purple endpoint, a `0.16`
offset and a one-digit tile fill each turn it red. The file was restored and
the suite re-run green afterwards.

It deliberately does not police the diagonal, and it cannot judge legibility.

## What I could not check

**Visual QA is outstanding.** I have no browser and no dev stack, and a favicon
is genuinely among the hardest things to verify without one: it renders in
browser chrome at sizes nothing else uses, through the OS's own colour-scheme
signal, and it is aggressively cached. I checked the values are right. I did
**not** see the mark.

The specific risk the issue flags is real and unmeasured: seven true stops on a
diagonal across two letterforms can crowd at 16px. All seven light hues sit in a
narrow luminance band (measured ~3.0–3.6:1 against the dark tile, ~2.7–5.5:1
against the light one), so adjacent stops may read as one smear rather than
seven. If it muddies, the issue already names the fallback — a documented
four-stop *subset* of the spectrum, the argument
`--faction-default-total-rainbow` makes for short ramps — which would be a
value change to this same file plus one line in the test.

### What to eyeball

1. **16px, both tiles.** The real tab-bar size. Does the ramp still read as a
   rainbow, or as mud? This is the one that decides whether seven stops survive.
2. **32px and 64px, both tiles.** Bookmark bar and tab-hover.
3. **No purple anywhere.** The ramp must end magenta.
4. **The magenta endpoint against the pale tile** — the lowest-contrast pairing
   at the glyph's thinnest point.
5. **The teal stop is visible at all.** It is new to this mark, and it sits
   mid-ramp between green and blue, its two nearest neighbours in luminance.
6. **Flip the OS colour scheme** and confirm the tile still inverts (light tile
   under an OS dark scheme) — I did not change that logic, but nothing exercises
   it in CI.
7. **Hard-reload / clear the icon cache.** A stale favicon will show the old
   purple ramp and read as "no change".

## Checks

`tsc --noEmit` clean · `eslint` clean on the new file · `vitest run` 153 files /
2569 tests green · `vite build` succeeds. None of them can see the icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)