### PR TITLE
Delete the dead, drifted Tailwind faction palette

### DIFF
--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -9,20 +9,14 @@ export default {
         display: ["Lora", "serif"],
         body: ["Courier Prime", "monospace"],
         accent: ["Bebas Neue", "sans-serif"],
-        // Per-faction headline fonts
-        "faction-ua": ["IM Fell English", "serif"],
-        "faction-everymen": ["Special Elite", "serif"],
-        "faction-wow": ["Caveat", "cursive"],
-        "faction-snide": ["Permanent Marker", "cursive"],
-        "faction-ephemerists": ["Cinzel", "serif"],
-        "faction-singularity": ["Share Tech Mono", "monospace"],
-        "faction-ua-masters": ["UnifrakturCook", "serif"],
-        // Style-named aliases (handoff naming)
-        "faction-marker": ["Permanent Marker", "cursive"],
-        "faction-codex": ["Cinzel", "serif"],
-        "faction-blackletter": ["UnifrakturCook", "serif"],
-        "faction-script": ["Caveat", "cursive"],
-        "faction-old": ["IM Fell English", "serif"],
+        // No faction rows here: the per-faction headline stacks live in
+        // index.css as --font-faction-* (marker/codex/blackletter/script/old
+        // and the slug-named set). Twelve hand-duplicated entries sat here —
+        // seven slug-named, five style-named "handoff" aliases — and Tailwind
+        // emitted none of them: every consumer reaches the stack through
+        // var(--font-faction-*), never a `font-faction-*` utility. Removed in
+        // #1212 alongside the faction colour block, same reasoning as the
+        // fontSize note below.
       },
       colors: {
         paper: "var(--color-bg-page)",
@@ -34,14 +28,20 @@ export default {
         surface: "var(--color-bg-surface)",
         "surface-alt": "var(--color-bg-surface-alt)",
         accent: "var(--color-accent-primary)",
-        // Faction palette — rainbow primaries (light mode; dark mode via CSS vars)
-        ua: { DEFAULT: "#7c3aed", accent: "#a78bfa" },
-        everymen: { DEFAULT: "#ca8a04", accent: "#fbbf24" },
-        wow: { DEFAULT: "#be185d", accent: "#f472b6" },
-        snide: { DEFAULT: "#6fae00", accent: "#b6ff2e" },
-        ephemerists: { DEFAULT: "#1d6e72", accent: "#b0863a" },
-        singularity: { DEFAULT: "#2563eb", accent: "#60a5fa" },
-        "ua-masters": { DEFAULT: "#c2410c", accent: "#fb923c" },
+        // No faction rows here. Every row above is var()-backed, so index.css
+        // stays the only home for a colour VALUE; a literal-hex faction block
+        // sat here for seven slugs and was a second place for the numbers to
+        // drift. It had drifted four ways by the time it went: `ua` was
+        // #7c3aed purple against a live burnt-sienna --faction-ua (#848),
+        // `everymen` and `wow` held na-spectrum stops rather than their own
+        // hues (the pink moved to Cozy Coven in #784, WOW took yellow in
+        // #812), Coven had no row at all, and `ua-masters` is not a faction.
+        // The `accent:` sub-key named a --faction-*-accent tier that has never
+        // existed. Tailwind emitted none of it — no bg-/text-/border-/ring-/
+        // from- utility for any of those keys appears in src. Removed in #1212.
+        // Faction colour is read through factionCssVar() / factionFill()
+        // (utils/factions.ts) against --faction-{key}-*, never a Tailwind
+        // utility.
       },
       // No fontSize block: the type scale lives in index.css as --text-*
       // (label tier) and --text-content/title/heading/display (content tier).


### PR DESCRIPTION
Deletes the `theme.extend.colors` faction block from `frontend/tailwind.config.ts`, and — after checking each entry as the issue asked — the twelve faction rows in `fontFamily` too. One file, 22 lines swapped for two comments.

Closes #1212

## How I established zero consumers

Tailwind class names are **generated**, so grepping the config keys proves nothing. I searched for the *generated class forms* instead, then confirmed against the compiler's own output.

**1. Every colour utility prefix Tailwind 3.4 emits for a colour key**, over the whole `frontend/` tree (not just `src`), for all seven keys × `DEFAULT` and `-accent` × optional `/opacity`:

`text- bg- border- border-x/y/t/r/b/l/s/e- divide- divide-x/y- outline- ring- ring-offset- shadow- drop-shadow- fill- stroke- accent- caret- placeholder- decoration- from- via- to-`

→ **0 hits.**

**2. Positive control**, because a regex that finds nothing is indistinguishable from a broken regex. The same expression against the semantic rows that *are* in use returned **247 hits** (`text-tertiary` 120, `bg-surface` 72, `bg-surface-alt` 42, `text-ink` 7, `border-ink` 5, `bg-paper` 1). The machinery works.

**3. Laundering patterns** (a value that passes every lint gate while being live):

- Computed class strings — `` `bg-${slug}` `` / `"text-" + key` — for all 22 prefixes → 0. One apparent hit was `` `wz-wow-motto-${uid}` ``, an SVG element id matching `to-${`.
- `theme('colors.ua')` / `bg-[theme(colors.ua)]` arbitrary values → 0.
- `safelist` in the config → absent, so nothing is force-generated.

**4. Directories outside CI's reach**, called out because a consumer there fails no check:

- `.design-sync/previews/` — outside `tsconfig`'s `include: ["src"]` (#1051). It exists at **repo root**, not under `frontend/`, so a `frontend/`-scoped grep would have missed it. 0 colour-utility hits.
- `frontend/e2e/` — nightly-only, outside PR CI. 0 hits.
- `frontend/.ds-kit/`, `frontend/scripts/`, `frontend/public/`, `frontend/index.html` → 0 hits.

**5. The decisive check — the compiler's output.** Tailwind only emits a utility it finds in `content`. I built `main` before touching anything and grepped the bundled CSS: **zero** `.text-ua` / `.bg-wow` / `.from-snide`-style rules. Then rebuilt after the deletion:

```
before.css  102434 bytes  73b31d9667e3a1b8490c2993ec2ed458
after.css   102434 bytes  73b31d9667e3a1b8490c2993ec2ed458    diff: empty
```

**Byte-identical, same md5, and the same Vite content-hash filename** (`index-DCKHwdqZ.css`). Vite hashes on content, so an unchanged filename is independent confirmation. If the block had been live, the output would differ.

## The fontFamily block — and a correction to my own first pass

The issue said to check each entry and not assume. My first count was **wrong** and I nearly kept five dead entries: a naive `grep font-faction-marker` reports 14 hits, which looks live. All 14 are `--font-faction-marker`, the **CSS custom property** in `index.css` — not the Tailwind utility. Separating the two forms:

| entry | `--font-*` var refs | real `font-*` class uses | verdict |
|---|---|---|---|
| `display`, `body` | 45, 216 | **25, 164** | keep |
| `accent` | 48 | **0** | left alone — out of scope, see below |
| the 7 slug-named `faction-*` | 0 | **0** | deleted |
| `faction-marker` / `codex` / `blackletter` / `script` / `old` | 14 / 10 / 2 / 31 / 2 | **0** | deleted |

The built CSS agrees: the only `.font-*` rules emitted are `.font-body` and `.font-display` (plus core `.font-bold` / `.font-medium` / `.font-semibold`, which come from Tailwind's own fontWeight scale, not this config). **No `.font-faction-*` rule exists in the bundle at all** — so all twelve were dead, including the five "handoff naming" aliases the issue only asked me to check.

Every font stack keeps a live home in `index.css` (`--font-faction-typewriter` = Special Elite, `--font-faction-terminal` = Share Tech Mono, and so on), and consumers reach them through `var()`. Nothing loses a typeface.

## Drift: the issue said three ways, it was four — and the shape is different

Re-derived from `index.css` on disk rather than the issue's table, since #1220 (`9c6379fa`) landed first. The block claimed to be "rainbow primaries", but it was never the faction spine — three of its hexes are **na-spectrum stops**:

| key | config held | live `--faction-{key}` | |
|---|---|---|---|
| `ua` | `#7c3aed` purple | `#c24a18` burnt sienna | drifted (#848) |
| `everymen` | `#ca8a04` = `--faction-default-stop-3` | `#c1272d` red | drifted |
| `wow` | `#be185d` = `--faction-default-stop-7` | `#e0a800` yellow | drifted (pink left for Coven in #784; WOW took yellow in #812) |
| `snide` | `#6fae00` | `#6fae00` | matches |
| `ephemerists` | `#1d6e72` | `#1d6e72` | matches |
| `singularity` | `#2563eb` | `#2563eb` | matches |
| `ua-masters` | `#c2410c` | — not a faction | n/a |
| `coven` | — absent | `#ec5f99` | missing |

The **fourth** drift the issue didn't list: the `accent:` sub-key named a `--faction-*-accent` tier that **has never existed** in `index.css` (`grep -- '--faction-[a-z]*-accent:'` returns 0). The live accent concept is `--faction-{key}-card-accent`. So half of every row pointed at a token tier that was never real.

Also a small factual correction: the issue says `ua-masters` "appears nowhere else in the repo". The underscore form does — `computeFactionMultiplier('ua_masters', 'ua', TUNED)` in `src/utils/__tests__/points.test.ts:48`, a bare slug string in a test. Not a Tailwind consumer, so the deletion stands.

## Verification

All four CI steps for the `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` (`eslint src`) | clean |
| `npm run typecheck` (`tsc --noEmit`) | 0 errors |
| `npm test` (`vitest run`) | **152 files / 2564 tests passed** |
| `npm run build` (`vite build`) | success, CSS byte-identical |

One extra, because CI has a **blind spot on this exact file**: `tsconfig.json` is `include: ["src"]` and lint is `eslint src`, so `tailwind.config.ts` is covered by *neither*. It belongs to `tsconfig.node.json`, which is only a project reference and is not built by `tsc --noEmit`. I typechecked it explicitly — `tsc -p tsconfig.node.json --noEmit` → 0 errors. Worth knowing that a green `frontend` job does not by itself prove this file compiles.

## What to eyeball

Honestly: **nothing should change, and I have byte-identical CSS to back that up** — this is the rare case where a green build *is* the proof, because the artifact is unchanged rather than merely non-erroring. I could not screenshot (renderer times out, no dev stack), so **visual QA is outstanding**; a quick confidence pass if you want one:

- **Nothing at all** is the expected result. If any colour or typeface moves, the block *was* in use, this issue's premise was wrong, and it should be reopened as a migration rather than worked around — the issue says exactly this.
- Faction-skinned surfaces in **both themes** (a task card, a praxis card, a comment voice) — the per-faction headline fonts and hues come from `--font-faction-*` / `--faction-{key}-*`, untouched here.
- The UA surfaces specifically, since UA held the most-drifted value (`#7c3aed`); if anything anywhere was silently rendering purple, this is where it would surface.

## Notes for the dispatcher

- `index.css` is **untouched** — it belongs to #1213 this wave.
- Possible follow-up, deliberately left alone as out of scope: `fontFamily.accent` (`Bebas Neue`) also has **zero** Tailwind class consumers — `.font-accent` is absent from the built CSS, and all 48 hits are `--font-accent`. It is not a faction entry, so #1212's scope does not cover it. Worth a small issue.
- Minor pre-existing inconsistency spotted, not in this footprint: `factions.ts` has `ua: { color: "#c2541f" }` while `index.css` has `--faction-ua: #c24a18`. That file's docblock says the two "MUST stay in sync". `#c2541f` is `--faction-default-vote-on` / `--faction-default-stop-2`. Not touched here.
- `.design-sync/previews/UACrest.tsx` references `font-faction-engraved-caps` and `font-faction-gilt`, and `BRIEF-ua-identity.md` references `font-faction-serif` / `font-faction-deco` — **none of these were ever keys in this config**, so those previews already relied on utilities that do not exist. Pre-existing and unrelated to this deletion, but it confirms `.design-sync` is not a reliable signal of what is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
