### PR TITLE
Let the server default the /tasks character exclusion, so the page fetches once (#1229)

### DIFF
--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -52,6 +52,13 @@ async def list_tasks(
     is_admin = account is not None and await account_has_admin_role(
         account.id, session
     )
+    # The viewer is the exclusion default (#1229): the browse hides tasks you
+    # have already started, and the server already knows who you are. Clients
+    # that echoed their own character id back made the page fetch twice — once
+    # before /auth/me settled and once after. An explicit value still wins;
+    # anonymous callers get None, which excludes nothing.
+    if exclude_character_id is None and viewer is not None:
+        exclude_character_id = viewer.id
     tasks = await service_list_tasks(
         session,
         status=status,

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -255,6 +255,57 @@ async def test_list_tasks_exclude_character_id(
 
 
 @pytest.mark.asyncio
+async def test_list_tasks_defaults_exclusion_to_viewer(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """An authenticated browse excludes the viewer's own started tasks without
+    the client passing exclude_character_id (#1229) — anonymous excludes none."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo"},
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+
+    resp = await client.get("/tasks", headers=auth_headers)
+    assert resp.status_code == 200
+    assert active_task.id not in [t["id"] for t in resp.json()]
+
+    anon_resp = await client.get("/tasks")
+    assert anon_resp.status_code == 200
+    assert active_task.id in [t["id"] for t in anon_resp.json()]
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_explicit_exclusion_beats_viewer_default(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """An explicitly passed exclude_character_id wins over the viewer default,
+    so the viewer's own started task stays visible when another id is named."""
+    create_resp = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo"},
+        headers=auth_headers,
+    )
+    assert create_resp.status_code == 201
+
+    resp = await client.get(
+        "/tasks",
+        params={"exclude_character_id": character2.id},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert active_task.id in [t["id"] for t in resp.json()]
+
+
+@pytest.mark.asyncio
 async def test_propose_task_with_description(
     client: AsyncClient,
     character2: Character,

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -60,7 +60,6 @@ export interface TaskFilters {
   status?: string
   faction?: string
   level?: number
-  exclude_character_id?: number
   created_by?: number
   task_type?: TaskType
   /**

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -105,7 +105,6 @@ export interface TasksState {
 export function useTasks(): TasksState {
   const { user } = useAuth()
   const navigate = useNavigate()
-  const characterId = user?.character?.id
 
   const [factions, setFactions] = useState<FactionOut[]>([])
   const [factionConfigs, setFactionConfigs] = useState<FactionConfigOut[]>([])
@@ -144,10 +143,12 @@ export function useTasks(): TasksState {
         faction: faction || undefined,
         level: level === '' ? undefined : level,
         q: trimmedQuery || undefined,
-        exclude_character_id: characterId,
+        // The server excludes the authenticated viewer's own started tasks by
+        // default (#1229). Echoing the character id back here added an
+        // auth-dependent dep that made the page fetch twice.
         limit,
       }),
-    [taskType, status, faction, level, trimmedQuery, characterId],
+    [taskType, status, faction, level, trimmedQuery],
     PAGE_LIMIT,
   )
   const tasks = data ?? []


### PR DESCRIPTION
Closes #1229

Logged in, `/tasks` fetched the list twice: once before `/auth/me` settled and once after. `useTasks` read `characterId` off `useAuth()` and passed it as `exclude_character_id`, which put an auth-dependent value in the `usePagedResource` dep list. The dep flipped from `undefined` to a real id, and the fetch re-ran.

The exclusion itself is load-bearing — without it the browse lists tasks you already have a praxis on and offers a signup that fails. Only its plumbing changed: the route already resolves `viewer` for the metatask level gate, so it defaults `exclude_character_id` to `viewer.id` itself. With the id out of the dep list there is no auth-dependent dep left, so the race is gone by construction rather than by a guard someone has to remember. No `enabled` option was added to `useResource` and the fetch is not hand-rolled.

`TaskFilters.exclude_character_id` is deleted — `useTasks` was its only caller.

## Seam tested at

The backend route, `GET /tasks` — three cases, red first:

- **authenticated, no param** → the viewer's own started task is excluded. This is the one that went red on the real defect (`assert 2 not in [2]`) before the fix.
- **anonymous** → excludes nothing (asserted in the same test, so the default can't quietly over-apply).
- **explicit value wins** → browsing as a character who has started a task, but naming a *different* id, keeps that task visible.

The pre-existing `test_list_tasks_exclude_character_id` is unchanged and still passes.

## Verification run

- `pytest --cov --cov-fail-under=80` — 854 passed, 90.22% coverage
- `tsc --noEmit` clean, `eslint src` clean
- `vitest run` — 2566 passed across 154 files
- `vite build` + initial-load byte budget — exit 0 (the CSS line already warns on `main`; no CSS touched here)

## What to eyeball

No browser or dev stack was available in this worktree, so visual QA is outstanding:

- **`/tasks` logged in, network panel open — exactly ONE `/tasks` request.** Two was the bug.
- **Tasks you already have in progress must still be absent** from that list. If a task you have a praxis on reappears, the exclusion has been lost rather than moved.
- **Logged out `/tasks` unchanged** — every active task listed, nothing excluded.
- Filter changes (type/status/faction/level/search) should still fire one request each, signed in or not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)