### PR TITLE
The plural of praxis is praxis (#1136)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -89,18 +89,19 @@ reads SNIDE; a praxis of that task reads SNIDE.
 
 **Praxis**:
 A character's (or group's) record of doing one task — from claiming it through posting the
-proof Sally shows after "jump really high". One task has many praxes. A praxis exists from
+proof Sally shows after "jump really high". One task has many praxis. A praxis exists from
 the moment it's claimed (`in_progress`), so it is *not* synonymous with the completion; it's
 the whole record that spans claim → proof. One praxis becomes open to community voting once
 it is **submitted** (see **Praxis status**).
-_Avoid_: "sealed" (legacy term, retired — the code/DB/UI all say *submitted*); post, entry.
+_Avoid_: "sealed" (legacy term, retired — the code/DB/UI all say *submitted*); post, entry;
+"praxes" (*praxis* is both the singular and the plural here — "one praxis", "many praxis").
 
 **Praxis type**:
 Which collaboration shape a doing-of-a-task takes: **solo**, **collab**, or **duel**. Solo and
 collab are *one shared praxis* (collab just has many members on it); a **duel** is **two linked
-praxes that compete** — see **Duel**.
+praxis that compete** — see **Duel**.
 
-**Duel** *(two-linked-praxes model; ADR-0011 — landed)*:
+**Duel** *(two-linked-praxis model; ADR-0011 — landed)*:
 A head-to-head competition between two characters on the same task. Each side authors **its own
 `type=solo` praxis** — own owner, body, media, votes — and the two are joined by a **Duel link**.
 The win/loss multiplier is applied per **side** at scoring time and **floats with the votes until
@@ -185,7 +186,7 @@ window of `era.collab_auto_submit_days` (10); if every member submits it goes Li
 otherwise **silence is consent** — when the window elapses with no edit, it auto-publishes. Any
 member **editing the document** during the window is a hard reset: it cancels the countdown and
 clears everyone's `has_submitted`, dropping back to plain drafting ("an edit means we're not
-done"). A member may also **leave** to drop their hold. Solo and duel praxes do not use this.
+done"). A member may also **leave** to drop their hold. Solo and duel praxis do not use this.
 _Avoid_: "unanimous"/"all must submit" (the timeout publishes without unanimity); "approval".
 
 **In-progress privacy**:
@@ -223,7 +224,7 @@ not a discard — vote history survives the trip.
 _Avoid_: "withdraw" as a synonym for delete (a withdrawn praxis still exists and can return).
 
 **Task bank**:
-The set of a character's `in_progress` praxes, capped per character by the era's
+The set of a character's `in_progress` praxis, capped per character by the era's
 `max_task_signups`. Claiming a task ("signing up") adds to the bank; submitting or
 withdrawing frees a slot.
 
@@ -361,15 +362,15 @@ present reality.
 - **Praxis-wide**: once applied, **every member** of that praxis banks the bonus — scoring does
   **no** per-member access re-check; `get_meta_task_points` is a dumb sum of attached
   `point_value`s. _Avoid_: per-member metatask gating (rejected — see ADR-0015).
-- **Duel symmetry**: a metatask applies to **both** linked duel praxes (ADR-0011), so neither
+- **Duel symmetry**: a metatask applies to **both** linked duel praxis (ADR-0011), so neither
   duelist gains a base-point head start. (Today's single-praxis duel already gets this via
-  praxis-wide; the two-praxes model needs both-sides attachment — coordinates with #185.)
+  praxis-wide; the two-praxis model needs both-sides attachment — coordinates with #185.)
 - **See**, **propose**, and **apply** all gate at **level 5** — distinct actions that share a
   level. A praxis holds **1** metatask until the applying character reaches **level 7**, which
   raises the cap to **3** (`metatasks_per_praxis_base`/`_max`/`_max_level`).
 
 **Register row / Praxis Index**:
-The faction's list view of submitted praxes; the praxis **card** lives here (compact, next to
+The faction's list view of submitted praxis; the praxis **card** lives here (compact, next to
 task cards). Distinct from **Praxis Read** — the detail page showing one praxis in full
 (account body, evidence, the voting control).
 
@@ -463,7 +464,7 @@ The one character an account is currently **stepped into** (`account.active_char
 resolved by `resolve_active_character`). It is the **actor** for every authenticated write
 path and the **viewer** for read-time, viewer-relative fields — you act *as* the life you
 carry, switch to carry another (`POST /me/active-character`; FieldDesk `enterLife`). A second
-life is a **sock puppet**: fully independent — own identity, score, faction, praxes, votes —
+life is a **sock puppet**: fully independent — own identity, score, faction, praxis, votes —
 **except** the account-scoped anti-cheat guards (no voting on a sibling's praxis; no ganging
 to flag). Edit/delete is **carried-character-only**: you manage only the life you're wearing.
 _Avoid_: acting as "the first/oldest character" (the pre-ADR-0025 bug); an account-wide edit
@@ -527,7 +528,7 @@ members (ADR-0024). Endpoint is `POST /praxes/{id}/withdraw`; ADR-0007 also call
 entirely); "reopen"/"resubmit" as separate operations (retired in ADR-0007).
 
 **Member** *(of a praxis)*:
-A co-owner. Solo/duel praxes have exactly one (the creator); a collab has all its
+A co-owner. Solo/duel praxis have exactly one (the creator); a collab has all its
 collaborators (ADR-0013). Membership — not authorship — is the visibility and edit key for
 an `in_progress` praxis. _Avoid_: "owner"/"creator" when the rule is really "any member".
 

--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -115,7 +115,7 @@ test.describe('collaboration lifecycle', () => {
 
       // Page: the published praxis renders on its detail page.
       const page = await seed.alice.ctx.newPage()
-      await page.goto(`/praxes/${seed.praxisId}`)
+      await page.goto(`/praxis/${seed.praxisId}`)
       await expect(page.getByRole('heading', { name: `Collab life` })).toBeVisible()
       // Creator byline (scope to main — the name also appears in nav + sidebar card).
       await expect(page.getByRole('main').getByRole('link', { name: seed.alice.name })).toBeVisible()
@@ -131,7 +131,7 @@ test.describe('collaboration lifecycle', () => {
       const page = await seed.alice.ctx.newPage()
       await page.goto('/')
       const sidebar = page.locator('aside')
-      await expect(sidebar.locator(`a[href="/praxes/${seed.praxisId}/edit"]`)).toBeVisible()
+      await expect(sidebar.locator(`a[href="/praxis/${seed.praxisId}/edit"]`)).toBeVisible()
       await expect(sidebar.getByText(seed.task.title)).toBeVisible()
     } finally {
       await seed.alice.ctx.close()
@@ -147,7 +147,7 @@ test.describe('collaboration lifecycle', () => {
       const page = await seed.bob.ctx.newPage()
       await page.goto('/')
       const sidebar = page.locator('aside')
-      await expect(sidebar.locator(`a[href="/praxes/${seed.praxisId}/edit"]`)).toBeVisible()
+      await expect(sidebar.locator(`a[href="/praxis/${seed.praxisId}/edit"]`)).toBeVisible()
     } finally {
       await seed.alice.ctx.close()
       await seed.bob.ctx.close()
@@ -165,7 +165,7 @@ test.describe('collaboration lifecycle', () => {
     try {
       await bothEditAndSubmit(seed)
       const page = await seed.bob.ctx.newPage()
-      await page.goto(`/praxes/${seed.praxisId}`)
+      await page.goto(`/praxis/${seed.praxisId}`)
       // Scope to main: the collaborator's name must appear in the praxis CONTENT,
       // not merely in the nav/sidebar chrome (where the logged-in viewer's own
       // name shows regardless).
@@ -234,8 +234,8 @@ test.describe('collaboration UI (clicked buttons)', () => {
       const aPage = await alice.ctx.newPage()
       await aPage.goto(`/tasks/${task.id}`)
       await aPage.getByRole('button', { name: SNIDE_SIGNUP }).click()
-      await aPage.waitForURL(/\/praxes\/\d+\/edit/)
-      const praxisId = Number(aPage.url().match(/\/praxes\/(\d+)\/edit/)![1])
+      await aPage.waitForURL(/\/praxis\/\d+\/edit/)
+      const praxisId = Number(aPage.url().match(/\/praxis\/(\d+)\/edit/)![1])
 
       // 2. Flip solo → collab through the ModePicker.
       await aPage.getByRole('button', { name: SNIDE_COLLAB_MODE }).click()
@@ -253,16 +253,16 @@ test.describe('collaboration UI (clicked buttons)', () => {
       const bPage = await bob.ctx.newPage()
       await bPage.goto('/updates?filter=requests')
       await bPage.getByRole('main').getByRole('button', { name: 'Accept' }).click()
-      await bPage.waitForURL(/\/praxes\/\d+\/edit/)
+      await bPage.waitForURL(/\/praxis\/\d+\/edit/)
 
       // 5. Both edit the body, then cast through the footer PublishButton.
       //    Alice reloads so her roster reflects Bob's membership (her cast label
       //    depends on the live member count) before she casts.
-      await aPage.goto(`/praxes/${praxisId}/edit`)
+      await aPage.goto(`/praxis/${praxisId}/edit`)
       await aPage.locator('textarea').first().fill('Alice weaves her part')
       await aPage.getByRole('button', { name: SNIDE_CAST }).click()
 
-      await bPage.goto(`/praxes/${praxisId}/edit`)
+      await bPage.goto(`/praxis/${praxisId}/edit`)
       await bPage.locator('textarea').first().fill('Bob weaves his part')
       await bPage.getByRole('button', { name: SNIDE_CAST }).click()
 
@@ -272,7 +272,7 @@ test.describe('collaboration UI (clicked buttons)', () => {
       // 6. The published praxis renders on its detail page (creator byline in
       //    main — mirrors the green API-driven lifecycle assertion above).
       const view = await alice.ctx.newPage()
-      await view.goto(`/praxes/${praxisId}`)
+      await view.goto(`/praxis/${praxisId}`)
       await expect(
         view.getByRole('main').getByRole('link', { name: alice.name }),
       ).toBeVisible()
@@ -289,7 +289,7 @@ test.describe('collaboration UI (clicked buttons)', () => {
     const seed = await seedCollabDraft(browser, 'ui-kick')
     try {
       const page = await seed.alice.ctx.newPage()
-      await page.goto(`/praxes/${seed.praxisId}/edit`)
+      await page.goto(`/praxis/${seed.praxisId}/edit`)
       await expect(
         page.getByRole('button', {
           name: new RegExp(`(kick|remove).*${seed.bob.name}`, 'i'),
@@ -308,7 +308,7 @@ test.describe('collaboration UI (clicked buttons)', () => {
     const seed = await seedCollabDraft(browser, 'ui-leave')
     try {
       const page = await seed.bob.ctx.newPage()
-      await page.goto(`/praxes/${seed.praxisId}/edit`)
+      await page.goto(`/praxis/${seed.praxisId}/edit`)
       await expect(page.getByRole('button', { name: /leave/i })).toBeVisible()
     } finally {
       await seed.alice.ctx.close()
@@ -325,7 +325,7 @@ test.describe('collaboration UI (clicked buttons)', () => {
       // Alice casts (API) → the collab enters `pending`; Bob is the holdout.
       await seed.alice.ctx.request.post(`${API}/praxes/${seed.praxisId}/submit`)
       const page = await seed.bob.ctx.newPage()
-      await page.goto(`/praxes/${seed.praxisId}`)
+      await page.goto(`/praxis/${seed.praxisId}`)
       // The unsubmit control must NOT be offered to a member who never cast.
       await expect(
         page.getByRole('button', { name: 'unsubmit', exact: true }),

--- a/frontend/e2e/contrast.spec.ts
+++ b/frontend/e2e/contrast.spec.ts
@@ -62,7 +62,7 @@ type ViewportName = keyof typeof VIEWPORTS
  * is why its ROSTER_PAIRS block measures a pairing rather than a documented
  * role — read that block's header before assuming a token is covered here.
  */
-const SHARED_ROUTES = ['/', '/tasks', '/praxes', '/leaderboard', '/factions']
+const SHARED_ROUTES = ['/', '/tasks', '/praxis', '/leaderboard', '/factions']
 
 // This spec opts out of the shared bot's saved cookie: it re-logs per faction
 // against its own dev account so it can't leave other specs' bot in Snide.

--- a/frontend/e2e/duel-zzz-resolved.spec.ts
+++ b/frontend/e2e/duel-zzz-resolved.spec.ts
@@ -63,7 +63,7 @@ test.describe('duel resolved rail (isolated — triggers a destructive era reset
         const alicePraxisId = await createSoloDraft(alice, task.id, `Duel resolved ${RUN}`)
 
         const alicePage = await alice.ctx.newPage()
-        await alicePage.goto(`/praxes/${alicePraxisId}/edit`)
+        await alicePage.goto(`/praxis/${alicePraxisId}/edit`)
         await challengeViaUi(alicePage, bob.name)
 
         const bobPage = await bob.ctx.newPage()
@@ -71,7 +71,7 @@ test.describe('duel resolved rail (isolated — triggers a destructive era reset
         await waitForDuelAttached(bobPage, alice.name)
         await sealViaUi(bobPage)
 
-        await alicePage.goto(`/praxes/${alicePraxisId}/edit`)
+        await alicePage.goto(`/praxis/${alicePraxisId}/edit`)
         await waitForDuelAttached(alicePage, bob.name)
         await sealViaUi(alicePage) // → settled
 
@@ -89,7 +89,7 @@ test.describe('duel resolved rail (isolated — triggers a destructive era reset
         // with the votes" tally the settled reading renders. `DuelCard` (#1090)
         // has an explicit `resolved` reading, so this is a live contract now — it
         // stays fixme only because the era reset above needs admin auth.
-        await alicePage.goto(`/praxes/${alicePraxisId}`)
+        await alicePage.goto(`/praxis/${alicePraxisId}`)
         const main = alicePage.getByRole('main')
         await expect(main.getByText(/floats with the votes/i)).toBeHidden()
         await expect(main.getByText(/winner|won|final/i)).toBeVisible()

--- a/frontend/e2e/duel.helpers.ts
+++ b/frontend/e2e/duel.helpers.ts
@@ -81,7 +81,7 @@ export async function createSoloDraft(
 
 /**
  * Issue a challenge through the composer UI. `page` must already be at the
- * challenger's /praxes/:id/edit. Flips to duel mode via the mode chip, searches
+ * challenger's /praxis/:id/edit. Flips to duel mode via the mode chip, searches
  * the opponent, and picks them from the dropdown — picking is what issues the
  * challenge (controls.tsx onPick = state.sendChallenge). Asserts the attached
  * opponent chip so the challenge is confirmed before returning.
@@ -114,14 +114,14 @@ export async function challengeViaUi(page: Page, opponentName: string): Promise<
 /**
  * Accept a pending challenge through the opponent's updates feed. Lands the
  * opponent on their freshly-created opponent-praxis composer (feed card
- * landOnPraxis → /praxes/:id/edit). Accept/Decline live only on /updates.
+ * landOnPraxis → /praxis/:id/edit). Accept/Decline live only on /updates.
  */
 export async function acceptDuelViaUi(page: Page): Promise<void> {
   await page.goto('/updates')
   const accept = page.getByRole('button', { name: 'Accept Duel' })
   await expect(accept).toBeVisible()
   await accept.click()
-  await page.waitForURL(/\/praxes\/\d+\/edit/)
+  await page.waitForURL(/\/praxis\/\d+\/edit/)
 }
 
 /**

--- a/frontend/e2e/duel.spec.ts
+++ b/frontend/e2e/duel.spec.ts
@@ -63,7 +63,7 @@ test.describe('duel lifecycle', () => {
     try {
       // 1. Challenge (UI): Alice flips to duel mode and picks Bob → duel pending.
       const alicePage = await alice.ctx.newPage()
-      await alicePage.goto(`/praxes/${alicePraxisId}/edit`)
+      await alicePage.goto(`/praxis/${alicePraxisId}/edit`)
       await challengeViaUi(alicePage, bob.name)
 
       // 2. Accept (UI): Bob accepts on his updates feed → duel active, and Bob
@@ -77,7 +77,7 @@ test.describe('duel lifecycle', () => {
 
       // 3b. Alice reloads (her page still shows the pre-accept state) and seals →
       //     both sides submitted → duel settled.
-      await alicePage.goto(`/praxes/${alicePraxisId}/edit`)
+      await alicePage.goto(`/praxis/${alicePraxisId}/edit`)
       await waitForDuelAttached(alicePage, bob.name)
       await sealViaUi(alicePage)
 
@@ -85,7 +85,7 @@ test.describe('duel lifecycle', () => {
       //    live tally. Backend analogue: test_duel_detail_returns_both_sides_with_tallies.
       //    #1090 replaced the "⚔ Duel vs …" rail headline with the card's own
       //    label, so the anchor is the label rather than the old glyph.
-      await alicePage.goto(`/praxes/${alicePraxisId}`)
+      await alicePage.goto(`/praxis/${alicePraxisId}`)
       const main = alicePage.getByRole('main')
       await expect(main.getByText(/The duel/i).first()).toBeVisible()
       await expect(main.getByText(bob.name).first()).toBeVisible()
@@ -101,14 +101,14 @@ test.describe('duel lifecycle', () => {
   // ACTIVE duel (→ declined, no forfeit penalty). Backend already allowed it
   // (services/duel.py); #956 added the composer-chip "dissolve duel" control
   // (aria-label "dissolve the duel") reachable while the duel is active. Alice's
-  // in_progress praxis redirects /praxes/{id} → the edit composer, where the chip
+  // in_progress praxis redirects /praxis/{id} → the edit composer, where the chip
   // (and its dissolve button) live.
   test('D1: an active duel can be neutrally dissolved by a participant', async ({ browser }) => {
     const seed = await seedChallenge(browser)
     const { alice, bob, alicePraxisId } = seed
     try {
       const alicePage = await alice.ctx.newPage()
-      await alicePage.goto(`/praxes/${alicePraxisId}/edit`)
+      await alicePage.goto(`/praxis/${alicePraxisId}/edit`)
       await challengeViaUi(alicePage, bob.name)
 
       const bobPage = await bob.ctx.newPage()
@@ -116,7 +116,7 @@ test.describe('duel lifecycle', () => {
 
       // Intended: a dissolve/cancel control is reachable to a participant on the
       // active-duel view. None exists today.
-      await alicePage.goto(`/praxes/${alicePraxisId}`)
+      await alicePage.goto(`/praxis/${alicePraxisId}`)
       await expect(
         alicePage.getByRole('main').getByRole('button', { name: /dissolve|call off the duel|cancel the duel/i }),
       ).toBeVisible()
@@ -135,7 +135,7 @@ test.describe('duel lifecycle', () => {
     const { alice, bob, alicePraxisId } = seed
     try {
       const alicePage = await alice.ctx.newPage()
-      await alicePage.goto(`/praxes/${alicePraxisId}/edit`)
+      await alicePage.goto(`/praxis/${alicePraxisId}/edit`)
       await challengeViaUi(alicePage, bob.name) // pending — NOT accepted
 
       const bobPage = await bob.ctx.newPage()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,10 +68,10 @@ export default function App() {
           <Route path="/" element={<RootLanding />} />
           <Route path="/tasks" element={<Tasks />} />
           <Route path="/tasks/:id" element={<TaskDetail />} />
-          <Route path="/praxes" element={<Praxes />} />
-          <Route path="/praxes/:id" element={<PraxisDetail />} />
+          <Route path="/praxis" element={<Praxes />} />
+          <Route path="/praxis/:id" element={<PraxisDetail />} />
           <Route
-            path="/praxes/:id/edit"
+            path="/praxis/:id/edit"
             element={
               <ProtectedRoute>
                 <EditPraxis />

--- a/frontend/src/__tests__/praxisPlural.test.ts
+++ b/frontend/src/__tests__/praxisPlural.test.ts
@@ -62,7 +62,16 @@ const routePaths = (source: string) => stripModulePaths(stripComments(source))
 const SELF = '__tests__/praxisPlural.test.ts'
 
 describe('the API keeps saying /praxes (#1136)', () => {
-  const apiFiles = sourceFiles(join(SRC_DIR, 'api'))
+  /**
+   * Shipped client modules only. `api/__tests__/sessionRedirect.test.ts` holds
+   * both kinds at once — `shouldReturnToLanding(status, requestUrl, pathname)`
+   * takes an API URL *and* a `window.location.pathname` — so a route path in
+   * there is correct, not a regression. Nothing under `__tests__` issues a
+   * request, which is what this rule is about.
+   */
+  const apiFiles = sourceFiles(join(SRC_DIR, 'api')).filter(
+    (path) => !toRelative(path).startsWith('api/__tests__/'),
+  )
 
   it('never requests the frontend route path /praxis', () => {
     // If this fails, a rename crossed the seam: the client is now calling an
@@ -79,7 +88,7 @@ describe('the API keeps saying /praxes (#1136)', () => {
     const occurrences = apiFiles
       .map((path) => readFileSync(path, 'utf8').match(/\/praxes/g)?.length ?? 0)
       .reduce((total, n) => total + n, 0)
-    expect(occurrences).toBeGreaterThanOrEqual(30)
+    expect(occurrences).toBeGreaterThanOrEqual(25)
   })
 })
 

--- a/frontend/src/__tests__/praxisPlural.test.ts
+++ b/frontend/src/__tests__/praxisPlural.test.ts
@@ -40,13 +40,23 @@ const toRelative = (path: string) => relative(SRC_DIR, path).split('\\').join('/
 const stripComments = (source: string) =>
   source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
 
-/** `from './praxes/usePraxes'` / `import('../pages/praxes/x')` — a directory, not a URL. */
-const stripImportSpecifiers = (source: string) =>
+/**
+ * `pages/praxes/` is a real source directory — an import specifier, or a plain
+ * path string a source-scanning test reads a file by. Renaming directories is
+ * out of scope for #1136, so those are not findings.
+ *
+ * A route segment after `/praxes/` is always `:id` or `${...}` or a number; a
+ * letter there means a filesystem path.
+ */
+const stripModulePaths = (source: string) =>
   source
+    // `import { x } from './praxis'` is the api/praxis.ts MODULE, not a URL.
     .replace(/from\s*['"][^'"]+['"]/g, 'from ""')
     .replace(/import\s*\(\s*['"][^'"]+['"]\s*\)/g, 'import("")')
+    // `readFileSync('../../pages/praxes/usePraxes.ts')` is a path on disk.
+    .replace(/praxes\/(?=[A-Za-z_])/g, 'DIR/')
 
-const routePaths = (source: string) => stripImportSpecifiers(stripComments(source))
+const routePaths = (source: string) => stripModulePaths(stripComments(source))
 
 /** This file spells the forbidden path in its own fixtures. */
 const SELF = '__tests__/praxisPlural.test.ts'
@@ -108,9 +118,13 @@ describe('the scan sees the codebase', () => {
     expect(sourceFiles(SRC_DIR).length).toBeGreaterThan(100)
   })
 
-  it('strips comments and import paths, but not real route literals', () => {
+  it('strips comments and source paths, but not real route literals', () => {
     expect(routePaths('// GET /praxes/{id}/voters')).not.toContain('/praxes')
     expect(routePaths("import x from './praxes/usePraxes'")).not.toContain('/praxes')
+    expect(routePaths("readFileSync('../../pages/praxes/usePraxes.ts')")).not.toContain('/praxes')
+    expect(routePaths("import { getPraxis } from './praxis'")).not.toContain('/praxis')
     expect(routePaths('navigate(`/praxes/${id}/edit`)')).toContain('/praxes')
+    expect(routePaths('<Route path="/praxes/:id" />')).toContain('/praxes')
+    expect(routePaths("<Link to='/praxes'>")).toContain('/praxes')
   })
 })

--- a/frontend/src/__tests__/praxisPlural.test.ts
+++ b/frontend/src/__tests__/praxisPlural.test.ts
@@ -1,0 +1,116 @@
+/**
+ * #1136 — the plural of *praxis* is *praxis*, and the rename must not have
+ * touched the API.
+ *
+ * THE TRAP THIS GUARD EXISTS FOR
+ * ------------------------------
+ * `/praxes/{id}` is spelled identically as the **frontend route** and as the
+ * **backend API path**. #1136 renamed the route to `/praxis/{id}` and left the
+ * API alone. A find/replace that does not tell them apart renames the endpoints
+ * too — and then every request 404s while the app still builds, still
+ * typechecks, and still passes every test that does not hit the network. The
+ * repo's harness is `renderToStaticMarkup` only, so *nothing else here can see
+ * that failure*. Hence a source scan.
+ *
+ * The discriminator is the directory: everything under `api/` is an API path
+ * and stays `/praxes`; a `/praxes` anywhere else is a router path and is a
+ * regression. Comments are stripped first, because prose that documents a
+ * backend endpoint (`GET /praxes/{id}/voters`) is describing the API correctly
+ * and is not a finding. Import specifiers are stripped too — `pages/praxes/` is
+ * a real directory, and renaming directories is out of scope for #1136.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+const SRC_DIR = fileURLToPath(new URL('..', import.meta.url))
+const LOCALES_DIR = join(SRC_DIR, 'locales', 'en')
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry: string) => {
+    const path = join(dir, entry)
+    if (statSync(path).isDirectory()) return sourceFiles(path)
+    return /\.tsx?$/.test(entry) ? [path] : []
+  })
+}
+
+const toRelative = (path: string) => relative(SRC_DIR, path).split('\\').join('/')
+
+const stripComments = (source: string) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+
+/** `from './praxes/usePraxes'` / `import('../pages/praxes/x')` — a directory, not a URL. */
+const stripImportSpecifiers = (source: string) =>
+  source
+    .replace(/from\s*['"][^'"]+['"]/g, 'from ""')
+    .replace(/import\s*\(\s*['"][^'"]+['"]\s*\)/g, 'import("")')
+
+const routePaths = (source: string) => stripImportSpecifiers(stripComments(source))
+
+/** This file spells the forbidden path in its own fixtures. */
+const SELF = '__tests__/praxisPlural.test.ts'
+
+describe('the API keeps saying /praxes (#1136)', () => {
+  const apiFiles = sourceFiles(join(SRC_DIR, 'api'))
+
+  it('never requests the frontend route path /praxis', () => {
+    // If this fails, a rename crossed the seam: the client is now calling an
+    // endpoint the backend does not serve. Put `/praxes` back.
+    const offenders = apiFiles
+      .filter((path) => /\/praxis(?=[/'"`?])/.test(routePaths(readFileSync(path, 'utf8'))))
+      .map(toRelative)
+    expect(offenders).toEqual([])
+  })
+
+  it('still holds the API paths it is supposed to hold', () => {
+    // Guards the guard: were api/ emptied of /praxes, the assertion above would
+    // pass by finding nothing at all.
+    const occurrences = apiFiles
+      .map((path) => readFileSync(path, 'utf8').match(/\/praxes/g)?.length ?? 0)
+      .reduce((total, n) => total + n, 0)
+    expect(occurrences).toBeGreaterThanOrEqual(30)
+  })
+})
+
+describe('no router path says /praxes (#1136)', () => {
+  it('has no /praxes left outside api/', () => {
+    const offenders = sourceFiles(SRC_DIR)
+      .filter((path) => !toRelative(path).startsWith('api/') && toRelative(path) !== SELF)
+      .filter((path) => /\/praxes/.test(routePaths(readFileSync(path, 'utf8'))))
+      .map(toRelative)
+    expect(offenders).toEqual([])
+  })
+})
+
+describe('no user-visible string says "praxes" (#1136)', () => {
+  /** Values only — `praxes` is a live i18n KEY in admin.json and feed.json. */
+  function stringValues(node: unknown): string[] {
+    if (typeof node === 'string') return [node]
+    if (node && typeof node === 'object') return Object.values(node).flatMap(stringValues)
+    return []
+  }
+
+  const catalogs = readdirSync(LOCALES_DIR).filter((entry) => entry.endsWith('.json'))
+
+  it.each(catalogs)('%s', (catalog) => {
+    const values = stringValues(JSON.parse(readFileSync(join(LOCALES_DIR, catalog), 'utf8')))
+    expect(values.filter((value) => /praxes/i.test(value))).toEqual([])
+  })
+
+  it('reads catalogs that actually contain copy', () => {
+    expect(catalogs.length).toBeGreaterThan(5)
+  })
+})
+
+describe('the scan sees the codebase', () => {
+  it('reads a non-empty file set', () => {
+    expect(sourceFiles(SRC_DIR).length).toBeGreaterThan(100)
+  })
+
+  it('strips comments and import paths, but not real route literals', () => {
+    expect(routePaths('// GET /praxes/{id}/voters')).not.toContain('/praxes')
+    expect(routePaths("import x from './praxes/usePraxes'")).not.toContain('/praxes')
+    expect(routePaths('navigate(`/praxes/${id}/edit`)')).toContain('/praxes')
+  })
+})

--- a/frontend/src/api/__tests__/sessionRedirect.test.ts
+++ b/frontend/src/api/__tests__/sessionRedirect.test.ts
@@ -22,19 +22,19 @@ import { shouldReturnToLanding } from '../axios'
  */
 describe('401 handling', () => {
   it('leaves a guest on the page they asked for', () => {
-    for (const pathname of ['/tasks/46', '/praxes/2', '/factions/coven', '/about']) {
+    for (const pathname of ['/tasks/46', '/praxis/2', '/factions/coven', '/about']) {
       expect(shouldReturnToLanding(401, '/auth/me', pathname)).toBe(false)
     }
   })
 
   it('still returns to landing when a real request 401s mid-session', () => {
-    expect(shouldReturnToLanding(401, '/praxes/2/votes', '/praxes/2')).toBe(true)
+    expect(shouldReturnToLanding(401, '/praxes/2/votes', '/praxis/2')).toBe(true)
     expect(shouldReturnToLanding(401, '/tasks/46/signup', '/tasks/46')).toBe(true)
   })
 
   it('ignores non-401 failures', () => {
     for (const status of [200, 403, 404, 500, undefined]) {
-      expect(shouldReturnToLanding(status, '/praxes/2/votes', '/praxes/2')).toBe(false)
+      expect(shouldReturnToLanding(status, '/praxes/2/votes', '/praxis/2')).toBe(false)
     }
   })
 

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -15,7 +15,7 @@ export default function NavBar() {
   const links = [
     { to: '/', label: t('nav.home'), end: true },
     { to: '/tasks', label: t('nav.tasks') },
-    { to: '/praxes', label: t('nav.praxis') },
+    { to: '/praxis', label: t('nav.praxis') },
     { to: '/leaderboard', label: t('nav.players') },
     { to: '/factions', label: t('nav.factions') },
     { to: '/updates', label: t('nav.updates') },

--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -34,7 +34,7 @@ describe('normalizeFeedItem', () => {
     expect(row.action).toBe('completed a task')
     expect(row.actorHref).toBe('/characters/3')
     expect(row.headline).toBe('Reforest')
-    expect(row.headlineHref).toBe('/praxes/7')
+    expect(row.headlineHref).toBe('/praxis/7')
     expect(row.points).toBe('40 pts')
     expect(row.badge?.label).toBe('Friend')
   })
@@ -52,7 +52,7 @@ describe('normalizeFeedItem', () => {
     expect(row.action).toBe('submitted their part of')
     expect(row.actorHref).toBe('/characters/8')
     expect(row.headline).toBe('Plant a tree')
-    expect(row.headlineHref).toBe('/praxes/12')
+    expect(row.headlineHref).toBe('/praxis/12')
     expect(row.points).toBe('25 pts')
     expect(row.badge?.label).toBe('Your Stuff')
   })
@@ -78,7 +78,7 @@ describe('normalizeFeedItem', () => {
     expect(row.action).toBe(collabCopy('coven', 'nudgeFeedAction'))
     expect(row.actorHref).toBe('/characters/8')
     expect(row.headline).toBe('Plant a tree')
-    expect(row.headlineHref).toBe('/praxes/12/edit')
+    expect(row.headlineHref).toBe('/praxis/12/edit')
     expect(row.badge?.label).toBe('Collab')
   })
 
@@ -95,7 +95,7 @@ describe('normalizeFeedItem', () => {
       }),
     )!
     expect(row.badge?.label).toBe('Duel')
-    expect(row.headlineHref).toBe('/praxes/13/edit')
+    expect(row.headlineHref).toBe('/praxis/13/edit')
   })
 
   it('resolves a taunt from the catalog, quotes it, and drops points', () => {
@@ -174,7 +174,7 @@ describe('normalizeFeedItem', () => {
     expect(row.headline).toBe('the second half is yours @ada')
     // Speech, so it is quoted like a taunt rather than titled like a task.
     expect(row.headlineQuoted).toBe(true)
-    expect(row.headlineHref).toBe('/praxes/12')
+    expect(row.headlineHref).toBe('/praxis/12')
     expect(row.points).toBeNull()
     expect(row.level).toBeNull()
   })
@@ -205,7 +205,7 @@ describe('normalizeFeedItem', () => {
       item('comment_mention', { comment_id: 11, praxis_id: 12, excerpt: 'hi' }),
     )!
     expect(row.actions.map((action) => action.id)).toEqual(['reply'])
-    expect(row.actions[0].href).toBe('/praxes/12')
+    expect(row.actions[0].href).toBe('/praxis/12')
     expect(row.actions[0].call).toBeUndefined()
   })
 
@@ -246,7 +246,7 @@ describe('FeedRowContent', () => {
     expect(html).toContain('Ada')
     expect(html).toContain('completed a task')
     expect(html).toContain('Reforest')
-    expect(html).toContain('href="/praxes/7"')
+    expect(html).toContain('href="/praxis/7"')
   })
 
   // ADR-0039: an unaffiliated (na) actor's monogram avatar is the rainbow ring,
@@ -303,7 +303,7 @@ describe('FeedRowContent', () => {
     )
     // Quoted (curly quotes from the catalog) AND clickable.
     expect(mentionHtml).toContain('“over to you”')
-    expect(mentionHtml).toContain('href="/praxes/12"')
+    expect(mentionHtml).toContain('href="/praxis/12"')
     // The CTA is the second route to the same page, not a second destination.
     expect(mentionHtml).toContain('Reply')
 
@@ -323,7 +323,7 @@ describe('FeedRowContent', () => {
     // Its only destination is the actor — the quote itself goes nowhere.
     expect(tauntHtml).toContain('href="/characters/9"')
     expect(tauntHtml, 'the quote is a paragraph, not a link').toContain('<p class="font-body"')
-    for (const route of ['href="/praxes', 'href="/tasks']) {
+    for (const route of ['href="/praxis', 'href="/tasks']) {
       expect(tauntHtml, `${route} must not appear on a taunt`).not.toContain(route)
     }
   })

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -68,7 +68,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
     if (result.ok) {
       // New members land on the editor so they can contribute; the editor
       // self-locks if the collab is already submitted (controlsLocked). (#298)
-      navigate(`/praxes/${result.praxisId ?? praxis_id}/edit`);
+      navigate(`/praxis/${result.praxisId ?? praxis_id}/edit`);
       return;
     }
     // The hook swallowed the failure into `error` (rendered below) but doesn't
@@ -80,7 +80,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
     try {
       await respondToInvite(praxis_id, invite_id, true);
       // Raced free between the two calls — land on the collab like happy path.
-      navigate(`/praxes/${praxis_id}/edit`);
+      navigate(`/praxis/${praxis_id}/edit`);
     } catch (err) {
       const detail = (err as { response?: { data?: { detail?: unknown } } })
         ?.response?.data?.detail;
@@ -108,7 +108,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
       }
       await respondToInvite(praxis_id, invite_id, true);
       setShowDropModal(false);
-      navigate(`/praxes/${praxis_id}`);
+      navigate(`/praxis/${praxis_id}`);
     } catch (err) {
       setDropError(
         extractError(err, i18n.t("feed:collabInvite.bankFull.dropError")),
@@ -277,7 +277,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
         {status === "accepted" && (
           <div style={{ marginTop: "var(--space-sm)", marginLeft: "var(--space-3xl)" }}>
             <Link
-              to={`/praxes/${praxis_id}`}
+              to={`/praxis/${praxis_id}`}
               className="eyebrow"
               style={{ color: "var(--badge-collab)", textDecoration: "none" }}
             >

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -79,7 +79,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
     // Accepting creates the opponent's fresh praxis server-side — land the
     // responder on its editor so they can start working (mirrors collab).
     navigate(
-      praxisId ? `/praxes/${praxisId}/edit` : `/praxes/${challenger_praxis_id}`,
+      praxisId ? `/praxis/${praxisId}/edit` : `/praxis/${challenger_praxis_id}`,
     );
   };
 
@@ -348,7 +348,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
         {status === "accepted" && (
           <div style={{ marginTop: "var(--space-sm)", marginLeft: "var(--space-3xl)" }}>
             <Link
-              to={`/praxes/${challenger_praxis_id}`}
+              to={`/praxis/${challenger_praxis_id}`}
               className="eyebrow"
               style={{ color: "var(--badge-duel)", textDecoration: "none" }}
             >

--- a/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
+++ b/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
@@ -73,7 +73,7 @@ export default function FeedCardEraAnnouncement({ item, archive }: Props) {
           {i18n.t('feed:eraAnnouncement.seeNewTasks')}
         </Link>
         <Link
-          to="/praxes"
+          to="/praxis"
           style={{
             fontFamily: "'Courier Prime', monospace",
             fontSize: 'var(--text-base)',

--- a/frontend/src/components/feed/normalizeFeedItem.ts
+++ b/frontend/src/components/feed/normalizeFeedItem.ts
@@ -108,7 +108,7 @@ function buildAwaitingActions(payload: Record<string, any>): FeedRowAction[] {
       id: 'fileIt',
       label: i18n.t('feed:rowAction.fileIt'),
       tone: 'primary',
-      href: `/praxes/${payload.praxis_id}/edit`,
+      href: `/praxis/${payload.praxis_id}/edit`,
     },
   ]
   if (payload.praxis_type === 'collab') {
@@ -123,7 +123,7 @@ function buildAwaitingActions(payload: Record<string, any>): FeedRowAction[] {
 }
 
 /**
- * Where a comment lives: `/praxes/{id}` or `/tasks/{id}`, never both.
+ * Where a comment lives: `/praxis/{id}` or `/tasks/{id}`, never both.
  *
  * A comment hangs off EXACTLY ONE target — `num_nonnulls(praxis_id, task_id) = 1`
  * is a DB CHECK (migration 0005) and the service guards it with a 422 first — so
@@ -135,7 +135,7 @@ function buildAwaitingActions(payload: Record<string, any>): FeedRowAction[] {
  * on IS the deep link; landing there and reading the thread is the behaviour.
  */
 function commentTargetHref(payload: Record<string, any>): string | null {
-  if (payload.praxis_id != null) return `/praxes/${payload.praxis_id}`
+  if (payload.praxis_id != null) return `/praxis/${payload.praxis_id}`
   if (payload.task_id != null) return `/tasks/${payload.task_id}`
   return null
 }
@@ -182,7 +182,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
           ? { type: 'friend', label: i18n.t('feed:badge.friend') }
           : { type: 'duel', label: i18n.t('feed:badge.foe') },
         headline: p.task_title ?? null,
-        headlineHref: p.praxis_id != null ? `/praxes/${p.praxis_id}` : null,
+        headlineHref: p.praxis_id != null ? `/praxis/${p.praxis_id}` : null,
         headlineQuoted: false,
         points:
           p.task_point_value != null
@@ -219,7 +219,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         action: i18n.t('feed:row.action.collaboratorSubmitted'),
         badge: { type: 'your_stuff', label: i18n.t('feed:badge.yourStuff') },
         headline: p.task_title ?? null,
-        headlineHref: p.praxis_id != null ? `/praxes/${p.praxis_id}` : null,
+        headlineHref: p.praxis_id != null ? `/praxis/${p.praxis_id}` : null,
         headlineQuoted: false,
         points:
           p.task_point_value != null
@@ -235,7 +235,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
                   id: 'fileYours',
                   label: i18n.t('feed:rowAction.fileYours'),
                   tone: 'primary',
-                  href: `/praxes/${p.praxis_id}/edit`,
+                  href: `/praxis/${p.praxis_id}/edit`,
                 },
               ]
             : [],
@@ -254,7 +254,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? { type: 'duel', label: i18n.t('feed:badge.duel') }
             : { type: 'collab', label: i18n.t('feed:badge.collab') },
         headline: p.task_title ?? null,
-        headlineHref: p.praxis_id != null ? `/praxes/${p.praxis_id}/edit` : null,
+        headlineHref: p.praxis_id != null ? `/praxis/${p.praxis_id}/edit` : null,
         headlineQuoted: false,
         points:
           p.task_point_value != null
@@ -290,7 +290,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
             ? { type: 'collab', label: i18n.t('feed:badge.collab') }
             : { type: 'duel', label: i18n.t('feed:badge.duel') },
         headline: p.task_title ?? null,
-        headlineHref: p.praxis_id != null ? `/praxes/${p.praxis_id}/edit` : null,
+        headlineHref: p.praxis_id != null ? `/praxis/${p.praxis_id}/edit` : null,
         headlineQuoted: false,
         points:
           p.task_point_value != null
@@ -307,7 +307,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
                   id: 'answer',
                   label: i18n.t('feed:rowAction.answer'),
                   tone: 'primary',
-                  href: `/praxes/${p.praxis_id}/edit`,
+                  href: `/praxis/${p.praxis_id}/edit`,
                 },
               ]
             : [],
@@ -351,7 +351,7 @@ export function normalizeFeedItem(item: ActivityFeedItem): FeedRow | null {
         action: i18n.t('feed:row.action.votedOnYourPraxis'),
         badge: { type: 'your_stuff', label: i18n.t('feed:badge.yourStuff') },
         headline: p.praxis_title ?? null,
-        headlineHref: p.praxis_id != null ? `/praxes/${p.praxis_id}` : null,
+        headlineHref: p.praxis_id != null ? `/praxis/${p.praxis_id}` : null,
         headlineQuoted: false,
         points:
           p.points_earned != null

--- a/frontend/src/components/layout/MobileTabBar.tsx
+++ b/frontend/src/components/layout/MobileTabBar.tsx
@@ -8,7 +8,7 @@ type TabKey = 'nav.home' | 'nav.tasks' | 'nav.praxis' | 'nav.players' | 'nav.fac
 const TABS: { to: string; key: TabKey; end?: boolean }[] = [
   { to: '/', key: 'nav.home', end: true },
   { to: '/tasks', key: 'nav.tasks' },
-  { to: '/praxes', key: 'nav.praxis' },
+  { to: '/praxis', key: 'nav.praxis' },
   { to: '/leaderboard', key: 'nav.players' },
   { to: '/factions', key: 'nav.factions' },
 ]

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -251,7 +251,7 @@ export default function Sidebar() {
             {activeTasks.map((praxis) => (
               <div key={praxis.id} className="flex items-start justify-between gap-3">
                 <Link
-                  to={`/praxes/${praxis.id}/edit`}
+                  to={`/praxis/${praxis.id}/edit`}
                   className="font-display min-w-0"
                   style={{ fontSize: 'var(--text-content)', lineHeight: 1.25, color: 'var(--color-text-primary)', textDecoration: 'none' }}
                 >
@@ -478,7 +478,7 @@ function AwaitingSubmissionRow({
         />
         <div className="flex-1 min-w-0">
           <Link
-            to={`/praxes/${praxisId}/edit`}
+            to={`/praxis/${praxisId}/edit`}
             className="font-body block truncate"
             style={{ fontSize: 'var(--text-xl)', fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
           >
@@ -491,7 +491,7 @@ function AwaitingSubmissionRow({
       </div>
       <div className="flex items-center gap-1.5" style={{ marginTop: 'var(--space-xs)', marginLeft: 'var(--space-2xl)' }}>
         <Link
-          to={`/praxes/${praxisId}/edit`}
+          to={`/praxis/${praxisId}/edit`}
           style={{
             ...REQUEST_BUTTON_BASE,
             background: isDuel ? 'var(--badge-duel)' : 'var(--badge-collab)',

--- a/frontend/src/components/layout/__tests__/MobileTabBar.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileTabBar.test.tsx
@@ -19,7 +19,7 @@ describe('MobileTabBar', () => {
     for (const label of ['Home', 'Tasks', 'Praxis', 'Players', 'Factions']) {
       expect(html).toContain(label)
     }
-    for (const href of ['href="/"', 'href="/tasks"', 'href="/praxes"', 'href="/leaderboard"', 'href="/factions"']) {
+    for (const href of ['href="/"', 'href="/tasks"', 'href="/praxis"', 'href="/leaderboard"', 'href="/factions"']) {
       expect(html).toContain(href)
     }
   })

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -75,7 +75,7 @@ export function PraxisTitle({
   fonts?: PraxisCardFonts;
 }) {
   return (
-    <Link to={`/praxes/${praxis.id}`}>
+    <Link to={`/praxis/${praxis.id}`}>
       <h3
         className="content-title font-display font-semibold leading-tight hover:underline"
         style={{

--- a/frontend/src/hooks/__tests__/searchQueryParamAdoption.test.ts
+++ b/frontend/src/hooks/__tests__/searchQueryParamAdoption.test.ts
@@ -23,7 +23,7 @@ const SOURCE_DIRECTORY = path.dirname(fileURLToPath(import.meta.url))
 /** The feed hooks #660 requires to bind their search box to `?q=`. */
 const FEED_HOOKS = [
   { name: 'useTasks', relativePath: '../../pages/tasks/useTasks.ts' },
-  { name: 'usePraxes', relativePath: '../../pages/praxes/usePraxes.ts' },
+  { name: 'usePraxes', relativePath: '../../pages/praxis/usePraxes.ts' },
 ] as const
 
 function readFeedHookSource(relativePath: string): string {

--- a/frontend/src/hooks/__tests__/searchQueryParamAdoption.test.ts
+++ b/frontend/src/hooks/__tests__/searchQueryParamAdoption.test.ts
@@ -23,7 +23,7 @@ const SOURCE_DIRECTORY = path.dirname(fileURLToPath(import.meta.url))
 /** The feed hooks #660 requires to bind their search box to `?q=`. */
 const FEED_HOOKS = [
   { name: 'useTasks', relativePath: '../../pages/tasks/useTasks.ts' },
-  { name: 'usePraxes', relativePath: '../../pages/praxis/usePraxes.ts' },
+  { name: 'usePraxes', relativePath: '../../pages/praxes/usePraxes.ts' },
 ] as const
 
 function readFeedHookSource(relativePath: string): string {

--- a/frontend/src/locales/en/admin.json
+++ b/frontend/src/locales/en/admin.json
@@ -108,7 +108,7 @@
       },
       "filter": {
         "all": "All",
-        "praxes": "Praxes",
+        "praxes": "Praxis",
         "comments": "Comments"
       },
       "byline": "by {{author}}",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -442,7 +442,7 @@
     },
     "successMeta": {
       "heading": "Meta task proposed!",
-      "body": "An admin will review it. Once activated, {{faction}} players can apply it to their praxes for a points bonus."
+      "body": "An admin will review it. Once activated, {{faction}} players can apply it to their praxis for a points bonus."
     },
     "factionSelectorLabel": "Choose a faction for this task, or leave it open to everyone",
     "factionDescriptor": {

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -5,21 +5,21 @@
   },
   "listPage": {
     "title": "Praxis",
-    "intro": "Proof of action. All praxes from across World Zero.",
+    "intro": "Proof of action. All praxis from across World Zero.",
     "loading": "Loading praxis...",
-    "empty": "No praxes yet. Be the first.",
+    "empty": "No praxis yet. Be the first.",
     "emptyFiltered": "Nothing filed under those terms. Clear the search or pick a different faction.",
     "count": "{{count}} shown",
     "loadMore": "Load more",
     "taskFilter": {
       "notice": "Proof of action, narrowed to a single task.",
-      "clear": "Show all praxes"
+      "clear": "Show all praxis"
     },
     "filter": {
       "typeLabel": "type:",
       "showLabel": "show:",
       "searchPlaceholder": "Search proof, task, or player…",
-      "searchLabel": "Search praxes",
+      "searchLabel": "Search praxis",
       "all": "All",
       "needsMyVote": "needs my vote",
       "voted": "voted",
@@ -108,7 +108,7 @@
       "tasks": "Tasks",
       "current": "Praxis"
     },
-    "back": "Praxes",
+    "back": "Praxis",
     "sections": {
       "proof": "Proof",
       "writeUp": "Write-up",

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -53,7 +53,7 @@ export default function EditPraxis() {
   // rather than push: the composer is not a step in the history of reading a
   // praxis, and Back should leave the way it came.
   if (state.phase === "handoff") {
-    return <Navigate to={`/praxes/${state.praxis.id}`} replace />;
+    return <Navigate to={`/praxis/${state.praxis.id}`} replace />;
   }
 
   const slug = state.task?.primary_faction_slug ?? null;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -73,7 +73,7 @@ export default function Home() {
     setSignupMsg(null)
     try {
       const praxis = await createPraxis({ task_id: id, type: 'solo' })
-      navigate(`/praxes/${praxis.id}/edit`)
+      navigate(`/praxis/${praxis.id}/edit`)
     } catch (err) {
       setSignupMsg(extractError(err, t('signup.error')))
     }
@@ -188,7 +188,7 @@ export default function Home() {
 
       {/* ── FEATURED PRAXIS ── */}
       <section style={{ paddingTop: 'var(--space-4xl)' }}>
-        <SectionHeader title={t('sections.featuredPraxis.title')} href="/praxes" linkLabel={t('sections.featuredPraxis.link')} />
+        <SectionHeader title={t('sections.featuredPraxis.title')} href="/praxis" linkLabel={t('sections.featuredPraxis.link')} />
         {feed.length === 0 ? (
           <p className="font-body text-muted">{t('sections.featuredPraxis.empty')}</p>
         ) : (

--- a/frontend/src/pages/PraxisDetail.tsx
+++ b/frontend/src/pages/PraxisDetail.tsx
@@ -60,7 +60,7 @@ export default function PraxisDetail() {
   // (praxis_visibility_condition), and #1071's waiting surface gives every one
   // of them somewhere to land, so this redirect cannot strand a viewer.
   if (state.praxis.status === 'in_progress' || state.praxis.status === 'pending') {
-    return <Navigate to={`/praxes/${state.praxis.id}/edit`} replace />
+    return <Navigate to={`/praxis/${state.praxis.id}/edit`} replace />
   }
 
   const Archetype = pickVariant(

--- a/frontend/src/pages/__tests__/EditPraxisBackAffordance.test.tsx
+++ b/frontend/src/pages/__tests__/EditPraxisBackAffordance.test.tsx
@@ -13,7 +13,7 @@
  * other stage. The dispatcher draws NONE.
  *
  * The invariant #567 actually bought is unchanged, and is what this file pins:
- * **from every state of `/praxes/:id/edit`, at every width, there is exactly one
+ * **from every state of `/praxis/:id/edit`, at every width, there is exactly one
  * way back and never zero.** Two halves, two files:
  *
  *   never TWO  → this file. Every skin is mocked to null, so a breadcrumb in the
@@ -87,7 +87,7 @@ function render(
 }
 
 const WIDTHS = ["mobile", "desktop"] as const;
-const BACK_LINK = 'href="/praxes/55"';
+const BACK_LINK = 'href="/praxis/55"';
 
 const DRAWN_STATES = ["composing", "waiting", "completed"] as const;
 

--- a/frontend/src/pages/admin/ModerationTab.tsx
+++ b/frontend/src/pages/admin/ModerationTab.tsx
@@ -340,7 +340,7 @@ export default function ModerationTab() {
                   <div className="flex items-start gap-4">
                     <div className="flex-1">
                       <Link
-                        to={`/praxes/${item.praxis.id}`}
+                        to={`/praxis/${item.praxis.id}`}
                         className="font-display text-lg font-bold"
                         style={{ color: 'inherit' }}
                       >
@@ -361,7 +361,7 @@ export default function ModerationTab() {
                         </p>
                       )}
                       <Link
-                        to={`/praxes/${item.praxis.id}`}
+                        to={`/praxis/${item.praxis.id}`}
                         className="eyebrow"
                         style={{ display: 'inline-block', marginTop: 'var(--space-sm)' }}
                       >
@@ -441,7 +441,7 @@ export default function ModerationTab() {
                       {/* Linkback to the thread the comment lives on. */}
                       <Link
                         to={item.comment.praxis_id != null
-                          ? `/praxes/${item.comment.praxis_id}`
+                          ? `/praxis/${item.comment.praxis_id}`
                           : `/tasks/${item.comment.task_id}`}
                         className="eyebrow"
                         style={{ display: 'inline-block', marginTop: 'var(--space-sm)' }}

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -33,7 +33,7 @@
  * FINDING`, `THE ACCOUNT`, `THE EVIDENCE`, `alone / in concord / in dispute` —
  * was **deleted** with this issue; `editPraxis.ephemerists.collab` survives
  * because it is not composer page copy but `collabCopy`'s override table, read
- * by `CollabRoster` on `/praxes/:id` too. The masthead's one word is the
+ * by `CollabRoster` on `/praxis/:id` too. The masthead's one word is the
  * faction's NAME out of `factions.json` (`factionName`), the same string the
  * praxis-detail masthead sets — a name, not a voice.
  *

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -30,7 +30,7 @@
  * deleted with this issue, and the archetype reads `editPraxis.composer.*` like
  * every other skin. `editPraxis.everymen.collab` SURVIVES: that block is
  * `collabCopy`'s override table, a different resolver that also feeds
- * `CollabRoster` on `/praxes/:id`, and it is pinned by `collabCopy.test.ts`.
+ * `CollabRoster` on `/praxis/:id`, and it is pinned by `collabCopy.test.ts`.
  *
  * The masthead plate is the one place the design puts words on the dress, and
  * the design's own word there is faction voice (`FILE YOUR REPORT`), which

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/InviteSearch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/InviteSearch.test.tsx
@@ -31,7 +31,7 @@ function duelSide(characterId: number, name: string): DuelSideOut {
 /**
  * A duel side's composer state. `praxis.created_by_id` is the VIEWER's own
  * character id — a duel side's composer only ever renders its own praxis,
- * never the rival's (per the reproduce case: "As B, open /praxes/<B's>/edit").
+ * never the rival's (per the reproduce case: "As B, open /praxis/<B's>/edit").
  */
 function duelState(viewerCharacterId: number): EditPraxisState {
   const duel: DuelDetailOut = {

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/covenComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/covenComposer.test.tsx
@@ -16,7 +16,7 @@
  *
  * `editPraxis.coven.collab` is deliberately exempt: that block is `collabCopy`'s
  * override table, a different resolver, and it also feeds `CollabRoster` on the
- * read page `/praxes/:id`. `collabCopy.test.ts` pins it from the other side.
+ * read page `/praxis/:id`. `collabCopy.test.ts` pins it from the other side.
  *
  * renderToStaticMarkup needs no DOM, matching the rest of this suite. Effects
  * never run, so nothing here can assert on state that arrives after mount.

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/everymenComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/everymenComposer.test.tsx
@@ -138,7 +138,7 @@ describe("Everymen composer copy is the neutral set (ADR-0065 §3)", () => {
   });
 
   it("keeps editPraxis.everymen.collab, which is not composer copy", () => {
-    // collabCopy's override table, also read by CollabRoster on /praxes/:id.
+    // collabCopy's override table, also read by CollabRoster on /praxis/:id.
     expect(i18n.t("forms:editPraxis.everymen.collab.castAction")).toBe(
       "Sign off on my part",
     );

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/snideComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/snideComposer.test.tsx
@@ -130,7 +130,7 @@ describe("SNIDE composer copy is the shared neutral set (ADR-0065 §3)", () => {
   });
 
   it("kept editPraxis.snide.collab — collabCopy's table, not page copy", () => {
-    // Also read by CollabRoster on /praxes/:id, a surface this epic is not
+    // Also read by CollabRoster on /praxis/:id, a surface this epic is not
     // touching. `collabCopy.test.ts` is the other half of this guard.
     expect(i18n.exists("forms:editPraxis.snide.collab.castAction")).toBe(true);
     expect(i18n.exists("forms:editPraxis.snide.collab.successHeading")).toBe(true);

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -62,7 +62,7 @@ export function Breadcrumb({
       </Link>
       <span> &rsaquo; </span>
       <Link
-        to={`/praxes/${praxisId}`}
+        to={`/praxis/${praxisId}`}
         style={{ color: "inherit", textDecoration: "none" }}
       >
         {t("breadcrumb.praxis")}

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -77,7 +77,7 @@ export type SaveStatus = "idle" | "saving" | "saved" | "error";
  * The last two are what a published praxis used to get instead: a **locked
  * composer**, i.e. a third read-only rendering of a praxis beside the detail
  * page and this surface. Owner ruling on #1164: a multi-party praxis shows the
- * completed reading with a way through to `/praxes/:id`, and a solo one — which
+ * completed reading with a way through to `/praxis/:id`, and a solo one — which
  * has no roster and never had anyone to wait for — simply hands off.
  *
  * `controlsLocked` therefore stops meaning "render the composer, disabled" and
@@ -580,7 +580,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
           viewerId != null &&
           loaded.members.some((member) => member.character_id === viewerId);
         if (!isMember) {
-          navigate(`/praxes/${idParam}`, { replace: true });
+          navigate(`/praxis/${idParam}`, { replace: true });
           return;
         }
         setPraxis(loaded);
@@ -877,7 +877,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
           return;
         }
       }
-      navigate(`/praxes/${idParam}`);
+      navigate(`/praxis/${idParam}`);
     } catch (err) {
       setError(extractError(err, i18n.t("forms:editPraxis.errors.publish")));
     } finally {
@@ -1014,7 +1014,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   // Deliberately not a timer — the player leaves when they've read it (#591).
   const continueFromCollabSuccess = useCallback(() => {
     setCollabSuccess(false);
-    navigate(`/praxes/${idParam}`);
+    navigate(`/praxis/${idParam}`);
   }, [idParam, navigate]);
 
   const cancel = useCallback(async () => {

--- a/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
+++ b/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
@@ -739,7 +739,7 @@ export default function PraxisWaitingSurface({
           <ComposerFooter
             end={
               <Link
-                to={`/praxes/${praxis.id}`}
+                to={`/praxis/${praxis.id}`}
                 className={primaryClass}
                 style={dress.primaryStyle}
               >

--- a/frontend/src/pages/editPraxis/waiting/__tests__/praxisWaitingSurface.test.tsx
+++ b/frontend/src/pages/editPraxis/waiting/__tests__/praxisWaitingSurface.test.tsx
@@ -434,7 +434,7 @@ describe("the clock is config-driven, not assumed", () => {
  * COMPOSER — a form with every control hidden, and a third read-only rendering
  * of a praxis beside the detail page and this surface. Owner ruling: this
  * surface, in a reading that says everybody is in and offers the way out to
- * `/praxes/:id`.
+ * `/praxis/:id`.
  */
 describe("collab — everybody is in (#1164)", () => {
   const published = state({
@@ -465,7 +465,7 @@ describe("collab — everybody is in (#1164)", () => {
 
   it("links out to the praxis — the whole reason this beats a redirect", () => {
     expect(html).toContain(collabCopy(SLUG, "completedReadAction"));
-    expect(html).toContain('href="/praxes/1"');
+    expect(html).toContain('href="/praxis/1"');
   });
 
   it("keeps the write-up read-only, and offers no way back into it", () => {
@@ -541,7 +541,7 @@ describe("duel — both sides are in (#1164)", () => {
     // where it lives instead of pretending the rival's text is here.
     expect(html).toContain(collabCopy(SLUG, "duelCompletedPlaceholder"));
     expect(html).not.toContain(collabCopy(SLUG, "duelSealedPlaceholder"));
-    expect(html).toContain('href="/praxes/1"');
+    expect(html).toContain('href="/praxis/1"');
   });
 
   it("offers no pull-back — after settlement that would be a forfeit", () => {

--- a/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
@@ -96,7 +96,7 @@ describe('mobile FieldDesk-home content-slot invariant', () => {
     it(`${slug} renders the active-tasks list (continue link)`, () => {
       const { html, text } = render(<Skin state={baseState()} />)
       expect(text, 'active task title slot').toContain('Sunday Soup')
-      expect(html, 'continue-in-progress slot').toContain('href="/praxes/55/edit"')
+      expect(html, 'continue-in-progress slot').toContain('href="/praxis/55/edit"')
     })
 
     it(`${slug} renders the empty state when no active tasks`, () => {

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -312,7 +312,7 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
               {activeTasks.map((praxis, index) => (
                 <Link
                   key={praxis.id}
-                  to={`/praxes/${praxis.id}/edit`}
+                  to={`/praxis/${praxis.id}/edit`}
                   className="flex items-center gap-3"
                   style={{
                     padding: 'var(--space-md) 0',

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -274,7 +274,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
             {activeTasks.map((praxis, index) => (
               <Link
                 key={praxis.id}
-                to={`/praxes/${praxis.id}/edit`}
+                to={`/praxis/${praxis.id}/edit`}
                 className="flex items-center gap-3"
                 style={{
                   padding: 'var(--space-md) 0',

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsHome.tsx
@@ -197,7 +197,7 @@ export default function EphemeristsHome({ state }: { state: FieldDeskHomeState }
             {activeTasks.map((praxis, index) => (
               <Link
                 key={praxis.id}
-                to={`/praxes/${praxis.id}/edit`}
+                to={`/praxis/${praxis.id}/edit`}
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${GOLD_DEEP}`, textDecoration: 'none' }}
               >

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenHome.tsx
@@ -243,7 +243,7 @@ export default function EverymenHome({ state }: { state: FieldDeskHomeState }) {
             {activeTasks.map((praxis, index) => (
               <Link
                 key={praxis.id}
-                to={`/praxes/${praxis.id}/edit`}
+                to={`/praxis/${praxis.id}/edit`}
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid color-mix(in srgb, var(--everymen-ink) 20%, transparent)`, textDecoration: 'none' }}
               >

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityHome.tsx
@@ -212,7 +212,7 @@ export default function SingularityHome({ state }: { state: FieldDeskHomeState }
             {activeTasks.map((praxis, index) => (
               <Link
                 key={praxis.id}
-                to={`/praxes/${praxis.id}/edit`}
+                to={`/praxis/${praxis.id}/edit`}
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${signal(14)}`, textDecoration: 'none' }}
               >

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideHome.tsx
@@ -187,7 +187,7 @@ export default function SnideHome({ state }: { state: FieldDeskHomeState }) {
             {activeTasks.map((praxis, index) => (
               <Link
                 key={praxis.id}
-                to={`/praxes/${praxis.id}/edit`}
+                to={`/praxis/${praxis.id}/edit`}
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${LINE}`, textDecoration: 'none' }}
               >

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaHome.tsx
@@ -228,7 +228,7 @@ export default function UaHome({ state }: { state: FieldDeskHomeState }) {
             {activeTasks.map((praxis, index) => (
               <Link
                 key={praxis.id}
-                to={`/praxes/${praxis.id}/edit`}
+                to={`/praxis/${praxis.id}/edit`}
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid var(--faction-ua-hair)`, textDecoration: 'none' }}
               >

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
@@ -225,7 +225,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
               {activeTasks.map((praxis) => (
                 <WowQuestFrame key={praxis.id}>
                   <Link
-                    to={`/praxes/${praxis.id}/edit`}
+                    to={`/praxis/${praxis.id}/edit`}
                     style={{
                       display: "block",
                       minHeight: TAP,

--- a/frontend/src/pages/praxes/__tests__/taskFilterNotice.test.tsx
+++ b/frontend/src/pages/praxes/__tests__/taskFilterNotice.test.tsx
@@ -3,7 +3,7 @@
  *
  * `renderToStaticMarkup` never runs effects, so the fetch can't be observed —
  * but `useSearchParams` is read during render, not in an effect, so mounting
- * <Praxes /> under a `MemoryRouter` at `/praxes?task_id=7` DOES exercise the
+ * <Praxes /> under a `MemoryRouter` at `/praxis?task_id=7` DOES exercise the
  * real `usePraxes` param read. That makes this the closest thing to the bug's
  * actual symptom the repo can assert: the page landed on with a task filter used
  * to be indistinguishable from the bare feed.
@@ -45,28 +45,28 @@ function text(entry: string): string {
 describe.each(['desktop', 'mobile'] as const)('%s praxis feed with ?task_id=', (formFactor) => {
   it('announces that the feed is narrowed to one task', () => {
     mocks.formFactor = formFactor
-    const out = text('/praxes?task_id=7')
+    const out = text('/praxis?task_id=7')
     expect(out, 'the notice').toContain(NOTICE)
     expect(out, 'a way back to the whole feed').toContain(CLEAR)
   })
 
   it('says nothing about a task filter on the bare feed', () => {
     mocks.formFactor = formFactor
-    const out = text('/praxes')
+    const out = text('/praxis')
     expect(out).not.toContain(NOTICE)
     expect(out).not.toContain(CLEAR)
   })
 
   it('treats a junk task_id as no filter at all', () => {
     mocks.formFactor = formFactor
-    expect(text('/praxes?task_id=abc')).not.toContain(NOTICE)
+    expect(text('/praxis?task_id=abc')).not.toContain(NOTICE)
   })
 })
 
 describe('desktop intro copy', () => {
   it('drops the "all praxes from across World Zero" claim when filtered', () => {
     mocks.formFactor = 'desktop'
-    expect(text('/praxes'), 'unfiltered still says it').toContain(INTRO)
-    expect(text('/praxes?task_id=7'), 'a subset must not claim to be all').not.toContain(INTRO)
+    expect(text('/praxis'), 'unfiltered still says it').toContain(INTRO)
+    expect(text('/praxis?task_id=7'), 'a subset must not claim to be all').not.toContain(INTRO)
   })
 })

--- a/frontend/src/pages/praxes/__tests__/taskFilterParam.test.ts
+++ b/frontend/src/pages/praxes/__tests__/taskFilterParam.test.ts
@@ -1,5 +1,5 @@
 /**
- * #1050 — `/praxes?task_id=N` showed the whole feed. The link was built by every
+ * #1050 — `/praxis?task_id=N` showed the whole feed. The link was built by every
  * task surface, the API accepted the param, and `usePraxes` read no params at
  * all, so the filter died on arrival.
  *
@@ -90,7 +90,7 @@ describe('usePraxes sends the task filter it reads', () => {
     expect(USE_PRAXES_SOURCE).toMatch(/\[taskId, type, faction, voted, sort, trimmedQuery\]/)
   })
 
-  it('leaves it optional — a bare /praxes is still the whole feed', () => {
+  it('leaves it optional — a bare /praxis is still the whole feed', () => {
     // `?? undefined` (above) rather than a required argument, and nothing
     // bails out early when the param is missing.
     expect(USE_PRAXES_SOURCE).not.toMatch(/if \(!taskId\) return/)

--- a/frontend/src/pages/praxes/taskFilterParam.ts
+++ b/frontend/src/pages/praxes/taskFilterParam.ts
@@ -2,17 +2,17 @@
  * `?task_id=` on the praxis feed (#1050) — the pure half.
  *
  * Task-detail surfaces have always linked "view all N praxis" to
- * `/praxes?task_id=${task.id}`, and the backend list route has always accepted
+ * `/praxis?task_id=${task.id}`, and the backend list route has always accepted
  * `task_id`. The feed hook read no search params at all, so the filter was built
  * by the linker and thrown away by the page it landed on: the player asked for
  * one task's proof and silently got the whole game's.
  *
  * The fix is this one read in `usePraxes`, not a change in every caller. It is
  * still worth having now that the task-details v2 skins expand their gallery in
- * place instead of linking out: `/praxes?task_id=N` is a URL people can share or
+ * place instead of linking out: `/praxis?task_id=N` is a URL people can share or
  * bookmark, and today it lies.
  *
- * The filter is strictly OPTIONAL — a bare `/praxes` is still the whole feed.
+ * The filter is strictly OPTIONAL — a bare `/praxis` is still the whole feed.
  *
  * Kept pure and separate from the hook so it is testable: the repo's harness is
  * `renderToStaticMarkup` only (no jsdom, effects never run), so a self-fetching

--- a/frontend/src/pages/praxes/usePraxes.ts
+++ b/frontend/src/pages/praxes/usePraxes.ts
@@ -16,7 +16,7 @@
  * The second URL-borne axis is `?task_id=` (#1050): task surfaces have always
  * linked "view all praxis" here with it, and the API has always accepted it, but
  * this hook read no params so the filter was dropped on arrival. It is optional
- * — a bare `/praxes` is still the whole feed — and the pages announce it when
+ * — a bare `/praxis` is still the whole feed — and the pages announce it when
  * set, so a narrowed feed never looks like the whole register. See
  * `./taskFilterParam.ts`.
  */

--- a/frontend/src/pages/praxisDetail/DuelCard.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCard.tsx
@@ -34,7 +34,7 @@
  *    the duel `active`, so ADR-0062's published-only redirect does not catch it,
  *    and `_duel_side_hidden_condition` (`services/praxis.py`) leaves the AUTHOR
  *    able to load their own live side. They get the composer's waiting surface
- *    at `/praxes/{id}/edit`, which narrates the wait properly; a second, thinner
+ *    at `/praxis/{id}/edit`, which narrates the wait properly; a second, thinner
  *    account of the same beat here is the one-state-two-owners problem ADR-0062
  *    exists to prevent.
  *
@@ -385,7 +385,7 @@ export function DuelCard({ state, style, heading, ink }: DuelCardProps) {
       <div style={{ borderTop: hairline, marginTop: 'var(--space-md)', paddingTop: 'var(--space-md)' }}>
         {rival.praxis_id != null ? (
           <Link
-            to={`/praxes/${rival.praxis_id}`}
+            to={`/praxis/${rival.praxis_id}`}
             style={{
               display: 'flex',
               alignItems: 'center',

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -240,7 +240,7 @@ describe('Coven praxis detail — the shared layout contract', () => {
 
     const phone = render(state(), 'mobile')
     expect(phone.html, 'phone back link to the praxis index').toContain('href="/praxes"')
-    expect(phone.text, 'and its label').toContain('Praxes')
+    expect(phone.text, 'and its label').toContain('Praxis')
   })
 
   it('gives the desktop aside the eight designs 330px track, and none on mobile', () => {

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -236,10 +236,10 @@ describe('Coven praxis detail — the shared layout contract', () => {
     const wide = render(state())
     expect(wide.html, 'breadcrumb links to the task bank').toContain('href="/tasks"')
     expect(wide.html, 'breadcrumb links to the task').toContain('href="/tasks/7"')
-    expect(wide.html, 'no phone back link on desktop').not.toContain('href="/praxes"')
+    expect(wide.html, 'no phone back link on desktop').not.toContain('href="/praxis"')
 
     const phone = render(state(), 'mobile')
-    expect(phone.html, 'phone back link to the praxis index').toContain('href="/praxes"')
+    expect(phone.html, 'phone back link to the praxis index').toContain('href="/praxis"')
     expect(phone.text, 'and its label').toContain('Praxis')
   })
 
@@ -382,10 +382,10 @@ describe('Coven praxis detail — the state axes', () => {
 
   it('shows owner controls to a member and nothing to a visitor', () => {
     expect(render(state()).html, 'a visitor gets no edit link').not.toContain(
-      'href="/praxes/1/edit"',
+      'href="/praxis/1/edit"',
     )
     const owner = state({ isOwner: true, user: VIEWER })
-    expect(render(owner).html).toContain('href="/praxes/1/edit"')
+    expect(render(owner).html).toContain('href="/praxis/1/edit"')
   })
 
   it('lists who voted and each voters own rung, never an average', () => {

--- a/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
@@ -196,7 +196,7 @@ describe('duel card — the three readings', () => {
     )
     expect(text, 'nothing is final yet').not.toContain('frozen at era close')
     // The rival's row is the cross-link, and it points AWAY from this page.
-    expect(html).toContain('href="/praxes/2"')
+    expect(html).toContain('href="/praxis/2"')
     expect(text).toContain('Read their praxis')
   })
 
@@ -220,7 +220,7 @@ describe('duel card — the three readings', () => {
     expect(text, "the forfeiter's total is gone").not.toContain('15.4')
     // The thrown side is back to `in_progress`, so this 404s. It stays a plain
     // link on purpose — it degrades, it does not break the page.
-    expect(html).toContain('href="/praxes/2"')
+    expect(html).toContain('href="/praxis/2"')
   })
 
   it('forfeited by THIS side: the dimmed row is whoever threw it', () => {

--- a/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
@@ -279,10 +279,10 @@ describe("Ephemerists praxis detail — copy is neutral (ADR-0061)", () => {
     // one voiced slot with no neutral twin, so it is gone rather than restated
     // — the other seven skins mount the cluster unlabelled too.
     expect(render(state()).html, "visitor gets no owner controls").not.toContain(
-      "/praxes/1/edit",
+      "/praxis/1/edit",
     );
     const owner = render(state({ isOwner: true }));
-    expect(owner.html, "the shared invariant controls").toContain("/praxes/1/edit");
+    expect(owner.html, "the shared invariant controls").toContain("/praxis/1/edit");
     expect(owner.text, "and no label over them").not.toContain("Amend the record");
   });
 

--- a/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
@@ -375,10 +375,10 @@ describe("Everymen praxis detail — the state axes", () => {
 
   it("shows owner controls to a member and nothing to a visitor", () => {
     expect(render(state()).html, "a visitor gets no edit link").not.toContain(
-      'href="/praxes/1/edit"',
+      'href="/praxis/1/edit"',
     );
     const owner = state({ isOwner: true, user: VIEWER });
-    expect(render(owner).html).toContain('href="/praxes/1/edit"');
+    expect(render(owner).html).toContain('href="/praxis/1/edit"');
   });
 
   it("lists who voted and each voter's own rung, never an average", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
@@ -279,10 +279,10 @@ describe("Singularity praxis detail — the inherited layout contract", () => {
     const wide = render(state());
     expect(wide.html, "breadcrumb to the task bank").toContain('href="/tasks"');
     expect(wide.html, "breadcrumb to the task").toContain('href="/tasks/7"');
-    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxes"');
+    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxis"');
 
     const phone = render(state(), "mobile");
-    expect(phone.html, "phone back link to the praxis index").toContain('href="/praxes"');
+    expect(phone.html, "phone back link to the praxis index").toContain('href="/praxis"');
   });
 });
 
@@ -457,10 +457,10 @@ describe("Singularity praxis detail — the state axes", () => {
 
   it("shows owner controls to a member and nothing to a visitor", () => {
     expect(render(state()).html, "a visitor gets no edit link").not.toContain(
-      'href="/praxes/1/edit"',
+      'href="/praxis/1/edit"',
     );
     const owner = state({ isOwner: true, user: VIEWER });
-    expect(render(owner).html).toContain('href="/praxes/1/edit"');
+    expect(render(owner).html).toContain('href="/praxis/1/edit"');
   });
 
   it("lists who voted and each voter's own rung, never an average", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -222,7 +222,7 @@ describe("S.N.I.D.E. praxis detail — the inherited layout contract", () => {
 
     const phone = render(state(), "mobile");
     expect(phone.html, "phone back link to the praxis index").toContain('href="/praxes"');
-    expect(phone.text, "and its label").toContain("Praxes");
+    expect(phone.text, "and its label").toContain("Praxis");
   });
 
   it("gives the desktop aside the eight designs' 330px track, and none on mobile", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -218,10 +218,10 @@ describe("S.N.I.D.E. praxis detail — the inherited layout contract", () => {
     const wide = render(state());
     expect(wide.html, "breadcrumb links to the task bank").toContain('href="/tasks"');
     expect(wide.html, "breadcrumb links to the task").toContain('href="/tasks/7"');
-    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxes"');
+    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxis"');
 
     const phone = render(state(), "mobile");
-    expect(phone.html, "phone back link to the praxis index").toContain('href="/praxes"');
+    expect(phone.html, "phone back link to the praxis index").toContain('href="/praxis"');
     expect(phone.text, "and its label").toContain("Praxis");
   });
 
@@ -424,10 +424,10 @@ describe("S.N.I.D.E. praxis detail — the state axes", () => {
 
   it("shows owner controls to a member and nothing to a visitor", () => {
     expect(render(state()).html, "a visitor gets no edit link").not.toContain(
-      'href="/praxes/1/edit"',
+      'href="/praxis/1/edit"',
     );
     const owner = state({ isOwner: true, user: VIEWER });
-    expect(render(owner).html).toContain('href="/praxes/1/edit"');
+    expect(render(owner).html).toContain('href="/praxis/1/edit"');
   });
 
   it("lists who voted and each voter's own rung, never an average", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -372,10 +372,10 @@ describe("UA praxis detail — the layout contract (#1129)", () => {
     const wide = render(state());
     expect(wide.html, "to the task bank").toContain('href="/tasks"');
     expect(wide.html, "to the task").toContain('href="/tasks/7"');
-    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxes"');
+    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxis"');
 
     const phone = render(state(), "mobile");
-    expect(phone.html, "phone back link").toContain('href="/praxes"');
+    expect(phone.html, "phone back link").toContain('href="/praxis"');
   });
 });
 

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -176,10 +176,10 @@ describe("Unaffiliated praxis detail — layout contract", () => {
     const wide = render(state());
     expect(wide.html, "breadcrumb links to the task bank").toContain('href="/tasks"');
     expect(wide.html, "breadcrumb links to the task").toContain('href="/tasks/7"');
-    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxes"');
+    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxis"');
 
     const phone = render(state(), "mobile");
-    expect(phone.html, "phone back link to the praxis index").toContain('href="/praxes"');
+    expect(phone.html, "phone back link to the praxis index").toContain('href="/praxis"');
     expect(phone.text, "centred page label").toContain("Praxis");
   });
 
@@ -338,10 +338,10 @@ describe("Unaffiliated praxis detail — the state axes", () => {
 
   it("shows owner controls to a member and nothing to a visitor", () => {
     expect(render(state()).html, "a visitor gets no edit link").not.toContain(
-      'href="/praxes/1/edit"',
+      'href="/praxis/1/edit"',
     );
     const owner = state({ isOwner: true, user: VIEWER });
-    expect(render(owner).html).toContain('href="/praxes/1/edit"');
+    expect(render(owner).html).toContain('href="/praxis/1/edit"');
   });
 
   it("shows the steward bar only in admin mode", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -180,7 +180,6 @@ describe("Unaffiliated praxis detail — layout contract", () => {
 
     const phone = render(state(), "mobile");
     expect(phone.html, "phone back link to the praxis index").toContain('href="/praxes"');
-    expect(phone.text, "and its label").toContain("Praxes");
     expect(phone.text, "centred page label").toContain("Praxis");
   });
 

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -353,10 +353,10 @@ describe("WOW praxis detail — the layout contract (#1129)", () => {
     const wide = render(state());
     expect(wide.html, "to the task bank").toContain('href="/tasks"');
     expect(wide.html, "to the task").toContain('href="/tasks/7"');
-    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxes"');
+    expect(wide.html, "no phone back link on desktop").not.toContain('href="/praxis"');
 
     const phone = render(state(), "mobile");
-    expect(phone.html, "phone back link").toContain('href="/praxes"');
+    expect(phone.html, "phone back link").toContain('href="/praxis"');
   });
 });
 

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -304,7 +304,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
         marginBottom: 'var(--space-md)',
       }}
     >
-      <Link to="/praxes" style={crumbLink}>
+      <Link to="/praxis" style={crumbLink}>
         <span aria-hidden>‹ </span>
         {t('detail.back')}
       </Link>

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -302,7 +302,7 @@ export default function DefaultPraxisDetail({
       }}
     >
       <Link
-        to="/praxes"
+        to="/praxis"
         className="eyebrow"
         style={{
           letterSpacing: '0.2em',

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -447,7 +447,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
         marginBottom: "var(--space-lg)",
       }}
     >
-      <Link to="/praxes" style={{ ...eyebrow, color: NILE, textDecoration: "none" }}>
+      <Link to="/praxis" style={{ ...eyebrow, color: NILE, textDecoration: "none" }}>
         <span aria-hidden>‹ </span>
         {t("detail.back")}
       </Link>

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -328,7 +328,7 @@ export default function EverymenPraxisDetail({
       }}
     >
       <Link
-        to="/praxes"
+        to="/praxis"
         className="eyebrow"
         style={{
           letterSpacing: "0.2em",

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -362,7 +362,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
       ) : (
         <>
           <Link
-            to="/praxes"
+            to="/praxis"
             style={{
               ...LABEL,
               fontSize: "var(--text-lg)",

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -394,7 +394,7 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
         marginBottom: "var(--space-md)",
       }}
     >
-      <Link to="/praxes" style={{ ...eyebrow, color: INK, textDecoration: "none" }}>
+      <Link to="/praxis" style={{ ...eyebrow, color: INK, textDecoration: "none" }}>
         <span aria-hidden="true">‹ </span>
         {t("detail.back")}
       </Link>

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -383,7 +383,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
       }}
     >
       <Link
-        to="/praxes"
+        to="/praxis"
         style={{
           ...UA_EYEBROW,
           color: "var(--faction-ua-card-accent)",

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -359,7 +359,7 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
         marginBottom: 'var(--space-md)',
       }}
     >
-      <Link to="/praxes" style={{ ...EYEBROW, color: PLUM, textDecoration: 'none' }}>
+      <Link to="/praxis" style={{ ...EYEBROW, color: PLUM, textDecoration: 'none' }}>
         <span aria-hidden>‹ </span>
         {t('detail.back')}
       </Link>

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -320,7 +320,7 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
-        <Link to={`/praxes/${praxis.id}/edit`} className="font-body eyebrow hover:underline" style={{ color: 'var(--color-text-tertiary)' }}>
+        <Link to={`/praxis/${praxis.id}/edit`} className="font-body eyebrow hover:underline" style={{ color: 'var(--color-text-tertiary)' }}>
           {t('detail.owner.edit')}
         </Link>
         <PraxisSubmitControls state={state} />

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -11,7 +11,7 @@
  *
  * We render to static markup (no DOM, no context) and assert on the structural
  * anchors each slot leaves behind: slot text and the stable hrefs
- * (`/tasks`, `/praxes/:id/edit`). Distinctive fixture values keep the substring
+ * (`/tasks`, `/praxis/:id/edit`). Distinctive fixture values keep the substring
  * checks from colliding with incidental markup. Submissions are left empty so
  * the test never has to mount the context-bound <PraxisCard> wrapper — the
  * praxis section is anchored instead by its always-present sort toggle, and
@@ -148,7 +148,7 @@ describe("task-detail content-slot invariant", () => {
       const { html } = render(
         <Archetype state={baseState({ mySubmission: MY_PRAXIS })} />,
       );
-      expect(html, "edit-submission slot").toContain('href="/praxes/55/edit"');
+      expect(html, "edit-submission slot").toContain('href="/praxis/55/edit"');
     });
 
     it(`${slug} renders the continue control while in progress`, () => {
@@ -158,7 +158,7 @@ describe("task-detail content-slot invariant", () => {
         />,
       );
       expect(html, "continue-in-progress slot").toContain(
-        'href="/praxes/99/edit"',
+        'href="/praxis/99/edit"',
       );
     });
   }

--- a/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
@@ -16,7 +16,7 @@
  *  3. **No colour escapes index.css.** Every pigment on this skin is a token;
  *     a literal hex in a style/fill/stroke is a dark-mode bug that renders fine.
  *  4. **No in-progress roster** (owner ruling 2026-07-28) and **no dead
- *     `/praxes?task_id=` link** (the gallery expands in place instead).
+ *     `/praxis?task_id=` link** (the gallery expands in place instead).
  *
  * The harness is `renderToStaticMarkup` — no DOM, no effects. `useFormFactor`
  * therefore always reports its server default, so only the DESKTOP size set is

--- a/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
@@ -17,7 +17,7 @@
  *     base and total stay separately legible either way (ADR-0053's
  *     dead-arithmetic trap is reconstructing one from the other).
  *  4. The gallery's "view all" expands IN PLACE. The old build linked out to
- *     `/praxes?task_id=N`, which showed the whole feed — the praxis feed read no
+ *     `/praxis?task_id=N`, which showed the whole feed — the praxis feed read no
  *     such param until #1050.
  *  5. The dress is actually mounted: the broadsheet backdrop class and the
  *     masthead's faction line.

--- a/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
@@ -19,7 +19,7 @@
  *     decision 3) — the header count is the only place that number appears.
  *  4. **The `×mult` badge is off the raw factor**, not a reconstructed
  *     `modifiedPoints / basePoints` ratio (ADR-0053's trap, ADR-0055's rule).
- *  5. **No `/praxes?task_id=N`.** The gallery expands in place; the link was
+ *  5. **No `/praxis?task_id=N`.** The gallery expands in place; the link was
  *     dead on every archetype before #1050 and is not wanted now either.
  *
  * `renderToStaticMarkup` only: no DOM, no effects, so `useFormFactor()` reports
@@ -220,7 +220,7 @@ describe("Singularity task detail — the shared anatomy", () => {
     expect(text).toContain(long);
   });
 
-  it("never links out to the /praxes?task_id feed filter", () => {
+  it("never links out to the /praxis?task_id feed filter", () => {
     const { html } = render(<SingularityTaskDetail state={baseState()} />);
     expect(html).not.toContain("task_id=");
   });

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -43,7 +43,7 @@ import type { TaskDetailState } from "../useTaskDetail";
  *   The factor arrives raw on the state contract; it is never reconstructed as
  *   `modifiedPoints / basePoints` (ADR-0053's dead-arithmetic trap).
  * - **The gallery expands in place.** Reading a task's proof shouldn't bounce
- *   you to the feed. (`/praxes?task_id=N` dropped its filter entirely until
+ *   you to the feed. (`/praxis?task_id=N` dropped its filter entirely until
  *   #1050 taught `usePraxes` to read the param; the in-place expand is the
  *   ruling either way.)
  *
@@ -272,7 +272,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
   const desktop = formFactor !== "mobile";
   const size = SIZES[formFactor];
   // The gallery expands in place. It deliberately does NOT link out to
-  // `/praxes?task_id=N` — the reader stays on the task. That URL does filter
+  // `/praxis?task_id=N` — the reader stays on the task. That URL does filter
   // properly since #1050; before it, it silently showed the whole feed.
   const [showAllPraxis, setShowAllPraxis] = useState(false);
   const {
@@ -478,7 +478,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
           >
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxes/${mySubmission.id}/edit`} style={goldButton}>
+          <Link to={`/praxis/${mySubmission.id}/edit`} style={goldButton}>
             {t("detail.submitted.edit")}
           </Link>
         </div>
@@ -497,7 +497,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
           >
             {t("detail.inProgress.text")}
           </div>
-          <Link to={`/praxes/${inProgressPraxisId}/edit`} style={goldButton}>
+          <Link to={`/praxis/${inProgressPraxisId}/edit`} style={goldButton}>
             {t("detail.inProgress.continue")}
           </Link>
           <button

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -94,7 +94,7 @@ export default function DefaultTaskDetail({
   const { t } = useTranslation("tasks");
   const desktop = useFormFactor() !== "mobile";
   // The gallery expands in place (the design's own "View all N praxis →" /
-  // "Show fewer ↑"). It deliberately does NOT link out to `/praxes?task_id=N`:
+  // "Show fewer ↑"). It deliberately does NOT link out to `/praxis?task_id=N`:
   // the reader stays on the task. That URL does filter properly since #1050;
   // before it, the feed read no such param and showed everything.
   const [showAllPraxis, setShowAllPraxis] = useState(false);
@@ -319,7 +319,7 @@ export default function DefaultTaskDetail({
           >
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxes/${mySubmission.id}/edit`} style={primaryButton}>
+          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryButton}>
             {t("detail.submitted.edit")}
           </Link>
         </div>
@@ -346,7 +346,7 @@ export default function DefaultTaskDetail({
             }}
           >
             <Link
-              to={`/praxes/${inProgressPraxisId}/edit`}
+              to={`/praxis/${inProgressPraxisId}/edit`}
               style={{ ...primaryButton, flex: 1, width: "auto" }}
             >
               {t("detail.inProgress.continue")}

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -48,7 +48,7 @@ import type { TaskDetailState } from "../useTaskDetail";
  * - **Copy is the shared neutral `detail.*` set** (ADR-0057). None of the
  *   design's words survive, and none of the retired faction voice does either.
  * - **The gallery expands in place.** "View all" is a local expand: the reader
- *   stays on the task. (`/praxes?task_id=N` did not filter at all until #1050.)
+ *   stays on the task. (`/praxis?task_id=N` did not filter at all until #1050.)
  *
  * ONE RESPONSIVE COMPONENT (ADR-0058): `useFormFactor()` picks the size set and
  * collapses the two-column split. The separate Ephemerists mobile skin and the
@@ -460,7 +460,7 @@ export default function EphemeristsTaskDetail({
   const desktop = useFormFactor() !== "mobile";
   const size = SIZES[desktop ? "desktop" : "mobile"];
   // The gallery expands in place. It deliberately does NOT link out to
-  // `/praxes?task_id=N` — the reader stays on the task. That URL does filter
+  // `/praxis?task_id=N` — the reader stays on the task. That URL does filter
   // properly since #1050; before it, it silently showed the whole feed.
   const [showAllPraxis, setShowAllPraxis] = useState(false);
   const {
@@ -952,7 +952,7 @@ export default function EphemeristsTaskDetail({
           <div style={{ ...quietItalic, marginBottom: "var(--space-sm)" }}>
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxes/${mySubmission.id}/edit`} style={primaryButton}>
+          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryButton}>
             {t("detail.submitted.edit")}
           </Link>
         </div>
@@ -965,7 +965,7 @@ export default function EphemeristsTaskDetail({
             <span style={{ ...quietItalic, color: NILE }}>{t("detail.inProgress.text")}</span>
           </div>
           <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", flexWrap: "wrap" }}>
-            <Link to={`/praxes/${inProgressPraxisId}/edit`} style={{ ...primaryButton, flex: 1, width: "auto" }}>
+            <Link to={`/praxis/${inProgressPraxisId}/edit`} style={{ ...primaryButton, flex: 1, width: "auto" }}>
               {t("detail.inProgress.continue")}
             </Link>
             <button onClick={handleDrop} style={quietButton}>

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -143,7 +143,7 @@ function initialsOf(name: string): string {
  *   `modifiedPoints / basePoints`, which is ADR-0053's dead-arithmetic trap.
  *   `era_1` neutralises every faction, so it is invisible today.
  * - **The gallery expands in place.** It does NOT link out to
- *   `/praxes?task_id=N` — the reader stays on the task. The old Everymen build
+ *   `/praxis?task_id=N` — the reader stays on the task. The old Everymen build
  *   carried that link back when the feed read no such param and silently showed
  *   everything; the URL filters properly since #1050.
  * - **Copy is the shared neutral `detail.*` set** (ADR-0057). The union voice
@@ -691,7 +691,7 @@ export default function EverymenTaskDetail({
               {t("detail.submitted.text")}
             </span>
           </div>
-          <Link to={`/praxes/${mySubmission.id}/edit`} style={primaryBar}>
+          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryBar}>
             {t("detail.submitted.edit")}
           </Link>
         </div>
@@ -718,7 +718,7 @@ export default function EverymenTaskDetail({
               {t("detail.inProgress.text")}
             </span>
           </div>
-          <Link to={`/praxes/${inProgressPraxisId}/edit`} style={primaryBar}>
+          <Link to={`/praxis/${inProgressPraxisId}/edit`} style={primaryBar}>
             {t("detail.inProgress.continue")}
           </Link>
           <button

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -156,7 +156,7 @@ export default function SingularityTaskDetail({
   const { t } = useTranslation("tasks");
   const desktop = useFormFactor() !== "mobile";
   // The gallery expands in place. It deliberately does NOT link out to
-  // `/praxes?task_id=N` — the reader stays on the task (#1030 replaced the link
+  // `/praxis?task_id=N` — the reader stays on the task (#1030 replaced the link
   // on na). That URL does filter properly since #1050; before it, it silently
   // showed the whole feed.
   const [showAllPraxis, setShowAllPraxis] = useState(false);
@@ -619,7 +619,7 @@ export default function SingularityTaskDetail({
           >
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxes/${mySubmission.id}/edit`} style={primaryButton}>
+          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryButton}>
             {prompt}
             {t("detail.submitted.edit")}
           </Link>
@@ -647,7 +647,7 @@ export default function SingularityTaskDetail({
             }}
           >
             <Link
-              to={`/praxes/${inProgressPraxisId}/edit`}
+              to={`/praxis/${inProgressPraxisId}/edit`}
               style={{
                 ...primaryButton,
                 flex: 1,

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -56,7 +56,7 @@ import type { TaskDetailState } from "../useTaskDetail";
  *   `status === "active"` gate and suppresses the thread's own heading so this
  *   page carries one dressed section head, not two (ADR-0006).
  * - The gallery expands **in place**. It deliberately does not link out to
- *   `/praxes?task_id=N` — the reader stays on the task. That URL does filter
+ *   `/praxis?task_id=N` — the reader stays on the task. That URL does filter
  *   properly since #1050; before it, it silently showed the whole feed.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0058): `useFormFactor()` picks the size set and
@@ -465,7 +465,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
           >
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxes/${mySubmission.id}/edit`} style={plateButton(true)}>
+          <Link to={`/praxis/${mySubmission.id}/edit`} style={plateButton(true)}>
             <XMark size={17} />
             <span style={plateLabel}>{t("detail.submitted.edit")}</span>
             <XMark size={17} />
@@ -489,7 +489,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
           >
             {t("detail.inProgress.text")}
           </div>
-          <Link to={`/praxes/${inProgressPraxisId}/edit`} style={plateButton(true)}>
+          <Link to={`/praxis/${inProgressPraxisId}/edit`} style={plateButton(true)}>
             <XMark size={17} />
             <span style={plateLabel}>{t("detail.inProgress.continue")}</span>
             <XMark size={17} />

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -54,7 +54,7 @@ import type { TaskDetailState } from "../useTaskDetail";
  *   basePoints` (ADR-0053's dead arithmetic).
  * - **The gallery expands in place.** "View all" is a show-more/show-fewer
  *   toggle, as on na — the reader stays on the task. The old link went to
- *   `/praxes?task_id=N`, which showed the whole feed until #1050 taught it to
+ *   `/praxis?task_id=N`, which showed the whole feed until #1050 taught it to
  *   filter.
  *
  * ONE RESPONSIVE COMPONENT (ADR-0058): `useFormFactor()` picks the size set and
@@ -343,7 +343,7 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
           <div style={{ ...aside, marginBottom: "var(--space-sm)" }}>
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxes/${mySubmission.id}/edit`} style={primaryAction}>
+          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryAction}>
             {t("detail.submitted.edit")}
           </Link>
         </div>
@@ -382,7 +382,7 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
             }}
           >
             <Link
-              to={`/praxes/${inProgressPraxisId}/edit`}
+              to={`/praxis/${inProgressPraxisId}/edit`}
               style={{ ...primaryAction, flex: 1, width: "auto" }}
             >
               {t("detail.inProgress.continue")}

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -228,7 +228,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
   const desktop = formFactor !== "mobile";
   const size = SIZES[desktop ? "desktop" : "mobile"];
   // The gallery expands IN PLACE. It deliberately does not link out to
-  // `/praxes?task_id=N` — the reader stays on the task. #1030 found that link
+  // `/praxis?task_id=N` — the reader stays on the task. #1030 found that link
   // dead on every archetype (the feed read no such param and showed everything);
   // #1050 made the URL filter, and the in-place expand still stands.
   const [showAllPraxis, setShowAllPraxis] = useState(false);
@@ -461,7 +461,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
       {mySubmission && (
         <div>
           <div style={plateHeading}>{t("detail.submitted.text")}</div>
-          <Link to={`/praxes/${mySubmission.id}/edit`} style={ctaStyle(true)}>
+          <Link to={`/praxis/${mySubmission.id}/edit`} style={ctaStyle(true)}>
             <Star size={13} color={GOLD} />
             {t("detail.submitted.edit")}
           </Link>
@@ -471,7 +471,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
       {!mySubmission && isInProgress && inProgressPraxisId !== null && (
         <div>
           <div style={plateHeading}>{t("detail.inProgress.text")}</div>
-          <Link to={`/praxes/${inProgressPraxisId}/edit`} style={ctaStyle(true)}>
+          <Link to={`/praxis/${inProgressPraxisId}/edit`} style={ctaStyle(true)}>
             <Star size={13} color={GOLD} />
             {t("detail.inProgress.continue")}
           </Link>

--- a/frontend/src/pages/taskDetail/useTaskDetail.ts
+++ b/frontend/src/pages/taskDetail/useTaskDetail.ts
@@ -213,7 +213,7 @@ export function useTaskDetail(idParam: string | undefined): TaskDetailState {
     setSignupError(null);
     try {
       const praxis = await createPraxis({ task_id: task.id, type: "solo" });
-      navigate(`/praxes/${praxis.id}/edit`);
+      navigate(`/praxis/${praxis.id}/edit`);
     } catch (err) {
       setSignupError(extractError(err, "Could not sign up for this task."));
     }

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -163,7 +163,7 @@ export function useTasks(): TasksState {
     setSignupMsg(null)
     try {
       const praxis = await createPraxis({ task_id: id, type: 'solo' })
-      navigate(`/praxes/${praxis.id}/edit`)
+      navigate(`/praxis/${praxis.id}/edit`)
     } catch (err) {
       setSignupMsg({ id, msg: extractError(err, 'Could not sign up — make sure you are logged in.'), ok: false })
     }

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -139,7 +139,7 @@ const ACCENT_PAIRS: Pair[] = [
  *     file could ever have named the pairing. The manifest is authored from
  *     index.css's stated roles, and "the collab roster paints this on UA's
  *     cream" was not one.
- *   - `e2e/contrast.spec.ts` walks `/`, `/tasks`, `/praxes`, `/leaderboard`,
+ *   - `e2e/contrast.spec.ts` walks `/`, `/tasks`, `/praxis`, `/leaderboard`,
  *     `/factions` and `/factions/{slug}`. The composer is on none of them, and
  *     the roster only renders at >= 2 members with a MIXED cast state — a
  *     fixture no route walk reaches. So the sweep never rendered the surface.


### PR DESCRIPTION
The plural of *praxis* is *praxis*. Glossary, copy and routes — code identifiers and Python docstrings left alone per the ruling.

Closes #1136

## The seam I tested at

`frontend/src/__tests__/praxisPlural.test.ts` — a **source scan**, in the shape of `eagerPathImports.test.ts`.

This issue's failure mode is a clean build and a dead app: `/praxes/{id}` is spelled identically as the frontend route and the backend API path, so a find/replace that cannot tell them apart renames the endpoints too and every request 404s. I proved the blindness rather than assuming it — with the trap injected into `api/praxis.ts`:

```
tsc exit with broken API: 0
```

`tsc`, eslint, the build and all 2,634 other tests stay green with every API call broken. The harness is `renderToStaticMarkup` only, so nothing here can issue a request. A source scan is the only honest seam available per-PR.

The guard fails in **both** directions, verified by injection:

| injected defect | result |
|---|---|
| `api/praxis.ts` → `/praxis` (the trap) | 2 assertions red |
| `App.tsx` → `/praxes` (rename reverted) | 1 assertion red |
| real tree | 17 passed |

It also asserts no catalog **value** contains "praxes", and guards itself — an `api/` emptied of `/praxes` would make the first rule pass by finding nothing.

## Before/after: the API is untouched

| | before | after |
|---|---|---|
| `frontend/src/api/` — shipped client modules | 26 | **26** (`git diff` empty) |
| `frontend/src/api/__tests__/` | 4 | 3 (see canary below) |
| `frontend/src` outside `api/` — router paths | 168 | **0** |
| `frontend/e2e` — `${API}/praxes` calls | 14 | **14** |
| `frontend/e2e` — route paths | 27 | **0** |

Not one backend route is renamed. The discriminator was the directory, plus two refinements the directory rule alone gets wrong:

- **Comments documenting an endpoint** (`GET /praxes/{id}/voters` ×8, `POST /praxes/{id}/nudge`) are describing the API correctly and stay.
- **`api/__tests__/sessionRedirect.test.ts` — the canary the issue named.** `shouldReturnToLanding(status, requestUrl, pathname)` takes an API URL *and* a `window.location.pathname`, both on one line. Only the 3rd argument moved; the request URLs still read `/praxes`. This is the sole file under `api/` with a diff (3 lines).

The sweep also matched four things that are not URLs — reverted by hand: two module imports of the `pages/praxes/` **directory**, a filesystem path string in `searchQueryParamAdoption.test.ts` (this one broke a test at import time and caught itself), and a filename in a comment.

## Redirects

**None added** — the issue rules them out explicitly ("Nobody has these bookmarked", owner 2026-07-29). A bookmarked `/praxes/123` now 404s by decision, not oversight.

## Verification

`tsc --noEmit` ✅ · eslint ✅ · vitest 2,634 passed ✅ · `vite build` ✅ · budget exits 0 (CSS sits on a pre-existing WARN; no CSS touched).

Note `tsconfig.json` includes only `src`, so **e2e is not typechecked** and is nightly-only — those 41 sites rest on the `${API}` discriminator plus grep, not a compiler.

## What to eyeball

Visual/network QA is outstanding — I have no browser or dev stack, and **a broken API path is invisible to every check I can run**. Please walk it with the network panel open:

1. **Navigate to a praxis** from the feed — URL bar should read `/praxis/123`, and the page must actually populate (body, votes, comments).
2. **Edit one** — `/praxis/123/edit`, then submit and confirm it saves.
3. **Network panel**: requests must still go to **`/praxes/...`**. A URL bar saying `/praxis` while the network says `/praxes` is the correct end state.
4. **Praxis index** `/praxis` — copy reads "All praxis from across World Zero", "Show all praxis", search label "Praxis"; the mobile back link reads "Praxis".
5. `/praxis?task_id=N` still filters to one task.
6. **Admin moderation** filter chip reads "Praxis".
7. A **guest deep link** to `/praxis/123` must not bounce to the homepage (that is what `sessionRedirect` guards).
