### PR TITLE
The portrait ring stops asking for a drag it cannot take (#1263)

### DIFF
--- a/frontend/src/components/CredentialCard.tsx
+++ b/frontend/src/components/CredentialCard.tsx
@@ -170,11 +170,19 @@ export default function CredentialCard({
               ) : null}
             </div>
           )
+          // The ring has no text, so its label is its whole accessible name —
+          // and it only ever opens PortraitPicker's file input. It used to
+          // promise a drop target that has never existed here (no onDrop, no
+          // onDragOver), which handed a screen-reader user an instruction the
+          // control cannot accept (#1263). One string, both consumers, so the
+          // tooltip and the accessible name cannot drift apart.
+          const uploadLabel = t('credential.uploadTitle')
           return onAvatarClick ? (
             <button
               type="button"
               onClick={onAvatarClick}
-              title={t('credential.uploadTitle')}
+              aria-label={uploadLabel}
+              title={uploadLabel}
               style={ringStyle}
             >
               {inner}

--- a/frontend/src/components/__tests__/credentialCard.test.tsx
+++ b/frontend/src/components/__tests__/credentialCard.test.tsx
@@ -5,6 +5,8 @@
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so the copy keys resolve to English text.
+import '../../i18n'
 import CredentialCard from '../CredentialCard'
 
 describe('CredentialCard', () => {
@@ -34,5 +36,42 @@ describe('CredentialCard', () => {
       <CredentialCard displayName="   " handle="wanderer" factionSlug={null} level={1} score={0} />,
     )
     expect(html).toContain('Wanderer')
+  })
+})
+
+/**
+ * #1263. The portrait ring is a plain `onClick` button — a second trigger for
+ * PortraitPicker's hidden file input — and there is no `onDrop`/`onDragOver`
+ * anywhere in the component. Its `title` was "Drag a photo here, or click to
+ * upload", and a `title` with no other labelling IS the button's accessible
+ * name, so a screen-reader user was handed an instruction the control cannot
+ * accept. The ruling was to fix the copy, not to build the drop target.
+ */
+describe('CredentialCard portrait ring — the label names what the control does', () => {
+  const ringOf = (html: string) => /<button[^>]*>/.exec(html)?.[0] ?? ''
+
+  it('gives the upload ring an accessible name describing a click', () => {
+    const html = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" factionSlug="na" level={1} score={0} onAvatarClick={() => {}} />,
+    )
+    const ring = ringOf(html)
+    expect(ring, 'the ring is a real button when it uploads').toBeTruthy()
+    expect(ring).toContain('aria-label="Click to upload a photo"')
+    expect(ring, 'the tooltip says the same thing').toContain('title="Click to upload a photo"')
+  })
+
+  it('promises no drag-and-drop the component cannot honour', () => {
+    const html = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" factionSlug="coven" level={1} score={0} onAvatarClick={() => {}} />,
+    )
+    expect(html.toLowerCase(), 'no false affordance in any label').not.toContain('drag')
+  })
+
+  it('renders no button — and no upload label — when the ring is not an affordance', () => {
+    const html = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" factionSlug="coven" level={1} score={0} />,
+    )
+    expect(ringOf(html), 'a display-only ring is not a control').toBe('')
+    expect(html).not.toContain('upload')
   })
 })

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -132,7 +132,7 @@
     "fallbackName": "Wanderer",
     "credential": "credential",
     "unaffiliated": "unaffiliated",
-    "uploadTitle": "Drag a photo here, or click to upload",
+    "uploadTitle": "Click to upload a photo",
     "blankPassport": "A blank passport, waiting for its first stamp.",
     "factionToBeChosen": "— faction to be chosen —",
     "lvl": "lvl {{level}}",


### PR DESCRIPTION
Closes #1263

## The seam

`CredentialCard`'s portrait ring, rendered as a `<button>` when `onAvatarClick`
is supplied (the create-character live preview is its only caller). The ring has
no text content, so whatever labels it *is* its accessible name.

It carried `title={t('credential.uploadTitle')}` = "Drag a photo here, or click
to upload", and there is no `onDrop` or `onDragOver` anywhere in the file — the
ring only ever calls `fileInputRef.current?.click()`. A screen-reader user was
handed an instruction the control cannot accept.

## Red first

Three tests were added to `credentialCard.test.tsx` at that seam. Two went red on
the real defect before any fix:

- accessible name describes a click → received `<button type="button" title="Drag a photo here, or click to upload" ...>` with no `aria-label` at all
- no `drag` anywhere in the rendered markup → failed

The third (no button and no upload label when the ring is display-only, e.g. the
FieldDesk life-cards where the whole card is already a button) passed from the
start and is there as a regression guard.

## The fix — copy, not capability

Per the owner ruling on the issue: drag-and-drop is a *feature*, this is a
*defect*, and building the drop target would smuggle a capability in under a bug
fix. So:

- `common.credential.uploadTitle` → `"Click to upload a photo"`. The key is kept:
  `uploadTitle` describing a click is fine; a `title` describing a drag was the
  problem. **The string had no other consumer** — grep across `src` found exactly
  the one call site and the one catalog entry.
- The ring gets an explicit `aria-label`. That is the move #1149 correctly
  refused *only* because at the time it would have codified a false instruction;
  now the copy is true, labelling the control is right.
- One local `uploadLabel` expression feeds both the `aria-label` and the `title`,
  so the announced name and the tooltip cannot drift — the same
  one-expression-two-consumers shape #1149 used for the status line.

No new source of truth for the ring's state was added: the ring says nothing
about the chosen file. That readout stays in `PortraitPicker`, where #1149 put it.

## Verification

- `tsc --noEmit` — clean
- `vitest run` — 166 files, 2672 tests, all passing
- `eslint src` — clean
- `vite build` — ok; `npm run budget` — JS ok, CSS carries a pre-existing WARN
  (no CSS was touched in this PR)
- No browser available in this environment, so **visual QA is outstanding**.

## What to eyeball

- `/characters/new` (Create Character), desktop: hover the portrait ring on the
  live credential preview — the tooltip should read "Click to upload a photo".
  Click it; the file dialog should still open (it shares `fileInputRef` with the
  "Choose a photo" button below the form).
- Same page with a screen reader / the browser's accessibility inspector: the
  ring's accessible name should be "Click to upload a photo", not the old drag
  sentence and not an empty name.
- Same page with a faction selected vs. unaffiliated (`na`) — the ring's skin
  differs (accent hoop vs. the spectrum conic) but the label must not.
- FieldDesk, where `CredentialCard` renders without `onAvatarClick`: the ring
  should still be a plain `<div>` with no tooltip, no label, and no pointer
  cursor — nothing there became clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)