### PR TITLE
Name the busy button, on the three controls whose in-flight label was punctuation (#1236)

### DIFF
--- a/frontend/src/__tests__/busyLabelAccessibleName.test.tsx
+++ b/frontend/src/__tests__/busyLabelAccessibleName.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * A busy button still has to be called something (#1236).
+ *
+ * THE BUG CLASS. A control that swaps its label for a spinner-ish string while
+ * the request is in flight keeps its accessible name in that text — none of
+ * these buttons carries an `aria-label`, so the visible text IS the name. When
+ * the busy string is nothing but punctuation ("…", "..."), pressing the button
+ * renames it from "Post comment" to a name screen readers announce as nothing
+ * at all, or as a literal "horizontal ellipsis". Tabbing back to it, or hearing
+ * the rename announced, tells the user neither what the control is nor that
+ * anything is happening.
+ *
+ * The fix is the copy, not an `aria-label`: "Posting…" keeps the ellipsis as an
+ * affix rather than as the whole name, so the visible text and the accessible
+ * name are the same true string.
+ *
+ * WHAT THIS PROVES. The harness is `renderToStaticMarkup` only — no jsdom, no
+ * accessibility tree — so nothing here runs the accname algorithm. It asserts
+ * the input that algorithm reads: the text inside each rendered <button>. The
+ * catalog scan is the ratchet — it covers the busy strings on surfaces this
+ * harness cannot mount (the flag form, the unsubmit confirm), and any busy key
+ * added later.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+
+import '../i18n'
+import { resources } from '../i18n'
+import { ComposerControls } from '../components/comments/shared'
+
+/** Every <button>'s text content, tags stripped — what names the control. */
+function buttonNames(markup: string): string[] {
+  return [...markup.matchAll(/<button[^>]*>(.*?)<\/button>/gs)].map((match) =>
+    match[1].replace(/<[^>]*>/g, '').trim(),
+  )
+}
+
+/** Key names whose value is, by construction, a control's in-flight label. */
+const BUSY_KEY = /^(posting|submitting|saving|sending|deleting|updating|uploading|working|busy)$/
+
+function busyStrings(node: unknown, path: string[] = []): [string, string][] {
+  if (typeof node === 'string') {
+    return BUSY_KEY.test(path[path.length - 1] ?? '') ? [[path.join('.'), node]] : []
+  }
+  if (node === null || typeof node !== 'object') return []
+  return Object.entries(node).flatMap(([key, value]) => busyStrings(value, [...path, key]))
+}
+
+describe('a control in flight keeps a speakable name', () => {
+  it('ComposerControls: the comment submit button is named while posting', () => {
+    const markup = renderToStaticMarkup(
+      <ComposerControls
+        value="something worth keeping"
+        onChange={() => {}}
+        onSubmit={() => {}}
+        submitting
+        accent="var(--color-accent-primary)"
+        onAccent="var(--faction-default-on-accent)"
+      />,
+    )
+    // All eight voices and the inline editor render this one control, and none
+    // passes a `submittingLabel`, so this single string names every one of them.
+    expect(buttonNames(markup)).toContain('Posting…')
+  })
+
+  it('no busy string in any catalog is punctuation alone', () => {
+    const punctuationOnly = busyStrings(resources.en).filter(([, value]) => !/\p{L}/u.test(value))
+    expect(punctuationOnly).toEqual([])
+  })
+})

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -150,7 +150,7 @@
     },
     "owner": {
       "edit": "edit this praxis",
-      "submitting": "...",
+      "submitting": "Unsubmitting…",
       "unsubmit": "unsubmit",
       "unsubmitDuelLive": "pull my entry back",
       "confirmPrompt": "Sure? Points & votes will pause.",
@@ -174,7 +174,7 @@
       "reasonGroupLabel": "Flag reason",
       "notePlaceholder": "Add a note (optional)",
       "submit": "Submit flag",
-      "submitting": "...",
+      "submitting": "Submitting…",
       "cancel": "Cancel",
       "error": "Couldn't flag this. Please try again."
     },
@@ -205,7 +205,7 @@
     "composerPlaceholder": "Say something worth keeping…",
     "mentionHint": "@ to mention",
     "post": "Post comment",
-    "posting": "…",
+    "posting": "Posting…",
     "edited": "edited",
     "edit": "edit",
     "delete": "delete",


### PR DESCRIPTION
Closes #1236

## The defect

`comments.posting` was a bare `"…"`. None of these buttons carries an `aria-label`, so the visible text **is** the accessible name: the moment you press it, a button called "Post comment" becomes a button called "…", which screen readers announce as nothing at all or as a literal "horizontal ellipsis".

**Seam under test:** the text content of a rendered `<button>` while `submitting` — the input the accname algorithm reads. The harness is `renderToStaticMarkup` only (no jsdom, no a11y tree), so nothing here runs accname itself; a test that asserted "the button exists" or "the markup contains Post" would pass against the broken version. The failing test enumerated all three bad strings by name before the fix.

Fix is the copy, not an `aria-label` — once the string is true, the accessible name is fine, and the ellipsis is an affix rather than the whole name.

## The sweep the issue asked for

Grepped for the same shape — a busy/pending state whose entire label is punctuation — across all 11 catalogs and across TSX literals (`? '…'`, `>…<`, `{'...'}`). **Two siblings, both on the praxis detail page**, both the identical bug (whole button label, no `aria-label`):

| key | was | now | consumer |
|---|---|---|---|
| `comments.posting` | `…` | `Posting…` | `ComposerControls` — all 8 voices + inline `CommentEditor` |
| `detail.flag.submitting` | `...` | `Submitting…` | `FlagControl.tsx:110`, `praxisDetail/shared.tsx:583` (paired with "Submit flag") |
| `detail.owner.submitting` | `...` | `Unsubmitting…` | `praxisDetail/shared.tsx:475` — the unsubmit confirm, shared by all four `UNSUBMIT_COPY` variants |

Not swept, all reviewed and clean: `common.loading`, `feed.loadingMore`, `admin.saving`, `forms.busy`, `common.sending` etc. already read as words; `FactionCard`'s `"…"` is a truncation affix, not a label; `votes.plateTopMark` (`✦`) is decorative and has no consumers.

Per the issue, `post` stays `"Post comment"` and `edit`/`delete` stay lowercase — deliberately kept.

## Scope held

One string covers all eight voices; no voice is patched and no `submittingLabel` is introduced. No collision with #1205 — it has already landed on this base (`MAX_COMMENT_BODY` is present) and the composer test is untouched.

## Guard left behind

`frontend/src/__tests__/busyLabelAccessibleName.test.tsx` — one render assertion through `ComposerControls` (proving the string reaches the button that names it), plus a catalog scan asserting no busy-state key resolves to a value without a letter. The scan is what covers the flag form and the unsubmit confirm, which this DOM-less harness cannot mount, and any busy key added later.

## Verification

- `tsc --noEmit` clean
- `eslint src` clean
- `vitest run` — 167 files, 2671 tests pass
- `vite build` clean; `npm run budget` — JS ok. CSS is a pre-existing WARN (20.7 KB vs 19.5 KB); this diff is three JSON strings and a test file and touches no CSS.
- No browser available: **visual QA is outstanding.**

## What to eyeball

1. **Comment composer, mid-post** — any praxis with comments, on any of the 8 faction voices: type a comment, hit Post, and confirm the button reads `Posting…` and does not jump width awkwardly or wrap. The na/Unaffiliated skin is the one the design sheet draws.
2. **Inline comment editor, mid-save** — edit your own comment and save: the same control renders with a `Save` label and now falls back to `Posting…` while in flight. Worth a look at whether "Posting…" reads oddly under a Save button, or whether that one wants its own `submittingLabel` in a follow-up.
3. **Flag form, mid-submit** — praxis detail, flag a praxis, pick a reason, submit: the danger-red button should read `Submitting…`. Two mounts of this exist (`FlagControl` at 9px and the detail page's own at `--text-sm`) — check the small one for wrapping.
4. **Unsubmit confirm, mid-withdraw** — your own submitted praxis, "unsubmit" then confirm: the uppercase Courier button should read `UNSUBMITTING…`. Check the three longer variants too (collab whole, collab part, live duel), where the confirm it replaces is much wider — the width change is more visible there.
5. Dark mode on 3 and 4, since both sit on danger-tinted grounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)