### PR TITLE
Snide's praxis write-up loses the rule that separated nothing (#1285)

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -382,6 +382,28 @@ describe("S.N.I.D.E. praxis detail — the dress traps", () => {
     expect(render(state()).text).toContain("Walked the whole ridge before dark.");
   });
 
+  it("heads sections with the censor rule and closes no box with it", () => {
+    // #1285, the praxis twin of #1145. The rule is a section-head ornament: it
+    // runs out of a slab headline and separates the head from what follows. A
+    // fifth used to hang off the FOOT of the write-up panel on `marginTop`,
+    // where it separated the last line of the body from the box's own edge a
+    // few pixels down — i.e. from nothing.
+    const { html } = render(state());
+    // One rule per non-plate section head on a solo, visible praxis: proof,
+    // write-up, who-voted, discussion. The score and vote heads sit ON the
+    // black plate and take the broken ACID rule instead, which is a different
+    // ornament and deliberately not counted here.
+    expect(html.split("snd-censor").length - 1).toBe(4);
+    // …and the count alone can be rebalanced. Pin the SHAPE too: the first rule
+    // after the body text must belong to the next section's head, so it has to
+    // trail that heading's label rather than sit between the body and the edge.
+    const body = "Walked the whole ridge before dark.";
+    const afterBody = html.slice(html.indexOf(body) + body.length);
+    expect(afterBody.indexOf("snd-censor")).toBeGreaterThan(
+      afterBody.indexOf("Who voted"),
+    );
+  });
+
   it("mounts ONE score readout and invents no arithmetic", () => {
     const { text } = render(state());
     expect(text, "base").toContain("12");

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -751,7 +751,6 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
           className="markdown-preview content-text"
           style={{ fontFamily: TYPE, lineHeight: 1.6, color: INK }}
         />
-        <CensorRule style={{ marginTop: "var(--space-lg)" }} />
       </div>
     </section>
   );


### PR DESCRIPTION
Closes #1285

## The seam

`SnidePraxisDetail`'s **rendered markup** — specifically which `.snd-censor`
ornaments the skin emits and *where* each one sits relative to the write-up body.
Not a CSS seam: the rule is the `CensorRule` component (`<span class="snd-censor">`),
and its pigments live in `index.css`, so there is no border property to grep for.

## What was wrong

`SnidePraxisDetail.tsx:754` carried the byte-identical ornament #1145 (PR #1282)
removed from the **task** description box:

```tsx
<div style={clipping}>
  <MarkdownPreview source={praxis.body_text} … />
  <CensorRule style={{ marginTop: "var(--space-lg)" }} />
</div>
```

It was the block-level trailing child of a boxed panel, so it separated nothing —
there was no content beneath it, only the box's own edge a few pixels down.
#1145's "Done when" named the task detail, and `SnidePraxisDetail` has its own
design lineage and its own tests, so that deletion did not and could not cover it.

## Sorting the call sites by shape

The file had three `CensorRule` mentions on `main`: the component definition, one
call inside `sectionHead`, and the trailing one.

| site | shape | verdict |
|---|---|---|
| `:198` | the component itself | — |
| `:336` | flex-stretched sibling of a slab headline (`flex: "1 1 20%"`), inside `sectionHead` | **KEEP** — the skin's signature; it runs out of a heading and separates the head from what follows |
| `:754` | block-level trailing child of a boxed panel, hung on `marginTop` | **DELETE** |

The `sectionHead` helper is shared by every section, so keeping `:336` keeps all
of them at once. `sectionHead(…, { onPlate: true })` takes a broken **acid** rule
instead (the censor's photocopier ink is invisible on the black plate) — a
different ornament, untouched here.

## Red first

The guard went in before the deletion and failed on the real defect:

- count assertion — `expected 5 to be 4`;
- and the shape assertion is independently load-bearing. I re-added the ornament
  with the count expectation rebalanced to 5, and the shape assertion still failed
  (`expected 42 to be greater than 4189` — the next rule after the body text landed
  42 chars later, i.e. at the panel foot, instead of after the next heading's label).
  So a rule re-added at the foot fails even if the count is rebalanced elsewhere.

Then green: `frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx`,
19 tests passing.

## Verification

- `tsc --noEmit` clean · `eslint src` clean
- `vitest run` — 166 files / 2670 tests, all passing
- `vite build` ok; `npm run budget` — JS ok, CSS carries a **pre-existing** WARN
  (20.7 KB vs a 19.5 KB warn line). No CSS was touched by this PR.
- **Visual QA is outstanding** — I have no browser or dev stack here.

## What to eyeball

1. **S.N.I.D.E. praxis detail, solo, with a write-up** (`/praxis/{id}` on a praxis
   whose task faction is `snide`) — the write-up clipping's bottom edge. The last
   line of the body should now sit on the box's padding, with no strip of censor
   blocks between it and the border.
2. **The same page's section heads** — Proof, Write-up, Who voted, Discussion must
   each still carry the censor rule running out of the slab headline.
3. **Score and Cast-your-vote** (the black-plate heads) — still the broken acid
   rule, unchanged.
4. **Dark mode** on the same page — the clipping flips, the plate does not; the
   remaining rules should read the same at both themes.
5. **Mobile form factor** — the rail rides above the proof; check the write-up
   panel's foot again at that breakpoint, since it takes a different padding.
6. A praxis with **no** `body_text` (the whole write-up section is absent) and a
   **collab** praxis (Members section head gets its own rule) — neither should have
   gained or lost a rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)