### PR TITLE
Stop the duel picker offering your own alt (#1257)

### DIFF
--- a/frontend/src/pages/editPraxis/useEditPraxis.test.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.test.ts
@@ -5,7 +5,12 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { updatePraxis } from "../../api/praxis";
-import { draftNeedsTitle, flushEdits, hasUnsavedEdits } from "./useEditPraxis";
+import {
+  draftNeedsTitle,
+  flushEdits,
+  hasUnsavedEdits,
+  selfExcludedPickIds,
+} from "./useEditPraxis";
 // The mode-switch confirm moved out of the hook with the rest of them (#1082)
 // and now returns a whole ConfirmRequest instead of a `window.confirm` string.
 import { modeSwitchConfirm } from "../../components/confirm/composerConfirms";
@@ -173,5 +178,38 @@ describe("modeSwitchConfirm", () => {
       expect(request?.title.trim()).not.toBe("");
       expect(request?.confirmLabel.trim()).not.toBe("");
     }
+  });
+});
+
+/**
+ * Which of the viewer's own lives the invite/opponent picker withholds (#1257).
+ *
+ * The seam under test is the exclusion set that feeds the invite-search filter.
+ * It used to be exactly one id — the life you are carrying — which left every
+ * *other* life on your account offered as a duel opponent, and #1237 blocks
+ * both sides of a duel landing on one account. Selecting one could only 400.
+ */
+describe("selfExcludedPickIds", () => {
+  const roster = new Set([1, 2, 3]);
+
+  it("withholds the whole account roster in duel mode — none of them can be duelled", () => {
+    const excluded = selfExcludedPickIds(1, roster, true);
+    expect(excluded.has(2)).toBe(true);
+    expect(excluded.has(3)).toBe(true);
+  });
+
+  it("withholds only the carried life for a collab invite — inviting your own alt is legal", () => {
+    const excluded = selfExcludedPickIds(1, roster, false);
+    expect(excluded.has(1)).toBe(true);
+    expect(excluded.has(2)).toBe(false);
+    expect(excluded.has(3)).toBe(false);
+  });
+
+  it("still withholds the carried life in duel mode before the roster lands", () => {
+    expect(selfExcludedPickIds(1, new Set(), true).has(1)).toBe(true);
+  });
+
+  it("withholds nothing when nobody is carrying a life and the roster is empty", () => {
+    expect(selfExcludedPickIds(undefined, new Set(), true).size).toBe(0);
   });
 });

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -48,6 +48,7 @@ import {
 } from "../../components/confirm/composerConfirms";
 import { useGameConfig } from "../../hooks/useGameConfig";
 import { listRelationships } from "../../api/relationships";
+import { getMyCharacters } from "../../api/me";
 import { getTask, type TaskOut } from "../../api/tasks";
 import { listCharacters, type CharacterOut } from "../../api/characters";
 import { listMetatasks } from "../../api/metaTasks";
@@ -466,6 +467,29 @@ export function draftNeedsTitle(
   );
 }
 
+/**
+ * Which of the viewer's own lives the invite/opponent picker withholds (#1257).
+ *
+ * Collab invites withhold only the life you are carrying — inviting your own alt
+ * to a collab is doing a task with yourself, which splits no points unfairly and
+ * which the backend allows. Duel mode withholds the whole account roster: #1237
+ * blocked both sides of a duel landing on one account, so offering an alt as an
+ * opponent could only ever earn a 400 on Challenge.
+ *
+ * `ownCharacterIds` is empty until the lazy `/me/characters` read lands (and
+ * stays empty if it fails), so the carried life is unioned in rather than
+ * assumed present — the narrow old rule remains the floor.
+ */
+export function selfExcludedPickIds(
+  carriedCharacterId: number | undefined,
+  ownCharacterIds: Set<number>,
+  duelMode: boolean,
+): Set<number> {
+  const excluded = new Set<number>(duelMode ? ownCharacterIds : []);
+  if (carriedCharacterId != null) excluded.add(carriedCharacterId);
+  return excluded;
+}
+
 export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const navigate = useNavigate();
   const { user, refetch, loading: authLoading } = useAuth();
@@ -516,6 +540,10 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const duelLevelRequired = gameConfig?.duel_level_required ?? null;
   const autoSubmitDays = gameConfig?.collab_auto_submit_days ?? null;
   const [foeIds, setFoeIds] = useState<Set<number>>(new Set());
+  // Every life on the viewer's account (#1257) — read lazily when the duel pane
+  // opens, since only duel mode withholds them and there is no app-wide cache of
+  // the roster to read. Empty until it lands, and on failure.
+  const [ownCharacterIds, setOwnCharacterIds] = useState<Set<number>>(new Set());
   // Seal confirmation (#718) — opened by PublishButton in duel mode.
   const [duelSealOpen, setDuelSealOpen] = useState(false);
 
@@ -621,6 +649,24 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
         /* foes-first ordering is a nicety; ignore failures */
       });
   }, [user?.character?.id]);
+
+  // The account's own roster, for the duel opponent picker only (#1257). The
+  // picker already fetches per keystroke, so one read on a pane the player has
+  // just opened costs nothing on mount.
+  useEffect(() => {
+    if (!duelPaneOpen || !user?.character) return;
+    let cancelled = false;
+    getMyCharacters()
+      .then((roster) => {
+        if (!cancelled) setOwnCharacterIds(new Set(roster.map((c) => c.id)));
+      })
+      .catch(() => {
+        /* the carried life stays withheld either way — see selfExcludedPickIds */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [duelPaneOpen, user?.character?.id]);
 
   // ---- Duel detail (opponent chip + status) whenever this praxis is a duel side ----
   useEffect(() => {
@@ -1153,15 +1199,24 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
             .filter((i) => i.status === "pending")
             .map((i) => i.invitee_id),
         );
+        // The picker is choosing an *opponent* only while a duel is being set up;
+        // with a challenge already attached it is hidden, and otherwise it is
+        // choosing collab invitees.
+        const pickingOpponent = praxis.duel_id == null && duelPaneOpen;
+        const selfExcluded = selfExcludedPickIds(
+          user?.character?.id,
+          ownCharacterIds,
+          pickingOpponent,
+        );
         const filtered = results.filter(
           (c) =>
-            c.id !== user?.character?.id &&
+            !selfExcluded.has(c.id) &&
             !memberIds.has(c.id) &&
             !pendingInviteIds.has(c.id),
         );
         // In duel mode, surface the viewer's foes first (soft ordering; anyone
         // eligible can still be challenged).
-        if (praxis.duel_id == null && duelPaneOpen && foeIds.size > 0) {
+        if (pickingOpponent && foeIds.size > 0) {
           filtered.sort(
             (a, b) => Number(foeIds.has(b.id)) - Number(foeIds.has(a.id)),
           );
@@ -1177,7 +1232,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     return () => {
       cancelled = true;
     };
-  }, [inviteQuery, praxis, user, duelPaneOpen, foeIds]);
+  }, [inviteQuery, praxis, user, duelPaneOpen, foeIds, ownCharacterIds]);
 
   const sendInvite = useCallback(
     async (character: CharacterOut) => {


### PR DESCRIPTION
Closes #1257

#1237 (PR #1256) closed the backend hole — one account can no longer hold both
sides of a duel. The UI kept **offering** the move: the opponent picker still
listed your other lives, so selecting one and hitting Challenge could only ever
return a 400. The rule was enforced but not expressed, which inverts "hide
unusable controls; don't show them disabled".

Per the owner ruling: **option 2**, widen the existing client-side filter.
Options 1 (`exclude_my_account` on the public `GET /characters`) and 3 (leave it,
improve the error) are not touched.

## The seam

The exclusion set that feeds the invite-search filter in
`pages/editPraxis/useEditPraxis.ts`. It was literally one id —

```ts
c.id !== user?.character?.id   // your ACTIVE character, already excluded
```

— which withheld the life you are *carrying* but not your other lives on the
same account. The defect is the width of that set, so that is where the failing
test went: `selfExcludedPickIds` is exported from the hook module and unit-tested
directly, matching the existing `hasUnsavedEdits` / `flushEdits` / `draftNeedsTitle`
pattern in `useEditPraxis.test.ts` (the harness runs no effects, so a hook-level
test is not available).

Red first: all four new cases failed with `selfExcludedPickIds is not a function`,
then green.

## The change

- `selfExcludedPickIds(carriedCharacterId, ownCharacterIds, duelMode)` — the whole
  account roster in duel mode, just the carried life otherwise. The carried life is
  unioned in rather than assumed present, so the old narrow rule stays the floor if
  the roster read has not landed or failed.
- `ownCharacterIds` is read **lazily from `GET /me/characters`** when the duel pane
  opens, not on composer mount. There is no app-wide roster cache to read
  (`CharacterSwitcherSheet` and `FieldDesk` each fetch it lazily too), and the picker
  already fetches per keystroke, so one read on a just-opened pane is not the
  load-time concern of #1218.
- The `praxis.duel_id == null && duelPaneOpen` condition already used for foes-first
  ordering is now a named `pickingOpponent` local and gates both.

Backend cross-check: the guard is `Character.account_id` equality
(`services/duel.py:_characters_share_account`), and `GET /characters` search returns
**active** characters only, while `/me/characters` returns active + paused — so the
roster is a superset of anything the picker can surface for your account. No gap.

## Collab invites are unchanged

The same picker serves collab invites and the widened set does **not** apply there —
this is the ruling, not an oversight. Inviting your own alt to a collab is doing a
task with yourself: it splits no points unfairly and the backend allows it.
Extending the duel rule sideways would have the UI enforce a game rule the API
permits, the exact mirror of the bug being fixed.

## Verification

- `tsc --noEmit` — clean
- `vitest run` — 166 files / 2673 tests pass (4 new)
- `eslint` on both touched files — clean
- `vite build` — ok; `npm run budget` — JS ok, CSS carries a pre-existing WARN
  (unchanged by this PR; no CSS touched)
- No browser available here: **visual QA is outstanding.**

## What to eyeball

1. `/praxis/:id/edit` on a solo draft, click **Duel**, type 2+ chars of one of your
   own alts' names → it must not appear in the dropdown. Other players still do.
2. Same pane, before the roster read lands (throttle the network): the carried life
   is still withheld, and no alt flickers into the list and back out.
3. `/me/characters` failing (block it in devtools): the picker still works and still
   withholds the carried life; no error surfaces.
4. **Collab, unchanged:** switch the same praxis to **Collab** and search for the
   same alt — it must still be offered and still invitable end to end.
5. Foes-first ordering in duel mode still puts foes at the top of the list.
6. Switch carried character (character switcher), reopen the duel pane — the
   exclusion follows the new account context (it is the same account, so the same
   roster is withheld).

🤖 Generated with [Claude Code](https://claude.com/claude-code)