### PR TITLE
The Coven profile stops calling its players Warriors of Whimsy (#1291)

### DIFF
--- a/frontend/src/pages/characterProfile/FactionProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/FactionProfileBody.tsx
@@ -12,15 +12,10 @@
  * the top entry) — plus the two kept features: proposed tasks (faction
  * TaskCard) and friend/foe (faction-skinned, folded into the identity area).
  *
- * The default / unaffiliated skin is fully built; register a faction's row
- * below and its players adopt the bespoke skin with no other change (#460):
- *
- *   ua:          UaProfileBody,
- *   wow:         CovenProfileBody,
- *   snide:       SnideProfileBody,
- *   ephemerists: EphemeristsProfileBody,
- *   singularity: SingularityProfileBody,
- *   everymen:    EverymenProfileBody,
+ * The default / unaffiliated skin is fully built; a faction adopts its bespoke
+ * skin by declaring a `profileBody` row in its own manifest (#460, #782) —
+ * `factions/coven.ts` names `CovenProfileBody`, and so on for ua, wow, snide,
+ * ephemerists, singularity and everymen. No dispatcher is touched.
  *
  * Albescent claims no profile skin (#783): a member's profile is the default
  * one, because a profile is exactly where a secret society would give itself

--- a/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
@@ -15,6 +15,7 @@ import FactionProfileBody, {
   type ProfileBodyProps,
 } from "../FactionProfileBody";
 import { surfaceMap } from "../../../factions";
+import { factionName } from "../../../utils/factions";
 
 function makeCharacter(overrides: Partial<CharacterOut> = {}): CharacterOut {
   return {
@@ -111,6 +112,32 @@ describe("FactionProfileBody dispatch", () => {
         expect(html, `${slug} is not labelled faction-pending`).not.toContain(
           "faction pending",
         );
+      }
+    }
+  });
+
+  it("never names another faction in a bespoke profile skin (#1291)", () => {
+    // The seam is the rendered markup. Every one of these skins was ported from
+    // another faction's design template, and a template port carries CONTENT
+    // across as easily as it carries geometry — Coven's identity eyebrow read
+    // "Player · Warriors of Whimsy" for exactly that reason. A per-faction body
+    // that names a DIFFERENT faction is always a bug, so this is one loop over
+    // the registry rather than one assertion per skin: the next port is covered
+    // the moment its manifest row lands.
+    const slugs = Object.keys(surfaceMap("profileBody"));
+    const escape = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    for (const slug of slugs) {
+      const text = renderBody({ faction_slug: slug }).replace(/<[^>]*>/g, " ");
+      for (const other of slugs) {
+        if (other === slug) continue;
+        const name = factionName(other);
+        // Letter boundaries, not a bare substring: `names.ua` is "UA", which
+        // would otherwise match inside any all-caps word containing it.
+        const mention = new RegExp(`(?<![A-Za-z])${escape(name)}(?![A-Za-z])`);
+        expect(
+          mention.test(text),
+          `${slug} profile names ${other} ("${name}")`,
+        ).toBe(false);
       }
     }
   });

--- a/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
@@ -118,7 +118,11 @@ const kit: ProfileKit = {
   headerDecoration: <Watermark />,
   nameSize: 56,
   nameExtra: { fontFamily: HAND },
-  playerEyebrow: 'Player · Warriors of Whimsy',
+  // #1291: this read "Player · Warriors of Whimsy" — WOW's name, carried over
+  // with the geometry when this body was ported from WOW's template. Resolved
+  // from `slug` through the factions.json catalog now (ADR-0038), so a future
+  // port cannot bring another faction's name with it.
+  playerEyebrow: (faction) => `Player · ${faction}`,
   progressionStyle: {
     marginTop: 'var(--space-xl)',
     background: CARD,

--- a/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
@@ -99,7 +99,7 @@ const kit: ProfileKit = {
   ),
   nameSize: 48,
   nameExtra: { color: BAND_INK, letterSpacing: '0.08em', textTransform: 'uppercase' },
-  playerEyebrow: 'Player · The Ephemerists',
+  playerEyebrow: (faction) => `Player · ${faction}`,
   progressionStyle: {
     marginTop: 'var(--space-xl)',
     background: 'transparent',

--- a/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
@@ -99,7 +99,7 @@ const kit: ProfileKit = {
   ),
   nameSize: 72,
   nameExtra: { color: CREAM, textShadow: '3px 3px 0 rgba(0,0,0,0.3)', letterSpacing: '0.02em' },
-  playerEyebrow: 'Player · The Everymen',
+  playerEyebrow: (faction) => `Player · The ${faction}`,
   progressionStyle: {
     marginTop: 'var(--space-xl)',
     background: INK,

--- a/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
@@ -93,7 +93,7 @@ const kit: ProfileKit = {
     letterSpacing: '0.04em',
     textShadow: '0 0 12px rgba(74,222,128,0.35)',
   },
-  playerEyebrow: '> PLAYER: SINGULARITY // NODE STATUS: ONLINE',
+  playerEyebrow: (faction) => `> PLAYER: ${faction.toUpperCase()} // NODE STATUS: ONLINE`,
   progressionStyle: {
     marginTop: 'var(--space-xl)',
     background: VOID,

--- a/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
@@ -101,7 +101,7 @@ const kit: ProfileKit = {
   ),
   nameSize: 60,
   nameExtra: { transform: 'skewX(-5deg)', textShadow: `3px 3px 0 ${PINK}`, textTransform: 'uppercase' },
-  playerEyebrow: 'Player · S.N.I.D.E.',
+  playerEyebrow: (faction) => `Player · ${faction}`,
   progressionStyle: {
     marginTop: 'var(--space-xl)',
     background: INK,

--- a/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/UaProfileBody.tsx
@@ -95,6 +95,9 @@ const kit: ProfileKit = {
     </div>
   ),
   nameSize: 56,
+  // The one eyebrow kept as a literal (#1291): the catalog name for `ua` is the
+  // initialism "UA", and this masthead spells the institution out. Deriving it
+  // would mean either changing the copy or hardcoding the long form anyway.
   playerEyebrow: 'Practising · University of Asthmatics',
   progressionStyle: {
     marginTop: 'var(--space-xl)',

--- a/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
@@ -132,7 +132,7 @@ const kit: ProfileKit = {
     </div>
   ),
   nameSize: 48,
-  playerEyebrow: 'Warriors of Whimsy · the Court',
+  playerEyebrow: (faction) => `${faction} · the Court`,
   progressionStyle: {
     marginTop: 'var(--space-xl)',
     background: PLATE,

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -23,6 +23,7 @@ import { badgeArtFor } from '../../../components/badges/badgeArt'
 import CredentialCard from '../../../components/CredentialCard'
 import PraxisCard from '../../../components/PraxisCard'
 import TaskCard from '../../../components/TaskCard'
+import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import type { ProfileBodyProps } from '../FactionProfileBody'
 
@@ -76,8 +77,19 @@ export interface ProfileKit {
   nameSize?: number
   /** Optional CSS text-shadow / transform on the name. */
   nameExtra?: CSSProperties
-  /** Eyebrow above the name, e.g. "Player · University of Asthmatics". */
-  playerEyebrow: string
+  /** Eyebrow above the name, e.g. "Player · Cozy Coven".
+   *
+   *  Prefer the FUNCTION form: it is handed the faction's display name resolved
+   *  from `slug` through the factions.json catalog (ADR-0038), so the eyebrow
+   *  cannot name a faction other than the one it skins. Coven's eyebrow read
+   *  "Player · Warriors of Whimsy" for a year because it was a literal that rode
+   *  in with a ported template (#1291) — a literal replacement would only have
+   *  reset the same trap.
+   *
+   *  A plain string is still accepted for the one eyebrow whose wording is not
+   *  derivable from the catalog (UA spells its institution out where the catalog
+   *  holds the initials). `factionProfileBody.test.tsx` guards either form. */
+  playerEyebrow: string | ((factionName: string) => string)
 
   /* ── progression panel ── */
   /** Style for the progression panel container. */
@@ -266,6 +278,13 @@ export function ProfileSkin({
     : String(character.level)
   const levelUnit = kit.levelUnitLabel ?? 'pts this level'
 
+  // Resolved from the KIT's slug, not the character's: the kit is the archetype
+  // speaking about itself, and `character.faction_slug` is nullable.
+  const playerEyebrow =
+    typeof kit.playerEyebrow === 'function'
+      ? kit.playerEyebrow(factionName(kit.slug))
+      : kit.playerEyebrow
+
   const credential = (
     <CredentialCard
       displayName={character.display_name}
@@ -388,7 +407,7 @@ export function ProfileSkin({
                   marginBottom: 'var(--space-sm)',
                 }}
               >
-                {kit.playerEyebrow}
+                {playerEyebrow}
               </div>
 
               <h1


### PR DESCRIPTION
Closes #1291

A Cozy Coven player's profile announced them as **Warriors of Whimsy**. The
string rode in with the geometry when `CovenProfileBody` was ported from WOW's
design template — the structure was the thing being reused, and a piece of WOW's
content came with it.

## The seam

The **rendered markup**. A per-faction profile body that names a *different*
faction is always a bug, so the guard is one loop over
`surfaceMap('profileBody')` rather than seven individual assertions: render each
registered skin through the real dispatcher, strip tags, and assert the text
mentions no other registered faction's catalog name. The next ported skin is
covered the moment its manifest row lands.

Committed red first — it failed on exactly one case:

```
× never names another faction in a bespoke profile skin (#1291)
  → coven profile names wow ("Warriors of Whimsy")
```

The match uses letter boundaries rather than a bare substring, because
`names.ua` is the two-letter "UA" and would otherwise hit inside any all-caps
word containing it.

## The fix

`ProfileKit.playerEyebrow` now accepts `(factionName: string) => string`, and
`ProfileSkin` hands it the name resolved from the kit's **own slug** through
`factionName()` → `factions.json` `names.<slug>` (ADR-0038). A literal
`'Player · Cozy Coven'` would have fixed this instance and reset the same trap
for the next port, which is the part the issue cared about.

Resolved from `kit.slug`, not `character.faction_slug`: the kit is the archetype
speaking about itself, and the character's slug is nullable.

## The sweep

`playerEyebrow` was the only hardcoded faction name in
`pages/characterProfile/archetypes/` — every other faction reference in that
directory is a `--faction-<slug>-*` CSS var, a `slug:` field, or prose in a
docstring. `DefaultProfileBody` already did the right thing
(`factionName(character.faction_slug)`).

Coven was the only skin naming **another** faction. For the six naming their
own, judgement call, stated per the issue:

| skin | before | after | rendered |
|---|---|---|---|
| coven | `'Player · Warriors of Whimsy'` | `` `Player · ${faction}` `` | **changed** → "Player · Cozy Coven" |
| wow | `'Warriors of Whimsy · the Court'` | `` `${faction} · the Court` `` | identical |
| snide | `'Player · S.N.I.D.E.'` | `` `Player · ${faction}` `` | identical |
| ephemerists | `'Player · The Ephemerists'` | `` `Player · ${faction}` `` | identical |
| everymen | `'Player · The Everymen'` | `` `Player · The ${faction}` `` | identical |
| singularity | `'> PLAYER: SINGULARITY // …'` | `` `> PLAYER: ${faction.toUpperCase()} // …` `` | identical |
| ua | `'Practising · University of Asthmatics'` | **kept as a literal** | identical |

I converted the five that derive from the catalog with **zero copy change** —
verified by rendering all seven eyebrows before and after; only coven's string
moves. That is the drift risk removed at no cost, and it is where the next port
would have copied from.

**UA stays a literal**, with a comment saying why: `names.ua` is the initialism
"UA" and this masthead spells the institution out. Deriving it would mean either
changing shipped copy (a style/copy decision, not a bug fix) or hardcoding the
long form anyway. It names its own faction, so it is not the reported bug.
`playerEyebrow` therefore keeps a `string | (fn)` union for that one case.

Also corrected `FactionProfileBody.tsx`'s docstring, which carried the *same*
WOW/Coven mixup (`wow: CovenProfileBody,`) and additionally described a
registration mechanism that #782 replaced with per-faction manifests.

## Verification

- `tsc --noEmit` — clean
- `eslint src` — clean
- `vitest run` — **2670 passed / 166 files**
- `vite build` — ok; `npm run budget` — JS ok (131.9 KB), CSS WARN at 20.7 KB
  **pre-existing** (this branch touches no CSS)
- No new API endpoints consumed.
- **No visual QA** — I have no browser or dev stack. Only Coven's eyebrow text
  changes; nothing about layout, colour or type moved.

## What to eyeball

- **Cozy Coven player profile, desktop** — the identity eyebrow above the
  hand-lettered name should now read "Player · Cozy Coven". This is the fix; it
  is one word longer than the old string, so check it still sits on one line
  against the turning-pentagram watermark.
- **WOW player profile, desktop** — "Warriors of Whimsy · the Court", unchanged.
  It was correct before and must stay correct.
- **UA player profile** — "Practising · University of Asthmatics", unchanged.
- **S.N.I.D.E. / Ephemerists / Everymen / Singularity player profiles** — all
  four eyebrows should be byte-identical to main; a quick glance that none of
  them lost its dot-separated shape or its terminal-prompt caps.
- **Unaffiliated (`na`) and Albescent profiles** — the default skin, untouched;
  confirm they still say "Unaffiliated · faction pending".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
