### PR TITLE
One caching policy for /game-config and /factions, with a five-minute staleness bound

### DIFF
--- a/frontend/src/hooks/__tests__/cachedResource.test.ts
+++ b/frontend/src/hooks/__tests__/cachedResource.test.ts
@@ -1,0 +1,123 @@
+/**
+ * #1284 — the one caching policy behind `useGameConfig` and `useFactions`.
+ *
+ * Seam: the extracted staleness predicate (`isFresh`) and the React-free cache
+ * mechanics (`createResourceCache`). The hook wrapper is a four-line
+ * `useState`/`useEffect` over these; the repo has no DOM harness, so the
+ * dedupe and the revalidation are proved here, against an injected `now` and a
+ * fake system clock — never by waiting.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import {
+  CACHE_TTL_MS,
+  createResourceCache,
+  isFresh,
+} from '../cachedResource'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('isFresh', () => {
+  it('an absent entry is never fresh', () => {
+    expect(isFresh(null, 0)).toBe(false)
+  })
+
+  it('is fresh right up to the TTL and stale at it', () => {
+    const entry = { value: 'x', fetchedAt: 1_000 }
+    expect(isFresh(entry, 1_000)).toBe(true)
+    expect(isFresh(entry, 1_000 + CACHE_TTL_MS - 1)).toBe(true)
+    expect(isFresh(entry, 1_000 + CACHE_TTL_MS)).toBe(false)
+    expect(isFresh(entry, 1_000 + CACHE_TTL_MS * 10)).toBe(false)
+  })
+
+  it('the bound is a few minutes, not seconds — long enough that ordinary navigation is free', () => {
+    expect(CACHE_TTL_MS).toBeGreaterThanOrEqual(60_000)
+    expect(CACHE_TTL_MS).toBeLessThanOrEqual(15 * 60_000)
+  })
+})
+
+describe('createResourceCache', () => {
+  it('dedupes concurrent consumers into ONE request', async () => {
+    const fetchFn = vi.fn(() => Promise.resolve(['ua', 'wow']))
+    const cache = createResourceCache(fetchFn)
+
+    // Five call sites mounting in the same paint.
+    const results = await Promise.all([
+      cache.load(),
+      cache.load(),
+      cache.load(),
+      cache.load(),
+      cache.load(),
+    ])
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(results.every((r) => r?.[0] === 'ua')).toBe(true)
+  })
+
+  it('serves later mounts from the cache without a second request', async () => {
+    const fetchFn = vi.fn(() => Promise.resolve('config'))
+    const cache = createResourceCache(fetchFn)
+
+    await cache.load()
+    // A later navigation mounts another consumer.
+    expect(await cache.load()).toBe('config')
+    expect(cache.peek()).toBe('config')
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('null until settled: peek is null before the first response', () => {
+    const cache = createResourceCache(() => Promise.resolve('config'))
+    expect(cache.peek()).toBeNull()
+  })
+
+  it('goes stale past the TTL and the next load refetches', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-30T12:00:00Z'))
+
+    let era = 'era_1'
+    const fetchFn = vi.fn(() => Promise.resolve(era))
+    const cache = createResourceCache(fetchFn)
+
+    await cache.load()
+
+    // A moment before the bound: zero extra requests, still the old value.
+    vi.setSystemTime(Date.now() + CACHE_TTL_MS - 1)
+    era = 'era_2'
+    expect(await cache.load()).toBe('era_1')
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    // Past the bound: the era rolled over server-side and the next mount sees
+    // it, with no reload.
+    vi.setSystemTime(Date.now() + 1)
+    expect(await cache.load()).toBe('era_2')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+
+    // ...and the refreshed entry is itself good for another full window.
+    vi.setSystemTime(Date.now() + CACHE_TTL_MS - 1)
+    expect(await cache.load()).toBe('era_2')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('a failed fetch resolves null, keeps the last good value, and lets the next mount retry', async () => {
+    let attempt = 0
+    const fetchFn = vi.fn(() => {
+      attempt += 1
+      return attempt === 2
+        ? Promise.reject(new Error('offline'))
+        : Promise.resolve(`ok-${attempt}`)
+    })
+    const cache = createResourceCache(fetchFn)
+
+    expect(await cache.load()).toBe('ok-1')
+
+    vi.useFakeTimers()
+    vi.setSystemTime(Date.now() + CACHE_TTL_MS)
+    expect(await cache.load()).toBeNull()
+    // The stale-but-real value survives a failed revalidation.
+    expect(cache.peek()).toBe('ok-1')
+
+    expect(await cache.load()).toBe('ok-3')
+    expect(fetchFn).toHaveBeenCalledTimes(3)
+  })
+})

--- a/frontend/src/hooks/cachedResource.ts
+++ b/frontend/src/hooks/cachedResource.ts
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * The one caching policy shared by every app-wide read-once endpoint
+ * (`/game-config`, `/factions`). A single implementation rather than a pair of
+ * hand-rolled module caches, because two copies drift into two policies — and
+ * the second copy would also trip `sonarjs/no-identical-functions`.
+ *
+ * Policy: module-level entry + a shared in-flight promise, so N consumers
+ * mounting in the same paint cost ONE request; then stale-while-revalidate past
+ * {@link CACHE_TTL_MS}. A hard reload always refetches — the cache lives in
+ * module scope, not storage.
+ */
+
+/**
+ * Staleness bound: **5 minutes**.
+ *
+ * There is no push channel from the server, so the client cannot be told that
+ * the era rolled over or that an admin flipped a faction's visibility; it can
+ * only decide when to stop trusting what it holds. Five minutes is the smallest
+ * number that keeps ordinary browsing at zero requests — a player crossing
+ * /tasks → /factions → a faction page → /praxes does that in well under five
+ * minutes, and pays nothing for it — while bounding staleness to something a
+ * player would not sit through: an era transition or a visibility flip surfaces
+ * on the next navigation after the window closes, without a reload. It also
+ * caps the worst case at ~12 requests/hour/endpoint for someone who idles on a
+ * page and navigates once every five minutes, against one request per
+ * navigation before this existed.
+ */
+export const CACHE_TTL_MS = 5 * 60 * 1000
+
+export interface CacheEntry<T> {
+  readonly value: T
+  /** `Date.now()` at the moment the fetch RESOLVED, not when it was issued. */
+  readonly fetchedAt: number
+}
+
+/**
+ * The staleness predicate, extracted so the TTL is provable without waiting on
+ * a clock: pass an entry and a `now`, get an answer. An absent entry is never
+ * fresh.
+ */
+export function isFresh(
+  entry: CacheEntry<unknown> | null,
+  now: number,
+  ttlMs: number = CACHE_TTL_MS,
+): boolean {
+  return entry !== null && now - entry.fetchedAt < ttlMs
+}
+
+export interface ResourceCache<T> {
+  /** The held value, fresh or stale; `null` before the first response. */
+  peek: () => T | null
+  /**
+   * The cached value if it is still fresh; otherwise a fetch. Concurrent
+   * callers share one in-flight request, so N consumers mounting in the same
+   * paint cost one round trip.
+   */
+  load: () => Promise<T | null>
+}
+
+/**
+ * The cache itself, with no React in it — exported so the dedupe and the
+ * revalidation are testable directly (the repo has no DOM harness, so hooks are
+ * tested through their extracted mechanics).
+ */
+export function createResourceCache<T>(fetchFn: () => Promise<T>): ResourceCache<T> {
+  let entry: CacheEntry<T> | null = null
+  let inFlight: Promise<T | null> | null = null
+
+  return {
+    peek: () => entry?.value ?? null,
+    load: () => {
+      // The freshness gate lives HERE, not in the caller: a consumer that
+      // forgot to ask would otherwise refetch on every mount, which is the bug
+      // this issue is about.
+      if (entry && isFresh(entry, Date.now())) return Promise.resolve(entry.value)
+      inFlight ??= fetchFn()
+        .then((value) => {
+          entry = { value, fetchedAt: Date.now() }
+          inFlight = null
+          return value
+        })
+        .catch(() => {
+          // Leave the previous entry in place and drop the promise, so the next
+          // consumer to mount retries instead of inheriting the failure.
+          inFlight = null
+          return null
+        })
+      return inFlight
+    },
+  }
+}
+
+/**
+ * Build a hook that reads `fetchFn` once per {@link CACHE_TTL_MS} across the
+ * whole app.
+ *
+ * Returns `null` until the first response lands (the null-until-settled
+ * contract every call site already codes against). Once a value exists it stays
+ * on screen through revalidation — a TTL expiry must not flash an empty page
+ * mid-session.
+ */
+export function createCachedResource<T>(fetchFn: () => Promise<T>): () => T | null {
+  const cache = createResourceCache(fetchFn)
+
+  return function useCachedResource(): T | null {
+    const [value, setValue] = useState<T | null>(cache.peek)
+
+    useEffect(() => {
+      let cancelled = false
+      void cache.load().then((fetched) => {
+        if (fetched !== null && !cancelled) setValue(fetched)
+      })
+      return () => {
+        cancelled = true
+      }
+    }, [])
+
+    return value
+  }
+}

--- a/frontend/src/hooks/useFactions.ts
+++ b/frontend/src/hooks/useFactions.ts
@@ -1,0 +1,25 @@
+import { getFactions } from '../api/factions'
+import { createCachedResource } from './cachedResource'
+
+/**
+ * The `/factions` directory — the visible faction slugs, app-wide.
+ *
+ * Five surfaces read this list (tasks, praxes, the factions directory, a
+ * faction detail page, propose-task) and each used to fire its own request, so
+ * `/factions` cost a round trip on **every** SPA navigation (#1284). One
+ * request per page load now covers all five.
+ *
+ * **Staleness bound: 5 minutes** (`CACHE_TTL_MS`) — the same policy, from the
+ * same module, as `useGameConfig`. An admin flipping a faction's visibility
+ * surfaces on the first navigation after the bound, without a reload.
+ *
+ * NOT interchangeable with `useGameConfig()?.factions`: `/factions` returns the
+ * VISIBLE factions (slug only), while game-config returns every configured
+ * faction (including `na` and hidden ones) with its scoring modifiers and no
+ * visibility at all. Different sets, different fields, neither derivable from
+ * the other.
+ *
+ * Returns `null` until the first response lands; call sites that want an empty
+ * list while it settles do `useFactions() ?? []`.
+ */
+export const useFactions = createCachedResource(getFactions)

--- a/frontend/src/hooks/useGameConfig.ts
+++ b/frontend/src/hooks/useGameConfig.ts
@@ -1,36 +1,21 @@
-import { useEffect, useState } from 'react'
-import { getGameConfig, type GameConfigOut } from '../api/gameConfig'
-
-let cachedConfig: GameConfigOut | null = null
-let fetchPromise: Promise<GameConfigOut> | null = null
+import { getGameConfig } from '../api/gameConfig'
+import { createCachedResource } from './cachedResource'
 
 /**
  * Hook to fetch and cache the current era game config.
- * Config is fetched once and shared across all consumers.
+ *
+ * Fetched once and shared across all consumers — N components mounting in the
+ * same paint cost one `/game-config` request, and navigating between pages
+ * costs none.
+ *
+ * **Staleness bound: 5 minutes** (`CACHE_TTL_MS`). The cache used to be
+ * written once and never cleared, so an era transition mid-session served stale
+ * rules until a reload (#1284). There is no push channel from the server, so
+ * the client cannot be told the era rolled over; instead each entry is stamped
+ * when it resolves and the first consumer to mount past the bound refetches.
+ * The policy lives in `cachedResource.ts` and is shared verbatim with
+ * `useFactions` — one cache story, not two.
+ *
+ * Returns `null` until the first response lands.
  */
-export function useGameConfig() {
-  const [config, setConfig] = useState<GameConfigOut | null>(cachedConfig)
-
-  useEffect(() => {
-    if (cachedConfig) {
-      setConfig(cachedConfig)
-      return
-    }
-    if (!fetchPromise) {
-      fetchPromise = getGameConfig()
-        .then((data) => {
-          cachedConfig = data
-          return data
-        })
-        .catch(() => {
-          fetchPromise = null
-          return null as unknown as GameConfigOut
-        })
-    }
-    fetchPromise.then((data) => {
-      if (data) setConfig(data)
-    })
-  }, [])
-
-  return config
-}
+export const useGameConfig = createCachedResource(getGameConfig)

--- a/frontend/src/pages/factionDetail/useFactionDetail.ts
+++ b/frontend/src/pages/factionDetail/useFactionDetail.ts
@@ -4,14 +4,15 @@
  * same way the hero already does, without re-implementing the fetch.
  *
  * Behaviour preserved 1:1 from the original page (out-of-order-safe fetch keyed
- * on slug, faction-cleared-before-refetch, not-found when the slug has no match,
- * page backdrop themed to the faction). The returned {@link FactionDetailState}
- * is the stable contract every faction-body archetype consumes.
+ * on slug, not-found when the slug has no match, page backdrop themed to the
+ * faction). The returned {@link FactionDetailState} is the stable contract every
+ * faction-body archetype consumes. The faction itself is derived from the
+ * app-wide `useFactions` cache (#1284), which subsumes the old
+ * clear-before-refetch: a derived match cannot lag the slug.
  */
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  getFactions,
   getFactionStatus,
   getInvitations,
   chooseFaction,
@@ -21,6 +22,7 @@ import { listCharacters, type CharacterOut } from "../../api/characters";
 import { listTasks, type TaskOut } from "../../api/tasks";
 import { listPraxes, type PraxisCardOut } from "../../api/praxis";
 import { useAuth } from "../../auth/AuthContext";
+import { useFactions } from "../../hooks/useFactions";
 import { useGameConfig } from "../../hooks/useGameConfig";
 import { extractError } from "../../utils/errors";
 import { useFactionBackdrop } from "../../components/backdrop/BackdropContext";
@@ -83,11 +85,18 @@ export function useFactionDetail(
   const [joining, setJoining] = useState(false);
   const [joinError, setJoinError] = useState<string | null>(null);
 
-  const [faction, setFaction] = useState<FactionOut | null>(null);
+  // The directory list is app-wide cached (#1284), so `faction` is DERIVED from
+  // it rather than fetched and mirrored here. That also replaces the old
+  // clear-before-refetch: change the slug and the derived match changes with it,
+  // with no window where the previous faction is still on screen.
+  const allFactions = useFactions();
+  const faction: FactionOut | null =
+    allFactions?.find((f) => f.slug === slug) ?? null;
+
   const [members, setMembers] = useState<CharacterOut[]>([]);
   const [tasks, setTasks] = useState<TaskOut[]>([]);
   const [recentPraxis, setRecentPraxis] = useState<PraxisCardOut[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [entitiesLoading, setEntitiesLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
 
   // App-wide cached game config — used for per-faction display-point multipliers.
@@ -102,22 +111,15 @@ export function useFactionDetail(
     // Guard against out-of-order responses: if the slug changes mid-fetch, the
     // stale request must not overwrite the newer faction's data.
     let cancelled = false;
-    setLoading(true);
+    setEntitiesLoading(true);
     setFetchError(null);
-    // Clear any prior faction so an unknown slug falls through to "not found"
-    // instead of showing the previously-viewed faction during/after the fetch.
-    setFaction(null);
     Promise.all([
-      getFactions(),
       listCharacters({ faction: slug }),
       listTasks({ faction: slug, status: "active" }),
       listPraxes({ faction: slug, status: "submitted", limit: 12 }),
     ])
-      .then(([factions, mems, tsks, praxis]) => {
+      .then(([mems, tsks, praxis]) => {
         if (cancelled) return;
-        const match = factions.find((f) => f.slug === slug);
-        if (!match) return; // faction stays null → renders the not-found state
-        setFaction(match);
         setMembers(mems);
         setTasks(tsks);
         setRecentPraxis(praxis);
@@ -127,7 +129,7 @@ export function useFactionDetail(
           setFetchError(extractError(err, t("detail.errors.load")));
       })
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) setEntitiesLoading(false);
       });
     return () => {
       cancelled = true;
@@ -195,7 +197,10 @@ export function useFactionDetail(
 
   return {
     slug,
-    loading,
+    // "Nothing to draw yet" still means both halves: an unresolved directory
+    // must not fall through to the not-found state, which is what a settled
+    // `entitiesLoading` with `allFactions` still null would do.
+    loading: entitiesLoading || allFactions === null,
     faction,
     fetchError,
 

--- a/frontend/src/pages/factions/useFactionsDirectory.ts
+++ b/frontend/src/pages/factions/useFactionsDirectory.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import {
-  getFactions,
   getFactionStatus,
   getInvitations,
   type FactionOut,
@@ -8,9 +7,15 @@ import {
   type InvitationLetterOut,
 } from '../../api/factions'
 import { useAuth } from '../../auth/AuthContext'
+import { useFactions } from '../../hooks/useFactions'
 
 /**
- * The `/factions` directory fetch, shared by both form factors (#1116).
+ * The factions-directory read, shared by both form factors (#1116).
+ *
+ * `/factions` itself is no longer fetched here: it comes from the app-wide
+ * `useFactions` cache (#1284), so arriving from any other surface costs nothing.
+ * What this hook still owns is the viewer's membership status + invitations,
+ * which are per-character and not cacheable app-wide.
  *
  * The desktop grid and the phone directory used to own a private copy of this
  * effect, which made `/factions` the one page dispatcher whose data lived BELOW
@@ -35,21 +40,20 @@ export function useFactionsDirectory(): FactionsDirectoryState {
   const { user } = useAuth()
   const characterId = user?.character?.id ?? null
 
-  const [factions, setFactions] = useState<FactionOut[]>([])
+  // The directory list itself is app-wide cached (#1284) — this page no longer
+  // owns the request, it derives from the shared hook.
+  const factions = useFactions()
   const [factionPage, setFactionPage] = useState<FactionPageOut | null>(null)
   const [invitations, setInvitations] = useState<InvitationLetterOut[]>([])
-  const [loading, setLoading] = useState(true)
+  const [membershipLoading, setMembershipLoading] = useState(true)
   const [error, setError] = useState<unknown>(null)
 
   useEffect(() => {
     let cancelled = false
-    setLoading(true)
+    setMembershipLoading(true)
     setError(null)
 
     const load = async () => {
-      const factionsData = await getFactions()
-      if (cancelled) return
-      setFactions(factionsData)
       if (characterId == null) return
       // The invitations feed backs the letters PANEL only — never card state.
       const [statusData, invitesData] = await Promise.all([getFactionStatus(), getInvitations()])
@@ -63,7 +67,7 @@ export function useFactionsDirectory(): FactionsDirectoryState {
         if (!cancelled) setError(err)
       })
       .finally(() => {
-        if (!cancelled) setLoading(false)
+        if (!cancelled) setMembershipLoading(false)
       })
 
     return () => {
@@ -71,5 +75,14 @@ export function useFactionsDirectory(): FactionsDirectoryState {
     }
   }, [characterId])
 
-  return { factions, factionPage, invitations, loading, error }
+  return {
+    factions: factions ?? [],
+    factionPage,
+    invitations,
+    // Still one flag, and it still means "nothing to draw yet": the grid needs
+    // the faction list, so a settled membership read with `factions` still null
+    // is not loaded. Keeping the two apart would flash an empty grid.
+    loading: membershipLoading || factions === null,
+    error,
+  }
 }

--- a/frontend/src/pages/praxes/usePraxes.ts
+++ b/frontend/src/pages/praxes/usePraxes.ts
@@ -20,10 +20,11 @@
  * set, so a narrowed feed never looks like the whole register. See
  * `./taskFilterParam.ts`.
  */
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { listPraxes, type PraxisCardOut, type PraxisType } from '../../api/praxis'
-import { getFactions, type FactionOut } from '../../api/factions'
+import type { FactionOut } from '../../api/factions'
+import { useFactions } from '../../hooks/useFactions'
 import { usePagedResource } from '../../hooks/usePagedResource'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
 import { useSearchQueryParam } from '../../hooks/useSearchQueryParam'
@@ -83,7 +84,8 @@ export interface PraxesFeedState {
 }
 
 export function usePraxes(): PraxesFeedState {
-  const [factions, setFactions] = useState<FactionOut[]>([])
+  // App-wide cached, one request per page load across all five consumers (#1284).
+  const factions: FactionOut[] = useFactions() ?? []
   const [type, setTypeState] = useState<PraxisTypeFilter>('all')
   const [faction, setFactionState] = useState('')
   const [voted, setVotedState] = useState<VotedFilter>('')
@@ -95,10 +97,6 @@ export function usePraxes(): PraxesFeedState {
   const taskId = readTaskIdParam(searchParams)
 
   const debouncedQuery = useDebouncedValue(query, 200)
-
-  useEffect(() => {
-    getFactions().then(setFactions).catch(() => {})
-  }, [])
 
   const trimmedQuery = debouncedQuery.trim()
   const { data, loading, error, hasMore, loadMore, resetWindow } = usePagedResource(

--- a/frontend/src/pages/proposeTask/useProposeTask.ts
+++ b/frontend/src/pages/proposeTask/useProposeTask.ts
@@ -17,11 +17,12 @@
  * slug and metatasks are faction-open, so anyone may apply an `na` metatask
  * (#894).
  */
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { proposeTask, type TaskCreate } from "../../api/tasks";
 import { proposeMetatask, type MetataskProposal } from "../../api/metaTasks";
-import { getFactions, type FactionOut } from "../../api/factions";
+import type { FactionOut } from "../../api/factions";
+import { useFactions } from "../../hooks/useFactions";
 import { useAuth } from "../../auth/AuthContext";
 import { extractError } from "../../utils/errors";
 import i18n from "../../i18n";
@@ -127,7 +128,8 @@ export interface ProposeTaskState {
 export function useProposeTask(): ProposeTaskState {
   const { user } = useAuth();
   const navigate = useNavigate();
-  const [factions, setFactions] = useState<FactionOut[]>([]);
+  // App-wide cached, one request per page load across all five consumers (#1284).
+  const factions: FactionOut[] = useFactions() ?? [];
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [pointValue, setPointValue] = useState<string>("10");
@@ -141,12 +143,6 @@ export function useProposeTask(): ProposeTaskState {
   const [success, setSuccess] = useState(false);
   const [isMetaTask, setIsMetaTask] = useState(false);
   const [metaBonusValue, setMetaBonusValue] = useState("10");
-
-  useEffect(() => {
-    getFactions()
-      .then(setFactions)
-      .catch(() => {});
-  }, []);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -3,7 +3,8 @@
  * the legacy Tasks.tsx so the desktop list and the mobile browse skin consume
  * one source of truth (mirrors useTaskDetail for the detail page).
  *
- * The factions/factionConfigs fetch on mount, the status/faction/level filter
+ * The factions/factionConfigs reads (both app-wide cached hooks), the
+ * status/faction/level filter
  * state, the task read keyed on those filters + the viewer's character id, and
  * the signup → navigate-to-edit handler with its inline message. The free-text search (#661) rides
  * alongside them, debounced 200ms via `useDebouncedValue` — the idiom #644 set on
@@ -17,12 +18,13 @@
  * era's `level_thresholds` off the same `/game-config` payload the faction
  * modifiers ride on (#1046), never a hardcoded range. See `./levelFilters.ts`.
  */
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { listTasks, type TaskOut, type TaskType } from '../../api/tasks'
 import { createPraxis } from '../../api/praxis'
-import { getFactions, type FactionOut } from '../../api/factions'
+import type { FactionOut } from '../../api/factions'
 import type { FactionConfigOut } from '../../api/gameConfig'
+import { useFactions } from '../../hooks/useFactions'
 import { useGameConfig } from '../../hooks/useGameConfig'
 import { extractError } from '../../utils/errors'
 import { useAuth } from '../../auth/AuthContext'
@@ -107,11 +109,12 @@ export function useTasks(): TasksState {
   const { user } = useAuth()
   const navigate = useNavigate()
 
-  const [factions, setFactions] = useState<FactionOut[]>([])
-  // One `/game-config` read for the whole app (#1141) — the shared cache in
-  // `useGameConfig`, derived rather than mirrored into two more `useState`s.
+  // One `/factions` read for the whole app (#1284) and one `/game-config`
+  // (#1141) — both from shared module caches, derived rather than mirrored into
+  // local `useState`s.
   // Both slices are empty until it lands, which is what they were before: the
   // faction modifier settles at 1.0 and the level filter stays hidden (#1046).
+  const factions: FactionOut[] = useFactions() ?? []
   const gameConfig = useGameConfig()
   const factionConfigs: FactionConfigOut[] = gameConfig?.factions ?? []
   const levelThresholds = gameConfig?.level_thresholds ?? []
@@ -125,10 +128,6 @@ export function useTasks(): TasksState {
   // Debounced so a refetch fires once the typing settles, not per keystroke —
   // the same 200ms the praxis feed uses (#644).
   const debouncedQuery = useDebouncedValue(query, 200)
-
-  useEffect(() => {
-    getFactions().then(setFactions).catch(() => {})
-  }, [])
 
   const trimmedQuery = debouncedQuery.trim()
   const { data, loading, error, hasMore, loadMore, resetWindow } = usePagedResource(


### PR DESCRIPTION
Closes #1284

Builds the **owner decision** in the second comment (dedupe **and** invalidate), not the triage comment above it (dedupe, never invalidate).

## TTL: **5 minutes** (`CACHE_TTL_MS` in `frontend/src/hooks/cachedResource.ts`)

One number, one module, both caches. The justification is in the docblock, in short:

- **Long enough that ordinary browsing is free.** `/tasks` -> `/factions` -> a faction page -> `/praxes` happens in well under five minutes, so a normal browse session pays exactly one `/factions` and one `/game-config` request.
- **Short enough to notice.** An era transition or an admin faction-visibility flip surfaces on the first navigation after the window closes - no reload, and not a session-long lie.
- **Bounded worst case.** Someone who idles and navigates once every five minutes costs ~12 requests/hour/endpoint, against one per navigation today.

A hard reload always refetches: the cache is module scope, not storage.

## The seam I tested at

`isFresh(entry, now, ttl)` - the staleness predicate, pure and injectable - plus `createResourceCache(fetchFn)`, the React-free cache mechanics (`peek` / `load`). The hook wrapper `createCachedResource` is a `useState` + `useEffect` over those two. `frontend/src/hooks/__tests__/cachedResource.test.ts` proves the TTL against an injected `now` and a fake system clock; nothing waits on a real clock.

**The test went red on a real defect, not a strawman.** The first cut put the freshness gate in the *hook* and left `load()` unconditional, so any caller that forgot to ask refetched on every mount - the exact shape of the bug this issue is about. `expected "spy" to be called 1 times, but got 2 times`. The gate now lives inside `load()`, which is the only entry point.

## What changed

**New - one policy, one implementation**
- `frontend/src/hooks/cachedResource.ts` - module-level entry + shared in-flight promise, then stale-while-revalidate past the TTL. A single implementation rather than two hand-rolled caches, because two copies drift into two policies (and the second copy would trip `sonarjs/no-identical-functions` anyway).
- `frontend/src/hooks/useFactions.ts` - `createCachedResource(getFactions)`. Docblock records the bound *and* that `/factions` is **not** interchangeable with `useGameConfig()?.factions`: different sets (visible vs. all, 6 vs. 9), different fields (`status` vs. six scoring modifiers), neither derivable from the other. They stay separate.
- `frontend/src/hooks/useGameConfig.ts` - now the same `createCachedResource`, so it gains the TTL instead of donating its never-invalidates flaw. Same staleness bound, documented.

Behaviour notes baked into the shared cache: a value stays on screen through revalidation (a TTL expiry must not flash an empty page mid-session), and a failed revalidation keeps the last good value while dropping the in-flight promise so the next mount retries.

**The five call sites - all now derive, none mirror**
- `frontend/src/pages/tasks/useTasks.ts`, `frontend/src/pages/praxes/usePraxes.ts`, `frontend/src/pages/proposeTask/useProposeTask.ts` - `useState` + fetch effect deleted; `const factions = useFactions() ?? []`.
- `frontend/src/pages/factions/useFactionsDirectory.ts` - keeps only the per-character status/invitations fetch (not cacheable app-wide). `loading` is now `membershipLoading || factions === null`, so a settled membership read with the directory still unresolved does **not** flash an empty grid.
- `frontend/src/pages/factionDetail/useFactionDetail.ts` - `faction` is derived from the cached list, which *subsumes* the old `setFaction(null)` clear-before-refetch (a derived match cannot lag the slug). `loading` is `entitiesLoading || allFactions === null` so an unresolved directory cannot fall through to the not-found state.

`null`-until-settled holds everywhere: the hook returns `null` until the first response, and every call site keeps its previous empty-list/loading contract.

## Verification

- `tsc --noEmit` - clean (run after each file, and again after rebasing onto `origin/main` @ `d15f501a`).
- `vitest run` - **169 files / 2693 tests pass**, including the 8 new ones.
- `eslint src` - clean.
- `vite build` - ok. `npm run budget` - JS 132.0 KB (ok), CSS 20.7 KB WARN. **The CSS warning is pre-existing** - this PR touches no CSS; budget exits 0.

**I could not run the issue's click-through measurement.** I have no browser and no dev stack, so the "N navigations, M requests" counts in the issue body are not reproduced here. What I verified instead is the mechanism that produces them: `load()` called five times concurrently invokes `fetchFn` **once** (the five-consumers case), a later `load()` inside the window invokes it **zero** more times (the navigation case), and the first `load()` past the bound refetches and returns the new value (the era-transition case). Visual QA and a real request count are outstanding.

## What to eyeball

- **The TTL number itself** - 5 minutes is my call from the "a few minutes, not seconds" brief. It is one constant in one place if you want it different.
- **Stale-while-revalidate vs. blank-and-refetch.** Past the bound the hook keeps showing the last value while the refetch flies, rather than dropping to `null`. That avoids an empty-page flash every 5 minutes, but it means the first paint after expiry is briefly the old data. I judged the flash worse; say the word if not.
- **`/factions` page loading gate.** `loading` now ORs in `factions === null`. Worth a look that the directory and the faction-detail not-found state still behave on a cold load and on a bad slug.
- **Faction detail's dropped `setFaction(null)`.** Navigating slug -> slug should no longer show the previous faction at all. Please click one faction then another.
- **Propose-task's faction picker** on a cold load - it now starts from `[]` via the hook rather than its own `useState`, and `DefaultProposeTask` falls back to the JS registry when the list is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
