### PR TITLE
The opponent's hue was unguarded at the praxis-detail call site — no defect found, but now it fails loudly (#1308)

### DIFF
--- a/frontend/src/components/duel/wowLists.tsx
+++ b/frontend/src/components/duel/wowLists.tsx
@@ -1,11 +1,13 @@
 /**
- * WOW — THE LISTS (#895). The vocabulary the four duel surfaces share.
+ * WOW — THE LISTS (#895). The vocabulary the duel surfaces share.
  *
  * WOW's duel conceit is a tourney joust: a gold-framed enclosure (the *lists*),
  * a checkered barrier rail, a rosette for the rider who comes from elsewhere,
  * and a ribbon that goes home with the loser. This module holds the pieces that
- * would otherwise be drawn four times — the token names, the barrier band, the
- * rosette, and the seal's voice resolver.
+ * would otherwise be drawn twice — the token names, the barrier band, the
+ * rosette, and the seal's voice resolver. It shipped serving FOUR surfaces; the
+ * two `*DuelRail` skins went with the rail in #1090, so the consumers are now
+ * `WowDuelSealConfirm` and `WowMobileDuelSealConfirm`.
  *
  * WHY THE ROSETTE IS THE ONLY PLACE THE OPPONENT'S COLOUR LANDS
  * -------------------------------------------------------------
@@ -14,8 +16,10 @@
  * cream-and-gold chrome most of those are illegible as a text ground and several
  * are illegible as an ink. The kit's answer, and the load-bearing decision of
  * its rail: hold the foreign colour as a RING and a BAR — never behind or as
- * text. `Rosette` is that ring, drawn once. Nothing in these four files paints
- * text in `accent` or on `accent`.
+ * text. `Rosette` is that ring, drawn once. Nothing in these two seal frames
+ * paints text in `accent` or on `accent`, and `__tests__/wowSealAccent.test.tsx`
+ * holds them to it (#1115). The same rule at the praxis-detail call site is
+ * `pages/praxisDetail/__tests__/duelCardOpponentInk.test.tsx` (#1308).
  *
  * MOTION lives in index.css behind `prefers-reduced-motion: no-preference`
  * (`.wow-duel-twinkle`, `.wow-duel-ribbon-sway`), never inline. Both marks reuse

--- a/frontend/src/pages/praxisDetail/DuelCard.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCard.tsx
@@ -98,10 +98,17 @@ const AVATAR_SIZE = 30
  * hostile hue sit inside cream-and-gold chrome with no contrast fix. `name`,
  * `total` and `muted` are all `color:`, and `plate` sits directly behind a
  * duellist's disc; none of them is a legal home for `accent`/`soft` off a duel
- * payload, or for `factionCssVar(rival.faction_slug, …)`. The structural guard
- * that used to assert this died with the duel rail (#1090/#1115), so this
- * comment is the whole of it — a call site that passes a foreign hue here will
- * fail nothing.
+ * payload, or for `factionCssVar(rival.faction_slug, …)`.
+ *
+ * The structural guard that used to assert this died with the duel rail (#1090);
+ * #1115 restored it on the seal skins and #1308 restored it HERE, where it
+ * belongs — `__tests__/duelCardOpponentInk.test.tsx` walks the whole
+ * `surfaceMap('praxisDetail')` registry with a foreign rival and fails any
+ * archetype that lands one of the opponent's tokens in a `color:` or a
+ * `background:`. `line` is the exception the rule already grants: a hairline or a
+ * disc outline IS the "plate edge", so an edge in the rival's hue is legal and
+ * the guard only reads inks and grounds. Nothing else about this comment is
+ * advisory any more.
  */
 export interface DuelCardInk {
   /** The duellist's name. Default `--faction-default-card-text`. */

--- a/frontend/src/pages/praxisDetail/__tests__/duelCardOpponentInk.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelCardOpponentInk.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * PRAXIS DETAIL: THE OPPONENT'S COLOUR IS NEVER AN INK AND NEVER A GROUND (#1308).
+ *
+ * The other half of #1115. That issue recovered the retired duel rail's guard
+ * (#895, killed with the rail in #1090) and re-aimed it at the seal skins
+ * (`components/duel/wowLists.tsx` + the two `Wow*DuelSealConfirm` frames). It
+ * could not reach the second surface the rail's death left unguarded, and
+ * `DuelCardInk`'s docstring said so in as many words: "the structural guard that
+ * used to assert this died with the duel rail … so this comment is the whole of
+ * it". This file is the rest of it.
+ *
+ * THE RULE (WORLD_ZERO_STYLE §"On the lists"). The opponent's faction colour
+ * arrives as `accent`/`soft` (#310) and can be ANY hue in the palette —
+ * S.N.I.D.E.'s acid green, Singularity's petrol blue, Everymen's red. It is
+ * therefore held as a **rosette ring, a plate edge and a bar — never as an ink
+ * and never behind text**, which is what lets a hostile hue sit inside another
+ * faction's chrome with no contrast fix anywhere.
+ *
+ * WHY THIS FILE AND NOT #1115's. On the seal the component derives the foreign
+ * tokens itself and hands them to one consumer, so rendering the component is
+ * the whole test. Here the violation is one level UP: `DuelCard` takes its paint
+ * from a `DuelCardInk` the ARCHETYPE fills in, and every archetype fills it in
+ * separately. So this walks the real `surfaceMap('praxisDetail')` registry with a
+ * foreign rival in the duel, exactly as `archetypeSlots.test.tsx` walks it for
+ * content slots — a faction that registers tomorrow is guarded with no edit here.
+ *
+ * WHY NO OTHER GATE SEES IT. `factionContrast.test.ts` measures token VALUES.
+ * This is a PAIRING — which token got painted behind, or as, which string — and
+ * no contrast row can express it. An archetype that tinted the rival's name with
+ * the rival's own hue would pass every other gate in the repo.
+ *
+ * WHERE THIS DEVIATES FROM #1115. The seal's ground scan exempts `aria-hidden`
+ * ornament, because the rosette's field genuinely IS drawn in `soft` and holds no
+ * text. This card draws no ornament in the foreign hue at all, so there is
+ * nothing to exempt — and the one slot that would have slipped through such an
+ * exemption is `plate`, the fill behind a duellist's disc, which `DuelCardInk`
+ * names as illegal and which renders on an `aria-hidden` span. Keeping the
+ * carve-out would have licensed the single most likely way this rule breaks
+ * here, so the scan covers every tag.
+ *
+ * Rendered with `renderToStaticMarkup` — no DOM in this harness (SPEC-testing.md)
+ * — so the assertions read the serialized inline styles the archetype emitted.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import { surfaceMap } from '../../../factions'
+import { factionCssVar } from '../../../utils/factions'
+import DefaultPraxisDetail from '../archetypes/DefaultPraxisDetail'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import type { PraxisOut } from '../../../api/praxis'
+import type { DuelDetailOut, DuelSideOut } from '../../../api/duel'
+
+/**
+ * Three genuinely different opponents — the same three the retired rail guard
+ * and #1115 used: S.N.I.D.E.'s acid green, Singularity's petrol blue, Everymen's
+ * red. The point of the rule is that the hue is arbitrary, so one opponent would
+ * prove nothing.
+ */
+const OPPONENTS = ['snide', 'singularity', 'everymen'] as const
+
+const PRAXIS: PraxisOut = {
+  id: 1,
+  task_id: 7,
+  task_title: 'A Chore Nobody Logged',
+  task_point_value: 12,
+  task_level_required: 2,
+  task_faction_slug: null,
+  type: 'duel',
+  status: 'submitted',
+  title: 'The Long Way Round',
+  body_text: 'Walked the whole ridge before dark.',
+  moderation_status: 'visible',
+  admin_note: null,
+  flagged_at: null,
+  submitted_at: '2026-01-03T00:00:00Z',
+  submit_proposed_at: null,
+  created_by_id: 3,
+  created_by_display_name: 'Ada',
+  created_by_faction_slug: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-03T00:00:00Z',
+  members: [],
+  invites: [],
+  media_items: [],
+  score: 30,
+  metatask_points: 0,
+  display_multiplier: 1.0,
+  points_from_votes: 18,
+  is_top_for_task: false,
+  duel_id: 5,
+  can_flag: true,
+  applied_metatasks: [],
+}
+
+/**
+ * A live (`settled`) duel — the reading that prints both names, both totals and
+ * the cross-link, so the card carries its full complement of strings.
+ *
+ * This side wears the HOST archetype's own slug, so the only foreign hue in the
+ * whole fixture is the rival's and any hit is unambiguous. Neither side has an
+ * avatar, which is the state that draws `plate`.
+ */
+function duelAgainst(hostSlug: string, rivalSlug: string): DuelDetailOut {
+  const side = (overrides: Partial<DuelSideOut>): DuelSideOut => ({
+    praxis_id: 1,
+    character_id: 3,
+    display_name: 'Ada',
+    faction_slug: hostSlug,
+    avatar_url: '',
+    points_from_votes: 18,
+    is_submitted: true,
+    ...overrides,
+  })
+  return {
+    id: 5,
+    task_id: 7,
+    status: 'settled',
+    forfeited_by_character_id: null,
+    challenger: side({}),
+    opponent: side({
+      praxis_id: 2,
+      character_id: 4,
+      display_name: 'Rax',
+      faction_slug: rivalSlug,
+      points_from_votes: 15.4,
+    }),
+    viewer_is_participant: false,
+    winner_character_id: null,
+    challenger_final_points: null,
+    opponent_final_points: null,
+  } as unknown as DuelDetailOut
+}
+
+function state(duel: DuelDetailOut): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: PRAXIS,
+    fetchError: null,
+    votes: { praxis_id: 1, total_votes: 2, total_score: 18 },
+    voters: [],
+    duel,
+    isOwner: false,
+    showAdminBar: false,
+    user: null,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: '',
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: '',
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleFlag: async () => {},
+    handleKickMember: async () => {},
+  }
+}
+
+// The Default fallback is a registered renderable too — guard it beside the map,
+// the shape `archetypeSlots.test.tsx` established.
+const ARCHETYPES = { ...surfaceMap('praxisDetail'), __default__: DefaultPraxisDetail }
+
+/**
+ * Every token that carries the opponent's identity: the hue itself, the card
+ * `accent` and the `soft` tint (#310). `var(--faction-snide)` is not a substring
+ * of `var(--faction-snide-card-accent)` — the closing paren keeps the three
+ * apart — so each is matched exactly.
+ */
+function foreignTokens(slug: string): string[] {
+  return [factionCssVar(slug), factionCssVar(slug, 'card-accent'), factionCssVar(slug, 'light')]
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+describe('praxis detail: the opponent colour is never an ink and never a ground', () => {
+  const cases = Object.entries(ARCHETYPES).flatMap(([slug, Archetype]) =>
+    OPPONENTS
+      // A rival of the HOST's own faction is not a foreign hue — the page is
+      // already painted in it, so the tokens would collide by design rather than
+      // by mistake. The rule is about a colour from elsewhere.
+      .filter((opponent) => opponent !== slug)
+      .map((opponent) => [slug, opponent, Archetype] as const),
+  )
+
+  it.each(cases)('%s detail, %s rival', (_slug, opponent, Archetype) => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Archetype state={state(duelAgainst(_slug, opponent))} />
+      </MemoryRouter>,
+    )
+    const text = html.replace(/<[^>]*>/g, '')
+    const foreign = `(?:${foreignTokens(opponent).map(escapeRegExp).join('|')})`
+
+    // COUNTERWEIGHT, and the reason "the token appears nowhere" is not a test
+    // that passes on an empty string: the card is genuinely on the page, with
+    // the rival named and both totals printed.
+    expect(text, `the ${_slug} page drew no duel card at all`).toContain('Rax')
+    expect(text, "this side's total").toContain('18.0')
+    expect(text, "the rival's total").toContain('15.4')
+
+    // `color:` may never name the opponent's hue — not on a name, not on a
+    // total, not on the verdict line. Anchored so `border-color:` /
+    // `background-color:` can't satisfy the match by accident.
+    const asInk = new RegExp(`(?:^|[;"{])color:\\s*${foreign}`)
+    expect(
+      asInk.test(html),
+      `the ${opponent} hue is painted as an ink on the ${_slug} praxis detail`,
+    ).toBe(false)
+
+    // ...and it may never be a GROUND either, on any tag. See the header for why
+    // this scan carries no `aria-hidden` carve-out where the seal's does.
+    const asGround = new RegExp(`(?:^|[;"{])background(?:-color|-image)?:[^;"]*${foreign}`)
+    const grounds = (html.match(/<[a-z]+[^>]*>/g) ?? []).filter((tag) => asGround.test(tag))
+    expect(
+      grounds,
+      `the ${opponent} hue is a ground on the ${_slug} praxis detail`,
+    ).toEqual([])
+  })
+})


### PR DESCRIPTION
Closes #1308

**No live defect.** Every one of the nine praxis-detail archetypes already obeys the rule — none of them reads the rival's slug at all, and the guard passed green on first run (24/24). This restores the structural guard around correct code, exactly as #1115 did for the seal.

## The seam

`WORLD_ZERO_STYLE.md` §"On the lists": the opponent's faction colour **can be any hue in the palette**, so it is held as a *rosette ring, a plate edge and a bar — never as an ink and never behind text*.

#1115 could only reach the seal skins, where the component derives `accent`/`soft` itself. Here the seam is **one level up**: `DuelCard` takes its paint from a `DuelCardInk` that each *archetype* fills in, so the violation would live in the call site, not the component. `DuelCardInk`'s own docstring admitted it — "so this comment is the whole of it".

New guard: `frontend/src/pages/praxisDetail/__tests__/duelCardOpponentInk.test.tsx`. It walks the real `surfaceMap('praxisDetail')` registry (plus the `Default` fallback) with a foreign rival in a `settled` duel — the same registry walk `archetypeSlots.test.tsx` uses, so a faction that registers tomorrow is guarded with no edit here.

- **24 cases** — 9 archetypes × 3 opponents (`snide` / `singularity` / `everymen`, #1115's three), minus the 3 host-slug collisions. A rival of the host's own faction is not a foreign hue, so those are filtered out deliberately.
- Tokens checked: `var(--faction-<rival>)`, `-card-accent` and `-light`.
- Reused from #1115: the anchored `(?:^|[;"{])color:\s*<token>` ink regex, `escapeRegExp`, and the opening-tag ground scan.
- **Counterweight** (#1115 used the `2px solid accent` ring; this card never draws the accent at all, so it needed a different one): every case asserts the card is genuinely on the page — the rival is named and both totals print. Without it, "the token appears nowhere" is a test that passes on an empty string.

## Sabotage — blast radius

Three deliberate violations, each reverted; working tree is clean and the suite is green.

| # | Sabotage | Where | Failed |
|---|---|---|---|
| 1 | opponent `card-accent` as an **ink** on the duellist's name | `DuelCard` (shared) | **24 of 24** |
| 2 | opponent `light` as a **ground behind text** on the duel row | `DuelCard` (shared) | **24 of 24** |
| 3 | opponent `light` as `ink.plate` — the disc fill | **call site** (`DefaultPraxisDetail`) | **6 of 24** |

Sabotage 3 is the one that matters most. 6 = `__default__` + `albescent` (which forwards to Default whole) × 3 opponents — i.e. the guard sees a violation introduced *one level up*, in an archetype, which is the whole reason this issue existed separately from #1115.

## One deliberate deviation from #1115

#1115's ground scan exempts `aria-hidden` ornament, because the seal's rosette field genuinely *is* drawn in `soft` and holds no text. **This scan carries no such carve-out**, and sabotage 3 is the evidence: the offending tag it caught was

```
<span aria-hidden="true" style="…;background:var(--faction-snide-light);…">
```

`plate` is the card's only non-`color:` slot, `DuelCardInk` names it illegal, and it renders on an `aria-hidden` span — so keeping the carve-out would have licensed the single most likely way this rule breaks here. Nothing on this card draws the foreign hue as ornament, so there is nothing legitimate to exempt. `line` (a hairline / disc outline) stays legal: that *is* the "plate edge" the rule grants, and the guard reads only inks and grounds.

## Also

`components/duel/wowLists.tsx` claimed "Nothing in these **four** files paints text in `accent`". The two `*DuelRail` skins went with the rail in #1090, so it has been two seal frames (`WowDuelSealConfirm`, `WowMobileDuelSealConfirm`) — fixed here, along with the header's matching "four surfaces" / "drawn four times". Both that comment and `DuelCard`'s now name the test file that asserts them.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` **169 files / 2709 tests green** · `vite build` OK · `npm run budget`: JS ok, CSS at a pre-existing WARN (20.7 KB vs 19.5 KB) — **no CSS is touched by this PR**.

Rebased on latest `origin/main` (d15f501a). No collision with PR #1329, which leaves `DuelCard.tsx` untouched.

**Visual QA is outstanding** — I have no browser or dev stack here. The diff is one new test file plus two comment blocks, so there is no rendered change to eyeball, but see below.

## What to eyeball

- Nothing should look different. The only non-test change is prose in two docstrings.
- If you want to confirm the guard is pointed at a live surface: open any praxis that is one side of a settled duel, on a faction-skinned detail page (Coven / S.N.I.D.E. / UA / Ephemerists / WOW / Singularity / Everymen / Albescent). The rival's row should carry **that page's** faction inks, never the rival faction's colour — the rival reads as foreign only through the *absence* of the spectrum ring, which is the side you are on.
- The rival's disc outline and the two hairlines are the "plate edge" the rule allows; check they still read as the host faction's hairline, not the rival's hue.
