### PR TITLE
Let the feed's drop-to-accept modal out of the card it was trapped in (#1273)

### DIFF
--- a/frontend/src/components/feed/FeedBankFullModal.tsx
+++ b/frontend/src/components/feed/FeedBankFullModal.tsx
@@ -1,0 +1,206 @@
+/**
+ * The feed's drop-to-accept modal (#322 collab / #314 duel), lifted out of the
+ * card and onto `document.body` (#1273).
+ *
+ * WHY IT IS A PORTAL. Both cards used to render this overlay as their own
+ * child, with `position: fixed; inset: 0`. That is written to cover the
+ * viewport and it never did. The feed chassis is `.sidebar-card`, which sets
+ * `backdrop-filter: blur(var(--card-blur))`, and a `backdrop-filter` other than
+ * `none` establishes a containing block for `position: fixed` descendants
+ * exactly as `transform` and `filter` do. So `inset: 0` resolved to the ~120px
+ * card. Seven of the nine faction frames then clip their ornament with
+ * `overflow: hidden` (epic #1192's bespoke chassis dress), which turned a
+ * mispositioned overlay into a clipped, substantially unusable one — the state
+ * #1148 found and deliberately refused to make worse.
+ *
+ * `createPortal` to `document.body` escapes both at once: the containing block,
+ * because the overlay is no longer a descendant of the card, and every
+ * ancestor's `overflow`, for the same reason. This is the shape `ConfirmDialog`
+ * (#1082) already uses, including the guard below.
+ *
+ * WHY IT IS ONE COMPONENT. The collab and duel cards drew the same modal twice,
+ * character for character, and the portal + Escape + focus wiring the move to
+ * `document.body` requires would have been a third and fourth copy. Everything
+ * that actually differs between the two — the wording, and what "drop this one"
+ * does to a praxis (delete if you authored it, leave if you joined) — arrives as
+ * props, so this component carries no policy and no i18n keys of its own. That
+ * also keeps each card's literal `feed:*.bankFull.*` keys in the card file,
+ * where the catalog sweep can still see them.
+ *
+ * ACCESSIBILITY IS NOT OPTIONAL HERE. Appended at the end of `<body>`, an
+ * unlabelled div is a nameless blob a long Tab away from the button that opened
+ * it — a portal that keeps its labelling and its focus is the difference between
+ * fixing a visual bug and trading it for an access one. So it is a named
+ * `role="dialog"`, focus moves into the panel on open, and Escape dismisses.
+ * None of those three can run in this repo's `renderToStaticMarkup` harness
+ * (no DOM, no effects), so only the static contract is asserted in tests and the
+ * behaviour is hand-verified — the same split `ConfirmDialog` documents.
+ */
+import { useEffect, useId, useRef } from 'react'
+import { createPortal } from 'react-dom'
+
+/** One in-progress praxis the viewer may drop to free a bank slot. */
+export interface BankFullDropOption {
+  /** The praxis id — the React key, never rendered. */
+  id: number
+  /** The fully worded button, built by the caller from its own catalog keys. */
+  label: string
+  /** Drop this praxis and retry the accept. Delete vs. leave is the caller's. */
+  onSelect: () => void
+}
+
+export default function FeedBankFullModal({
+  title,
+  body,
+  cancelLabel,
+  options,
+  busy,
+  error,
+  onDismiss,
+}: {
+  title: string
+  body: string
+  cancelLabel: string
+  options: BankFullDropOption[]
+  /** A drop is in flight — every choice is inert until it settles. */
+  busy: boolean
+  /** A failed drop/retry, already worded. Empty when there is nothing to say. */
+  error: string
+  onDismiss: () => void
+}) {
+  const titleId = useId()
+  const bodyId = useId()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Focus lands on the panel, not on a drop button: every drop destroys or
+  // leaves a praxis, so nothing in here is a safe default to pre-select. The
+  // panel's name and description are read out instead.
+  useEffect(() => {
+    panelRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onDismiss()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [onDismiss])
+
+  const modal = (
+    <div
+      role="presentation"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 1000,
+        background: 'var(--color-overlay-strong)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 'var(--space-xl)',
+      }}
+      onClick={onDismiss}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={bodyId}
+        tabIndex={-1}
+        style={{
+          background: 'var(--color-bg-surface)',
+          border: '1px solid var(--color-border)',
+          padding: 'var(--space-xl)',
+          maxWidth: 420,
+          width: '100%',
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <p
+          id={titleId}
+          className="eyebrow"
+          style={{ marginBottom: 'var(--space-sm)' }}
+        >
+          {title}
+        </p>
+        <p
+          id={bodyId}
+          className="font-body"
+          style={{
+            fontSize: 'var(--text-content)',
+            marginBottom: 'var(--space-lg)',
+            color: 'var(--color-text-secondary)',
+          }}
+        >
+          {body}
+        </p>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-sm)',
+            maxHeight: 260,
+            overflowY: 'auto',
+          }}
+        >
+          {options.map((option) => (
+            <button
+              key={option.id}
+              onClick={option.onSelect}
+              disabled={busy}
+              style={{
+                background: 'var(--color-bg-surface-alt)',
+                border: '1px solid var(--color-border)',
+                padding: 'var(--space-sm) var(--space-md)',
+                cursor: busy ? 'not-allowed' : 'pointer',
+                textAlign: 'left',
+                fontFamily: "'Courier Prime', monospace",
+                fontSize: 'var(--text-content)',
+                color: 'var(--color-text-primary)',
+              }}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+        {error && (
+          <p
+            className="eyebrow"
+            style={{
+              color: 'var(--color-danger)',
+              marginTop: 'var(--space-md)',
+            }}
+          >
+            {error}
+          </p>
+        )}
+        <button
+          onClick={onDismiss}
+          style={{
+            marginTop: 'var(--space-lg)',
+            fontFamily: "'Courier Prime', monospace",
+            fontSize: 'var(--text-sm)',
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            background: 'transparent',
+            border: '1px solid var(--color-border)',
+            padding: 'var(--space-xs) var(--space-lg)',
+            cursor: 'pointer',
+            color: 'var(--color-text-secondary)',
+          }}
+        >
+          {cancelLabel}
+        </button>
+      </div>
+    </div>
+  )
+
+  // The guard is for this repo's test harness: `renderToStaticMarkup` runs with
+  // no document and cannot render a portal, so there the tree stays inline and
+  // the markup is still assertable. In the browser this branch is never taken.
+  return typeof document === 'undefined'
+    ? modal
+    : createPortal(modal, document.body)
+}

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -15,6 +15,7 @@ import {
 import { extractError } from "../../utils/errors";
 import { factionFill } from "../../utils/factions";
 import FeedBadge from "./FeedBadge";
+import FeedBankFullModal from "./FeedBankFullModal";
 
 interface Props {
   item: ActivityFeedItem;
@@ -295,104 +296,25 @@ export default function FeedCardCollabInvite({ item }: Props) {
         )}
       </div>
 
-      {/* Task-bank-full drop-to-accept modal (#322) */}
+      {/* Task-bank-full drop-to-accept modal (#322). Mounted on document.body
+          by the shared modal — inside this card it was clipped to the card
+          (#1273). */}
       {showDropModal && (
-        <div
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 1000,
-            background: "rgba(0,0,0,0.5)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: "var(--space-xl)",
-          }}
-          onClick={() => setShowDropModal(false)}
-        >
-          <div
-            style={{
-              background: "var(--color-bg-surface)",
-              border: "1px solid var(--color-border)",
-              padding: "var(--space-xl)",
-              maxWidth: 420,
-              width: "100%",
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <p className="eyebrow" style={{ marginBottom: "var(--space-sm)" }}>
-              {i18n.t("feed:collabInvite.bankFull.title")}
-            </p>
-            <p
-              className="font-body"
-              style={{
-                fontSize: "var(--text-content)",
-                marginBottom: "var(--space-lg)",
-                color: "var(--color-text-secondary)",
-              }}
-            >
-              {i18n.t("feed:collabInvite.bankFull.body", { max: maxTaskSlots })}
-            </p>
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: "var(--space-sm)",
-                maxHeight: 260,
-                overflowY: "auto",
-              }}
-            >
-              {activeTasks.map((praxis) => (
-                <button
-                  key={praxis.id}
-                  onClick={() =>
-                    handleDrop(praxis.id, praxis.created_by_id)
-                  }
-                  disabled={dropping}
-                  style={{
-                    background: "var(--color-bg-surface-alt)",
-                    border: "1px solid var(--color-border)",
-                    padding: "var(--space-sm) var(--space-md)",
-                    cursor: dropping ? "not-allowed" : "pointer",
-                    textAlign: "left",
-                    fontFamily: "'Courier Prime', monospace",
-                    fontSize: "var(--text-content)",
-                    color: "var(--color-text-primary)",
-                  }}
-                >
-                  {i18n.t("feed:collabInvite.bankFull.dropOption", {
-                    title: praxis.title || praxis.task_title,
-                  })}
-                </button>
-              ))}
-            </div>
-            {dropError && (
-              <p
-                className="eyebrow"
-                style={{ color: "var(--color-danger)", marginTop: "var(--space-md)" }}
-              >
-                {dropError}
-              </p>
-            )}
-            <button
-              onClick={() => setShowDropModal(false)}
-              style={{
-                marginTop: "var(--space-lg)",
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-sm)",
-                fontWeight: 700,
-                textTransform: "uppercase",
-                background: "transparent",
-                border: "1px solid var(--color-border)",
-                padding: "var(--space-xs) var(--space-lg)",
-                cursor: "pointer",
-                color: "var(--color-text-secondary)",
-              }}
-            >
-              {i18n.t("feed:collabInvite.bankFull.cancel")}
-            </button>
-          </div>
-        </div>
+        <FeedBankFullModal
+          title={i18n.t("feed:collabInvite.bankFull.title")}
+          body={i18n.t("feed:collabInvite.bankFull.body", { max: maxTaskSlots })}
+          cancelLabel={i18n.t("feed:collabInvite.bankFull.cancel")}
+          options={activeTasks.map((praxis) => ({
+            id: praxis.id,
+            label: i18n.t("feed:collabInvite.bankFull.dropOption", {
+              title: praxis.title || praxis.task_title,
+            }),
+            onSelect: () => handleDrop(praxis.id, praxis.created_by_id),
+          }))}
+          busy={dropping}
+          error={dropError}
+          onDismiss={() => setShowDropModal(false)}
+        />
       )}
     </>
   );

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -12,6 +12,7 @@ import { cancelChallenge, respondToChallenge } from "../../api/duel";
 import { factionFill } from "../../utils/factions";
 import { extractError } from "../../utils/errors";
 import FeedBadge from "./FeedBadge";
+import FeedBankFullModal from "./FeedBankFullModal";
 
 interface Props {
   item: ActivityFeedItem;
@@ -366,102 +367,26 @@ export default function FeedCardDuelChallenge({ item }: Props) {
         )}
       </div>
 
-      {/* Task-list-full modal */}
+      {/* Task-list-full modal (#314). Mounted on document.body by the shared
+          modal — inside this card it was clipped to the card (#1273). */}
       {showDropModal && (
-        <div
-          style={{
-            position: "fixed",
-            inset: 0,
-            zIndex: 1000,
-            background: "rgba(0,0,0,0.5)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            padding: "var(--space-xl)",
-          }}
-          onClick={() => setShowDropModal(false)}
-        >
-          <div
-            style={{
-              background: "var(--color-bg-surface)",
-              border: "1px solid var(--color-border)",
-              padding: "var(--space-xl)",
-              maxWidth: 420,
-              width: "100%",
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            <p className="eyebrow" style={{ marginBottom: "var(--space-sm)" }}>
-              {i18n.t("feed:duelChallenge.bankFull.title")}
-            </p>
-            <p
-              className="font-body"
-              style={{
-                fontSize: "var(--text-content)",
-                marginBottom: "var(--space-lg)",
-                color: "var(--color-text-secondary)",
-              }}
-            >
-              {i18n.t("feed:duelChallenge.bankFull.body", { max: maxTaskSlots })}
-            </p>
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: "var(--space-sm)",
-                maxHeight: 260,
-                overflowY: "auto",
-              }}
-            >
-              {activeTasks.map((praxis) => (
-                <button
-                  key={praxis.id}
-                  onClick={() => dropAndRetry(praxis)}
-                  disabled={busy}
-                  style={{
-                    background: "var(--color-bg-surface-alt)",
-                    border: "1px solid var(--color-border)",
-                    padding: "var(--space-sm) var(--space-md)",
-                    cursor: busy ? "not-allowed" : "pointer",
-                    textAlign: "left",
-                    fontFamily: "'Courier Prime', monospace",
-                    fontSize: "var(--text-content)",
-                    color: "var(--color-text-primary)",
-                  }}
-                >
-                  {i18n.t("feed:duelChallenge.bankFull.dropOption", {
-                    title: praxis.title || praxis.task_title,
-                  })}
-                </button>
-              ))}
-            </div>
-            {dropError && (
-              <p
-                className="eyebrow"
-                style={{ color: "var(--color-danger)", marginTop: "var(--space-md)" }}
-              >
-                {dropError}
-              </p>
-            )}
-            <button
-              onClick={() => setShowDropModal(false)}
-              style={{
-                marginTop: "var(--space-lg)",
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-sm)",
-                fontWeight: 700,
-                textTransform: "uppercase",
-                background: "transparent",
-                border: "1px solid var(--color-border)",
-                padding: "var(--space-xs) var(--space-lg)",
-                cursor: "pointer",
-                color: "var(--color-text-secondary)",
-              }}
-            >
-              {i18n.t("feed:duelChallenge.bankFull.cancel")}
-            </button>
-          </div>
-        </div>
+        <FeedBankFullModal
+          title={i18n.t("feed:duelChallenge.bankFull.title")}
+          body={i18n.t("feed:duelChallenge.bankFull.body", {
+            max: maxTaskSlots,
+          })}
+          cancelLabel={i18n.t("feed:duelChallenge.bankFull.cancel")}
+          options={activeTasks.map((praxis) => ({
+            id: praxis.id,
+            label: i18n.t("feed:duelChallenge.bankFull.dropOption", {
+              title: praxis.title || praxis.task_title,
+            }),
+            onSelect: () => dropAndRetry(praxis),
+          }))}
+          busy={busy}
+          error={dropError}
+          onDismiss={() => setShowDropModal(false)}
+        />
       )}
     </>
   );

--- a/frontend/src/components/feed/__tests__/feedBankFullModal.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedBankFullModal.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * #1273 — the drop-to-accept modal escapes the feed card.
+ *
+ * THE BUG. `FeedCardCollabInvite` and `FeedCardDuelChallenge` each rendered a
+ * `position: fixed; inset: 0` overlay as their own child. That is written to
+ * cover the viewport and it never did: the feed chassis is `.sidebar-card`,
+ * which sets `backdrop-filter`, and a `backdrop-filter` other than `none`
+ * establishes a containing block for `position: fixed` descendants exactly as
+ * `transform` does. So `inset: 0` resolved to the ~120px card. Seven of the
+ * nine faction frames additionally clip their ornament with `overflow: hidden`,
+ * which turned "mispositioned" into "unusable".
+ *
+ * THE SEAM UNDER TEST. The overlay is no longer part of either card's own
+ * markup — it is one component, `FeedBankFullModal`, mounted through
+ * `createPortal(…, document.body)`, which escapes both the containing block and
+ * every ancestor's `overflow`.
+ *
+ * WHAT THIS HARNESS CAN AND CANNOT PROVE. `renderToStaticMarkup` in the `node`
+ * environment has no DOM, no layout and no effects. So:
+ *   - it CANNOT prove the overlay now covers the viewport, that it is unclipped
+ *     on the seven bespoke frames, or that Escape / focus-on-open work. Those
+ *     are visual and behavioural and are hand-verified;
+ *   - it CAN prove the structural facts the fix consists of, and those are what
+ *     is asserted here: neither card file still owns a `position: "fixed"`
+ *     block, both route through the shared modal, and that modal reaches
+ *     `document.body`;
+ *   - it CAN prove the dialog contract that the move to `document.body` makes
+ *     load-bearing. Appended at the end of `body`, an unlabelled div is a blob
+ *     with no name and no role, so the accessible name/description wiring is
+ *     asserted statically the way `ConfirmDialog`'s is.
+ */
+import { readFileSync } from 'node:fs'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import FeedBankFullModal from '../FeedBankFullModal'
+
+const source = (file: string) =>
+  readFileSync(new URL(`../${file}`, import.meta.url), 'utf8')
+
+describe('the drop-to-accept overlay is not part of the card', () => {
+  // The two victims, and the exact string that was the bug.
+  it.each(['FeedCardCollabInvite.tsx', 'FeedCardDuelChallenge.tsx'])(
+    '%s renders no fixed overlay of its own',
+    (file) => {
+      const text = source(file)
+      expect(text).not.toContain('position: "fixed"')
+      expect(text).toContain('<FeedBankFullModal')
+    },
+  )
+
+  it('the shared modal mounts on document.body', () => {
+    const text = source('FeedBankFullModal.tsx')
+    expect(text).toContain('createPortal')
+    expect(text).toContain('document.body')
+  })
+})
+
+describe('FeedBankFullModal dialog contract', () => {
+  const markup = (overrides?: { error?: string }) =>
+    renderToStaticMarkup(
+      <FeedBankFullModal
+        title="Task bank full"
+        body="You have 20 in-progress tasks. Drop one to accept this collaboration:"
+        cancelLabel="Cancel"
+        options={[
+          { id: 7, label: 'Drop: Sweep the stoop', onSelect: () => {} },
+          { id: 9, label: 'Drop: Mend the fence', onSelect: () => {} },
+        ]}
+        busy={false}
+        error={overrides?.error ?? ''}
+        onDismiss={() => {}}
+      />,
+    )
+
+  it('is a named modal dialog', () => {
+    const html = markup()
+    expect(html).toContain('role="dialog"')
+    expect(html).toContain('aria-modal="true"')
+    // The accessible name must point at a heading that actually renders.
+    const labelledBy = /aria-labelledby="([^"]+)"/.exec(html)?.[1]
+    expect(labelledBy, 'the dialog names itself').toBeTruthy()
+    expect(html).toContain(`id="${labelledBy}"`)
+    expect(html).toContain('Task bank full')
+  })
+
+  it('offers one drop per in-progress praxis, plus a way out', () => {
+    const html = markup()
+    expect(html).toContain('Drop: Sweep the stoop')
+    expect(html).toContain('Drop: Mend the fence')
+    expect(html).toContain('Cancel')
+  })
+
+  it('surfaces a failed drop', () => {
+    expect(markup({ error: 'Could not drop that task. Try again.' })).toContain(
+      'Could not drop that task. Try again.',
+    )
+  })
+})


### PR DESCRIPTION
Closes #1273

## The bug, and why `position: fixed` was not fixed

`FeedCardCollabInvite` and `FeedCardDuelChallenge` each rendered their
drop-to-accept modal as their own child, with `position: fixed; inset: 0;
z-index: 1000`. That is written to cover the viewport. It never did:

1. the feed chassis is `.sidebar-card`, which sets `backdrop-filter:
   blur(var(--card-blur))` (`index.css:2712`), and a `backdrop-filter` other
   than `none` establishes a containing block for `position: fixed`
   descendants exactly as `transform` and `filter` do;
2. so `inset: 0` resolved to the ~120px **card**, not the viewport;
3. and seven of the nine frames clip their bespoke ornament with
   `overflow: hidden` on the outer wrapper — verified again on this base:
   `Coven`, `Ephemerists`, `Everymen`, `Singularity`, `Snide`, `Ua`, `Wow`.
   (`Albescent` has none; `FactionFeedFrame`'s single `overflow: hidden` is on
   #1148's inert `aria-hidden` ornament layer, not on the card.)

So on those seven the modal was clipped and the accept path was substantially
broken; on `na` and `albescent` it was unclipped but anchored to the card.

## The fix

A portal, following `ConfirmDialog` (#1082) rather than inventing a pattern —
including its `typeof document === 'undefined'` guard for this repo's
server-render test harness. `createPortal(…, document.body)` escapes the
containing block and every ancestor's `overflow` in one move, because the
overlay stops being a descendant at all.

The two modals were the same markup twice, character for character, so they are
now **one** component, `FeedBankFullModal` — otherwise the portal + Escape +
focus wiring would have been a third and fourth copy. The two cards shed 153
lines between them; the shared component is 206, roughly 65 of which are its
docstring and prop docs -- so shipped code is up ~50 lines and the duplication
is gone. It carries no policy and no catalog keys: the wording and what "drop this one"
does to a praxis (delete if you authored it, leave if you joined) stay in the
cards, which also keeps each literal `feed:*.bankFull.*` key where the catalog
sweep can see it.

### Accessibility, since the issue asked

There was no `aria` wiring to keep — the overlay had none. Moving it to the end
of `<body>` makes that materially worse (a nameless blob, a long Tab away from
the button that opened it), so this adds the minimum that makes a portal
honest: `role="dialog"` + `aria-modal`, named by `aria-labelledby` and described
by `aria-describedby`, focus into the panel on open, Escape to dismiss.
Focus lands on the **panel**, not on a drop button — every option here destroys
or leaves a praxis, so nothing in the dialog is a safe default to pre-select.

One token substitution: the scrim was a hardcoded `rgba(0,0,0,0.5)`, now
`var(--color-overlay-strong)` (colours live only in `index.css`). That is a
slightly lighter scrim than before — flagged for `frontend-style` if the dim
should be heavier, but it is the token every other portal-modal already uses.

## The seam I tested at

**The overlay is no longer part of either card's own markup, and the shared
modal reaches `document.body`.**

`frontend/src/components/feed/__tests__/feedBankFullModal.test.tsx` — the
failing test came first (it could not even resolve `FeedBankFullModal`).

What it proves:
- neither card file still contains `position: "fixed"`, and both render
  `<FeedBankFullModal`;
- the shared modal's source mounts through `createPortal` on `document.body`;
- the dialog contract the move makes load-bearing: `role="dialog"`,
  `aria-modal="true"`, an `aria-labelledby` whose target `id` actually renders,
  one drop button per in-progress praxis, the cancel, the error surface.

**What it does not prove, and cannot.** The harness is `renderToStaticMarkup` in
vitest's `node` environment — no DOM, no layout, no effects. It cannot show that
the overlay now covers the viewport, that it is unclipped on the seven bespoke
frames, or that Escape / focus-on-open / backdrop-dismiss fire. Source-text
assertions are used for the structural half deliberately (established here —
10+ existing suites read source with `readFileSync`), because a portal is
invisible to a server renderer. **This bug is visual by nature; I could not run
a browser. The fix is unverified by eye.**

## Verification

- `tsc --noEmit` — clean
- `eslint src` — clean
- `vitest run` — 169 files, 2691 tests, all passing
- `vite build` — ok; `npm run budget` — exit 0 (the CSS `WARN` is pre-existing
  and untouched here; no CSS changed)

## What to eyeball

Fill your task bank to the cap, then have someone send you a **collab invite**
and a **duel challenge**, and press Accept. The modal must cover the whole
viewport and be fully usable — not clipped to the feed card.

The seven frames that were **clipping** it, each needing its own look:

- [ ] `Coven` (`CovenFeedFrame`)
- [ ] `Ephemerists` (`EphemeristsFeedFrame`)
- [ ] `Everymen` (`EverymenFeedFrame`)
- [ ] `Singularity` (`SingularityFeedFrame`)
- [ ] `Snide` (`SnideFeedFrame`)
- [ ] `UA` (`UaFeedFrame`)
- [ ] `WOW` (`WowFeedFrame`)

And the two that were only **mispositioned**:

- [ ] `Albescent` (`AlbescentFeedFrame`)
- [ ] `na` / unaffiliated (`FactionFeedFrame`'s `DefaultFeedFrame`)

Also worth a look, since none of it can be tested here:

- [ ] the scrim reads dark enough at `--color-overlay-strong`, in light **and**
      dark;
- [ ] Escape closes it, clicking the scrim closes it, clicking inside does not;
- [ ] on open, a screen reader announces the title and the "you have N
      in-progress tasks" line;
- [ ] the modal still sits **above** the mobile tab bar and the faction
      backdrops (it kept `z-index: 1000`, now in the body stacking context
      rather than the card's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
