### PR TITLE
Five clips, one request (#1286)

### DIFF
--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -312,6 +312,43 @@ export async function uploadPraxisMedia(id: number, file: File): Promise<MediaIt
   return data
 }
 
+/**
+ * One entry per file submitted to the batch route — `schemas/praxis.py`'s
+ * `MediaUploadResultOut`. Exactly one of `media_item` / `error` is set.
+ *
+ * `filename` is echoed back verbatim and unsanitized so a failure can name the
+ * file the player recognises. It is for DISPLAY only: two files in one selection
+ * can share a basename, so callers must attribute by position (the array is in
+ * request order), never by matching on this string.
+ */
+export interface MediaUploadResultOut {
+  filename: string
+  media_item: MediaItemOut | null
+  error: string | null
+  status_code: number | null
+}
+
+/**
+ * Upload N media files to one praxis in a single multipart request (#1286).
+ *
+ * Partial success by design: the 201 means "the request was processed", not
+ * "everything landed", so read every entry. Results come back in request order
+ * and `display_order` is derived from request position server-side (this route
+ * takes no `display_order` field), appended after any media already attached.
+ *
+ * `uploadPraxisMedia` above stays — the crop/rotate path uploads one edited
+ * image at a time by design (#514).
+ */
+export async function uploadPraxisMediaBatch(
+  id: number,
+  files: File[],
+): Promise<MediaUploadResultOut[]> {
+  const form = new FormData()
+  for (const file of files) form.append('files', file)
+  const { data } = await api.post<MediaUploadResultOut[]>(`/praxes/${id}/media/batch`, form)
+  return data
+}
+
 export async function deletePraxisMedia(id: number, mediaId: number): Promise<void> {
   await api.delete(`/praxes/${id}/media/${mediaId}`)
 }

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -107,6 +107,7 @@
       "drop": "Could not drop the task.",
       "changeMode": "Could not change mode.",
       "upload": "Could not upload {{name}}.",
+      "uploadNamed": "Could not upload {{name}} — {{reason}}",
       "removeMedia": "Could not remove media item.",
       "invite": "Could not invite {{name}}.",
       "leave": "Could not leave the collab.",

--- a/frontend/src/pages/editPraxis/__tests__/mediaBatchUpload.test.ts
+++ b/frontend/src/pages/editPraxis/__tests__/mediaBatchUpload.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Seam: `uploadMediaInChunks` — the whole video/audio attach path between "the
+ * player picked N files" and "the composer has media to merge and errors to
+ * show" (#1286).
+ *
+ * This is the seam worth pinning because it is the one that changed shape: five
+ * serial single-file round trips became one batched request whose response
+ * carries a per-file outcome. Everything the old loop guaranteed — per-file
+ * error attribution by name, selection order in the gallery, one failure not
+ * sinking its neighbours — now has to be re-derived from that array, and this
+ * file is where that derivation is asserted. The hook above it only calls
+ * `setMedia` / `setError` with what comes back.
+ *
+ * The API client is mocked: the contract under test is how many requests are
+ * issued, what each carries, and how the results are attributed — not axios.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import '../../../i18n'
+import type { MediaItemOut, MediaUploadResultOut } from '../../../api/praxis'
+
+vi.mock('../../../api/praxis', () => ({
+  uploadPraxisMediaBatch: vi.fn(),
+}))
+
+import { uploadPraxisMediaBatch } from '../../../api/praxis'
+import {
+  MEDIA_BATCH_MAX_BYTES,
+  MEDIA_BATCH_MAX_FILES,
+  chunkForBatchUpload,
+  uploadMediaInChunks,
+} from '../mediaBatchUpload'
+
+const batchMock = vi.mocked(uploadPraxisMediaBatch)
+
+/** A File of a given byte size — size is what the chunker reads. */
+function fakeFile(name: string, bytes = 1024): File {
+  return new File([new Uint8Array(bytes)], name, { type: 'video/mp4' })
+}
+
+function ok(filename: string, id: number): MediaUploadResultOut {
+  return {
+    filename,
+    media_item: {
+      id,
+      praxis_id: 7,
+      type: 'video',
+      file_path: `m/${id}.mp4`,
+      display_order: id,
+      created_at: '2026-07-30T00:00:00Z',
+    } satisfies MediaItemOut,
+    error: null,
+    status_code: null,
+  }
+}
+
+function failed(filename: string, error: string, statusCode = 422): MediaUploadResultOut {
+  return { filename, media_item: null, error, status_code: statusCode }
+}
+
+beforeEach(() => {
+  batchMock.mockReset()
+})
+
+describe('uploadMediaInChunks', () => {
+  it('sends five files as ONE request and returns them in selection order', async () => {
+    const files = ['a', 'b', 'c', 'd', 'e'].map((n) => fakeFile(`${n}.mp4`))
+    batchMock.mockResolvedValue(files.map((file, index) => ok(file.name, index + 1)))
+
+    const outcome = await uploadMediaInChunks(7, files)
+
+    expect(batchMock).toHaveBeenCalledTimes(1)
+    expect(batchMock).toHaveBeenCalledWith(7, files)
+    expect(outcome.uploaded.map((item) => item.id)).toEqual([1, 2, 3, 4, 5])
+    expect(outcome.errors).toEqual([])
+  })
+
+  it('lets one file fail mid-batch, names it, and still lands the other four in order', async () => {
+    const files = ['a', 'b', 'bad', 'd', 'e'].map((n) => fakeFile(`${n}.mp4`))
+    batchMock.mockResolvedValue([
+      ok('a.mp4', 1),
+      ok('b.mp4', 2),
+      failed('bad.mp4', 'Unsupported media type.'),
+      ok('d.mp4', 4),
+      ok('e.mp4', 5),
+    ])
+
+    const outcome = await uploadMediaInChunks(7, files)
+
+    expect(outcome.uploaded.map((item) => item.id)).toEqual([1, 2, 4, 5])
+    expect(outcome.errors).toHaveLength(1)
+    expect(outcome.errors[0]).toContain('bad.mp4')
+    expect(outcome.errors[0]).toContain('Unsupported media type.')
+  })
+
+  it('attributes by position, not by name, when two files share a basename (#1336)', async () => {
+    const files = [fakeFile('clip.mp4'), fakeFile('clip.mp4'), fakeFile('other.mp4')]
+    batchMock.mockResolvedValue([
+      failed('clip.mp4', 'File too large (max 100 MB).', 413),
+      ok('clip.mp4', 2),
+      ok('other.mp4', 3),
+    ])
+
+    const outcome = await uploadMediaInChunks(7, files)
+
+    // The survivor is the SECOND clip.mp4; matching on filename would have
+    // dropped whichever one the lookup happened to find first.
+    expect(outcome.uploaded.map((item) => item.id)).toEqual([2, 3])
+    expect(outcome.errors).toHaveLength(1)
+  })
+
+  it('reports every file in a chunk when the whole request fails', async () => {
+    const files = [fakeFile('a.mp4'), fakeFile('b.mp4')]
+    batchMock.mockRejectedValue({ message: 'Network Error' })
+
+    const outcome = await uploadMediaInChunks(7, files)
+
+    expect(outcome.uploaded).toEqual([])
+    expect(outcome.errors).toHaveLength(2)
+  })
+
+  it('does not abandon later chunks when an earlier chunk fails outright', async () => {
+    const files = Array.from({ length: MEDIA_BATCH_MAX_FILES + 1 }, (_, index) =>
+      fakeFile(`clip-${index}.mp4`),
+    )
+    batchMock
+      .mockRejectedValueOnce({ message: 'Network Error' })
+      .mockResolvedValueOnce([ok(`clip-${MEDIA_BATCH_MAX_FILES}.mp4`, 99)])
+
+    const outcome = await uploadMediaInChunks(7, files)
+
+    expect(batchMock).toHaveBeenCalledTimes(2)
+    expect(outcome.uploaded.map((item) => item.id)).toEqual([99])
+    expect(outcome.errors).toHaveLength(MEDIA_BATCH_MAX_FILES)
+  })
+
+  it('keeps selection order across chunk boundaries', async () => {
+    const files = Array.from({ length: MEDIA_BATCH_MAX_FILES + 2 }, (_, index) =>
+      fakeFile(`clip-${index}.mp4`),
+    )
+    batchMock
+      .mockResolvedValueOnce(
+        files.slice(0, MEDIA_BATCH_MAX_FILES).map((file, index) => ok(file.name, index)),
+      )
+      .mockResolvedValueOnce(
+        files.slice(MEDIA_BATCH_MAX_FILES).map((file, index) => ok(file.name, MEDIA_BATCH_MAX_FILES + index)),
+      )
+
+    const outcome = await uploadMediaInChunks(7, files)
+
+    expect(outcome.uploaded.map((item) => item.id)).toEqual(
+      Array.from({ length: MEDIA_BATCH_MAX_FILES + 2 }, (_, index) => index),
+    )
+  })
+})
+
+describe('chunkForBatchUpload', () => {
+  it('keeps a normal selection in a single chunk', () => {
+    const files = ['a', 'b', 'c', 'd', 'e'].map((n) => fakeFile(`${n}.mp4`, 4 * 1024 * 1024))
+    expect(chunkForBatchUpload(files)).toEqual([files])
+  })
+
+  it('splits on the file-count ceiling', () => {
+    const files = Array.from({ length: MEDIA_BATCH_MAX_FILES * 2 + 1 }, (_, index) =>
+      fakeFile(`clip-${index}.mp4`),
+    )
+    const chunks = chunkForBatchUpload(files)
+    expect(chunks.map((chunk) => chunk.length)).toEqual([
+      MEDIA_BATCH_MAX_FILES,
+      MEDIA_BATCH_MAX_FILES,
+      1,
+    ])
+  })
+
+  it('splits on the cumulative-byte ceiling', () => {
+    const big = Math.floor(MEDIA_BATCH_MAX_BYTES * 0.6)
+    const files = [fakeFile('a.mp4', big), fakeFile('b.mp4', big), fakeFile('c.mp4', big)]
+    expect(chunkForBatchUpload(files).map((chunk) => chunk.length)).toEqual([1, 1, 1])
+  })
+
+  it('never drops a file that is bigger than the byte ceiling on its own', () => {
+    const files = [fakeFile('huge.mp4', MEDIA_BATCH_MAX_BYTES + 1), fakeFile('small.mp4')]
+    const chunks = chunkForBatchUpload(files)
+    expect(chunks.flat().map((file) => file.name)).toEqual(['huge.mp4', 'small.mp4'])
+  })
+
+  it('has nothing to send for an empty selection', () => {
+    expect(chunkForBatchUpload([])).toEqual([])
+  })
+})

--- a/frontend/src/pages/editPraxis/mediaBatchUpload.ts
+++ b/frontend/src/pages/editPraxis/mediaBatchUpload.ts
@@ -1,0 +1,136 @@
+/**
+ * Attaching video/audio to a praxis: chunk the selection, batch each chunk into
+ * one request, and hand the composer back media in selection order plus one
+ * error per file that failed (#1286).
+ *
+ * This replaced an `await`-inside-`for` — five clips were five serial round
+ * trips of file-sized requests. The batch route (`POST /praxes/{id}/media/batch`,
+ * #1298) is partial-success and returns one entry per submitted file in request
+ * order, which is what lets the two behaviours the old loop provided survive:
+ * per-file error attribution, and gallery order taken from the request rather
+ * than from whoever finished first.
+ *
+ * The image path is deliberately not routed through here. Images go to the
+ * crop/rotate modal and are edited and uploaded one at a time by design (#514).
+ */
+import i18n from '../../i18n'
+import { uploadPraxisMediaBatch, type MediaItemOut } from '../../api/praxis'
+import { extractError } from '../../utils/errors'
+
+/**
+ * Files per request.
+ *
+ * ponytail: the only hard ceiling the backend documents is Starlette's
+ * `max_files=1000`, and blowing it fails the WHOLE request with a bare 400
+ * before the handler runs — no per-file entries, nothing to attribute. Twenty
+ * sits two orders of magnitude under that, and also bounds what a single retry
+ * costs. The upgrade path, if a real selection ever gets near it, is to raise
+ * this once the deployed proxy's body limit has actually been measured.
+ */
+export const MEDIA_BATCH_MAX_FILES = 20
+
+/**
+ * Cumulative bytes per request.
+ *
+ * ponytail: there is no application-level total-bytes cap, and Render's edge
+ * proxy limit was not discoverable from the repo (#1298) — so this is a
+ * self-imposed budget, not a measured one. 100 MB matches the backend's
+ * documented per-file `MEDIA_MAX_BYTES`, which is the one number the stack does
+ * commit to, and it bounds the temp-file spooling Starlette does for every part
+ * over 1 MB: without a budget, a 20-file selection could push ~2 GB through the
+ * container's ephemeral filesystem before the handler saw a byte. The composer
+ * already refuses files over 50 MB (`MAX_FILE_SIZE`), so in practice a normal
+ * selection of clips is one request and only a deliberate pile of large video
+ * splits. Upgrade path: measure the deployed limit, then raise or drop this.
+ */
+export const MEDIA_BATCH_MAX_BYTES = 100 * 1024 * 1024
+
+export interface BatchUploadOutcome {
+  /** Successfully stored media, in selection order — ready to append to the gallery. */
+  uploaded: MediaItemOut[]
+  /** One message per failed file, in selection order. */
+  errors: string[]
+}
+
+/**
+ * Split a selection into requests that stay under both ceilings.
+ *
+ * A file larger than the byte budget still gets sent — alone, in its own chunk.
+ * Silently dropping it would be worse than letting the server rule on it.
+ */
+export function chunkForBatchUpload(files: File[]): File[][] {
+  const chunks: File[][] = []
+  let current: File[] = []
+  let currentBytes = 0
+
+  for (const file of files) {
+    const wouldExceed =
+      current.length >= MEDIA_BATCH_MAX_FILES ||
+      (current.length > 0 && currentBytes + file.size > MEDIA_BATCH_MAX_BYTES)
+    if (wouldExceed) {
+      chunks.push(current)
+      current = []
+      currentBytes = 0
+    }
+    current.push(file)
+    currentBytes += file.size
+  }
+  if (current.length > 0) chunks.push(current)
+  return chunks
+}
+
+/** "Could not upload clip.mp4 — Unsupported media type." */
+function namedFailure(name: string, reason: string): string {
+  return i18n.t('forms:editPraxis.errors.uploadNamed', { name, reason })
+}
+
+/**
+ * Upload a video/audio selection, one request per chunk, sequentially.
+ *
+ * Chunks are NOT fired in parallel: `docs/agents/load-time.md` records what
+ * simultaneous requests do to a throttled uplink, and media payloads are the
+ * worst possible thing to race. Sequential chunks are already a large win over
+ * one request per file.
+ *
+ * A chunk whose request fails outright (network, or a batch-wide 4xx) yields one
+ * error per file it carried — exactly what the old per-file loop produced — and
+ * the remaining chunks still go.
+ */
+export async function uploadMediaInChunks(
+  praxisId: number,
+  files: File[],
+): Promise<BatchUploadOutcome> {
+  const uploaded: MediaItemOut[] = []
+  const errors: string[] = []
+
+  for (const chunk of chunkForBatchUpload(files)) {
+    let results
+    try {
+      results = await uploadPraxisMediaBatch(praxisId, chunk)
+    } catch (err) {
+      for (const file of chunk) {
+        errors.push(
+          extractError(err, i18n.t('forms:editPraxis.errors.upload', { name: file.name })),
+        )
+      }
+      continue
+    }
+    // Attribute by POSITION. The response is in request order and two files in
+    // one selection can share a basename (#1336), so matching on `filename`
+    // could hand a failure the wrong file's name.
+    results.forEach((result, index) => {
+      const name = chunk[index]?.name ?? result.filename
+      if (result.media_item) {
+        uploaded.push(result.media_item)
+      } else {
+        errors.push(
+          result.error
+            ? namedFailure(name, result.error)
+            : i18n.t('forms:editPraxis.errors.upload', { name }),
+        )
+      }
+    })
+  }
+
+  return { uploaded, errors }
+}

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -58,6 +58,7 @@ import {
   blobToFile,
   partitionByEditability,
 } from "../../components/imageEdit/imageEditHelpers";
+import { uploadMediaInChunks } from "./mediaBatchUpload";
 import i18n from "../../i18n";
 
 export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
@@ -766,18 +767,20 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       // without a manual save (autosave covers title/body only; #297).
       const { toEdit, toUploadDirect } = partitionByEditability(valid);
       const praxisId = parseInt(idParam, 10);
-      for (const file of toUploadDirect) {
-        try {
-          const uploaded = await uploadPraxisMedia(praxisId, file);
-          setMedia((previous) => [...previous, uploaded]);
-        } catch (err) {
-          setError(
-            extractError(
-              err,
-              i18n.t("forms:editPraxis.errors.upload", { name: file.name }),
-            ),
-          );
+      if (toUploadDirect.length > 0) {
+        // One request for the whole selection instead of one per file (#1286).
+        // Tiles now appear together rather than trickling in — that is the
+        // accepted cost of the single round trip, so no artificial staggering.
+        const { uploaded, errors } = await uploadMediaInChunks(
+          praxisId,
+          toUploadDirect,
+        );
+        if (uploaded.length > 0) {
+          setMedia((previous) => [...previous, ...uploaded]);
         }
+        // One error slot, so the last failure wins — exactly what the old
+        // per-file loop left on screen when several files failed.
+        if (errors.length > 0) setError(errors[errors.length - 1]);
       }
       // Queue images for the modal; they're edited + uploaded one at a time.
       if (toEdit.length > 0) {


### PR DESCRIPTION
Five clips were five serial round trips of file-sized requests, because the composer's attach path did `await uploadPraxisMedia` inside a `for`. It now sends the whole video/audio selection to `POST /praxes/{id}/media/batch` (#1298) and reads one per-file outcome back.

Closes #1286

**Depends on #1334** — the endpoint this calls. That PR was still open when this was written; the client is built against its pinned contract (201, top-level array in request order, `MediaUploadResultOut = { filename, media_item, error, status_code }`, `display_order` derived server-side from request position). This branch is rebased on `origin/main` and does not contain the backend half, so it must not merge before #1334.

## Seam under test

`uploadMediaInChunks` — everything between "the player picked N files" and "the composer has media to merge and errors to show". That is the seam that changed shape: the guarantees the old loop got for free (per-file attribution, selection order, one failure not sinking its neighbours) now have to be re-derived from a result array, and that derivation is what `src/pages/editPraxis/__tests__/mediaBatchUpload.test.ts` pins. The API client is mocked, so the assertions are about how many requests go out, what each carries, and how results are attributed — not about axios.

The case the issue named is the second test: one file fails mid-batch, names itself, and the other four still land in selection order. It was written first and failed on a missing module.

## What survives, unchanged

- **Per-file error attribution.** Every failed entry produces its own message. A single "upload failed" for the batch would have been the regression the issue calls out.
- **Attribution is by POSITION, not `filename`.** The response is in request order; two files in one selection can share a basename (#1336), so matching on the echoed name could hand a failure the wrong file's name. `filename` is display-only, and the test with two `clip.mp4`s pins it.
- **Selection order in the gallery**, taken from the response's request-ordered entries.
- **A whole-request failure still reports per file** — one error each, via `extractError` with the same `errors.upload` fallback the loop used, which is exactly what a network error produced before.
- **The error banner still shows the last failure.** `error` is one slot, so N failures showed the last one under the old loop too; that is preserved deliberately rather than collapsed to a summary.

## What changes deliberately

`setMedia` is one merge, so tiles appear together instead of trickling in. No artificial staggering was added to simulate the old feel.

New copy key `forms:editPraxis.errors.uploadNamed` — "Could not upload {{name}} — {{reason}}". The batch's per-file `error` is a bare detail ("Unsupported media type."), and the old path showed that detail with no name attached. Composing the two is what makes a failing file actually name itself, which is what the issue asks for, without losing the reason.

## Chunking policy

Sequential chunks, split on **20 files** or **100 MB cumulative** per request, whichever comes first. Both constants are `ponytail:`-marked in `mediaBatchUpload.ts`.

- **20 files** — the one hard ceiling the backend documents is Starlette's `max_files=1000`, and exceeding it fails the *whole* request with a bare 400 before the handler runs, so there would be no per-file entries to attribute. Twenty is two orders of magnitude under it and bounds what a retry costs.
- **100 MB** — there is no application-level total-bytes cap and Render's edge-proxy limit was not discoverable from the repo (#1298 says so explicitly), so this is a self-imposed budget rather than a measured one. It matches the backend's documented per-file `MEDIA_MAX_BYTES`, the one figure the stack does commit to, and it bounds the temp-file spooling Starlette does for every part over 1 MB — without a budget a 20-file selection could push ~2 GB through the container's ephemeral filesystem before the handler saw a byte.
- **Chunks go one at a time, not in parallel.** `docs/agents/load-time.md` records what simultaneous requests do to a throttled uplink, and media payloads are the worst possible thing to race.
- A file bigger than the byte budget is sent alone in its own chunk rather than dropped, and a chunk that fails outright does not abandon the chunks after it. Both are pinned by tests.

The composer already refuses files over 50 MB (`MAX_FILE_SIZE`), so a normal selection of clips is one request and only a deliberate pile of large video splits.

## Not touched

The image crop/rotate queue. `uploadPraxisMedia` stays and images still go one at a time by design (#514).

## Measurement — what I could not take

The issue asks for a throttled before/after. I could not take one and am not going to assert a number I did not measure. `scripts/measure-load.mjs` measures **page LCP** on navigation; it does not drive a file picker and has no way to time an upload, and it needs a running API plus Postgres plus the endpoint from #1334, which is not on `main` yet.

What is deterministic and test-asserted: **five audio/video files now issue one request instead of five.** The saving is four round trips of request setup and TLS/latency overhead per attach, which is the whole point of the change; the byte volume on the wire is unchanged.

## Verification

`tsc --noEmit` clean · `eslint src --max-warnings=0` clean · `vitest run` 2696 passed / 169 files · `vite build` clean. `npm run budget` reports a pre-existing CSS **warning** (20.7 KB vs a 19.5 KB warn line) — no CSS was touched here; JS is unchanged and inside budget.

**Visual QA is outstanding** — I have no browser and no dev stack.

## What to eyeball

1. Attach five clips at once and confirm the network panel shows **one** `POST /praxes/{id}/media/batch`, not five `/media` posts.
2. The five tiles appear **together**, in the order you picked them, appended after any media already on the praxis.
3. Attach a mix where one file is rejected (a `.pdf` renamed, or anything the type partition sends direct) — the banner should read "Could not upload X — Unsupported media type." and the other four should still be in the gallery.
4. Pull the network cable mid-attach: the banner should still name a file, as before.
5. Attach images and confirm the crop/rotate modal is completely unchanged, one image at a time, still hitting the single-file `/media` route.
6. Reload the composer after an attach and confirm the gallery order persisted (server `display_order`, not client arrangement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
