### PR TITLE
The feed body grows a points slot and an ink seam (#1252)

### DIFF
--- a/frontend/src/components/__tests__/feedRow.test.tsx
+++ b/frontend/src/components/__tests__/feedRow.test.tsx
@@ -4,14 +4,19 @@
  * This guards (a) the normalizer maps each faction event to the right slots and
  * leaves the four companions alone, and (b) the row renders its invariant slots.
  */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
 import { normalizeFeedItem, FACTION_ROW_TYPES } from '../feed/normalizeFeedItem'
 import FeedRowContent from '../feed/FeedRowContent'
+import { FeedRowSkinContext, type FeedRowSkin } from '../feed/feedRowSkin'
 import type { ActivityFeedItem } from '../../api/activityFeed'
 import '../../i18n'
 import { collabCopy } from '../collab/collabCopy'
+import { AA_NORMAL, contrastRatio, formatRatio, parseColor, requiredRatio } from '../../utils/contrast'
+import { readThemes, resolveVar } from '../../utils/__tests__/cssVars'
 
 function item(type: string, payload: Record<string, unknown>): ActivityFeedItem {
   return {
@@ -349,6 +354,114 @@ describe('FeedRowContent', () => {
     // neutral a dark half (#8b8aa0) that a pinned literal could never see.
     expect(html).toContain('color:var(--faction-default)')
     expect(html).not.toContain('background-clip:text')
+  })
+})
+
+/**
+ * THE CHASSIS → BODY SEAM (#1252).
+ *
+ * Two claims, and the first is the one worth pinning hardest: a frame that
+ * publishes nothing must render byte-for-byte what the body renders outside any
+ * provider. Eight chassis publish nothing today, so a seam that is not inert is
+ * a silent redress of the whole feed.
+ */
+describe('FeedRowContent skin seam', () => {
+  const skinned = (skin: FeedRowSkin, slug = 'coven') =>
+    renderToStaticMarkup(
+      <MemoryRouter>
+        <FeedRowSkinContext.Provider value={skin}>
+          <FeedRowContent row={completionRow(slug)} avatarUrl={null} />
+        </FeedRowSkinContext.Provider>
+      </MemoryRouter>,
+    )
+  const bare = (slug: string) =>
+    renderToStaticMarkup(
+      <MemoryRouter>
+        <FeedRowContent row={completionRow(slug)} avatarUrl={null} />
+      </MemoryRouter>,
+    )
+
+  it('renders identically inside an empty provider and outside any provider', () => {
+    for (const slug of ['coven', 'wow', 'singularity', 'na', 'albescent']) {
+      expect(skinned({}, slug), slug).toBe(bare(slug))
+    }
+  })
+
+  it('lets a chassis repoint the actor ink and the monogram glyph', () => {
+    const html = skinned({ ink: { actor: 'var(--faction-coven-card-text)', monogram: 'var(--faction-coven-ward-card)' } })
+    expect(html).toContain('color:var(--faction-coven-card-text)')
+    expect(html).toContain('color:var(--faction-coven-ward-card)')
+    // …and only the fields it named: the headline rule is a FILL and stays the
+    // faction's own, which is ADR-0039's half of this row.
+    expect(html).toContain('background:var(--faction-coven)')
+  })
+
+  it('lets a chassis draw the points figure as an object, with the row values', () => {
+    const html = skinned({
+      points: (figure) => <b data-plaque>{`${figure.points}/${figure.level}`}</b>,
+    })
+    expect(html).toContain('<b data-plaque="true">40 pts/null</b>')
+    // The shared eyebrow line is REPLACED, never printed twice — drawing the
+    // figure beside the skin's own is the duplication the seam exists to avoid.
+    expect(html).not.toContain('class="eyebrow"')
+  })
+
+  it('never calls the points renderer for a row with no figure', () => {
+    // The gate is shared, so a skin gets no empty plaque to guard against.
+    const taunt = normalizeFeedItem(
+      item('foe_taunt', { from_character_id: 9, taunt_id: 2, faction_slug: 'coven', trigger_type: 'level_up', from_name: 'Ada', to_name: 'Bo' }),
+    )!
+    let calls = 0
+    renderToStaticMarkup(
+      <MemoryRouter>
+        <FeedRowSkinContext.Provider value={{ points: () => { calls += 1; return null } }}>
+          <FeedRowContent row={taunt} avatarUrl={null} />
+        </FeedRowSkinContext.Provider>
+      </MemoryRouter>,
+    )
+    expect(calls).toBe(0)
+  })
+})
+
+/**
+ * The monogram glyph's ink, measured as the PAIRING the row actually emits
+ * (#1252). `factionContrast.test.ts` can only ask whether a token clears AA on
+ * the surface its documentation names; this asks which token the component put
+ * on the disc, and measures that one.
+ *
+ * The disc read the global `--color-text-on-accent` (#ffffff) until #1252 —
+ * white being a statement about the app's accent buttons, not about legibility
+ * on a faction hue. It failed 4.5:1 on twelve of these fourteen pairs.
+ */
+describe('the monogram disc is inked with the faction pair, not a global neutral', () => {
+  const THEMES = readThemes(readFileSync(fileURLToPath(new URL('../../index.css', import.meta.url)), 'utf8'))
+  const FILL_SLUGS = ['ua', 'wow', 'everymen', 'coven', 'snide', 'ephemerists', 'singularity']
+
+  it.each(FILL_SLUGS)('%s: the emitted glyph ink clears AA on the disc fill in both themes', (slug) => {
+    const html = renderToStaticMarkup(<MemoryRouter><FeedRowContent row={completionRow(slug)} avatarUrl={null} /></MemoryRouter>)
+    // Scoped to the disc's own element: `FeedBadge` paints the SAME global
+    // neutral on its own fills, which is a different pairing and #1252 does not
+    // touch it. Measured, because "the same token must be wrong there too" is a
+    // guess: the badge fills are theme-invariant and all three clear white —
+    // `--badge-friend` 9.11:1, `--badge-collab` 5.02:1, `--badge-duel` 4.83:1.
+    const disc = html.match(/<div style="width:28px[^"]*"/)?.[0] ?? ''
+    expect(disc, `${slug} monogram disc`).toContain(`color:var(--faction-${slug}-on-fill)`)
+    expect(disc).not.toContain('var(--color-text-on-accent)')
+
+    for (const theme of ['light', 'dark'] as const) {
+      const glyph = parseColor(resolveVar(`--faction-${slug}-on-fill`, theme, THEMES) ?? '')
+      const fill = parseColor(resolveVar(`--faction-${slug}`, theme, THEMES) ?? '')
+      expect(glyph, `${slug} on-fill (${theme})`).not.toBeNull()
+      expect(fill, `${slug} fill (${theme})`).not.toBeNull()
+      const ratio = contrastRatio(glyph!, fill!)
+      expect(ratio, `${slug} monogram on its disc (${theme}) = ${formatRatio(ratio)}`).toBeGreaterThanOrEqual(AA_NORMAL)
+    }
+  })
+
+  // The 12px bold glyph owes the 4.5:1 normal floor, not the 3:1 large one —
+  // "check the size before the threshold" (WORLD_ZERO_STYLE §3).
+  it('measures the glyph at the normal-text floor', () => {
+    expect(requiredRatio(12, 700)).toBe(AA_NORMAL)
   })
 })
 

--- a/frontend/src/components/feed/FeedRowContent.tsx
+++ b/frontend/src/components/feed/FeedRowContent.tsx
@@ -1,9 +1,11 @@
+import { useContext } from 'react'
 import { Link } from 'react-router-dom'
 import i18n from '../../i18n'
-import { factionCssVar, factionFill, isKnownFaction } from '../../utils/factions'
+import { factionFill, isKnownFaction } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import FeedBadge from './FeedBadge'
 import FeedRowActions from './FeedRowActions'
+import { FeedRowSkinContext, resolveFeedRowInk } from './feedRowSkin'
 import type { FeedRow } from './normalizeFeedItem'
 
 /**
@@ -23,6 +25,13 @@ import type { FeedRow } from './normalizeFeedItem'
  * painted elements, so they ask `factionFill` and an unaffiliated actor gets the
  * spectrum. The actor's NAME is a single-ink `color:` — no stop of a seven-stop
  * ramp is legible as text (#649) — so `na` stays neutral grey there on purpose.
+ *
+ * #1252 changed it a third time, and this one is the chassis's rather than the
+ * payload's: the slots are no longer all fed from `row`. A faction frame may now
+ * publish a {@link FeedRowSkin} — a points renderer and an ink bag — and this
+ * body reads it from above. Nothing here dispatches on the slug to find that
+ * skin; the body stays faction-blind and paints whatever its chassis handed it.
+ * See `feedRowSkin.ts` for why it is a context and not a prop.
  */
 export default function FeedRowContent({
   row,
@@ -31,9 +40,13 @@ export default function FeedRowContent({
   row: FeedRow
   avatarUrl: string | null
 }) {
+  // The chassis's dress, or an empty bag outside one. Every field falls back to
+  // what this body painted before it existed — except the monogram glyph, whose
+  // old default failed AA on twelve of fourteen faction fills (#1252).
+  const skin = useContext(FeedRowSkinContext)
   // Scalar ink only — the actor's name. Never a fill: those go through
   // factionFill so `na` reaches the spectrum.
-  const accent = factionCssVar(row.slug)
+  const ink = resolveFeedRowInk(skin.ink, row.slug)
   const known = isKnownFaction(row.slug)
   const initial = row.actor?.[0]?.toUpperCase() ?? '·'
 
@@ -42,12 +55,12 @@ export default function FeedRowContent({
       <Link
         to={row.actorHref}
         className="font-body"
-        style={{ fontSize: 'var(--text-content)', fontWeight: 700, color: accent, textDecoration: 'none' }}
+        style={{ fontSize: 'var(--text-content)', fontWeight: 700, color: ink.actor, textDecoration: 'none' }}
       >
         {row.actor}
       </Link>
     ) : (
-      <span className="font-body" style={{ fontSize: 'var(--text-content)', fontWeight: 700, color: accent }}>
+      <span className="font-body" style={{ fontSize: 'var(--text-content)', fontWeight: 700, color: ink.actor }}>
         {row.actor}
       </span>
     )
@@ -56,7 +69,15 @@ export default function FeedRowContent({
   return (
     <div style={{ padding: 'var(--space-md) var(--space-lg)', position: 'relative' }}>
       <div style={{ display: 'flex', alignItems: 'flex-start', gap: 'var(--space-md)' }}>
-        {/* Avatar — real image if present, else a faction-tinted monogram. */}
+        {/* Avatar — real image if present, else a faction-tinted monogram. The
+            glyph on that disc is inked with the faction's `-on-fill`, the pair
+            #649 measured for text on a faction fill, NOT the global
+            `--color-text-on-accent` it used to read: white is a statement about
+            the app's accent buttons and fails 4.5:1 on twelve of the fourteen
+            (faction × theme) disc fills, bottoming out at 1.21:1 on S.N.I.D.E.
+            in dark (#1252). A chassis may still repoint it — the disc fades to
+            53% of the hue over the CHASSIS ground, so its lower half is not the
+            hue's question alone. */}
         {row.actor && (
           <MaybeLink href={row.actorHref}>
             {avatarUrl ? (
@@ -75,7 +96,7 @@ export default function FeedRowContent({
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
-                  color: 'var(--color-text-on-accent)',
+                  color: ink.monogram,
                   fontFamily: "'Courier Prime', monospace",
                   // eslint-disable-next-line local/no-raw-style-values -- ornament: monogram glyph sized to the 28px avatar disc
                   fontSize: 12,
@@ -176,13 +197,23 @@ export default function FeedRowContent({
                 {row.headline}
               </span>
             )}
-            {(row.points || row.level != null) && (
-              <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
-                {row.points}
-                {row.points && row.level != null ? ' · ' : ''}
-                {row.level != null ? i18n.t('feed:row.level', { level: row.level }) : ''}
-              </span>
-            )}
+            {/* THE POINTS SLOT (#1252). The figure is the one part of the row
+                two design sheets draw as an OBJECT rather than a line — WOW's
+                crooked gold plaque, the Everymen's stamped circular seal — and
+                a chassis had no way to reach it, nor any value to strike one
+                with. A frame that publishes no `points` renderer gets the
+                eyebrow line below, unchanged; the gate is shared, so a skin
+                never has to guard for an empty figure. */}
+            {(row.points || row.level != null) &&
+              (skin.points ? (
+                skin.points({ points: row.points, level: row.level })
+              ) : (
+                <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+                  {row.points}
+                  {row.points && row.level != null ? ' · ' : ''}
+                  {row.level != null ? i18n.t('feed:row.level', { level: row.level }) : ''}
+                </span>
+              ))}
           </div>
         </div>
       )}

--- a/frontend/src/components/feed/SingularityFeedFrame.tsx
+++ b/frontend/src/components/feed/SingularityFeedFrame.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react'
 import i18n from '../../i18n'
+import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
@@ -97,9 +98,14 @@ const NOTICE = 'var(--faction-singularity-card-notice)'
  * `--color-text-on-accent` is deliberately NOT repointed. The companions' accept
  * buttons paint it on `--badge-duel` (#dc2626), where white is 4.83:1 and the
  * near-black `-on-accent` would be 3.92:1 — repointing it to fix one pairing
- * would break the other. The one place it is genuinely wrong on this chassis is
- * `FeedRowContent`'s monogram disc (white on the phosphor fill, 1.74:1), and
- * that needs an ink seam on the shared body, which is outside this footprint.
+ * would break the other. The place it was genuinely wrong on this chassis was
+ * `FeedRowContent`'s monogram disc, which is why that repoint could never have
+ * been the fix: one token, two pairings, and a cascade override cannot tell them
+ * apart. #1252 settled it in the body instead — the disc is a faction FILL, so
+ * its glyph takes `--faction-singularity-on-fill` (5.17:1 light, 7.41:1 dark)
+ * rather than a global neutral (5.17:1 light but 2.54:1 dark). The 1.74:1 this
+ * note used to quote was white on `--faction-singularity-card-accent`, the
+ * phosphor; the disc is painted from `--faction-singularity`, the blue.
  */
 const ON_CHASSIS_INK = {
   '--color-text-primary': BRIGHT,
@@ -110,6 +116,16 @@ const ON_CHASSIS_INK = {
   '--color-bg-surface': PANEL,
   '--color-bg-surface-alt': READOUT,
 } as CSSProperties
+
+/**
+ * The one body ink the cascade repoint above cannot reach (#1252). The actor's
+ * name is `--faction-singularity` — the BLUE, a `--faction-*` token rather than
+ * a `--color-*` one, so `ON_CHASSIS_INK` never sees it — and blue on the
+ * terminal is 3.67:1 in light against the 4.5:1 an 18px/700 name owes. The
+ * phosphor this whole chassis speaks in clears it twice over (10.88:1 light,
+ * 11.18:1 dark).
+ */
+const ROW_SKIN = { ink: { actor: 'var(--faction-singularity-card-accent)' } } satisfies FeedRowSkin
 
 /** Terminal label voice — every small mark on the chrome speaks in it. */
 const LABEL: CSSProperties = {
@@ -290,8 +306,12 @@ export default function SingularityFeedFrame({
         {archive}
       </div>
 
-      {/* The printout — the shared body, unchanged, on repointed ink. */}
-      <div style={{ position: 'relative', zIndex: 2, ...ON_CHASSIS_INK }}>{children}</div>
+      {/* The printout — the shared body, unchanged, on repointed ink. The
+          cascade carries the `--color-*` half; `ROW_SKIN` carries the one ink
+          that is a `--faction-*` token and so cannot ride it. */}
+      <div style={{ position: 'relative', zIndex: 2, ...ON_CHASSIS_INK }}>
+        <FeedRowSkinContext.Provider value={ROW_SKIN}>{children}</FeedRowSkinContext.Provider>
+      </div>
     </article>
   )
 }

--- a/frontend/src/components/feed/UaFeedFrame.tsx
+++ b/frontend/src/components/feed/UaFeedFrame.tsx
@@ -1,6 +1,7 @@
 import { useFormFactor } from '../../hooks/useFormFactor'
 import { UaSigil } from '../cards/UaSigil'
 import { UA_DISPLAY, UA_EYEBROW, UaInkColumn } from '../cards/uaAtoms'
+import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
@@ -46,6 +47,16 @@ import type { FeedFrameProps } from './feedFrameProps'
  * is fluid, and `useFormFactor` only trims the gutter where a phone column has
  * none to spare.
  */
+/**
+ * The shared body's one ink that is wrong on this leaf (#1252). The row paints
+ * the actor's name in the faction's raw hue, which was measured against the
+ * app's neutral page: `--faction-ua` is 4.04:1 on this parchment in light, and
+ * the name is 18px/700, so it owes 4.5:1. The practice's own accent — the ink
+ * this card already sets on its band — clears both halves (5.18:1 light,
+ * 6.58:1 dark). A repoint, not a new token.
+ */
+const ROW_SKIN: FeedRowSkin = { ink: { actor: 'var(--faction-ua-card-accent)' } }
+
 export default function UaFeedFrame({
   kicker,
   time,
@@ -134,7 +145,7 @@ export default function UaFeedFrame({
         {archive}
       </div>
 
-      {children}
+      <FeedRowSkinContext.Provider value={ROW_SKIN}>{children}</FeedRowSkinContext.Provider>
     </div>
   )
 }

--- a/frontend/src/components/feed/WowFeedFrame.tsx
+++ b/frontend/src/components/feed/WowFeedFrame.tsx
@@ -1,4 +1,5 @@
 import { useFormFactor } from '../../hooks/useFormFactor'
+import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
 import type { FeedFrameProps } from './feedFrameProps'
 
 /**
@@ -38,15 +39,20 @@ import type { FeedFrameProps } from './feedFrameProps'
  * reason it always was: it belongs to the row SENTENCE, which the shared body
  * composes generically and a chassis cannot see.
  *
- * THE SHEET'S CROOKED POINTS PLAQUE IS NOT DRAWN HERE, and cannot be from this
- * seam. Points live on the shared, faction-blind body (`FeedRowContent` sets
- * them beside the level), and the chassis only ever sees `children` — it has no
- * points value to strike a plaque with, and reaching into the body's markup to
- * restyle one would be the chassis special-casing a payload, which the seam
- * forbids. Drawing its own plaque would print the figure twice, exactly as
- * re-drawing the kit's wax seal would have put two crests on one row (the actor's
- * portrait already IS the crest, `WowAvatar` #897). It stays undrawn until the
- * shared body grows a slot for it.
+ * THE SHEET'S CROOKED POINTS PLAQUE IS STILL NOT DRAWN HERE — but it is no
+ * longer unreachable. Points live on the shared, faction-blind body
+ * (`FeedRowContent` sets them beside the level), and a chassis used to see only
+ * `children`: no points value to strike a plaque with, and reaching into the
+ * body's markup to restyle one would be the chassis special-casing a payload,
+ * which the seam forbids. Drawing its own plaque would print the figure twice,
+ * exactly as re-drawing the kit's wax seal would have put two crests on one row
+ * (the actor's portrait already IS the crest, `WowAvatar` #897).
+ *
+ * #1252 grew the body the slot this note asked for: publish a
+ * {@link FeedRowSkin} with a `points` renderer and it draws the figure INSTEAD
+ * of the shared eyebrow line, with the row's own values. Striking the plaque is
+ * dress and belongs to #1204's own follow-up; what this file claims today is
+ * the ink half of that seam, below.
  *
  * WHERE THE SHEET'S LITERALS LANDED. Every one maps onto a shipped
  * `--faction-wow-*` token; nothing is ported and nothing new is minted:
@@ -95,6 +101,17 @@ const SIZES: Record<'desktop' | 'mobile', SizeSet> = {
   desktop: { head: 'var(--space-sm) var(--space-lg)', kicker: 'var(--text-lg)' },
   mobile: { head: 'var(--space-xs) var(--space-md)', kicker: 'var(--text-md)' },
 }
+
+/**
+ * The ink half of the body seam (#1252), and the sharpest instance of it in the
+ * feed. The shared row paints the actor's name in `--faction-wow` — the gold,
+ * measured against the app's neutral page — and on this cream sheet that is
+ * **1.96:1**, against the 4.5:1 the name owes at 18px/700. The gold is a fill
+ * and a frame here and never type, which is exactly the constraint
+ * WORLD_ZERO_STYLE §3 records for it; the plum this card already speaks in is
+ * the accent that carries text (5.79:1 light, 7.94:1 dark).
+ */
+const ROW_SKIN: FeedRowSkin = { ink: { actor: PLUM } }
 
 export default function WowFeedFrame({
   kicker,
@@ -213,7 +230,7 @@ export default function WowFeedFrame({
           their own `var(--space-md) var(--space-lg)` — so the chassis adds none.
           The v1 frame wrapped children in another `--space-md` and double-padded
           every card. */}
-      {children}
+      <FeedRowSkinContext.Provider value={ROW_SKIN}>{children}</FeedRowSkinContext.Provider>
     </article>
   )
 }

--- a/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * THE INK HALF OF THE BODY SEAM, end to end (#1252).
+ *
+ * Two claims that no other test can make, because both only exist once a frame
+ * and a body are rendered together:
+ *
+ *  1. **The context crosses the `children` boundary.** `FeedCardRouter` BUILDS
+ *     the body and hands it to the chassis, so the frame has no call site to
+ *     pass props at. React resolves context by position in the rendered tree
+ *     rather than by where the element was created — this asserts that, because
+ *     the whole seam rests on it.
+ *  2. **The ink a frame publishes clears AA on that frame's own ground.** This
+ *     is the pairing question §3 keeps re-learning: a token measured against the
+ *     app's near-white page is not measured against a faction's sheet. The
+ *     shared row paints the actor's name in `--faction-{slug}` and pays 1.96:1
+ *     on WOW's cream, 3.67:1 on the Singularity terminal and 4.04:1 on UA's
+ *     parchment — at 18px/700 the name owes 4.5:1.
+ *
+ * Grounds are read from index.css rather than pinned, and a GRADIENT ground is
+ * measured at every stop it declares: UA's parchment is a three-stop sheet, and
+ * "clears on the middle stop" is not a claim about the card.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import UaFeedFrame from '../UaFeedFrame'
+import WowFeedFrame from '../WowFeedFrame'
+import SingularityFeedFrame from '../SingularityFeedFrame'
+import FeedRowContent from '../FeedRowContent'
+import { normalizeFeedItem } from '../normalizeFeedItem'
+import { AA_NORMAL, contrastRatio, formatRatio, parseColor } from '../../../utils/contrast'
+import { readThemes, resolveVar, type Theme } from '../../../utils/__tests__/cssVars'
+import '../../../i18n'
+
+const THEMES = readThemes(readFileSync(fileURLToPath(new URL('../../../index.css', import.meta.url)), 'utf8'))
+
+/** Every solid colour a ground declares — one for a flat token, three for a gradient. */
+function groundStops(name: string, theme: Theme): string[] {
+  const raw = resolveVar(name, theme, THEMES)
+  expect(raw, `${name} (${theme}) must resolve`).not.toBeNull()
+  const stops = raw!.match(/#[0-9a-fA-F]{3,8}\b|rgba?\([^)]*\)/g)
+  expect(stops, `${name} (${theme}) declared no solid stop`).not.toBeNull()
+  return stops!
+}
+
+function row(slug: string) {
+  return normalizeFeedItem({
+    type: 'friend_completion',
+    item_key: 'friend_completion:1',
+    timestamp: '2026-01-01T00:00:00Z',
+    actor_display_name: 'Ada',
+    actor_faction_slug: slug,
+    actor_avatar_url: null,
+    payload: { character_id: 3, praxis_id: 7, task_title: 'Reforest', task_point_value: 40 },
+    context_faction_slug: slug,
+  })!
+}
+
+const CASES = [
+  { slug: 'ua', Frame: UaFeedFrame, ink: '--faction-ua-card-accent', ground: '--faction-ua-parchment' },
+  { slug: 'wow', Frame: WowFeedFrame, ink: '--faction-wow-card-accent', ground: '--faction-wow-card-bg' },
+  {
+    slug: 'singularity',
+    Frame: SingularityFeedFrame,
+    ink: '--faction-singularity-card-accent',
+    ground: '--faction-singularity-term-bg',
+  },
+] as const
+
+describe.each(CASES)('$slug feed chassis re-inks the shared body', ({ slug, Frame, ink, ground }) => {
+  it('reaches the actor name inside children it did not mount', () => {
+    const html = renderToStaticMarkup(
+      <MemoryRouter>
+        <Frame kicker="Task completed" time="2h ago" tag={null} archive={null}>
+          <FeedRowContent row={row(slug)} avatarUrl={null} />
+        </Frame>
+      </MemoryRouter>,
+    )
+    expect(html).toContain(`color:var(${ink})`)
+    // The row's default hue is gone from the NAME. It stays on the fills — the
+    // headline rule and the monogram disc — which are ADR-0039's, not this seam's.
+    expect(html).toContain(`background:var(--faction-${slug})`)
+    expect(html).not.toContain(`font-weight:700;color:var(--faction-${slug})`)
+  })
+
+  it.each(['light', 'dark'] as Theme[])('clears AA on its own ground in %s', (theme) => {
+    const text = parseColor(resolveVar(ink, theme, THEMES) ?? '')
+    expect(text, `${ink} (${theme})`).not.toBeNull()
+    for (const stop of groundStops(ground, theme)) {
+      const surface = parseColor(stop)
+      expect(surface, `${ground} stop ${stop}`).not.toBeNull()
+      const ratio = contrastRatio(text!, surface!)
+      expect(ratio, `${ink} on ${stop} (${theme}) = ${formatRatio(ratio)}`).toBeGreaterThanOrEqual(AA_NORMAL)
+    }
+  })
+})

--- a/frontend/src/components/feed/feedRowSkin.ts
+++ b/frontend/src/components/feed/feedRowSkin.ts
@@ -1,0 +1,141 @@
+import { createContext } from 'react'
+import type { ReactNode } from 'react'
+import { factionCssVar } from '../../utils/factions'
+
+/**
+ * THE BODY SEAM (#1252) — how a feed CHASSIS dresses and re-inks the shared row.
+ *
+ * ## Why this exists
+ *
+ * #1194 split a feed card into three layers: `FeedItemSlot` (the archive) →
+ * `FactionFeedFrame` (the chassis, one per faction) → the body (`FeedRowContent`,
+ * faction-blind). A chassis receives only `children`, so the body was unreachable
+ * from the one layer a dress issue is allowed to rewrite. Four independent agents
+ * in epic #1192 hit that wall on four different parts of the row and all four
+ * refused the two available workarounds — special-casing a payload from the
+ * chassis, or drawing a second copy of a figure the body already prints.
+ *
+ * That is the seam WORLD_ZERO_STYLE §3 names: *when a shared component's ink is
+ * wrong on your ground, add the ink prop once rather than working around it eight
+ * times*. It is `DuelCardInk` (#1153) and `DuelSlotTheme` (#1168) a third time,
+ * and it keeps their two load-bearing details:
+ *
+ *   1. **Every field defaults to what the body painted before**, so a faction
+ *      that supplies nothing is byte-identical. The ONE deliberate exception is
+ *      `monogram` — see its docblock; leaving that default alone would be
+ *      preserving a measured AA failure.
+ *   2. **Resolve field-by-field, never by spread.** `{...DEFAULTS, ...ink}` lets
+ *      an explicit `undefined` in a partially-filled bag erase a default, which
+ *      Everymen's duel-seal skin relies on not happening (#1168).
+ *
+ * ## Why a context and not a prop
+ *
+ * `DuelCard` takes props because its dresser MOUNTS it. This body's dresser does
+ * not: `FeedCardRouter` builds `<FeedRowContent>` and hands it to the chassis as
+ * `children`, so a frame has no call site to pass props at. Threading the bag
+ * through the router instead would put a slug→skin registry back in a shared
+ * file, which is the per-surface map #782 deleted, and would mean eight dress
+ * branches editing one file — the shape that reddened `main` twice.
+ *
+ * A context inverts that: the frame publishes, the body reads, and a faction's
+ * dress lives in the faction's own file. React resolves context by position in
+ * the rendered tree rather than by where the element was created, so wrapping
+ * already-built `children` works. `VoteFactionContext` (#855) is the same move
+ * for the same reason — reading from above leaves nine parallel call sites
+ * untouched.
+ *
+ * ## What a frame may put here
+ *
+ * Tokens it already owns. This is a place to REPOINT existing inks, never a
+ * reason to mint one, and never a home for a hue measured on some other ground:
+ * the whole failure it exists to fix is an ink measured against the app's page
+ * being painted on a faction's sheet.
+ */
+export interface FeedRowInk {
+  /**
+   * The actor's name.
+   *
+   * Default `factionCssVar(slug)` — the faction's raw hue, which is what the row
+   * has always painted. That default is legible on the app's neutral page and
+   * MEASURABLY IS NOT on most faction chassis: at 18px/700 it owes 4.5:1 and
+   * pays 1.96:1 on WOW's cream, 2.41:1 on the S.N.I.D.E. slip, 2.98:1 on the
+   * Coven ward, 3.67:1 on the Singularity terminal, 4.04:1 on UA's parchment,
+   * 4.15:1 on the Ephemerists plate and 4.49:1 on Everymen's paper (light
+   * theme; #1252 measured all sixteen). A chassis whose ground fails passes the
+   * accent it measured instead.
+   *
+   * It stays the default rather than becoming `-card-accent` globally because
+   * `card-accent` is measured against `-card-bg`, and only three of the eight
+   * chassis paint the body on `-card-bg`. The ground decides, so the ground's
+   * owner decides.
+   */
+  actor?: string
+  /**
+   * The monogram glyph inside the faction-tinted avatar disc.
+   *
+   * Default `factionCssVar(slug, 'on-fill')` — and this one is a CHANGE from
+   * what the body painted before (#1252). It read the global
+   * `--color-text-on-accent` (#ffffff), which is a statement about the app's
+   * accent buttons and not about legibility on a faction hue: white fails 4.5:1
+   * on twelve of the fourteen (faction × theme) disc fills, down to 1.21:1 on
+   * S.N.I.D.E. in dark. `--faction-{key}-on-fill` is the ink #649 minted for
+   * exactly this question and `factionContrast.test.ts` has gated all fourteen
+   * pairs since; it clears 4.59:1–15.55:1. This is §3's rule that *a fill gets a
+   * named ink, never a nearby neutral* (#1169).
+   *
+   * A chassis still gets the slot because the disc is a GRADIENT — 135°, the hue
+   * down to 53% of it — so its lower half composites over the chassis ground and
+   * the answer stops being a property of the hue alone.
+   *
+   * Unused on an `na`/albescent row: that monogram rides a neutral interior
+   * inside the spectrum ring, painted from `--color-text-primary` on
+   * `--color-bg-surface-alt`, and both of those a chassis can already repoint
+   * through the `[data-theme="dark"]`-style cascade (`SingularityFeedFrame` does).
+   */
+  monogram?: string
+}
+
+/** What the body paints when a chassis hands in nothing. */
+export function resolveFeedRowInk(
+  ink: FeedRowInk | undefined,
+  slug: string | null,
+): Required<FeedRowInk> {
+  return {
+    actor: ink?.actor ?? factionCssVar(slug),
+    monogram: ink?.monogram ?? factionCssVar(slug, 'on-fill'),
+  }
+}
+
+/** The figure the row would otherwise print in its own eyebrow voice. */
+export interface FeedRowPoints {
+  /** Pre-formatted points string, e.g. "40 pts" / "+12 pts", or null. */
+  points: string | null
+  level: number | null
+}
+
+export interface FeedRowSkin {
+  /** Re-point the body's inks for this chassis's ground. */
+  ink?: FeedRowInk
+  /**
+   * Draw the points/level figure instead of the shared eyebrow line.
+   *
+   * A renderer rather than a style bag because the four asks are STRUCTURE, not
+   * colour: WOW's sheet strikes a crooked gold plaque (`rotate(-2deg)`) with a ✦
+   * beside the total, and the Everymen slip stamps a 66px circular seal at
+   * `rotate(-4deg)` inside a double red ring. Neither is reachable by repainting
+   * a `<span>`.
+   *
+   * It is called under exactly the condition the default line renders under — a
+   * row with a headline and at least one of points/level — so a skin never has
+   * to guard for an empty figure, and a row that printed nothing before still
+   * prints nothing.
+   */
+  points?: (figure: FeedRowPoints) => ReactNode
+}
+
+/**
+ * Published by a faction chassis, read by the shared body. The default is empty:
+ * a card rendered outside any provider — and every one of the eight frames that
+ * publishes nothing — keeps today's rendering.
+ */
+export const FeedRowSkinContext = createContext<FeedRowSkin>({})


### PR DESCRIPTION
Closes #1252

## The seam I tested at

**The chassis → body boundary.** `FactionFeedFrame` receives only `children`, and
`FeedCardRouter` — not the frame — builds `<FeedRowContent>`. So the question the
tests ask first is: *can a layer that did not mount the body reach into it, and is
it inert when it doesn't try?* The red test was written there: an empty provider
must render byte-for-byte what no provider renders, across a themed faction, `na`
and `albescent`.

`FeedRowContent` now takes a **points slot** and an **ink seam**, following
`DuelCardInk` (#1153) and `DuelSlotTheme` (#1168): every field defaults to what the
body painted before, resolved **field-by-field, never by spread**.

**It arrives as a context, not a prop.** `DuelCard` takes props because its dresser
mounts it; this body's dresser does not. Threading a bag through the router instead
would put a slug→skin registry back into a shared file (the per-surface map #782
deleted) and would mean eight dress branches editing one file — the shape that
reddened `main` twice. `VoteFactionContext` (#855) is the same move for the same
reason. React resolves context by tree position rather than by where the element was
created, so wrapping already-built `children` works; `feedRowInk.test.tsx` asserts
exactly that, because the whole seam rests on it.

## What I implemented vs. what the seam now makes possible

| The four asks | Status |
|---|---|
| WOW crooked plaque (#1204) | **Possible, not built** — `skin.points` renders the figure instead of the eyebrow line, with the row's own `{ points, level }`. Striking the plaque is dress and belongs to #1204's follow-up. |
| Everymen circular seal (#1200) | **Possible, not built** — same slot. |
| Singularity `<pre>` readout (#1202) | **Still not possible.** That is the *whole body* re-laid-out, not a slot; neither an ink bag nor a points renderer reaches it. Needs its own decision. |
| Monogram disc AA (#1202) | **Fixed**, and not by the seam — see below. |

The ink seam has three consumers today (UA, WOW, Singularity); the points slot has
none. It ships unconsumed deliberately, per the owner ruling.

## Measured contrast — every ratio computed with `frontend/src/utils/contrast.ts` against the repo's own `index.css` resolver, both themes

**The reported 1.74:1 is not a pairing this row draws.** It is white on
`--faction-singularity-card-accent` (the phosphor), in both themes. The disc is
painted from `--faction-singularity` — the **blue**. The failure is real; the
backdrop named was the wrong one, and it measured 2.54:1, not 1.74:1.

### 1. Monogram glyph on the disc fill — `--color-text-on-accent` (#ffffff), the old default

| faction | light | dark |
|---|---|---|
| ua | 4.90 | **3.08** |
| wow | **2.15** | **1.62** |
| everymen | 5.84 | **3.49** |
| snide | **2.72** | **1.21** |
| ephemerists | 5.96 | **3.11** |
| singularity | 5.17 | **2.54** |
| coven | **3.15** | **2.65** |

**12 of 14 fail** the 4.5:1 floor (12px bold ⇒ normal text; `requiredRatio(12,700)`
is asserted in the test).

### 2. The same glyph on `--faction-{key}-on-fill`, the new default

| faction | light | dark |
|---|---|---|
| ua | 4.59 | 5.59 |
| wow | 8.76 | 11.61 |
| everymen | 5.84 | 5.40 |
| snide | 6.93 | 15.55 |
| ephemerists | 5.96 | 6.05 |
| singularity | 5.17 | 7.41 |
| coven | 5.98 | 7.11 |

**14 of 14 pass.** Not a new token: #649 minted `-on-fill` for exactly "text on a
faction fill" and `factionContrast.test.ts` has gated all fourteen pairs since. This
is §3's rule that *a fill gets a named ink, never a nearby neutral* (#1169) — white
is a statement about the app's accent buttons, not about legibility on a faction hue.

### 3. The actor's name — `--faction-{key}` on each chassis's own ground (18px/700 ⇒ 4.5:1)

| chassis | ground | light | dark | now |
|---|---|---|---|---|
| wow | `--faction-wow-card-bg` | **1.96** | 11.19 | `-card-accent` (plum) 5.79 / 7.94 ✅ |
| snide | `--faction-snide-slip-paper` | **2.41** | 15.55 | unfixed |
| coven | `--faction-coven-ward-card` | **2.98** | 6.69 | unfixed |
| singularity | `--faction-singularity-term-bg` | **3.67** | 7.66 | `-card-accent` (phosphor) 10.88 / 11.18 ✅ |
| ua | `--faction-ua-parchment` | **4.04** | 5.35 | `-card-accent` 5.18 / 6.58 ✅ |
| ephemerists | plate + wash | **4.15** | **3.16** | unfixed |
| everymen | `--everymen-paper` | **4.49** | 4.91 | unfixed |

**All seven fail in light; Ephemerists fails in both.** This is a finding of the
mandated measurement, not of the issue. Three are fixed here because each has an
existing accent it already speaks in that clears on its own ground — no token minted,
one line each. **The other four need a token decision**: `--everymen-red` is 4.49 as
type (§3 already records that number), and no existing accent survives the S.N.I.D.E.
slip or the Ephemerists plate. That is a `-quiet`-shaped mint per §3 and wants its own
issue. If you would rather all seven landed together, the three frame edits are the
obvious revert.

### 4. Not touched, measured because "the same token must be wrong there too" is a guess

`FeedBadge` paints the same `--color-text-on-accent` on its own fills. All three
clear and are theme-invariant: `--badge-friend` 9.11, `--badge-collab` 5.02,
`--badge-duel` 4.83.

### 5. A finding this PR deliberately does NOT fix — the disc's fade

`factionFill(slug,'disc')` is `linear-gradient(135deg, hue, 53% hue)`, so the glyph's
lower half composites over the **chassis ground**. Modelling the 12px glyph's band as
the middle ~43% of that diagonal (hue at 87% → 66%), the worst stop under the glyph is
below 4.5:1 for **both** candidate inks on several chassis — Everymen light (white
3.67 / on-fill 3.67), UA dark (3.80 / 3.24), Coven dark (3.32 / 3.90). No ink fixes
that; only the fade does. The gradient is #1269's (merged as #1331) and the brief puts
it explicitly out of scope, so it is reported, not changed. The ink seam exists partly
for this: once the fill fades over a chassis ground, the answer stops being a property
of the hue alone.

## What is NOT in here

- `ErrorBanner` / `OwnerControls` / `FlagControl` / `ComposerControls` — #1231.
- The modal blocks of `FeedCardCollabInvite` / `FeedCardDuelChallenge` — #1273.
- The disc gradient / `factionColor` — #1269, merged as #1331. This PR consumes
  `factionFill(slug,'disc')` and does not touch it.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` 2718/2718 · `vite build` ok ·
`npm run budget` unchanged (the CSS **WARN** is pre-existing on `main`; this PR adds
no CSS). The AA guard was negative-checked by flipping the WOW case back to the raw
hue: it fails at 1.96:1.

**No browser and no dev stack here — visual QA is outstanding.**

## What to eyeball, both themes

1. **Every feed row's avatar monogram.** The letter is now the faction's `-on-fill`
   ink instead of white — near-black on WOW gold, S.N.I.D.E. acid and Coven pink;
   warm white on UA. Does it read at 28px, especially in the *lower-right* of the
   disc where the fill fades to 53% (finding 5)?
2. **The actor's name on the UA, WOW and Singularity cards.** WOW's goes gold → plum,
   UA's hue → its card accent, Singularity's blue → phosphor. Does each still read as
   that faction's voice, and does it hold on the ground in **light**, which is the
   half that was failing?
3. **The other five chassis are untouched** — Everymen, S.N.I.D.E., Ephemerists,
   Coven, Albescent/na. Their names should look exactly as before (and still fail AA
   in light; finding 3).
4. **`na` and `albescent` rows.** Rainbow ring, neutral interior, grey name — the seam
   must not have moved them at all.
5. **The points/level line** on any completion row: still one eyebrow line, still one
   copy of the figure. Nothing publishes a `points` renderer yet, so any change there
   is a bug.
