### PR TITLE
Document that na's avatar, backdrop and feed frame are the designed neutral

### DIFF
--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -12,6 +12,11 @@ import DefaultSigil from '../cards/DefaultSigil'
  * the UNAFFILIATED / no-faction (`na`) skin (#418): the portrait/monogram inside
  * a thin spectrum ring, tagged with the spectrum sigil — every path still open.
  * All colours via --faction-default-* tokens; flips light/dark.
+ *
+ * THERE IS NO `DefaultAvatar.tsx`, AND THAT IS NOT A GAP. `DefaultAvatar` is
+ * defined in this file rather than registered as a skin, so a listing of the
+ * avatar skins shows only the factions that override it. The na kit is complete;
+ * it just lives here.
  */
 export interface FactionAvatarProps {
   character: CharacterOut

--- a/frontend/src/components/backdrop/FactionBackdrop.tsx
+++ b/frontend/src/components/backdrop/FactionBackdrop.tsx
@@ -4,6 +4,16 @@ import { useBackdropSlug } from './BackdropContext'
 import { pickVariant } from '../../utils/factionDispatch'
 import { surfaceMap } from '../../factions'
 
+/**
+ * Per-faction page-ground dispatcher, keyed by the slug the surrounding page
+ * puts on {@link useBackdropSlug}.
+ *
+ * THERE IS NO `DefaultBackdrop.tsx`, AND THAT IS NOT A GAP. The fallback below
+ * is `WatercolorBackground` — the site's own watercolour ground, which is the
+ * designed neutral for a page with no faction (`default ≡ na ≡ Unaffiliated` is
+ * one identity, ADR-0039/0046/0048). A `na` or unregistered slug is served that,
+ * not left bare, so there is nothing for a separate default skin to draw.
+ */
 export default function FactionBackdrop() {
   const slug = useBackdropSlug()
   const Backdrop = pickVariant(surfaceMap('backdrop'), slug, WatercolorBackground)

--- a/frontend/src/components/feed/FactionFeedFrame.tsx
+++ b/frontend/src/components/feed/FactionFeedFrame.tsx
@@ -11,6 +11,13 @@
  * which every design sheet puts on the chassis. The contract is now
  * {@link FeedFrameProps}; read its docblock before writing a faction skin.
  * Nothing may be written against the old `{ children }` shape.
+ *
+ * THERE IS NO `DefaultFeedFrame.tsx`, AND THAT IS NOT A GAP. `DefaultFeedFrame`
+ * is defined below rather than registered as a skin, so a listing of the feed
+ * frames shows only the factions that override it. It stays here on purpose: the
+ * dispatcher special-cases it by IDENTITY (`Frame === DefaultFeedFrame`) to hand
+ * it the slug the faction frames do not take, and that check is only readable
+ * next to the thing it compares against.
  */
 import { pickVariant } from '../../utils/factionDispatch'
 import { surfaceMap } from '../../factions'

--- a/frontend/src/factions/manifest.ts
+++ b/frontend/src/factions/manifest.ts
@@ -13,6 +13,15 @@
  * everywhere, including on surfaces that do not exist yet. Partial registration
  * is the normal case, not a degraded one.
  *
+ * `Default*` NAMES AN ARCHETYPE, NOT NECESSARILY A FILE. Three surfaces carry
+ * their na rendering inside the dispatcher instead of in a skin module:
+ * `avatar` (`DefaultAvatar`, in `FactionAvatar.tsx`), `feedFrame`
+ * (`DefaultFeedFrame`, in `FactionFeedFrame.tsx`) and `backdrop` (which falls
+ * back to the site's own `WatercolorBackground`). Counting skin files therefore
+ * UNDERCOUNTS those three by one each — every slug is still served. Read an
+ * absent `Default*.tsx` as "co-located with its dispatcher", never as a hole in
+ * the na kit.
+ *
  * Adding a faction: one new module here, one line in `./index.ts`. Adding a
  * SURFACE: one field here, one entry in `SURFACE_KEYS`, and the dispatcher calls
  * `surfaceMap('<key>')` instead of declaring its own map.


### PR DESCRIPTION
Closes #1317

Documentation only. **31 added lines, all of them comments. No new components, no behaviour change.**

## What was actually wrong

Nothing in the code — the defect was in what the file listing *implies*. `avatar`, `backdrop` and `feedFrame` have no `Default*.tsx`, so an audit that counts skin files concludes the na kit is missing three surfaces. It isn't. Re-verified on disk this run:

| Surface | Where na's rendering actually lives |
|---|---|
| `avatar` | `DefaultAvatar`, defined in `components/avatar/FactionAvatar.tsx` |
| `feedFrame` | `DefaultFeedFrame`, defined in `components/feed/FactionFeedFrame.tsx` |
| `backdrop` | falls back to the site's own `WatercolorBackground` |

Per the issue, **no `Default*.tsx` files were created.** `DefaultFeedFrame` in particular has to stay next to its dispatcher: `FactionFeedFrame` special-cases it by identity (`Frame === DefaultFeedFrame`) to pass the slug the faction frames don't take, and that check is only readable beside the thing it compares against.

## The change

- **The three dispatchers** each now state that their na rendering is the one defined in-file (`FactionBackdrop.tsx` had no docblock at all; the other two had top docblocks that stopped short of saying it).
- **`factions/manifest.ts`** — the override-only paragraph said an undeclared surface "resolves to that surface's own `Default*` archetype", which is the exact sentence that invites the wrong conclusion. It now records that `Default*` names an archetype, not necessarily a file, and names the three surfaces that carry theirs in the dispatcher.

Deliberately no counts in the prose — a "7 skins" number in a comment is a state mirror that rots.

## Seam tested at

**The dispatcher fallback seam** — `pickVariant(map, slug, Default)` for a `na`/null/unregistered slug. No new test: this is a comment-only change, and the seam already has runnable checks that assert exactly what the new comments claim.

- `src/components/__tests__/factionFeedFrame.test.tsx:101` — *"gives a null/neutral slug the Unaffiliated chassis, NOT a passthrough (#1194)"*. That is the executable form of "an unregistered slug is served, not bare."
- `src/components/avatar/__tests__/factionAvatar.test.tsx:67` — pins the `DefaultAvatar` render.

**One honest gap, noted not fixed:** `backdrop` is the one of the three with no direct test. The only file touching that dispatcher (`layoutShell.test.tsx:22`) mocks it out entirely — `vi.mock('../backdrop/FactionBackdrop', () => ({ default: () => null }))`. So the `na → WatercolorBackground` fallback is asserted by a comment now and nothing else. The issue scoped this to docs, so I left it; worth a follow-up if you want the claim pinned.

## Verification

All run locally against a verified-real toolchain (`npx tsc --version` → 5.9.3, so the 0-error result is not the absent-binary false pass):

- `tsc --noEmit` — clean, exit 0
- `eslint src --max-warnings 0` — clean
- `vitest run` — **174 files, 2767 tests, all passing**
- `vite build` — built
- `npm run budget` — JS 132.1 KB ok. CSS 20.7 KB carries a pre-existing WARN (>19.5 KB); non-blocking and untouched by this change, which adds no CSS and no shipped bytes at all (comments are stripped).

No browser tools in this environment, so no visual QA was performed — see below.

## What to eyeball

**Nothing renders differently.** Every changed line is inside a `/** */` or `//` block; the bundle is byte-identical in behaviour. There is no faction/page/state combination to check, and visual QA is not outstanding for this PR.

If you want to sanity-check the *claims* rather than the render, the fastest path is an unaffiliated (`na`) character: their avatar shows the conic spectrum ring, their feed cards take the Unaffiliated chassis with the 4px spectrum rule, and their pages sit on the site watercolour ground — three surfaces the old file listing said were missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
