### PR TITLE
The desktop rail scrolls with the page, not in its own box

### DIFF
--- a/frontend/src/components/layout/SidebarColumn.tsx
+++ b/frontend/src/components/layout/SidebarColumn.tsx
@@ -40,23 +40,30 @@ export interface SidebarColumnProps {
 }
 
 /**
- * The handle is the only way back from a collapsed rail, so the column is
- * sticky — otherwise a player deep in a long `/tasks` list would have to scroll
- * back to the top to recover it. `top-14` matches `NavBar`'s `sticky top-0 h-14`.
+ * The rail scrolls WITH the page — a sticky, self-scrolling column put a second
+ * scrollbar next to the page's own, which read as chrome, not content. The one
+ * thing that must survive deep scroll is the handle while COLLAPSED: it is the
+ * only way back, so it alone goes sticky in that state — `self-stretch`
+ * (overriding the grid's `items-start`) keeps the column full row height so the
+ * sticky handle has room to travel. While
+ * expanded it stays in flow — pinning it would float it over the rail's own
+ * panels as they scrolled underneath. `top-14` matches `NavBar`'s
+ * `sticky top-0 h-14`.
  */
-const SIDEBAR_COLUMN =
-  'hidden lg:block lg:col-start-1 lg:row-start-1 lg:sticky lg:top-14 lg:max-h-[calc(100vh-3.5rem)] lg:overflow-y-auto'
+const SIDEBAR_COLUMN = 'hidden lg:block lg:col-start-1 lg:row-start-1 lg:self-stretch'
 
 export default function SidebarColumn({ collapsed, onToggle }: SidebarColumnProps) {
   const { pendingRequests, refetch } = usePendingRequests()
 
   return (
     <div className={SIDEBAR_COLUMN}>
-      <SidebarHandle
-        collapsed={collapsed}
-        onToggle={onToggle}
-        pendingCount={pendingRequests.length}
-      />
+      <div className={collapsed ? 'lg:sticky lg:top-14' : undefined}>
+        <SidebarHandle
+          collapsed={collapsed}
+          onToggle={onToggle}
+          pendingCount={pendingRequests.length}
+        />
+      </div>
       <div hidden={collapsed}>
         <Sidebar pendingRequests={pendingRequests} refetchPendingRequests={refetch} />
       </div>


### PR DESCRIPTION
## What

The left sidebar column on desktop had its own \`sticky\` + \`overflow-y-auto\` box, which drew a second scrollbar next to the page's own (very visible with Windows classic scrollbars). The rail now scrolls with the page.

The one documented reason for the old stickiness — the fold handle being the only way back from a collapsed rail — is preserved: while **collapsed**, the handle alone is \`sticky top-14\` (with \`self-stretch\` on the column so it has a full-height track to stick in). While **expanded** it stays in flow, since a pinned handle would float over the rail's own panels as they scrolled underneath.

## Verified

- Expanded, 1440px viewport: column is \`static\`/\`overflow: visible\`, no inner scrollbar, rail scrolls with the page.
- Collapsed, scrolled 3000px deep: handle pinned at 56px under the navbar, fully visible.
- 26 layout tests pass; eslint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)