### PR TITLE
The style ratchet learns to see a minus sign (#1233)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -411,7 +411,7 @@ A file only moves to phase 2 when it is clean on **both** axes — no un-annotat
 
 **Enforcement.** The `local/no-raw-style-values` ESLint rule fails the build on a raw numeric `fontSize`/`padding`/`margin`/`gap` in an inline style. Files not yet migrated are grandfathered in `frontend/.eslint-legacy-raw-styles.txt`. **That list only ever shrinks** — migrating a file means deleting its line; no file may ever be added to it. The hatch above is what keeps that literally true: ornament is not a permanent residue on the list, it is a per-line directive on a delisted file. The list reaches **empty** when #750 (the spacing sweep) closes and the last file moves to phase 2. **It is empty now** — so a newly-flagged violation is fixed in place or hatched per-line, never grandfathered.
 
-**What the rule sees.** A raw value is a raw value whichever notation carries it, so the rule covers three shapes: a numeric inline style (`padding: 6`), a length string including `rem`/`em` (`padding: '0.6rem 1.2rem'`), and an **arbitrary Tailwind spacing utility** (`mt-[6px]`, `px-[10px]`) — the last of these leaves the style object entirely and so needs a separate `className` check (#763). It walks ternaries, `&&` chains and template literals, because the recurring lesson of #770/#789 is that *any* indirection hid the value from a literal-only check.
+**What the rule sees.** A raw value is a raw value whichever notation carries it, so the rule covers three shapes: a numeric inline style (`padding: 6`), a length string including `rem`/`em` (`padding: '0.6rem 1.2rem'`), and an **arbitrary Tailwind spacing utility** (`mt-[6px]`, `px-[10px]`) — the last of these leaves the style object entirely and so needs a separate `className` check (#763). It walks ternaries, `&&` chains and template literals, because the recurring lesson of #770/#789 is that *any* indirection hid the value from a literal-only check. **A sign is an indirection too**: `marginLeft: -3.5` is a `UnaryExpression` wrapping a literal, not a literal, so for four issues the ratchet caught `3.5` and waved the negative through — and negative margins are common in exactly the place this section cares about, pulling ornament back over a padded edge. The rule unwraps `-`/`+` before judging the operand (#1233), which leaves `-0` reading as `0` and staying exempt. **A negated token is spelled `calc(-1 * var(--space-lg))`** — the one calc composition §4a's warning above does not cover, because it names a rung rather than routing around one.
 
 **What it deliberately does not see**, each a judgement rather than an oversight:
 
@@ -421,6 +421,7 @@ A file only moves to phase 2 when it is clean on **both** axes — no un-annotat
 | `text-[13px]` | A `--text-*` token names a **tier**. Flagging arbitrary type mechanically would pin ornament to a tier it was never part of — the coupling this section forbids. |
 | `calc(...)` | Named above; composing around the scale is a review rule, not a regex. |
 | `w-`/`h-`/`top-`/`inset-` | Ornament geometry, already carved out above. |
+| `marginLeft: -bleed` | A minus sign over an **identifier** or inside a template literal. Reading it needs flow analysis; the sign itself is closed (#1233), the indirection under it is not. |
 
 ---
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -163,6 +163,14 @@ function findRawSpacingClass(node) {
 }
 
 function isRawPxValue(node) {
+  // `marginLeft: -3.5` is a UnaryExpression wrapping a Literal, not a Literal,
+  // so a Literal-only check waved every negative through while catching the
+  // identical positive (#1233) — the sixth laundering pattern past the five the
+  // #763 audit named. Unwrap the sign and judge the operand: `-0` then reads as
+  // `0` and stays exempt, and `-3.5` reports like `3.5`.
+  if (node.type === 'UnaryExpression' && (node.operator === '-' || node.operator === '+')) {
+    return isRawPxValue(node.argument)
+  }
   // Zero is exempt: it is the absence of spacing, not a choice from the scale.
   // It is unit-less and theme-invariant, so it carries none of the drift the
   // token scale exists to prevent — and there is deliberately no --space-none
@@ -210,6 +218,20 @@ function isRawPxValue(node) {
 // Gap C — `calc()`. `calc(3.5rem + env(safe-area-inset-bottom))` passes, since
 //   the component split never sees a bare length. 4a already names this
 //   ("never compose with calc() to dodge the scale"); it is a review rule.
+//
+// Gap D — a MINUS SIGN the AST cannot resolve. The `UnaryExpression` unwrap
+//   above (#1233) closes `marginLeft: -3.5` — but only where the operand is a
+//   literal to judge. Two shapes remain, and both are the sign meeting an
+//   indirection rather than a new hole in the negative case:
+//     - `marginLeft: -bleed` (EphemeristsTaskCard) negates an Identifier whose
+//       number lives in a `SizeSet` table. Reading it needs flow analysis this
+//       rule deliberately does not do — the same "laundered through a data
+//       structure" shape the #763 audit named for positives.
+//     - ``margin: `0 calc(-1 * ${padX})` `` builds the sign inside a template
+//       literal, where it is already Gap C wearing a minus.
+//   Every current use is legitimate (declared ornament geometry; a negated
+//   `--space-*` token) — but that is a fact about today's tree, not a guarantee
+//   the rule enforces, and only review holds it.
 const noRawStyleValues = {
   rules: {
     'no-raw-style-values': {

--- a/frontend/src/components/factionHero/SnideFactionHero.tsx
+++ b/frontend/src/components/factionHero/SnideFactionHero.tsx
@@ -234,6 +234,7 @@ export default function SnideFactionHero({
                 position: "absolute",
                 top: -9,
                 left: "50%",
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: half the 52px tape strip, centring it on the sigil disc's crown. The offset IS the drawn strip's width; a rung slides the tape off-centre.
                 marginLeft: -26,
                 width: 52,
                 height: 18,

--- a/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
@@ -239,10 +239,7 @@ export default function UaScoreStamp({ praxis, showCrown }: ScoreStampProps) {
       <div
         style={{
           display: "flex",
-          // ornament: the ring overlaps the plate's foot; that overlap IS the
-          // drawing. No directive — a unary minus is not a Literal, so the rule
-          // never sees it (one of the #750 laundering shapes) and the directive
-          // would report as unused.
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: the ring overlaps the plate's foot by 6px; that overlap IS the drawing, and the nearest rungs (4/8) either open a gap under the plate or swallow its last working line.
           marginTop: -6,
         }}
       >

--- a/frontend/src/components/vote/EphemeristsVote.tsx
+++ b/frontend/src/components/vote/EphemeristsVote.tsx
@@ -138,6 +138,7 @@ export default function EphemeristsVote({
             right: 14,
             top: '50%',
             height: 1.5,
+            // eslint-disable-next-line local/no-raw-style-values -- ornament: half the drawn 1.5px rail, centring the hairline on `top: 50%`. The offset IS the stroke; the smallest rung is 4px, which drops the rail below the metals it threads.
             marginTop: -1,
             background:
               active > 0

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -45,6 +45,7 @@ export default function Admin() {
               cursor: 'pointer',
               color: activeTab === key ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)',
               borderBottom: activeTab === key ? '2px solid var(--color-text-primary)' : '2px solid transparent',
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the negation of the 2px border above it, so the active tab's underline lands ON the bar's rule rather than under it. The offset IS the drawn stroke (§4a ring-inset shape); any rung breaks the seam.
               marginBottom: -2,
               fontFamily: "'Courier Prime', monospace",
               fontSize: 'var(--text-base)',

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -382,9 +382,11 @@ function PointsWard({ size, points }: { size: number; points: number }) {
       {WARD_STARS.map(([x, y, delay]) => (
         // Two nodes, not one: the outer span is CENTRED on the point by
         // transform (a negative half-pixel margin would be spacing wearing
-        // ornament's clothes, and the ratchet's Literal-only check waves a
-        // unary minus through), and `epTwinkle` animates `transform` — so the
+        // ornament's clothes), and `epTwinkle` animates `transform` — so the
         // keyframe would overwrite that centring if they shared an element.
+        // This is where the ratchet's blind spot to a unary minus was found;
+        // that hole is closed now (#1233), and the two nodes still stand on
+        // the animation argument alone.
         <span
           key={`${x}-${y}`}
           aria-hidden

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -296,6 +296,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
         {/* ③ RE: YOU — join / gate / standing (taped dispatch) */}
         {membership.state !== "none" && (
           <div style={{ position: "relative", transform: "rotate(-1deg)" }}>
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: half the 60px tape strip, centring it over the dispatch panel's head. The offset IS the drawn strip's width; a rung slides the tape off-centre. */}
             <Tape style={{ top: -10, left: "50%", marginLeft: -30, width: 60, transform: "rotate(-5deg)" }} />
             <div style={{ ...INK_PANEL, padding: "var(--space-xl)" }}>
               <Halftone on="ink" />

--- a/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
@@ -138,8 +138,12 @@ export default function CovenFactionPage({ state }: { state: FactionDetailState 
         position: 'relative',
         fontFamily: CHROME,
         color: INK,
-        marginLeft: -16,
-        marginRight: -16,
+        // Full-bleed: cancel the mobile shell's gutter so the candle wash runs
+        // to the viewport edge, then put it back on the content. Layout, not
+        // ornament — it is the shell's own `--space-lg`, and the raw -16 could
+        // drift off it silently (#1233). Same spelling as `MobileStickyBar`.
+        marginLeft: 'calc(-1 * var(--space-lg))',
+        marginRight: 'calc(-1 * var(--space-lg))',
         paddingLeft: 'var(--space-lg)',
         paddingRight: 'var(--space-lg)',
       }}

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -489,7 +489,9 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
           top: '55%',
           width: 200,
           height: 200,
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: half the 200px candle halo, centring the glow on its anchor. The offsets ARE the drawn disc's size; no rung halves it.
           marginLeft: -100,
+          // eslint-disable-next-line local/no-raw-style-values -- ornament: the vertical half of the same halo centring.
           marginTop: -100,
           borderRadius: '50%',
           background: 'var(--faction-coven-slip-sigil-halo)',


### PR DESCRIPTION
Closes #1233

`local/no-raw-style-values` ended `isRawPxValue` with `if (node.type !== 'Literal') return false`. A negative numeric literal is not a `Literal` — it is a `UnaryExpression` wrapping one — so `marginLeft: -3.5` passed lint while `marginLeft: 3.5` was caught. Sixth laundering pattern past the five the #763 audit named, and the one that matters most for *this* ratchet: a negative margin is how ornament gets pulled back over a padded edge.

## The seam I tested at

**The rule itself** — `isRawPxValue`'s treatment of a signed operand. Tested by **probe**, the approach every prior tightening of this rule used (#770, #789, #793: "verified by probe"); there is no `RuleTester` harness in this repo, and `eslint.config.js` sits outside `tsconfig.json`'s `include`, so a vitest import of it would need an `allowJs` change to buy a worse test than running the linter.

A probe file holding `marginLeft: -3.5`, `marginTop: -8`, `fontSize: +14`, `paddingLeft: cond ? -4 : 0`, `gap: x ?? -6`, `marginRight: -0`, `marginBottom: 0`, `padding: 'var(--space-sm)'` and `top: -3.5`:

- **Before the unwrap: 0 errors.** Every signed shape escaped, including through the ternary and `??` paths #750 had already closed for positives.
- **After: exactly 5** — the five signed raw values. `-0` reads as `0` and stays exempt (the unwrap recurses, so the existing zero exemption covers it unchanged), `0` and the token string stay clean, and `top` is not a scale property (§4a ornament geometry).

The probe was deleted before the first commit. A second proof rides in the sweep: **none of the seven new disable directives reports as unused**, which is the #789 test — an unused-directive warning is what a rule that cannot see the value produces.

## The rule's number: 9 sites, 7 files

Not the issue's ~101. That grep counted `top:`/`left:`/`inset:`, which are ornament geometry and deliberately outside `STYLE_PROPS` (§4a), and counted `transform: translate(-50%…)` strings, which are not spacing at all. The rule's own newly-caught set:

| Site | Verdict |
|---|---|
| `factionDetail/mobileArchetypes/CovenFactionPage.tsx` ×2 | **token** |
| `factionHero/SnideFactionHero.tsx` | ornament |
| `factionDetail/archetypes/SnideFactionBody.tsx` | ornament |
| `praxisCard/scoreStamp/UaScoreStamp.tsx` | ornament |
| `vote/EphemeristsVote.tsx` | ornament |
| `praxisDetail/archetypes/CovenPraxisDetail.tsx` ×2 | ornament |
| `pages/Admin.tsx` | ornament |

**2 token-migrated / 7 hatched.**

### Why that split

The token migration is the only site where the value is **layout**. `CovenFactionPage`'s `marginLeft/Right: -16` cancels the *mobile shell's own gutter* to run the candle wash to the viewport edge — 16px is exactly `--space-lg`, and `MobileStickyBar` (whose docstring names "the mobile shell's 16px gutter") and `WowFactionPage` already spell that bleed `calc(-1 * var(--space-lg))`. §4a: **an on-scale value can never be ornament**. Left raw, the bleed could drift off the padding that restores it.

The seven hatched sites all meet §4a's two conditions — **off-scale** *and* **in register with raw ornament geometry beside them**:

- **The three "half the drawn thing" centrings** — Snide's tape strips (`-26` of `width: 52`, `-30` of `width: 60`), Coven's candle halo (`-100` of a 200px disc), Ephemerists' rail (`-1` of a drawn `height: 1.5`). The offset *is* the drawn element's size; no rung is half of it, and rounding slides the ornament off the thing it centres on.
- **Two overlaps that are the drawing** — UA's ensō ring pulled `-6` over the plate's foot (nearest rungs 4/8 either open a gap or eat its last working line), and Admin's `-2`, the negation of the 2px border the active tab's underline must land *on*. Admin is the §4a **ring-stroke** shape stated horizontally: the offset is the drawn stroke, and any rung breaks the seam.

No blanket disable, no invented token.

## KNOWN GAPS — added Gap D

The unwrap closes the sign only where the operand is a literal to judge. Two shapes remain, and I documented rather than hid them, per the file's own doctrine:

- `marginLeft: -bleed` (`EphemeristsTaskCard`) negates an **Identifier** whose number lives in a `SizeSet` table — the "laundered through a data structure" shape, now wearing a minus. Reading it needs flow analysis this rule deliberately does not do. (That value is legitimate: `ruleBleed` is declared `/** …Geometry. */`.)
- ``margin: `0 calc(-1 * ${padX})` `` builds the sign inside a template literal — already Gap C wearing a minus.

Every current use of both is legitimate, but that is a fact about today's tree rather than something the rule enforces. `WORLD_ZERO_STYLE.md` §4a gets the matching row and a note that **a negated token is spelled `calc(-1 * var(--space-lg))`** — the one calc composition §4a's "never compose with calc()" warning does not cover, since it names a rung instead of routing around one.

Two files carried in-tree comments saying no directive was possible *because* the rule could not see a unary minus (`UaScoreStamp`, `CovenEditPraxis`). Those claims are now false: the first becomes a real directive, the second loses the clause — its two-node twinkle stands on the `epTwinkle`-animates-`transform` argument, which never depended on the gap.

## Verification

`npx eslint .` (whole tree, not just `src`) **0 problems** · `tsc --noEmit` clean · `vitest run` **179 files / 2965 tests pass** · `vite build` clean · `npm run budget` exit 0 with the **pre-existing** `WARN CSS 20.6 KB` unchanged (no CSS added).

## What to eyeball

**Visual QA is outstanding** — I have no browser. Replacing or hatching an ornament offset cannot move a pixel where the value is unchanged, and six of the seven hatches are comment-only. The two places where something could actually shift:

1. **Coven mobile faction page** (`/factions/coven` on a phone) — the only *value* change. `-16` → `calc(-1 * var(--space-lg))` is a no-op **iff** `--space-lg` is 16px, which `index.css` confirms; worth a glance that the candle wash still reaches both viewport edges and the content is not double-inset.
2. **S.N.I.D.E. faction hero + faction body dispatch panel** — the two tape strips. Unchanged values, but they are the sites a reviewer should check if the reasoning on "half the drawn width" is disputed.

Also worth a glance, all unchanged values: the **UA praxis-card score stamp** (ensō sitting on the plate's foot), the **Ephemerists vote rail** hairline, the **Coven praxis-detail candle halo**, and the **Admin tab bar** underline seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
