### PR TITLE
GET /tasks: faction becomes a union, and the level default gets its name

### DIFF
--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
@@ -35,7 +35,9 @@ router = APIRouter()
 async def list_tasks(
     status: Optional[str] = None,
     can_sign_up: bool = False,
-    faction: Optional[str] = None,
+    # Repeated ``?faction=everymen&faction=ua`` is a union (#1364); one value
+    # still narrows to one faction, and none at all filters nothing.
+    faction: Optional[list[str]] = Query(None),
     min_points: Optional[int] = None,
     max_points: Optional[int] = None,
     exclude_character_id: Optional[int] = None,

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -395,6 +395,11 @@ async def in_progress_counts_for_tasks(
 
 #: ``sort`` value that orders the task list by creation time, newest first.
 SORT_NEWEST = "newest"
+#: ``sort`` value that orders the task list by creation time, oldest first.
+SORT_OLDEST = "oldest"
+#: ``sort`` value naming the browse default — easiest first, richest within a
+#: level. Ascending only: there is no level-descending option (#1364).
+SORT_LEVEL = "level"
 
 
 async def list_tasks(
@@ -402,7 +407,7 @@ async def list_tasks(
     *,
     status: Optional[str] = None,
     can_sign_up: bool = False,
-    faction: Optional[str] = None,
+    faction: Optional[list[str]] = None,
     min_points: Optional[int] = None,
     max_points: Optional[int] = None,
     exclude_character_id: Optional[int] = None,
@@ -446,8 +451,14 @@ async def list_tasks(
     made them invisible. Anonymous viewers get ``[]``: ``evaluate_signup``
     refuses them, so there is no honest list to return.
 
-    ``sort='newest'`` orders by creation time (newest first); the default
-    ordering surfaces the easiest, highest-value tasks first.
+    ``faction`` is a list of slugs matched as a union (#1364), so the browse
+    filter can hold several factions at once; an empty list is no filter.
+
+    ``sort`` is one of :data:`SORT_NEWEST`, :data:`SORT_OLDEST` or
+    :data:`SORT_LEVEL`, the latter being the default when ``sort`` is absent —
+    easiest first, richest within a level. Level *ascending* is the only level
+    ordering there is. The two chronological sorts tiebreak on ``id`` so a
+    paged read stays stable when rows share a ``created_at``.
     """
     # Collect hidden faction slugs to exclude their tasks (faction-rules seam, #171)
     hidden_slugs = await hidden_faction_slugs(session)
@@ -546,8 +557,12 @@ async def list_tasks(
         if exclude_character_id is None:
             exclude_character_id = viewer.id
 
-    if faction:
-        query = query.where(Task.primary_faction_slug == faction)
+    # Multi-select faction (#1364): an empty list — or one holding only blanks,
+    # which is what a cleared client-side filter sends — means "no faction
+    # filter", never "match nothing".
+    faction_slugs = [slug for slug in (faction or []) if slug]
+    if faction_slugs:
+        query = query.where(Task.primary_faction_slug.in_(faction_slugs))
     if min_points is not None:
         query = query.where(Task.point_value >= min_points)
     if max_points is not None:
@@ -593,7 +608,11 @@ async def list_tasks(
 
     if sort == SORT_NEWEST:
         query = query.order_by(Task.created_at.desc(), Task.id.desc())
+    elif sort == SORT_OLDEST:
+        query = query.order_by(Task.created_at.asc(), Task.id.asc())
     else:
+        # SORT_LEVEL, and the fall-through for an absent or unrecognised sort:
+        # the browse ordering Tasks.tsx gets by sending no ``sort`` at all.
         query = query.order_by(Task.level_required.asc(), Task.point_value.desc())
     query = query.limit(limit).offset(offset)
     result = await session.execute(query)

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -232,6 +232,163 @@ async def test_list_tasks_filter_by_faction(
 
 
 @pytest.mark.asyncio
+async def test_list_tasks_filter_by_multiple_factions(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    faction_ephemerists: Faction,
+):
+    """Repeated ?faction= returns the union; one slug still narrows to one; an
+    absent or empty faction filters nothing at all (#1364)."""
+    unaffiliated_task = Task(
+        title="Cross-Faction Sort Task",
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug=UNAFFILIATED_FACTION_SLUG,
+    )
+    ephemerist_task = Task(
+        title="Ephemerist Task",
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ephemerists",
+    )
+    db_session.add_all([unaffiliated_task, ephemerist_task])
+    await db_session.commit()
+
+    both = await client.get(
+        "/tasks", params={"faction": ["ua", UNAFFILIATED_FACTION_SLUG]}
+    )
+    assert both.status_code == 200
+    both_ids = {t["id"] for t in both.json()}
+    assert {active_task.id, unaffiliated_task.id} <= both_ids
+    assert ephemerist_task.id not in both_ids
+    assert {t["primary_faction_slug"] for t in both.json()} == {
+        "ua",
+        UNAFFILIATED_FACTION_SLUG,
+    }
+
+    one = await client.get("/tasks", params={"faction": "ua"})
+    assert one.status_code == 200
+    assert {t["primary_faction_slug"] for t in one.json()} == {"ua"}
+
+    # No faction axis at all, and a cleared one, are both "no filter" — never
+    # "match nothing".
+    for params in ({}, {"faction": ""}):
+        unfiltered = await client.get("/tasks", params=params)
+        assert unfiltered.status_code == 200
+        unfiltered_ids = {t["id"] for t in unfiltered.json()}
+        assert {
+            active_task.id,
+            unaffiliated_task.id,
+            ephemerist_task.id,
+        } <= unfiltered_ids
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_sort_oldest_reverses_newest(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+):
+    """?sort=oldest is ?sort=newest reversed, and the id tiebreak keeps both
+    stable across limits — rows written in one transaction share created_at.
+
+    The point values rise with creation order so the level default (point value
+    DESC) cannot masquerade as chronological order.
+    """
+    for index in range(3):
+        db_session.add(
+            Task(
+                title=f"Chronology Task {index}",
+                description="",
+                point_value=5 + index,
+                level_required=0,
+                status=TaskStatus.active,
+                created_by=character.id,
+                primary_faction_slug="ua",
+            )
+        )
+    await db_session.commit()
+
+    newest = await client.get("/tasks", params={"sort": "newest"})
+    oldest = await client.get("/tasks", params={"sort": "oldest"})
+    assert newest.status_code == 200
+    assert oldest.status_code == 200
+    newest_ids = [t["id"] for t in newest.json()]
+    oldest_ids = [t["id"] for t in oldest.json()]
+    assert len(oldest_ids) == 4
+    assert oldest_ids == sorted(oldest_ids)
+    assert oldest_ids == list(reversed(newest_ids))
+
+    for limit in (2, 3):
+        page = await client.get("/tasks", params={"sort": "oldest", "limit": limit})
+        assert [t["id"] for t in page.json()] == oldest_ids[:limit]
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_default_sort_is_level_then_point_value(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+):
+    """No ?sort= keeps today's browse ordering — level ascending, point value
+    descending. Tasks.tsx sends no sort at all, so this is the regression guard;
+    ?sort=level names that same default explicitly (#1364)."""
+    high_level = Task(
+        title="High Level Task",
+        description="",
+        point_value=30,
+        level_required=2,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    cheap = Task(
+        title="Cheap Task",
+        description="",
+        point_value=5,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    rich = Task(
+        title="Rich Task",
+        description="",
+        point_value=20,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add_all([high_level, cheap, rich])
+    await db_session.commit()
+
+    default = await client.get("/tasks")
+    assert default.status_code == 200
+    # active_task is level 0 / 10 points, so it lands between rich and cheap.
+    assert [t["id"] for t in default.json()] == [
+        rich.id,
+        active_task.id,
+        cheap.id,
+        high_level.id,
+    ]
+
+    named = await client.get("/tasks", params={"sort": "level"})
+    assert named.status_code == 200
+    assert named.json() == default.json()
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_exclude_character_id(
     client: AsyncClient,
     character: Character,


### PR DESCRIPTION
Closes #1364

Backend only — no frontend file is touched.

## The seam I tested at

`GET /tasks` over HTTP (`backend/tests/integration/test_tasks.py`), not the service function. Both halves of this issue only meet at the route: FastAPI's repeated-query parsing is what turns `?faction=a&faction=b` into a list, and a service-level test would have passed a list by hand and proved nothing about the wire format.

## What changed

**Faction is a union.** `faction` becomes `Optional[list[str]] = Query(None)` on the route and `Optional[list[str]]` on `list_tasks`, and the equality becomes `.in_()`. One slug still narrows to one. An absent list — or one holding only blanks, which is what a cleared client-side filter sends as `?faction=` — is no filter at all, never "match nothing".

**The sort axis gains `oldest`, and the default gets a name.** `SORT_OLDEST` is `created_at ASC, id ASC`, the exact reverse of the existing `SORT_NEWEST`; the `id` tiebreak is what makes both stable across limits, since rows written in one transaction share `created_at` under `func.now()`. The old `else` branch is now named `SORT_LEVEL` and stays the default when `sort` is absent. Level **ascending only** — no level-descending option exists.

## The red loop

The multi-faction test went red on the real defect immediately (`assert {1, 2} <= {2}` — FastAPI kept only the last repeated value).

The `oldest` test **passed on first run for the wrong reason** and had to be tightened. With four equal-point, equal-level tasks the level default happened to return them in id order, so `oldest == reversed(newest)` held without any `oldest` branch existing. The committed version gives the rows rising point values so the level default (point value DESC) cannot masquerade as chronological order, plus an explicit `oldest_ids == sorted(oldest_ids)`. It then failed `[4, 7, 6, 5] == [4, 5, 6, 7]`, which is the actual defect.

The regression guard — no `sort` yields level ASC, point value DESC — was written to be green from the start and stayed green through the change. `?sort=level` is asserted to return byte-identical JSON to the no-sort call.

## Premise correction

The issue body warns off touching `level`/`can_sign_up` because #1130 would conflict. #1130 has since shipped: `backend/routers/tasks.py` already carries `can_sign_up: bool = False` and there is no `level` param left. Nothing in that area was touched either way.

## Tests

```
pytest --cov=. --cov-fail-under=80   # 890 passed, 90.61% coverage
```
(run from `backend/` against a dedicated `wz1364_test` database)

Three tests added to `backend/tests/integration/test_tasks.py`:
- `test_list_tasks_filter_by_multiple_factions`
- `test_list_tasks_sort_oldest_reverses_newest`
- `test_list_tasks_default_sort_is_level_then_point_value`

## What to eyeball

- **The regression guard is the one that matters.** `Tasks.tsx` sends no `sort` at all and depends on level-ascending; `Home.tsx` and `api/admin.ts` pass `sort=newest`. Neither ordering moved — confirm the browse page and the home rail look exactly as they did.
- An unrecognised `?sort=` still silently falls through to the level default rather than 422-ing. That is today's behaviour, deliberately preserved; the praxis feed 422s instead, so the two endpoints differ. Say the word if you want them aligned — it is out of scope here.
- The empty-faction normalisation strips blanks in the service, so `?faction=` and `?faction=&faction=ua` both do the sane thing regardless of what F1 ends up emitting.
- No visual QA was possible — no browser or dev stack in this worktree. Verified via pytest only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
