### PR TITLE
GET /praxes: era scope, multi-select faction, and vote-count sorts (#1362)

### DIFF
--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -144,6 +144,12 @@ async def get_character_praxes(
     what the profile page actually fetches; both AND the shared
     :func:`praxis_membership_condition` onto the unchanged viewer gate
     :func:`praxis_visibility_condition`, so the two spellings cannot drift.
+
+    One deliberate difference since #1362: this route is **all eras**, while
+    ``GET /praxes`` now defaults to
+    :class:`services.praxis.PraxisEraScope.this_era` (opt out with
+    ``?era_scope=all_eras``). A whole-career record has no era rail to set, so
+    it keeps the unbounded list.
     """
     result = await session.execute(
         select(Praxis)

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -8,7 +8,16 @@ import logging
 import os
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Query,
+    Response,
+    UploadFile,
+)
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
@@ -61,6 +70,7 @@ from services.praxis import (
     kick_member,
     leave_praxis,
     list_praxes,
+    PraxisEraScope,
     PraxisSort,
     VotedFilter,
     remove_metatask,
@@ -91,9 +101,10 @@ async def list_praxes_route(
     type: Optional[str] = None,
     status: Optional[str] = None,
     moderation_status: Optional[str] = None,
-    faction: Optional[str] = None,
+    faction: Optional[List[str]] = Query(None),
     q: Optional[str] = None,
     sort: Optional[str] = None,
+    era_scope: str = PraxisEraScope.this_era.value,
     voted: Optional[str] = None,
     limit: int = 50,
     offset: int = 0,
@@ -106,6 +117,13 @@ async def list_praxes_route(
             praxis_sort = PraxisSort(sort)
         except ValueError:
             raise HTTPException(status_code=422, detail=f"Invalid praxis sort: {sort}")
+
+    try:
+        era_scope_value = PraxisEraScope(era_scope)
+    except ValueError:
+        raise HTTPException(
+            status_code=422, detail=f"Invalid praxis era scope: {era_scope}"
+        )
 
     voted_filter: Optional[VotedFilter] = None
     if voted is not None:
@@ -140,6 +158,7 @@ async def list_praxes_route(
         faction=faction,
         search=q,
         sort=praxis_sort,
+        era_scope=era_scope_value,
         voted=voted_filter,
         viewer_id=viewer.id if viewer else None,
         viewer_account_id=viewer.account_id if viewer else None,

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -50,7 +50,11 @@ from services.praxis_scoring import Contribution, compute_contributions
 from services.faction_service import faction_permits
 from services.media import process_and_save_media
 from services.meta_task import metatask_cap_for_level
-from services.era import get_current_era_row, get_or_create_stats
+from services.era import (
+    get_current_era_row,
+    get_current_era_row_safe,
+    get_or_create_stats,
+)
 from services.nudge import nudged_at_map
 from services.level_jump import available_level_reach, consume_level_jump
 from models.duel import Duel, DuelStatus
@@ -797,14 +801,47 @@ def praxis_visibility_condition(viewer_id: Optional[int]):
 class PraxisSort(str, Enum):
     """Feed orderings for the ``status=submitted`` praxis feed (#658).
 
-    Both sort on ``Praxis.submitted_at`` — when the praxis was *filed* — not
-    ``created_at``, which is merely when the draft was started (i.e. when the
-    author signed up for the task). A praxis begun three weeks ago and filed
-    this morning is news, and belongs at the top of ``newest``.
+    ``newest``/``oldest`` sort on ``Praxis.submitted_at`` — when the praxis was
+    *filed* — not ``created_at``, which is merely when the draft was started
+    (i.e. when the author signed up for the task). A praxis begun three weeks
+    ago and filed this morning is news, and belongs at the top of ``newest``.
+
+    ``most_voted``/``least_voted`` (#1362) order on how many votes a praxis has
+    drawn. ``voter_count`` on the card is computed in Python by
+    :func:`services.vote_tally.tally_votes` *after* the fetch, so it cannot
+    order the query — the ORDER BY uses a correlated ``COUNT`` over ``Vote``
+    counting exactly the same rows. Both carry a mandatory ``submitted_at DESC``
+    tiebreak: most praxes have zero votes, so ties are the common case, and the
+    feed's growing window (``usePagedResource`` refetches a wider ``limit``)
+    would shuffle rows between pages under an untied ordering.
     """
 
     newest = "newest"
     oldest = "oldest"
+    most_voted = "most_voted"
+    least_voted = "least_voted"
+
+
+class PraxisEraScope(str, Enum):
+    """Which era's praxes a praxis list shows (#1362).
+
+    Neither ``Praxis`` nor ``Task`` carries an ``era_id``, and an era reset
+    (:func:`services.era.apply_era_reset`) never touches praxes — so a praxis
+    list is an all-eras-forever list unless it is bounded by seal time.
+    ``this_era`` (the default) is ``Praxis.submitted_at >= Era.started_at`` for
+    the live era row; ``all_eras`` is the opt-out that restores the unbounded
+    list. No column and no migration: the seal time already carries the fact.
+
+    An *unsealed* praxis (``submitted_at IS NULL``, which by definition is every
+    ``in_progress`` draft) is in-flight work and passes both scopes — it belongs
+    to no past era, and excluding it would empty the sidebar's draft list.
+
+    Read-side only. Past-era praxes remain votable and the score recalc still
+    re-sums every era — that is #1345, deliberately not this scope.
+    """
+
+    this_era = "this_era"
+    all_eras = "all_eras"
 
 
 class VotedFilter(str, Enum):
@@ -833,9 +870,10 @@ async def list_praxes(
     praxis_type: Optional[PraxisType] = None,
     status: Optional[PraxisStatus] = None,
     moderation_status: Optional[str] = None,
-    faction: Optional[str] = None,
+    faction: Optional[List[str]] = None,
     search: Optional[str] = None,
     sort: Optional[PraxisSort] = None,
+    era_scope: PraxisEraScope = PraxisEraScope.this_era,
     voted: Optional[VotedFilter] = None,
     viewer_id: Optional[int] = None,
     viewer_account_id: Optional[int] = None,
@@ -870,8 +908,15 @@ async def list_praxes(
     already surfaces for its own duelist. A leading ``@`` is a sigil and is
     dropped for the player axis only, matching the character search (#624).
 
+    ``faction`` is a multi-select (#1362): a list of task faction slugs, ORed.
+    An empty list is a no-op, not "match nothing".
+
     ``sort`` only applies to the ``status=submitted`` feed and is ignored
     otherwise; every caller that passes no ``sort`` keeps ``created_at DESC``.
+
+    ``era_scope`` defaults to ``this_era`` — praxes sealed since the live era
+    began, plus every unsealed draft. See :class:`PraxisEraScope` for why that
+    is a seal-time bound and not a column.
 
     ``voted`` (needs ``viewer_account_id``) is the account-scoped vote filter
     (#644 §6): ``yes`` = my account has voted this praxis; ``no`` = *needs my
@@ -884,9 +929,11 @@ async def list_praxes(
     # need it, and joining once keeps ``?faction=x&q=y`` from double-joining.
     query = query.join(Task, Praxis.task_id == Task.id)
 
-    if faction is not None:
-        # Praxis has no faction of its own; it inherits the linked task's faction.
-        query = query.where(Task.primary_faction_slug == faction)
+    if faction:
+        # Praxis has no faction of its own; it inherits the linked task's
+        # faction. Multi-select (#1362): an EMPTY list means "no faction filter",
+        # never "match nothing" — clearing every checkbox shows everything.
+        query = query.where(Task.primary_faction_slug.in_(faction))
 
     if search:
         term = search.strip()
@@ -997,16 +1044,46 @@ async def list_praxes(
         # That invariant is also what lets the sort below be a plain ORDER BY
         # with no coalesce and no NULLS-FIRST-on-DESC trap.
 
+    if era_scope == PraxisEraScope.this_era:
+        era_row = await get_current_era_row_safe(session)
+        # None = the era is unseeded. Fall through UNSCOPED rather than
+        # returning nothing: an install with no era row is not an install where
+        # nobody has done anything.
+        if era_row is not None:
+            query = query.where(
+                or_(
+                    Praxis.submitted_at.is_(None),
+                    Praxis.submitted_at >= era_row.started_at,
+                )
+            )
+
     query = query.options(selectinload(Praxis.media_items))
     if sort is not None and status == PraxisStatus.submitted:
-        order = (
-            Praxis.submitted_at.asc()
-            if sort == PraxisSort.oldest
-            else Praxis.submitted_at.desc()
-        )
+        if sort in (PraxisSort.most_voted, PraxisSort.least_voted):
+            # Correlated COUNT — the same rows tally_votes counts for
+            # ``voter_count``, which is computed after the fetch and so cannot
+            # order the query. The submitted_at tiebreak is mandatory; see
+            # PraxisSort.
+            vote_count = (
+                select(func.count(Vote.id))
+                .where(Vote.praxis_id == Praxis.id)
+                .scalar_subquery()
+            )
+            order = (
+                vote_count.desc()
+                if sort == PraxisSort.most_voted
+                else vote_count.asc(),
+                Praxis.submitted_at.desc(),
+            )
+        else:
+            order = (
+                Praxis.submitted_at.asc()
+                if sort == PraxisSort.oldest
+                else Praxis.submitted_at.desc(),
+            )
     else:
-        order = Praxis.created_at.desc()
-    query = query.order_by(order).limit(limit).offset(offset)
+        order = (Praxis.created_at.desc(),)
+    query = query.order_by(*order).limit(limit).offset(offset)
     result = await session.execute(query)
     praxes = list(result.scalars().all())
     for praxis in praxes:
@@ -2223,6 +2300,7 @@ __all__ = [
     "list_praxes",
     "praxis_membership_condition",
     "praxis_visibility_condition",
+    "PraxisEraScope",
     "PraxisSort",
     "VotedFilter",
     "moderate_praxis",

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -337,15 +337,19 @@ async def test_feed_sort_orders_by_submitted_at_not_created_at(
             )
         )
 
+    # all_eras: these seal times are days old, and the feed now defaults to
+    # this-era-only (#1362). The subject here is the ordering, not the scope.
     newest = await client.get(
-        "/praxes", params={"status": "submitted", "sort": "newest"}
+        "/praxes",
+        params={"status": "submitted", "sort": "newest", "era_scope": "all_eras"},
     )
     assert newest.status_code == 200
     newest_ids = [item["id"] for item in newest.json() if item["id"] in ids]
     assert newest_ids == ids  # praxis 0 sealed most recently
 
     oldest = await client.get(
-        "/praxes", params={"status": "submitted", "sort": "oldest"}
+        "/praxes",
+        params={"status": "submitted", "sort": "oldest", "era_scope": "all_eras"},
     )
     assert oldest.status_code == 200
     oldest_ids = [item["id"] for item in oldest.json() if item["id"] in ids]
@@ -382,7 +386,9 @@ async def test_list_praxes_without_sort_keeps_created_at_desc(
             )
         )
 
-    resp = await client.get("/praxes", params={"status": "submitted"})
+    resp = await client.get(
+        "/praxes", params={"status": "submitted", "era_scope": "all_eras"}
+    )
     assert resp.status_code == 200
     got = [item["id"] for item in resp.json() if item["id"] in ids]
     # created_at DESC — last created first, i.e. the reverse of `ids`.

--- a/backend/tests/integration/test_praxis_feed_scope.py
+++ b/backend/tests/integration/test_praxis_feed_scope.py
@@ -1,0 +1,318 @@
+"""Integration tests for the praxis feed's era scope, multi-faction filter and
+vote-count sorts (#1362).
+
+Seam under test: the query :func:`services.praxis.list_praxes` builds — era
+scope is a ``submitted_at`` bound against the current ``Era`` row, faction is an
+``IN`` over the linked task's faction, and the vote sorts order by a correlated
+``COUNT`` over ``Vote`` with a mandatory ``submitted_at DESC`` tiebreak. The
+route is exercised too, for the repeated-``?faction=`` plumbing that only FastAPI
+can prove.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from models.vote import Vote
+from services.praxis import PraxisEraScope, PraxisSort, list_praxes
+
+
+async def _make_praxis(
+    db_session: AsyncSession,
+    character: Character,
+    *,
+    title: str,
+    submitted_at: datetime | None,
+    faction_slug: str = "ua",
+    status: PraxisStatus = PraxisStatus.submitted,
+) -> Praxis:
+    """A solo praxis on its own task, with its seal time pinned."""
+    task = Task(
+        title=f"Task for {title}",
+        description="",
+        point_value=10,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug=faction_slug,
+    )
+    db_session.add(task)
+    await db_session.flush()
+
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=status,
+        title=title,
+        body_text="proof",
+        submitted_at=submitted_at,
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=praxis.id, character_id=character.id))
+    await db_session.commit()
+    await db_session.refresh(praxis)
+    return praxis
+
+
+@pytest_asyncio.fixture
+async def faction_wow(db_session: AsyncSession) -> Faction:
+    """Second faction row for the multi-select union (FK on Task)."""
+    existing = await db_session.execute(select(Faction).where(Faction.slug == "wow"))
+    if existing.scalar_one_or_none() is None:
+        db_session.add(Faction(slug="wow", status=FactionStatus.visible))
+        await db_session.commit()
+    result = await db_session.execute(select(Faction).where(Faction.slug == "wow"))
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# 1. Era scope
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_era_scope_hides_praxes_sealed_before_the_era_started(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+):
+    """Default is *this era*: a praxis sealed before ``Era.started_at`` is gone,
+    and ``all_eras`` brings it back."""
+    before = await _make_praxis(
+        db_session,
+        character,
+        title="Last era",
+        submitted_at=era.started_at - timedelta(days=30),
+    )
+    after = await _make_praxis(
+        db_session,
+        character,
+        title="This era",
+        submitted_at=era.started_at + timedelta(minutes=1),
+    )
+
+    scoped = await list_praxes(db_session, status=PraxisStatus.submitted)
+    assert [p.id for p in scoped] == [after.id]
+
+    unscoped = await list_praxes(
+        db_session,
+        status=PraxisStatus.submitted,
+        era_scope=PraxisEraScope.all_eras,
+    )
+    assert {p.id for p in unscoped} == {before.id, after.id}
+
+
+@pytest.mark.asyncio
+async def test_era_scope_keeps_unsealed_drafts(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+):
+    """An in-progress praxis has a NULL ``submitted_at`` by definition, so era
+    scope must not delete the sidebar's drafts."""
+    draft = await _make_praxis(
+        db_session,
+        character,
+        title="Draft",
+        submitted_at=None,
+        status=PraxisStatus.in_progress,
+    )
+
+    got = await list_praxes(
+        db_session,
+        member_id=character.id,
+        status=PraxisStatus.in_progress,
+        viewer_id=character.id,
+    )
+    assert [p.id for p in got] == [draft.id]
+
+
+@pytest.mark.asyncio
+async def test_era_scope_falls_through_when_the_era_is_unseeded(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+):
+    """No Era row for the live config key ⇒ unscoped, not empty."""
+    old = await _make_praxis(
+        db_session,
+        character,
+        title="Ancient",
+        submitted_at=era.started_at - timedelta(days=365),
+    )
+    # Simulate the unseeded era without breaking the CharacterStats FK.
+    era.config_key = "era_not_seeded"
+    await db_session.commit()
+
+    got = await list_praxes(db_session, status=PraxisStatus.submitted)
+    assert [p.id for p in got] == [old.id]
+
+
+# ---------------------------------------------------------------------------
+# 2. Multi-select faction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_faction_filter_is_a_union_over_slugs(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+    faction_wow: Faction,
+):
+    sealed = era.started_at + timedelta(minutes=1)
+    ua_praxis = await _make_praxis(
+        db_session, character, title="UA", submitted_at=sealed, faction_slug="ua"
+    )
+    wow_praxis = await _make_praxis(
+        db_session, character, title="WOW", submitted_at=sealed, faction_slug="wow"
+    )
+
+    both = await list_praxes(
+        db_session, status=PraxisStatus.submitted, faction=["ua", "wow"]
+    )
+    assert {p.id for p in both} == {ua_praxis.id, wow_praxis.id}
+
+    one = await list_praxes(db_session, status=PraxisStatus.submitted, faction=["wow"])
+    assert [p.id for p in one] == [wow_praxis.id]
+
+    empty = await list_praxes(db_session, status=PraxisStatus.submitted, faction=[])
+    assert {p.id for p in empty} == {ua_praxis.id, wow_praxis.id}
+
+
+@pytest.mark.asyncio
+async def test_route_accepts_repeated_faction_params(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+    faction_wow: Faction,
+):
+    """``?faction=ua&faction=wow`` — the plumbing only FastAPI can prove."""
+    sealed = era.started_at + timedelta(minutes=1)
+    ua_praxis = await _make_praxis(
+        db_session, character, title="UA route", submitted_at=sealed, faction_slug="ua"
+    )
+    wow_praxis = await _make_praxis(
+        db_session, character, title="WOW route", submitted_at=sealed, faction_slug="wow"
+    )
+
+    resp = await client.get(
+        "/praxes", params=[("status", "submitted"), ("faction", "ua"), ("faction", "wow")]
+    )
+    assert resp.status_code == 200
+    assert {item["id"] for item in resp.json()} == {ua_praxis.id, wow_praxis.id}
+
+    single = await client.get("/praxes", params={"status": "submitted", "faction": "wow"})
+    assert single.status_code == 200
+    assert [item["id"] for item in single.json()] == [wow_praxis.id]
+
+
+# ---------------------------------------------------------------------------
+# 3. Vote-count sorts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vote_sorts_order_by_count_and_break_ties_by_seal_time(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    era: Era,
+):
+    """``most_voted``/``least_voted`` order on the vote count, and the mandatory
+    ``submitted_at DESC`` tiebreak keeps a growing window stable: the shorter
+    page must be a prefix of the longer one (``usePagedResource`` refetches a
+    wider ``limit``)."""
+    sealed = era.started_at + timedelta(minutes=1)
+    # Three zero-vote praxes so ties are the common case, plus two with votes.
+    tied_new = await _make_praxis(
+        db_session, character, title="Tie new", submitted_at=sealed + timedelta(hours=3)
+    )
+    tied_mid = await _make_praxis(
+        db_session, character, title="Tie mid", submitted_at=sealed + timedelta(hours=2)
+    )
+    tied_old = await _make_praxis(
+        db_session, character, title="Tie old", submitted_at=sealed + timedelta(hours=1)
+    )
+    one_vote = await _make_praxis(
+        db_session, character, title="One vote", submitted_at=sealed
+    )
+    two_votes = await _make_praxis(
+        db_session, character, title="Two votes", submitted_at=sealed
+    )
+    db_session.add_all(
+        [
+            Vote(
+                praxis_id=one_vote.id,
+                voter_character_id=character2.id,
+                voter_account_id=character2.account_id,
+                value=3,
+            ),
+            Vote(
+                praxis_id=two_votes.id,
+                voter_character_id=character2.id,
+                voter_account_id=character2.account_id,
+                value=3,
+            ),
+            Vote(
+                praxis_id=two_votes.id,
+                voter_character_id=character3.id,
+                voter_account_id=character3.account_id,
+                value=5,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    most = await list_praxes(
+        db_session, status=PraxisStatus.submitted, sort=PraxisSort.most_voted
+    )
+    assert [p.id for p in most] == [
+        two_votes.id,
+        one_vote.id,
+        tied_new.id,
+        tied_mid.id,
+        tied_old.id,
+    ]
+
+    least = await list_praxes(
+        db_session, status=PraxisStatus.submitted, sort=PraxisSort.least_voted
+    )
+    assert [p.id for p in least] == [
+        tied_new.id,
+        tied_mid.id,
+        tied_old.id,
+        one_vote.id,
+        two_votes.id,
+    ]
+
+    # Growing window: limit=3 must be the prefix of limit=5, for both sorts.
+    for sort in (PraxisSort.most_voted, PraxisSort.least_voted):
+        narrow = await list_praxes(
+            db_session, status=PraxisStatus.submitted, sort=sort, limit=3
+        )
+        wide = await list_praxes(
+            db_session, status=PraxisStatus.submitted, sort=sort, limit=5
+        )
+        assert [p.id for p in narrow] == [p.id for p in wide][:3]
+
+
+@pytest.mark.asyncio
+async def test_route_rejects_an_unknown_sort_and_era_scope(client: AsyncClient):
+    bad_sort = await client.get("/praxes", params={"sort": "most_liked"})
+    assert bad_sort.status_code == 422
+
+    bad_scope = await client.get("/praxes", params={"era_scope": "next_era"})
+    assert bad_scope.status_code == 422

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -230,6 +230,12 @@ export async function listPraxes(filters?: {
   voted?: 'yes' | 'no'
   /** Seal-date order (#644 §2). Defaults server-side to `newest`. */
   sort?: 'newest' | 'oldest'
+  /**
+   * Era scope (#1362). Defaults server-side to `this_era` — praxes sealed since
+   * the live era began, plus every unsealed draft. Pass `all_eras` on a surface
+   * that is a career record rather than a feed of current activity.
+   */
+  era_scope?: 'this_era' | 'all_eras'
   limit?: number
   offset?: number
 }): Promise<PraxisCardOut[]> {

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -47,7 +47,12 @@ export default function CharacterProfile() {
       const cid = Number(id);
       return Promise.all([
         getCharacter(cid),
-        listPraxes({ character_id: cid }),
+        // A profile is a career record, not a feed of current activity: it shows
+        // what this player has done regardless of era (owner ruling, #1362).
+        // Without this the grid inherits the new `this_era` default and reads
+        // empty for everyone the morning after an era reset — and it disagrees
+        // with GET /characters/{id}/praxes, which stays all-eras.
+        listPraxes({ character_id: cid, era_scope: "all_eras" }),
         listTasks({ created_by: cid }),
       ]);
     },


### PR DESCRIPTION
Closes #1362

Backend only — no frontend file is touched. Three additions to `list_praxes` and its route.

## Seam tested at

`services.praxis.list_praxes` **query construction** — the era bound, the faction `IN`, and the
`ORDER BY`. New file `backend/tests/integration/test_praxis_feed_scope.py` drives the service
directly for the SQL, and goes through `GET /praxes` only for the two things FastAPI alone can
prove: repeated `?faction=a&faction=b` binding to a list, and the 422 on an unknown `era_scope`.
The loop went red first on the missing `PraxisEraScope` import, then on each assertion.

## 1. Era scope — `era_scope=this_era` (default) / `all_eras`

`Praxis.submitted_at >= Era.started_at` for the live era row. No column, no migration. The era row
is resolved with `services.era.get_current_era_row_safe`; `None` (unseeded) falls through
**unscoped**, not empty.

One judgement call the issue did not cover: an **unsealed** praxis (`submitted_at IS NULL`, which
is every `in_progress` draft by definition) passes both scopes. A bare `>=` is NULL-false, so the
strict predicate would have emptied the sidebar's draft list and task detail's "your draft for this
task" — `list_praxes` is shared by all of them. Drafts are in-flight work and belong to no past era.
Covered by `test_era_scope_keeps_unsealed_drafts`.

## 2. Faction is multi-select

`faction: Optional[List[str]] = Query(None)` → `Task.primary_faction_slug.in_(faction)`. Guarded on
`if faction:` so an **empty list is a no-op**, never "match nothing". A single `?faction=wow` still
behaves exactly as before (route test asserts this).

## 3. `most_voted` / `least_voted`

Correlated `COUNT` over `Vote` in the `ORDER BY` — the same rows `tally_votes` counts for
`voter_count`, which is computed in Python after the fetch and so cannot order the query. Both
carry the mandatory `, submitted_at DESC` tiebreak; the test asserts the growing-window property
directly (`limit=3` result must be the prefix of `limit=5` with three praxes tied on zero votes),
which is what `usePagedResource` needs.

## Blast radius — worth eyeballing

`list_praxes` is shared, so the new **default** reaches every caller of `GET /praxes`, not just the
feed: home, faction detail, task detail, and the character profile grid. Consequences:

- **Two existing tests changed.** `test_feed_sort_orders_by_submitted_at_not_created_at` and
  `test_list_praxes_without_sort_keeps_created_at_desc` pin seal times *days* in the past, i.e.
  before the test era's `started_at`. They now pass `era_scope=all_eras`; their subject is ordering,
  not scope. Nothing else in the suite moved.
- **The profile grid is now this-era by default.** `CharacterProfile.tsx` fetches
  `/praxes?character_id=`, so it narrows; `GET /characters/{id}/praxes` (a whole-career record with
  no era rail) deliberately stays all-eras. That route's "cannot drift" docstring now names the one
  difference instead of quietly being wrong.
- **In a live DB**, anything sealed before the era row's `started_at` disappears from those surfaces
  unless `?era_scope=all_eras` is passed. That is the point of the feature, but it is the one thing
  worth looking at with real data.

## For F2 (#1366)

The query param is **`era_scope`**, values `this_era` / `all_eras`, and `faction` repeats.
`frontend/src/api/praxis.ts` `listPraxes` is untouched by design — its `faction?: string` and
`sort?: 'newest' | 'oldest'` types need widening when the bar is mounted.

## What to eyeball

- The NULL-`submitted_at` carve-out above — it is the one deviation from the issue text.
- Whether the profile grid should be era-scoped (I think yes, since stats already are per-era) or
  should pass `all_eras`; either way it is a frontend one-liner in F2.

Visual QA is outstanding — no browser or dev stack in this environment.
