### PR TITLE
F3 — the task browse's two filter rows become one FilterBar (#1367)

### DIFF
--- a/frontend/src/api/__tests__/taskQueryParams.test.ts
+++ b/frontend/src/api/__tests__/taskQueryParams.test.ts
@@ -1,0 +1,40 @@
+/**
+ * The seam: how `listTasks` SERIALISES its query string (#1367 / #1364).
+ *
+ * `GET /tasks` takes `faction: list[str] = Query(None)` — a repeated
+ * `?faction=a&faction=b`. Axios's default array rendering is `faction[]=a`,
+ * which FastAPI does not read at all: the request would 200 with an unfiltered
+ * list while the bar showed faction chips. Nothing type-checks that gap and no
+ * component test can see it, so it is pinned here, at the client.
+ */
+import { describe, it, expect } from 'vitest'
+import api from '../axios'
+import { REPEATED_QUERY_PARAMS } from '../tasks'
+
+function uri(params: Record<string, unknown>): string {
+  return api.getUri({
+    url: '/tasks',
+    params,
+    paramsSerializer: REPEATED_QUERY_PARAMS,
+  })
+}
+
+describe('listTasks query serialisation', () => {
+  it('repeats the bare `faction` key for a multi-select union', () => {
+    const out = uri({ faction: ['everymen', 'coven'] })
+    expect(out).toContain('faction=everymen')
+    expect(out).toContain('faction=coven')
+  })
+
+  it('never emits the bracketed array form FastAPI ignores', () => {
+    expect(uri({ faction: ['everymen', 'coven'] })).not.toContain('faction%5B%5D')
+    expect(uri({ faction: ['everymen', 'coven'] })).not.toContain('faction[]')
+  })
+
+  it('leaves single-valued axes alone', () => {
+    const out = uri({ faction: ['ua'], status: 'active', sort: 'level' })
+    expect(out).toContain('status=active')
+    expect(out).toContain('sort=level')
+    expect(out).toContain('faction=ua')
+  })
+})

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -56,9 +56,21 @@ export interface TaskCreate {
   metatask_faction_slug?: string
 }
 
+/**
+ * The orderings `GET /tasks` accepts (#1364). An ABSENT sort still means
+ * `level` — `level_required ASC, point_value DESC`, the browse ordering the
+ * page has always had. `level` is ascending only; there is no descending twin.
+ */
+export type TaskSort = 'newest' | 'oldest' | 'level'
+
 export interface TaskFilters {
   status?: string
-  faction?: string
+  /**
+   * Repeated `?faction=` — a UNION, not an intersection (#1364). One slug
+   * narrows to one faction; none at all filters nothing. See
+   * {@link REPEATED_QUERY_PARAMS} for why the serializer is not the default.
+   */
+  faction?: string[]
   /**
    * Narrow the list to tasks the authenticated viewer could claim right now
    * (#1130). The server evaluates its own sign-up predicate, so a faction
@@ -75,14 +87,25 @@ export interface TaskFilters {
    * (#661; author axis added in #681).
    */
   q?: string
-  /** 'newest' orders by creation time (newest first); default sorts by level/points. */
-  sort?: string
+  sort?: TaskSort
   limit?: number
   offset?: number
 }
 
+/**
+ * Axios renders an array param as `faction[]=a&faction[]=b` by default. FastAPI
+ * reads a repeated `faction: list[str] = Query(None)` — the bracketed key is
+ * simply not the parameter, so the union filter would silently do NOTHING and
+ * the page would show an unfiltered list with faction chips on it.
+ * `indexes: null` is axios's "repeat the bare key" mode.
+ */
+export const REPEATED_QUERY_PARAMS = { indexes: null } as const
+
 export async function listTasks(filters?: TaskFilters): Promise<TaskOut[]> {
-  const { data } = await api.get<TaskOut[]>('/tasks', { params: filters })
+  const { data } = await api.get<TaskOut[]>('/tasks', {
+    params: filters,
+    paramsSerializer: REPEATED_QUERY_PARAMS,
+  })
   return data
 }
 

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -19,7 +19,13 @@
     "allTasks": "All tasks",
     "canSignUp": "I can sign up",
     "tasks": "Tasks",
-    "metatasks": "Metatasks"
+    "metatasks": "Metatasks",
+    "status": {
+      "all": "All",
+      "active": "Active",
+      "retired": "Retired",
+      "pending": "Pending"
+    }
   },
   "mobile": {
     "count": "{{count}} shown",

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -1,18 +1,12 @@
 import { useTranslation } from 'react-i18next'
 import TaskCard from '../components/taskCard/TaskCard'
 import PageTitle from '../components/ui/PageTitle'
-import FilterStamps from '../components/ui/FilterStamps'
-import FilterFactionTabs from '../components/ui/FilterFactionTabs'
 import { extractError } from '../utils/errors'
 import { useFormFactor } from '../hooks/useFormFactor'
 import { useTasks, type TasksState } from './tasks/useTasks'
 import DefaultTasks from './tasks/mobileArchetypes/DefaultTasks'
-import CanSignUpEmpty from './tasks/CanSignUpEmpty'
+import TaskFilterBar, { TaskListEmpty } from './tasks/TaskFilterBar'
 import MetataskSeal from '../components/metataskSeal/MetataskSeal'
-import type { TaskType } from '../api/tasks'
-
-/** The eligibility filter's two stamps: everything, or only what I can claim. */
-const ELIGIBILITY_OPTIONS = ['all', 'canSignUp']
 
 export default function Tasks() {
   const state = useTasks()
@@ -36,18 +30,7 @@ function DesktopTasks({ state }: { state: TasksState }) {
     tasks,
     loading,
     error,
-    factions,
-    statusFilters,
     taskType,
-    setTaskType,
-    status,
-    setStatus,
-    faction,
-    setFaction,
-    canSignUp,
-    setCanSignUp,
-    query,
-    setQuery,
     hasMore,
     loadMore,
     signupMsg,
@@ -61,46 +44,12 @@ function DesktopTasks({ state }: { state: TasksState }) {
     <div className="py-8">
       <PageTitle title="Tasks" eyebrow={`${tasks.length} shown`} />
 
-      {/* Filters (Style Guide §5.3) */}
-      <div className="flex flex-col gap-2.5 mb-6">
-        <TaskTypeToggle value={taskType} onChange={setTaskType} />
-        <FilterStamps options={statusFilters} value={status} onChange={setStatus} />
-        <FilterFactionTabs factions={factions} value={faction} onChange={setFaction} />
-        {/* "Tasks I can sign up for" (#1130), in the slot the level filter
-            used to hold. Hidden when logged out: the server answers `[]` for an
-            anonymous viewer, so it is a control that cannot work — and this page
-            hides unusable controls rather than disabling them. Anonymous browse
-            keeps search, faction, type and points; the default ordering is still
-            level-ascending, so the ladder stays legible without it. */}
-        {user && (
-          <FilterStamps
-            label={t('browse.eligibility')}
-            options={ELIGIBILITY_OPTIONS}
-            optionLabels={{
-              all: t('browse.allTasks'),
-              canSignUp: t('browse.canSignUp'),
-            }}
-            value={canSignUp ? 'canSignUp' : 'all'}
-            onChange={(next) => setCanSignUp(next === 'canSignUp')}
-          />
-        )}
-        <input
-          type="search"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder={t('listPage.filter.searchPlaceholder')}
-          aria-label={t('listPage.filter.searchLabel')}
-          className="font-body"
-          style={{
-            fontSize: 'var(--text-sm)',
-            padding: 'var(--space-sm) var(--space-md)',
-            maxWidth: 320,
-            background: 'var(--color-bg-surface)',
-            border: '1px solid var(--color-border-strong)',
-            color: 'var(--color-text-primary)',
-            borderRadius: 4,
-          }}
-        />
+      {/* One filter surface for both form factors (#1367, epic #1361). The
+          stamp stack, the faction tabs and the inline search input that used to
+          sit here are gone — every axis they held is a rail in the bar, and
+          every axis now rides in the URL. */}
+      <div className="mb-6">
+        <TaskFilterBar state={state} />
       </div>
 
       {signupMsg && (
@@ -117,13 +66,7 @@ function DesktopTasks({ state }: { state: TasksState }) {
           <button onClick={() => window.location.reload()} className="underline">{tc('states.tryRefreshing')}</button>
         </p>
       ) : tasks.length === 0 ? (
-        /* An empty eligible list has a reason worth naming — most often a full
-           task bank, which is a gate on the player, not on the catalogue. */
-        canSignUp ? (
-          <CanSignUpEmpty />
-        ) : (
-          <p className="font-body text-muted">{t('listPage.empty')}</p>
-        )
+        <TaskListEmpty state={state} />
       ) : (
         <>
           {isMetatask ? (
@@ -170,54 +113,6 @@ function DesktopTasks({ state }: { state: TasksState }) {
           )}
         </>
       )}
-    </div>
-  )
-}
-
-/**
- * Task / Metatask browse toggle (#934) — rubber-stamp pair, sharing the status
- * filter's stamp voice. Switching mode resets the growing window (setter side).
- */
-function TaskTypeToggle({
-  value,
-  onChange,
-}: {
-  value: TaskType
-  onChange: (value: TaskType) => void
-}) {
-  const { t } = useTranslation('tasks')
-  const options: ReadonlyArray<{ key: TaskType; label: string }> = [
-    { key: 'standard', label: t('browse.tasks') },
-    { key: 'metatask', label: t('browse.metatasks') },
-  ]
-  return (
-    <div className="flex gap-1.5 items-center">
-      <span className="eyebrow">{t('browse.taskType')}</span>
-      {options.map((option) => {
-        const active = value === option.key
-        return (
-          <button
-            key={option.key}
-            type="button"
-            onClick={() => onChange(option.key)}
-            className="font-body uppercase"
-            style={{
-              border: `2px solid ${active ? 'var(--color-text-primary)' : 'var(--color-border-strong)'}`,
-              borderRadius: 0,
-              background: active ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
-              color: active ? 'var(--color-bg-page)' : 'var(--color-text-primary)',
-              fontSize: 'var(--text-base)',
-              fontWeight: 700,
-              letterSpacing: '0.1em',
-              padding: 'var(--space-xs) var(--space-sm)',
-              cursor: 'pointer',
-              transition: 'all 120ms',
-            }}
-          >
-            {option.label}
-          </button>
-        )
-      })}
     </div>
   )
 }

--- a/frontend/src/pages/factionDetail/useFactionDetail.ts
+++ b/frontend/src/pages/factionDetail/useFactionDetail.ts
@@ -159,7 +159,9 @@ export function useFactionDetail(
     setFetchError(null);
     Promise.all([
       listCharacters({ faction: slug }),
-      listTasks({ faction: slug, status: "active" }),
+      // `faction` is a repeated union param since #1364; one slug is a
+      // one-element union, not a scalar.
+      listTasks({ faction: [slug], status: "active" }),
       listPraxes({ faction: slug, status: "submitted", limit: 12 }),
     ])
       .then(([mems, tsks, praxis]) => {

--- a/frontend/src/pages/tasks/CanSignUpEmpty.tsx
+++ b/frontend/src/pages/tasks/CanSignUpEmpty.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useMyActiveTasks } from '../../hooks/useMyActiveTasks'
 import { useGameConfig } from '../../hooks/useGameConfig'
+import { FilterBarEmpty } from '../../components/ui/FilterBar'
 
 /** Fallback bank size before `/game-config` lands, matching the Sidebar meter. */
 const DEFAULT_MAX_TASK_SLOTS = 20
@@ -29,7 +30,12 @@ const DEFAULT_MAX_TASK_SLOTS = 20
  * envelope or header on GET /tasks — which is a bigger change than the sentence
  * is worth today.
  */
-export default function CanSignUpEmpty() {
+export default function CanSignUpEmpty({
+  onClearAll,
+}: {
+  /** Present once the filter bar owns the axis (#1367) — the way back out. */
+  onClearAll?: () => void
+}) {
   const { t } = useTranslation('tasks')
   const { activeTasks } = useMyActiveTasks()
   const gameConfig = useGameConfig()
@@ -38,10 +44,14 @@ export default function CanSignUpEmpty() {
   const bankFull = activeTasks.length >= maxTaskSlots
 
   return (
-    <p className="font-body text-muted">
-      {bankFull
-        ? t('listPage.bankFull', { used: activeTasks.length, max: maxTaskSlots })
-        : t('listPage.emptyEligible')}
-    </p>
+    <FilterBarEmpty
+      title={t('listPage.emptyCaughtUp')}
+      hint={
+        bankFull
+          ? t('listPage.bankFull', { used: activeTasks.length, max: maxTaskSlots })
+          : t('listPage.emptyEligible')
+      }
+      onClearAll={onClearAll}
+    />
   )
 }

--- a/frontend/src/pages/tasks/TaskFilterBar.tsx
+++ b/frontend/src/pages/tasks/TaskFilterBar.tsx
@@ -68,6 +68,17 @@ export default function TaskFilterBar({ state }: { state: TasksState }) {
     clearFilters,
   } = state
 
+  // Keyed by the raw status the API expects, with the keys written out rather
+  // than interpolated: the catalog types its keys as a union, so a template
+  // literal does not typecheck — and a computed key is invisible to the
+  // unused-key sweep either way.
+  const statusLabels: Record<string, string> = {
+    [TASK_STATUS_DEFAULT]: t('browse.status.all'),
+    active: t('browse.status.active'),
+    retired: t('browse.status.retired'),
+    pending: t('browse.status.pending'),
+  }
+
   const rails: FilterRail[] = [
     {
       key: 'type',
@@ -100,11 +111,14 @@ export default function TaskFilterBar({ state }: { state: TasksState }) {
       defaultValue: TASK_STATUS_DEFAULT,
       // 2 segments logged out, 3 or 4 for a viewer allowed the extra states —
       // `statusFilters` is the permission boundary and the rail takes it whole.
-      // ponytail: the segment text is the raw status value, which is what the
-      // stamps showed (uppercased by CSS). There is no localized label for a
-      // task status anywhere in the catalogs, and authoring one is F1's remit,
-      // not this issue's.
-      segments: statusFilters.map((option) => ({ value: option, label: option })),
+      // The value stays the raw status the API expects; only the label is
+      // localized. `FilterStamps` uppercased its options in CSS, so rendering
+      // the bare value on a rail that does not would have shipped a mixed-case
+      // row ("All active retired pending").
+      segments: statusFilters.map((option) => ({
+        value: option,
+        label: statusLabels[option] ?? option,
+      })),
       onChange: setStatus,
     },
   ]

--- a/frontend/src/pages/tasks/TaskFilterBar.tsx
+++ b/frontend/src/pages/tasks/TaskFilterBar.tsx
@@ -1,0 +1,165 @@
+import { useTranslation } from 'react-i18next'
+import FilterBar, {
+  FilterBarEmpty,
+  selectEmptyState,
+  type FilterRail,
+} from '../../components/ui/FilterBar'
+import CanSignUpEmpty from './CanSignUpEmpty'
+import {
+  appliedFilterCount,
+  TASK_SORT_DEFAULT,
+  TASK_STATUS_DEFAULT,
+  TASK_TYPE_DEFAULT,
+  type TasksState,
+} from './useTasks'
+import type { TaskSort, TaskType } from '../../api/tasks'
+
+/** The eligibility axis, as a rail: everything, or only what I can claim. */
+const ELIGIBILITY_DEFAULT = 'all'
+const ELIGIBILITY_ON = 'canSignUp'
+
+/**
+ * The task browse's filter bar — the shared `FilterBar` (#1365) wired to
+ * `useTasks`, replacing BOTH hand-rolled filter rows: the desktop stamp stack
+ * (`FilterStamps` × 2 + `FilterFactionTabs` + an inline search input) and the
+ * mobile chip rows (`ChipRow` × 3 + `FactionSigilRow`).
+ *
+ * ONE component for both form factors, not a mobile twin: `FilterBar` is chrome
+ * rather than a faction-dressed surface, so it sits outside the
+ * `MOBILE_ARCHETYPE_BY_SLUG` seam and folds itself down on the phone.
+ *
+ * Four rails. Two of them are here because the alternative was worse:
+ *
+ *   - **sort** did not exist on this page at all. The page got
+ *     `level_required ASC, point_value DESC` by sending no `sort`, so mounting a
+ *     bare newest/oldest pair would have silently deleted the ladder ordering.
+ *     Naming it `level` and defaulting to it keeps today's behaviour and makes
+ *     it selectable. Ascending only — there is no level-descending option.
+ *   - **task type** (#934) was a hand-rolled inline-styled toggle that no
+ *     `FilterStamps` sweep would have caught, so leaving it would have shipped a
+ *     stamp above a rail — the exact inconsistency this epic exists to remove.
+ *
+ * The eligibility rail (#1130) keeps its `user &&` gate: the server answers `[]`
+ * for an anonymous viewer, so it is a control that cannot work logged out, and
+ * this page hides unusable controls rather than disabling them (STYLE §1.4).
+ * Status keeps its viewer-gated segment count for the same reason — `retired`
+ * and `pending` are a permission boundary, and a logged-out viewer gets two
+ * segments, not four.
+ */
+export default function TaskFilterBar({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const { t: tc } = useTranslation('common')
+  const {
+    user,
+    factions,
+    statusFilters,
+    taskType,
+    setTaskType,
+    sort,
+    setSort,
+    status,
+    setStatus,
+    selectedFactions,
+    setSelectedFactions,
+    canSignUp,
+    setCanSignUp,
+    query,
+    setQuery,
+    clearFilters,
+  } = state
+
+  const rails: FilterRail[] = [
+    {
+      key: 'type',
+      label: t('browse.taskType'),
+      value: taskType,
+      defaultValue: TASK_TYPE_DEFAULT,
+      segments: [
+        { value: 'standard', label: t('browse.tasks') },
+        { value: 'metatask', label: t('browse.metatasks') },
+      ],
+      onChange: (next) => setTaskType(next as TaskType),
+    },
+    {
+      key: 'sort',
+      label: tc('filters.bar.sortLabel'),
+      // The default leads, as it does on every other rail here.
+      segments: [
+        { value: 'level', label: tc('filters.bar.sort.level') },
+        { value: 'newest', label: tc('filters.bar.sort.newest') },
+        { value: 'oldest', label: tc('filters.bar.sort.oldest') },
+      ],
+      value: sort,
+      defaultValue: TASK_SORT_DEFAULT,
+      onChange: (next) => setSort(next as TaskSort),
+    },
+    {
+      key: 'status',
+      label: tc('filters.status'),
+      value: status,
+      defaultValue: TASK_STATUS_DEFAULT,
+      // 2 segments logged out, 3 or 4 for a viewer allowed the extra states —
+      // `statusFilters` is the permission boundary and the rail takes it whole.
+      // ponytail: the segment text is the raw status value, which is what the
+      // stamps showed (uppercased by CSS). There is no localized label for a
+      // task status anywhere in the catalogs, and authoring one is F1's remit,
+      // not this issue's.
+      segments: statusFilters.map((option) => ({ value: option, label: option })),
+      onChange: setStatus,
+    },
+  ]
+
+  if (user) {
+    rails.push({
+      key: 'eligibility',
+      label: t('browse.eligibility'),
+      value: canSignUp ? ELIGIBILITY_ON : ELIGIBILITY_DEFAULT,
+      defaultValue: ELIGIBILITY_DEFAULT,
+      segments: [
+        { value: ELIGIBILITY_DEFAULT, label: t('browse.allTasks') },
+        { value: ELIGIBILITY_ON, label: t('browse.canSignUp') },
+      ],
+      onChange: (next) => setCanSignUp(next === ELIGIBILITY_ON),
+    })
+  }
+
+  return (
+    <FilterBar
+      rails={rails}
+      factions={factions}
+      selectedFactions={selectedFactions}
+      onFactionsChange={setSelectedFactions}
+      onClearAll={clearFilters}
+      search={{
+        value: query,
+        onChange: setQuery,
+        placeholder: t('listPage.filter.searchPlaceholder'),
+        label: t('listPage.filter.searchLabel'),
+      }}
+    />
+  )
+}
+
+/**
+ * Which of the three empty states an empty task list gets (#1361 ruling 9).
+ *
+ * `caughtUp` stays `CanSignUpEmpty`'s job: a full task bank empties the eligible
+ * list wholesale, and "you already hold twenty" is a different sentence from
+ * "nothing matches" — see that component for why the count is the client's own.
+ */
+export function TaskListEmpty({ state }: { state: TasksState }) {
+  const { t } = useTranslation('tasks')
+  const kind = selectEmptyState(appliedFilterCount(state), state.canSignUp)
+
+  if (kind === 'caughtUp') return <CanSignUpEmpty onClearAll={state.clearFilters} />
+  if (kind === 'filtered') {
+    return (
+      <FilterBarEmpty
+        title={t('listPage.emptyFiltered')}
+        onClearAll={state.clearFilters}
+      />
+    )
+  }
+  // `register` — nothing is filtered, so there is nothing to clear.
+  return <FilterBarEmpty title={t('listPage.empty')} />
+}

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -75,14 +75,17 @@ const CANNED: TasksState = {
   statusFilters: ['All', 'active'],
   taskType: 'standard',
   setTaskType: () => {},
+  sort: 'level',
+  setSort: () => {},
   status: 'All',
   setStatus: () => {},
-  faction: '',
-  setFaction: () => {},
+  selectedFactions: [],
+  setSelectedFactions: () => {},
   canSignUp: false,
   setCanSignUp: () => {},
   query: '',
   setQuery: () => {},
+  clearFilters: () => {},
   hasMore: false,
   loadMore: () => {},
   signupMsg: null,
@@ -94,7 +97,10 @@ const CANNED: TasksState = {
 // What the mocked hook hands back; each test replaces it before rendering.
 const state: { current: TasksState } = { current: CANNED }
 
-vi.mock('../useTasks', () => ({
+// PARTIAL: only the hook is canned. The module also exports the filter defaults
+// and the pure param helpers, which `TaskFilterBar` reads for real.
+vi.mock('../useTasks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../useTasks')>()),
   useTasks: () => state.current,
 }))
 
@@ -126,8 +132,24 @@ describe('Tasks form-factor dispatch', () => {
     state.current = CANNED
     const out = html()
     expect(out, 'no mobile skin').not.toContain('mobile-tasks-browse')
-    // The desktop rubber-stamp status filter (FilterStamps) is desktop-only chrome.
-    expect(out.toLowerCase(), 'desktop status filter').toContain('status:')
+    // The desktop page title; the filter bar itself is now shared chrome and so
+    // is no longer a form-factor discriminator (#1367).
+    expect(out, 'desktop page title').toContain('Tasks')
+  })
+
+  it('mounts the shared filter bar on BOTH form factors (#1367)', () => {
+    for (const formFactor of ['mobile', 'desktop'] as const) {
+      dispatch.formFactor = formFactor
+      state.current = CANNED
+      const out = html()
+      expect(out, formFactor).toContain('filter-bar')
+      expect(out, `${formFactor}: search moved into the bar`).toContain(
+        'filter-bar__search',
+      )
+      expect(out, `${formFactor}: no stamp row survives`).not.toContain(
+        'stamp-inactive-dashed',
+      )
+    }
   })
 })
 
@@ -191,15 +213,13 @@ describe('task-browse card + CTA parity (ADR-0056)', () => {
 describe('can-sign-up filter (#1130)', () => {
   const CAN_SIGN_UP = i18n.t('tasks:browse.canSignUp')
 
-  it('offers the filter on both form factors when signed in', () => {
-    for (const formFactor of ['mobile', 'desktop'] as const) {
-      dispatch.formFactor = formFactor
-      state.current = { ...CANNED, user: VIEWER }
-      expect(text().toLowerCase(), formFactor).toContain(CAN_SIGN_UP.toLowerCase())
-    }
+  it('offers the rail when signed in', () => {
+    dispatch.formFactor = 'desktop'
+    state.current = { ...CANNED, user: VIEWER }
+    expect(text().toLowerCase()).toContain(CAN_SIGN_UP.toLowerCase())
   })
 
-  it('hides the filter on both when logged out', () => {
+  it('hides the rail on both form factors when logged out', () => {
     for (const formFactor of ['mobile', 'desktop'] as const) {
       dispatch.formFactor = formFactor
       state.current = { ...CANNED, user: null }
@@ -221,5 +241,60 @@ describe('can-sign-up filter (#1130)', () => {
     dispatch.formFactor = 'desktop'
     state.current = { ...CANNED, user: VIEWER, canSignUp: false, tasks: [] }
     expect(text()).toContain(i18n.t('tasks:listPage.empty'))
+  })
+})
+
+/**
+ * The two rails the bar mount had to get right (#1367).
+ *
+ * The status rail is a PERMISSION boundary, not decoration: `retired` and
+ * `pending` are the viewer's to see or not, so the rail takes a variable
+ * segment count rather than a fixed four. And the sort rail defaults to
+ * `level` — the ordering the page already had by sending no `sort` at all —
+ * so it must sit on its default and raise no chip on a fresh load.
+ */
+describe('the task rails', () => {
+  const SEES_EVERYTHING: CurrentUser = {
+    ...VIEWER,
+    can_see_retired_tasks: true,
+    can_see_pending_tasks: true,
+  }
+
+  it('gives a logged-out viewer two status segments, not four', () => {
+    dispatch.formFactor = 'desktop'
+    state.current = { ...CANNED, user: null, statusFilters: ['All', 'active'] }
+    const out = html()
+    expect(out, 'no retired segment').not.toContain('>retired<')
+    expect(out, 'no pending segment').not.toContain('>pending<')
+    expect(out, 'no rail is four segments wide').not.toContain(
+      'width:calc((100% - 2 * var(--filter-rail-pad)) / 4)',
+    )
+  })
+
+  it('widens the status rail to four for a viewer allowed the extra states', () => {
+    dispatch.formFactor = 'desktop'
+    state.current = {
+      ...CANNED,
+      user: SEES_EVERYTHING,
+      statusFilters: ['All', 'active', 'retired', 'pending'],
+    }
+    const out = html()
+    expect(out).toContain('>retired<')
+    expect(out).toContain('>pending<')
+    expect(out, 'a 4-segment thumb').toContain(
+      'width:calc((100% - 2 * var(--filter-rail-pad)) / 4)',
+    )
+  })
+
+  it('opens on `level`, raising no applied chip', () => {
+    dispatch.formFactor = 'desktop'
+    state.current = { ...CANNED, user: VIEWER }
+    const out = html()
+    expect(out, 'the level segment is the selected one').toContain(
+      `aria-pressed="true">${i18n.t('common:filters.bar.sort.level')}<`,
+    )
+    expect(out, 'a default rail is not an applied filter').not.toContain(
+      'filter-bar__applied',
+    )
   })
 })

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -264,8 +264,12 @@ describe('the task rails', () => {
     dispatch.formFactor = 'desktop'
     state.current = { ...CANNED, user: null, statusFilters: ['All', 'active'] }
     const out = html()
-    expect(out, 'no retired segment').not.toContain('>retired<')
-    expect(out, 'no pending segment').not.toContain('>pending<')
+    expect(out, 'no retired segment').not.toContain(
+      `>${i18n.t('tasks:browse.status.retired')}<`,
+    )
+    expect(out, 'no pending segment').not.toContain(
+      `>${i18n.t('tasks:browse.status.pending')}<`,
+    )
     expect(out, 'no rail is four segments wide').not.toContain(
       'width:calc((100% - 2 * var(--filter-rail-pad)) / 4)',
     )
@@ -279,8 +283,10 @@ describe('the task rails', () => {
       statusFilters: ['All', 'active', 'retired', 'pending'],
     }
     const out = html()
-    expect(out).toContain('>retired<')
-    expect(out).toContain('>pending<')
+    // The segment shows the localized label; the VALUE stays the raw status
+    // the API expects, which is what `statusFilters` above carries.
+    expect(out).toContain(`>${i18n.t('tasks:browse.status.retired')}<`)
+    expect(out).toContain(`>${i18n.t('tasks:browse.status.pending')}<`)
     expect(out, 'a 4-segment thumb').toContain(
       'width:calc((100% - 2 * var(--filter-rail-pad)) / 4)',
     )

--- a/frontend/src/pages/tasks/__tests__/taskFilterParams.test.ts
+++ b/frontend/src/pages/tasks/__tests__/taskFilterParams.test.ts
@@ -1,0 +1,124 @@
+/**
+ * The seam: the task browse's URL param contract (#1367, epic #1361 ruling 7).
+ *
+ * Every filter axis rides in the address bar, so the whole filter set survives
+ * a paste or a refresh. The parts worth pinning are the ones that are pure
+ * functions of a param set — the repo's harness has no DOM, so the hook itself
+ * is not renderable here, and these are deliberately the hook's whole decision.
+ *
+ * Three decisions:
+ *   1. non-default values only — a clean browse has a clean address
+ *   2. faction is REPEATED (`?faction=a&faction=b`), the union B2 (#1364) reads
+ *   3. "clear all" clears search too, and touches nothing it does not own
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  CAN_SIGN_UP_ON,
+  TASK_FILTER_PARAMS,
+  TASK_SORT_DEFAULT,
+  TASK_STATUS_DEFAULT,
+  TASK_TYPE_DEFAULT,
+  clearedFilterParams,
+  nextFactionParams,
+  nextFilterParams,
+  readFilterParam,
+} from '../useTasks'
+
+const params = (query: string) => new URLSearchParams(query)
+
+describe('readFilterParam — a missing param IS the default', () => {
+  it('falls back when the axis is absent', () => {
+    expect(
+      readFilterParam(params(''), TASK_FILTER_PARAMS.sort, TASK_SORT_DEFAULT),
+    ).toBe('level')
+  })
+
+  it('falls back when the axis is present but blank', () => {
+    expect(
+      readFilterParam(params('sort='), TASK_FILTER_PARAMS.sort, TASK_SORT_DEFAULT),
+    ).toBe('level')
+  })
+
+  it('hydrates a pasted link', () => {
+    expect(
+      readFilterParam(
+        params('sort=oldest&status=retired'),
+        TASK_FILTER_PARAMS.status,
+        TASK_STATUS_DEFAULT,
+      ),
+    ).toBe('retired')
+  })
+})
+
+describe('nextFilterParams — non-default values only', () => {
+  it('writes a non-default axis', () => {
+    const next = nextFilterParams(
+      params(''),
+      TASK_FILTER_PARAMS.sort,
+      'newest',
+      TASK_SORT_DEFAULT,
+    )
+    expect(next.toString()).toBe('sort=newest')
+  })
+
+  it('REMOVES the axis when it returns to its default', () => {
+    const next = nextFilterParams(
+      params('sort=newest'),
+      TASK_FILTER_PARAMS.sort,
+      TASK_SORT_DEFAULT,
+      TASK_SORT_DEFAULT,
+    )
+    expect(next.has('sort')).toBe(false)
+  })
+
+  it('carries every other param through untouched', () => {
+    const next = nextFilterParams(
+      params('q=moss&faction=coven'),
+      TASK_FILTER_PARAMS.taskType,
+      'metatask',
+      TASK_TYPE_DEFAULT,
+    )
+    expect(next.get('q')).toBe('moss')
+    expect(next.get('faction')).toBe('coven')
+    expect(next.get('type')).toBe('metatask')
+  })
+
+  it('never mutates the param set it was handed', () => {
+    const previous = params('sort=newest')
+    nextFilterParams(previous, TASK_FILTER_PARAMS.sort, 'oldest', TASK_SORT_DEFAULT)
+    expect(previous.get('sort')).toBe('newest')
+  })
+})
+
+describe('nextFactionParams — the repeated union (#1364)', () => {
+  it('repeats the key once per selected slug', () => {
+    expect(nextFactionParams(params(''), ['everymen', 'coven']).toString()).toBe(
+      'faction=everymen&faction=coven',
+    )
+  })
+
+  it('replaces the previous selection rather than appending to it', () => {
+    const next = nextFactionParams(params('faction=ua&faction=wow'), ['coven'])
+    expect(next.getAll('faction')).toEqual(['coven'])
+  })
+
+  it('drops the param entirely when nothing is selected', () => {
+    expect(nextFactionParams(params('faction=ua'), []).has('faction')).toBe(false)
+  })
+})
+
+describe('clearedFilterParams — every axis home, search included', () => {
+  it('clears all five axes and the search', () => {
+    const next = clearedFilterParams(
+      params(
+        `type=metatask&sort=oldest&status=retired&faction=ua&faction=coven&can_sign_up=${CAN_SIGN_UP_ON}&q=moss`,
+      ),
+    )
+    expect(next.toString()).toBe('')
+  })
+
+  it('leaves params this page does not own alone', () => {
+    const next = clearedFilterParams(params('sort=oldest&ref=newsletter'))
+    expect(next.toString()).toBe('ref=newsletter')
+  })
+})

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -2,18 +2,19 @@ import { useTranslation } from 'react-i18next'
 import type { TasksState } from '../useTasks'
 import TaskCard from '../../../components/taskCard/TaskCard'
 import MetataskSeal from '../../../components/metataskSeal/MetataskSeal'
-import FactionSigilRow from '../../../components/ui/FactionSigilRow'
-import { ChipRow, Chip } from '../../../components/ui/ChipRow'
-import CanSignUpEmpty from '../CanSignUpEmpty'
+import TaskFilterBar, { TaskListEmpty } from '../TaskFilterBar'
 
 /**
- * Default MOBILE task-browse skin — a scannable single-column card list with
- * phone-native filter chips (horizontal-scroll rows for status / faction /
- * eligibility), NOT the desktop sidebar. Consumes the shared `useTasks()` state so a
- * chip tap updates the same filter state that keys the task read, and the
- * rendered set changes. The page chrome is faction-agnostic; each card in the
- * results list picks its own skin from its task's faction slug (#565). Mirrors
- * the DefaultTaskDetail mobile idiom (#496–#500).
+ * Default MOBILE task-browse skin — a scannable single-column card list, NOT the
+ * desktop sidebar. Consumes the shared `useTasks()` state so a filter change
+ * updates the same state that keys the task read, and the rendered set changes.
+ * The page chrome is faction-agnostic; each card in the results list picks its
+ * own skin from its task's faction slug (#565). Mirrors the DefaultTaskDetail
+ * mobile idiom (#496–#500).
+ *
+ * The chip rows and the sigil row are gone (#1367): filtering is the shared
+ * `FilterBar`, which is one component for both form factors and collapses
+ * itself on the phone. `ChipRow` survives — `DefaultPlayers` still uses it.
  *
  * The results list renders the SHARED `<TaskCard>` — the one call site
  * ADR-0056 turned on. Each faction card sizes itself for the phone via
@@ -32,18 +33,7 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
     tasks,
     loading,
     error,
-    factions,
-    statusFilters,
     taskType,
-    setTaskType,
-    status,
-    setStatus,
-    faction,
-    setFaction,
-    canSignUp,
-    setCanSignUp,
-    query,
-    setQuery,
     hasMore,
     loadMore,
     signupMsg,
@@ -63,61 +53,7 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
       </h1>
       <p className="eyebrow mb-3">{t('mobile.count', { count: tasks.length })}</p>
 
-      {/* Search */}
-      <input
-        type="search"
-        value={query}
-        onChange={(event) => setQuery(event.target.value)}
-        placeholder={t('listPage.filter.searchPlaceholder')}
-        aria-label={t('listPage.filter.searchLabel')}
-        className="font-body w-full mb-3"
-        style={{
-          fontSize: 'var(--text-md)',
-          padding: 'var(--space-sm) var(--space-md)',
-          background: 'var(--color-bg-surface)',
-          border: '1px solid var(--color-border-strong)',
-          color: 'var(--color-text-primary)',
-          borderRadius: 6,
-        }}
-      />
-
-      {/* Task / Metatask mode toggle (#934) */}
-      <ChipRow label={t('browse.taskType')}>
-        <Chip on={taskType === 'standard'} onClick={() => setTaskType('standard')}>
-          {t('browse.tasks')}
-        </Chip>
-        <Chip on={taskType === 'metatask'} onClick={() => setTaskType('metatask')}>
-          {t('browse.metatasks')}
-        </Chip>
-      </ChipRow>
-
-      {/* Status chips */}
-      <ChipRow label={tc('filters.status')}>
-        {statusFilters.map((option) => (
-          <Chip key={option} on={status === option} onClick={() => setStatus(option)}>
-            {option}
-          </Chip>
-        ))}
-      </ChipRow>
-
-      {/* Faction sigils */}
-      <div className="mb-2">
-        <FactionSigilRow factions={factions} value={faction} onChange={setFaction} />
-      </div>
-
-      {/* Eligibility chips (#1130), replacing the level row. Hidden when logged
-          out — the server answers `[]` for an anonymous viewer, so the chip
-          could only ever empty the page. */}
-      {user && (
-        <ChipRow label={t('browse.eligibility')}>
-          <Chip on={!canSignUp} onClick={() => setCanSignUp(false)}>
-            {t('browse.allTasks')}
-          </Chip>
-          <Chip on={canSignUp} onClick={() => setCanSignUp(true)}>
-            {t('browse.canSignUp')}
-          </Chip>
-        </ChipRow>
-      )}
+      <TaskFilterBar state={state} />
 
       {/* Signup outcome — the CTA arrived with the shared card (ADR-0056), so
           the message that answers it has to arrive too. */}
@@ -136,13 +72,7 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
             {t('mobile.loadError')}
           </p>
         ) : tasks.length === 0 ? (
-          /* A full task bank empties the eligible list wholesale, so the empty
-             state has to name it rather than blame the filters. */
-          canSignUp ? (
-            <CanSignUpEmpty />
-          ) : (
-            <p className="font-body text-muted">{t('listPage.empty')}</p>
-          )
+          <TaskListEmpty state={state} />
         ) : (
           <div className="flex flex-col gap-3">
             {isMetatask ? (

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -131,6 +131,26 @@ export function clearedFilterParams(previous: URLSearchParams): URLSearchParams 
   return next
 }
 
+/**
+ * How many axes are narrowing the list — the input to `selectEmptyState`.
+ *
+ * It counts the SEARCH box, which raises no chip in the bar but absolutely
+ * narrows the list. Without it, "search for xyzzy with eligibility on" would
+ * pick the caught-up empty state and claim nothing is open to you, when the
+ * search is what emptied the page — the same unchecked claim `selectEmptyState`
+ * exists to avoid.
+ */
+export function appliedFilterCount(state: TasksState): number {
+  return (
+    state.selectedFactions.length +
+    (state.taskType === TASK_TYPE_DEFAULT ? 0 : 1) +
+    (state.sort === TASK_SORT_DEFAULT ? 0 : 1) +
+    (state.status === TASK_STATUS_DEFAULT ? 0 : 1) +
+    (state.canSignUp ? 1 : 0) +
+    (state.query.trim() ? 1 : 0)
+  )
+}
+
 export interface SignupMessage {
   id: number
   msg: string

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -1,18 +1,24 @@
 /**
- * useTasks — the shared task-browse data + filter state, extracted verbatim from
- * the legacy Tasks.tsx so the desktop list and the mobile browse skin consume
- * one source of truth (mirrors useTaskDetail for the detail page).
+ * useTasks — the shared task-browse data + filter state, so the desktop list and
+ * the mobile browse skin consume one source of truth (mirrors useTaskDetail for
+ * the detail page).
  *
- * The factions/factionConfigs reads (both app-wide cached hooks), the
- * status/faction/eligibility filter
- * state, the task read keyed on those filters + the viewer's character id, and
- * the signup → navigate-to-edit handler with its inline message. The free-text search (#661) rides
- * alongside them, debounced 200ms via `useDebouncedValue` — the idiom #644 set on
- * the praxis feed — but its value lives in the URL (`?q=`, via
- * `useSearchQueryParam`, #660) rather than local state, so a pasted or refreshed
- * link restores it. The read runs through the shared `usePagedResource` growing
- * window (#645): filter setters (search included) reset the window and a full
- * page exposes "load more".
+ * The factions/factionConfigs reads (both app-wide cached hooks), the filter
+ * state, the task read keyed on those filters, and the signup →
+ * navigate-to-edit handler with its inline message.
+ *
+ * EVERY axis lives in the URL (#1367, epic #1361 ruling 7) — type, sort, status,
+ * faction and eligibility joined `?q=`, which `useSearchQueryParam` has owned
+ * since #660. There is no mirrored `useState` for any of them: the URL is the
+ * single source of truth, so a pasted or refreshed link restores the whole
+ * filter set, and "clear all" is one param write rather than five setter calls.
+ * Writes replace rather than push, for the reason `useSearchQueryParam` gives:
+ * Back should leave the page, not walk the filters one at a time.
+ *
+ * The free-text search is debounced 200ms via `useDebouncedValue` — the idiom
+ * #644 set on the praxis feed. The read runs through the shared
+ * `usePagedResource` growing window (#645): filter setters (search included)
+ * reset the window and a full page exposes "load more".
  *
  * The level filter is gone (#1130). It selected `level_required >= level` — the
  * tasks you are locked OUT of — and no level number could express WOW's
@@ -22,8 +28,13 @@
  * an era value and #1046's "never hardcode an EraConfig value" is not reopened.
  */
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { listTasks, type TaskOut, type TaskType } from '../../api/tasks'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import {
+  listTasks,
+  type TaskOut,
+  type TaskSort,
+  type TaskType,
+} from '../../api/tasks'
 import { createPraxis } from '../../api/praxis'
 import type { FactionOut } from '../../api/factions'
 import type { FactionConfigOut } from '../../api/gameConfig'
@@ -34,11 +45,91 @@ import { useAuth } from '../../auth/AuthContext'
 import { computeDisplayPoints, computeFactionMultiplier } from '../../utils/points'
 import { usePagedResource } from '../../hooks/usePagedResource'
 import { useDebouncedValue } from '../../hooks/useDebouncedValue'
-import { useSearchQueryParam } from '../../hooks/useSearchQueryParam'
+import {
+  SEARCH_QUERY_PARAM,
+  useSearchQueryParam,
+} from '../../hooks/useSearchQueryParam'
 import type { CurrentUser } from '../../api/auth'
 
 /** How many rows a page fetches; "load more" grows the window by this step. */
 const PAGE_LIMIT = 50
+
+/**
+ * The URL params the task browse owns, beside `useSearchQueryParam`'s `?q=`.
+ * Named here rather than inline so a typo can't silently drop an axis, and so
+ * "clear all" can enumerate them.
+ */
+export const TASK_FILTER_PARAMS = {
+  taskType: 'type',
+  sort: 'sort',
+  status: 'status',
+  faction: 'faction',
+  canSignUp: 'can_sign_up',
+} as const
+
+/** Browse mode default: ordinary tasks, metatasks excluded backend-side. */
+export const TASK_TYPE_DEFAULT: TaskType = 'standard'
+/**
+ * Sort default (#1361 ruling 6). NOT the first segment and NOT `newest`: the
+ * page has always been `level_required ASC, point_value DESC`, which it got by
+ * sending no `sort` at all. Naming that ordering is what stops a bare
+ * newest/oldest pair from silently deleting it.
+ */
+export const TASK_SORT_DEFAULT: TaskSort = 'level'
+export const TASK_STATUS_DEFAULT = 'All'
+/** The eligibility axis is a flag; this is its one non-default value. */
+export const CAN_SIGN_UP_ON = '1'
+
+/** Navigation options for every filter write: replace, never push. */
+const FILTER_NAV_OPTIONS = { replace: true } as const
+
+/** Read one single-valued axis. A missing or blank param IS the default. */
+export function readFilterParam(
+  params: URLSearchParams,
+  key: string,
+  defaultValue: string,
+): string {
+  return params.get(key) || defaultValue
+}
+
+/**
+ * The next param set for one axis. Non-default values only: an axis sitting on
+ * its default is REMOVED from the URL rather than spelled out, so a clean
+ * browse has a clean address. Every other param carries through untouched.
+ */
+export function nextFilterParams(
+  previous: URLSearchParams,
+  key: string,
+  value: string,
+  defaultValue: string,
+): URLSearchParams {
+  const next = new URLSearchParams(previous)
+  if (value === defaultValue) next.delete(key)
+  else next.set(key, value)
+  return next
+}
+
+/** Multi-select faction as the repeated `?faction=` union B2 (#1364) accepts. */
+export function nextFactionParams(
+  previous: URLSearchParams,
+  slugs: string[],
+): URLSearchParams {
+  const next = new URLSearchParams(previous)
+  next.delete(TASK_FILTER_PARAMS.faction)
+  for (const slug of slugs) next.append(TASK_FILTER_PARAMS.faction, slug)
+  return next
+}
+
+/**
+ * Every axis back to its default, search included — what "clear all filters"
+ * means. Params this page does not own are left alone.
+ */
+export function clearedFilterParams(previous: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(previous)
+  for (const key of Object.values(TASK_FILTER_PARAMS)) next.delete(key)
+  next.delete(SEARCH_QUERY_PARAM)
+  return next
+}
 
 export interface SignupMessage {
   id: number
@@ -58,9 +149,10 @@ export interface TasksState {
   // Reference data
   factions: FactionOut[]
   factionConfigs: FactionConfigOut[]
+  /** Viewer-gated: `retired` / `pending` only for a viewer allowed to see them. */
   statusFilters: string[]
 
-  // Filter state (setters reset the growing window).
+  // Filter state. Every setter writes the URL and resets the growing window.
   /**
    * Browse mode (#934): 'standard' lists ordinary tasks (the default, metatasks
    * excluded backend-side), 'metatask' lists issuing-faction metatask rows —
@@ -68,10 +160,14 @@ export interface TasksState {
    */
   taskType: TaskType
   setTaskType: (taskType: TaskType) => void
+  /** Ordering (#1364). Defaults to `level`; see {@link TASK_SORT_DEFAULT}. */
+  sort: TaskSort
+  setSort: (sort: TaskSort) => void
   status: string
   setStatus: (status: string) => void
-  faction: string
-  setFaction: (faction: string) => void
+  /** Faction multi-select — a union, empty meaning "every faction". */
+  selectedFactions: string[]
+  setSelectedFactions: (slugs: string[]) => void
   /**
    * "Tasks I can sign up for" (#1130). Defaults OFF — the tasks page is a
    * catalogue, and hiding most of it by default would make tasks look scarce
@@ -84,6 +180,8 @@ export interface TasksState {
   /** Raw search box value (bind directly); the fetch reads a debounced copy (#661). */
   query: string
   setQuery: (query: string) => void
+  /** Every axis back to its default, search included. */
+  clearFilters: () => void
 
   // Growing window (#645).
   hasMore: boolean
@@ -120,10 +218,26 @@ export function useTasks(): TasksState {
   const factions: FactionOut[] = useFactions() ?? []
   const gameConfig = useGameConfig()
   const factionConfigs: FactionConfigOut[] = gameConfig?.factions ?? []
-  const [taskType, setTaskTypeState] = useState<TaskType>('standard')
-  const [status, setStatusState] = useState('All')
-  const [faction, setFactionState] = useState('')
-  const [canSignUp, setCanSignUpState] = useState(false)
+
+  const [searchParams, setSearchParams] = useSearchParams()
+  const taskType = readFilterParam(
+    searchParams,
+    TASK_FILTER_PARAMS.taskType,
+    TASK_TYPE_DEFAULT,
+  ) as TaskType
+  const sort = readFilterParam(
+    searchParams,
+    TASK_FILTER_PARAMS.sort,
+    TASK_SORT_DEFAULT,
+  ) as TaskSort
+  const status = readFilterParam(
+    searchParams,
+    TASK_FILTER_PARAMS.status,
+    TASK_STATUS_DEFAULT,
+  )
+  const selectedFactions = searchParams.getAll(TASK_FILTER_PARAMS.faction)
+  const canSignUp =
+    searchParams.get(TASK_FILTER_PARAMS.canSignUp) === CAN_SIGN_UP_ON
   const [query, setQueryState] = useSearchQueryParam()
   const [signupMsg, setSignupMsg] = useState<SignupMessage | null>(null)
 
@@ -132,16 +246,21 @@ export function useTasks(): TasksState {
   const debouncedQuery = useDebouncedValue(query, 200)
 
   const trimmedQuery = debouncedQuery.trim()
+  // `getAll` hands back a fresh array every render, so the dep key is the joined
+  // string; the array itself only reaches the request body.
+  const factionKey = selectedFactions.join(',')
   const { data, loading, error, hasMore, loadMore, resetWindow } = usePagedResource(
     (limit) =>
       listTasks({
         // 'standard' → omit task_type so the backend applies its default
         // (metatasks excluded); 'metatask' → list only metatask rows.
         task_type: taskType === 'metatask' ? 'metatask' : undefined,
-        status: status === 'All' ? undefined : status,
-        faction: faction || undefined,
-        // Omitted rather than sent as false so the query key stays the shape it
-        // had before the filter existed.
+        status: status === TASK_STATUS_DEFAULT ? undefined : status,
+        faction: selectedFactions.length > 0 ? selectedFactions : undefined,
+        // Every default is omitted rather than spelled out, so the common
+        // request keeps the exact shape it had before the axis existed. An
+        // absent `sort` already means level-ascending server-side.
+        sort: sort === TASK_SORT_DEFAULT ? undefined : sort,
         can_sign_up: canSignUp || undefined,
         q: trimmedQuery || undefined,
         // The server excludes the authenticated viewer's own started tasks by
@@ -149,18 +268,34 @@ export function useTasks(): TasksState {
         // auth-dependent dep that made the page fetch twice.
         limit,
       }),
-    [taskType, status, faction, canSignUp, trimmedQuery],
+    [taskType, sort, status, factionKey, canSignUp, trimmedQuery],
     PAGE_LIMIT,
   )
   const tasks = data ?? []
 
   // Every filter change resets the window so "load more" can't strand a grown
   // page against a freshly-narrowed result set.
-  const setTaskType = (next: TaskType) => { setTaskTypeState(next); resetWindow() }
-  const setStatus = (next: string) => { setStatusState(next); resetWindow() }
-  const setFaction = (next: string) => { setFactionState(next); resetWindow() }
-  const setCanSignUp = (next: boolean) => { setCanSignUpState(next); resetWindow() }
+  const writeParams = (
+    build: (previous: URLSearchParams) => URLSearchParams,
+  ): void => {
+    setSearchParams(build, FILTER_NAV_OPTIONS)
+    resetWindow()
+  }
+  const setAxis = (key: string, value: string, defaultValue: string): void =>
+    writeParams((previous) => nextFilterParams(previous, key, value, defaultValue))
+
+  const setTaskType = (next: TaskType) =>
+    setAxis(TASK_FILTER_PARAMS.taskType, next, TASK_TYPE_DEFAULT)
+  const setSort = (next: TaskSort) =>
+    setAxis(TASK_FILTER_PARAMS.sort, next, TASK_SORT_DEFAULT)
+  const setStatus = (next: string) =>
+    setAxis(TASK_FILTER_PARAMS.status, next, TASK_STATUS_DEFAULT)
+  const setSelectedFactions = (slugs: string[]) =>
+    writeParams((previous) => nextFactionParams(previous, slugs))
+  const setCanSignUp = (next: boolean) =>
+    setAxis(TASK_FILTER_PARAMS.canSignUp, next ? CAN_SIGN_UP_ON : '', '')
   const setQuery = (next: string) => { setQueryState(next); resetWindow() }
+  const clearFilters = () => writeParams(clearedFilterParams)
 
   const handleSignup = async (id: number) => {
     setSignupMsg(null)
@@ -172,7 +307,7 @@ export function useTasks(): TasksState {
     }
   }
 
-  const statusFilters = ['All', 'active']
+  const statusFilters = [TASK_STATUS_DEFAULT, 'active']
   if (user?.can_see_retired_tasks) statusFilters.push('retired')
   if (user?.can_see_pending_tasks) statusFilters.push('pending')
 
@@ -204,14 +339,17 @@ export function useTasks(): TasksState {
 
     taskType,
     setTaskType,
+    sort,
+    setSort,
     status,
     setStatus,
-    faction,
-    setFaction,
+    selectedFactions,
+    setSelectedFactions,
     canSignUp,
     setCanSignUp,
     query,
     setQuery,
+    clearFilters,
 
     hasMore,
     loadMore,


### PR DESCRIPTION
Closes #1367

Part of #1361 (F3). Mounts the shared `FilterBar` (#1365) on the task browse and deletes **both** hand-rolled filter rows.

## The seam I tested at

Two, both pure and both invisible to a component test:

1. **`listTasks`' query serialisation** (`src/api/__tests__/taskQueryParams.test.ts`). Axios renders an array param as `faction[]=a&faction[]=b`; FastAPI's `faction: list[str] = Query(None)` reads a repeated bare key. Verified with a real `buildURL` run before writing the fix — the union filter would have 200'd with an **unfiltered list while the bar showed faction chips**. Fixed with `paramsSerializer: { indexes: null }`, pinned at the client.
2. **The URL param contract** (`src/pages/tasks/__tests__/taskFilterParams.test.ts`, 12 cases). Non-default-values-only, the repeated faction union, and "clear all" clearing search too while leaving params the page does not own alone.

Plus 3 new rail cases in `dispatch.test.tsx` for the permission boundary (status rail is 2 segments logged out, 4 for a viewer allowed `retired`/`pending`) and the `level` default raising no chip.

## What changed

| file | change |
|---|---|
| `api/tasks.ts` | `faction: string` → `string[]` (repeated union, #1364); `sort` gets a `TaskSort` type; repeated-key serializer |
| `pages/tasks/useTasks.ts` | every axis moves into the URL; `faction` → `selectedFactions`; new `sort` axis; `clearFilters`; pure param helpers + `appliedFilterCount` |
| `pages/tasks/TaskFilterBar.tsx` | **new** — one bar for both form factors, plus `TaskListEmpty` |
| `pages/Tasks.tsx` | −121 lines: the stamp stack, the faction tabs, the inline search input and the local `TaskTypeToggle` are gone |
| `pages/tasks/mobileArchetypes/DefaultTasks.tsx` | −96 lines: 3 `ChipRow`s + `FactionSigilRow` + the inline search gone. **`ChipRow` itself survives** (`DefaultPlayers`, `MobilePraxisFeed`) |
| `pages/tasks/CanSignUpEmpty.tsx` | renders through `FilterBarEmpty` so all three empty states share one chrome; gains a "clear all filters" way out |
| `pages/factionDetail/useFactionDetail.ts` | one line — `faction: slug` → `faction: [slug]`, forced by the type change |

## Two things the issue body says NOT to do, which I did anyway

The issue's "Explicitly not this issue" section is **stale** (its own comment says so, and I re-verified on `origin/main`):

- **#1130 shipped in full.** `levelFilters.ts` is gone, `levelThresholds` is gone, there is no level dropdown. Its eligibility control shipped as a **second `FilterStamps`** inside the very block this issue deletes. Following "do not add the eligibility rail here" literally would have deleted a live feature, so it is **carried over as a rail** (2 segments, default `all`, `user &&` gate kept — the server answers `[]` for an anonymous viewer).
- **The `TaskTypeToggle` (#934)** was hand-rolled with inline styles, not `FilterStamps`, so F4 (#1368) would not have swept it — the page would have shipped a stamp-styled toggle above a rail-styled bar. Per owner ruling it moves into the bar as a 2-segment rail, reusing `browse.tasks` / `browse.metatasks`. The local component is deleted.

## The rails

| rail | segments | default |
|---|---|---|
| type | Tasks · Metatasks | Tasks (`standard`) |
| sort | **Level** · Newest · Oldest | `level` |
| status | All · active *(· retired · pending)* | All |
| eligibility (`user &&`) | All tasks · I can sign up | all |

- **Sort is new — the page had no sort control.** It sent no `sort` and got `level_required ASC, point_value DESC`; a bare newest/oldest pair would have silently deleted that. `level` leads the rail because the default leads on every other rail here (F1's own test comment orders it the same way).
- No new locale keys. Everything comes from `filters.bar.*` / `filters.status` in `common.json` and `browse.*` / `listPage.*` in `tasks.json`.

## What to eyeball

I have **no browser and no dev stack — visual QA is outstanding.**

1. **Desktop `/tasks`** — the bar opens expanded; four rails wrap sensibly; the thumb lands on Level / Tasks / All.
2. **Mobile `/tasks`** — the bar arrives **collapsed** (F1's behaviour), so status, sort, type and eligibility are now one tap behind "Filters" where they used to be always-visible chip rows. That is the shipped `FilterBar` contract, but it is a real change to phone browse and worth a look.
3. **Status segment casing** — the segments render the raw status value (`All`, `active`, `retired`, `pending`), which is what the stamps showed, uppercased by CSS. The rail does not uppercase, so they now read mixed-case. There is no localized task-status label anywhere in the catalogs and authoring one is F1's remit, not this issue's — **flagging to `frontend-style`** rather than inventing keys or an inline `textTransform`.
4. **A 4-segment status rail at the rail's `min-width: 220px`** — `retired`/`pending` are longer words than the era rail's two; check the label ellipsis for an admin viewer.
5. **URL round-trip** — set every axis, copy the address, paste into a new tab; then "Clear all" and confirm the address goes clean.
6. **Empty states** — filter to nothing (filtered + Clear all filters), fresh load with an empty bank (register, no button), eligibility-only with a full task bank (`CanSignUpEmpty` now renders inside `FilterBarEmpty`; the bank-full sentence is the hint).

## Verification

`tsc --noEmit` clean · `eslint src --max-warnings=0` clean · `vitest run` **182 files / 3087 tests green** · `vite build` ok · `npm run budget`: JS ok at 132.2 KB; **CSS WARNs at 21.8 KB, unchanged from `origin/main`** — this branch edits no CSS.
