### PR TITLE
An answer, not an archive, is what clears "still waiting" (#1342)

### DIFF
--- a/frontend/src/components/__tests__/feedChassis.test.tsx
+++ b/frontend/src/components/__tests__/feedChassis.test.tsx
@@ -223,6 +223,33 @@ describe('archiving never answers anything (ADR-0066)', () => {
       stillWaiting,
     )
   })
+
+  it('keeps the tag while the request is genuinely pending (ADR-0070)', () => {
+    const pending = [
+      ['collab_invite', { ...FAT_PAYLOAD, invite_status: 'pending' }],
+      ['duel_challenge', { ...FAT_PAYLOAD, duel_status: 'pending' }],
+    ] as const
+    for (const [type, payload] of pending) {
+      expect(render(item(type, payload), true), `${type} pending`).toContain(stillWaiting)
+    }
+  })
+
+  it('drops the tag once the request WAS answered (#1342)', () => {
+    // Archiving still is not an answer — but an answer is. The tag reads the
+    // source row's status off the per-type payload key, never the card's
+    // session-local response state, which is empty on a fresh archive load.
+    const answered = [
+      ['collab_invite', 'invite_status', 'accepted'],
+      ['collab_invite', 'invite_status', 'declined'],
+      // A duel reports 'active' rather than 'accepted' once taken up.
+      ['duel_challenge', 'duel_status', 'active'],
+      ['duel_challenge', 'duel_status', 'declined'],
+    ] as const
+    for (const [type, key, status] of answered) {
+      const html = render(item(type, { ...FAT_PAYLOAD, [key]: status }), true)
+      expect(html, `${type} ${status}`).not.toContain(stillWaiting)
+    }
+  })
 })
 
 describe('the undo strip degrades rather than vanishing', () => {

--- a/frontend/src/components/feed/FeedCardRouter.tsx
+++ b/frontend/src/components/feed/FeedCardRouter.tsx
@@ -6,7 +6,7 @@ import FactionFeedFrame from './FactionFeedFrame'
 import FeedItemSlot from './FeedItemSlot'
 import FeedRowContent from './FeedRowContent'
 import { normalizeFeedItem } from './normalizeFeedItem'
-import { feedKicker, STILL_WAITING_TYPES } from './feedItemLabels'
+import { feedKicker, isStillWaiting } from './feedItemLabels'
 import FeedCardEraAnnouncement from './FeedCardEraAnnouncement'
 import FeedCardCollabInvite from './FeedCardCollabInvite'
 import FeedCardDuelChallenge from './FeedCardDuelChallenge'
@@ -72,14 +72,13 @@ export default function FeedCardRouter({ item, archivedView = false, onArchiveCh
   // fault that hid every @mention ever sent.
   if (!row && !Companion && !isEraAnnouncement) return null
 
-  // "Still waiting" only in the archive, and only where there is something to
-  // wait for: archiving never answers anything (ADR-0066), so an archived duel
-  // challenge or collab invite is still open and says so. In the live feed the
-  // card's own buttons already make that plain.
+  // "Still waiting" only in the archive, and only where something really is
+  // still waiting: archiving never answers anything (ADR-0065), so an archived
+  // duel challenge or collab invite that is STILL PENDING is open and says so —
+  // one accepted or declined after it was archived is not, and must not (#1342).
+  // In the live feed the card's own buttons already make that plain.
   const tag =
-    archivedView && STILL_WAITING_TYPES.has(item.type)
-      ? i18n.t('feed:archive.stillWaiting')
-      : null
+    archivedView && isStillWaiting(item) ? i18n.t('feed:archive.stillWaiting') : null
 
   const renderBody = (): ReactNode => {
     if (row) return <FeedRowContent row={row} avatarUrl={item.actor_avatar_url} />

--- a/frontend/src/components/feed/feedItemLabels.ts
+++ b/frontend/src/components/feed/feedItemLabels.ts
@@ -1,4 +1,5 @@
 import type { ActivityFeedItem } from '../../api/activityFeed'
+import { requestStatusOf } from '../../hooks/useRespondToRequest'
 import i18n from '../../i18n'
 
 /**
@@ -35,12 +36,37 @@ const KICKER_KEY = {
   comment_mention: 'feed:kicker.comment_mention',
 } as const
 
-/** Feed types the archive tags "still waiting" — archiving never answers
- *  anything, so an archived challenge or invite is still open (ADR-0066). */
-export const STILL_WAITING_TYPES: ReadonlySet<string> = new Set([
+/** The two request types the archive can tag "still waiting". The tag is NOT a
+ *  property of the type — see {@link isStillWaiting}. */
+const REQUEST_TYPES: ReadonlySet<string> = new Set([
   'duel_challenge',
   'collab_invite',
 ])
+
+/**
+ * Is this item an obligation nobody has answered yet?
+ *
+ * Two conditions, and the second one is the whole of #1342. Archiving never
+ * answers anything (ADR-0065), so an archived request is still open — but
+ * *answering* it does, and a request archived while pending and accepted a week
+ * later kept reading "still waiting" because the tag was keyed on the item's
+ * TYPE alone. Since #1301 windowed the live feed to pending requests, the
+ * Archived tab is the only place a resolved request appears at all, so that
+ * stale tag went from an edge case to the ordinary way you meet one.
+ *
+ * "Unanswered" is per-type (ADR-0070); for these two it is `status === pending`,
+ * read off the source row via the payload's per-type status key. Deliberately
+ * NOT the `status` that `useRespondToRequest` returns: that is session-local
+ * response state, empty until the viewer clicks in this very session, so it
+ * cannot speak for a request answered days ago.
+ *
+ * A payload missing its status field normalizes to `pending`, which keeps the
+ * tag — the safe direction, since over-reporting an obligation is recoverable
+ * and silently dropping one is not.
+ */
+export function isStillWaiting(item: ActivityFeedItem): boolean {
+  return REQUEST_TYPES.has(item.type) && requestStatusOf(item) === 'pending'
+}
 
 /**
  * The one feed type that cannot be archived. It is *state*, not an event: it

--- a/frontend/src/hooks/useRespondToRequest.ts
+++ b/frontend/src/hooks/useRespondToRequest.ts
@@ -29,12 +29,18 @@ export function normalizeRequestStatus(
   return 'accepted'
 }
 
-/** Read the item's current status from the right payload field per type. */
+/**
+ * Read the item's current status from the right payload field per type.
+ *
+ * `payload` is an untyped `Record<string, any>` off the wire, so read it
+ * optionally: a malformed item falls through to 'pending' rather than throwing
+ * inside a render.
+ */
 export function requestStatusOf(item: ActivityFeedItem): RequestResponseStatus {
   const raw =
     item.type === 'duel_challenge'
-      ? item.payload.duel_status
-      : item.payload.invite_status
+      ? item.payload?.duel_status
+      : item.payload?.invite_status
   return normalizeRequestStatus(raw)
 }
 


### PR DESCRIPTION
Closes #1342

## The defect

`feedItemLabels.ts` applied the "still waiting" tag by **type** —
`STILL_WAITING_TYPES = { duel_challenge, collab_invite }` — never by status. Every
request in the Archived tab wore the tag forever, including ones accepted or declined
days after they were archived.

The failing test printed the bug verbatim: one card rendering **"Still waiting"** in the
kicker band and **"Accepted — view collaboration"** in its body.

## The premise correction (the issue's stated evidence was wrong)

The issue says `FeedCardCollabInvite.tsx`'s `status === "accepted"` branches prove the
payload carries what the label needs. It does not — that `status` comes from
`useRespondToRequest(item)` and is **session-local response state**, populated only after
the viewer clicks in this session. Keying the tag off it would look right in manual
testing and be wrong on every fresh Archived load.

The real source is the payload, under per-type keys the backend already emits
(`activity_feed.py`): `_collab_invite_item` → `invite_status`, `_duel_challenge_item` →
`duel_status`. Both read from the source row at read time (ADR-0023), so they are current.

Verified the fix is even reachable: `activity_feed.py:1295` sets
`pending_invites_only=not archived`, so the Archived view alone carries resolved rows with
their real status.

## Seam under test

**The pure predicate `isStillWaiting(item)` in `feedItemLabels.ts`** — not a click. The
frontend harness is `renderToStaticMarkup` only (no DOM, no effects), so the tests drive the
predicate through `FeedCardRouter`'s tag slot with status-bearing payloads. Both directions
are covered for both types: pending → tag present; `accepted` / `declined` / `active` → tag
gone. The loop went red on `collab_invite accepted` before the fix.

## The fix

`isStillWaiting(item)` = the type is a request **and** `requestStatusOf(item) === 'pending'`.
No new helper: `requestStatusOf` already existed in `hooks/useRespondToRequest.ts` and
already knew the per-type key switch. `STILL_WAITING_TYPES` stops being exported and becomes
the module-private `REQUEST_TYPES` — it was never a tag predicate, only half of one.

One-line hardening at the shared trust boundary: `requestStatusOf` now reads `item.payload?.`
(payload is an untyped `Record<string, any>` off the wire). A missing status normalizes to
`pending`, which **keeps** the tag — the safe direction, since over-reporting an obligation is
recoverable and silently dropping one is not. That also means the existing chassis tests,
whose fixtures carry no status field, keep asserting exactly what they always did.

## Doctrine

- **ADR-0065** holds unchanged: archiving is a view state and never a decision. An archived
  *pending* request is still open and still says so. What clears the tag is an answer.
- **ADR-0070**'s per-type table is the predicate: for these two, unanswered ≡ `pending`.
- **Scope held**: `awaiting_submission` and `invitation_letter` are deliberately **not** added
  to the tag — that is epic #1419's work.
- The `status === "accepted"` / `"declined"` branches in `FeedCardCollabInvite.tsx` are
  **untouched**. They are reachable only via Archived since #1301, so they are live code.

## Verification

- `tsc --noEmit` clean · `eslint src` clean · `vitest run` **3117 passed / 184 files** ·
  `vite build` ok · `npm run budget` JS ok (132.2 KB).
- The budget's CSS **WARN** (21.8 KB vs 19.5 KB) is pre-existing — this branch touches no CSS.
- **Visual QA is outstanding**: no browser tools and no dev stack in this environment.

## What to eyeball

1. **Archived tab, a collab invite you accepted after archiving it** — the "Still waiting"
   pill should be gone, and the body's "Accepted — view collaboration" line should stand alone.
2. **Archived tab, a duel challenge you declined after archiving it** — no pill.
3. **Archived tab, a genuinely untouched invite or challenge** — pill still there. This is the
   ADR-0065 case and the one that must not regress.
4. **Live feed** — no pill anywhere, as before; the card's own accept/decline buttons say it.
5. **The tag's chassis slot per faction** — the pill now appears on strictly fewer cards, so
   glance at a faction feed frame for a header that only looked balanced with the tag present.
   Any spacing that reads wrong there is a `frontend-style` question, not a change I made.
6. Plain events (`friend_completion` et al.) still never carry the pill, archived or not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
