### PR TITLE
The era-reset defection purge deleted rows for the era it had just created (#1372)

### DIFF
--- a/backend/models/faction_defection_history.py
+++ b/backend/models/faction_defection_history.py
@@ -11,7 +11,13 @@ class FactionDefectionHistory(Base):
 
     Used to enforce the rule that players cannot rejoin factions they have
     defected from (with exceptions for factions where can_always_rejoin is True).
-    All rows for an era are deleted on era reset.
+
+    Rows are **retained** across an era reset — nothing is ever deleted here.
+    The reset's fresh start on the join gate comes from era scoping, not from a
+    purge: every reader filters on the era in hand
+    (:func:`services.faction_service.can_join_faction`,
+    :func:`services.faction_service.get_defection_history`, and the
+    activity feed), so a prior era's rows can never gate a new-era join (#1372).
     """
 
     __tablename__ = "faction_defection_history"

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from fastapi import HTTPException
-from sqlalchemy import delete, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
@@ -9,25 +9,12 @@ from models.character import Character
 from models.character_stats import CharacterStats
 from models.duel import Duel, DuelStatus
 from models.era import Era
-from models.faction_defection_history import FactionDefectionHistory
 from models.praxis import Praxis
 from services.duel_outcome import duel_winner
 from services.scoring import snide_tie_winner_id
 from services.vote_tally import get_tally, tally_votes
 
 ERA_RESET_DEFAULT_FACTION: str = "na"
-
-
-async def clear_defection_history_for_era(
-    era_id: int,
-    session: AsyncSession,
-) -> None:
-    """Delete all defection records for a given era. Called during era reset."""
-    await session.execute(
-        delete(FactionDefectionHistory).where(
-            FactionDefectionHistory.era_id == era_id,
-        )
-    )
 
 
 async def get_current_era_row(session: AsyncSession) -> Era:
@@ -239,7 +226,7 @@ async def resolve_duels_at_era_close(
 
 
 async def apply_era_reset(
-    characters: list,
+    characters: list[Character],
     new_era_row: Era,
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
@@ -249,6 +236,13 @@ async def apply_era_reset(
     Preserves historical stats rows for prior eras. Also freezes every unresolved
     duel outcome — era close is the moment a duel acquires a definitive winner
     (ADR-0011 / ADR-0052).
+
+    Defection history is **not** purged. ``reset_faction`` returns everyone to
+    ``na``, and a fresh start on the join gate falls out of era scoping alone:
+    every reader of ``FactionDefectionHistory`` filters on the era in hand
+    (``services.faction_service.can_join_faction``, ``get_defection_history``,
+    ``services.activity_feed``), so prior-era rows can never gate a new-era join.
+    The rows stay as history (#1372).
     """
     # Freeze duels first: the outcome must be computed against the closing era's
     # tallies, before any stats row for the new era exists. The closing era is the
@@ -286,9 +280,5 @@ async def apply_era_reset(
 
         if era.reset_faction:
             character.faction_slug = ERA_RESET_DEFAULT_FACTION
-
-    # Clear defection history so players can join any faction fresh
-    if era.reset_faction:
-        await clear_defection_history_for_era(new_era_row.id, session)
 
     await session.flush()

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -13,7 +13,7 @@ from models.faction_defection_history import FactionDefectionHistory
 from models.invitation_letter import InvitationLetter
 from models.task import Task
 from services.character import ALBESCENT_FACTION_SLUG, can_start_as_albescent
-from services.era import clear_defection_history_for_era, get_current_era_row, get_or_create_stats
+from services.era import get_current_era_row, get_or_create_stats
 
 UA_FACTION_SLUG: str = "ua"
 UNAFFILIATED_FACTION_SLUG: str = "na"

--- a/backend/tests/integration/test_era_reset_defection_retention.py
+++ b/backend/tests/integration/test_era_reset_defection_retention.py
@@ -1,0 +1,124 @@
+"""An era reset retains defection history and still frees the join gate (#1372).
+
+The seam under test is ``apply_era_reset`` → ``can_join_faction``. The reset used
+to call a purge keyed on the *new* era row's id, which by construction holds zero
+defection rows, so it could never delete anything; the purge is gone. These tests
+pin what actually makes the rule work: rows survive the reset as history, and the
+fresh start on the join gate comes from era scoping alone — every reader filters
+on the era in hand, so a prior era's row cannot gate a new-era join.
+"""
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.account import Account
+from models.character import Character
+from models.era import Era
+from models.faction import Faction
+from models.faction_defection_history import FactionDefectionHistory
+from services.era import apply_era_reset
+from services.faction_service import can_join_faction, get_defection_history
+
+DEFECTED_FROM_SLUG: str = "ua"
+
+
+async def _defect(
+    session: AsyncSession, character: Character, era: Era
+) -> FactionDefectionHistory:
+    """Stamp a defection from ``ua`` in the given era, as ``choose_faction`` does."""
+    defection = FactionDefectionHistory(
+        character_id=character.id,
+        faction_slug=DEFECTED_FROM_SLUG,
+        era_id=era.id,
+    )
+    session.add(defection)
+    await session.flush()
+    return defection
+
+
+async def _close_era(
+    session: AsyncSession, account: Account, characters: list[Character]
+) -> Era:
+    """Append the next Era row and run the reset over ``characters``."""
+    new_era_row = Era(
+        name=CURRENT_ERA.name,
+        config_key=CURRENT_ERA.config_key,
+        started_by=account.id,
+    )
+    session.add(new_era_row)
+    await session.flush()
+    await apply_era_reset(characters, new_era_row, session)
+    return new_era_row
+
+
+@pytest.mark.asyncio
+async def test_era_reset_retains_prior_era_defection_rows(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+):
+    """The closing era's defection rows are still there after the reset."""
+    assert CURRENT_ERA.reset_faction is True
+    await _defect(db_session, character, era)
+
+    await _close_era(db_session, account, [character])
+
+    retained = await get_defection_history(character.id, era.id, db_session)
+    assert [row.faction_slug for row in retained] == [DEFECTED_FROM_SLUG]
+
+
+@pytest.mark.asyncio
+async def test_era_reset_does_not_block_rejoining_in_the_new_era(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+):
+    """A faction defected from last era is joinable again this era.
+
+    ``ua`` has ``can_always_rejoin=False``, so the only thing that can permit the
+    join is era scoping — the retained prior-era row must not be consulted.
+    """
+    await _defect(db_session, character, era)
+    assert (
+        await can_join_faction(
+            character.id, DEFECTED_FROM_SLUG, era.id, db_session
+        )
+        is False
+    ), "the defection must gate the join within its own era"
+
+    new_era_row = await _close_era(db_session, account, [character])
+
+    assert (
+        await can_join_faction(
+            character.id, DEFECTED_FROM_SLUG, new_era_row.id, db_session
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_era_reset_leaves_other_characters_history_alone(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    character2: Character,
+    era: Era,
+    faction_ua: Faction,
+):
+    """No row for any character is dropped — the reset touches this table not at all."""
+    await _defect(db_session, character, era)
+    await _defect(db_session, character2, era)
+
+    await _close_era(db_session, account, [character, character2])
+
+    result = await db_session.execute(
+        select(FactionDefectionHistory.character_id).where(
+            FactionDefectionHistory.era_id == era.id
+        )
+    )
+    assert sorted(result.scalars().all()) == sorted([character.id, character2.id])


### PR DESCRIPTION
`apply_era_reset` called `clear_defection_history_for_era(new_era_row.id, session)` — the `Era` row inserted moments earlier in the same function, which by construction holds zero defection rows. Defections stamp the era current at defect time, so the delete could never match anything. The docstring on `FactionDefectionHistory` advertised the purge as a rule ("All rows for an era are deleted on era reset"); nothing has ever been deleted.

What actually frees the join gate after a reset is **era scoping**. `can_join_faction`, `get_defection_history` and the activity-feed query all filter on the era in hand, so a prior era's rows can never gate a new-era join. Retention is the real behaviour and it is harmless.

Passing the *closing* era id instead would make the delete work, but no reader benefits from it — it would only destroy history — so this deletes the purge rather than fixing it.

## Seam under test

`apply_era_reset` → `can_join_faction`. The honest "red" for a dead-code deletion is a test that pins the retention the docstring now claims, so `tests/integration/test_era_reset_defection_retention.py` asserts that after a reset with `reset_faction=True` the closing era's rows still exist and a `can_always_rejoin=False` faction is joinable again in the new era.

I verified the test is not vacuous: temporarily reintroducing the purge keyed on the **closing** era id turns 2 of the 3 red. The third (the join gate) stays green either way — which is the point, and is what makes deleting the purge safe.

## Changes

- `backend/services/era.py` — deleted `clear_defection_history_for_era` and its call site; dropped the now-unused `delete` and `FactionDefectionHistory` imports; annotated `apply_era_reset(characters: list[Character], ...)`; documented why history is kept.
- `backend/services/faction_service.py` — removed the dead import (it never called the function).
- `backend/models/faction_defection_history.py` — docstring now describes retention and names the era-scoped readers.
- `backend/tests/integration/test_era_reset_defection_retention.py` — new, 3 tests.

Net −24 lines of source, +124 of test.

## Tests

`pytest --cov=. --cov-fail-under=80` from `backend/` against a dedicated `wz1372_test` DB: **900 passed, coverage 90.77%**. No migration — nothing about the schema changes, only which rows survive (all of them, as before).

## What to eyeball

- That deleting rather than era-correcting the purge is the call you want. Old-era defection rows now accumulate forever by design; the table has a `(character_id, faction_slug, era_id)` unique constraint so growth is bounded by characters × factions × eras.
- The `FactionDefectionHistory` docstring — it is now the only place stating the retention contract, so it should read as a rule, not a note.
- No visual QA applies (backend only), and none was performed.

Not touched: #1345, the score recalc's missing era bound. Same reset-path family, distinct defect.

Closes #1372

🤖 Generated with [Claude Code](https://claude.com/claude-code)