### PR TITLE
A praxis marked failed banks no points — and that is all it changes (#1373)

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -488,11 +488,10 @@ async def admin_delete_praxis(
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ):
-    praxis = await session.get(Praxis, praxis_id)
-    if praxis is None:
-        raise HTTPException(status_code=404, detail="Praxis not found.")
-    praxis.moderation_status = ModerationStatus.hidden
-    await session.flush()
+    # Soft-delete is a moderation transition spelled a second way, so it routes
+    # through the same service — which is what recalculates the members' stats
+    # (#1373). Hiding a praxis in the route used to leave its points banked.
+    await moderate_praxis(praxis_id, ModerationStatus.hidden.value, None, session)
 
 
 @router.post("/characters/{character_id}/ban", status_code=200)

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -22,6 +22,16 @@ from services.scoring import compute_level
 # Factions that never receive invitation letters (ADR-0022 / ADR-0019 sentinels).
 _NON_INVITE_FACTION_SLUGS: frozenset[str] = frozenset({"na", "albescent"})
 
+# Moderation states that earn nobody points (#1373). ``hidden`` is off the site
+# entirely; ``failed`` is an admin ruling that the work was not done, so it keeps
+# its banner and its place in the feed but banks nothing. Both praxis gathers
+# below read this one set so they cannot drift apart. It mirrors the accepted set
+# in ``services.character.py``'s Albescent-unlock query, which has always counted
+# only ``visible`` + ``flagged`` — a flagged praxis is merely *awaiting* a ruling.
+_UNSCORED_MODERATION_STATUSES: frozenset[ModerationStatus] = frozenset(
+    {ModerationStatus.hidden, ModerationStatus.failed}
+)
+
 
 async def _deliver_earned_invitations(
     character_id: int,
@@ -95,7 +105,9 @@ async def recalculate_character_stats(
 
     Gathers all submitted praxes the character has a stake in — solo/duel praxes
     they authored, plus collab praxes they are a member of — then delegates all
-    scoring arithmetic to ``compute_contributions`` (ADR-0014).
+    scoring arithmetic to ``compute_contributions`` (ADR-0014). Praxes in an
+    ``_UNSCORED_MODERATION_STATUSES`` state are left out of the gather entirely,
+    so they also stop counting toward faction invitations (ADR-0022).
 
     Safe to call on praxis creation (0 votes → base points only) or after any
     vote change.
@@ -121,7 +133,7 @@ async def recalculate_character_stats(
             Praxis.created_by_id == character_id,
             Praxis.type == PraxisType.solo,
             Praxis.status == PraxisStatus.submitted,
-            Praxis.moderation_status != ModerationStatus.hidden,
+            Praxis.moderation_status.notin_(list(_UNSCORED_MODERATION_STATUSES)),
         )
     )
     solo_praxes = list(solo_result.scalars().all())
@@ -134,7 +146,7 @@ async def recalculate_character_stats(
             PraxisMember.character_id == character_id,
             Praxis.type == PraxisType.collab,
             Praxis.status == PraxisStatus.submitted,
-            Praxis.moderation_status != ModerationStatus.hidden,
+            Praxis.moderation_status.notin_(list(_UNSCORED_MODERATION_STATUSES)),
         )
     )
     collab_praxes = list(collab_result.scalars().all())

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -994,14 +994,7 @@ async def list_praxes(
                 )
                 .exists()
             )
-            query = query.where(
-                ~account_voted,
-                ~account_member,
-                # Same "votable" half, for the other permanent block: a failed
-                # praxis is closed to voting (#1373, ``services.vote``). It stays
-                # in the unfiltered feed; it just cannot need anyone's vote.
-                Praxis.moderation_status != ModerationStatus.failed,
-            )
+            query = query.where(~account_voted, ~account_member)
 
     if moderation_status is not None:
         try:

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -994,7 +994,14 @@ async def list_praxes(
                 )
                 .exists()
             )
-            query = query.where(~account_voted, ~account_member)
+            query = query.where(
+                ~account_voted,
+                ~account_member,
+                # Same "votable" half, for the other permanent block: a failed
+                # praxis is closed to voting (#1373, ``services.vote``). It stays
+                # in the unfiltered feed; it just cannot need anyone's vote.
+                Praxis.moderation_status != ModerationStatus.failed,
+            )
 
     if moderation_status is not None:
         try:
@@ -2100,8 +2107,18 @@ async def moderate_praxis(
     new_status: str,
     admin_note: Optional[str],
     session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
 ) -> Praxis:
-    """Admin moderation: update moderation_status and admin_note."""
+    """Admin moderation: update moderation_status and admin_note.
+
+    Every transition recalculates each member's stats (#1373). ``hidden`` and
+    ``failed`` are unscored (see ``services.character_stats``), so both marking
+    and *un*marking moves the members' scores — and a score that only corrects
+    itself on the author's next unrelated vote is the bug this closes. The
+    recalc is unconditional rather than gated on "did the scored-ness change":
+    it is the same handful of queries the vote path already runs per vote, and
+    an admin action is rare.
+    """
     praxis = await get_praxis(praxis_id, session)
 
     try:
@@ -2119,6 +2136,7 @@ async def moderate_praxis(
         praxis.admin_note = None
 
     await session.flush()
+    await recalculate_members_stats(praxis, session, era)
     return await get_praxis(praxis_id, session)
 
 

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -41,7 +41,13 @@ async def cast_or_update_vote(
 ) -> Vote:
     """Cast or update a vote on a solo or collab praxis.
 
-    Every rule here is account-level (ADR-0041): alt characters on one account
+    Rule (0) — a ``failed`` praxis is closed to voting (#1373) — is the one
+    praxis-level block: it holds for every viewer. Since #1373 a failed praxis
+    banks no points, so a vote on one could only burn a voter's finite budget
+    (ADR-0043) for nothing. It stays listed and keeps its banner; only the
+    ratings module closes.
+
+    Every other rule here is account-level (ADR-0041): alt characters on one account
     cannot vote on each other's praxes, cannot rate a duel any of them is in,
     and — since #1150 — cannot hold more than one vote on the same praxis. The
     third is not an extra rejection: an alt's second rating *updates* the
@@ -54,6 +60,11 @@ async def cast_or_update_vote(
     """
     if not 1 <= value <= 5:
         raise HTTPException(status_code=422, detail="Vote value must be between 1 and 5.")
+
+    if _voting_closed(praxis):
+        raise HTTPException(
+            status_code=403, detail="Voting is closed on a praxis marked failed."
+        )
 
     # Account-level anti-self-vote (A) and duel anti-participation (B) are the two
     # PERMANENT ineligibility rules. They are factored into helpers so this
@@ -124,6 +135,16 @@ async def cast_or_update_vote(
 # ---------------------------------------------------------------------------
 
 
+def _voting_closed(praxis: Praxis) -> bool:
+    """0. The praxis itself is closed to voting — it was marked ``failed`` (#1373).
+
+    Viewer-independent, so it needs no session and the page-wide map can apply it
+    from the rows it already holds. ``hidden`` is not listed here: a hidden praxis
+    404s at the door (:func:`cast_vote_on_praxis`) before voting is ever asked.
+    """
+    return praxis.moderation_status == ModerationStatus.failed
+
+
 async def _voter_account_owns_praxis(
     voter: Character, praxis: Praxis, session: AsyncSession
 ) -> bool:
@@ -182,9 +203,12 @@ async def viewer_can_vote(
 ) -> bool:
     """Whether ``voter`` may vote on ``praxis`` under the PERMANENT rules (#998).
 
-    Returns ``False`` only when account-level ownership (A) or duel
-    participation (B) applies — the same two blocks ``cast_or_update_vote``
-    enforces. Budget exhaustion is NOT considered: it is temporary and
+    Returns ``False`` when the praxis is closed to voting (0), or when
+    account-level ownership (A) or duel participation (B) applies — the same
+    three blocks ``cast_or_update_vote`` enforces. Rule 0 is the only one that
+    also applies to an anonymous viewer: a failed praxis is closed to everyone,
+    so logging in would not open it. Budget exhaustion is NOT considered: it is
+    temporary and
     re-rating an existing vote is free, so the module stays visible for
     out-of-budget viewers. One-vote-per-account (#1150) is not considered
     either, for the same reason: an account that has already voted may still
@@ -192,6 +216,8 @@ async def viewer_can_vote(
     (``voter is None``) get ``True`` — the client shows its own login gate
     regardless.
     """
+    if _voting_closed(praxis):
+        return False
     if voter is None:
         return True
     if await _voter_account_owns_praxis(voter, praxis, session):
@@ -209,10 +235,11 @@ async def viewer_can_vote_map(
     Mirrors how crowned_ids / viewer_votes / applied_metatasks are precomputed
     by the card-list route: one ownership query and one duel query for the whole
     page, rather than the per-praxis predicate per card. Anonymous viewer → all
-    ``True``.
+    ``True`` except the failed cards, which are closed to everyone (#1373).
     """
+    closed_ids = {praxis.id for praxis in praxes if _voting_closed(praxis)}
     if voter is None:
-        return {praxis.id: True for praxis in praxes}
+        return {praxis.id: praxis.id not in closed_ids for praxis in praxes}
 
     praxis_ids = {praxis.id for praxis in praxes}
     if not praxis_ids:
@@ -228,7 +255,7 @@ async def viewer_can_vote_map(
             Character.account_id == account_id,
         )
     )
-    blocked_ids = set(owned_result.scalars().all())
+    blocked_ids = set(owned_result.scalars().all()) | closed_ids
 
     # B. Duel participation — for every active duel touching a page praxis, block
     # BOTH of its sides (that are on this page) when the viewer's account is a

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -41,13 +41,7 @@ async def cast_or_update_vote(
 ) -> Vote:
     """Cast or update a vote on a solo or collab praxis.
 
-    Rule (0) — a ``failed`` praxis is closed to voting (#1373) — is the one
-    praxis-level block: it holds for every viewer. Since #1373 a failed praxis
-    banks no points, so a vote on one could only burn a voter's finite budget
-    (ADR-0043) for nothing. It stays listed and keeps its banner; only the
-    ratings module closes.
-
-    Every other rule here is account-level (ADR-0041): alt characters on one account
+    Every rule here is account-level (ADR-0041): alt characters on one account
     cannot vote on each other's praxes, cannot rate a duel any of them is in,
     and — since #1150 — cannot hold more than one vote on the same praxis. The
     third is not an extra rejection: an alt's second rating *updates* the
@@ -60,11 +54,6 @@ async def cast_or_update_vote(
     """
     if not 1 <= value <= 5:
         raise HTTPException(status_code=422, detail="Vote value must be between 1 and 5.")
-
-    if _voting_closed(praxis):
-        raise HTTPException(
-            status_code=403, detail="Voting is closed on a praxis marked failed."
-        )
 
     # Account-level anti-self-vote (A) and duel anti-participation (B) are the two
     # PERMANENT ineligibility rules. They are factored into helpers so this
@@ -135,16 +124,6 @@ async def cast_or_update_vote(
 # ---------------------------------------------------------------------------
 
 
-def _voting_closed(praxis: Praxis) -> bool:
-    """0. The praxis itself is closed to voting — it was marked ``failed`` (#1373).
-
-    Viewer-independent, so it needs no session and the page-wide map can apply it
-    from the rows it already holds. ``hidden`` is not listed here: a hidden praxis
-    404s at the door (:func:`cast_vote_on_praxis`) before voting is ever asked.
-    """
-    return praxis.moderation_status == ModerationStatus.failed
-
-
 async def _voter_account_owns_praxis(
     voter: Character, praxis: Praxis, session: AsyncSession
 ) -> bool:
@@ -203,12 +182,9 @@ async def viewer_can_vote(
 ) -> bool:
     """Whether ``voter`` may vote on ``praxis`` under the PERMANENT rules (#998).
 
-    Returns ``False`` when the praxis is closed to voting (0), or when
-    account-level ownership (A) or duel participation (B) applies — the same
-    three blocks ``cast_or_update_vote`` enforces. Rule 0 is the only one that
-    also applies to an anonymous viewer: a failed praxis is closed to everyone,
-    so logging in would not open it. Budget exhaustion is NOT considered: it is
-    temporary and
+    Returns ``False`` only when account-level ownership (A) or duel
+    participation (B) applies — the same two blocks ``cast_or_update_vote``
+    enforces. Budget exhaustion is NOT considered: it is temporary and
     re-rating an existing vote is free, so the module stays visible for
     out-of-budget viewers. One-vote-per-account (#1150) is not considered
     either, for the same reason: an account that has already voted may still
@@ -216,8 +192,6 @@ async def viewer_can_vote(
     (``voter is None``) get ``True`` — the client shows its own login gate
     regardless.
     """
-    if _voting_closed(praxis):
-        return False
     if voter is None:
         return True
     if await _voter_account_owns_praxis(voter, praxis, session):
@@ -235,11 +209,10 @@ async def viewer_can_vote_map(
     Mirrors how crowned_ids / viewer_votes / applied_metatasks are precomputed
     by the card-list route: one ownership query and one duel query for the whole
     page, rather than the per-praxis predicate per card. Anonymous viewer → all
-    ``True`` except the failed cards, which are closed to everyone (#1373).
+    ``True``.
     """
-    closed_ids = {praxis.id for praxis in praxes if _voting_closed(praxis)}
     if voter is None:
-        return {praxis.id: praxis.id not in closed_ids for praxis in praxes}
+        return {praxis.id: True for praxis in praxes}
 
     praxis_ids = {praxis.id for praxis in praxes}
     if not praxis_ids:
@@ -255,7 +228,7 @@ async def viewer_can_vote_map(
             Character.account_id == account_id,
         )
     )
-    blocked_ids = set(owned_result.scalars().all()) | closed_ids
+    blocked_ids = set(owned_result.scalars().all())
 
     # B. Duel participation — for every active duel touching a page praxis, block
     # BOTH of its sides (that are on this page) when the viewer's account is a

--- a/backend/tests/integration/test_failed_praxis.py
+++ b/backend/tests/integration/test_failed_praxis.py
@@ -1,0 +1,194 @@
+"""A praxis an admin marks ``failed`` earns nobody points, and closes to voting (#1373).
+
+Seams under test:
+
+1. ``services.character_stats.recalculate_character_stats`` — the score gather.
+   A ``failed`` praxis must contribute 0 to its author's and (for a collab) every
+   member's recomputed score, the same way ``hidden`` already does.
+2. ``services.praxis.moderate_praxis`` (reached via ``PATCH
+   /admin/praxes/{id}/moderate``) — the moderation transition must *trigger* the
+   recompute, so a score corrected only on the next unrelated vote is a bug.
+3. ``services.vote`` — voting closes on a failed praxis (owner-unruled
+   sub-question; see the PR description). Listing deliberately does NOT change:
+   a failed praxis stays in the feed wearing its banner.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.account import Account
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.praxis import ModerationStatus, Praxis, PraxisStatus
+from models.roles import AccountRole, Role
+from models.vote import Vote
+from services.character_stats import recalculate_character_stats
+
+
+async def _make_admin(account: Account, session: AsyncSession) -> None:
+    """Grant the admin role to an account."""
+    role = Role(name="admin", description="Administrator")
+    session.add(role)
+    await session.flush()
+    session.add(
+        AccountRole(account_id=account.id, role_id=role.id, granted_by=account.id)
+    )
+    await session.commit()
+
+
+async def _score_of(character_id: int, session: AsyncSession) -> int:
+    result = await session.execute(
+        select(CharacterStats).where(CharacterStats.character_id == character_id)
+    )
+    stats = result.scalars().first()
+    return stats.score if stats is not None else 0
+
+
+@pytest.mark.asyncio
+async def test_failed_solo_praxis_contributes_nothing(
+    db_session: AsyncSession,
+    character: Character,
+    praxis_solo: Praxis,
+    vote: Vote,
+):
+    """A solo praxis worth points before the mark is worth 0 after it."""
+    await recalculate_character_stats(character.id, db_session)
+    before = await _score_of(character.id, db_session)
+    assert before > 0, "fixture must earn points, or the drop below proves nothing"
+
+    praxis_solo.moderation_status = ModerationStatus.failed
+    await db_session.flush()
+    await recalculate_character_stats(character.id, db_session)
+
+    assert await _score_of(character.id, db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_failed_collab_praxis_contributes_nothing_to_members(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    praxis_collab: Praxis,
+):
+    """Both collab members lose the points — the member gather filters too."""
+    praxis_collab.status = PraxisStatus.submitted
+    await db_session.flush()
+
+    for member in (character, character2):
+        await recalculate_character_stats(member.id, db_session)
+    before = {
+        member.id: await _score_of(member.id, db_session)
+        for member in (character, character2)
+    }
+    assert all(score > 0 for score in before.values()), before
+
+    praxis_collab.moderation_status = ModerationStatus.failed
+    await db_session.flush()
+    for member in (character, character2):
+        await recalculate_character_stats(member.id, db_session)
+
+    assert await _score_of(character.id, db_session) == 0
+    # character2 starts the era with a seeded score, so assert the drop, not zero.
+    assert await _score_of(character2.id, db_session) < before[character2.id]
+
+
+@pytest.mark.asyncio
+async def test_admin_marking_failed_recomputes_the_score(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    auth_headers2: dict,
+    character: Character,
+    character2: Character,
+    praxis_solo: Praxis,
+):
+    """submit → vote → score > 0 → admin marks failed → score drops, no other action."""
+    await _make_admin(account, db_session)
+
+    vote_response = await client.post(
+        f"/praxes/{praxis_solo.id}/vote", json={"value": 5}, headers=auth_headers2
+    )
+    assert vote_response.status_code == 200
+    before = await _score_of(character.id, db_session)
+    assert before > 0
+
+    moderate_response = await client.patch(
+        f"/admin/praxes/{praxis_solo.id}/moderate",
+        json={"status": "failed", "admin_note": "Proof does not show the task."},
+        headers=auth_headers,
+    )
+    assert moderate_response.status_code == 200
+    assert moderate_response.json()["moderation_status"] == "failed"
+
+    assert await _score_of(character.id, db_session) == 0
+
+
+@pytest.mark.asyncio
+async def test_restoring_a_failed_praxis_restores_the_score(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    character: Character,
+    praxis_solo: Praxis,
+    vote: Vote,
+):
+    """The mark is reversible: back to ``visible`` and the points return."""
+    await _make_admin(account, db_session)
+    await recalculate_character_stats(character.id, db_session)
+    before = await _score_of(character.id, db_session)
+    assert before > 0
+
+    for status in ("failed", "visible"):
+        response = await client.patch(
+            f"/admin/praxes/{praxis_solo.id}/moderate",
+            json={"status": status},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+
+    assert await _score_of(character.id, db_session) == before
+
+
+@pytest.mark.asyncio
+async def test_failed_praxis_closes_to_voting(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    auth_headers2: dict,
+    character2: Character,
+    praxis_solo: Praxis,
+):
+    """Voting closes: the budget must not be spent on a praxis that cannot score.
+
+    ``character2`` is requested so the voter really exists — without it the POST
+    403s on "no active character" and the test would pass for the wrong reason.
+    """
+    praxis_solo.moderation_status = ModerationStatus.failed
+    await db_session.commit()
+
+    response = await client.post(
+        f"/praxes/{praxis_solo.id}/vote", json={"value": 5}, headers=auth_headers2
+    )
+    assert response.status_code == 403, response.text
+
+    detail = await client.get(f"/praxes/{praxis_solo.id}", headers=auth_headers2)
+    assert detail.status_code == 200
+    assert detail.json()["viewer_can_vote"] is False
+
+
+@pytest.mark.asyncio
+async def test_failed_praxis_stays_listed(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    praxis_solo: Praxis,
+):
+    """Listing is unchanged — failed is a public mark of shame, not a removal."""
+    praxis_solo.moderation_status = ModerationStatus.failed
+    await db_session.commit()
+
+    response = await client.get("/praxes")
+    assert response.status_code == 200
+    assert praxis_solo.id in {item["id"] for item in response.json()}

--- a/backend/tests/integration/test_failed_praxis.py
+++ b/backend/tests/integration/test_failed_praxis.py
@@ -1,4 +1,4 @@
-"""A praxis an admin marks ``failed`` earns nobody points, and closes to voting (#1373).
+"""A praxis an admin marks ``failed`` earns nobody points — and that is ALL it changes (#1373).
 
 Seams under test:
 
@@ -8,9 +8,11 @@ Seams under test:
 2. ``services.praxis.moderate_praxis`` (reached via ``PATCH
    /admin/praxes/{id}/moderate``) — the moderation transition must *trigger* the
    recompute, so a score corrected only on the next unrelated vote is a bug.
-3. ``services.vote`` — voting closes on a failed praxis (owner-unruled
-   sub-question; see the PR description). Listing deliberately does NOT change:
-   a failed praxis stays in the feed wearing its banner.
+3. Listing and voting deliberately do NOT change. Owner ruling (Molly,
+   2026-07-30): only points change. A failed praxis stays in the feed wearing its
+   banner, and stays votable. The last two tests pin that, because "a vote that
+   cannot move a score should be blocked" is a tempting tidy-up that has already
+   been proposed once and ruled against.
 """
 
 import pytest
@@ -154,17 +156,24 @@ async def test_restoring_a_failed_praxis_restores_the_score(
 
 
 @pytest.mark.asyncio
-async def test_failed_praxis_closes_to_voting(
+async def test_failed_praxis_stays_votable(
     client: AsyncClient,
     db_session: AsyncSession,
     auth_headers2: dict,
     character2: Character,
     praxis_solo: Praxis,
 ):
-    """Voting closes: the budget must not be spent on a praxis that cannot score.
+    """Voting stays OPEN on a failed praxis — owner ruling (Molly, 2026-07-30).
+
+    `failed` changes exactly one thing: the praxis banks no points. It keeps its
+    place in the feed, it keeps its banner, and it keeps its ratings module. The
+    argument for closing voting was that a vote costs the voter finite budget
+    (ADR-0043) and can no longer move any score; the ruling is that only the
+    scoring changes, so this test exists to stop that reasoning being re-applied
+    later as an obvious tidy-up.
 
     ``character2`` is requested so the voter really exists — without it the POST
-    403s on "no active character" and the test would pass for the wrong reason.
+    403s on "no active character" and this would pass for the wrong reason.
     """
     praxis_solo.moderation_status = ModerationStatus.failed
     await db_session.commit()
@@ -172,11 +181,11 @@ async def test_failed_praxis_closes_to_voting(
     response = await client.post(
         f"/praxes/{praxis_solo.id}/vote", json={"value": 5}, headers=auth_headers2
     )
-    assert response.status_code == 403, response.text
+    assert response.status_code == 200, response.text
 
     detail = await client.get(f"/praxes/{praxis_solo.id}", headers=auth_headers2)
     assert detail.status_code == 200
-    assert detail.json()["viewer_can_vote"] is False
+    assert detail.json()["viewer_can_vote"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1373

A praxis an admin marks `failed` kept every point it had earned: the score recompute excluded only `hidden`, so `failed` sailed through both gathers with its points intact.

## Owner ruling — the scope of this fix

The issue left an unruled sub-question: beyond points, should `failed` also leave listings and lose voting? **Molly ruled (2026-07-30): only points change.** A failed praxis stays in the feed, keeps its banner, and stays votable.

This branch originally also closed voting — the argument being that a vote costs finite per-era budget (ADR-0043) and could no longer move any score. That half has been **reverted** to match the ruling. `services/vote.py` is untouched from `main`, and the `voted=no` filter still surfaces failed praxes under "needs my vote".

`test_failed_praxis_closes_to_voting` was **inverted rather than deleted**, into `test_failed_praxis_stays_votable`. "A vote that cannot move a score should be blocked" is a tempting tidy-up that has already been proposed once and ruled against, so it wants a guard rather than a silence.

## What changed

- **`services/character_stats.py`** — new `_UNSCORED_MODERATION_STATUSES = {hidden, failed}`, read by both praxis gathers instead of each spelling `!= hidden`. This also stops a failed praxis counting toward faction invitation thresholds, since `_deliver_earned_invitations` consumes the same gather — which matches `services/character.py`'s Albescent-unlock query, that one having always accepted only `visible` + `flagged`.
- **`services/praxis.py`** — `moderate_praxis` gains `era: EraConfig = CURRENT_ERA` and calls `recalculate_members_stats` after every transition, so scores correct themselves on the admin action rather than on the author's next unrelated vote.
- **`routers/admin.py`** — a separate bug found on the way: `DELETE /admin/praxes/{id}` was setting `moderation_status = hidden` **in the route handler**, bypassing the service, so hiding a praxis also left its points banked. It now routes through `moderate_praxis`; 4 lines of route logic deleted.

## Seam and the red step

`services.character_stats.recalculate_character_stats` — the score gather — and `services.praxis.moderate_praxis` for the trigger. The loop was genuinely red first: 4 of 6 tests failed on `main`'s behaviour, e.g. `assert 15 == 0`.

One test initially passed for the wrong reason — the voter fixture did not exist, so the POST 403'd on "no active character" rather than on the rule under test. Requesting `character2` made it truly red.

## Tests

`TEST_DATABASE_URL=…/wz1373_test pytest --cov=. --cov-fail-under=80` from `/backend` → **903 passed, coverage 90.82%**. No migration: no schema change.

## Worth filing separately

- **Duel settlement ignores moderation status.** `services/duel_outcome.py::duel_winner` compares vote tallies only, so a failed duel side can still *win* on votes collected before the mark. The failed author now banks nothing, but the multiplier applied to the **opponent** still moves.
- **`all_time_score` is a `max()` high-water mark**, so failing a praxis lowers `score` but not `all_time_score`. Looks deliberate (ADR-0044); left alone.
- **The praxis card still renders its computed total** (ADR-0047 stamp) on a failed praxis that banks nothing.

## What to eyeball

1. Mark a praxis failed in the admin UI — the author's score should drop immediately, not on their next vote.
2. The failed praxis should still appear in the feed, still wear its banner, and still accept a star rating.
3. Restore it to `visible` — the points should come back.
4. Hide a praxis via the admin route and confirm its points also leave (that path was silently broken before).

Backend only; no visual QA was possible here beyond the above being described rather than observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)