### PR TITLE
The feed row's actor name clears AA on the last four chassis (#1341)

### DIFF
--- a/frontend/src/components/feed/CovenFeedFrame.tsx
+++ b/frontend/src/components/feed/CovenFeedFrame.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react'
 import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
+import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
 
 /**
  * Cozy Coven — THE CANDLELIT SLIP, as a feed card (dress issue #1197, epic
@@ -48,6 +49,20 @@ import type { FeedFrameProps } from './feedFrameProps'
  * gradient's worst stop — see the slip block in index.css (#1023) and the ward
  * block (#1031).
  */
+
+/**
+ * The one ink on the SLIP the head's measurements never covered (#1341). The
+ * shared body paints the actor's name in the raw `--faction-coven` — a hue
+ * measured against the app's neutral page — and on this near-white ward stock
+ * that is 2.98:1, where 18px/700 owes 4.5:1 (700 weight only reaches the
+ * large-text 3:1 exemption at 18.66px).
+ *
+ * `-slip-deep` is the same pink taken down for exactly this: it is already what
+ * this card's points numeral and braid strands are struck in, and it is already
+ * measured on this ground — 4.70:1 light / 9.77:1 dark. A repoint, not a mint.
+ * The bright `-slip-pk` is ornament only and stays so; it is 3.25:1 as type.
+ */
+const ROW_SKIN: FeedRowSkin = { ink: { actor: 'var(--faction-coven-slip-deep)' } }
 
 const CHROME = 'var(--font-faction-rounded)' /* Quicksand */
 const DISPLAY = 'var(--font-faction-witch)' /* Grenze Gotisch */
@@ -270,7 +285,9 @@ export default function CovenFeedFrame({ kicker, time, tag, archive, children }:
 
       {/* THE SLIP — the shared payload body. No padding and no ink of ours: every
           body already pads itself, and the body is faction-blind by contract. */}
-      <div style={{ position: 'relative' }}>{children}</div>
+      <div style={{ position: 'relative' }}>
+        <FeedRowSkinContext.Provider value={ROW_SKIN}>{children}</FeedRowSkinContext.Provider>
+      </div>
     </article>
   )
 }

--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -59,6 +59,7 @@ import {
   GlyphRegister,
   INK,
   LINE,
+  NILE,
   OCHRE,
   PLATE,
   READING,
@@ -69,6 +70,28 @@ import {
 } from '../factionMarks/ephemeristsPlate'
 import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
+import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
+
+/**
+ * The one body ink the plate's own measurements never covered (#1341). The
+ * shared row paints the actor's name in the raw `--faction-ephemerists`, a hue
+ * measured against the app's neutral page: 4.37:1 on the bare papyrus and
+ * 4.15:1 once the light theme's gold {@link WASH} is composited over it, where
+ * 18px/700 owes 4.5:1 (700 weight reaches the large-text 3:1 exemption only at
+ * 18.66px). It is a LIGHT-only miss — the dark plate takes no wash at all and
+ * the same hue reads 5.56:1 there. #1252 recorded a dark failure by measuring
+ * the light wash over the dark plate; that composite is not a surface this
+ * chassis ever paints.
+ *
+ * {@link NILE} is the same teal walked down for type on this plate: 5.01:1 bare,
+ * 4.76:1 under the wash, 7.00:1 dark. It is also, exactly, the ink this faction
+ * declares for "links" — and the actor's name IS a link to that player. A
+ * repoint, not a mint. `-plate-quiet` clears too (5.60 / 5.32 / 5.98) and was
+ * rejected: it is the MUTED role's ink, and painting the row's one identity slot
+ * in a brown quieter than the body copy loses the faction rather than legibly
+ * keeping it.
+ */
+const ROW_SKIN: FeedRowSkin = { ink: { actor: NILE } }
 
 /**
  * The masthead's second ink tier. Declared here rather than beside its siblings
@@ -269,7 +292,7 @@ export default function EphemeristsFeedFrame({
         {/* The shared payload — the slot-driven row or one of the three
             companions. Its inks are the global text tokens, which follow the
             theme exactly as the plate ground does, so nothing is set on it. */}
-        {children}
+        <FeedRowSkinContext.Provider value={ROW_SKIN}>{children}</FeedRowSkinContext.Provider>
       </div>
     </div>
   )

--- a/frontend/src/components/feed/EverymenFeedFrame.tsx
+++ b/frontend/src/components/feed/EverymenFeedFrame.tsx
@@ -35,17 +35,32 @@
  * INK. The band is `--everymen-red` as a FILL, inked in
  * `--everymen-masthead-text` — the pairing the broadsheet chrome already
  * measured (5.24:1 light / 4.59:1 dark). #1223 established that red is only
- * 4.49:1 as TYPE on `--everymen-paper`, so no red label is set on the stock:
- * on the paper red is a fill, and the ink on it is the masthead's. The dateline
- * and the tag chip therefore print at FULL masthead ink and separate themselves
- * by face and size — the shared band's 0.7 opacity would have walked the dark
- * pairing down to roughly 3.2:1.
+ * 4.49:1 as TYPE on `--everymen-paper`, so no red label is set on the stock BY
+ * THIS FRAME: on the paper red is a fill, and the ink on it is the masthead's.
+ * The dateline and the tag chip therefore print at FULL masthead ink and
+ * separate themselves by face and size — the shared band's 0.7 opacity would
+ * have walked the dark pairing down to roughly 3.2:1.
+ *
+ * The SHARED BODY did set one, and nothing here could see it (#1341): the
+ * actor's name paints `factionCssVar(slug)` — `--faction-everymen`, the same
+ * #c1272d — at 18px/700, which owes 4.5:1 because 700 weight only reaches the
+ * large-text 3:1 exemption at 18.66px. So that 4.49:1 near-miss was a live
+ * pairing on this card and not a hypothetical, and #1223's "never set there" had
+ * quietly stopped being true one layer down. This is the only chassis of the
+ * four where no existing token could take the job: `--everymen-red` misses in
+ * light, `-red-deep` is 2.67:1 in dark, and `-sheet-accent` is the same red
+ * measured on the lighter sheet PANEL, so it misses in light too. Hence
+ * `--everymen-paper-accent`, the red walked down for this stock — a mint, and
+ * the only one this issue makes (5.09:1 light / 6.09:1 dark).
  *
  * One responsive component, no mobile twin (ADR-0056 / 0058 / 0063): the slip
  * tightens its band and drops the masthead a size on a phone.
  */
 import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
+import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
+
+const ROW_SKIN: FeedRowSkin = { ink: { actor: 'var(--everymen-paper-accent)' } }
 
 export default function EverymenFeedFrame({
   kicker,
@@ -188,7 +203,9 @@ export default function EverymenFeedFrame({
         </div>
 
         {/* The shared payload body, printed on the stock. */}
-        <div style={{ position: 'relative', zIndex: 2 }}>{children}</div>
+        <div style={{ position: 'relative', zIndex: 2 }}>
+          <FeedRowSkinContext.Provider value={ROW_SKIN}>{children}</FeedRowSkinContext.Provider>
+        </div>
       </div>
     </article>
   )

--- a/frontend/src/components/feed/SnideFeedFrame.tsx
+++ b/frontend/src/components/feed/SnideFeedFrame.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from 'react'
 import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
+import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
 
 /**
  * S.N.I.D.E. activity-feed CHASSIS (surface #12, SPEC-faction-ui-profile.md §12).
@@ -51,6 +52,23 @@ import type { FeedFrameProps } from './feedFrameProps'
  * rotated card fouls its neighbours' edges and the shadow eats the gutter — and
  * the stripe narrows. Everything else is identical.
  */
+/**
+ * The shared body's one ink that is wrong on this stock (#1341). The row paints
+ * the actor's name in the raw `--faction-snide`, measured against the app's
+ * neutral page: 2.41:1 on the light slip, and the name is 18px/700, so it owes
+ * 4.5:1 rather than the large-text 3:1. It is the *deep* acid at that — the
+ * bright pigment reads 1.07:1 there.
+ *
+ * The ink that fixes it is the one this faction already minted for exactly the
+ * question "acid, but as TYPE on the slip": `-slip-acid-ink`, 5.21:1 light /
+ * 15.55:1 dark, and the same ink a resolved @mention prints in a comment on this
+ * very card. A repoint, not a mint — {@link FeedRowInk.actor}'s docblock makes
+ * this slot a place to re-point an existing ink and never a reason to make one —
+ * and the acid stays a DRAWN thing everywhere else on the slip (the sprocket
+ * stripe, the rule under the intake bar, the tag chip's edge).
+ */
+const ROW_SKIN: FeedRowSkin = { ink: { actor: 'var(--faction-snide-slip-acid-ink)' } }
+
 export default function SnideFeedFrame({
   kicker,
   time,
@@ -184,7 +202,9 @@ export default function SnideFeedFrame({
 
         {/* The slip's body — the shared payload, which self-pads and paints its
             own inks. It gets a stock and nothing else. */}
-        <div style={{ position: 'relative' }}>{children}</div>
+        <div style={{ position: 'relative' }}>
+          <FeedRowSkinContext.Provider value={ROW_SKIN}>{children}</FeedRowSkinContext.Provider>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedRowInk.test.tsx
@@ -28,9 +28,13 @@ import { describe, it, expect } from 'vitest'
 import UaFeedFrame from '../UaFeedFrame'
 import WowFeedFrame from '../WowFeedFrame'
 import SingularityFeedFrame from '../SingularityFeedFrame'
+import SnideFeedFrame from '../SnideFeedFrame'
+import CovenFeedFrame from '../CovenFeedFrame'
+import EphemeristsFeedFrame from '../EphemeristsFeedFrame'
+import EverymenFeedFrame from '../EverymenFeedFrame'
 import FeedRowContent from '../FeedRowContent'
 import { normalizeFeedItem } from '../normalizeFeedItem'
-import { AA_NORMAL, contrastRatio, formatRatio, parseColor } from '../../../utils/contrast'
+import { AA_NORMAL, compositeOver, contrastRatio, formatRatio, parseColor } from '../../../utils/contrast'
 import { readThemes, resolveVar, type Theme } from '../../../utils/__tests__/cssVars'
 import '../../../i18n'
 
@@ -58,18 +62,70 @@ function row(slug: string) {
   })!
 }
 
+/**
+ * A wash the chassis lays over its own ground before the body lands on it
+ * (#1341). Resolved per theme and composited when it yields a colour, which is
+ * what makes it theme-correct for free: `--faction-ephemerists-plate-wash` is a
+ * gradient by day and the keyword `none` at night, so the dark plate is measured
+ * bare — exactly as it is painted. Measuring the LIGHT wash over the DARK plate
+ * is how #1252 recorded a 3.16:1 dark failure that no surface has.
+ *
+ * The tightest stop is the one that gates: a top-anchored ramp fading to
+ * transparent is at full strength where the row's first line sits.
+ */
+function veiledGround(stop: string, veil: string | null, theme: Theme) {
+  const surface = parseColor(stop)
+  expect(surface, `ground stop ${stop}`).not.toBeNull()
+  if (!veil) return surface!
+  const raw = resolveVar(veil, theme, THEMES)
+  const first = raw?.match(/#[0-9a-fA-F]{3,8}\b|rgba?\([^)]*\)/)?.[0]
+  const wash = first ? parseColor(first) : null
+  return wash ? compositeOver(wash, surface!) : surface!
+}
+
 const CASES = [
-  { slug: 'ua', Frame: UaFeedFrame, ink: '--faction-ua-card-accent', ground: '--faction-ua-parchment' },
-  { slug: 'wow', Frame: WowFeedFrame, ink: '--faction-wow-card-accent', ground: '--faction-wow-card-bg' },
+  { slug: 'ua', Frame: UaFeedFrame, ink: '--faction-ua-card-accent', ground: '--faction-ua-parchment', veil: null },
+  { slug: 'wow', Frame: WowFeedFrame, ink: '--faction-wow-card-accent', ground: '--faction-wow-card-bg', veil: null },
   {
     slug: 'singularity',
     Frame: SingularityFeedFrame,
     ink: '--faction-singularity-card-accent',
     ground: '--faction-singularity-term-bg',
+    veil: null,
+  },
+  // The four #1252 left, fixed by #1341. Three repoint to an ink their own
+  // family already declares for type on this exact stock; only Everymen mints.
+  {
+    slug: 'snide',
+    Frame: SnideFeedFrame,
+    ink: '--faction-snide-slip-acid-ink',
+    ground: '--faction-snide-slip-paper',
+    veil: null,
+  },
+  {
+    slug: 'coven',
+    Frame: CovenFeedFrame,
+    ink: '--faction-coven-slip-deep',
+    ground: '--faction-coven-ward-card',
+    veil: null,
+  },
+  {
+    slug: 'ephemerists',
+    Frame: EphemeristsFeedFrame,
+    ink: '--faction-ephemerists-plate-nile',
+    ground: '--faction-ephemerists-plate-bg',
+    veil: '--faction-ephemerists-plate-wash',
+  },
+  {
+    slug: 'everymen',
+    Frame: EverymenFeedFrame,
+    ink: '--everymen-paper-accent',
+    ground: '--everymen-paper',
+    veil: null,
   },
 ] as const
 
-describe.each(CASES)('$slug feed chassis re-inks the shared body', ({ slug, Frame, ink, ground }) => {
+describe.each(CASES)('$slug feed chassis re-inks the shared body', ({ slug, Frame, ink, ground, veil }) => {
   it('reaches the actor name inside children it did not mount', () => {
     const html = renderToStaticMarkup(
       <MemoryRouter>
@@ -89,9 +145,8 @@ describe.each(CASES)('$slug feed chassis re-inks the shared body', ({ slug, Fram
     const text = parseColor(resolveVar(ink, theme, THEMES) ?? '')
     expect(text, `${ink} (${theme})`).not.toBeNull()
     for (const stop of groundStops(ground, theme)) {
-      const surface = parseColor(stop)
-      expect(surface, `${ground} stop ${stop}`).not.toBeNull()
-      const ratio = contrastRatio(text!, surface!)
+      const surface = veiledGround(stop, veil, theme)
+      const ratio = contrastRatio(text!, surface)
       expect(ratio, `${ink} on ${stop} (${theme}) = ${formatRatio(ratio)}`).toBeGreaterThanOrEqual(AA_NORMAL)
     }
   })

--- a/frontend/src/components/feed/feedRowSkin.ts
+++ b/frontend/src/components/feed/feedRowSkin.ts
@@ -46,10 +46,21 @@ import { factionCssVar } from '../../utils/factions'
  *
  * ## What a frame may put here
  *
- * Tokens it already owns. This is a place to REPOINT existing inks, never a
- * reason to mint one, and never a home for a hue measured on some other ground:
- * the whole failure it exists to fix is an ink measured against the app's page
- * being painted on a faction's sheet.
+ * Tokens it already owns. This is a place to REPOINT existing inks and never a
+ * home for a hue measured on some other ground: the whole failure it exists to
+ * fix is an ink measured against the app's page being painted on a faction's
+ * sheet.
+ *
+ * It used to say "never a reason to mint one", and #1341 is the exception that
+ * had to be written down. Repointing needs a rung that already survives the
+ * chassis's ground, and three of the four chassis #1252 left had one — the acid
+ * S.N.I.D.E. had already walked down for type on the slip, the pink Coven strikes
+ * its numerals in, the nile Ephemerists sets its links in. Everymen had none: its
+ * red misses in light on `--everymen-paper`, `-red-deep` misses in dark, and
+ * `-sheet-accent` is the same red measured on the lighter sheet PANEL. So the
+ * rule is about ORDER, not prohibition — look for the existing (role, ground)
+ * ink first, and mint the sibling only once the family is shown not to have one.
+ * `--everymen-paper-accent` is #1173's split applied to the accent role.
  */
 export interface FeedRowInk {
   /**
@@ -57,12 +68,17 @@ export interface FeedRowInk {
    *
    * Default `factionCssVar(slug)` — the faction's raw hue, which is what the row
    * has always painted. That default is legible on the app's neutral page and
-   * MEASURABLY IS NOT on most faction chassis: at 18px/700 it owes 4.5:1 and
+   * MEASURABLY IS NOT on ANY of the seven bespoke chassis: at 18px/700 it owes
+   * 4.5:1 (700 weight reaches the large-text 3:1 exemption only at 18.66px) and
    * pays 1.96:1 on WOW's cream, 2.41:1 on the S.N.I.D.E. slip, 2.98:1 on the
    * Coven ward, 3.67:1 on the Singularity terminal, 4.04:1 on UA's parchment,
-   * 4.15:1 on the Ephemerists plate and 4.49:1 on Everymen's paper (light
-   * theme; #1252 measured all sixteen). A chassis whose ground fails passes the
-   * accent it measured instead.
+   * 4.15:1 on the Ephemerists plate under its gold wash and 4.49:1 on Everymen's
+   * paper. All seven are LIGHT-theme misses and the raw hue clears in dark on
+   * every one of them — #1252's "Ephemerists 3.16:1 dark" was the light wash
+   * composited over the dark plate, where `-plate-wash` resolves to `none`.
+   * A chassis whose ground fails passes the accent it measured instead; all
+   * seven now do (#1252, then #1341), and `feedRowInk.test.tsx` renders each
+   * frame around the shared body and re-measures the pairing it publishes.
    *
    * It stays the default rather than becoming `-card-accent` globally because
    * `card-accent` is measured against `-card-bg`, and only three of the eight

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1431,6 +1431,15 @@
      on the paper, so a surface that mixes the two sheets is safe). A SIBLING:
      `--everymen-muted` keeps every job it has on the paper. */
   --everymen-quiet: #63533b;
+  /* The PAPER STOCK's accent ink (#1341) — the same (role, ground) split
+     `--faction-everymen-sheet-accent` already makes, one stock further down.
+     The red is 4.95:1 on the sheet panel and 4.49:1 here, so the feed row's
+     actor name — 18px/700, which owes 4.5:1 and not the large-text 3:1 — misses
+     by 0.01 on the broadsheet's own paper. Every OTHER job the red has on this
+     stock is a fill or a rule (the masthead band, the frame, the stamp wash),
+     and those are unaffected: this is a SIBLING, minted so `--everymen-red`
+     keeps all of them. Walked down until it clears with room: 5.09:1. */
+  --everymen-paper-accent: #b32227;
   --everymen-field: #c1272d;
   --everymen-field-deep: #8d1c20;
   --faction-everymen-card-bg: var(--everymen-paper);
@@ -2276,6 +2285,13 @@
      comfortable ground in either theme. Aliased rather than copied so a repaint
      of the dark muted ink carries the deep stock with it. */
   --everymen-quiet: var(--everymen-muted);
+  /* The paper stock's accent ink at night (#1341). `--everymen-red` is 4.16:1 on
+     the dark paper — a real failure, not a near-miss — so this half takes the
+     lifted red the faction already uses for type after dark, the value
+     --faction-everymen-sheet-accent carries. Declared rather than aliased for
+     the reason the slip/note/composer families are declared apart: same value
+     today, a different stock's contract tomorrow. 6.09:1. */
+  --everymen-paper-accent: #f4726c;
   --everymen-field: #3c1416;
   --everymen-field-deep: #5a1d20;
   /* Broadsheet chrome (#841): the frame rule lifts off near-black (the light

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1047,15 +1047,34 @@ const ARCHETYPE_PAIRS: Pair[] = [
   { what: "everymen masthead band, ink", surface: "--everymen-red", text: "--everymen-masthead-text" },
 
   // ── THE FEED ROW'S ACTOR NAME, on the four chassis #1252 left (#1341) ────
+  //
   // `resolveFeedRowInk` defaults `actor` to `factionCssVar(slug)` — the raw
-  // spine hue — at 18px/700, which owes 4.5:1 (700 weight only reaches the
-  // large-text exemption at 18.66px). #1252 repointed UA, WOW and Singularity to
-  // an accent that already cleared their own ground; these four had no such
-  // accent under the name the seam reaches for.
-  { what: "snide slip, actor name", surface: "--faction-snide-slip-paper", text: "--faction-snide" },
-  { what: "coven ward card, actor name", surface: "--faction-coven-ward-card", text: "--faction-coven" },
-  { what: "ephemerists plate, actor name", surface: "--faction-ephemerists-plate-bg", text: "--faction-ephemerists" },
-  { what: "everymen paper, actor name", surface: "--everymen-paper", text: "--faction-everymen" },
+  // spine hue — at 18px/700, which owes 4.5:1 because 700 weight only reaches
+  // the large-text exemption at 18.66px. #1252 repointed UA, WOW and Singularity
+  // to an accent that already cleared their own ground and left these four,
+  // which failed in LIGHT at 2.41 (snide), 2.98 (coven), 4.37 (ephemerists, and
+  // 4.15 with the plate wash composited) and 4.49 (everymen). All four clear
+  // dark on the raw hue; #1252's "ephemerists 3.16:1 dark" was the LIGHT wash
+  // measured over the DARK plate, and `--faction-ephemerists-plate-wash` is
+  // `none` in dark, so that composite is not a surface anything paints.
+  //
+  // THREE OF THE FOUR ADD NO ROW, which is a finding rather than an omission —
+  // each fix repoints to an ink whose pairing with that exact ground is already
+  // asserted above, and a second `what` for two identical tokens measures
+  // nothing new (the same call the four "checked and deliberately NOT written"
+  // pairings make further up):
+  //   snide       -slip-acid-ink on -slip-paper   = `snide slip, mention ink`
+  //   coven       -slip-deep     on -ward-card    = `coven ward panel, accent ink`
+  //   ephemerists -plate-nile    on -plate-bg     = `ephemerists plate, links`
+  //
+  // Everymen is the one mint, and the one new row. Its red has no rung that
+  // survives this stock in both themes: `--everymen-red` is the 4.49 above,
+  // `-red-deep` is 2.67:1 at night, and `--faction-everymen-sheet-accent` is the
+  // same red measured on the lighter sheet PANEL, so it carries the light miss
+  // with it. `--everymen-paper-accent` is #1173's (role, ground) split applied
+  // to the ACCENT role instead of the muted one — the shape the family already
+  // uses for `-sheet-accent`, one stock further down.
+  { what: "everymen paper, actor name", surface: "--everymen-paper", text: "--everymen-paper-accent" },
 
   // Albescent's FACTION tokens are gone (#783) — it renders Default's surfaces,
   // which `default` already covers. What remains is the always-light palette

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1046,6 +1046,17 @@ const ARCHETYPE_PAIRS: Pair[] = [
   // print at FULL ink and separate themselves by face rather than by opacity.
   { what: "everymen masthead band, ink", surface: "--everymen-red", text: "--everymen-masthead-text" },
 
+  // ── THE FEED ROW'S ACTOR NAME, on the four chassis #1252 left (#1341) ────
+  // `resolveFeedRowInk` defaults `actor` to `factionCssVar(slug)` — the raw
+  // spine hue — at 18px/700, which owes 4.5:1 (700 weight only reaches the
+  // large-text exemption at 18.66px). #1252 repointed UA, WOW and Singularity to
+  // an accent that already cleared their own ground; these four had no such
+  // accent under the name the seam reaches for.
+  { what: "snide slip, actor name", surface: "--faction-snide-slip-paper", text: "--faction-snide" },
+  { what: "coven ward card, actor name", surface: "--faction-coven-ward-card", text: "--faction-coven" },
+  { what: "ephemerists plate, actor name", surface: "--faction-ephemerists-plate-bg", text: "--faction-ephemerists" },
+  { what: "everymen paper, actor name", surface: "--everymen-paper", text: "--faction-everymen" },
+
   // Albescent's FACTION tokens are gone (#783) — it renders Default's surfaces,
   // which `default` already covers. What remains is the always-light palette
   // private to the reveal surfaces (invitation letter, secret placeholder). It


### PR DESCRIPTION
Closes #1341

## The seam under test

`components/feed/feedRowSkin.ts` — the `ink.actor` slot. `resolveFeedRowInk` defaults it to `factionCssVar(slug)`, the faction's raw spine hue, which the shared body paints at 18px/700. 700 weight only reaches WCAG's large-text exemption at 18.66px, so that name owes **4.5:1** and not 3:1.

The loop went red at that seam first: commit 1 (`90ed2fc`) adds four rows to `factionContrast.test.ts` against the inks that ship today and they fail at the ratios below, in **light only**. Commit 2 (`87e0d3e`) makes them green.

## Measured — every number from `utils/contrast.ts`, none by hand

Grounds are what each frame actually paints: `--faction-snide-slip-paper`, `--faction-coven-ward-card`, `--faction-ephemerists-plate-bg` (under `-plate-wash`), `--everymen-paper`.

| chassis | ink before | light | dark | ink after | light | dark |
|---|---|---|---|---|---|---|
| S.N.I.D.E. | `--faction-snide` | **2.41** | 15.55 | `--faction-snide-slip-acid-ink` | 5.21 | 15.55 |
| Cozy Coven | `--faction-coven` | **2.98** | 6.69 | `--faction-coven-slip-deep` | 4.70 | 9.77 |
| Ephemerists | `--faction-ephemerists` | **4.37** bare / **4.15** washed | 5.56 | `--faction-ephemerists-plate-nile` | 5.01 bare / 4.76 washed | 7.00 |
| Everymen | `--faction-everymen` | **4.49** | 4.91 | `--everymen-paper-accent` *(new)* | 5.09 | 6.09 |

**Two of the issue's numbers do not survive re-measurement.**

1. **Ephemerists dark is not 3.16:1 — it is 5.56:1 and passes.** 3.16 is the *light* theme's gold wash composited over the *dark* plate. `--faction-ephemerists-plate-wash` is the keyword `none` in dark, so that composite is a surface nothing paints. The 4.15 light figure is real and is the *washed* reading; bare papyrus is 4.37.
2. **All four are light-theme-only misses.** The raw hue clears 4.5:1 in dark on every one of the four.

## Three repoints, one mint — not four mints

The issue's premise was that no existing token in these families survives their own ground. That is false for three of the four, and the owner's comment on the issue had already caught two of them. Each repoint lands on an ink its own family declares *for type on that exact stock*, and each pairing is **already asserted** in `factionContrast.test.ts`:

- `-slip-acid-ink` — "acid that is TEXT", the ink a resolved @mention prints in on this very card → `snide slip, mention ink`
- `-slip-deep` — the pink Coven strikes its points numeral and braid strands in → `coven ward panel, accent ink`
- `-plate-nile` — the ink Ephemerists declares for **links**, and the actor's name *is* a link to that player → `ephemerists plate, links`

So three of the four add **no row**: a second `what` for two identical tokens measures nothing new, which is the call the file already makes for four other pairings.

`--faction-ephemerists-plate-quiet` clears too (5.60 / 5.32 washed / 5.98) and was rejected: it is the **muted** role's ink, and painting the row's one identity slot in a brown quieter than the body copy loses the faction rather than legibly keeping it.

**Everymen is the one genuine mint.** Its red has no rung that survives `--everymen-paper` in both themes — `--everymen-red` is the 4.49 miss, `-red-deep` is **2.67:1** at night, and `--faction-everymen-sheet-accent` is that same red measured on the lighter sheet *panel*, so it carries the light miss with it. `--everymen-paper-accent` is #1173's (role, ground) split applied to the **accent** role instead of the muted one — the shape `-sheet-accent` already uses, one stock further down. Both cascades, no ternary.

`feedRowSkin.ts`'s docblock said "never a reason to mint one". It now says the rule is about **order** — look for the existing (role, ground) ink first, mint only once the family is shown not to have one — because otherwise this diff silently contradicts the file it lands in.

## Guards

`feedRowInk.test.tsx` (the end-to-end seam test) grows from 3 chassis to **all 7**. It renders each frame *around* the shared body and asserts both that the published ink reaches the actor name across the `children` boundary and that it clears AA on that frame's own ground, at every stop a gradient ground declares. It also now composites a **chassis wash per theme**, which is what makes the Ephemerists plate honest and is exactly the error that produced the bogus 3.16 dark figure. Verified biting: pointing the Ephemerists case back at the raw hue fails at `4.15:1 (light)` and passes dark.

Full suite: **3129 passed / 184 files**. `tsc --noEmit` clean, eslint clean.

## Bundle budget

`npm run budget` → **CSS 21.8 KB** (warn > 19.5, fail > 24.4) — the same figure as `main`, still WARN, unchanged by this PR. Exact gzip bytes: base `22349` → head `22362`, **+13 bytes**. JS 132.2 KB, ok.

## What to eyeball

**Visual QA is outstanding — this agent has no browser and no dev stack.** Everything above is tests, `tsc` and the byte budget. Worth a look, both themes:

1. **The four feed rows.** S.N.I.D.E. actor name goes deep acid green on the light slip and bright acid at night; Coven goes deep pink; Ephemerists goes nile teal; Everymen goes a walked-down red. Check none of the four now reads as body copy or as a mistake.
2. **Everymen light specifically** — `#b32227` against `#c1272d` is a small step and the name sits right under a masthead band painted in the *undimmed* red. Confirm the two reds do not look like a printing error side by side.
3. **Everymen dark** — the actor name changes here even though the old hue passed at 4.91:1. It moves to `#f4726c`, the faction's existing red-as-ink after dark, for margin and family consistency. Deliberate, worth confirming it reads.
4. **Ephemerists near the top of the leaf**, where the gold wash is at full strength (4.76:1 there vs 5.01 lower down).
5. **Coven at 4.70:1** is the tightest reading in the set — already an asserted pairing on that ground, but it is the one to look at hardest.
6. The three chassis #1252 already fixed (UA, WOW, Singularity) are untouched.

## Noticed, not fixed

`EphemeristsFeedFrame.tsx:79` declares a local `BAND_QUIET` whose comment says it lives there "only because this issue's footprint is…, a follow-up whose whole diff is a move can hoist it". `ephemeristsPlate.tsx:56` **already exports `BAND_QUIET` with the identical value**, so the local one is now a synonym. Left alone — it is a documented deferral with its own owner, and it is not this diff's business.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
