### PR TITLE
The admin MCP's hide tool calls a path that exists (#1371)

### DIFF
--- a/mcp/worldzero-admin/server.py
+++ b/mcp/worldzero-admin/server.py
@@ -102,16 +102,6 @@ async def _patch(path: str, body: dict) -> Any:
         return response.json()
 
 
-async def _delete(path: str) -> None:
-    token = await _get_token()
-    async with httpx.AsyncClient() as client:
-        response = await client.delete(
-            f"{API_URL}{path}",
-            headers={"Authorization": f"Bearer {token}"},
-        )
-        response.raise_for_status()
-
-
 # ---------------------------------------------------------------------------
 # Read / Inspect tools
 # ---------------------------------------------------------------------------
@@ -119,7 +109,7 @@ async def _delete(path: str) -> None:
 
 @mcp.tool()
 async def wz_overview() -> dict:
-    """Get a game-wide stats overview: counts of accounts, characters, active tasks, submissions, and votes."""
+    """Get a game-wide stats overview: counts of accounts, characters, active tasks, praxes, and votes."""
     return await _get("/admin/overview")
 
 
@@ -319,15 +309,18 @@ async def wz_suspend_account(account_id: int, suspended: bool) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Submission tools
+# Praxis tools
 # ---------------------------------------------------------------------------
 
 
 @mcp.tool()
-async def wz_delete_submission(submission_id: int) -> str:
-    """Permanently delete a submission."""
-    await _delete(f"/admin/submissions/{submission_id}")
-    return f"Submission {submission_id} deleted."
+async def wz_hide_praxis(praxis_id: int) -> dict:
+    """Hide a praxis from public view.
+
+    Args:
+        praxis_id: The praxis's ID.
+    """
+    return await _patch(f"/admin/praxes/{praxis_id}/moderate", {"status": "hidden"})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1371

`wz_delete_submission` called `DELETE /admin/submissions/{id}`. That path retired when the submissions router was folded into praxes, so the tool **404'd on every use** — it has not worked since the rename.

## What changed

One file, `mcp/worldzero-admin/server.py`:

- `wz_delete_submission` → **`wz_hide_praxis`**, calling `PATCH /admin/praxes/{id}/moderate` with `{status: "hidden"}`.
- `_delete` deleted — the broken tool was its only caller.
- `wz_overview`'s docstring said "submissions"; `OverviewStats` has a `praxis` field, so it pointed at a key that does not exist.

## Two decisions worth stating

**Not `DELETE /admin/praxes/{id}`.** That route survives, but it does not delete either — it only sets `moderation_status = hidden`, duplicating the moderate PATCH. #1386 proposes removing it, and the issue's own comment says whichever lands first, the MCP should target the PATCH. Aiming at it would have moved the breakage rather than fixed it.

**No `admin_note` parameter**, though the endpoint accepts one. `moderate_praxis` persists the note only for `failed` and *nulls* it for `visible`; on `hidden` it is silently discarded. A parameter that is dropped on the floor is a lie in the tool signature.

## Testing — read this before merging

**No test, and none is runnable here.** `mcp/` has no test suite, no pytest collection, and sits outside CI's `test` job, which runs `pytest` from `backend/`. Nothing under `backend/` changed, so CI passing says nothing about this diff.

The seam is the tool → HTTP-path contract, and the only honest check is a live call against a running backend — which is what the issue's acceptance criterion asks for ("succeeds against a running backend"). Verified so far: the file byte-compiles, and `grep` for `/admin/submissions` across the repo now returns nothing.

## What to eyeball

1. With the backend running, call `wz_hide_praxis` on a real praxis id and confirm it returns a `PraxisOut` rather than a 404.
2. Confirm the praxis is actually hidden afterwards — the frontend uses this same PATCH, so the effect should match the admin UI's hide button.
3. The tool **renamed**, so any saved prompt or habit using `wz_delete_submission` will now report an unknown tool rather than a 404. That is the intended trade; nothing is lost, since the old name never worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)