### PR TITLE
The CSS budget's warn line sits above the stylesheet again (#1325)

### DIFF
--- a/frontend/scripts/bundle-budget.mjs
+++ b/frontend/scripts/bundle-budget.mjs
@@ -50,10 +50,31 @@ const DIST = join(dirname(fileURLToPath(import.meta.url)), '..', 'dist')
  * WARN sits just above today's number so any real growth speaks up immediately,
  * while the build stays green. Ratchet WARN downward each time a chunk moves
  * off the entry path — the budget is a ledger of progress, not a fixed wall.
+ *
+ * CSS ledger (#1325): the CSS warn line sat at 20,000 while the stylesheet was
+ * 20.7 KB, so every build printed the loud WARN block and the check stopped
+ * carrying information — three separate agents in one batch each reported it as
+ * "not mine", which is the tell. A check that warns unconditionally has been
+ * turned off without anyone deciding to turn it off.
+ *
+ * Raised to 23,000 against a measured 22,362 (21.84 KiB gzipped) on `main` at
+ * 7ce689b4, after epic #1361. That epic was the honest moment to re-price this:
+ * it ADDED `components/ui/FilterBar/` (~518 lines, ~60 selectors) and then
+ * DELETED three filter components — and the deletion moved nothing, because
+ * Vite had already tree-shaken them (verified: identical bundle content hashes
+ * across #1368). The stylesheet grew because a shared component replaced four
+ * bespoke ones, which is the trade the epic was for.
+ *
+ * The alternative — shed ~700 bytes to fit the old line — was rejected: the
+ * growth is real and paid for, and fitting a line the code has outgrown just
+ * moves the lie. FAIL stays at 25,000, which is now only 2.6 KB away, so this
+ * is a genuine wall rather than a formality. TARGET stays at 20,000 and is now
+ * BELOW warn, giving CSS the same shape JS has: a number to ratchet back down
+ * to, not a restatement of the warn line.
  */
 const BUDGETS = {
   js: { warn: 150_000, fail: 180_000, target: 120_000 },
-  css: { warn: 20_000, fail: 25_000, target: 20_000 },
+  css: { warn: 23_000, fail: 25_000, target: 20_000 },
 }
 
 /** Asset paths the entry HTML forces the browser to fetch before first render. */


### PR DESCRIPTION
Closes #1325

The CSS warn line was 20,000 while the stylesheet was 20.7 KB, so **every build printed the loud WARN block**. A check that warns unconditionally carries no information — three separate agents in one batch each reported it as "not mine", which is the tell. It had been turned off without anyone deciding to turn it off.

## The number

`css: { warn: 20_000 → 23_000 }`, against a **measured 22,362 bytes (21.84 KiB gzipped)** on `main` at `7ce689b4`. Built and measured directly, not estimated.

```
before:  WARN CSS  21.8 KB   warn>19.5 KB  fail>24.4 KB  target 19.5 KB
after:   ok   CSS  21.8 KB   warn>22.5 KB  fail>24.4 KB  target 19.5 KB
```

## Why raise rather than shed

Epic #1361 was the honest moment to re-price this, and it is why the issue was deferred until now rather than fixed against a number that was about to move twice.

That epic **added** `components/ui/FilterBar/` (~518 lines, ~60 selectors) and then **deleted** `FilterStamps`, `FilterFactionTabs` and `FactionSigilRow`. The deletion moved nothing — Vite had already tree-shaken them, verified in #1368 by building the base commit and getting *identical bundle content hashes*. So the stylesheet grew because one shared component replaced four bespoke ones, which is the trade the epic was for.

The issue's option 1 — shed ~700 bytes to fit the old line — was the rejected lever. The growth is real and paid for, and fitting a line the code has outgrown just relocates the lie.

## What the other two numbers do now

- **FAIL stays 25,000**, now only 2.6 KB away. That is a genuine wall, not a formality.
- **TARGET stays 20,000**, and is now *below* warn for the first time — giving CSS the same shape JS has (`target 120_000` under `warn 150_000`): a number to ratchet back down to, rather than a restatement of the warn line. The old config had warn and target both at 20,000, which is why the issue noted CSS "has no headroom band by design".

## Verification that the guard still bites

Silencing a check and fixing a check look identical in a green build, so I checked the difference. With warn temporarily lowered to 22,000 (below the actual 22,362) the WARN block fires and the script still exits 0 — the designed non-blocking behaviour. Restored to 23,000, the build reports "Within budget".

## What to eyeball

Nothing visual — this touches only `frontend/scripts/bundle-budget.mjs`. The thing to sanity-check is the judgement: 23,000 leaves ~640 bytes of headroom before the next warning, which is roughly 50 token declarations at the rate #1341 measured (2 declarations = 13 bytes). If you would rather it spoke up sooner, 22,500 is the tighter option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)