### PR TITLE
No invitation to the faction you are already in (#1425)

### DIFF
--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -34,7 +34,7 @@ _UNSCORED_MODERATION_STATUSES: frozenset[ModerationStatus] = frozenset(
 
 
 async def _deliver_earned_invitations(
-    character_id: int,
+    character: Character,
     praxes: list[Praxis],
     contributions: dict[int, Contribution],
     session: AsyncSession,
@@ -48,9 +48,16 @@ async def _deliver_earned_invitations(
     from X's tasks — both from this same submitted-praxis set recalc already scored, so
     vote-driven point gains trigger delivery too. Idempotent on the
     (character, faction, era) unique key.
+
+    The character's *current* faction is excluded (#1425): you cannot be invited to
+    join the faction you are already in, and doing your own faction's tasks is the
+    most ordinary thing a player does. Keyed on membership at delivery time, not on
+    history — defect away from X and re-cross X's thresholds and X re-invites you.
     """
     if not praxes:
         return
+
+    uninvitable = _NON_INVITE_FACTION_SLUGS | {character.faction_slug}
 
     task_rows = await session.execute(
         select(Task.id, Task.primary_faction_slug).where(
@@ -63,7 +70,7 @@ async def _deliver_earned_invitations(
     points_by_faction: dict[str, float] = {}
     for praxis in praxes:
         slug = faction_by_task.get(praxis.task_id) or "na"
-        if slug in _NON_INVITE_FACTION_SLUGS:
+        if slug in uninvitable:
             continue
         task_ids_by_faction.setdefault(slug, set()).add(praxis.task_id)
         contribution = contributions.get(praxis.id)
@@ -81,7 +88,7 @@ async def _deliver_earned_invitations(
 
     already = await session.execute(
         select(InvitationLetter.faction_slug).where(
-            InvitationLetter.character_id == character_id,
+            InvitationLetter.character_id == character.id,
             InvitationLetter.era_id == era_row.id,
         )
     )
@@ -91,7 +98,7 @@ async def _deliver_earned_invitations(
         # backstop against a concurrent double-deliver; the held-set check avoids
         # the common case.
         session.add(
-            InvitationLetter(character_id=character_id, faction_slug=slug, era_id=era_row.id)
+            InvitationLetter(character_id=character.id, faction_slug=slug, era_id=era_row.id)
         )
 
 
@@ -167,5 +174,5 @@ async def recalculate_character_stats(
 
     # ADR-0022: deliver any faction invitations this submitted-praxis set now earns.
     await _deliver_earned_invitations(
-        character_id, all_praxes, contributions, session, era, era_row
+        author, all_praxes, contributions, session, era, era_row
     )

--- a/backend/tests/integration/test_invitation_delivery.py
+++ b/backend/tests/integration/test_invitation_delivery.py
@@ -2,8 +2,11 @@
 
 A character earns faction X's InvitationLetter once it has >= invitation_task_threshold
 (2) completed distinct tasks for X AND >= invitation_point_threshold (50) points from X's
-tasks. Delivery runs inside recalculate_character_stats. ua has modifier 1.0 in Era 1, so
-point_value maps 1:1 to points here.
+tasks. Delivery runs inside recalculate_character_stats. Every Era 1 solo-task modifier is
+1.0, so point_value maps 1:1 to points here.
+
+The shared ``character`` fixture is a member of ``ua``, and #1425 excludes a character's own
+faction from delivery — so the positive cases below qualify ``snide`` instead.
 """
 import pytest
 from sqlalchemy import select
@@ -63,14 +66,15 @@ async def _seed_faction(db_session: AsyncSession, slug: str) -> None:
 async def test_two_tasks_and_fifty_points_delivers_letter(
     db_session, character: Character, era: Era, faction_ua: Faction
 ):
-    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
-    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
+    await _seed_faction(db_session, "snide")
+    await _submit(db_session, character, await _task(db_session, character, "snide", 30))
+    await _submit(db_session, character, await _task(db_session, character, "snide", 30))
     await db_session.commit()
 
     await recalculate_character_stats(character.id, db_session)
     await db_session.commit()
 
-    assert "ua" in await _letters(db_session, character)
+    assert "snide" in await _letters(db_session, character)
 
 
 @pytest.mark.asyncio
@@ -78,7 +82,8 @@ async def test_one_task_no_letter(
     db_session, character: Character, era: Era, faction_ua: Faction
 ):
     # 60 points but only ONE distinct task → task threshold (2) not met.
-    task = await _task(db_session, character, "ua", 30)
+    await _seed_faction(db_session, "snide")
+    task = await _task(db_session, character, "snide", 30)
     await _submit(db_session, character, task)
     await _submit(db_session, character, task)
     await db_session.commit()
@@ -94,8 +99,9 @@ async def test_below_points_threshold_no_letter(
     db_session, character: Character, era: Era, faction_ua: Faction
 ):
     # 2 distinct tasks but only 40 points (< 50).
-    await _submit(db_session, character, await _task(db_session, character, "ua", 20))
-    await _submit(db_session, character, await _task(db_session, character, "ua", 20))
+    await _seed_faction(db_session, "snide")
+    await _submit(db_session, character, await _task(db_session, character, "snide", 20))
+    await _submit(db_session, character, await _task(db_session, character, "snide", 20))
     await db_session.commit()
 
     await recalculate_character_stats(character.id, db_session)
@@ -108,8 +114,9 @@ async def test_below_points_threshold_no_letter(
 async def test_delivery_is_idempotent(
     db_session, character: Character, era: Era, faction_ua: Faction
 ):
-    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
-    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
+    await _seed_faction(db_session, "snide")
+    await _submit(db_session, character, await _task(db_session, character, "snide", 30))
+    await _submit(db_session, character, await _task(db_session, character, "snide", 30))
     await db_session.commit()
 
     await recalculate_character_stats(character.id, db_session)
@@ -128,18 +135,64 @@ async def test_faction_scoped_no_bleed(
     db_session, character: Character, era: Era, faction_ua: Faction
 ):
     await _seed_faction(db_session, "snide")
-    # Qualify ua (2 tasks, 60 pts); only 1 snide task (no bleed of ua progress into snide).
-    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
-    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
+    await _seed_faction(db_session, "wow")
+    # Qualify snide (2 tasks, 60 pts); only 1 wow task (no bleed of snide progress into wow).
     await _submit(db_session, character, await _task(db_session, character, "snide", 30))
+    await _submit(db_session, character, await _task(db_session, character, "snide", 30))
+    await _submit(db_session, character, await _task(db_session, character, "wow", 30))
     await db_session.commit()
 
     await recalculate_character_stats(character.id, db_session)
     await db_session.commit()
 
     letters = await _letters(db_session, character)
-    assert "ua" in letters
-    assert "snide" not in letters
+    assert "snide" in letters
+    assert "wow" not in letters
+
+
+@pytest.mark.asyncio
+async def test_own_faction_never_delivers(
+    db_session, character: Character, era: Era, faction_ua: Faction
+):
+    # #1425: the `character` fixture is IN ua. Doing ua tasks — the most ordinary
+    # thing a player does — must not invite them to the faction they already hold,
+    # while an *other* faction they also qualify for still delivers.
+    await _seed_faction(db_session, "snide")
+    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
+    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
+    await _submit(db_session, character, await _task(db_session, character, "snide", 30))
+    await _submit(db_session, character, await _task(db_session, character, "snide", 30))
+    await db_session.commit()
+
+    await recalculate_character_stats(character.id, db_session)
+    await db_session.commit()
+
+    assert await _letters(db_session, character) == {"snide"}
+
+
+@pytest.mark.asyncio
+async def test_defection_reopens_former_faction_invite(
+    db_session, character: Character, era: Era, faction_ua: Faction
+):
+    # #1425: the guard keys on the faction held at DELIVERY time, not on history.
+    # Qualify ua while in ua (no letter), then defect to snide — ua's letter is now
+    # a legitimate re-invitation and must arrive on the next recalc.
+    await _seed_faction(db_session, "snide")
+    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
+    await _submit(db_session, character, await _task(db_session, character, "ua", 30))
+    await db_session.commit()
+
+    await recalculate_character_stats(character.id, db_session)
+    await db_session.commit()
+    assert "ua" not in await _letters(db_session, character)
+
+    character.faction_slug = "snide"
+    await db_session.commit()
+
+    await recalculate_character_stats(character.id, db_session)
+    await db_session.commit()
+
+    assert "ua" in await _letters(db_session, character)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1425

A character in Cozy Coven who did Coven tasks crossed Coven's own invitation threshold and
was delivered **Coven's own invitation letter** — the feed then rendered "You've received an
invitation to join Cozy Coven" to a member of Cozy Coven.

`_deliver_earned_invitations` (the function the issue calls `_deliver_invitation_letters`)
excluded the ADR-0022 sentinels and letters already held, and nothing else. It never had the
character's faction to check against — it only ever received `character_id`.

## The seam

`services/character_stats.py::_deliver_earned_invitations`, exercised end to end through its
only public entry point `recalculate_character_stats`, asserted on `invitation_letter` rows.
The two new tests went red on the real defect before the fix:

```
FAILED test_own_faction_never_delivers            - assert {'snide','ua'} == {'snide'}
FAILED test_defection_reopens_former_faction_invite - assert 'ua' not in {'ua'}
```

## The fix

`_deliver_earned_invitations` now takes the `Character` (the caller already had it loaded as
`author`, so this costs no query) instead of a bare `character_id`, and folds the current
faction into the existing sentinel skip:

```py
uninvitable = _NON_INVITE_FACTION_SLUGS | {character.faction_slug}
```

Keyed on membership **at delivery time**, not on history — defect away from X, keep earning
X points, and X re-invites you. That is the re-invitation path and it has its own test.

This is the only place an `InvitationLetter` is created outside tests (grepped: the model is
otherwise only read, by `activity_feed`, `faction_service`, `character`, and `routers/factions`),
so the guard is at the one seam they all route through.

## Do old own-faction letters exist in the wild? Yes — and they stay.

The fix is **not** retroactive. Any letter already written for a character's own faction keeps
rendering. The local dev DB has zero `invitation_letter` rows at all, so it proves nothing
either way, but the mechanism is the ordinary case — doing your own faction's tasks — so
production very likely holds such rows.

**I recommend no cleanup**, and not only because #1425 says none is required for correctness.
A cleanup keyed on `letter.faction_slug = character.faction_slug` cannot distinguish a bug row
from a **consumed** invitation: a letter for X earned legitimately while in Y, after which the
player joined X, matches that predicate exactly. Deleting those would revoke real state —
`get_account_invited_faction_slugs` (ADR-0019) pools letters across the account to gate what
faction a *sibling* character may be created into, so a delete would silently take a faction
away from the account's next character. The dead copy is cosmetic; the delete is not.

#1424 / F4 suppressing `Accept` defensively for the own-faction case remains the right cover
for the legacy rows, and this PR makes sure it never has to cover a new one.

## Existing tests changed (they encoded the bug)

The shared `character` fixture is a member of `ua`, so three passing tests asserted that a ua
member is delivered ua's letter — the exact defect. They now qualify `snide` instead (every
Era 1 solo modifier is 1.0, so the 1:1 point arithmetic in the file's docstring still holds).
`test_one_task_no_letter` and `test_below_points_threshold_no_letter` moved to `snide` too:
left on `ua` they would still pass, but vacuously — via the new own-faction guard rather than
the threshold they exist to test. `test_faction_scoped_no_bleed` becomes snide-qualifies /
wow-does-not.

## What to eyeball

- The one-line semantic: is "your current faction is uninvitable" right for a character sitting
  in `na`? `na` is already in `_NON_INVITE_FACTION_SLUGS`, so unaffiliated players are
  unaffected and still collect every letter they earn.
- Changing the signature from `character_id: int` to `character: Character` — private function,
  one caller, and it removes a redundant lookup rather than adding a parameter. Say the word if
  you'd rather it stayed `character_id` plus a slug argument.
- Whether you agree with the no-cleanup ruling above, given the consumed-invitation collision.
- Backend-only change; no migration, no schema change, no API shape change. No visual QA was
  possible (no browser tooling in this worktree) — but nothing rendered changes except that the
  bogus card stops being created.

## Tests

`pytest --cov=. --cov-fail-under=80` from `/backend` against a dedicated `wz1425_test`:
**908 passed**, coverage 90.88%.
