### PR TITLE
The faction invitation letter gains Accept and Not now (#1424)

### DIFF
--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -7,7 +7,10 @@ interface AuthState {
   refetch: () => Promise<void>
 }
 
-const AuthContext = createContext<AuthState>({
+/** Exported for tests only: the harness is `renderToStaticMarkup`, so a
+ *  component that reads the signed-in character has no other way to be given
+ *  one — `AuthProvider` fetches, and effects never run there. */
+export const AuthContext = createContext<AuthState>({
   user: null,
   loading: true,
   refetch: async () => {},

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -1,27 +1,171 @@
+import { useState, type CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import { Trans } from "react-i18next";
 import type { ActivityFeedItem } from "../../api/activityFeed";
+import { chooseFaction } from "../../api/factions";
+import { useAuth } from "../../auth/AuthContext";
 import i18n from "../../i18n";
-import { factionCssVar, factionName } from "../../utils/factions";
+import { extractError } from "../../utils/errors";
+import {
+  UNAFFILIATED_FACTION_SLUG,
+  factionCssVar,
+  factionName,
+} from "../../utils/factions";
+import { notifyRequestsChanged } from "../../utils/requestsBus";
 import FeedBadge from "./FeedBadge";
 
 interface Props {
   item: ActivityFeedItem;
+  /**
+   * "Not now" — the slot's own archive write, handed down by `FeedCardRouter`
+   * (#1424). Absent in the Archived tab, where the slot's action is *restore*
+   * and a "Not now" that un-archived would be a lie.
+   */
+  onNotNow?: () => void;
 }
+
+/**
+ * The three states `Accept` can be in for a (current faction, letter faction)
+ * pair. Pure, exported, and tested directly: the harness is
+ * `renderToStaticMarkup`, so the branch is provable but the click is not.
+ */
+export type AcceptMode = "one-click" | "confirm-first" | "suppressed";
+
+/**
+ * Which `Accept` a holder of this letter gets.
+ *
+ * - **suppressed** — the letter names the faction the character is already in.
+ *   Reachable *even after #1425 stopped delivering them*: a letter earned for X
+ *   while in Y stays on the account after joining X, and that row is
+ *   indistinguishable from the legacy bug row it also gates sibling-character
+ *   creation with (ADR-0019). `POST /factions/choose` answers those 422
+ *   "Already a member of this faction.", so the control is not drawn at all —
+ *   the card falls back to `View Factions →` (CLAUDE.md: hide, never disable).
+ * - **one-click** — unaffiliated. A first join destroys nothing, so a dialog in
+ *   front of the happy path would only be noise (epic #1419 decision 10).
+ * - **confirm-first** — affiliated with a *different* real faction. Accepting is
+ *   a defection: `defect_to_faction` writes a `FactionDefectionHistory` row and
+ *   `can_join_faction` then bars the faction being left for the rest of the era.
+ *   Next to a fast triage queue's "Still waiting" skip, an unguarded click there
+ *   costs a player an era.
+ *
+ * A nullish current slug is treated as unaffiliated: `/updates` is a protected
+ * route so a character always exists, and the safe reading of "no faction
+ * recorded" is that nothing is being left behind.
+ */
+export function acceptMode(
+  currentSlug: string | null | undefined,
+  letterSlug: string,
+): AcceptMode {
+  if (currentSlug === letterSlug) return "suppressed";
+  if (!currentSlug || currentSlug === UNAFFILIATED_FACTION_SLUG) return "one-click";
+  return "confirm-first";
+}
+
+const CONTROL: CSSProperties = {
+  fontFamily: "'Courier Prime', monospace",
+  fontSize: "var(--text-sm)",
+  fontWeight: 700,
+  textTransform: "uppercase",
+  letterSpacing: "0.1em",
+  padding: "var(--space-xs) var(--space-lg)",
+  border: "none",
+  cursor: "pointer",
+};
+
+/** The deferral control, and the shape the plain link already had. */
+const QUIET: CSSProperties = {
+  ...CONTROL,
+  background: "transparent",
+  color: "var(--color-text-secondary)",
+  border: "1px solid var(--color-border)",
+};
 
 /**
  * The faction invitation letter — a PAYLOAD BODY inside the faction chassis as of
  * #1194 (epic #1192 decision 9), not a card that brings its own chrome.
  *
  * It lost its own kicker and its own timestamp: the chassis band draws both for
- * every card now, and a body that drew them too printed each twice. Its content
- * and its link are untouched.
+ * every card now, and a body that drew them too printed each twice.
+ *
+ * #1424 gave it the pair of controls that let it sit in the Requests queue and
+ * ever leave it — `Accept` and `Not now`. Both are zero new backend:
+ *
+ *  - **Accept** is `POST /factions/choose`, which since #454 already *requires*
+ *    holding that faction's current-era letter. It always was the accept
+ *    endpoint. See {@link acceptMode} for the three branches it has.
+ *  - **Not now** is the slot's existing archive write, wearing a label. It is
+ *    emphatically **not** "Decline": ADR-0065/0066 say archiving never answers
+ *    anything, the letter stays valid, the factions page still joins, and
+ *    `InvitationLetter` has no status column to decline into.
+ *
+ * The confirm step is the inline two-stage idiom `InvitationLetterPopup` already
+ * uses for the same act — prose plus [confirm] [cancel] replacing the button
+ * row — not a new dialog component.
  */
-export default function FeedCardInvitationLetter({ item }: Props) {
+export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
   const { faction_slug } = item.payload;
   // Scalar ink for both the highlighted name and the link — `na` stays neutral
   // there on purpose (ADR-0039 §2), and the cascade owns the dark half.
   const color = factionCssVar(faction_slug);
+
+  const { user, refetch } = useAuth();
+  const mode = acceptMode(user?.character?.faction_slug, faction_slug);
+  const currentName = factionName(user?.character?.faction_slug ?? UNAFFILIATED_FACTION_SLUG);
+  const letterName = factionName(faction_slug);
+
+  const [confirming, setConfirming] = useState(false);
+  const [joining, setJoining] = useState(false);
+  const [joined, setJoined] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const join = async () => {
+    if (joining) return;
+    setJoining(true);
+    setError(null);
+    try {
+      await chooseFaction(faction_slug);
+      setJoined(true);
+      setConfirming(false);
+      // The character's faction is on /auth/me and dresses most of the site, so
+      // the feed alone is not enough — refresh the character context, then let
+      // the bell and the queue count follow.
+      await refetch();
+      notifyRequestsChanged();
+    } catch (err) {
+      // `extractError` returns the backend `detail` verbatim, which is what
+      // makes each refusal legible rather than generic: "Cannot rejoin a faction
+      // you have left." (403), the ADR-0021 Albescent eligibility bar (403) and
+      // "Already a member of this faction." (422) all speak for themselves.
+      setError(extractError(err, i18n.t("feed:invitationLetter.error")));
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  const acceptStyle: CSSProperties = {
+    ...CONTROL,
+    background: color,
+    color: "var(--color-bg-page)",
+    cursor: joining ? "not-allowed" : "pointer",
+  };
+
+  const viewFactions = (
+    <Link
+      to="/factions"
+      style={{
+        fontFamily: "'Courier Prime', monospace",
+        fontSize: "var(--text-sm)",
+        fontWeight: 700,
+        textTransform: "uppercase",
+        letterSpacing: "0.1em",
+        color,
+        textDecoration: "none",
+      }}
+    >
+      {i18n.t("feed:invitationLetter.viewFactions")}
+    </Link>
+  );
 
   return (
     <div style={{ padding: "var(--space-lg) var(--space-xl)", position: "relative" }}>
@@ -52,7 +196,7 @@ export default function FeedCardInvitationLetter({ item }: Props) {
         <Trans
           ns="feed"
           i18nKey="invitationLetter.sentence"
-          values={{ faction: factionName(faction_slug) }}
+          values={{ faction: letterName }}
           components={{ 1: <span style={{ color, fontWeight: 700 }} /> }}
         />
       </p>
@@ -68,20 +212,109 @@ export default function FeedCardInvitationLetter({ item }: Props) {
         {i18n.t("feed:invitationLetter.body")}
       </p>
 
-      <Link
-        to="/factions"
-        style={{
-          fontFamily: "'Courier Prime', monospace",
-          fontSize: "var(--text-sm)",
-          fontWeight: 700,
-          textTransform: "uppercase",
-          letterSpacing: "0.1em",
-          color,
-          textDecoration: "none",
-        }}
-      >
-        {i18n.t("feed:invitationLetter.viewFactions")}
-      </Link>
+      {confirming ? (
+        <div data-invitation-confirm>
+          <p
+            className="font-display italic"
+            style={{
+              fontSize: "var(--text-content)",
+              color: "var(--color-text-primary)",
+              marginBottom: "var(--space-xs)",
+            }}
+          >
+            {i18n.t("feed:invitationLetter.confirm.title", {
+              current: currentName,
+              faction: letterName,
+            })}
+          </p>
+          <p
+            className="font-body"
+            style={{
+              fontSize: "var(--text-content)",
+              color: "var(--color-text-secondary)",
+              marginBottom: "var(--space-md)",
+            }}
+          >
+            {i18n.t("feed:invitationLetter.confirm.body", { current: currentName })}
+          </p>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "var(--space-sm)",
+              flexWrap: "wrap",
+            }}
+          >
+            <button type="button" onClick={() => void join()} disabled={joining} style={acceptStyle}>
+              {i18n.t("feed:invitationLetter.confirm.confirm")}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              disabled={joining}
+              style={QUIET}
+            >
+              {i18n.t("feed:invitationLetter.confirm.cancel")}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "var(--space-md)",
+            flexWrap: "wrap",
+          }}
+        >
+          {joined ? (
+            <span
+              className="eyebrow"
+              style={{ color }}
+              data-invitation-accepted
+            >
+              {i18n.t("feed:invitationLetter.accepted", { faction: letterName })}
+            </span>
+          ) : (
+            <>
+              {mode !== "suppressed" && (
+                <button
+                  type="button"
+                  data-invitation-accept={mode}
+                  onClick={() => {
+                    if (mode === "confirm-first") setConfirming(true);
+                    else void join();
+                  }}
+                  disabled={joining}
+                  style={acceptStyle}
+                >
+                  {i18n.t("feed:invitationLetter.accept")}
+                </button>
+              )}
+              {onNotNow && (
+                <button type="button" data-invitation-not-now onClick={onNotNow} style={QUIET}>
+                  {i18n.t("feed:invitationLetter.notNow")}
+                </button>
+              )}
+            </>
+          )}
+          {viewFactions}
+        </div>
+      )}
+
+      {error && (
+        <p
+          className="font-body"
+          style={{
+            fontSize: "var(--text-content)",
+            color: "var(--color-danger)",
+            marginTop: "var(--space-sm)",
+            marginBottom: 0,
+          }}
+        >
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/feed/FeedCardRouter.tsx
+++ b/frontend/src/components/feed/FeedCardRouter.tsx
@@ -43,9 +43,19 @@ import FeedCardInvitationLetter from './FeedCardInvitationLetter'
  * backend types now render.
  */
 
+/**
+ * What every companion body is handed. `onNotNow` is the slot's archive write
+ * under the body's own label — only the invitation letter takes it (#1424); the
+ * other two answer their request outright and archiving is not their deferral.
+ */
+interface CompanionProps {
+  item: ActivityFeedItem
+  onNotNow?: () => void
+}
+
 /** The three interactive companions — payload BODIES inside the chassis since
  *  #1194, keeping their own accept/decline handlers (epic decision 9). */
-const COMPANION_BODIES: Record<string, React.ComponentType<{ item: ActivityFeedItem }>> = {
+const COMPANION_BODIES: Record<string, React.ComponentType<CompanionProps>> = {
   invitation_letter: FeedCardInvitationLetter,
   duel_challenge: FeedCardDuelChallenge,
   collab_invite: FeedCardCollabInvite,
@@ -80,14 +90,17 @@ export default function FeedCardRouter({ item, archivedView = false, onArchiveCh
   const tag =
     archivedView && isStillWaiting(item) ? i18n.t('feed:archive.stillWaiting') : null
 
-  const renderBody = (): ReactNode => {
+  // "Not now" is the archive write, so it is only offered where the slot's
+  // action IS archiving. In the Archived tab that action is restore, and a
+  // "Not now" that un-archived the card would mean the opposite of its label.
+  const renderBody = (act: (() => void) | null): ReactNode => {
     if (row) return <FeedRowContent row={row} avatarUrl={item.actor_avatar_url} />
-    return <Companion item={item} />
+    return <Companion item={item} onNotNow={archivedView ? undefined : (act ?? undefined)} />
   }
 
   return (
     <FeedItemSlot item={item} archivedView={archivedView} onArchiveChange={onArchiveChange}>
-      {(archive) =>
+      {(archive, act) =>
         isEraAnnouncement ? (
           <FeedCardEraAnnouncement item={item} archive={archive} />
         ) : (
@@ -98,7 +111,7 @@ export default function FeedCardRouter({ item, archivedView = false, onArchiveCh
             tag={tag}
             archive={archive}
           >
-            {renderBody()}
+            {renderBody(act)}
           </FactionFeedFrame>
         )
       }

--- a/frontend/src/components/feed/FeedItemSlot.tsx
+++ b/frontend/src/components/feed/FeedItemSlot.tsx
@@ -66,8 +66,13 @@ export default function FeedItemSlot({
    *  the undo strip is standing in. */
   onArchiveChange?: () => void
   /** Draws the card, given the finished archive control (or `null` when this
-   *  item offers none). */
-  children: (archive: ReactNode) => ReactNode
+   *  item offers none) and the bare action behind it (likewise `null`).
+   *
+   *  The second argument is for a body that needs the SAME write under its own
+   *  label — the invitation letter's "Not now" (#1424). It is deliberately the
+   *  action and not a second button: dismissing lives here, once, so the undo
+   *  strip still stands in this slot and no card reimplements the write. */
+  children: (archive: ReactNode, act: (() => void) | null) => ReactNode
 }) {
   const [phase, setPhase] = useState<Phase>('card')
   const [undoPhase, setUndoPhase] = useState<FeedUndoPhase>('undo')
@@ -228,6 +233,7 @@ export default function FeedItemSlot({
         offersControl ? (
           <FeedArchiveButton onAct={act} variant={archivedView ? 'restore' : 'archive'} />
         ) : null,
+        offersControl ? act : null,
       )}
     </div>
   )

--- a/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
+++ b/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * THE THREE ACCEPTS OF THE INVITATION LETTER (#1424).
+ *
+ * The seam under test is the pure predicate `acceptMode(currentSlug,
+ * letterSlug)` **and the render decision that follows from it** — asserted as
+ * one pair, because a correct predicate wired to nothing would still pass.
+ *
+ * The harness is `renderToStaticMarkup`: no DOM, so no effect runs and no click
+ * fires. What it can prove is exactly what matters here — WHICH CONTROL EXISTS
+ * for a given (current faction, letter faction) pair, and that the branch the
+ * markup chose is the branch the predicate names. The confirm step's *contents*
+ * are one click away and therefore unreachable; that its button is armed to
+ * `confirm-first` rather than joining outright is the claim that stands in for
+ * it, and it is the load-bearing half: `defect_to_faction` closes the faction
+ * you left for the rest of the era.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import { AuthContext } from '../../../auth/AuthContext'
+import FeedCardInvitationLetter, { acceptMode } from '../FeedCardInvitationLetter'
+import type { ActivityFeedItem } from '../../../api/activityFeed'
+import type { CurrentUser } from '../../../api/auth'
+
+const LETTER_SLUG = 'snide'
+
+const letter: ActivityFeedItem = {
+  type: 'invitation_letter',
+  item_key: 'invitation_letter:1',
+  timestamp: '2026-01-01T00:00:00Z',
+  actor_display_name: 'Ada',
+  actor_faction_slug: null,
+  actor_avatar_url: null,
+  payload: { faction_slug: LETTER_SLUG },
+  context_faction_slug: LETTER_SLUG,
+}
+
+/** Only the one field this card reads; the rest of /auth/me is irrelevant here. */
+function viewer(factionSlug: string | null): CurrentUser {
+  return { character: { faction_slug: factionSlug } } as unknown as CurrentUser
+}
+
+function render(factionSlug: string | null, onNotNow?: () => void): string {
+  return renderToStaticMarkup(
+    <AuthContext.Provider value={{ user: viewer(factionSlug), loading: false, refetch: async () => {} }}>
+      <MemoryRouter>
+        <FeedCardInvitationLetter item={letter} onNotNow={onNotNow} />
+      </MemoryRouter>
+    </AuthContext.Provider>,
+  )
+}
+
+const VIEW_FACTIONS = i18n.t('feed:invitationLetter.viewFactions')
+const ACCEPT = i18n.t('feed:invitationLetter.accept')
+const NOT_NOW = i18n.t('feed:invitationLetter.notNow')
+
+describe('acceptMode — the predicate', () => {
+  it('suppresses Accept when the letter names the faction you are already in', () => {
+    // Still reachable after #1425 stopped delivering these: a letter earned for
+    // X while in Y survives joining X, and that consumed row is what ADR-0019
+    // gates sibling-character creation with. POST /factions/choose answers it
+    // 422 "Already a member of this faction."
+    expect(acceptMode(LETTER_SLUG, LETTER_SLUG)).toBe('suppressed')
+  })
+
+  it('is one click from unaffiliated — a first join destroys nothing', () => {
+    expect(acceptMode('na', LETTER_SLUG)).toBe('one-click')
+    // No character faction recorded reads the same way: nothing is left behind.
+    expect(acceptMode(null, LETTER_SLUG)).toBe('one-click')
+    expect(acceptMode(undefined, LETTER_SLUG)).toBe('one-click')
+  })
+
+  it('confirms first from any real faction — accepting is a defection', () => {
+    expect(acceptMode('coven', LETTER_SLUG)).toBe('confirm-first')
+    expect(acceptMode('wow', LETTER_SLUG)).toBe('confirm-first')
+  })
+})
+
+describe('the controls the card actually draws', () => {
+  it('arms Accept to one click for an unaffiliated viewer', () => {
+    const html = render('na')
+    expect(html).toContain('data-invitation-accept="one-click"')
+    expect(html).toContain(ACCEPT)
+  })
+
+  it('arms Accept to the confirm step for an affiliated viewer', () => {
+    const html = render('coven')
+    expect(html).toContain('data-invitation-accept="confirm-first"')
+    // The confirm prose is one click away, so it must NOT be in the first paint.
+    expect(html).not.toContain('data-invitation-confirm')
+  })
+
+  it('draws no Accept at all on an own-faction letter — hidden, never disabled', () => {
+    const html = render(LETTER_SLUG)
+    expect(html).not.toContain('data-invitation-accept')
+    expect(html).not.toContain(`>${ACCEPT}<`)
+  })
+
+  it('still offers View Factions in the suppressed case', () => {
+    // The fallback is the whole reason suppressing is safe: the faction page is
+    // still the route to everything the letter was for.
+    expect(render(LETTER_SLUG)).toContain(VIEW_FACTIONS)
+    // ...and it is not a suppressed-only consolation; every state keeps it.
+    expect(render('na')).toContain(VIEW_FACTIONS)
+    expect(render('coven')).toContain(VIEW_FACTIONS)
+  })
+
+  it('draws Not now only when the slot hands down an archive write', () => {
+    // The Archived tab withholds it: there the slot's action is *restore*, and a
+    // "Not now" that un-archived would mean the opposite of its label.
+    expect(render('coven', () => {})).toContain(NOT_NOW)
+    expect(render('coven')).not.toContain(NOT_NOW)
+    // It survives suppression — archiving a stale card is still meaningful, and
+    // "Not now" is a deferral, never an answer (ADR-0065/0066).
+    expect(render(LETTER_SLUG, () => {})).toContain(NOT_NOW)
+  })
+
+  it('says "Not now", never "Decline" — the letter stays valid', () => {
+    expect(NOT_NOW).not.toMatch(/decline/i)
+    expect(render('na', () => {})).not.toMatch(/decline/i)
+  })
+})


### PR DESCRIPTION
The faction invitation letter's only control was a `View Factions →` link — navigation, not an
answer. It now has the pair that lets it enter the Requests queue (#1422) and ever leave it.
**Zero new backend, zero new components, zero i18n changes.**

## The seam under test

`acceptMode(currentSlug, letterSlug) → 'one-click' | 'confirm-first' | 'suppressed'`, **and the
render decision that follows from it**, asserted as one pair — a correct predicate wired to nothing
would still pass. The harness is `renderToStaticMarkup`, so no click can fire; that the Accept
button is *armed* to `confirm-first` rather than joining outright is the claim that stands in for
the dialog, and it is the load-bearing half.

The tests were mutation-checked, not just run green:

| mutant | result |
|---|---|
| drop the `suppressed` branch | 2 tests fail |
| `confirm-first` → `one-click` | 2 tests fail |

## Accept

`POST /factions/choose`, which since #454 already *requires* holding that faction's current-era
letter. It always was the accept endpoint.

| Viewer's faction | Behaviour |
|---|---|
| `na` / none recorded | **one click.** A first join destroys nothing; a dialog there is noise. |
| any other real faction | **inline confirm** naming what is lost — `defect_to_faction` writes a `FactionDefectionHistory` row and `can_join_faction` then closes the faction you left for the rest of the era. |
| **the letter's own faction** | **no Accept at all** — hidden, not disabled (CLAUDE.md). |

The confirm is the two-stage idiom `InvitationLetterPopup` already uses for this exact act (prose +
`[Yes, defect] [Cancel]` replacing the button row), not a new dialog component.

### Why the own-faction guard is still needed after #1425

#1425 (merged as #1447) stopped *delivering* own-faction letters. It deliberately did not clean up
the existing ones, because a `letter.faction_slug = character.faction_slug` row cannot be told apart
from a **consumed** invitation — earned for X while in Y, then joined X — and
`get_account_invited_faction_slugs` (ADR-0019) pools letters across the **account** to gate sibling
character creation. Deleting them would revoke live state. So the row is reachable, and without the
guard `POST /factions/choose` answers a live button with **422 "Already a member of this faction."**

The two cases are kept as separate branches, as the issue asks: "affiliated with Y, accepting X"
(confirm) is not "affiliated with X, holding X's letter" (suppress).

## Not now — not Decline

ADR-0065/0066: archiving never answers anything. After "Not now" the letter is still valid, the
faction is still joinable, nothing is revoked, and `InvitationLetter` has no status column to
decline into.

So "Not now" **is** the slot's existing archive write, wearing a label. `FeedItemSlot` now hands the
bare action down beside the finished ✕ node, so the undo strip still stands in the slot and no card
body reimplements dismissing — the doctrine that file's docblock states. `FeedCardRouter` withholds
it in the **Archived** tab, where the slot's action is *restore* and a "Not now" that un-archived
would mean the opposite of its label.

## Errors

Each refusal surfaces its own backend `detail` verbatim via `extractError` rather than a generic
failure: **403** "Cannot rejoin a faction you have left.", **403** the ADR-0021 Albescent
eligibility bar, and **422** as a belt-and-braces net under the suppression above.

## Invalidation

`await refetch()` on the auth context (the character's faction is on `/auth/me` and dresses most of
the site) and then `notifyRequestsChanged()` for the bell and the queue count.

## i18n

**`frontend/src/locales/en/feed.json` is untouched.** Every key came from #1421 already:
`accept`, `notNow`, `accepted`, `error`, `confirm.{title,body,confirm,cancel}`. Nothing was missing.

One key #1421 authored is **not consumed here**: `invitationLetter.setAside` ("Set aside — the
invitation still stands"). Routing "Not now" into the slot means the undo strip replaces the card,
which is strictly better than an inline note and reuses the whole archive interaction. If that
string was meant for the queue advancing past a "Not now", it is #1422's to spend.

## What to eyeball

**No browser tools on this agent — visual QA is outstanding.** Specifically:

1. **The Accept button's ink.** It follows `InvitationLetterPopup`'s established join CTA — faction
   accent ground, `--color-bg-page` text. Worth a contrast check on all seven accents in **both**
   themes; if it needs a different pairing that is a `frontend-style` call, not mine.
2. **Three controls in one row** (`Accept` · `Not now` · `View Factions →`) inside eight faction
   chassis skins, at narrow widths — the row wraps, but wrapping is not the same as looking right.
3. **Two dismiss routes on one card.** The chassis ✕ and the labelled `Not now` do the same thing.
   That is deliberate (the ✕ is universal chrome across all 15 types; the labelled button is the
   answer-pair), but it should be looked at.
4. **The confirm step in place** — it replaces the button row rather than opening a modal, so the
   card grows by two paragraphs inside whatever frame it is in.
5. **The happy path end to end**: accept from `na`, and watch the whole site re-dress as `refetch()`
   lands. The card should flip to "Joined {faction}" and Accept should vanish (the refetched
   character now makes the mode `suppressed`).
6. The local dev DB has **zero** `invitation_letter` rows — seeding one is a prerequisite for any of
   the above.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` **3203 passed / 186 files** ·
`vite build` clean · `npm run budget` within budget (JS 132.6 KB, CSS 22.0 KB).

Did **not** touch `pages/Updates.tsx`, the queue container, or `locales/en/feed.json` — #1422 owns
those and is running in parallel.

Closes #1424

🤖 Generated with [Claude Code](https://claude.com/claude-code)
