### PR TITLE
The rail stops listing pending requests; the queue is the only surface (#1423)

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -2,15 +2,12 @@ import { type CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../../auth/AuthContext'
-import { type ActivityFeedItem } from '../../api/activityFeed'
 import { relativeTime } from '../../utils/dates'
 import { factionCssVar, factionName } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import { useSidebarPanels } from '../../hooks/useSidebarPanels'
 import { praxisModeLabel } from '../../utils/praxis'
-import { useRespondToRequest } from '../../hooks/useRespondToRequest'
 import { useGameConfig } from '../../hooks/useGameConfig'
-import { REQUESTS_QUEUE_LINK } from '../../pages/updates/requestsQueueAnchor'
 
 const DEFAULT_MAX_TASK_SLOTS = 20
 
@@ -51,13 +48,27 @@ function SectionHeader({ label }: { label: string }) {
 
 /**
  * Always-on right sidebar (Style Guide §4.2), redesigned into the unaffiliated
- * "all paths" rainbow-spectrum identity: character card + pending requests +
- * in-progress tasks + recent global activity + propose CTA.
+ * "all paths" rainbow-spectrum identity: character card + in-progress tasks +
+ * recent global activity + propose CTA.
  *
- * Three of those four panels used to be three separate fetches made here, each
- * one waiting on `/auth/me`. They are one request now, made before this
- * component exists — see `hooks/useSidebarPanels` (#1344). Identity is still
- * read from auth: the character card is `/auth/me`'s payload, not the rail's.
+ * Those panels used to be three separate fetches made here, each one waiting on
+ * `/auth/me`. They are one request now, made before this component exists — see
+ * `hooks/useSidebarPanels` (#1344). Identity is still read from auth: the
+ * character card is `/auth/me`'s payload, not the rail's.
+ *
+ * IT NO LONGER LISTS PENDING REQUESTS (#1423, ADR-0070)
+ * -----------------------------------------------------
+ * A fourth panel used to render collab invites, duel challenges and your own
+ * outstanding submissions with inline accept/decline. Under "an unanswered
+ * obligation lives in the queue, never in the stream" there is exactly one
+ * surface a request can be answered on, and it is the Requests queue at
+ * `REQUESTS_QUEUE_ANCHOR` on `/updates`. This panel was the surface it
+ * replaced, so it is gone rather than duplicated.
+ *
+ * The response's `pending_requests` is still fetched and still read — but only
+ * for its LENGTH now, by the collapsed handle's badge (`SidebarColumn`), the
+ * mobile bell (`MobileHeader`) and the mobile FieldDesk. Nothing renders the
+ * items.
  */
 export default function Sidebar() {
   const { t } = useTranslation('common')
@@ -65,10 +76,8 @@ export default function Sidebar() {
   const character = user?.character
 
   const {
-    pending_requests: pendingRequests,
     global_activity: globalActivity,
     active_praxes: activeTasks,
-    refetch: refetchPanels,
   } = useSidebarPanels()
   const gameConfig = useGameConfig()
 
@@ -203,36 +212,6 @@ export default function Sidebar() {
       ) : (
         <section style={panelStyle}>
           <p className="eyebrow text-center">{t('sidebar.characterCard.noCharacter')}</p>
-        </section>
-      )}
-
-      {/* ── Pending Requests Panel ── */}
-      {pendingRequests.length > 0 && (
-        <section style={panelStyle}>
-          <SectionHeader label={t('sidebar.pendingRequests.heading', { count: pendingRequests.length })} />
-          <div className="flex flex-col gap-1.5">
-            {pendingRequests.map((item, index) =>
-              // "Waiting on you to submit" — a collab/duel already in your court.
-              // No accept/decline; a single link to the editor (#updates-badge).
-              item.type === 'awaiting_submission' ? (
-                <AwaitingSubmissionRow
-                  key={`${item.type}-${index}`}
-                  item={item}
-                  isFirst={index === 0}
-                />
-              ) : (
-                <PendingRequestRow
-                  key={`${item.type}-${index}`}
-                  item={item}
-                  isFirst={index === 0}
-                  // An accepted collab/duel becomes an in-progress praxis, so
-                  // the request has to move bars (#346). Both panels come from
-                  // one response now, so that is one refetch, not two.
-                  onResolved={refetchPanels}
-                />
-              ),
-            )}
-          </div>
         </section>
       )}
 
@@ -432,177 +411,5 @@ export default function Sidebar() {
         <span>{t('actions.proposeTask')}</span>
       </Link>
     </aside>
-  )
-}
-
-const REQUEST_BUTTON_BASE: CSSProperties = {
-  fontFamily: "'Courier Prime', monospace",
-  fontSize: 'var(--text-xs)',
-  fontWeight: 700,
-  textTransform: 'uppercase',
-  letterSpacing: '0.08em',
-  padding: 'var(--space-xs) var(--space-sm)',
-}
-
-/**
- * A "waiting on you to submit" row: a collab/duel praxis already in the
- * viewer's court (#updates-badge). Unlike PendingRequestRow there's no
- * accept/decline — just a link into the editor to post your part.
- */
-function AwaitingSubmissionRow({
-  item,
-  isFirst,
-}: {
-  item: ActivityFeedItem
-  isFirst: boolean
-}) {
-  const { t } = useTranslation('common')
-  const praxisId = item.payload.praxis_id
-  const isDuel = item.payload.praxis_type === 'duel'
-  return (
-    <div
-      className="py-1.5"
-      style={{ borderTop: !isFirst ? '1px dashed var(--color-border)' : undefined }}
-    >
-      <div className="flex items-center gap-2">
-        {/* task-faction dot in place of an actor avatar */}
-        <span
-          className="shrink-0 rounded-full"
-          style={{
-            width: 24,
-            height: 24,
-            background: `linear-gradient(135deg, ${factionCssVar(item.payload.task_faction_slug, 'light')}, ${factionCssVar(item.payload.task_faction_slug)})`,
-          }}
-        />
-        <div className="flex-1 min-w-0">
-          <Link
-            to={`/praxis/${praxisId}/edit`}
-            className="font-body block truncate"
-            style={{ fontSize: 'var(--text-xl)', fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
-          >
-            {item.payload.task_title}
-          </Link>
-          <span className="eyebrow block" style={{ color: 'var(--color-text-tertiary)' }}>
-            {isDuel ? t('requests.awaitingSubmissionDuel') : t('requests.awaitingSubmissionCollab')}
-          </span>
-        </div>
-      </div>
-      <div className="flex items-center gap-1.5" style={{ marginTop: 'var(--space-xs)', marginLeft: 'var(--space-2xl)' }}>
-        <Link
-          to={`/praxis/${praxisId}/edit`}
-          style={{
-            ...REQUEST_BUTTON_BASE,
-            background: isDuel ? 'var(--badge-duel)' : 'var(--badge-collab)',
-            color: 'var(--color-text-on-accent)',
-            border: 'none',
-            textDecoration: 'none',
-          }}
-        >
-          {t('actions.submit')}
-        </Link>
-      </div>
-    </div>
-  )
-}
-
-/**
- * One actionable row in the Pending Requests panel: accept/decline inline via
- * the shared request hook (#346) — same logic the feed cards use.
- */
-function PendingRequestRow({
-  item,
-  isFirst,
-  onResolved,
-}: {
-  item: ActivityFeedItem
-  isFirst: boolean
-  onResolved: () => void
-}) {
-  const { t } = useTranslation('common')
-  const isCollab = item.type === 'collab_invite'
-  const actorId = isCollab
-    ? item.payload.inviter_character_id
-    : item.payload.challenger_character_id
-  const badgeVar = isCollab ? 'var(--badge-collab)' : 'var(--badge-duel)'
-  const { accept, decline, loading, error } = useRespondToRequest(item)
-
-  const respond = async (action: typeof accept) => {
-    const result = await action()
-    if (result.ok) onResolved()
-  }
-
-  return (
-    <div
-      className="py-1.5"
-      style={{ borderTop: !isFirst ? '1px dashed var(--color-border)' : undefined }}
-    >
-      <div className="flex items-center gap-2">
-        <Link to={`/characters/${actorId}`} className="shrink-0">
-          <div
-            className="rounded-full"
-            style={{
-              width: 24,
-              height: 24,
-              background: `linear-gradient(135deg, ${factionCssVar(item.actor_faction_slug, 'light')}, ${factionCssVar(item.actor_faction_slug)})`,
-            }}
-          />
-        </Link>
-        <div className="flex-1 min-w-0">
-          <Link
-            to={`/characters/${actorId}`}
-            className="font-body block truncate"
-            /* An actor byline in a dense 24px-avatar notification row —
-               scanned, not read. Label tier by the role vocabulary (§4), not
-               an exception to the content floor. */
-            style={{ fontSize: 'var(--text-xl)', fontWeight: 700, color: 'var(--color-text-primary)', textDecoration: 'none' }}
-          >
-            {item.actor_display_name}
-          </Link>
-          <Link
-            to={REQUESTS_QUEUE_LINK}
-            className="eyebrow block"
-            style={{ color: 'var(--color-text-tertiary)', textDecoration: 'none' }}
-          >
-            {isCollab ? t('requests.collabInvite') : t('requests.duelChallenge')}
-          </Link>
-        </div>
-      </div>
-      <div className="flex items-center gap-1.5" style={{ marginTop: 'var(--space-xs)', marginLeft: 'var(--space-2xl)' }}>
-        <button
-          onClick={() => respond(accept)}
-          disabled={loading}
-          style={{
-            ...REQUEST_BUTTON_BASE,
-            background: badgeVar,
-            color: 'var(--color-text-on-accent)',
-            border: 'none',
-            cursor: loading ? 'not-allowed' : 'pointer',
-          }}
-        >
-          {t('actions.accept')}
-        </button>
-        <button
-          onClick={() => respond(decline)}
-          disabled={loading}
-          style={{
-            ...REQUEST_BUTTON_BASE,
-            background: 'transparent',
-            color: 'var(--color-text-secondary)',
-            border: '1px solid var(--color-border)',
-            cursor: loading ? 'not-allowed' : 'pointer',
-          }}
-        >
-          {t('actions.decline')}
-        </button>
-      </div>
-      {error && (
-        <span
-          className="eyebrow block"
-          style={{ color: 'var(--color-danger)', marginTop: 'var(--space-xs)', marginLeft: 'var(--space-2xl)' }}
-        >
-          {error}
-        </span>
-      )}
-    </div>
   )
 }

--- a/frontend/src/components/layout/SidebarColumn.tsx
+++ b/frontend/src/components/layout/SidebarColumn.tsx
@@ -26,15 +26,21 @@ import SidebarHandle from './SidebarHandle'
  * reopen; how long stale rail data may be trusted is deliberately left open
  * (#1346).
  *
- * WHY THE COUNT IS READ HERE AND NOT DRILLED
- * ------------------------------------------
- * Both children need it — the rail lists the requests, and the collapsed handle
- * badges their count, since the rail is the only desktop surface for collab
- * invites and duel challenges. #1343 hoisted a single `usePendingRequests()`
- * here and passed it down, because that hook held per-instance state with no
- * shared cache: one call per consumer was one REQUEST per consumer. The
- * provider IS that shared cache, so the drilling is gone — `Sidebar` reads the
- * context itself, and this component reads only the number it draws.
+ * WHY THIS READS `pending_requests` AT ALL
+ * ----------------------------------------
+ * For one number, for one child. The rail used to LIST the requests and the
+ * handle badged their count, so #1343 hoisted a single `usePendingRequests()`
+ * here and passed it down — that hook held per-instance state with no shared
+ * cache, so one call per consumer was one REQUEST per consumer. The provider is
+ * that shared cache now, and since #1423 the rail lists nothing: the queue on
+ * `/updates` is the only surface a request can be answered on (ADR-0070). What
+ * is left is the collapsed handle's badge, which is the only thing that tells a
+ * folded-away desktop something is waiting, and it takes the count as a prop.
+ *
+ * Reading the array only to take its `.length` is now true of EVERY consumer —
+ * here, the mobile bell and the mobile FieldDesk. Serving them a count instead
+ * of up to 100 serialized feed items is a backend change to `/me/sidebar`, and
+ * is filed rather than faked here.
  */
 export interface SidebarColumnProps {
   readonly collapsed: boolean

--- a/frontend/src/components/layout/SidebarHandle.tsx
+++ b/frontend/src/components/layout/SidebarHandle.tsx
@@ -57,11 +57,14 @@ function HandleButton({
 }
 
 /**
- * The collapsed handle carries the pending-request count, because folding the
- * rail away would otherwise silently hide incoming collab invites and duel
- * challenges — the sidebar panel is their only desktop surface. The count
- * reaches assistive tech through the BUTTON's accessible name; the badge itself
- * is decorative and `aria-hidden`, exactly as the mobile bell's is.
+ * The collapsed handle carries the pending-request count. It was put here
+ * because folding the rail away would otherwise hide the rail's own list of
+ * incoming collab invites and duel challenges; since #1423 there is no such
+ * list — requests are answered in the queue on `/updates` (ADR-0070) — so what
+ * the badge now does is tell a folded-away desktop that the queue has something
+ * in it. The count reaches assistive tech through the BUTTON's accessible name;
+ * the badge itself is decorative and `aria-hidden`, exactly as the mobile
+ * bell's is.
  *
  * The count is a PROP, not a read of its own. It is one number and the parent
  * already has it; since #1344 the panels have a single owner above the whole
@@ -118,7 +121,16 @@ export default function SidebarHandle({
 }: {
   readonly collapsed: boolean
   readonly onToggle: () => void
-  /** Pending collab invites + duel challenges; badged only while collapsed. */
+  /**
+   * Pending collab invites + duel challenges; badged only while collapsed.
+   *
+   * "Only while collapsed" was decided when the expanded rail listed them in
+   * full, so a badge on top of the list would have been noise. #1423 deleted
+   * that list and did not widen this: an expanded desktop rail now shows no
+   * pending-request count at all, and reaches the queue through NavBar's
+   * unbadged `Updates` link. Whether the badge should follow the count into the
+   * expanded state is an owner call, not a silent one.
+   */
   readonly pendingCount: number
 }) {
   const { t } = useTranslation('common')

--- a/frontend/src/components/layout/__tests__/SidebarHandle.test.tsx
+++ b/frontend/src/components/layout/__tests__/SidebarHandle.test.tsx
@@ -1,14 +1,17 @@
 /**
  * #1191 — folding the rail away must not silently hide incoming requests.
  *
- * The sidebar's pending-requests panel is the ONLY desktop surface for collab
- * invites and duel challenges, so the collapsed handle carries their count. The
- * badge is decorative (`aria-hidden`, and colour alone), so the count has to
- * reach assistive tech through the button's accessible name — that is what is
- * pinned here.
+ * The collapsed handle carries the count of pending collab invites and duel
+ * challenges. The badge is decorative (`aria-hidden`, and colour alone), so the
+ * count has to reach assistive tech through the button's accessible name — that
+ * is what is pinned here.
  *
- * The count arrives as a prop: `SidebarColumn` reads it once and shares it with
- * the rail, so folding does not cost a second `limit: 100` fetch (#1343).
+ * The count arrives as a prop: `SidebarColumn` reads it once, so folding does
+ * not cost a second fetch (#1343/#1344).
+ *
+ * The rail itself no longer lists the requests (#1423, ADR-0070) — the queue on
+ * `/updates` does — so the expanded state's silence is now a deliberate gap
+ * rather than a redundancy. See `SidebarHandle`'s `pendingCount` docstring.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect, vi } from 'vitest'
@@ -43,7 +46,7 @@ describe('SidebarHandle — collapsed pending badge', () => {
     expect(html).toContain('aria-expanded="false"')
   })
 
-  it('never shows a badge while expanded — the rail lists them itself', () => {
+  it('never shows a badge while expanded — unchanged by #1423, pending an owner call', () => {
     const html = render(false, 3)
     expect(html).toContain('aria-label="Collapse sidebar"')
     expect(html).not.toContain('>3<')

--- a/frontend/src/components/layout/__tests__/sidebarPendingRequests.test.tsx
+++ b/frontend/src/components/layout/__tests__/sidebarPendingRequests.test.tsx
@@ -84,17 +84,20 @@ describe('the rail and its pending requests', () => {
     const html = render(false)
 
     // The panel's heading and its two row kinds, by the copy they rendered.
+    //
+    // These four are LITERALS on purpose. Their catalog keys
+    // (`common:sidebar.pendingRequests.heading`, `common:requests.*`) went with
+    // the markup, and a negative assertion phrased as `i18n.t('<deleted key>')`
+    // compares against the key string itself — which the page never contains,
+    // so the guard would pass without looking at anything. `actions.accept` and
+    // `actions.decline` below survive and have other readers, so those stay
+    // catalog-driven.
     expect(html, 'panel heading').not.toContain('Pending Requests')
-    expect(html, 'PendingRequestRow kicker').not.toContain(
-      i18n.t('common:requests.collabInvite'),
-    )
-    expect(html, 'PendingRequestRow kicker').not.toContain(
-      i18n.t('common:requests.duelChallenge'),
-    )
-    expect(html, 'AwaitingSubmissionRow kicker').not.toContain(
-      i18n.t('common:requests.awaitingSubmissionCollab'),
-    )
+    expect(html, 'PendingRequestRow kicker').not.toContain('Collab Invite')
+    expect(html, 'PendingRequestRow kicker').not.toContain('Duel Challenge')
+    expect(html, 'AwaitingSubmissionRow kicker').not.toContain('Your turn')
     // Answering happens in the queue now, never here (ADR-0070).
+    expect(i18n.t('common:actions.accept'), 'guard: key resolves').toBe('Accept')
     expect(html, 'accept').not.toContain(i18n.t('common:actions.accept'))
     expect(html, 'decline').not.toContain(i18n.t('common:actions.decline'))
   })

--- a/frontend/src/components/layout/__tests__/sidebarPendingRequests.test.tsx
+++ b/frontend/src/components/layout/__tests__/sidebarPendingRequests.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * #1423 — the rail stops LISTING pending requests, but keeps COUNTING them.
+ *
+ * The seam is `SidebarColumn`: the one place the provider's `pending_requests`
+ * array meets both of its consumers. Under ADR-0070 the actionable pile lives
+ * in the Requests queue on `/updates` and nowhere else, so the rail must render
+ * no accept/decline control — while the collapsed handle's badge, which is the
+ * only thing telling a folded-away desktop that something is waiting, must
+ * still read the same array's length.
+ *
+ * A count that silently reads 0 looks like "nothing pending" rather than like a
+ * bug, which is why it is pinned here rather than left to the deletion's
+ * typecheck.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import type { ActivityFeedItem } from '../../../api/activityFeed'
+import type { CurrentUser } from '../../../api/auth'
+
+const panelsMock = vi.fn()
+vi.mock('../../../hooks/useSidebarPanels', () => ({
+  useSidebarPanels: () => panelsMock(),
+}))
+
+// Effects never run under `renderToStaticMarkup`, so both of these would sit at
+// their loading defaults; mock them to render a signed-in rail.
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: { character: null } as unknown as CurrentUser }),
+}))
+vi.mock('../../../hooks/useGameConfig', () => ({
+  useGameConfig: () => null,
+}))
+
+import SidebarColumn from '../SidebarColumn'
+
+const pendingRequest = (type: string): ActivityFeedItem =>
+  ({
+    type,
+    item_key: `${type}:1`,
+    timestamp: new Date().toISOString(),
+    actor_display_name: 'Wren',
+    actor_faction_slug: 'ua',
+    actor_avatar_url: null,
+    context_faction_slug: 'ua',
+    payload: {
+      inviter_character_id: 7,
+      challenger_character_id: 7,
+      praxis_id: 3,
+      praxis_type: 'collab',
+      task_title: 'Mend the orrery',
+      task_faction_slug: 'ua',
+    },
+  }) as ActivityFeedItem
+
+const THREE_PENDING = [
+  pendingRequest('collab_invite'),
+  pendingRequest('duel_challenge'),
+  pendingRequest('awaiting_submission'),
+]
+
+function render(collapsed: boolean): string {
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={['/']}>
+      <SidebarColumn collapsed={collapsed} onToggle={() => {}} />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  panelsMock.mockReturnValue({
+    pending_requests: THREE_PENDING,
+    global_activity: [],
+    active_praxes: [],
+    refetch: vi.fn(),
+    loading: false,
+  })
+})
+
+describe('the rail and its pending requests', () => {
+  it('lists no pending request, and offers no way to answer one', () => {
+    const html = render(false)
+
+    // The panel's heading and its two row kinds, by the copy they rendered.
+    expect(html, 'panel heading').not.toContain('Pending Requests')
+    expect(html, 'PendingRequestRow kicker').not.toContain(
+      i18n.t('common:requests.collabInvite'),
+    )
+    expect(html, 'PendingRequestRow kicker').not.toContain(
+      i18n.t('common:requests.duelChallenge'),
+    )
+    expect(html, 'AwaitingSubmissionRow kicker').not.toContain(
+      i18n.t('common:requests.awaitingSubmissionCollab'),
+    )
+    // Answering happens in the queue now, never here (ADR-0070).
+    expect(html, 'accept').not.toContain(i18n.t('common:actions.accept'))
+    expect(html, 'decline').not.toContain(i18n.t('common:actions.decline'))
+  })
+
+  it('still badges the count on the collapsed handle', () => {
+    const html = render(true)
+    expect(html).toContain('aria-label="Expand sidebar — 3 pending requests"')
+    expect(html).toContain('>3<')
+  })
+
+  it('badges nothing when the array is empty — 0 is not a silent failure', () => {
+    panelsMock.mockReturnValue({
+      pending_requests: [],
+      global_activity: [],
+      active_praxes: [],
+      refetch: vi.fn(),
+      loading: false,
+    })
+    expect(render(true)).toContain('aria-label="Expand sidebar"')
+  })
+})

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -345,12 +345,6 @@
     "collab": "Collab",
     "duel": "Duel"
   },
-  "requests": {
-    "collabInvite": "Collab Invite",
-    "duelChallenge": "Duel Challenge",
-    "awaitingSubmissionCollab": "Your turn — submit your collab",
-    "awaitingSubmissionDuel": "Your turn — submit your duel"
-  },
   "sidebar": {
     "toggle": {
       "collapse": "Collapse sidebar",
@@ -368,10 +362,6 @@
       "score": "Score",
       "allTime": "All-Time",
       "current": "Current"
-    },
-    "pendingRequests": {
-      "heading_one": "Pending Requests · {{count}}",
-      "heading_other": "Pending Requests · {{count}}"
     },
     "activeTasks": {
       "heading": "In progress tasks",


### PR DESCRIPTION
Closes #1423

Last child of epic #1419. The Requests queue on `/updates` (#1422) is not a fourth surface for pending requests — it is a relocation, and this deletes the one it replaced.

## The seam I tested at

`SidebarColumn` — the one place the provider's `pending_requests` array meets both of its consumers. The new guard (`__tests__/sidebarPendingRequests.test.tsx`) went red on the real defect first: with three pending requests in the provider, the rail rendered the panel heading, both row kinds and live Accept/Decline buttons. It now asserts the rail renders none of that **and** that the collapsed handle still badges `3` off the same array — a count that silently reads `0` looks like "nothing pending" rather than like a bug, so it is pinned rather than left to the typecheck.

## Deleted

- the Pending Requests panel in `Sidebar.tsx`, `AwaitingSubmissionRow`, `PendingRequestRow`, `REQUEST_BUTTON_BASE`, and the `useRespondToRequest` / `REQUESTS_QUEUE_LINK` / `ActivityFeedItem` imports they orphaned
- `common:sidebar.pendingRequests.*` **and** the whole `common:requests.*` block (`collabInvite`, `duelChallenge`, `awaitingSubmissionCollab`, `awaitingSubmissionDuel`) — the deleted rows were their only readers

**On the dead-copy check.** Verified three ways, source and tests alike: by full key, by last path segment, and against every `t(\`...\`)` template-literal construction in the tree (the only ones that build keys dynamically target `taunts:` and `duelSeal.wow.`). The new guard deliberately asserts on **literal English** for the deleted strings — `expect(html).not.toContain(i18n.t('<deleted key>'))` compares against the key string, which the page never contains, so the guard would pass without looking at anything. `actions.accept` / `actions.decline` survive and have other readers, so those stay catalog-driven, with an explicit `toBe('Accept')` resolve-guard above them.

## The issue's `limit: 1` is now a backend change, and I did not fake it

`hooks/usePendingRequests.ts` **no longer exists.** #1412 landed #1344's compound endpoint after this issue was written: the rail's three fetches are one `GET /me/sidebar`, and `pending_requests` arrives as `list[ActivityFeedItem]` capped at `SIDEBAR_REQUESTS_LIMIT = 100` (`backend/services/activity_feed.py:1413`) with no counts in the response — `get_sidebar_feed` deliberately skips the count queries.

So there is no `getActivityFeed({ limit })` call left on this path and no frontend lever for the payload win. After this PR **every** consumer of `pending_requests` reads only `.length` (`SidebarColumn`, `MobileHeader`, `useFieldDeskHome`), so serialising up to 100 feed items to render one number is now pure waste — but fixing it means adding a count field to `SidebarOut` and is a backend change, outside this PR's scope. Worth its own issue; I found no existing one. Behaviour is unchanged either way.

Hazard check: `useRespondToRequest` goes from three callers to two (`FeedCardCollabInvite`, `FeedCardDuelChallenge`, plus `requestStatusOf` in `feedItemLabels`). Not orphaned, and `tsc` is clean. The nine deep links #1421 repointed are untouched — `REQUESTS_QUEUE_LINK` still has its other eight call sites.

## One thing that needs an owner call, not mine

**An expanded desktop rail now shows no pending-request count at all.** The handle badges only while collapsed, and its stated reason was "the rail lists them itself" — a rationale this PR falsifies. An expanded desktop reaches the queue through NavBar's *unbadged* `Updates` link. I did not widen the badge to the expanded state, since the epic scoped the surviving count to two consumers and that is a behaviour change nobody asked for. Docstrings in `SidebarHandle.tsx` / `SidebarColumn.tsx` and the test's header now say this out loud instead of repeating the old reason.

## The `setAside` string you asked about

`feed:invitationLetter.setAside` — "Set aside — the invitation still stands" — is **still an orphan** (only reader is the catalog). Not deleted.

**And no, the undo strip says nothing equivalent.** After "Not now", `FeedItemSlot` renders `feed:archive.archived` → **`Archived "{title}"`** with an `Undo`. That is the generic archive vocabulary: it tells the player the letter was *filed away*, not that it *still stands*. The one sentence that expresses ADR-0065 to the player — that archiving never answers anything, and the factions page still works — is the orphaned string. Owner decision.

## What to eyeball

- Desktop rail: no Pending Requests panel between the character card and In Progress; spacing between those two panels looks right with the section gone.
- Collapsed handle still badges the count, and the number includes `invitation_letter` since #1420 — expected, not a bug.
- Mobile bell badge unchanged.
- Accept/decline a collab invite or duel challenge from the queue on `/updates#requests-queue`: the `requestsBus` subscription is untouched, so the bell and handle counts should drop without a reload.
- Desktop-expanded: confirm you are content that the only signal is the unbadged NavBar `Updates` link.

**Visual QA is outstanding** — no browser or dev stack in this environment; verified via tsc, eslint, vitest, build and the byte budget only.

## Checks

- `tsc --noEmit` — clean
- `eslint src` — clean
- `vitest run` — **188 files / 3230 tests passed**
- `vite build` — ok
- Budget: CSS **22,723 bytes** gzipped (script reads 22.2 KB), down 12 bytes from main's 22,735 against the 23,000 warn line. JS 130.9 KB, ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
