### PR TITLE
The Updates page survives a counts payload without by_type

### DIFF
--- a/frontend/src/api/__tests__/feedCountsShape.test.ts
+++ b/frontend/src/api/__tests__/feedCountsShape.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The Updates page went blank the moment its updates arrived.
+ *
+ * `FeedCounts.by_type` (#1420) is typed as required, and `typeFacetOptions`
+ * spreads `Object.keys(byType)` to build the facet's row list. `Object.keys`
+ * throws on `undefined` — so a response without the field takes React's render
+ * down and unmounts the tree, which is a WHITE PAGE rather than a broken
+ * widget.
+ *
+ * The timing is the tell, and it is why this was reported as "fine while
+ * loading, blank once loaded": `useUpdates` seeds its state with `EMPTY_COUNTS`
+ * (which has `by_type: {}`), then does `setCounts(response.counts)` — replacing
+ * the whole object with whatever the wire sent. The safe default only ever
+ * covers the loading frame.
+ *
+ * A frontend built after #1420 talking to a backend from before it is the
+ * ordinary way this happens — a `uvicorn` that was not restarted is enough.
+ * That is not an exotic state and it must degrade, not detonate: a stale count
+ * is a wrong number, and a wrong number is worth vastly less than a lost page.
+ *
+ * So the wire shape is normalised once, at the boundary, and `FeedCounts` stops
+ * being a promise the server has not actually made.
+ */
+import { describe, it, expect } from 'vitest'
+import { normalizeFeedCounts } from '../activityFeed'
+
+describe('normalizeFeedCounts', () => {
+  it('fills by_type when the server omits it, instead of letting Object.keys throw', () => {
+    const fromOlderBackend = {
+      all: 4,
+      friends: 1,
+      foes: 0,
+      your_stuff: 2,
+      global_count: 1,
+      requests: 3,
+    }
+
+    const counts = normalizeFeedCounts(fromOlderBackend)
+
+    expect(counts.by_type).toEqual({})
+    // The actual crash, pinned: this is what `typeFacetOptions` does first.
+    expect(() => Object.keys(counts.by_type)).not.toThrow()
+  })
+
+  it('keeps every number the server did send', () => {
+    const counts = normalizeFeedCounts({
+      all: 4,
+      friends: 1,
+      foes: 0,
+      your_stuff: 2,
+      global_count: 1,
+      requests: 3,
+      by_type: { nudge: 2, global_task: 2 },
+    })
+
+    expect(counts).toEqual({
+      all: 4,
+      friends: 1,
+      foes: 0,
+      your_stuff: 2,
+      global_count: 1,
+      requests: 3,
+      by_type: { nudge: 2, global_task: 2 },
+    })
+  })
+
+  it('survives a counts object that is missing entirely', () => {
+    // Defended because the alternative is the same white page. A badge reading
+    // zero is a wrong number; a blank page is no page.
+    const counts = normalizeFeedCounts(undefined)
+
+    expect(counts.by_type).toEqual({})
+    expect(counts.all).toBe(0)
+    expect(counts.requests).toBe(0)
+  })
+
+  it('does not invent counts for a type the server said nothing about', () => {
+    // The zero rows the facet hides must come from the SERVER (decision 20 —
+    // "this view has no nudges" is a different claim from "this view cannot
+    // have any"). Normalising must not manufacture that distinction.
+    const counts = normalizeFeedCounts({ all: 1, by_type: { nudge: 0 } })
+
+    expect(counts.by_type).toEqual({ nudge: 0 })
+  })
+})

--- a/frontend/src/api/activityFeed.ts
+++ b/frontend/src/api/activityFeed.ts
@@ -52,6 +52,46 @@ export interface ActivityFeedResponse {
   next_cursor: string | null
 }
 
+/** What every field of `FeedCounts` means when the server did not send it. */
+const ABSENT_COUNTS: FeedCounts = {
+  all: 0,
+  friends: 0,
+  foes: 0,
+  your_stuff: 0,
+  global_count: 0,
+  requests: 0,
+  by_type: {},
+}
+
+/**
+ * Make the wire shape match what `FeedCounts` promises, because the server does
+ * not always keep that promise.
+ *
+ * `by_type` arrived with #1420. A frontend built after it, talking to a backend
+ * from before it, gets a `counts` object without the field — and a `uvicorn`
+ * that was not restarted is enough to be in that state. `typeFacetOptions` then
+ * spreads `Object.keys(by_type)` to build its row list, `Object.keys` throws on
+ * `undefined`, and the throw happens during render, so React unmounts the tree:
+ * the whole page goes white rather than one widget breaking.
+ *
+ * `useUpdates` seeds its state with defaults and then replaces the object
+ * wholesale on load, so the safe value only ever covers the loading frame. That
+ * is exactly how it was reported: fine while the updates load, blank when they
+ * arrive.
+ *
+ * Normalising here rather than at the crash site keeps `FeedCounts` honest for
+ * every consumer, including ones not written yet — a guard inside
+ * `typeFacetOptions` would fix this page and leave the next reader of
+ * `by_type` to rediscover it.
+ *
+ * A missing count degrades to zero. A wrong number is worth far less than a
+ * lost page, and the zero is visible: the badge reads 0 instead of the app
+ * disappearing.
+ */
+export function normalizeFeedCounts(raw: Partial<FeedCounts> | undefined | null): FeedCounts {
+  return { ...ABSENT_COUNTS, ...(raw ?? {}) }
+}
+
 /** Result of archiving/restoring one item. `archived` is the state AFTER the
  *  call (both endpoints are idempotent); `changed` says whether a row moved. */
 export interface FeedItemArchiveResult {
@@ -100,7 +140,9 @@ export async function getActivityFeed(params?: {
     params,
     paramsSerializer: FEED_PARAMS_SERIALIZER,
   })
-  return data
+  // The one place a `FeedCounts` enters the app, so the one place it has to be
+  // made true. See `normalizeFeedCounts`.
+  return { ...data, counts: normalizeFeedCounts(data?.counts) }
 }
 
 /**


### PR DESCRIPTION
Live-QA regression from epic #1419: **the filters render fine while the updates load, then the page goes blank the moment they arrive.**

## The crash

`FeedCounts.by_type` arrived with #1420 and is typed as **required**. `typeFacetOptions` builds its row list like this:

```ts
const candidates = [
  ...Object.keys(FEED_TYPE_LABEL_KEY),
  ...Object.keys(byType),      // ← throws if the field is absent
  ...selected,
]
```

The two *other* reads of `byType` in that function are guarded (`byType[type] ?? 0`); this one is not. `Object.keys(undefined)` throws a `TypeError`, and it throws **during render**, so React unmounts the tree — a white page rather than a broken widget.

**Proven, not assumed.** Before writing the fix I ran a scratch test against `main`: `typeFacetOptions(undefined as never, [])` throws `TypeError`. It's deleted; the committed suite pins the boundary instead.

## Why the timing is the diagnosis

`useUpdates` seeds its state with `EMPTY_COUNTS`, which carries `by_type: {}` — then does `setCounts(response.counts)`, replacing the object **wholesale**. So the safe default only ever covers the loading frame, and the crash lands exactly when the data does. That is the reported symptom, precisely.

## How anyone gets here

A frontend built after #1420 talking to a backend from before it. **A `uvicorn` that was not restarted is enough** — this is an ordinary local state, not an exotic one, and it must degrade rather than detonate.

## Why the boundary, not the crash site

`getActivityFeed` is the only function that produces an `ActivityFeedResponse`, and both `setCounts` calls consume it — so it is the one place a `FeedCounts` enters the app, and the one place the shape can be made true. A guard inside `typeFacetOptions` would have fixed this page and left the next reader of `by_type` to rediscover the same hole.

A missing count degrades to **zero**. A wrong number is worth far less than a lost page, and a zero badge is visible where a blank screen is not.

## Tests

Four, at the normaliser. Including one asserting the fix does **not** manufacture zero rows for types the server never mentioned — epic decision 20 distinguishes "this view has no nudges" from "this view cannot have any", and normalising must not blur that.

`tsc --noEmit` clean · `eslint src --max-warnings=0` clean · **3234 tests / 189 files** green · `vite build` clean.

## What to eyeball

1. `/updates` loads and stays on screen — the actual report.
2. The type facet still lists its rows with counts against a **current** backend.
3. Against a **stale** backend the page now renders with the type facet showing only the types you have selected (all counts zero) instead of going blank.
4. The six tab badges still read their real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)