### PR TITLE
Every praxis upload gets its own directory, so same-named files stop clobbering each other (#1336)

### DIFF
--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -394,6 +394,13 @@ async def delete_media_route(
         os.remove(abs_path)
     except OSError:
         pass
+    # Each upload owns its directory (#1336), so removing the file leaves that
+    # directory empty. rmdir refuses a non-empty one, which is exactly the guard
+    # we want for pre-#1336 rows that still share a per-praxis directory.
+    try:
+        os.rmdir(os.path.dirname(abs_path))
+    except OSError:
+        pass
 
     await session.delete(media_item)
     await session.flush()

--- a/backend/services/media.py
+++ b/backend/services/media.py
@@ -10,6 +10,7 @@ import io
 import logging
 import os
 import re
+import uuid
 
 from fastapi import HTTPException, UploadFile
 from PIL import Image
@@ -32,10 +33,24 @@ MEDIA_FILENAME_MAX_LEN = 100
 
 
 def _sanitize_filename(raw: str) -> str:
-    """Strip path components and replace unsafe chars; cap at 100 chars."""
+    """Strip path components and replace unsafe chars; cap at 100 chars.
+
+    Trust boundary: ``raw`` is a client-supplied filename on its way to the
+    filesystem. Separators and NUL bytes are outside ``[\\w.\\-]`` and become
+    underscores, so nothing here can introduce a new path segment; ``.`` and
+    ``..`` survive the character class, though, and are rejected by name — a
+    relative path ending in ``..`` points at a directory, not a file.
+
+    This is deliberately lossy (``my photo.jpg`` and ``my_photo.jpg`` collapse
+    to one name, as do two names differing only past character 100). Uniqueness
+    is not its job: ``process_and_save_media`` gives every upload its own
+    directory, so a collapsed basename never means a collided path.
+    """
     basename = os.path.basename(raw or "upload")
     cleaned = re.sub(r"[^\w.\-]", "_", basename)[:MEDIA_FILENAME_MAX_LEN]
-    return cleaned or "upload"
+    if cleaned in ("", ".", ".."):
+        return "upload"
+    return cleaned
 
 
 def _detect_media_type(content_type: str) -> MediaType:
@@ -102,13 +117,27 @@ async def process_and_save_media(
 
     Router contract: the caller has already validated the praxis exists and
     is owned by the current character. This function writes the file under
-    ``MEDIA_ROOT/<character_id>/<praxis_id>/`` and returns an unattached
-    ``MediaItem``; the caller is responsible for ``session.add`` + commit.
+    ``MEDIA_ROOT/<character_id>/<praxis_id>/<unique>/`` and returns an
+    unattached ``MediaItem``; the caller is responsible for ``session.add`` +
+    commit.
+
+    **Every upload gets its own directory** (#1336). Uploading ``photo.jpg``
+    twice used to write both to one path: the second overwrote the first while
+    both rows survived, so one row served someone else's bytes — and deleting
+    either row removed the only file, 404-ing the survivor. Uniquifying the
+    *directory* rather than the basename keeps ``file_path``'s last segment
+    exactly what the player picked, which the composer renders as the
+    attachment caption and as the remove button's accessible name.
+
+    Paths stay relative (CLAUDE.md): the returned value is joined onto
+    ``MEDIA_ROOT`` to read or delete, and onto ``MEDIA_BASE_URL`` to serve.
     """
     content_type = upload.content_type or ""
     media_type = _detect_media_type(content_type)
 
-    relative_directory = os.path.join(str(character_id), str(praxis_id))
+    relative_directory = os.path.join(
+        str(character_id), str(praxis_id), uuid.uuid4().hex
+    )
     absolute_directory = os.path.join(settings.MEDIA_ROOT, relative_directory)
     filename = _sanitize_filename(upload.filename or "upload")
     absolute_path = os.path.join(absolute_directory, filename)

--- a/backend/tests/integration/test_praxis_media_batch.py
+++ b/backend/tests/integration/test_praxis_media_batch.py
@@ -341,3 +341,82 @@ async def test_collab_batch_cancels_pending_publish_for_real(
     detail = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
     assert detail.json()["submit_proposed_at"] is None
     assert detail.json()["status"] == "in_progress"
+
+
+@pytest.mark.asyncio
+async def test_same_named_files_in_one_batch_keep_their_own_bytes(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+    media_root,
+):
+    """Two files called ``proof.jpg`` both survive, each with its own bytes (#1336).
+
+    Distinct paths alone would not prove the fix — the bug was two rows over
+    one clobbered file — so this reads back what each row actually points at.
+    """
+    praxis_id = await _in_progress_solo(client, active_task, auth_headers)
+    first_bytes = _jpeg_bytes(32, 32)
+    second_bytes = _jpeg_bytes(64, 48)
+    assert first_bytes != second_bytes
+
+    response = await client.post(
+        f"/praxes/{praxis_id}/media/batch",
+        files=[
+            ("files", ("proof.jpg", first_bytes, "image/jpeg")),
+            ("files", ("proof.jpg", second_bytes, "image/jpeg")),
+        ],
+        headers=auth_headers,
+    )
+
+    assert response.status_code == 201, response.text
+    results = response.json()
+    assert [entry["error"] for entry in results] == [None, None]
+    # The client-supplied name is still what the composer is told about.
+    assert [entry["filename"] for entry in results] == ["proof.jpg", "proof.jpg"]
+
+    paths = [entry["media_item"]["file_path"] for entry in results]
+    assert paths[0] != paths[1]
+    # The player-visible basename survives — the uniqueness is a directory.
+    assert [os.path.basename(path) for path in paths] == ["proof.jpg", "proof.jpg"]
+    for path, expected in zip(paths, (first_bytes, second_bytes)):
+        with open(os.path.join(str(media_root), path), "rb") as handle:
+            assert handle.read() == expected
+
+    detail = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert len(detail.json()["media_items"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_deleting_one_same_named_file_leaves_the_other_readable(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+    media_root,
+):
+    """Removing one attachment must not 404 its same-named sibling (#1336)."""
+    praxis_id = await _in_progress_solo(client, active_task, auth_headers)
+    second_bytes = _jpeg_bytes(64, 48)
+
+    upload = await client.post(
+        f"/praxes/{praxis_id}/media/batch",
+        files=[
+            ("files", ("proof.jpg", _jpeg_bytes(32, 32), "image/jpeg")),
+            ("files", ("proof.jpg", second_bytes, "image/jpeg")),
+        ],
+        headers=auth_headers,
+    )
+    assert upload.status_code == 201, upload.text
+    first_item, second_item = (entry["media_item"] for entry in upload.json())
+
+    deletion = await client.delete(
+        f"/praxes/{praxis_id}/media/{first_item['id']}", headers=auth_headers
+    )
+    assert deletion.status_code == 204, deletion.text
+
+    survivor = os.path.join(str(media_root), second_item["file_path"])
+    with open(survivor, "rb") as handle:
+        assert handle.read() == second_bytes
+    assert not os.path.exists(os.path.join(str(media_root), first_item["file_path"]))

--- a/backend/tests/unit/test_media_service.py
+++ b/backend/tests/unit/test_media_service.py
@@ -111,6 +111,70 @@ async def test_process_and_save_media_image_writes_and_returns_unattached(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_same_filename_uploads_keep_their_own_bytes(tmp_path, monkeypatch):
+    """Two uploads named the same must not clobber each other (#1336).
+
+    Seam: ``process_and_save_media`` is the single naming seam both the
+    single-file and the batch route go through, so the collision is provable
+    here without HTTP. Distinct paths alone would not prove it — the bug was
+    two rows over one file — so this asserts the *contents* behind each row.
+    """
+    monkeypatch.setattr(media.settings, "MEDIA_ROOT", str(tmp_path))
+
+    first = await media.process_and_save_media(
+        _make_upload("proof.jpg", b"FIRST-UPLOAD-BYTES", "image/jpeg"),
+        praxis_id=11,
+        character_id=3,
+        display_order=0,
+    )
+    second = await media.process_and_save_media(
+        _make_upload("proof.jpg", b"SECOND-UPLOAD-BYTES", "image/jpeg"),
+        praxis_id=11,
+        character_id=3,
+        display_order=1,
+    )
+
+    assert first.file_path != second.file_path
+    with open(os.path.join(str(tmp_path), first.file_path), "rb") as handle:
+        assert handle.read() == b"FIRST-UPLOAD-BYTES"
+    with open(os.path.join(str(tmp_path), second.file_path), "rb") as handle:
+        assert handle.read() == b"SECOND-UPLOAD-BYTES"
+
+
+@pytest.mark.asyncio
+async def test_stored_path_keeps_the_player_visible_basename(tmp_path, monkeypatch):
+    """The composer renders ``file_path.split("/").pop()`` — keep it readable."""
+    monkeypatch.setattr(media.settings, "MEDIA_ROOT", str(tmp_path))
+
+    media_item = await media.process_and_save_media(
+        _make_upload("my cool video!.mp4", b"video bytes", "video/mp4"),
+        praxis_id=11,
+        character_id=3,
+        display_order=0,
+    )
+
+    assert os.path.basename(media_item.file_path) == "my_cool_video_.mp4"
+
+
+@pytest.mark.asyncio
+async def test_stored_path_is_relative_and_stays_under_media_root(tmp_path, monkeypatch):
+    """A hostile filename cannot escape MEDIA_ROOT and never lands absolute."""
+    monkeypatch.setattr(media.settings, "MEDIA_ROOT", str(tmp_path))
+
+    for hostile in ("../../../../etc/passwd", "..", "/etc/passwd", "nul\x00.jpg"):
+        media_item = await media.process_and_save_media(
+            _make_upload(hostile, b"bytes", "image/jpeg"),
+            praxis_id=11,
+            character_id=3,
+            display_order=0,
+        )
+        assert not os.path.isabs(media_item.file_path)
+        resolved = os.path.realpath(os.path.join(str(tmp_path), media_item.file_path))
+        assert resolved.startswith(os.path.realpath(str(tmp_path)) + os.sep)
+        assert os.path.isfile(resolved)
+
+
+@pytest.mark.asyncio
 async def test_process_and_save_media_unsupported_type_rejected(tmp_path, monkeypatch):
     """A non-image/video/audio upload raises 422 and writes nothing."""
     monkeypatch.setattr(media.settings, "MEDIA_ROOT", str(tmp_path))


### PR DESCRIPTION
Closes #1336

Two uploads sharing a filename wrote to **one path**: the second clobbered the first while **both rows survived**, so one row served the other's bytes — and deleting either row removed the only file, leaving the survivor pointing at a 404.

## The seam

`services.media.process_and_save_media` — the single naming seam. Both upload routes go through it (`POST /praxes/{id}/media` at `routers/praxes.py:311`, and the batch route via `add_media_batch`), so one change covers both. That is the upgrade path the existing `ponytail:` comment in `services/praxis.py` already named.

## The fix: uniquify the directory, not the basename

`{character_id}/{praxis_id}/{uuid4().hex}/{filename}`.

The basename is player-visible — all eight edit-praxis archetypes render `item.file_path.split("/").pop()` as the attachment caption and as the remove button's accessible name. A uuid *suffix* would show up there; a uuid *directory* does not. Paths stay relative, as CLAUDE.md requires. No new column, no schema change.

This also fixes the sanitizer's manufactured collisions for free: `my photo.jpg` / `my_photo.jpg` both normalise to `my_photo.jpg`, and names differing only past character 100 collapse — none of those are collisions on the player's disk any more.

Second commit: `os.rmdir` the now-empty directory after `os.remove` in the delete route, since each upload now owns a directory. `rmdir` refuses a non-empty directory, which is exactly the guard needed for pre-#1336 rows that still share one directory per praxis.

## Existing stored media keeps working

**No migration, no backfill.** The only consumers of `file_path` are `os.path.join(MEDIA_ROOT, file_path)` (delete route) and URL concatenation (`/media/{file_path}` in `MediaGallery`, `mediaUrl()` in the cards). Nothing parses the path's structure or its depth, so old two-segment paths resolve exactly as before. Old rows keep their existing collision behaviour among themselves — that is unfixable without moving bytes, and is not worth a backfill.

## Trust-boundary audit (asked for explicitly)

`_sanitize_filename` was **already safe against traversal**, and I confirmed rather than assumed it: `os.path.basename` strips separators, and the `[^\w.\-]` class turns `/`, `\` and NUL into `_`, so a client filename can never introduce a path segment. One real gap: `.` and `..` survive the character class, and `_sanitize_filename("..")` returned `".."`, making a relative path that points at a **directory** — `open()` then raised and the upload 500'd. Now rejected by name (→ `upload`). There is a test asserting every hostile name resolves to a real file under `MEDIA_ROOT`.

`process_and_save_avatar` is untouched: its `avatar.jpg` is a deliberate overwrite, one avatar per character.

## Tests (red first, at the seam)

- `tests/unit/test_media_service.py` — two same-named uploads, **asserting contents** behind each row (distinct paths alone would pass with clobbered bytes); basename preserved; hostile names stay under `MEDIA_ROOT` and land relative.
- `tests/integration/test_praxis_media_batch.py` — the route seam: two `proof.jpg` files in one batch, both rows survive with their own bytes; and deleting one leaves its same-named sibling readable.

Verified both integration tests fail on the pre-fix `media.py` (`FileNotFoundError` on the survivor) and pass after.

```
pytest --cov=. --cov-fail-under=80   # 926 passed, coverage 91.09%
```
(run against a dedicated `wz1336_test` database)

## What to eyeball

- **Upload the same filename twice in the composer** — both attachments should appear, each showing its own image, both captioned with the real filename (no uuid in the caption text).
- **Delete one of that pair** — the other must still render, not break to a 404.
- **Existing praxes with media from before this branch** — images should still load; their paths are unchanged.
- The batch endpoint still reports failures by the **raw client filename**, unchanged.
- No visual QA was possible here (no browser/dev stack in this environment) — verified by tests only. No frontend files were touched.

## Follow-up, deliberately not done here

The `ponytail:` comment at `backend/services/praxis.py:1553-1559` now describes a bug that is fixed and should be deleted. A sibling agent owns `services/praxis.py` on this batch (#1345), so I left it alone rather than create a conflict.
