### PR TITLE
The vote plate stops outliving the control it promises (#1429)

### DIFF
--- a/frontend/src/components/vote/VoteUI.tsx
+++ b/frontend/src/components/vote/VoteUI.tsx
@@ -2,6 +2,7 @@ import type { } from 'react'
 import { pickVariant } from '../../utils/factionDispatch'
 import { surfaceMap } from '../../factions'
 import { useAuth } from '../../auth/AuthContext'
+import type { CurrentUser } from '../../api/auth'
 import DefaultVote from './DefaultVote'
 import { VoteFactionContext } from './VoteShell'
 
@@ -27,16 +28,36 @@ export interface VoteUIProps {
   viewerCanVote?: boolean
 }
 
+/**
+ * Should the vote region exist at all for this viewer? (#998, #1429)
+ *
+ * `false` only for a logged-in viewer the backend says can never vote here —
+ * account ownership or duel participation, the two PERMANENT blocks. Anonymous
+ * viewers are always `true`: they fall through to the per-widget login gate, and
+ * that CTA is deliberate (#855). The backend never sends `viewer_can_vote:false`
+ * to a logged-out visitor either (`services/vote.viewer_can_vote`), so the `user`
+ * half is the client's belt-and-braces.
+ *
+ * THE ONE PREDICATE. `VoteUI` applies it to itself, and every caller that draws
+ * chrome AROUND the widget — heading, prompt, plate — applies the same call to
+ * that chrome. #1429 is what happens when the two halves are derived separately:
+ * the widget hid itself and eight archetypes kept drawing an empty "Cast your
+ * vote" plate over the hole.
+ */
+export function voteRegionVisible(
+  user: CurrentUser | null,
+  viewerCanVote?: boolean,
+): boolean {
+  return !(user && viewerCanVote === false)
+}
+
 export default function VoteUI({
   factionSlug,
   viewerCanVote,
   ...props
 }: VoteUIProps & { factionSlug?: string | null }) {
   const { user } = useAuth()
-  // Hide the whole module for a logged-in viewer the backend says can never
-  // vote here (ownership / duel participation, #998). Anonymous viewers fall
-  // through to the per-widget login gate — the login CTA is deliberate.
-  if (user && viewerCanVote === false) {
+  if (!voteRegionVisible(user, viewerCanVote)) {
     return null
   }
   const Variant = pickVariant(surfaceMap('vote'), factionSlug, DefaultVote)

--- a/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Vote-region ownership gate (#1429).
+ *
+ * `VoteUI` has always hidden ITSELF for a logged-in viewer the backend says can
+ * never vote here (`viewer_can_vote === false`: account ownership or duel
+ * participation — the two PERMANENT blocks, #998). The chrome around it did not:
+ * every archetype drew the "Cast your vote" heading and its prompt OUTSIDE that
+ * component, so the author of a praxis got a section that promised a control and
+ * then rendered nothing under it. CLAUDE.md's rule is to hide an unusable
+ * control, and an empty plate is that failure one step further along.
+ *
+ * The seam under test is the region decision, not the widget: `voteRegionVisible`
+ * in `components/vote/VoteUI` is the ONE predicate, consumed by `VoteUI` for
+ * itself and by each archetype for the section it wraps around it. This walks the
+ * real `surfaceMap('praxisDetail')` registry (plus the Default fallback) exactly
+ * as `archetypeSlots.test.tsx` does, so a new faction skin is picked up here with
+ * no edit to this file — a test that pinned only `Default` would not have caught
+ * a bug that shipped in eight archetypes at once.
+ *
+ * Three viewers, because the gate is not simply `viewer_can_vote`:
+ *  - the owner (logged in, `false`) gets NO region at all;
+ *  - an eligible logged-in viewer still gets it;
+ *  - an ANONYMOUS viewer gets it even on `false`, because `VoteUI` deliberately
+ *    falls through to the per-widget login gate for logged-out visitors (#855).
+ *
+ * SSR-only harness (`renderToStaticMarkup`, no DOM, effects never run), so the
+ * signed-in viewer is supplied through the exported `AuthContext` rather than a
+ * provider that fetches — and through `state.user`, which `usePraxisDetail` reads
+ * off that same context.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect } from "vitest";
+import type { ReactElement } from "react";
+import "../../../i18n";
+import { surfaceMap } from "../../../factions";
+import { AuthContext } from "../../../auth/AuthContext";
+import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
+import type { PraxisDetailState } from "../usePraxisDetail";
+import type { PraxisOut } from "../../../api/praxis";
+import type { CurrentUser } from "../../../api/auth";
+
+const HEADING = "Cast your vote";
+const PROMPT = "How much did this move you?";
+
+const PRAXIS: PraxisOut = {
+  id: 1,
+  task_id: 7,
+  task_title: "Mangrove",
+  task_point_value: 30,
+  task_level_required: 3,
+  task_faction_slug: "ua",
+  type: "solo",
+  status: "submitted",
+  title: "Reforestation",
+  body_text: "Seedlings planted along the estuary.",
+  moderation_status: "visible",
+  admin_note: null,
+  flagged_at: null,
+  submitted_at: "2026-01-02T00:00:00Z",
+  submit_proposed_at: null,
+  created_by_id: 3,
+  created_by_display_name: "Ada",
+  created_by_faction_slug: "ua",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-02T00:00:00Z",
+  members: [],
+  invites: [],
+  media_items: [],
+  score: 46,
+  metatask_points: 0,
+  display_multiplier: 1.0,
+  points_from_votes: 16,
+  is_top_for_task: false,
+  duel_id: null,
+  can_flag: true,
+  applied_metatasks: [],
+};
+
+function viewer(): CurrentUser {
+  return {
+    account_id: 1,
+    character: {
+      id: 3,
+      username: "ada",
+      display_name: "Ada",
+      bio: null,
+      avatar_url: null,
+      location: null,
+      level: 8,
+      score: 100,
+      all_time_score: 100,
+      faction_slug: "ua",
+      status: "active",
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    is_admin: false,
+    can_create_additional_character: false,
+    can_start_as_albescent: false,
+    albescent_revealed: false,
+    can_propose_task: false,
+    can_propose_metatask: false,
+    can_see_retired_tasks: false,
+    can_see_pending_tasks: false,
+    can_comment: true,
+    second_character_level_required: 5,
+    era_name: "Era 3",
+    level_jump_reach: 0,
+    level_jump_available: false,
+  };
+}
+
+/** Detail state for one viewer, carrying the backend's eligibility answer. */
+function state(user: CurrentUser | null, viewerCanVote: boolean): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: { ...PRAXIS, viewer_can_vote: viewerCanVote },
+    fetchError: null,
+    comments: null,
+    votes: { praxis_id: 1, total_votes: 4, total_score: 16 },
+    voters: [],
+    duel: null,
+    isOwner: false,
+    showAdminBar: false,
+    user,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: "",
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: "",
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleFlag: async () => {},
+    handleKickMember: async () => {},
+  };
+}
+
+function render(element: ReactElement, user: CurrentUser | null): string {
+  const html = renderToStaticMarkup(
+    <AuthContext.Provider value={{ user, loading: false, refetch: async () => {} }}>
+      <MemoryRouter>{element}</MemoryRouter>
+    </AuthContext.Provider>,
+  );
+  return html.replace(/<[^>]*>/g, "");
+}
+
+// Default fallback is a registered renderable too — walk it alongside the map.
+const archetypes = { ...surfaceMap("praxisDetail"), __default__: DefaultPraxisDetail };
+
+describe("praxis-read vote region — ownership gate (#1429)", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} draws no vote region for a viewer who can never vote`, () => {
+      const user = viewer();
+      const text = render(<Archetype state={state(user, false)} />, user);
+      expect(text, "no heading over an absent control").not.toContain(HEADING);
+      expect(text, "and no prompt either").not.toContain(PROMPT);
+    });
+
+    it(`${slug} still draws the vote region for an eligible viewer`, () => {
+      const user = viewer();
+      const text = render(<Archetype state={state(user, true)} />, user);
+      expect(text, "the heading").toContain(HEADING);
+      expect(text, "the prompt").toContain(PROMPT);
+    });
+
+    it(`${slug} keeps the region for an anonymous viewer on the same answer`, () => {
+      // The logged-out visitor never gets `false` from the backend, but the
+      // client must not hide the login gate if one ever arrives (#855).
+      const text = render(<Archetype state={state(null, false)} />, null);
+      expect(text, "the login gate still needs its heading").toContain(HEADING);
+    });
+  }
+});

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -76,7 +76,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import MediaGallery from '../../../components/MediaGallery'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
-import VoteUI from '../../../components/vote/VoteUI'
+import VoteUI, { voteRegionVisible } from '../../../components/vote/VoteUI'
 import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
 import MetataskSeal from '../../../components/metataskSeal/MetataskSeal'
 import { CollabRoster } from '../../../components/collab/CollabRoster'
@@ -532,7 +532,11 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
   )
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
-  const voteBlock = (
+  // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
+  // its heading and its prompt are the promise of a control, so they may not
+  // outlive the control. The author of a praxis can never vote on it, and used
+  // to get this section drawn empty.
+  const voteBlock = voteRegionVisible(state.user, praxis.viewer_can_vote) && (
     <section style={panel}>
       {sectionHead(t('detail.vote.heading'))}
       <p

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -98,7 +98,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import MediaGallery from '../../../components/MediaGallery'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
-import VoteUI from '../../../components/vote/VoteUI'
+import VoteUI, { voteRegionVisible } from '../../../components/vote/VoteUI'
 import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
 import MetataskSeal from '../../../components/metataskSeal/MetataskSeal'
 import { CollabRoster } from '../../../components/collab/CollabRoster'
@@ -508,7 +508,11 @@ export default function DefaultPraxisDetail({
   )
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
-  const voteBlock = (
+  // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
+  // its heading and its prompt are the promise of a control, so they may not
+  // outlive the control. The author of a praxis can never vote on it, and used
+  // to get this section drawn empty.
+  const voteBlock = voteRegionVisible(state.user, praxis.viewer_can_vote) && (
     <section style={panel}>
       {sectionHead(t('detail.vote.heading'))}
       <p

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -86,7 +86,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import MediaGallery from "../../../components/MediaGallery";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
-import VoteUI from "../../../components/vote/VoteUI";
+import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import { reframeLabel } from "../../../components/vote/voteReframes";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
 import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
@@ -649,7 +649,11 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   );
 
   // ── Vote · voters · flag ─────────────────────────────────────────────────
-  const voteBlock = (
+  // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
+  // its heading and its prompt are the promise of a control, so they may not
+  // outlive the control. The author of a praxis can never vote on it, and used
+  // to get this section drawn empty.
+  const voteBlock = voteRegionVisible(state.user, praxis.viewer_can_vote) && (
     <section style={panel}>
       {sectionHead(t("detail.vote.heading"))}
       <p style={{ ...gloss, margin: "0 0 var(--space-md)" }}>{t("detail.vote.prompt")}</p>

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -77,7 +77,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import MediaGallery from "../../../components/MediaGallery";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
-import VoteUI from "../../../components/vote/VoteUI";
+import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
 import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
@@ -601,7 +601,11 @@ export default function EverymenPraxisDetail({
   );
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
-  const voteBlock = (
+  // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
+  // its heading and its prompt are the promise of a control, so they may not
+  // outlive the control. The author of a praxis can never vote on it, and used
+  // to get this section drawn empty.
+  const voteBlock = voteRegionVisible(state.user, praxis.viewer_can_vote) && (
     <section style={panel}>
       {sectionHead(t("detail.vote.heading"))}
       <p

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import MediaGallery from "../../../components/MediaGallery";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
-import VoteUI from "../../../components/vote/VoteUI";
+import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
 import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
@@ -569,7 +569,11 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
   );
 
   // ── Vote · voters · flag ──────────────────────────────────────────────────
-  const voteBlock = (
+  // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
+  // its heading and its prompt are the promise of a control, so they may not
+  // outlive the control. The author of a praxis can never vote on it, and used
+  // to get this section drawn empty.
+  const voteBlock = voteRegionVisible(state.user, praxis.viewer_can_vote) && (
     <section style={panel}>
       {sectionHead(t("detail.vote.heading"))}
       <p

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -103,7 +103,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import MediaGallery from "../../../components/MediaGallery";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
-import VoteUI from "../../../components/vote/VoteUI";
+import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
 import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
@@ -633,7 +633,11 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
   //
   // The amp meter is bolted to the plate: `SnideVote` paints acid and vote-off
   // captions that measure 2.6:1 on cream and 15.7:1 on ink.
-  const voteBlock = (
+  // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
+  // its heading and its prompt are the promise of a control, so they may not
+  // outlive the control. The author of a praxis can never vote on it, and used
+  // to get this section drawn empty.
+  const voteBlock = voteRegionVisible(state.user, praxis.viewer_can_vote) && (
     <section style={plate}>
       {sectionHead(t("detail.vote.heading"), { onPlate: true })}
       <p

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import MediaGallery from "../../../components/MediaGallery";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
-import VoteUI from "../../../components/vote/VoteUI";
+import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
 import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
@@ -622,7 +622,11 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
   // The widget is UA's growing mandala, dispatched on the TASK's faction. Its
   // cores punch to `--faction-ua-card-bg`, which is why this panel is that stock
   // and not the lift: on any other sheet the mandala stops being an aperture.
-  const voteBlock = (
+  // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
+  // its heading and its prompt are the promise of a control, so they may not
+  // outlive the control. The author of a praxis can never vote on it, and used
+  // to get this section drawn empty.
+  const voteBlock = voteRegionVisible(state.user, praxis.viewer_can_vote) && (
     <section style={panel}>
       {panelHead(t("detail.vote.heading"))}
       <p

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import MediaGallery from '../../../components/MediaGallery'
 import MarkdownPreview from '../../editPraxis/blocks/MarkdownPreview'
-import VoteUI from '../../../components/vote/VoteUI'
+import VoteUI, { voteRegionVisible } from '../../../components/vote/VoteUI'
 import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
 import MetataskSeal from '../../../components/metataskSeal/MetataskSeal'
 import { CollabRoster } from '../../../components/collab/CollabRoster'
@@ -573,7 +573,11 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
   // praxis still votes in that task's voice (ADR-0039). The widget draws its own
   // "Cast thy Verdict" line, so the gloss here is the shared neutral prompt in
   // the scribe's hand rather than a second archaic call.
-  const voteBlock = (
+  // Gated on the ONE predicate `VoteUI` gates ITSELF on (#1429): the plate,
+  // its heading and its prompt are the promise of a control, so they may not
+  // outlive the control. The author of a praxis can never vote on it, and used
+  // to get this section drawn empty.
+  const voteBlock = voteRegionVisible(state.user, praxis.viewer_can_vote) && (
     <section style={panel}>
       {panelHead('vote', t('detail.vote.heading'))}
       <p


### PR DESCRIPTION
Closes #1429

## The seam

The bug is not in `VoteUI` and it is not eight separate bugs. It is one decision —
**"does the vote region exist for this viewer at all?"** — derived in two places that
could not see each other: `VoteUI` hid *itself*, and every archetype drew the heading,
the prompt and the plate *around* it unconditionally. The author of a praxis got a
section that promises a control and then renders nothing.

So the seam under test is the **region decision**, and it now has exactly one
expression, living next to the guard it replaces:

```ts
// components/vote/VoteUI.tsx
export function voteRegionVisible(user: CurrentUser | null, viewerCanVote?: boolean): boolean {
  return !(user && viewerCanVote === false)
}
```

`VoteUI` applies it to itself; each of the eight archetypes applies the same call to the
chrome it wraps around it — `const voteBlock = voteRegionVisible(state.user, praxis.viewer_can_vote) && (…)`,
which is the idiom those files already use for `votersBlock`. Two lines per archetype,
no new abstraction, and the chrome stays bespoke per faction.

`state.user` is `useAuth().user` — `usePraxisDetail` reads it off that same context
(`usePraxisDetail.ts:143`), so the two halves cannot disagree about who is looking.

The issue's preferred shape was "move the heading and prompt inside `VoteUI`". That is not
buildable: the heading is `sectionHead(…)` in five archetypes, `panelHead(…)` in UA,
`panelHead('vote', …)` in WOW and `sectionHead(…, { onPlate: true })` in S.N.I.D.E., on
four different plates. Unifying it would flatten eight card archetypes into one. Sharing
the *predicate* rather than the *markup* gets the same "one owner" property without that.

## Verified, not assumed

`backend/services/vote.py:180` — `viewer_can_vote` returns `True` for `voter is None`, so a
logged-out visitor never receives `false` and the anonymous login gate (#855) is unaffected
either way. The `user &&` half of the predicate is the client's belt-and-braces, kept
verbatim from the guard it replaces.

## Red first

`frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx` walks the real
`surfaceMap('praxisDetail')` registry plus the `Default` fallback — the same walk
`archetypeSlots.test.tsx` uses, so a new faction skin is covered here with no edit to the
file. Three viewers per archetype: the owner gets **no** region, an eligible viewer still
gets one, and an anonymous viewer keeps it even on `false`.

Before the fix: **9 failed / 18 passed** — every archetype red on the owner case, both
positive cases already green, i.e. the loop failed on the actual defect and nothing else.
After: 27/27.

## Checks

- `tsc --noEmit` — clean
- `vitest run` (full) — 190 files, 3261 tests, all pass
- `eslint` on every touched path — clean
- `vite build` + `npm run budget` — within budget (JS 130.9 KB, CSS 22.2 KB, both `ok`)
- **Visual QA outstanding**: no browser or dev stack in this environment.

## What to eyeball

1. Your **own** praxis, on each faction skin — the "Cast your vote" plate should be gone
   entirely, not empty. Check the vertical rhythm where it used to sit: no orphan gap
   between the score block and "Who voted" / the flag card.
2. **Someone else's** praxis — plate unchanged, control present.
3. **Logged out** — the plate and its "Log in to vote" gate must still be there, in the
   task faction's voice.
4. A **duel** praxis you are a participant in — same permanent block, so the plate should
   be gone there too.
5. Mobile width on any of the above (praxis detail is one responsive component, ADR-0063).

## Deliberately not in scope

`components/praxisCard/shared.tsx`'s `PraxisVoteFooter` wraps `VoteUI` in a
`marginTop: var(--space-md)` div and leaves that margin behind when the widget hides. It
draws no heading and no prompt, so it is an invisible few pixels rather than a broken
promise — out of this issue's scope, and worth its own line if anyone sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
