### PR TITLE
The edit-praxis link stops pointing at a redirect back to the page you are on (#1397)

### DIFF
--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -36,39 +36,13 @@ import { factionCssVar } from '../../utils/factions'
 import ConfirmDialog from '../confirm/ConfirmDialog'
 import { kickMemberConfirm } from '../confirm/composerConfirms'
 import { collabCopy } from './collabCopy'
+import { deriveCollabGate } from './collabGate'
 
-export type CollabState =
-  | 'awaiting'
-  | 'writing'
-  | 'waiting'
-  | 'holdout'
-  | 'published'
-
-export interface CollabGate {
-  memberCount: number
-  castCount: number
-  iCast: boolean
-  state: CollabState
-}
-
-/** Pure derivation of the consensus gate from the member list. */
-export function deriveCollabGate(
-  members: readonly PraxisMemberOut[],
-  currentCharacterId: number | null | undefined,
-): CollabGate {
-  const memberCount = members.length
-  const castCount = members.filter((m) => m.has_submitted).length
-  const iCast = members.some(
-    (m) => m.character_id === currentCharacterId && m.has_submitted,
-  )
-  let state: CollabState
-  // First, because every test below it lies at one member (#1274).
-  if (memberCount < 2) state = 'awaiting'
-  else if (castCount === 0) state = 'writing'
-  else if (castCount >= memberCount) state = 'published'
-  else state = iCast ? 'waiting' : 'holdout'
-  return { memberCount, castCount, iCast, state }
-}
+// The consensus state machine moved to `collabGate.ts` (#1397) — it is pure, and
+// keeping it here billed every caller for this component's dialog and copy.
+// Re-exported so every existing importer still reaches it by this path.
+export { deriveCollabGate } from './collabGate'
+export type { CollabGate, CollabState } from './collabGate'
 
 export function CollabRoster({
   praxisType,

--- a/frontend/src/components/collab/collabGate.ts
+++ b/frontend/src/components/collab/collabGate.ts
@@ -1,0 +1,54 @@
+/**
+ * The ADR-0012 lazy-consensus state machine, as a pure function.
+ *
+ * Lifted out of `CollabRoster.tsx` verbatim (#1397). It was always pure, but
+ * living in a component module meant every importer paid for the roster, its
+ * `ConfirmDialog`, and the eight-faction `composerConfirms` copy — ~50 KB gzip
+ * of chunk for a fifteen-line reduce over `members[]`. `deriveEditPraxisPhase`
+ * calls it, and the praxis-detail page calls that, so the bill landed on a page
+ * that draws no roster at all.
+ *
+ * KEEP THIS MODULE A LEAF: types in, plain object out, no component imports.
+ * `CollabRoster` re-exports all three names, so nothing that reached for them by
+ * the old path had to change.
+ *
+ *   member_count < 2                      → awaiting  (S0) a crew of one
+ *   cast_count === 0                      → writing   (S1) nobody cast yet
+ *   0 < cast < count, I cast               → waiting   (S2) my part is in
+ *   0 < cast < count, I didn't             → holdout   (S3) the circle waits on me
+ *   cast_count === member_count           → published (S4) every part woven
+ */
+import type { PraxisMemberOut } from '../../api/praxis'
+
+export type CollabState =
+  | 'awaiting'
+  | 'writing'
+  | 'waiting'
+  | 'holdout'
+  | 'published'
+
+export interface CollabGate {
+  memberCount: number
+  castCount: number
+  iCast: boolean
+  state: CollabState
+}
+
+/** Pure derivation of the consensus gate from the member list. */
+export function deriveCollabGate(
+  members: readonly PraxisMemberOut[],
+  currentCharacterId: number | null | undefined,
+): CollabGate {
+  const memberCount = members.length
+  const castCount = members.filter((m) => m.has_submitted).length
+  const iCast = members.some(
+    (m) => m.character_id === currentCharacterId && m.has_submitted,
+  )
+  let state: CollabState
+  // First, because every test below it lies at one member (#1274).
+  if (memberCount < 2) state = 'awaiting'
+  else if (castCount === 0) state = 'writing'
+  else if (castCount >= memberCount) state = 'published'
+  else state = iCast ? 'waiting' : 'holdout'
+  return { memberCount, castCount, iCast, state }
+}

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -150,10 +150,10 @@
     "owner": {
       "edit": "edit this praxis",
       "submitting": "Unsubmitting…",
-      "unsubmit": "unsubmit",
+      "unsubmit": "unsubmit to edit",
       "unsubmitDuelLive": "pull my entry back",
-      "confirmPrompt": "Sure? Points & votes will pause.",
-      "confirmPromptCollab": "Sure? This reopens the praxis for the whole group — every member's part is uncast, and points & votes pause.",
+      "confirmPrompt": "Sure? Only you can see it until you submit again, and points & votes pause. Resubmitting stamps a new date, so it returns to the top of the feed.",
+      "confirmPromptCollab": "Sure? This reopens the praxis for the whole group — every member's part is uncast, only members can see it, and points & votes pause. Resubmitting stamps a new date, so it returns to the top of the feed.",
       "confirmPromptCollabPart": "Sure? This pulls back only your part — your co-authors' casts stand.",
       "confirmPromptDuelLive": "Sure? The duel hasn't settled and your rival hasn't cast, so this is a free reopen — nothing is marked against you. Points & votes pause.",
       "confirmUnsubmit": "Yes, unsubmit",

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -68,7 +68,7 @@
     },
     "submitted": {
       "text": "You've filed praxis for this task",
-      "edit": "Edit praxis"
+      "view": "Read your praxis"
     },
     "brief": {
       "heading": "Task Description"

--- a/frontend/src/pages/editPraxis/editPraxisPhase.ts
+++ b/frontend/src/pages/editPraxis/editPraxisPhase.ts
@@ -1,0 +1,124 @@
+/**
+ * Which face `/praxis/:id/edit` wears, derived from data alone (ADR-0059).
+ *
+ * Lifted out of `useEditPraxis.ts` verbatim (#1397) because the praxis-detail
+ * page needs the same answer — its owner cluster hides the edit link on
+ * `handoff`, the phase whose whole job is to redirect back to that page. Reading
+ * the composer's own predicate is what stops the two drifting; importing it from
+ * `useEditPraxis` would have dragged the composer's entire api/upload plumbing
+ * (a 54 KB-gzip chunk) onto every praxis-detail load. This module is a leaf on
+ * purpose — keep it that way.
+ *
+ * `useEditPraxis` re-exports all three names, so every existing importer is
+ * untouched.
+ */
+import { deriveCollabGate } from "../../components/collab/collabGate";
+import type { PraxisOut } from "../../api/praxis";
+import type { DuelDetailOut } from "../../api/duel";
+
+/**
+ * Which face the composer is wearing (ADR-0059).
+ *
+ *  - `composing` — the faction archetype: the editor proper.
+ *  - `waiting`   — the shared waiting surface: my part is submitted and the
+ *    praxis is held open on somebody else.
+ *  - `completed` — the same surface in its completed reading: everybody is in,
+ *    so there is nothing left to wait for and nothing left to author (#1164).
+ *  - `handoff`   — nothing for `/edit` to draw at all; the read page owns it
+ *    from here, so the route redirects (#1164).
+ *
+ * The last two are what a published praxis used to get instead: a **locked
+ * composer**, i.e. a third read-only rendering of a praxis beside the detail
+ * page and this surface. Owner ruling on #1164: a multi-party praxis shows the
+ * completed reading with a way through to `/praxis/:id`, and a solo one — which
+ * has no roster and never had anyone to wait for — simply hands off.
+ *
+ * `controlsLocked` therefore stops meaning "render the composer, disabled" and
+ * starts meaning "hand off". It still guards the one composer that legitimately
+ * renders locked: a **moderated** (hidden/failed) praxis, which is the
+ * archetype's own state to tell and never reaches this dispatch.
+ */
+export type EditPraxisPhase = "composing" | "waiting" | "completed" | "handoff";
+
+/**
+ * The two phases that draw `PraxisWaitingSurface` instead of the composer's own
+ * regions — while the praxis waits on somebody else, and (#1164) once everybody
+ * is in.
+ *
+ * Every archetype asks this, because since #1189 the stage swap is the
+ * archetype's: it is the one that holds the faction's dress, and the dispatcher
+ * could only hand the shared surface an undressed one. One predicate so eight
+ * skins cannot disagree about when the composer stops being a composer.
+ */
+export function isWaitingStage(phase: EditPraxisPhase): boolean {
+  return phase === "waiting" || phase === "completed";
+}
+
+/**
+ * The phase, derived from data alone — no transient flag (ADR-0059).
+ *
+ * Deriving rather than latching means re-entry behaves the same as the cast
+ * itself: re-opening `/edit` on a part you already filed shows the waiting
+ * surface, which is the only place that offers a way back into your own text.
+ * Latching a boolean at publish time would have left that re-entry on the
+ * locked composer — the dead end #1077 patched with a single footer button.
+ *
+ * The `composing` fall-throughs are deliberate, not defaults:
+ *  - **The holdout case.** Others submitted and I have not: `deriveCollabGate`
+ *    calls that `holdout`, and it keeps the normal composer, because what it
+ *    needs is an editor, not a status page (#1080). What it gains in #1164 is
+ *    the ADR-0012 countdown, drawn beside the roster in the composer — it is the
+ *    only player the deadline actually threatens.
+ *  - **A forfeited duel.** The outcome is the read page's to tell (ADR-0059),
+ *    and the completed reading's "both sides are in" would be a lie: a forfeit
+ *    is an unsubmit, so the forfeiter's own side is back out (`unsubmit_praxis`
+ *    returns it to `in_progress`). Left exactly as ADR-0059 set it.
+ *  - **A moderated praxis.** Hidden/failed is the archetype's own locked state,
+ *    and a cheerful "your part is submitted" over it would be a lie.
+ *
+ * `duel == null` (the detail fetch is still in flight) also reads as
+ * `composing`: the surface names the rival, so it renders nothing at all rather
+ * than a panel with a hole where the opponent goes.
+ *
+ * **Once everybody is in** (#1164) the answer is `completed`, not `composing`:
+ *  - A collab is tested on `status === 'submitted'` rather than on the gate,
+ *    because a window that lapses auto-publishes the collab with a holdout still
+ *    outstanding (ADR-0012) — `submitted` is the fact, the gate is not.
+ *  - A `settled`/`resolved` duel joins it. ADR-0059 sent those to the read page
+ *    on the grounds that stage 3 is its business; the ruling on #1164 keeps that
+ *    true of the *outcome* and still refuses `/edit` a locked composer.
+ *  - A `declined` challenge never became a duel. What is left is an ordinary
+ *    published solo praxis, so it hands off like one.
+ */
+export function deriveEditPraxisPhase(
+  praxis: PraxisOut | null,
+  duel: DuelDetailOut | null,
+  currentCharacterId: number | null | undefined,
+): EditPraxisPhase {
+  if (!praxis) return "composing";
+  if (
+    praxis.moderation_status === "hidden" ||
+    praxis.moderation_status === "failed"
+  ) {
+    return "composing";
+  }
+  // A duel side is `type='solo'` + a duel_id (ADR-0011), so it must be tested
+  // before the collab branch and never by `type`.
+  if (praxis.duel_id != null) {
+    if (praxis.status !== "submitted") return "composing";
+    if (duel == null) return "composing";
+    if (duel.forfeited_by_character_id != null) return "composing";
+    if (duel.status === "active" || duel.status === "pending") return "waiting";
+    if (duel.status === "declined") return "handoff";
+    return "completed";
+  }
+  if (praxis.type === "collab" && praxis.members.length > 1) {
+    if (praxis.status === "submitted") return "completed";
+    return deriveCollabGate(praxis.members, currentCharacterId).state ===
+      "waiting"
+      ? "waiting"
+      : "composing";
+  }
+  // Solo — including a one-member collab, which has nobody to wait for either.
+  return praxis.status === "submitted" ? "handoff" : "composing";
+}

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -37,6 +37,10 @@ import {
 import { sendNudge } from "../../api/nudge";
 import { deriveCollabGate } from "../../components/collab/CollabRoster";
 import {
+  deriveEditPraxisPhase,
+  type EditPraxisPhase,
+} from "./editPraxisPhase";
+import {
   deleteCollabConfirm,
   dissolveDuelConfirm,
   dropTaskConfirm,
@@ -66,111 +70,16 @@ export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
 export type SaveStatus = "idle" | "saving" | "saved" | "error";
 
 /**
- * Which face the composer is wearing (ADR-0059).
- *
- *  - `composing` — the faction archetype: the editor proper.
- *  - `waiting`   — the shared waiting surface: my part is submitted and the
- *    praxis is held open on somebody else.
- *  - `completed` — the same surface in its completed reading: everybody is in,
- *    so there is nothing left to wait for and nothing left to author (#1164).
- *  - `handoff`   — nothing for `/edit` to draw at all; the read page owns it
- *    from here, so the route redirects (#1164).
- *
- * The last two are what a published praxis used to get instead: a **locked
- * composer**, i.e. a third read-only rendering of a praxis beside the detail
- * page and this surface. Owner ruling on #1164: a multi-party praxis shows the
- * completed reading with a way through to `/praxis/:id`, and a solo one — which
- * has no roster and never had anyone to wait for — simply hands off.
- *
- * `controlsLocked` therefore stops meaning "render the composer, disabled" and
- * starts meaning "hand off". It still guards the one composer that legitimately
- * renders locked: a **moderated** (hidden/failed) praxis, which is the
- * archetype's own state to tell and never reaches this dispatch.
+ * The phase predicate moved to `editPraxisPhase.ts` (#1397) so the praxis-detail
+ * page can read the composer's own answer without pulling this module's api and
+ * upload plumbing into its chunk. Re-exported here because every existing
+ * importer — and this hook — reaches for it by this path.
  */
-export type EditPraxisPhase = "composing" | "waiting" | "completed" | "handoff";
-
-/**
- * The two phases that draw `PraxisWaitingSurface` instead of the composer's own
- * regions — while the praxis waits on somebody else, and (#1164) once everybody
- * is in.
- *
- * Every archetype asks this, because since #1189 the stage swap is the
- * archetype's: it is the one that holds the faction's dress, and the dispatcher
- * could only hand the shared surface an undressed one. One predicate so eight
- * skins cannot disagree about when the composer stops being a composer.
- */
-export function isWaitingStage(phase: EditPraxisPhase): boolean {
-  return phase === "waiting" || phase === "completed";
-}
-
-/**
- * The phase, derived from data alone — no transient flag (ADR-0059).
- *
- * Deriving rather than latching means re-entry behaves the same as the cast
- * itself: re-opening `/edit` on a part you already filed shows the waiting
- * surface, which is the only place that offers a way back into your own text.
- * Latching a boolean at publish time would have left that re-entry on the
- * locked composer — the dead end #1077 patched with a single footer button.
- *
- * The `composing` fall-throughs are deliberate, not defaults:
- *  - **The holdout case.** Others submitted and I have not: `deriveCollabGate`
- *    calls that `holdout`, and it keeps the normal composer, because what it
- *    needs is an editor, not a status page (#1080). What it gains in #1164 is
- *    the ADR-0012 countdown, drawn beside the roster in the composer — it is the
- *    only player the deadline actually threatens.
- *  - **A forfeited duel.** The outcome is the read page's to tell (ADR-0059),
- *    and the completed reading's "both sides are in" would be a lie: a forfeit
- *    is an unsubmit, so the forfeiter's own side is back out (`unsubmit_praxis`
- *    returns it to `in_progress`). Left exactly as ADR-0059 set it.
- *  - **A moderated praxis.** Hidden/failed is the archetype's own locked state,
- *    and a cheerful "your part is submitted" over it would be a lie.
- *
- * `duel == null` (the detail fetch is still in flight) also reads as
- * `composing`: the surface names the rival, so it renders nothing at all rather
- * than a panel with a hole where the opponent goes.
- *
- * **Once everybody is in** (#1164) the answer is `completed`, not `composing`:
- *  - A collab is tested on `status === 'submitted'` rather than on the gate,
- *    because a window that lapses auto-publishes the collab with a holdout still
- *    outstanding (ADR-0012) — `submitted` is the fact, the gate is not.
- *  - A `settled`/`resolved` duel joins it. ADR-0059 sent those to the read page
- *    on the grounds that stage 3 is its business; the ruling on #1164 keeps that
- *    true of the *outcome* and still refuses `/edit` a locked composer.
- *  - A `declined` challenge never became a duel. What is left is an ordinary
- *    published solo praxis, so it hands off like one.
- */
-export function deriveEditPraxisPhase(
-  praxis: PraxisOut | null,
-  duel: DuelDetailOut | null,
-  currentCharacterId: number | null | undefined,
-): EditPraxisPhase {
-  if (!praxis) return "composing";
-  if (
-    praxis.moderation_status === "hidden" ||
-    praxis.moderation_status === "failed"
-  ) {
-    return "composing";
-  }
-  // A duel side is `type='solo'` + a duel_id (ADR-0011), so it must be tested
-  // before the collab branch and never by `type`.
-  if (praxis.duel_id != null) {
-    if (praxis.status !== "submitted") return "composing";
-    if (duel == null) return "composing";
-    if (duel.forfeited_by_character_id != null) return "composing";
-    if (duel.status === "active" || duel.status === "pending") return "waiting";
-    if (duel.status === "declined") return "handoff";
-    return "completed";
-  }
-  if (praxis.type === "collab" && praxis.members.length > 1) {
-    if (praxis.status === "submitted") return "completed";
-    return deriveCollabGate(praxis.members, currentCharacterId).state ===
-      "waiting"
-      ? "waiting"
-      : "composing";
-  }
-  // Solo — including a one-member collab, which has nobody to wait for either.
-  return praxis.status === "submitted" ? "handoff" : "composing";
-}
+export {
+  deriveEditPraxisPhase,
+  isWaitingStage,
+  type EditPraxisPhase,
+} from "./editPraxisPhase";
 
 export interface EditPraxisState {
   // Routing / loading

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -426,11 +426,17 @@ describe('Coven praxis detail — the state axes', () => {
   })
 
   it('shows owner controls to a member and nothing to a visitor', () => {
-    expect(render(state()).html, 'a visitor gets no edit link').not.toContain(
-      'href="/praxis/1/edit"',
+    // #1397: the cluster is anchored on the UNSUBMIT control now. On a
+    // submitted solo `/edit` redirects straight back to this page, so the edit
+    // link is hidden and unsubmitting is the way into the composer.
+    expect(render(state()).text, 'a visitor gets no owner controls').not.toContain(
+      'unsubmit',
     )
     const owner = state({ isOwner: true, user: VIEWER })
-    expect(render(owner).html).toContain('href="/praxis/1/edit"')
+    expect(render(owner).text).toContain('unsubmit')
+    expect(render(owner).html, 'and nothing that round-trips').not.toContain(
+      'href="/praxis/1/edit"',
+    )
   })
 
   it('lists who voted and each voters own rung, never an average', () => {

--- a/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
@@ -279,11 +279,15 @@ describe("Ephemerists praxis detail — copy is neutral (ADR-0061)", () => {
     // The design labels this cluster ("Amend the record"). That label was the
     // one voiced slot with no neutral twin, so it is gone rather than restated
     // — the other seven skins mount the cluster unlabelled too.
-    expect(render(state()).html, "visitor gets no owner controls").not.toContain(
-      "/praxis/1/edit",
+    // #1397: the cluster is anchored on the UNSUBMIT control now. On a
+    // submitted solo `/edit` redirects straight back to this page, so the edit
+    // link is hidden and unsubmitting is the way into the composer.
+    expect(render(state()).text, "visitor gets no owner controls").not.toContain(
+      "unsubmit",
     );
     const owner = render(state({ isOwner: true }));
-    expect(owner.html, "the shared invariant controls").toContain("/praxis/1/edit");
+    expect(owner.text, "the shared invariant controls").toContain("unsubmit");
+    expect(owner.html, "and nothing that round-trips").not.toContain("/praxis/1/edit");
     expect(owner.text, "and no label over them").not.toContain("Amend the record");
   });
 

--- a/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
@@ -375,11 +375,17 @@ describe("Everymen praxis detail — the state axes", () => {
   });
 
   it("shows owner controls to a member and nothing to a visitor", () => {
-    expect(render(state()).html, "a visitor gets no edit link").not.toContain(
-      'href="/praxis/1/edit"',
+    // #1397: the cluster is anchored on the UNSUBMIT control now. On a
+    // submitted solo `/edit` redirects straight back to this page, so the edit
+    // link is hidden and unsubmitting is the way into the composer.
+    expect(render(state()).text, "a visitor gets no owner controls").not.toContain(
+      "unsubmit",
     );
     const owner = state({ isOwner: true, user: VIEWER });
-    expect(render(owner).html).toContain('href="/praxis/1/edit"');
+    expect(render(owner).text).toContain("unsubmit");
+    expect(render(owner).html, "and nothing that round-trips").not.toContain(
+      'href="/praxis/1/edit"',
+    );
   });
 
   it("lists who voted and each voter's own rung, never an average", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * The owner's "edit this praxis" link only shows when `/edit` has something to
+ * draw (#1397).
+ *
+ * `/praxis/:id/edit` renders `EditPraxis`, which `<Navigate replace>`s back to
+ * `/praxis/:id` whenever `deriveEditPraxisPhase` answers `handoff` (#1164). The
+ * link here was gated on `isOwner` alone, and this page only ever renders a
+ * PUBLISHED praxis (ADR-0062 redirects both open statuses to the composer) — so
+ * on a submitted solo it round-tripped every single time it was visible, with
+ * `replace` swallowing even the history trace. "It did not route me anywhere."
+ *
+ * The seam under test is `PraxisOwnerActions`: given a state, is a
+ * `/praxis/:id/edit` href in the markup? The fix is a hide, not a removal, so
+ * every non-handoff phase below is asserted to KEEP its link — otherwise this
+ * file could not tell "dropped the dead link" from "dropped editing".
+ *
+ * The way to edit a published praxis is the control in the same flex row:
+ * unsubmit → confirm → `PraxisDetail` redirects the now-`in_progress` praxis
+ * straight into the composer. So the unsubmit trigger must survive wherever the
+ * edit link goes.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import { PraxisOwnerActions } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import type { PraxisOut, PraxisMemberOut, PraxisStatus } from '../../../api/praxis'
+import type { CharacterOut, CurrentUser } from '../../../api/auth'
+import type { DuelDetailOut, DuelSideOut, DuelStatus } from '../../../api/duel'
+
+const EDIT_HREF = 'href="/praxis/1/edit"'
+
+function render(element: ReactElement): { html: string; text: string } {
+  const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+function member(characterId: number, name: string): PraxisMemberOut {
+  return {
+    id: characterId * 10,
+    praxis_id: 1,
+    character_id: characterId,
+    character_display_name: name,
+    has_submitted: true,
+    joined_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+function praxis(overrides: Partial<PraxisOut> = {}): PraxisOut {
+  return {
+    id: 1,
+    task_id: 7,
+    task_title: 'Mangrove',
+    task_point_value: 30,
+    task_level_required: 3,
+    task_faction_slug: null,
+    type: 'solo',
+    // EVERY case here is submitted: ADR-0062 means nothing else reaches the page.
+    status: 'submitted' as PraxisStatus,
+    title: 'Reforestation',
+    body_text: 'Seedlings.',
+    moderation_status: 'visible',
+    admin_note: null,
+    flagged_at: null,
+    submitted_at: '2026-01-02T00:00:00Z',
+    submit_proposed_at: null,
+    created_by_id: 1,
+    created_by_display_name: 'Ada',
+    created_by_faction_slug: 'wow',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+    members: [member(1, 'Ada')],
+    invites: [],
+    media_items: [],
+    score: 0,
+    metatask_points: 0,
+    display_multiplier: 1.0,
+    points_from_votes: 0,
+    is_top_for_task: false,
+    duel_id: null,
+    can_flag: true,
+    applied_metatasks: [],
+    ...overrides,
+  } as PraxisOut
+}
+
+function duel(status: DuelStatus): DuelDetailOut {
+  const side = (praxisId: number, characterId: number, name: string): DuelSideOut => ({
+    praxis_id: praxisId,
+    character_id: characterId,
+    display_name: name,
+    faction_slug: 'wow',
+    avatar_url: '',
+    points_from_votes: 0,
+    is_submitted: true,
+  })
+  return {
+    id: 5,
+    task_id: 7,
+    status,
+    forfeited_by_character_id: null,
+    challenger: side(1, 1, 'Ada'),
+    opponent: side(2, 2, 'Rax'),
+    viewer_is_participant: true,
+    winner_character_id: null,
+    challenger_final_points: null,
+    opponent_final_points: null,
+  }
+}
+
+function user(): CurrentUser {
+  const character: CharacterOut = {
+    id: 1,
+    username: 'ada',
+    display_name: 'Ada',
+    bio: null,
+    avatar_url: null,
+    location: null,
+    level: 5,
+    score: 0,
+    all_time_score: 0,
+    faction_slug: 'wow',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+  }
+  return {
+    account_id: 1,
+    character,
+    is_admin: false,
+    can_create_additional_character: false,
+    can_start_as_albescent: false,
+    albescent_revealed: false,
+    can_propose_task: false,
+    can_propose_metatask: false,
+    can_see_retired_tasks: false,
+    can_see_pending_tasks: false,
+    can_comment: true,
+    second_character_level_required: 5,
+    era_name: 'Era 1',
+    level_jump_reach: 0,
+    level_jump_available: false,
+  }
+}
+
+function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: praxis(),
+    fetchError: null,
+    comments: null,
+    votes: null,
+    voters: [],
+    duel: null,
+    isOwner: true,
+    showAdminBar: false,
+    user: user(),
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: '',
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleFlag: async () => {},
+    handleKickMember: async () => {},
+    ...overrides,
+  } as PraxisDetailState
+}
+
+const COLLAB_MEMBERS = [member(1, 'Ada'), member(2, 'Beth')]
+
+describe('the dead edit link is gone (#1397)', () => {
+  it('a submitted solo praxis offers its owner no link to /edit', () => {
+    const { html } = render(<PraxisOwnerActions state={state({})} />)
+    expect(html).not.toContain(EDIT_HREF)
+  })
+
+  it('a one-member collab hands off the same way, so it loses the link too', () => {
+    const { html } = render(
+      <PraxisOwnerActions state={state({ praxis: praxis({ type: 'collab' }) })} />,
+    )
+    expect(html).not.toContain(EDIT_HREF)
+  })
+
+  it('a declined challenge is an ordinary published solo — no link', () => {
+    const { html } = render(
+      <PraxisOwnerActions
+        state={state({ praxis: praxis({ duel_id: 5 }), duel: duel('declined') })}
+      />,
+    )
+    expect(html).not.toContain(EDIT_HREF)
+  })
+
+  it('the way to edit — the unsubmit control — survives beside it', () => {
+    const { text } = render(<PraxisOwnerActions state={state({})} />)
+    expect(text.toLowerCase()).toContain('unsubmit')
+  })
+})
+
+describe('every phase that /edit still draws keeps its link (#1397)', () => {
+  it('a published collab reaches the completed reading', () => {
+    const { html } = render(
+      <PraxisOwnerActions
+        state={state({ praxis: praxis({ type: 'collab', members: COLLAB_MEMBERS }) })}
+      />,
+    )
+    expect(html).toContain(EDIT_HREF)
+  })
+
+  it.each<DuelStatus>(['pending', 'active'])(
+    'a duel side at %s reaches the waiting surface',
+    (status) => {
+      const { html } = render(
+        <PraxisOwnerActions
+          state={state({ praxis: praxis({ duel_id: 5 }), duel: duel(status) })}
+        />,
+      )
+      expect(html).toContain(EDIT_HREF)
+    },
+  )
+
+  it('a moderated praxis reaches its own locked composer', () => {
+    const { html } = render(
+      <PraxisOwnerActions
+        state={state({ praxis: praxis({ moderation_status: 'failed' }) })}
+      />,
+    )
+    expect(html).toContain(EDIT_HREF)
+  })
+})

--- a/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
@@ -457,11 +457,17 @@ describe("Singularity praxis detail — the state axes", () => {
   });
 
   it("shows owner controls to a member and nothing to a visitor", () => {
-    expect(render(state()).html, "a visitor gets no edit link").not.toContain(
-      'href="/praxis/1/edit"',
+    // #1397: the cluster is anchored on the UNSUBMIT control now. On a
+    // submitted solo `/edit` redirects straight back to this page, so the edit
+    // link is hidden and unsubmitting is the way into the composer.
+    expect(render(state()).text, "a visitor gets no owner controls").not.toContain(
+      "unsubmit",
     );
     const owner = state({ isOwner: true, user: VIEWER });
-    expect(render(owner).html).toContain('href="/praxis/1/edit"');
+    expect(render(owner).text).toContain("unsubmit");
+    expect(render(owner).html, "and nothing that round-trips").not.toContain(
+      'href="/praxis/1/edit"',
+    );
   });
 
   it("lists who voted and each voter's own rung, never an average", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -446,11 +446,17 @@ describe("S.N.I.D.E. praxis detail — the state axes", () => {
   });
 
   it("shows owner controls to a member and nothing to a visitor", () => {
-    expect(render(state()).html, "a visitor gets no edit link").not.toContain(
-      'href="/praxis/1/edit"',
+    // #1397: the cluster is anchored on the UNSUBMIT control now. On a
+    // submitted solo `/edit` redirects straight back to this page, so the edit
+    // link is hidden and unsubmitting is the way into the composer.
+    expect(render(state()).text, "a visitor gets no owner controls").not.toContain(
+      "unsubmit",
     );
     const owner = state({ isOwner: true, user: VIEWER });
-    expect(render(owner).html).toContain('href="/praxis/1/edit"');
+    expect(render(owner).text).toContain("unsubmit");
+    expect(render(owner).html, "and nothing that round-trips").not.toContain(
+      'href="/praxis/1/edit"',
+    );
   });
 
   it("lists who voted and each voter's own rung, never an average", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -488,12 +488,19 @@ describe("UA praxis detail — the state axes", () => {
   });
 
   it("renders as visitor, owner and steward", () => {
+    // #1397: the cluster is anchored on the UNSUBMIT control now. On a
+    // submitted solo `/edit` redirects straight back to this page, so the edit
+    // link is hidden and unsubmitting is the way into the composer.
     expect(render(state()).text, "a visitor gets no owner controls").not.toContain(
-      "edit this praxis",
+      "unsubmit",
     );
     expect(render(state({ isOwner: true, user: VIEWER })).text, "the owner does").toContain(
-      "edit this praxis",
+      "unsubmit",
     );
+    expect(
+      render(state({ isOwner: true, user: VIEWER })).text,
+      "and no link that would round-trip",
+    ).not.toContain("edit this praxis");
     expect(render(state({ showAdminBar: true })).text, "a steward gets the bar").toContain(
       "ADMIN",
     );

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -370,11 +370,17 @@ describe("Unaffiliated praxis detail — the state axes", () => {
   });
 
   it("shows owner controls to a member and nothing to a visitor", () => {
-    expect(render(state()).html, "a visitor gets no edit link").not.toContain(
-      'href="/praxis/1/edit"',
+    // #1397: the cluster is anchored on the UNSUBMIT control now. On a
+    // submitted solo `/edit` redirects straight back to this page, so the edit
+    // link is hidden and unsubmitting is the way into the composer.
+    expect(render(state()).text, "a visitor gets no owner controls").not.toContain(
+      "unsubmit",
     );
     const owner = state({ isOwner: true, user: VIEWER });
-    expect(render(owner).html).toContain('href="/praxis/1/edit"');
+    expect(render(owner).text).toContain("unsubmit");
+    expect(render(owner).html, "and nothing that round-trips").not.toContain(
+      'href="/praxis/1/edit"',
+    );
   });
 
   it("shows the steward bar only in admin mode", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
@@ -230,10 +230,30 @@ describe('unsubmitCase — the branch, straight off the backend', () => {
 })
 
 describe('unsubmit confirm copy (#1094)', () => {
-  it('solo: the shipped prompt is unchanged', () => {
+  it('solo: the prompt names both real costs of reopening (#1397)', () => {
+    // Unsubmit is the way to edit a published praxis now that the dead `/edit`
+    // link is gone, so the prompt owes the player the two things it costs that
+    // are NOT free — both read straight off the backend:
+    //  - visibility: `praxis_visibility_condition` (ADR-0024) shows an
+    //    `in_progress` praxis to its members only, and a solo has one member.
+    //  - the date: `_apply_seal` is the only writer of `submitted_at` and sets
+    //    it to `now` on EVERY seal, and the feed sorts on it — so a resubmitted
+    //    praxis reappears at the top with a new date.
+    // Everything else really is cheap (votes, comments, media and
+    // `all_time_score` all survive; no cooldown, no cap), so the copy must not
+    // invent a third warning.
     const rendered = text(<PraxisSubmitControls state={state({})} />)
-    expect(rendered).toMatch(/Sure\? Points & votes will pause\./)
+    expect(rendered, 'members-only while editing').toMatch(/Only you can see it/)
+    expect(rendered, 'the publish date is overwritten').toMatch(/new date/)
+    expect(rendered, 'and the original promise survives').toMatch(/points & votes pause/)
     expect(rendered).toMatch(/Yes, unsubmit/)
+  })
+
+  it('solo: the trigger reads as the way to edit (#1397)', () => {
+    const rendered = text(
+      <PraxisSubmitControls state={state({ showWithdrawConfirm: false })} />,
+    )
+    expect(rendered).toMatch(/unsubmit to edit/)
   })
 
   it('collab: the prompt says the whole group reopens, not just your part', () => {
@@ -243,8 +263,9 @@ describe('unsubmit confirm copy (#1094)', () => {
     expect(rendered).toMatch(/whole group/i)
     expect(rendered).toMatch(/every member's part is uncast/i)
     expect(rendered).toMatch(/Yes, reopen for everyone/i)
-    // The solo promise must not be the thing a co-author reads.
-    expect(rendered).not.toMatch(/Sure\? Points & votes will pause\./)
+    // The solo promise must not be the thing a co-author reads. Anchored on the
+    // SHIPPED solo string (#1397) — quoting the retired one would pass vacuously.
+    expect(rendered).not.toMatch(/Only you can see it/)
   })
 
   it('collab mid-consensus: only your part comes back, and no scoring promise', () => {
@@ -272,8 +293,8 @@ describe('unsubmit confirm copy (#1094)', () => {
       expect(rendered).toMatch(/Yes, pull my entry back/i)
       expect(rendered).not.toMatch(/forfeit/i)
       expect(rendered).not.toMatch(/wins by default/i)
-      // Nor the solo prompt it used to fall through to.
-      expect(rendered).not.toMatch(/Sure\? Points & votes will pause\./)
+      // Nor the solo prompt it used to fall through to (shipped string, #1397).
+      expect(rendered).not.toMatch(/Only you can see it/)
     },
   )
 

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -427,13 +427,20 @@ describe("WOW praxis detail — the state axes", () => {
   });
 
   it("renders as visitor, owner and steward", () => {
+    // #1397: the cluster is anchored on the UNSUBMIT control now. On a
+    // submitted solo `/edit` redirects straight back to this page, so the edit
+    // link is hidden and unsubmitting is the way into the composer.
     expect(render(state()).text, "a visitor gets no owner controls").not.toContain(
-      "edit this praxis",
+      "unsubmit",
     );
     expect(
       render(state({ isOwner: true, user: VIEWER })).text,
       "the owner does",
-    ).toContain("edit this praxis");
+    ).toContain("unsubmit");
+    expect(
+      render(state({ isOwner: true, user: VIEWER })).text,
+      "and no link that would round-trip",
+    ).not.toContain("edit this praxis");
     expect(
       render(state({ showAdminBar: true })).text,
       "a steward gets the bar",

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -36,6 +36,7 @@ import { TaskCrown } from '../../components/factionMarks/TaskCrown'
 import CommentThread from '../../components/comments/CommentThread'
 import DuelSealConfirm from '../../components/duel/DuelSealConfirm'
 import type { PraxisDetailState } from './usePraxisDetail'
+import { deriveEditPraxisPhase } from '../editPraxis/useEditPraxis'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
 import type { DuelDetailOut } from '../../api/duel'
 import { flagReasonOptions } from '../../utils/flagReasons'
@@ -310,8 +311,34 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
 
 export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
-  const { praxis, isOwner, withdrawError } = state
+  const { praxis, isOwner, duel, user, withdrawError } = state
   if (!praxis || !isOwner) return null
+
+  // THE EDIT LINK ONLY SHOWS WHEN `/edit` HAS SOMETHING TO DRAW (#1397).
+  //
+  // `EditPraxis` redirects straight back here whenever `deriveEditPraxisPhase`
+  // answers `handoff` (#1164), and `replace` means the redirect leaves no
+  // history trace — the page simply did not change. This page renders a
+  // PUBLISHED praxis only (ADR-0062), and `handoff` is exactly "published, with
+  // nobody to wait for": a solo, a one-member collab, a declined challenge. So
+  // the link was gated on `isOwner` alone and round-tripped every time it was
+  // visible.
+  //
+  // Asking the composer's own predicate rather than re-deriving the statuses is
+  // the point: the two can't drift, and the phases that still draw a real
+  // surface — the waiting surface for a live duel, the completed reading for a
+  // published collab, the locked composer for a moderated praxis — keep their
+  // link untouched.
+  //
+  // The way to EDIT a published praxis is the control beside it: unsubmit →
+  // confirm → `PraxisDetail` redirects the now-`in_progress` praxis into the
+  // composer. That journey already worked; it was just outshouted by a link
+  // that promised the same thing and did nothing. Deliberately NOT an
+  // auto-unsubmit on click — that would silently spend the two-step confirm
+  // #1094 wrote to keep this beat truthful, and on a settled duel side the same
+  // click would be a permanent forfeit.
+  const handsOff =
+    deriveEditPraxisPhase(praxis, duel, user?.character?.id) === 'handoff'
 
   // EVERY praxis keeps the cluster here, duel or not (#1090). #752 had moved it
   // into the duel RAIL — "the state and the control that changes it share a
@@ -327,9 +354,11 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
-        <Link to={`/praxis/${praxis.id}/edit`} className="font-body eyebrow hover:underline" style={{ color: 'var(--color-text-tertiary)' }}>
-          {t('detail.owner.edit')}
-        </Link>
+        {!handsOff && (
+          <Link to={`/praxis/${praxis.id}/edit`} className="font-body eyebrow hover:underline" style={{ color: 'var(--color-text-tertiary)' }}>
+            {t('detail.owner.edit')}
+          </Link>
+        )}
         <PraxisSubmitControls state={state} />
       </div>
       {withdrawError && <p className="font-body content-text mb-3" style={{ color: 'var(--color-danger)' }}>{withdrawError}</p>}

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -36,7 +36,9 @@ import { TaskCrown } from '../../components/factionMarks/TaskCrown'
 import CommentThread from '../../components/comments/CommentThread'
 import DuelSealConfirm from '../../components/duel/DuelSealConfirm'
 import type { PraxisDetailState } from './usePraxisDetail'
-import { deriveEditPraxisPhase } from '../editPraxis/useEditPraxis'
+// The LEAF module, not `useEditPraxis` — reaching for the hook's barrel would
+// drag the composer's api and upload plumbing onto every praxis-detail load.
+import { deriveEditPraxisPhase } from '../editPraxis/editPraxisPhase'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
 import type { DuelDetailOut } from '../../api/duel'
 import { flagReasonOptions } from '../../utils/flagReasons'

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -11,7 +11,7 @@
  *
  * We render to static markup (no DOM, no context) and assert on the structural
  * anchors each slot leaves behind: slot text and the stable hrefs
- * (`/tasks`, `/praxis/:id/edit`). Distinctive fixture values keep the substring
+ * (`/tasks`, `/praxis/:id`, `/praxis/:id/edit`). Distinctive fixture values keep the substring
  * checks from colliding with incidental markup. Submissions are left empty so
  * the test never has to mount the context-bound <PraxisCard> wrapper — the
  * praxis section is anchored instead by its always-present sort toggle, and
@@ -144,11 +144,14 @@ describe("task-detail content-slot invariant", () => {
       ).toBe(true);
     });
 
-    it(`${slug} renders the edit control for a submitted praxis`, () => {
+    it(`${slug} renders the my-submission control`, () => {
       const { html } = render(
         <Archetype state={baseState({ mySubmission: MY_PRAXIS })} />,
       );
-      expect(html, "edit-submission slot").toContain('href="/praxis/55/edit"');
+      // #1397: the slot points at the READ page. `mySubmission` is submitted by
+      // construction, and `/edit` bounces a submitted praxis straight back to
+      // `/praxis/:id` — the button used to change nothing at all.
+      expect(html, "my-submission slot").toContain('href="/praxis/55"');
     });
 
     it(`${slug} renders the continue control while in progress`, () => {

--- a/frontend/src/pages/taskDetail/__tests__/mySubmissionLink.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mySubmissionLink.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * "Your praxis" on task detail points at the READ page, not at `/edit` (#1397).
+ *
+ * The seam is the `mySubmission` block every task-detail skin draws. That row
+ * comes out of `listPraxes({ task_id, status: "submitted" })`, so it is submitted
+ * BY CONSTRUCTION — and `/praxis/:id/edit` `<Navigate replace>`s a submitted solo
+ * straight back to `/praxis/:id` (#1164). The button therefore round-tripped
+ * every time it was visible, with `replace` swallowing even the history trace.
+ *
+ * `PraxisCardOut` carries no `duel_id` and no `members`, so this surface cannot
+ * ask `deriveEditPraxisPhase` the way the praxis-detail owner cluster does. It
+ * does not need to: `/praxis/:id` is the right destination for every case, and
+ * it is where the control that actually reopens the praxis for editing lives.
+ *
+ * The DRAFT link beside it is untouched and asserted here as well — a draft is
+ * `in_progress`, `/edit` is exactly what it should open, and without this half
+ * the file could not tell "dropped the dead link" from "dropped editing".
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import "../../../i18n";
+import { surfaceMap } from "../../../factions";
+import DefaultTaskDetail from "../archetypes/DefaultTaskDetail";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut } from "../../../api/tasks";
+import type { PraxisCardOut } from "../../../api/praxis";
+
+const TASK: TaskOut = {
+  id: 207,
+  title: "A Very Human Thing",
+  description: "Make something small and honest.",
+  point_value: 18,
+  level_required: 2,
+  status: "active",
+  task_type: "standard",
+  created_by: 31,
+  primary_faction_slug: null,
+  metatask_faction_slug: null,
+  is_task_vision_eligible: false,
+  created_at: "2026-01-01T00:00:00Z",
+  in_progress_count: 6,
+  created_by_display_name: "Wren Abalone",
+  created_by_faction_slug: null,
+  created_by_level: 4,
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+/** The viewer's own row out of the submissions gallery — always `submitted`. */
+const MY_SUBMISSION = {
+  id: 91,
+  task_id: 207,
+  task_title: TASK.title,
+  task_point_value: 18,
+  task_level_required: 2,
+  type: "solo",
+  status: "submitted",
+  title: "Estuary",
+  moderation_status: "visible",
+  created_by_id: 42,
+  created_by_display_name: "Adabel",
+  created_at: "2026-01-02T00:00:00Z",
+  updated_at: "2026-01-03T00:00:00Z",
+  submitted_at: "2026-01-03T00:00:00Z",
+  member_count: 1,
+  score: 18,
+  voter_count: 0,
+  metatask_points: 0,
+  display_multiplier: 1.0,
+  points_from_votes: 0,
+  is_top_for_task: false,
+  task_faction_slug: null,
+} as PraxisCardOut;
+
+function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    comments: null,
+    submissions: [],
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: true,
+    levelJumpSignup: false,
+    slotsOpen: 2,
+    maxTaskSlots: 3,
+    basePoints: 18,
+    factionMultiplier: 1.0,
+    modifiedPoints: 18,
+    inProgressCount: 6,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+function render(element: ReactElement): string {
+  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>);
+}
+
+const archetypes = {
+  ...surfaceMap("taskDetail"),
+  __default__: DefaultTaskDetail,
+};
+
+describe("the submitted-praxis button reaches a page that exists (#1397)", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} sends the author to the praxis, not to a redirect`, () => {
+      const html = render(
+        <Archetype state={baseState({ mySubmission: MY_SUBMISSION, canSignUp: false })} />,
+      );
+      expect(html, "no link into the handoff").not.toContain('href="/praxis/91/edit"');
+      expect(html, "the read page, where reopening lives").toContain('href="/praxis/91"');
+    });
+
+    it(`${slug} still opens a DRAFT in the composer`, () => {
+      const html = render(
+        <Archetype
+          state={baseState({
+            isInProgress: true,
+            inProgressPraxisId: 91,
+            canSignUp: false,
+          })}
+        />,
+      );
+      expect(html, "a draft belongs in /edit").toContain('href="/praxis/91/edit"');
+    });
+  }
+});

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -481,8 +481,13 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
           >
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxis/${mySubmission.id}/edit`} style={goldButton}>
-            {t("detail.submitted.edit")}
+          {/* The READ page, not `/edit` (#1397). `mySubmission` comes out of
+              the submitted-only gallery fetch, and `/edit` redirects a
+              submitted praxis straight back to `/praxis/:id` (#1164) — so this
+              button used to change nothing at all. Reopening for editing lives
+              on the praxis page, one honest hop away. */}
+          <Link to={`/praxis/${mySubmission.id}`} style={goldButton}>
+            {t("detail.submitted.view")}
           </Link>
         </div>
       )}

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -322,8 +322,13 @@ export default function DefaultTaskDetail({
           >
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryButton}>
-            {t("detail.submitted.edit")}
+          {/* The READ page, not `/edit` (#1397). `mySubmission` comes out of
+              the submitted-only gallery fetch, and `/edit` redirects a
+              submitted praxis straight back to `/praxis/:id` (#1164) — so this
+              button used to change nothing at all. Reopening for editing lives
+              on the praxis page, one honest hop away. */}
+          <Link to={`/praxis/${mySubmission.id}`} style={primaryButton}>
+            {t("detail.submitted.view")}
           </Link>
         </div>
       )}

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -953,8 +953,13 @@ export default function EphemeristsTaskDetail({
           <div style={{ ...quietItalic, marginBottom: "var(--space-sm)" }}>
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryButton}>
-            {t("detail.submitted.edit")}
+          {/* The READ page, not `/edit` (#1397). `mySubmission` comes out of
+              the submitted-only gallery fetch, and `/edit` redirects a
+              submitted praxis straight back to `/praxis/:id` (#1164) — so this
+              button used to change nothing at all. Reopening for editing lives
+              on the praxis page, one honest hop away. */}
+          <Link to={`/praxis/${mySubmission.id}`} style={primaryButton}>
+            {t("detail.submitted.view")}
           </Link>
         </div>
       )}

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -692,8 +692,13 @@ export default function EverymenTaskDetail({
               {t("detail.submitted.text")}
             </span>
           </div>
-          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryBar}>
-            {t("detail.submitted.edit")}
+          {/* The READ page, not `/edit` (#1397). `mySubmission` comes out of
+              the submitted-only gallery fetch, and `/edit` redirects a
+              submitted praxis straight back to `/praxis/:id` (#1164) — so this
+              button used to change nothing at all. Reopening for editing lives
+              on the praxis page, one honest hop away. */}
+          <Link to={`/praxis/${mySubmission.id}`} style={primaryBar}>
+            {t("detail.submitted.view")}
           </Link>
         </div>
       )}

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -621,9 +621,14 @@ export default function SingularityTaskDetail({
           >
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryButton}>
+          {/* The READ page, not `/edit` (#1397). `mySubmission` comes out of
+              the submitted-only gallery fetch, and `/edit` redirects a
+              submitted praxis straight back to `/praxis/:id` (#1164) — so this
+              button used to change nothing at all. Reopening for editing lives
+              on the praxis page, one honest hop away. */}
+          <Link to={`/praxis/${mySubmission.id}`} style={primaryButton}>
             {prompt}
-            {t("detail.submitted.edit")}
+            {t("detail.submitted.view")}
           </Link>
         </div>
       )}

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -469,9 +469,14 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
           >
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxis/${mySubmission.id}/edit`} style={plateButton(true)}>
+          {/* The READ page, not `/edit` (#1397). `mySubmission` comes out of
+              the submitted-only gallery fetch, and `/edit` redirects a
+              submitted praxis straight back to `/praxis/:id` (#1164) — so this
+              button used to change nothing at all. Reopening for editing lives
+              on the praxis page, one honest hop away. */}
+          <Link to={`/praxis/${mySubmission.id}`} style={plateButton(true)}>
             <XMark size={17} />
-            <span style={plateLabel}>{t("detail.submitted.edit")}</span>
+            <span style={plateLabel}>{t("detail.submitted.view")}</span>
             <XMark size={17} />
           </Link>
         </div>

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -347,8 +347,13 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
           <div style={{ ...aside, marginBottom: "var(--space-sm)" }}>
             {t("detail.submitted.text")}
           </div>
-          <Link to={`/praxis/${mySubmission.id}/edit`} style={primaryAction}>
-            {t("detail.submitted.edit")}
+          {/* The READ page, not `/edit` (#1397). `mySubmission` comes out of
+              the submitted-only gallery fetch, and `/edit` redirects a
+              submitted praxis straight back to `/praxis/:id` (#1164) — so this
+              button used to change nothing at all. Reopening for editing lives
+              on the praxis page, one honest hop away. */}
+          <Link to={`/praxis/${mySubmission.id}`} style={primaryAction}>
+            {t("detail.submitted.view")}
           </Link>
         </div>
       )}

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -463,9 +463,14 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
       {mySubmission && (
         <div>
           <div style={plateHeading}>{t("detail.submitted.text")}</div>
-          <Link to={`/praxis/${mySubmission.id}/edit`} style={ctaStyle(true)}>
+          {/* The READ page, not `/edit` (#1397). `mySubmission` comes out of
+              the submitted-only gallery fetch, and `/edit` redirects a
+              submitted praxis straight back to `/praxis/:id` (#1164) — so this
+              button used to change nothing at all. Reopening for editing lives
+              on the praxis page, one honest hop away. */}
+          <Link to={`/praxis/${mySubmission.id}`} style={ctaStyle(true)}>
             <Star size={13} color={GOLD} />
-            {t("detail.submitted.edit")}
+            {t("detail.submitted.view")}
           </Link>
         </div>
       )}


### PR DESCRIPTION
Closes #1397

## The seam

`PraxisOwnerActions` (`praxisDetail/shared.tsx`) and the `mySubmission` block in the eight `*TaskDetail.tsx` archetypes. The question both are tested on is one question: **given this state, is there an `href` into `/praxis/:id/edit` that would bounce straight back?**

The failing test came first and went red on the real defect — three handoff cases on praxis detail (submitted solo, one-member collab, declined challenge) and nine archetypes on task detail — while the non-handoff cases stayed green, so the loop could tell "removed the dead link" from "removed editing".

## What was wrong

Confirmed the issue's diagnosis against the code, line by line. The redirect is deliberate (#1164); the links were never updated. `EditPraxis` `<Navigate replace>`s to `/praxis/:id` when `deriveEditPraxisPhase` answers `handoff`, and `replace` leaves no history trace, so the page simply does not change.

## The fix

**Praxis detail — hide the link when `/edit` would hand off.** The owner cluster now asks the composer's own predicate rather than re-deriving statuses, so the two cannot drift. Every phase that still draws a real surface keeps its link, asserted case by case:

| state (always `submitted` here — ADR-0062) | phase | link |
|---|---|---|
| solo / one-member collab | `handoff` | **hidden** |
| declined challenge | `handoff` | **hidden** |
| published collab | `completed` | kept |
| duel side, duel `pending`/`active` | `waiting` | kept |
| moderated hidden/failed | `composing` | kept |

Not an auto-unsubmit on click — that would spend the two-step confirm #1094 wrote to keep this beat truthful, and on a settled duel side the same click is a permanent forfeit.

**Task detail — the button reaches a page that exists.** `mySubmission` comes out of `listPraxes({ task_id, status: "submitted" })`, so it is submitted by construction, and `PraxisCardOut` carries no `duel_id` and no `members` — this surface *cannot* ask for the phase. It does not need to: `/praxis/:id` is right for every case, and it is where reopening lives. `detail.submitted.edit` → `detail.submitted.view` ("Read your praxis"). The sibling **"Continue editing"** draft link is untouched and asserted in the same loop.

**The surviving control carries the intent.** `unsubmit` → `unsubmit to edit`, and the solo/collab prompts now name the two costs that are *not* free. Both were verified in the backend, not taken on trust:

- **members-only while editing** — `praxis_visibility_condition` (ADR-0024) shows an `in_progress` praxis to its members only.
- **the publish date is overwritten** — `_apply_seal` is the only writer of `submitted_at` and sets it to `now` on *every* seal (`collab_consensus.py`), and the feed sorts on it, so a resubmitted praxis reappears at the top with a new date.

Everything else really is cheap (votes, comments, media and `all_time_score` all survive; no cooldown, no cap), so the copy invents no third warning. The duel-live variant ("pull my entry back") and the settled-duel forfeit modal are untouched, as ruled.

## Two pure moves, for a measured reason

Importing `deriveEditPraxisPhase` from `useEditPraxis` dragged the composer's whole api/upload graph onto the praxis-detail route. Measured, not guessed:

| variant | praxis-detail route, gzip | chunks |
|---|---|---|
| baseline | 210.7 KB | 25 |
| naive import from `useEditPraxis` | 216.2 KB | 29 |
| **shipped** | **210.9 KB** | **24** |

So `deriveEditPraxisPhase` moved to `editPraxis/editPraxisPhase.ts`, and `deriveCollabGate` — pure, but living in a component module and billing every caller for `ConfirmDialog` + the eight-faction confirm copy — moved to `components/collab/collabGate.ts`. Both old modules re-export all the names, so **no existing importer changed**. Verbatim moves, no behaviour change.

## Test-file edits, and why none of them went vacuous

- Eight archetype tests used the edit link as the marker for "owner controls are mounted". Re-anchored on the **unsubmit** control, which is what actually distinguishes owner from visitor now, plus a positive assertion that nothing round-trips.
- `archetypeSlots.test.tsx`'s submission slot now anchors on `/praxis/55`.
- `unsubmitConfirmCopy.test.tsx` had two **negative** assertions quoting the old solo prompt byte-for-byte. Changing the prompt would have left them passing vacuously, so they were repointed at the shipped string. The solo case now asserts both costs are named *and* that the original points-and-votes promise survives.

## i18n

`tasks.json` `detail.submitted.edit` is retired. Grepped by full key, by last path segment, and by its rendered string `"Edit praxis"` across `frontend/src`, `frontend/e2e` and `docs` — no reader anywhere, including tests. `praxis.json` `detail.owner.edit` **stays**: the link still renders on the four non-handoff phases.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` 3306/3306 · `vite build` clean · `npm run budget` within budget (JS 130.9 KB, CSS 22.2 KB) · e2e untouched (its `/edit` references are draft-sidebar links and direct `page.goto`s, not these affordances).

**No visual QA** — I have no browser or dev stack. The list below is what a human should look at.

## What to eyeball

1. **Own a submitted solo praxis, open `/praxis/:id`.** The owner row should read only `unsubmit to edit` — no `edit this praxis` beside it. Click it: the confirm should name members-only, points-and-votes pausing, and the new date. Confirm, and you should land in the composer.
2. **The confirm prompt's length.** It roughly doubled and renders as an `.eyebrow` in a wrapping flex row. It fits the existing collab prompt's footprint, but nobody has *seen* it — if it wraps badly that is a `frontend-style` question, not a behaviour one.
3. **Own a submitted praxis in a live duel** — `edit this praxis` should still be there and should open the waiting surface. Same for a **published collab** (completed reading) and a **failed/hidden** praxis (locked composer).
4. **A task you have filed praxis for.** The panel button should read `Read your praxis` and land on the praxis page. Check all eight skins — the button keeps each faction's own dress (gold plate, ransom plate, poster bar…), only the label and target changed.
5. **A task you have a draft on.** `Continue editing` must still go to `/praxis/:id/edit`.

## Flagged for the orchestrator

Two files outside my brief's stated footprint, both pure moves needed by the measurement above: `components/collab/CollabRoster.tsx` and `pages/editPraxis/useEditPraxis.ts`. Neither is the sibling agent's `praxisDetail/archetypes/*` — but if another branch in this batch touches them, this is where it will conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
