### PR TITLE
An era reset stops undoing itself: the score recalc is bounded to one era

### DIFF
--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -1,10 +1,11 @@
 """Service for recomputing and persisting CharacterStats from current vote data."""
 
-from sqlalchemy import select
+from sqlalchemy import ColumnElement, and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
+from models.character_stats import CharacterStats
 from models.era import Era
 from models.invitation_letter import InvitationLetter
 from models.praxis import (
@@ -15,7 +16,7 @@ from models.praxis import (
     PraxisType,
 )
 from models.task import Task
-from services.era import get_current_era_row, get_or_create_stats
+from services.era import get_current_era_row, get_next_era_row, get_or_create_stats
 from services.praxis_scoring import Contribution, compute_contributions
 from services.scoring import compute_level
 
@@ -31,6 +32,72 @@ _NON_INVITE_FACTION_SLUGS: frozenset[str] = frozenset({"na", "albescent"})
 _UNSCORED_MODERATION_STATUSES: frozenset[ModerationStatus] = frozenset(
     {ModerationStatus.hidden, ModerationStatus.failed}
 )
+
+
+def _era_window_condition(
+    era_row: Era, next_era_row: Era | None
+) -> ColumnElement[bool]:
+    """The seal-time bound that puts a praxis inside ``era_row``'s era (#1345).
+
+    ``CharacterStats`` is one row per (character, era), so a gather that summed
+    every praxis ever filed was crediting one era's row with another era's work
+    — which is how an era reset silently undid itself on the next recalc.
+
+    ``Praxis`` carries no ``era_id``, so era membership is a **seal-time** fact:
+    ``[era.started_at, next_era.started_at)``, the same bound
+    :class:`services.praxis.PraxisEraScope` reads (#1362). Both gathers below
+    compose this with ``_UNSCORED_MODERATION_STATUSES`` so they cannot drift.
+
+    A NULL ``submitted_at`` counts for the **live** era only.
+    ``services.collab_consensus._apply_seal`` establishes
+    ``status == submitted ⟹ submitted_at IS NOT NULL``, so no honest row lands
+    in that branch; it exists so corrupt data cannot silently zero a score, and
+    confining it to the open era stops one such row scoring once per era that
+    ever ran.
+
+    ponytail: seal time is the bound because there is no column to read. #1398
+    adds ``praxis.era_id`` stamped at submit — when it lands, this collapses to
+    ``Praxis.era_id == era_row.id`` and both callers below simplify with it.
+    """
+    if next_era_row is None:
+        return or_(
+            Praxis.submitted_at.is_(None),
+            Praxis.submitted_at >= era_row.started_at,
+        )
+    return and_(
+        Praxis.submitted_at >= era_row.started_at,
+        Praxis.submitted_at < next_era_row.started_at,
+    )
+
+
+async def _credit_all_time_score(
+    character_id: int, from_era_id: int, delta: int, session: AsyncSession
+) -> None:
+    """Move ``all_time_score`` by ``delta`` on ``from_era_id``'s row and every later one.
+
+    ``all_time_score`` is LIFETIME CUMULATIVE — a sum across eras, so era 1's 500
+    plus era 2's 30 is 530 (#1345). Before the gather was era-bounded this fell
+    out of ``max(all_time_score, total_score)`` by accident, because
+    ``total_score`` *was* the lifetime sum; bounding the gather turns that same
+    line into "your best single era".
+
+    It is applied as a delta rather than re-derived as ``SUM(score)`` because
+    ``EraConfig.reset_all_time_score`` lets an era declare a fresh lifetime, and
+    that zero baseline lives in the row ``services.era.apply_era_reset`` wrote —
+    a re-derivation would undo it exactly the way the unbounded gather undid a
+    score reset. Crediting *forward* is what lets a vote on a closed era's
+    praxis raise the author's lifetime figure without moving the ladder they are
+    climbing today. In an ordinary live-era recalc there are no later rows, so
+    this touches only the row the caller already holds.
+    """
+    result = await session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character_id,
+            CharacterStats.era_id >= from_era_id,
+        )
+    )
+    for stats in result.scalars():
+        stats.all_time_score += delta
 
 
 async def _deliver_earned_invitations(
@@ -110,11 +177,26 @@ async def recalculate_character_stats(
 ) -> None:
     """Recompute and persist score, level, and vote budget for a character.
 
-    Gathers all submitted praxes the character has a stake in — solo/duel praxes
-    they authored, plus collab praxes they are a member of — then delegates all
-    scoring arithmetic to ``compute_contributions`` (ADR-0014). Praxes in an
+    Gathers the submitted praxes the character has a stake in **that belong to
+    ``era_row``'s era** — solo/duel praxes they authored, plus collab praxes they
+    are a member of — then delegates all scoring arithmetic to
+    ``compute_contributions`` (ADR-0014). Praxes in an
     ``_UNSCORED_MODERATION_STATUSES`` state are left out of the gather entirely,
     so they also stop counting toward faction invitations (ADR-0022).
+
+    The era bound is the fix for #1345: the row being written is one era's
+    (ADR-0042/ADR-0044), so summing every praxis ever filed made an era reset
+    undo itself the next time anything triggered a recalc. See
+    ``_era_window_condition`` for why it is a seal-time bound.
+
+    ``era_row`` may be a **past** era — the vote path passes the era a praxis was
+    sealed in, so a vote on closed-era work credits that era's row. In that case
+    no faction invitation is delivered: the letters carry an ``era_id`` and an
+    invite is a thing you receive in the era you are playing, not one recomputing
+    history hands you now.
+
+    ``score`` and ``level`` are per-era; ``all_time_score`` stays lifetime — see
+    ``_credit_all_time_score``.
 
     Safe to call on praxis creation (0 votes → base points only) or after any
     vote change.
@@ -134,6 +216,10 @@ async def recalculate_character_stats(
     stats = await get_or_create_stats(session, character_id, era_row.id)
     author_level = stats.level
 
+    # None ⟹ era_row is the live era: no upper bound, and invitations may land.
+    next_era_row = await get_next_era_row(era_row, session)
+    within_era = _era_window_condition(era_row, next_era_row)
+
     # Gather solo praxes (including duel sides) authored by this character.
     solo_result = await session.execute(
         select(Praxis).where(
@@ -141,6 +227,7 @@ async def recalculate_character_stats(
             Praxis.type == PraxisType.solo,
             Praxis.status == PraxisStatus.submitted,
             Praxis.moderation_status.notin_(list(_UNSCORED_MODERATION_STATUSES)),
+            within_era,
         )
     )
     solo_praxes = list(solo_result.scalars().all())
@@ -154,6 +241,7 @@ async def recalculate_character_stats(
             Praxis.type == PraxisType.collab,
             Praxis.status == PraxisStatus.submitted,
             Praxis.moderation_status.notin_(list(_UNSCORED_MODERATION_STATUSES)),
+            within_era,
         )
     )
     collab_praxes = list(collab_result.scalars().all())
@@ -168,9 +256,15 @@ async def recalculate_character_stats(
 
     # Vote budget is computed on read (services.scoring.compute_votes_available)
     # from stats.score and stats.votes_spent_this_era, so no bookkeeping needed here.
+    score_delta = total_score - stats.score
     stats.score = total_score
-    stats.all_time_score = max(stats.all_time_score, total_score)
     stats.level = compute_level(total_score, era)
+    if score_delta:
+        await _credit_all_time_score(character_id, era_row.id, score_delta, session)
+
+    if next_era_row is not None:
+        # Recomputing a closed era. ADR-0022 invitations are current-era mail.
+        return
 
     # ADR-0022: deliver any faction invitations this submitted-praxis set now earns.
     await _deliver_earned_invitations(

--- a/backend/services/collab_consensus.py
+++ b/backend/services/collab_consensus.py
@@ -25,7 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from game_config import CURRENT_ERA, EraConfig
 from models.praxis import Praxis, PraxisInviteStatus, PraxisStatus, PraxisType
 from services.character_stats import recalculate_character_stats
-from services.era import get_current_era_row
+from services.era import get_era_row_for_praxis
 
 
 def _apply_seal(praxis: Praxis) -> None:
@@ -58,7 +58,7 @@ async def seal_to_live(praxis: Praxis, session: AsyncSession, era: EraConfig) ->
     """
     _apply_seal(praxis)
     await session.flush()
-    era_row = await get_current_era_row(session)
+    era_row = await get_era_row_for_praxis(praxis, session)
     for member in praxis.members:
         await recalculate_character_stats(member.character_id, session, era, era_row=era_row)
     await session.flush()
@@ -110,7 +110,7 @@ async def on_member_edit(
     await session.flush()
     if was_live:
         # Leaving Live changes scoring — recompute every member's stats.
-        era_row = await get_current_era_row(session)
+        era_row = await get_era_row_for_praxis(praxis, session)
         for member in praxis.members:
             await recalculate_character_stats(member.character_id, session, era, era_row=era_row)
         await session.flush()
@@ -232,7 +232,7 @@ async def on_member_leave(
             # Unlike the takeover path, this fires on scored praxes: the
             # collab_own/other_modifier pair gives way to own/other_task_modifier
             # under an already-published praxis, so the survivor is repriced.
-            era_row = await get_current_era_row(session)
+            era_row = await get_era_row_for_praxis(praxis, session)
             await recalculate_character_stats(
                 survivor_character_id, session, era, era_row=era_row
             )

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -109,6 +109,48 @@ async def get_closing_era_id(new_era_row: Era, session: AsyncSession) -> int | N
     return result.scalar_one_or_none()
 
 
+async def get_next_era_row(era_row: Era, session: AsyncSession) -> Era | None:
+    """The era that succeeded ``era_row``, or None when ``era_row`` is the live one.
+
+    Mirror of :func:`get_closing_era_id`, and the upper half of an era's window.
+    ``Era`` rows are only ever appended, one per reset, so "the next era" is the
+    next id. Together with ``era_row.started_at`` this bounds an era to
+    ``[started_at, next.started_at)`` — the seal-time window
+    :func:`services.character_stats.recalculate_character_stats` scores against
+    (#1345). ``None`` doubles as "this era is still open", which is why the same
+    call also answers *may this recalc deliver invitations?*
+    """
+    result = await session.execute(
+        select(Era).where(Era.id > era_row.id).order_by(Era.id).limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_era_row_for_praxis(praxis: Praxis, session: AsyncSession) -> Era:
+    """The era a praxis belongs to — the latest era that started at or before its seal.
+
+    ``Praxis`` carries no ``era_id``; era membership is a **seal-time** fact, the
+    same bound :class:`services.praxis.PraxisEraScope` reads (#1362). An unsealed
+    praxis (``submitted_at IS NULL``) is in-flight work and belongs to the era in
+    progress, so it resolves to the current era — as does any praxis somehow
+    sealed before the first ``Era`` row existed.
+
+    Used by the vote path: a vote on a closed era's praxis credits *that* era's
+    stats row, not the ladder the author is climbing today (#1345).
+    """
+    if praxis.submitted_at is not None:
+        result = await session.execute(
+            select(Era)
+            .where(Era.started_at <= praxis.submitted_at)
+            .order_by(Era.id.desc())
+            .limit(1)
+        )
+        era_row = result.scalar_one_or_none()
+        if era_row is not None:
+            return era_row
+    return await get_current_era_row(session)
+
+
 async def resolve_duels_at_era_close(
     session: AsyncSession,
     resolved_at: datetime | None = None,

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -53,6 +53,7 @@ from services.meta_task import metatask_cap_for_level
 from services.era import (
     get_current_era_row,
     get_current_era_row_safe,
+    get_era_row_for_praxis,
     get_or_create_stats,
 )
 from services.nudge import nudged_at_map
@@ -156,9 +157,14 @@ async def recalculate_members_stats(
     that already hold an ``era_row`` (e.g. a duel-forfeit recalc that reuses it)
     pass it in to avoid a re-fetch. ``leave_praxis`` deliberately does NOT use
     this — it recalcs only the single leaver, not all members.
+
+    The era defaulted to is **the praxis's**, not the live one (#1345): scores
+    are per-era, so a change to a closed era's praxis — a moderation ruling, a
+    metatask, an unsubmit — has to move that era's row or it moves nothing at
+    all. For a praxis sealed in the era in progress the two are the same row.
     """
     if era_row is None:
-        era_row = await get_current_era_row(session)
+        era_row = await get_era_row_for_praxis(praxis, session)
     for member in praxis.members:
         await recalculate_character_stats(
             member.character_id, session, era, era_row=era_row
@@ -1409,7 +1415,10 @@ async def unsubmit_praxis(
     # Recalc *every* member: on a collab, co-authors' scores also counted this
     # praxis while it was submitted, so all of them must drop (the submit paths
     # already recalc all members — this fixes the prior single-actor under-recalc).
-    era_row = await get_current_era_row(session)
+    # The era is the one the praxis was sealed in — the seal time survives the
+    # status flip above, and it is that era's row the points came out of (#1345).
+    # The forfeit winner's duel side is the same praxis's era by construction.
+    era_row = await get_era_row_for_praxis(praxis, session)
     await recalculate_members_stats(praxis, session, era, era_row=era_row)
     if forfeit_winner_character_id is not None:
         await recalculate_character_stats(
@@ -2059,8 +2068,11 @@ async def leave_praxis(
     # A departure can complete the consensus among those who stayed.
     await collab_consensus.on_member_leave(praxis, session, era)
 
-    # The leaver's stake is gone — recompute their stats regardless.
-    await recalculate_character_stats(character_id, session, era)
+    # The leaver's stake is gone — recompute their stats regardless, against the
+    # era the praxis belongs to, since that is the row their stake was in (#1345).
+    await recalculate_character_stats(
+        character_id, session, era, era_row=await get_era_row_for_praxis(praxis, session)
+    )
     await session.flush()
     return await get_praxis(praxis_id, session)
 

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -10,7 +10,11 @@ from models.duel import Duel, DuelStatus
 from models.praxis import ModerationStatus, Praxis, PraxisMember
 from models.vote import Vote
 from services.character_stats import recalculate_character_stats
-from services.era import get_current_era_row, get_or_create_stats
+from services.era import (
+    get_current_era_row,
+    get_era_row_for_praxis,
+    get_or_create_stats,
+)
 from services.scoring import compute_votes_available
 
 
@@ -51,6 +55,12 @@ async def cast_or_update_vote(
     ``CharacterStats`` row per (character, era). An account with several
     characters deliberately carries several budgets; it just cannot spend them
     twice on one praxis.
+
+    There is deliberately **no era gate**: a closed era's praxis stays votable
+    (#1345). The vote spends *this* era's budget, but it is credited to the era
+    the praxis was sealed in — so it makes the historical record and the
+    author's lifetime ``all_time_score`` more accurate without moving the ladder
+    anyone is climbing today.
     """
     if not 1 <= value <= 5:
         raise HTTPException(status_code=422, detail="Vote value must be between 1 and 5.")
@@ -90,12 +100,19 @@ async def cast_or_update_vote(
         existing.voter_character_id = voter.id
         existing.value = value
         await session.flush()
-        await recalculate_character_stats(praxis.created_by_id, session, era)
+        await recalculate_character_stats(
+            praxis.created_by_id,
+            session,
+            era,
+            era_row=await get_era_row_for_praxis(praxis, session),
+        )
         await session.flush()
         await session.refresh(existing)
         return existing
 
-    # New vote — deduct from budget via CharacterStats (on-read recomputation)
+    # New vote — deduct from budget via CharacterStats (on-read recomputation).
+    # The budget is always the *voter's current* era, whatever era the praxis is
+    # from: voting on old work still costs a vote today (#1345).
     era_row = await get_current_era_row(session)
     stats = await get_or_create_stats(session, voter.id, era_row.id)
 
@@ -111,7 +128,12 @@ async def cast_or_update_vote(
     stats.votes_spent_this_era += 1
     session.add(vote)
     await session.flush()
-    await recalculate_character_stats(praxis.created_by_id, session, era, era_row=era_row)
+    await recalculate_character_stats(
+        praxis.created_by_id,
+        session,
+        era,
+        era_row=await get_era_row_for_praxis(praxis, session),
+    )
     await session.flush()
     await session.refresh(vote)
     return vote

--- a/backend/tests/integration/test_era_scoped_recalc.py
+++ b/backend/tests/integration/test_era_scoped_recalc.py
@@ -34,6 +34,7 @@ from models.praxis import (
 )
 from models.task import Task, TaskStatus
 from services.character_stats import recalculate_character_stats
+from services.era import apply_era_reset
 from services.praxis import moderate_praxis
 from services.vote import cast_vote_on_praxis
 
@@ -220,6 +221,48 @@ async def test_era_reset_does_not_undo_itself_on_the_next_recalc(
 
     assert (await _stats(db_session, character, current_era)).score == 0
     assert (await _stats(db_session, character, current_era)).level == 0
+
+
+@pytest.mark.asyncio
+async def test_a_real_era_reset_survives_the_backfill_recalc(
+    db_session: AsyncSession,
+    character: Character,
+    account,
+    prior_era: Era,
+    faction_ua: Faction,
+):
+    """The reported flow end to end: score, reset through
+    :func:`services.era.apply_era_reset`, then run the recalc the admin
+    backfill runs. The new era starts at zero and lifetime keeps the history."""
+    await _sealed_praxis(
+        db_session,
+        character,
+        title="Last era's work",
+        points=PRIOR_ERA_POINTS,
+        sealed_at=prior_era.started_at + timedelta(days=1),
+    )
+    await recalculate_character_stats(character.id, db_session, era_row=prior_era)
+    await db_session.commit()
+    banked = (await _stats(db_session, character, prior_era)).score
+    assert banked == round(PRIOR_ERA_POINTS * UA_OWN_TASK_MODIFIER)
+
+    new_era = Era(
+        name=CURRENT_ERA.name,
+        config_key=CURRENT_ERA.config_key,
+        started_by=account.id,
+    )
+    db_session.add(new_era)
+    await db_session.flush()
+    await apply_era_reset([character], new_era, db_session)
+    await db_session.commit()
+
+    await recalculate_character_stats(character.id, db_session)
+    await db_session.commit()
+
+    new_stats = await _stats(db_session, character, new_era)
+    assert new_stats.score == 0
+    assert new_stats.level == 0
+    assert new_stats.all_time_score == banked
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_era_scoped_recalc.py
+++ b/backend/tests/integration/test_era_scoped_recalc.py
@@ -1,0 +1,352 @@
+"""Era-bounded score recalculation (#1345).
+
+Seam under test: the praxis gather inside
+:func:`services.character_stats.recalculate_character_stats`. It must sum only
+the praxes sealed inside the window of the era whose ``CharacterStats`` row it
+is writing — ``[era.started_at, next_era.started_at)`` — instead of every
+praxis ever filed, which is what let an era reset silently undo itself on the
+next recalc.
+
+Two companion seams ride along, both settled by the owner rulings on #1345:
+:func:`services.vote.cast_or_update_vote` credits *the praxis's* era rather
+than the live one, and ``all_time_score`` is the lifetime cumulative sum across
+eras (era 1's 500 plus era 2's 30 is 530) rather than a best-single-era figure.
+"""
+from datetime import timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from models.invitation_letter import InvitationLetter
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from services.character_stats import recalculate_character_stats
+from services.vote import cast_vote_on_praxis
+
+# Read the modifier from the era config rather than hardcoding it (ADR-0042).
+UA_OWN_TASK_MODIFIER: float = CURRENT_ERA.factions["ua"].own_task_modifier
+
+# Deliberately different per-era totals: if the prior era's work were worth the
+# same as this era's, a broken era bound would still produce the right number.
+PRIOR_ERA_POINTS: int = 100
+CURRENT_ERA_POINTS: int = 10
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — two Era rows, so there is a closed era and a live one
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def prior_era(db_session: AsyncSession, era: Era) -> Era:
+    """The conftest ``era`` row, backdated so a later era can succeed it."""
+    era.started_at = era.started_at - timedelta(days=60)
+    await db_session.commit()
+    await db_session.refresh(era)
+    return era
+
+
+@pytest_asyncio.fixture
+async def current_era(db_session: AsyncSession, prior_era: Era, account) -> Era:
+    """The live Era row — ``get_current_era_row`` takes the highest id."""
+    row = Era(
+        name=CURRENT_ERA.name,
+        config_key=CURRENT_ERA.config_key,
+        started_by=account.id,
+        started_at=prior_era.started_at + timedelta(days=30),
+    )
+    db_session.add(row)
+    await db_session.commit()
+    await db_session.refresh(row)
+    return row
+
+
+@pytest_asyncio.fixture
+async def faction_wow(db_session: AsyncSession) -> Faction:
+    """A faction the test characters are *not* in, so invites can be earned."""
+    result = await db_session.execute(select(Faction).where(Faction.slug == "wow"))
+    if result.scalar_one_or_none() is None:
+        db_session.add(Faction(slug="wow", status=FactionStatus.visible))
+        await db_session.commit()
+    result = await db_session.execute(select(Faction).where(Faction.slug == "wow"))
+    return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _sealed_praxis(
+    db_session: AsyncSession,
+    character: Character,
+    *,
+    title: str,
+    points: int,
+    sealed_at,
+    faction_slug: str = "ua",
+    task: Task | None = None,
+) -> Praxis:
+    """A submitted solo praxis with its seal time pinned, on its own task."""
+    if task is None:
+        task = Task(
+            title=f"Task for {title}",
+            description="",
+            point_value=points,
+            level_required=0,
+            status=TaskStatus.active,
+            created_by=character.id,
+            primary_faction_slug=faction_slug,
+        )
+        db_session.add(task)
+        await db_session.flush()
+
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.submitted,
+        title=title,
+        body_text="proof",
+        submitted_at=sealed_at,
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=praxis.id, character_id=character.id))
+    await db_session.commit()
+    await db_session.refresh(praxis)
+    return praxis
+
+
+async def _stats(
+    db_session: AsyncSession, character: Character, era_row: Era
+) -> CharacterStats:
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era_row.id,
+        )
+    )
+    return result.scalar_one()
+
+
+async def _seed_both_eras(
+    db_session: AsyncSession, character: Character, prior_era: Era, current_era: Era
+) -> Praxis:
+    """One scoring praxis in the closed era, one in the live era. Returns the old one."""
+    old = await _sealed_praxis(
+        db_session,
+        character,
+        title="Last era's work",
+        points=PRIOR_ERA_POINTS,
+        sealed_at=prior_era.started_at + timedelta(days=1),
+    )
+    await _sealed_praxis(
+        db_session,
+        character,
+        title="This era's work",
+        points=CURRENT_ERA_POINTS,
+        sealed_at=current_era.started_at + timedelta(minutes=1),
+    )
+    return old
+
+
+# ---------------------------------------------------------------------------
+# 1. The era bound itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recalc_sums_only_the_era_whose_row_it_writes(
+    db_session: AsyncSession,
+    character: Character,
+    prior_era: Era,
+    current_era: Era,
+    faction_ua: Faction,
+):
+    """The live-era recalc ignores a prior era's praxis (lower bound), and a
+    prior-era recalc ignores this era's (upper bound)."""
+    await _seed_both_eras(db_session, character, prior_era, current_era)
+
+    await recalculate_character_stats(character.id, db_session)
+    await db_session.commit()
+
+    current_stats = await _stats(db_session, character, current_era)
+    assert current_stats.score == round(CURRENT_ERA_POINTS * UA_OWN_TASK_MODIFIER)
+
+    await recalculate_character_stats(character.id, db_session, era_row=prior_era)
+    await db_session.commit()
+
+    prior_stats = await _stats(db_session, character, prior_era)
+    assert prior_stats.score == round(PRIOR_ERA_POINTS * UA_OWN_TASK_MODIFIER)
+    current_stats = await _stats(db_session, character, current_era)
+    assert current_stats.score == round(CURRENT_ERA_POINTS * UA_OWN_TASK_MODIFIER)
+
+
+@pytest.mark.asyncio
+async def test_era_reset_does_not_undo_itself_on_the_next_recalc(
+    db_session: AsyncSession,
+    character: Character,
+    prior_era: Era,
+    current_era: Era,
+    faction_ua: Faction,
+):
+    """The reported symptom: a fresh era's zeroed row stays zero until this era
+    earns something, no matter how much the character banked last era."""
+    await _sealed_praxis(
+        db_session,
+        character,
+        title="Last era's work",
+        points=PRIOR_ERA_POINTS,
+        sealed_at=prior_era.started_at + timedelta(days=1),
+    )
+
+    await recalculate_character_stats(character.id, db_session)
+    await db_session.commit()
+
+    assert (await _stats(db_session, character, current_era)).score == 0
+    assert (await _stats(db_session, character, current_era)).level == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. all_time_score stays lifetime-scoped
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_all_time_score_is_the_lifetime_sum_across_eras(
+    db_session: AsyncSession,
+    character: Character,
+    prior_era: Era,
+    current_era: Era,
+    faction_ua: Faction,
+):
+    """Bounding the gather must not delete history: all-time is both eras' scores."""
+    await _seed_both_eras(db_session, character, prior_era, current_era)
+
+    await recalculate_character_stats(character.id, db_session)
+    await recalculate_character_stats(character.id, db_session, era_row=prior_era)
+    await db_session.commit()
+
+    current_stats = await _stats(db_session, character, current_era)
+    expected = round(PRIOR_ERA_POINTS * UA_OWN_TASK_MODIFIER) + round(
+        CURRENT_ERA_POINTS * UA_OWN_TASK_MODIFIER
+    )
+    assert current_stats.all_time_score == expected
+    assert current_stats.all_time_score > current_stats.score
+
+
+# ---------------------------------------------------------------------------
+# 3. A vote on a closed era's praxis (owner ruling 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_vote_on_past_era_praxis_credits_that_era_not_this_one(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    prior_era: Era,
+    current_era: Era,
+    faction_ua: Faction,
+):
+    """Past-era praxes stay votable; the vote moves the historical record and
+    the lifetime figure, never the ladder anyone is climbing today."""
+    old = await _seed_both_eras(db_session, character, prior_era, current_era)
+
+    await recalculate_character_stats(character.id, db_session)
+    await recalculate_character_stats(character.id, db_session, era_row=prior_era)
+    await db_session.commit()
+
+    before_current = await _stats(db_session, character, current_era)
+    before_score = before_current.score
+    before_level = before_current.level
+    before_all_time = before_current.all_time_score
+    before_prior_score = (await _stats(db_session, character, prior_era)).score
+
+    await cast_vote_on_praxis(character2, old.id, 5, db_session)
+    await db_session.commit()
+
+    prior_stats = await _stats(db_session, character, prior_era)
+    current_stats = await _stats(db_session, character, current_era)
+
+    gain = prior_stats.score - before_prior_score
+    assert gain > 0, "the closed era's own row must record the vote"
+    assert current_stats.score == before_score
+    assert current_stats.level == before_level
+    assert current_stats.all_time_score == before_all_time + gain
+
+
+# ---------------------------------------------------------------------------
+# 4. Invitations belong to the era being played (owner ruling: guard delivery)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_past_era_recalc_delivers_no_invitation(
+    db_session: AsyncSession,
+    character: Character,
+    character3: Character,
+    prior_era: Era,
+    current_era: Era,
+    faction_ua: Faction,
+    faction_wow: Faction,
+):
+    """Recomputing a closed era must not hand out a faction invite now. The
+    control character does the same two tasks in the live era and does get one."""
+    first_task = Task(
+        title="WOW task one",
+        description="",
+        point_value=PRIOR_ERA_POINTS,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="wow",
+    )
+    second_task = Task(
+        title="WOW task two",
+        description="",
+        point_value=PRIOR_ERA_POINTS,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="wow",
+    )
+    db_session.add_all([first_task, second_task])
+    await db_session.flush()
+
+    for index, task in enumerate((first_task, second_task)):
+        await _sealed_praxis(
+            db_session,
+            character,
+            title=f"Closed-era wow {index}",
+            points=PRIOR_ERA_POINTS,
+            sealed_at=prior_era.started_at + timedelta(days=1),
+            task=task,
+        )
+        await _sealed_praxis(
+            db_session,
+            character3,
+            title=f"Live-era wow {index}",
+            points=PRIOR_ERA_POINTS,
+            sealed_at=current_era.started_at + timedelta(minutes=1),
+            task=task,
+        )
+
+    await recalculate_character_stats(character.id, db_session, era_row=prior_era)
+    await recalculate_character_stats(character3.id, db_session)
+    await db_session.commit()
+
+    letters = await db_session.execute(
+        select(InvitationLetter.character_id, InvitationLetter.faction_slug)
+    )
+    delivered = set(letters.all())
+    assert (character3.id, "wow") in delivered, "control: the thresholds are met"
+    assert (character.id, "wow") not in delivered

--- a/backend/tests/integration/test_era_scoped_recalc.py
+++ b/backend/tests/integration/test_era_scoped_recalc.py
@@ -25,9 +25,16 @@ from models.character_stats import CharacterStats
 from models.era import Era
 from models.faction import Faction, FactionStatus
 from models.invitation_letter import InvitationLetter
-from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.praxis import (
+    ModerationStatus,
+    Praxis,
+    PraxisMember,
+    PraxisStatus,
+    PraxisType,
+)
 from models.task import Task, TaskStatus
 from services.character_stats import recalculate_character_stats
+from services.praxis import moderate_praxis
 from services.vote import cast_vote_on_praxis
 
 # Read the modifier from the era config rather than hardcoding it (ADR-0042).
@@ -282,6 +289,40 @@ async def test_vote_on_past_era_praxis_credits_that_era_not_this_one(
     assert current_stats.score == before_score
     assert current_stats.level == before_level
     assert current_stats.all_time_score == before_all_time + gain
+
+
+@pytest.mark.asyncio
+async def test_failing_a_past_era_praxis_debits_that_era(
+    db_session: AsyncSession,
+    character: Character,
+    prior_era: Era,
+    current_era: Era,
+    faction_ua: Faction,
+):
+    """Every praxis-scoped recalc asks the same question as the vote path. A
+    moderation ruling on closed-era work has to reach the closed era's row —
+    #1373's "a failed praxis loses its points" must not become a no-op there."""
+    old = await _seed_both_eras(db_session, character, prior_era, current_era)
+
+    await recalculate_character_stats(character.id, db_session)
+    await recalculate_character_stats(character.id, db_session, era_row=prior_era)
+    await db_session.commit()
+
+    before_current = await _stats(db_session, character, current_era)
+    before_score = before_current.score
+    before_all_time = before_current.all_time_score
+    before_prior_score = (await _stats(db_session, character, prior_era)).score
+
+    await moderate_praxis(
+        old.id, ModerationStatus.failed.value, "Not actually done", db_session
+    )
+    await db_session.commit()
+
+    prior_stats = await _stats(db_session, character, prior_era)
+    current_stats = await _stats(db_session, character, current_era)
+    assert prior_stats.score == 0
+    assert current_stats.score == before_score
+    assert current_stats.all_time_score == before_all_time - before_prior_score
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An era reset zeroed every `CharacterStats` row, and then the next score recalc re-summed **every praxis ever filed** — so the reset silently undid itself the moment anything triggered a recalc. `CharacterStats` is one row per (character, era) by design (ADR-0042 / ADR-0044), so an unbounded gather was crediting one era's row with another era's work.

Closes #1345

## Seam under test

`services.character_stats.recalculate_character_stats` — the praxis gather. The loop went red on the real defect first: a character with 100 points of last-era work and 10 of this era scored **110** for the live era, and a freshly reset row came back at **100** instead of 0.

Two companion seams ride along, both from the owner rulings on the issue: `services.vote.cast_or_update_vote`'s choice of *which* era row a vote credits, and the meaning of `all_time_score`.

## What changed

**The bound.** `_era_window_condition` — a praxis belongs to `[era.started_at, next_era.started_at)`. `Praxis` has no `era_id`, so this is a **seal-time** bound, the same mechanism #1362 established for the feed rather than a second one. Both gathers compose it with #1373's `_UNSCORED_MODERATION_STATUSES` so they cannot drift. A NULL `submitted_at` counts for the **live era only**: `_apply_seal` guarantees `status == submitted ⟹ submitted_at IS NOT NULL`, so no honest row lands there — the branch stops corrupt data silently zeroing a score, and confining it to the open era stops one such row scoring once per era that ever ran. Marked `ponytail:` with the upgrade path — #1398's `praxis.era_id` collapses this to `Praxis.era_id == era_row.id`.

**`services/era.py`** gains `get_next_era_row` (the mirror of the already-present `get_closing_era_id`; `None` doubles as "this era is still open") and `get_era_row_for_praxis` (which era a seal time falls in).

**What is per-era vs lifetime.** `score` and `level` are now bounded to the era whose row is being written. `all_time_score` is **not** bounded — the owner ruled it is lifetime *cumulative* (era 1's 500 plus era 2's 30 is 530). That needed care: today's `max(all_time_score, total_score)` got the right answer only *because* the gather was unbounded, so bounding it would have silently turned the same line into "your best single era". It is now applied as a delta credited forward across the character's later era rows. Delta rather than a re-derived `SUM(score)` because `EraConfig.reset_all_time_score` lets an era declare a fresh lifetime, and that zero baseline lives in the row `apply_era_reset` wrote — a re-derivation would undo it exactly the way the unbounded gather undid a score reset.

**Votes on closed-era work** stay accepted and spend today's budget, but recalculate against **the praxis's** era: the historical row and `all_time_score` rise, the current-era score and level do not move.

**Invitation delivery is guarded.** Recomputing a closed era delivers no `InvitationLetter` — those carry an `era_id` and are mail you get in the era you are playing.

**Every praxis-scoped recalc routes through the one resolver.** `recalculate_members_stats`, `unsubmit_praxis`, `leave_praxis` and the three `collab_consensus` sites all asked the same question and answered "today's era". For a praxis sealed in the era in progress that resolves to the same row, so live behaviour is unchanged — but for closed-era work it silently no-oped, which meant #1373's "a failed praxis loses its points" never reached history. There is a test for that specifically.

Not touched, and deliberately: `services/duel.py`'s `end_duel` and `services/character.py`'s ban-forfeit recalc still resolve the live era, because `resolve_duels_at_era_close` moves every `active`/`settled` duel to `resolved` at era close — neither path can see a past-era duel.

## Tests

`backend/tests/integration/test_era_scoped_recalc.py`, 7 tests. The two eras are given deliberately different totals (100 vs 10) so a broken bound cannot pass by arithmetic accident, and there is a companion assertion in each that `all_time_score` did **not** drop.

- the live-era recalc ignores a prior era's praxis, and a prior-era recalc ignores this era's (both bounds)
- a fresh era's zeroed row stays zero — the reported symptom
- the same through a real `apply_era_reset` followed by the recalc the admin backfill runs
- `all_time_score` is both eras' scores summed
- a vote on closed-era work: that era's row rises, current score and level do not, lifetime rises by the same amount
- failing a closed era's praxis debits that era
- a past-era recalc delivers no invitation (with a live-era control character proving the thresholds are actually met)

```
pytest --cov=. --cov-fail-under=80     # 933 passed, 91.28% coverage
```

## What to eyeball

- **The `all_time_score` semantics change.** The owner suggested deriving it as `SUM(score)` over the per-era rows; I used a forward-credited delta instead, purely so `reset_all_time_score=True` survives. Same number for ruling 4, one more knob preserved — but it is a judgement call on top of the ruling, so worth a look.
- **Legacy `all_time_score` values** are high-water marks, not sums. Existing rows carry that skew forward; new movement is correct. Pre-launch data, and #1398 wipes it anyway.
- A character profile and the admin panel after an era reset — `all_time_score` should hold its history while `score`/`level` show zero.
- Voting on an old praxis: the star lands, the budget is spent, the leaderboard does not move.
- No frontend change and no migration. No browser tools here, so visual QA is outstanding.

## Notes for other work

- **`services/vote.py` recalculates only `praxis.created_by_id`, never the other collab members.** A vote on a collab praxis moves the starter's score and nobody else's. Pre-existing, orthogonal to the era bound, untouched here — worth its own issue.
- `#1398` should delete `_era_window_condition` in favour of `Praxis.era_id == era_row.id` and simplify `get_era_row_for_praxis` to a column read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
