### PR TITLE
C:/Program Files/Git/auth/me stops asking the database for the same era four times

### DIFF
--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -82,29 +82,96 @@ ALBESCENT_FACTION_SLUG = "albescent"
 _ALBESCENT_SENTINEL_SLUGS: frozenset[str] = frozenset({"na", "albescent"})
 
 
-async def _account_has_character_at_level(
+async def account_peak_character_level(
     account_id: int,
-    min_level: int,
+    era_id: int,
     session: AsyncSession,
-) -> bool:
-    """True when the account has at least one active character with stats.level >= min_level
-    in the current era."""
-    era_row = await get_current_era_row(session)
-    result = await session.execute(
-        select(Character.id)
+) -> int:
+    """Highest level among the account's active characters in ``era_id`` (0 if none).
+
+    One query answers every account-collective level gate at once: the two /auth/me
+    flags below used to ask "is anyone at level N?" twice with different N (#1381).
+    """
+    peak = await session.scalar(
+        select(func.max(CharacterStats.level))
+        .select_from(Character)
         .join(
             CharacterStats,
             (CharacterStats.character_id == Character.id)
-            & (CharacterStats.era_id == era_row.id),
+            & (CharacterStats.era_id == era_id),
         )
         .where(
             Character.account_id == account_id,
             Character.status == CharacterStatus.active,
-            CharacterStats.level >= min_level,
         )
-        .limit(1)
     )
-    return result.scalar_one_or_none() is not None
+    return peak or 0
+
+
+async def _account_covers_every_faction(
+    account_id: int,
+    session: AsyncSession,
+    era: EraConfig,
+) -> bool:
+    """Coverage half of the Albescent gate — see :func:`can_start_as_albescent`."""
+    required_faction_slugs = frozenset(
+        slug for slug in era.factions if slug not in _ALBESCENT_SENTINEL_SLUGS
+    )
+    if not required_faction_slugs:
+        return True
+
+    covered_result = await session.execute(
+        select(Task.primary_faction_slug)
+        .distinct()
+        .join(Praxis, Praxis.task_id == Task.id)
+        .join(Character, Character.id == Praxis.created_by_id)
+        .where(
+            Character.account_id == account_id,
+            Character.status.in_(list(_ROSTER_STATUSES)),
+            Praxis.status == PraxisStatus.submitted,
+            Praxis.moderation_status.in_(
+                [ModerationStatus.visible, ModerationStatus.flagged]
+            ),
+            Task.primary_faction_slug.in_(list(required_faction_slugs)),
+        )
+    )
+    covered_slugs = frozenset(row[0] for row in covered_result.all())
+    return covered_slugs >= required_faction_slugs
+
+
+@dataclasses.dataclass(frozen=True)
+class AccountEligibility:
+    """The two account-collective unlock flags /auth/me dresses the site with.
+
+    Defaults are the "era not seeded yet" answer: no unlocks.
+    """
+
+    can_create_additional_character: bool = False
+    can_start_as_albescent: bool = False
+
+
+async def load_account_eligibility(
+    account_id: int,
+    era_id: int,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+) -> AccountEligibility:
+    """Both unlock flags off a single level query (plus coverage when it can matter).
+
+    Both gates read the same account-collective level, so asking for the peak once
+    answers both — and the Albescent coverage query is only worth issuing when the
+    level half already passed.
+    """
+    peak_level = await account_peak_character_level(account_id, era_id, session)
+    return AccountEligibility(
+        can_create_additional_character=(
+            peak_level >= era.second_character_level_required
+        ),
+        can_start_as_albescent=(
+            peak_level >= era.albescent_level_required
+            and await _account_covers_every_faction(account_id, session, era)
+        ),
+    )
 
 
 async def can_create_additional_character(
@@ -117,9 +184,9 @@ async def can_create_additional_character(
     Requires at least one existing active character at level
     ``era.second_character_level_required`` or above in the current era.
     """
-    return await _account_has_character_at_level(
-        account_id, era.second_character_level_required, session
-    )
+    era_row = await get_current_era_row(session)
+    eligibility = await load_account_eligibility(account_id, era_row.id, session, era)
+    return eligibility.can_create_additional_character
 
 
 async def can_start_as_albescent(
@@ -145,34 +212,9 @@ async def can_start_as_albescent(
     the same "a player's own lives" set as :data:`_ROSTER_STATUSES`. A banned
     life's work does not carry the account through the gate.
     """
-    if not await _account_has_character_at_level(
-        account_id, era.albescent_level_required, session
-    ):
-        return False
-
-    required_faction_slugs = frozenset(
-        slug for slug in era.factions if slug not in _ALBESCENT_SENTINEL_SLUGS
-    )
-    if not required_faction_slugs:
-        return True
-
-    covered_result = await session.execute(
-        select(Task.primary_faction_slug)
-        .distinct()
-        .join(Praxis, Praxis.task_id == Task.id)
-        .join(Character, Character.id == Praxis.created_by_id)
-        .where(
-            Character.account_id == account_id,
-            Character.status.in_(list(_ROSTER_STATUSES)),
-            Praxis.status == PraxisStatus.submitted,
-            Praxis.moderation_status.in_(
-                [ModerationStatus.visible, ModerationStatus.flagged]
-            ),
-            Task.primary_faction_slug.in_(list(required_faction_slugs)),
-        )
-    )
-    covered_slugs = frozenset(row[0] for row in covered_result.all())
-    return covered_slugs >= required_faction_slugs
+    era_row = await get_current_era_row(session)
+    eligibility = await load_account_eligibility(account_id, era_row.id, session, era)
+    return eligibility.can_start_as_albescent
 
 
 async def get_account_invited_faction_slugs(
@@ -203,33 +245,47 @@ async def get_account_invited_faction_slugs(
     return sorted(row[0] for row in result.all())
 
 
-async def list_current_era_invitations_for_character(
+async def list_era_invitations_for_character(
     character_id: int,
+    era_id: int,
     session: AsyncSession,
 ) -> list[str]:
-    """Faction slugs THIS character holds a current-era invitation letter for (#243).
+    """Faction slugs THIS character holds an invitation letter for in ``era_id`` (#243).
 
     Unlike :func:`get_account_invited_faction_slugs` (account-pooled, used to gate
     creation/join), this is per-character: it powers the /auth/me invitation
     watcher, which diffs the active life's own earned invites. ``Character.account``
     is ``lazy="raise"``, so the letter rows are queried explicitly by character_id
     (mirroring how #459 badges do sibling queries). The ``na`` sentinel and
-    ``albescent`` are excluded — never invite-joinable. Returns ``[]`` when the era
-    is unseeded or no invites exist.
+    ``albescent`` are excluded — never invite-joinable.
+
+    Takes the era id rather than resolving it so /auth/me, which needs the same
+    row for three other reads, resolves it once (#1381).
     """
-    era_row = await get_current_era_row_safe(session)
-    if era_row is None:
-        return []
     result = await session.execute(
         select(InvitationLetter.faction_slug)
         .distinct()
         .where(
             InvitationLetter.character_id == character_id,
-            InvitationLetter.era_id == era_row.id,
+            InvitationLetter.era_id == era_id,
             InvitationLetter.faction_slug.notin_(list(_ALBESCENT_SENTINEL_SLUGS)),
         )
     )
     return sorted(row[0] for row in result.all())
+
+
+async def list_current_era_invitations_for_character(
+    character_id: int,
+    session: AsyncSession,
+) -> list[str]:
+    """:func:`list_era_invitations_for_character` for the live era.
+
+    Returns ``[]`` when the era is unseeded or no invites exist.
+    """
+    era_row = await get_current_era_row_safe(session)
+    if era_row is None:
+        return []
+    return await list_era_invitations_for_character(character_id, era_row.id, session)
 
 
 async def _derive_unique_username(display_name: str, session: AsyncSession) -> str:

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -259,8 +259,8 @@ async def list_era_invitations_for_character(
     (mirroring how #459 badges do sibling queries). The ``na`` sentinel and
     ``albescent`` are excluded — never invite-joinable.
 
-    Takes the era id rather than resolving it so /auth/me, which needs the same
-    row for three other reads, resolves it once (#1381).
+    Takes the era id rather than resolving it: /auth/me — the only caller — needs
+    the same era row for three other reads, so it resolves it once (#1381).
     """
     result = await session.execute(
         select(InvitationLetter.faction_slug)
@@ -272,20 +272,6 @@ async def list_era_invitations_for_character(
         )
     )
     return sorted(row[0] for row in result.all())
-
-
-async def list_current_era_invitations_for_character(
-    character_id: int,
-    session: AsyncSession,
-) -> list[str]:
-    """:func:`list_era_invitations_for_character` for the live era.
-
-    Returns ``[]`` when the era is unseeded or no invites exist.
-    """
-    era_row = await get_current_era_row_safe(session)
-    if era_row is None:
-        return []
-    return await list_era_invitations_for_character(character_id, era_row.id, session)
 
 
 async def _derive_unique_username(display_name: str, session: AsyncSession) -> str:

--- a/backend/services/current_user.py
+++ b/backend/services/current_user.py
@@ -2,6 +2,14 @@
 
 Shared by GET /auth/me and POST /me/active-character so the "switch life then
 return the refreshed user" path doesn't duplicate the composition.
+
+Every signed-in page load gates on this request, so the composition is written
+to spend as few round trips as it can (#1381). It cannot spend them *in
+parallel*: one request holds one ``AsyncSession``, which is a single connection
+with a single cursor, so ``asyncio.gather`` over these reads would interleave on
+the same connection rather than overlap. The win is therefore fewer queries —
+the era row is resolved once here and threaded into every read that needs it,
+and the two eligibility flags share one level query.
 """
 from dataclasses import asdict
 
@@ -12,14 +20,14 @@ from game_config import CURRENT_ERA, EraConfig
 from models.account import Account
 from schemas.auth import CurrentUser
 from services.character import (
+    AccountEligibility,
     build_character_out,
-    can_create_additional_character,
-    can_start_as_albescent,
-    list_current_era_invitations_for_character,
+    list_era_invitations_for_character,
+    load_account_eligibility,
     resolve_active_character,
 )
 from services.character_capabilities import compute_capabilities
-from services.era import load_current_era_stats
+from services.era import get_current_era_row_safe, load_era_stats
 
 
 async def build_current_user(
@@ -27,32 +35,36 @@ async def build_current_user(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> CurrentUser:
+    # Resolved once for the stats, invitation and eligibility reads below. None in
+    # a fresh environment where no era row has been seeded yet, which is what the
+    # zero-stats / no-unlocks fallbacks answer to.
+    era_row = await get_current_era_row_safe(session)
     character = await resolve_active_character(account, session)
 
     char_out = None
     character_level: int | None = None
     level_jump_used_at_level: int | None = None
     if character:
-        stats = await load_current_era_stats(character.id, session)
+        stats = None
         # #243: surface the active life's own current-era invitation letters so the
         # frontend InvitationWatcher can detect newly-earned ones.
-        invitations = await list_current_era_invitations_for_character(
-            character.id, session
-        )
+        invitations: list[str] = []
+        if era_row is not None:
+            stats = await load_era_stats(character.id, era_row.id, session)
+            invitations = await list_era_invitations_for_character(
+                character.id, era_row.id, session
+            )
         char_out = build_character_out(character, stats, invitations=invitations)
         character_level = stats.level if stats else 0
         level_jump_used_at_level = stats.level_jump_used_at_level if stats else None
 
     is_admin = await account_has_admin_role(account.id, session)
 
-    # Eligibility flags depend on the era being seeded. Fall back to False in
-    # fresh test environments where no era row exists yet.
-    try:
-        can_create_more = await can_create_additional_character(account.id, session, era)
-        can_albescent = await can_start_as_albescent(account.id, session, era)
-    except Exception:
-        can_create_more = False
-        can_albescent = False
+    eligibility = (
+        await load_account_eligibility(account.id, era_row.id, session, era)
+        if era_row is not None
+        else AccountEligibility()
+    )
 
     capabilities = compute_capabilities(
         character_level,
@@ -66,8 +78,8 @@ async def build_current_user(
         account_id=account.id,
         character=char_out,
         is_admin=is_admin,
-        can_create_additional_character=can_create_more,
-        can_start_as_albescent=can_albescent,
+        can_create_additional_character=eligibility.can_create_additional_character,
+        can_start_as_albescent=eligibility.can_start_as_albescent,
         albescent_revealed=account.albescent_revealed,
         second_character_level_required=era.second_character_level_required,
         era_name=era.name,

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -43,6 +43,26 @@ async def get_current_era_row_safe(session: AsyncSession) -> Era | None:
     return result.scalar_one_or_none()
 
 
+async def load_era_stats(
+    character_id: int,
+    era_id: int,
+    session: AsyncSession,
+) -> CharacterStats | None:
+    """A character's CharacterStats row for an era already in hand, or None.
+
+    Split out of :func:`load_current_era_stats` so a caller that has already
+    resolved the era row — /auth/me composes four such reads (#1381) — pays for
+    it once instead of once per lookup.
+    """
+    result = await session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character_id,
+            CharacterStats.era_id == era_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
 async def load_current_era_stats(
     character_id: int,
     session: AsyncSession,
@@ -55,13 +75,7 @@ async def load_current_era_stats(
     era_row = await get_current_era_row_safe(session)
     if era_row is None:
         return None
-    result = await session.execute(
-        select(CharacterStats).where(
-            CharacterStats.character_id == character_id,
-            CharacterStats.era_id == era_row.id,
-        )
-    )
-    return result.scalar_one_or_none()
+    return await load_era_stats(character_id, era_row.id, session)
 
 
 async def get_or_create_stats(
@@ -75,13 +89,7 @@ async def get_or_create_stats(
     (see services.scoring.compute_votes_available), so new rows start with
     votes_spent_this_era = 0 — no explicit seeding of the budget is required.
     """
-    result = await session.execute(
-        select(CharacterStats).where(
-            CharacterStats.character_id == character_id,
-            CharacterStats.era_id == era_id,
-        )
-    )
-    stats = result.scalar_one_or_none()
+    stats = await load_era_stats(character_id, era_id, session)
     if stats is None:
         stats = CharacterStats(
             character_id=character_id,

--- a/backend/tests/integration/test_current_user_queries.py
+++ b/backend/tests/integration/test_current_user_queries.py
@@ -1,0 +1,100 @@
+"""Query-count guard for the /auth/me composition (#1381).
+
+Every signed-in page load gates on this request, so the number of round trips it
+makes is a behaviour worth pinning: a regression here is paid by the whole site.
+The seam under test is ``services.current_user.build_current_user`` — the counter
+listens on SQLAlchemy's ``Engine`` class (events on the class fire for every
+engine, including the async engine behind the test connection) and keeps only
+SELECTs, so transaction bookkeeping cannot skew the count.
+"""
+import contextlib
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import event, select
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.account import Account
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.invitation_letter import InvitationLetter
+from models.roles import AccountRole, Role
+
+
+@contextlib.contextmanager
+def count_selects():
+    statements: list[str] = []
+
+    def _record(conn, cursor, statement, parameters, context, executemany) -> None:
+        if statement.lstrip().upper().startswith("SELECT"):
+            statements.append(statement)
+
+    event.listen(Engine, "before_cursor_execute", _record)
+    try:
+        yield statements
+    finally:
+        event.remove(Engine, "before_cursor_execute", _record)
+
+
+@pytest.fixture
+async def dressed_viewer(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+) -> Account:
+    """A signed-in viewer with every /auth/me branch live.
+
+    Admin role, a carried life at the albescent level gate, and an invitation
+    letter — so the counted request exercises the deepest path rather than the
+    early-return one.
+    """
+    account.active_character_id = character.id
+
+    role = Role(name="admin")
+    db_session.add(role)
+    await db_session.flush()
+    db_session.add(
+        AccountRole(account_id=account.id, role_id=role.id, granted_by=account.id)
+    )
+
+    stats = await db_session.scalar(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character.id,
+            CharacterStats.era_id == era.id,
+        )
+    )
+    stats.level = CURRENT_ERA.albescent_level_required
+    stats.score = 1000
+
+    db_session.add(
+        InvitationLetter(
+            character_id=character.id,
+            era_id=era.id,
+            faction_slug="ua",
+        )
+    )
+    await db_session.commit()
+    return account
+
+
+@pytest.mark.asyncio
+async def test_auth_me_query_count(
+    client: AsyncClient,
+    dressed_viewer: Account,
+    auth_headers: dict,
+):
+    """/auth/me stays within its round-trip budget.
+
+    Baseline before #1381 was 12 SELECTs (11 in ``build_current_user`` plus the
+    auth dependency's account load), four of which re-read the same Era row.
+    Raise this number only with a reason.
+    """
+    with count_selects() as statements:
+        resp = await client.get("/auth/me", headers=auth_headers)
+
+    assert resp.status_code == 200
+    assert len(statements) <= 8, "\n\n".join(statements)


### PR DESCRIPTION
## Seam under test

`services.current_user.build_current_user` — the composition behind `GET /auth/me` and
`POST /me/active-character`. Guard: `backend/tests/integration/test_current_user_queries.py`
counts SELECTs for one real signed-in request (admin role, carried life at the Albescent
level gate, an invitation letter) via a `before_cursor_execute` listener on the `Engine`
class.

## Measured, not quoted

The title says ~8-10. **The real figure was 11** inside `build_current_user` (12 SELECTs for
the whole request, the 12th being the auth dependency's account load). Counted with the
listener above, not by reading the code. Four of the 11 were the *same* Era row select.

| | SELECTs in `build_current_user` | SELECTs for the request | `/auth/me` median | mean |
|---|---|---|---|---|
| before | **11** | 12 | 8.54 / 8.63 / 8.73 / 8.89 ms | 9.0-10.4 ms |
| after | **7** | 8 | 6.70 / 6.71 / 6.99 / 7.23 ms | 7.1-7.9 ms |

n=200 requests per run, 20 discarded warm-ups, four runs each side, same process/DB
(`wz1381_test` on the compose Postgres). **≈ -21% wall time, -4 round trips.** A round trip
on this path costs ≈ 0.47 ms.

## Reduced, not parallelised

`asyncio.gather` is **ruled out**, per the issue discussion. One request holds one
`AsyncSession` = one connection with one cursor; gathering these reads would interleave on
that connection rather than overlap, and giving each branch its own session breaks the
one-session-per-request invariant (and would make the reads read outside the request's
transaction). The module docstring now records that so the next reader doesn't retry it.

What actually changed:

1. **The era row is resolved once** (`get_current_era_row_safe`) and threaded into the
   stats, invitation and eligibility reads. It was being re-selected four times: once each
   inside `load_current_era_stats`, `list_current_era_invitations_for_character`, and twice
   inside `_account_has_character_at_level`. `services/era.py` and `services/character.py`
   grow `load_era_stats(character_id, era_id, …)` / `list_era_invitations_for_character(
   character_id, era_id, …)`; the era-resolving wrappers stay for their other callers.
   **-3 queries.**
2. **The two eligibility gates share one query.** They asked "does the account have a
   character at level N?" twice with different N. Now one `max(level)` query answers both,
   behind `load_account_eligibility` → `AccountEligibility`, which is the single home for
   both flags — `can_create_additional_character` and `can_start_as_albescent` delegate to
   it, so no rule moved. **-1 query.**
3. The blanket `try/except Exception` around the eligibility flags is gone. Its only real
   case was "era not seeded yet", which is now the explicit `era_row is None` branch; other
   exceptions no longer get silently swallowed into `False`.
4. `list_current_era_invitations_for_character` lost its only caller, so it is deleted
   rather than left as a public no-caller wrapper. `get_or_create_stats` now reuses
   `load_era_stats` instead of restating its select.

### What I did *not* do, and why

The issue's option (iii) also asked for the **admin** check to be folded into the same
query. I folded 2 of the 3 account-scoped checks, not 3. `dependencies.py` already imports
`services.character`, so `character.py` cannot import back to reach the role tables; folding
admin in means exporting SQL column fragments from two modules and composing them in
`current_user.py`, plus an optional pre-fetched-level parameter on
`load_account_eligibility`. Measured price of leaving it alone: **one round trip, ≈ 0.5 ms**
of the remaining 6.9 ms. Say the word and I'll take it.

Two other folds were considered and rejected: stats + invitations into one `array_agg`
left join (Postgres-only, fiddly NULL filtering, 1 round trip), and eager-loading roles onto
the account in `get_current_account` (would load roles on *every* authenticated request to
help one).

## Behaviour

`/auth/me` returns a **byte-identical** payload before and after. Verified by dumping
`resp.text` for the dressed viewer and for the no-character viewer, running the same dump
against `services/` checked out at the base commit, and diffing: the only difference is the
fixture row's own `created_at`, which differs between *runs*, not between code versions.

One deliberate cost, on a rare write path: `can_create_additional_character` now routes
through `load_account_eligibility`, which also evaluates the Albescent flag — so character
creation by an account already at the Albescent level spends one extra coverage query. That
buys a single home for both rules; character creation happens once or twice per account.

## Tests

```
TEST_DATABASE_URL=postgresql+asyncpg://…/wz1381_test pytest --cov=. --cov-fail-under=80
```
934 passed, coverage 91.31%. The 20 `can_start_as_albescent` scenarios in
`test_albescent_unlock.py` cover the rewritten gate; `test_auth_me_no_character` covers the
unseeded-era branch that the deleted `try/except` used to catch.

No frontend change, no migration. Visual QA outstanding — this agent has no browser.

Closes #1381
