### PR TITLE
Six consumer-less endpoints go, leak first: delete GET /characters/{id}/relationships and five dead routes

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -461,39 +461,6 @@ async def retire_task(
     return await build_task_out(task, session)
 
 
-class TaskVisionToggle(BaseModel):
-    is_task_vision_eligible: bool
-
-
-@router.patch("/tasks/{task_id}/task-vision", response_model=TaskOut)
-async def admin_toggle_task_vision(
-    task_id: int,
-    data: TaskVisionToggle,
-    _: Account = Depends(require_admin),
-    session: AsyncSession = Depends(get_db),
-):
-    """Admin-only: toggle whether Ephemerists/Albescent can access a retired task."""
-    task = await session.get(Task, task_id)
-    if task is None:
-        raise HTTPException(status_code=404, detail="Task not found.")
-    task.is_task_vision_eligible = data.is_task_vision_eligible
-    await session.flush()
-    await session.refresh(task)
-    return await build_task_out(task, session)
-
-
-@router.delete("/praxes/{praxis_id}", status_code=204)
-async def admin_delete_praxis(
-    praxis_id: int,
-    _: Account = Depends(require_admin),
-    session: AsyncSession = Depends(get_db),
-):
-    # Soft-delete is a moderation transition spelled a second way, so it routes
-    # through the same service — which is what recalculates the members' stats
-    # (#1373). Hiding a praxis in the route used to leave its points banked.
-    await moderate_praxis(praxis_id, ModerationStatus.hidden.value, None, session)
-
-
 @router.post("/characters/{character_id}/ban", status_code=200)
 async def ban_character(
     character_id: int,

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -12,11 +12,9 @@ from db import get_db
 from dependencies import get_current_character, get_current_character_optional
 from models.account import Account
 from models.character import Character, CharacterStatus
-from models.relationship import Relationship
 from models.praxis import Praxis, PraxisStatus
 from models.vote import Vote
 from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
-from schemas.relationship import RelationshipOut
 from schemas.praxis import PraxisOut
 from services.auth import get_current_account
 from services.badge import list_badges_for_character
@@ -189,21 +187,6 @@ async def upload_avatar(
     await session.refresh(character)
     stats = await load_current_era_stats(character_id, session)
     return build_character_out(character, stats)
-
-
-@router.get("/{character_id}/relationships", response_model=list[RelationshipOut])
-async def get_character_relationships(
-    character_id: int,
-    session: AsyncSession = Depends(get_db),
-):
-    result = await session.execute(
-        select(Relationship).where(
-            (Relationship.from_character_id == character_id)
-            | (Relationship.to_character_id == character_id)
-        )
-    )
-    relationships = result.scalars().all()
-    return [RelationshipOut.model_validate(relationship) for relationship in relationships]
 
 
 @router.get("/{character_id}/stats/votes-received")

--- a/backend/routers/duel.py
+++ b/backend/routers/duel.py
@@ -13,25 +13,13 @@ from schemas.duel import DuelChallengeIn, DuelDetailOut, DuelOut, DuelRespondIn
 from schemas.praxis import PraxisOut
 from services.duel import (
     cancel_duel_challenge,
-    get_duel,
     get_duel_detail,
     issue_duel_challenge,
-    list_pending_duel_challenges_for_character,
     respond_to_duel_challenge,
 )
 from services.praxis import build_praxis_out
 
 router = APIRouter()
-
-
-@router.get("/pending", response_model=list[DuelOut])
-async def list_pending_challenges_route(
-    character: Character = Depends(get_current_character),
-    session: AsyncSession = Depends(get_db),
-):
-    """Return pending duel challenges where the current character is the opponent."""
-    duels = await list_pending_duel_challenges_for_character(character.id, session)
-    return [DuelOut.model_validate(duel) for duel in duels]
 
 
 @router.post("/challenge", response_model=DuelOut, status_code=201)
@@ -60,15 +48,6 @@ async def get_duel_detail_route(
     """Read-oriented duel view for the praxis read page: both sides' display
     info + live vote points + ``viewer_is_participant`` in one round trip (#308)."""
     return await get_duel_detail(duel_id, viewer, session)
-
-
-@router.get("/{duel_id}", response_model=DuelOut)
-async def get_duel_route(
-    duel_id: int,
-    session: AsyncSession = Depends(get_db),
-):
-    duel = await get_duel(duel_id, session)
-    return DuelOut.model_validate(duel)
 
 
 @router.post("/{duel_id}/respond", response_model=DuelOut)

--- a/backend/routers/factions.py
+++ b/backend/routers/factions.py
@@ -11,7 +11,6 @@ from models.account import Account
 from models.character import Character
 from models.faction import Faction, FactionStatus
 from schemas.faction import (
-    DefectionHistoryOut,
     FactionChoiceRequest,
     FactionOut,
     FactionPageOut,
@@ -23,7 +22,6 @@ from services.character import ALBESCENT_FACTION_SLUG
 from services.era import get_current_era_row
 from services.faction_service import (
     defect_to_faction,
-    get_defection_history,
     get_invitation_status,
 )
 from models.invitation_letter import InvitationLetter
@@ -121,21 +119,4 @@ async def list_invitations(
             delivered_at=letter.delivered_at,
         )
         for letter in letters
-    ]
-
-
-@router.get("/defection-history", response_model=list[DefectionHistoryOut])
-async def list_defection_history(
-    character: Character = Depends(get_current_character),
-    session: AsyncSession = Depends(get_db),
-):
-    """Return defection history for the current character in the current era."""
-    era_row = await get_current_era_row(session)
-    records = await get_defection_history(character.id, era_row.id, session)
-    return [
-        DefectionHistoryOut(
-            faction_slug=record.faction_slug,
-            defected_at=record.defected_at,
-        )
-        for record in records
     ]

--- a/backend/schemas/faction.py
+++ b/backend/schemas/faction.py
@@ -38,10 +38,3 @@ class InvitationLetterOut(BaseModel):
     delivered_at: datetime
 
     model_config = {"from_attributes": True}
-
-
-class DefectionHistoryOut(BaseModel):
-    faction_slug: str
-    defected_at: datetime
-
-    model_config = {"from_attributes": True}

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -461,17 +461,3 @@ async def maybe_settle_duel(praxis_id: int, session: AsyncSession) -> None:
     ):
         duel.status = DuelStatus.settled
         await session.flush()
-
-
-async def list_pending_duel_challenges_for_character(
-    character_id: int,
-    session: AsyncSession,
-) -> list[Duel]:
-    """Return pending duel challenges where character_id is the opponent."""
-    result = await session.execute(
-        select(Duel).where(
-            Duel.opponent_character_id == character_id,
-            Duel.status == DuelStatus.pending,
-        )
-    )
-    return list(result.scalars().all())

--- a/backend/tests/integration/test_admin.py
+++ b/backend/tests/integration/test_admin.py
@@ -10,7 +10,7 @@ from models.character_stats import CharacterStats
 from models.contact import ContactMessage
 from models.era import Era
 from models.faction import Faction
-from models.praxis import Praxis, ModerationStatus
+from models.praxis import Praxis
 from models.roles import AccountRole, Role
 from models.task import Task, TaskStatus
 
@@ -219,25 +219,6 @@ async def test_admin_create_task(
     assert data["title"] == "Admin-created"
     assert data["status"] == "active"
     assert data["point_value"] == 50
-
-
-@pytest.mark.asyncio
-async def test_admin_toggle_task_vision(
-    client: AsyncClient,
-    account: Account,
-    active_task: Task,
-    auth_headers: dict,
-    db_session: AsyncSession,
-):
-    await _make_admin(account, db_session)
-
-    resp = await client.patch(
-        f"/admin/tasks/{active_task.id}/task-vision",
-        json={"is_task_vision_eligible": True},
-        headers=auth_headers,
-    )
-    assert resp.status_code == 200
-    assert resp.json()["is_task_vision_eligible"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -635,28 +616,8 @@ async def test_admin_messages(
 
 
 # ---------------------------------------------------------------------------
-# Hide / unhide praxis via DELETE and moderate endpoints
+# Hide / unhide praxis via the moderate endpoint
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_admin_delete_praxis_hides_it(
-    client: AsyncClient,
-    account: Account,
-    auth_headers: dict,
-    db_session: AsyncSession,
-    praxis_solo: Praxis,
-):
-    """DELETE /admin/praxes/{id} sets moderation_status to hidden (soft-delete)."""
-    await _make_admin(account, db_session)
-
-    resp = await client.delete(f"/admin/praxes/{praxis_solo.id}", headers=auth_headers)
-    assert resp.status_code == 204
-
-    # Verify the row is still in the DB but now hidden
-    result = await db_session.execute(select(Praxis).where(Praxis.id == praxis_solo.id))
-    updated = result.scalar_one()
-    assert updated.moderation_status == ModerationStatus.hidden
 
 
 @pytest.mark.asyncio
@@ -749,20 +710,6 @@ async def test_admin_moderate_nonexistent_praxis_returns_404(
     assert resp.status_code == 404
 
 
-@pytest.mark.asyncio
-async def test_admin_delete_nonexistent_praxis_returns_404(
-    client: AsyncClient,
-    account: Account,
-    auth_headers: dict,
-    db_session: AsyncSession,
-):
-    """DELETE on a praxis that does not exist returns 404."""
-    await _make_admin(account, db_session)
-
-    resp = await client.delete("/admin/praxes/999999", headers=auth_headers)
-    assert resp.status_code == 404
-
-
 # ---------------------------------------------------------------------------
 # Additional 403 coverage — multiple admin endpoints
 # ---------------------------------------------------------------------------
@@ -809,12 +756,21 @@ async def test_non_admin_cannot_patch_task(
 
 
 @pytest.mark.asyncio
-async def test_non_admin_cannot_delete_praxis(
+async def test_non_admin_cannot_moderate_praxis(
     client: AsyncClient,
     auth_headers: dict,
 ):
-    """Non-admin account receives 403 on DELETE /admin/praxes/{id}."""
-    resp = await client.delete("/admin/praxes/1", headers=auth_headers)
+    """Non-admin account receives 403 on PATCH /admin/praxes/{id}/moderate.
+
+    This guard used to point at ``DELETE /admin/praxes/{id}``, deleted in #1386.
+    It is repointed rather than dropped so the surviving hide path keeps its
+    only non-admin 403 assertion.
+    """
+    resp = await client.patch(
+        "/admin/praxes/1/moderate",
+        json={"status": "hidden"},
+        headers=auth_headers,
+    )
     assert resp.status_code == 403
 
 

--- a/backend/tests/integration/test_admin.py
+++ b/backend/tests/integration/test_admin.py
@@ -41,7 +41,7 @@ async def test_admin_endpoints_require_admin_role(
 
 
 # ---------------------------------------------------------------------------
-# Tasks — list, approve, retire, reactivate, create, task-vision
+# Tasks — list, approve, retire, reactivate, create
 # ---------------------------------------------------------------------------
 
 

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -733,50 +733,39 @@ async def test_delete_character_wrong_owner(
 
 
 # ---------------------------------------------------------------------------
-# Relationships endpoint
+# Relationships endpoint — deleted, see below
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_get_character_relationships_empty(
-    client: AsyncClient, character: Character
-):
-    """GET /characters/{id}/relationships returns empty list when none exist."""
-    resp = await client.get(f"/characters/{character.id}/relationships")
-    assert resp.status_code == 200
-    assert resp.json() == []
-
-
-@pytest.mark.asyncio
-async def test_get_character_relationships_with_data(
+async def test_character_relationships_endpoint_is_gone(
     client: AsyncClient,
     db_session: AsyncSession,
     character: Character,
     character2: Character,
 ):
-    """GET /characters/{id}/relationships returns seeded relationships."""
+    """``GET /characters/{id}/relationships`` must not exist.
+
+    It served any character's complete friend/foe graph to *unauthenticated*
+    callers, so integer ids could be walked to enumerate the whole social
+    graph. It had no consumer — the profile page reads the viewer-scoped
+    ``GET /relationships``. Deletion is the fix, so this pins 404: asserting
+    "requires auth" instead would let the endpoint come back.
+    """
     from models.relationship import Relationship, RelationshipStatus, RelationshipType
 
-    rel = Relationship(
-        from_character_id=character.id,
-        to_character_id=character2.id,
-        type=RelationshipType.friend,
-        status=RelationshipStatus.active,
+    db_session.add(
+        Relationship(
+            from_character_id=character.id,
+            to_character_id=character2.id,
+            type=RelationshipType.friend,
+            status=RelationshipStatus.active,
+        )
     )
-    db_session.add(rel)
     await db_session.commit()
 
     resp = await client.get(f"/characters/{character.id}/relationships")
-    assert resp.status_code == 200
-    data = resp.json()
-    assert len(data) == 1
-    assert data[0]["from_character_id"] == character.id
-    assert data[0]["to_character_id"] == character2.id
-
-    # Also visible from the other side
-    resp2 = await client.get(f"/characters/{character2.id}/relationships")
-    assert resp2.status_code == 200
-    assert len(resp2.json()) == 1
+    assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_factions.py
+++ b/backend/tests/integration/test_factions.py
@@ -83,19 +83,6 @@ async def test_faction_status_unauthenticated(client: AsyncClient):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_defection_history_empty(
-    client: AsyncClient,
-    character: Character,
-    auth_headers: dict,
-    era: Era,
-):
-    """A fresh character has no defection history."""
-    resp = await client.get("/factions/defection-history", headers=auth_headers)
-    assert resp.status_code == 200
-    assert resp.json() == []
-
-
 # ---------------------------------------------------------------------------
 # Choose faction (defection)
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_votes.py
+++ b/backend/tests/integration/test_votes.py
@@ -542,12 +542,6 @@ async def test_duel_challenge_issue_and_cancel(
     assert duel["task_id"] == active_task.id
     duel_id = duel["id"]
 
-    # Pending list for character (the opponent)
-    pending_resp = await client.get("/duels/pending", headers=auth_headers)
-    assert pending_resp.status_code == 200
-    pending = pending_resp.json()
-    assert any(d["id"] == duel_id for d in pending)
-
     # Challenger (character2) cancels
     cancel_resp = await client.post(f"/duels/{duel_id}/cancel", headers=auth_headers2)
     assert cancel_resp.status_code == 200
@@ -593,11 +587,6 @@ async def test_duel_challenge_accept_creates_opponent_praxis(
     duel = accept_resp.json()
     assert duel["status"] == "active"
     assert duel["opponent_praxis_id"] is not None
-
-    # GET the duel
-    get_resp = await client.get(f"/duels/{duel_id}")
-    assert get_resp.status_code == 200
-    assert get_resp.json()["status"] == "active"
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/duel.ts
+++ b/frontend/src/api/duel.ts
@@ -66,11 +66,6 @@ export async function issueChallenge(data: DuelChallengeIn): Promise<DuelOut> {
   return result
 }
 
-export async function getDuel(duelId: number): Promise<DuelOut> {
-  const { data } = await api.get<DuelOut>(`/duels/${duelId}`)
-  return data
-}
-
 export async function getDuelDetail(duelId: number): Promise<DuelDetailOut> {
   const { data } = await api.get<DuelDetailOut>(`/duels/${duelId}/detail`)
   // Server truth for BOTH sides' `points_from_votes` — retire any local override
@@ -95,10 +90,5 @@ export async function respondToChallenge(duelId: number, data: DuelRespondIn): P
 
 export async function cancelChallenge(duelId: number): Promise<DuelOut> {
   const { data } = await api.post<DuelOut>(`/duels/${duelId}/cancel`)
-  return data
-}
-
-export async function listPendingChallenges(): Promise<DuelOut[]> {
-  const { data } = await api.get<DuelOut[]>('/duels/pending')
   return data
 }


### PR DESCRIPTION
Closes #1386

## The leak is the first commit, on its own

`5483e383` deletes `GET /characters/{character_id}/relationships` and nothing else. It is first deliberately, so that if anything else in this sweep turns out to be contentious the leak still closes on its own and can be merged or cherry-picked independently.

The route had **no auth dependency of any kind**, and there is no global auth middleware (`main.py` mounts only Session and CORS). Any unauthenticated caller could walk integer character ids and enumerate every character's complete friend/foe graph, including relationship type and status. No other surface exposes an *arbitrary* character's edges — `CharacterProfile.tsx` uses the viewer-scoped `GET /relationships`, which sits behind `get_current_character`.

## Seam under test

The **HTTP route table** — an unauthenticated request against the app's router, asserting the path resolves to 404.

The failing test came first and went red on the real defect: `200 == 404` with no auth header at all. It pins **404, not 401**, because deletion is the fix — an "auth required" assertion would let the endpoint come back. The test still seeds a real relationship row first, so it fails if the route is restored in any form rather than passing vacuously.

For the other five routes there is no code left to test. The honest checks are the grep proving zero consumers (below), the full suite staying green, and `tsc` clean. I did not invent tests for deleted code.

## Deleted (5 routes + 2 client twins)

| Route | Why it is safe |
|---|---|
| `GET /characters/{id}/relationships` | The leak. Zero consumers outside its own two tests. |
| `GET /duels/pending` | Client twin `listPendingChallenges` had zero callers. Pending challenges reach the UI via the **activity feed** (`services/activity_feed.py` registers `_duel_challenges_query` / `_duel_challenge_item` as a feed source). |
| `GET /duels/{duel_id}` | Client twin `getDuel` had zero callers; every reader uses `/duels/{id}/detail`. Deleting it also removes the route-ordering hazard — it was declared *after* `/pending` and `/{id}/detail` precisely so it would not shadow them. |
| `GET /factions/defection-history` | No frontend hit. Its data is already folded into `/factions/status` (`faction_service.py:258`). |
| `PATCH /admin/tasks/{id}/task-vision` | Not in `api/admin.ts`, not in the MCP, not in scripts. |
| `DELETE /admin/praxes/{id}` | No caller, and it never deleted anything — since #1373 it routes to `moderate_praxis(status=hidden)`, duplicating the moderate PATCH the frontend uses. |

Also deleted: `DefectionHistoryOut` (response-only schema for a deleted route), `TaskVisionToggle`, and `list_pending_duel_challenges_for_character` (called only by the deleted route). `get_duel` and `get_defection_history` **stay** — both still have internal service callers.

### Stale premises in the issue, re-derived

- The issue justified deleting `/duels/pending` by citing `hooks/usePendingRequests.ts`. **That file no longer exists** — #1423 deleted it when the panel moved to the Requests queue. I re-derived the claim against the activity feed itself rather than inheriting it.
- I confirmed `mcp/worldzero-admin/server.py:323` now calls `/admin/praxes/{id}/moderate`, so #1371's repoint landed and nothing targets the deleted DELETE route.
- `GET /activity-feed` appears in the issue only as the *replacement* for `/duels/pending`, not as a deletion target. It is untouched — it is the whole Updates page.
- The issue comment says item 3 duplicates #1384. It does not: #1384 is about `GET /factions/invitations`, a **different route**. Only the file is shared. #1384 is still open and unaffected.

### Near-miss avoided

`deletePraxis` in `api/praxis.ts` hits the **player-facing** `/praxes/{id}`, not the admin route. It is live and untouched — the names collide but the paths do not.

## Kept, with reasons — please read

**1. `getTaskSignups` — NOT deleted. The issue contradicts an owner ruling recorded in the code.**

The issue says to delete the client function while keeping the route. But `api/tasks.ts` carries an explicit ruling written at the time of #1262:

> No callers as of #1262, deliberately. […] The route, `TaskSignupOut` and this client survive because "who signed up for this task" is a plausible future surface and they cost nothing at rest.

The ruling covers *the client*, not just the route. The issue read it as route-only. It is consumer-less, but **deliberately** so — that is retention, not rot. I left it rather than guess. Say the word and it goes in a one-line follow-up.

**2. `TaskOut.is_task_vision_eligible` — NOT deleted. Ownership collision.**

Removing the field requires editing `backend/services/task.py:242` (`build_task_out`), a file another in-flight issue owns and I was scoped out of, plus `routers/admin.py:435` (`PendingTaskOut`), a backend contract test, and ~30 frontend test fixtures. It is also the read-side of a **live column** populated from era config via `seed.py` and `import_tasks_csv.py`, for a feature `SPEC-backend-architecture.md:249` records as declared-but-unbuilt. The admin *toggle* is gone as asked; the field wants its own issue once the sibling lands.

**3. `POST /admin/characters/backfill-stats` — untouched, needs your ruling.**

The issue flagged this verify-first and said not to silently delete. I confirmed it: consumer-less everywhere (`routers/admin.py:210`, only its own test). **Keep as a break-glass ops tool, or delete?** Your call — I did not act on it.

## Test-coverage note

`DELETE /admin/praxes/{id}`'s non-admin 403 test was **repointed** at the moderate route rather than dropped. Moderate had hide/unhide/failed/404 coverage but no non-admin assertion, so deleting the test outright would have silently lost that guard. Its 404 and hide behaviours were already covered by existing moderate tests. The two duel test usages were incidental re-assertions inside cancel-flow and accept-flow tests; both flows still assert their own subject directly.

## Verification

- Grep for every deleted path, client function and schema name across `backend`, `frontend/src`, `mcp`, `scripts`, `docs`: **zero hits**.
- Backend: **931 passed**, coverage **91.42%** (gate 80%).
- Frontend: `tsc --noEmit` clean (verified `tsc --version` actually runs — 5.9.3 — so this is not a false zero-error pass), `eslint` clean, **3306 vitest tests pass**, `vite build` succeeds, initial-load byte budget within limits (JS 130.9 KB, CSS 22.2 KB).
- Rebased onto latest `origin/main` (`ef5564b1`) and the full suite re-run green there.

**Visual QA is outstanding** — I have no browser tools or dev stack in this environment. The frontend change is the removal of two never-called API client functions, so no rendered surface should move, but that is reasoned, not observed.
