### PR TITLE
backfill-stats is consumer-less on purpose — say so where a sweep will look

### DIFF
--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -212,7 +212,19 @@ async def backfill_all_character_stats(
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ) -> dict:
-    """Recompute CharacterStats for every character using current vote data."""
+    """Recompute CharacterStats for every character using current vote data.
+
+    **Consumer-less on purpose — do not delete it (owner ruling, 2026-07-31).**
+    Nothing in the frontend or the admin MCP calls this, so a dead-endpoint sweep
+    finds it and proposes removal; #1386 did exactly that and was told to keep it.
+    It is a break-glass operations tool, and the value of one is that it is there
+    on the day you need it rather than on the day someone thought to add it.
+
+    It earns that standing: scoring is recomputed rather than stored as a running
+    total, so a bug in the recalc path leaves every score wrong until something
+    recomputes them. #1345 (the era bound) and #1373 (failed praxes score zero)
+    are both changes whose backfill this is.
+    """
     characters = await list_active_characters(session)
     era_row = await get_current_era_row(session)
     for character in characters:


### PR DESCRIPTION
Owner ruling (Molly, 2026-07-31): **`POST /admin/characters/backfill-stats` stays.**

#1386 swept six consumer-less endpoints and stopped at this one rather than deleting it silently — correctly, since the issue said not to. This records the answer.

## Why in the code rather than only on the issue

Because that is what demonstrably works in this repo. In the same sweep, #1386 kept `getTaskSignups` **only** because #1262's ruling had been written into `api/tasks.ts`, where a grep hits it. A ruling that lives in a closed issue is one an agent has to already know to go looking for — and the whole failure mode of a dead-code sweep is that it greps for consumers, finds none, and is right about the grep.

## The justification, kept

Scoring in this codebase is **recomputed, not accumulated**. So a defect anywhere in the recalc path leaves every score silently wrong until something recomputes them — and #1345 (era-bounded recalc) and #1373 (failed praxes score zero) are both changes whose backfill this endpoint is. It earns its keep by existing on the day it is needed, not on the day someone thinks to write it.

Docstring only. No behaviour change, no route change, no test change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)