### PR TITLE
The praxis feed stops re-counting votes once per card

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -59,7 +59,13 @@ from services.era import (
 from services.nudge import nudged_at_map
 from services.level_jump import available_level_reach, consume_level_jump
 from models.duel import Duel, DuelStatus
-from services.vote_tally import crowned_praxis_ids, get_tally, tally_votes, ViewerVote
+from services.vote_tally import (
+    crowned_praxis_ids,
+    get_tally,
+    tally_votes,
+    ViewerVote,
+    VoteTally,
+)
 
 
 EVERYMEN_FACTION_SLUG = "everymen"
@@ -497,6 +503,7 @@ async def build_praxis_card_out(
     applied_metatasks: Optional[dict[int, list[TaskOut]]] = None,
     viewer_can_vote: Optional[dict[int, bool]] = None,
     duel_ids: Optional[dict[int, int]] = None,
+    tallies: Optional[dict[int, VoteTally]] = None,
 ) -> PraxisCardOut:
     """Lightweight card for list views.
 
@@ -537,6 +544,13 @@ async def build_praxis_card_out(
     the duel lookup is not a per-card query (N+1). When absent, this builder
     loads the single praxis's duel id itself (single-card callers). A missing
     entry means the praxis is not a duel side (``duel_id=None``).
+
+    ``tallies`` maps praxis id → its :class:`~services.vote_tally.VoteTally`;
+    list routes precompute it once via :func:`~services.vote_tally.tally_votes`
+    so the vote sum is not a per-card query (#1378). That map covers every id it
+    was gathered for, zero-vote praxes included, so a *missing* entry means "not
+    in the batch" and this builder falls back to tallying the single praxis
+    itself (single-card callers) rather than reading absence as no votes.
     """
     task_title = praxis.task.title if praxis.task else ""
     task_point_value = praxis.task.point_value if praxis.task else 0
@@ -551,8 +565,12 @@ async def build_praxis_card_out(
 
     viewer_vote_info = viewer_votes.get(praxis.id) if viewer_votes else None
 
-    tally_map = await tally_votes([praxis.id], session)
-    tally = get_tally(tally_map, praxis.id)
+    # Votes. Reuse the precomputed page-wide map when the list route supplies it
+    # (#1378); otherwise tally this praxis alone. Membership is the coverage
+    # test, not truthiness: a zero-vote praxis IS in the map, with an empty tally.
+    tally = tallies.get(praxis.id) if tallies is not None else None
+    if tally is None:
+        tally = get_tally(await tally_votes([praxis.id], session), praxis.id)
 
     # Score (ADR-0053), computed for the AUTHOR. Reuse the precomputed map when
     # the list route supplies it; otherwise score this praxis alone.
@@ -632,12 +650,14 @@ async def build_praxis_cards(
     session: AsyncSession,
     viewer: Optional[Character],
 ) -> list[PraxisCardOut]:
-    """Enrich a whole page of praxes into cards, six PAGE-WIDE queries deep.
+    """Enrich a whole page of praxes into cards, seven PAGE-WIDE queries deep.
 
     Every lookup here is deliberately one query for the list rather than one per
-    card, and they are listed together so that stays true — a seventh per-card
+    card, and they are listed together so that stays true — an eighth per-card
     query added inside :func:`build_praxis_card_out` would be invisible at the
     call site but would multiply by the page size.
+    ``tests/integration/test_praxis_list_query_count.py`` asserts a small page
+    and a large one cost the same, which is what stops that happening again.
 
     Lifted out of the ``/praxes`` route body so a second caller (the rail's
     compound read, #1344) gets an identical card rather than a near-miss
@@ -672,6 +692,11 @@ async def build_praxis_cards(
     # duel lookup per card. A duel side is stored type='solo' + a non-null
     # duel_id (ADR-0011), so the card mode label/chip gates on this, not type.
     duel_ids = await duel_id_map(praxes, session)
+    # Vote tallies (#1378): one grouped aggregate for the whole page — this was
+    # the last per-card query here, a one-element ``tally_votes`` call inside the
+    # builder, costing +1 SELECT per row on every list and doubling on each
+    # "load more" refetch.
+    tallies = await tally_votes([praxis.id for praxis in praxes], session)
     return [
         await build_praxis_card_out(
             praxis,
@@ -682,6 +707,7 @@ async def build_praxis_cards(
             applied_metatasks=applied_metatasks,
             viewer_can_vote=viewer_can_vote,
             duel_ids=duel_ids,
+            tallies=tallies,
         )
         for praxis in praxes
     ]

--- a/backend/services/vote_tally.py
+++ b/backend/services/vote_tally.py
@@ -31,13 +31,21 @@ _EMPTY_TALLY = VoteTally(points_from_votes=0, voter_count=0)
 
 
 async def tally_votes(
-    praxis_ids: list[int],
+    praxis_ids: Collection[int],
     session: AsyncSession,
 ) -> dict[int, VoteTally]:
-    """Return a ``VoteTally`` for each requested praxis id.
+    """Return a ``VoteTally`` for **every** requested praxis id — ONE query.
 
-    Praxes with no votes are not included in the result; callers should use
-    the helper :func:`get_tally`.
+    The result covers exactly ``praxis_ids``: a praxis with no votes gets an
+    empty tally instead of being omitted, so ``praxis_id in result`` means "this
+    id was in the batch" and never "this id has no votes" (#1378). Page-wide
+    callers such as :func:`services.praxis.build_praxis_cards` use that
+    membership to decide whether the precomputed map answers for a card or the
+    card must fall back to its own query — with a sparse map, a praxis outside
+    the batch would silently read as zero votes.
+
+    :func:`get_tally` remains the safe reader for callers holding a map that was
+    gathered for a *different* id set (scoring's opponent lookups).
     """
     if not praxis_ids:
         return {}
@@ -47,13 +55,15 @@ async def tally_votes(
         .where(Vote.praxis_id.in_(praxis_ids))
         .group_by(Vote.praxis_id)
     )
-    return {
-        pid: VoteTally(
+    tallies: dict[int, VoteTally] = {
+        praxis_id: _EMPTY_TALLY for praxis_id in praxis_ids
+    }
+    for pid, total, count in agg_result.all():
+        tallies[pid] = VoteTally(
             points_from_votes=int(total or 0),
             voter_count=int(count or 0),
         )
-        for pid, total, count in agg_result.all()
-    }
+    return tallies
 
 
 def get_tally(tallies: dict[int, VoteTally], praxis_id: int) -> VoteTally:

--- a/backend/tests/integration/test_praxis_list_query_count.py
+++ b/backend/tests/integration/test_praxis_list_query_count.py
@@ -1,0 +1,224 @@
+"""#1378 — the praxis list must cost a constant number of queries.
+
+**The seam under test** is ``GET /praxes`` → :func:`services.praxis.build_praxis_cards`
+→ :func:`services.praxis.build_praxis_card_out`. That gather page-batches six maps
+(crowns, viewer votes, author contributions, applied metatasks, vote eligibility,
+duel ids) with explicit "never a per-card query" comments — but the card builder
+still called :func:`services.vote_tally.tally_votes` with a one-element list per
+praxis, so the vote tally was the one un-batched map: +1 SELECT per row.
+
+Two assertions, and they are different things:
+
+- **query count** — a small page and a larger one cost the *same* number of
+  SELECTs, signed in and anonymous. This is what stops the N+1 growing back;
+  this repo has re-grown one before (#1377 is the sibling guard for ``/tasks``).
+- **behaviour** — every card's ``points_from_votes``/``voter_count`` still equals
+  what :func:`~services.vote_tally.tally_votes` says for that praxis *alone*,
+  including the zero-vote praxis (absent from the aggregate) and a praxis whose
+  votes span more than one voter account. A batch that changes an answer is a
+  bug, not an optimisation.
+"""
+from contextlib import contextmanager
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task
+from models.vote import Vote
+from services.vote_tally import get_tally, tally_votes
+
+#: Rows on the small page, and on the large one. The gap is the whole test: any
+#: per-row query shows up as a difference between the two counts.
+SMALL_PAGE_PRAXES = 2
+LARGE_PAGE_PRAXES = 12
+
+
+@contextmanager
+def _count_selects(db_connection):
+    """Collect every SELECT issued on the test connection while the block runs."""
+    selects: list[str] = []
+    sync_connection = db_connection.sync_connection
+
+    def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            selects.append(statement)
+
+    event.listen(sync_connection, "before_cursor_execute", before_cursor_execute)
+    try:
+        yield selects
+    finally:
+        event.remove(sync_connection, "before_cursor_execute", before_cursor_execute)
+
+
+async def _add_submitted_praxes(
+    db_session: AsyncSession,
+    task: Task,
+    author: Character,
+    count: int,
+    *,
+    start: int = 0,
+) -> list[Praxis]:
+    """``count`` submitted solo praxes by ``author`` — the ordinary feed row."""
+    praxes = []
+    for index in range(start, start + count):
+        praxis = Praxis(
+            task_id=task.id,
+            created_by_id=author.id,
+            type=PraxisType.solo,
+            status=PraxisStatus.submitted,
+            # #658 guards the submitted feed on submitted_at IS NOT NULL.
+            submitted_at=datetime.now(timezone.utc),
+            title=f"Praxis {index}",
+            body_text="proof",
+        )
+        db_session.add(praxis)
+        await db_session.flush()
+        db_session.add(PraxisMember(praxis_id=praxis.id, character_id=author.id))
+        praxes.append(praxis)
+    await db_session.commit()
+    return praxes
+
+
+async def _cast(
+    db_session: AsyncSession, praxis: Praxis, voter: Character, value: int
+) -> None:
+    db_session.add(
+        Vote(
+            praxis_id=praxis.id,
+            voter_character_id=voter.id,
+            voter_account_id=voter.account_id,
+            value=value,
+        )
+    )
+    await db_session.commit()
+
+
+@pytest_asyncio.fixture
+async def feed_page(
+    db_session: AsyncSession,
+    active_task: Task,
+    character2: Character,
+    character3: Character,
+) -> list[Praxis]:
+    """A small page, one row voted and one not — a page of identical rows would
+    hide a tally query that only fires for praxes that HAVE votes."""
+    praxes = await _add_submitted_praxes(
+        db_session, active_task, character2, SMALL_PAGE_PRAXES
+    )
+    await _cast(db_session, praxes[0], character3, 4)
+    return praxes
+
+
+@pytest.mark.asyncio
+async def test_signed_in_feed_query_count_does_not_scale_with_page_size(
+    client: AsyncClient,
+    db_connection,
+    db_session: AsyncSession,
+    feed_page: list[Praxis],
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    auth_headers: dict,
+):
+    """A signed-in 12-row page costs the same queries as a 2-row page (#1378)."""
+    with _count_selects(db_connection) as small_page:
+        small = await client.get("/praxes?limit=50", headers=auth_headers)
+    assert small.status_code == 200
+    assert len(small.json()) == SMALL_PAGE_PRAXES
+    small_count = len(small_page)
+
+    await _add_submitted_praxes(
+        db_session,
+        active_task,
+        character2,
+        LARGE_PAGE_PRAXES - SMALL_PAGE_PRAXES,
+        start=SMALL_PAGE_PRAXES,
+    )
+
+    with _count_selects(db_connection) as large_page:
+        large = await client.get("/praxes?limit=50", headers=auth_headers)
+    assert large.status_code == 200
+    assert len(large.json()) == LARGE_PAGE_PRAXES
+    assert len(large_page) == small_count, (
+        f"{small_count} queries for {SMALL_PAGE_PRAXES} rows but "
+        f"{len(large_page)} for {LARGE_PAGE_PRAXES}: "
+        + "\n".join(large_page)
+    )
+
+
+@pytest.mark.asyncio
+async def test_anonymous_feed_query_count_does_not_scale_with_page_size(
+    client: AsyncClient,
+    db_connection,
+    db_session: AsyncSession,
+    feed_page: list[Praxis],
+    active_task: Task,
+    character2: Character,
+):
+    """The guest feed pays the same N+1; it must go flat too (#1378)."""
+    with _count_selects(db_connection) as small_page:
+        small = await client.get("/praxes?limit=50")
+    assert small.status_code == 200
+    small_count = len(small_page)
+
+    await _add_submitted_praxes(
+        db_session,
+        active_task,
+        character2,
+        LARGE_PAGE_PRAXES - SMALL_PAGE_PRAXES,
+        start=SMALL_PAGE_PRAXES,
+    )
+
+    with _count_selects(db_connection) as large_page:
+        large = await client.get("/praxes?limit=50")
+    assert large.status_code == 200
+    assert len(large.json()) == LARGE_PAGE_PRAXES
+    assert len(large_page) == small_count, "\n".join(large_page)
+
+
+@pytest.mark.asyncio
+async def test_batched_tallies_equal_the_per_praxis_tally(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    auth_headers: dict,
+):
+    """Every card's vote fields match the tally computed for that praxis alone.
+
+    The page deliberately mixes the cases: a praxis with no votes at all (absent
+    from the aggregate, so a page-wide map must not read that absence as
+    "uncovered"), a praxis voted once, and a praxis voted by two different voter
+    ACCOUNTS — the sum and the count both have to carry across.
+    """
+    unvoted, single_voter, two_voters = await _add_submitted_praxes(
+        db_session, active_task, character2, 3
+    )
+    await _cast(db_session, single_voter, character3, 2)
+    await _cast(db_session, two_voters, character, 5)
+    await _cast(db_session, two_voters, character3, 3)
+
+    response = await client.get("/praxes?limit=50", headers=auth_headers)
+    assert response.status_code == 200
+    rows = {row["id"]: row for row in response.json()}
+    assert {unvoted.id, single_voter.id, two_voters.id} <= set(rows)
+
+    for praxis_id, row in rows.items():
+        tally = get_tally(await tally_votes([praxis_id], db_session), praxis_id)
+        assert row["points_from_votes"] == tally.points_from_votes, praxis_id
+        assert row["voter_count"] == tally.voter_count, praxis_id
+
+    # The mix actually exercised the cases it claims to.
+    assert rows[unvoted.id]["voter_count"] == 0
+    assert rows[unvoted.id]["points_from_votes"] == 0
+    assert rows[single_voter.id]["voter_count"] == 1
+    assert rows[two_voters.id]["voter_count"] == 2
+    assert rows[two_voters.id]["points_from_votes"] == 8


### PR DESCRIPTION
Closes #1378

## The seam under test

`GET /praxes` -> `services.praxis.build_praxis_cards` -> `build_praxis_card_out`.
The page gather gathers six maps page-wide (crowns, viewer votes, author
contributions, applied metatasks, vote eligibility, duel ids) with explicit
"never a per-card query" comments -- but the builder still called
`services.vote_tally.tally_votes([praxis.id], session)` for its own row. The
batch API was already there; it was simply never passed through.

## Measurement (the "red")

Counted with an `event.listen` on the test connection (same harness as #1377's
`test_task_list_query_count.py`), 50 submitted praxes on one page:

| page | before | after |
|---|---:|---:|
| `GET /praxes?limit=50` **signed in** | **72** SELECTs | **23** |
| `GET /praxes?limit=50` **anonymous** | **67** SELECTs | **18** |

Exactly -49: fifty one-element aggregates became one grouped aggregate. The new
count is flat -- a 2-row page and a 12-row page now cost the same, and
`tests/integration/test_praxis_list_query_count.py` asserts that equality
(signed in *and* anonymous) so the N+1 cannot grow back.

Server *timing* is not quoted: `scripts/measure-load.mjs` needs a running dev
stack, which this agent has no access to. The query count is the measurement
that was actually taken; no browser QA was possible, and there is no frontend
change to look at.

## What changed

- `services/vote_tally.py` -- `tally_votes` now returns an entry for **every**
  requested id, empty tally included, instead of omitting vote-less praxes. That
  makes `praxis_id in tallies` mean "this id was in the batch" and never "this
  id has no votes". This is the coverage record #1377's `SignupFacts.task_ids`
  keeps, without a second type: the map already knows its own domain. `get_tally`
  is untouched and stays the safe reader for maps gathered over a different id
  set (scoring's opponent lookups). Every existing caller reads through
  `get_tally` or an `if tally` guard, so a present-but-empty entry gives them the
  same answer as an absent one.
- `services/praxis.py`
  - `build_praxis_card_out` takes `tallies`, the seventh optional page-wide map,
    following the same precompute-or-self-compute rule as its six siblings. A
    praxis outside the supplied map falls back to its own tally rather than
    reading absence as zero votes.
  - `build_praxis_cards` gathers `tally_votes` for the page beside the other six.

No new aggregation: `tally_votes` is still the one place that runs
`func.sum(Vote.value)` (ADR-0014), and the single-praxis detail path
(`build_praxis_out`) is unchanged.

Both other card surfaces ride along free -- `GET /me/...` active praxes
(`routers/me.py`) and the task-detail / profile grids, which reach the same
route via `?task_id=` / `?character_id=`.

## Behavioural guard

`test_batched_tallies_equal_the_per_praxis_tally` builds a page that mixes the
cases -- a praxis with **no votes at all** (the one the sparse map used to omit),
a praxis voted once, and a praxis voted by **two different voter accounts** --
and asserts every card's `points_from_votes` and `voter_count` equals what
`tally_votes` says for that praxis in isolation. It passes before and after.

## Verification

`pytest --cov=. --cov-fail-under=80` from `backend/` against a dedicated
`wz1378_test` DB: **935 passed, coverage 91.55%**. No migration, no frontend
change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)