### PR TITLE
One query, one response: invitation letters fold onto /factions/status (#1384)

### DIFF
--- a/backend/routers/factions.py
+++ b/backend/routers/factions.py
@@ -24,7 +24,6 @@ from services.faction_service import (
     defect_to_faction,
     get_invitation_status,
 )
-from models.invitation_letter import InvitationLetter
 
 router = APIRouter()
 
@@ -76,13 +75,21 @@ async def get_faction_status(
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
-    """Return faction page data: current faction and status of all factions.
+    """Return faction page data: current faction, per-faction status, and letters.
 
     Albescent (ADR-0027, #390) is omitted from ``all_factions`` unless this
     account has been revealed to the secret society.
+
+    ``invitations`` is not filtered the same way, and does not need to be:
+    ``_NON_INVITE_FACTION_SLUGS`` (services/character_stats.py) means no
+    Albescent letter is ever delivered, so there is nothing here to leak. This
+    array replaces ``GET /factions/invitations`` (#1384), which re-ran the same
+    ``InvitationLetter`` select against the same character and era row that
+    ``get_invitation_status`` already runs — and whose only caller paired the
+    two requests anyway.
     """
     era_row = await get_current_era_row(session)
-    status_map = await get_invitation_status(
+    status_map, letters = await get_invitation_status(
         character.id, era_row.id, session
     )
     all_factions = [
@@ -96,27 +103,5 @@ async def get_faction_status(
     return FactionPageOut(
         current_faction_slug=character.faction_slug,
         all_factions=all_factions,
+        invitations=[InvitationLetterOut.model_validate(letter) for letter in letters],
     )
-
-
-@router.get("/invitations", response_model=list[InvitationLetterOut])
-async def list_invitations(
-    character: Character = Depends(get_current_character),
-    session: AsyncSession = Depends(get_db),
-):
-    """Return all invitation letters delivered to the current character."""
-    era_row = await get_current_era_row(session)
-    result = await session.execute(
-        select(InvitationLetter).where(
-            InvitationLetter.character_id == character.id,
-            InvitationLetter.era_id == era_row.id,
-        )
-    )
-    letters = result.scalars().all()
-    return [
-        InvitationLetterOut(
-            faction_slug=letter.faction_slug,
-            delivered_at=letter.delivered_at,
-        )
-        for letter in letters
-    ]

--- a/backend/schemas/faction.py
+++ b/backend/schemas/faction.py
@@ -28,13 +28,19 @@ class FactionStatusOut(BaseModel):
     status: FactionMembershipStatus
 
 
-class FactionPageOut(BaseModel):
-    current_faction_slug: str
-    all_factions: list[FactionStatusOut]
-
-
 class InvitationLetterOut(BaseModel):
     faction_slug: str
     delivered_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class FactionPageOut(BaseModel):
+    current_faction_slug: str
+    all_factions: list[FactionStatusOut]
+    # #1384: the letters themselves, not just the "invited" status they imply.
+    # A per-faction status row is the wrong home for a timestamp — delivered_at
+    # is meaningless on a row reading "defected" — so the letters stay their own
+    # list. They ride here because the query behind `all_factions` had already
+    # read them; the deleted GET /factions/invitations re-ran it verbatim.
+    invitations: list[InvitationLetterOut]

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -244,14 +244,23 @@ async def get_invitation_status(
     era_id: int,
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
-) -> dict[str, str]:
-    """Return a dict mapping faction slug to relationship status.
+) -> tuple[dict[str, str], list[InvitationLetter]]:
+    """Return the per-faction relationship status **and** the letters behind it.
 
-    Possible values: "member", "invited", "not_invited", "defected", "can_return".
+    The status map keys every faction slug in the era to one of "member",
+    "invited", "not_invited", "defected", "can_return".
+
+    The letters come back alongside it because ``GET /factions/invitations`` used
+    to re-run this function's exact ``InvitationLetter`` select — same character,
+    same era row — and callers paired the two requests (#1384). Handing back the
+    rows already read is what lets one response serve both, so the *status* view
+    (a slug's state) and the *letter* view (when it arrived) never cost two
+    queries again. Only the slugs are needed here; the caller wants
+    ``delivered_at`` too, so the rows are not reduced before returning.
     """
     character = await session.get(Character, character_id)
     if character is None:
-        return {}
+        return {}, []
 
     current_faction = character.faction_slug
 
@@ -264,9 +273,8 @@ async def get_invitation_status(
             InvitationLetter.era_id == era_id,
         )
     )
-    invited_slugs = {
-        letter.faction_slug for letter in invitation_result.scalars().all()
-    }
+    letters = list(invitation_result.scalars().all())
+    invited_slugs = {letter.faction_slug for letter in letters}
 
     status_map: dict[str, str] = {}
     for slug, faction_config in era.factions.items():
@@ -281,4 +289,4 @@ async def get_invitation_status(
         else:
             status_map[slug] = "not_invited"
 
-    return status_map
+    return status_map, letters

--- a/backend/tests/integration/test_factions.py
+++ b/backend/tests/integration/test_factions.py
@@ -78,6 +78,69 @@ async def test_faction_status_unauthenticated(client: AsyncClient):
     assert resp.status_code == 401
 
 
+@pytest.mark.asyncio
+async def test_faction_status_carries_invitation_letters(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    faction_ua: Faction,
+    era: Era,
+    db_session: AsyncSession,
+):
+    """The letters the deleted /factions/invitations returned now ride on /status (#1384).
+
+    Asserts the VALUE, not merely the field's presence: the ``delivered_at`` the
+    fold emits must be the stored letter's own timestamp, because the two routes
+    always read the exact same rows.
+    """
+    from datetime import datetime
+
+    from sqlalchemy import select
+
+    from models.invitation_letter import InvitationLetter
+
+    db_session.add(InvitationLetter(
+        character_id=character.id,
+        faction_slug="ua",
+        era_id=era.id,
+    ))
+    await db_session.commit()
+
+    stored = (await db_session.execute(
+        select(InvitationLetter).where(InvitationLetter.character_id == character.id)
+    )).scalars().one()
+
+    resp = await client.get("/factions/status", headers=auth_headers)
+    assert resp.status_code == 200
+    letters = resp.json()["invitations"]
+    assert [letter["faction_slug"] for letter in letters] == ["ua"]
+    assert datetime.fromisoformat(letters[0]["delivered_at"]) == stored.delivered_at
+
+
+@pytest.mark.asyncio
+async def test_faction_status_invitations_empty_without_letters(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    faction_ua: Faction,
+    era: Era,
+):
+    """Holding no letters, the folded array is present and empty — never absent."""
+    resp = await client.get("/factions/status", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["invitations"] == []
+
+
+@pytest.mark.asyncio
+async def test_invitations_endpoint_is_gone(
+    client: AsyncClient,
+    auth_headers: dict,
+):
+    """GET /factions/invitations is deleted — it ran /status's exact query (#1384)."""
+    resp = await client.get("/factions/invitations", headers=auth_headers)
+    assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # Defection history
 # ---------------------------------------------------------------------------

--- a/frontend/src/api/factions.ts
+++ b/frontend/src/api/factions.ts
@@ -13,14 +13,18 @@ export interface FactionStatusOut {
   status: string // member, invited, not_invited, defected, can_return
 }
 
-export interface FactionPageOut {
-  current_faction_slug: string
-  all_factions: FactionStatusOut[]
-}
-
 export interface InvitationLetterOut {
   faction_slug: string
   delivered_at: string
+}
+
+export interface FactionPageOut {
+  current_faction_slug: string
+  all_factions: FactionStatusOut[]
+  // #1384: the letters arrive with the status map. `GET /factions/invitations`
+  // ran the same query the status map was already built from, and every caller
+  // requested the pair, so there is no longer a second endpoint to call.
+  invitations: InvitationLetterOut[]
 }
 
 export async function getFactions(): Promise<FactionOut[]> {
@@ -30,11 +34,6 @@ export async function getFactions(): Promise<FactionOut[]> {
 
 export async function getFactionStatus(): Promise<FactionPageOut> {
   const res = await api.get<FactionPageOut>('/factions/status')
-  return res.data
-}
-
-export async function getInvitations(): Promise<InvitationLetterOut[]> {
-  const res = await api.get<InvitationLetterOut[]>('/factions/invitations')
   return res.data
 }
 

--- a/frontend/src/pages/factionDetail/useFactionDetail.ts
+++ b/frontend/src/pages/factionDetail/useFactionDetail.ts
@@ -14,7 +14,6 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   getFactionStatus,
-  getInvitations,
   chooseFaction,
   type FactionOut,
 } from "../../api/factions";
@@ -191,13 +190,15 @@ export function useFactionDetail(
       return;
     }
     let cancelled = false;
-    Promise.all([getFactionStatus(), getInvitations()])
-      .then(([page, invites]) => {
+    // One request, not two: the letters ride on the status payload (#1384),
+    // which is the same query the status map was derived from anyway.
+    getFactionStatus()
+      .then((page) => {
         if (cancelled) return;
         setRawStatus(
           page.all_factions.find((f) => f.slug === slug)?.status ?? "not_invited",
         );
-        setHasInvite(invites.some((inv) => inv.faction_slug === slug));
+        setHasInvite(page.invitations.some((inv) => inv.faction_slug === slug));
       })
       .catch(() => {
         if (!cancelled) {

--- a/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
+++ b/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
@@ -37,7 +37,7 @@ const FACTIONS: FactionOut[] = [
 
 function status(rows: Array<[string, string]>): FactionPageOut {
   const all_factions: FactionStatusOut[] = rows.map(([slug, status]) => ({ slug, status }))
-  return { current_faction_slug: 'coven', all_factions }
+  return { current_faction_slug: 'coven', all_factions, invitations: [] }
 }
 
 // A viewer who is a Coven member, recruited by S.N.I.D.E., and not invited by

--- a/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
+++ b/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
@@ -24,9 +24,10 @@ const NA_SLUG = 'na'
  * code: `_NON_INVITE_FACTION_SLUGS = {"na", "albescent"}` (backend
  * services/character_stats.py) means no letter is ever written for those two,
  * and `get_account_invited_faction_slugs` excludes the same pair while being
- * ACCOUNT-pooled — strictly broader than the character-scoped
- * /factions/invitations. So every slug this feed can return already reports
- * `invited` in /factions/status. The view's selectState stays as-is (#733).
+ * ACCOUNT-pooled — strictly broader than the character-scoped letters. So every
+ * slug this feed can return already reports `invited` in the same payload's
+ * status map: since #1384 the letters and that map are one `/factions/status`
+ * response, built from one query. The view's selectState stays as-is (#733).
  */
 export default function DefaultFactionsDirectory({ state }: { state: FactionsDirectoryState }) {
   const { t } = useTranslation('factions')

--- a/frontend/src/pages/factions/useFactionsDirectory.ts
+++ b/frontend/src/pages/factions/useFactionsDirectory.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import {
   getFactionStatus,
-  getInvitations,
   type FactionOut,
   type FactionPageOut,
   type InvitationLetterOut,
@@ -15,7 +14,9 @@ import { useFactions } from '../../hooks/useFactions'
  * `/factions` itself is no longer fetched here: it comes from the app-wide
  * `useFactions` cache (#1284), so arriving from any other surface costs nothing.
  * What this hook still owns is the viewer's membership status + invitations,
- * which are per-character and not cacheable app-wide.
+ * which are per-character and not cacheable app-wide. Those two arrive together
+ * on `/factions/status` (#1384) — the letters ride on the same payload as the
+ * status map they were derived from, so this is one request, not two.
  *
  * The desktop grid and the phone directory used to own a private copy of this
  * effect, which made `/factions` the one page dispatcher whose data lived BELOW
@@ -27,6 +28,9 @@ import { useFactions } from '../../hooks/useFactions'
  * The failure is returned raw rather than as a message: the two surfaces phrase
  * their own fallback copy, and a shared hook has no business picking one.
  */
+/** Stable identity for the signed-out / not-yet-loaded case. */
+const NO_INVITATIONS: InvitationLetterOut[] = []
+
 export interface FactionsDirectoryState {
   readonly factions: FactionOut[]
   /** The viewer's per-faction membership status; null while signed out. */
@@ -44,7 +48,6 @@ export function useFactionsDirectory(): FactionsDirectoryState {
   // owns the request, it derives from the shared hook.
   const factions = useFactions()
   const [factionPage, setFactionPage] = useState<FactionPageOut | null>(null)
-  const [invitations, setInvitations] = useState<InvitationLetterOut[]>([])
   const [membershipLoading, setMembershipLoading] = useState(true)
   const [error, setError] = useState<unknown>(null)
 
@@ -56,10 +59,9 @@ export function useFactionsDirectory(): FactionsDirectoryState {
     const load = async () => {
       if (characterId == null) return
       // The invitations feed backs the letters PANEL only — never card state.
-      const [statusData, invitesData] = await Promise.all([getFactionStatus(), getInvitations()])
+      const statusData = await getFactionStatus()
       if (cancelled) return
       setFactionPage(statusData)
-      setInvitations(invitesData)
     }
 
     load()
@@ -78,7 +80,7 @@ export function useFactionsDirectory(): FactionsDirectoryState {
   return {
     factions: factions ?? [],
     factionPage,
-    invitations,
+    invitations: factionPage?.invitations ?? NO_INVITATIONS,
     // Still one flag, and it still means "nothing to draw yet": the grid needs
     // the faction list, so a settled membership read with `factions` still null
     // is not loaded. Keeping the two apart would flash an empty grid.


### PR DESCRIPTION
`GET /factions/invitations` ran the query `GET /factions/status` had already run. Its one useful field now rides on the status payload and the route is gone.

Closes #1384

## The "exact query" claim — verified, and it holds

Both selects were `InvitationLetter` filtered on `character_id` **and** `era_id`, nothing else:

- `services/faction_service.py` `get_invitation_status` — reached via `/factions/status`
- `routers/factions.py` `list_invitations` — `/factions/invitations`

Both resolved the era the same way, `await get_current_era_row(session)` at route level, so the two `era_id` values were the same row by construction. **No filter, era scope, or ordering differed.** The only asymmetry was downstream: `get_invitation_status` threw `delivered_at` away and kept the slugs. That discarded field was the whole reason the second endpoint existed.

Both callers requested the pair together (`useFactionsDirectory.ts`, `useFactionDetail.ts`), so this is one round trip where there were two.

## Shape: an `invitations` array, not `invited_at` on the status row

Per the ruling on the issue. A per-faction status row is the wrong home for a timestamp — `delivered_at` is meaningless on a row reading `defected`, and it is the smaller client change since both hooks already consume a letters array.

## The one place the two routes were not symmetric

`/factions/status` filters Albescent out of `all_factions` unless the account has been revealed (ADR-0027); the deleted route filtered nothing. **The new array is likewise unfiltered, which preserves the old behaviour exactly and leaks nothing:** `_NON_INVITE_FACTION_SLUGS = {"na", "albescent"}` in `services/character_stats.py` means no Albescent letter is ever delivered, so there is no row for a filter to catch. Adding one would have been dead code. Noted in the route docstring so a future reader does not have to re-derive it.

`useCreateCharacter.ts` was in scope but is untouched: it calls `GET /me/invited-factions`, a different, ADR-0019 **account**-pooled endpoint. That pooling is unchanged — nothing here narrows it to per-character.

## Seam under test

The API boundary: what `/factions/status` emits, and that the second route is gone.

- `test_faction_status_carries_invitation_letters` — asserts the **value**, comparing the emitted `delivered_at` against the stored row, not merely that the field exists
- `test_faction_status_invitations_empty_without_letters` — the array is present and empty, never absent
- `test_invitations_endpoint_is_gone` — 404
- grep: zero remaining references to `getInvitations` or the route path outside the 404 test

All three were written first and failed for the right reasons (`KeyError: 'invitations'`, then `403 != 404`).

## Verification

No browser or dev stack in this worktree — everything below is tests and build output.

- `pytest` full suite: **935 passed**, coverage 91.49% (gate 80%), against a dedicated `wz1384_test` DB
- `tsc --noEmit`: clean (tsc 5.9.3 confirmed actually resolvable, not a false empty pass)
- `vitest run`: **3336 passed** across 194 files
- `eslint src --max-warnings=0`: clean
- `vite build` + `npm run budget`: within budget (JS 131.0 KB, CSS 22.3 KB gzipped)

## Net

One fewer route, one fewer HTTP round trip on two surfaces. Line count across the seven source files is +65/−63, a wash: the deleted route pays for the docstrings explaining why the fold is safe. The test file is the only real growth (+63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)