### PR TITLE
componentSrcMap gets a guard, because a hand-written map without one re-rots

### DIFF
--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -117,7 +117,6 @@
     "FactionProfileBody": "src/pages/characterProfile/FactionProfileBody.tsx",
     "FactionSelectCard": "src/components/selectCard/FactionSelectCard.tsx",
     "FactionSigil": "src/components/sigil/FactionSigil.tsx",
-    "FactionSigilRow": "src/components/ui/FactionSigilRow.tsx",
     "FactionsDirectoryView": "src/pages/factions/mobileArchetypes/FactionsDirectoryView.tsx",
     "FeedArchiveButton": "src/components/feed/FeedArchiveButton.tsx",
     "FeedBadge": "src/components/feed/FeedBadge.tsx",
@@ -134,9 +133,7 @@
     "FeedRowActions": "src/components/feed/FeedRowActions.tsx",
     "FeedRowContent": "src/components/feed/FeedRowContent.tsx",
     "FeedUndoStrip": "src/components/feed/FeedUndoStrip.tsx",
-    "FilterFactionTabs": "src/components/ui/FilterFactionTabs.tsx",
     "FilterLevelNodes": "src/components/ui/FilterLevelNodes.tsx",
-    "FilterStamps": "src/components/ui/FilterStamps.tsx",
     "HoldoutPublishNotice": "src/pages/editPraxis/blocks/HoldoutPublishNotice.tsx",
     "ImageEditModal": "src/components/imageEdit/ImageEditModal.tsx",
     "InvitationLetterPopup": "src/components/InvitationLetterPopup.tsx",
@@ -156,7 +153,6 @@
     "MobileHeader": "src/components/layout/MobileHeader.tsx",
     "MobilePraxisFeed": "src/pages/praxes/MobilePraxisFeed.tsx",
     "MobileTabBar": "src/components/layout/MobileTabBar.tsx",
-    "MobileUpdates": "src/pages/updates/MobileUpdates.tsx",
     "NavBar": "src/components/NavBar.tsx",
     "OwnerControls": "src/components/comments/OwnerControls.tsx",
     "PageTitle": "src/components/ui/PageTitle.tsx",
@@ -481,9 +477,6 @@
       "cardMode": "single",
       "viewport": "1200x900"
     },
-    "FactionSigilRow": {
-      "cardMode": "column"
-    },
     "FactionsDirectoryView": {
       "cardMode": "single",
       "viewport": "390x760"
@@ -491,13 +484,7 @@
     "FeedChassisBand": {
       "cardMode": "column"
     },
-    "FilterFactionTabs": {
-      "cardMode": "column"
-    },
     "FilterLevelNodes": {
-      "cardMode": "column"
-    },
-    "FilterStamps": {
       "cardMode": "column"
     },
     "ImageEditModal": {
@@ -535,10 +522,6 @@
     },
     "MobileTabBar": {
       "cardMode": "column"
-    },
-    "MobileUpdates": {
-      "cardMode": "single",
-      "viewport": "390x760"
     },
     "NavBar": {
       "cardMode": "column"

--- a/frontend/.ds-kit/index.tsx
+++ b/frontend/.ds-kit/index.tsx
@@ -114,7 +114,6 @@ export { default as FactionFeedFrame } from "../src/components/feed/FactionFeedF
 export { default as FactionProfileBody } from "../src/pages/characterProfile/FactionProfileBody";
 export { default as FactionSelectCard } from "../src/components/selectCard/FactionSelectCard";
 export { default as FactionSigil } from "../src/components/sigil/FactionSigil";
-export { default as FactionSigilRow } from "../src/components/ui/FactionSigilRow";
 export { default as FactionsDirectoryView } from "../src/pages/factions/mobileArchetypes/FactionsDirectoryView";
 export { default as FeedArchiveButton } from "../src/components/feed/FeedArchiveButton";
 export { default as FeedBadge } from "../src/components/feed/FeedBadge";
@@ -132,9 +131,7 @@ export { default as FeedItemSlot } from "../src/components/feed/FeedItemSlot";
 export { default as FeedRowActions } from "../src/components/feed/FeedRowActions";
 export { default as FeedRowContent } from "../src/components/feed/FeedRowContent";
 export { default as FeedUndoStrip } from "../src/components/feed/FeedUndoStrip";
-export { default as FilterFactionTabs } from "../src/components/ui/FilterFactionTabs";
 export { default as FilterLevelNodes } from "../src/components/ui/FilterLevelNodes";
-export { default as FilterStamps } from "../src/components/ui/FilterStamps";
 export { default as HoldoutPublishNotice } from "../src/pages/editPraxis/blocks/HoldoutPublishNotice";
 export { default as ImageEditModal } from "../src/components/imageEdit/ImageEditModal";
 export { default as InvitationLetterPopup } from "../src/components/InvitationLetterPopup";
@@ -155,7 +152,6 @@ export { default as MetataskSealStack } from "../src/components/metataskSeal/Met
 export { default as MobileHeader } from "../src/components/layout/MobileHeader";
 export { default as MobilePraxisFeed } from "../src/pages/praxes/MobilePraxisFeed";
 export { default as MobileTabBar } from "../src/components/layout/MobileTabBar";
-export { default as MobileUpdates } from "../src/pages/updates/MobileUpdates";
 export { default as NavBar } from "../src/components/NavBar";
 export { OwnerControls } from "../src/components/comments/OwnerControls";
 export { default as PageTitle } from "../src/components/ui/PageTitle";

--- a/frontend/src/__tests__/designSyncSrcMap.test.ts
+++ b/frontend/src/__tests__/designSyncSrcMap.test.ts
@@ -41,17 +41,18 @@
  *
  * WHY THIS LIVES IN `frontend/src/__tests__`
  * ------------------------------------------
- * `.design-sync/` sits outside `tsconfig`'s `include: ["src"]`, so CI's
- * `tsc --noEmit` never looks at it (#1328). Vitest is the one CI step that can:
- * it runs from `frontend/`, in node, with the whole repo on disk, so a test
- * under `src/` can read `../.design-sync/config.json`. That is the only reason
- * this file is here rather than next to the thing it guards.
+ * Both files this guards — `.design-sync/config.json` and `.ds-kit/index.tsx`
+ * — sit outside `tsconfig`'s `include: ["src"]`, so CI's `tsc --noEmit` never
+ * looks at either (#1328). Vitest is the one CI step that can: it runs from
+ * `frontend/`, in node, with the whole repo on disk, so a test under `src/`
+ * can read them. That is the only reason this file is here rather than next
+ * to the things it guards.
  *
  * This does NOT close #1328. That issue is about the preview `.tsx` files
  * failing *typecheck* — a different failure needing tsc coverage of
- * `.design-sync/previews/`. The two share a root cause (nothing verifies that
- * directory against reality) but not a fix; this guard checks path resolution
- * in one JSON file and typechecks nothing.
+ * `.design-sync/previews/`. The two share a root cause (that whole area is
+ * outside every CI net) but not a fix: this guard resolves paths and
+ * typechecks nothing, so it would not catch a preview whose props drifted.
  */
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, relative } from 'node:path'

--- a/frontend/src/__tests__/designSyncSrcMap.test.ts
+++ b/frontend/src/__tests__/designSyncSrcMap.test.ts
@@ -1,0 +1,113 @@
+/**
+ * #1405 — every `componentSrcMap` value in `.design-sync/config.json` names a
+ * file that actually exists, matched case-exactly.
+ *
+ * `componentSrcMap` is the export contract for `/design-sync`: it pins one
+ * source path per published component name. A stale entry is silent. Nothing
+ * renders it, nothing imports it, and the sync republishes a path that no
+ * longer resolves — so the design system's view of the component tree drifts
+ * from the tree. The map had rotted to 39 unresolved of 126 before anyone
+ * measured it, and the only reason it was ever noticed is that an agent went
+ * looking.
+ *
+ * WHY A GUARD AND NOT A GENERATOR
+ * -------------------------------
+ * The obvious fix is to derive the map from the filesystem and delete the hand
+ * maintenance. It does not survive contact with the data. The map is a curated
+ * selection, not a path index:
+ *
+ *   - it publishes 253 of 309 candidate `.tsx` files — the other 56 are
+ *     deliberately not in the kit, and a walk cannot infer that intent;
+ *   - five entries are aliases whose key is not the file's basename
+ *     (`EverymenCard` → `EverymenFactionCard.tsx`, `BackdropProvider` →
+ *     `BackdropContext.tsx`, `CommentFlagControl` → `FlagControl.tsx`);
+ *   - two of those aliases — `VoteLoginGate` and `VoteSummary` — point at the
+ *     *same* file, `vote/VoteShell.tsx`. A filesystem walk yields one name per
+ *     file and can never produce a many-to-one mapping.
+ *
+ * So the names are a human decision and stay hand-written. What was missing was
+ * never the derivation, it was the check: a hand-written map with no guard
+ * re-grows this backlog on the next rename wave. That makes this a ratchet
+ * problem, and the ratchet is the deliverable.
+ *
+ * WHY CASE-EXACT, AND WHY NOT `existsSync`
+ * ----------------------------------------
+ * `existsSync` is case-insensitive on Windows and on macOS's default volume, so
+ * a mis-cased entry passes on a contributor's machine and fails only on Linux
+ * CI — or, worse, passes everywhere and silently publishes a path the design
+ * system cannot fetch. The `UA`→`Ua` / `SNIDE`→`Snide` sweep (#1315) produced
+ * exactly eight of these. `readdirSync` reports the real on-disk casing, so
+ * membership in a set built from it is a case-exact test on every platform.
+ *
+ * WHY THIS LIVES IN `frontend/src/__tests__`
+ * ------------------------------------------
+ * `.design-sync/` sits outside `tsconfig`'s `include: ["src"]`, so CI's
+ * `tsc --noEmit` never looks at it (#1328). Vitest is the one CI step that can:
+ * it runs from `frontend/`, in node, with the whole repo on disk, so a test
+ * under `src/` can read `../.design-sync/config.json`. That is the only reason
+ * this file is here rather than next to the thing it guards.
+ *
+ * This does NOT close #1328. That issue is about the preview `.tsx` files
+ * failing *typecheck* — a different failure needing tsc coverage of
+ * `.design-sync/previews/`. The two share a root cause (nothing verifies that
+ * directory against reality) but not a fix; this guard checks path resolution
+ * in one JSON file and typechecks nothing.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+const REPO_ROOT = fileURLToPath(new URL('../../..', import.meta.url))
+const FRONTEND_DIR = join(REPO_ROOT, 'frontend')
+const CONFIG_PATH = join(REPO_ROOT, '.design-sync', 'config.json')
+
+function filesUnder(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry: string) => {
+    const path = join(dir, entry)
+    return statSync(path).isDirectory() ? filesUnder(path) : [path]
+  })
+}
+
+/** Map values are relative to `frontend/`, POSIX-separated. */
+const toMapPath = (path: string) => relative(FRONTEND_DIR, path).split('\\').join('/')
+
+/** Real on-disk casing — see the case-exactness note above. */
+const realPaths = new Set(filesUnder(join(FRONTEND_DIR, 'src')).map(toMapPath))
+
+const componentSrcMap: Record<string, string | null> = JSON.parse(
+  readFileSync(CONFIG_PATH, 'utf8'),
+).componentSrcMap
+
+/** A `null` value excludes a name from the kit and pins no path. */
+const pinned = Object.entries(componentSrcMap).filter(
+  (entry): entry is [string, string] => entry[1] !== null,
+)
+
+describe('componentSrcMap stays in sync with the tree (#1405)', () => {
+  it('pins every published component at a path that exists, case-exactly', () => {
+    // A failure here means a rename or a surface collapse moved a file and left
+    // the map behind. Repoint the entry, or drop it if the component is gone.
+    const unresolved = pinned
+      .filter(([, path]) => !realPaths.has(path))
+      .map(([name, path]) => `${name} -> ${path}`)
+    expect(unresolved).toEqual([])
+  })
+})
+
+describe('the scan sees the codebase', () => {
+  it('reads a non-empty file set, so it cannot pass by finding nothing', () => {
+    expect(realPaths.size).toBeGreaterThan(100)
+  })
+
+  it('reads a non-empty map, so a bad parse cannot pass vacuously', () => {
+    expect(pinned.length).toBeGreaterThan(100)
+  })
+
+  it('distinguishes casing, so a mis-cased entry cannot pass on Windows', () => {
+    const mixedCase = pinned.map(([, path]) => path).find((path) => path !== path.toUpperCase())
+    if (!mixedCase) throw new Error('no mixed-case path to probe with')
+    expect(realPaths.has(mixedCase)).toBe(true)
+    expect(realPaths.has(mixedCase.toUpperCase())).toBe(false)
+  })
+})

--- a/frontend/src/__tests__/designSyncSrcMap.test.ts
+++ b/frontend/src/__tests__/designSyncSrcMap.test.ts
@@ -84,6 +84,11 @@ const pinned = Object.entries(componentSrcMap).filter(
   (entry): entry is [string, string] => entry[1] !== null,
 )
 
+/** Per-component render settings (`cardMode`, `viewport`), keyed by the same names. */
+const overrides: Record<string, unknown> = JSON.parse(
+  readFileSync(CONFIG_PATH, 'utf8'),
+).overrides
+
 describe('componentSrcMap stays in sync with the tree (#1405)', () => {
   it('pins every published component at a path that exists, case-exactly', () => {
     // A failure here means a rename or a surface collapse moved a file and left
@@ -92,6 +97,14 @@ describe('componentSrcMap stays in sync with the tree (#1405)', () => {
       .filter(([, path]) => !realPaths.has(path))
       .map(([name, path]) => `${name} -> ${path}`)
     expect(unresolved).toEqual([])
+  })
+
+  it('carries no render override for a component the kit does not publish', () => {
+    // `overrides` is keyed by the same names, so deleting an entry from one map
+    // orphans the other. Dead settings here are silently ignored by the sync —
+    // the same invisible rot, one keystroke away.
+    const names = new Set(pinned.map(([name]) => name))
+    expect(Object.keys(overrides).filter((name) => !names.has(name))).toEqual([])
   })
 })
 

--- a/frontend/src/__tests__/designSyncSrcMap.test.ts
+++ b/frontend/src/__tests__/designSyncSrcMap.test.ts
@@ -99,6 +99,24 @@ describe('componentSrcMap stays in sync with the tree (#1405)', () => {
     expect(unresolved).toEqual([])
   })
 
+  it('re-exports only real files from the committed barrel', () => {
+    // `.ds-kit/index.tsx` is generated from componentSrcMap by
+    // `.design-sync/gen-barrel.mjs` — but it is COMMITTED, so it drifts with
+    // the map and holds the same dead paths as genuine broken imports. Its own
+    // header calls it gitignored; it is not. Nothing catches that today:
+    // `.ds-kit/` is outside `tsconfig`'s `include: ["src"]` so tsc skips it,
+    // and no app module imports it so `vite build` never resolves it either.
+    // Regenerate with `node .design-sync/gen-barrel.mjs` when this fails.
+    const barrel = readFileSync(join(FRONTEND_DIR, '.ds-kit', 'index.tsx'), 'utf8')
+    const unresolved = [...barrel.matchAll(/from\s+'([^']+)'|from\s+"([^"]+)"/g)]
+      .map(([, single, double]) => single ?? double)
+      // `./provider` is hand-written and sits beside the barrel, not under src/.
+      .filter((specifier) => specifier.startsWith('../'))
+      .map((specifier) => `${specifier.replace(/^\.\.\//, '')}.tsx`)
+      .filter((path) => !realPaths.has(path))
+    expect(unresolved).toEqual([])
+  })
+
   it('carries no render override for a component the kit does not publish', () => {
     // `overrides` is keyed by the same names, so deleting an entry from one map
     // orphans the other. Dead settings here are silently ignored by the sync —


### PR DESCRIPTION
Closes #1405

## The seam I tested at

`.design-sync/config.json`'s `componentSrcMap` (and the barrel generated from it), resolved against the **real on-disk tree** — not the sync's output, and not `existsSync`.

The guard **is** the red loop here. I wrote it first, watched it fail with the count, then made it pass.

## The number moved: 4 unresolved of 253, not 39 of 126

The issue's 39-of-126 is stale. PR #1410 ("recover the orphaned 258-sync state and follow the rename wave to 253 components") landed after the issue was written and already did the bulk repair — including all eight `UA`→`Ua` / `SNIDE`→`Snide` case-renames the issue's re-measurement comment lists.

What I measured on `origin/main`: **253 entries, 4 unresolved, 0 case-only mismatches.** The 4 are exactly the churn the brief warned about, and all four are straight deletes:

| Entry | Deleted by |
|---|---|
| `FactionSigilRow`, `FilterFactionTabs`, `FilterStamps` | #1435 (#1368) |
| `MobileUpdates` | #1452 (#1421) |

Every surviving mention of those four names in `frontend/src` is prose in a docstring naming what replaced them — not a live import. So: dropped, not repointed.

## Generated or guarded? **Guarded** — deriving it does not survive the data

Rung one was "does this map need to exist at all", and the honest answer is yes. It is a curated selection, not a path index:

- it publishes **253 of 309** candidate `.tsx` files — the other 56 are deliberately out of the kit, and a filesystem walk cannot infer that intent;
- **five entries are aliases** whose key is not the file's basename (`EverymenCard` → `EverymenFactionCard.tsx`, `BackdropProvider` → `BackdropContext.tsx`, `CommentFlagControl` → `FlagControl.tsx`);
- two of those aliases — `VoteLoginGate` and `VoteSummary` — point at the **same file**, `vote/VoteShell.tsx`. A walk yields one name per file and can never produce a many-to-one mapping.

So the names stay hand-written. What was missing was never the derivation, it was the check. That makes this a ratchet problem, and the ratchet is the deliverable — correcting 4 paths with no guard is the one outcome that guarantees this issue exists again next month.

## A second rot the issue does not name: the committed barrel

`frontend/.ds-kit/index.tsx` is generated from `componentSrcMap` by `.design-sync/gen-barrel.mjs` — but it is **committed**, so it had drifted identically and carried the same four dead paths as genuine broken imports:

```
export { default as FilterStamps } from "../src/components/ui/FilterStamps";
```

Nothing catches that. `.ds-kit/` is outside `tsconfig`'s `include: ["src"]` so `tsc --noEmit` skips it, and no app module imports the barrel so `vite build` never resolves it either. (Its own header comment claims the file is gitignored. `git ls-files` disagrees.) Regenerated: 249 components, 4 lines removed, no other drift.

Worth noting the map was one keystroke from a third rot: `overrides` (a sibling map of per-component render settings, keyed by the same names) was a *strict subset* of `componentSrcMap`, so deleting from one without the other orphans four settings the sync silently ignores. Removed those too, and the invariant is now asserted.

## The guard

`frontend/src/__tests__/designSyncSrcMap.test.ts` — six assertions:

1. every pinned `componentSrcMap` value names a file that exists, **case-exactly**
2. every `../src/...` specifier in the committed barrel resolves
3. no `overrides` entry for a component the kit does not publish
4-6. self-checks: the scan reads a non-empty file set, a non-empty map, and **distinguishes casing**

**Case-exactness is the load-bearing bit.** `existsSync` is case-insensitive on Windows and on macOS's default volume, so a mis-cased entry passes locally and fails only on Linux CI. `readdirSync` reports the real on-disk casing, so membership in a set built from it is case-exact everywhere. #1315's `UA`→`Ua` sweep produced eight of these; a case-blind guard would have caught none.

## Why the test lives under `frontend/src/__tests__`

Because that is the only place CI can see it. Per the CI config, the `frontend` job runs `npm test` from `frontend/`; vitest's `include` is `src/**/*.test.{ts,tsx}` and it runs in node with the whole repo on disk, so a test under `src/` can read `../.design-sync/config.json`. Same home as the other repo-hygiene ratchets (`eagerPathImports`, `noInjectedStylesheets`), whose posture I followed — including their "the scan sees the codebase" self-check, so this cannot pass by finding nothing.

## Re #1328 — same family, and one guard does **not** cover both

Read it, did not build it. #1328 reports that seven of eight `.design-sync/previews/*.tsx` already fail typecheck. Shared root cause: that whole area sits outside every CI net. But not a shared fix — **this guard resolves paths and typechecks nothing**, so it would not catch a preview whose props drifted from the real type. #1328 still needs tsc coverage of `previews/`, and still needs its "are the previews still wanted?" decision answered first.

What this PR does contribute to #1328 is the *mechanism*: it demonstrates that CI **can** reach that directory today via vitest, so the "give it its own tsconfig and a CI step" option is cheaper than "#1328 says CI cannot see it at all" implies.

## Verification

No browser tools and no dev stack in this worktree, so everything below is tests and static checks. Ran all five CI steps locally against a verified-real toolchain (`tsc 5.9.3`, `vitest 2.1.9` — checked `--version` actually resolves, so no false-zero pass):

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — **195 files, 3342 tests, all passing**
- `npm run build` — built
- `npm run budget` — within budget (JS 131.0 KB, CSS 22.3 KB; unchanged, this touches no shipped code)

Both new assertions **mutation-tested**, not just observed green:

- mis-cased one live entry (`NavBar.tsx` → `navbar.tsx`) → guard went red, which is precisely what `existsSync` on Windows would have waved through
- restored the pre-fix barrel → guard went red naming all four dead specifiers

Also ran `node .design-sync/gen-barrel.mjs` end to end: it now completes at 249 components. Before this change it threw `ENOENT` on the first dead path, so the map's real consumer was already broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)