### PR TITLE
The composer's error banner gets the ground it is drawn on (#1231)

### DIFF
--- a/frontend/src/__tests__/composerErrorBannerGround.test.tsx
+++ b/frontend/src/__tests__/composerErrorBannerGround.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * The composer error banner's ground seam (#1231).
+ *
+ * `ErrorBanner` took no props, so every one of the eight composers painted the
+ * neutral `--color-danger` on its own faction sheet and no skin could reach it
+ * — WORLD_ZERO_STYLE §3's #1153 case, a missing seam rather than a missing
+ * measurement. It matters because the neutral ink misses AA on ALL EIGHT
+ * composer grounds in light under its own veil (3.31:1 on the Ephemerists plate
+ * up to 4.41:1 on the na sheet); the per-ground ratios are asserted in
+ * `utils/__tests__/factionContrast.test.ts`, and this file pins the SEAM those
+ * ratios are only reachable through.
+ *
+ * Two claims, and the second is the one #1153 says to write down: a skin that
+ * supplies an ink gets it, and a skin that supplies NOTHING renders exactly
+ * what the banner painted before. A default that drifts is how a "byte
+ * identical" seam quietly repaints eight surfaces.
+ *
+ * The third claim is a source guard, because it is unreachable from markup: the
+ * banner's WASH and RULE must stay the neutral `--color-danger-*` rungs on
+ * every skin. ADR-0061 — danger is the platform speaking, not a faction — and a
+ * `style` prop generous enough to carry the ink is also generous enough to
+ * repaint the veil, which is the thing that ruling forbids.
+ *
+ * `renderToStaticMarkup` only — no jsdom, effects never run.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+
+import { ErrorBanner } from "../pages/editPraxis/archetypes/shared";
+
+const ARCHETYPE_DIR = fileURLToPath(
+  new URL("../pages/editPraxis/archetypes/", import.meta.url),
+);
+
+/** slug → the alarm token that composer hands the banner. */
+const COMPOSER_ALARM: Record<string, string> = {
+  DefaultEditPraxis: "--faction-default-card-alarm",
+  CovenEditPraxis: "--faction-coven-card-alarm",
+  EphemeristsEditPraxis: "--faction-ephemerists-card-alarm",
+  EverymenEditPraxis: "--faction-everymen-card-alarm",
+  SingularityEditPraxis: "--faction-singularity-card-alarm",
+  // The one mint. Its CARD is photocopier-black in both themes (§6), so
+  // `-card-alarm` is pinned bright and reads 1.56:1 on the light xerox stock —
+  // while this composer's sheet flips.
+  SnideEditPraxis: "--faction-snide-composer-alarm",
+  UaEditPraxis: "--faction-ua-card-alarm",
+  WowEditPraxis: "--faction-wow-card-alarm",
+};
+
+function source(name: string): string {
+  return readFileSync(`${ARCHETYPE_DIR}${name}.tsx`, "utf8");
+}
+
+describe("the composer error banner's ground seam", () => {
+  it("takes the ink a skin supplies", () => {
+    const html = renderToStaticMarkup(
+      <ErrorBanner
+        message="that did not go in"
+        style={{ color: "var(--faction-ua-card-alarm)" }}
+      />,
+    );
+    expect(html).toContain("var(--faction-ua-card-alarm)");
+    expect(html).not.toContain("var(--color-danger)");
+  });
+
+  it("keeps today's rendering for a skin that supplies none", () => {
+    const bare = renderToStaticMarkup(<ErrorBanner message="nope" />);
+    const undefinedStyle = renderToStaticMarkup(
+      <ErrorBanner message="nope" style={undefined} />,
+    );
+    expect(bare).toBe(undefinedStyle);
+    expect(bare).toContain("color:var(--color-danger)");
+    expect(bare).toContain("background:var(--color-danger-veil)");
+    expect(bare).toContain("border:1px solid var(--color-danger-edge)");
+  });
+
+  it("renders nothing when there is no message", () => {
+    expect(
+      renderToStaticMarkup(
+        <ErrorBanner message="" style={{ color: "var(--faction-wow-card-alarm)" }} />,
+      ),
+    ).toBe("");
+  });
+
+  it.each(Object.entries(COMPOSER_ALARM))(
+    "%s hands the banner an ink measured on its own sheet",
+    (archetype, token) => {
+      const text = source(archetype);
+      expect(text).toContain(`const ALARM = "var(${token})";`);
+      expect(text).toContain(
+        "<ErrorBanner message={state.error} style={{ color: ALARM }} />",
+      );
+      // The dress carries the same constant, so pressing Submit cannot change
+      // the pairing under the banner (ADR-0059, and the reason the dress passes
+      // ELEMENTS rather than copies).
+      expect(text).toContain("alarm: ALARM,");
+    },
+  );
+
+  it("leaves the wash and the rule neutral on every skin (ADR-0061)", () => {
+    for (const archetype of Object.keys(COMPOSER_ALARM)) {
+      const text = source(archetype);
+      expect(text).not.toContain("--color-danger-veil");
+      expect(text).not.toContain("--color-danger-edge");
+      expect(text).not.toContain("--color-danger-ring");
+    }
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -669,6 +669,14 @@
   --faction-snide-composer-bar: #14110b; /* masthead bar + the censor stripe */
   --faction-snide-composer-grain: rgba(20, 17, 11, 0.09); /* the raster */
   --faction-snide-composer-acid-ink: #457000; /* acid that is TEXT, not a line */
+  /* The error banner's ink, and the ONE mint #1231 needed (§3, "same ink,
+     second ground"). Seven skins hand that banner their existing
+     `--faction-{key}-card-alarm`; this faction cannot, because its CARD is
+     photocopier-black in BOTH themes (§6) so `-card-alarm` is pinned bright and
+     reads 1.56:1 on the light xerox stock, while this sheet FLIPS. Same hue as
+     `-slip-pink-ink` today and declared rather than borrowed for #1181's
+     reason. Measured under `--color-danger-veil`: 4.97:1 light, 5.83:1 dark. */
+  --faction-snide-composer-alarm: #be185d;
 
   /* ══ S.N.I.D.E. — THE INTERCEPTED SLIP (feed chassis + comment sheet, #1198) ══
      Design: `Snide Comment + Update Cards.dc.html` — a flyposted xerox slip
@@ -688,13 +696,24 @@
      S.N.I.D.E. feed card invisible at night, with the actor line at 2.92:1.
 
      ONE PAIRING STILL DOES NOT CLEAR AA, and it is not reachable from here:
-     `--color-danger` measures 4.28:1 on this stock (it is 4.75 on the na sheet,
+     `--color-danger` measures 4.28:1 on this stock bare, and 3.97:1 once
+     #1169's `--color-danger-veil` is laid over it (it is 4.75 on the na sheet,
      3.98 on UA's cream, and was 3.90 on the invariant black card this replaces,
      so the move is an improvement rather than a regression). It is painted by
      `OwnerControls`, `ComposerControls` and `CommentFlagControl`, none of which
      takes an ink prop — §3's #1153 case: a missing seam, not a missing
-     measurement. If that seam is ever added, the slip needs its own
-     `-slip-alarm`; `-card-notice`/`-card-credit` are measured on `-card-bg`.
+     measurement.
+
+     WHAT THAT SEAM WILL NOT NEED IS A NEW TOKEN (#1231, correcting this
+     paragraph). It used to end "the slip needs its own `-slip-alarm`", and that
+     was already wrong when written: `--faction-snide-slip-pink-ink` three
+     declarations below is this faction's alarm hue walked for exactly this
+     flipping stock, and it measures 5.35:1 bare / 4.97:1 veiled in light and
+     7.06:1 / 5.83:1 in dark. The caution the sentence was really carrying still
+     holds and is the useful half — `-card-notice`/`-card-credit`/`-card-alarm`
+     are measured on `-card-bg`, which for S.N.I.D.E. is photocopier-black in
+     BOTH themes (§6), so `--faction-snide-card-alarm` is pinned bright and
+     reads 1.56:1 here. Reach for the walked pink, not the card family.
 
      So this is a THIRD flipping S.N.I.D.E. stock beside `-note-*` (the task
      card's clipping) and `-composer-*` (the edit-praxis sheet), declared rather
@@ -1892,6 +1911,7 @@
   --faction-snide-composer-bar: #080706;
   --faction-snide-composer-grain: rgba(244, 241, 232, 0.07);
   --faction-snide-composer-acid-ink: #b6ff2e;
+  --faction-snide-composer-alarm: #ff69ac;
 
   /* ── The intercepted slip, lights out (#1198) ──
      The stock and its type SWAP, as the clipping's and the sheet's do. The intake

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -118,6 +118,11 @@ const CHROME = "var(--font-faction-rounded)"; /* Quicksand — body + label */
 
 /* The slip's pigments, named for the ROLE each plays in the design's skin row. */
 const SHEET = "var(--faction-coven-ward-card)";
+/* The error banner's ink (#1231). The banner sits straight on the sheet, and
+ * the neutral `--color-danger` under its own veil misses AA there in light
+ * (4.23:1 on this ground); this is #1449's alarm rung, already measured
+ * on paper. The veil and the edge stay neutral — ADR-0061. */
+const ALARM = "var(--faction-coven-card-alarm)";
 const FIELD = "var(--faction-coven-ward-page)";
 const INK = "var(--faction-coven-slip-ink)";
 const SOFT = "var(--faction-coven-slip-soft)";
@@ -599,6 +604,7 @@ export default function CovenEditPraxis({ state }: Props) {
     // one ground `slip-deep` misses (4.44:1). The accent is also a border and a
     // ring stroke there, and INK clears the 3:1 graphic floor just as easily.
     accent: INK,
+    alarm: ALARM,
     pageStyle: { fontFamily: CHROME, color: INK },
     breadcrumbInk: LABEL,
     sheetStyle,
@@ -944,7 +950,7 @@ export default function CovenEditPraxis({ state }: Props) {
           </div>
         </ComposerSection>
 
-        <ErrorBanner message={state.error} />
+        <ErrorBanner message={state.error} style={{ color: ALARM }} />
 
         {/* [Cancel] … [Submit] — the global order from #646, stacked here
             because Coven's cast is a full-bleed band rather than an inline

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -118,6 +118,11 @@ interface Props {
  * skin row rather than for its colour — `ink` is the design's `ink` and its
  * `accent`, which are the same value in both themes. */
 const SHEET = "var(--faction-default-card-bg)";
+/* The error banner's ink (#1231). The banner sits straight on the sheet, and
+ * the neutral `--color-danger` under its own veil misses AA there in light
+ * (4.41:1 on this ground); this is #1449's alarm rung, already measured
+ * on paper. The veil and the edge stay neutral — ADR-0061. */
+const ALARM = "var(--faction-default-card-alarm)";
 const FIELD = "var(--faction-default-composer-field)";
 const INK = "var(--faction-default-card-text)";
 const MUTED = "var(--faction-default-card-muted)";
@@ -199,6 +204,7 @@ const slip = {
  */
 export const DEFAULT_COMPOSER_DRESS: ComposerDress = {
   accent: INK,
+  alarm: ALARM,
   pageStyle: { fontFamily: TITLE_FACE, color: INK },
   sheetStyle,
   masthead,
@@ -561,7 +567,7 @@ export default function DefaultEditPraxis({ state }: Props) {
           </div>
         </ComposerSection>
 
-        <ErrorBanner message={state.error} />
+        <ErrorBanner message={state.error} style={{ color: ALARM }} />
 
         <ComposerRule style={{ background: HAIR }} />
 

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -150,6 +150,11 @@ interface Props {
 /* The cast's own pair. Not exported by the plate module because no other
  * surface has a primary button; declared in `index.css` in both themes. */
 const CTA = "var(--faction-ephemerists-plate-cta-bg)";
+/* The error banner's ink (#1231). The banner sits straight on the sheet, and
+ * the neutral `--color-danger` under its own veil misses AA there in light
+ * (3.31:1 on this ground); this is #1449's alarm rung, already measured
+ * on paper. The veil and the edge stay neutral — ADR-0061. */
+const ALARM = "var(--faction-ephemerists-card-alarm)";
 const CTA_INK = "var(--faction-ephemerists-plate-cta-ink)";
 
 /* ── Ornament geometry (WORLD_ZERO_STYLE §4a: not layout spacing) ──
@@ -427,6 +432,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
 
   const dress: ComposerDress = {
     accent: BRASS,
+    alarm: ALARM,
     pageStyle: { fontFamily: DECO, color: INK },
     breadcrumbInk: QUIET,
     sheetStyle,
@@ -763,7 +769,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
           </div>
         </ComposerSection>
 
-        <ErrorBanner message={state.error} />
+        <ErrorBanner message={state.error} style={{ color: ALARM }} />
 
         {/* The footer's own divider. `ComposerRule` hands its whole box over
             when it is given children, so the flute replaces the hairline. */}

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -128,6 +128,11 @@ interface Props {
  *    See the header for which reds may be ink and on what. ── */
 /** The newsprint the order is printed on — the faction's own card ground. */
 const PAPER = "var(--everymen-paper)";
+/* The error banner's ink (#1231). The banner sits straight on the sheet, and
+ * the neutral `--color-danger` under its own veil misses AA there in light
+ * (3.47:1 on this ground); this is #1449's alarm rung, already measured
+ * on paper. The veil and the edge stay neutral — ADR-0061. */
+const ALARM = "var(--faction-everymen-card-alarm)";
 /** The pasted-on plate: the task slip, every field, every proof tile. */
 const PANEL = "var(--faction-everymen-sheet-panel)";
 /** Text ink. FLIPS with the paper — deliberately not `--everymen-ink`. */
@@ -377,6 +382,7 @@ export default function EverymenEditPraxis({ state }: Props) {
 
   const dress: ComposerDress = {
     accent: ACCENT,
+    alarm: ALARM,
     pageStyle: { fontFamily: COURIER, color: INK },
     breadcrumbInk: MUTED,
     sheetStyle,
@@ -760,7 +766,7 @@ export default function EverymenEditPraxis({ state }: Props) {
           </div>
         </ComposerSection>
 
-        <ErrorBanner message={state.error} />
+        <ErrorBanner message={state.error} style={{ color: ALARM }} />
 
         {dashRule}
 

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -151,6 +151,11 @@ interface Props {
  * plays in this design's skin row rather than for its colour. Both halves are
  * near-black and the cascade flips the phosphor — see the header. */
 const CHASSIS = "var(--faction-singularity-term-bg)";
+/* The error banner's ink (#1231). The banner sits straight on the sheet, and
+ * the neutral `--color-danger` under its own veil misses AA there in light
+ * (3.85:1 on this ground); this is #1449's alarm rung, already measured
+ * on paper. The veil and the edge stay neutral — ADR-0061. */
+const ALARM = "var(--faction-singularity-card-alarm)";
 const CHROME = "var(--faction-singularity-term-chrome)";
 /** The raised box: fields, the task slip, proof tiles. */
 const PANEL = "var(--faction-singularity-term-panel)";
@@ -370,6 +375,7 @@ export default function SingularityEditPraxis({ state }: Props) {
 
   const dress: ComposerDress = {
     accent: ACCENT,
+    alarm: ALARM,
     pageStyle: { fontFamily: FACE, color: INK },
     sheetStyle,
     masthead,
@@ -738,7 +744,7 @@ export default function SingularityEditPraxis({ state }: Props) {
           </div>
         </ComposerSection>
 
-        <ErrorBanner message={state.error} />
+        <ErrorBanner message={state.error} style={{ color: ALARM }} />
 
         <ComposerRule
           style={{

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -122,6 +122,12 @@ const BAR = "var(--faction-snide-composer-bar)";
 const GRAIN = "var(--faction-snide-composer-grain)";
 /* Acid as TEXT: deep in the light half, bright on the dark stock. */
 const ACID_INK = "var(--faction-snide-composer-acid-ink)";
+/* The error banner's ink (#1231), and the one skin in the set that could not
+ * take `--faction-snide-card-alarm`: the CARD is photocopier-black in both
+ * themes (§6) so that rung is pinned bright and reads 1.56:1 on the light
+ * xerox stock, while THIS sheet flips. 4.97:1 light / 5.83:1 dark under the
+ * neutral veil, which — per ADR-0061 — stays neutral. */
+const ALARM = "var(--faction-snide-composer-alarm)";
 
 /* THE PRESS — theme-invariant pigments. `ACID` is acid as a DRAWN THING (the
  * masthead rule, the blobs, the submit bar), and `PRESS_INK` is the near-black
@@ -360,6 +366,7 @@ export default function SnideEditPraxis({ state }: Props) {
 
   const dress: ComposerDress = {
     accent: ACID_INK,
+    alarm: ALARM,
     pageStyle: { fontFamily: BODY_FACE, color: INK },
     sheetStyle,
     masthead,
@@ -713,7 +720,7 @@ export default function SnideEditPraxis({ state }: Props) {
           </div>
         </ComposerSection>
 
-        <ErrorBanner message={state.error} />
+        <ErrorBanner message={state.error} style={{ color: ALARM }} />
 
         {/* [Cancel] … [Submit] — the global order from #646, stacked rather than
             ranged because SNIDE's cast is a bar and not a button. The exits keep

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -137,6 +137,11 @@ interface Props {
 /* The practice's inks, named for the ROLE each plays in the design's skin row.
  * Every one carries both themes in `index.css`. */
 const SHEET = "var(--faction-ua-card-bg)"; /* the sun-bleached sheet */
+/* The error banner's ink (#1231). The banner sits straight on the sheet, and
+ * the neutral `--color-danger` under its own veil misses AA there in light
+ * (3.71:1 on this ground); this is #1449's alarm rung, already measured
+ * on paper. The veil and the edge stay neutral — ADR-0061. */
+const ALARM = "var(--faction-ua-card-alarm)";
 const FIELD = "var(--faction-ua-panel)"; /* inset panel — fields, wells */
 const INK = "var(--faction-ua-card-text)";
 const BODY = "var(--faction-ua-card-body)";
@@ -256,6 +261,7 @@ export default function UaEditPraxis({ state }: Props) {
 
   const dress: ComposerDress = {
     accent: ACCENT,
+    alarm: ALARM,
     pageStyle: { fontFamily: UA_TEXT, color: INK },
     sheetStyle,
     ground: groundLayer,
@@ -601,7 +607,7 @@ export default function UaEditPraxis({ state }: Props) {
           </div>
         </ComposerSection>
 
-        <ErrorBanner message={state.error} />
+        <ErrorBanner message={state.error} style={{ color: ALARM }} />
 
         <ComposerRule style={{ background: HAIR }} />
 

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -157,6 +157,11 @@ const LORA = "var(--faction-wow-body-font)";
 /* ── The chronicle palette. Every one a shipped --faction-wow-* token. ── */
 /** The sheet: cream parchment by day, the deep ground by night. */
 const SHEET = "var(--faction-wow-card-bg)";
+/* The error banner's ink (#1231). The banner sits straight on the sheet, and
+ * the neutral `--color-danger` under its own veil misses AA there in light
+ * (4.08:1 on this ground); this is #1449's alarm rung, already measured
+ * on paper. The veil and the edge stay neutral — ADR-0061. */
+const ALARM = "var(--faction-wow-card-alarm)";
 /** The inset parchment plate every editable field is set on. */
 const FIELD = "var(--faction-wow-chronicle-panel)";
 /** Body ink. 14:1 on both grounds. */
@@ -334,6 +339,7 @@ export default function WowEditPraxis({ state }: Props) {
 
   const dress: ComposerDress = {
     accent: PLUM,
+    alarm: ALARM,
     pageStyle: { fontFamily: LORA, color: INK },
     breadcrumbInk: LABEL,
     sheetStyle,
@@ -681,7 +687,7 @@ export default function WowEditPraxis({ state }: Props) {
           </div>
         </ComposerSection>
 
-        <ErrorBanner message={state.error} />
+        <ErrorBanner message={state.error} style={{ color: ALARM }} />
 
         <Zig id="footer" />
 

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -98,9 +98,32 @@ export function TitleCounter({ length, color }: TitleCounterProps) {
 
 interface ErrorBannerProps {
   message: string;
+  /**
+   * The skin's dress for the banner — in practice its alarm INK (#1231).
+   *
+   * The danger hues themselves stay neutral: ADR-0061 says danger is the
+   * platform speaking, not a faction, so the `-veil` wash and the `-edge` rule
+   * are #1169's global rungs on every skin. What is faction-aware is the GROUND
+   * the banner is drawn against — this banner sits in the composer's content
+   * column, i.e. straight on the skin's sheet — and therefore which ink clears
+   * on it. That is §3's "same ink, second ground", not a faction danger colour.
+   *
+   * It matters because the neutral ink misses AA on ALL EIGHT composer sheets
+   * in light: `--color-danger` under its own veil measures 3.31:1 (Ephemerists)
+   * to 4.41:1 (na). Dark was never the miss (4.80–5.97). Seven skins pass their
+   * existing `--faction-{key}-card-alarm` (#1449) and mint nothing; S.N.I.D.E.
+   * is the one exception and the reason is §6 — its CARD is photocopier-black
+   * in both themes, so `--faction-snide-card-alarm` is pinned bright and reads
+   * 1.56:1 on the composer's light xerox stock, while the composer's sheet
+   * flips. It passes `--faction-snide-composer-alarm` instead.
+   *
+   * Optional, and a skin that passes nothing renders byte-identically to what
+   * this banner painted before (#1153's rule).
+   */
+  style?: CSSProperties;
 }
 
-export function ErrorBanner({ message }: ErrorBannerProps) {
+export function ErrorBanner({ message, style }: ErrorBannerProps) {
   if (!message) return null;
   return (
     <div
@@ -112,6 +135,7 @@ export function ErrorBanner({ message }: ErrorBannerProps) {
         padding: "var(--space-sm) var(--space-md)",
         background: "var(--color-danger-veil)",
         border: "1px solid var(--color-danger-edge)",
+        ...style,
       }}
     >
       {message}
@@ -903,6 +927,14 @@ export function ComposerPage({
 export interface ComposerDress {
   /** The one colour the surface leans on for marks, rings and headings. */
   accent: string;
+  /**
+   * The skin's alarm ink, measured on ITS OWN sheet under `--color-danger-veil`
+   * (#1231). Carried on the dress for the same reason the masthead and the
+   * ground are: the waiting surface mounts the same {@link ErrorBanner} on the
+   * same stock, so the pairing must not change the moment you press Submit.
+   * Omit it and the banner keeps the neutral `--color-danger`.
+   */
+  alarm?: string;
   /** The skin's root style — its body face and ink. */
   pageStyle?: CSSProperties;
   /** The breadcrumb's ink, where the skin tints it. */

--- a/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
+++ b/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
@@ -725,7 +725,12 @@ export default function PraxisWaitingSurface({
           </ComposerSection>
         )}
 
-        <ErrorBanner message={state.error} />
+        {/* Same banner, same stock, same ink — the dress carries the alarm so
+            the pairing cannot change the moment you press Submit (#1231). */}
+        <ErrorBanner
+          message={state.error}
+          style={dress.alarm ? { color: dress.alarm } : undefined}
+        />
 
         {rule("footer")}
 

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1063,6 +1063,55 @@ const ARCHETYPE_PAIRS: Pair[] = [
   // print at FULL ink and separate themselves by face rather than by opacity.
   { what: "everymen masthead band, ink", surface: "--everymen-red", text: "--everymen-masthead-text" },
 
+  // ── THE COMPOSER'S ERROR BANNER, on all eight sheets (#1231) ─────────────
+  //
+  // `ErrorBanner` took no props, so every composer painted the neutral
+  // `--color-danger` on its own faction stock and no skin could reach it —
+  // #1153's missing seam, not a missing measurement. ADR-0061 keeps the hues
+  // neutral (the `-veil` wash and the `-edge` rule are #1169's global rungs on
+  // every skin); what is faction-aware is THE GROUND, and therefore the ink.
+  //
+  // The neutral ink missed AA on ALL EIGHT sheets in light under its own veil —
+  // 3.31 (ephemerists), 3.47 (everymen), 3.71 (ua), 3.85 (singularity), 3.97
+  // (snide), 4.08 (wow), 4.23 (coven), 4.41 (na) — and cleared on all eight in
+  // dark (4.80-5.97). That asymmetry is #1449's finding restated: the light hue
+  // was chosen against the app's near-white page, and six of these sheets are
+  // warm paper while two are near-black in both themes.
+  //
+  // SEVEN SKINS MINT NOTHING. `--faction-{key}-card-alarm` already exists for
+  // all eight keys in both cascades, and it clears every composer ground it is
+  // asked for here (5.70 worst, on the Ephemerists plate). That is #1302's
+  // shape: a shared component inside a faction frame takes the faction's card
+  // ink family rather than a global functional one.
+  //
+  // S.N.I.D.E. IS THE ONE MINT, and the reason is §6 rather than a hue: its
+  // CARD is photocopier-black in BOTH themes, so `-card-alarm` is pinned bright
+  // and reads 1.56:1 on the composer's light xerox stock — while the composer
+  // sheet flips. `--faction-snide-composer-alarm` is that walked pink, declared
+  // in the composer block rather than borrowed from `-slip-pink-ink`, which is
+  // #1181's rule (same value today, a different surface's contract tomorrow).
+  //
+  // The veiled reading is the one on screen, and it is the tighter one on the
+  // six paper stocks (a wash of the ink's own polarity) while it LIFTS the two
+  // near-black grounds toward the ink. Either way it is what gates (§3, #1302).
+  ...(
+    [
+      ["na", "--faction-default-card-bg", "--faction-default-card-alarm"],
+      ["coven", "--faction-coven-ward-card", "--faction-coven-card-alarm"],
+      ["ephemerists", "--faction-ephemerists-plate-bg", "--faction-ephemerists-card-alarm"],
+      ["everymen", "--everymen-paper", "--faction-everymen-card-alarm"],
+      ["singularity", "--faction-singularity-term-bg", "--faction-singularity-card-alarm"],
+      ["snide", "--faction-snide-composer-sheet", "--faction-snide-composer-alarm"],
+      ["ua", "--faction-ua-card-bg", "--faction-ua-card-alarm"],
+      ["wow", "--faction-wow-card-bg", "--faction-wow-card-alarm"],
+    ] as const
+  ).map(([key, surface, text]) => ({
+    what: `${key} composer error banner, alarm ink under the danger veil`,
+    surface,
+    veil: "--color-danger-veil" as Veil,
+    text,
+  })),
+
   // ── THE FEED ROW'S ACTOR NAME, on the four chassis #1252 left (#1341) ────
   //
   // `resolveFeedRowInk` defaults `actor` to `factionCssVar(slug)` — the raw


### PR DESCRIPTION
## The seam I am testing at

**`ErrorBanner`'s ink, on the ground the composer actually paints.** The banner
sits in the composer's content column — straight on the skin's sheet — and took
no props, so all eight composers painted the neutral `--color-danger` on eight
different faction stocks and no skin could reach it. WORLD_ZERO_STYLE §3's
#1153 case: a missing seam, not a missing measurement.

`ADR-0061` holds. **Nothing here is a faction danger colour.** The `-veil` wash
and the `-edge` rule stay #1169's global rungs on every skin (there is a source
guard asserting that). What became faction-aware is the *ground*, and therefore
which ink clears on it.

## I measured before minting, and the AA half was NOT already solved

The issue asked me to check whether #1169's ladder clears on all eight grounds.
It does not — in **light**, on **all eight**. Dark was never the miss.

`--color-danger` under `--color-danger-veil`, via `utils/contrast.ts` and the
test's own resolver (no hand arithmetic — #1198):

| composer | ground | light | dark |
|---|---|---:|---:|
| Ephemerists | `--faction-ephemerists-plate-bg` | **3.31** | 5.12 |
| Everymen | `--everymen-paper` | **3.47** | 4.99 |
| UA | `--faction-ua-card-bg` | **3.71** | 4.80 |
| Singularity | `--faction-singularity-term-bg` | **3.85** | 5.97 |
| S.N.I.D.E. | `--faction-snide-composer-sheet` | **3.97** | 5.62 |
| WOW | `--faction-wow-card-bg` | **4.08** | 5.35 |
| Coven | `--faction-coven-ward-card` | **4.23** | 5.16 |
| na | `--faction-default-card-bg` | **4.41** | 5.01 |

**This is the number #1451 asked for.** The ladder is fine in dark and short in
light on warm paper; #1451's fifteen praxis-detail sites should expect the same
shape rather than a uniform pass.

## Seven skins mint NOTHING — the ink already existed

`--faction-{key}-card-alarm` (#1449, all eight keys, both cascades) clears every
composer ground it is asked for. Worst reading **5.70** (Ephemerists plate).
This is #1302's shape: a shared component inside a faction frame takes the
faction's card ink family rather than a global functional one.

| composer | alarm ink | light | dark |
|---|---|---:|---:|
| Ephemerists | `-card-alarm` | 5.70 | 7.46 |
| Everymen | `-card-alarm` | 5.96 | 7.27 |
| UA | `-card-alarm` | 6.38 | 7.00 |
| WOW | `-card-alarm` | 7.03 | 7.80 |
| Coven | `-card-alarm` | 7.28 | 7.51 |
| na | `-card-alarm` | 7.58 | 7.30 |
| Singularity | `-card-alarm` | 9.79 | 8.70 |
| **S.N.I.D.E.** | **`--faction-snide-composer-alarm` (minted)** | **4.97** | **5.83** |

## One mint, and the reason is §6 rather than a hue

S.N.I.D.E.'s **card** is photocopier-black in *both* themes, so
`--faction-snide-card-alarm` is pinned bright (`#fca5a5`) and reads **1.56:1**
on the composer's light xerox stock — while the composer's **sheet flips**.
That mismatch is the whole exception. `--faction-snide-composer-alarm` is that
pink walked for a flipping stock (`#be185d` / `#ff69ac`), declared in the
composer block rather than borrowed from `-slip-pink-ink`, per #1181's rule that
this block states verbatim.

Per the red block, the eight rows went into `ARCHETYPE_PAIRS` **first** and I
watched all eight fail in light at exactly the ratios above before wiring
anything.

## The stale paragraph (`index.css`)

It said the slip "needs its own `-slip-alarm`". That was already wrong when
written: `--faction-snide-slip-pink-ink`, **three declarations below it**, is
this faction's alarm hue walked for that exact flipping stock (5.35 bare / 4.97
veiled light, 7.06 / 5.83 dark). Rewritten to keep the half that is still true —
the seam in `OwnerControls` / `ComposerControls` / `CommentFlagControl` is still
missing, and `-card-*` inks are measured on `-card-bg`, which for this faction
is a different question. Its 4.28:1 figure is also now stated bare *and* veiled,
since #1169 tightened it to 3.97.

## CSS budget

**22,830 bytes gzipped, against a 23,000 warn line.** Baseline `origin/main` is
22,814, so this is **+16 bytes** (+80 raw — two declarations; comments are
stripped by the minifier). 170 bytes still in hand. `bundle-budget.mjs` reports
`ok`, no WARN. Reusing `-card-alarm` for seven skins instead of minting eight
`-composer-alarm` pairs is what kept it there, for zero rendered difference.

## What to eyeball

- Trigger a save error on each composer in **light** mode: the banner's text
  should be a deep red on the warm sheets, a pale red on the two near-black
  ones, and **hot pink on S.N.I.D.E.** — not the same `#dc2626` on all eight.
- The **wash and the 1px rule stay identical** on every skin. Only the letters
  changed colour. If a veil looks faction-tinted, that is the bug.
- **Press Submit while the banner is up.** `PraxisWaitingSurface` mounts the
  same banner and now reads `dress.alarm`, so the ink must not change at the
  stage boundary.
- **Dark mode is unchanged in kind but not in value** — it was already clearing;
  the inks moved from 4.80–5.97 up to 7.00–8.70.
- S.N.I.D.E. specifically: check the banner in **both** themes. Light is the one
  that was 3.97 and it is the theme where `-card-alarm` would have been invisible.

## Verification

No browser tools and no dev stack here, so everything above is from tests:
`tsc --noEmit` clean, `eslint --max-warnings=0` clean, **3364 tests / 195 files
pass** (16 new contrast assertions + 12 seam assertions), `vite build` green,
byte budget `ok`.

## Notes for the dispatcher

- I edited the eight archetypes and `PraxisWaitingSurface.tsx` beyond my named
  scope (`shared.tsx`, `index.css`, the component). Each edit is one `const` and
  one `style` prop — no logic, no state, no API. Without them the seam exists
  and the measured AA failure still ships.
- `#1232` is **CLOSED** and its composer rows are already on `main`, so the
  boundary note in my brief was stale. My eight rows are purely additive to
  `ARCHETYPE_PAIRS` — no existing row restated, which is the shape that reddened
  `main` before.

Closes #1231
