### PR TITLE
ComposerStickyFooter had no callers, and neither did the constant under it (#1430)

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -813,45 +813,6 @@ export function ComposerFooter({ start, end, style }: ComposerFooterProps) {
   );
 }
 
-/**
- * The fixed MobileTabBar plus its safe-area padding, as a length (mirrors
- * MobileLayout's <main> bottom padding). Promoted here from the retired
- * `mobileArchetypes/shared.tsx` (#1181): the composer is one responsive
- * component now, so the phone's viewport plumbing has to live where that one
- * component can reach it.
- */
-export const MOBILE_TABBAR_CLEARANCE =
-  "calc(3.5rem + env(safe-area-inset-bottom))";
-
-/**
- * Submit bar pinned above the fixed tab bar on a phone.
- *
- * Sticky (in-flow), not fixed, so it never overlaps content — it flows at the
- * end of the scroll and pins while the body scrolls under it. When the keyboard
- * opens, the layout viewport shrinks and the bar rides up with it, keeping the
- * cast reachable.
- */
-export function ComposerStickyFooter({
-  children,
-  style,
-}: {
-  children: ReactNode;
-  style?: CSSProperties;
-}) {
-  return (
-    <div
-      style={{
-        position: "sticky",
-        bottom: MOBILE_TABBAR_CLEARANCE,
-        zIndex: 8,
-        ...style,
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
 interface ComposerPageProps {
   sizes: ComposerSizes;
   /** The skin's root: its body face and its ink. */


### PR DESCRIPTION
`ComposerStickyFooter` — the phone submit bar meant to pin above the tab bar — had zero callers. It is scaffolding left behind when #1181 collapsed the composer's mobile twin into one responsive tree: the shipped mobile composer reaches the ordinary `ComposerFooter` through `useComposerSizes`, and the v2 design draws no pinned submit bar. Not a gap waiting to be filled.

**What else the deletion orphaned.** `MOBILE_TABBAR_CLEARANCE`, directly above it. The sticky footer was its only reader anywhere in the repo. The three other surfaces that clear the fixed tab bar (`ShellContent`, the two `characterPaths` mobile archetypes, `factionDetail/mobileArchetypes/shared`) each write `calc(3.5rem + env(safe-area-inset-bottom))` themselves and never imported this constant, so nothing is stranded. Unifying them is a different change and out of scope here.

39 lines removed from `frontend/src/pages/editPraxis/archetypes/shared.tsx`. Nothing else in the file is touched, including #1231's `ErrorBanner` `style` prop and `ComposerDress.alarm`, which landed an hour before this branch.

### Proof of zero callers

`git grep` across the whole repo — source, tests, `docs/`, and `.design-sync/` — before the edit:

- `ComposerStickyFooter` → 1 hit, its own definition. Looser `StickyFooter` → the same 1 hit.
- `MOBILE_TABBAR_CLEARANCE` → 2 hits, its definition and the sticky footer's use of it.
- No barrel re-exports this file (`export *` exists only under `components/ui/FilterBar/`), and no `import * as` namespace import reaches it, so there is no indirect path.
- `.design-sync/config.json` maps component FILES, never these exports; `designSyncSrcMap.test.ts` is unaffected.
- Neither name appears in any `__tests__` file, positively or negatively. That mattered: this repo has had a near-miss where a seemingly-orphaned i18n key was read by a *negative* assertion, so deleting it would have made the guard pass vacuously.

### Verification

This is a pure deletion, so the honest checks are the typecheck, the suite staying green, and the grep above — not an invented test for deleted code. I have no browser or dev stack here, so nothing was checked visually; the sticky footer rendered on no screen to begin with.

- `tsc --noEmit` — clean.
- `vitest run` — 197 files, 3385 tests, all passing.
- `eslint src --max-warnings 0` — clean.
- `vite build` — succeeds; `npm run budget` within budget (JS 131.0 KB, CSS 22.3 KB gzipped).

Closes #1430
