### PR TITLE
A vote on a collab is credited to every member, not just the starter (#1465)

### DIFF
--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -16,7 +16,12 @@ from models.praxis import (
     PraxisType,
 )
 from models.task import Task
-from services.era import get_current_era_row, get_next_era_row, get_or_create_stats
+from services.era import (
+    get_current_era_row,
+    get_era_row_for_praxis,
+    get_next_era_row,
+    get_or_create_stats,
+)
 from services.praxis_scoring import Contribution, compute_contributions
 from services.scoring import compute_level
 
@@ -270,3 +275,47 @@ async def recalculate_character_stats(
     await _deliver_earned_invitations(
         author, all_praxes, contributions, session, era, era_row
     )
+
+
+async def recalculate_members_stats(
+    praxis: Praxis,
+    session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
+    *,
+    era_row: Era | None = None,
+) -> None:
+    """Recalculate stats for every member of ``praxis``, then flush (#492).
+
+    **The member set is the unit of recalculation for anything that changes what
+    a praxis is worth** — a seal, an unsubmit, a metatask, a moderation ruling,
+    a vote. A collab is co-owned by all its members (ADR-0013) and the gather in
+    :func:`recalculate_character_stats` picks collabs up by *membership*, so the
+    whole tally lands on every member; recalculating ``created_by_id`` alone
+    moves the starter and silently strands everyone else (#1465). A solo or duel
+    praxis has exactly one member — its author — so this is the right call for
+    every praxis type and there is no branch to get wrong.
+
+    It lives here rather than in ``services.praxis`` because two of its three
+    callers are *upstream* of that module in the import graph:
+    ``services.praxis`` imports both ``services.vote`` and
+    ``services.collab_consensus``, so neither could reach it there without a
+    cycle (#1465). ``services.character_stats`` is imported by all three.
+
+    Callers that already hold an ``era_row`` (e.g. a duel-forfeit recalc that
+    reuses it) pass it in to avoid a re-fetch. ``leave_praxis`` deliberately does
+    NOT use this — it recalcs only the single leaver, who is by then no longer a
+    member.
+
+    The era defaulted to is **the praxis's**, not the live one (#1345): scores
+    are per-era, so a change to a closed era's praxis — a moderation ruling, a
+    metatask, an unsubmit, a vote — has to move that era's row or it moves
+    nothing at all. For a praxis sealed in the era in progress the two are the
+    same row.
+    """
+    if era_row is None:
+        era_row = await get_era_row_for_praxis(praxis, session)
+    for member in praxis.members:
+        await recalculate_character_stats(
+            member.character_id, session, era, era_row=era_row
+        )
+    await session.flush()

--- a/backend/services/collab_consensus.py
+++ b/backend/services/collab_consensus.py
@@ -24,7 +24,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from game_config import CURRENT_ERA, EraConfig
 from models.praxis import Praxis, PraxisInviteStatus, PraxisStatus, PraxisType
-from services.character_stats import recalculate_character_stats
+from services.character_stats import (
+    recalculate_character_stats,
+    recalculate_members_stats,
+)
 from services.era import get_era_row_for_praxis
 
 
@@ -58,10 +61,7 @@ async def seal_to_live(praxis: Praxis, session: AsyncSession, era: EraConfig) ->
     """
     _apply_seal(praxis)
     await session.flush()
-    era_row = await get_era_row_for_praxis(praxis, session)
-    for member in praxis.members:
-        await recalculate_character_stats(member.character_id, session, era, era_row=era_row)
-    await session.flush()
+    await recalculate_members_stats(praxis, session, era)
 
 
 async def settle_if_window_lapsed(
@@ -110,10 +110,7 @@ async def on_member_edit(
     await session.flush()
     if was_live:
         # Leaving Live changes scoring — recompute every member's stats.
-        era_row = await get_era_row_for_praxis(praxis, session)
-        for member in praxis.members:
-            await recalculate_character_stats(member.character_id, session, era, era_row=era_row)
-        await session.flush()
+        await recalculate_members_stats(praxis, session, era)
 
 
 async def on_submit(

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -45,7 +45,10 @@ from schemas.praxis import (
 from services import collab_consensus
 from services.vote import viewer_can_vote_map
 from services.vote_tally import crowned_praxis_ids, viewer_votes_for
-from services.character_stats import recalculate_character_stats
+from services.character_stats import (
+    recalculate_character_stats,
+    recalculate_members_stats,
+)
 from services.praxis_scoring import Contribution, compute_contributions
 from services.faction_service import faction_permits
 from services.media import process_and_save_media
@@ -147,35 +150,6 @@ async def _count_in_progress_praxes(character_id: int, session: AsyncSession) ->
         )
     )
     return result.scalar_one()
-
-
-async def recalculate_members_stats(
-    praxis: Praxis,
-    session: AsyncSession,
-    era: EraConfig = CURRENT_ERA,
-    *,
-    era_row: Optional[Era] = None,
-) -> None:
-    """Recalculate stats for every member of ``praxis``, then flush (#492).
-
-    Lifts the per-member recalc loop copy-pasted across ``submit_praxis``,
-    ``unsubmit_praxis``, ``apply_metatask``, and ``remove_metatask``. Callers
-    that already hold an ``era_row`` (e.g. a duel-forfeit recalc that reuses it)
-    pass it in to avoid a re-fetch. ``leave_praxis`` deliberately does NOT use
-    this — it recalcs only the single leaver, not all members.
-
-    The era defaulted to is **the praxis's**, not the live one (#1345): scores
-    are per-era, so a change to a closed era's praxis — a moderation ruling, a
-    metatask, an unsubmit — has to move that era's row or it moves nothing at
-    all. For a praxis sealed in the era in progress the two are the same row.
-    """
-    if era_row is None:
-        era_row = await get_era_row_for_praxis(praxis, session)
-    for member in praxis.members:
-        await recalculate_character_stats(
-            member.character_id, session, era, era_row=era_row
-        )
-    await session.flush()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -9,12 +9,8 @@ from models.character import Character
 from models.duel import Duel, DuelStatus
 from models.praxis import ModerationStatus, Praxis, PraxisMember
 from models.vote import Vote
-from services.character_stats import recalculate_character_stats
-from services.era import (
-    get_current_era_row,
-    get_era_row_for_praxis,
-    get_or_create_stats,
-)
+from services.character_stats import recalculate_members_stats
+from services.era import get_current_era_row, get_or_create_stats
 from services.scoring import compute_votes_available
 
 
@@ -61,6 +57,11 @@ async def cast_or_update_vote(
     the praxis was sealed in — so it makes the historical record and the
     author's lifetime ``all_time_score`` more accurate without moving the ladder
     anyone is climbing today.
+
+    A vote is credited to every **member** of the praxis, not to its
+    ``created_by_id`` (#1465). On a collab the starter is only one co-owner
+    (ADR-0013) and the whole tally lands on each of them; on a solo or duel
+    praxis the member set is exactly the author, so one call covers every type.
     """
     if not 1 <= value <= 5:
         raise HTTPException(status_code=422, detail="Vote value must be between 1 and 5.")
@@ -99,44 +100,37 @@ async def cast_or_update_vote(
         # the character-scoped ``viewer_vote`` star all name the same character.
         existing.voter_character_id = voter.id
         existing.value = value
-        await session.flush()
-        await recalculate_character_stats(
-            praxis.created_by_id,
-            session,
-            era,
-            era_row=await get_era_row_for_praxis(praxis, session),
+        cast = existing
+    else:
+        # New vote — deduct from budget via CharacterStats (on-read recomputation).
+        # The budget is always the *voter's current* era, whatever era the praxis
+        # is from: voting on old work still costs a vote today (#1345).
+        era_row = await get_current_era_row(session)
+        stats = await get_or_create_stats(session, voter.id, era_row.id)
+
+        if compute_votes_available(stats, era) <= 0:
+            raise HTTPException(
+                status_code=403, detail="No votes remaining in your budget."
+            )
+
+        cast = Vote(
+            praxis_id=praxis.id,
+            voter_character_id=voter.id,
+            voter_account_id=voter.account_id,
+            value=value,
         )
-        await session.flush()
-        await session.refresh(existing)
-        return existing
+        stats.votes_spent_this_era += 1
+        session.add(cast)
 
-    # New vote — deduct from budget via CharacterStats (on-read recomputation).
-    # The budget is always the *voter's current* era, whatever era the praxis is
-    # from: voting on old work still costs a vote today (#1345).
-    era_row = await get_current_era_row(session)
-    stats = await get_or_create_stats(session, voter.id, era_row.id)
-
-    if compute_votes_available(stats, era) <= 0:
-        raise HTTPException(status_code=403, detail="No votes remaining in your budget.")
-
-    vote = Vote(
-        praxis_id=praxis.id,
-        voter_character_id=voter.id,
-        voter_account_id=voter.account_id,
-        value=value,
-    )
-    stats.votes_spent_this_era += 1
-    session.add(vote)
+    # ONE recalc for both branches (#1465). Keeping a copy inside each is how the
+    # two drifted before: the new-cast path and the re-rate path each recalculated
+    # ``created_by_id`` alone, so a collab's co-members were stranded on the way up
+    # *and* left holding unsupported points on the way down.
     await session.flush()
-    await recalculate_character_stats(
-        praxis.created_by_id,
-        session,
-        era,
-        era_row=await get_era_row_for_praxis(praxis, session),
-    )
+    await recalculate_members_stats(praxis, session, era)
     await session.flush()
-    await session.refresh(vote)
-    return vote
+    await session.refresh(cast)
+    return cast
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_collab_vote_recalc.py
+++ b/backend/tests/integration/test_collab_vote_recalc.py
@@ -1,0 +1,213 @@
+"""A vote on a collab praxis must move **every** member's score (#1465).
+
+Seam under test: :func:`services.vote.cast_or_update_vote` — the one function
+behind both ``POST /praxes/{id}/vote`` outcomes (a new cast and a re-rate). It
+recalculated ``praxis.created_by_id`` only, so on a collab the starter moved and
+every co-member's ``CharacterStats`` stayed at whatever the last *other* trigger
+left it at.
+
+A one-member fixture cannot see this defect at all — solo praxes have exactly
+one member, who *is* ``created_by_id``. Every test here uses a two-member collab
+with a third-party voter, and asserts on the **non-starter**.
+
+``all_time_score`` rides along because #1345 made it a credited-forward delta
+rather than a re-derived sum: a member who is never recalculated never accrues,
+so the loss does not self-heal on a later pass.
+"""
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from services.character_stats import recalculate_character_stats
+from services.vote import cast_vote_on_praxis
+
+# Read the modifier from the era config rather than hardcoding it (ADR-0042).
+UA_COLLAB_OWN_MODIFIER: float = CURRENT_ERA.factions["ua"].collab_own_modifier
+
+# A point value big enough that the pre-vote baseline is comfortably non-zero:
+# if a member's expected delta were 0, a broken fix would pass.
+COLLAB_TASK_POINTS: int = 40
+
+FIRST_VOTE_VALUE: int = 5
+RE_RATED_VOTE_VALUE: int = 1
+
+
+def _expected_member_score(points_from_votes: int) -> int:
+    """What every member of the fixture collab is worth. Votes are flat and
+    un-split: each member banks the praxis's whole tally (ADR-0014)."""
+    return round(COLLAB_TASK_POINTS * UA_COLLAB_OWN_MODIFIER + points_from_votes)
+
+
+@pytest_asyncio.fixture
+async def collab_task(db_session: AsyncSession, character: Character) -> Task:
+    task = Task(
+        title="A task worth collaborating on",
+        description="",
+        point_value=COLLAB_TASK_POINTS,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add(task)
+    await db_session.commit()
+    await db_session.refresh(task)
+    return task
+
+
+@pytest_asyncio.fixture
+async def submitted_collab(
+    db_session: AsyncSession,
+    collab_task: Task,
+    character: Character,
+    character3: Character,
+) -> Praxis:
+    """A sealed two-member collab: ``character`` started it, ``character3`` did not.
+
+    ``character3`` is the one every assertion below is really about — the member
+    the vote path never looked at.
+    """
+    praxis = Praxis(
+        task_id=collab_task.id,
+        created_by_id=character.id,
+        type=PraxisType.collab,
+        status=PraxisStatus.submitted,
+        title="Two of us",
+        body_text="proof",
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add_all(
+        [
+            PraxisMember(
+                praxis_id=praxis.id, character_id=character.id, has_submitted=True
+            ),
+            PraxisMember(
+                praxis_id=praxis.id, character_id=character3.id, has_submitted=True
+            ),
+        ]
+    )
+    await db_session.commit()
+    await db_session.refresh(praxis)
+
+    # Baseline: both members already banked the un-voted collab, so the defect
+    # shows up as a missing *delta* rather than as a member who never scored.
+    for member in (character, character3):
+        await recalculate_character_stats(member.id, db_session)
+    await db_session.commit()
+    return praxis
+
+
+async def _stats(
+    db_session: AsyncSession, character_id: int, era_row: Era
+) -> CharacterStats:
+    result = await db_session.execute(
+        select(CharacterStats).where(
+            CharacterStats.character_id == character_id,
+            CharacterStats.era_id == era_row.id,
+        )
+    )
+    return result.scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_baseline_both_members_bank_the_unvoted_collab(
+    db_session: AsyncSession,
+    character: Character,
+    character3: Character,
+    submitted_collab: Praxis,
+    era: Era,
+    faction_ua: Faction,
+):
+    """Control. Both members score the collab equally before any vote, so a
+    later assertion about one of them moving is about the vote, not the seal."""
+    baseline = _expected_member_score(0)
+    assert baseline > 0, "fixture must produce a non-zero baseline"
+    assert (await _stats(db_session, character.id, era)).score == baseline
+    assert (await _stats(db_session, character3.id, era)).score == baseline
+
+
+@pytest.mark.asyncio
+async def test_a_vote_on_a_collab_moves_every_member_not_just_the_starter(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    submitted_collab: Praxis,
+    era: Era,
+    faction_ua: Faction,
+):
+    """The reported symptom: your collaborator's praxis gains votes and your own
+    score does not move."""
+    await cast_vote_on_praxis(character2, submitted_collab.id, FIRST_VOTE_VALUE, db_session)
+    await db_session.commit()
+
+    expected = _expected_member_score(FIRST_VOTE_VALUE)
+    starter_stats = await _stats(db_session, character.id, era)
+    member_stats = await _stats(db_session, character3.id, era)
+
+    assert starter_stats.score == expected
+    assert member_stats.score == expected, (
+        "the non-starter member banks the same vote points as the starter"
+    )
+    assert member_stats.score - _expected_member_score(0) == FIRST_VOTE_VALUE
+
+
+@pytest.mark.asyncio
+async def test_a_collab_vote_moves_every_member_all_time_score(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    submitted_collab: Praxis,
+    era: Era,
+    faction_ua: Faction,
+):
+    """``all_time_score`` is credited forward as a delta (#1345), so a member who
+    is never recalculated never accrues and the loss is permanent."""
+    before = (await _stats(db_session, character3.id, era)).all_time_score
+
+    await cast_vote_on_praxis(character2, submitted_collab.id, FIRST_VOTE_VALUE, db_session)
+    await db_session.commit()
+
+    after = await _stats(db_session, character3.id, era)
+    assert after.all_time_score == before + FIRST_VOTE_VALUE
+    assert after.all_time_score == after.score
+
+
+@pytest.mark.asyncio
+async def test_re_rating_a_collab_vote_down_moves_every_member_down(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    submitted_collab: Praxis,
+    era: Era,
+    faction_ua: Faction,
+):
+    """The way down. There is no unvote route — the write surface is POST-only
+    (``routers/votes.py``) — so the reverse direction is a *re-rate*, which lands
+    in the update branch of the same function. A one-sided recalc there leaves
+    the other members holding points no vote supports."""
+    await cast_vote_on_praxis(character2, submitted_collab.id, FIRST_VOTE_VALUE, db_session)
+    await db_session.commit()
+    await cast_vote_on_praxis(
+        character2, submitted_collab.id, RE_RATED_VOTE_VALUE, db_session
+    )
+    await db_session.commit()
+
+    expected = _expected_member_score(RE_RATED_VOTE_VALUE)
+    assert (await _stats(db_session, character.id, era)).score == expected
+    member_stats = await _stats(db_session, character3.id, era)
+    assert member_stats.score == expected, (
+        "a re-rate down must debit the non-starter too"
+    )
+    assert member_stats.all_time_score == expected


### PR DESCRIPTION
A vote on a collab praxis moved the starter's score and nobody else's. `services/vote.py` recalculated `praxis.created_by_id`, but `recalculate_character_stats` gathers collabs by **membership** — so every co-member scores the praxis, and every co-member was being left stale.

Closes #1465

## Seam under test

`services.vote.cast_or_update_vote` — the one function behind both outcomes of `POST /praxes/{id}/vote` (a new cast and a re-rate). The red loop is `backend/tests/integration/test_collab_vote_recalc.py`: a two-member collab (`character` started it, `character3` did not) with a third party voting. Three of the four tests failed on the real defect before the fix; the fourth is the control.

The fixture deliberately runs a baseline recalc first, so both members already bank the un-voted collab. That makes the defect show up as a **missing delta** on a genuinely non-zero score rather than as a member who simply never scored — a test where the expected delta is 0 passes on a broken fix. The re-rate failure was the clearest: `assert 40 == 41`, the non-starter pinned at its baseline while the starter tracked the vote.

## The fix

The helper already existed. What did not exist was a way to reach it.

`recalculate_members_stats` lived in `services/praxis.py`, but `services/praxis.py` imports **both** `services/vote.py` and `services/collab_consensus.py` — so neither of the two modules that needed the walker could import it without a cycle. It moves to `services/character_stats.py`, which all three already import, next to the `recalculate_character_stats` it wraps. No second walker was written; the one that existed now has one home and three module-level callers.

Then:

- **`services/vote.py`** calls it. That is the fix.
- The two recalc copies inside `cast_or_update_vote` **collapse to one call after the branch**. That duplication is exactly how the new-cast path and the re-rate path came to carry the same bug twice, and there is no longer a place for them to drift apart again.
- **`services/collab_consensus.py`** swaps its two hand-rolled member loops (`seal_to_live`, `on_member_edit`) for the same helper. Behaviour is identical — the helper *is* the loop they were running — and the codebase now has one member walker instead of three.

No migration. No config or rule values touched.

## The three things the issue asked me to check

**1. Does the consensus/seal path have the same gap? — No.** `seal_to_live` and `on_member_edit` already walked `praxis.members` inline; they were correct, and only got refactored onto the shared helper. `on_member_leave` recalculates the survivor alone, which is right rather than lucky: the leaver is recalculated by `leave_praxis`, and by the time that branch runs `convert_to_solo` has left exactly one member, so "the survivor" and "every member" are the same set.

I also checked the neighbouring member-dropping path, `change_praxis_type`. It is guarded to `in_progress`/`pending`, so the members a takeover drops never held points. No gap.

**2. Does an unvote have it? — There is no unvote.** The vote write surface is a single route, `POST /praxes/{praxis_id}/vote`; `routers/votes.py` is read-only and carries an explicit "do not re-add a vote write route to this module" note from #637. There is no DELETE anywhere.

But the prediction behind the question was right. The way down is a **re-rate**, and it lands in the update branch of the same function — which had its own copy of the one-sided recalc. Dropping a 5 to a 1 debited the starter and left every co-member holding points no vote supported. `test_re_rating_a_collab_vote_down_moves_every_member_down` pins it, and the branch collapse means one call now serves both directions.

**3. Does `all_time_score` drift? — Yes, and permanently.** Since #1345 it is credited forward as a delta (`_credit_all_time_score`) rather than re-derived from a sum, so a member who is never recalculated never accrues: the points are not merely late, they are gone, and no later recalc restores them. `test_a_collab_vote_moves_every_member_all_time_score` asserts the non-starter's lifetime figure moves by the vote's value.

## Verification

```
TEST_DATABASE_URL=postgresql+asyncpg://.../wz1465_test \
  python -m pytest --cov=. --cov-fail-under=80
```
`942 passed in 92.81s`, total coverage **91.63%**. Re-ran the vote/praxis suites after rebasing onto `dd81e17d`: 121 passed.

Backend-only change, verified by tests — no browser or dev stack was available in this worktree.
