### PR TITLE
GET /me/sidebar ships a pending-request COUNT, not up to 100 hydrated items (#1456)

### DIFF
--- a/backend/routers/me.py
+++ b/backend/routers/me.py
@@ -82,9 +82,11 @@ async def my_sidebar(
     """
     character = await resolve_active_character(account, session)
     if character is None:
-        return SidebarOut(pending_requests=[], global_activity=[], active_praxes=[])
+        return SidebarOut(
+            pending_requests_count=0, global_activity=[], active_praxes=[]
+        )
 
-    pending_requests, global_activity = await get_sidebar_feed(
+    pending_requests_count, global_activity = await get_sidebar_feed(
         character_id=character.id,
         session=session,
         session_factory=session_factory,
@@ -99,9 +101,7 @@ async def my_sidebar(
         viewer_account_id=character.account_id,
     )
     return SidebarOut(
-        pending_requests=[
-            ActivityFeedItem.model_validate(asdict(item)) for item in pending_requests
-        ],
+        pending_requests_count=pending_requests_count,
         global_activity=[
             ActivityFeedItem.model_validate(asdict(item)) for item in global_activity
         ],

--- a/backend/schemas/sidebar.py
+++ b/backend/schemas/sidebar.py
@@ -13,10 +13,18 @@ class SidebarOut(BaseModel):
     sites already refetch, and fattening that payload would make every one of
     them heavier (#1349). This carries only what the panels need.
 
-    The two feed panels are two slices of a single fan-out over the activity
-    feed — see :func:`services.activity_feed.get_sidebar_feed`.
+    Requests are a NUMBER, not a list (#1456). The rail listed them until
+    #1423; under ADR-0070 the Requests queue on ``/updates`` is the only
+    surface a request can be answered on, so all that is left here is the
+    badge on the collapsed handle, the mobile bell and the mobile FieldDesk —
+    three consumers of one integer. Shipping up to a hundred hydrated feed
+    items on a page-load path to produce it was the whole of the cost.
+
+    The count is the same one ``counts.requests`` reports, so the badge and
+    the queue's card list cannot disagree — see
+    :func:`services.activity_feed.get_sidebar_feed`.
     """
 
-    pending_requests: list[ActivityFeedItem]
+    pending_requests_count: int
     global_activity: list[ActivityFeedItem]
     active_praxes: list[PraxisCardOut]

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -1406,11 +1406,8 @@ async def _build_fetch_context(
     )
 
 
-# The two feed panels on the desktop rail (#1344). The requests panel wants
-# every unresolved invite and challenge — inherently a small set, and already
-# bounded far below this by SUB_QUERY_LIMIT per source; the global panel is a
-# glance, not a list.
-SIDEBAR_REQUESTS_LIMIT = 100
+# The rail's global panel is a glance, not a list. The requests side has no
+# limit constant any more: it is a COUNT, and a number has nothing to truncate.
 SIDEBAR_GLOBAL_LIMIT = 5
 
 
@@ -1418,47 +1415,58 @@ async def get_sidebar_feed(
     character_id: int,
     session: AsyncSession,
     session_factory: Callable,
-) -> tuple[list[ActivityFeedItemDC], list[ActivityFeedItemDC]]:
-    """The rail's ``requests`` and ``global`` panels, from ONE fan-out (#1344).
+) -> tuple[int, list[ActivityFeedItemDC]]:
+    """The rail's pending-request COUNT and its ``global`` panel, in one pass.
 
-    The rail used to ask ``/activity-feed`` twice, once per filter, and each ask
-    paid the full five-round-trip pre-fetch *and* the fifteen badge COUNT
-    queries. Both panels are slices of the same registry, so this runs the
-    fan-out once over the union of their sources and partitions the result by
-    which panel each source belongs to.
+    Returns ``(pending_requests_count, global_activity)``, the list newest-first.
 
-    No counts: the rail draws no badges. That is the whole reason this does not
-    simply call :func:`get_activity_feed` twice — the counts are more than half
-    the queries and none of them are looked at.
+    WHY A COUNT AND NOT A LIST (#1456)
+    ----------------------------------
+    This used to hand back up to a hundred fully-hydrated request items so that
+    three consumers — the collapsed rail handle, the mobile bell and the mobile
+    FieldDesk — could each read ``.length``. Since #1423 nothing renders them:
+    the Requests queue on ``/updates`` is the only surface a request can be
+    answered on (ADR-0070). One integer is the whole of what is left.
 
-    Returns ``(pending_requests, global_activity)``, each newest-first.
+    The two sides do not share a fan-out, because they no longer overlap: the
+    four request sources and the two global sources are disjoint in the
+    registry. Requests are counted with :func:`_run_source_count`, global news
+    is fetched with :func:`_run_source_fetch`, and all six queries still go out
+    concurrently — the same six round trips as before, four of them now COUNTs
+    over the identical windowed Select instead of row hydration.
+
+    WHY THE NUMBER CANNOT DRIFT FROM THE QUEUE
+    ------------------------------------------
+    It is the same computation ``counts.requests`` runs, from the same
+    ``_visible_types`` authority and the same live context (ADR-0036): one COUNT
+    per source, wrapping that source's own query so it inherits the same WHERE,
+    the same ``SUB_QUERY_LIMIT`` window and the same archive filter. A badge that
+    disagreed with the list under it is precisely what that ADR exists to
+    prevent, and the equality is pinned by
+    ``test_sidebar_badge_equals_the_requests_queue_card_count``.
     """
     fetch_ctx, archive_view = await _build_fetch_context(
         character_id, session, before_cursor=None, archived=False
     )
-    panel_filters = frozenset({FILTER_REQUESTS, FILTER_GLOBAL})
-    sources = [
-        source for source in FEED_SOURCES if not source.filters.isdisjoint(panel_filters)
-    ]
-    results = await asyncio.gather(*(
-        _run_source_fetch(source, fetch_ctx, archive_view, session_factory)
-        for source in sources
-    ))
 
-    def panel(feed_filter: str, limit: int) -> list[ActivityFeedItemDC]:
-        items = [
-            item
-            for source, source_items in zip(sources, results)
-            if feed_filter in source.filters
-            for item in source_items
-        ]
-        items.sort(key=lambda item: item.timestamp, reverse=True)
-        return items[:limit]
+    def sources_for(feed_filter: str) -> list[FeedSource]:
+        visible = _visible_types(feed_filter, archived=False)
+        return [source for source in FEED_SOURCES if source.item_type in visible]
 
-    return (
-        panel(FILTER_REQUESTS, SIDEBAR_REQUESTS_LIMIT),
-        panel(FILTER_GLOBAL, SIDEBAR_GLOBAL_LIMIT),
+    request_counts, global_results = await asyncio.gather(
+        asyncio.gather(*(
+            _run_source_count(source, fetch_ctx, archive_view, session_factory)
+            for source in sources_for(FILTER_REQUESTS)
+        )),
+        asyncio.gather(*(
+            _run_source_fetch(source, fetch_ctx, archive_view, session_factory)
+            for source in sources_for(FILTER_GLOBAL)
+        )),
     )
+
+    global_activity = [item for items in global_results for item in items]
+    global_activity.sort(key=lambda item: item.timestamp, reverse=True)
+    return sum(request_counts), global_activity[:SIDEBAR_GLOBAL_LIMIT]
 
 
 async def get_activity_feed(

--- a/backend/tests/integration/test_me_sidebar.py
+++ b/backend/tests/integration/test_me_sidebar.py
@@ -17,11 +17,15 @@ which is the shape this issue exists to remove.
 """
 
 import pytest
+import pytest_asyncio
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import services.activity_feed as activity_feed_service
 from models.character import Character
+from models.duel import Duel, DuelStatus
+from models.era import Era
+from models.invitation_letter import InvitationLetter
 from models.praxis import (
     Praxis,
     PraxisInvite,
@@ -31,6 +35,7 @@ from models.praxis import (
     PraxisType,
 )
 from models.task import Task
+from services.activity_feed import REQUEST_ITEM_TYPES
 
 
 @pytest.mark.asyncio
@@ -174,3 +179,163 @@ async def test_sidebar_without_a_character_is_empty(
         "global_activity": [],
         "active_praxes": [],
     }
+
+
+@pytest_asyncio.fixture
+async def four_request_types(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+    faction_ephemerists,
+) -> int:
+    """One UNANSWERED item of each of the four request types, plus an ANSWERED
+    twin of each that must not be counted. Returns the expected count (4).
+
+    The answered twins are the point. A fixture of all-pending items passes on a
+    broken filter — it is only the twins that prove the badge is reading the
+    same ADR-0070 "unanswered" window the queue reads, per type:
+
+    ``collab_invite``      status is ``pending``
+    ``duel_challenge``     status is ``pending``
+    ``awaiting_submission``  ``PraxisMember.has_submitted`` is false
+    ``invitation_letter``  the letter's faction is not the one you now stand in
+    """
+    def praxis(owner_id: int, praxis_type: PraxisType, title: str) -> Praxis:
+        return Praxis(
+            task_id=active_task.id,
+            created_by_id=owner_id,
+            type=praxis_type,
+            status=PraxisStatus.in_progress,
+            title=title,
+            body_text="proof",
+        )
+
+    # --- collab_invite: one pending (counts), one declined (does not) --------
+    open_collab = praxis(character2.id, PraxisType.collab, "Open collab")
+    answered_collab = praxis(character2.id, PraxisType.collab, "Answered collab")
+    # --- duel_challenge: one pending (counts), one active (does not) -- -------
+    open_duel_praxis = praxis(character2.id, PraxisType.duel, "Open duel")
+    answered_duel_praxis = praxis(character2.id, PraxisType.duel, "Answered duel")
+    # --- awaiting_submission: viewer un-submitted (counts) / submitted (not) -
+    my_turn = praxis(character2.id, PraxisType.collab, "My turn")
+    already_filed = praxis(character2.id, PraxisType.collab, "Already filed")
+    db_session.add_all([
+        open_collab, answered_collab, open_duel_praxis,
+        answered_duel_praxis, my_turn, already_filed,
+    ])
+    await db_session.flush()
+
+    db_session.add_all([
+        PraxisInvite(
+            praxis_id=open_collab.id,
+            inviter_id=character2.id,
+            invitee_id=character.id,
+            status=PraxisInviteStatus.pending,
+        ),
+        PraxisInvite(
+            praxis_id=answered_collab.id,
+            inviter_id=character2.id,
+            invitee_id=character.id,
+            status=PraxisInviteStatus.declined,
+        ),
+        Duel(
+            task_id=active_task.id,
+            challenger_praxis_id=open_duel_praxis.id,
+            opponent_character_id=character.id,
+            status=DuelStatus.pending,
+        ),
+        Duel(
+            task_id=active_task.id,
+            challenger_praxis_id=answered_duel_praxis.id,
+            opponent_character_id=character.id,
+            status=DuelStatus.active,
+        ),
+        PraxisMember(
+            praxis_id=my_turn.id, character_id=character.id, has_submitted=False
+        ),
+        PraxisMember(
+            praxis_id=already_filed.id, character_id=character.id, has_submitted=True
+        ),
+        # A letter for a faction the viewer does NOT stand in is an open ask...
+        InvitationLetter(
+            character_id=character.id, faction_slug="ephemerists", era_id=era.id
+        ),
+        # ...and one for the faction they already joined is answered by standing.
+        InvitationLetter(
+            character_id=character.id,
+            faction_slug=character.faction_slug,
+            era_id=era.id,
+        ),
+    ])
+    await db_session.commit()
+    return 4
+
+
+@pytest.mark.asyncio
+async def test_sidebar_badge_equals_the_requests_queue_card_count(
+    client: AsyncClient,
+    four_request_types: int,
+    auth_headers: dict,
+):
+    """THE guard: the badge's number IS the number of cards the queue presents.
+
+    The badge on the collapsed rail, the mobile bell and the FieldDesk all read
+    one integer; the Requests queue on ``/updates`` renders the cards. They are
+    computed by different code paths — a COUNT over each source's own windowed
+    query here, a fan-out and a sort there — so nothing but this assertion stops
+    them drifting the first time either side's idea of "unanswered" moves. A
+    badge reading 5 over a list of 3 is exactly what ADR-0036 exists to prevent.
+    """
+    sidebar = await client.get("/me/sidebar", headers=auth_headers)
+    assert sidebar.status_code == 200
+    badge = sidebar.json()["pending_requests_count"]
+
+    queue = await client.get(
+        "/activity-feed", params={"filter": "requests"}, headers=auth_headers
+    )
+    assert queue.status_code == 200
+    queue_body = queue.json()
+
+    assert badge == four_request_types, (
+        "one unanswered item of each of the four request types is 4; the "
+        f"badge said {badge}"
+    )
+    assert badge == len(queue_body["items"]), (
+        f"badge {badge} vs {len(queue_body['items'])} cards in the queue"
+    )
+    assert badge == queue_body["counts"]["requests"], (
+        f"badge {badge} vs the queue's own tab count "
+        f"{queue_body['counts']['requests']}"
+    )
+    # ...and it is one of EACH type, so no single type is carrying the number.
+    assert sorted(item["type"] for item in queue_body["items"]) == sorted(
+        REQUEST_ITEM_TYPES
+    )
+
+
+@pytest.mark.asyncio
+async def test_sidebar_ships_the_number_without_the_items(
+    client: AsyncClient,
+    four_request_types: int,
+    auth_headers: dict,
+):
+    """The whole point of #1456: a count, and no request items in the payload.
+
+    Asserting the absence, not merely the presence of the count — shipping both
+    would leave the up-to-100 hydrated items on the page-load path that this
+    exists to take off it.
+    """
+    response = await client.get("/me/sidebar", headers=auth_headers)
+    assert response.status_code == 200
+    body = response.json()
+
+    assert body["pending_requests_count"] == four_request_types
+    assert "pending_requests" not in body, (
+        "the response still carries the request items it was meant to stop "
+        "serialising"
+    )
+    # The other two panels still ship their items — this narrows one field.
+    assert isinstance(body["global_activity"], list)
+    assert isinstance(body["active_praxes"], list)

--- a/backend/tests/integration/test_me_sidebar.py
+++ b/backend/tests/integration/test_me_sidebar.py
@@ -86,7 +86,7 @@ async def test_sidebar_returns_all_three_panels(
     assert response.status_code == 200
     data = response.json()
 
-    assert [item["type"] for item in data["pending_requests"]] == ["collab_invite"]
+    assert data["pending_requests_count"] == 1  # the collab invite
     # `active_task` is active in the current era, so it is global news. The
     # global panel also carries the era announcement — the rail renders that
     # type too — so this asserts membership, not the whole list.
@@ -175,7 +175,7 @@ async def test_sidebar_without_a_character_is_empty(
     response = await client.get("/me/sidebar", headers=auth_headers)
     assert response.status_code == 200
     assert response.json() == {
-        "pending_requests": [],
+        "pending_requests_count": 0,
         "global_activity": [],
         "active_praxes": [],
     }

--- a/frontend/src/api/sidebar.ts
+++ b/frontend/src/api/sidebar.ts
@@ -10,8 +10,17 @@ import type { PraxisCardOut } from './praxis'
  * into that payload would make every one of those refetches heavier (#1349).
  */
 export interface SidebarPanels {
-  /** Unresolved collab invites + duel challenges, and your own outstanding submissions. */
-  pending_requests: ActivityFeedItem[]
+  /**
+   * How many unanswered requests are waiting — collab invites, duel challenges,
+   * your own outstanding submissions and faction invitation letters.
+   *
+   * A number, not a list (#1456). The rail listed these until #1423; the queue
+   * on `/updates` owns the cards now (ADR-0070), so every consumer left — the
+   * collapsed handle's badge, the mobile bell, the mobile FieldDesk — wanted
+   * only `.length`. It is the same number the queue's own `counts.requests`
+   * reports, so the badge and the card list cannot disagree.
+   */
+  pending_requests_count: number
   /** Recent site-wide news — new tasks and era announcements. */
   global_activity: ActivityFeedItem[]
   /** In-progress praxes the carried character is a MEMBER of (so accepted

--- a/frontend/src/components/layout/MobileHeader.tsx
+++ b/frontend/src/components/layout/MobileHeader.tsx
@@ -18,9 +18,9 @@ export default function MobileHeader() {
   // The same pending-request count the desktop rail surfaces, from the same
   // response; drives the bell badge so the Updates page is reachable from the
   // phone header (#572). Reading it here costs no request (#1344) — it used to
-  // be a second, byte-identical limit-100 feed call.
-  const { pending_requests: pendingRequests } = useSidebarPanels()
-  const pendingCount = pendingRequests.length
+  // be a second, byte-identical limit-100 feed call, and until #1456 it was
+  // still a list of items this only ever measured.
+  const { pending_requests_count: pendingCount } = useSidebarPanels()
 
   return (
     <header

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -65,10 +65,9 @@ function SectionHeader({ label }: { label: string }) {
  * `REQUESTS_QUEUE_ANCHOR` on `/updates`. This panel was the surface it
  * replaced, so it is gone rather than duplicated.
  *
- * The response's `pending_requests` is still fetched and still read — but only
- * for its LENGTH now, by the collapsed handle's badge (`SidebarColumn`), the
- * mobile bell (`MobileHeader`) and the mobile FieldDesk. Nothing renders the
- * items.
+ * The response no longer carries the request items at all (#1456) — only
+ * `pending_requests_count`, read by the collapsed handle's badge
+ * (`SidebarColumn`), the mobile bell (`MobileHeader`) and the mobile FieldDesk.
  */
 export default function Sidebar() {
   const { t } = useTranslation('common')

--- a/frontend/src/components/layout/SidebarColumn.tsx
+++ b/frontend/src/components/layout/SidebarColumn.tsx
@@ -26,8 +26,8 @@ import SidebarHandle from './SidebarHandle'
  * reopen; how long stale rail data may be trusted is deliberately left open
  * (#1346).
  *
- * WHY THIS READS `pending_requests` AT ALL
- * ----------------------------------------
+ * WHY THIS READS `pending_requests_count` AT ALL
+ * ----------------------------------------------
  * For one number, for one child. The rail used to LIST the requests and the
  * handle badged their count, so #1343 hoisted a single `usePendingRequests()`
  * here and passed it down — that hook held per-instance state with no shared
@@ -37,10 +37,9 @@ import SidebarHandle from './SidebarHandle'
  * is left is the collapsed handle's badge, which is the only thing that tells a
  * folded-away desktop something is waiting, and it takes the count as a prop.
  *
- * Reading the array only to take its `.length` is now true of EVERY consumer —
- * here, the mobile bell and the mobile FieldDesk. Serving them a count instead
- * of up to 100 serialized feed items is a backend change to `/me/sidebar`, and
- * is filed rather than faked here.
+ * Every consumer wanted only that number — here, the mobile bell and the mobile
+ * FieldDesk — so since #1456 the response carries the count itself rather than
+ * up to 100 serialized feed items for three callers to run `.length` over.
  */
 export interface SidebarColumnProps {
   readonly collapsed: boolean
@@ -61,7 +60,7 @@ export interface SidebarColumnProps {
 const SIDEBAR_COLUMN = 'hidden lg:block lg:col-start-1 lg:row-start-1 lg:self-stretch'
 
 export default function SidebarColumn({ collapsed, onToggle }: SidebarColumnProps) {
-  const { pending_requests: pendingRequests } = useSidebarPanels()
+  const { pending_requests_count: pendingCount } = useSidebarPanels()
 
   return (
     <div className={SIDEBAR_COLUMN}>
@@ -69,7 +68,7 @@ export default function SidebarColumn({ collapsed, onToggle }: SidebarColumnProp
         <SidebarHandle
           collapsed={collapsed}
           onToggle={onToggle}
-          pendingCount={pendingRequests.length}
+          pendingCount={pendingCount}
         />
       </div>
       <div hidden={collapsed}>

--- a/frontend/src/components/layout/__tests__/MobileHeader.test.tsx
+++ b/frontend/src/components/layout/__tests__/MobileHeader.test.tsx
@@ -4,7 +4,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // Initialize the i18n catalog so nav/settings copy keys resolve to English text.
 import '../../../i18n'
 import type { CurrentUser } from '../../../api/auth'
-import type { ActivityFeedItem } from '../../../api/activityFeed'
 
 // useAuth reads from context whose value is populated by an async effect that
 // never runs under renderToStaticMarkup — mock it to control signed-in state.
@@ -36,7 +35,7 @@ const signedOut = { user: null }
 
 beforeEach(() => {
   pendingMock.mockReturnValue({
-    pending_requests: [],
+    pending_requests_count: 0,
     global_activity: [],
     active_praxes: [],
     refetch: vi.fn(),
@@ -64,7 +63,7 @@ describe('MobileHeader bell', () => {
 
     // Three pending requests → badge count is rendered.
     pendingMock.mockReturnValue({
-      pending_requests: [{}, {}, {}] as ActivityFeedItem[],
+      pending_requests_count: 3,
       global_activity: [],
       active_praxes: [],
       refetch: vi.fn(),

--- a/frontend/src/components/layout/__tests__/sidebarPendingRequests.test.tsx
+++ b/frontend/src/components/layout/__tests__/sidebarPendingRequests.test.tsx
@@ -1,12 +1,13 @@
 /**
  * #1423 — the rail stops LISTING pending requests, but keeps COUNTING them.
  *
- * The seam is `SidebarColumn`: the one place the provider's `pending_requests`
- * array meets both of its consumers. Under ADR-0070 the actionable pile lives
- * in the Requests queue on `/updates` and nowhere else, so the rail must render
- * no accept/decline control — while the collapsed handle's badge, which is the
+ * The seam is `SidebarColumn`: the one place the provider's request data meets
+ * both of its consumers. Under ADR-0070 the actionable pile lives in the
+ * Requests queue on `/updates` and nowhere else, so the rail must render no
+ * accept/decline control — while the collapsed handle's badge, which is the
  * only thing telling a folded-away desktop that something is waiting, must
- * still read the same array's length.
+ * still show the number. Since #1456 that number arrives AS a number:
+ * `pending_requests_count`, with no items behind it to measure.
  *
  * A count that silently reads 0 looks like "nothing pending" rather than like a
  * bug, which is why it is pinned here rather than left to the deletion's
@@ -17,7 +18,6 @@ import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import '../../../i18n'
 import i18n from '../../../i18n'
-import type { ActivityFeedItem } from '../../../api/activityFeed'
 import type { CurrentUser } from '../../../api/auth'
 
 const panelsMock = vi.fn()
@@ -36,30 +36,10 @@ vi.mock('../../../hooks/useGameConfig', () => ({
 
 import SidebarColumn from '../SidebarColumn'
 
-const pendingRequest = (type: string): ActivityFeedItem =>
-  ({
-    type,
-    item_key: `${type}:1`,
-    timestamp: new Date().toISOString(),
-    actor_display_name: 'Wren',
-    actor_faction_slug: 'ua',
-    actor_avatar_url: null,
-    context_faction_slug: 'ua',
-    payload: {
-      inviter_character_id: 7,
-      challenger_character_id: 7,
-      praxis_id: 3,
-      praxis_type: 'collab',
-      task_title: 'Mend the orrery',
-      task_faction_slug: 'ua',
-    },
-  }) as ActivityFeedItem
-
-const THREE_PENDING = [
-  pendingRequest('collab_invite'),
-  pendingRequest('duel_challenge'),
-  pendingRequest('awaiting_submission'),
-]
+// The rail has nothing to list any more, so this fixture is just the number
+// the badge is meant to show (#1456). It used to be three hydrated feed items
+// that only ever had `.length` taken off them.
+const PENDING_COUNT = 3
 
 function render(collapsed: boolean): string {
   return renderToStaticMarkup(
@@ -71,7 +51,7 @@ function render(collapsed: boolean): string {
 
 beforeEach(() => {
   panelsMock.mockReturnValue({
-    pending_requests: THREE_PENDING,
+    pending_requests_count: PENDING_COUNT,
     global_activity: [],
     active_praxes: [],
     refetch: vi.fn(),
@@ -108,9 +88,9 @@ describe('the rail and its pending requests', () => {
     expect(html).toContain('>3<')
   })
 
-  it('badges nothing when the array is empty — 0 is not a silent failure', () => {
+  it('badges nothing when the count is 0 — 0 is not a silent failure', () => {
     panelsMock.mockReturnValue({
-      pending_requests: [],
+      pending_requests_count: 0,
       global_activity: [],
       active_praxes: [],
       refetch: vi.fn(),

--- a/frontend/src/hooks/useSidebarPanels.tsx
+++ b/frontend/src/hooks/useSidebarPanels.tsx
@@ -12,7 +12,7 @@ import { useAuth } from '../auth/AuthContext'
 import { onRequestsChanged } from '../utils/requestsBus'
 
 const EMPTY_PANELS: SidebarPanels = {
-  pending_requests: [],
+  pending_requests_count: 0,
   global_activity: [],
   active_praxes: [],
 }

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
@@ -30,7 +30,7 @@ vi.mock('../../../hooks/useMyCharacterStats', () => ({
 }))
 vi.mock('../../../hooks/useSidebarPanels', () => ({
   useSidebarPanels: () => ({
-    pending_requests: [],
+    pending_requests_count: 0,
     global_activity: [],
     active_praxes: [],
     loading: false,

--- a/frontend/src/pages/fieldDesk/useFieldDeskHome.ts
+++ b/frontend/src/pages/fieldDesk/useFieldDeskHome.ts
@@ -34,7 +34,7 @@ export interface FieldDeskHomeState {
   votesReceived: number
   /** In-progress praxes (membership-scoped) — the active-tasks list. */
   activeTasks: PraxisCardOut[]
-  /** Count of pending collab invites + duel challenges. */
+  /** Count of unanswered requests, straight from `/me/sidebar` (#1456). */
   pendingCount: number
   /** Whether the active-tasks list is still loading. */
   loadingTasks: boolean
@@ -50,7 +50,7 @@ export function useFieldDeskHome(): FieldDeskHomeState | null {
   // downstream values are their empty defaults and we return null below.
   const {
     active_praxes: activeTasks,
-    pending_requests: pendingRequests,
+    pending_requests_count: pendingCount,
     loading: loadingTasks,
   } = useSidebarPanels()
   const { votesReceived } = useMyCharacterStats(character?.id)
@@ -62,7 +62,7 @@ export function useFieldDeskHome(): FieldDeskHomeState | null {
     eraName: user?.era_name ?? '',
     votesReceived,
     activeTasks,
-    pendingCount: pendingRequests.length,
+    pendingCount,
     loadingTasks,
     canProposeTask: user?.can_propose_task ?? false,
   }


### PR DESCRIPTION
Closes #1456

## The seam

`GET /me/sidebar`'s response contract — specifically **the equality between its badge number and the Requests queue's card count**. That equality is the whole risk here; the payload saving is the easy part.

## Verified the issue's premise before building

All three consumers read only `.length` — confirmed in `SidebarColumn.tsx`, `MobileHeader.tsx`, `useFieldDeskHome.ts`. `hooks/usePendingRequests.ts` is indeed gone, so there is no frontend `limit` lever. `get_sidebar_feed` does skip the count queries.

One thing the issue did not say, and which decided the design: **the 4 request sources and the 2 global sources are disjoint in `FEED_SOURCES`.** Nothing in the requests half was feeding the global panel, so the requests half could be swapped for COUNTs with no loss.

## The fix

`get_sidebar_feed` now returns `(pending_requests_count, global_activity)`. The four request sources go through `_run_source_count` — *the identical helper `counts.requests` uses* — instead of `_run_source_fetch`. `SidebarOut.pending_requests` becomes `pending_requests_count: int`; `SIDEBAR_REQUESTS_LIMIT` is deleted (a number has nothing to truncate).

Source selection for both panels now derives from `_visible_types()` rather than reading `source.filters` directly, so the sidebar obeys the same single ADR-0070 authority as the queue and the badges.

Why it cannot drift: same `_visible_types` set, same live `FeedContext`, and one COUNT per source wrapping that source's own Select — so it inherits the same WHERE, the same `SUB_QUERY_LIMIT` window and the same archive filter (ADR-0036).

## Measurements (both sides, as the issue asked)

| | before | after |
|---|---|---|
| SQL statements for `GET /me/sidebar` | **36** | **36** |
| of which `count(*)` | 0 | 4 (replacing 4 hydrating SELECTs) |
| response bytes, 4 pending requests | 3,939 | **2,493** |

**Zero added queries** — measured with a `before_cursor_execute` listener over the whole request on the old code and the new. The four request-source SELECTs became four COUNTs over the identical subquery; same six concurrent round trips on the feed side, minus the row hydration and `to_item` mapping.

Payload: ~362 bytes per request item, so **~1.4 KB saved at 4 pending items and ~36 KB at the old 100-item cap**, on a signed-in first-wave page-load request.

## Tests (written first, and mutation-checked)

`test_sidebar_badge_equals_the_requests_queue_card_count` builds one **unanswered** item of each of the four request types **plus an answered twin of each** — declined invite, active duel, `has_submitted=True` member, and a letter for the faction the viewer already stands in. It pins `badge == 4 == len(queue items) == counts.requests`, and that the queue shows one of each type so no single type carries the number.

The twins are the point, and they bite: flipping `unanswered_requests_only` to `False` in the count path makes the test fail with **7 vs 4**. A fixture of all-pending items would have passed that mutation.

`test_sidebar_ships_the_number_without_the_items` asserts the **absence** of `pending_requests`, not just the presence of the count.

## Verification

No browser or dev stack in this worktree, so everything below is tests.

- backend: **940 passed**, coverage 91.60% (`--cov-fail-under=80`), against dedicated `wz1456_test`
- frontend: `tsc --noEmit` clean, `eslint` clean, **vitest 3385 passed / 197 files**, `vite build` clean

The `node_modules` junction was removed before finishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)