### PR TITLE
The composer stops reading back a praxis it was just handed

### DIFF
--- a/frontend/src/api/__tests__/justCreatedPraxis.test.ts
+++ b/frontend/src/api/__tests__/justCreatedPraxis.test.ts
@@ -1,0 +1,86 @@
+/**
+ * The seam: the one-slot handoff between `createPraxis` and the composer it
+ * navigates to (#1379).
+ *
+ * Every signup does `createPraxis(...)` then `navigate('/praxis/{id}/edit')`,
+ * and the composer opened by reading the same row straight back. `POST /praxes`
+ * and `GET /praxes/{id}` both return `build_praxis_out(praxis, viewer=...)`, so
+ * that read was a round trip for a payload the client already held — the first
+ * link of the deepest waterfall in the app.
+ *
+ * What this file proves is the slot's contract, which is where the danger is: a
+ * carried payload that outlives its navigation would be shown as if it were
+ * fresh. It cannot prove request counts — there is no DOM here and effects
+ * never run (see `docs/spec/SPEC-testing.md`); `composerWaterfall.test.ts`
+ * carries that part as a source ratchet.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createPraxis, takeJustCreatedPraxis, type PraxisOut } from '../praxis'
+
+const post = vi.fn()
+
+// Hoisted above the import above by vitest's transform, so `praxis.ts` binds
+// this instead of the real client. No server, no DOM — the slot is the subject.
+vi.mock('../axios', () => ({
+  default: {
+    post: (...args: unknown[]) => post(...args),
+  },
+}))
+
+/** Only the id is read by the slot; the rest of the row travels untouched. */
+function praxisRow(id: number): PraxisOut {
+  return { id, title: `praxis ${id}` } as unknown as PraxisOut
+}
+
+beforeEach(() => {
+  post.mockReset()
+  // Drain anything a previous test parked, so each case starts empty.
+  takeJustCreatedPraxis(-1)
+})
+
+describe('takeJustCreatedPraxis', () => {
+  it('hands the composer the row the signup just created', async () => {
+    post.mockResolvedValueOnce({ data: praxisRow(7) })
+    const created = await createPraxis({ task_id: 1, type: 'solo' })
+
+    expect(takeJustCreatedPraxis(7)).toBe(created)
+  })
+
+  it('is empty when nothing was created — the composer falls back to the read', () => {
+    expect(takeJustCreatedPraxis(7)).toBeNull()
+  })
+
+  it('gives the row away once and only once', async () => {
+    post.mockResolvedValueOnce({ data: praxisRow(7) })
+    await createPraxis({ task_id: 1, type: 'solo' })
+
+    expect(takeJustCreatedPraxis(7)).not.toBeNull()
+    // A remount, or a return to this composer after editing elsewhere, must
+    // re-read the server rather than replay a payload that has had time to rot.
+    expect(takeJustCreatedPraxis(7)).toBeNull()
+  })
+
+  it('refuses to hand one praxis row to a different praxis', async () => {
+    post.mockResolvedValueOnce({ data: praxisRow(7) })
+    await createPraxis({ task_id: 1, type: 'solo' })
+
+    expect(takeJustCreatedPraxis(8)).toBeNull()
+  })
+
+  it('clears the slot on a miss, so a later id can never collect a stale row', async () => {
+    post.mockResolvedValueOnce({ data: praxisRow(7) })
+    await createPraxis({ task_id: 1, type: 'solo' })
+
+    takeJustCreatedPraxis(8)
+    expect(takeJustCreatedPraxis(7)).toBeNull()
+  })
+
+  it('keeps only the latest create — two signups in a row cannot cross', async () => {
+    post.mockResolvedValueOnce({ data: praxisRow(7) })
+    await createPraxis({ task_id: 1, type: 'solo' })
+    post.mockResolvedValueOnce({ data: praxisRow(9) })
+    await createPraxis({ task_id: 2, type: 'solo' })
+
+    expect(takeJustCreatedPraxis(7)).toBeNull()
+  })
+})

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -277,8 +277,41 @@ export async function getPraxis(id: number): Promise<PraxisOut> {
 // Create / update / delete
 // ---------------------------------------------------------------------------
 
+/**
+ * The praxis a signup just created, held for the composer it is about to land
+ * on (#1379).
+ *
+ * Every signup path — the task list, the task detail page and the home
+ * FieldDesk — does `createPraxis(...)` then `navigate('/praxis/{id}/edit')`,
+ * and the composer's first act was `getPraxis(id)`: a full round trip to read
+ * back a row the client had been handed milliseconds earlier. `POST /praxes`
+ * and `GET /praxes/{id}` both return `build_praxis_out(praxis, viewer=...)`
+ * with the same viewer, so the two payloads are the same object — the read was
+ * pure latency, and on the deepest waterfall in the app.
+ *
+ * ONE SLOT, CONSUMED ONCE. It lives in module memory rather than in router
+ * state deliberately: history state survives Back/Forward, so a carried praxis
+ * would be replayed — stale — onto a composer the player returns to after
+ * editing. This slot is cleared by the first read and by any reload, so the
+ * only thing that can ever consume it is the navigation that follows the
+ * create. A miss is free: the composer falls back to `getPraxis`.
+ */
+let justCreatedPraxis: PraxisOut | null = null
+
+/**
+ * Take the just-created praxis if it is the one being asked for. Always clears
+ * the slot, match or not — a carried payload nobody claimed immediately is a
+ * payload that has had time to go stale.
+ */
+export function takeJustCreatedPraxis(praxisId: number): PraxisOut | null {
+  const carried = justCreatedPraxis
+  justCreatedPraxis = null
+  return carried?.id === praxisId ? carried : null
+}
+
 export async function createPraxis(data: PraxisCreate): Promise<PraxisOut> {
   const { data: result } = await api.post<PraxisOut>('/praxes', data)
+  justCreatedPraxis = result
   return result
 }
 

--- a/frontend/src/factions/lazyArchetype.tsx
+++ b/frontend/src/factions/lazyArchetype.tsx
@@ -122,6 +122,23 @@ export async function preloadAllArchetypes(): Promise<void> {
 }
 
 /**
+ * Start a dispatched archetype's chunk without rendering it.
+ *
+ * The wrapper requests its chunk from an effect, so the download cannot begin
+ * until the archetype is on screen — and a page that knows which faction it
+ * will wear before it is ready to draw (the composer: the praxis payload names
+ * the task's faction a round trip before `getTask` answers) would otherwise
+ * spend that whole round trip not downloading it (#1379).
+ *
+ * A plain component passes through as a no-op, which is what the `Default*`
+ * fall-through needs: it is in the caller's chunk already.
+ */
+export function preloadArchetype(component: AnyArchetype): void {
+  const deferred = component as Partial<LazyArchetype<AnyArchetype>>
+  void deferred.preload?.()
+}
+
+/**
  * The component a dispatched archetype actually resolves to.
  *
  * A manifest entry is now a loader, so `surfaceMap()` hands back the deferred

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -14,6 +14,7 @@ import ConfirmDialog from "../components/confirm/ConfirmDialog";
 import DuelSealConfirm from "../components/duel/DuelSealConfirm";
 import { pickVariant } from "../utils/factionDispatch";
 import { surfaceMap } from "../factions";
+import { preloadArchetype } from "../factions/lazyArchetype";
 import {
   useEditPraxis,
 } from "./editPraxis/useEditPraxis";
@@ -27,6 +28,22 @@ export default function EditPraxis() {
   const state = useEditPraxis(id);
 
   if (state.loading) {
+    // Start the faction composer's chunk while the rest of the load finishes
+    // (#1379) — the move `RootLanding` makes for its landing chunk, for the
+    // same reason. The praxis names the task's faction (`task_faction_slug` is
+    // `Task.primary_faction_slug`, off one builder server-side), and it lands a
+    // round trip before `getTask` — which is what `loading` is still waiting
+    // on. Without this the chunk is not even REQUESTED until that answer
+    // arrives, so the composer's last wave is a download that could have
+    // travelled with the one before it. It cannot change what renders: the
+    // dispatch below still reads the task.
+    preloadArchetype(
+      pickVariant(
+        surfaceMap("editPraxis"),
+        state.praxis?.task_faction_slug,
+        DefaultEditPraxis,
+      ),
+    );
     return (
       <div className="py-8 font-body text-muted">
         <PageTitle title={t("editPraxis.loadingPageTitle")} />

--- a/frontend/src/pages/editPraxis/__tests__/composerWaterfall.test.ts
+++ b/frontend/src/pages/editPraxis/__tests__/composerWaterfall.test.ts
@@ -1,0 +1,102 @@
+/**
+ * #1379 — waterfall guard for the composer.
+ *
+ * The seam is the SHAPE OF THE LOAD: which requests wait on which. The composer
+ * is the page every task signup lands on, and its chain ran
+ * `getPraxis → getTask → the faction archetype's chunk` with `listMetatasks`
+ * hanging off the first link for no reason. Three of those edges were false.
+ *
+ * WHAT THIS CANNOT DO. There is no jsdom in this repo — vitest runs in `node`
+ * and every render goes through `renderToStaticMarkup`, so effects never run
+ * and nothing here can observe "three requests instead of six". Two of the
+ * three fixes are removals of a WAIT, not of a call, and a wait is invisible to
+ * a test that cannot run the effect that does the waiting.
+ *
+ * So this reads the source, the posture `searchQueryParamAdoption.test.ts` set
+ * for exactly this reason. It proves the false edges are not spelled in the
+ * file; it does not prove the page is fast. The number belongs in the PR, off
+ * `scripts/measure-load.mjs`. What it is worth is that all three regressions
+ * are silent ones: re-nesting `listMetatasks` inside the praxis `.then()`, or
+ * dropping the handoff for a plain `getPraxis`, would type-check, pass every
+ * other test, and quietly restore the round trips.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const HERE = path.dirname(fileURLToPath(import.meta.url))
+
+function read(relativePath: string): string {
+  return readFileSync(path.join(HERE, relativePath), 'utf8')
+}
+
+const hookSource = read('../useEditPraxis.ts')
+const dispatcherSource = read('../../EditPraxis.tsx')
+
+/**
+ * The body of the initial-load effect, from its banner to its dependency list.
+ * Sliced rather than searched whole-file, because "the file mentions
+ * `listMetatasks`" is true either way — the question is whether the call sits
+ * INSIDE this effect, waiting on a payload it reads nothing from.
+ */
+const loadEffect = hookSource.slice(
+  hookSource.indexOf('// ---- Initial load ----'),
+  hookSource.indexOf('}, [idParam,'),
+)
+
+describe('the composer does not re-read the praxis a signup just created', () => {
+  it('slices the load effect it means to inspect', () => {
+    // Guard the guard: if the banner or the dep list is renamed, this slice
+    // would silently become empty and every assertion below would pass on air.
+    expect(loadEffect).toContain('getPraxis')
+    expect(loadEffect.length).toBeGreaterThan(200)
+  })
+
+  it('takes the carried row before deciding to fetch', () => {
+    expect(loadEffect).toContain('takeJustCreatedPraxis(praxisId)')
+  })
+
+  it('still falls back to the read when nothing was carried', () => {
+    // The handoff is an optimisation, never a requirement: a bookmark, a
+    // reload, a co-author's link and a Back all arrive with an empty slot.
+    expect(loadEffect).toMatch(/carried[\s\S]*getPraxis\(praxisId\)/)
+  })
+})
+
+describe('the seal list does not wait on the praxis', () => {
+  it('is not fetched inside the initial-load effect', () => {
+    expect(loadEffect).not.toContain('listMetatasks')
+  })
+
+  it('is fetched from its own viewer-keyed effect', () => {
+    expect(hookSource).toMatch(
+      /listMetatasks\(\)[\s\S]{0,400}?\}, \[user\?\.character\?\.id\]\)/,
+    )
+  })
+})
+
+describe('the faction archetype chunk does not wait on getTask', () => {
+  /** Everything the dispatcher does while `state.loading` is still true. */
+  const loadingBranch = dispatcherSource.slice(
+    dispatcherSource.indexOf('if (state.loading) {'),
+    dispatcherSource.indexOf('if (!state.praxis) {'),
+  )
+
+  it('slices the loading branch it means to inspect', () => {
+    expect(loadingBranch).toContain('editPraxis.loadingPageTitle')
+  })
+
+  it('warms the chunk from the praxis, which lands a round trip earlier', () => {
+    expect(loadingBranch).toContain('preloadArchetype')
+    // `task_faction_slug` IS `Task.primary_faction_slug` — one builder,
+    // server-side — so the warm and the dispatch below can never disagree.
+    expect(loadingBranch).toContain('task_faction_slug')
+  })
+
+  it('still dispatches on the task, so the warm cannot change what renders', () => {
+    expect(dispatcherSource).toContain(
+      'const slug = state.task?.primary_faction_slug ?? null;',
+    )
+  })
+})

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -21,6 +21,7 @@ import {
   leavePraxis,
   removeMetatask,
   submitPraxis,
+  takeJustCreatedPraxis,
   unsubmitPraxis,
   updatePraxis,
   uploadPraxisMedia,
@@ -505,10 +506,25 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     // Wait for auth to resolve before the membership guard — otherwise a
     // still-loading `user` would bounce to the read page, which redirects
     // in_progress praxes right back here (infinite loop).
+    //
+    // This costs nothing and delays nothing (#1379): `/praxis/:id/edit` is
+    // wrapped in `<ProtectedRoute>`, which renders a spinner instead of its
+    // children while `/auth/me` is in flight — so this hook is not mounted, and
+    // this effect not run, until auth has already resolved. `refetch()` never
+    // sets `loading` back to true. The guard is the floor if the route is ever
+    // unwrapped, not a gate anything waits on.
     if (authLoading) return;
     const praxisId = parseInt(idParam, 10);
     setLoading(true);
-    getPraxis(praxisId)
+    // A signup that just created this praxis was handed the whole row; take it
+    // rather than spending a round trip reading it back (#1379). Same builder,
+    // same viewer, server-side — see `takeJustCreatedPraxis`. A miss (any other
+    // way of arriving here) falls through to the read.
+    const carried = takeJustCreatedPraxis(praxisId);
+    const loadPraxis = carried
+      ? Promise.resolve(carried)
+      : getPraxis(praxisId);
+    loadPraxis
       .then(async (loaded) => {
         // A collab is co-owned — any member may edit (ADR-0013), not just the
         // creator. Gating on created_by_id looped non-creator members between
@@ -532,28 +548,35 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
         setAppliedMetataskList(loaded.applied_metatasks ?? []);
         lastSavedTitleRef.current = initialTitle;
         lastSavedBodyRef.current = initialBody;
-        await Promise.all([
-          getTask(loaded.task_id)
-            .then(setTask)
-            .catch(() => {
-              /* non-fatal */
-            }),
-          listMetatasks()
-            .then((all) =>
-              setMetatasks(all.filter((mt) => mt.eligible_for_current_user)),
-            )
-            .catch(() => {
-              /* non-fatal */
-            }),
-        ]);
+        await getTask(loaded.task_id)
+          .then(setTask)
+          .catch(() => {
+            /* non-fatal */
+          });
       })
       .catch(() => setError(i18n.t("forms:editPraxis.errors.load")))
       .finally(() => setLoading(false));
     // The membership guard above reads only `user?.character?.id`, so that is
-    // the whole dependency (#1390). Depending on `user` reloaded the praxis,
-    // its task and the metatask list every time `/auth/me` refetched — which a
-    // star cast does — and flashed the editor back to its loading state.
+    // the whole dependency (#1390). Depending on `user` reloaded the praxis and
+    // its task every time `/auth/me` refetched — which a star cast does — and
+    // flashed the editor back to its loading state.
   }, [idParam, user?.character?.id, authLoading, navigate]);
+
+  // The seals this viewer may apply (#933). It sat inside the praxis `.then()`
+  // above, which made it wait a whole round trip on a payload it reads nothing
+  // from — the list is keyed on the VIEWER (`eligible_for_current_user`), not
+  // on the praxis (#1379). Fired here it leaves at mount, beside the praxis
+  // read, and no longer holds `loading` open either.
+  useEffect(() => {
+    if (!user?.character) return;
+    listMetatasks()
+      .then((all) =>
+        setMetatasks(all.filter((mt) => mt.eligible_for_current_user)),
+      )
+      .catch(() => {
+        /* the seal picker stays empty; the composer is unaffected */
+      });
+  }, [user?.character?.id]);
 
   useEffect(() => {
     if (!user?.character) return;


### PR DESCRIPTION
Closes #1379

## What I found before touching anything

I re-derived the waterfall rather than trusting the table, and **one of the issue's two named fixes is a no-op while a wave it never named is free**.

**`/praxis/:id/edit` is wrapped in `<ProtectedRoute>`**, which renders a spinner *instead of its children* while `/auth/me` is in flight. So `useEditPraxis` is not mounted — and its `if (authLoading) return` not reached — until auth has already resolved. `refetch()` never sets `loading` back to true either (`AuthProvider.fetchUser` only ever sets it false). Ungating `getPraxis` from `authLoading` *from inside this hook* cannot start anything earlier, because the hook does not exist yet. Fix direction 1 and Ruling 1 are answering a gate that is already open; the guard stays, with a comment recording why it costs nothing.

That same fact makes the page one wave **deeper** than the issue counted: a `React.lazy` route chunk is requested when its element first renders, and ProtectedRoute short-circuits before that. The route chunk does not begin downloading until `/auth/me` answers. (This is the same effect #1380 wrote `hadSessionLastVisit()` to work around for `RootLanding` — the repo already has the receipt.)

### Derived wave counts

No browser tools and no dev stack here, so this is **derived from the source, not measured** — `scripts/measure-load.mjs` needs a served build plus a live API, and its `ROUTES` list has no `/praxis/:id/edit` entry to begin with. Stated so it can be checked.

**Cold deep link, signed in, bespoke-faction task**

| | before | after |
|---|---|---|
| 1 | `index.html` | same |
| 2 | entry JS + CSS | same |
| 3 | `/auth/me` — ProtectedRoute holds everything | same |
| 4 | `EditPraxis` route chunk | same |
| 5 | `getPraxis` · foes · `/game-config` | `getPraxis` · foes · `/game-config` · **`listMetatasks`** |
| 6 | `getTask` · `listMetatasks` · duel detail | `getTask` · duel detail · **archetype chunk** |
| 7 | faction archetype chunk | — |
| | **7** (6 on a default-skin task) | **6** (5 on a default-skin task) |

**Post-signup landing — the path the issue is actually about** (`handleSignup` → `createPraxis` → `navigate`; SPA nav, auth warm, route chunk cold)

| | before | after |
|---|---|---|
| 1 | `EditPraxis` route chunk | same |
| 2 | `getPraxis` · foes · `/game-config` | `getTask` · `listMetatasks` · foes · `/game-config` · archetype chunk · duel detail |
| 3 | `getTask` · `listMetatasks` · duel detail | — |
| 4 | faction archetype chunk | — |
| | **4** | **2** |

Acceptance criterion "≤4 serialized waves": met on the signup landing (2). On a cold deep link it is 6, not ≤4 — the two remaining are the shell (`html → entry → chunk`) and the ProtectedRoute → route-chunk edge, neither of which lives in this hook. See "follow-up" below.

## The two removable waves

**1. `getPraxis` on the signup landing — deleted, not parallelised.** Every signup path does `createPraxis(...)` then `navigate('/praxis/{id}/edit')`, and the composer's first act was to read the same row straight back. `POST /praxes` and `GET /praxes/{id}` both `return await build_praxis_out(praxis, session, viewer=...)` (`routers/praxes.py:171-207`) — same builder, same viewer, identical payload. So `createPraxis` now parks the row in a one-slot module handoff and the composer takes it.

One slot, consumed once, id-matched, cleared on a miss. Module memory rather than router state *deliberately*: history state survives Back/Forward, so a carried praxis would be replayed — stale — onto a composer the player returns to after editing. Module memory dies with the reload and with the first read, so the only navigation that can ever consume it is the one that follows the create. A miss is free: fall through to `getPraxis`.

Putting it in `createPraxis` rather than at the call sites means **`useTasks.ts`, `useTaskDetail.ts` and `Home.tsx` all needed zero edits** — all three signup paths route through the one client function.

**2. The faction archetype chunk's dependence on `getTask`.** The composer's last wave is a *download* gated on a *request*: the dispatcher picks the archetype off `task.primary_faction_slug`, so the chunk is not even requested until `getTask` answers. But the praxis payload already carries that exact value — `task_faction_slug` is `Task.primary_faction_slug`, populated by the same builder (`services/praxis.py:292`) — and it lands a whole round trip earlier. `EditPraxis.tsx` now warms the chunk from the praxis while `state.loading` is still true, the same move `RootLanding` makes for its landing chunk. **It cannot change what renders**: the dispatch below still reads the task, so the warm is only ever a head start on the same file (or, for a default-skin task, a no-op).

`preloadArchetype()` is a four-line sibling of the existing `resolvedArchetype()` in `lazyArchetype.tsx`.

**Plus: `listMetatasks()` off the praxis chain** (fix direction 2 — this one was right). It sat inside `getPraxis.then()` waiting on a payload it reads nothing from; the list is keyed on the *viewer* (`eligible_for_current_user`). It now fires from its own `user?.character?.id`-keyed effect at mount, and no longer holds `loading` open.

Accepted trade: `loading` no longer waits for the seal list. On a cold load the list still wins comfortably (it starts a full round trip before `getTask`, which still gates `loading`), so the "+Add seal" slot is present at first paint as before. On the *carried* path the two start together, so a solo draft can paint a few ms before the slot appears. One frame, on the fast path, in exchange for a round trip.

## The seam I tested at

**`takeJustCreatedPraxis`'s contract** — `src/api/__tests__/justCreatedPraxis.test.ts`, 6 real assertions with a mocked axios. This is where the danger is: a carried payload that outlives its navigation would be shown as if it were fresh. Consume-once, id-match, cleared on a miss, latest-create-only.

**The shape of the load** — `src/pages/editPraxis/__tests__/composerWaterfall.test.ts`, a **source ratchet**, the `searchQueryParamAdoption.test.ts` posture.

What it does: slices the initial-load effect out of `useEditPraxis.ts` and the `state.loading` branch out of `EditPraxis.tsx`, and pins that the carried row is taken before the fetch, that the fallback survives, that `listMetatasks` is *not* inside the load effect, and that the dispatcher warms from `task_faction_slug`. Both slices are covered by a "guard the guard" case, so a renamed banner cannot silently empty one and let the rest pass on air.

What it does **not** do: it cannot count requests. There is no jsdom — vitest runs in `node`, everything renders through `renderToStaticMarkup`, effects never run — and two of the three fixes remove a *wait*, not a *call*, which is invisible to a test that cannot run the effect doing the waiting. It proves the false edges are not spelled in the file; it does not prove the page is fast. What it is worth is that all three regressions are silent: re-nesting `listMetatasks`, or dropping the handoff for a plain `getPraxis`, would type-check and pass every other test.

**Verified it bites**: re-pointed at the pre-fix `useEditPraxis.ts` and `EditPraxis.tsx` off `origin/main@0d28b39d`, 5 of 8 fail. The 3 that survive are the two slice guards and "still dispatches on the task" — all three unchanged by this PR by design.

## Verification

- `tsc --noEmit` clean · `eslint .` clean (exit 0) · `vitest run` **199 files / 3399 tests passed**
- `npm run build` + `npm run budget`: within budget, entry 131.0 KB gz JS / 22.3 KB CSS (`ok` on both)
- No browser, no dev stack: the wave tables above are derived from source, not observed.

## For #1392 (the file split, unblocked by this)

A natural seam, free intelligence: the hook's async loads are **four independent effects with three different keys** — the praxis chain (`idParam`), the viewer-keyed reads (`user?.character?.id`: foes, and now metatasks), the pane-keyed read (`duelPaneOpen`: own roster) and the praxis-derived read (`praxis?.duel_id`: duel detail). Only the first two touch `loading`. That is a clean `useComposerLoad` boundary taking `idParam` + the viewer id and returning `{praxis, task, metatasks, foeIds, loading, error}` — it needs none of the mutation callbacks below it, and after this PR the last coupling between them (`listMetatasks` living inside the praxis `.then()`) is gone.

## Follow-up worth filing

**`<ProtectedRoute>` costs every protected route a full round trip of chunk download.** It renders a spinner instead of its children while `/auth/me` is in flight, so the lazy route chunk for `/praxis/:id/edit`, `/characters/:id/edit`, `/admin` etc. is not requested until auth answers — two serialized waves where one would do. #1380 already solved exactly this for `RootLanding` with a stored session hint; the same warm (`void importEditPraxis()` from the loading branch, or a `preload` on the route's lazy component) would fold wave 4 into wave 3 for every protected page at once. Out of scope here — it is `App.tsx` / `ProtectedRoute.tsx`, not this hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
