### PR TITLE
The praxis detail's alarm marks get the wall they are drawn on (#1451)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -553,6 +553,26 @@
   --faction-snide-wall: #efece3; /* flyposted xerox-paper wall (FLIP in dark) */
   --faction-snide-wall-deep: #e0ddd1;
   --faction-snide-wall-text: #14110b;
+  /* THE WALL'S TWO ALARM INKS, and the ONE mint #1451 needed — the third time
+     this faction has been the lone exception to "reuse `-card-alarm`" (#1302,
+     #1231), and always for the §6 reason rather than a hue: its CARD is
+     photocopier-black in BOTH themes, so `-card-alarm` (#fca5a5) and
+     `-card-notice` (#fbbf24) are pinned bright and read 1.61:1 / 1.41:1 on the
+     light wall, while this ground FLIPS.
+     Nor is the clipping's walked pink enough. `--faction-snide-note-pink-ink`
+     (#be185d) was measured on the note stock (#f4f1e8), and `.snd-detail-sheet`
+     runs a 180deg ramp from `-wall` down to `-wall-deep`, a shade under it:
+     4.44:1 bare and 4.14:1 veiled at that end. #1028 again — a second ground
+     invalidates the reading, and the ramp means this surface HAS a second
+     ground. So the pair is walked until it clears the deep end too. Measured
+     under `--color-danger-veil`, the wash the praxis detail's failed banner and
+     its pull-back button both wear:
+       alarm  6.21:1 wall / 5.41:1 deep (light), 5.73 / 6.27 (dark)
+       notice 5.58:1 wall / 4.86:1 deep (light), 9.17 / 10.03 (dark)
+     Dark keeps the faction's night pink and amber unchanged; light was the only
+     miss, exactly as in #1449 and #1231. */
+  --faction-snide-wall-alarm: #9d174d;
+  --faction-snide-wall-notice: #92400e;
   /* SNIDE font set — a ransom note mixes many faces in one surface */
   --faction-snide-font-impact: "Anton", Impact, sans-serif;
   --faction-snide-font-cond: var(--font-accent); /* Bebas Neue */
@@ -714,6 +734,12 @@
      are measured on `-card-bg`, which for S.N.I.D.E. is photocopier-black in
      BOTH themes (§6), so `--faction-snide-card-alarm` is pinned bright and
      reads 1.56:1 here. Reach for the walked pink, not the card family.
+
+     ONE GROUND WHERE THE WALKED PINK IS STILL NOT DEEP ENOUGH (#1451): the
+     flyposted WALL, whose 180deg ramp bottoms out a shade below every stock in
+     this family. `--faction-snide-wall-alarm` / `-wall-notice` are declared up
+     beside `--faction-snide-wall` for that end of the ramp; the reading here is
+     about this stock and does not travel to that one.
 
      So this is a THIRD flipping S.N.I.D.E. stock beside `-note-*` (the task
      card's clipping) and `-composer-*` (the edit-praxis sheet), declared rather
@@ -1872,6 +1898,10 @@
   --faction-snide-wall: #141310;
   --faction-snide-wall-deep: #0b0a08;
   --faction-snide-wall-text: #e9e6da;
+  /* The night pair: the faction's own bright pink and amber, unwalked — on a
+     near-black wall the light values would be the miss, so only light moved. */
+  --faction-snide-wall-alarm: #ff69ac;
+  --faction-snide-wall-notice: #fbbf24;
   /* The evidence slab, lights out (#842): the plate itself is already ink, so
      only its printed shadow and the score well deepen. */
   --faction-snide-slab-shadow: rgba(0, 0, 0, 0.5);

--- a/frontend/src/pages/praxisDetail/__tests__/detailWallAlarmInk.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/detailWallAlarmInk.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * The praxis detail's alarm marks take the ink measured on the skin's own wall
+ * (#1451).
+ *
+ * Praxis detail is ONE shared page that nine factions dress (ADR-0061), so the
+ * five slots `shared.tsx` owns — the failed banner's title and admin note, the
+ * withdraw error, the forfeit trigger, the pull-back confirm's label — painted
+ * `--color-danger` / `--color-warning` onto nine different grounds. The neutral
+ * hues were chosen against the app's near-white page and miss AA on every one of
+ * those walls in light (3.11:1 on the Ephemerists papyrus up to 4.41:1 on the na
+ * sheet, veiled). `utils/__tests__/factionContrast.test.ts` owns the ratios;
+ * this file pins the DISPATCH those ratios are only reachable through.
+ *
+ * Two claims worth separating. The ink resolves off `task_faction_slug` — the
+ * same slug `pages/PraxisDetail` picks the archetype with, so the ink and the
+ * wall can never disagree — and it is the CARD family for seven skins with
+ * S.N.I.D.E. the one exception (§6: its card is photocopier-black in both themes
+ * while its wall flips, which is also why #1302 and #1231 each carved it out).
+ *
+ * The third is a source guard, because it is unreachable from markup: the WASH
+ * and the RULE stay the neutral `--color-danger-*` rungs (#1169). ADR-0061 —
+ * danger is the platform speaking; only the paper under it is the faction's.
+ *
+ * `renderToStaticMarkup` only — no jsdom, effects never run.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import {
+  PraxisStatusBanners,
+  PraxisOwnerActions,
+  PraxisSubmitControls,
+} from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import type { PraxisOut } from '../../../api/praxis'
+
+const SHARED_SOURCE = readFileSync(
+  fileURLToPath(new URL('../shared.tsx', import.meta.url)),
+  'utf8',
+)
+
+/**
+ * slug → the alarm token the wall under it was measured with. Seven reuse the
+ * card family; S.N.I.D.E. is the mint. `albescent` renders
+ * `DefaultPraxisDetail` plus an ornament layer (#1140), so it shares na's wall
+ * and must therefore share na's ink — `null` is the unaffiliated task.
+ */
+const WALL_ALARM: [string | null, string][] = [
+  [null, '--faction-default-card-alarm'],
+  ['na', '--faction-default-card-alarm'],
+  ['albescent', '--faction-default-card-alarm'],
+  ['coven', '--faction-coven-card-alarm'],
+  ['ephemerists', '--faction-ephemerists-card-alarm'],
+  ['everymen', '--faction-everymen-card-alarm'],
+  ['singularity', '--faction-singularity-card-alarm'],
+  ['snide', '--faction-snide-wall-alarm'],
+  ['ua', '--faction-ua-card-alarm'],
+  ['wow', '--faction-wow-card-alarm'],
+]
+
+function praxis(overrides: Partial<PraxisOut> = {}): PraxisOut {
+  return {
+    id: 1,
+    task_id: 7,
+    task_title: 'Mangrove',
+    task_point_value: 30,
+    task_level_required: 3,
+    task_faction_slug: null,
+    type: 'solo',
+    status: 'submitted',
+    title: 'Reforestation',
+    body_text: 'Seedlings.',
+    moderation_status: 'visible',
+    admin_note: null,
+    flagged_at: null,
+    submitted_at: '2026-01-02T00:00:00Z',
+    submit_proposed_at: null,
+    created_by_id: 1,
+    created_by_display_name: 'Ada',
+    created_by_faction_slug: 'na',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-02T00:00:00Z',
+    members: [],
+    invites: [],
+    media_items: [],
+    score: 0,
+    metatask_points: 0,
+    display_multiplier: 1.0,
+    points_from_votes: 0,
+    is_top_for_task: false,
+    duel_id: null,
+    can_flag: true,
+    applied_metatasks: [],
+    ...overrides,
+  } as PraxisOut
+}
+
+function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: praxis(),
+    fetchError: null,
+    comments: null,
+    votes: null,
+    voters: [],
+    duel: null,
+    isOwner: true,
+    showAdminBar: false,
+    user: null,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: '',
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: '',
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleFlag: async () => {},
+    ...overrides,
+  } as PraxisDetailState
+}
+
+function html(element: ReactElement): string {
+  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+}
+
+describe('the praxis detail wall carries its own alarm ink (#1451)', () => {
+  it.each(WALL_ALARM)('%s: the failed banner reads its wall', (slug, token) => {
+    const markup = html(
+      <PraxisStatusBanners
+        state={state({
+          praxis: praxis({
+            task_faction_slug: slug,
+            moderation_status: 'failed',
+            admin_note: 'No proof attached.',
+          }),
+        })}
+      />,
+    )
+    expect(markup).toContain(`color:var(${token})`)
+    expect(markup).not.toContain('color:var(--color-danger)')
+    expect(markup).not.toContain('color:var(--color-warning)')
+    // The banner's own wash and rule stay the neutral rungs.
+    expect(markup).toContain('background:var(--color-danger-veil)')
+    expect(markup).toContain('border:2px solid var(--color-danger-edge)')
+  })
+
+  it.each(WALL_ALARM)('%s: the withdraw error reads its wall', (slug, token) => {
+    const markup = html(
+      <PraxisOwnerActions
+        state={state({
+          praxis: praxis({ task_faction_slug: slug }),
+          withdrawError: 'That did not go through.',
+        })}
+      />,
+    )
+    expect(markup).toContain(`color:var(${token})`)
+    expect(markup).not.toContain('color:var(--color-danger)')
+  })
+
+  it.each(WALL_ALARM)('%s: the pull-back confirm reads its wall', (slug, token) => {
+    const markup = html(
+      <PraxisSubmitControls
+        state={state({
+          praxis: praxis({ task_faction_slug: slug }),
+          showWithdrawConfirm: true,
+        })}
+      />,
+    )
+    expect(markup).toContain(`color:var(${token})`)
+    expect(markup).not.toContain('color:var(--color-danger)')
+    // The fill and the 1.5px rule are still the platform's red.
+    expect(markup).toContain('background:var(--color-danger-veil)')
+    expect(markup).toContain('border:1.5px solid var(--color-danger)')
+  })
+
+  it('the notice role stays a second hue on the same banner', () => {
+    const markup = html(
+      <PraxisStatusBanners
+        state={state({
+          praxis: praxis({
+            task_faction_slug: 'wow',
+            moderation_status: 'failed',
+            admin_note: 'No proof attached.',
+          }),
+        })}
+      />,
+    )
+    expect(markup).toContain('color:var(--faction-wow-card-alarm)')
+    expect(markup).toContain('color:var(--faction-wow-card-notice)')
+  })
+
+  it('leaves the neutral-chrome cards alone — that ground is #1413', () => {
+    // `PraxisAdminBar` and `PraxisFlagBlock` sit on `.sidebar-card`, whose
+    // translucent `--color-bg-surface` composites to a near-white lift on every
+    // skin in light. The global inks are correct against THAT stock; the faction
+    // inks are not (`--faction-singularity-card-alarm` reads 1.00:1 on it). The
+    // ground is what is broken there, and it belongs to #1413.
+    expect(SHARED_SOURCE).toContain(
+      "className=\"sidebar-card mb-4\" style={{ padding: 'var(--space-md) var(--space-lg)' }}",
+    )
+    for (const block of ['PraxisAdminBar', 'PraxisFlagBlock']) {
+      const body = SHARED_SOURCE.slice(SHARED_SOURCE.indexOf(`export function ${block}`))
+      expect(body.slice(0, body.indexOf('\n}\n'))).toContain('var(--color-danger)')
+    }
+  })
+})

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -42,6 +42,61 @@ import { deriveEditPraxisPhase } from '../editPraxis/editPraxisPhase'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
 import type { DuelDetailOut } from '../../api/duel'
 import { flagReasonOptions } from '../../utils/flagReasons'
+import { factionCssVar } from '../../utils/factions'
+
+// ── The detail WALL's alarm inks (#1451) ─────────────────────────────────────
+//
+// Praxis detail is one shared page every faction dresses (ADR-0061), so the
+// slots below paint onto NINE different grounds. `--color-danger` and
+// `--color-warning` were chosen against the app's near-white page, and measured
+// on the walls those skins actually paint they miss AA on every one of them in
+// light — 3.11:1 on the Ephemerists papyrus up to 4.41:1 on the na sheet, with
+// Everymen also short at 4.47:1 in dark. That is #1302's shape, third instance:
+// a shared component inside a faction frame takes the faction's own card ink
+// family rather than a global functional one, resolved off the SAME slug the
+// archetype was dispatched on (`task_faction_slug`, see `pages/PraxisDetail`).
+//
+// THIS IS NOT A DRESS SEAM, which is why it does not reopen ADR-0061. No skin
+// supplies anything and no prop exists to supply it through; the ink is a
+// function of the ground, the ground is a function of the slug, and the slug is
+// already in `state`. The wash and the rule stay the neutral `--color-danger-*`
+// rungs (#1169) on every skin — danger is the platform speaking, and only the
+// paper under it is the faction's.
+//
+// SEVEN SKINS MINT NOTHING: `--faction-{key}-card-alarm` (#1449) and
+// `-card-notice` (#694) already exist for all eight keys in both cascades and
+// clear every wall they are asked for here (worst 4.56:1, the notice ink under
+// the danger veil on the Ephemerists page). S.N.I.D.E. is the exception for the
+// third time (#1302, #1231) and for the same §6 reason: its CARD is
+// photocopier-black in both themes so both card inks are pinned bright, while
+// its wall FLIPS. See `--faction-snide-wall-alarm` in index.css.
+//
+// WHAT IS DELIBERATELY NOT ROUTED, and the measurement that decides it. Ten of
+// the fifteen alarm sites on this page are inside `PraxisAdminBar` and
+// `PraxisFlagBlock`, and those do NOT sit on a faction wall — they sit on
+// `.sidebar-card`, which fills with the translucent `--color-bg-surface`
+// (0.72 white in light, 0.04 in dark). Composited, that is a near-white lift in
+// light on EVERY skin, so the global inks are the right ones there and the
+// faction inks are the wrong ones: `--faction-singularity-card-alarm` on that
+// composite reads 1.00:1. What is actually broken is the GROUND — the same
+// 0.72 white over Singularity's near-black terminal leaves `--color-danger` at
+// 2.54:1, and at 4.37 / 4.45 / 4.45 on the Ephemerists, UA and deep-S.N.I.D.E.
+// pages. That is #1413 ("`.sidebar-card` grounds on a translucent surface"),
+// whose blast radius is every neutral-chrome card on this page, and it is a
+// stock question rather than an ink one. Repointing these ten first would have
+// to be undone by it.
+const WALL_INK: Record<string, { alarm: string; notice: string }> = {
+  snide: {
+    alarm: 'var(--faction-snide-wall-alarm)',
+    notice: 'var(--faction-snide-wall-notice)',
+  },
+}
+
+/** The destructive / cautionary ink measured on this praxis's detail wall. */
+function wallInk(praxis: PraxisOut, role: 'alarm' | 'notice'): string {
+  const slug = praxis.task_faction_slug ?? ''
+  return WALL_INK[slug]?.[role] ?? factionCssVar(slug, `card-${role}`)
+}
 
 // ── Egalitarian byline (#387) ────────────────────────────────────────────────
 //
@@ -295,11 +350,16 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
               from the label tier (nearest token to its old 16px), never the
               content floor — see WORLD_ZERO_STYLE.md §4, ornament role. */}
           <span style={{ fontSize: 'var(--text-xl)' }}>&#10007;</span>
+          {/* Both inks are measured on THIS skin's wall under the veil above
+              (#1451). The title's 24px/700 already cleared the 3:1 large-text
+              floor on all nine (3.11:1 worst) and moves anyway: the alarm and
+              notice roles are the banner's own `-veil`/`-edge` rungs rejoining
+              their washes, which is #1449's rule for which mark takes which. */}
           <div>
-            <span className="font-body content-title" style={{ color: 'var(--color-danger)', fontWeight: 700, display: 'block' }}>
+            <span className="font-body content-title" style={{ color: wallInk(praxis, 'alarm'), fontWeight: 700, display: 'block' }}>
               {t('detail.banners.failedTitle')}
             </span>
-            <span className="font-body content-text" style={{ color: 'var(--color-warning)' }}>
+            <span className="font-body content-text" style={{ color: wallInk(praxis, 'notice') }}>
               {praxis.admin_note}
             </span>
           </div>
@@ -363,7 +423,7 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
         )}
         <PraxisSubmitControls state={state} />
       </div>
-      {withdrawError && <p className="font-body content-text mb-3" style={{ color: 'var(--color-danger)' }}>{withdrawError}</p>}
+      {withdrawError && <p className="font-body content-text mb-3" style={{ color: wallInk(praxis, 'alarm') }}>{withdrawError}</p>}
     </div>
   )
 }
@@ -482,7 +542,7 @@ export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
        dialog mounts over it as a fixed overlay. Skinned by the TASK's
        faction, matching the composer's own dispatch. */
     <>
-      <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-danger)' }}>
+      <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: wallInk(praxis, 'alarm') }}>
         {t('duelForfeit.action')}
       </button>
       {showWithdrawConfirm && (
@@ -508,7 +568,10 @@ export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
       <button
         onClick={handleWithdraw}
         disabled={withdrawing}
-        style={{ background: 'var(--color-danger-veil)', border: '1.5px solid var(--color-danger)', color: 'var(--color-danger)', fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', padding: 'var(--space-xs) var(--space-md)', cursor: 'pointer', borderRadius: 0 }}
+        // The LABEL takes the wall's alarm ink (#1451); the fill and the rule
+        // stay the neutral rungs. `--color-danger` as a 1.5px rule owes 3:1
+        // (WCAG 1.4.11) and clears it on all nine walls — 3.31:1 worst.
+        style={{ background: 'var(--color-danger-veil)', border: '1.5px solid var(--color-danger)', color: wallInk(praxis, 'alarm'), fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', padding: 'var(--space-xs) var(--space-md)', cursor: 'pointer', borderRadius: 0 }}
       >
         {withdrawing ? t('detail.owner.submitting') : t(unsubmitCopy.confirm)}
       </button>

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1112,6 +1112,39 @@ const ARCHETYPE_PAIRS: Pair[] = [
     text,
   })),
 
+  // ── THE PRAXIS DETAIL'S OWN ALARM MARKS, on all nine walls (#1451) ───────
+  //
+  // RED FIRST: these rows name `--color-danger` / `--color-warning`, the inks
+  // `praxisDetail/shared.tsx` ships today, so the manifest states the failure
+  // before the fix moves it.
+  ...(
+    [
+      ["na", "--faction-default-card-bg"],
+      ["coven", "--faction-coven-ward-page"],
+      ["ephemerists", "--faction-ephemerists-plate-page"],
+      ["everymen", "--faction-everymen-sheet-panel"],
+      ["singularity", "--faction-singularity-term-bg"],
+      ["snide", "--faction-snide-wall"],
+      ["snide deep", "--faction-snide-wall-deep"],
+      ["ua", "--faction-ua-page"],
+      ["wow", "--faction-wow-detail-field"],
+    ] as const
+  ).flatMap(([key, surface]) => [
+    { what: `${key} praxis detail wall, alarm ink`, surface, text: "--color-danger" },
+    {
+      what: `${key} praxis detail wall, alarm ink under the danger veil`,
+      surface,
+      veil: "--color-danger-veil" as Veil,
+      text: "--color-danger",
+    },
+    {
+      what: `${key} praxis detail wall, notice ink under the danger veil`,
+      surface,
+      veil: "--color-danger-veil" as Veil,
+      text: "--color-warning",
+    },
+  ]),
+
   // ── THE FEED ROW'S ACTOR NAME, on the four chassis #1252 left (#1341) ────
   //
   // `resolveFeedRowInk` defaults `actor` to `factionCssVar(slug)` — the raw

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1114,34 +1114,69 @@ const ARCHETYPE_PAIRS: Pair[] = [
 
   // ── THE PRAXIS DETAIL'S OWN ALARM MARKS, on all nine walls (#1451) ───────
   //
-  // RED FIRST: these rows name `--color-danger` / `--color-warning`, the inks
-  // `praxisDetail/shared.tsx` ships today, so the manifest states the failure
-  // before the fix moves it.
+  // `praxisDetail/shared.tsx` owns five slots that every skin mounts on its own
+  // page ground: the failed banner's title and admin note, the withdraw error,
+  // the forfeit trigger and the pull-back confirm. All five painted the neutral
+  // `--color-danger` / `--color-warning`, and ADR-0061 makes this ONE shared
+  // page that nine factions dress — so those are global functional inks landing
+  // on nine different stocks. #1302's third instance, on a fourth surface.
+  //
+  // THE WALL IS NOT `-card-bg`, and for six of the nine it is not even the token
+  // the composer rows above measure (#1302's warning, restated). Four skins put
+  // the page on a class in this file — `.eph-plate-sheet`, `.em-dispatch`,
+  // `.snd-detail-sheet`, `.wow-detail-field` — and the surface column is read
+  // off those rules rather than generated from the key. S.N.I.D.E. contributes
+  // TWO grounds because its sheet is a 180deg ramp from `-wall` to `-wall-deep`,
+  // and the deep end is what gates the light hue. `na` covers Albescent, which
+  // renders `DefaultPraxisDetail` plus an ornament layer (#1140).
+  //
+  // WHAT FAILED, measured before the fix: 25 of these 54 assertions in light and
+  // one in dark. Bare on the wall, `--color-danger` ran 3.32 (ephemerists) to
+  // 4.75 (na); under its own veil — the banner's and the confirm button's fill —
+  // 3.11 to 4.41, i.e. every one of the nine. `--color-warning` under that same
+  // veil ran 3.23 to 4.62. Dark cleared everywhere except Everymen at 4.47.
+  //
+  // SEVEN SKINS MINT NOTHING. `-card-alarm` (#1449) and `-card-notice` (#694)
+  // exist for all eight keys in both cascades and clear every wall asked of them
+  // here — worst 4.56:1, the notice ink under the danger veil on the Ephemerists
+  // page. S.N.I.D.E. is the one mint for the third time (#1302, #1231) and for
+  // the same §6 reason its card gives every time: photocopier-black in BOTH
+  // themes, so both card inks are pinned bright and read 1.61 / 1.41 on the
+  // light wall. Its own walked pink is not enough either — `-note-pink-ink` was
+  // measured on the note stock and reads 4.14:1 veiled at the ramp's deep end —
+  // so `--faction-snide-wall-alarm` / `-wall-notice` are declared for this
+  // ground, and the deep-end row below is the one that pins them.
   ...(
     [
-      ["na", "--faction-default-card-bg"],
-      ["coven", "--faction-coven-ward-page"],
-      ["ephemerists", "--faction-ephemerists-plate-page"],
-      ["everymen", "--faction-everymen-sheet-panel"],
-      ["singularity", "--faction-singularity-term-bg"],
-      ["snide", "--faction-snide-wall"],
-      ["snide deep", "--faction-snide-wall-deep"],
-      ["ua", "--faction-ua-page"],
-      ["wow", "--faction-wow-detail-field"],
+      ["na", "--faction-default-card-bg", "--faction-default-card"],
+      ["coven", "--faction-coven-ward-page", "--faction-coven-card"],
+      ["ephemerists", "--faction-ephemerists-plate-page", "--faction-ephemerists-card"],
+      ["everymen", "--faction-everymen-sheet-panel", "--faction-everymen-card"],
+      ["singularity", "--faction-singularity-term-bg", "--faction-singularity-card"],
+      // Both ends of `.snd-detail-sheet`'s ramp, against the wall-scoped mint.
+      ["snide", "--faction-snide-wall", "--faction-snide-wall"],
+      ["snide deep", "--faction-snide-wall-deep", "--faction-snide-wall"],
+      ["ua", "--faction-ua-page", "--faction-ua-card"],
+      ["wow", "--faction-wow-detail-field", "--faction-wow-card"],
     ] as const
-  ).flatMap(([key, surface]) => [
-    { what: `${key} praxis detail wall, alarm ink`, surface, text: "--color-danger" },
+  ).flatMap(([key, surface, family]) => [
+    // The withdraw error and the forfeit trigger — bare on the wall.
+    { what: `${key} praxis detail wall, alarm ink`, surface, text: `${family}-alarm` },
+    // The failed banner's title and the pull-back confirm's label, both of
+    // which fill with `--color-danger-veil` before the ink lands. The rule and
+    // the wash stay #1169's neutral rungs on every skin (ADR-0061).
     {
       what: `${key} praxis detail wall, alarm ink under the danger veil`,
       surface,
       veil: "--color-danger-veil" as Veil,
-      text: "--color-danger",
+      text: `${family}-alarm`,
     },
+    // The moderator's fail note, inside that same banner.
     {
       what: `${key} praxis detail wall, notice ink under the danger veil`,
       surface,
       veil: "--color-danger-veil" as Veil,
-      text: "--color-warning",
+      text: `${family}-notice`,
     },
   ]),
 
@@ -1362,5 +1397,21 @@ describe("the card sheet's alarm and notice inks stay apart (#1449)", () => {
         ).not.toBe(notice.raw);
       });
     }
+  }
+
+  // The S.N.I.D.E. WALL pair (#1451) is the same two roles on a ground the card
+  // family cannot reach, so it owes the same non-ratio assertion: a `var()`
+  // alias between them would leave every ratio above green.
+  for (const theme of BOTH_THEMES) {
+    it(`snide wall alarm is not wall notice (${theme})`, () => {
+      const alarm = resolveColor("--faction-snide-wall-alarm", theme);
+      const notice = resolveColor("--faction-snide-wall-notice", theme);
+      expect(alarm.color, `--faction-snide-wall-alarm (${theme}) resolved to "${alarm.raw}"`).not.toBeNull();
+      expect(notice.color, `--faction-snide-wall-notice (${theme}) resolved to "${notice.raw}"`).not.toBeNull();
+      expect(
+        alarm.raw,
+        `snide (${theme}) prints the destructive and the cautionary mark on the wall in one colour.`,
+      ).not.toBe(notice.raw);
+    });
   }
 });


### PR DESCRIPTION
Closes #1451

## The measurement, and what it changed

The owner ruling was *"land #1231, then measure these fifteen sites against every faction's detail wall, and mint only what still fails."* #1231 landed. It did **not** darken the global — it routed the composer's error banner per faction — so `--color-danger` is still `#dc2626` / `#f87171` and the "darkened global clears everywhere" outcome was never on the table.

Measured on the walls the nine skins actually paint (not `-card-bg`, and for six of them not the token #1231's composer rows use either): **25 of 54 new assertions red in light, 1 in dark.**

### The fifteen sites are two populations, and only one of them is an ink bug

| where | sites | ground | verdict |
|---|---|---|---|
| `PraxisStatusBanners`, `PraxisOwnerActions`, `PraxisSubmitControls` | **5** (`:299 :302 :366 :485 :511`) | the faction's own detail wall | **fixed here** |
| `PraxisAdminBar`, `PraxisFlagBlock` | **10** | `.sidebar-card` → translucent `--color-bg-surface` | **not an ink bug — see below** |

## Before → after (light; the gating theme)

Bare / under `--color-danger-veil` / notice under that same veil.

| detail wall | before | after |
|---|---|---|
| na `--faction-default-card-bg` | 4.75 / **4.41** / 4.62 | 8.18 / 7.58 / 6.47 |
| coven `--faction-coven-ward-page` | **4.31 / 4.00 / 4.16** | 7.41 / 6.89 / 5.88 |
| ephemerists `--faction-ephemerists-plate-page` | **3.32 / 3.11 / 3.23** | 5.72 / 5.35 / 4.56 |
| everymen `--faction-everymen-sheet-panel` | **4.10 / 3.81 / 3.96** | 7.05 / 6.56 / 5.60 |
| singularity `--faction-singularity-term-bg` | **3.93 / 3.85 / 3.70** | 9.99 / 9.79 / 11.13 |
| snide `--faction-snide-wall` | **4.09 / 3.80 / 3.95** | 6.67 / 6.21 / 5.58 |
| snide deep `--faction-snide-wall-deep` | **3.55 / 3.31 / 3.44** | 5.79 / 5.41 / 4.86 |
| ua `--faction-ua-page` | **3.56 / 3.32 / 3.46** | 6.13 / 5.72 / 4.88 |
| wow `--faction-wow-detail-field` | **3.88 / 3.62 / 3.76** | 6.68 / 6.22 / 5.31 |

Dark cleared everywhere except **Everymen at 4.47** (alarm veiled); it is 6.51 now. Worst reading anywhere after the fix: **4.56**, the notice ink under the danger veil on the Ephemerists page.

## Seven skins mint nothing; S.N.I.D.E. is the one mint, for the third time

`-card-alarm` (#1449) and `-card-notice` (#694) already exist for all eight keys in both cascades and clear every wall asked of them. `factionCssVar` resolves them off `task_faction_slug` — the same slug `pages/PraxisDetail` dispatches the archetype with, so the ink and the wall cannot disagree. **No prop, no seam, no ADR-0061 change:** the ink is a function of the ground and the ground is already in `state`.

S.N.I.D.E. is carved out again for the same §6 reason #1302 and #1231 each found: its card is photocopier-black in *both* themes, so `-card-alarm` (`#fca5a5`) and `-card-notice` (`#fbbf24`) are pinned bright and read **1.61 / 1.41** on its light wall, while the wall flips.

Its own walked pink is not enough either, and this is the part worth reading: `--faction-snide-note-pink-ink` (`#be185d`) was measured on the note stock `#f4f1e8`, but `.snd-detail-sheet` is a **180deg ramp** from `-wall` down to `-wall-deep`, a shade under it — **4.44 bare, 4.14 veiled** at that end. #1028 again, arriving as a gradient rather than a repaint. So `--faction-snide-wall-alarm` (`#9d174d` / `#ff69ac`) and `-wall-notice` (`#92400e` / `#fbbf24`) are declared for that ground, and the `snide deep` row is what pins them. Dark keeps the faction's existing night pink and amber unchanged.

**Tokens minted: 2** (4 declarations across the two cascades).

## The ten sites this deliberately does not touch

`PraxisAdminBar` and `PraxisFlagBlock` sit on `.sidebar-card`, which fills with `--color-bg-surface` — `rgba(255,255,255,0.72)` light, `0.04` dark. Composited, that is a **near-white lift on every skin in light**, so the global inks are the correct ones there and the faction inks are actively wrong: `--faction-singularity-card-alarm` on that composite reads **1.00:1**.

What *is* broken there is the ground. The same 0.72 white over Singularity's near-black terminal leaves `--color-danger` at **2.54:1**, and at **4.37 / 4.45 / 4.45** on the Ephemerists, UA and deep-S.N.I.D.E. pages. That is **#1413** verbatim ("`.sidebar-card` grounds on a translucent `--color-bg-surface` and fails AA over Singularity's always-dark praxis-detail page", blast radius "every neutral-chrome card on that page") — a stock question, not an ink one, and repointing these ten first would only have to be undone by it. The reasoning and the numbers are recorded at the seam in `shared.tsx`, and a test pins that they stay on the global inks so this is a decision rather than an oversight.

## One judgement call

`:299` (the failed banner's title, 24px/700) already cleared its 3:1 large-text floor everywhere — 3.11 worst. It moves anyway, because leaving it on `--color-danger` while the note beneath it moved would have printed one banner reading in two ink families. Which mark takes which was **not** re-decided: the alarm and notice roles simply rejoin the `--color-danger-veil` wash and `--color-danger-edge` rule the banner already wears, which is #1449's own rule for the assignment.

## The stale comment

`index.css` ~690 was already rewritten by #1231 before I got here, and it is true. I added one cross-reference so the next reader does not carry `-slip-pink-ink`'s 5.35 onto the wall and land on 4.14.

## What to eyeball

- A **failed** praxis on each of the nine skins: the ✗ banner's title and the moderator's note should now read in the faction's own red/amber on the page ground, with the pink wash and the 2px rule unchanged.
- The same banner on **S.N.I.D.E.** specifically, scrolled to the **bottom** of a long page — that deep end of the ramp is the ground the mint exists for.
- A praxis you own: **"unsubmit" → confirm**. The confirm button's *label* is now the faction's alarm ink; its fill (`--color-danger-veil`) and 1.5px rule (`--color-danger`) are untouched.
- A **settled duel** side you own: the **Forfeit** trigger.
- The **steward bar** and the **report card** should look exactly as they did — that is the #1413 boundary, and any change there is a bug in this PR.
- **Albescent** takes na's ink (it renders `DefaultPraxisDetail` plus the ornament layer), which the seam test pins.

## Verification

No browser and no dev stack, so everything below is tests and the build.

- `vitest run` — **3473 passed / 198 files**, including 54 new contrast assertions (red at the ratios above before the fix, in the first commit) and 32 new seam assertions.
- `tsc --noEmit` clean; `eslint` clean on the touched files.
- `vite build` + `bundle-budget`: **CSS 22,865 B gzipped**, up **+35 B** from main's 22,830 against the 23,000 warn line — **135 B of headroom left**, still `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
