### PR TITLE
FactionBackdrop's na fallback stops being a docblock claim and becomes a test

### DIFF
--- a/frontend/src/components/backdrop/BackdropContext.tsx
+++ b/frontend/src/components/backdrop/BackdropContext.tsx
@@ -18,7 +18,14 @@ interface BackdropContextValue {
   setSlug: (slug: string | null) => void
 }
 
-const BackdropContext = createContext<BackdropContextValue>({
+/**
+ * Exported so a test can render a dispatcher at a chosen slug. `useFactionBackdrop`
+ * sets the slug from an EFFECT, and the suite renders with `renderToStaticMarkup`
+ * where effects never run — so a provider is the only way to reach any slug but
+ * `null`. Same reason `AuthContext`, `VoteFactionContext` and `FeedRowSkinContext`
+ * are exported. Pages use the two hooks below, never this.
+ */
+export const BackdropContext = createContext<BackdropContextValue>({
   slug: null,
   setSlug: () => {},
 })

--- a/frontend/src/components/backdrop/__tests__/factionBackdrop.test.tsx
+++ b/frontend/src/components/backdrop/__tests__/factionBackdrop.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Page-ground dispatch guard (per-faction surface `backdrop`) — #1406.
+ *
+ * THE SEAM: `slug on BackdropContext` → `the component FactionBackdrop renders`.
+ * Nothing else. The backdrops themselves are markup-free ornaments whose whole
+ * metaphor lives in index.css; what can silently break is the lookup.
+ *
+ * Written because `FactionBackdrop`'s docblock ASSERTS a fallback ("a `na` or
+ * unregistered slug is served WatercolorBackground, not left bare") and nothing
+ * checked it. Its only appearance in the suite was `layoutShell.test.tsx:22`,
+ * which mocks the component out to `null` — correct for a test about the shell,
+ * and worth nothing here. A green suite guarded no part of the claim.
+ *
+ * The `na` path is live, not hypothetical: `CharacterProfile` puts
+ * `character.faction_slug` on the context unfiltered, and an unaffiliated
+ * character's slug IS `"na"` (ADR-0030; `na` is deliberately absent from the
+ * manifest list, from `GET /factions` and from `FACTION_RAINBOW_ORDER` —
+ * surfaces supply it as a sentinel). So the fallback branch runs on every
+ * unaffiliated player's profile.
+ *
+ * WHY BOTH HALVES ARE HERE. A fallback test alone cannot tell "falls back
+ * correctly" from "always falls back" — neuter the dispatch to
+ * `pickVariant(map, null, WatercolorBackground)` and a fallback-only file stays
+ * green while every faction loses its ground. So every registered slug is
+ * pinned to its OWN backdrop, byte for byte, in the same file.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ComponentType } from 'react'
+import { describe, it, expect } from 'vitest'
+
+import FactionBackdrop from '../FactionBackdrop'
+import { BackdropContext } from '../BackdropContext'
+import WatercolorBackground from '../../layout/WatercolorBackground'
+import CovenBackdrop from '../CovenBackdrop'
+import EphemeristsBackdrop from '../EphemeristsBackdrop'
+import EverymenBackdrop from '../EverymenBackdrop'
+import SingularityBackdrop from '../SingularityBackdrop'
+import SnideBackdrop from '../SnideBackdrop'
+import UaBackdrop from '../UaBackdrop'
+import WowBackdrop from '../WowBackdrop'
+
+/** Render the dispatcher as if a page had themed the ground to `slug`. */
+function backdropFor(slug: string | null): string {
+  return renderToStaticMarkup(
+    <BackdropContext.Provider value={{ slug, setSlug: () => {} }}>
+      <FactionBackdrop />
+    </BackdropContext.Provider>,
+  )
+}
+
+/** What the component would draw if it were reached directly. */
+function markupOf(Component: ComponentType): string {
+  return renderToStaticMarkup(<Component />)
+}
+
+const WATERCOLOR = markupOf(WatercolorBackground)
+
+/** Every slug that claims `backdrop` in its manifest, and the skin it claims. */
+const REGISTERED: ReadonlyArray<readonly [string, ComponentType]> = [
+  ['coven', CovenBackdrop],
+  ['ephemerists', EphemeristsBackdrop],
+  ['everymen', EverymenBackdrop],
+  ['singularity', SingularityBackdrop],
+  ['snide', SnideBackdrop],
+  ['ua', UaBackdrop],
+  ['wow', WowBackdrop],
+]
+
+describe('FactionBackdrop dispatch', () => {
+  it('gives every registered faction its OWN ground, not the watercolor', () => {
+    for (const [slug, Skin] of REGISTERED) {
+      expect(backdropFor(slug), `${slug} reaches its own backdrop`).toBe(
+        markupOf(Skin),
+      )
+      expect(backdropFor(slug), `${slug} is not the neutral ground`).not.toBe(
+        WATERCOLOR,
+      )
+    }
+  })
+
+  it('serves `na` the watercolor ground rather than nothing (#1406)', () => {
+    // The claim the docblock makes and nothing checked. `na` has no manifest by
+    // design, so it can only arrive here through the fallback — and it must
+    // arrive somewhere, because an unaffiliated profile page would otherwise
+    // render a bare white sheet.
+    expect(backdropFor('na')).toBe(WATERCOLOR)
+    expect(backdropFor('na')).not.toBe('')
+  })
+
+  it('serves a null slug the same watercolor ground', () => {
+    // The mixed/neutral page case (feed, directories) and the pre-load frame of
+    // every faction page, where `character?.faction_slug` is still undefined.
+    expect(backdropFor(null)).toBe(WATERCOLOR)
+  })
+
+  it('serves an unregistered slug the watercolor ground, never a blank page', () => {
+    expect(backdropFor('no-such-faction')).toBe(WATERCOLOR)
+  })
+
+  it('gives albescent exactly `na`’s ground, leaking nothing (ADR-0027/0048)', () => {
+    // Albescent ships a manifest but deliberately claims no `backdrop`, so it
+    // falls through here — which is the correct behaviour, not an oversight. A
+    // dispatcher that hardcoded a faction roster instead of reading the manifest
+    // would be the way it acquires a visible ground and stops hiding. Compared
+    // against na's OWN render, so the two move together forever.
+    expect(backdropFor('albescent')).toBe(backdropFor('na'))
+    expect(backdropFor('albescent')).not.toContain('albescent')
+  })
+})


### PR DESCRIPTION
Closes #1406

## The seam

`slug on BackdropContext` → `the component FactionBackdrop renders`. Nothing else. The seven faction backdrops are ornament shells whose whole metaphor lives in `index.css` (`CovenBackdrop` is one `<div className="coven-backdrop">`), so what can silently break is the lookup, not the drawing.

## Docblock vs. code: they AGREE

Traced end to end before writing anything. `pickVariant(surfaceMap('backdrop'), slug, WatercolorBackground)` with `FACTION_ALIASES` empty and no `na` manifest means `na`, `null`, `albescent` and any unregistered slug all land on the fallback, exactly as the docblock says. **No production fix was needed** — the defect was purely the absent coverage. The only source change is one `export`.

The `na` branch is live, not hypothetical: `CharacterProfile.tsx:71` puts `character?.faction_slug` on the context unfiltered, and an unaffiliated character's slug **is** `"na"` (ADR-0030, and `api/characters.ts` says so in terms). The fallback runs on every unaffiliated player's profile page.

## What was wrong before

`FactionBackdrop`'s only appearance anywhere in the suite was `components/__tests__/layoutShell.test.tsx:22`, which mocks it to `() => null`. That mock is correct for a test about the shell and is left alone, per the issue. It simply guarded no part of the fallback claim.

## Why a test could reach the seam at all

`useFactionBackdrop` sets the slug from a `useEffect`, and the harness is `renderToStaticMarkup` with no jsdom — effects never run, so the context is stuck at `null` and only the fallback case is reachable. `BackdropContext` is now exported so a test can render at a chosen slug. That is established practice here: `AuthContext`, `VoteFactionContext` and `FeedRowSkinContext` are all exported and driven the same way from tests. Pages still use the two hooks.

## Proving it bites

Both halves are in one file deliberately — a fallback-only test cannot tell "falls back correctly" from "always falls back". Three mutations of the dispatch line, each run against the new file:

| Mutation | Result |
|---|---|
| `pickVariant(map, **null**, WatercolorBackground)` — always fall back | **1 failed**, 4 passed — only the registered-faction test |
| `pickVariant(map, slug)` — drop the fallback (the docblock's claim removed) | **4 failed**, 1 passed — every fallback test, registered factions still green |
| `pickVariant(map, slug, **CovenBackdrop**)` — fallback identity swapped | **3 failed**, 2 passed — pins *which* ground, not merely that there is one |

Each mutation leaves the other half green, which is the proof the two halves are independently load-bearing rather than one assertion written twice.

Mutation C leaving the albescent test green is correct, not a hole: that test compares `albescent` to `na`'s own render, so the two moved to Coven together. Pinning them to each other rather than to a literal is the same discipline as `factionAlbescentHidesInPlainSight.test.ts` — it is what stops Albescent acquiring a visible ground of its own without a test going red (ADR-0027/0048). Albescent ships a manifest and deliberately claims no `backdrop`; a dispatcher that hardcoded a faction roster is exactly how it would stop hiding.

## Verification

No browser tools and no dev stack here, so this is verified by test and build only:

- `npx tsc --noEmit` — clean
- `npx vitest run` — **201 files / 3492 tests passed**
- `npx eslint src/components/backdrop --max-warnings 0` — clean
- `npx vite build` + `node scripts/bundle-budget.mjs` — within budget (JS 131.0 KB, CSS 22.3 KB, both `ok`)

No CSS touched, no new API endpoints, nothing deferred to `frontend-style`.

Files: `frontend/src/components/backdrop/BackdropContext.tsx` (one export + why), `frontend/src/components/backdrop/__tests__/factionBackdrop.test.tsx` (new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)