### PR TITLE
Three comments stop citing a mechanism #1382 retired

### DIFF
--- a/docs/adr/0017-praxis-read-page.md
+++ b/docs/adr/0017-praxis-read-page.md
@@ -92,8 +92,14 @@ backend aggregation and it is not the story this page tells — the page is abou
 earned*, not *how the rating is spread*. The faction reframe ramp still appears as the
 **interactive caster** (`<VoteUI>` in cast mode); it just isn't rendered as a distribution.
 
-**Backend impact: none for scoring** — both numbers already exist on `PraxisOut` /
-`VoteSummary`.
+**Backend impact: none for scoring** — both numbers already exist on `PraxisOut`.
+
+> Amended 2026-07-31 (#1382): this sentence used to read "`PraxisOut` / `VoteSummary`".
+> `VoteSummary` and its `GET /praxes/{id}/votes` endpoint were retired when the vote
+> POST began returning the tally it had already computed. Nothing about the decision
+> above changes — the numbers were always on `PraxisOut` too, which is why the probe
+> turned out to be redundant. Note `VoteSummary` is *also* the name of an unrelated
+> React component in `VoteShell.tsx`, which is untouched and still exists.
 
 ### 4. Evidence reuses `MediaGallery`; archetype owns only the framing
 

--- a/frontend/src/pages/editPraxis/useComposerRoster.ts
+++ b/frontend/src/pages/editPraxis/useComposerRoster.ts
@@ -13,7 +13,11 @@
  * what keeps its three effects inside the #1390 ratchet
  * (`hooks/__tests__/authDepNarrowing.test.ts`): they key on
  * `user?.character?.id`, a value a `/auth/me` refetch cannot disturb, never on
- * the auth object a star cast replaces.
+ * the auth object itself — which that endpoint replaces on every answer,
+ * changed or not.
+ *
+ * A star cast was the loudest source of those refetches until #1382 returned
+ * the tally from the vote POST and retired it. The rule outlives the example.
  */
 import { useCallback, useEffect, useState } from "react";
 import {

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -267,8 +267,13 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       .finally(() => setLoading(false));
     // The membership guard above reads only `user?.character?.id`, so that is
     // the whole dependency (#1390). Depending on `user` reloaded the praxis and
-    // its task every time `/auth/me` refetched — which a star cast does — and
-    // flashed the editor back to its loading state.
+    // its task every time `/auth/me` refetched, flashing the editor back to its
+    // loading state — that endpoint mints a new object on every answer, so the
+    // object identity is never a safe dependency, changed or not.
+    //
+    // Casting a star used to be the loudest trigger; #1382 retired that refetch
+    // by returning the tally from the vote POST. The narrowing stands without
+    // it — every other refetch mints the same new object.
   }, [idParam, user?.character?.id, authLoading, navigate]);
 
   // The seals this viewer may apply (#933). It sat inside the praxis `.then()`


### PR DESCRIPTION
Follow-up housekeeping from #1382 (PR #1489), which retired the per-star `/auth/me` refetch by returning the tally from the vote POST.

Three places still explain themselves by pointing at that mechanism. All three were **accurate when written**, which is exactly what makes them worth fixing — a comment that cites a retired mechanism is how the next reader re-derives it.

| file | was | now |
|---|---|---|
| `pages/editPraxis/useEditPraxis.ts` | "every time `/auth/me` refetched — **which a star cast does**" | states the rule (`/auth/me` mints a new object on every answer, so its identity is never a safe dependency) and notes #1382 retired that particular trigger |
| `pages/editPraxis/useComposerRoster.ts` | "never on the auth object **a star cast replaces**" | same correction; "the rule outlives the example" |
| `docs/adr/0017-praxis-read-page.md` | "both numbers already exist on `PraxisOut` / **`VoteSummary`**" | amended in place — `VoteSummary` and `GET /praxes/{id}/votes` are retired |

**The narrowing itself is untouched and still load-bearing.** #1390 narrowed those effects because `/auth/me` returns a fresh object identity on every answer — a star cast was the loudest trigger, not the only one. Removing the example without keeping the rule would have invited someone to widen the deps back.

**The ADR is amended, not rewritten.** The decision it records did not change; if anything #1382 vindicated it — the numbers were always on `PraxisOut` too, which is precisely why the separate probe turned out to be redundant.

The ADR note also records something worth not losing: **`VoteSummary` is still the name of an unrelated React component in `VoteShell.tsx`.** #1382's agent spotted that collision and correctly left the component alone; without a note, the next person greping for the retired schema finds a live component.

## Why this is its own PR

The #1382 agent flagged the first two but could not touch them — #1392 owned `useEditPraxis.ts` at the time. #1392 has since merged, so the file is free.

Comments and documentation only: no behaviour, no test, no exported symbol. `tsc --noEmit` clean, `eslint src --max-warnings=0` clean, **3520 tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)