### PR TITLE
The admin gate asks who you are, not how strong you are (#1488)

### DIFF
--- a/frontend/src/auth/ProtectedRoute.tsx
+++ b/frontend/src/auth/ProtectedRoute.tsx
@@ -52,7 +52,11 @@ export default function ProtectedRoute({ children, warm, adminOnly = false }: Pr
     return <Navigate to="/?login=required" replace />
   }
 
-  if (adminOnly && (user.character?.level ?? 0) < 1) {
+  // `is_admin`, never `character.level`: level is a game stat and admin is a
+  // permission, and reading the stat was wrong both ways — it admitted every
+  // levelled player and turned away an admin whose life had not scored (#1488).
+  // `CurrentUser`'s server-computed flags are the whole permission surface.
+  if (adminOnly && !user.is_admin) {
     return <Navigate to="/" replace />
   }
 

--- a/frontend/src/auth/__tests__/protectedRoute.test.tsx
+++ b/frontend/src/auth/__tests__/protectedRoute.test.tsx
@@ -52,8 +52,13 @@ vi.mock('react-router-dom', async (importOriginal) => ({
 
 const PAGE = <div data-page="protected" />
 
-const signedIn = (level: number): CurrentUser =>
-  ({ account_id: 1, is_admin: level >= 1, character: { level } } as unknown as CurrentUser)
+/** Level and admin status are independent facts and the helper keeps them so:
+ *  `level` is a game stat, `is_admin` is the permission (#1488). Deriving one
+ *  from the other here is what let the guard's own confusion of the two go
+ *  unnoticed — a fixture that cannot express "level 5, not an admin" cannot
+ *  catch a gate that lets one in. */
+const signedIn = (level: number, isAdmin = false): CurrentUser =>
+  ({ account_id: 1, is_admin: isAdmin, character: { level } } as unknown as CurrentUser)
 
 /** The node test env has no `localStorage`; `hadSessionLastVisit` treats that
  *  as "no hint", which is the guest default. */
@@ -151,14 +156,33 @@ describe('a protected route shows no surface it should not', () => {
     expect(markup).not.toContain('data-page="protected"')
   })
 
+  it('redirects a non-admin away from an adminOnly route at any character level', () => {
+    // The gate used to read `character.level < 1`, so every levelled player who
+    // typed `/admin` got the admin surface (#1488). Levelling up is not a
+    // promotion; the case above passes on both predicates and proves nothing.
+    const markup = renderGuard({ user: signedIn(7), loading: false }, { adminOnly: true })
+
+    expect(markup).toContain('data-redirect="/"')
+    expect(markup).not.toContain('data-page="protected"')
+  })
+
   it('renders its children for a resolved signed-in viewer', () => {
     const markup = renderGuard({ user: signedIn(0), loading: false })
 
     expect(markup).toContain('data-page="protected"')
   })
 
-  it('renders its children on an adminOnly route for a viewer who passes the gate', () => {
-    const markup = renderGuard({ user: signedIn(1), loading: false }, { adminOnly: true })
+  it('renders its children on an adminOnly route for an admin', () => {
+    const markup = renderGuard({ user: signedIn(3, true), loading: false }, { adminOnly: true })
+
+    expect(markup).toContain('data-page="protected"')
+    expect(markup).not.toContain('data-redirect')
+  })
+
+  it('renders its children on an adminOnly route for an admin at character level 0', () => {
+    // The other half of the same defect: the level gate turned away a real
+    // admin whose carried life had not scored yet.
+    const markup = renderGuard({ user: signedIn(0, true), loading: false }, { adminOnly: true })
 
     expect(markup).toContain('data-page="protected"')
     expect(markup).not.toContain('data-redirect')


### PR DESCRIPTION
The `adminOnly` gate asked how strong you were, not who you were.

```diff
-if (adminOnly && (user.character?.level ?? 0) < 1) {
+if (adminOnly && !user.is_admin) {
```

Closes #1488

## The seam

`ProtectedRoute`'s decision — which of {loading surface, redirect, children} it
renders for a given resolved session — observed as markup through the existing
`renderToStaticMarkup` harness in `frontend/src/auth/__tests__/protectedRoute.test.tsx`.
`Navigate` is already mocked there into a `data-redirect` attribute, so a
redirect is distinguishable from a blank render. That is the whole seam: the
predicate is a pure function of `user`, and the guard is the only thing standing
between a URL and the admin surface.

## Both directions were wrong, so both are tested

The old predicate confused a game stat with a permission, and it failed each way:

- **too open** — any player with a level-1 character who typed `/admin` got the
  admin page. `pages/Admin.tsx` has no guard of its own.
- **too closed** — a real admin whose carried life was level 0 got bounced to `/`.

New tests, red on `main` before the fix and named for what they assert:

| test | on `main` | now |
|---|---|---|
| non-admin at character level 7 on an `adminOnly` route | rendered the page | redirected to `/` |
| admin at character level 0 on an `adminOnly` route | redirected to `/` | renders the page |

Both had to move. The pre-existing "redirects a non-admin" case used a level-0
character, which passes under either predicate and so proved nothing about this
bug — it is kept, and the level-7 case is what actually holds the line.

The fixture was part of the blind spot: `signedIn(level)` derived
`is_admin: level >= 1`, so neither case above could even be written. It now takes
the two facts separately, which is the same distinction the fix is about.

## Not a data leak

Every admin endpoint is `require_admin`-enforced server-side, so a non-admin who
reached the page got a shell whose requests 403. What leaked was the surface: its
structure, and moderation controls that looked clickable to someone who could not
use them — against the house rule that unusable controls are hidden, not shown
disabled.

## The other `character.level` permission gates

The issue asked whether `561596bd` ("drop hardcoded frontend level gates") missed
more than one site. It did not — I swept every `character.level` comparison in
`frontend/src/`. That commit touched `ProtectedRoute.tsx` only to delete a stale
comment and left the predicate under it, which is exactly how the one survivor
survived.

The two remaining level comparisons are the sanctioned pattern, not the defect,
and are left alone:

- `pages/FieldDesk.tsx:62` — compares against `user.second_character_level_required`,
  and gates on the server-computed `can_create_additional_character` flag anyway.
- `pages/editPraxis/useEditPraxis.ts:650` — compares against
  `gameConfig.duel_level_required`.

Both read a threshold the backend supplies rather than a number written into the
frontend, which is what `561596bd` was for. Everything else matching `.level` is
display: roman-numeral rank formatters, profile progress bars, avatar labels.

## Verification

No browser or dev stack here, so this is tests only — but the predicate is pure
and the harness renders the real component, so the markup is the behaviour.

- `vitest run` — 3522 passed / 202 files, including all 17 of #1483's tests in
  this file (now 19)
- `tsc --noEmit` clean, `eslint --max-warnings=0` clean, `vite build` clean

#1483's warm-on-loading behaviour and the guard order (loading → signed-out →
adminOnly → children) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
