### PR TITLE
TaskOut stops serializing is_task_vision_eligible; the parked column stays

### DIFF
--- a/.design-sync/previews/_fixtures.tsx
+++ b/.design-sync/previews/_fixtures.tsx
@@ -56,7 +56,6 @@ export function makeTask(overrides: Partial<TaskOut> = {}): TaskOut {
     created_by: 7,
     primary_faction_slug: 'ua',
     metatask_faction_slug: null,
-    is_task_vision_eligible: true,
     created_at: NOW,
     can_submit_praxis: true,
     allowed_modes: ['solo', 'collab'],

--- a/backend/models/task.py
+++ b/backend/models/task.py
@@ -56,6 +56,11 @@ class Task(TimestampMixin, Base):
     metatask_faction_slug: Mapped[Optional[str]] = mapped_column(
         ForeignKey("faction.slug"), nullable=True
     )
+    # Parked v2 feature (SPEC-backend-architecture §9 "Intentional v2
+    # deferrals"): Task Vision would let Ephemerists see retired tasks. The
+    # column and its TaskDef writer stay so an era can mark tasks eligible;
+    # nothing reads it yet and it is deliberately NOT on the wire (#1471) —
+    # give it a reader before serialising it again.
     is_task_vision_eligible: Mapped[bool] = mapped_column(
         Boolean, default=False, nullable=False
     )

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -444,7 +444,6 @@ async def list_pending_tasks(
             created_by=task.created_by,
             primary_faction_slug=task.primary_faction_slug,
             metatask_faction_slug=task.metatask_faction_slug,
-            is_task_vision_eligible=task.is_task_vision_eligible,
             created_at=task.created_at,
             in_progress_count=in_progress_counts.get(task.id, 0),
             created_by_name=display_name or "",

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -20,7 +20,6 @@ class TaskOut(BaseModel):
     created_by: int
     primary_faction_slug: str
     metatask_faction_slug: Optional[str] = None
-    is_task_vision_eligible: bool
     created_at: datetime
     # Derived, read-time count of characters actively working on this task —
     # active-signup population (Praxis.status in [in_progress, pending]), the

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -241,7 +241,6 @@ async def build_task_out(
         created_by=task.created_by,
         primary_faction_slug=task.primary_faction_slug,
         metatask_faction_slug=task.metatask_faction_slug,
-        is_task_vision_eligible=task.is_task_vision_eligible,
         created_at=task.created_at,
         in_progress_count=in_progress_count,
         created_by_display_name=author.display_name,

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -963,10 +963,13 @@ async def test_get_task_response_fields(client: AsyncClient, active_task: Task):
     required_fields = {
         "id", "title", "description", "point_value",
         "level_required", "status", "created_by",
-        "primary_faction_slug", "is_task_vision_eligible", "created_at",
+        "primary_faction_slug", "created_at",
         "in_progress_count",
     }
     assert required_fields.issubset(data.keys())
+    # Parked v2 feature, deliberately off the wire (#1471) — the Task column
+    # and its TaskDef writer survive, but nothing serialises them.
+    assert "is_task_vision_eligible" not in data
     # account_id and email must never be exposed
     assert "account_id" not in data
     assert "email" not in data

--- a/frontend/src/__tests__/accessibleNameSpacing.test.tsx
+++ b/frontend/src/__tests__/accessibleNameSpacing.test.tsx
@@ -57,7 +57,6 @@ function metatask(): TaskOut {
     created_by: 1,
     primary_faction_slug: null,
     metatask_faction_slug: 'snide',
-    is_task_vision_eligible: false,
     created_at: '2026-01-01T00:00:00Z',
     can_submit_praxis: false,
     allowed_modes: [],

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -14,7 +14,6 @@ export interface TaskOut {
   created_by: number
   primary_faction_slug: string | null
   metatask_faction_slug: string | null
-  is_task_vision_eligible: boolean
   created_at: string
   // Derived, read-time count of characters actively working on this task —
   // active-signup population (in_progress + pending), consistent with

--- a/frontend/src/components/__tests__/factionCardSlots.test.tsx
+++ b/frontend/src/components/__tests__/factionCardSlots.test.tsx
@@ -265,7 +265,6 @@ const TASK: TaskOut = {
   created_by: 3,
   primary_faction_slug: "ua",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   can_submit_praxis: true,
   allowed_modes: ["solo"],

--- a/frontend/src/components/metataskSeal/__tests__/sealSkinsA.test.tsx
+++ b/frontend/src/components/metataskSeal/__tests__/sealSkinsA.test.tsx
@@ -26,7 +26,6 @@ function metatask(slug: string, overrides: Partial<TaskOut> = {}): TaskOut {
     created_by: 1,
     primary_faction_slug: null,
     metatask_faction_slug: slug,
-    is_task_vision_eligible: false,
     created_at: "2026-01-01T00:00:00Z",
     can_submit_praxis: false,
     allowed_modes: [],

--- a/frontend/src/components/metataskSeal/__tests__/sealSkinsB.test.tsx
+++ b/frontend/src/components/metataskSeal/__tests__/sealSkinsB.test.tsx
@@ -29,7 +29,6 @@ function metatask(slug: string, overrides: Partial<TaskOut> = {}): TaskOut {
     created_by: 1,
     primary_faction_slug: null,
     metatask_faction_slug: slug,
-    is_task_vision_eligible: false,
     created_at: "2026-01-01T00:00:00Z",
     can_submit_praxis: false,
     allowed_modes: [],

--- a/frontend/src/components/metataskSeal/metataskCompose.test.tsx
+++ b/frontend/src/components/metataskSeal/metataskCompose.test.tsx
@@ -31,7 +31,6 @@ function metatask(
     created_by: 1,
     primary_faction_slug: null,
     metatask_faction_slug: slug,
-    is_task_vision_eligible: false,
     created_at: "2026-01-01T00:00:00Z",
     can_submit_praxis: true,
     allowed_modes: ["solo"],

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -47,7 +47,6 @@ function metatask(overrides: Partial<TaskOut>): TaskOut {
     created_by: 3,
     primary_faction_slug: 'snide',
     metatask_faction_slug: 'snide',
-    is_task_vision_eligible: false,
     created_at: '2026-01-01T00:00:00Z',
     can_submit_praxis: false,
     allowed_modes: [],

--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -65,7 +65,6 @@ function metatask(overrides: Partial<TaskOut> = {}): TaskOut {
     created_by: 3,
     primary_faction_slug: 'ephemerists',
     metatask_faction_slug: 'ephemerists',
-    is_task_vision_eligible: false,
     created_at: '2026-01-01T00:00:00Z',
     can_submit_praxis: false,
     allowed_modes: [],

--- a/frontend/src/components/taskCard/__tests__/defaultTaskCard.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/defaultTaskCard.test.tsx
@@ -42,7 +42,6 @@ const TASK: TaskOut = {
   created_by: 3,
   primary_faction_slug: null,
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: '2026-01-01T00:00:00Z',
   in_progress_count: 6,
   can_submit_praxis: true,

--- a/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
@@ -54,7 +54,6 @@ const TASK: TaskOut = {
   created_by: 3,
   primary_faction_slug: null,
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: '2026-01-01T00:00:00Z',
   in_progress_count: 6,
   can_submit_praxis: true,

--- a/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
+++ b/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
@@ -21,7 +21,6 @@ function task(overrides: Partial<TaskOut> & { id: number }): TaskOut {
     created_by: 1,
     primary_faction_slug: null,
     metatask_faction_slug: null,
-    is_task_vision_eligible: false,
     created_at: "2026-07-01T00:00:00Z",
     can_submit_praxis: true,
     allowed_modes: [],

--- a/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
@@ -90,7 +90,6 @@ function makeTask(): TaskOut {
     created_by: 7,
     primary_faction_slug: 'ephemerists',
     metatask_faction_slug: null,
-    is_task_vision_eligible: false,
     created_at: '2026-01-01T00:00:00Z',
     can_submit_praxis: true,
     allowed_modes: ['solo'],

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -68,7 +68,6 @@ function task(allowedModes: string[], slug: string | null = null): TaskOut {
     created_by: 3,
     primary_faction_slug: slug,
     metatask_faction_slug: null,
-    is_task_vision_eligible: false,
     created_at: "2026-01-01T00:00:00Z",
     can_submit_praxis: true,
     allowed_modes: allowedModes,

--- a/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
@@ -121,7 +121,6 @@ const SEAL: TaskOut = {
   created_by: 9,
   primary_faction_slug: null,
   metatask_faction_slug: "snide",
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   can_submit_praxis: false,
   allowed_modes: [],

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -179,7 +179,6 @@ const SEAL_METATASK: TaskOut = {
   created_by: 9,
   primary_faction_slug: null,
   metatask_faction_slug: "snide",
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   can_submit_praxis: false,
   allowed_modes: [],

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -146,7 +146,6 @@ const SEAL_METATASK: TaskOut = {
   created_by: 9,
   primary_faction_slug: null,
   metatask_faction_slug: 'coven',
-  is_task_vision_eligible: false,
   created_at: '2026-01-01T00:00:00Z',
   can_submit_praxis: false,
   allowed_modes: [],

--- a/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
@@ -71,7 +71,6 @@ const METATASK: TaskOut = {
   created_by: 9,
   primary_faction_slug: null,
   metatask_faction_slug: "everymen",
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   can_submit_praxis: false,
   allowed_modes: [],

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -297,7 +297,6 @@ describe("S.N.I.D.E. praxis detail — copy is neutral (ADR-0061)", () => {
             created_by: 9,
             primary_faction_slug: null,
             metatask_faction_slug: "snide",
-            is_task_vision_eligible: false,
             created_at: "2026-01-01T00:00:00Z",
             can_submit_praxis: false,
             allowed_modes: [],

--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -260,7 +260,6 @@ describe("UA praxis detail — copy is neutral (ADR-0061)", () => {
               created_by: 9,
               primary_faction_slug: null,
               metatask_faction_slug: "ua",
-              is_task_vision_eligible: false,
               created_at: "2026-01-01T00:00:00Z",
               can_submit_praxis: false,
               allowed_modes: [],

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -255,7 +255,6 @@ describe("WOW praxis detail — copy is neutral (ADR-0061)", () => {
               created_by: 9,
               primary_faction_slug: null,
               metatask_faction_slug: "wow",
-              is_task_vision_eligible: false,
               created_at: "2026-01-01T00:00:00Z",
               can_submit_praxis: false,
               allowed_modes: [],

--- a/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
@@ -65,7 +65,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: "albescent",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 6,
   created_by_display_name: "Wren Abalone",

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -46,7 +46,6 @@ const TASK: TaskOut = {
   created_by: 3,
   primary_faction_slug: "snide",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   can_submit_praxis: true,
   allowed_modes: ["solo"],

--- a/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
@@ -41,7 +41,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: "coven",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 9,
   created_by_display_name: "Wren Abalone",

--- a/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
@@ -48,7 +48,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: null,
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 6,
   created_by_display_name: "Wren Abalone",

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -51,7 +51,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: "ephemerists",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 9,
   created_by_display_name: "Wren Abalone",

--- a/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
@@ -47,7 +47,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: "everymen",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 23,
   created_by_display_name: "Wren Abalone",

--- a/frontend/src/pages/taskDetail/__tests__/levelJump.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/levelJump.test.tsx
@@ -30,7 +30,6 @@ const TASK_ABOVE: TaskOut = {
   created_by: 1,
   primary_faction_slug: "snide",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   can_submit_praxis: true,
   allowed_modes: ["solo"],

--- a/frontend/src/pages/taskDetail/__tests__/mySubmissionLink.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mySubmissionLink.test.tsx
@@ -38,7 +38,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: null,
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 6,
   created_by_display_name: "Wren Abalone",

--- a/frontend/src/pages/taskDetail/__tests__/praxisGalleryBasis.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/praxisGalleryBasis.test.tsx
@@ -46,7 +46,6 @@ const TASK: TaskOut = {
   created_by: 3,
   primary_faction_slug: "snide",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   can_submit_praxis: true,
   allowed_modes: ["solo"],

--- a/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
@@ -44,7 +44,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: "singularity",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 17,
   created_by_display_name: "Wren Abalone",

--- a/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
@@ -49,7 +49,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: "snide",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 9,
   created_by_display_name: "Wren Abalone",

--- a/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
@@ -47,7 +47,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: "ua",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 17,
   created_by_display_name: "Ines Aurel",

--- a/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
@@ -39,7 +39,6 @@ const TASK: TaskOut = {
   created_by: 31,
   primary_faction_slug: "wow",
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: "2026-01-01T00:00:00Z",
   in_progress_count: 4,
   created_by_display_name: "Wren Abalone",

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -37,7 +37,6 @@ const TASK: TaskOut = {
   created_by: 3,
   primary_faction_slug: null,
   metatask_faction_slug: null,
-  is_task_vision_eligible: false,
   created_at: '2026-01-01T00:00:00Z',
   in_progress_count: 6,
   can_submit_praxis: true,


### PR DESCRIPTION
Closes #1471

## What went, and what deliberately stayed

**Wire field only.** The column, the `TaskDef` config field, and the seed writer are all untouched.

| Layer | Before | After |
|---|---|---|
| `TaskOut.is_task_vision_eligible` (`backend/schemas/task.py`) | serialized on every task in every list response | **deleted** |
| `services/task.py::build_task_out` | passed the kwarg | **deleted** |
| `routers/admin.py::PendingTaskOut` (subclasses `TaskOut`) | passed the kwarg | **deleted** |
| `frontend/src/api/tasks.ts` `TaskOut` | declared, never read | **deleted** |
| 34 fixtures (`frontend/src/**`, `.design-sync/previews/_fixtures.tsx`) | declared to satisfy the type | **deleted** |
| `models/task.py` column | live | **KEPT** (+ a comment saying why) |
| `game_config.py::TaskDef.is_task_vision_eligible` | live | **KEPT** |
| `seed.py`, `import_tasks_csv.py` writers | live | **KEPT** |

## What the era config actually does with it

`is_task_vision_eligible` is **not an `EraConfig` field** — it is a per-task field on `TaskDef` (`game_config.py:53`, default `False`). The writer path is real and live: `seed.py:170` copies `task_def.is_task_vision_eligible` onto each seeded `Task` row, and `_template.py:105` documents it for era authors.

But **`backend/eras/era_1.py` never mentions it** (zero occurrences — read-only check, that file belongs to a sibling this run). So every era-1 `TaskDef` takes the default and every seeded row is `False`. `import_tasks_csv.py:226` also hardcodes `False`. With the admin `PATCH .../task-vision` toggle deleted in #1386, **no writer can ever set it `True` today** — the column is dormant in practice.

**It is dormant on purpose, not by accident.** `docs/spec/SPEC-backend-architecture.md` §9 "Intentional v2 deferrals" lists Task Vision explicitly: *config flag `is_task_vision_eligible` exists / No service exposes retired tasks to Ephemerists* — under a heading that says "parked, not built — do not 'fix' them". So this PR does **not** touch the column or the config field. If they should go, that is the dormant-`EraConfig`-style deletion in #1388 and it needs an owner ruling against SPEC §9 first.

I left a comment on the column pointing at SPEC §9, so the next dead-code sweep does not read "no readers" as "delete me".

## Zero-consumer proof

Checked before deleting, across the whole repo (excluding `.git`, `node_modules`, `.venv`):

- by wire name `is_task_vision_eligible` — every frontend hit was either the `api/tasks.ts` interface declaration or a fixture literal
- by camelCase / partial spellings, case-insensitively (`taskVision`, `TaskVision`, `task_vision`) — no other spelling exists
- no `expect(...)` anywhere reads it, in either suite — so nothing was asserting on the value and no guard goes vacuous
- all 34 fixture hits were verified to be standalone `is_task_vision_eligible: false|true,` lines before they were stripped

The one **positive** assertion was `backend/tests/integration/test_tasks.py`, whose `required_fields` set asserted the field is *present* in `GET /tasks/{id}`. Removed from the set and replaced with `assert "is_task_vision_eligible" not in data`, so re-serializing it fails a test rather than passing silently.

## Relationship to #1387

#1387 **does** list this field, but with the note *"owned by the dead-endpoint sweep from this audit (pairs with the task-vision route); skip here if that lands first"*. This is that sweep's other half, so the row is now discharged — #1387 should skip it rather than do it twice. Commented there.

## Verification

No browser or dev stack in this worktree, so everything below is tests and typecheck.

- `pytest --cov=. --cov-fail-under=80` on dedicated DB `wz1471_test` — **949 passed**, 91.68% coverage
- `tsc --noEmit` — clean
- `vitest run` — **3520 passed** across 202 files
- `eslint .` — exit 0
- `vite build` — clean

No new test added: this is a pure deletion, and the honest checks are the greps, the typecheck, and the suites staying green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)