### PR TITLE
The duel picker stops re-deriving whose account a character is on

### DIFF
--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -44,20 +44,37 @@ async def list_characters(
     search: Optional[str] = None,
     faction: Optional[str] = None,
     exclude_active_task_id: Optional[int] = None,
+    exclude_own_account: bool = False,
     limit: int = 50,
     offset: int = 0,
     session: AsyncSession = Depends(get_db),
+    viewer: Optional[Character] = Depends(get_current_character_optional),
 ):
     """List all active characters. Optionally filter by name or faction.
 
     ``exclude_active_task_id`` hides players already active on that task (invite
     search pre-filter, #320).
+
+    ``exclude_own_account`` hides every life on the caller's own account — the
+    account-level identity rule of ADR-0041, which the duel-opponent picker needs
+    and used to re-derive client-side off a second request (#1385). Opt-in, so
+    the default path ignores the viewer entirely.
+
+    **From an anonymous caller the flag is a silent no-op**, not a 401 or a 422:
+    there is no viewer to exclude, the combination is meaningless rather than
+    malformed, and rejecting would make a deliberately public route
+    conditionally authenticated. That is never a security hole — the exclusion is
+    picker convenience, and ``services.duel`` independently enforces the rule at
+    both challenge and accept (``_characters_share_account``).
     """
     rows = await list_characters_for_viewer(
         session,
         search=search,
         faction_slug=faction,
         exclude_active_task_id=exclude_active_task_id,
+        exclude_account_id=(
+            viewer.account_id if exclude_own_account and viewer is not None else None
+        ),
         limit=limit,
         offset=offset,
     )

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -548,6 +548,7 @@ async def list_characters_for_viewer(
     search: Optional[str] = None,
     faction_slug: Optional[str] = None,
     exclude_active_task_id: Optional[int] = None,
+    exclude_account_id: Optional[int] = None,
     limit: int = 50,
     offset: int = 0,
 ) -> list[tuple[Character, CharacterStats | None]]:
@@ -558,6 +559,12 @@ async def list_characters_for_viewer(
     search doesn't surface players the backend would 409 (#320). Everymen are
     never excluded (Double Dipper perk: they may hold multiple memberships per
     task), mirroring :func:`services.praxis.is_active_member_of_task`.
+
+    ``exclude_account_id`` drops every life on one account — the account-level
+    identity rule of ADR-0041, and the same comparison
+    :func:`services.duel._characters_share_account` makes. The duel-opponent
+    picker asks for it so it does not have to re-derive the roster client-side
+    (#1385); the duel service remains the enforcement.
     """
     from services.praxis import EVERYMEN_FACTION_SLUG
 
@@ -609,6 +616,8 @@ async def list_characters_for_viewer(
         )
     if faction_slug:
         query = query.where(Character.faction_slug == faction_slug)
+    if exclude_account_id is not None:
+        query = query.where(Character.account_id != exclude_account_id)
     if exclude_active_task_id is not None:
         active_member_ids = (
             select(PraxisMember.character_id)

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -271,6 +271,73 @@ async def test_list_characters_excludes_players_active_on_task(
 
 
 @pytest.mark.asyncio
+async def test_list_characters_excludes_own_account(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    character2: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    """exclude_own_account hides every life on the VIEWER'S ACCOUNT (#1385).
+
+    The alt is the case that matters: a second character on the viewer's own
+    account reads as a different player by id alone, which is exactly the hole
+    ``services.duel._characters_share_account`` closes (ADR-0041, #1237). A
+    cross-account control proves the filter narrows rather than empties.
+    """
+    alt = Character(
+        account_id=account.id,
+        username="altlife",
+        display_name="Alt Life",
+        faction_slug="ua",
+    )
+    db_session.add(alt)
+    await db_session.flush()
+    db_session.add(
+        CharacterStats(
+            character_id=alt.id,
+            era_id=era.id,
+            score=0,
+            all_time_score=0,
+            level=0,
+            votes_spent_this_era=0,
+        )
+    )
+    await db_session.commit()
+
+    resp = await client.get(
+        "/characters",
+        params={"exclude_own_account": True},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert character.id not in ids  # the carried life
+    assert alt.id not in ids  # the alt — invisible to an id-only rule
+    assert character2.id in ids  # another account → still listed
+
+
+@pytest.mark.asyncio
+async def test_list_characters_exclude_own_account_anonymous_is_noop(
+    client: AsyncClient, character: Character, character2: Character
+):
+    """Anonymous + the param is a documented no-op, not a 401 or a 422 (#1385).
+
+    There is no viewer to exclude, and the real enforcement lives in
+    ``services.duel``; rejecting would make a deliberately public route
+    conditionally authenticated for no security gain.
+    """
+    resp = await client.get("/characters", params={"exclude_own_account": True})
+    assert resp.status_code == 200
+    ids = [c["id"] for c in resp.json()]
+    assert character.id in ids
+    assert character2.id in ids
+
+
+@pytest.mark.asyncio
 async def test_list_characters_limit_offset(
     client: AsyncClient, character: Character, character2: Character
 ):

--- a/frontend/src/api/characters.ts
+++ b/frontend/src/api/characters.ts
@@ -30,6 +30,13 @@ export async function listCharacters(params?: {
   faction?: string
   /** Hide players already active on this task (invite-search pre-filter, #320). */
   exclude_active_task_id?: number
+  /**
+   * Hide every life on the caller's own account (ADR-0041), resolved server-side
+   * from the bearer token — the duel picker's rule, which it used to re-derive
+   * from a second `/me/characters` read (#1385). A no-op when anonymous. Leave
+   * unset (not `false`) to keep the request byte-identical to the public form.
+   */
+  exclude_own_account?: boolean
   limit?: number
 }): Promise<CharacterOut[]> {
   const { data } = await api.get<CharacterOut[]>('/characters', { params })

--- a/frontend/src/pages/editPraxis/useComposerRoster.ts
+++ b/frontend/src/pages/editPraxis/useComposerRoster.ts
@@ -5,8 +5,8 @@
  * One search box serves two jobs (#311) — collab invitees while the praxis is a
  * collab, an opponent while a duel is being set up — so the filter, the two
  * "send" calls that clear it, and the roster writes that follow all live
- * together. The two viewer-keyed reads the filter depends on (active foes for
- * ordering, the account's own lives for exclusion) come with it.
+ * together. The one viewer-keyed read the filter still depends on (active foes,
+ * for ordering) comes with it.
  *
  * Split out of `useEditPraxis.ts` (#1392); behaviour unchanged. It reads
  * `useAuth()` directly rather than taking the viewer as a parameter, which is
@@ -31,33 +31,9 @@ import { getDuelDetail, issueChallenge, type DuelDetailOut } from "../../api/due
 import { sendNudge } from "../../api/nudge";
 import { listCharacters, type CharacterOut } from "../../api/characters";
 import { listRelationships } from "../../api/relationships";
-import { getMyCharacters } from "../../api/me";
 import { useAuth } from "../../auth/AuthContext";
 import { extractError } from "../../utils/errors";
 import i18n from "../../i18n";
-
-/**
- * Which of the viewer's own lives the invite/opponent picker withholds (#1257).
- *
- * Collab invites withhold only the life you are carrying — inviting your own alt
- * to a collab is doing a task with yourself, which splits no points unfairly and
- * which the backend allows. Duel mode withholds the whole account roster: #1237
- * blocked both sides of a duel landing on one account, so offering an alt as an
- * opponent could only ever earn a 400 on Challenge.
- *
- * `ownCharacterIds` is empty until the lazy `/me/characters` read lands (and
- * stays empty if it fails), so the carried life is unioned in rather than
- * assumed present — the narrow old rule remains the floor.
- */
-export function selfExcludedPickIds(
-  carriedCharacterId: number | undefined,
-  ownCharacterIds: Set<number>,
-  duelMode: boolean,
-): Set<number> {
-  const excluded = new Set<number>(duelMode ? ownCharacterIds : []);
-  if (carriedCharacterId != null) excluded.add(carriedCharacterId);
-  return excluded;
-}
 
 export interface ComposerRoster {
   inviteQuery: string;
@@ -91,10 +67,6 @@ export function useComposerRoster(options: {
   const [inviteOpen, setInviteOpen] = useState(false);
   const [inviting, setInviting] = useState(false);
   const [foeIds, setFoeIds] = useState<Set<number>>(new Set());
-  // Every life on the viewer's account (#1257) — read lazily when the duel pane
-  // opens, since only duel mode withholds them and there is no app-wide cache of
-  // the roster to read. Empty until it lands, and on failure.
-  const [ownCharacterIds, setOwnCharacterIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     if (!user?.character) return;
@@ -105,24 +77,6 @@ export function useComposerRoster(options: {
       });
   }, [user?.character?.id]);
 
-  // The account's own roster, for the duel opponent picker only (#1257). The
-  // picker already fetches per keystroke, so one read on a pane the player has
-  // just opened costs nothing on mount.
-  useEffect(() => {
-    if (!duelPaneOpen || !user?.character) return;
-    let cancelled = false;
-    getMyCharacters()
-      .then((roster) => {
-        if (!cancelled) setOwnCharacterIds(new Set(roster.map((c) => c.id)));
-      })
-      .catch(() => {
-        /* the carried life stays withheld either way — see selfExcludedPickIds */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [duelPaneOpen, user?.character?.id]);
-
   // ---- Invite search (debounced via input change handler in caller, but
   // we keep the actual fetch here so archetypes can wire the input directly) ----
   useEffect(() => {
@@ -132,12 +86,24 @@ export function useComposerRoster(options: {
       setInviteOpen(false);
       return;
     }
+    // The picker is choosing an *opponent* only while a duel is being set up;
+    // with a challenge already attached it is hidden, and otherwise it is
+    // choosing collab invitees.
+    const pickingOpponent = praxis.duel_id == null && duelPaneOpen;
     let cancelled = false;
     void (async () => {
       try {
         const results = await listCharacters({
           search: inviteQuery,
           exclude_active_task_id: praxis.task_id,
+          // Duel mode withholds the viewer's whole ACCOUNT, not just the life
+          // they are carrying: #1237 blocked both sides of a duel landing on one
+          // account, so offering an alt could only ever earn a 400 on Challenge.
+          // The server answers that (#1385) — it is the only party that knows
+          // which characters share an account, and asking it costs no request.
+          // Collab invites deliberately do NOT set this: inviting your own alt to
+          // a collab is allowed, so only the carried life is withheld below.
+          exclude_own_account: pickingOpponent || undefined,
           limit: 8,
         });
         if (cancelled) return;
@@ -147,18 +113,9 @@ export function useComposerRoster(options: {
             .filter((i) => i.status === "pending")
             .map((i) => i.invitee_id),
         );
-        // The picker is choosing an *opponent* only while a duel is being set up;
-        // with a challenge already attached it is hidden, and otherwise it is
-        // choosing collab invitees.
-        const pickingOpponent = praxis.duel_id == null && duelPaneOpen;
-        const selfExcluded = selfExcludedPickIds(
-          user?.character?.id,
-          ownCharacterIds,
-          pickingOpponent,
-        );
         const filtered = results.filter(
           (c) =>
-            !selfExcluded.has(c.id) &&
+            c.id !== user?.character?.id &&
             !memberIds.has(c.id) &&
             !pendingInviteIds.has(c.id),
         );
@@ -183,14 +140,7 @@ export function useComposerRoster(options: {
     // `user` narrowed to the id the filter actually reads (#1390) — otherwise
     // every `/auth/me` refetch re-ran the character search behind an open
     // invite box.
-  }, [
-    inviteQuery,
-    praxis,
-    user?.character?.id,
-    duelPaneOpen,
-    foeIds,
-    ownCharacterIds,
-  ]);
+  }, [inviteQuery, praxis, user?.character?.id, duelPaneOpen, foeIds]);
 
   /** Empty the box the way both "send" paths do: query, results, dropdown. */
   const clearPicker = useCallback(() => {

--- a/frontend/src/pages/editPraxis/useEditPraxis.test.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.test.ts
@@ -5,12 +5,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { updatePraxis } from "../../api/praxis";
-import {
-  draftNeedsTitle,
-  flushEdits,
-  hasUnsavedEdits,
-  selfExcludedPickIds,
-} from "./useEditPraxis";
+import { draftNeedsTitle, flushEdits, hasUnsavedEdits } from "./useEditPraxis";
 // The mode-switch confirm moved out of the hook with the rest of them (#1082)
 // and now returns a whole ConfirmRequest instead of a `window.confirm` string.
 import { modeSwitchConfirm } from "../../components/confirm/composerConfirms";
@@ -181,35 +176,10 @@ describe("modeSwitchConfirm", () => {
   });
 });
 
-/**
- * Which of the viewer's own lives the invite/opponent picker withholds (#1257).
- *
- * The seam under test is the exclusion set that feeds the invite-search filter.
- * It used to be exactly one id — the life you are carrying — which left every
- * *other* life on your account offered as a duel opponent, and #1237 blocks
- * both sides of a duel landing on one account. Selecting one could only 400.
+/*
+ * The invite/opponent picker's own-account exclusion used to be proven here, on
+ * a `selfExcludedPickIds` helper that re-derived the rule client-side off a
+ * `/me/characters` read. #1385 moved the rule to the one party that can answer
+ * it — `GET /characters?exclude_own_account=true` — so it is now pinned at the
+ * HTTP seam in `backend/tests/integration/test_characters.py`.
  */
-describe("selfExcludedPickIds", () => {
-  const roster = new Set([1, 2, 3]);
-
-  it("withholds the whole account roster in duel mode — none of them can be duelled", () => {
-    const excluded = selfExcludedPickIds(1, roster, true);
-    expect(excluded.has(2)).toBe(true);
-    expect(excluded.has(3)).toBe(true);
-  });
-
-  it("withholds only the carried life for a collab invite — inviting your own alt is legal", () => {
-    const excluded = selfExcludedPickIds(1, roster, false);
-    expect(excluded.has(1)).toBe(true);
-    expect(excluded.has(2)).toBe(false);
-    expect(excluded.has(3)).toBe(false);
-  });
-
-  it("still withholds the carried life in duel mode before the roster lands", () => {
-    expect(selfExcludedPickIds(1, new Set(), true).has(1)).toBe(true);
-  });
-
-  it("withholds nothing when nobody is carrying a life and the roster is empty", () => {
-    expect(selfExcludedPickIds(undefined, new Set(), true).size).toBe(0);
-  });
-});

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -115,12 +115,8 @@ export {
 /**
  * The invite/opponent search box, the two sends that clear it, and the roster
  * writes that follow (kick, rescind, nudge) moved to `useComposerRoster.ts`
- * (#1392). `selfExcludedPickIds` is re-exported: `useEditPraxis.test.ts` calls
- * it directly, which is the only way to prove the #1257 rule with no effects in
- * the harness.
+ * (#1392).
  */
-export { selfExcludedPickIds } from "./useComposerRoster";
-
 export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const navigate = useNavigate();
   const { user, refetch, loading: authLoading } = useAuth();


### PR DESCRIPTION
Closes #1385

## The seam under test

**HTTP.** `exclude_own_account=` is a wire contract — whether FastAPI reads the
boolean axios sends, and whether the *route* (not the service) resolves the
viewer — is only observable through a request. Both new tests live in
`backend/tests/integration/test_characters.py` and go through `AsyncClient`.

Both assert **by value**: the account siblings are absent *and* a cross-account
character is present. Absence alone would pass on an endpoint returning nothing.
The alt is the interesting row — a second character on the viewer's own account
reads as a different player by id alone, which is exactly the hole
`services.duel._characters_share_account` closes (ADR-0041, #1237). The
single-character case proves nothing; it passed before.

Written red first: the unknown param was ignored, so the carried life came back
in an unfiltered list.

## Did the client mirror match the server rule?

**Not quite — and the gap was a real one.** In duel mode `selfExcludedPickIds`
withheld the union of `/me/characters` and the carried life, which *when the
read had landed* matched `_characters_share_account`. But `ownCharacterIds`
started empty and **stayed empty when `/me/characters` failed**:

```ts
.catch(() => {
  /* the carried life stays withheld either way — see selfExcludedPickIds */
});
```

So between opening the duel pane and that read resolving — and permanently, on
any failure — the picker degraded to the *pre-#1257* rule and offered account
siblings the backend would 400 on Challenge. The deleted test
`"still withholds the carried life in duel mode before the roster lands"`
pinned that degraded state as intended behaviour. The mirror was a best-effort
approximation of the rule, not a copy of it.

## Is the mirror gone?

Yes. `selfExcludedPickIds`, the `ownCharacterIds` state, the effect that filled
it, its re-export from `useEditPraxis.ts`, and its four unit tests are all
deleted. `grep -rn "selfExcludedPickIds\|ownCharacterIds" frontend/src` returns
only a tombstone comment pointing at the new backend test. Net **−73 lines**.

What survives client-side is one inline `c.id !== user?.character?.id` — the
carried life. That is **not** the account rule and never was: the backend
*allows* inviting your own alt to a collab, so collab deliberately does not send
the param, and the account-wide exclusion would be wrong there.

## Security posture

The param is convenience shape, not enforcement. `services/duel.py` still checks
`_characters_share_account` independently at **both** entry points — challenge
(`issue_duel_challenge`) and accept (`respond_to_duel_challenge`) — and
`test_duel_self_duel.py` still passes untouched. Nothing here is an exclusion
the client enforces and the server does not; it is the reverse, which is the
point.

## The anonymous-caller ruling

`exclude_own_account=true` with no viewer is a **silent no-op**, per the owner's
ruling on the issue, documented in the route docstring and pinned by
`test_list_characters_exclude_own_account_anonymous_is_noop`. Not a 401 (it
would make a deliberately public route conditionally authenticated), not a 422
(the combination is meaningless, not malformed).

The client sends `exclude_own_account: pickingOpponent || undefined`, so the
collab and anonymous paths omit the key entirely — `GET /characters` without the
param is byte-identical. No repeated/array param here, so the
`paramsSerializer: { indexes: null }` trap does not apply.

## The cost claim, corrected

The issue's headline framing ("pays an extra request") is right but the owner's
correction stands: the `/me/characters` read was gated on `duelPaneOpen`, so the
saving is **one request per duel-pane open**, not one per EditPraxis load. The
win being banked here is the deleted mirror.

## Verified

No browser or dev stack available — everything below is test-only.

- `pytest --cov=. --cov-fail-under=80` — **951 passed, 91.68%** (dedicated `wz1385_test`)
- `tsc --noEmit` — clean (run through a real junction; `tsc --version` verified first)
- `vitest run` — **3516 passed** / 202 files
- `eslint src` — clean
- `vite build` + `bundle-budget.mjs` — within budget (JS 131.1 KB, CSS 22.4 KB)
- Re-ran `test_characters` + `test_duel_self_duel` + `test_multi_character` after rebasing onto `b14b4a00` — 61 passed

Rebased onto latest `origin/main`; the node_modules junction was removed before finishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)