### PR TITLE
SPEC §8's two "current instance" citations point at code that moved

### DIFF
--- a/docs/spec/SPEC-backend-architecture.md
+++ b/docs/spec/SPEC-backend-architecture.md
@@ -228,13 +228,21 @@ use the canonical one.
   parameter.
 - Module-level imports between `services/*` files that form cycles. If you
   need a function-scoped import to break a cycle, it's a code smell: leave a
-  `# TODO: break cycle` comment and open a task. The one current instance is
-  `services/era.py:96`.
+  `# TODO: break cycle` comment and open a task. There are **seven** current
+  instances (2026-07-31), and they are not scattered — they orbit one triangle:
+  four in `services/praxis.py` + `services/vote.py` all import `services.duel`,
+  because `services/duel.py` imports `_count_in_progress_praxes`, `get_praxis`
+  and `is_active_member_of_task` at module level. The remaining three are in
+  `services/character.py` (one of them the `praxis → faction_service → character`
+  loop). Breaking the triangle needs `get_praxis` to move, which is why #1391's
+  third cut exists.
 - String literals for domain values (`status == "active"`). Use the Enum.
 - Hand-written joins where a declared `relationship()` would load the same
   data. Most of our models have no `relationship()` declarations today.
 - Fat route handlers that inline query construction. `routers/tasks.py::list_tasks`
-  is the current worst offender.
+  used to be the worst offender and is now the example of the fix: it is a thin
+  parameter-forwarder, and the query it used to inline lives in
+  `services/task.py::list_tasks`.
 - Leaking `account_id` / `email` onto a public `*Out` schema. Always check
   before adding a field.
 


### PR DESCRIPTION
The orchestrator's half of #1391. Its agent verified both citations and could not fix them — `docs/spec/` sits outside the backend agent's file scope.

Both were stale in a way that **misleads rather than merely dates**.

## "The one current instance is `services/era.py:96`"

Stale twice over, and I verified each half:

- `backend/services/era.py` has **zero** function-scoped service imports today.
- Line 96 is now `era_id=era_id,` inside `get_or_create_stats`.

So a reader who follows the citation lands on an unrelated line and reasonably concludes the smell no longer exists. There are **seven**, and the useful fact is that they are not scattered — four orbit one triangle: `services/praxis.py` and `services/vote.py` import `services.duel` inside function bodies because `services/duel.py` imports `_count_in_progress_praxes`, `get_praxis` and `is_active_member_of_task` at module level.

Naming the *shape* beats naming a line number that will move again — which is exactly how this citation broke.

## "`routers/tasks.py::list_tasks` is the current worst offender"

It was fixed. `backend/routers/tasks.py` is a thin parameter-forwarder; the query construction lives in `backend/services/task.py::list_tasks`.

Left alone, the spec cites its own best worked example of the fix as the outstanding problem. Reframed to say that, so the entry still earns its place: the rule stands, and the named file now demonstrates compliance instead of violation.

## Note

The `# TODO: break cycle` guidance is unchanged, and so is the rule. Only the evidence moved.

Documentation only — no code, no test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)