### PR TITLE
The two sign-out buttons stop asking who just signed out (#1349)

### DIFF
--- a/frontend/src/__tests__/rootLandingChunks.test.tsx
+++ b/frontend/src/__tests__/rootLandingChunks.test.tsx
@@ -70,7 +70,7 @@ function withSessionHint(hint: string | null): void {
 function renderRoot(session: { user: CurrentUser | null; loading: boolean }): string {
   return renderToStaticMarkup(
     <MemoryRouter>
-      <AuthContext.Provider value={{ ...session, refetch: async () => {} }}>
+      <AuthContext.Provider value={{ ...session, refetch: async () => {}, signOut: async () => {} }}>
         {/* Stands in for App's one Suspense boundary. A distinctive fallback so
             "chunk still in flight" is never mistaken for a rendered page. */}
         <Suspense fallback={<div data-page="suspended" />}>

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,10 +1,20 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
-import { getMe, type CurrentUser } from '../api/auth'
+import { getMe, logout, type CurrentUser } from '../api/auth'
 
 interface AuthState {
   user: CurrentUser | null
   loading: boolean
   refetch: () => Promise<void>
+  /**
+   * End the session and drop the app to its logged-out state.
+   *
+   * Exists so that signing out does not have to `logout()` and then `refetch()`
+   * (#1349). That second call was a request whose answer the client already
+   * held: the cookie is gone, so `/auth/me` can only 401, and `/auth/me` is a
+   * `SESSION_PROBE` (`api/axios.ts`) precisely so that 401 is swallowed. It cost
+   * a round trip to reach the `user = null` the caller had already caused.
+   */
+  signOut: () => Promise<void>
 }
 
 /** Exported for tests only: the harness is `renderToStaticMarkup`, so a
@@ -14,6 +24,7 @@ export const AuthContext = createContext<AuthState>({
   user: null,
   loading: true,
   refetch: async () => {},
+  signOut: async () => {},
 })
 
 const SESSION_HINT_KEY = 'wz_session_hint'
@@ -46,6 +57,23 @@ function rememberSession(signedIn: boolean): void {
   }
 }
 
+/**
+ * The sign-out wiring, extracted so it is unit-testable in a DOM-less env
+ * (`renderToStaticMarkup`, no jsdom — effects never run, so the provider's own
+ * closure is unreachable from a test). Lives here rather than beside a page
+ * because both sign-out buttons — the desktop NavBar and the mobile Settings
+ * surface — route through the one context method.
+ */
+export function runSignOut(
+  endSession: () => Promise<void>,
+  forgetViewer: () => void,
+): () => Promise<void> {
+  return async () => {
+    await endSession()
+    forgetViewer()
+  }
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<CurrentUser | null>(null)
   const [loading, setLoading] = useState(true)
@@ -64,12 +92,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  // No `/auth/me` follow-up: ending the session IS the new state, and the
+  // provider owns both halves of it — see `AuthState.signOut`.
+  const signOut = runSignOut(logout, () => {
+    setUser(null)
+    rememberSession(false)
+    setLoading(false)
+  })
+
   useEffect(() => {
     void fetchUser()
   }, [])
 
   return (
-    <AuthContext.Provider value={{ user, loading, refetch: fetchUser }}>
+    <AuthContext.Provider value={{ user, loading, refetch: fetchUser, signOut }}>
       {children}
     </AuthContext.Provider>
   )

--- a/frontend/src/auth/__tests__/authRefetchLedger.test.ts
+++ b/frontend/src/auth/__tests__/authRefetchLedger.test.ts
@@ -1,0 +1,260 @@
+/**
+ * #1349 — the `useAuth().refetch()` ledger.
+ *
+ * `refetch()` reloads the WHOLE of `CurrentUser`: the carried character, its
+ * era stats, its invitation letters, and a dozen server-computed capability
+ * flags. The refetch family (#1346) has been closing it down one reason at a
+ * time — #1382 retired the per-star reload, #1390 stopped a fresh `CurrentUser`
+ * object fanning out into unrelated reads — and this is the closing sweep: an
+ * inventory in which every surviving call site is written down with the reason
+ * it survives.
+ *
+ * WHAT THIS PROVES, AND WHAT IT CANNOT
+ * ------------------------------------
+ * Vitest runs in the `node` environment with no jsdom, so the harness is
+ * `renderToStaticMarkup` and effects never run. Nothing in this repo can assert
+ * "one request instead of two". So this is a SOURCE test, the same posture as
+ * `hooks/__tests__/authDepNarrowing.test.ts`: it reads the tree and pins the
+ * shape the fix turns on. Its value is the ratchet — a call site added later
+ * fails the suite until somebody writes down why the whole identity has to be
+ * re-read, which is exactly the discipline the sweep exists to leave behind.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+import { runSignOut } from '../AuthContext'
+
+const SOURCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+type Verdict =
+  /** The mutation genuinely changed `CurrentUser` and nothing cheaper exists. */
+  | 'identity-changed'
+  /** The server already handed the client the answer; consuming it is #1383. */
+  | 'response-in-hand'
+
+interface LedgerEntry {
+  file: string
+  calls: number
+  verdict: Verdict
+  why: string
+}
+
+/**
+ * Every `useAuth().refetch()` in the tree, with its justification.
+ *
+ * The classification the sweep landed on, from tracing each mutation into the
+ * service that answers it:
+ *
+ *  - 8 calls are `identity-changed` — publishing, withdrawing or leaving a
+ *    praxis all run a stats recalc (points, level, and on publish the delivery
+ *    of newly-earned invitation letters); creating, editing and deleting a life
+ *    all change or re-resolve the carried one; dev-login has no other way to
+ *    learn who just signed in.
+ *  - 6 calls are `response-in-hand`, and are #1383's to delete, not this
+ *    sweep's: two discard the `CurrentUser` that `POST /me/active-character`
+ *    already returns, and four follow `POST /factions/choose`, which #1383
+ *    item 1 widens to return `CurrentUser` too.
+ *  - The 2 that were neither — the post-`logout()` reloads in `NavBar` and
+ *    `Settings` — are gone. See the `signOut` rule below.
+ */
+const LEDGER: LedgerEntry[] = [
+  {
+    file: 'components/CharacterSwitcherSheet.tsx',
+    calls: 1,
+    verdict: 'response-in-hand',
+    why: 'POST /me/active-character already returns the refreshed CurrentUser (#1383 item 4).',
+  },
+  {
+    file: 'components/InvitationLetterPopup.tsx',
+    calls: 1,
+    verdict: 'response-in-hand',
+    why: 'Accepting a letter joins the faction; POST /factions/choose returns {slug,status} (#1383 item 1).',
+  },
+  {
+    file: 'components/feed/FeedCardInvitationLetter.tsx',
+    calls: 1,
+    verdict: 'response-in-hand',
+    why: 'The feed-row twin of the popup — same join, same narrow response (#1383 item 1).',
+  },
+  {
+    file: 'pages/FieldDesk.tsx',
+    calls: 2,
+    verdict: 'response-in-hand',
+    why: 'Life switch (#1383 item 4) and the Albescent join (#1383 item 1).',
+  },
+  {
+    file: 'pages/Home.tsx',
+    calls: 1,
+    verdict: 'identity-changed',
+    why: 'POST /auth/dev-login sets the cookie and returns nothing — /auth/me is the only way to learn who that is.',
+  },
+  {
+    file: 'pages/characterPaths/useCreateCharacter.ts',
+    calls: 1,
+    verdict: 'identity-changed',
+    why: 'The server carries the new life immediately; every capability flag is recomputed against it.',
+  },
+  {
+    file: 'pages/characterPaths/useEditCharacter.ts',
+    calls: 2,
+    verdict: 'identity-changed',
+    why: 'Edit returns a CharacterOut, not a CurrentUser; delete makes the server re-resolve the active life (or none).',
+  },
+  {
+    file: 'pages/editPraxis/useEditPraxis.ts',
+    calls: 3,
+    verdict: 'identity-changed',
+    why: 'publish / pullBack / leaveCollab each run a backend stats recalc; publish also delivers invitation letters.',
+  },
+  {
+    file: 'pages/factionDetail/useFactionDetail.ts',
+    calls: 1,
+    verdict: 'response-in-hand',
+    why: 'Join or defect; POST /factions/choose returns {slug,status} (#1383 item 1).',
+  },
+  {
+    file: 'pages/praxisDetail/usePraxisDetail.ts',
+    calls: 1,
+    verdict: 'identity-changed',
+    why: 'Withdraw runs unsubmit_praxis, which recalculates every member — the points come back off.',
+  },
+]
+
+/** Source files, tests excluded — a test may name `refetch()` freely. */
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory).flatMap((entry) => {
+    const full = path.join(directory, entry)
+    if (statSync(full).isDirectory()) {
+      return entry === '__tests__' ? [] : sourceFiles(full)
+    }
+    return /\.tsx?$/.test(entry) ? [full] : []
+  })
+}
+
+/** Comments say `refetch()` too, and they are not call sites. */
+function withoutComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+}
+
+/**
+ * Files that bind `refetch` off `useAuth()` itself, mapped to their call count.
+ *
+ * Deliberately narrow: `useResource` and `useSidebarPanels` expose a `refetch`
+ * of their own, and those are ordinary re-reads of one list, not identity
+ * reloads. Only a bare `refetch` destructured from `useAuth()` counts.
+ */
+function measureAuthRefetches(): Map<string, number> {
+  const measured = new Map<string, number>()
+  for (const file of sourceFiles(SOURCE_ROOT)) {
+    const code = withoutComments(readFileSync(file, 'utf8'))
+    // `[^{}]` and not `[^}]`: the latter happily starts the match at an earlier
+    // brace and swallows the real destructuring pattern whole.
+    const bindsRefetch = [...code.matchAll(/\{([^{}]*)\}\s*=\s*useAuth\(\)/g)].some((binding) =>
+      binding[1]
+        .split(',')
+        .map((name) => name.trim())
+        .includes('refetch'),
+    )
+    if (!bindsRefetch) continue
+    const calls = code.match(/\brefetch\(\)/g)?.length ?? 0
+    if (calls > 0) {
+      measured.set(path.relative(SOURCE_ROOT, file).split(path.sep).join('/'), calls)
+    }
+  }
+  return measured
+}
+
+describe('the useAuth().refetch() inventory matches the ledger', () => {
+  const measured = measureAuthRefetches()
+
+  it('has no call site the ledger does not justify', () => {
+    const unledgered = [...measured.keys()].filter(
+      (file) => !LEDGER.some((entry) => entry.file === file),
+    )
+    expect(unledgered).toEqual([])
+  })
+
+  it('has no ledger entry whose call site is gone', () => {
+    const stale = LEDGER.map((entry) => entry.file).filter((file) => !measured.has(file))
+    expect(stale).toEqual([])
+  })
+
+  it.each(LEDGER)('$file reloads the whole identity $calls time(s): $why', ({ file, calls }) => {
+    expect(measured.get(file)).toBe(calls)
+  })
+
+  it('totals the count this sweep reports', () => {
+    // 16 before, in 12 files — the same headline figure the issue was filed
+    // with, though not the same sixteen: #1382 had already deleted the per-star
+    // reload it named, and a faction letter gained an Accept button (#1424)
+    // that added one back.
+    const total = [...measured.values()].reduce((sum, calls) => sum + calls, 0)
+    expect(total).toBe(14)
+    expect(measured.size).toBe(10)
+  })
+
+  it('leaves nothing classified as merely redundant', () => {
+    // The two that were — `logout()` then `refetch()` — are deleted. Anything
+    // that lands in this state again should be deleted, not written down.
+    const verdicts = new Set(LEDGER.map((entry) => entry.verdict))
+    expect([...verdicts].sort()).toEqual(['identity-changed', 'response-in-hand'])
+  })
+})
+
+describe('signing out never re-asks who the viewer is', () => {
+  const files = sourceFiles(SOURCE_ROOT)
+
+  it('routes every sign-out through AuthContext, which alone imports `logout`', () => {
+    // A component that imports `logout` has to clear the auth state itself, and
+    // `refetch()` is the only handle it has for that — which is how both
+    // sign-out buttons ended up paying for a `/auth/me` they knew the answer to.
+    const importsLogout = /import\s*\{[^}]*\blogout\b[^}]*\}\s*from\s*['"][^'"]*api\/auth['"]/
+    const importers = files
+      .filter((file) => importsLogout.test(readFileSync(file, 'utf8')))
+      .map((file) => path.relative(SOURCE_ROOT, file).split(path.sep).join('/'))
+    expect(importers).toEqual(['auth/AuthContext.tsx'])
+  })
+
+  it('clears the viewer locally instead of refetching a guaranteed 401', () => {
+    // `/auth/me` is a SESSION_PROBE (`api/axios.ts`), so the post-logout 401 was
+    // swallowed rather than fatal — it just cost a round trip to arrive at the
+    // `null` the caller had already caused. What keeps the client honest without
+    // it: the provider sets the same `null` and the same session hint that a
+    // failed `/auth/me` would have set.
+    const source = withoutComments(
+      readFileSync(path.join(SOURCE_ROOT, 'auth', 'AuthContext.tsx'), 'utf8'),
+    )
+    expect(source).toMatch(/runSignOut\(logout,/)
+    expect(source).toMatch(/setUser\(null\)/)
+    expect(source).toMatch(/rememberSession\(false\)/)
+  })
+})
+
+describe('runSignOut', () => {
+  it('ends the session, then forgets the viewer', async () => {
+    const order: string[] = []
+    const endSession = async () => {
+      order.push('logout')
+    }
+    const forgetViewer = () => {
+      order.push('forget')
+    }
+    await runSignOut(endSession, forgetViewer)()
+    expect(order).toEqual(['logout', 'forget'])
+  })
+
+  it('keeps the viewer if the session could not be ended', async () => {
+    let forgotten = false
+    const failed = runSignOut(
+      async () => {
+        throw new Error('network')
+      },
+      () => {
+        forgotten = true
+      },
+    )
+    await expect(failed()).rejects.toThrow('network')
+    expect(forgotten).toBe(false)
+  })
+})

--- a/frontend/src/auth/__tests__/protectedRoute.test.tsx
+++ b/frontend/src/auth/__tests__/protectedRoute.test.tsx
@@ -76,7 +76,7 @@ function renderGuard(
 ): string {
   const { warm = async () => {}, adminOnly = false } = props
   return renderToStaticMarkup(
-    <AuthContext.Provider value={{ ...session, refetch: async () => {} }}>
+    <AuthContext.Provider value={{ ...session, refetch: async () => {}, signOut: async () => {} }}>
       <ProtectedRoute warm={warm} adminOnly={adminOnly}>
         {PAGE}
       </ProtectedRoute>

--- a/frontend/src/components/CharacterSwitcherSheet.tsx
+++ b/frontend/src/components/CharacterSwitcherSheet.tsx
@@ -48,6 +48,9 @@ export default function CharacterSwitcherSheet({
     setSwitching(id)
     try {
       await setActiveCharacter(id)
+      // Carrying a different life changes the whole of `CurrentUser`. This POST
+      // already RETURNS that object and we throw it away — adopting it instead
+      // is #1383's item 4, not this sweep's (#1349 ledger).
       await refetch()
       onClose()
     } finally {

--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -92,6 +92,10 @@ export default function InvitationLetterPopup({
     setJoinError(null)
     try {
       await chooseFaction(factionSlug)
+      // Same as the faction page's join: the choose response is `{slug, status}`,
+      // and membership moves faction slug + capability flags together. Also what
+      // clears this letter out of `user.character.invitations` so the watcher
+      // stops re-opening the prospectus (#1383 item 1 would make it cheaper).
       await refetch()
       onClose() // advance the queue; watcher keys the popup per slug so state resets
     } catch (err) {

--- a/frontend/src/components/NavBar.tsx
+++ b/frontend/src/components/NavBar.tsx
@@ -2,12 +2,12 @@ import { NavLink } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth/AuthContext'
 import { useAdminMode } from '../auth/AdminModeContext'
-import { loginWithGoogle, logout } from '../api/auth'
+import { loginWithGoogle } from '../api/auth'
 import { useTheme } from '../hooks/useTheme'
 
 export default function NavBar() {
   const { t } = useTranslation('common')
-  const { user, refetch } = useAuth()
+  const { user, signOut } = useAuth()
   const { theme, toggle } = useTheme()
   const { adminMode, toggleAdminMode } = useAdminMode()
   const dark = theme === 'dark'
@@ -20,11 +20,6 @@ export default function NavBar() {
     { to: '/factions', label: t('nav.factions') },
     { to: '/updates', label: t('nav.updates') },
   ]
-
-  const handleLogout = async () => {
-    await logout()
-    await refetch()
-  }
 
   return (
     <nav
@@ -156,7 +151,7 @@ export default function NavBar() {
                   {t('nav.createCharacter')}
                 </NavLink>
               )}
-              <button onClick={handleLogout} className="btn-outline" style={{ padding: 'var(--space-xs) var(--space-md)' }}>
+              <button onClick={signOut} className="btn-outline" style={{ padding: 'var(--space-xs) var(--space-md)' }}>
                 {t('nav.logout')}
               </button>
             </>

--- a/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
+++ b/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
@@ -44,7 +44,7 @@ function viewer(factionSlug: string | null): CurrentUser {
 
 function render(factionSlug: string | null, onNotNow?: () => void): string {
   return renderToStaticMarkup(
-    <AuthContext.Provider value={{ user: viewer(factionSlug), loading: false, refetch: async () => {} }}>
+    <AuthContext.Provider value={{ user: viewer(factionSlug), loading: false, refetch: async () => {}, signOut: async () => {} }}>
       <MemoryRouter>
         <FeedCardInvitationLetter item={letter} onNotNow={onNotNow} />
       </MemoryRouter>

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -51,6 +51,8 @@ export default function FieldDesk() {
     setSwitching(id)
     try {
       await setActiveCharacter(id)
+      // As in CharacterSwitcherSheet: the POST already returns the refreshed
+      // `CurrentUser`; consuming it instead of re-asking is #1383 item 4.
       await refetch()
       navigate(`/characters/${id}`)
     } finally {
@@ -141,6 +143,10 @@ export default function FieldDesk() {
         <AlbescentInvitation
           lives={lives}
           onJoined={async () => {
+            // Joining Albescent moves `faction_slug`, `albescent_revealed` and
+            // the capability flags at once, and `POST /factions/choose` returns
+            // only `{slug, status}` — so the whole object has to be re-read
+            // until #1383 item 1 widens that response.
             await refetch()
             setLives(await getMyCharacters())
           }}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -163,6 +163,9 @@ export default function Home() {
         {!user && import.meta.env.DEV && (
           <div className="relative" style={{ marginTop: 'var(--space-lg)' }}>
             <button
+              // The mirror image of sign-out, and the one case that genuinely
+              // has to ask: `POST /auth/dev-login` sets the cookie and returns
+              // nothing, so `/auth/me` is the only way to learn who that is.
               onClick={async () => { await devLogin(); await refetch() }}
               className="btn-outline"
               style={{ padding: 'var(--space-xs) var(--space-md)' }}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,21 +1,8 @@
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../auth/AuthContext'
-import { logout } from '../api/auth'
 import { useTheme } from '../hooks/useTheme'
 import { useFormFactor } from '../hooks/useFormFactor'
 import DefaultSettings from './settings/mobileArchetypes/DefaultSettings'
-
-/**
- * Sign-out action, extracted so the wiring is unit-testable in a DOM-less env:
- * end the session via the existing auth client, then refetch so the app drops
- * back to the logged-out state. No new auth logic — `logout` is reused verbatim.
- */
-export function runSignOut(logout: () => Promise<void>, refetch: () => Promise<void>): () => Promise<void> {
-  return async () => {
-    await logout()
-    await refetch()
-  }
-}
 
 /**
  * Settings (#520) — a MOBILE-only surface. Desktop keeps its NavBar controls
@@ -26,7 +13,7 @@ export function runSignOut(logout: () => Promise<void>, refetch: () => Promise<v
  */
 export default function Settings() {
   const formFactor = useFormFactor()
-  const { user, refetch } = useAuth()
+  const { user, signOut } = useAuth()
   const { theme, toggle } = useTheme()
 
   if (formFactor !== 'mobile') {
@@ -38,7 +25,7 @@ export default function Settings() {
       character={user?.character ?? null}
       dark={theme === 'dark'}
       onToggleTheme={toggle}
-      onSignOut={runSignOut(logout, refetch)}
+      onSignOut={signOut}
     />
   )
 }

--- a/frontend/src/pages/characterPaths/useEditCharacter.ts
+++ b/frontend/src/pages/characterPaths/useEditCharacter.ts
@@ -112,6 +112,9 @@ export function useEditCharacter(): EditCharacterState {
         location: location || undefined,
       })
       setCharacter(updated)
+      // The edited life may BE the carried one, whose name/bio/avatar the rail
+      // and every byline draw from `/auth/me`. `updated` is a CharacterOut, not
+      // a CurrentUser, so it cannot be adopted wholesale (#1349 ledger).
       await refetch()
       navigate(`/characters/${characterId}`)
     } catch (err) {

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -337,6 +337,9 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       let refreshed: PraxisOut | null = null;
       let refreshedDuel: DuelDetailOut | null = duel;
       try {
+        // Going live runs `recalculate_members_stats`, which both moves points
+        // and delivers any newly-earned faction invitation letters — and those
+        // reach the InvitationWatcher only through `user.character.invitations`.
         await refetch();
         // Reload the praxis too: `refetch` is the AUTH refetch (points/level),
         // so it says nothing about who has now cast. The fresh member list is
@@ -499,6 +502,8 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     if (!confirmed) return;
     try {
       await leavePraxis(praxis.id);
+      // `leave_praxis` runs `recalculate_character_stats` for the leaver — the
+      // stake is gone, so score and level really move here.
       await refetch();
     } catch (err) {
       setError(extractError(err, i18n.t("forms:editPraxis.errors.leave")));

--- a/frontend/src/pages/factionDetail/useFactionDetail.ts
+++ b/frontend/src/pages/factionDetail/useFactionDetail.ts
@@ -224,6 +224,9 @@ export function useFactionDetail(
     setJoinError(null);
     try {
       await chooseFaction(slug);
+      // Membership dresses the whole site off `/auth/me` — faction slug, the
+      // level-jump allowance, `albescent_revealed`. `POST /factions/choose`
+      // answers `{slug, status}`, so nothing cheaper exists yet (#1383 item 1).
       await refetch();
       setRawStatus("member");
     } catch (err) {

--- a/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
@@ -151,7 +151,7 @@ function state(user: CurrentUser | null, viewerCanVote: boolean): PraxisDetailSt
 
 function render(element: ReactElement, user: CurrentUser | null): string {
   const html = renderToStaticMarkup(
-    <AuthContext.Provider value={{ user, loading: false, refetch: async () => {} }}>
+    <AuthContext.Provider value={{ user, loading: false, refetch: async () => {}, signOut: async () => {} }}>
       <MemoryRouter>{element}</MemoryRouter>
     </AuthContext.Provider>,
   );

--- a/frontend/src/pages/praxisDetail/usePraxisDetail.ts
+++ b/frontend/src/pages/praxisDetail/usePraxisDetail.ts
@@ -234,6 +234,8 @@ export function usePraxisDetail(idParam: string | undefined): PraxisDetailState 
       const updated = await unsubmitPraxis(praxis.id);
       setPraxis(updated);
       setShowWithdrawConfirm(false);
+      // `unsubmit_praxis` recalculates every member's stats: the points this
+      // praxis was carrying come back off the rail's score and can drop a level.
       void refetch();
     } catch (err) {
       setWithdrawError(extractError(err, t("detail.errors.withdraw")));

--- a/frontend/src/pages/settings/__tests__/defaultSettings.test.tsx
+++ b/frontend/src/pages/settings/__tests__/defaultSettings.test.tsx
@@ -4,18 +4,20 @@
  * seams the screen wires to, not synthetic clicks:
  *   - the dark-mode toggle delegates to `useTheme`'s `nextTheme`/`applyTheme`,
  *     which flip the real `[data-theme]` cascade (exercised via a document shim);
- *   - sign-out runs the extracted `runSignOut`, which invokes the reused `logout`;
  *   - the render shows ONLY real controls — the parked notifications / privacy /
  *     about rows are absent (ADR-0035).
+ *
+ * Sign-out moved out of this file with #1349: the screen now passes
+ * `useAuth().signOut` straight through, and the wiring it used to assert here is
+ * covered where it now lives — `auth/__tests__/authRefetchLedger.test.ts`.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 // Initialize the i18n catalog so shared copy keys resolve to English text.
 import '../../../i18n'
 import DefaultSettings from '../mobileArchetypes/DefaultSettings'
-import { runSignOut } from '../../Settings'
 import { nextTheme, applyTheme } from '../../../hooks/useTheme'
 import type { CharacterOut } from '../../../api/auth'
 
@@ -124,12 +126,3 @@ describe('mobile Settings — dark-mode toggle flips [data-theme]', () => {
   })
 })
 
-describe('mobile Settings — sign out invokes logout', () => {
-  it('runSignOut ends the session via the reused auth client, then refetches', async () => {
-    const logout = vi.fn().mockResolvedValue(undefined)
-    const refetch = vi.fn().mockResolvedValue(undefined)
-    await runSignOut(logout, refetch)()
-    expect(logout).toHaveBeenCalledOnce()
-    expect(refetch).toHaveBeenCalledOnce()
-  })
-})

--- a/frontend/src/pages/settings/mobileArchetypes/DefaultSettings.tsx
+++ b/frontend/src/pages/settings/mobileArchetypes/DefaultSettings.tsx
@@ -10,7 +10,7 @@ export interface DefaultSettingsProps {
   dark: boolean
   /** Reused verbatim from `useTheme().toggle` — flips `[data-theme]` + persists. */
   onToggleTheme: () => void
-  /** Reused auth sign-out (`logout()` + refetch). */
+  /** Reused auth sign-out — `useAuth().signOut`. */
   onSignOut: () => void
 }
 


### PR DESCRIPTION
## The measurement first — the "16 across 12" is a coincidence, not the same sixteen

`git grep` for a bare `refetch` destructured from `useAuth()`, comments stripped:

| | before this PR | after |
|---|---|---|
| call sites | **16** | **14** |
| files | **12** | **10** |

The headline number is unchanged from the issue body, but **not the same set**. `components/vote/useVote.ts` is gone — #1382 (PR #1489) retired the per-star reload the title names — and `components/feed/FeedCardInvitationLetter.tsx` arrived on 2026-07-31 with #1424's Accept button. One out, one in.

So: **1 of the original 16 was already deleted upstream. This PR deletes 2 more. The remaining 13 are justified, not changed.**

## What is actually left, traced end to end

Every surviving site was traced into the service that answers its mutation:

**8 are `identity-changed` — the payload genuinely moved and nothing cheaper exists.**
`submit_praxis` → `recalculate_members_stats` (points, level, *and* `_deliver_earned_invitations`, which reach the InvitationWatcher only via `user.character.invitations`); `unsubmit_praxis` → recalc for every member; `leave_praxis` → `recalculate_character_stats` for the leaver; create/edit/delete character change or re-resolve the carried life; `POST /auth/dev-login` returns nothing, so `/auth/me` is the only way to learn who signed in.

**6 are `response-in-hand` — and they are #1383's to delete, not this sweep's.**
Two discard the `CurrentUser` that `POST /me/active-character` already returns (`routers/me.py:44-51`); four follow `POST /factions/choose`, which answers `{slug, status}`. The owner's own comment on #1349 assigns both to #1383 ("Consuming it is part of #1383"), and #1383 item 1 + item 4 name these exact six lines. Left alone deliberately.

**2 were neither — and those are deleted.** `NavBar` and `Settings` both ran `logout()` then `refetch()`. That second call asks a question the client had already answered: the cookie is gone, so `/auth/me` can only 401 — and `/auth/me` is in `SESSION_PROBES` (`api/axios.ts`) precisely so that 401 is swallowed rather than bouncing the viewer. It cost a full round trip to arrive at the `user = null` the caller had just caused.

### What keeps the data fresh instead

Nothing goes stale: `AuthContext.signOut` sets **the same two things** the failed probe would have set — `setUser(null)` and `rememberSession(false)` — without the request. If `logout()` itself fails, the viewer is *not* forgotten (the session is still live, so the old state is the correct one); a test pins that.

## The two upstream fixes I did not re-propose

Both were checked and are unavailable, per #1390's agent and the owner's rescope: memoising in `AuthProvider` cannot work (a post-mutation `/auth/me` is *correctly* a new object), and splitting `CurrentUser` into stable/volatile halves was killed in the #1349 rescope. Dependency narrowing (#1390/#1392) is already the repo idiom and already ratcheted.

## The seam I tested at

**Source, not behaviour** — and the PR says so because the harness cannot do otherwise. Vitest runs in `node` with no jsdom; the harness is `renderToStaticMarkup` and effects never run, so **nothing in this repo can assert "one request instead of two"**, and I did not write a test that pretends to.

New: `frontend/src/auth/__tests__/authRefetchLedger.test.ts` — same posture as `hooks/__tests__/authDepNarrowing.test.ts`. It walks `src/`, finds every file that destructures a bare `refetch` off `useAuth()`, counts the calls with comments stripped, and diffs that against a **ledger carrying a verdict and a reason per site**. That is the issue's "justify each keeper in a comment" acceptance criterion turned into a guard: a new `refetch()` fails the suite until somebody writes down why the whole identity must be re-read.

**Verified it bites**, the way #1390 and #1379 verified theirs — `git checkout origin/main -- NavBar.tsx Settings.tsx` and re-run:

```
× has no call site the ledger does not justify
    + "components/NavBar.tsx",
    + "pages/Settings.tsx",
× totals the count this sweep reports          (16, expected 14)
× routes every sign-out through AuthContext, which alone imports `logout`
    + "components/NavBar.tsx",
    + "pages/Settings.tsx",
```

3 failed / 15 passed on pre-fix sources; 18/18 on the fix.

`runSignOut` moved from `Settings.tsx` to `AuthContext.tsx` (both sign-out buttons route through the one context method now), and its DOM-less unit test moved with it.

## Verification

No browser and no dev stack here — everything below is the CI set, run locally.

- `tsc --noEmit` — clean
- `eslint src --max-warnings=0` — clean
- `vitest run` — **3535 passed / 203 files**, 0 failed
- `vite build` — ok; `npm run budget` — JS 131.1 KB, CSS 22.3 KB, within budget
- No backend change, so no pytest run and no test DB needed.

## Not done, on purpose

The 6 `response-in-hand` sites. Deleting them needs the client contract (`setUser(response)`) that #1383 item 4 owns, plus the widened `/factions/choose` of item 1 — backend work outside this agent's scope. #1349's own comment thread assigns them there. Each one now carries an inline comment naming the issue that will kill it, and the ledger records the verdict, so #1383 lands against a written-down starting position rather than a re-derivation.

Closes #1349
