### PR TITLE
Admins import tasks by CSV upload; the run-by-hand script becomes a thin CLI over the shared importer

### DIFF
--- a/backend/import_tasks_csv.py
+++ b/backend/import_tasks_csv.py
@@ -1,248 +1,106 @@
-"""
-Import tasks from a CSV file into the World Zero database.
+"""Import tasks from a CSV file into the World Zero database.
+
+A thin CLI over ``services.task_import``. Parsing, validation and insertion all
+live in that service and are shared with ``POST /admin/tasks/import-csv``, the
+admin-UI path (#1376) — do not grow a second CSV parser here.
 
 Usage:
-    python import_tasks_csv.py                               # dev, default CSV path
-    python import_tasks_csv.py path/to/tasks.csv            # dev, custom path
-    python import_tasks_csv.py --env prod                   # prod, default CSV path
-    python import_tasks_csv.py path/to/tasks.csv --env prod # prod, custom path
-    add --dry-run to any of the above to preview without writing
+    python import_tasks_csv.py path/to/tasks.csv              # dev
+    python import_tasks_csv.py path/to/tasks.csv --env prod   # prod
+    add --dry-run to any of the above to validate without writing
 
-CSV columns expected: Name, Faction, Description, Level, Points, ImagePath
+CSV columns expected: Name, Faction, Description, Level, Points
 
-Data corrections applied automatically:
-  - Faction slug typos mapped to canonical slugs: anolog → everymen, us_masters → ua
-  - "The Rotation Of Cubes In Your Mind": faction assigned to singularity
-  - "One of many Cultural Bridges": level=4, point_value=40
+The import is atomic: if any row fails validation nothing is written, and every
+failing row is listed so the file can be fixed in one pass. Legacy faction slugs
+are normalised automatically (see FACTION_ALIASES in the service) and each
+correction is reported.
 """
 
 import argparse
 import asyncio
-import csv
 import sys
 from pathlib import Path
-from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from models.account import Account, AccountStatus
-from models.character import Character, CharacterStatus
-from models.faction import Faction
 from models.roles import AccountRole, Role
-from models.task import Task, TaskStatus
 from script_utils import add_env_argument, get_settings
-
-# ---------------------------------------------------------------------------
-# Corrections
-# ---------------------------------------------------------------------------
+from services.task_import import TaskImportError, import_tasks_from_csv
 
 DEFAULT_CSV_PATH = Path.home() / "Downloads" / "W0 tasks - Unsorted.csv"
 
-# Faction slug typos / legacy slugs in the CSV → canonical slugs (ADR-0004)
-FACTION_CORRECTIONS: dict[str, str] = {
-    "anolog": "everymen",
-    "analog": "everymen",
-    "gestalt": "wow",
-    "journeymen": "ephemerists",
-    "us_masters": "ua",
-    "ua_masters": "ua",
-}
 
-# Per-task field overrides keyed by exact task name
-FIELD_OVERRIDES: dict[str, dict] = {
-    "The Rotation Of Cubes In Your Mind": {"primary_faction_slug": "singularity"},
-    "One of many Cultural Bridges":       {"level_required": 4, "point_value": 40},
-}
+async def _first_admin_account(session) -> Account | None:
+    """Any active admin account — the CLI has no signed-in user to credit."""
+    result = await session.execute(
+        select(Account)
+        .join(AccountRole, AccountRole.account_id == Account.id)
+        .join(Role, Role.id == AccountRole.role_id)
+        .where(Role.name == "admin", Account.status == AccountStatus.active)
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def parse_csv(csv_path: Path) -> list[dict[str, Any]]:
-    """Read CSV and return a list of raw row dicts."""
-    with csv_path.open(newline="", encoding="utf-8") as f:
-        return list(csv.DictReader(f))
-
-
-def apply_corrections(rows: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[str]]:
-    """
-    Normalise rows, apply faction corrections and field overrides.
-    Returns (cleaned_rows, warnings).
-    """
-    cleaned = []
-    warnings = []
-
-    for raw in rows:
-        name        = raw.get("Name", "").strip()
-        faction     = raw.get("Faction", "").strip()
-        description = raw.get("Description", "").strip() or None
-        level_raw   = raw.get("Level", "").strip()
-        points_raw  = raw.get("Points", "").strip()
-
-        if not name:
-            warnings.append("Skipped row with empty Name")
-            continue
-
-        # Apply faction slug corrections
-        if faction in FACTION_CORRECTIONS:
-            old = faction
-            faction = FACTION_CORRECTIONS[faction]
-            warnings.append(f"  [{name}] faction corrected: '{old}' → '{faction}'")
-
-        faction = faction or None  # empty string → None
-
-        # Parse level and points
-        try:
-            level = int(level_raw)
-        except ValueError:
-            level = None  # will be resolved by FIELD_OVERRIDES or flagged
-
-        try:
-            points = int(points_raw)
-        except ValueError:
-            points = None  # will be resolved by FIELD_OVERRIDES or flagged
-
-        row = {
-            "title":                name,
-            "description":          description,
-            "primary_faction_slug": faction,
-            "level_required":       level,
-            "point_value":          points,
-        }
-
-        # Apply per-task overrides
-        if name in FIELD_OVERRIDES:
-            overrides = FIELD_OVERRIDES[name]
-            row.update(overrides)
-            warnings.append(f"  [{name}] field overrides applied: {overrides}")
-
-        # Final validation — skip if still missing required numeric fields
-        if row["level_required"] is None or row["point_value"] is None:
-            warnings.append(
-                f"  SKIPPED [{name}]: missing level or points "
-                f"(level={level_raw!r}, points={points_raw!r}) — add to FIELD_OVERRIDES to include"
-            )
-            continue
-
-        cleaned.append(row)
-
-    return cleaned, warnings
-
-
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-async def run(csv_path: Path, dry_run: bool, env: str) -> None:
+async def run(csv_path: Path, dry_run: bool, env: str) -> int:
     settings = get_settings(env)
     print(f"Environment : {env}")
-    print(f"Database    : {settings.DATABASE_URL.split('@')[-1]}\n")  # host/db only, no creds
-
-    rows = parse_csv(csv_path)
-    print(f"Read {len(rows)} rows from {csv_path}\n")
-
-    tasks_data, warnings = apply_corrections(rows)
-
-    if warnings:
-        print("── Corrections & warnings ──────────────────────────────")
-        for warning in warnings:
-            print(warning)
-        print()
+    print(f"Database    : {settings.DATABASE_URL.split('@')[-1]}\n")  # host/db only
 
     engine = create_async_engine(settings.DATABASE_URL, echo=False)
     async_session = async_sessionmaker(engine, expire_on_commit=False)
 
-    async with async_session() as session:
+    try:
+        async with async_session() as session:
+            admin = await _first_admin_account(session)
+            if admin is None:
+                print("ERROR: No active admin account found in the database.")
+                return 1
 
-        # Validate faction slugs against DB
-        result = await session.execute(select(Faction.slug))
-        valid_slugs: set[str] = {row[0] for row in result.all()}
-
-        bad_slugs = {
-            task_data["primary_faction_slug"]
-            for task_data in tasks_data
-            if task_data["primary_faction_slug"] and task_data["primary_faction_slug"] not in valid_slugs
-        }
-        if bad_slugs:
-            print(f"ERROR: Unknown faction slug(s) after corrections: {bad_slugs}")
-            print("Add them to FACTION_CORRECTIONS or fix the CSV before running again.")
-            await engine.dispose()
-            sys.exit(1)
-
-        # Find admin character
-        admin_result = await session.execute(
-            select(Account)
-            .join(AccountRole, AccountRole.account_id == Account.id)
-            .join(Role, Role.id == AccountRole.role_id)
-            .where(Role.name == "admin", Account.status == AccountStatus.active)
-            .limit(1)
-        )
-        admin_account = admin_result.scalar_one_or_none()
-        if not admin_account:
-            print("ERROR: No active admin account found in the database.")
-            await engine.dispose()
-            sys.exit(1)
-
-        char_result = await session.execute(
-            select(Character)
-            .where(
-                Character.account_id == admin_account.id,
-                Character.status == CharacterStatus.active,
-            )
-            .limit(1)
-        )
-        admin_character = char_result.scalar_one_or_none()
-        if not admin_character:
-            print(f"ERROR: Admin account (id={admin_account.id}) has no active character.")
-            await engine.dispose()
-            sys.exit(1)
-
-        print(f"Creator: character '{admin_character.username}' (id={admin_character.id})\n")
-
-        # Preview / insert
-        print("── Tasks to import ─────────────────────────────────────")
-        print(f"{'#':<4} {'Title':<45} {'Faction':<14} {'Lvl':>3} {'Pts':>5}")
-        print("─" * 75)
-
-        inserted = 0
-        for row_number, task_data in enumerate(tasks_data, 1):
-            faction_display = task_data["primary_faction_slug"] or "(none)"
-            print(
-                f"{row_number:<4} {task_data['title'][:44]:<45} {faction_display:<14} "
-                f"{task_data['level_required']:>3} {task_data['point_value']:>5}"
-            )
-
-            if not dry_run:
-                task = Task(
-                    title=task_data["title"],
-                    description=task_data["description"],
-                    point_value=task_data["point_value"],
-                    level_required=task_data["level_required"],
-                    primary_faction_slug=task_data["primary_faction_slug"],
-                    created_by=admin_character.id,
-                    status=TaskStatus.active,
-                    is_task_vision_eligible=False,
+            try:
+                outcome = await import_tasks_from_csv(
+                    csv_path.read_bytes(), admin, session
                 )
-                session.add(task)
-                inserted += 1
+            except TaskImportError as exc:
+                print("Import rejected — nothing was written:\n")
+                for error in exc.errors:
+                    print(f"  {error.msg}")
+                await session.rollback()
+                return 1
 
-        print("─" * 75)
+            for warning in outcome.warnings:
+                print(f"  {warning}")
+            if outcome.warnings:
+                print()
 
-        if dry_run:
-            print(f"\nDRY RUN — {len(tasks_data)} tasks would be inserted. Nothing written.")
-        else:
-            await session.commit()
-            print(f"\n✓ Inserted {inserted} tasks successfully.")
+            for title in outcome.created_titles:
+                print(f"  {title}")
 
-    await engine.dispose()
+            # The service only flushes; committing (or not) is the caller's call,
+            # which is what makes --dry-run a real exercise of the real path.
+            if dry_run:
+                await session.rollback()
+                print(f"\nDRY RUN — {outcome.created_count} tasks would be created.")
+            else:
+                await session.commit()
+                print(f"\nInserted {outcome.created_count} tasks successfully.")
+    finally:
+        await engine.dispose()
+
+    return 0
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Import tasks from a CSV into World Zero.")
-    parser.add_argument("csv_path", nargs="?", default=str(DEFAULT_CSV_PATH), help="Path to the CSV file")
-    parser.add_argument("--dry-run", action="store_true", help="Preview without writing to the database")
+    parser.add_argument(
+        "csv_path", nargs="?", default=str(DEFAULT_CSV_PATH), help="Path to the CSV file"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Validate without writing to the database"
+    )
     add_env_argument(parser)
     args = parser.parse_args()
 
@@ -251,7 +109,7 @@ def main() -> None:
         print(f"ERROR: CSV file not found: {csv_path}")
         sys.exit(1)
 
-    asyncio.run(run(csv_path, args.dry_run, args.env))
+    sys.exit(asyncio.run(run(csv_path, args.dry_run, args.env)))
 
 
 if __name__ == "__main__":

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, File, Header, HTTPException, UploadFile
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -32,6 +32,7 @@ from schemas.admin import (
     OverviewStats,
     RoleAction,
     SuspendAction,
+    TaskImportResult,
     TaskStatusAction,
 )
 from schemas.task import TaskCreate, TaskOut
@@ -65,6 +66,11 @@ from services.admin_service import (
 )
 from services.character_stats import recalculate_character_stats
 from services.era import apply_era_reset, get_current_era_row
+from services.task_import import (
+    TaskImportError,
+    import_tasks_from_csv,
+    resolve_admin_character,
+)
 from services.scoring import compute_votes_available
 from services.auth import create_jwt
 
@@ -495,15 +501,7 @@ async def admin_create_task(
     session: AsyncSession = Depends(get_db),
 ):
     """Admin-only: create a task directly in active status."""
-    result = await session.execute(
-        select(Character)
-        .where(
-            Character.account_id == admin.id,
-            Character.status == CharacterStatus.active,
-        )
-        .limit(1)
-    )
-    character = result.scalar_one_or_none()
+    character = await resolve_admin_character(admin, session)
     if character is None:
         raise HTTPException(status_code=422, detail="Admin must have an active character.")
 
@@ -538,3 +536,30 @@ async def admin_create_task(
     await session.flush()
     await session.refresh(task)
     return await build_task_out(task, session)
+
+
+@router.post("/tasks/import-csv", response_model=TaskImportResult, status_code=201)
+async def admin_import_tasks_csv(
+    file: UploadFile = File(...),
+    admin: Account = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
+):
+    """Admin-only: bulk-create tasks from an uploaded CSV (#1376).
+
+    Atomic — either every row becomes a task or none does. Rejections come back
+    as a 422 whose ``detail`` is one ``{row, msg}`` object per failing row, so the
+    admin can fix the whole file in one pass. Nothing is added to the session
+    before validation succeeds, and ``get_db`` rolls back on the raise besides.
+    """
+    try:
+        outcome = await import_tasks_from_csv(await file.read(), admin, session)
+    except TaskImportError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=[{"row": error.row, "msg": error.msg} for error in exc.errors],
+        )
+    return TaskImportResult(
+        created_count=outcome.created_count,
+        created_titles=outcome.created_titles,
+        warnings=outcome.warnings,
+    )

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -173,6 +173,21 @@ class TaskStatusAction(BaseModel):
     status: Literal["pending", "active", "retired"]
 
 
+class TaskImportResult(BaseModel):
+    """Readout for a successful CSV task import (#1376).
+
+    Only ever returned when the whole file imported — the import is atomic, so
+    there is deliberately no partial-success shape. Failures come back as a 422
+    whose ``detail`` is one ``{row, msg}`` object per rejected row.
+    """
+
+    created_count: int
+    created_titles: list[str]
+    # Corrections applied on the way in (e.g. a legacy faction slug), so the admin
+    # sees what the importer changed and not only what it wrote.
+    warnings: list[str]
+
+
 class RoleAction(BaseModel):
     role: str = Field(..., min_length=1, max_length=50)
     action: Literal["grant", "revoke"]

--- a/backend/services/task_import.py
+++ b/backend/services/task_import.py
@@ -1,0 +1,306 @@
+"""Bulk task creation from a CSV (#1376).
+
+Owns the parse → validate → insert pipeline for admin CSV task imports. Both
+callers share this module: the admin route (``POST /admin/tasks/import-csv``,
+a browser file upload) and the standalone CLI (``backend/import_tasks_csv.py``),
+which is now a thin wrapper. There is deliberately only one CSV parser.
+
+**The import is atomic.** Every row is validated before anything is written; if
+any row fails, nothing is created and every failing row is reported at once so
+the admin can fix the whole file in a single pass. The alternative — importing
+the good rows and reporting the bad ones — makes the natural next move (fix the
+few bad rows, re-upload the file) duplicate every good row.
+
+Imported tasks are ordinary runtime-owned rows, exactly like those from
+``POST /admin/tasks``. They are **not** era config: nothing here reads or writes
+``EraConfig``, and an import must never be mistaken for era content. Validation
+deliberately mirrors the admin-create path — it reuses ``TaskCreate``, so the
+two cannot drift on ``point_value > 0`` / ``level_required >= 0``.
+"""
+
+import csv
+import io
+from dataclasses import dataclass
+
+from pydantic import ValidationError
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.account import Account
+from models.character import Character, CharacterStatus
+from models.faction import Faction
+from models.task import Task, TaskStatus, TaskType
+from schemas.task import TaskCreate
+
+# CSV columns, as written by the spreadsheet the game's tasks are drafted in.
+COLUMN_TITLE = "Name"
+COLUMN_FACTION = "Faction"
+COLUMN_DESCRIPTION = "Description"
+COLUMN_LEVEL = "Level"
+COLUMN_POINTS = "Points"
+
+REQUIRED_COLUMNS: tuple[str, ...] = (
+    COLUMN_TITLE,
+    COLUMN_FACTION,
+    COLUMN_DESCRIPTION,
+    COLUMN_LEVEL,
+    COLUMN_POINTS,
+)
+
+# The sentinel slug for a task no single faction owns. Same default as
+# POST /admin/tasks; `primary_faction_slug` is NOT NULL, so "" can never pass through.
+CROSS_FACTION_SLUG = "na"
+
+# Legacy/typo faction slugs seen in the source spreadsheet → canonical slugs
+# (ADR-0004). Corrections are reported back to the admin, never applied silently.
+FACTION_ALIASES: dict[str, str] = {
+    "anolog": "everymen",
+    "analog": "everymen",
+    "gestalt": "wow",
+    "journeymen": "ephemerists",
+    "us_masters": "ua",
+    "ua_masters": "ua",
+}
+
+# A tasks CSV is a few hundred rows of prose. Anything larger is a mistake or an
+# attack, and it is cheaper to refuse it than to parse it.
+CSV_MAX_BYTES = 2 * 1024 * 1024  # 2 MB
+
+# Spreadsheet line number of the first data row: line 1 is the header. Errors are
+# reported in these terms so "Row 7" means row 7 in the admin's spreadsheet.
+FIRST_DATA_ROW = 2
+
+
+@dataclass(frozen=True)
+class RowError:
+    """One rejected row, addressed by the line number the admin sees."""
+
+    row: int
+    msg: str
+
+
+class TaskImportError(Exception):
+    """The file cannot be imported. Carries every failing row, not just the first.
+
+    ``row`` is ``None`` for whole-file problems (bad encoding, missing column).
+    """
+
+    def __init__(self, errors: list[RowError]) -> None:
+        self.errors = errors
+        super().__init__("; ".join(error.msg for error in errors))
+
+
+@dataclass(frozen=True)
+class ParsedRow:
+    """A validated row, ready to become a Task once the faction slug checks out."""
+
+    row: int
+    task: TaskCreate
+
+
+@dataclass(frozen=True)
+class ImportOutcome:
+    """What the import did, for the admin's readout."""
+
+    created_titles: list[str]
+    warnings: list[str]
+
+    @property
+    def created_count(self) -> int:
+        return len(self.created_titles)
+
+
+def _fail(msg: str, row: int | None = None) -> TaskImportError:
+    return TaskImportError([RowError(row=row or 0, msg=msg)])
+
+
+def _decode(raw: bytes) -> str:
+    """Decode an uploaded file, tolerating the BOM Excel writes."""
+    if len(raw) > CSV_MAX_BYTES:
+        raise _fail(
+            f"File is too large ({len(raw)} bytes). "
+            f"The limit is {CSV_MAX_BYTES // (1024 * 1024)} MB."
+        )
+    if not raw.strip():
+        raise _fail("The file is empty.")
+    try:
+        # utf-8-sig strips a leading BOM if present and is plain utf-8 otherwise.
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise _fail(
+            "The file is not valid UTF-8 text. Export it from your spreadsheet as CSV."
+        )
+
+
+def _pydantic_message(exc: ValidationError) -> str:
+    """Flatten a Pydantic error into one admin-readable clause."""
+    return "; ".join(
+        f"{'.'.join(str(part) for part in error['loc']) or 'row'}: {error['msg']}"
+        for error in exc.errors()
+    )
+
+
+def parse_task_csv(raw: bytes) -> tuple[list[ParsedRow], list[str]]:
+    """Parse and validate every row. Returns (rows, warnings).
+
+    Raises :class:`TaskImportError` listing *every* invalid row. Faction slugs are
+    normalised here but only checked against the database in
+    :func:`import_tasks_from_csv`, which is where the DB is available.
+    """
+    reader = csv.DictReader(io.StringIO(_decode(raw)))
+
+    missing = [
+        column for column in REQUIRED_COLUMNS if column not in (reader.fieldnames or [])
+    ]
+    if missing:
+        raise _fail(f"Missing required column(s): {', '.join(missing)}.")
+
+    rows: list[ParsedRow] = []
+    errors: list[RowError] = []
+    warnings: list[str] = []
+    seen_titles: set[str] = set()
+
+    for offset, raw_row in enumerate(reader):
+        row_number = FIRST_DATA_ROW + offset
+        # A short row leaves later columns as None; a long one collects the extras
+        # under the None key. Both are normalised to "" rather than crashing.
+        cell = {
+            column: (raw_row.get(column) or "").strip() for column in REQUIRED_COLUMNS
+        }
+        title = cell[COLUMN_TITLE]
+
+        if not title:
+            errors.append(RowError(row_number, f"Row {row_number}: Name is required."))
+            continue
+
+        label = f'Row {row_number} ("{title}")'
+
+        if title in seen_titles:
+            errors.append(
+                RowError(row_number, f"{label}: duplicated earlier in this file.")
+            )
+            continue
+        seen_titles.add(title)
+
+        numbers: dict[str, int] = {}
+        for column, field in ((COLUMN_LEVEL, "level"), (COLUMN_POINTS, "points")):
+            try:
+                numbers[field] = int(cell[column])
+            except ValueError:
+                errors.append(
+                    RowError(
+                        row_number,
+                        f"{label}: {column} must be a whole number "
+                        f"(got {cell[column]!r}).",
+                    )
+                )
+        if len(numbers) < 2:
+            continue
+
+        faction = cell[COLUMN_FACTION]
+        if faction in FACTION_ALIASES:
+            corrected = FACTION_ALIASES[faction]
+            warnings.append(f"{label}: faction '{faction}' corrected to '{corrected}'.")
+            faction = corrected
+
+        try:
+            # Reusing TaskCreate is what keeps import and POST /admin/tasks
+            # enforcing the same invariants.
+            task = TaskCreate(
+                title=title,
+                description=cell[COLUMN_DESCRIPTION],
+                point_value=numbers["points"],
+                level_required=numbers["level"],
+                primary_faction_slug=faction or CROSS_FACTION_SLUG,
+            )
+        except ValidationError as exc:
+            errors.append(RowError(row_number, f"{label}: {_pydantic_message(exc)}"))
+            continue
+
+        rows.append(ParsedRow(row=row_number, task=task))
+
+    if errors:
+        raise TaskImportError(errors)
+    if not rows:
+        raise _fail("The file has a header but no task rows.")
+
+    return rows, warnings
+
+
+async def resolve_admin_character(
+    admin: Account, session: AsyncSession
+) -> Character | None:
+    """The character credited as an admin-authored task. ``created_by`` is NOT NULL.
+
+    Returns ``None`` rather than raising so each caller can report the failure in
+    its own vocabulary; both admin task-creation paths share this lookup so they
+    cannot disagree about which character gets the credit.
+    """
+    result = await session.execute(
+        select(Character)
+        .where(
+            Character.account_id == admin.id,
+            Character.status == CharacterStatus.active,
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def import_tasks_from_csv(
+    raw: bytes, admin: Account, session: AsyncSession
+) -> ImportOutcome:
+    """Create one active task per CSV row, or create nothing at all.
+
+    Raises :class:`TaskImportError` with every failing row; the caller maps that
+    to a response. Nothing is added to the session unless every row validates.
+    """
+    rows, warnings = parse_task_csv(raw)
+
+    character = await resolve_admin_character(admin, session)
+    if character is None:
+        raise _fail("Admin must have an active character to author imported tasks.")
+
+    known_slugs = set(
+        (await session.execute(select(Faction.slug))).scalars().all()
+    )
+    existing_titles = set(
+        (await session.execute(select(Task.title))).scalars().all()
+    )
+
+    errors: list[RowError] = []
+    for parsed in rows:
+        label = f'Row {parsed.row} ("{parsed.task.title}")'
+        if parsed.task.primary_faction_slug not in known_slugs:
+            errors.append(
+                RowError(
+                    parsed.row,
+                    f"{label}: unknown faction "
+                    f"'{parsed.task.primary_faction_slug}'.",
+                )
+            )
+        if parsed.task.title in existing_titles:
+            errors.append(RowError(parsed.row, f"{label}: a task with this name already exists."))
+    if errors:
+        raise TaskImportError(errors)
+
+    for parsed in rows:
+        session.add(
+            Task(
+                title=parsed.task.title,
+                # `description` is NOT NULL — a blank cell is "", never None.
+                description=parsed.task.description or "",
+                point_value=parsed.task.point_value,
+                level_required=parsed.task.level_required,
+                primary_faction_slug=parsed.task.primary_faction_slug,
+                task_type=TaskType.standard,
+                created_by=character.id,
+                status=TaskStatus.active,
+            )
+        )
+    await session.flush()
+
+    return ImportOutcome(
+        created_titles=[parsed.task.title for parsed in rows],
+        warnings=warnings,
+    )

--- a/backend/tests/integration/test_admin_task_import.py
+++ b/backend/tests/integration/test_admin_task_import.py
@@ -1,0 +1,461 @@
+"""Integration tests for POST /admin/tasks/import-csv (#1376).
+
+The seam under test is the **HTTP multipart boundary**: a browser file upload
+into an admin-only route. A service-level test cannot exercise the multipart
+wire contract, the ``require_admin`` gate, or the response shape the admin UI
+renders, so every test here drives the real endpoint.
+
+The import is ATOMIC — if any row fails validation, nothing is written. The
+rejection tests therefore assert on the database, not just the status code.
+"""
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.account import Account
+from models.character import Character
+from models.faction import Faction, FactionStatus
+from models.roles import AccountRole, Role
+from models.task import Task, TaskStatus, TaskType
+
+IMPORT_URL = "/admin/tasks/import-csv"
+
+HEADER = "Name,Faction,Description,Level,Points"
+
+
+async def _make_admin(account: Account, session: AsyncSession) -> None:
+    """Grant the admin role to an account."""
+    role = Role(name="admin", description="Administrator")
+    session.add(role)
+    await session.flush()
+    session.add(
+        AccountRole(account_id=account.id, role_id=role.id, granted_by=account.id)
+    )
+    await session.commit()
+
+
+def _upload(csv_text: str) -> dict:
+    """Build the multipart payload httpx sends for a browser file picker."""
+    return {"file": ("tasks.csv", csv_text.encode("utf-8"), "text/csv")}
+
+
+async def _task_titles(session: AsyncSession) -> set[str]:
+    return set((await session.execute(select(Task.title))).scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Auth guard — the one that must not be forgotten
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_admin_is_refused(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """A signed-in non-admin gets 403 and writes nothing."""
+    before = await _task_titles(db_session)
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files=_upload(f"{HEADER}\nSneaky Task,ua,Nope,0,10\n"),
+    )
+
+    assert resp.status_code == 403
+    assert await _task_titles(db_session) == before
+
+
+@pytest.mark.asyncio
+async def test_anonymous_is_refused(client: AsyncClient, db_session: AsyncSession):
+    """No credentials at all — refused before any parsing happens."""
+    before = await _task_titles(db_session)
+
+    resp = await client.post(
+        IMPORT_URL, files=_upload(f"{HEADER}\nSneaky Task,ua,Nope,0,10\n")
+    )
+
+    assert resp.status_code in (401, 403)
+    assert await _task_titles(db_session) == before
+
+
+# ---------------------------------------------------------------------------
+# Happy path — asserted by value
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_well_formed_csv_creates_exactly_those_tasks(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """Every field lands with the value the CSV named."""
+    await _make_admin(account, db_session)
+
+    csv_text = (
+        f"{HEADER}\n"
+        "Sweep The Steps,ua,Sweep them until they shine,2,30\n"
+        'Quiet Hour,,"Sit still, say nothing",0,10\n'
+    )
+
+    resp = await client.post(IMPORT_URL, headers=auth_headers, files=_upload(csv_text))
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["created_count"] == 2
+    assert body["created_titles"] == ["Sweep The Steps", "Quiet Hour"]
+
+    swept = (
+        await db_session.execute(
+            select(Task).where(Task.title == "Sweep The Steps")
+        )
+    ).scalar_one()
+    assert swept.description == "Sweep them until they shine"
+    assert swept.point_value == 30
+    assert swept.level_required == 2
+    assert swept.primary_faction_slug == "ua"
+    assert swept.status == TaskStatus.active
+    assert swept.task_type == TaskType.standard
+    assert swept.created_by == character.id
+
+    # An empty Faction column means "cross-faction", which is the `na` sentinel —
+    # the same default POST /admin/tasks applies. The column is NOT NULL, so this
+    # also guards the NULL the standalone script used to write.
+    quiet = (
+        await db_session.execute(select(Task).where(Task.title == "Quiet Hour"))
+    ).scalar_one()
+    assert quiet.primary_faction_slug == "na"
+    assert quiet.description == "Sit still, say nothing"
+    assert quiet.point_value == 10
+    assert quiet.level_required == 0
+
+
+@pytest.mark.asyncio
+async def test_empty_description_is_stored_as_empty_string(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """`description` is NOT NULL — a blank column must become '', never NULL."""
+    await _make_admin(account, db_session)
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files=_upload(f"{HEADER}\nBare Bones,ua,,1,5\n"),
+    )
+
+    assert resp.status_code == 201, resp.text
+    task = (
+        await db_session.execute(select(Task).where(Task.title == "Bare Bones"))
+    ).scalar_one()
+    assert task.description == ""
+
+
+@pytest.mark.asyncio
+async def test_legacy_faction_alias_is_corrected_and_reported(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """A known legacy slug is normalised, and the admin is told it happened."""
+    await _make_admin(account, db_session)
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files=_upload(f"{HEADER}\nOld Slug Task,us_masters,Legacy,1,15\n"),
+    )
+
+    assert resp.status_code == 201, resp.text
+    task = (
+        await db_session.execute(select(Task).where(Task.title == "Old Slug Task"))
+    ).scalar_one()
+    assert task.primary_faction_slug == "ua"
+
+    warnings = resp.json()["warnings"]
+    assert any("us_masters" in w and "ua" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Rejection — atomic, and the message names the row
+# ---------------------------------------------------------------------------
+
+
+def _messages(resp) -> list[str]:
+    return [item["msg"] for item in resp.json()["detail"]]
+
+
+@pytest.mark.asyncio
+async def test_malformed_row_rejects_the_whole_file(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """One bad row rejects every row — the import is atomic."""
+    await _make_admin(account, db_session)
+    before = await _task_titles(db_session)
+
+    csv_text = (
+        f"{HEADER}\n"
+        "Good Row One,ua,Fine,1,10\n"
+        "Bad Points,ua,Points are not a number,1,lots\n"
+        "Good Row Two,ua,Also fine,2,20\n"
+    )
+
+    resp = await client.post(IMPORT_URL, headers=auth_headers, files=_upload(csv_text))
+
+    assert resp.status_code == 422, resp.text
+    messages = _messages(resp)
+    assert len(messages) == 1
+    # Row 3 = spreadsheet line 3 (header is line 1, first data row is line 2).
+    assert "Row 3" in messages[0]
+    assert "Bad Points" in messages[0]
+    assert "lots" in messages[0]
+
+    # Nothing written — not even the two well-formed rows.
+    assert await _task_titles(db_session) == before
+
+
+@pytest.mark.asyncio
+async def test_every_bad_row_is_reported_not_just_the_first(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """The admin fixes the whole file in one pass, not one row per upload."""
+    await _make_admin(account, db_session)
+
+    csv_text = (
+        f"{HEADER}\n"
+        "Zero Points,ua,Must be positive,1,0\n"
+        "Good Row,ua,Fine,1,10\n"
+        ",ua,No name at all,1,10\n"
+        "Negative Level,ua,Must be >= 0,-1,10\n"
+    )
+
+    resp = await client.post(IMPORT_URL, headers=auth_headers, files=_upload(csv_text))
+
+    assert resp.status_code == 422, resp.text
+    messages = _messages(resp)
+    assert len(messages) == 3
+    assert any("Row 2" in m for m in messages)
+    assert any("Row 4" in m for m in messages)
+    assert any("Row 5" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_unknown_faction_slug_names_the_row(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """An unknown faction is a rejection, not a silent NULL or a FK explosion."""
+    await _make_admin(account, db_session)
+    before = await _task_titles(db_session)
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files=_upload(f"{HEADER}\nWrong Faction,not_a_faction,Nope,1,10\n"),
+    )
+
+    assert resp.status_code == 422, resp.text
+    messages = _messages(resp)
+    assert "Row 2" in messages[0]
+    assert "not_a_faction" in messages[0]
+    assert await _task_titles(db_session) == before
+
+
+@pytest.mark.asyncio
+async def test_duplicate_title_within_the_file_is_rejected(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    await _make_admin(account, db_session)
+    before = await _task_titles(db_session)
+
+    csv_text = (
+        f"{HEADER}\n"
+        "Same Name,ua,First,1,10\n"
+        "Same Name,ua,Second,2,20\n"
+    )
+
+    resp = await client.post(IMPORT_URL, headers=auth_headers, files=_upload(csv_text))
+
+    assert resp.status_code == 422, resp.text
+    assert "Row 3" in _messages(resp)[0]
+    assert await _task_titles(db_session) == before
+
+
+@pytest.mark.asyncio
+async def test_title_that_already_exists_is_rejected(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """Re-uploading a file that was already imported must not duplicate tasks."""
+    await _make_admin(account, db_session)
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files=_upload(f"{HEADER}\n{active_task.title},ua,Duplicate,1,10\n"),
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "Row 2" in _messages(resp)[0]
+
+    count = len(
+        (
+            await db_session.execute(
+                select(Task).where(Task.title == active_task.title)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_required_column_is_rejected(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """A CSV with the wrong header fails on the header, not row by row."""
+    await _make_admin(account, db_session)
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files=_upload("Name,Faction,Description,Level\nNo Points,ua,Missing,1\n"),
+    )
+
+    assert resp.status_code == 422, resp.text
+    assert "Points" in _messages(resp)[0]
+
+
+@pytest.mark.asyncio
+async def test_empty_file_is_rejected(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    await _make_admin(account, db_session)
+
+    resp = await client.post(IMPORT_URL, headers=auth_headers, files=_upload(""))
+
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_no_data_rows_is_rejected(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """A header-only file is a mistake worth naming, not a silent no-op."""
+    await _make_admin(account, db_session)
+
+    resp = await client.post(IMPORT_URL, headers=auth_headers, files=_upload(HEADER))
+
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_utf8_bom_header_is_tolerated(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """Excel writes a BOM; without utf-8-sig the first column name is mangled."""
+    await _make_admin(account, db_session)
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files={
+            "file": (
+                "tasks.csv",
+                b"\xef\xbb\xbf" + f"{HEADER}\nBOM Task,ua,From Excel,1,10\n".encode(),
+                "text/csv",
+            )
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["created_titles"] == ["BOM Task"]
+
+
+@pytest.mark.asyncio
+async def test_non_utf8_bytes_are_rejected(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """A binary file dropped into the picker fails on decode, not on insert."""
+    await _make_admin(account, db_session)
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files={"file": ("tasks.png", b"\x89PNG\r\n\x1a\n\xff\xfe\xfd", "text/csv")},
+    )
+
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_admin_without_an_active_character_is_rejected(
+    client: AsyncClient,
+    account: Account,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """`created_by` is NOT NULL — an admin with no character cannot import."""
+    await _make_admin(account, db_session)
+    db_session.add(Faction(slug="ua", status=FactionStatus.visible))
+    await db_session.commit()
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files=_upload(f"{HEADER}\nNo Author,ua,Nobody to credit,1,10\n"),
+    )
+
+    assert resp.status_code == 422, resp.text

--- a/frontend/src/api/__tests__/taskImportRowErrors.test.ts
+++ b/frontend/src/api/__tests__/taskImportRowErrors.test.ts
@@ -1,0 +1,40 @@
+/**
+ * #1376 — the CSV import panel lists every rejected row, not just the first.
+ *
+ * `extractError` only ever surfaces `detail[0].msg`, so the panel needs the full
+ * array. This guards the narrowing: a row-level 422 yields every row, and any
+ * other failure shape yields `[]` so the panel falls back to a headline message
+ * instead of rendering an empty error box.
+ */
+import { describe, it, expect } from "vitest";
+import { taskImportRowErrors } from "../admin";
+
+const rowRejection = (detail: unknown) => ({ response: { data: { detail } } });
+
+describe("taskImportRowErrors", () => {
+  it("returns every rejected row in order", () => {
+    const err = rowRejection([
+      { row: 2, msg: 'Row 2 ("Zero Points"): point_value: Input should be greater than 0' },
+      { row: 5, msg: "Row 5: Name is required." },
+    ]);
+
+    expect(taskImportRowErrors(err)).toEqual([
+      { row: 2, msg: 'Row 2 ("Zero Points"): point_value: Input should be greater than 0' },
+      { row: 5, msg: "Row 5: Name is required." },
+    ]);
+  });
+
+  it("ignores a plain-string detail — that is a headline, not a row list", () => {
+    expect(taskImportRowErrors(rowRejection("Admin access required."))).toEqual([]);
+  });
+
+  it("drops malformed entries rather than rendering undefined rows", () => {
+    const err = rowRejection([{ row: 2, msg: "Row 2: bad." }, { nope: true }, "text"]);
+    expect(taskImportRowErrors(err)).toEqual([{ row: 2, msg: "Row 2: bad." }]);
+  });
+
+  it("returns [] for a network failure with no response at all", () => {
+    expect(taskImportRowErrors(new Error("Network Error"))).toEqual([]);
+    expect(taskImportRowErrors(undefined)).toEqual([]);
+  });
+});

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -170,6 +170,48 @@ export async function adminPatchTask(id: number, patch: AdminTaskPatch): Promise
   return data
 }
 
+/** Readout for a successful CSV task import (#1376). */
+export interface TaskImportResult {
+  created_count: number
+  created_titles: string[]
+  /** Corrections applied on the way in, e.g. a legacy faction slug. */
+  warnings: string[]
+}
+
+/** One rejected CSV row, as the backend's 422 `detail` reports it. */
+export interface TaskImportRowError {
+  row: number
+  msg: string
+}
+
+/**
+ * Bulk-create tasks from a CSV. **Atomic**: on success every row became a task;
+ * on failure nothing was created and `taskImportRowErrors` lists every bad row.
+ *
+ * The Content-Type is deliberately left to the browser — setting it by hand
+ * drops the multipart boundary.
+ */
+export async function importTasksCsv(file: File): Promise<TaskImportResult> {
+  const form = new FormData()
+  form.append('file', file)
+  const { data } = await api.post<TaskImportResult>('/admin/tasks/import-csv', form)
+  return data
+}
+
+/**
+ * Every per-row rejection from a failed `importTasksCsv`, or `[]` if the failure
+ * was not a row-level one (network, 403, 500) — those go through `extractError`.
+ */
+export function taskImportRowErrors(err: unknown): TaskImportRowError[] {
+  const detail = (err as { response?: { data?: { detail?: unknown } } })?.response?.data
+    ?.detail
+  if (!Array.isArray(detail)) return []
+  return detail.filter(
+    (item): item is TaskImportRowError =>
+      typeof item?.msg === 'string' && typeof item?.row === 'number',
+  )
+}
+
 export async function moderatePraxis(
   id: number,
   status: string,

--- a/frontend/src/locales/en/admin.json
+++ b/frontend/src/locales/en/admin.json
@@ -79,6 +79,16 @@
       "cancel": "cancel"
     }
   },
+  "import": {
+    "heading": "Import tasks from CSV",
+    "columns": "Columns: Name, Faction, Description, Level, Points. Leave Faction blank for a cross-faction task.",
+    "atomicNote": "All rows import together. If any row is invalid nothing is created, and every problem is listed below so you can fix the file in one pass.",
+    "submit": "import",
+    "importing": "importing…",
+    "failed": "Could not import the file.",
+    "created": "Imported {{total}} task(s).",
+    "rejected": "Nothing was imported. {{total}} row(s) need fixing:"
+  },
   "moderation": {
     "loadError": "Couldn't load moderation data.",
     "actionError": "Moderation action failed.",

--- a/frontend/src/pages/admin/TaskImportPanel.tsx
+++ b/frontend/src/pages/admin/TaskImportPanel.tsx
@@ -1,0 +1,130 @@
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  importTasksCsv,
+  taskImportRowErrors,
+  type TaskImportResult,
+  type TaskImportRowError,
+} from "../../api/admin";
+import { extractError } from "../../utils/errors";
+
+interface Props {
+  /** Called after a successful import so the task list picks up the new rows. */
+  onImported: () => void;
+}
+
+/**
+ * Admin CSV task import (#1376).
+ *
+ * The import is atomic and the copy says so: a file with any invalid row creates
+ * nothing, and every rejected row comes back at once so the admin fixes the
+ * whole file in one pass rather than one upload per mistake.
+ *
+ * ponytail: a plain file input, no drag-and-drop and no preview grid — the issue
+ * asked for "nothing fancy" for a rarely-used surface. If imports become routine,
+ * the upgrade path is a dry-run preview endpoint (the service already separates
+ * validation from insertion, so it is a second route, not a rewrite).
+ */
+export default function TaskImportPanel({ onImported }: Props) {
+  const { t } = useTranslation(["admin", "common"]);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [result, setResult] = useState<TaskImportResult | null>(null);
+  const [rowErrors, setRowErrors] = useState<TaskImportRowError[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setResult(null);
+    setRowErrors([]);
+    setError(null);
+  };
+
+  const handleImport = async () => {
+    if (!file) return;
+    setImporting(true);
+    reset();
+    try {
+      const imported = await importTasksCsv(file);
+      setResult(imported);
+      setFile(null);
+      if (inputRef.current) inputRef.current.value = "";
+      onImported();
+    } catch (err) {
+      const rows = taskImportRowErrors(err);
+      setRowErrors(rows);
+      // Row-level rejections are already listed; only surface a headline message
+      // for the failures that are not per-row (403, network, server error).
+      if (rows.length === 0) setError(extractError(err, t("import.failed")));
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  return (
+    <div className="card px-4 py-3 mb-4 flex flex-col gap-2">
+      <p className="font-display text-lg font-bold">{t("import.heading")}</p>
+      <p className="font-body text-xs text-muted">{t("import.columns")}</p>
+      <p className="font-body text-xs text-muted">{t("import.atomicNote")}</p>
+
+      <div className="flex items-center gap-2 flex-wrap">
+        <input
+          ref={inputRef}
+          type="file"
+          accept=".csv,text/csv"
+          className="font-body text-xs"
+          onChange={(e) => {
+            setFile(e.target.files?.[0] ?? null);
+            reset();
+          }}
+        />
+        <button
+          onClick={() => void handleImport()}
+          disabled={!file || importing}
+          className="btn-primary text-xs"
+        >
+          {importing ? t("import.importing") : t("import.submit")}
+        </button>
+      </div>
+
+      {error && (
+        <p className="font-body content-text text-red-600 border-2 border-red-300 px-3 py-2">
+          {error}
+        </p>
+      )}
+
+      {rowErrors.length > 0 && (
+        <div className="border-2 border-red-300 px-3 py-2">
+          <p className="font-body content-text text-red-600">
+            {t("import.rejected", { total: rowErrors.length })}
+          </p>
+          <ul className="font-body text-xs text-red-600 list-disc pl-5 mt-1">
+            {rowErrors.map((rowError, index) => (
+              <li key={`${rowError.row}-${index}`}>{rowError.msg}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {result && (
+        <div className="border-2 border-border px-3 py-2">
+          <p className="font-body content-text">
+            {t("import.created", { total: result.created_count })}
+          </p>
+          <ul className="font-body text-xs text-muted list-disc pl-5 mt-1">
+            {result.created_titles.map((title) => (
+              <li key={title}>{title}</li>
+            ))}
+          </ul>
+          {result.warnings.length > 0 && (
+            <ul className="font-body text-xs text-muted list-disc pl-5 mt-1">
+              {result.warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/TasksTab.tsx
+++ b/frontend/src/pages/admin/TasksTab.tsx
@@ -9,6 +9,7 @@ import {
 import type { TaskOut } from "../../api/tasks";
 import { mergeAdminTaskRows } from "./adminTaskRows";
 import type { AdminTaskRow } from "./adminTaskRows";
+import TaskImportPanel from "./TaskImportPanel";
 import { extractError } from "../../utils/errors";
 
 type StatusFilter = "all" | "pending" | "active" | "retired";
@@ -127,6 +128,8 @@ export default function TasksTab() {
           {actionError}
         </p>
       )}
+
+      <TaskImportPanel onImported={refresh} />
 
       {/* Filter chips */}
       <div className="flex gap-2 mb-4">


### PR DESCRIPTION
Admins can now import tasks by uploading a CSV in the Admin → Tasks tab. The importer that already existed as a run-by-hand script is now a service that both the route and the CLI share — there is still exactly one CSV parser.

Closes #1376

## Atomicity: the import is ATOMIC

Every row is validated before anything is written. If any row fails, **nothing is created** and every failing row comes back at once, so the admin fixes the whole file in one pass.

The rejected alternative was partial import (create the good rows, report the bad ones). It makes the natural next move — fix the three bad rows, re-upload the file — duplicate every good row. The UI copy says the same thing the backend does: *"All rows import together. If any row is invalid nothing is created, and every problem is listed below so you can fix the file in one pass."*

Atomicity is structural, not a convention: nothing is added to the session until validation passes, and `get_db` rolls back on the raise anyway.

## Seam under test

**The HTTP multipart boundary.** A browser file upload into an admin-only route — a service-level test cannot exercise the multipart wire contract, the `require_admin` gate, or the response shape the UI renders. All 16 backend tests drive the real endpoint (`backend/tests/integration/test_admin_task_import.py`); the rejection tests assert on the **database**, not just the status code.

## What was reused, not rewritten

`backend/import_tasks_csv.py` (258 lines) → `backend/services/task_import.py`, and the script is now a 116-line CLI wrapper that calls the same `import_tasks_from_csv`. `--dry-run` now exercises the *real* insert path and rolls back, instead of being a separate print-only branch.

Row validation builds a `TaskCreate` — the same schema `POST /admin/tasks` uses — so the import and admin-create paths cannot drift on `point_value > 0` / `level_required >= 0`. Both paths now share one `resolve_admin_character` lookup.

## Two latent bugs the script had

Neither could ever have worked against the real schema:

- `description=None` — the column is `nullable=False`. A CSV row with a blank Description would have raised `IntegrityError`. Now `""`, matching `admin_create_task`.
- `primary_faction_slug=None` — also `nullable=False`. A blank Faction column would have raised. Now the `na` cross-faction sentinel, matching `admin_create_task`.

## Deliberate calls

- **`FIELD_OVERRIDES` dropped.** Per-task patches hardcoded for one historical spreadsheet (`"The Rotation Of Cubes In Your Mind"`, `"One of many Cultural Bridges"`). With per-row errors and a UI, the admin fixes the CSV — that is the point of the feature. `FACTION_ALIASES` (legacy slug normalisation) is kept and every correction is now *reported* to the admin rather than applied silently.
- **No era config is read or written.** Imported tasks are runtime-owned rows like any admin-created task, never era content. Nothing here touches `EraConfig`, so there is no `era.*` value to read.
- **Task Vision untouched.** The service does not set `is_task_vision_eligible`; the column default (`False`) applies, which is what the old script wrote explicitly. Still parked per SPEC §9, still off the wire per #1471.
- **`seed.py` not touched.** Checked for the field-default disagreement the brief warned about: `seed.py` copies `TaskDef.is_task_vision_eligible`, which import has no CSV column for and correctly leaves at the default. No seeding path is involved, so the early-return starvation hazard is not in play.
- **Validation matches admin-create exactly** — no extra era-level ceiling check, because the issue rules the import must enforce the same invariants as `POST /admin/tasks`, which has none.

## Trust-boundary handling

- `require_admin` on the route; the whole `/admin` surface is already gated on `user.is_admin` (#1488 / PR #1491), so the UI needs no separate hiding.
- 2 MB file cap, refused before parsing.
- `utf-8-sig` decode (Excel writes a BOM); non-UTF-8 bytes are refused on decode, not on insert.
- Header validated before any row.
- Unknown faction slug is a named rejection, not an FK explosion.
- Duplicate titles — within the file *and* against existing tasks — are rejected, so re-uploading an already-imported file cannot silently double the task list.

## What to eyeball

1. **The atomicity ruling.** Atomic, not partial. The issue said "which rows imported, which failed and why"; I read that as *per-row reporting*, delivered on the rejection path, and chose atomic commit semantics for the duplicate footgun above. Reverse it if you disagree.
2. **`FIELD_OVERRIDES` deletion** — the two hardcoded per-task fixes are gone. If that spreadsheet is still the import source, those two rows will now be rejected by name until the CSV is corrected.
3. **Error shape.** 422 with `detail: [{row, msg}]`. Chosen because the existing `extractError` already understands `detail[0].msg`, so generic callers get a sensible message free while the panel renders the full list.
4. **Row numbers are spreadsheet line numbers** — header is line 1, first data row is "Row 2".
5. **The panel's placement** — top of the Tasks tab, above the filter chips.
6. **`admin_create_task` refactor** — its inline character lookup now calls the shared helper. Small diff, but it touches an existing route; the audit wants that route moved to a service later.

## Verification

No browser tools or dev stack in this worktree — verified entirely by tests.

- Backend: **971 passed**, coverage **91.73%** (`--cov-fail-under=80`), dedicated DB `wz1376_test`.
- Frontend: `tsc --noEmit` clean (verified the compiler actually ran), `eslint --max-warnings=0` clean, **3518 vitest tests pass**, `vite build` clean, byte budget **within** (JS 131.3 KB, CSS 22.3 KB — the panel lands in the lazy `Admin` chunk).
- The `node_modules` junction was removed before finishing; main's `node_modules` verified intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
