### PR TITLE
The roster absorbs the invite chips and grows a four-state pill (#1416)

### DIFF
--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -1,31 +1,39 @@
 /**
- * Collab submission roster (#591). One shared, faction-token-themed block that
- * replaces the flat member-pill list in the composer and the plain member byline
- * on the praxis detail page. It renders the ADR-0012 lazy-consensus state live:
- * who has cast, who is still weaving, and the gate progress.
+ * Collab submission roster (#591, rebuilt #1416). One shared,
+ * faction-token-themed block that replaces the flat member-pill list in the
+ * composer and the plain member byline on the praxis detail page. It renders the
+ * ADR-0012 lazy-consensus state live: who is on the praxis, who has submitted,
+ * and the gate progress.
  *
- * State machine (derived from `members[]` — see docs/design/collab-submission):
- *   member_count < 2                    → awaiting  (S0) a crew of one
- *   cast_count === 0                    → writing   (S1) nobody cast yet
- *   0 < cast_count < member_count, I cast → waiting  (S2) my part is in, others aren't
- *   0 < cast_count < member_count, I didn't → holdout (S3) the circle waits on me
- *   cast_count === member_count         → published (S4) every part woven
+ * The consensus state machine lives in `collabGate.ts`; the row model — the
+ * merge of `members[]` and `invites[]` into four states, and the monogram
+ * derivation — lives in `rosterRows.ts`. Both are pure leaves, and both are
+ * separate modules for the same measured reason (#1397): a pure function
+ * imported from here bills its caller for `ConfirmDialog` and eight factions of
+ * confirm copy, which is what put ~5.5 KB gzip of composer on a praxis-detail
+ * route that draws no roster.
  *
- * S0 is #1274's. Below two members every consensus reading is degenerate —
- * `cast_count >= member_count` makes a lone author "published", and the bar can
- * only read 0% or 100% — so `awaiting` draws neither: just the author's row and
- * a line naming whoever was invited and has not answered.
+ * WHAT #1416 CHANGED. Invited people are now IN the roster. They used to be
+ * dashed chips drawn outside it by `InviteSearch`, and a declined invite was
+ * filtered away everywhere it appeared — so the one question this block exists
+ * to answer was split across two widgets and one silent deletion. The pill went
+ * from a boolean (`has_submitted`) to the four states in `RosterRowState`, and
+ * the rescind × moved onto the invited row it belongs to. The rows themselves
+ * lost their filled/dashed frames: done-ness now reads on the avatar and the
+ * pill, and the rows are separated by a hairline instead.
  *
  * Pure display everywhere (#646): the cast / pull-back action lives in the
  * composer footer's PublishButton, not the roster, so both the composer and the
  * read-only detail view consume this the same way. Spacing/type via Tailwind
- * utilities + --text-* tokens, not raw inline pixels (#588 lint guard).
+ * utilities and the --text- / --space- token scales, not raw inline pixels
+ * (#588 lint guard).
  *
  * Every word resolves through `collabCopy(factionSlug, key)`, so each faction
  * speaks the same states in its own voice and anything it hasn't overridden
  * falls back to the shared `editPraxis.collab.*` block (#591).
  */
 import { useState } from 'react'
+import type { CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import type {
   PraxisInviteOut,
@@ -36,13 +44,45 @@ import { factionCssVar } from '../../utils/factions'
 import ConfirmDialog from '../confirm/ConfirmDialog'
 import { kickMemberConfirm } from '../confirm/composerConfirms'
 import { collabCopy } from './collabCopy'
+import type { CollabCopyKey } from './collabCopy'
 import { deriveCollabGate } from './collabGate'
+import { RosterAvatar } from './RosterAvatar'
+import { buildRosterRows, isRowDone } from './rosterRows'
+import type { RosterRow, RosterRowState } from './rosterRows'
 
 // The consensus state machine moved to `collabGate.ts` (#1397) — it is pure, and
 // keeping it here billed every caller for this component's dialog and copy.
 // Re-exported so every existing importer still reaches it by this path.
 export { deriveCollabGate } from './collabGate'
 export type { CollabGate, CollabState } from './collabGate'
+
+/** Diameter of the row monogram. The duel side draws the same circle at 28. */
+const AVATAR_SIZE = 34
+/** The design's 6px status dot. */
+const DOT_SIZE = 6
+
+/**
+ * The ink for text sitting ON the faction's card-accent, declared once on the
+ * roster root so the filled pill can name it with a fallback.
+ *
+ * `-on-accent` (#924) is exactly this measurement — it is what ConfirmDialog's
+ * primary button reads — but EPHEMERISTS HAS NONE: #1232 deleted it when its
+ * last consumer moved to the Valley plate's own CTA pair. index.css belongs to
+ * frontend-style, so rather than mint a faction token from here the pill falls
+ * back to that faction's own sheet (`card-bg`), which is the ink index.css
+ * already measures its card family against. Restoring
+ * `--faction-ephemerists-on-accent` (plus its ACCENT_PAIRS row) is the real fix
+ * and is flagged on the PR.
+ */
+const ON_ACCENT_PROPERTY = '--roster-on-accent'
+
+/** Which copy key each of the four states speaks through. */
+const PILL_KEY_BY_STATE: Record<RosterRowState, CollabCopyKey> = {
+  filed: 'pillCast',
+  accepted: 'pillWeaving',
+  invited: 'pillInvited',
+  declined: 'pillDeclined',
+}
 
 export function CollabRoster({
   praxisType,
@@ -53,6 +93,7 @@ export function CollabRoster({
   taskPointValue,
   onKick,
   onNudge,
+  onRescindInvite,
 }: {
   /**
    * `PraxisOut.type` — the ONLY thing that decides whether this block belongs on
@@ -68,10 +109,15 @@ export function CollabRoster({
   praxisType: PraxisType
   members: readonly PraxisMemberOut[]
   /**
-   * `PraxisOut.invites`, for the `awaiting` line only: a crew of one is only
-   * legible next to who has been asked. Optional because the backend serialises
-   * invites to MEMBERS ONLY (`build_praxis_out`), so a stranger reading the
-   * detail page legitimately has none and gets the neutral fallback line.
+   * `PraxisOut.invites`. Since #1416 these are ROWS, not just the awaiting
+   * line's names: a pending invite reads Invited and a declined one reads
+   * Declined, in the same list as the members.
+   *
+   * Optional, and legitimately empty rather than merely absent: the backend
+   * serialises invites to MEMBERS ONLY (`build_praxis_out`), so a stranger
+   * reading the detail page has none. Invite rows must therefore degrade to
+   * nothing — no empty row, no crash — which they do by construction, since
+   * they exist only where the data does.
    */
   invites?: readonly PraxisInviteOut[]
   currentCharacterId: number | null | undefined
@@ -79,7 +125,7 @@ export function CollabRoster({
   taskPointValue?: number | null
   /**
    * Remove another member (#959). Receives the target's CHARACTER id. When
-   * provided, a kick × renders on every OTHER member's pill — but only if the
+   * provided, a kick × renders on every OTHER member's row — but only if the
    * viewer is themselves a member and the collab is still open, mirroring the
    * backend `kick_member` guard ("any member may kick any other, not self, and
    * only while in_progress/pending" — #1076). The confirm step lives here so
@@ -88,14 +134,25 @@ export function CollabRoster({
    */
   onKick?: (memberId: number) => void | Promise<void>
   /**
-   * Poke a member who has not cast yet (#1083). Receives the target's CHARACTER
-   * id. When provided, a Nudge button renders on every OTHER member's pill that
-   * is still weaving — but only if the VIEWER has cast, mirroring the backend
-   * rule ("any member who has cast may nudge a member who has not"): you do not
-   * get to hurry people you have not caught up with. Left undefined on the
-   * read-only detail mount, which draws no author controls at all (#646).
+   * Poke a member who has not submitted yet (#1083). Receives the target's
+   * CHARACTER id. When provided, a Nudge button renders on every OTHER member's
+   * row that is still outstanding — but only if the VIEWER has submitted,
+   * mirroring the backend rule ("any member who has cast may nudge a member who
+   * has not"): you do not get to hurry people you have not caught up with. Left
+   * undefined on the read-only detail mount, which draws no author controls at
+   * all (#646).
    */
   onNudge?: (characterId: number) => void | Promise<void>
+  /**
+   * Withdraw a still-pending invite (#421). Receives the INVITE id, not a
+   * character id — an invite is the thing being cancelled.
+   *
+   * It arrived here with #1416: the × used to live on the pending-invite chips
+   * that `InviteSearch` drew beside the roster, and absorbing those chips into
+   * the roster would otherwise have deleted the control with them. Optional for
+   * the same reason `onKick` is — the read-only detail mount passes none.
+   */
+  onRescindInvite?: (inviteId: number) => void | Promise<void>
 }) {
   const { t } = useTranslation('forms')
   // The member a kick is waiting on confirmation for (#1082). Declared before
@@ -116,11 +173,15 @@ export function CollabRoster({
   const notice = factionCssVar(factionSlug, 'card-notice')
   const credit = factionCssVar(factionSlug, 'card-credit')
   const quiet = factionCssVar(factionSlug, 'card-muted')
+  const onAccent = `var(${ON_ACCENT_PROPERTY}, ${factionCssVar(factionSlug, 'card-bg')})`
   // A crew of one has no consensus to report, so the tally chip and the bar are
   // both withheld rather than printed at their degenerate readings (#1274) —
   // which also keeps `pct` off a zero denominator on an empty roster.
   const awaiting = gate.state === 'awaiting'
   const pct = awaiting ? 0 : Math.round((gate.castCount / gate.memberCount) * 100)
+
+  // Members and invites, one ordered list (#1416). Pure, and tested as such.
+  const rows = buildRosterRows(members, invites)
 
   // Mirror the backend: only a member may kick, never themselves, and only
   // while the praxis is still open (#1076). `published` is that last condition
@@ -151,9 +212,9 @@ export function CollabRoster({
   // Who has been asked and has not answered — the whole content of `awaiting`
   // beyond the author's own row. Filtered HERE rather than at eleven call sites,
   // for the same reason the state machine lives here.
-  const pendingInvitees = (invites ?? [])
-    .filter((invite) => invite.status === 'pending')
-    .map((invite) => invite.invitee_display_name)
+  const pendingInvitees = rows
+    .filter((row) => row.state === 'invited')
+    .map((row) => row.name)
 
   const banner =
     gate.state === 'awaiting'
@@ -176,19 +237,35 @@ export function CollabRoster({
           : null
 
   return (
-    <div className="flex flex-col gap-2">
-      {/* Header: label + cast progress chip. Both this and the bar below are the
-          consensus reading, which `awaiting` has nothing true to say — a tally
-          of one over one is not a gate anybody is waiting on. */}
-      {!awaiting && (
-        <div className="flex items-center gap-2" style={{ justifyContent: 'space-between' }}>
+    <div
+      className="flex flex-col gap-2"
+      style={{ [ON_ACCENT_PROPERTY]: factionCssVar(factionSlug, 'on-accent') } as CSSProperties}
+    >
+      {/* Panel header (#1416): the block names itself and reports the gate on
+          one row. `Collaborators · N` used to be the ComposerSection label at
+          nine separate mounts, which meant the heading and the tally could —
+          and did — disagree about how many people were on the praxis.
+
+          N counts MEMBERS, not rows: an invited or declined row is somebody who
+          has been asked, not somebody who is on it, and the tally beside it
+          reads out of the same denominator. */}
+      <div className="flex items-center justify-between gap-2">
+        <span className="eyebrow text-[10px]" style={{ color: 'var(--color-text-secondary)' }}>
+          {t('editPraxis.composer.collaboratorsLabel', { count: gate.memberCount })}
+        </span>
+        {/* `awaiting` has nothing true to say here — a tally of one over one is
+            not a gate anybody is waiting on (#1274). */}
+        {!awaiting && (
           <span className="eyebrow text-[10px]" style={{ color: 'var(--color-text-secondary)' }}>
             {collabCopy(factionSlug, 'castStatus', { cast: gate.castCount, total: gate.memberCount })}
           </span>
-        </div>
-      )}
+        )}
+      </div>
 
-      {/* Progress bar */}
+      {/* Progress bar. The design draws none, and #1416 asked for that to be a
+          decision rather than an omission: it stays. It is the only glanceable
+          reading of the gate, and it is the element carrying `aria-valuenow` —
+          deleting it would leave a screen reader with the tally string alone. */}
       {!awaiting && (
         <div
           role="progressbar"
@@ -203,105 +280,117 @@ export function CollabRoster({
       )}
 
       {/* Roster rows */}
-      <div className="flex flex-col gap-1">
-        {members.map((member) => {
-          const isMe = member.character_id === currentCharacterId
-          const cast = member.has_submitted
+      <div className="flex flex-col">
+        {rows.map((row, index) => {
+          const done = isRowDone(row.state)
+          const isMe =
+            row.member != null && row.member.character_id === currentCharacterId
           return (
             <div
-              key={member.id}
-              className="flex items-center gap-2 px-3 py-1"
+              key={row.key}
+              className="flex items-center"
               style={{
-                borderRadius: 4,
-                border: cast ? `1.5px solid ${accent}` : '1.5px dashed var(--color-border)',
-                // A cast row is a filled row, and the fill has to be a SURFACE.
-                // It used to be `card-muted`, which is the faction's muted TEXT
-                // ink — every other caller in the app reads it as `color:` — so
-                // the row came out as a slab of ink with the accent pill printed
-                // on it at 1.05:1 light / 1.17:1 dark (#694). `card-bg` is the
-                // faction's own sheet, and it is the surface the whole
-                // `card-{text,muted,accent}` family is already measured against,
-                // so filling with it makes the rendered pairing identical to one
-                // the token test has gated since #651.
-                background: cast ? factionCssVar(factionSlug, 'card-bg') : 'transparent',
-                // ...and once the row paints its own ground, it must paint its
-                // own ink: an inherited colour is whatever the MOUNT set, and
-                // this component has three mounts on eight sheets.
-                color: cast ? factionCssVar(factionSlug, 'card-text') : undefined,
+                gap: 'var(--space-sm)',
+                padding: 'var(--space-md) 0',
+                // Rows are separated by a hairline rather than framed
+                // individually — the state now reads on the avatar and the pill,
+                // and eight frames stacked on a faction sheet read as a table.
+                borderTop: index === 0 ? undefined : '1px solid var(--color-border)',
               }}
             >
-              <span className="font-body text-[12px]" style={{ fontWeight: cast ? 700 : 400, flex: 1 }}>
-                {member.character_display_name}
+              <RosterAvatar
+                name={row.name}
+                size={AVATAR_SIZE}
+                borderColor={done ? accent : quiet}
+                dashed={row.state === 'invited'}
+                color={done ? accent : undefined}
+              />
+
+              <span
+                className="font-body text-[13px]"
+                style={{
+                  flex: 1,
+                  minWidth: 0,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  fontWeight: done ? 700 : 400,
+                }}
+              >
+                {row.name}
                 {isMe && (
-                  <span style={{ color: cast ? quiet : 'var(--color-text-tertiary)' }}> · {collabCopy(factionSlug, 'you')}</span>
+                  <span style={{ color: quiet }}> · {collabCopy(factionSlug, 'you')}</span>
                 )}
-                {gate.state === 'published' && taskPointValue != null && (
+                {done && gate.state === 'published' && taskPointValue != null && (
                   <span style={{ color: credit, fontWeight: 700 }}> +{taskPointValue}</span>
                 )}
               </span>
-              <span className="eyebrow text-[9px]" style={{ color: cast ? accent : notice }}>
-                {cast ? `✓ ${collabCopy(factionSlug, 'pillCast')}` : collabCopy(factionSlug, 'pillWeaving')}
-              </span>
-              {/* Nudge — only on a member who is still weaving, never my own row
+
+              {/* Nudge — only on a member who has not submitted, never my own row
                   (#1083). Disabled state comes from `member.nudged_at`, which the
                   server sends and clears when the 24h window lapses; nothing
-                  about it is remembered here, so a reload cannot un-nudge it. */}
-              {canNudge && !isMe && !cast && (
+                  about it is remembered here, so a reload cannot un-nudge it.
+                  An invited/declined row has no member to nudge. */}
+              {canNudge && row.member != null && !isMe && !done && (
                 <button
                   type="button"
-                  disabled={member.nudged_at != null}
-                  onClick={() => onNudge?.(member.character_id)}
+                  disabled={row.member.nudged_at != null}
+                  onClick={() => onNudge?.(row.member!.character_id)}
                   title={collabCopy(factionSlug, 'nudgeDescription')}
                   aria-label={collabCopy(
                     factionSlug,
-                    member.nudged_at != null ? 'nudgeSentAria' : 'nudgeAria',
-                    { name: member.character_display_name },
+                    row.member.nudged_at != null ? 'nudgeSentAria' : 'nudgeAria',
+                    { name: row.name },
                   )}
-                  className="eyebrow text-[9px] px-2 py-1"
+                  className="eyebrow text-[12px]"
                   style={{
+                    padding: 'var(--space-xs) var(--space-sm)',
                     borderRadius: 4,
                     border: `1px solid ${
-                      member.nudged_at != null ? 'var(--color-border)' : accent
+                      row.member.nudged_at != null ? 'var(--color-border)' : accent
                     }`,
                     background: 'transparent',
-                    color:
-                      member.nudged_at != null
-                        ? 'var(--color-text-tertiary)'
-                        : accent,
-                    cursor: member.nudged_at != null ? 'default' : 'pointer',
+                    color: row.member.nudged_at != null ? quiet : accent,
+                    cursor: row.member.nudged_at != null ? 'default' : 'pointer',
+                    whiteSpace: 'nowrap',
                   }}
                 >
                   {collabCopy(
                     factionSlug,
-                    member.nudged_at != null ? 'nudgeSentAction' : 'nudgeAction',
+                    row.member.nudged_at != null ? 'nudgeSentAction' : 'nudgeAction',
                   )}
                 </button>
               )}
-              {/* Kick × — on every OTHER member's pill (never my own), gated to
+
+              {/* Kick × — on every OTHER member's row (never my own), gated to
                   members (#959). The glyph is an ornament; the button's name is
                   the aria-label so screen readers and the e2e locator resolve it. */}
-              {canKick && !isMe && (
-                <button
-                  type="button"
-                  onClick={() => setPendingKick(member)}
-                  aria-label={t('editPraxis.invite.kickMemberAria', {
-                    name: member.character_display_name,
-                  })}
-                  style={{
-                    background: 'transparent',
-                    border: 'none',
-                    // Follows the row: on a filled row the ground is the faction
-                    // sheet, so the glyph takes that sheet's muted ink.
-                    color: cast ? quiet : 'var(--color-text-tertiary)',
-                    cursor: 'pointer',
-                    fontSize: 'var(--text-md)',
-                    lineHeight: 1,
-                    padding: 0,
-                  }}
-                >
-                  ×
-                </button>
+              {canKick && row.member != null && !isMe && (
+                <RowGlyphButton
+                  label={t('editPraxis.invite.kickMemberAria', { name: row.name })}
+                  color={quiet}
+                  onClick={() => setPendingKick(row.member!)}
+                />
               )}
+
+              {/* Rescind × — the pending-invite chip's control, now on the row
+                  that chip became (#421, moved #1416). Only a still-pending
+                  invite can be withdrawn; a declined one is already answered. */}
+              {onRescindInvite != null && row.invite != null && row.state === 'invited' && (
+                <RowGlyphButton
+                  label={t('editPraxis.invite.rescindInviteAria', { name: row.name })}
+                  color={quiet}
+                  onClick={() => void onRescindInvite(row.invite!.id)}
+                />
+              )}
+
+              <StatusPill
+                row={row}
+                label={collabCopy(factionSlug, PILL_KEY_BY_STATE[row.state])}
+                accent={accent}
+                quiet={quiet}
+                onAccent={onAccent}
+              />
             </div>
           )
         })}
@@ -310,8 +399,9 @@ export function CollabRoster({
       {/* Per-state banner */}
       {banner && (
         <p
-          className="font-body text-[11px] px-3 py-2"
+          className="font-body text-[11px]"
           style={{
+            padding: 'var(--space-sm) var(--space-md)',
             borderRadius: 4,
             color: banner.tone,
             border: `1px solid ${banner.tone}`,
@@ -337,5 +427,96 @@ export function CollabRoster({
         />
       )}
     </div>
+  )
+}
+
+/**
+ * The four-state pill (#1416), replacing the boolean that read only submitted /
+ * not submitted.
+ *
+ * It never communicates by colour alone: every state carries its own word, the
+ * two unanswered ones are additionally DASHED, and the leading dot is
+ * `aria-hidden` ornament rather than the message.
+ */
+function StatusPill({
+  row,
+  label,
+  accent,
+  quiet,
+  onAccent,
+}: {
+  row: RosterRow
+  label: string
+  accent: string
+  quiet: string
+  onAccent: string
+}) {
+  const done = isRowDone(row.state)
+  // Asked but not answered — the two states that are not membership.
+  const unanswered = row.state === 'invited' || row.state === 'declined'
+  return (
+    <span
+      className="eyebrow text-[12px]"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 'var(--space-xs)',
+        padding: 'var(--space-xs) var(--space-sm)',
+        borderRadius: 4,
+        border: `1px ${unanswered ? 'dashed' : 'solid'} ${done ? accent : quiet}`,
+        background: done ? accent : 'transparent',
+        color: done ? onAccent : quiet,
+        whiteSpace: 'nowrap',
+        flexShrink: 0,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: DOT_SIZE,
+          height: DOT_SIZE,
+          borderRadius: '50%',
+          flexShrink: 0,
+          background: done ? 'currentColor' : unanswered ? 'transparent' : accent,
+          border: unanswered ? `1px solid ${quiet}` : undefined,
+        }}
+      />
+      {label}
+    </span>
+  )
+}
+
+/**
+ * The row's × controls — kick and rescind — which are the same button with two
+ * names. Extracted because they were literally identical apart from the label
+ * and the handler, and `sonarjs/no-identical-functions` is on.
+ */
+function RowGlyphButton({
+  label,
+  color,
+  onClick,
+}: {
+  label: string
+  color: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      style={{
+        background: 'transparent',
+        border: 'none',
+        color,
+        cursor: 'pointer',
+        fontSize: 'var(--text-xl)',
+        lineHeight: 1,
+        padding: 0,
+        flexShrink: 0,
+      }}
+    >
+      ×
+    </button>
   )
 }

--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -209,22 +209,15 @@ export function CollabRoster({
     void onKick(member.character_id)
   }
 
-  // Who has been asked and has not answered — the whole content of `awaiting`
-  // beyond the author's own row. Filtered HERE rather than at eleven call sites,
-  // for the same reason the state machine lives here.
-  const pendingInvitees = rows
-    .filter((row) => row.state === 'invited')
-    .map((row) => row.name)
-
+  // `awaiting` used to have a second line naming whoever had been invited and
+  // not answered (#1274) — it existed because those people were nowhere in the
+  // roster. They are rows now, so the line printed the same name three lines
+  // above itself; it went with the chips (#1416). What is left is the one fact
+  // rows cannot state: nobody else has joined yet.
   const banner =
     gate.state === 'awaiting'
       ? {
-          text:
-            pendingInvitees.length > 0
-              ? collabCopy(factionSlug, 'rosterAwaitingInvited', {
-                  names: pendingInvitees.join(', '),
-                })
-              : collabCopy(factionSlug, 'rosterAwaitingAlone'),
+          text: collabCopy(factionSlug, 'rosterAwaitingAlone'),
           tone: quiet,
           warn: false,
         }

--- a/frontend/src/components/collab/RosterAvatar.tsx
+++ b/frontend/src/components/collab/RosterAvatar.tsx
@@ -1,0 +1,58 @@
+/**
+ * The one monogram circle a praxis draws next to a person's name (#1416).
+ *
+ * There were two of these and the roster's redesign wanted a third: the duel
+ * waiting surface's `SideAvatar` (28px, first character only, faction-tinted)
+ * and the invite dropdown's bare dot. This is that component extracted, so the
+ * roster row and the duel side draw the same circle at two sizes rather than
+ * two circles that merely resemble each other.
+ *
+ * A LEAF on purpose — colours arrive as props rather than being resolved from a
+ * slug here. The roster paints its own state (accent when the row is done, the
+ * muted ink otherwise, dashed while an invite is unanswered); the duel side
+ * paints the SIDE's faction, never the page's. One component cannot know which,
+ * and guessing is what would have made it a third idiom instead of a shared one.
+ */
+import { rosterInitials } from './rosterRows'
+
+export function RosterAvatar({
+  name,
+  size,
+  background = 'transparent',
+  borderColor,
+  dashed = false,
+  color,
+}: {
+  /** Display name; the monogram is derived, never passed in. */
+  name: string
+  /** Diameter in px. 34 on the roster row, 28 on a duel side. */
+  size: number
+  background?: string
+  borderColor: string
+  /** An unanswered invite is drawn as a dashed outline, like its status pill. */
+  dashed?: boolean
+  color?: string
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className="flex items-center justify-center font-body"
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        flexShrink: 0,
+        background,
+        border: `1px ${dashed ? 'dashed' : 'solid'} ${borderColor}`,
+        color,
+        // The monogram is ornament next to a name that is right there in text,
+        // so it takes the label tier rather than the design's raw 13px.
+        fontSize: 'var(--text-lg)',
+        fontWeight: 700,
+        lineHeight: 1,
+      }}
+    >
+      {rosterInitials(name)}
+    </span>
+  )
+}

--- a/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
+++ b/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
@@ -112,7 +112,7 @@ describe('CollabRoster render', () => {
     const html = renderToStaticMarkup(
       <CollabRoster praxisType="collab" members={[member(1, true), member(2, false)]} currentCharacterId={1} factionSlug={null} />,
     )
-    expect(html).toContain('✓ submitted')
+    expect(html).toContain('submitted')
     expect(html).toContain('not submitted')
     expect(html).toContain('1 of 2 submitted')
   })
@@ -161,13 +161,15 @@ describe('CollabRoster — a one-member collab (#1274)', () => {
     expect(html([invite(2, 'Invitee', 'pending')])).toContain('Invitee')
   })
 
-  it('ignores answered invites', () => {
+  // The awaiting LINE names only whoever has not answered. A declined invite is
+  // now a row of its own (#1416), so it is on the page — but it is not somebody
+  // the collab is still waiting on, and the line must not say it is.
+  it('names only the unanswered in the awaiting line', () => {
     const answered = html([
       invite(2, 'Accepted One', 'accepted'),
       invite(3, 'Declined One', 'declined'),
     ])
     expect(answered).not.toContain('Accepted One')
-    expect(answered).not.toContain('Declined One')
     // …and falls back to the nobody-yet line, which the composer needs too:
     // invites are member-only on the wire, so a stranger's read view sees [].
     expect(answered).toContain('Nobody else has joined')
@@ -187,6 +189,170 @@ describe('CollabRoster — a one-member collab (#1274)', () => {
     )
     expect(lone).not.toContain('All parts submitted')
     expect(lone).not.toContain('+30')
+  })
+})
+
+/**
+ * #1416 — invites are rows, and the pill has four states.
+ *
+ * Every state is asserted, and each assertion also checks the three it is NOT:
+ * a test that only looks for its own word cannot tell "renders the right pill"
+ * from "always renders one pill".
+ */
+describe('CollabRoster — the four-state pill (#1416)', () => {
+  const PILLS = ['submitted', 'invited', 'declined'] as const
+  const render = (
+    members: PraxisMemberOut[],
+    invites: PraxisInviteOut[] = [],
+  ) =>
+    renderToStaticMarkup(
+      <CollabRoster
+        praxisType="collab"
+        members={members}
+        invites={invites}
+        currentCharacterId={1}
+        factionSlug={null}
+      />,
+    )
+
+  // "not submitted" contains "submitted", so the accepted case is read off the
+  // full pill string rather than by substring.
+  const pillsIn = (html: string) =>
+    PILLS.filter((word) => html.includes(`>${word}</span>`))
+
+  it('filed — a member who has submitted', () => {
+    const html = render([member(1, true), member(2, true)])
+    expect(pillsIn(html)).toEqual(['submitted'])
+    expect(html).not.toContain('not submitted')
+  })
+
+  it('accepted — a member who has not', () => {
+    const html = render([member(1, false), member(2, false)])
+    expect(html).toContain('not submitted')
+    expect(pillsIn(html)).toEqual([])
+  })
+
+  it('invited — a pending invite, which used to live outside the roster', () => {
+    const html = render([member(1, false)], [invite(2, 'Asked', 'pending')])
+    expect(html).toContain('Asked')
+    expect(pillsIn(html)).toEqual(['invited'])
+  })
+
+  it('declined — which used to be filtered away entirely', () => {
+    const html = render([member(1, false)], [invite(2, 'Refused', 'declined')])
+    expect(html).toContain('Refused')
+    expect(pillsIn(html)).toEqual(['declined'])
+  })
+
+  it('draws all four at once, one pill each', () => {
+    const html = render(
+      [member(1, true), member(2, false)],
+      [invite(3, 'Asked', 'pending'), invite(4, 'Refused', 'declined')],
+    )
+    expect(pillsIn(html)).toEqual(['submitted', 'invited', 'declined'])
+    expect(html).toContain('not submitted')
+  })
+
+  // The pill must not carry its state in colour alone: the two unanswered
+  // states are additionally dashed, and every state has its own word.
+  it('dashes the unanswered states', () => {
+    expect(render([member(1, false)], [invite(2, 'Asked', 'pending')])).toContain('dashed')
+    expect(render([member(1, false)], [invite(2, 'Refused', 'declined')])).toContain('dashed')
+    expect(render([member(1, true), member(2, false)])).not.toContain('dashed')
+  })
+
+  it('derives a monogram for every row', () => {
+    const html = render([member(1, false)], [invite(2, 'Ada Lovelace', 'pending')])
+    expect(html).toContain('>AL<')
+  })
+})
+
+describe('CollabRoster — the panel header (#1416)', () => {
+  const header = (members: PraxisMemberOut[]) =>
+    renderToStaticMarkup(
+      <CollabRoster
+        praxisType="collab"
+        members={members}
+        currentCharacterId={1}
+        factionSlug={null}
+      />,
+    )
+
+  // Zero is reachable: `praxisType` is the only gate, so a collab whose members
+  // have not loaded still mounts this block (#1274).
+  it('names itself at zero members, with no tally to report', () => {
+    const html = header([])
+    expect(html).toContain('Collaborators · 0')
+    expect(html).not.toContain('submitted')
+  })
+
+  it('names itself at one member, still with no tally', () => {
+    const html = header([member(1, false)])
+    expect(html).toContain('Collaborators · 1')
+    expect(html).not.toContain('of 1 submitted')
+  })
+
+  it('reports the gate beside the count once there is one', () => {
+    const html = header([member(1, true), member(2, false), member(3, false)])
+    expect(html).toContain('Collaborators · 3')
+    expect(html).toContain('1 of 3 submitted')
+  })
+
+  // The count is MEMBERS, not rows — an invited row is somebody who has been
+  // asked, and the tally beside it reads out of the same denominator.
+  it('counts members, not invites', () => {
+    const html = renderToStaticMarkup(
+      <CollabRoster
+        praxisType="collab"
+        members={[member(1, true), member(2, false)]}
+        invites={[invite(3, 'Asked', 'pending')]}
+        currentCharacterId={1}
+        factionSlug={null}
+      />,
+    )
+    expect(html).toContain('Collaborators · 2')
+    expect(html).toContain('1 of 2 submitted')
+  })
+})
+
+// The rescind × moved off the pending-invite chips and onto the invited row
+// those chips became (#421, moved #1416) — deleting the chips without it would
+// have deleted the feature.
+describe('CollabRoster rescind × visibility (#1416)', () => {
+  const rescind = () => {}
+  const html = (status: PraxisInviteOut['status']) =>
+    renderToStaticMarkup(
+      <CollabRoster
+        praxisType="collab"
+        members={[member(1, false)]}
+        invites={[invite(2, 'Asked', status)]}
+        currentCharacterId={1}
+        factionSlug={null}
+        onRescindInvite={rescind}
+      />,
+    )
+
+  it('offers the × on a still-pending invite', () => {
+    expect(html('pending')).toContain('rescind invite to Asked')
+  })
+
+  it('withholds it from an invite that has already been answered', () => {
+    expect(html('declined')).not.toContain('rescind invite to Asked')
+  })
+
+  // The read-only detail mount passes no callback and draws no author controls.
+  it('withholds it where no handler is passed', () => {
+    expect(
+      renderToStaticMarkup(
+        <CollabRoster
+          praxisType="collab"
+          members={[member(1, false)]}
+          invites={[invite(2, 'Asked', 'pending')]}
+          currentCharacterId={1}
+          factionSlug={null}
+        />,
+      ),
+    ).not.toContain('rescind invite to Asked')
   })
 })
 

--- a/frontend/src/components/collab/__tests__/rosterRows.test.ts
+++ b/frontend/src/components/collab/__tests__/rosterRows.test.ts
@@ -1,0 +1,196 @@
+/**
+ * #1416 — the roster's row model.
+ *
+ * The seam under test is the PURE half: which of the four states a given
+ * (member, invite) pair selects, and the monogram derivation. The harness is
+ * `renderToStaticMarkup` only — effects never run and a click cannot be
+ * simulated — so everything worth asserting about behaviour has to be a
+ * function, and this is it.
+ */
+import { describe, it, expect } from 'vitest'
+import type { PraxisInviteOut, PraxisMemberOut } from '../../../api/praxis'
+import { buildRosterRows, isRowDone, rosterInitials } from '../rosterRows'
+
+function member(id: number, submitted: boolean): PraxisMemberOut {
+  return {
+    id,
+    praxis_id: 1,
+    character_id: id,
+    character_display_name: `M${id}`,
+    has_submitted: submitted,
+    joined_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+function invite(
+  id: number,
+  inviteeId: number,
+  status: PraxisInviteOut['status'],
+  createdAt = '2026-01-01T00:00:00Z',
+): PraxisInviteOut {
+  return {
+    id,
+    praxis_id: 1,
+    inviter_id: 1,
+    invitee_id: inviteeId,
+    inviter_display_name: 'M1',
+    invitee_display_name: `I${inviteeId}`,
+    status,
+    created_at: createdAt,
+  }
+}
+
+describe('buildRosterRows — the four states', () => {
+  it('a submitted member is filed', () => {
+    expect(buildRosterRows([member(1, true)], [])[0]).toMatchObject({
+      state: 'filed',
+      name: 'M1',
+    })
+  })
+
+  it('a member who has not submitted is accepted', () => {
+    expect(buildRosterRows([member(1, false)], [])[0].state).toBe('accepted')
+  })
+
+  it('a pending invite is invited', () => {
+    const rows = buildRosterRows([], [invite(9, 20, 'pending')])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ state: 'invited', name: 'I20' })
+  })
+
+  // The state that did not exist before: a declined invite used to be filtered
+  // away everywhere it appeared, so a refusal read exactly like never asking.
+  it('a declined invite is declined, not dropped', () => {
+    const rows = buildRosterRows([], [invite(9, 20, 'declined')])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({ state: 'declined', name: 'I20' })
+  })
+
+  it('only filed counts as done', () => {
+    expect(isRowDone('filed')).toBe(true)
+    expect(isRowDone('accepted')).toBe(false)
+    expect(isRowDone('invited')).toBe(false)
+    expect(isRowDone('declined')).toBe(false)
+  })
+})
+
+describe('buildRosterRows — merging the two arrays', () => {
+  it('lists members first, then whoever has been asked', () => {
+    const rows = buildRosterRows(
+      [member(1, true), member(2, false)],
+      [invite(9, 30, 'pending'), invite(10, 31, 'declined')],
+    )
+    expect(rows.map((row) => row.state)).toEqual([
+      'filed',
+      'accepted',
+      'invited',
+      'declined',
+    ])
+  })
+
+  // Accepting an invite does not delete it, so every member invited into a
+  // collab still has an `accepted` invite on the wire. Drawing it would list
+  // them twice — once as a member and once as a ghost.
+  it('drops an invite whose invitee is already a member', () => {
+    const rows = buildRosterRows(
+      [member(7, false)],
+      [invite(9, 7, 'pending'), invite(10, 7, 'declined')],
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].state).toBe('accepted')
+  })
+
+  it('ignores an accepted invite even when the member row is missing', () => {
+    expect(buildRosterRows([], [invite(9, 30, 'accepted')])).toHaveLength(0)
+  })
+
+  // B1 §4: a character can hold a declined invite AND a later pending one.
+  it('newest wins — a re-invited player reads as invited', () => {
+    const rows = buildRosterRows(
+      [],
+      [
+        invite(9, 30, 'declined', '2026-01-01T00:00:00Z'),
+        invite(12, 30, 'pending', '2026-02-01T00:00:00Z'),
+      ],
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].state).toBe('invited')
+  })
+
+  it('newest wins whichever order the server sent them in', () => {
+    const rows = buildRosterRows(
+      [],
+      [
+        invite(12, 30, 'pending', '2026-02-01T00:00:00Z'),
+        invite(9, 30, 'declined', '2026-01-01T00:00:00Z'),
+      ],
+    )
+    expect(rows.map((row) => row.state)).toEqual(['invited'])
+  })
+
+  // Two invites issued in the same second are indistinguishable by timestamp,
+  // so the monotonic id breaks the tie.
+  it('breaks a timestamp tie on the invite id', () => {
+    const rows = buildRosterRows(
+      [],
+      [
+        invite(12, 30, 'pending', '2026-02-01T00:00:00Z'),
+        invite(13, 30, 'declined', '2026-02-01T00:00:00Z'),
+      ],
+    )
+    expect(rows.map((row) => row.state)).toEqual(['declined'])
+  })
+
+  // The read-only praxis-detail mount for a NON-member: the backend serialises
+  // invites to members only, so the array is legitimately empty rather than
+  // merely absent. Invite rows must degrade to nothing, not to an empty row.
+  it('degrades to members alone when invites are absent', () => {
+    expect(buildRosterRows([member(1, false)], undefined)).toHaveLength(1)
+  })
+
+  it('renders no rows at all for an empty praxis', () => {
+    expect(buildRosterRows([], undefined)).toEqual([])
+  })
+
+  it('gives members and invites non-colliding keys at the same id', () => {
+    const rows = buildRosterRows([member(1, false)], [invite(1, 30, 'pending')])
+    expect(new Set(rows.map((row) => row.key)).size).toBe(2)
+  })
+})
+
+describe('rosterInitials', () => {
+  it('takes the first and last word of a full name', () => {
+    expect(rosterInitials('Molly Sanderson')).toBe('MS')
+  })
+
+  it('skips the middle names', () => {
+    expect(rosterInitials('ada byron king lovelace')).toBe('AL')
+  })
+
+  it('gives a one-word name its first two letters', () => {
+    expect(rosterInitials('Molly')).toBe('MO')
+  })
+
+  it('survives a one-letter name', () => {
+    expect(rosterInitials('M')).toBe('M')
+  })
+
+  // Display names are free text, so punctuation must not become a monogram.
+  it('strips punctuation rather than initialling it', () => {
+    expect(rosterInitials('J.R. Tolkien')).toBe('JT')
+    expect(rosterInitials('  ~molly~  ')).toBe('MO')
+    expect(rosterInitials("O'Neill")).toBe('ON')
+  })
+
+  it('keeps non-ASCII letters', () => {
+    expect(rosterInitials('Émile Zola')).toBe('ÉZ')
+  })
+
+  it('falls back to ? for an empty or missing name', () => {
+    expect(rosterInitials('')).toBe('?')
+    expect(rosterInitials('   ')).toBe('?')
+    expect(rosterInitials('!!!')).toBe('?')
+    expect(rosterInitials(null)).toBe('?')
+    expect(rosterInitials(undefined)).toBe('?')
+  })
+})

--- a/frontend/src/components/collab/collabCopy.ts
+++ b/frontend/src/components/collab/collabCopy.ts
@@ -48,6 +48,12 @@ export type CollabCopyKey =
   | 'castStatus'
   | 'pillCast'
   | 'pillWeaving'
+  // The roster's other two states (#1416). `pillCast`/`pillWeaving` already name
+  // the two a MEMBER can be in — submitted, and on the crew but not submitted —
+  // so absorbing the invites needed only the two states that are not membership
+  // at all: asked and not answered, and asked and refused.
+  | 'pillInvited'
+  | 'pillDeclined'
   | 'you'
   | 'progressAria'
   | 'bannerWaiting'
@@ -186,6 +192,14 @@ export type CollabCopyKey =
  * non-members, for whom the backend serialises no invites at all, so the
  * fallback line has to work as a neutral statement to a stranger.
  *
+ * `pillInvited` / `pillDeclined` (#1416) join them, and the issue asks for it by
+ * name so that absorbing invites into the roster costs no faction a translation.
+ * They also earn it: an invite's status is a fact about the INVITEE — they have
+ * not answered, or they said no — and the roster speaks in the voice of the
+ * TASK's faction, which is frequently not theirs. A voiced refusal would put
+ * words in the mouth of someone who is not on this praxis at all. The two
+ * membership states stay voiced, because those people did join.
+ *
  * The `holdout*` and `completed*` blocks (#1164) are the same block finished.
  * The first says what the ADR-0012 window does to the member who has not
  * submitted — a deadline and its escape, stated once; the second is the reading
@@ -209,6 +223,8 @@ export const SHARED_DEFAULT_COLLAB_KEYS: readonly CollabCopyKey[] = [
   'duelPullBackAction',
   'rosterAwaitingAlone',
   'rosterAwaitingInvited',
+  'pillInvited',
+  'pillDeclined',
   'awaitingStatusMeta',
   'awaitingHeading',
   'awaitingBody',

--- a/frontend/src/components/collab/collabCopy.ts
+++ b/frontend/src/components/collab/collabCopy.ts
@@ -63,7 +63,6 @@ export type CollabCopyKey =
   // It replaces the banner AND the consensus readings, which are degenerate at
   // one member, so it is not a `banner*` key.
   | 'rosterAwaitingAlone'
-  | 'rosterAwaitingInvited'
   | 'castAction'
   | 'castFinalAction'
   | 'pullBackAction'
@@ -184,13 +183,13 @@ export type CollabCopyKey =
  * still override any of them; per-faction frames for this surface are a
  * follow-up wave, not a debt this one incurs.
  *
- * The two `rosterAwaiting*` lines (#1274) join them as well. They state a fact
- * about the praxis rather than address the player — nobody else is on this
- * collab yet, and here is who was invited and has not answered — which is the
- * same register as the invite chips they sit under, and the same tier as the
- * other mechanics lines here. They are also read on the PUBLIC detail page by
- * non-members, for whom the backend serialises no invites at all, so the
- * fallback line has to work as a neutral statement to a stranger.
+ * `rosterAwaitingAlone` (#1274) joins them as well. It states a fact about the
+ * praxis rather than addressing the player — nobody else is on this collab yet —
+ * which is the same tier as the other mechanics lines here. It is also read on
+ * the PUBLIC detail page by non-members, so it has to work as a neutral
+ * statement to a stranger. Its sibling `rosterAwaitingInvited`, which named the
+ * outstanding invitees, went with the invite chips in #1416: those people are
+ * roster rows now, so the line repeated a name three lines above itself.
  *
  * `pillInvited` / `pillDeclined` (#1416) join them, and the issue asks for it by
  * name so that absorbing invites into the roster costs no faction a translation.
@@ -222,7 +221,6 @@ export const SHARED_DEFAULT_COLLAB_KEYS: readonly CollabCopyKey[] = [
   'kickAction',
   'duelPullBackAction',
   'rosterAwaitingAlone',
-  'rosterAwaitingInvited',
   'pillInvited',
   'pillDeclined',
   'awaitingStatusMeta',

--- a/frontend/src/components/collab/rosterRows.ts
+++ b/frontend/src/components/collab/rosterRows.ts
@@ -1,0 +1,136 @@
+/**
+ * The roster's row model, as pure functions (#1416).
+ *
+ * The roster used to draw `members[]` only, with a boolean pill: submitted or
+ * not. Invited people were not in it at all — pending invites were dashed chips
+ * drawn OUTSIDE it by `InviteSearch`, and declined invites were filtered away
+ * everywhere. That split meant the one question the block exists to answer —
+ * "who is on this praxis and where are they up to?" — was spread across two
+ * unrelated widgets and one silent deletion.
+ *
+ * So the roster merges two arrays into one ordered list of rows, each in one of
+ * four states:
+ *
+ *   filed    — a `members[]` row with has_submitted === true
+ *   accepted — a `members[]` row with has_submitted === false
+ *   invited  — an `invites[]` row with status === 'pending'
+ *   declined — an `invites[]` row with status === 'declined'
+ *
+ * KEEP THIS MODULE A LEAF, for the same measured reason `collabGate.ts` is one
+ * (#1397): types in, plain data out, no component imports. The test file reaches
+ * these directly so it never drags `ConfirmDialog` and eight factions of confirm
+ * copy into a unit test of a string function.
+ */
+import type { PraxisInviteOut, PraxisMemberOut } from '../../api/praxis'
+
+/** The four readings a roster row can carry. */
+export type RosterRowState = 'filed' | 'accepted' | 'invited' | 'declined'
+
+export interface RosterRow {
+  /** React key. Members and invites have overlapping ids, so it is prefixed. */
+  key: string
+  state: RosterRowState
+  name: string
+  /**
+   * The member behind a `filed`/`accepted` row — the nudge button and the kick ×
+   * both need the whole record (character id, `nudged_at`), and an invite row
+   * has neither. Undefined for `invited`/`declined`.
+   */
+  member?: PraxisMemberOut
+  /**
+   * The invite behind an `invited`/`declined` row, for the rescind × (#421).
+   * Undefined for `filed`/`accepted`.
+   */
+  invite?: PraxisInviteOut
+}
+
+/**
+ * Merge members and invites into the displayed order: members first (the people
+ * actually on the praxis), then whoever has been asked, in the order the server
+ * sent them.
+ *
+ * Two dedupe rules, both about the same fact — an invite outlives its answer:
+ *
+ *  - An invite whose invitee is already a member is dropped. Accepting an invite
+ *    does not delete it, so every member of a collab that was invited into it
+ *    still has an `accepted` row on the wire; drawing it would list them twice.
+ *  - A character can hold a declined invite AND a later pending one. **Newest
+ *    wins**, so a re-invited player reads as Invited rather than as a stale
+ *    refusal. `created_at` is the order; the id breaks a tie, since it is
+ *    monotonic and the timestamps of two invites issued in the same second are
+ *    not distinguishable.
+ */
+export function buildRosterRows(
+  members: readonly PraxisMemberOut[],
+  invites: readonly PraxisInviteOut[] | undefined,
+): RosterRow[] {
+  const memberIds = new Set(members.map((member) => member.character_id))
+  const newestByInvitee = new Map<number, PraxisInviteOut>()
+
+  for (const invite of invites ?? []) {
+    if (invite.status !== 'pending' && invite.status !== 'declined') continue
+    if (memberIds.has(invite.invitee_id)) continue
+    const held = newestByInvitee.get(invite.invitee_id)
+    if (held == null || isNewer(invite, held)) {
+      newestByInvitee.set(invite.invitee_id, invite)
+    }
+  }
+
+  return [
+    ...members.map(
+      (member): RosterRow => ({
+        key: `m-${member.id}`,
+        state: member.has_submitted ? 'filed' : 'accepted',
+        name: member.character_display_name,
+        member,
+      }),
+    ),
+    ...[...newestByInvitee.values()].map(
+      (invite): RosterRow => ({
+        key: `i-${invite.id}`,
+        state: invite.status === 'pending' ? 'invited' : 'declined',
+        name: invite.invitee_display_name,
+        invite,
+      }),
+    ),
+  ]
+}
+
+function isNewer(candidate: PraxisInviteOut, held: PraxisInviteOut): boolean {
+  if (candidate.created_at !== held.created_at) {
+    return candidate.created_at > held.created_at
+  }
+  return candidate.id > held.id
+}
+
+/** A row that is done — the only state the roster paints as complete. */
+export function isRowDone(state: RosterRowState): boolean {
+  return state === 'filed'
+}
+
+/**
+ * Two-letter monogram for the avatar.
+ *
+ * Display names are free text, so this strips anything that is not a letter or
+ * a digit before splitting: `J.R. Tolkien` reads JT, not `J.T`. A single word
+ * gives its first two characters (`Molly` → MO) because one letter in a 34px
+ * circle reads as an accident. `?` is the empty case — a blank circle looks like
+ * a rendering failure, and a display name is never blank on the wire, so this is
+ * a floor rather than a state anyone should see.
+ *
+ * ponytail: no per-script handling. `toUpperCase()` is the whole
+ * internationalisation story, which is right for Latin and Cyrillic and wrong
+ * for scripts with no case and for names where the meaningful unit is not the
+ * first grapheme. The upgrade path is `Intl.Segmenter`, once a name in the wild
+ * actually breaks.
+ */
+export function rosterInitials(name: string | null | undefined): string {
+  const words = (name ?? '')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean)
+  if (words.length === 0) return '?'
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase()
+  return (words[0][0] + words[words.length - 1][0]).toUpperCase()
+}

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -183,7 +183,6 @@
       "bannerHoldout": "Waiting on you — submit your part.",
       "bannerPublished": "All parts submitted. Every member is credited.",
       "rosterAwaitingAlone": "Nobody else has joined this collab yet.",
-      "rosterAwaitingInvited": "Invited, not answered yet: {{names}}.",
       "castAction": "Submit my part",
       "castFinalAction": "Submit — this one publishes it",
       "pullBackAction": "Pull my part back",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -175,6 +175,8 @@
       "castStatus": "{{cast}} of {{total}} submitted",
       "pillCast": "submitted",
       "pillWeaving": "not submitted",
+      "pillInvited": "invited",
+      "pillDeclined": "declined",
       "you": "you",
       "progressAria": "{{cast}} of {{total}} members have submitted their part",
       "bannerWaiting": "Submitted. Waiting on the others.",

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -746,11 +746,14 @@ export default function CovenEditPraxis({ state }: Props) {
         {state.showInviteBox && (
           <ComposerSection
             label={
+              // The roster names itself now — `Collaborators · N` sits on its
+              // own header row inside the panel, beside the tally it used to
+              // disagree with (#1416). Only the duel guise of this block still
+              // needs a section label, and `undefined` drops the heading row
+              // rather than printing an empty one.
               state.duelMode
                 ? t("editPraxis.composer.opponentLabel")
-                : t("editPraxis.composer.collaboratorsLabel", {
-                    count: praxis.members.length,
-                  })
+                : undefined
             }
             rule={braidRule}
             labelStyle={labelStyle}

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -380,11 +380,14 @@ export default function DefaultEditPraxis({ state }: Props) {
         {state.showInviteBox && (
           <ComposerSection
             label={
+              // The roster names itself now — `Collaborators · N` sits on its
+              // own header row inside the panel, beside the tally it used to
+              // disagree with (#1416). Only the duel guise of this block still
+              // needs a section label, and `undefined` drops the heading row
+              // rather than printing an empty one.
               state.duelMode
                 ? t("editPraxis.composer.opponentLabel")
-                : t("editPraxis.composer.collaboratorsLabel", {
-                    count: praxis.members.length,
-                  })
+                : undefined
             }
             labelStyle={labelStyle}
           >

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -575,11 +575,14 @@ export default function EphemeristsEditPraxis({ state }: Props) {
           <ComposerSection
             rule={flute}
             label={
+              // The roster names itself now — `Collaborators · N` sits on its
+              // own header row inside the panel, beside the tally it used to
+              // disagree with (#1416). Only the duel guise of this block still
+              // needs a section label, and `undefined` drops the heading row
+              // rather than printing an empty one.
               state.duelMode
                 ? t("editPraxis.composer.opponentLabel")
-                : t("editPraxis.composer.collaboratorsLabel", {
-                    count: praxis.members.length,
-                  })
+                : undefined
             }
             labelStyle={sectionLabel}
           >

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -564,11 +564,14 @@ export default function EverymenEditPraxis({ state }: Props) {
         {state.showInviteBox && (
           <ComposerSection
             label={
+              // The roster names itself now — `Collaborators · N` sits on its
+              // own header row inside the panel, beside the tally it used to
+              // disagree with (#1416). Only the duel guise of this block still
+              // needs a section label, and `undefined` drops the heading row
+              // rather than printing an empty one.
               state.duelMode
                 ? t("editPraxis.composer.opponentLabel")
-                : t("editPraxis.composer.collaboratorsLabel", {
-                    count: praxis.members.length,
-                  })
+                : undefined
             }
             rule={dashRule}
             labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -547,11 +547,14 @@ export default function SingularityEditPraxis({ state }: Props) {
         {state.showInviteBox && (
           <ComposerSection
             label={
+              // The roster names itself now — `Collaborators · N` sits on its
+              // own header row inside the panel, beside the tally it used to
+              // disagree with (#1416). Only the duel guise of this block still
+              // needs a section label, and `undefined` drops the heading row
+              // rather than printing an empty one.
               state.duelMode
                 ? t("editPraxis.composer.opponentLabel")
-                : t("editPraxis.composer.collaboratorsLabel", {
-                    count: praxis.members.length,
-                  })
+                : undefined
             }
             rule={hairRule}
             labelStyle={{ fontFamily: FACE, color: MUTED }}

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -528,11 +528,14 @@ export default function SnideEditPraxis({ state }: Props) {
           <ComposerSection
             rule={censorStripe}
             label={
+              // The roster names itself now — `Collaborators · N` sits on its
+              // own header row inside the panel, beside the tally it used to
+              // disagree with (#1416). Only the duel guise of this block still
+              // needs a section label, and `undefined` drops the heading row
+              // rather than printing an empty one.
               state.duelMode
                 ? t("editPraxis.composer.opponentLabel")
-                : t("editPraxis.composer.collaboratorsLabel", {
-                    count: praxis.members.length,
-                  })
+                : undefined
             }
             labelStyle={{ color: MUTED }}
           >

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -406,11 +406,14 @@ export default function UaEditPraxis({ state }: Props) {
         {state.showInviteBox && (
           <ComposerSection
             label={
+              // The roster names itself now — `Collaborators · N` sits on its
+              // own header row inside the panel, beside the tally it used to
+              // disagree with (#1416). Only the duel guise of this block still
+              // needs a section label, and `undefined` drops the heading row
+              // rather than printing an empty one.
               state.duelMode
                 ? t("editPraxis.composer.opponentLabel")
-                : t("editPraxis.composer.collaboratorsLabel", {
-                    count: praxis.members.length,
-                  })
+                : undefined
             }
             rule={rule}
             labelStyle={labelStyle}

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -477,11 +477,14 @@ export default function WowEditPraxis({ state }: Props) {
         {state.showInviteBox && (
           <ComposerSection
             label={
+              // The roster names itself now — `Collaborators · N` sits on its
+              // own header row inside the panel, beside the tally it used to
+              // disagree with (#1416). Only the duel guise of this block still
+              // needs a section label, and `undefined` drops the heading row
+              // rather than printing an empty one.
               state.duelMode
                 ? t("editPraxis.composer.opponentLabel")
-                : t("editPraxis.composer.collaboratorsLabel", {
-                    count: praxis.members.length,
-                  })
+                : undefined
             }
             rule={<Zig id="invite" />}
             labelStyle={LABEL_STYLE}

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/InviteSearch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/InviteSearch.test.tsx
@@ -86,18 +86,21 @@ describe("InviteSearch — the duel chip names the other side (#1226)", () => {
  * #1274 — the composer's collab block for a crew of ONE.
  *
  * Two facts have to survive together on this surface, which is why they are
- * asserted in one place: the roster now renders (it is gated on `type`, and a
- * collab is a collab at one member), and the pending-invite chip path still
- * draws the person who was asked. The chip is what the roster's `awaiting` line
- * defers to here — the composer is the one mount that withholds `invites` from
- * `CollabRoster`, because printing the same name twice, once without the
- * rescind ×, would be worse than the bug.
+ * asserted in one place: the roster renders (it is gated on `type`, and a collab
+ * is a collab at one member), and the person who was asked is still drawn, with
+ * the rescind × still reachable.
+ *
+ * #1416 changed WHERE. The pending-invite chips this file was written against
+ * are gone: the roster draws invited and declined as rows of its own and carries
+ * the rescind ×, so the composer now passes `invites` like every other mount.
+ * The old comment here defended the chips on the grounds that the roster would
+ * otherwise print the same name twice — which was true, and the fix was to stop
+ * printing it in two widgets rather than to withhold data from one of them.
  *
  * `praxis.invites` reaches this render straight from `GET /praxes/:id`, which
  * the composer re-fetches after `inviteToPraxis` resolves (`useEditPraxis`
  * `sendInvite`). The backend serialises `invites` to MEMBERS ONLY
- * (`build_praxis_out`), which is why the read page's roster carries the line
- * itself and a stranger sees the neutral fallback.
+ * (`build_praxis_out`), which is why a stranger's read view has none at all.
  */
 function member(characterId: number, name: string): PraxisMemberOut {
   return {
@@ -143,6 +146,7 @@ function collabState(invites: PraxisInviteOut[]): EditPraxisState {
     inviteResults: [],
     inviteOpen: false,
     autoSubmitDays: 3,
+    cancelInvite: () => {},
   } as unknown as EditPraxisState;
 }
 
@@ -157,17 +161,18 @@ describe("InviteSearch — a collab whose crew is still one (#1274)", () => {
     expect(html).not.toContain("1 of 1");
   });
 
-  it("still draws the pending-invite chip and its rescind control", () => {
+  it("draws the invitee as a roster row, with the rescind control on it", () => {
     const html = chipHtml(collabState([pendingInvite("Asked Player")]));
     expect(html).toContain("Asked Player");
-    expect(html).toContain("pending");
+    expect(html).toContain("invited");
     expect(html).toContain("rescind invite to Asked Player");
   });
 
-  // The chip owns the invitee's name on this surface, so the roster must not
-  // print it a second time.
+  // The roster owns the invitee's name on this surface. Nothing else may print
+  // it — not a chip beside the roster, and not the awaiting line beneath it,
+  // which is the pair of duplications #1416 collapsed.
   it("names the invitee exactly once", () => {
     const html = chipHtml(collabState([pendingInvite("Asked Player")]));
-    expect(html.split("Asked Player").length - 1).toBe(2); // chip text + aria-label
+    expect(html.split("Asked Player").length - 1).toBe(2); // row text + aria-label
   });
 });

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -158,21 +158,25 @@ export function InviteSearch({
                 )}
               </span>
             )
-          : [
-              // Live cast-status roster replaces the flat member pills (#591).
-              // `invites` is deliberately NOT passed here, and this is the only
-              // mount that withholds it (#1274): the roster's `awaiting` line
-              // names outstanding invitees, and on THIS surface they are already
-              // drawn as the pending chips immediately below — with the rescind
-              // × the line cannot offer. One fact, one place.
-              <div key="roster" style={{ flex: "1 1 100%" }}>
+          : (
+              // Live status roster replaces the flat member pills (#591) and,
+              // since #1416, the pending-invite chips that used to sit beside
+              // it. This mount used to withhold `invites` on the grounds that
+              // the chips below already named them — but the chips WERE the
+              // second place, and a declined invite had no first one. The roster
+              // now draws invited and declined as rows of its own and carries
+              // the rescind × the chips owned, so "one fact, one place" is
+              // finally true rather than merely asserted.
+              <div style={{ flex: "1 1 100%" }}>
                 <CollabRoster
                   praxisType={praxis.type}
                   members={praxis.members}
+                  invites={praxis.invites}
                   currentCharacterId={state.currentCharacterId}
                   factionSlug={praxis.task_faction_slug}
                   taskPointValue={praxis.task_point_value}
                   onKick={state.kickMember}
+                  onRescindInvite={state.cancelInvite}
                 />
                 {/* The ADR-0012 countdown, for the holdout only (#1164). It
                     renders itself to nothing for every other viewer and for a
@@ -186,46 +190,8 @@ export function InviteSearch({
                   submitProposedAt={praxis.submit_proposed_at}
                   autoSubmitDays={state.autoSubmitDays}
                 />
-              </div>,
-              ...praxis.invites
-                .filter((invite) => invite.status === "pending")
-                .map((invite) => (
-                  <span
-                    key={`i-${invite.id}`}
-                    style={{
-                      fontFamily: skin.fontFamily,
-                      fontSize: "var(--text-md)",
-                      padding: "var(--space-xs) var(--space-sm)",
-                      background: skin.pendingBg ?? "transparent",
-                      color: skin.pendingColor ?? "inherit",
-                      border: "1px dashed currentColor",
-                    }}
-                  >
-                    {invite.invitee_display_name}{" "}
-                    <em>· {t("editPraxis.invite.statusPending")}</em>
-                    {/* Inviter rescinds a still-pending invite (#421). */}
-                    <button
-                      type="button"
-                      onClick={() => void state.cancelInvite(invite.id)}
-                      aria-label={t("editPraxis.invite.rescindInviteAria", {
-                        name: invite.invitee_display_name,
-                      })}
-                      style={{
-                        background: "transparent",
-                        border: "none",
-                        color: "inherit",
-                        cursor: "pointer",
-                        fontSize: "var(--text-xl)",
-                        lineHeight: 1,
-                        padding: 0,
-                        marginLeft: "var(--space-xs)",
-                      }}
-                    >
-                      ×
-                    </button>
-                  </span>
-                )),
-            ]}
+              </div>
+            )}
       </div>
       {!challengeAttached && (duelMode || castCount === 0) && (
       <div style={{ position: "relative" }}>

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -526,7 +526,14 @@ export function ComposerStatusRow({
 }
 
 interface ComposerSectionProps {
-  label: ReactNode;
+  /**
+   * Optional since #1416: a region whose control names itself draws no heading
+   * row at all, rather than an empty one that still spends its margins. The
+   * collab roster is the live case — it grew its own `Collaborators · N` header
+   * beside the tally, so nine mounts stopped passing a label rather than
+   * printing the count twice and letting the two disagree.
+   */
+  label?: ReactNode;
   /** The right-hand end of the label row — a counter, a word count, a hint. */
   meta?: ReactNode;
   /**
@@ -561,36 +568,46 @@ export function ComposerSection({
   children,
 }: ComposerSectionProps) {
   const heading = composerLabelStyle(labelStyle);
+  // No label and no meta means no heading row. The rule above it still draws:
+  // it separates the regions, and that is not the label's job — but the rule
+  // carries no margin of its own (the heading row was supplying the whole gap),
+  // so an unheaded section stands the control off the hairline itself.
+  const headed = label != null || meta != null;
   return (
     <section style={style}>
       {rule === false ? null : (rule ?? <ComposerRule />)}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "baseline",
-          justifyContent: "space-between",
-          gap: "var(--space-md)",
-          margin:
-            rule === false
-              ? "0 0 var(--space-md)"
-              : "var(--space-lg) 0 var(--space-md)",
-        }}
-      >
-        {htmlFor ? (
-          <label htmlFor={htmlFor} style={heading}>
-            {label}
-          </label>
-        ) : (
-          <span style={heading}>{label}</span>
-        )}
-        {meta != null && (
-          <span
-            style={composerLabelStyle({ letterSpacing: "0.06em", ...metaStyle })}
-          >
-            {meta}
-          </span>
-        )}
-      </div>
+      {!headed && rule !== false && (
+        <div aria-hidden style={{ height: "var(--space-lg)" }} />
+      )}
+      {headed && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            justifyContent: "space-between",
+            gap: "var(--space-md)",
+            margin:
+              rule === false
+                ? "0 0 var(--space-md)"
+                : "var(--space-lg) 0 var(--space-md)",
+          }}
+        >
+          {htmlFor ? (
+            <label htmlFor={htmlFor} style={heading}>
+              {label}
+            </label>
+          ) : (
+            <span style={heading}>{label}</span>
+          )}
+          {meta != null && (
+            <span
+              style={composerLabelStyle({ letterSpacing: "0.06em", ...metaStyle })}
+            >
+              {meta}
+            </span>
+          )}
+        </div>
+      )}
       {children}
     </section>
   );

--- a/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
+++ b/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
@@ -92,6 +92,7 @@ import { Link } from "react-router-dom";
 import type { DuelSideOut } from "../../../api/duel";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
 import { collabCopy } from "../../../components/collab/collabCopy";
+import { RosterAvatar } from "../../../components/collab/RosterAvatar";
 import { duelSides } from "../../../components/duel/shared";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
 import { useGameConfig } from "../../../hooks/useGameConfig";
@@ -263,23 +264,14 @@ export function CollabPublishClock({
 
 function SideAvatar({ side }: { side: DuelSideOut }) {
   return (
-    <span
-      className="flex items-center justify-center"
-      style={{
-        width: 28,
-        height: 28,
-        borderRadius: "50%",
-        flexShrink: 0,
-        // The SIDE's own faction, never the page's: a duel is the one place two
-        // factions share a surface, and the avatar is who is speaking.
-        background: factionCssVar(side.faction_slug, "light"),
-        border: `1px solid ${factionCssVar(side.faction_slug, "border")}`,
-        fontSize: "var(--text-md)",
-        fontWeight: 700,
-      }}
-    >
-      {side.display_name.charAt(0).toUpperCase()}
-    </span>
+    <RosterAvatar
+      name={side.display_name}
+      size={28}
+      // The SIDE's own faction, never the page's: a duel is the one place two
+      // factions share a surface, and the avatar is who is speaking.
+      background={factionCssVar(side.faction_slug, "light")}
+      borderColor={factionCssVar(side.faction_slug, "border")}
+    />
   );
 }
 
@@ -609,19 +601,13 @@ export default function PraxisWaitingSurface({
           )}
         </section>
 
-        {/* Who else is outstanding, under the composer's own section label —
-            `Collaborators · N` or `Opponent`, the same words the composer used
-            for the same block a moment ago. The collab reuses the roster
-            unchanged: it is the same component the composer and the read page
-            already mount, and it takes the faction slug itself. */}
+        {/* Who else is outstanding. The collab reuses the roster unchanged: it
+            is the same component the composer and the read page already mount,
+            and it takes the faction slug itself — including, since #1416, its
+            own `Collaborators · N` header, which is why only the duel guise
+            still passes a section label here. */}
         <ComposerSection
-          label={
-            isDuel
-              ? t("editPraxis.composer.opponentLabel")
-              : t("editPraxis.composer.collaboratorsLabel", {
-                  count: praxis.members.length,
-                })
-          }
+          label={isDuel ? t("editPraxis.composer.opponentLabel") : undefined}
           rule={rule("roster")}
           labelStyle={dress.labelStyle}
         >


### PR DESCRIPTION
Rebuilds `CollabRoster` to the design in #1409: invites become rows, the boolean pill becomes four states, every row gets an initials monogram, and the block grows its own header.

Closes #1416

## The seam I tested at

The **pure** half — `components/collab/rosterRows.ts`, a leaf with no component imports (same reason `collabGate.ts` is one, #1397). `buildRosterRows(members, invites)` picks the state; `rosterInitials(name)` derives the monogram. The harness is `renderToStaticMarkup` only, so nothing here can test a click; what it *can* test is which of the four states a given (member, invite) pair selects, and it does, for every state including the three each case must NOT render. `CollabRoster.test.tsx` then asserts the rendered markup: all four pills, the dashed treatment on the two unanswered ones, and the header at zero / one / many.

## What I deleted

- **The pending-invite chips** in `InviteSearch` (`controls.tsx`, −38 lines) and, with them, the composer's special case that withheld `invites` from the roster. It is now the only mount that passes everything.
- **`rosterAwaitingInvited`** — the #1274 line that named the outstanding invitees. Those people are rows now, so the line printed the same name three lines above itself. One copy key, one union member, one branch.
- **`SideAvatar`'s body** in `PraxisWaitingSurface` — it is a `RosterAvatar` at 28px now. (Visible change: a duel side shows two letters instead of one.)
- The roster row's **filled/dashed frames** and the `#694` card-bg fill. Done-ness reads on the avatar and the pill; rows are separated by a hairline.
- The **`Collaborators · N` section label** at nine mounts (eight composer archetypes + the waiting surface). `ComposerSection`'s `label` is now optional and drops the whole heading row — margins included — when there is nothing to head.

## What I kept, deliberately

- **The `role="progressbar"` bar.** #1416 asked for this to be a decision rather than an omission. The design draws none, but it is the only glanceable reading of the gate and the element carrying `aria-valuenow`; deleting it leaves a screen reader with the tally string alone.
- The per-state banner, the kick × and its confirm, the `+N` credit on published rows.
- **The rescind ×.** It lived on the chips I deleted, so it moved onto the invited row via a new optional `onRescindInvite` prop — same shape as `onKick`, so the read-only detail mount passes none and draws nothing. Deleting the chips without it would have deleted a feature (#421).

## Copy: two new keys, not four

`pillCast` / `pillWeaving` already name the two states a MEMBER can be in, and eight factions voice both ("still on the clock", "still walking", "pending"). Minting `pillAccepted` would have silenced all eight on a pill they already own. So only `pillInvited` / `pillDeclined` are new — both in `SHARED_DEFAULT_COLLAB_KEYS`, so no faction owes a translation. They earn the shared tier on their own account too: an invite's status is a fact about the invitee, and the roster speaks in the TASK faction's voice, which is frequently not theirs.

## One styling question for `frontend-style`

The filled pill needs an ink for text on `card-accent`. The token family **does** carry one — `--faction-{key}-on-accent` (#924), what `ConfirmDialog`'s primary button reads — but **Ephemerists has none**: #1232 deleted it when its last consumer moved to the Valley plate's own CTA pair. I did not mint a faction token from a file that does not own `index.css`. Instead the roster declares the ink once as `--roster-on-accent` and the pill reads `var(--roster-on-accent, <card-bg>)`, so Ephemerists falls back to its own sheet.

**The real fix is one line in `index.css` plus one `ACCENT_PAIRS` row restoring `--faction-ephemerists-on-accent`.** Worth a follow-up.

## Notes for the batch

- **Not blocked by #1415 (B1)**, and built against the API as it exists today. Two things B1 will ship that this PR leaves a seam for and does not consume: the member `submitted_at` timestamp (the design's optional per-row timestamp line — out of scope here, it belongs to #1418/F3) and the bulk nudge endpoint.
- The issue's blast-radius note says the eight `praxisDetail` mounts pass **no `invites`**. **They all do** (`DefaultPraxisDetail.tsx:663` and siblings). It does not change the outcome — the backend serialises invites to members only, so a stranger's array is empty and the invite rows degrade to nothing — but the degradation is data-level, not prop-level.
- Those eight detail mounts keep their own `detail.sections.members` section head; the issue enumerated nine label sites and did not include them, and that heading is the detail page's neutral region title under ADR-0061.
- Widened footprint beyond `components/collab/**`: `pages/editPraxis/archetypes/*` (the nine label sites, `controls.tsx`, `shared.tsx`) and `waiting/PraxisWaitingSurface.tsx`. The issue mandates all of them ("do it in this PR so the two halves never disagree"); none is owned by a sibling this run.

## What to eyeball

I have no browser and no dev stack — everything below is verified by test and build only.

1. **A collab with one of each state** — filed / accepted / invited / declined stacked. Do the dashed avatar + dashed pill read as "not answered yet" rather than as a rendering fault?
2. **Ephemerists**, specifically. Its filled pill takes the `card-bg` fallback described above; every other faction takes its measured `-on-accent`.
3. **Snide and Singularity** (dark card sheets) — the row hairline is the global `--color-border` and the meta ink is now the faction's `card-muted` on every row, not just the filled ones.
4. **The nine unheaded sections.** The heading row is gone; the rule above it now stands the roster off by a single `--space-lg`. Check the collab block does not sit tighter or looser than its neighbours on each composer skin.
5. **The waiting surface's duel sides** — two-letter monograms where there was one.
6. **The praxis-detail mounts**, where "Members" now sits above the roster's own "Collaborators · N".
7. **Phone.** The row is avatar + name + up to two controls + pill; the pill is `flex-shrink: 0` and the name ellipsises, but I could not measure a real viewport. The × controls keep the sizes they had — no touch-target regression, no improvement either.

## Verification

- `tsc --noEmit` — clean
- `vitest run` — 203 files, 3554 tests, all passing (21 new in `rosterRows.test.ts`, 13 new in `CollabRoster.test.tsx`)
- `eslint src --max-warnings=0` — clean (the `no-raw-style-values` ratchet included; the new files use `--text-*` / `--space-*` throughout)
- `vite build` — ok
- `npm run budget` — JS 131.1 KB / CSS 22.3 KB, within budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)
