### PR TITLE
Fix: .filter-bar no longer clips the desktop facet popover

### DIFF
--- a/frontend/src/components/ui/FilterBar/__tests__/filterBarOverflow.test.ts
+++ b/frontend/src/components/ui/FilterBar/__tests__/filterBarOverflow.test.ts
@@ -1,0 +1,44 @@
+/**
+ * #1506 — `.filter-bar` must never clip its own overflow.
+ *
+ * `OptionPicker`'s desktop panel (`.filter-factions__popover`, shared by every
+ * facet the bar mounts — type, faction, whatever comes next) is
+ * `position: absolute` inside a `.filter-bar` descendant. An `overflow:
+ * hidden` on that ancestor clips the panel to the bar's own box, so pressing
+ * a facet trigger shows only the corner of the menu that survives the clip.
+ * That is exactly what happened live on Updates (#1506) and would happen
+ * identically on Tasks, Praxes and `admin/ModerationTab` — every `FilterBar`
+ * consumer shares this one rule.
+ *
+ * Braces prove nothing (a merge can drop an `@media` opener and still read as
+ * a match): this asserts on the DECLARATION inside the extracted `.filter-bar`
+ * rule body, not on the file merely containing the string "overflow". Reusing
+ * `ruleBodies` — the same brace-balanced extractor the contrast/token ratchets
+ * already trust — rather than inventing a second parser.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { ruleBodies, stripComments } from '../../../../utils/__tests__/cssVars'
+
+const css = stripComments(
+  readFileSync(fileURLToPath(new URL('../../../../index.css', import.meta.url)), 'utf8'),
+)
+
+describe('.filter-bar does not clip its overflow (#1506)', () => {
+  it('declares no overflow: hidden/clip that would trap an absolutely-positioned popover', () => {
+    const bodies = ruleBodies(css, '.filter-bar')
+    expect(bodies.length, '.filter-bar rule must exist').toBeGreaterThan(0)
+    for (const body of bodies) {
+      expect(body).not.toMatch(/overflow\s*:\s*(hidden|clip)\b/)
+    }
+  })
+
+  it('still rounds the spectrum strip to the bar\'s top corners', () => {
+    // Since the bar itself no longer clips, the full-bleed rainbow edge needs
+    // its own top radius or it would square off past the bar's rounded corner.
+    const bodies = ruleBodies(css, '.filter-bar__spectrum')
+    expect(bodies.length).toBeGreaterThan(0)
+    expect(bodies.some((body) => /border-(top-(left|right)-radius|radius)\s*:/.test(body))).toBe(true)
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5195,14 +5195,20 @@
 .filter-bar {
   border: 1px solid var(--color-border);
   border-radius: var(--space-md);
-  overflow: hidden;
+  /* No overflow: hidden — OptionPicker's desktop popover is an absolutely
+     positioned descendant that must escape this box. The bar's own
+     background still respects border-radius on all four corners without
+     it; only .filter-bar__spectrum below needs an explicit clip. */
   background: var(--color-bg-surface);
 }
 
-/* The spectrum edge along the top of the bar — ruling 1's ring, laid flat. */
+/* The spectrum edge along the top of the bar — ruling 1's ring, laid flat.
+   Rounded on its own top corners so it still follows the bar's radius now
+   that the bar no longer clips its children with overflow: hidden. */
 .filter-bar__spectrum {
   height: var(--filter-rail-pad);
   background: var(--faction-default-rainbow);
+  border-radius: var(--space-md) var(--space-md) 0 0;
 }
 
 .filter-bar__body {

--- a/frontend/src/utils/__tests__/cssVars.ts
+++ b/frontend/src/utils/__tests__/cssVars.ts
@@ -22,7 +22,7 @@ const CUSTOM_PROP = /(--[\w-]+)\s*:\s*([^;]+);/g;
 const VAR_REF = /var\(\s*(--[\w-]+)\s*(?:,\s*([^)]*))?\)/;
 
 /** Strip comments so `/* … *​/` text can't be mistaken for a declaration. */
-function stripComments(css: string): string {
+export function stripComments(css: string): string {
   return css.replace(COMMENT, "");
 }
 
@@ -32,7 +32,7 @@ function stripComments(css: string): string {
  * (base, then the per-faction blocks), so all of them must merge — later
  * declarations win, as the cascade does.
  */
-function ruleBodies(css: string, selector: string): string[] {
+export function ruleBodies(css: string, selector: string): string[] {
   const bodies: string[] = [];
   let cursor = 0;
   while (cursor < css.length) {


### PR DESCRIPTION
Closes #1506

## Diagnosis (verified against the worktree)

`.filter-bar` in `frontend/src/index.css` had `overflow: hidden`. `OptionPicker`'s desktop panel (`.filter-factions__popover`) is `position: absolute` inside `.filter-factions` (`position: relative`), a descendant of `.filter-bar`. An `overflow: hidden` ancestor clips an absolutely-positioned descendant regardless of `z-index`, so the popover was cut to the bar's box — a corner rather than a strip. Confirmed this reads the same on `origin/main` at the commit the worktree was cut from.

`OptionPicker` is a single generic component (`frontend/src/components/ui/FilterBar/OptionPicker.tsx`) used by **every** facet — type, faction, and any future one — through the identical `.filter-factions__popover`/`.filter-factions__trigger` classes (the naming is legacy from before #1446's generalization; see the docblock there). So the faction facet's popover on Tasks/Praxes, and any other facet any `FilterBar` consumer mounts, is freed by this same one-line change — there is no second popover class to check.

## Fix

- Dropped `overflow: hidden` from `.filter-bar`.
- Gave `.filter-bar__spectrum` (the full-bleed rainbow strip, the bar's first child) its own `border-radius: var(--space-md) var(--space-md) 0 0` so it still follows the bar's rounded top corners now that the parent no longer clips it.
- Left the bar's own bottom corners alone: an element's `background` always respects its own `border-radius` regardless of `overflow`, so `.filter-bar`'s bottom corners keep reading as rounded with no extra rule needed.

One change in `index.css`, no `OptionPicker.tsx` edit, no per-page patching — covers Tasks, Praxes, Updates and `admin/ModerationTab` identically. Mobile untouched: `.filter-factions__sheet` is `position: fixed` and was never affected by this ancestor's `overflow`.

## Guard

Added `frontend/src/components/ui/FilterBar/__tests__/filterBarOverflow.test.ts` — a source ratchet in the spirit of the repo's existing CSS ratchets (`factionColorIsCascadeBound.test.ts` etc.). It extracts the actual `.filter-bar` rule body via the existing brace-balanced `ruleBodies` helper (exported from `cssVars.ts` for this reuse, alongside `stripComments`) and asserts on the real declaration — `overflow: hidden|clip` — not on the file merely containing that string. **Braces prove nothing**: a naive "file contains 'overflow: hidden'" check would still pass if a merge moved the declaration into an unrelated rule, or fail to catch it moving back in under a different selector that isn't `.filter-bar` exactly (the extractor also rejects `.filter-bar__spectrum` as a match for `.filter-bar` by checking the character after the selector). I manually flipped the fix back to `overflow: hidden` to confirm the test goes red on the real defect, then restored it and reran — see the test seam note below.

Test seam: `.filter-bar`'s own overflow declaration, extracted from the source stylesheet, not the rendered DOM (the harness is `renderToStaticMarkup` only and computes no layout/CSS).

## Verification run

- `tsc --noEmit` — clean
- `vitest run` — full suite, 206 files / 3577 tests passed (including the new test and the two files whose exports it depends on)
- `vite build` + `npm run budget` — build succeeds, bundle within budget
- Inspected the **compiled** `dist/assets/index-*.css` directly and confirmed `.filter-bar` has no `overflow` declaration and `.filter-bar__spectrum` carries the new radius

## What to eyeball

I did no visual QA — no browser, no dev server. Please check in a real browser:

- **Updates** — press the type-facet trigger on desktop; the popover should now fully render below the trigger instead of showing only a corner.
- **Tasks** and **Praxes** — press the faction-facet trigger on desktop; same popover class, same fix, should be equally freed.
- **admin/ModerationTab** — whatever facet it mounts, on desktop.
- On all of the above, confirm the bar's **bottom corners** still read as rounded (not squared off now that `overflow: hidden` is gone) and the **rainbow spectrum strip** at the top still follows the bar's rounded top corners.
- **Mobile** on the same pages — confirm the bottom-sheet variant (`.filter-factions__sheet`) is unaffected, as expected since it was already `position: fixed`.
- If a popover renders wide enough to reach the bar's right edge, confirm it isn't clipped horizontally either (the original bug clipped both axes).