### PR TITLE
Double Dipper's "Begin again": the server says why, the client stops guessing (#1497)

### DIFF
--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -62,6 +62,12 @@ class TaskOut(BaseModel):
     can_submit_praxis: bool = False
     allowed_modes: list[str] = []
     eligible_for_current_user: bool = False
+    # *Why* sign-up is open or shut for this viewer — a SignupDenialReason value,
+    # SIGNUP_REASON_MULTI_MEMBERSHIP, or None when there is nothing to explain.
+    # The flag above says whether; this says which, so the client can label the
+    # call to action ("begin again" vs "you are already on this") without
+    # re-deriving a server rule from its own state (#1497).
+    signup_reason: Optional[str] = None
 
 
 class TaskCreate(BaseModel):

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -534,6 +534,14 @@ def meets_task_level(
     return character_level + level_reach >= task.level_required
 
 
+#: The one reason sign-up can be *open* that "you have not started this" does not
+#: explain: the viewer is already on the task and their faction may hold more than
+#: one membership on it (Double Dipper — ``can_hold_multiple_memberships``). It is
+#: never inferred from a slug; see :func:`signup_reason`, which derives it from the
+#: raw membership fact and the predicate's own verdict (#1497).
+SIGNUP_REASON_MULTI_MEMBERSHIP = "multi_membership"
+
+
 class SignupDenialReason(str, Enum):
     """Why the type-agnostic sign-up gates reject a claim (ADR-0008)."""
 
@@ -563,16 +571,22 @@ class SignupFacts:
     per page by :func:`gather_signup_facts`, a 50-row browse pays for them once
     instead of 50 times (#1377).
 
-    ``task_ids`` is the page these facts were gathered for.
-    ``active_member_task_ids`` is only meaningful within it, so
-    :func:`evaluate_signup` falls back to its own query for a task outside the
-    set rather than reading absence as "not a member".
+    ``task_ids`` is the page these facts were gathered for. Both membership sets
+    are only meaningful within it, so :func:`evaluate_signup` and
+    :func:`signup_reason` fall back to their own query for a task outside the set
+    rather than reading absence as "not a member".
+
+    The two membership sets answer different questions and differ by exactly the
+    Double Dipper ability: ``active_member_task_ids`` is what *blocks* a fresh
+    claim, ``held_membership_task_ids`` is what the viewer is on at all. The wire
+    needs both to say "begin again" rather than "you are already on this" (#1497).
     """
 
     stats: CharacterStats
     in_progress_praxis_count: int
     task_ids: frozenset[int]
     active_member_task_ids: frozenset[int]
+    held_membership_task_ids: frozenset[int]
 
 
 async def gather_signup_facts(
@@ -581,11 +595,16 @@ async def gather_signup_facts(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> SignupFacts:
-    """Read one page's worth of :class:`SignupFacts` in four queries, not four per row.
+    """Read one page's worth of :class:`SignupFacts` in five queries, not five per row.
 
     ``era`` is threaded into the membership read so a caller evaluating against a
     non-current ruleset gets facts from that same ruleset — precomputed facts
     that disagree with the predicate would be the #1377 bug wearing a new hat.
+
+    The fifth read is the raw membership set (#1497). It is a second page-wide
+    query rather than a Python derivation of the first because deriving it would
+    mean restating the Double Dipper carve-out outside the SQL that owns it — the
+    #1359 defect exactly.
     """
     era_row = await get_current_era_row(session)
     return SignupFacts(
@@ -594,6 +613,9 @@ async def gather_signup_facts(
         task_ids=frozenset(task_ids),
         active_member_task_ids=await active_member_task_ids(
             character, task_ids, session, era
+        ),
+        held_membership_task_ids=await held_membership_task_ids(
+            character, task_ids, session
         ),
     )
 
@@ -661,6 +683,46 @@ async def evaluate_signup(
         return SignupEligibility(False, SignupDenialReason.bank_full)
 
     return SignupEligibility(allowed=True)
+
+
+async def signup_reason(
+    character: Optional[Character],
+    task: Task,
+    eligibility: SignupEligibility,
+    session: AsyncSession,
+    *,
+    facts: Optional[SignupFacts] = None,
+) -> Optional[str]:
+    """The ``TaskOut.signup_reason`` the wire carries — *why* this viewer may or may
+    not claim this task (#1497).
+
+    ``None`` means "nothing to explain": an ordinary first claim, or an anonymous
+    viewer who has no standing to be given a reason. Otherwise it is either a
+    :class:`SignupDenialReason` value (the blocked state, so the client can say
+    which gate closed) or :data:`SIGNUP_REASON_MULTI_MEMBERSHIP`.
+
+    The allowed-but-notable case is derived, never branched on a slug: if
+    :func:`evaluate_signup` says yes *and* the viewer already holds a membership,
+    the only rule that can have let both be true is the multi-membership ability.
+    That is why this reads the raw membership set rather than
+    ``active_member_task_ids``, which the ability empties by construction.
+
+    ``facts`` is the page-wide precompute and carries #1377's property: an id
+    outside ``facts.task_ids`` falls back to its own read instead of taking the
+    absence as "not a member".
+    """
+    if eligibility.reason is not None:
+        return eligibility.reason.value
+    if not eligibility.allowed or character is None:
+        return None
+
+    if facts is not None and task.id in facts.task_ids:
+        holds_membership = task.id in facts.held_membership_task_ids
+    else:
+        holds_membership = task.id in await held_membership_task_ids(
+            character, [task.id], session
+        )
+    return SIGNUP_REASON_MULTI_MEMBERSHIP if holds_membership else None
 
 
 def _signup_denial_to_http(
@@ -1180,12 +1242,37 @@ def multi_membership_faction_slugs(era: EraConfig = CURRENT_ERA) -> tuple[str, .
     )
 
 
+def _held_membership_task_ids_subquery(character_id: int):
+    """Task IDs where ``character_id`` holds an active praxis membership — **the raw
+    fact, with no ability applied**.
+
+    "Active" means the praxis status is ``in_progress``, ``pending`` or ``submitted``.
+
+    "Am I on this task" is not the same question as "does being on this task stop me
+    claiming it again". Double Dipper is precisely the gap between the two, and
+    ``TaskOut.signup_reason`` needs both sides of it to tell "begin again" from
+    "you have never started this" (#1497).
+    :func:`active_member_task_ids_subquery` is this select plus the carve-out, so
+    the carve-out is still written exactly once.
+    """
+    return (
+        select(Praxis.task_id)
+        .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
+        .join(Character, Character.id == PraxisMember.character_id)
+        .where(
+            PraxisMember.character_id == character_id,
+            Praxis.status.in_(
+                [PraxisStatus.in_progress, PraxisStatus.pending, PraxisStatus.submitted]
+            ),
+        )
+    )
+
+
 def active_member_task_ids_subquery(
     character_id: int, era: EraConfig = CURRENT_ERA
 ):
-    """SQL subquery returning task IDs where ``character_id`` holds an active praxis membership.
+    """SQL subquery returning task IDs whose membership **blocks** a fresh claim.
 
-    "Active" means the praxis status is ``in_progress``, ``pending`` or ``submitted``.
     Used by the task-list query to exclude tasks the character is already working on,
     and by :func:`active_member_task_ids` for the Python answer.
 
@@ -1197,18 +1284,31 @@ def active_member_task_ids_subquery(
     their own list (#1359). The join is on the membership's character, whose id
     is a primary key, so it adds a row lookup and no fan-out.
     """
-    return (
-        select(Praxis.task_id)
-        .join(PraxisMember, PraxisMember.praxis_id == Praxis.id)
-        .join(Character, Character.id == PraxisMember.character_id)
-        .where(
-            PraxisMember.character_id == character_id,
-            Character.faction_slug.notin_(multi_membership_faction_slugs(era)),
-            Praxis.status.in_(
-                [PraxisStatus.in_progress, PraxisStatus.pending, PraxisStatus.submitted]
-            ),
+    return _held_membership_task_ids_subquery(character_id).where(
+        Character.faction_slug.notin_(multi_membership_faction_slugs(era))
+    )
+
+
+async def held_membership_task_ids(
+    character: Character,
+    task_ids: Collection[int],
+    session: AsyncSession,
+) -> frozenset[int]:
+    """Which of ``task_ids`` ``character`` is on **at all** — ONE query, no carve-out.
+
+    The batch sibling of :func:`active_member_task_ids`, reading
+    :func:`_held_membership_task_ids_subquery` instead. Takes no ``era`` because no
+    ruleset changes the raw fact; only what the fact *means* is era-dependent, and
+    that lives in :func:`multi_membership_faction_slugs`.
+    """
+    if not task_ids:
+        return frozenset()
+    result = await session.execute(
+        _held_membership_task_ids_subquery(character.id).where(
+            Praxis.task_id.in_(task_ids)
         )
     )
+    return frozenset(result.scalars().all())
 
 
 async def active_member_task_ids(
@@ -1700,6 +1800,7 @@ __all__ = [
     "flag_praxis",
     "gather_signup_facts",
     "get_praxis",
+    "held_membership_task_ids",
     "invite_to_praxis",
     "is_active_member_of_task",
     "is_task_eligible_for_character",
@@ -1714,6 +1815,8 @@ __all__ = [
     "moderate_praxis",
     "multi_membership_faction_slugs",
     "respond_to_invite",
+    "SIGNUP_REASON_MULTI_MEMBERSHIP",
+    "signup_reason",
     "SignupDenialReason",
     "SignupEligibility",
     "SignupFacts",

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -24,9 +24,10 @@ from services.praxis import (
     _count_in_progress_praxes,
     active_member_task_ids_subquery,
     allowed_praxis_modes,
-    can_submit_praxis_for_task,
+    evaluate_signup,
     gather_signup_facts,
     is_task_eligible_for_character,
+    signup_reason,
     SignupFacts,
 )
 from services.level_jump import available_level_reach
@@ -292,8 +293,14 @@ async def build_task_out_for_viewer(
         signup_facts = await gather_signup_facts(viewer, [task.id], session, era)
     stats = signup_facts.stats
 
-    base.can_submit_praxis = await can_submit_praxis_for_task(
-        viewer, task, session, era, facts=signup_facts
+    # One evaluation, both answers. `can_submit_praxis` is the verdict
+    # (`can_submit_praxis_for_task` is this same call with the reason discarded);
+    # `signup_reason` is *why*, so the client can label its call to action off the
+    # server's ruling instead of mirroring the rule locally and drifting (#1497).
+    eligibility = await evaluate_signup(viewer, task, session, era, facts=signup_facts)
+    base.can_submit_praxis = eligibility.allowed
+    base.signup_reason = await signup_reason(
+        viewer, task, eligibility, session, facts=signup_facts
     )
     base.allowed_modes = [m.value for m in allowed_praxis_modes(viewer, stats.level, era)]
     base.eligible_for_current_user = is_task_eligible_for_character(

--- a/backend/tests/integration/test_task_signup_reason.py
+++ b/backend/tests/integration/test_task_signup_reason.py
@@ -1,0 +1,182 @@
+"""#1497 — ``TaskOut.signup_reason``: the server says *why*, the client stops guessing.
+
+**The seam under test is the wire**: :func:`services.task.build_task_out_for_viewer`
+→ :class:`schemas.task.TaskOut`. #1359 stopped the browse SQL hiding a task an
+Everymen character may legitimately claim again, but the response still carried no
+way to tell "you have never started this" from "you are already on this and your
+faction lets you go again". The frontend re-derived that from its own membership
+state — the client-side mirror of a server rule that #1385 deleted elsewhere.
+
+Both halves are asserted: the perk holder gets an *allowed* reason, and a
+character **without** the perk still gets the blocked one. Without both, the suite
+cannot tell "fixed the CTA" from "removed the gate".
+"""
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.character import Character
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus, TaskType
+from services.praxis import (
+    SIGNUP_REASON_MULTI_MEMBERSHIP,
+    SignupDenialReason,
+    gather_signup_facts,
+)
+from services.task import build_task_out_for_viewer
+
+# The faction Era 1 grants Double Dipper to. Needed as a real row for the FK; the
+# *ability* is asserted off the config below, never assumed from the slug.
+EVERYMEN_SLUG = "everymen"
+
+
+@pytest_asyncio.fixture
+async def faction_everymen(db_session: AsyncSession) -> Faction:
+    """The 'everymen' faction row — its Double Dipper ability is the point here."""
+    existing = await db_session.execute(
+        select(Faction).where(Faction.slug == EVERYMEN_SLUG)
+    )
+    found = existing.scalar_one_or_none()
+    if found is not None:
+        return found
+    faction = Faction(slug=EVERYMEN_SLUG, status=FactionStatus.visible)
+    db_session.add(faction)
+    await db_session.commit()
+    await db_session.refresh(faction)
+    return faction
+
+
+async def _seed_in_progress_praxis(
+    db_session: AsyncSession, character: Character, task: Task
+) -> None:
+    praxis = Praxis(
+        task_id=task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        title="wip",
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=praxis.id, character_id=character.id))
+    await db_session.commit()
+
+
+async def _make_task(db_session: AsyncSession, author: Character) -> Task:
+    task = Task(
+        title="Another Task",
+        description="",
+        point_value=5,
+        level_required=0,
+        status=TaskStatus.active,
+        task_type=TaskType.standard,
+        created_by=author.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add(task)
+    await db_session.commit()
+    await db_session.refresh(task)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_perk_holder_already_on_the_task_gets_the_allowed_reason(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua: Faction,
+    faction_everymen: Faction,
+):
+    """Double Dipper: sign-up is open, and the wire says why — "begin again"."""
+    assert CURRENT_ERA.factions[EVERYMEN_SLUG].can_hold_multiple_memberships, (
+        "fixture premise: this era grants Double Dipper to Everymen"
+    )
+    await _seed_in_progress_praxis(db_session, character, active_task)
+    character.faction_slug = EVERYMEN_SLUG
+    await db_session.commit()
+
+    out = await build_task_out_for_viewer(active_task, character, db_session)
+
+    assert out.can_submit_praxis is True
+    assert out.signup_reason == SIGNUP_REASON_MULTI_MEMBERSHIP
+
+
+@pytest.mark.asyncio
+async def test_without_the_perk_the_same_task_still_reads_blocked(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua: Faction,
+):
+    """The other half — remove the gate and this is what fails."""
+    await _seed_in_progress_praxis(db_session, character, active_task)
+
+    out = await build_task_out_for_viewer(active_task, character, db_session)
+
+    assert out.can_submit_praxis is False
+    assert out.signup_reason == SignupDenialReason.already_active_member.value
+
+
+@pytest.mark.asyncio
+async def test_a_task_never_started_carries_no_reason(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua: Faction,
+    faction_everymen: Faction,
+):
+    """A plain first claim is not "again" — even for the perk holder."""
+    character.faction_slug = EVERYMEN_SLUG
+    await db_session.commit()
+
+    out = await build_task_out_for_viewer(active_task, character, db_session)
+
+    assert out.can_submit_praxis is True
+    assert out.signup_reason is None
+
+
+@pytest.mark.asyncio
+async def test_reason_is_the_same_whether_or_not_the_page_precomputed_facts(
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua: Faction,
+    faction_everymen: Faction,
+):
+    """#1377's property, extended to the new fact.
+
+    A list route gathers :class:`SignupFacts` once per page; a task **outside**
+    that page must fall back to its own read rather than take the absence of an
+    id from the bag as "no membership". Passing facts gathered for a different
+    task is exactly that case, and it must not silently downgrade the reason.
+    """
+    await _seed_in_progress_praxis(db_session, character, active_task)
+    character.faction_slug = EVERYMEN_SLUG
+    await db_session.commit()
+    other = await _make_task(db_session, character)
+
+    covered = await gather_signup_facts(
+        character, [active_task.id, other.id], db_session
+    )
+    assert (
+        await build_task_out_for_viewer(
+            active_task, character, db_session, signup_facts=covered
+        )
+    ).signup_reason == SIGNUP_REASON_MULTI_MEMBERSHIP
+
+    # Facts gathered for a page this task is not on: the id is absent from the
+    # bag for the *wrong* reason, so the builder must go and look.
+    uncovered = await gather_signup_facts(character, [other.id], db_session)
+    assert (
+        await build_task_out_for_viewer(
+            active_task, character, db_session, signup_facts=uncovered
+        )
+    ).signup_reason == SIGNUP_REASON_MULTI_MEMBERSHIP

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -43,9 +43,11 @@ export interface TaskOut {
   eligible_for_current_user: boolean
   // Why sign-up is open or shut for this viewer — the flag above says whether,
   // this says which, so the CTA can read "Begin again" without the client
-  // re-deriving a server rule (#1497). Optional because it is absent from every
-  // anonymous read and from any response predating it; `signupCtaKey` treats
-  // absent and unrecognised alike.
+  // re-deriving a server rule (#1497). A live backend response ALWAYS carries the
+  // key (null when there is nothing to explain, e.g. an anonymous read); optional
+  // here for the same reason `in_progress_count` is — so existing TaskOut fixtures
+  // stay valid rather than taking a mechanical edit. `signupCtaKey` maps absent,
+  // null and unrecognised alike to the plain CTA, so the widening is inert.
   signup_reason?: string | null
 }
 

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -41,6 +41,12 @@ export interface TaskOut {
   can_submit_praxis: boolean
   allowed_modes: string[]
   eligible_for_current_user: boolean
+  // Why sign-up is open or shut for this viewer — the flag above says whether,
+  // this says which, so the CTA can read "Begin again" without the client
+  // re-deriving a server rule (#1497). Optional because it is absent from every
+  // anonymous read and from any response predating it; `signupCtaKey` treats
+  // absent and unrecognised alike.
+  signup_reason?: string | null
 }
 
 export interface TaskCreate {

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -58,6 +58,7 @@
     },
     "signup": {
       "cta": "Sign up",
+      "ctaAgain": "Begin again",
       "slots": "You have {{open}} of {{max}} task slots open",
       "levelMet": "Level {{level}} met"
     },

--- a/frontend/src/pages/taskDetail/__tests__/signupCta.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/signupCta.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * "Begin again" — the sign-up CTA reads the server's reason (#1497).
+ *
+ * #1359 stopped the browse SQL hiding a task an Everymen character may claim a
+ * second time (`can_hold_multiple_memberships`, "Double Dipper"), but the detail
+ * page still ANDed its own "am I already on this" check into `canSignUp` — the
+ * client-side mirror of a server rule that #1385 deleted elsewhere. The mirror
+ * did not match: for a perk holder the server says yes and the mirror said no,
+ * so the CTA vanished for exactly the player the perk exists for.
+ *
+ * **Both halves are asserted, or this suite cannot tell "fixed the CTA" from
+ * "removed the gate":**
+ *  1. Server allows + reason `multi_membership`  -> CTA renders, reads "Begin again"
+ *  2. Server refuses (`already_active_member`)   -> no CTA at all, either label
+ *
+ * The render half walks the real `surfaceMap('taskDetail')` registry rather than
+ * one skin: the archetype dispatches on the TASK's faction, so an Everymen viewer
+ * meets whichever skin the task wears, and all of them must say it.
+ *
+ * Harness: `renderToStaticMarkup`, no DOM, no effects — so the hook itself is not
+ * mountable and its gate is pinned through the pure `canSignUpForTask`.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ReactElement } from "react";
+import { describe, it, expect } from "vitest";
+import "../../../i18n"; // real catalogs — a missing key throws rather than passing
+import { surfaceMap } from "../../../factions";
+import DefaultTaskDetail from "../archetypes/DefaultTaskDetail";
+import {
+  SIGNUP_REASON_MULTI_MEMBERSHIP,
+  canSignUpForTask,
+  signupCtaKey,
+} from "../signupCta";
+import type { TaskDetailState } from "../useTaskDetail";
+import type { TaskOut } from "../../../api/tasks";
+import type { PraxisCardOut } from "../../../api/praxis";
+
+const TASK: TaskOut = {
+  id: 91,
+  title: "Repair the towpath bridge",
+  description: "Two planks and a weekend.",
+  point_value: 30,
+  level_required: 1,
+  status: "active",
+  task_type: "standard",
+  created_by: 3,
+  primary_faction_slug: "everymen",
+  metatask_faction_slug: null,
+  created_at: "2026-01-01T00:00:00Z",
+  can_submit_praxis: true,
+  allowed_modes: ["solo"],
+  eligible_for_current_user: true,
+};
+
+/** A praxis the viewer already filed on this very task — the state the mirror keyed on. */
+const MY_PRAXIS: PraxisCardOut = {
+  id: 501,
+  task_id: TASK.id,
+  task_title: TASK.title,
+  task_point_value: 30,
+  task_level_required: 1,
+  type: "solo",
+  status: "submitted",
+  title: "First go",
+  moderation_status: "visible",
+  created_by_id: 3,
+  created_by_display_name: "Wren",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  submitted_at: "2026-01-02T00:00:00Z",
+  member_count: 1,
+  score: 4,
+  voter_count: 1,
+  metatask_points: 0,
+  display_multiplier: 1.0,
+  points_from_votes: 4,
+  is_top_for_task: false,
+  task_faction_slug: "everymen",
+};
+
+function baseState(overrides: Partial<TaskDetailState> = {}): TaskDetailState {
+  return {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    submissions: [],
+    comments: null,
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: true,
+    levelJumpSignup: false,
+    slotsOpen: 2,
+    maxTaskSlots: 3,
+    basePoints: 30,
+    factionMultiplier: 1.0,
+    modifiedPoints: 30,
+    inProgressCount: 4,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+    ...overrides,
+  };
+}
+
+function textOf(element: ReactElement): string {
+  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>).replace(
+    /<[^>]*>/g,
+    "",
+  );
+}
+
+const archetypes = {
+  ...surfaceMap("taskDetail"),
+  __default__: DefaultTaskDetail,
+};
+
+describe("signupCtaKey — the label follows the server's reason", () => {
+  it("maps the multi-membership reason to the 'again' copy", () => {
+    expect(signupCtaKey(SIGNUP_REASON_MULTI_MEMBERSHIP)).toBe(
+      "detail.signup.ctaAgain",
+    );
+  });
+
+  it("falls back to the plain CTA for no reason, or one it has never heard of", () => {
+    expect(signupCtaKey(null)).toBe("detail.signup.cta");
+    expect(signupCtaKey(undefined)).toBe("detail.signup.cta");
+    // A future backend reason must not blank the button.
+    expect(signupCtaKey("some_reason_from_a_later_era")).toBe(
+      "detail.signup.cta",
+    );
+  });
+});
+
+describe("canSignUpForTask — the deleted client-side mirror", () => {
+  it("says yes on the server's word alone", () => {
+    expect(canSignUpForTask({ signedIn: true, canSubmitPraxis: true })).toBe(
+      true,
+    );
+  });
+
+  it("says no when the server refuses, and when nobody is signed in", () => {
+    expect(canSignUpForTask({ signedIn: true, canSubmitPraxis: false })).toBe(
+      false,
+    );
+    expect(canSignUpForTask({ signedIn: false, canSubmitPraxis: true })).toBe(
+      false,
+    );
+  });
+
+  it("treats an absent flag as a refusal", () => {
+    // Anonymous and pre-#1497 reads carry no flag; absent must not read as yes.
+    expect(
+      canSignUpForTask({ signedIn: true, canSubmitPraxis: undefined }),
+    ).toBe(false);
+  });
+});
+
+describe("every task-detail skin renders both halves", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug}: the perk holder gets "Begin again", not "Sign up"`, () => {
+      // The state a Double Dipper viewer now produces: already on the task —
+      // draft AND filed praxis, the two terms the old mirror gated on — while
+      // the server still says yes and explains why.
+      const text = textOf(
+        <Archetype
+          state={baseState({
+            task: {
+              ...TASK,
+              can_submit_praxis: true,
+              signup_reason: SIGNUP_REASON_MULTI_MEMBERSHIP,
+            },
+            canSignUp: true,
+            isInProgress: true,
+            inProgressPraxisId: MY_PRAXIS.id,
+            mySubmission: MY_PRAXIS,
+            submissions: [MY_PRAXIS],
+          })}
+        />,
+      );
+      expect(text).toContain("Begin again");
+      expect(text).not.toContain("Sign up");
+    });
+
+    it(`${slug}: without the perk the gate still shuts`, () => {
+      // Same membership, no ability: the server refuses and names the gate, so
+      // no call to action renders under either label.
+      const text = textOf(
+        <Archetype
+          state={baseState({
+            task: {
+              ...TASK,
+              can_submit_praxis: false,
+              signup_reason: "already_active_member",
+            },
+            canSignUp: false,
+            isInProgress: true,
+            inProgressPraxisId: MY_PRAXIS.id,
+            mySubmission: MY_PRAXIS,
+            submissions: [MY_PRAXIS],
+          })}
+        />,
+      );
+      expect(text).not.toContain("Begin again");
+      expect(text).not.toContain("Sign up");
+    });
+
+    it(`${slug}: a first claim still reads "Sign up"`, () => {
+      const text = textOf(<Archetype state={baseState()} />);
+      expect(text).toContain("Sign up");
+      expect(text).not.toContain("Begin again");
+    });
+  }
+});

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -12,6 +12,7 @@ import {
   LevelJumpBanner,
   TaskDetailComments,
 } from "./shared";
+import { signupCtaKey } from "../signupCta";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -439,7 +440,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
         <div>
           <LevelJumpBanner state={state} />
           <button onClick={handleSignup} style={pinkButton}>
-            {t("detail.signup.cta")}
+            {t(signupCtaKey(task.signup_reason))}
           </button>
           <div
             style={{

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -12,6 +12,7 @@ import {
   LevelJumpBanner,
   TaskDetailComments,
 } from "./shared";
+import { signupCtaKey } from "../signupCta";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -285,7 +286,7 @@ export default function DefaultTaskDetail({
         <div>
           <LevelJumpBanner state={state} />
           <button onClick={handleSignup} style={primaryButton}>
-            {t("detail.signup.cta")}
+            {t(signupCtaKey(task.signup_reason))}
           </button>
           <div
             className="font-body"

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -12,6 +12,7 @@ import {
   LevelJumpBanner,
   TaskDetailComments,
 } from "./shared";
+import { signupCtaKey } from "../signupCta";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -930,7 +931,7 @@ export default function EphemeristsTaskDetail({
           <LevelJumpBanner state={state} />
           <button onClick={handleSignup} style={primaryButton}>
             <Sign name="openEye" size={15} color={CTA_INK} weight={1.4} />
-            <span style={{ whiteSpace: "nowrap" }}>{t("detail.signup.cta")}</span>
+            <span style={{ whiteSpace: "nowrap" }}>{t(signupCtaKey(task.signup_reason))}</span>
             <Sign name="planet" size={14} color={CTA_INK} weight={1.4} />
           </button>
           <div style={{ ...quietItalic, marginTop: "var(--space-sm)" }}>

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -12,6 +12,7 @@ import {
   LevelJumpBanner,
   TaskDetailComments,
 } from "./shared";
+import { signupCtaKey } from "../signupCta";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -639,7 +640,7 @@ export default function EverymenTaskDetail({
         <div>
           <LevelJumpBanner state={state} />
           <button onClick={handleSignup} style={primaryBar}>
-            {t("detail.signup.cta")}
+            {t(signupCtaKey(task.signup_reason))}
           </button>
           <div
             style={{

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -12,6 +12,7 @@ import {
   LevelJumpBanner,
   TaskDetailComments,
 } from "./shared";
+import { signupCtaKey } from "../signupCta";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -580,7 +581,7 @@ export default function SingularityTaskDetail({
           <LevelJumpBanner state={state} />
           <button onClick={handleSignup} style={primaryButton}>
             {prompt}
-            {t("detail.signup.cta")}
+            {t(signupCtaKey(task.signup_reason))}
             <Cursor />
           </button>
           <div

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -12,6 +12,7 @@ import {
   LevelJumpBanner,
   TaskDetailComments,
 } from "./shared";
+import { signupCtaKey } from "../signupCta";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -428,7 +429,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
           <LevelJumpBanner state={state} />
           <button onClick={handleSignup} style={plateButton(false)}>
             <XMark size={17} />
-            <span style={plateLabel}>{t("detail.signup.cta")}</span>
+            <span style={plateLabel}>{t(signupCtaKey(task.signup_reason))}</span>
             <XMark size={17} />
           </button>
           <div

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -21,6 +21,7 @@ import {
   LevelJumpBanner,
   TaskDetailComments,
 } from "./shared";
+import { signupCtaKey } from "../signupCta";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -325,7 +326,7 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
         <div>
           <LevelJumpBanner state={state} />
           <button onClick={handleSignup} style={primaryAction}>
-            {t("detail.signup.cta")}
+            {t(signupCtaKey(task.signup_reason))}
           </button>
           <div style={{ ...aside, marginTop: "var(--space-sm)" }}>
             {t("detail.signup.slots", { open: slotsOpen, max: maxTaskSlots })}

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -13,6 +13,7 @@ import {
   LevelJumpBanner,
   TaskDetailComments,
 } from "./shared";
+import { signupCtaKey } from "../signupCta";
 import type { TaskDetailState } from "../useTaskDetail";
 
 /**
@@ -443,7 +444,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
           <LevelJumpBanner state={state} />
           <button onClick={handleSignup} style={ctaStyle(false)}>
             <Star size={13} color={ON_PLUM} />
-            {t("detail.signup.cta")}
+            {t(signupCtaKey(task.signup_reason))}
           </button>
           <div style={{ ...quietNote, textAlign: "center", marginTop: "var(--space-sm)" }}>
             {t("detail.signup.slots", { open: slotsOpen, max: maxTaskSlots })}

--- a/frontend/src/pages/taskDetail/signupCta.ts
+++ b/frontend/src/pages/taskDetail/signupCta.ts
@@ -1,0 +1,61 @@
+/**
+ * Which label the sign-up call to action wears (#1497).
+ *
+ * The task detail used to AND its own "am I already on this" check into
+ * `canSignUp`, which is the client-side mirror of a server rule — the shape
+ * #1385 deleted elsewhere in this codebase after finding it did not actually
+ * match the server. It does not match here either: a faction may grant
+ * `can_hold_multiple_memberships` (Double Dipper), and for its members holding a
+ * membership does not close the gate at all. The mirror hid a sign-up button the
+ * server was perfectly willing to honour.
+ *
+ * So the reason comes down the wire on `TaskOut.signup_reason` and this maps it
+ * to a copy key. Nothing here re-derives eligibility — `can_submit_praxis` is
+ * still the only thing that decides whether the CTA renders; this only decides
+ * what it says once it does. No slug is compared: a second faction gaining the
+ * ability changes the backend's answer and nothing in this file.
+ */
+
+/** The server's word for "you are on this already, and your faction lets you go again". */
+export const SIGNUP_REASON_MULTI_MEMBERSHIP = "multi_membership";
+
+/**
+ * Whether the sign-up CTA renders at all.
+ *
+ * The guarantee is the *signature*: this cannot consult the viewer's membership,
+ * their drafts or their filed praxis, because it is never given them. Those were
+ * the terms of the deleted mirror, and a regression that re-adds one has to widen
+ * this interface to do it — which is a visible change rather than a silent
+ * `&& !isInProgress` slipped back into a long boolean.
+ */
+export function canSignUpForTask(params: {
+  /** Whether anyone is signed in at all. */
+  signedIn: boolean;
+  /** The server's ruling — `TaskOut.can_submit_praxis`, trusted, not recomputed. */
+  canSubmitPraxis: boolean | undefined;
+}): boolean {
+  return params.signedIn && !!params.canSubmitPraxis;
+}
+
+const CTA_KEY = "detail.signup.cta" as const;
+const CTA_AGAIN_KEY = "detail.signup.ctaAgain" as const;
+
+export type SignupCtaKey = typeof CTA_KEY | typeof CTA_AGAIN_KEY;
+
+/**
+ * The i18n key for the sign-up button, given the server's `signup_reason`.
+ *
+ * The return is the literal union rather than `string` so `t()` still checks it
+ * against the catalog — a key typo stays a compile error, which is the whole
+ * point of the typed catalog.
+ *
+ * Undefined and null get the same answer as any unrecognised reason: the plain
+ * CTA. A reason this build has never heard of must not blank the button.
+ */
+export function signupCtaKey(
+  signupReason: string | null | undefined,
+): SignupCtaKey {
+  return signupReason === SIGNUP_REASON_MULTI_MEMBERSHIP
+    ? CTA_AGAIN_KEY
+    : CTA_KEY;
+}

--- a/frontend/src/pages/taskDetail/useTaskDetail.ts
+++ b/frontend/src/pages/taskDetail/useTaskDetail.ts
@@ -24,6 +24,7 @@ import { extractError } from "../../utils/errors";
 import { computeDisplayPoints, computeFactionMultiplier } from "../../utils/points";
 import { useGameConfig } from "../../hooks/useGameConfig";
 import { isLevelJumpSignup } from "./levelJump";
+import { canSignUpForTask } from "./signupCta";
 
 const DEFAULT_MAX_TASK_SLOTS = 20;
 
@@ -302,8 +303,18 @@ export function useTaskDetail(idParam: string | undefined): TaskDetailState {
         )
       : (task?.point_value ?? 0);
 
-  const canSignUp =
-    !!user && !mySubmission && !isInProgress && !!task?.can_submit_praxis;
+  // The server is the only authority on whether this viewer may claim this task.
+  // `!mySubmission && !isInProgress` used to be ANDed in here — a local mirror of
+  // the "already on it" rule, and a wrong one: a faction may hold more than one
+  // membership on a task (Double Dipper), and for its members the server says yes
+  // while the mirror said no. It degraded silently too, since `isInProgress`
+  // comes from a separate fetch that never runs for an anonymous viewer and is
+  // false until it lands. Deleted per #1385's finding on the same shape; the
+  // "already on it" state now reaches the UI as `task.signup_reason` (#1497).
+  const canSignUp = canSignUpForTask({
+    signedIn: !!user,
+    canSubmitPraxis: task?.can_submit_praxis,
+  });
   // The signable task is a level-jump iff the viewer's faction grants reach, the
   // allowance is unspent, and the task sits above the viewer's own level. Logic
   // lives in the pure `isLevelJumpSignup` predicate so it is testable props-in/


### PR DESCRIPTION
Split out of #1359, which fixed the browse SQL but left the call to action reading as though the player had never started the task.

Closes #1497

## The seam under test

**The wire.** `services.task.build_task_out_for_viewer` → `TaskOut.signup_reason` on the backend; the pure `signupCtaKey` / `canSignUpForTask` on the frontend. The server already knew *why* a viewer may claim a task; it just never said so, and the client guessed.

The failing test came first at that seam (`ImportError: cannot import name 'SIGNUP_REASON_MULTI_MEMBERSHIP'`), then green.

## What was actually wrong

`useTaskDetail` ANDed `!mySubmission && !isInProgress` into `canSignUp` — a client-side mirror of a server rule, the same shape #1385 deleted elsewhere. It did not match the server, in the direction that matters: a faction with `can_hold_multiple_memberships` (Double Dipper) is exempt from the already-a-member gate, so the server said yes while the mirror said no. The CTA vanished for exactly the player the ability exists for. It also degraded silently — `isInProgress` comes from a separate fetch that never runs for an anonymous viewer and is `false` until it lands.

The comment directly beneath it already stated the doctrine — "We do NOT recompute eligibility — canSignUp already trusts the backend's `can_submit_praxis`" — and the line above it was the violation.

## Backend

`signup_reason` is net-new on `TaskOut`. It carries either a `SignupDenialReason` value (the blocked state, so the client can say *which* gate closed) or `SIGNUP_REASON_MULTI_MEMBERSHIP`, or `None` when there is nothing to explain.

The allowed-but-notable case is **derived, never branched on a slug**: if `evaluate_signup` says yes *and* the viewer already holds a membership, the only rule that can make both true is the multi-membership ability.

That needed a fact the code had deliberately erased. `active_member_task_ids_subquery` applies the carve-out *inside* the SQL (#1359), so for a perk holder the membership set is empty by construction — the server could not tell "on it, exempt" from "never started it". Split in two:

- `_held_membership_task_ids_subquery` — the raw fact, no ability applied
- `active_member_task_ids_subquery` — that select **plus** the carve-out

So the carve-out is still written exactly once, in the SQL that owns it, and #1359's property holds: the browse exclusion reaches it without going through the predicate.

`gather_signup_facts` goes from four page-wide queries to five. It is a second batched read rather than a Python derivation of the first, because deriving it would mean restating the carve-out outside the SQL — the #1359 defect exactly. **No new per-row query**; the #1377 property is preserved and directly tested (a task outside `facts.task_ids` falls back to its own read instead of taking absence as "not a member"). #1359's `era` threading is untouched.

## Frontend

`canSignUp` is now the server's word alone. The label comes off `signup_reason` via a pure `signupCtaKey`, swapped in **all nine registered detail skins** — the archetype dispatches on the *task's* faction, so a perk holder meets whichever skin the task wears, not just Everymen's.

`canSignUpForTask` exists so the deleted mirror is pinnable: the guarantee is its *signature*. It cannot consult membership because it is never given it, so re-adding the mirror requires widening a visible interface rather than slipping `&& !isInProgress` back into a long boolean.

New copy key `detail.signup.ctaAgain` — **"Begin again"**.

`signup_reason` is optional on the TS mirror. A live response always carries the key; optional matches the documented precedent set by `in_progress_count` on that same interface, so existing fixtures stay valid. `signupCtaKey` maps absent, null and unrecognised alike to the plain CTA, so an unknown future reason cannot blank the button.

## Tests — both halves, or the suite cannot tell "fixed the CTA" from "removed the gate"

Backend (`test_task_signup_reason.py`): perk holder on the task → `can_submit_praxis` True + `multi_membership`; **character without the perk, same fixture** → False + `already_active_member`; never-started → True + `None`; and the batched-facts fallback.

Frontend (`signupCta.test.tsx`, 32 tests): loops the real `surfaceMap('taskDetail')` registry, so all nine skins assert all three states — perk holder reads "Begin again" and not "Sign up"; without the perk **no CTA renders under either label**; a first claim still reads "Sign up".

## Verification

Backend `pytest --cov-fail-under=80`: **987 passed, 91.95%**. Frontend, all six CI steps: `tsc --noEmit`, `typecheck:design-sync`, `eslint`, `vitest` (**3609 passed / 207 files**), `vite build`, byte budget (JS 131.3 KB, CSS 22.4 KB — within budget).

## I did no visual QA

No browser and no dev stack in this worktree. Everything above is tests, tsc and eslint. Nobody has looked at this page.

## What to eyeball

1. **The copy itself.** "Begin again" is my wording, not the owner's — #1497 quotes it, but it is the one string here nobody has signed off in situ.
2. **How it looks in nine different skins.** The CTA is one shared key rendered through nine bespoke dresses — SNIDE's ransom plate, the Ephemerists' `white-space: nowrap` span, Singularity's terminal bar. "Begin again" is four characters longer than "Sign up" and may wrap or overflow somewhere a static-markup test cannot see.
3. **A behaviour change beyond the CTA label.** Dropping `!mySubmission` means the client now shows a sign-up CTA whenever the server allows one — including on a task whose earlier praxis is `completed` or `failed`, since those are not "active" memberships. The server has always permitted that; the client used to hide it. It will read as "Sign up" (not "Begin again", since no active membership is held). Worth confirming that is wanted.
4. **The perk holder's page as a whole.** The CTA now renders *alongside* the drop / "your submission" controls for the same task, which previously could not co-occur. Nine skins compose that action slot differently.
5. **Nothing said "you're already on this" that I missed.** I changed the CTA label; I did not audit every skin's surrounding prose for copy that assumes a single membership.
