### PR TITLE
ADR-0071: three doors lead into a praxis, and two of them are deliberate carve-outs (#1513)

### DIFF
--- a/docs/adr/0071-three-doors-lead-into-a-praxis-and-two-of-them-are-deliberate-carve-outs.md
+++ b/docs/adr/0071-three-doors-lead-into-a-praxis-and-two-of-them-are-deliberate-carve-outs.md
@@ -1,0 +1,80 @@
+# ADR-0071 — Three doors lead into a praxis, and two of them are deliberate carve-outs
+
+**Status:** Accepted
+**Date:** 2026-08-01
+**Relates to:** ADR-0008 (sign-up eligibility is one game-logic predicate),
+ADR-0051 (duel acceptance bypasses the task-level gate), ADR-0029
+(`faction_permits` is the single faction-rules seam), #292 (one named home for
+the task-level gate), #1511 (the collab bypasses become era fields), #1513 (this
+ADR). Supersedes nothing — ADR-0008 and ADR-0051 both stand.
+
+## Context
+
+`CONTEXT.md` states the governing invariant of **Sign-up eligibility** as being
+true "iff `create_praxis` would accept". That sentence describes a world with one
+door into a praxis. There are three, and two of them deliberately bypass gates
+the first one enforces:
+
+| Door | `task.level_required` | Faction | Task bank |
+|---|---|---|---|
+| `create_praxis` (sign up) | enforced | enforced | enforced |
+| `invite_to_praxis` (collab) | bypassed | bypassed | enforced on accept |
+| `respond_to_duel_challenge` (duel accept) | bypassed, for a flat `era.duel_level_required` floor | bypassed | enforced |
+
+Each door was reasoned about separately and correctly. Nothing wrote down that
+they form a family. The duel carve-out has ADR-0051 and an intent comment beside
+the check; the collab carve-out had neither — it was enforced by *absence*, a
+rule nothing can grep and no test can defend. So it reads as a bug to whoever
+finds it next, and the invariant above actively invites them to close it.
+
+#1511 replaced that absence with three era fields
+(`collab_invite_bypasses_level` / `_faction` / `_task_bank`) and pinned the
+behaviour with `backend/tests/integration/test_collab_invite_bypass.py`. This ADR
+records why they are set the way they are.
+
+## Decision
+
+**The collab-invite bypass is intended and stays** (owner ruling, 2026-08-01).
+It is an Easter egg encouraging collaboration across factions and character
+levels: a character who could never claim a task alone can be carried into it by
+someone who can, and can submit. Whether you could have claimed a task yourself
+and whether you may join someone else's praxis on it are different questions.
+
+Which gates the door lifts is era-owned, not hardcoded — the three
+`collab_invite_bypasses_*` fields on `EraConfig`. Era 1 sets them
+`(True, True, False)`: level and faction lifted, the task bank still charged, on
+the accept rather than the invite (values live in `backend/eras/era_1.py`).
+
+**The faction flag has no teeth today.** Setting `collab_invite_bypasses_faction`
+to `False` routes the invitee through `faction_permits`, which returns `True`
+unconditionally — there is currently no active faction gate anywhere (ADR-0029).
+The flag is wired so that a future faction rule reaches this door for free, not
+because turning it off refuses anything now.
+
+**The boundary — what no era flag lifts:**
+
+- the invitee must not already hold an active membership on that task (one live
+  praxis per character per task; a data-integrity rule, not an eligibility one);
+- a submitted praxis cannot be joined;
+- only members of the collab may invite (ADR-0013 — a collab is co-owned);
+- no self-invites.
+
+**Duels are out of scope and stay exactly as they are** (owner ruling). ADR-0051
+governs that door; this ADR only names it so the family is visible in one place.
+
+## Consequences
+
+- The invariant in `CONTEXT.md` is about the **sign-up** door specifically.
+  Reading it as a claim about every route into a praxis is what makes the collab
+  bypass look like a defect.
+- A "let's consolidate the eligibility gates" pass now has an ADR to amend
+  before it can close either carve-out — the same protection ADR-0051 already
+  gave duel acceptance.
+- **The economy is not at risk.** Cross-faction collab is a designed-for case,
+  not an escape hatch: scoring already routes it through
+  `compute_faction_multiplier(..., COLLABORATION_MODE_COLLAB)`, which has its own
+  own-faction/other-faction modifiers. Being carried onto a high-level task of
+  another faction is scored by rules that exist for precisely that shape.
+- An era that wants a stricter collab door flips a flag rather than editing
+  `invite_to_praxis`. Any change to Era 1's tuple should amend this ADR, because
+  the tuple *is* the Easter egg.


### PR DESCRIPTION
Closes #1513

Docs-only. Adds `docs/adr/0071-three-doors-lead-into-a-praxis-and-two-of-them-are-deliberate-carve-outs.md` and nothing else.

## Seam

None — this records a decision already made and already implemented (#1511, merged as PR #1515). There is no behaviour to test and no test was added; the bypass is already pinned by `backend/tests/integration/test_collab_invite_bypass.py`.

## What it records

- The **three-door table**: `create_praxis` enforces level/faction/bank; `invite_to_praxis` bypasses level and faction (bank charged on accept); duel acceptance bypasses `task.level_required` in favour of a flat `era.duel_level_required` floor.
- **The intent** (owner ruling, 2026-08-01): the collab bypass is an Easter egg encouraging collaboration across factions and character levels, not a bug to clean up.
- **Era-tunability** via the three `collab_invite_bypasses_*` fields from #1511, naming Era 1's tuple `(True, True, False)` and pointing at `eras/era_1.py` for the values rather than restating any (CLAUDE.md's "do not duplicate game rules into docs").
- **The boundary** no era flag lifts: no existing active membership on the task, no joining a submitted praxis, members-only invites, no self-invites.
- **The economy is fine**: cross-faction collab already routes through `compute_faction_multiplier(..., COLLABORATION_MODE_COLLAB)`, so it is a designed-for case.
- **Duels are out of scope** — ADR-0051 governs them; this ADR only points at that door so the family is visible in one place. Supersedes nothing.

## Accuracy note

`collab_invite_bypasses_faction` cannot refuse anything today: flipping it to `False` routes the invitee through `faction_permits`, which returns `True` unconditionally (ADR-0029, verified in `backend/services/faction_service.py`). The ADR says so plainly rather than implying the flag has teeth it does not yet have.

## Verification

Nothing to eyeball visually. No code touched, so both CI jobs should pass untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
