### PR TITLE
TaskOut.can_submit_praxis becomes can_sign_up — the field was the outlier (#1512)

### DIFF
--- a/.design-sync/previews/_fixtures.tsx
+++ b/.design-sync/previews/_fixtures.tsx
@@ -57,7 +57,7 @@ export function makeTask(overrides: Partial<TaskOut> = {}): TaskOut {
     primary_faction_slug: 'ua',
     metatask_faction_slug: null,
     created_at: NOW,
-    can_submit_praxis: true,
+    can_sign_up: true,
     allowed_modes: ['solo', 'collab'],
     eligible_for_current_user: true,
     ...overrides,

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -235,8 +235,14 @@ The single game-logic predicate behind the Sign-up affordance: whether a charact
 governing invariant: it is true **iff `create_praxis` would accept**, so the button
 hides exactly when the action would be rejected (level, **active
 membership**, task bank, Analog carve-out). See ADR-0008.
-_Avoid_: conflating with `can_submit_praxis` (the narrow dup-authorship rule only) or
-`eligible_for_current_user` (level only) — neither is the whole gate.
+One name, two surfaces, by design: `TaskOut.can_sign_up` is the predicate's answer for one
+task, and `GET /tasks?can_sign_up=` is the filter that keeps the tasks it answers true for
+(#1130). The field carried the name `can_submit_praxis` until #1512, which was false on its
+face — an invited collaborator may submit a praxis on a task they could never *claim*.
+_Avoid_: conflating with `eligible_for_current_user` (level only) — that is one input to
+the gate, not the gate. Sign-up eligibility is about *claiming*; whether a viewer may
+submit a praxis they are already a member of is a different question, and no flag answers
+it today.
 
 **Active membership**:
 A character holding a `PraxisMember` row on a non-deleted praxis for a task whose status

--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -29,7 +29,7 @@ These are non-negotiable and take precedence over any visual specification.
 4. **If you can't use it, you can't see it.** Buttons, menu items, and actions that the user lacks permission for (level gate, role, status) should not render at all. Don't show disabled controls — hide them. This is already the pattern in the codebase; maintain it.
 
    **Validation belongs in business logic, not UX.** Gate rules (level thresholds, faction rules, anti-self checks, one-per-task rules) live in backend services. The backend is authoritative.
-   - API responses include explicit `can_X` flags (`can_flag`, `can_submit_praxis`, `can_create_additional_character`, `allowed_modes`, `eligible_for_current_user`, etc.) computed server-side.
+   - API responses include explicit `can_X` flags (`can_flag`, `can_sign_up`, `can_create_additional_character`, `allowed_modes`, `eligible_for_current_user`, etc.) computed server-side.
    - The frontend consumes those flags and hides controls accordingly. Do not re-implement the rule in a component.
    - No hardcoded rule thresholds in the frontend. If you're writing `level >= 4` in a component, the backend should be returning a flag instead.
    - Disabled state (`<button disabled>`) is only for in-flight async and form validity — never for rule-based denial.

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -59,7 +59,7 @@ class TaskOut(BaseModel):
     # Viewer-relative capability flags — populated by the task router using
     # the authenticated viewer's character. Defaults keep the flags safe for
     # unauthenticated callers (empty modes, cannot submit, not eligible).
-    can_submit_praxis: bool = False
+    can_sign_up: bool = False
     allowed_modes: list[str] = []
     eligible_for_current_user: bool = False
     # *Why* sign-up is open or shut for this viewer — a SignupDenialReason value,

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -773,7 +773,7 @@ async def _check_create_preconditions(
         raise HTTPException(status_code=404, detail="Character not found.")
 
     # Type-agnostic gates: level, retired/pending, active-member, bank cap — one
-    # predicate, so the can_submit_praxis flag can't drift from enforcement.
+    # predicate, so the can_sign_up flag can't drift from enforcement.
     eligibility = await evaluate_signup(character, task, session, era)
     if not eligibility.allowed:
         raise _signup_denial_to_http(eligibility.reason, task, era)
@@ -1352,7 +1352,7 @@ async def is_active_member_of_task(
     return task.id in await active_member_task_ids(character, [task.id], session, era)
 
 
-async def can_submit_praxis_for_task(
+async def can_sign_up_for_task(
     character: Optional[Character],
     task: Task,
     session: AsyncSession,
@@ -1361,7 +1361,7 @@ async def can_submit_praxis_for_task(
     facts: Optional[SignupFacts] = None,
 ) -> bool:
     """Return True iff ``create_praxis``'s type-agnostic gates would accept — the
-    truthful ``can_submit_praxis`` flag on ``TaskOut`` (ADR-0008).
+    truthful ``can_sign_up`` flag on ``TaskOut`` (ADR-0008).
 
     Derives from :func:`evaluate_signup`, so it covers every shared gate: level,
     retired/pending faction carve-out, active-member (Everymen Double-Dipper
@@ -1842,7 +1842,7 @@ __all__ = [
     "allowed_praxis_modes",
     "cancel_pending_publish_on_edit",
     "can_flag_praxis",
-    "can_submit_praxis_for_task",
+    "can_sign_up_for_task",
     "can_view_praxis",
     "create_praxis",
     "delete_praxis",

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -208,7 +208,7 @@ async def build_task_out(
     """Convert a Task ORM instance to a TaskOut schema.
 
     This builder does not compute any viewer-relative fields; flags such as
-    ``can_submit_praxis``, ``allowed_modes``, and ``eligible_for_current_user``
+    ``can_sign_up``, ``allowed_modes``, and ``eligible_for_current_user``
     are left at their safe defaults. Use :func:`build_task_out_for_viewer`
     from a route that has an authenticated viewer available.
 
@@ -263,7 +263,7 @@ async def build_task_out_for_viewer(
 ) -> TaskOut:
     """Build a :class:`TaskOut` with viewer-relative capability flags.
 
-    Populates ``can_submit_praxis``, ``allowed_modes``, and
+    Populates ``can_sign_up``, ``allowed_modes``, and
     ``eligible_for_current_user`` using the authenticated viewer's character
     (``None`` for anonymous callers). All three flags default to the same
     safe values as :func:`build_task_out` when ``viewer`` is ``None``.
@@ -293,12 +293,12 @@ async def build_task_out_for_viewer(
         signup_facts = await gather_signup_facts(viewer, [task.id], session, era)
     stats = signup_facts.stats
 
-    # One evaluation, both answers. `can_submit_praxis` is the verdict
-    # (`can_submit_praxis_for_task` is this same call with the reason discarded);
+    # One evaluation, both answers. `can_sign_up` is the verdict
+    # (`can_sign_up_for_task` is this same call with the reason discarded);
     # `signup_reason` is *why*, so the client can label its call to action off the
     # server's ruling instead of mirroring the rule locally and drifting (#1497).
     eligibility = await evaluate_signup(viewer, task, session, era, facts=signup_facts)
-    base.can_submit_praxis = eligibility.allowed
+    base.can_sign_up = eligibility.allowed
     base.signup_reason = await signup_reason(
         viewer, task, eligibility, session, facts=signup_facts
     )

--- a/backend/tests/integration/test_signup_eligibility.py
+++ b/backend/tests/integration/test_signup_eligibility.py
@@ -1,7 +1,7 @@
 """#330 — the single sign-up eligibility predicate (evaluate_signup).
 
 The predicate is the test surface (ADR-0008): one place asserts each denial
-reason, and the regression pins the can_submit_praxis flag to the bank cap it
+reason, and the regression pins the can_sign_up flag to the bank cap it
 previously omitted.
 """
 from dataclasses import replace
@@ -17,7 +17,7 @@ from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
 from models.task import Task, TaskStatus, TaskType
 from services.praxis import (
     SignupDenialReason,
-    can_submit_praxis_for_task,
+    can_sign_up_for_task,
     evaluate_signup,
 )
 
@@ -142,12 +142,12 @@ async def test_evaluate_signup_bank_full(
 async def test_can_submit_flag_false_when_bank_full(
     db_session: AsyncSession, character: Character, active_task: Task, era: Era, faction_ua: Faction
 ):
-    """Regression: the can_submit_praxis flag now reflects the bank cap.
+    """Regression: the can_sign_up flag now reflects the bank cap.
 
     Before #330 the flag omitted the bank cap, so a full-bank character got
-    can_submit_praxis=True and the sign-up button lied.
+    can_sign_up=True and the sign-up button lied.
     """
     await _seed_in_progress_praxis(db_session, character, active_task)
     other = await _make_task(db_session, character)
     capped = replace(CURRENT_ERA, max_task_signups=1)
-    assert await can_submit_praxis_for_task(character, other, db_session, capped) is False
+    assert await can_sign_up_for_task(character, other, db_session, capped) is False

--- a/backend/tests/integration/test_task_list_query_count.py
+++ b/backend/tests/integration/test_task_list_query_count.py
@@ -1,7 +1,7 @@
 """#1377 — the signed-in task browse must cost a constant number of queries.
 
 **The seam under test** is ``GET /tasks`` → :func:`services.task.build_task_out_for_viewer`.
-The builder's viewer-relative fields (``can_submit_praxis``, ``allowed_modes``,
+The builder's viewer-relative fields (``can_sign_up``, ``allowed_modes``,
 ``eligible_for_current_user``) used to re-read the era row, the viewer's stats and
 the viewer's bank count once per row, so a 50-row page cost ~6 queries per row.
 The page-wide precomputes already in the route (``in_progress_counts_for_tasks``,
@@ -224,15 +224,15 @@ async def test_batched_flags_equal_the_per_task_predicates(
     for task_id, row in rows.items():
         task = await db_session.get(Task, task_id)
         eligibility = await evaluate_signup(character, task, db_session, CURRENT_ERA)
-        assert row["can_submit_praxis"] is eligibility.allowed, task_id
+        assert row["can_sign_up"] is eligibility.allowed, task_id
         assert row["eligible_for_current_user"] is is_task_eligible_for_character(
             character, task, stats.level, level_reach
         ), task_id
         assert row["allowed_modes"] == expected_modes, task_id
 
     # The mix actually exercised the gates it claims to.
-    assert rows[already_member.id]["can_submit_praxis"] is False
-    assert rows[too_hard.id]["can_submit_praxis"] is False
+    assert rows[already_member.id]["can_sign_up"] is False
+    assert rows[too_hard.id]["can_sign_up"] is False
     assert rows[too_hard.id]["eligible_for_current_user"] is False
-    assert rows[retired.id]["can_submit_praxis"] is False
-    assert all(rows[task.id]["can_submit_praxis"] is True for task in plain)
+    assert rows[retired.id]["can_sign_up"] is False
+    assert all(rows[task.id]["can_sign_up"] is True for task in plain)

--- a/backend/tests/integration/test_task_signup_reason.py
+++ b/backend/tests/integration/test_task_signup_reason.py
@@ -102,7 +102,7 @@ async def test_perk_holder_already_on_the_task_gets_the_allowed_reason(
 
     out = await build_task_out_for_viewer(active_task, character, db_session)
 
-    assert out.can_submit_praxis is True
+    assert out.can_sign_up is True
     assert out.signup_reason == SIGNUP_REASON_MULTI_MEMBERSHIP
 
 
@@ -119,7 +119,7 @@ async def test_without_the_perk_the_same_task_still_reads_blocked(
 
     out = await build_task_out_for_viewer(active_task, character, db_session)
 
-    assert out.can_submit_praxis is False
+    assert out.can_sign_up is False
     assert out.signup_reason == SignupDenialReason.already_active_member.value
 
 
@@ -138,7 +138,7 @@ async def test_a_task_never_started_carries_no_reason(
 
     out = await build_task_out_for_viewer(active_task, character, db_session)
 
-    assert out.can_submit_praxis is True
+    assert out.can_sign_up is True
     assert out.signup_reason is None
 
 

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -1472,13 +1472,42 @@ async def test_metatask_list_hidden_for_anonymous(
 
 
 @pytest.mark.asyncio
-async def test_get_task_can_submit_false_with_existing_praxis_non_analog(
+async def test_get_task_names_the_signup_flag_can_sign_up(
     client: AsyncClient,
     character: Character,
     active_task: Task,
     auth_headers: dict,
 ):
-    """A non-Analog viewer with an in-progress praxis sees can_submit_praxis=False."""
+    """The wire contract names the sign-up gate ``can_sign_up`` (#1512).
+
+    The flag is ``evaluate_signup(...).allowed`` — whether this viewer may
+    *claim* the task. It shipped as ``can_sign_up``, which asserted
+    something false: a character who could never claim a task can still be
+    invited into a collab on it and submit (#1511), so the old name reported
+    ``false`` about a task where a praxis is demonstrably submittable.
+
+    This pins the JSON **key**, not just the value. Every value-level test
+    below would still pass against the old name; only the wire key catches a
+    rename that stops half way — and a half-done rename hands the frontend
+    ``undefined``, which it reads as "cannot sign up" and hides the button.
+    """
+    resp = await client.get(f"/tasks/{active_task.id}", headers=auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["can_sign_up"] is True
+    # The literal old name, deliberately: this is the only place in the tree
+    # that may still spell it, and it spells it to assert its ABSENCE.
+    assert "can_submit_praxis" not in body
+
+
+@pytest.mark.asyncio
+async def test_get_task_can_sign_up_false_with_existing_praxis_non_analog(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """A non-Analog viewer with an in-progress praxis sees can_sign_up=False."""
     create_resp = await client.post(
         "/praxes",
         json={"task_id": active_task.id, "type": "solo"},
@@ -1488,18 +1517,18 @@ async def test_get_task_can_submit_false_with_existing_praxis_non_analog(
 
     resp = await client.get(f"/tasks/{active_task.id}", headers=auth_headers)
     assert resp.status_code == 200
-    assert resp.json()["can_submit_praxis"] is False
+    assert resp.json()["can_sign_up"] is False
 
 
 @pytest.mark.asyncio
-async def test_get_task_can_submit_true_for_analog_with_existing_praxis(
+async def test_get_task_can_sign_up_true_for_analog_with_existing_praxis(
     client: AsyncClient,
     character: Character,
     active_task: Task,
     auth_headers: dict,
     db_session: AsyncSession,
 ):
-    """Analog viewer with an existing praxis still sees can_submit_praxis=True."""
+    """Analog viewer with an existing praxis still sees can_sign_up=True."""
     from models.faction import Faction, FactionStatus
     from sqlalchemy import select as sa_select
 
@@ -1527,41 +1556,41 @@ async def test_get_task_can_submit_true_for_analog_with_existing_praxis(
 
     resp = await client.get(f"/tasks/{active_task.id}", headers=auth_headers)
     assert resp.status_code == 200
-    assert resp.json()["can_submit_praxis"] is True
+    assert resp.json()["can_sign_up"] is True
 
 
 @pytest.mark.asyncio
-async def test_get_task_can_submit_true_when_no_prior_praxis(
+async def test_get_task_can_sign_up_true_when_no_prior_praxis(
     client: AsyncClient,
     character: Character,
     active_task: Task,
     auth_headers: dict,
 ):
-    """Viewer with no existing praxis for the task sees can_submit_praxis=True."""
+    """Viewer with no existing praxis for the task sees can_sign_up=True."""
     resp = await client.get(f"/tasks/{active_task.id}", headers=auth_headers)
     assert resp.status_code == 200
-    assert resp.json()["can_submit_praxis"] is True
+    assert resp.json()["can_sign_up"] is True
 
 
 @pytest.mark.asyncio
-async def test_get_task_can_submit_false_for_anonymous(
+async def test_get_task_can_sign_up_false_for_anonymous(
     client: AsyncClient,
     active_task: Task,
 ):
-    """Unauthenticated viewer sees can_submit_praxis=False."""
+    """Unauthenticated viewer sees can_sign_up=False."""
     resp = await client.get(f"/tasks/{active_task.id}")
     assert resp.status_code == 200
-    assert resp.json()["can_submit_praxis"] is False
+    assert resp.json()["can_sign_up"] is False
 
 
 @pytest.mark.asyncio
-async def test_get_task_can_submit_false_level_too_low(
+async def test_get_task_can_sign_up_false_level_too_low(
     client: AsyncClient,
     character: Character,
     db_session: AsyncSession,
     auth_headers: dict,
 ):
-    """Character below task.level_required sees can_submit_praxis=False."""
+    """Character below task.level_required sees can_sign_up=False."""
     high_level_task = Task(
         title="Hard Task",
         description="Requires level 5",
@@ -1578,17 +1607,17 @@ async def test_get_task_can_submit_false_level_too_low(
     # character fixture starts at level 0, so level_required=5 blocks it
     resp = await client.get(f"/tasks/{high_level_task.id}", headers=auth_headers)
     assert resp.status_code == 200
-    assert resp.json()["can_submit_praxis"] is False
+    assert resp.json()["can_sign_up"] is False
 
 
 @pytest.mark.asyncio
-async def test_get_task_can_submit_false_retired_task(
+async def test_get_task_can_sign_up_false_retired_task(
     client: AsyncClient,
     character: Character,
     db_session: AsyncSession,
     auth_headers: dict,
 ):
-    """Character without Task Vision sees can_submit_praxis=False on a retired task."""
+    """Character without Task Vision sees can_sign_up=False on a retired task."""
     retired_task = Task(
         title="Retired Task",
         description="No longer active",
@@ -1604,11 +1633,11 @@ async def test_get_task_can_submit_false_retired_task(
 
     resp = await client.get(f"/tasks/{retired_task.id}", headers=auth_headers)
     assert resp.status_code == 200
-    assert resp.json()["can_submit_praxis"] is False
+    assert resp.json()["can_sign_up"] is False
 
 
 @pytest.mark.asyncio
-async def test_get_task_can_submit_false_joined_collaborator(
+async def test_get_task_can_sign_up_false_joined_collaborator(
     client: AsyncClient,
     character: Character,
     character2: Character,
@@ -1616,7 +1645,7 @@ async def test_get_task_can_submit_false_joined_collaborator(
     db_session: AsyncSession,
     auth_headers2: dict,
 ):
-    """A character who joined someone else's collab sees can_submit_praxis=False."""
+    """A character who joined someone else's collab sees can_sign_up=False."""
     from models.praxis import Praxis, PraxisMember, PraxisType
 
     collab = Praxis(
@@ -1635,11 +1664,11 @@ async def test_get_task_can_submit_false_joined_collaborator(
     # character2 is a joined collaborator, not the author
     resp = await client.get(f"/tasks/{active_task.id}", headers=auth_headers2)
     assert resp.status_code == 200
-    assert resp.json()["can_submit_praxis"] is False
+    assert resp.json()["can_sign_up"] is False
 
 
 @pytest.mark.asyncio
-async def test_get_task_can_submit_true_everymen_as_collaborator(
+async def test_get_task_can_sign_up_true_everymen_as_collaborator(
     client: AsyncClient,
     character: Character,
     character2: Character,
@@ -1647,7 +1676,7 @@ async def test_get_task_can_submit_true_everymen_as_collaborator(
     db_session: AsyncSession,
     auth_headers2: dict,
 ):
-    """Everymen (Double Dipper) member of a collab still sees can_submit_praxis=True."""
+    """Everymen (Double Dipper) member of a collab still sees can_sign_up=True."""
     from models.faction import FactionStatus
     from models.praxis import Praxis, PraxisMember, PraxisType
     from sqlalchemy import select
@@ -1675,7 +1704,7 @@ async def test_get_task_can_submit_true_everymen_as_collaborator(
 
     resp = await client.get(f"/tasks/{active_task.id}", headers=auth_headers2)
     assert resp.status_code == 200
-    assert resp.json()["can_submit_praxis"] is True
+    assert resp.json()["can_sign_up"] is True
 
 
 # ---------------------------------------------------------------------------
@@ -2448,7 +2477,7 @@ async def test_list_tasks_author_read_is_not_an_n_plus_1(
     case a deduped map cannot fake.
 
     The request is anonymous on purpose: the viewer-relative flags
-    (``can_submit_praxis`` and friends) do run per task, a pre-existing cost
+    (``can_sign_up`` and friends) do run per task, a pre-existing cost
     this issue does not touch, and including it would drown the signal.
     """
     for index in range(5):

--- a/frontend/src/__tests__/accessibleNameSpacing.test.tsx
+++ b/frontend/src/__tests__/accessibleNameSpacing.test.tsx
@@ -58,7 +58,7 @@ function metatask(): TaskOut {
     primary_faction_slug: null,
     metatask_faction_slug: 'snide',
     created_at: '2026-01-01T00:00:00Z',
-    can_submit_praxis: false,
+    can_sign_up: false,
     allowed_modes: [],
     eligible_for_current_user: false,
   }

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -38,7 +38,7 @@ export interface TaskOut {
   // Server-driven viewer-specific flags. Backend computes these for the
   // authenticated viewer. Default to permissive values when absent (older
   // clients / unauthenticated reads).
-  can_submit_praxis: boolean
+  can_sign_up: boolean
   allowed_modes: string[]
   eligible_for_current_user: boolean
   // Why sign-up is open or shut for this viewer — the flag above says whether,

--- a/frontend/src/components/__tests__/factionCardSlots.test.tsx
+++ b/frontend/src/components/__tests__/factionCardSlots.test.tsx
@@ -266,7 +266,7 @@ const TASK: TaskOut = {
   primary_faction_slug: "ua",
   metatask_faction_slug: null,
   created_at: "2026-01-01T00:00:00Z",
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/components/metataskSeal/__tests__/sealSkinsA.test.tsx
+++ b/frontend/src/components/metataskSeal/__tests__/sealSkinsA.test.tsx
@@ -27,7 +27,7 @@ function metatask(slug: string, overrides: Partial<TaskOut> = {}): TaskOut {
     primary_faction_slug: null,
     metatask_faction_slug: slug,
     created_at: "2026-01-01T00:00:00Z",
-    can_submit_praxis: false,
+    can_sign_up: false,
     allowed_modes: [],
     eligible_for_current_user: false,
     ...overrides,

--- a/frontend/src/components/metataskSeal/__tests__/sealSkinsB.test.tsx
+++ b/frontend/src/components/metataskSeal/__tests__/sealSkinsB.test.tsx
@@ -30,7 +30,7 @@ function metatask(slug: string, overrides: Partial<TaskOut> = {}): TaskOut {
     primary_faction_slug: null,
     metatask_faction_slug: slug,
     created_at: "2026-01-01T00:00:00Z",
-    can_submit_praxis: false,
+    can_sign_up: false,
     allowed_modes: [],
     eligible_for_current_user: false,
     ...overrides,

--- a/frontend/src/components/metataskSeal/metataskCompose.test.tsx
+++ b/frontend/src/components/metataskSeal/metataskCompose.test.tsx
@@ -32,7 +32,7 @@ function metatask(
     primary_faction_slug: null,
     metatask_faction_slug: slug,
     created_at: "2026-01-01T00:00:00Z",
-    can_submit_praxis: true,
+    can_sign_up: true,
     allowed_modes: ["solo"],
     eligible_for_current_user: true,
   };

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -48,7 +48,7 @@ function metatask(overrides: Partial<TaskOut>): TaskOut {
     primary_faction_slug: 'snide',
     metatask_faction_slug: 'snide',
     created_at: '2026-01-01T00:00:00Z',
-    can_submit_praxis: false,
+    can_sign_up: false,
     allowed_modes: [],
     eligible_for_current_user: false,
     ...overrides,

--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -66,7 +66,7 @@ function metatask(overrides: Partial<TaskOut> = {}): TaskOut {
     primary_faction_slug: 'ephemerists',
     metatask_faction_slug: 'ephemerists',
     created_at: '2026-01-01T00:00:00Z',
-    can_submit_praxis: false,
+    can_sign_up: false,
     allowed_modes: [],
     eligible_for_current_user: false,
     ...overrides,

--- a/frontend/src/components/taskCard/__tests__/defaultTaskCard.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/defaultTaskCard.test.tsx
@@ -44,7 +44,7 @@ const TASK: TaskOut = {
   metatask_faction_slug: null,
   created_at: '2026-01-01T00:00:00Z',
   in_progress_count: 6,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ['solo'],
   eligible_for_current_user: true,
 }

--- a/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
@@ -56,7 +56,7 @@ const TASK: TaskOut = {
   metatask_faction_slug: null,
   created_at: '2026-01-01T00:00:00Z',
   in_progress_count: 6,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ['solo'],
   eligible_for_current_user: true,
 }

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -213,7 +213,7 @@ export default function Home() {
               newestTask.primary_faction_slug,
               factionConfigs,
             )}
-            onSignup={user && newestTask.can_submit_praxis ? handleSignup : undefined}
+            onSignup={user && newestTask.can_sign_up ? handleSignup : undefined}
           />
         ) : (
           <p className="font-body text-muted">{t('sections.newestTask.empty')}</p>

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -85,7 +85,7 @@ function DesktopTasks({ state }: { state: TasksState }) {
                   task={task}
                   basePoints={task.point_value}
                   multiplier={displayMultiplierFor(task)}
-                  onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
+                  onSignup={user && task.can_sign_up ? handleSignup : undefined}
                 />
               ))}
             </div>

--- a/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
+++ b/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
@@ -22,7 +22,7 @@ function task(overrides: Partial<TaskOut> & { id: number }): TaskOut {
     primary_faction_slug: null,
     metatask_faction_slug: null,
     created_at: "2026-07-01T00:00:00Z",
-    can_submit_praxis: true,
+    can_sign_up: true,
     allowed_modes: [],
     eligible_for_current_user: true,
     ...overrides,

--- a/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
@@ -91,7 +91,7 @@ function makeTask(): TaskOut {
     primary_faction_slug: 'ephemerists',
     metatask_faction_slug: null,
     created_at: '2026-01-01T00:00:00Z',
-    can_submit_praxis: true,
+    can_sign_up: true,
     allowed_modes: ['solo'],
     eligible_for_current_user: true,
   }

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -69,7 +69,7 @@ function task(allowedModes: string[], slug: string | null = null): TaskOut {
     primary_faction_slug: slug,
     metatask_faction_slug: null,
     created_at: "2026-01-01T00:00:00Z",
-    can_submit_praxis: true,
+    can_sign_up: true,
     allowed_modes: allowedModes,
     eligible_for_current_user: true,
   } as unknown as TaskOut;

--- a/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/albescentPraxisDetail.test.tsx
@@ -122,7 +122,7 @@ const SEAL: TaskOut = {
   primary_faction_slug: null,
   metatask_faction_slug: "snide",
   created_at: "2026-01-01T00:00:00Z",
-  can_submit_praxis: false,
+  can_sign_up: false,
   allowed_modes: [],
   eligible_for_current_user: false,
 };

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -180,7 +180,7 @@ const SEAL_METATASK: TaskOut = {
   primary_faction_slug: null,
   metatask_faction_slug: "snide",
   created_at: "2026-01-01T00:00:00Z",
-  can_submit_praxis: false,
+  can_sign_up: false,
   allowed_modes: [],
   eligible_for_current_user: false,
 };

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -147,7 +147,7 @@ const SEAL_METATASK: TaskOut = {
   primary_faction_slug: null,
   metatask_faction_slug: 'coven',
   created_at: '2026-01-01T00:00:00Z',
-  can_submit_praxis: false,
+  can_sign_up: false,
   allowed_modes: [],
   eligible_for_current_user: false,
 }

--- a/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
@@ -72,7 +72,7 @@ const METATASK: TaskOut = {
   primary_faction_slug: null,
   metatask_faction_slug: "everymen",
   created_at: "2026-01-01T00:00:00Z",
-  can_submit_praxis: false,
+  can_sign_up: false,
   allowed_modes: [],
   eligible_for_current_user: false,
 };

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -298,7 +298,7 @@ describe("S.N.I.D.E. praxis detail — copy is neutral (ADR-0061)", () => {
             primary_faction_slug: null,
             metatask_faction_slug: "snide",
             created_at: "2026-01-01T00:00:00Z",
-            can_submit_praxis: false,
+            can_sign_up: false,
             allowed_modes: [],
             eligible_for_current_user: false,
           },

--- a/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/uaPraxisDetail.test.tsx
@@ -261,7 +261,7 @@ describe("UA praxis detail — copy is neutral (ADR-0061)", () => {
               primary_faction_slug: null,
               metatask_faction_slug: "ua",
               created_at: "2026-01-01T00:00:00Z",
-              can_submit_praxis: false,
+              can_sign_up: false,
               allowed_modes: [],
               eligible_for_current_user: false,
             },

--- a/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/wowPraxisDetail.test.tsx
@@ -256,7 +256,7 @@ describe("WOW praxis detail — copy is neutral (ADR-0061)", () => {
               primary_faction_slug: null,
               metatask_faction_slug: "wow",
               created_at: "2026-01-01T00:00:00Z",
-              can_submit_praxis: false,
+              can_sign_up: false,
               allowed_modes: [],
               eligible_for_current_user: false,
             },

--- a/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
@@ -70,7 +70,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Wren Abalone",
   created_by_faction_slug: "albescent",
   created_by_level: 4,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/archetypeSlots.test.tsx
@@ -47,7 +47,7 @@ const TASK: TaskOut = {
   primary_faction_slug: "snide",
   metatask_faction_slug: null,
   created_at: "2026-01-01T00:00:00Z",
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
@@ -46,7 +46,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Wren Abalone",
   created_by_faction_slug: "coven",
   created_by_level: 4,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
@@ -53,7 +53,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Wren Abalone",
   created_by_faction_slug: null,
   created_by_level: 4,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -56,7 +56,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Wren Abalone",
   created_by_faction_slug: "ephemerists",
   created_by_level: 4,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
@@ -52,7 +52,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Wren Abalone",
   created_by_faction_slug: "everymen",
   created_by_level: 4,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/levelJump.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/levelJump.test.tsx
@@ -31,7 +31,7 @@ const TASK_ABOVE: TaskOut = {
   primary_faction_slug: "snide",
   metatask_faction_slug: null,
   created_at: "2026-01-01T00:00:00Z",
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };
@@ -50,7 +50,7 @@ describe("isLevelJumpSignup — the three states", () => {
   });
 
   it("state 2: spent (allowance unavailable -> backend denies -> canSignUp false) -> false", () => {
-    // Once spent, the backend's can_submit_praxis is false, so canSignUp is
+    // Once spent, the backend's can_sign_up is false, so canSignUp is
     // false and the flag never fires — the task reads as locked.
     expect(
       isLevelJumpSignup({

--- a/frontend/src/pages/taskDetail/__tests__/mySubmissionLink.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/mySubmissionLink.test.tsx
@@ -43,7 +43,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Wren Abalone",
   created_by_faction_slug: null,
   created_by_level: 4,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/praxisGalleryBasis.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/praxisGalleryBasis.test.tsx
@@ -47,7 +47,7 @@ const TASK: TaskOut = {
   primary_faction_slug: "snide",
   metatask_faction_slug: null,
   created_at: "2026-01-01T00:00:00Z",
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/signupCta.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/signupCta.test.tsx
@@ -48,7 +48,7 @@ const TASK: TaskOut = {
   primary_faction_slug: "everymen",
   metatask_faction_slug: null,
   created_at: "2026-01-01T00:00:00Z",
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };
@@ -142,16 +142,16 @@ describe("signupCtaKey — the label follows the server's reason", () => {
 
 describe("canSignUpForTask — the deleted client-side mirror", () => {
   it("says yes on the server's word alone", () => {
-    expect(canSignUpForTask({ signedIn: true, canSubmitPraxis: true })).toBe(
+    expect(canSignUpForTask({ signedIn: true, canSignUp: true })).toBe(
       true,
     );
   });
 
   it("says no when the server refuses, and when nobody is signed in", () => {
-    expect(canSignUpForTask({ signedIn: true, canSubmitPraxis: false })).toBe(
+    expect(canSignUpForTask({ signedIn: true, canSignUp: false })).toBe(
       false,
     );
-    expect(canSignUpForTask({ signedIn: false, canSubmitPraxis: true })).toBe(
+    expect(canSignUpForTask({ signedIn: false, canSignUp: true })).toBe(
       false,
     );
   });
@@ -159,7 +159,7 @@ describe("canSignUpForTask — the deleted client-side mirror", () => {
   it("treats an absent flag as a refusal", () => {
     // Anonymous and pre-#1497 reads carry no flag; absent must not read as yes.
     expect(
-      canSignUpForTask({ signedIn: true, canSubmitPraxis: undefined }),
+      canSignUpForTask({ signedIn: true, canSignUp: undefined }),
     ).toBe(false);
   });
 });
@@ -175,7 +175,7 @@ describe("every task-detail skin renders both halves", () => {
           state={baseState({
             task: {
               ...TASK,
-              can_submit_praxis: true,
+              can_sign_up: true,
               signup_reason: SIGNUP_REASON_MULTI_MEMBERSHIP,
             },
             canSignUp: true,
@@ -198,7 +198,7 @@ describe("every task-detail skin renders both halves", () => {
           state={baseState({
             task: {
               ...TASK,
-              can_submit_praxis: false,
+              can_sign_up: false,
               signup_reason: "already_active_member",
             },
             canSignUp: false,

--- a/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
@@ -49,7 +49,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Wren Abalone",
   created_by_faction_slug: "singularity",
   created_by_level: 4,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
@@ -54,7 +54,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Wren Abalone",
   created_by_faction_slug: "snide",
   created_by_level: 4,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
@@ -52,7 +52,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Ines Aurel",
   created_by_faction_slug: "ua",
   created_by_level: 5,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
@@ -44,7 +44,7 @@ const TASK: TaskOut = {
   created_by_display_name: "Wren Abalone",
   created_by_faction_slug: "wow",
   created_by_level: 4,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ["solo"],
   eligible_for_current_user: true,
 };

--- a/frontend/src/pages/taskDetail/levelJump.ts
+++ b/frontend/src/pages/taskDetail/levelJump.ts
@@ -10,7 +10,7 @@
  * viewer's level and the task's requirement.
  *
  * Eligibility itself is NOT recomputed here. `canSignUp` already trusts the
- * backend's `can_submit_praxis`, which threads the same reach and is false once
+ * backend's `can_sign_up`, which threads the same reach and is false once
  * the allowance is spent. So a signable task ABOVE the viewer's level can only be
  * signable because of the allowance — that is exactly what this predicate marks.
  * When it returns false (allowance spent, or the task is plainly out of reach)

--- a/frontend/src/pages/taskDetail/signupCta.ts
+++ b/frontend/src/pages/taskDetail/signupCta.ts
@@ -10,7 +10,7 @@
  * server was perfectly willing to honour.
  *
  * So the reason comes down the wire on `TaskOut.signup_reason` and this maps it
- * to a copy key. Nothing here re-derives eligibility — `can_submit_praxis` is
+ * to a copy key. Nothing here re-derives eligibility — `can_sign_up` is
  * still the only thing that decides whether the CTA renders; this only decides
  * what it says once it does. No slug is compared: a second faction gaining the
  * ability changes the backend's answer and nothing in this file.
@@ -31,10 +31,10 @@ export const SIGNUP_REASON_MULTI_MEMBERSHIP = "multi_membership";
 export function canSignUpForTask(params: {
   /** Whether anyone is signed in at all. */
   signedIn: boolean;
-  /** The server's ruling — `TaskOut.can_submit_praxis`, trusted, not recomputed. */
-  canSubmitPraxis: boolean | undefined;
+  /** The server's ruling — `TaskOut.can_sign_up`, trusted, not recomputed. */
+  canSignUp: boolean | undefined;
 }): boolean {
-  return params.signedIn && !!params.canSubmitPraxis;
+  return params.signedIn && !!params.canSignUp;
 }
 
 const CTA_KEY = "detail.signup.cta" as const;

--- a/frontend/src/pages/taskDetail/useTaskDetail.ts
+++ b/frontend/src/pages/taskDetail/useTaskDetail.ts
@@ -267,7 +267,7 @@ export function useTaskDetail(idParam: string | undefined): TaskDetailState {
       setIsInProgress(false);
       setInProgressPraxisId(null);
       setSubmissions((prev) => prev.filter((s) => s.id !== targetPraxisId));
-      // `canSignUp` gates on `task.can_submit_praxis`, which the SERVER computes
+      // `canSignUp` gates on `task.can_sign_up`, which the SERVER computes
       // and flips to false once you are on the task. Clearing local state alone
       // leaves that stale `false` in place, so the sign-up button stayed hidden
       // until a manual reload. Re-read the task — it also refreshes
@@ -313,13 +313,13 @@ export function useTaskDetail(idParam: string | undefined): TaskDetailState {
   // "already on it" state now reaches the UI as `task.signup_reason` (#1497).
   const canSignUp = canSignUpForTask({
     signedIn: !!user,
-    canSubmitPraxis: task?.can_submit_praxis,
+    canSignUp: task?.can_sign_up,
   });
   // The signable task is a level-jump iff the viewer's faction grants reach, the
   // allowance is unspent, and the task sits above the viewer's own level. Logic
   // lives in the pure `isLevelJumpSignup` predicate so it is testable props-in/
   // value-out. We do NOT recompute eligibility — canSignUp already trusts the
-  // backend's `can_submit_praxis`.
+  // backend's `can_sign_up`.
   const levelJumpSignup = isLevelJumpSignup({
     canSignUp,
     levelJumpReach: user?.level_jump_reach ?? 0,

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -6,7 +6,7 @@
  *
  * The second half covers the ADR-0056 rewire (#1022): mobile browse renders the
  * SHARED <TaskCard>, so both branches must now show the same card and the same
- * signup CTA, gated identically on `can_submit_praxis`. Before the rewire mobile
+ * signup CTA, gated identically on `can_sign_up`. Before the rewire mobile
  * had no CTA at all, so "the button is there on mobile" is the regression this
  * pins.
  */
@@ -39,7 +39,7 @@ const TASK: TaskOut = {
   metatask_faction_slug: null,
   created_at: '2026-01-01T00:00:00Z',
   in_progress_count: 6,
-  can_submit_praxis: true,
+  can_sign_up: true,
   allowed_modes: ['solo'],
   eligible_for_current_user: true,
 }
@@ -170,7 +170,7 @@ describe('task-browse card + CTA parity (ADR-0056)', () => {
   })
 
   it('hides the CTA on both when the task refuses the viewer a praxis', () => {
-    const barred: TaskOut = { ...TASK, can_submit_praxis: false }
+    const barred: TaskOut = { ...TASK, can_sign_up: false }
     for (const formFactor of ['mobile', 'desktop'] as const) {
       dispatch.formFactor = formFactor
       state.current = { ...CANNED, user: VIEWER, tasks: [barred] }

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -19,7 +19,7 @@ import TaskFilterBar, { TaskListEmpty } from '../TaskFilterBar'
  * The results list renders the SHARED `<TaskCard>` — the one call site
  * ADR-0056 turned on. Each faction card sizes itself for the phone via
  * `useFormFactor()`, and mobile inherits the inline signup CTA (gated on
- * `can_submit_praxis` exactly as desktop is), the in-progress count and the
+ * `can_sign_up` exactly as desktop is), the in-progress count and the
  * multiplier badge, none of which the old mobile-only cards had. That was
  * shipped as a reversible experiment; the owner's hands-on verdict accepted it,
  * so the `mobileTaskCard` dispatcher and its nine cards are now deleted and
@@ -84,7 +84,7 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
                   task={task}
                   basePoints={task.point_value}
                   multiplier={displayMultiplierFor(task)}
-                  onSignup={user && task.can_submit_praxis ? handleSignup : undefined}
+                  onSignup={user && task.can_sign_up ? handleSignup : undefined}
                 />
               ))
             )}


### PR DESCRIPTION
Renames `TaskOut.can_submit_praxis` to `can_sign_up`.

Closes #1512

## The seam I tested at

**The JSON key on `GET /tasks/{id}`** — the wire contract the frontend actually reads.

That is the only seam where this rename can fail silently. Every existing test asserts the
flag's *value*, and all of them pass against either name; a rename that stops half way
still goes green everywhere while handing the frontend `undefined`, which `canSignUpForTask`
reads as "cannot sign up" and which hides the button. That is the bug class #1510 just
fixed. So the new test pins the key itself, and pins the absence of the old one:

```python
assert body["can_sign_up"] is True
assert "can_submit_praxis" not in body
```

It went red on the real defect first (`KeyError: 'can_sign_up'`), then green.

## What moved

- `backend/schemas/task.py` — the field.
- `backend/services/task.py` — `base.can_sign_up = eligibility.allowed`.
- `backend/services/praxis.py` — `can_submit_praxis_for_task` follows the field to
  `can_sign_up_for_task` (plus `__all__`).
- `frontend/src/api/tasks.ts` — `TaskOut.can_sign_up`.
- `signupCta.ts` / `useTaskDetail.ts` — the `canSubmitPraxis` parameter becomes `canSignUp`.
- ~35 test fixtures, `.design-sync/previews/_fixtures.tsx`, `CONTEXT.md`, `WORLD_ZERO_STYLE.md`.

The rename is safe because the function was already the thing being renamed to:
`can_submit_praxis_for_task` is literally `(await evaluate_signup(...)).allowed`. No
behaviour changes — this is a pure rename.

## Two things the issue got wrong, and how I resolved them

**1. There is no duplicate declaration in `tasks.ts` to delete.**

The issue says `frontend/src/api/tasks.ts:89` "already declares `can_sign_up?: boolean`,
written against the intended contract and currently never populated", and asks me to delete
it as a now-duplicate. That is false on both counts:

- Line 89 is not on `TaskOut` (lines 6–52). It is on **`TaskFilters`** (lines 73–100).
- It is the client mirror of the **query filter**, and it is populated —
  `useTasks.ts:284` sends `can_sign_up: canSignUp || undefined`.

Deleting it would have broken the live browse filter, which the same issue explicitly
forbids ("Keep the query filter working"). The issue contradicts itself and its own
explicit constraint settles it, so I left line 89 alone. `TaskOut.can_sign_up` and
`TaskFilters.can_sign_up` are two different interfaces naming one concept — the field, and
the filter over that field — which is exactly the agreement the rename was for.
`test_task_can_sign_up_filter.py` passes untouched.

**2. `docs/adr/*` keeps the old name deliberately.**

ADR-0007, ADR-0008 and ADR-0056 still say `can_submit_praxis`. An ADR records what was
decided when it was decided; rewriting one to match a later rename destroys the record.
(ADR-0008's prose is *already* historical in another way — it describes
`can_submit_praxis_for_task` as "the narrow dup-authorship rule", which the code stopped
being some time ago.) `docs/adr/` is also owned by #1513 right now, so this PR does not
touch it.

I did fix `CONTEXT.md`'s `_Avoid_` note, which a blind rename turned into "avoid conflating
`can_sign_up` with `can_sign_up`". It now warns off `eligible_for_current_user` only, and
records that the field and the filter share one name by design.

## Verification

- Backend: **1003 passed**, coverage 92.28% (gate 80%), on a dedicated `wz1512_test` DB.
- Frontend, all six CI steps: eslint clean · `tsc --noEmit` clean ·
  **`npm run typecheck:design-sync` clean** (the fixture rename lands there) ·
  vitest **3629 passed / 207 files** · `vite build` ok · byte budget within
  (JS 131.4 KB, CSS 22.4 KB).

One thing worth flagging: my rename `sed` initially ran over a binary
(`frontend/public/factionMarks/enso.webp` lost 2 bytes). Caught it in the commit stat and
restored the file from `origin/main`; the branch now changes **no binaries** — verified
with `git diff --numstat` against the base.

## No visual QA

**I did no visual QA.** I have no browser and no dev stack in this worktree — everything
above is tests, typecheck, lint and build only. The sign-up button's rendered behaviour was
not observed by a human or a browser in this PR.

## What to eyeball

- **The sign-up button still appears** on a task detail for a viewer who can claim it — this
  is the whole risk of the change, and the one thing tests can go green without.
- **The button still disappears** once you sign up, and after **Drop** it comes back without
  a manual reload (`useTaskDetail` re-reads the task for exactly this).
- **"Begin again"** copy still shows for an Everymen/Double-Dipper viewer already on a task.
- **The browse filter** — `/tasks` with the "can sign up" control on still narrows the list.
  This is the parameter the issue warned not to merge into the field; it is untouched, but
  it shares a name now and deserves one click.
- **The level-jump affordance** on a WOW viewer's above-level task, which gates on the
  renamed flag via `isLevelJumpSignup`.
- **Mobile `/tasks`** (`DefaultTasks.tsx`) signup CTA, gated on the same flag as desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
