### PR TITLE
The friend-signup card's level badge stops being null (#1518)

### DIFF
--- a/backend/schemas/activity_feed.py
+++ b/backend/schemas/activity_feed.py
@@ -133,6 +133,7 @@ class FriendSignupPayload(FeedPayloadBase):
     task_title: str
     task_point_value: int
     task_faction_slug: str
+    task_level_required: int
 
 
 class InvitationLetterPayload(FeedPayloadBase):

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -539,7 +539,6 @@ def _collab_invite_item(row: Any) -> ActivityFeedItemDC:
             task_point_value=row.task_point_value,
             task_faction_slug=row.task_faction_slug,
             invite_status=row.status.value,
-            # ponytail: only collab cards render a level badge
             inviter_character_id=row.inviter_id,
             task_level_required=row.task_level_required,
         ),
@@ -608,6 +607,7 @@ def _friend_signups_query(ctx: FeedContext) -> Select:
             Task.title.label("task_title"),
             Task.point_value.label("task_point_value"),
             Task.primary_faction_slug.label("task_faction_slug"),
+            Task.level_required.label("task_level_required"),
         )
         .join(Praxis, PraxisMember.praxis_id == Praxis.id)
         .join(Character, PraxisMember.character_id == Character.id)
@@ -637,6 +637,7 @@ def _friend_signup_item(row: Any) -> ActivityFeedItemDC:
             task_title=row.task_title,
             task_point_value=row.task_point_value,
             task_faction_slug=row.task_faction_slug,
+            task_level_required=row.task_level_required,
         ),
     )
 

--- a/backend/tests/integration/test_activity_feed.py
+++ b/backend/tests/integration/test_activity_feed.py
@@ -635,3 +635,75 @@ def test_every_registry_type_has_a_schema_variant():
     variants = get_args(get_args(ActivityFeedItem)[0])
     tags = {get_args(variant.model_fields["type"].annotation)[0] for variant in variants}
     assert tags == set(FEED_ITEM_TYPES)
+
+
+@pytest.mark.asyncio
+async def test_friend_signup_carries_the_task_level(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+):
+    """The friend-signup card's level badge, at the HTTP seam (#1518).
+
+    ``normalizeFeedItem`` has read ``p.task_level_required ?? null`` on this
+    card since it was written while the producer never emitted the key, so the
+    badge was permanently blank and the ``?? null`` kept anybody from noticing.
+    Asserting the *value* is the point — that the number arrives from the task
+    row rather than a schema default — hence the level below is not the
+    fixture's 0.
+
+    The presence assertion is not filler. Payload shapes are ``extra="forbid"``
+    (#1402), so a key added to the builder but not to ``FriendSignupPayload``
+    fails validation and the whole item is dropped from the feed rather than
+    rendered without a badge.
+    """
+    from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+    from models.relationship import Relationship, RelationshipStatus, RelationshipType
+
+    active_task.level_required = 3
+    db_session.add(
+        Relationship(
+            from_character_id=character.id,
+            to_character_id=character2.id,
+            type=RelationshipType.friend,
+            status=RelationshipStatus.active,
+        )
+    )
+    mine = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        title="Mine",
+        body_text="proof",
+    )
+    theirs = Praxis(
+        task_id=active_task.id,
+        created_by_id=character2.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        title="Theirs",
+        body_text="proof",
+    )
+    db_session.add_all([mine, theirs])
+    await db_session.flush()
+    db_session.add_all(
+        [
+            PraxisMember(praxis_id=mine.id, character_id=character.id),
+            PraxisMember(praxis_id=theirs.id, character_id=character2.id),
+        ]
+    )
+    await db_session.commit()
+
+    response = await client.get(
+        "/activity-feed",
+        params={"filter": "friends", "limit": 100, "types": ["friend_signup"]},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200, response.text
+    items = [i for i in response.json()["items"] if i["type"] == "friend_signup"]
+    assert len(items) == 1, f"the friend_signup item was dropped: {response.json()}"
+    assert items[0]["payload"]["task_level_required"] == 3


### PR DESCRIPTION
## The defect

`normalizeFeedItem.ts:209` reads `level: p.task_level_required ?? null` for `case 'friend_signup'`. The backend never sent the key: `_friend_signups_query` did not select `Task.level_required` and `_friend_signup_item` did not put it on the payload. The badge has been blank since the card was written, and the `?? null` is why nobody noticed — it degrades to a missing badge instead of a crash.

Verified the issue's mapping before changing anything. The three payloads that *do* emit the key are `global_task` (`activity_feed.py:442`/`:463`), `collab_invite` (`:507`/`:544`) and `awaiting_submission` (`:864`/`:899`), and each spells it the same two ways: `Task.level_required.label("task_level_required")` in the select, `task_level_required=row.task_level_required` in the builder. This matches that shape rather than inventing one. The task is already joined in `_friend_signups_query`, so this is one more column on an existing join — no extra query.

## The `extra="forbid"` trap

#1517 landed the declared payload models, and `FeedPayloadBase` sets `extra="forbid"`. Adding the key to the builder alone would not have produced a null badge — it would have failed validation and made the whole item **silently disappear** from the feed (the service fail-softs per item, per `test_a_malformed_payload_is_dropped_and_its_siblings_still_serve`). So `FriendSignupPayload` gains `task_level_required: int` in the same commit.

## Seam tested

The **HTTP seam** — `GET /activity-feed` through the real router, service, queries and response model, which is the only place the `extra="forbid"` validation actually runs. `backend/tests/integration/test_activity_feed.py::test_friend_signup_carries_the_task_level` sets up a friend on a shared in-progress task whose `level_required` is **3** (not the fixture's 0, so a schema default could not pass), then asserts two things:

1. exactly one `friend_signup` item is still in the response — the guard against the trap above;
2. `payload["task_level_required"] == 3` — the level actually arriving, not merely a 200.

Went red on the real defect first: `KeyError: 'task_level_required'`, with the presence assertion passing. Green after the fix.

## Also in the diff

Deleted a stale `ponytail:` comment in `_collab_invite_item` reading "only collab cards render a level badge" — already false before this PR (`global_task` renders one, and the frontend reads it at `:421`), and now false twice over. One-line deletion of a wrong claim sitting on the code I touched.

No frontend change: the consumer already reads the key. No migration; no model or schema-table change.

## Tests

```
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz1518_test \
  pytest --cov=. --cov-fail-under=80
```
→ **1006 passed**, coverage 92.37%.

## Visual QA: none

I have no browser and no dev stack. **I did no visual QA on this change** — the level badge is asserted only as a number on the wire, not as pixels on a card. Worth stating plainly that the Updates surface has never had any visual QA at all, so "the badge now renders correctly next to the points" is unverified by anyone, before or after this PR.

## What to eyeball

- A friend-signup row on **Updates** now shows a level badge where it previously showed none — confirm it appears, and that it sits alongside the points chip the way `global_task` and `collab_invite` rows do rather than pushing the row's layout around.
- A friend signup on a **level-0 task**: the value is now a real `0` rather than an absent key. Check the card does not render a "Level 0" badge if the intent was to hide it — the backend has always sent `0` for `global_task` in the same situation, so any hiding rule is the frontend's and should already be consistent.
- Per-faction feed frames (albescent / WOW / default chassis) with a friend-signup row, since the row is one element taller in the branches that render the badge inline.
- The **Requests** tab is unaffected — friend signups never appear there — but worth one glance that collab-invite cards are unchanged after the comment deletion (no behaviour touched).

Closes #1518