### PR TITLE
The kit is 21 surfaces x 9 identities, and two of the issue's counts were wrong

### DIFF
--- a/docs/agents/design-fidelity.md
+++ b/docs/agents/design-fidelity.md
@@ -69,5 +69,7 @@ So visual verification is a **separate gate**, and it is split:
   success without resizing.
 - **A human** does the mobile looking. Nothing in the toolchain covers it.
 
-Related: ADR-0049 (score stamp as a manifest surface), ADR-0050 (WOW/Coven
+Related: `docs/kit-structure.md` (what the kit is shaped like — the surface list,
+why each faction gets a bespoke component, and the two ways a faction silently
+loses one), ADR-0049 (score stamp as a manifest surface), ADR-0050 (WOW/Coven
 identity), `docs/spec/SPEC-faction-ui-profile.md`.

--- a/docs/kit-structure.md
+++ b/docs/kit-structure.md
@@ -1,0 +1,184 @@
+# The faction kit
+
+What the kit is shaped like, and the handful of things about it that the code
+cannot say out loud. Everything the code *can* say lives in
+`frontend/src/factions/` — read that first and treat this file as the commentary.
+
+## The shape
+
+**21 dispatched surfaces × 9 faction identities.**
+
+A **surface** is a place where a faction may look like itself: a task card, a
+vote widget, a comment voice, a whole page. The list is
+`SURFACE_KEYS` in `frontend/src/factions/manifest.ts`, and it is exhaustive by
+construction — a `satisfies` clause makes the array and the `FactionManifest`
+interface check each other, so a surface cannot exist without appearing in both.
+Each surface has exactly one dispatcher, which calls `surfaceMap('<key>')` and
+hands the result to `pickVariant`.
+
+An **identity** is a faction slug. Eight ship a manifest
+(`frontend/src/factions/index.ts`); the ninth is `na`, which ships none on
+purpose — see below.
+
+Do not maintain those two numbers here. Count them with
+`SURFACE_KEYS.length` and `FACTION_MANIFESTS.length + 1`; this section exists to
+say what the numbers *mean*, not to cache them. (They were 21 and 9 when this
+file was written, which is worth stating only because the epic that commissioned
+it went in believing the second number was 10.)
+
+## Why a bespoke component per faction, and not a props-driven skin
+
+The obvious design is one component that takes a palette and a few flags. It was
+rejected, and the reason is worth keeping: the factions do not differ by
+parameter. Coven's task card and Ephemerists' task card do not share a layout
+with different colours poured in — they share a *slot contract* and disagree
+about nearly everything else, down to which elements exist. A props-driven skin
+would have grown one flag per disagreement until the flags were a worse language
+for describing a card than JSX already is.
+
+So the kit is: **a shared library of parts, plus one bespoke component per
+faction per surface.** The shared part is real and load-bearing — a skin
+composes `DuelSealSheet`, `ScoreStamp`, `FeedItemSlot`, the card-footer classes —
+but the composition itself is hand-written per faction. When two skins genuinely
+converge, the fix is to lift the shared thing into the library, not to merge the
+skins behind a flag.
+
+The manifest is **override-only**: every field is optional, and an undeclared
+surface falls through to that surface's `Default*` archetype. A faction that
+declares nothing renders correctly everywhere, including on surfaces that do not
+exist yet. **Partial registration is the normal case, not a degraded one.**
+
+## `Default` ≡ `na` ≡ Unaffiliated is one identity
+
+Three names, one thing. `na` is the slug an unaffiliated player carries;
+`Unaffiliated` is what the copy calls them; `Default*` is what their components
+are named. There is no separate "default faction" and no fallback-that-isn't-a-
+faction. ADR-0039 settles it: `na` resolves to the neutral `--faction-default-*`
+set — a spectrum, not a hue — and never borrows another faction's colour.
+
+**The naming rule: an na component is `Default*`, never `Na*`.** This is why
+`na` has no manifest file. Registering it would mean naming, for every surface,
+the component that surface *already* falls back to.
+
+### The three `Default*` archetypes that are functions, not files
+
+`Default*` names an **archetype, not necessarily a module**. Three surfaces keep
+their na rendering inside the dispatcher:
+
+| Surface | What renders for `na` |
+|---|---|
+| `avatar` | `DefaultAvatar`, a local function in `components/avatar/FactionAvatar.tsx` |
+| `feedFrame` | `DefaultFeedFrame`, a local function in `components/feed/FactionFeedFrame.tsx` |
+| `backdrop` | `WatercolorBackground`, imported from `components/layout/` |
+
+All three are designed, shipped and rendering today — `DefaultAvatar`'s conic
+spectrum ring was drawn in #1127, `DefaultFeedFrame`'s spectrum spine in #1148 —
+and a test already pins the feed frame as the Unaffiliated chassis rather than a
+passthrough (#1194).
+
+This table is here for one reason: **the absence of `DefaultAvatar.tsx` has been
+read as a hole in the na kit by four separate audits.** It is a file-layout
+observation. Counting skin *files* undercounts these three surfaces by one each.
+If you are about to file "the na kit is missing an avatar", it is not.
+
+## Albescent's partial coverage is the steady state, not a gap
+
+Albescent declares a minority of the 21 surfaces, and that is correct and
+deliberate. It is a secret society hiding in plain sight (ADR-0027), so it must
+be indistinguishable from an unaffiliated player unless you already know what you
+are looking at.
+
+- **ADR-0046** freezes it: new surfaces fall through to na rather than getting an
+  Albescent skin by default.
+- **ADR-0048** unfreezes it *per surface, as designs land* — and every row it
+  gains is `Default` **plus a flourish** (a drifting spectrum wash, a turning
+  prism ring), never a repaint in its own colours. A repaint would put it back in
+  the spectrum and un-hide it.
+
+So the count rises one design at a time and is never expected to reach 21. **This
+has been re-derived as a coverage gap at least twice.** It is not one. The
+per-surface reasoning is in the docblocks in `frontend/src/factions/albescent.ts`,
+which is the only place that stays current.
+
+## Responsive or split by form factor
+
+**The rule, and it covers all 21 surfaces: a surface is one responsive component
+per faction unless its `SURFACE_KEYS` entry is prefixed `mobile`.** The key name
+*is* the status, so this document does not keep a 21-row table that would be
+wrong the day a surface lands. Grep the prefix.
+
+A skin that needs to know the viewport reads `useFormFactor()` internally, or
+composes a chassis that does — `DuelSealSheet` is the pattern: the skin declares
+its ground and its card, the chassis picks modal-over-scrim or full-bleed sheet.
+
+Two keys carry the prefix today, and they are not the same kind of thing:
+
+- **`mobileFactionPage` — a genuine twin, and genuine debt.** The faction detail
+  page is still two components per faction. #1314 collapses it and is blocked on
+  a design (#951). This is the last surface in the epic's collapse programme.
+- **`mobileFieldDesk` — not a twin, and not debt.** The phone home is a
+  *different screen*, not a narrow rendering of the roster: `pages/FieldDesk.tsx`
+  shows the account's roster of lives on a laptop and the carried life's home on
+  a phone. Different content, different job. Do not write it up as a split to be
+  collapsed, and do not "finish" it by building a desktop counterpart.
+
+Every collapse so far was licensed by its own record, one surface at a time —
+ADR-0056 (task cards), ADR-0058 (task detail), ADR-0061/0063 (praxis detail),
+ADR-0065 (the composer), ADR-0067 (praxis cards), #1319 (character profile),
+#1313 (the duel seal). ADR-0035 still governs what remains. **A licence to
+collapse one surface is not a licence to collapse the next**; each record says so
+in terms, and the next surface needs its own.
+
+## The two ways a faction silently loses a surface
+
+Both fail the same way — the faction renders its `Default*` skin, everything
+compiles, every test passes, and nobody notices for weeks. They are worth knowing
+because "it looks like na" is indistinguishable from "it *is* na" at a glance.
+
+1. **A manifest that is not in `FACTION_MANIFESTS`.** Adding a faction is two
+   edits — the module, and one line in `frontend/src/factions/index.ts`. Only the
+   second one is load-bearing at runtime, and omitting it is not a type error.
+2. **An entry read at module-evaluation time.** Dispatchers and archetypes import
+   each other, so `factions/index.ts` sits in a real ES-module cycle. This is why
+   every manifest entry is a thunk (`taskCard: () => UaTaskCard`) rather than a
+   bare reference: a bare reference is read while the modules are still
+   evaluating, lands on an uninitialised binding, and captures `undefined`
+   forever. **This is how UA lost its heraldic sigil during the #782 refactor.**
+   The thunk type now makes the seam correct by construction — do not "simplify"
+   it away, and do not turn `surfaceMap()` into a module-level const for the same
+   reason.
+
+`manifestsStayLazy.test.ts` and `addAFaction.test.tsx` guard both, and the second
+proves the add-a-faction path end to end with a fake faction.
+
+## Publishing the kit
+
+`.design-sync/` publishes a subset of these components as a design kit.
+`config.json`'s `componentSrcMap` **hardcodes source paths**, so any file move
+must update it in the same PR or the next sync republishes a stale path. Verify
+the whole map resolves before syncing rather than trusting review to catch one
+line:
+
+```sh
+python -c "import json,os; m=json.load(open('.design-sync/config.json'))['componentSrcMap']; print([k for k,v in m.items() if not os.path.exists('frontend/'+v)] or 'all paths resolve')"
+```
+
+`.design-sync/NOTES.md` covers the rest, including the part that surprises
+people: **the CLI that consumes this directory is not committed**, so a sync run
+is not reproducible from a clean checkout. `previews/` *is* committed and is
+typechecked in CI (`npm run typecheck:design-sync`), so a preview whose props
+drift is a red build for everyone.
+
+## Where the source of truth lives
+
+| Question | Answer |
+|---|---|
+| Which surfaces exist? | `SURFACE_KEYS`, `frontend/src/factions/manifest.ts` |
+| Which factions exist? | `FACTION_MANIFESTS`, `frontend/src/factions/index.ts`, plus `na` |
+| Which faction dresses which surface? | that faction's `frontend/src/factions/<slug>.ts` |
+| What does a surface's prop contract look like? | the field's type in `manifest.ts` |
+| Why does a surface look the way it does? | its ADR in `docs/adr/` |
+
+Deliberately absent: a faction × surface coverage matrix. The manifests are that
+matrix, they are one grep away, and a prose copy is wrong the day a surface
+lands. If you want the numbers, read them out of the code.


### PR DESCRIPTION
Closes #1320

Child F of epic #1312. Docs-only: `docs/kit-structure.md` (new) plus a one-line pointer to it from `docs/agents/design-fidelity.md`.

## Three counts measured, two of them wrong

The issue's "21 surfaces × 10 factions" was a claim, not a fact. I counted before writing it down.

| Claim | Measured | Source |
|---|---|---|
| 21 surfaces | **21 — correct** | `SURFACE_KEYS`, `frontend/src/factions/manifest.ts` |
| 10 factions | **9** | 8 manifests in `FACTION_MANIFESTS` + `na` |
| Albescent has 9 of 21 | **8 of 21** | `frontend/src/factions/albescent.ts` |

**Why 9, not 10.** The nine slugs are `ua`, `everymen`, `wow`, `snide`, `ephemerists`, `singularity`, `coven`, `albescent`, `na` — the same nine `backend/eras/era_1.py` declares and the same nine keys in `CSS_KEY`. Ten only appears if you count `na` and `default` as two identities, which is exactly the mistake the doc now exists to stop: `Default` ≡ `na` ≡ Unaffiliated is one thing, three names (ADR-0039).

The orchestrator's brief also flagged "albescent is an alias on some surfaces (ADR-0017 decision 7)". That is stale in the other direction: ADR-0017 decision 7 is the record that made Albescent **first-class** and dropped the `albescent → ua` alias, and `FACTION_ALIASES` is now empty. Albescent is a full identity that resolves to the neutral palette — not an alias.

Albescent's 8 (not 9) are `factionSelectCard`, `praxisCard`, `taskCard`, `taskDetail`, `praxisDetail`, `feedFrame`, `vote`, `metataskSeal`.

## Responsive vs split: the rule, not a 21-row table

The issue asked for the responsive-vs-split status of all 21 surfaces. A 21-row table is a state mirror that rots on the next surface, so the doc states the rule instead, and the rule genuinely covers all 21:

> **A surface is one responsive component per faction unless its `SURFACE_KEYS` entry is prefixed `mobile`.**

The key name *is* the status, so it cannot drift. Two keys carry the prefix, and the doc distinguishes them because they are not the same kind of thing:

- `mobileFactionPage` — a genuine twin and genuine debt; #1314, blocked on design #951.
- `mobileFieldDesk` — **not** a twin. `pages/FieldDesk.tsx` renders the account's roster of lives on a laptop and the carried life's home on a phone: different content, different job. Written up explicitly as *not* debt, per the issue.

## What else the doc records

Only things the code cannot say: why a bespoke component per faction beats a props-driven skin; the `Default*` naming rule; the three na fallbacks that are **local functions, not files** (four audits have now read that as a missing skin); why Albescent's partial coverage is the ADR-0046/0048 steady state rather than a gap; and the two ways a faction silently loses a surface. It ends with a source-of-truth table and an explicit note that a faction × surface matrix is deliberately absent.

## design-sync: config verified clean, re-run not possible here

- **`componentSrcMap` is already correct.** All **249** entries resolve against the post-#1315/#1316 tree — I checked every one, so the file-move worry in the issue is satisfied and `config.json` needs no edit. The doc ships the one-line check so the next mover can run it.
- **The re-run did not happen, and cannot happen in a worktree.** `.design-sync/NOTES.md` records that the CLI consuming this directory lives in gitignored `.ds-sync/` and is not committed, so a sync is not reproducible from a clean checkout. Per the dispatch brief I also did not touch `previews/` — it is typechecked in CI against real app types and another agent is concurrently editing frontend exports. **This needs the orchestrator/main session to run `/design-sync`.**

## Two things for the agent who owns `frontend/src/**` (I did not touch them)

Both understate WOW's coverage, which now measures **19 of 21** (all but `factionCard` and `factionBody`, the #951 pending set):

- `frontend/src/factions/index.ts` — the `FACTION_MANIFESTS` docblock says `wowRendersDefault.test.tsx` "pins which **six** surfaces are claimed".
- `frontend/src/factions/__tests__/wowRendersDefault.test.tsx:129` — the `describe` title says "**twenty** surfaces claimed". The `WOW_SKINNED` set it asserts against is correct; only the title is off by one.

## Not done: the CLAUDE.md routing-table row

The issue's done-when asks for the doc to be linked from the CLAUDE.md routing table. `CLAUDE.md` is owned by a concurrent agent in this batch, so I linked from `docs/agents/design-fidelity.md` instead and left CLAUDE.md alone. **The routing row still needs adding** — suggested: `| Kit shape: surfaces, faction identities, responsive-vs-split | docs/kit-structure.md |`.

## Seam and verification

No seam and no test — docs-only, no code path changed, nothing to eyeball visually. CI (`test` + `frontend`) should pass untouched; the diff contains no TypeScript, no CSS and no JSON. Every factual claim in the doc was read out of the code rather than out of the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)