### PR TITLE
The frontend sweeps out 5 dead exports, an empty alias map, 6 CSS classes and 41 copy keys (#1389)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ Read only what your task needs.
 - Faction config: `factions.ts`. Use `factionCssVar()` for styles.
 - Dark mode via the `[data-theme="dark"]` cascade — no `dark ? '#a' : '#b'` ternaries
 - Each faction has its own card archetype; don't unify
-- Reuse `.card-footer`, `.card-meta`, `.card-description` for repeated patterns
+- Reuse `.card-meta`, `.card-description` for repeated patterns
 - Hide unusable controls; don't show them disabled
 - Form factor (#494): a new dispatched surface provides a `Default*` mobile skin and dispatches through a parallel `MOBILE_ARCHETYPE_BY_SLUG` on `useFormFactor() === 'mobile'`. The mobile path stacks single-column — never fixed-px inline grids for layout structure. See `docs/spec/SPEC-faction-ui-profile.md` §1a.
 

--- a/frontend/src/components/factionMarks/uaAtoms.tsx
+++ b/frontend/src/components/factionMarks/uaAtoms.tsx
@@ -36,12 +36,6 @@ export const UA_EYEBROW: CSSProperties = {
   color: "var(--faction-ua-card-muted)",
 };
 
-/** The same label in the accent, for a section head that must lead the eye. */
-export const UA_EYEBROW_ACCENT: CSSProperties = {
-  ...UA_EYEBROW,
-  color: "var(--faction-ua-card-accent)",
-};
-
 /**
  * A drop shadow mixed from the ink token rather than a raw rgba.
  *
@@ -52,9 +46,6 @@ export const UA_EYEBROW_ACCENT: CSSProperties = {
 export function uaShade(percent: number): string {
   return `color-mix(in srgb, var(--faction-ua-card-text) ${percent}%, transparent)`;
 }
-
-/** The neutral hairline, as a border shorthand. */
-export const UA_HAIRLINE = "1px solid var(--faction-ua-rule)";
 
 /**
  * How much of the drawn box the ensō leaves clear, across the middle.

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -505,10 +505,10 @@ export function AlbescentSelectCard({ state = "locked", members, onVisit }: Omit
 // Retired/renamed slugs → their live archetype. Raw slug wins first, so a
 // first-class faction always renders its own card rather than a legacy skin.
 //
-// This is a SECOND alias table, parallel to FACTION_ALIASES in utils/factions.ts
-// which pickVariant already consults. Folding the two together is a behaviour
-// change (these two slugs are not in FACTION_ALIASES), so it is left alone here
-// and tracked as follow-up.
+// This is the only alias table left in the frontend. The general-purpose one in
+// utils/factions.ts had been an empty object since #232 and was deleted with the
+// four resolution branches that consulted it (#1389); these two slugs were never
+// in it, so nothing here changed.
 const LEGACY_SLUG: Record<string, string> = {
   gestalt: "coven",
   journeymen: "ephemerists",

--- a/frontend/src/components/sigil/UaSigil.tsx
+++ b/frontend/src/components/sigil/UaSigil.tsx
@@ -1,4 +1,3 @@
-import i18n from "../../i18n";
 import { Enso } from "../factionMarks";
 
 /**
@@ -60,38 +59,4 @@ export function UaSigil({
   color?: string;
 }) {
   return <Enso size={width} height={height} color={color} style={{ flexShrink: 0 }} />;
-}
-
-/**
- * The motto cartouche — a solid sienna ribbon with notched ends.
- *
- * Kept as-is structurally; only repointed off the legacy gilt-salon family onto
- * the fill/on-fill pair, which carries both themes (4.59:1 light, 5.59:1 dark).
- * Whether the practice still wants a motto ribbon at all is an archetype
- * question and belongs to the surfaces that draw it, not to this file.
- */
-export function MottoRibbon({
-  fontSize = 11,
-  padding = "5px 26px",
-}: {
-  fontSize?: number;
-  padding?: string;
-}) {
-  return (
-    <div
-      style={{
-        position: "relative",
-        width: "fit-content",
-        background: "var(--faction-ua)",
-        color: "var(--faction-ua-on-fill)",
-        fontFamily: 'var(--faction-ua-body-font)',
-        fontSize,
-        letterSpacing: "0.1em",
-        padding,
-        clipPath: "polygon(0 0,100% 0,96% 50%,100% 100%,0 100%,4% 50%)",
-      }}
-    >
-      {i18n.t("feed:identity.ua.motto")}
-    </div>
-  );
 }

--- a/frontend/src/components/vote/voteReframes.ts
+++ b/frontend/src/components/vote/voteReframes.ts
@@ -1,5 +1,4 @@
 import i18n from '../../i18n'
-import { FACTION_ALIASES } from '../../utils/factions'
 
 export interface ReframeTier {
   value: number
@@ -87,7 +86,7 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
     // The growing-mandala vote widget (#821): each rank is a "reading" of the
     // filed work as the mandala blooms fuller/warmer — faint → radiant. These
     // words are the mandala's per-rank captions AND UA's app-wide vote
-    // vocabulary (the voter-breakdown resolver reads them via reframeLabel).
+    // vocabulary (anything labelling a value reads them via reframeLabel).
     tiers: [
       { value: 1, label: i18n.t('votes:ua.faint') },
       { value: 2, label: i18n.t('votes:ua.forming') },
@@ -104,13 +103,10 @@ export const VOTE_REFRAMES: Record<string, VoteReframe> = {
 }
 
 /**
- * Label a vote value in a task faction's vocabulary (alias-aware, mirroring
- * pickVariant). Falls back to the arabic number when no reframe exists
- * (factionless / unknown slug).
+ * Label a vote value in a task faction's vocabulary. Falls back to the arabic
+ * number when no reframe exists (factionless / unknown slug).
  */
 export function reframeLabel(factionSlug: string | null | undefined, value: number): string {
-  const reframe =
-    VOTE_REFRAMES[factionSlug ?? ''] ??
-    VOTE_REFRAMES[FACTION_ALIASES[factionSlug ?? ''] ?? '']
+  const reframe = VOTE_REFRAMES[factionSlug ?? '']
   return reframe?.tiers.find((tier) => tier.value === value)?.label ?? String(value)
 }

--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -120,8 +120,8 @@ for (const [surface, bespoke] of Object.entries(BESPOKE)) {
 /* Coven and WOW are distinct factions that must never fall back on each      */
 /* other aesthetically, and a faction missing a custom experience is a design */
 /* bug. Any fallback goes to the generic Default (N/A) — pickVariant has no    */
-/* cross-faction path (FACTION_ALIASES is empty) — so this enforces the second */
-/* half: both must be bespoke on every surface the core factions are.         */
+/* cross-faction path at all — so this enforces the second half: both must be  */
+/* bespoke on every surface the core factions are.                            */
 /* -------------------------------------------------------------------------- */
 
 // The bar, derived so a new core surface raises it automatically: every surface

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2892,15 +2892,6 @@
 
   /* ── Task card shared patterns ── */
 
-  .card-footer {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-top: 1px dashed var(--color-border-strong);
-    padding-top: 5px;
-    margin-top: auto;
-  }
-
   .card-meta {
     font-size: var(--text-xs);
     text-transform: uppercase;
@@ -3190,12 +3181,6 @@
     @apply max-w-5xl mx-auto px-4 sm:px-6 py-8;
   }
 
-  .page-heading {
-    @apply font-display text-4xl font-bold mb-6;
-    font-style: italic;
-    color: var(--color-text-primary);
-  }
-
   /* ── Nav links (Courier Prime 10px uppercase — Style Guide §5.1) ── */
 
   .nav-link {
@@ -3262,10 +3247,6 @@
     background-image: radial-gradient(currentColor 32%, transparent 34%);
     background-size: 5px 5px;
   }
-  .ht-dots-lg {
-    background-image: radial-gradient(currentColor 30%, transparent 33%);
-    background-size: 8px 8px;
-  }
   .xerox {
     background-color: var(--faction-snide-paper);
     background-image:
@@ -3296,9 +3277,6 @@
   }
   .snide-tape::after {
     right: 0;
-  }
-  .snide-merrow {
-    background-image: repeating-conic-gradient(var(--faction-snide-acid) 0deg 18deg, var(--faction-snide-acid-deep) 18deg 36deg);
   }
 }
 
@@ -3386,22 +3364,6 @@
 @media (prefers-reduced-motion: no-preference) {
   .sg-scan { animation: sg-scan-sweep 5s linear infinite; }
   .sg-cursor { animation: wz-blink 1s step-end infinite; }
-}
-
-/* S.N.I.D.E. duel rail — the settled-state dot flickers like a failing xerox
-   lamp. Class-gated on reduced-motion like every other faction animation, so a
-   component never writes `animation:` inline and bypasses the gate. (#722) */
-@keyframes snide-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
-@media (prefers-reduced-motion: no-preference) {
-  .snide-pulse { animation: snide-pulse 1.6s ease-in-out infinite; }
-}
-
-/* Everymen duel rail — the "live" dot on the settled-standing strip pulses like a
-   dispatch-board indicator (#721). Stilled for reduced-motion, same as its
-   neighbours: the dot's meaning is carried by the note's copy, never by motion. */
-@keyframes ev-duel-pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.35; transform: scale(0.82); } }
-@media (prefers-reduced-motion: no-preference) {
-  .ev-duel-pulse { animation: ev-duel-pulse 1.1s ease-in-out infinite; }
 }
 
 /* ══ Praxis-card redesign vote widgets (#821) ══

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -33,12 +33,7 @@
     "badgesEarned": "{{count}} earned",
     "mobile": {
       "tabPraxis": "Praxis",
-      "tabTasks": "Tasks",
-      "stats": {
-        "points": "Points",
-        "praxis": "Praxis",
-        "tasks": "Tasks"
-      }
+      "tabTasks": "Tasks"
     },
     "wow": {
       "eyebrow": "Of the Court of Whimsy",
@@ -57,10 +52,6 @@
   "leaderboard": {
     "loading": "Loading...",
     "empty": "No players yet.",
-    "soloEyebrow": "Era I · Roll call",
-    "soloBody": "You're the first player on World Zero. The rankings will fill in as others arrive — until then, the board is yours alone.",
-    "rankingsSoFar": "Rankings so far",
-    "youFactionLevel": "{{faction}} · Level {{level}}",
     "desktop": {
       "title": "Players",
       "eyebrowEra": "{{era}} · The Standings",
@@ -108,7 +99,6 @@
       }
     },
     "mobile": {
-      "count": "{{count}} players",
       "sortEra": "Era",
       "sortAllTime": "All-time",
       "allFactions": "All",
@@ -123,9 +113,6 @@
   "collaborationCard": {
     "duel": "Duel",
     "collaboration": "Collaboration",
-    "titleFallback": "{{label}} · {{count}} players",
-    "viewDuel": "View duel",
-    "viewCollaboration": "View collaboration",
     "pending": "pending"
   },
   "credential": {
@@ -203,11 +190,6 @@
         "masthead": "The Codex Desk",
         "charEyebrow": "On the road",
         "questsHeading": "Surveys underway"
-      },
-      "albescent": {
-        "masthead": "The Desk",
-        "charEyebrow": "On record",
-        "questsHeading": "In hand"
       },
       "snide": {
         "masthead": "The Job Board",
@@ -374,9 +356,6 @@
       "empty": "No activity yet",
       "kickerNewTask": "New task",
       "kickerEra": "New era",
-      "eraBegun": "{{eraName}} has begun",
-      "newTask": "<0>New task:</0> <1>{{title}}</1>",
-      "completedTask": "<0>{{actor}}</0> completed <1>{{title}}</1>",
       "fallbackTaskTitle": "a task"
     }
   },
@@ -391,20 +370,6 @@
     "applying": "Applying…",
     "useOriginal": "Use original",
     "cancel": "Cancel"
-  },
-  "voteStamps": {
-    "a-start": "a start",
-    "solid": "solid",
-    "good": "good",
-    "excellent": "excellent",
-    "legendary": "legendary",
-    "rateAria": "Rate {{value}} — {{label}}",
-    "loginPrompt": "Log in to vote",
-    "voted_one": "Voted {{count}} pt",
-    "voted_other": "Voted {{count}} pts",
-    "summary_one": "{{count}} vote · {{points}} pts",
-    "summary_other": "{{count}} votes · {{points}} pts",
-    "saveError": "Could not save your vote. Please try again."
   },
   "settings": {
     "title": "Settings",

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -190,10 +190,6 @@
     }
   },
   "identity": {
-    "ua": {
-      "fullName": "University of Asthmatics",
-      "motto": "Ars Longa · Spiritus Brevis"
-    },
     "snide": {
       "wordmark": "S.N.I.D.E.",
       "fullName": "Society for Nihilistic Intent & Disruptive Efforts"
@@ -278,10 +274,7 @@
       "pointsUnit": "marks"
     },
     "coven": {
-      "windowTitle": "coven.exe",
-      "questMeta": "new quest · {{points}} pts",
       "signup": "sign up",
-      "points": "{{points}} pts",
       "masthead": "the cozy coven",
       "levelCaption": "level",
       "pointsUnit": "points"

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -26,16 +26,7 @@
       "voted": "Voted"
     }
   },
-  "mobileFeed": {
-    "unaffiliated": "Unaffiliated",
-    "untitled": "Untitled praxis",
-    "byline": "{{faction}} · {{time}}",
-    "tally_one": "{{points}} pts · {{count}} vote",
-    "tally_other": "{{points}} pts · {{count}} votes"
-  },
   "mobileCard": {
-    "taskRef": "Re · {{title}}",
-    "untitled": "Untitled praxis",
     "rosterMore": "+{{count}} more",
     "mediaMore": "+{{count}}",
     "mediaVideo": "video",

--- a/frontend/src/pages/editPraxis/blocks/useMediaArt.ts
+++ b/frontend/src/pages/editPraxis/blocks/useMediaArt.ts
@@ -54,14 +54,3 @@ export function pickArtKey(filename: string, kind?: MediaType): MediaArtKey {
   if (lower.includes("recipe") || lower.includes("card")) return "recipe";
   return "page";
 }
-
-export function mediaArtKeysFromFile(file: File): MediaArtKey {
-  const kind: MediaType | undefined = file.type.startsWith("image/")
-    ? "image"
-    : file.type.startsWith("video/")
-      ? "video"
-      : file.type.startsWith("audio/")
-        ? "audio"
-        : undefined;
-  return pickArtKey(file.name, kind);
-}

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -31,7 +31,6 @@
 import type { CSSProperties, ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
-import { reframeLabel } from '../../components/vote/voteReframes'
 import { TaskCrown } from '../../components/factionMarks/TaskCrown'
 import CommentThread from '../../components/comments/CommentThread'
 import DuelSealConfirm from '../../components/duel/DuelSealConfirm'
@@ -701,47 +700,6 @@ export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
           {flagError && <p className="font-body content-text" style={{ color: 'var(--color-danger)', marginTop: 'var(--space-sm)' }}>{flagError}</p>}
         </div>
       )}
-    </div>
-  )
-}
-
-// ── Voter breakdown (who voted + their value) ─────────────────────────────────
-//
-// Task-scoped surface: every voter's value is labelled in the *task* faction's
-// vocabulary (one reframe), not each voter's own. Read-only; faction-agnostic
-// structure, so it lives here and every archetype renders it identically.
-
-export function PraxisVoterBreakdown({ state }: { state: PraxisDetailState }) {
-  const { t } = useTranslation('praxis')
-  const { praxis, voters } = state
-  if (!praxis || voters.length === 0) return null
-
-  return (
-    <div className="sidebar-card card-on-page mb-4" style={{ padding: 'var(--space-lg) var(--space-lg)' }}>
-      <div className="flex items-baseline justify-between mb-3">
-        <span className="eyebrow">{t('detail.voters.heading')}</span>
-        <span className="eyebrow">{t('detail.voters.count', { count: voters.length })}</span>
-      </div>
-      <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>
-        {voters.map((voter) => (
-          <li
-            key={voter.character_id}
-            className="flex items-center justify-between"
-            style={{ padding: 'var(--space-xs) 0', borderTop: '1px solid var(--color-border)' }}
-          >
-            <Link
-              to={`/characters/${voter.character_id}`}
-              className="font-body"
-              style={{ fontSize: 'var(--text-lg)', color: 'var(--color-text-primary)', textDecoration: 'none' }}
-            >
-              {voter.display_name}
-            </Link>
-            <span className="font-body content-text" style={{ fontWeight: 700, color: 'var(--color-text-secondary)' }}>
-              {reframeLabel(praxis.task_faction_slug, voter.value)}
-            </span>
-          </li>
-        ))}
-      </ul>
     </div>
   )
 }

--- a/frontend/src/utils/__tests__/factionAlbescentHidesInPlainSight.test.ts
+++ b/frontend/src/utils/__tests__/factionAlbescentHidesInPlainSight.test.ts
@@ -18,7 +18,6 @@
  */
 import { describe, expect, it } from "vitest";
 import {
-  FACTION_ALIASES,
   FACTION_RAINBOW_ORDER,
   factionCssVar,
   factionFill,
@@ -122,8 +121,8 @@ describe("Albescent is indistinguishable from unaffiliated", () => {
   it("is not an alias — it is registered, just unthemed", () => {
     // Guards the other way of "fixing" this: re-pointing albescent at another
     // faction's identity. It borrows nobody's costume (it wore ua's before
-    // #232); it simply has none of its own.
-    expect(FACTION_ALIASES["albescent"]).toBeUndefined();
+    // #232); it simply has none of its own. There is no alias map left to
+    // check, so the resolved variables ARE the whole assertion.
     for (const suffix of SUFFIXES) {
       expect(factionCssVar("albescent", suffix)).not.toContain("--faction-ua");
     }

--- a/frontend/src/utils/__tests__/factionDispatch.test.ts
+++ b/frontend/src/utils/__tests__/factionDispatch.test.ts
@@ -7,7 +7,7 @@
  * factions/__tests__/surfaceDispatch.test.ts; that a manifest routes to every
  * surface at all is guarded generically by factions/__tests__/addAFaction.test.
  */
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { pickVariant } from '../factionDispatch'
 
 const A = () => null
@@ -35,21 +35,12 @@ describe('pickVariant', () => {
     expect(pickVariant(map, '__nope__')).toBeUndefined()
     expect(pickVariant(map, null)).toBeUndefined()
   })
-})
 
-// The alias branch: a derived slug inherits its canonical faction's variant.
-// FACTION_ALIASES is empty in production, so this is the only thing that
-// exercises the branch at all.
-describe('pickVariant alias resolution', () => {
-  it('resolves a slug through its alias to the canonical entry', async () => {
-    // resetModules so the dynamic import re-evaluates factionDispatch against
-    // the mocked FACTION_ALIASES instead of the already-cached real (empty) one.
-    vi.resetModules()
-    vi.doMock('../factions', () => ({ FACTION_ALIASES: { derived: 'coven' } }))
-    const { pickVariant: withAlias } = await import('../factionDispatch')
-    expect(withAlias(map, 'derived', Fallback)).toBe(A) // derived → coven → A
-    expect(withAlias({ coven: A }, 'derived')).toBe(A) // even with no fallback
-    vi.doUnmock('../factions')
-    vi.resetModules()
+  it('never resolves one faction to another', () => {
+    // The alias branch used to sit here, so a slug could reach a sibling
+    // faction's variant. Nothing may do that now: an unregistered slug takes
+    // the fallback or nothing, never `map`'s other entries.
+    expect(pickVariant(map, 'derived', Fallback)).toBe(Fallback)
+    expect(pickVariant({ coven: A }, 'derived')).toBeUndefined()
   })
 })

--- a/frontend/src/utils/factionDispatch.ts
+++ b/frontend/src/utils/factionDispatch.ts
@@ -5,24 +5,22 @@
  * Before this helper, ~10 dispatchers (TaskCard, PraxisCard, EditPraxis,
  * TaskDetail, VoteUI, FactionAvatar, FactionBackdrop,
  * FactionDetail heroes) each spelled "look up slug, else
- * default" three different ways and none of them handled faction-identity
- * aliases (then albescent→ua and aged_out→ua, both since retired). Routing
- * every dispatcher through `pickVariant` makes
- * slug-normalization, alias handling, and unknown-slug behaviour live in one
- * place, and means a new page dispatcher is one map + one call.
+ * default" three different ways. Routing every dispatcher through `pickVariant`
+ * makes slug-normalization and unknown-slug behaviour live in one place, and
+ * means a new page dispatcher is one map + one call.
  */
 import type { ComponentType } from 'react'
-
-import { FACTION_ALIASES } from './factions'
 
 /**
  * Resolve a faction slug to its archetype component.
  *
- * Lookup order: an explicit entry for the slug wins; then its alias's entry
- * (a derived slug inherits its canonical faction's variant without a duplicate
- * map row — the seam the retired aged_out→ua alias used; FACTION_ALIASES in
- * factions.ts is currently empty); then the supplied fallback. A
- * null/undefined/empty slug goes straight to the fallback.
+ * Lookup order: an explicit entry for the slug wins, then the supplied
+ * fallback. A null/undefined/empty slug goes straight to the fallback.
+ *
+ * There is no cross-faction path: a slug renders its own variant or the
+ * fallback, never a sibling faction's. The alias branch that used to sit here
+ * served albescent→ua and aged_out→ua, both retired (#232, #428), and left an
+ * empty map behind it.
  *
  * The fallback is optional: with one, you always get a component (the
  * "every faction renders something" page case); without one, you get
@@ -45,6 +43,5 @@ export function pickVariant<P>(
   fallback?: ComponentType<P>,
 ): ComponentType<P> | undefined {
   if (!slug) return fallback
-  const alias = FACTION_ALIASES[slug]
-  return map[slug] ?? (alias ? map[alias] : undefined) ?? fallback
+  return map[slug] ?? fallback
 }

--- a/frontend/src/utils/factions.ts
+++ b/frontend/src/utils/factions.ts
@@ -49,18 +49,6 @@ export interface FactionConfig {
 }
 
 /**
- * Faction-identity aliases: a derived/retired slug renders with its canonical
- * faction's identity (archetype + CSS theme). Single source of truth for the
- * relationship — consumed here by factionCssVar and by pickVariant in
- * utils/factionDispatch.ts.
- *
- * Currently empty: albescent became first-class (#232) and the last remaining
- * alias, aged_out, was retired with its faction (#428). Kept as the seam so a
- * future derived slug has one home; unknown slugs pass through unaliased.
- */
-export const FACTION_ALIASES: Record<string, string> = {};
-
-/**
  * Slug-to-CSS-variable-key mapping.
  * Faction slugs use underscores in the DB but CSS variables use hyphens.
  */
@@ -95,12 +83,11 @@ const CSS_KEY: Record<string, string> = {
 };
 
 /**
- * Resolve a slug (through aliases) to its CSS-variable key. Unknown/unregistered
- * slugs degrade to `default` (neutral grey / rainbow), never impersonate `ua`.
+ * Resolve a slug to its CSS-variable key. Unknown/unregistered slugs degrade to
+ * `default` (neutral grey / rainbow), never impersonate `ua`.
  */
 function resolveCssKey(slug: string | null | undefined): string {
-  const resolved = FACTION_ALIASES[slug ?? ""] ?? slug ?? "";
-  return CSS_KEY[resolved] ?? "default";
+  return CSS_KEY[slug ?? ""] ?? "default";
 }
 
 /**
@@ -302,7 +289,7 @@ export function factionFill(
  * absence of a faction identity rather than one of them. Testing the mapped
  * value, not key presence, is what keeps those two meanings apart — presence
  * alone reported `na` as a real faction and turned every unaffiliated ornament
- * grey (#749). Aliases resolve first, so a derived slug counts as known.
+ * grey (#749).
  *
  * `albescent` now sits on that same unthemed side (#783), and it is there for a
  * different reason than `na`: it IS a faction, it just refuses to look like one.
@@ -312,8 +299,8 @@ export function factionFill(
  * both grey out unaffiliated players AND expose a secret society.
  */
 export function isKnownFaction(slug: string | null | undefined): boolean {
-  const resolved = FACTION_ALIASES[slug ?? ""] ?? slug ?? "";
-  return resolved in CSS_KEY && CSS_KEY[resolved] !== "default";
+  const key = slug ?? "";
+  return key in CSS_KEY && CSS_KEY[key] !== "default";
 }
 
 /**


### PR DESCRIPTION
Frontend dead-code sweep: items 1-4 only. Items 5, 6 and 7 are deliberately **not** here, per the owner's ruling on the issue ("split items 5, 6 and 7 out. This issue stays a pure no-op sweep"). Filed as #1524.

Closes #1389

## Seam

The seam is **reachability**, not rendering: for every symbol, class and key, does any path in `src/` — including manifest/lazy indirection, template-literal key building, and tests — reach it? Nothing here changes behaviour, so the existing suite going green IS the check; no new tests for removed code. The one test added is a behavioural inversion (item 2).

## What landed

### Item 1 — five exported-never-imported symbols

`PraxisVoterBreakdown`, `MottoRibbon`, `mediaArtKeysFromFile`, `UA_EYEBROW_ACCENT`, `UA_HAIRLINE`. Each re-grepped on today's tree: exactly one occurrence, its own definition.

Two of the issue body's paths were wrong and the owner's correction was right — `MottoRibbon` is `components/sigil/UaSigil.tsx`, the UA atoms are `components/factionMarks/uaAtoms.tsx`.

`ComposerStickyFooter` + `MOBILE_TABBAR_CLEARANCE` were **already deleted** by #1478 (issue #1430). Nothing to do.

### Item 2 — `FACTION_ALIASES`

Empty object since #232; four live branches consulted it, each evaluating to "?? the same slug again". Deleted the object and all four branches (`pickVariant`, `resolveCssKey`, `isKnownFaction`, `reframeLabel`), plus the `vi.doMock` test that synthesised a fake alias to exercise a branch production could not reach.

That test is **replaced, not merely deleted**, by one asserting the property that now holds — `pickVariant` has no cross-faction path at all:

```ts
it('never resolves one faction to another', () => {
  expect(pickVariant(map, 'derived', Fallback)).toBe(Fallback)
  expect(pickVariant({ coven: A }, 'derived')).toBeUndefined()
})
```

The owner was right that the test surface was wider than the issue stated: `factionAlbescentHidesInPlainSight.test.ts` also imported and asserted on it, and `surfaceDispatch.test.ts` referenced it in a comment. Both handled. In the Albescent test only the `FACTION_ALIASES` assertion is dropped; the `factionCssVar` assertions that are the real statement stay.

`LEGACY_SLUG` in `FactionSelectCard.tsx` stays — it is the only real alias table, and neither of its slugs was ever in the deleted map. Its comment described itself as "a SECOND alias table, parallel to `FACTION_ALIASES`", so it is updated rather than left pointing at something gone.

The two remaining `FACTION_ALIASES` mentions in the tree are in `docs/adr/0017` and `0018`, describing decisions as they stood. ADRs are historical records; I did not rewrite them.

### Item 3 — six dead CSS classes + the stale pointer

`.card-footer`, `.page-heading`, `.ht-dots-lg`, `.snide-merrow`, `.snide-pulse`, `.ev-duel-pulse` (last two with their keyframes). `CLAUDE.md:80` no longer tells you to reuse `.card-footer`; it now names only the two that survive.

Verified in the **built** stylesheet, not just the source — a dropped brace can swallow a whole block while the source still looks plausible:

| absent after build | present after build |
|---|---|
| card-footer, page-heading, ht-dots-lg, snide-merrow, snide-pulse, ev-duel-pulse | card-meta, card-description, ht-dots, xerox, snide-tape, coven-moon-sparkle, sg-cursor |

**No contrast-baseline change, and that criterion is satisfied by not needing one.** The owner's comment said `.card-footer` "appears as a frozen selector throughout `e2e/contrastBaseline.ts`". It appears in nine `where:` fields, but that file states its own contract: *"THE KEY IS THE COLOUR PAIR, NOT THE DOM NODE... `where` is only a breadcrumb."* Entries are keyed on colour pairs, and no `src/` element carries the class, so nothing renders differently.

### Item 4 — 41 proven-dead i18n keys, with restated per-cluster counts

| cluster | keys | issue said |
|---|---|---|
| `praxis:mobileFeed.*` | 5 | 6 |
| `common:voteStamps.*` | 12 | 5 |
| `common:leaderboard.{soloEyebrow,soloBody,rankingsSoFar,youFactionLevel}` | 4 | 4 of 5 |
| `common:leaderboard.mobile.count` | 1 | contested — proven below |
| `common:profile.mobile.stats.*` | 3 | 3 |
| `common:collaborationCard.{titleFallback,viewDuel,viewCollaboration}` | 3 | 3 |
| `common:fieldDesk.home.albescent.*` | 3 | 3 |
| `common:sidebar.globalActivity.{eraBegun,newTask,completedTask}` | 3 | 3 |
| `feed:taskCard.coven.{windowTitle,questMeta,points}` | 3 | 3 |
| `praxis:mobileCard.{taskRef,untitled}` | 2 | 2 |
| `feed:identity.ua.{fullName,motto}` | 2 | 1 (+1 suspected) |
| **total** | **41** | ~40 |

Zero taunt-catalog edits. The catalogs are edited in place — 52 deletions, 1 insertion (a trailing comma), no reformatting churn.

**`charLimit` is DROPPED from the list (4 keys, both namespaces).** The issue's proof method — "the segment appears nowhere in `src/` outside `locales/`" — has a hole: `src/locales/__tests__/` is *under* `locales/`, so the exclusion hides it. Three tests in `catalog.test.ts` pin `forms:charLimit.{reached,approaching}` and `praxis:charLimit.terminal` as ADR-0010/ADR-0032's named examples, one using `forms:charLimit.reached` as its interpolation fixture. Deleting them means deleting two tests and rewriting a third — not a no-op. Left alone. This is the only cluster the hole affected; every other cluster was re-run with the corrected filter.

**`common:leaderboard.mobile.count` is RESTORED to the list, separately proven** as required. The live `mobile.count` is `pages/tasks/mobileArchetypes/DefaultTasks.tsx:54`, whose `t` is bound to `useTranslation('tasks')` — it reads `tasks:mobile.count`. Different namespace, same leaf: precisely the collision flagged. The `common:leaderboard` leaf has no reader.

**`feed:identity.ua.fullName` is PROMOTED from SUSPECTED**, with the required proof run first. Deleting `MottoRibbon` orphaned `motto`, emptying the cluster; enumerating every `identity.*.*` read in `src/` shows no `identity.ua` reader at all. The rest of the SUSPECTED tier is untouched.

Two further traps checked and cleared: template-literal key building (every such site — `feed:factionSelect.*`, `duelSeal.wow.*`, `feed:kicker.*`, `unaffiliated.*`, admin `tasks.*` — is in an unrelated cluster), and keys load-bearing via their *value* in a negative assertion. The latter had a near-miss: `albescentDetail.test.tsx` lists `"In hand"` in `CUT_VOCABULARY`, the same string as `fieldDesk.home.albescent.questsHeading`. It is a literal in the test, not a catalog read, so deleting the key cannot affect it.

## Verification

All six CI steps run locally, twice — before and after the rebase onto `main`:

- `eslint src` — clean
- `tsc --noEmit` — clean
- `vitest run` — **3629 passed, 207 files**
- `vite build` — ok
- initial-load byte budget — within budget (JS 131.9 KB, CSS 22.3 KB)
- `npm run typecheck:design-sync` — clean; no preview imports anything deleted

## Scope note

Two files here normally belong to the `frontend-style` owner: `src/index.css` (item 3) and `src/utils/factions.ts` (item 2). I edited both because the issue's items cannot be built otherwise, and both edits are pure removals of provably-unreferenced code with no design content. Flagging it rather than doing it silently.

## What to eyeball

A green build cannot vouch for deleted CSS or deleted copy. **I did no visual QA — there is no browser or dev stack in this worktree.** Please look at:

1. **The six CSS classes.** Nothing in `src/` referenced them, but a class can be applied by something grep cannot see. Most likely to show it: any page heading (`.page-heading`), the S.N.I.D.E. faction surfaces (`.ht-dots-lg`, `.snide-merrow`), and the S.N.I.D.E./Everymen duel rails (`.snide-pulse`, `.ev-duel-pulse` — the animated "live" dots).
2. **`.card-footer` specifically.** It is the one with a documented past life on the UA card and the one `CLAUDE.md` was still advertising. If a card footer row loses its dashed top border, this is why.
3. **The 41 copy keys.** Chiefly the mobile praxis feed, the leaderboard's solo/empty state (`soloEyebrow`/`soloBody` read like first-player-on-the-site copy that may be hard to reach by hand), the mobile profile stats strip, the collaboration card, the Albescent field desk, and the sidebar's global-activity rows. A raw key string rendered at a player is the failure mode.
4. **`feed:identity.ua.*`** — the UA motto ribbon and full name are gone from the catalog along with the component that drew them.
5. **`isKnownFaction` / `resolveCssKey`.** Both lost an alias hop that resolved to the same slug. `na` and `albescent` must still land unthemed — grey/rainbow, not UA's costume. The Albescent test covers it, but this is the highest-blast-radius change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
