### PR TITLE
The routing table learns where the kit's shape is written down

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ identity + era-as-ruleset in ADR-0041 / ADR-0042.
 | Testing approach | `docs/spec/SPEC-testing.md` |
 | Design intent, UX, faction archetypes | `WORLD_ZERO_STYLE.md` |
 | Building against a Claude design (fidelity rule, vendor-then-delete, what a green build misses) | `docs/agents/design-fidelity.md` |
+| Kit shape: how many surfaces, which faction identities, responsive-vs-split | `docs/kit-structure.md` |
 | Shipping a surface without slowing the site down (payload budget, what makes a surface free, asset + font rules) | `docs/agents/load-time.md` |
 | CSS variables (colors, type, themes) | `frontend/src/index.css` |
 | JS faction config | `frontend/src/utils/factions.ts` |


### PR DESCRIPTION
Follow-up to #1320 / PR #1523, which added `docs/kit-structure.md` but could not add its routing row — `CLAUDE.md` was owned by a concurrent agent (#1389) in the same batch. That agent's PR has merged, so the file is free.

One row, exactly as #1523 suggested:

```
| Kit shape: how many surfaces, which faction identities, responsive-vs-split | docs/kit-structure.md |
```

Without it the doc is reachable only from `docs/agents/design-fidelity.md`, and the routing table is the thing agents are told to read first.

## Why it is worth routing to

The doc exists because the counts were wrong. #1320 asserted 21 surfaces x 10 factions; the measured answer is **21 x 9**, and Albescent covers **8** of 21 rather than the claimed 9. The tenth identity only appears if `na` and `default` are counted separately — which is the confusion the doc is there to prevent.

Docs-only, one line. No visual QA needed.