### PR TITLE
HOTFIX: dedupe votes to the newest so migration 0011 stops blocking the API deploy

### DIFF
--- a/backend/alembic/versions/0011_vote_unique_per_account.py
+++ b/backend/alembic/versions/0011_vote_unique_per_account.py
@@ -18,13 +18,34 @@ which that handler does not catch (#1193 hit exactly this and died on a fresh
 DB). Any migration adding a UNIQUE constraint or index needs the
 ``pg_constraint`` lookup instead.
 
-**Pre-existing duplicates are NOT resolved here.** If some account already
-holds two votes on one praxis via alts, this migration RAISES with the count
-and changes nothing. Which of a player's real votes survives — earliest,
-latest, highest — is an owner call about someone's actual rating, not a
-builder's, and a migration is the worst place to guess it. Nothing is deleted:
-re-run once the owner has ruled and the surplus rows have been resolved by
-hand. The dev database had zero such pairs when this landed.
+**Pre-existing duplicates: the newest vote wins.** As first written this
+migration RAISED on any account already holding two votes on one praxis via
+alts, refusing to pick a survivor — earliest, latest, highest — because that is
+an owner call about someone's real rating. Amended 2026-08-02 after that guard
+fired on a production deploy (13 pairs) and blocked the API: **the owner has
+ruled that the most recent vote survives.** That is not a fresh rule so much as
+the existing one applied backwards — once the constraint lands, an account's
+second rating is an *update* that overwrites the older value
+(``services/vote.py::cast_or_update_vote``), so keeping the latest makes
+history consistent with the behaviour going forward instead of inventing a
+one-off. ``created_at DESC, id DESC`` — the id tiebreak so rows sharing a
+timestamp still resolve deterministically rather than by table order.
+
+**Two consequences of the DELETE are deliberately left unrepaired.** Both need
+an era attribution this migration cannot derive in SQL without guessing, which
+is the very thing the original guard refused to do:
+
+1. ``votes_spent_this_era`` is a *stored* counter (``votes_available`` is
+   computed on read from it and ``score`` — ``services/character.py``), so the
+   caster of a deleted row stays charged for it. The refund belongs to that
+   character's ``CharacterStats`` row for the era the deleted vote belongs to.
+2. A praxis score includes ``total_stars``, so removing a vote lowers the
+   recipient's score, and ``all_time_score`` is lifetime-cumulative — moved by
+   delta, never recomputed here.
+
+Both are owner follow-ups once the deploy is up;
+``POST /admin/characters/backfill-stats`` already recomputes per-era score and
+level. Getting the API deployable is this revision's only job.
 
 Revision ID: 0011_vote_unique_per_account
 Revises: 0010_feed_dismissal
@@ -42,39 +63,30 @@ depends_on: Union[str, Sequence[str], None] = None
 OLD_CONSTRAINT: str = "uq_vote_praxis"
 NEW_CONSTRAINT: str = "uq_vote_praxis_account"
 
-# Refuse rather than pick a survivor. Raised before either DDL statement so a
-# deployed DB with duplicates is left exactly as it was found.
+# Keep the newest vote per (praxis, account); delete the rest. ``created_at``
+# is NOT NULL (``models/vote.py``), so the ordering is total: the id tiebreak is
+# only ever reached when two rows genuinely share a timestamp.
 #
-# ``RAISE ... USING MESSAGE`` rather than ``RAISE '...%', n``: the statement runs
-# through the DBAPI, where a literal ``%`` is only safe while SQLAlchemy happens
-# to take its no-parameters path. Concatenation keeps the SQL ``%``-free.
-_GUARD_AGAINST_DUPLICATES: str = """
-DO $$
-DECLARE duplicate_pairs INTEGER;
-BEGIN
-    SELECT count(*) INTO duplicate_pairs FROM (
-        SELECT 1 FROM vote
-        GROUP BY praxis_id, voter_account_id
-        HAVING count(*) > 1
-    ) AS duplicates;
-    IF duplicate_pairs > 0 THEN
-        RAISE EXCEPTION USING
-            MESSAGE = '#1150: ' || duplicate_pairs || ' (praxis, account) pair(s)'
-                || ' hold more than one vote, so UNIQUE (praxis_id,'
-                || ' voter_account_id) cannot be added.',
-            DETAIL = 'This migration deliberately does not choose which real'
-                || ' vote survives (earliest? latest? highest?) - that is an'
-                || ' owner decision, not a builder''s. Nothing was changed.',
-            HINT = 'List them with: SELECT praxis_id, voter_account_id,'
-                || ' count(*) FROM vote GROUP BY praxis_id, voter_account_id'
-                || ' HAVING count(*) > 1;';
-    END IF;
-END $$;
+# A no-op on a fresh DB: ``0001_squashed`` builds from ``Base.metadata``, which
+# already declares ``uq_vote_praxis_account``, so no duplicate can exist there
+# and this deletes nothing. Idempotent for the same reason — re-running after
+# the constraint is in place can never match a second row.
+_DEDUPE_TO_LATEST: str = """
+DELETE FROM vote WHERE id IN (
+    SELECT id FROM (
+        SELECT id, row_number() OVER (
+            PARTITION BY praxis_id, voter_account_id
+            ORDER BY created_at DESC, id DESC
+        ) AS recency_rank
+        FROM vote
+    ) AS ranked
+    WHERE recency_rank > 1
+);
 """
 
 
 def upgrade() -> None:
-    op.execute(_GUARD_AGAINST_DUPLICATES)
+    op.execute(_DEDUPE_TO_LATEST)
 
     # Fresh DB: never existed (the model no longer declares it) -> no-op.
     op.execute(f"ALTER TABLE vote DROP CONSTRAINT IF EXISTS {OLD_CONSTRAINT}")

--- a/backend/tests/integration/test_vote_dedupe_migration.py
+++ b/backend/tests/integration/test_vote_dedupe_migration.py
@@ -1,0 +1,213 @@
+"""Migration 0011 dedupes to the newest vote per (praxis, account) (#1150).
+
+**Seam:** the migration's own ``upgrade()`` function, driven by a real Alembic
+``Operations`` bound to the test connection. Not a re-implementation of its SQL
+— the module's ``op`` global is swapped for the bound operations object, so the
+statements under test are byte-for-byte the ones a deploy runs.
+
+The integration schema comes from ``Base.metadata.create_all``, so it already
+carries ``uq_vote_praxis_account`` and can hold no duplicates. Each test
+therefore drops that constraint first to reproduce the *deployed* shape 0011
+actually meets, seeds the duplicates, and runs the migration. All of it lives
+inside the per-test transaction, so the constraint is back the moment the test
+ends.
+"""
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.account import Account
+from models.character import Character
+from models.praxis import Praxis
+from models.vote import Vote
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "alembic"
+    / "versions"
+    / "0011_vote_unique_per_account.py"
+)
+
+_BASE_TIME = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _load_migration() -> ModuleType:
+    """Import ``0011_vote_unique_per_account`` by path (its name starts with a digit)."""
+    spec = importlib.util.spec_from_file_location("migration_0011", _MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+async def _run_upgrade(session: AsyncSession) -> None:
+    """Execute the real ``upgrade()`` against the test connection."""
+    migration = _load_migration()
+    connection = await session.connection()
+
+    def _apply(sync_connection) -> None:
+        operations = Operations(MigrationContext.configure(sync_connection))
+        migration.op = operations  # the module's `from alembic import op` global
+        migration.upgrade()
+
+    await connection.run_sync(_apply)
+
+
+async def _drop_account_constraint(session: AsyncSession) -> None:
+    """Reproduce the pre-0011 deployed shape: character-scoped uniqueness only."""
+    await session.execute(
+        text("ALTER TABLE vote DROP CONSTRAINT IF EXISTS uq_vote_praxis_account")
+    )
+    await session.execute(
+        text(
+            "ALTER TABLE vote ADD CONSTRAINT uq_vote_praxis"
+            " UNIQUE (praxis_id, voter_character_id)"
+        )
+    )
+    await session.flush()
+
+
+async def _extra_character(
+    session: AsyncSession, account: Account, username: str
+) -> Character:
+    character = Character(
+        account_id=account.id,
+        username=username,
+        display_name=username,
+        faction_slug="ua",
+    )
+    session.add(character)
+    await session.flush()
+    return character
+
+
+async def _add_vote(
+    session: AsyncSession,
+    praxis: Praxis,
+    voter: Character,
+    value: int,
+    created_at: datetime,
+) -> Vote:
+    row = Vote(
+        praxis_id=praxis.id,
+        voter_character_id=voter.id,
+        voter_account_id=voter.account_id,
+        value=value,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    session.add(row)
+    await session.flush()
+    return row
+
+
+async def _account_constraint_exists(session: AsyncSession) -> bool:
+    result = await session.execute(
+        text("SELECT 1 FROM pg_constraint WHERE conname = 'uq_vote_praxis_account'")
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _votes_for(session: AsyncSession, praxis: Praxis) -> list[Vote]:
+    result = await session.execute(
+        select(Vote).where(Vote.praxis_id == praxis.id).order_by(Vote.id)
+    )
+    return list(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_upgrade_keeps_the_newest_vote_per_account(
+    db_session: AsyncSession,
+    praxis_solo: Praxis,
+    account2: Account,
+    character2: Character,
+    account3: Account,
+    character3: Character,
+) -> None:
+    """Two alts on one account collapse to the newer row; other accounts untouched.
+
+    This is the production failure: 0011 used to raise here rather than choose.
+    """
+    await _drop_account_constraint(db_session)
+
+    alt = await _extra_character(db_session, account2, "account2alt")
+    older = await _add_vote(db_session, praxis_solo, character2, 2, _BASE_TIME)
+    newer = await _add_vote(
+        db_session, praxis_solo, alt, 5, _BASE_TIME + timedelta(hours=1)
+    )
+    control = await _add_vote(
+        db_session, praxis_solo, character3, 3, _BASE_TIME + timedelta(hours=2)
+    )
+    older_id, newer_id, control_id = older.id, newer.id, control.id
+
+    await _run_upgrade(db_session)
+
+    surviving_ids = {row.id for row in await _votes_for(db_session, praxis_solo)}
+    assert surviving_ids == {newer_id, control_id}
+    assert older_id not in surviving_ids
+
+    survivor = await db_session.get(Vote, newer_id)
+    assert survivor is not None
+    assert survivor.value == 5
+    assert survivor.voter_character_id == alt.id
+
+    untouched = await db_session.get(Vote, control_id)
+    assert untouched is not None
+    assert untouched.value == 3
+    assert untouched.voter_character_id == character3.id
+
+    assert await _account_constraint_exists(db_session)
+
+
+@pytest.mark.asyncio
+async def test_upgrade_breaks_a_created_at_tie_on_the_higher_id(
+    db_session: AsyncSession,
+    praxis_solo: Praxis,
+    account2: Account,
+    character2: Character,
+) -> None:
+    """Identical timestamps still resolve deterministically — never table order."""
+    await _drop_account_constraint(db_session)
+
+    alt = await _extra_character(db_session, account2, "account2twin")
+    first = await _add_vote(db_session, praxis_solo, character2, 1, _BASE_TIME)
+    second = await _add_vote(db_session, praxis_solo, alt, 4, _BASE_TIME)
+    first_id, second_id = first.id, second.id
+    assert second_id > first_id
+
+    await _run_upgrade(db_session)
+
+    surviving = await _votes_for(db_session, praxis_solo)
+    assert [row.id for row in surviving] == [second_id]
+    assert surviving[0].value == 4
+
+
+@pytest.mark.asyncio
+async def test_upgrade_is_a_no_op_without_duplicates(
+    db_session: AsyncSession,
+    praxis_solo: Praxis,
+    character2: Character,
+    character3: Character,
+) -> None:
+    """The fresh-DB path: constraint already present, nothing to delete.
+
+    ``0001_squashed`` builds from ``Base.metadata``, so CI meets 0011 in exactly
+    this state. Running it twice also proves the dedupe is idempotent.
+    """
+    kept = await _add_vote(db_session, praxis_solo, character2, 2, _BASE_TIME)
+    other = await _add_vote(db_session, praxis_solo, character3, 5, _BASE_TIME)
+    expected = {(kept.id, 2), (other.id, 5)}
+
+    await _run_upgrade(db_session)
+    await _run_upgrade(db_session)
+
+    surviving = await _votes_for(db_session, praxis_solo)
+    assert {(row.id, row.value) for row in surviving} == expected
+    assert await _account_constraint_exists(db_session)


### PR DESCRIPTION
## Why prod is down

`alembic upgrade head` fails on deploy, so the API cannot ship and worldzero.org is serving a frontend newer than its API (the sign-up button is gone site-wide).

`0011_vote_unique_per_account` guards its `UNIQUE (praxis_id, voter_account_id)` with a duplicate check, and on production it fires:

```
#1150: 13 (praxis, account) pair(s) hold more than one vote, so
UNIQUE (praxis_id, voter_account_id) cannot be added.
```

**The guard worked as designed.** It deliberately refused to pick which of a player's real votes survives, calling that an owner decision rather than a builder's, and changed nothing.

## The owner ruling

**The most recent vote survives.** This is less a new rule than the existing one applied backwards: once the constraint lands, an account's second rating on a praxis becomes an *update* that overwrites the older value (`services/vote.py::cast_or_update_vote`). Deduping to latest makes history consistent with the behaviour going forward instead of inventing a one-off.

## The change

`backend/alembic/versions/0011_vote_unique_per_account.py` — the raise becomes a deterministic delete:

```sql
DELETE FROM vote WHERE id IN (
    SELECT id FROM (
        SELECT id, row_number() OVER (
            PARTITION BY praxis_id, voter_account_id
            ORDER BY created_at DESC, id DESC
        ) AS recency_rank
        FROM vote
    ) AS ranked
    WHERE recency_rank > 1
);
```

`id DESC` is the tiebreak: two rows sharing a `created_at` still resolve deterministically instead of by table order. `created_at` is NOT NULL (`models/vote.py`), so the ordering is total.

No-op and idempotent on a fresh DB — `0001_squashed` builds from `Base.metadata`, which already declares `uq_vote_praxis_account`, so no duplicate can exist and nothing is deleted. The existing `pg_constraint` lookup for the ADD is untouched (`EXCEPTION WHEN duplicate_object` is wrong here — see the docstring and #1193).

The module docstring is rewritten: it previously stated duplicates are NOT resolved and the migration raises, which is now false. It records the ruling, the date, and that this was amended in response to a failed production deploy.

## Deliberately NOT fixed here

Deleting a vote row has two consequences that cannot be correctly repaired in SQL, both because they need an era attribution this migration would have to guess at — exactly what the original guard refused to do. Both are stated in the docstring and are owner follow-ups **after** the deploy succeeds:

1. **`votes_spent_this_era` is a stored counter**, not derived — `votes_available` is computed on read from `score` and it (`services/character.py`). A deleted vote leaves its caster still charged. The refund belongs to that character's `CharacterStats` row for that vote's era.
2. **Praxis scores include `total_stars`**, so removing a vote lowers the recipient's score, and `all_time_score` is lifetime-cumulative — moved by delta, never recomputed.

`POST /admin/characters/backfill-stats` already recomputes per-era score and level and is the tool for (2). Getting the API deployable is this PR's only job.

## Seam under test

`backend/tests/integration/test_vote_dedupe_migration.py` drives the migration's **real `upgrade()`** through an Alembic `Operations` bound to the test connection (the module's `op` global is swapped for it), so the statements under test are byte-for-byte the ones a deploy runs — not a re-implementation of the SQL.

The integration schema comes from `Base.metadata.create_all` and so already carries the account constraint; each test first drops it and re-adds the character-scoped `uq_vote_praxis`, reproducing the *deployed* shape 0011 actually meets. All inside the per-test transaction.

Written first, and it went red on the real defect — the exact production error text:

```
asyncpg.exceptions.RaiseError: #1150: 1 (praxis, account) pair(s) hold more than one
vote, so UNIQUE (praxis_id, voter_account_id) cannot be added.
```

Three cases: two alts on one account collapse to the newer row while another account's vote is untouched; an identical-`created_at` pair resolves on the higher id; and the no-duplicates path (run twice) deletes nothing and leaves the constraint in place.

## Verification

Full Alembic round-trip on a dedicated throwaway DB `wz_prodfix_test`, seeded to reproduce the failure (two votes from **different characters on the same account** on one praxis, a control pair that must survive untouched, and two rows sharing a `created_at`):

| Step | Result |
|---|---|
| `alembic upgrade 0010_feed_dismissal`, seed the pre-#1150 shape | 5 votes, 2 duplicate pairs |
| `alembic upgrade head` | succeeds (previously raised) |
| survivors | newest of each pair; control row untouched; 0 duplicate pairs; `uq_vote_praxis_account` present |
| `alembic downgrade -1` | `uq_vote_praxis` restored |
| `alembic upgrade head` again | succeeds, data unchanged |
| `alembic check` | `No new upgrade operations detected.` |
| empty DB straight to `head` (CI's path) | succeeds, `alembic check` clean, dedupe deletes nothing |

Suite: `pytest --cov=. --cov-fail-under=80` against `wz_prodfix_test` — **1009 passed, coverage 92.43%**.

## Caveats

- **This fix has not been exercised against production data.** It has only been run against a synthetic reproduction of the reported failure shape. The 13 production pairs have not been inspected.
- **No visual QA applies** — this is a migration; the frontend job is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
