### PR TITLE
GET /tasks 422s an unrecognised sort instead of silently ordering by level (#1443)

### DIFF
--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -26,6 +26,7 @@ from services.task import (
     list_signups_for_task,
     list_tasks as service_list_tasks,
     propose_task,
+    TaskSort,
     update_task,
 )
 
@@ -52,6 +53,18 @@ async def list_tasks(
     viewer: Optional[Character] = Depends(get_current_character_optional),
     account: Optional[Account] = Depends(get_current_account_optional),
 ):
+    # An unrecognised sort is an error, not a silent fall-back to the level
+    # default (#1443) — matching GET /praxes, which has always raised here.
+    # Substituting an ordering nobody asked for returns 200 with plausible
+    # data, so a typo'd or retired value never surfaces. An ABSENT sort is
+    # still legal and still means level-ascending: Tasks.tsx sends none.
+    task_sort: Optional[TaskSort] = None
+    if sort is not None:
+        try:
+            task_sort = TaskSort(sort)
+        except ValueError:
+            raise HTTPException(status_code=422, detail=f"Invalid task sort: {sort}")
+
     is_admin = account is not None and await account_has_admin_role(
         account.id, session
     )
@@ -73,7 +86,7 @@ async def list_tasks(
         created_by=created_by,
         task_type=task_type,
         q=q,
-        sort=sort,
+        sort=task_sort,
         limit=limit,
         offset=offset,
         viewer=viewer,

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Collection, Optional
 
 from fastapi import HTTPException
@@ -413,13 +414,24 @@ async def in_progress_counts_for_tasks(
     return {task_id: int(count or 0) for task_id, count in agg_result.all()}
 
 
-#: ``sort`` value that orders the task list by creation time, newest first.
-SORT_NEWEST = "newest"
-#: ``sort`` value that orders the task list by creation time, oldest first.
-SORT_OLDEST = "oldest"
-#: ``sort`` value naming the browse default — easiest first, richest within a
-#: level. Ascending only: there is no level-descending option (#1364).
-SORT_LEVEL = "level"
+class TaskSort(str, Enum):
+    """The orderings ``GET /tasks`` accepts (#1364) — a closed set (#1443).
+
+    ``newest``/``oldest`` order on ``Task.created_at``, tiebroken on ``id`` so a
+    paged read stays stable when rows share a timestamp. ``level`` names the
+    browse default — easiest first, richest within a level — and is ascending
+    only: there is no level-descending twin.
+
+    Closed is the point. Until #1443 an unrecognised ``sort`` fell through to
+    ``level`` and returned 200, so a typo'd or retired value silently bought a
+    different ordering than the one asked for and nothing surfaced the mistake.
+    Mirrors :class:`services.praxis.PraxisSort`, whose router raises 422 on the
+    same input. An *absent* sort is still legal and still means ``level``.
+    """
+
+    newest = "newest"
+    oldest = "oldest"
+    level = "level"
 
 
 async def list_tasks(
@@ -434,7 +446,7 @@ async def list_tasks(
     created_by: Optional[int] = None,
     task_type: Optional[str] = None,
     q: Optional[str] = None,
-    sort: Optional[str] = None,
+    sort: Optional[TaskSort] = None,
     limit: int = 50,
     offset: int = 0,
     viewer: Optional[Character] = None,
@@ -474,11 +486,10 @@ async def list_tasks(
     ``faction`` is a list of slugs matched as a union (#1364), so the browse
     filter can hold several factions at once; an empty list is no filter.
 
-    ``sort`` is one of :data:`SORT_NEWEST`, :data:`SORT_OLDEST` or
-    :data:`SORT_LEVEL`, the latter being the default when ``sort`` is absent —
-    easiest first, richest within a level. Level *ascending* is the only level
-    ordering there is. The two chronological sorts tiebreak on ``id`` so a
-    paged read stays stable when rows share a ``created_at``.
+    ``sort`` is a :class:`TaskSort` or ``None``; ``None`` means
+    :attr:`TaskSort.level`, the browse ordering ``Tasks.tsx`` gets by sending no
+    ``sort`` at all. Rejecting an unknown *string* is the router's job (#1443) —
+    by the time it reaches here the value is already a member of the enum.
     """
     # Collect hidden faction slugs to exclude their tasks (faction-rules seam, #171)
     hidden_slugs = await hidden_faction_slugs(session)
@@ -632,13 +643,13 @@ async def list_tasks(
             Task.id.notin_(active_member_task_ids_subquery(exclude_character_id, era))
         )
 
-    if sort == SORT_NEWEST:
+    if sort == TaskSort.newest:
         query = query.order_by(Task.created_at.desc(), Task.id.desc())
-    elif sort == SORT_OLDEST:
+    elif sort == TaskSort.oldest:
         query = query.order_by(Task.created_at.asc(), Task.id.asc())
     else:
-        # SORT_LEVEL, and the fall-through for an absent or unrecognised sort:
-        # the browse ordering Tasks.tsx gets by sending no ``sort`` at all.
+        # TaskSort.level, and the fall-through for an ABSENT sort only — an
+        # unrecognised one never gets here, the router 422s it (#1443).
         query = query.order_by(Task.level_required.asc(), Task.point_value.desc())
     query = query.limit(limit).offset(offset)
     result = await session.execute(query)

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -389,6 +389,57 @@ async def test_list_tasks_default_sort_is_level_then_point_value(
 
 
 @pytest.mark.asyncio
+async def test_unknown_sort_is_rejected_and_absent_sort_still_defaults(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+):
+    """An unrecognised ?sort= is a 422, not the level default under a 200.
+
+    The seam is the trust boundary: GET /tasks parsing the raw query string.
+    Before #1443 'most_liked' fell through to level-ascending and returned
+    plausible-looking rows, so a typo'd or retired value never surfaced —
+    /praxes has always raised on the same input.
+
+    The absent half is the other required assertion: Tasks.tsx sends no sort at
+    all and depends on landing on level-ascending, so a route that rejected
+    everything would pass a one-sided test.
+    """
+    easy = Task(
+        title="Easy Task",
+        description="",
+        point_value=5,
+        level_required=0,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    hard = Task(
+        title="Hard Task",
+        description="",
+        point_value=50,
+        level_required=3,
+        status=TaskStatus.active,
+        created_by=character.id,
+        primary_faction_slug="ua",
+    )
+    db_session.add_all([easy, hard])
+    await db_session.commit()
+
+    rejected = await client.get("/tasks", params={"sort": "most_liked"})
+    assert rejected.status_code == 422
+
+    absent = await client.get("/tasks")
+    assert absent.status_code == 200
+    absent_ids = [task["id"] for task in absent.json()]
+    # Level ascending: the level-0 row precedes the level-3 one, and the rich
+    # level-3 row has not floated to the top on point value.
+    assert absent_ids.index(easy.id) < absent_ids.index(hard.id)
+    assert absent_ids[0] != hard.id
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_exclude_character_id(
     client: AsyncClient,
     character: Character,


### PR DESCRIPTION
Closes #1443

`GET /praxes` parses `?sort=` into `PraxisSort` and raises 422 on an unknown value. `GET /tasks` declared `sort: Optional[str] = None`, forwarded it unvalidated, and let it fall through the `if/elif/else` in `services/task.py` to the level default — so `?sort=most_liked` was an error on one endpoint and a silent no-op on the other.

Silently substituting a different ordering for the one that was asked for is the worse half of the pair: a typo'd or retired sort value returns 200 with plausible-looking data, so nothing surfaces the mistake.

## The seam under test

The trust boundary — `GET /tasks` parsing the raw query string. The failing test went red on the real defect (an unknown sort returning 200 with level-ordered rows), then green.

Both halves are asserted in one test, because a one-sided test cannot tell "validates" from "rejects everything":

- `?sort=most_liked` → 422
- no `sort` at all → 200, still level-ascending (`Tasks.tsx` sends none and depends on this; #1364 named that default `SORT_LEVEL` deliberately)

## What changed

- `services/task.py`: `SORT_NEWEST` / `SORT_OLDEST` / `SORT_LEVEL` become `TaskSort(str, Enum)`, mirroring `PraxisSort`; `list_tasks(sort=...)` now takes `Optional[TaskSort]`. The `else` branch keeps its comment, narrowed to the *absent* case.
- `routers/tasks.py`: parses `sort` in the same try/except shape `routers/praxes.py` uses, `detail=f"Invalid task sort: {sort}"`. No new helper — the `/praxes` side already solved this.
- `tests/integration/test_tasks.py`: one new test, `test_unknown_sort_is_rejected_and_absent_sort_still_defaults`.

No migration. No new dependency. No frontend files touched.

## Client check (the owner asked for this explicitly)

No live client value would 422 after this change:

- `frontend/src/pages/Home.tsx:67` sends `sort: 'newest'` — valid.
- `frontend/src/pages/tasks/useTasks.ts:283` sends `sort: sort === TASK_SORT_DEFAULT ? undefined : sort`, i.e. `'newest'`, `'oldest'`, or nothing.
- The three remaining `listTasks(...)` callers (`CharacterProfile.tsx`, `useFactionDetail.ts`, `Home.tsx:89`) send no `sort`.

One thing worth knowing, not a blocker: `readFilterParam` (`useTasks.ts:87`) is `params.get(key) || defaultValue` with no whitelist, so a hand-edited or stale bookmarked URL like `/tasks?sort=bogus` is forwarded verbatim and will now render the browse's error state instead of silently showing level order. That is the intended surfacing, but if it should degrade to the default client-side instead, that is a small frontend follow-up outside this PR's scope.

## Tests

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz1443_test \
  python -m pytest --cov=. --cov-fail-under=80 -q
```
`1011 passed`, coverage 92.43% (gate 80%).

## What to eyeball

**No visual QA was done** — this is a backend-only change and I have no browser or dev stack.

- `/tasks` with no sort still lands on the level-ascending browse order (easiest first, richest within a level) for both signed-in and anonymous viewers.
- The sort control's `newest` / `oldest` / `level` options each still return rows rather than an error banner.
- Hand-visit `/tasks?sort=bogus` and decide whether the new error state is the behaviour you want at the URL layer, or whether the client should clamp to the default (see the client-check note above).
- The 422 body is `{"detail": "Invalid task sort: bogus"}` — same shape `/praxes` emits, so any shared error renderer treats them alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)