### PR TITLE
The score stamp leaves a praxis that banked nothing (#1444)

### DIFF
--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -14,6 +14,25 @@ export type PraxisInviteStatus = 'pending' | 'accepted' | 'declined'
 export type ModerationStatus = 'visible' | 'flagged' | 'hidden' | 'failed'
 export type MediaType = 'image' | 'video' | 'audio'
 
+/**
+ * The moderation states that bank nobody any points — the frontend's mirror of
+ * `_UNSCORED_MODERATION_STATUSES` in `backend/services/character_stats.py`.
+ *
+ * `hidden` is off the site entirely; `failed` is an admin ruling that the work
+ * was not done, so it keeps its banner and its place in the feed but banks
+ * nothing (#1373). `flagged` is deliberately NOT here: a flag is a praxis
+ * *awaiting* a ruling, and it still counts.
+ *
+ * Lives beside {@link ModerationStatus} because it is a fact about the wire
+ * enum, not about any one surface, and because the pair is only safe as ONE
+ * list — the defect in #1444 was a card that stamped a computed total on a
+ * praxis whose score the backend had already declined to bank.
+ */
+export const UNSCORED_MODERATION_STATUSES: ReadonlySet<ModerationStatus> = new Set([
+  'hidden',
+  'failed',
+])
+
 export interface MediaItemOut {
   id: number
   praxis_id: number

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -79,6 +79,26 @@ describe('one score per card (#888, closes #663)', () => {
   // `MobileVoteFooter` had the identical assertion against an identical
   // `VoteUI` call. It is gone with the `mobilePraxisCard` surface (ADR-0067);
   // the desktop case above is what a phone renders now.
+
+  /**
+   * #1444 — and no score at all on a praxis that banked none.
+   *
+   * `ScoreStamp` owns the gate (it is the single mount for every surface that
+   * shows a total); this case pins that the CARD BODY actually routes through
+   * it, which is the surface the issue reported. ADR-0067 collapsed the mobile
+   * card into this same component, so one case covers both form factors.
+   */
+  it('stamps a visible praxis and stamps nothing on a failed one', () => {
+    const stamped = text(
+      render(<PraxisBody praxis={praxis({ moderation_status: 'visible' })} tint="#000" muted="#555" />),
+    )
+    expect(stamped, 'the total, to one decimal').toContain('12.5')
+
+    const failed = text(
+      render(<PraxisBody praxis={praxis({ moderation_status: 'failed' })} tint="#000" muted="#555" />),
+    )
+    expect(failed, 'a figure nobody banked').not.toContain('12.5')
+  })
 })
 
 describe('the byline portrait (#888)', () => {

--- a/frontend/src/components/praxisCard/scoreStamp/ScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/ScoreStamp.tsx
@@ -1,6 +1,10 @@
 import type { ScoredPraxis } from "./scoreBreakdown";
 import { pickVariant } from "../../../utils/factionDispatch";
 import { surfaceMap } from "../../../factions";
+import {
+  UNSCORED_MODERATION_STATUSES,
+  type ModerationStatus,
+} from "../../../api/praxis";
 import DefaultScoreStamp from "./DefaultScoreStamp";
 
 /**
@@ -34,15 +38,18 @@ import DefaultScoreStamp from "./DefaultScoreStamp";
  * slug are presentation inputs of this surface, and a future consumer that only
  * wants the rows shouldn't have to carry them.
  *
- * These are the only two extras, verified across all eight registered stamps:
- * every skin reads `score` + the breakdown terms, plus `is_top_for_task` for the
- * crown; the dispatcher alone reads `task_faction_slug`.
+ * These are the only extras, verified across all eight registered stamps: every
+ * skin reads `score` + the breakdown terms, plus `is_top_for_task` for the
+ * crown; the dispatcher alone reads `task_faction_slug` and
+ * `moderation_status`.
  */
 export interface StampablePraxis extends ScoredPraxis {
   /** Task Crown — top-scoring submitted praxis for its task (ADR-0028). */
   is_top_for_task: boolean;
   /** The task's faction: what the stamp surface dispatches on (ADR-0039). */
   task_faction_slug: string | null;
+  /** Whether the total was banked at all — see the gate below (#1444). */
+  moderation_status: ModerationStatus;
 }
 
 export interface ScoreStampProps {
@@ -55,6 +62,26 @@ export interface ScoreStampProps {
 }
 
 export default function ScoreStamp({ praxis, showCrown }: ScoreStampProps) {
+  /**
+   * No stamp on a praxis that banked nothing (#1444).
+   *
+   * #1373 ruled and shipped that a `failed` praxis contributes 0 to its author's
+   * score; `hidden` never contributed. Every skin below reads `score`, so on
+   * those two states the card said "failed" in its banner and `13.6 POINTS` in
+   * its stamp — a figure nobody holds. The banner is the honest signal and it
+   * stays; ADR-0047's rule that a row exists only when it tells the viewer
+   * something true applies a level up, to the whole mark.
+   *
+   * The gate is HERE, not in a card slot, because ADR-0049 made this the single
+   * mount for every surface that shows a total (the nine cards, the nine
+   * praxis-detail rails, the composer's waiting slip). Only `failed` and
+   * `hidden` — `flagged` is awaiting a ruling and still counts, which is why
+   * this reads the one shared set rather than naming a state inline.
+   *
+   * Nothing else about an unscored praxis changes: it keeps its place in the
+   * feed, its banner, and its votes (the #1373 ruling).
+   */
+  if (UNSCORED_MODERATION_STATUSES.has(praxis.moderation_status)) return null;
   const Stamp = pickVariant(
     surfaceMap("scoreStamp"),
     praxis.task_faction_slug,

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -21,6 +21,7 @@ import { surfaceMap } from '../../../../factions'
 import { scoreBreakdown, formatMult } from '../scoreBreakdown'
 import { applyCastTally } from '../../../vote/useVotedPraxis'
 import { recordCastTally, castTally, __resetCastTallies } from '../../../vote/castTallies'
+import ScoreStamp from '../ScoreStamp'
 import DefaultScoreStamp from '../DefaultScoreStamp'
 import EverymenScoreStamp from '../EverymenScoreStamp'
 import EphemeristsScoreStamp from '../EphemeristsScoreStamp'
@@ -163,6 +164,52 @@ describe('useVotedPraxis merge feeds the stamp breakdown (#912)', () => {
     const voted = applyCastTally(base, tally)
     expect(scoreBreakdown(voted)).toEqual(
       expect.objectContaining({ votes: 9, total: 18.6 }),
+    )
+  })
+})
+
+/**
+ * #1444 — a stamp may only name a number somebody banked.
+ *
+ * #1373 shipped the ruling that a `failed` praxis contributes 0 to its author's
+ * score, and `hidden` never contributed at all: `_UNSCORED_MODERATION_STATUSES`
+ * in `backend/services/character_stats.py` is the ONE predicate naming that
+ * pair. The card kept stamping its computed total anyway, so the failed banner
+ * and a `13.6 POINTS` mark sat in the same frame, and only one of them was true.
+ *
+ * The gate is on the DISPATCHER rather than a card slot because ADR-0049 made
+ * this component the single mount for every surface that shows a total — the
+ * nine cards, the nine praxis-detail rails, the composer's waiting slip. A gate
+ * at `desktop/shared.tsx` would leave the same untrue figure on the detail page
+ * one click away.
+ *
+ * Both halves are asserted deliberately: a stamp that hides on `failed` and a
+ * stamp that hides ALWAYS produce the same first assertion.
+ */
+describe('the stamp leaves an unscored praxis (#1444)', () => {
+  /** `task_faction_slug: null` resolves to the eagerly-imported Default stamp. */
+  const unscorable = (moderation_status: string) =>
+    praxis({ moderation_status, task_faction_slug: null, is_top_for_task: false })
+
+  it('renders nothing on a failed praxis — the banner is the honest signal', () => {
+    expect(renderToStaticMarkup(<ScoreStamp praxis={unscorable('failed')} />)).toBe('')
+  })
+
+  it('renders nothing on a hidden praxis — the other half of the same pair', () => {
+    expect(renderToStaticMarkup(<ScoreStamp praxis={unscorable('hidden')} />)).toBe('')
+  })
+
+  it('still stamps a visible praxis — otherwise the gate is "hide always"', () => {
+    const html = text(renderToStaticMarkup(<ScoreStamp praxis={unscorable('visible')} />))
+    expect(html).toContain('13.6')
+    expect(html).toContain('points')
+  })
+
+  it('still stamps a flagged praxis — a flag is awaiting a ruling, not a ruling', () => {
+    // `_UNSCORED_MODERATION_STATUSES` excludes `flagged` for the same reason:
+    // a flagged praxis is still counted, so its total is still banked.
+    expect(text(renderToStaticMarkup(<ScoreStamp praxis={unscorable('flagged')} />))).toContain(
+      '13.6',
     )
   })
 })

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -332,6 +332,28 @@ describe("Unaffiliated praxis detail — the state axes", () => {
     expect(render(unvoted).text).toContain("from votes");
   });
 
+  /**
+   * #1444 — the whole score SECTION leaves a praxis that banked nothing, not
+   * just the mark inside it.
+   *
+   * The stamp is gated in its dispatcher, which every surface mounts; the panel
+   * has to go with it or the page keeps a headed "Score" section with nothing
+   * under it. Both halves are asserted: a gate that hid the section ALWAYS would
+   * satisfy the first case on its own.
+   */
+  it("drops the score section on a failed praxis and keeps it on a scored one", () => {
+    const failed = state({
+      praxis: { ...PRAXIS, moderation_status: "failed", admin_note: "Not the task." },
+    });
+    const { text } = render(failed);
+    expect(text, "no headed empty panel").not.toContain("Score");
+    expect(text, "no total nobody banked").not.toContain("16.0");
+    // The banner is the honest signal and it stays (the #1373 ruling).
+    expect(text).toContain("Not the task.");
+
+    expect(render(state()).text, "a visible praxis still stamps").toContain("16.0");
+  });
+
   it("banners flagged, failed-with-note, and the crown", () => {
     expect(render(state()).text, "clean praxis has no banner").not.toContain("FLAGGED");
 

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -91,6 +91,7 @@ import {
   PraxisDetailComments,
   MemberByline,
   orderedMembers,
+  scoreWasBanked,
 } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
@@ -477,7 +478,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
   //
   // The candle sits behind it: `.cvn-candle` carries the flicker and its
   // reduced-motion guard, so stilled it is simply a steady glow.
-  const scoreBlock = (
+  const scoreBlock = !scoreWasBanked(praxis) ? null : (
     <section style={{ ...panel, position: 'relative', overflow: 'hidden' }}>
       {sectionHead(t('detail.score.heading'))}
       <span

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -113,6 +113,7 @@ import {
   PraxisDetailComments,
   MemberByline,
   orderedMembers,
+  scoreWasBanked,
 } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
@@ -478,7 +479,7 @@ export default function DefaultPraxisDetail({
   // VOTE AVERAGE, calls it the faction multiplier, and prints votes as a count.
   // The model is `(base + meta) × faction_mult + votes` (ADR-0014/0047/0053),
   // resolved once by `scoreBreakdown()` inside the stamp.
-  const scoreBlock = (
+  const scoreBlock = !scoreWasBanked(praxis) ? null : (
     <section style={panel}>
       {sectionHead(t('detail.score.heading'))}
       <div style={{ display: 'flex', justifyContent: 'center' }}>

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -132,6 +132,7 @@ import {
   PraxisDetailComments,
   MemberByline,
   orderedMembers,
+  scoreWasBanked,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 
@@ -610,7 +611,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   // faction, which lands `EphemeristsScoreStamp` here. The design's own
   // arithmetic is NOT built: the model is `(base + meta) × faction_mult + votes`
   // (ADR-0014/0047/0053), resolved once by `scoreBreakdown()` inside the stamp.
-  const scoreBlock = (
+  const scoreBlock = !scoreWasBanked(praxis) ? null : (
     <section style={panel}>
       {sectionHead(t("detail.score.heading"))}
       <div style={{ display: "flex", justifyContent: "center" }}>

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -93,6 +93,7 @@ import {
   PraxisDetailComments,
   MemberByline,
   orderedMembers,
+  scoreWasBanked,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 
@@ -562,7 +563,7 @@ export default function EverymenPraxisDetail({
   // design's own sums are NOT built: the model is
   // `(base + meta) × faction_mult + votes`, resolved once by `scoreBreakdown()`
   // inside the stamp (ADR-0014/0047/0053).
-  const scoreBlock = (
+  const scoreBlock = !scoreWasBanked(praxis) ? null : (
     <section style={panel}>
       {sectionHead(t("detail.score.heading"))}
       <div style={{ display: "flex", justifyContent: "center" }}>

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -18,6 +18,7 @@ import {
   PraxisDetailComments,
   MemberByline,
   orderedMembers,
+  scoreWasBanked,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 
@@ -530,7 +531,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
   // the struck well, the ruled register rows and the votes tally. No arithmetic
   // is restated here: `scoreBreakdown()` is the single authority (ADR-0053), and
   // the design's own multiplier-from-the-vote-average is not built.
-  const scoreBlock = (
+  const scoreBlock = !scoreWasBanked(praxis) ? null : (
     <section style={panel}>
       {sectionHead(t("detail.score.heading"))}
       <div style={{ display: "flex", justifyContent: "center" }}>

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -118,6 +118,7 @@ import {
   PraxisDetailComments,
   MemberByline,
   orderedMembers,
+  scoreWasBanked,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 
@@ -588,7 +589,7 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
   // foreign task keeps its own mark on this page. No term is restated here and
   // no arithmetic is invented: `scoreBreakdown()` is the only resolver
   // (ADR-0014/0047/0053).
-  const scoreBlock = (
+  const scoreBlock = !scoreWasBanked(praxis) ? null : (
     <section style={plate}>
       {sectionHead(t("detail.score.heading"), { onPlate: true })}
       <div style={{ display: "flex", justifyContent: "center" }}>

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -27,6 +27,7 @@ import {
   PraxisDetailComments,
   MemberByline,
   orderedMembers,
+  scoreWasBanked,
 } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 
@@ -571,7 +572,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
   // TASK's faction — so this page gets UA's own stamp, and the arithmetic is
   // `scoreBreakdown()`'s alone (ADR-0053). No second strip restating the same
   // terms, and no hand-drawn ensō: the stamp already owns the mark's score half.
-  const scoreBlock = (
+  const scoreBlock = !scoreWasBanked(praxis) ? null : (
     <section style={panel}>
       {panelHead(t("detail.score.heading"))}
       <div style={{ display: "flex", justifyContent: "center" }}>

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -19,6 +19,7 @@ import {
   PraxisDetailComments,
   MemberByline,
   orderedMembers,
+  scoreWasBanked,
 } from '../shared'
 import type { PraxisDetailState } from '../usePraxisDetail'
 
@@ -524,7 +525,7 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
   // member reading a foreign task's praxis on this page still sees that task's
   // stamp. The arithmetic is `scoreBreakdown()`'s alone (ADR-0053); this file
   // adds no second strip restating the same terms.
-  const scoreBlock = (
+  const scoreBlock = !scoreWasBanked(praxis) ? null : (
     <section style={panel}>
       {panelHead('score', t('detail.score.heading'))}
       <div style={{ display: 'flex', justifyContent: 'center' }}>

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -38,10 +38,30 @@ import type { PraxisDetailState } from './usePraxisDetail'
 // The LEAF module, not `useEditPraxis` — reaching for the hook's barrel would
 // drag the composer's api and upload plumbing onto every praxis-detail load.
 import { deriveEditPraxisPhase } from '../editPraxis/editPraxisPhase'
+import { UNSCORED_MODERATION_STATUSES } from '../../api/praxis'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
 import type { DuelDetailOut } from '../../api/duel'
 import { flagReasonOptions } from '../../utils/flagReasons'
 import { factionCssVar } from '../../utils/factions'
+
+/**
+ * Whether this praxis's score was actually banked (#1444).
+ *
+ * `ScoreStamp` renders nothing on a `failed` or `hidden` praxis: #1373 ruled
+ * those bank no points, and a mark naming a total nobody holds is simply false.
+ * Every archetype wraps its stamp in a HEADED panel, so the dispatcher's null
+ * would leave eight empty "Score" sections behind it — the panel goes with the
+ * mark. One predicate for both, so the page and the stamp cannot come to
+ * disagree about which praxes have a score to show.
+ *
+ * The honest signal survives here: {@link PraxisStatusBanners} draws the failed
+ * banner on this page too. It needs an `admin_note` to draw, so a praxis failed
+ * without one shows no banner AND now no score — a gap that predates this and
+ * belongs to the banner, not the stamp.
+ */
+export function scoreWasBanked(praxis: PraxisOut): boolean {
+  return !UNSCORED_MODERATION_STATUSES.has(praxis.moderation_status)
+}
 
 // ── The detail WALL's alarm inks (#1451) ─────────────────────────────────────
 //


### PR DESCRIPTION
Closes #1444

The praxis card rendered `<ScoreStamp>` unconditionally, so a `failed` praxis
showed its FAILED banner and `13.6 POINTS` in the same frame. Since #1373 that
number is not banked by anyone. The stamp now renders nothing on a praxis whose
score was never banked; the banner stays, because that is the honest signal.

## The seam

`components/praxisCard/scoreStamp/ScoreStamp.tsx` — the **dispatcher**, not the
card slot the issue cites. ADR-0049 made this the single mount for every surface
that shows a total, and grepping the callers found the same untrue figure on a
second surface:

- `components/praxisCard/desktop/shared.tsx:189` — the card (the reported one).
- `pages/praxisDetail/archetypes/*` — all eight bespoke score rails. A failed
  praxis's detail page **is** publicly reachable (`_can_view` in
  `services/praxis.py` refuses `hidden` only), so gating the card alone would
  have left the identical `16.0` one click away, next to the detail page's own
  failed banner.
- `pages/editPraxis/waiting/PraxisWaitingSurface.tsx` — unreachable for these
  states (`deriveEditPraxisPhase` sends `hidden`/`failed` to `composing`), so
  no behaviour change there.

**Mobile: there is no second card.** ADR-0067 collapsed `mobilePraxisCard` and
deleted the `praxisCard/mobile/` tree — the nine `desktop/` archetypes serve
both form factors, and `MobilePraxisFeed` mounts the same `PraxisCard`. So the
one gate covers the phone. I verified this rather than assuming it; the
directory name is a leftover the module docstring already flags.

## `hidden` — extended deliberately, and here is why

The ruling names `failed`. I extended it to `hidden` and did not invent a second
list: `api/praxis.ts` now exports `UNSCORED_MODERATION_STATUSES`, the frontend
mirror of `_UNSCORED_MODERATION_STATUSES` in
`backend/services/character_stats.py`, which is the one predicate naming that
pair. Reasons:

1. It is the same question with the same answer. `hidden` has always banked
   nothing; a stamp on it names a number nobody holds, identically.
2. It is **live**, not theoretical. `usePraxisCard` applies moderation
   optimistically — an admin clicking *Hide* in the feed re-renders that card in
   place with the HIDDEN badge and, before this, its old total still stamped.
   The two admin actions produced the same incoherence.
3. Encoding `failed` alone would create a narrower frontend list that disagrees
   with the backend's, which is the drift that comment exists to prevent.

`flagged` is deliberately excluded on both sides — a flag is a praxis *awaiting*
a ruling, and it still counts.

ADR-0047 does not settle `hidden` explicitly, but its stated policy ("a row
exists when it tells the viewer something the total mark does not already say")
is the same argument one level up, applied to the whole mark rather than a row.

## The consequence I had to handle

Each detail archetype wraps its stamp in a **headed panel**. A bare dispatcher
null would have left eight bordered "Score" sections with nothing inside — a
second bug. So `pages/praxisDetail/shared.tsx` exports one predicate,
`scoreWasBanked(praxis)`, and each archetype drops the whole panel with the
mark. One rule, one home; the eight files each add a name to an import list they
already had and one condition.

## Tests

Written at the seam first, red on the real defect, then green. Both halves are
asserted everywhere — without the second, a test cannot tell "hides on failed"
from "hides always":

- `scoreStamp.test.tsx` — the dispatcher: nothing on `failed`, nothing on
  `hidden`, still stamps `visible`, still stamps `flagged`.
- `cardChrome.test.tsx` — the card body actually routes through the gate.
- `unaffiliatedDetailV2.test.tsx` — the score *section* leaves a failed detail
  page (no headed empty panel, no total), the failed banner stays, and a scored
  praxis still shows `16.0`. I confirmed this one goes red by temporarily
  reverting the gate in `DefaultPraxisDetail`.

Local: eslint · `tsc --noEmit` · `vitest run` (208 files, 3643 tests) ·
`vite build` · byte budget (JS 131.9 KB, CSS 22.3 KB, both ok) ·
`typecheck:design-sync` — all six green.

## Open, not decided here

The detail page's failed banner needs an `admin_note` to draw. A praxis failed
without one now shows no banner **and** no score, where before it at least
showed a number. That gap predates this and belongs to the banner, not the
stamp — say the word and I will file it.

## What to eyeball

**I did no visual QA.** I have no browser and no dev stack, and a mark
disappearing is exactly what a green build cannot vouch for.

1. **A failed card in `/praxes`.** The stamp occupied the card's right column;
   with it gone, check the title/task/excerpt column reflows instead of leaving
   a hole, on all nine faction frames.
2. **Hide a card as an admin, in place.** The optimistic re-render should swap
   to the HIDDEN badge and lose its stamp without the frame jumping.
3. **A failed praxis's detail page, desktop and mobile.** The score panel is
   gone entirely. On desktop it sat in the aside; on mobile it sat above the
   proof (the responsive move in `unaffiliatedDetailV2.test.tsx`). Check neither
   layout is left with a gap or a stranded section heading.
4. **A normal praxis, card and detail.** The stamp must be exactly as before —
   this is the half a "hides always" bug would pass every test above but fail
   here.
5. **A flagged praxis** still shows its stamp, on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
