### PR TITLE
A failed praxis cannot win a duel (#1442)

### DIFF
--- a/backend/models/praxis.py
+++ b/backend/models/praxis.py
@@ -30,6 +30,21 @@ class ModerationStatus(enum.Enum):
     deleted = "deleted"
 
 
+# Moderation states that earn nobody points (#1373) — and, because of that, that
+# cannot win a duel (#1442). ``hidden`` is off the site entirely; ``failed`` is an
+# admin ruling that the work was not done, so it keeps its banner and its place in
+# the feed but banks nothing. It lives beside the enum because two layers read it
+# and must not drift: the scoring gather (``services.character_stats``) leaves
+# these praxes out, and the duel outcome rule
+# (``services.duel_outcome.duel_winner``) refuses to let one win. It mirrors the
+# accepted set in ``services.character``'s Albescent-unlock query, which has always
+# counted only ``visible`` + ``flagged`` — a flagged praxis is merely *awaiting* a
+# ruling.
+UNSCORED_MODERATION_STATUSES: frozenset["ModerationStatus"] = frozenset(
+    {ModerationStatus.hidden, ModerationStatus.failed}
+)
+
+
 class PraxisType(enum.Enum):
     solo = "solo"
     collab = "collab"

--- a/backend/services/badge.py
+++ b/backend/services/badge.py
@@ -84,19 +84,23 @@ async def _duel_winner_facts(
       fact, and these duels need no tally row at all.
     * ``active`` / ``settled`` — the winner comes from the one shared rule
       (:func:`services.duel_outcome.duel_winner`, ADR-0052) over the live tally:
-      forfeit first, then strictly-greater ``points_from_votes``, else a tie.
+      ineligible sides first (forfeit, or a moderation ruling that the work is
+      unscored — #1442), then strictly-greater ``points_from_votes``, else a tie.
 
-    Never infer a winner from the points: a forfeit winner can hold the *lower*
-    score, frozen or live.
+    Never infer a winner from the points: a forfeit winner — or the opponent of a
+    failed praxis — can hold the *lower* score, frozen or live.
     """
     if not character_ids:
         return DuelWinnerFacts()
 
     challenger_praxis = aliased(Praxis)
+    opponent_praxis = aliased(Praxis)
     duel_rows = (
         await session.execute(
             select(
                 challenger_praxis.created_by_id.label("challenger_character_id"),
+                challenger_praxis.moderation_status.label("challenger_moderation"),
+                opponent_praxis.moderation_status.label("opponent_moderation"),
                 Duel.opponent_character_id,
                 Duel.challenger_praxis_id,
                 Duel.opponent_praxis_id,
@@ -108,6 +112,13 @@ async def _duel_winner_facts(
             .join(
                 challenger_praxis,
                 challenger_praxis.id == Duel.challenger_praxis_id,
+            )
+            # Outer: an `active` duel has no opponent praxis yet, and a side an
+            # admin ruled unscored cannot win the badge any more than it can win
+            # the multiplier (#1442). Same join, no extra query.
+            .outerjoin(
+                opponent_praxis,
+                opponent_praxis.id == Duel.opponent_praxis_id,
             )
             .where(
                 Duel.status.in_(BADGE_DUEL_STATUSES),
@@ -172,6 +183,8 @@ async def _duel_winner_facts(
                     tallies, row.challenger_praxis_id
                 ).points_from_votes,
                 opponent_points=opponent_points,
+                challenger_moderation=row.challenger_moderation,
+                opponent_moderation=row.opponent_moderation,
                 forfeited_by_character_id=row.forfeited_by_character_id,
                 tie_break_winner_id=snide_tie_winner_id(
                     faction_by_character.get(row.challenger_character_id, ""),

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -9,11 +9,11 @@ from models.character_stats import CharacterStats
 from models.era import Era
 from models.invitation_letter import InvitationLetter
 from models.praxis import (
-    ModerationStatus,
     Praxis,
     PraxisMember,
     PraxisStatus,
     PraxisType,
+    UNSCORED_MODERATION_STATUSES,
 )
 from models.task import Task
 from services.era import (
@@ -29,17 +29,6 @@ from services.taunt_service import emit_recalc_taunts
 # Factions that never receive invitation letters (ADR-0022 / ADR-0019 sentinels).
 _NON_INVITE_FACTION_SLUGS: frozenset[str] = frozenset({"na", "albescent"})
 
-# Moderation states that earn nobody points (#1373). ``hidden`` is off the site
-# entirely; ``failed`` is an admin ruling that the work was not done, so it keeps
-# its banner and its place in the feed but banks nothing. Both praxis gathers
-# below read this one set so they cannot drift apart. It mirrors the accepted set
-# in ``services.character.py``'s Albescent-unlock query, which has always counted
-# only ``visible`` + ``flagged`` — a flagged praxis is merely *awaiting* a ruling.
-_UNSCORED_MODERATION_STATUSES: frozenset[ModerationStatus] = frozenset(
-    {ModerationStatus.hidden, ModerationStatus.failed}
-)
-
-
 def _era_window_condition(
     era_row: Era, next_era_row: Era | None
 ) -> ColumnElement[bool]:
@@ -52,7 +41,7 @@ def _era_window_condition(
     ``Praxis`` carries no ``era_id``, so era membership is a **seal-time** fact:
     ``[era.started_at, next_era.started_at)``, the same bound
     :class:`services.praxis.PraxisEraScope` reads (#1362). Both gathers below
-    compose this with ``_UNSCORED_MODERATION_STATUSES`` so they cannot drift.
+    compose this with ``UNSCORED_MODERATION_STATUSES`` so they cannot drift.
 
     A NULL ``submitted_at`` counts for the **live** era only.
     ``services.collab_consensus._apply_seal`` establishes
@@ -189,7 +178,7 @@ async def recalculate_character_stats(
     ``era_row``'s era** — solo/duel praxes they authored, plus collab praxes they
     are a member of — then delegates all scoring arithmetic to
     ``compute_contributions`` (ADR-0014). Praxes in an
-    ``_UNSCORED_MODERATION_STATUSES`` state are left out of the gather entirely,
+    ``UNSCORED_MODERATION_STATUSES`` state are left out of the gather entirely,
     so they also stop counting toward faction invitations (ADR-0022).
 
     The era bound is the fix for #1345: the row being written is one era's
@@ -241,7 +230,7 @@ async def recalculate_character_stats(
             Praxis.created_by_id == character_id,
             Praxis.type == PraxisType.solo,
             Praxis.status == PraxisStatus.submitted,
-            Praxis.moderation_status.notin_(list(_UNSCORED_MODERATION_STATUSES)),
+            Praxis.moderation_status.notin_(list(UNSCORED_MODERATION_STATUSES)),
             within_era,
         )
     )
@@ -255,7 +244,7 @@ async def recalculate_character_stats(
             PraxisMember.character_id == character_id,
             Praxis.type == PraxisType.collab,
             Praxis.status == PraxisStatus.submitted,
-            Praxis.moderation_status.notin_(list(_UNSCORED_MODERATION_STATUSES)),
+            Praxis.moderation_status.notin_(list(UNSCORED_MODERATION_STATUSES)),
             within_era,
         )
     )

--- a/backend/services/duel_outcome.py
+++ b/backend/services/duel_outcome.py
@@ -1,17 +1,40 @@
 """The single duel win/loss rule (ADR-0011, ADR-0052).
 
-One pure function decides who won a duel. It is deliberately dependency-free
-(plain ints in, an optional int out) so every consumer can share it without an
-import cycle:
+One pure function decides who won a duel. It is deliberately near
+dependency-free (ids, points and a moderation enum in, an optional id out) so
+every consumer can share it without an import cycle:
 
 - ``services.praxis_scoring`` — derives the live duel multiplier on every read.
 - ``services.era`` — freezes ``Duel.winner_character_id`` at era close.
-- the duel-winner badge (#748) — reads the frozen winner.
+- ``services.badge`` — the duel-winner badge (#748) over live duels.
 
 ``services.duel`` already imports ``services.era``, so the rule cannot live in
 ``services.duel`` without a cycle; it lives here instead.
 """
 from typing import Optional
+
+from models.praxis import UNSCORED_MODERATION_STATUSES, ModerationStatus
+
+
+def _can_win(
+    character_id: Optional[int],
+    moderation: Optional[ModerationStatus],
+    forfeited_by_character_id: Optional[int],
+) -> bool:
+    """Is this side still eligible to win the duel at all?
+
+    Two ways out, deliberately answered by *one* predicate: the player pulled
+    their entry back (forfeit, ADR-0011 §Forfeit) or a moderator ruled the work
+    unscored (``UNSCORED_MODERATION_STATUSES``, #1442). The two stay
+    distinguishable in the record — ``forfeited_by_character_id`` is a deliberate
+    player act and is never cleared, moderation is a judgement about the work, and
+    neither field is written from the other — but they carry the same consequence
+    here. Collapsing them at the point of *consequence* is what removes the
+    precedence question when one lands on each side.
+    """
+    if moderation in UNSCORED_MODERATION_STATUSES:
+        return False
+    return character_id is None or character_id != forfeited_by_character_id
 
 
 def duel_winner(
@@ -20,31 +43,65 @@ def duel_winner(
     opponent_character_id: Optional[int],
     challenger_points: int,
     opponent_points: int,
+    challenger_moderation: Optional[ModerationStatus],
+    opponent_moderation: Optional[ModerationStatus],
     forfeited_by_character_id: Optional[int] = None,
     tie_break_winner_id: Optional[int] = None,
 ) -> Optional[int]:
     """Return the winning character id, or ``None`` for a tie / no-contest.
 
-    Three branches, in priority order (ADR-0011):
+    Three branches, in priority order (ADR-0011, #1442):
 
-    1. **Forfeit.** ``forfeited_by_character_id`` set → the *other* side wins by
-       default and vote tallies do not decide the outcome.
+    1. **Eligibility.** A side that forfeited, or whose praxis a moderator ruled
+       unscored, cannot win — vote tallies do not decide the outcome:
+
+       * exactly one side ineligible → the *other* side wins, **even when the
+         ineligible side holds the higher tally**. That is the intended
+         consequence, not a bug: a duel has a second player, and the alternative
+         is losing to work a moderator judged did not meet the task.
+       * both sides ineligible → ``None``. Nobody won, and the tiebreak below does
+         not get to pick one of them.
     2. **Tally.** Otherwise the side with *strictly greater*
        ``VoteTally.points_from_votes`` wins.
     3. **Tiebreak.** Equal points returns ``tie_break_winner_id`` — a winner some
        faction ability grants on a tie (Snide wins ties, #748), pre-resolved from
        the factions by the caller (:func:`services.scoring.snide_tie_winner_id`)
-       so this rule stays plain-ints-in. ``None`` (the default) is a real tie, and
+       so this rule stays plain-ids-in. ``None`` (the default) is a real tie, and
        also the correct answer for a no-contest (a duel that never became votable),
        which callers express by passing equal points.
 
     Keeping the tiebreak *here* is the point: this is the one rule the badge
     (#748), the live multiplier, and the era-close freeze (ADR-0052) all share, so
-    a Snide tie must name the same winner in every one of them.
+    a Snide tie must name the same winner in every one of them. The moderation
+    arguments are **required** for the same reason — three callers read this rule,
+    and a defaulted "assume it passed" is exactly the drift that let a failed
+    praxis win (#1442).
+
+    Notes for the next reader:
+
+    * This does **not** contradict #1373 ("a failed praxis banks no points, and
+      that is all it changes"). That ruling is about *solo* scoring, where the only
+      person affected is the author. A duel has a second player whose recorded
+      result and multiplier follow this function, so "banks nothing but still beats
+      you" was incoherent. Do not simplify this back to points-only.
+    * The winner still banks their faction's guaranteed-win modifier: they won a
+      duel. Only the ineligible entry goes unscored.
+    * Frozen outcomes never recompute. Era close writes ``Duel.winner_character_id``
+      once (``0007_duel_frozen_outcome``, ADR-0052) and every reader trusts the
+      frozen value afterwards, so restoring a ``failed`` praxis to ``visible``
+      after its duel resolved does **not** reopen the result.
     """
-    if forfeited_by_character_id is not None:
-        if forfeited_by_character_id == challenger_character_id:
-            return opponent_character_id
+    challenger_can_win = _can_win(
+        challenger_character_id, challenger_moderation, forfeited_by_character_id
+    )
+    opponent_can_win = _can_win(
+        opponent_character_id, opponent_moderation, forfeited_by_character_id
+    )
+    if not challenger_can_win and not opponent_can_win:
+        return None
+    if not challenger_can_win:
+        return opponent_character_id
+    if not opponent_can_win:
         return challenger_character_id
 
     if challenger_points > opponent_points:

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -169,8 +169,9 @@ async def resolve_duels_at_era_close(
     A duel has no winner until the era closes — the tally floats live until this
     runs (ADR-0011). Here every ``active`` or ``settled`` duel gets:
 
-    - ``winner_character_id`` from the one shared rule (``duel_winner``): forfeit
-      → the non-forfeiter, else strictly greater ``points_from_votes``, tie → NULL.
+    - ``winner_character_id`` from the one shared rule (``duel_winner``): a side
+      that forfeited or that a moderator ruled unscored cannot win (#1442), else
+      strictly greater ``points_from_votes``, tie → NULL.
     - a snapshot of both sides' ``points_from_votes``, so a resolved surface can
       show vote shares without the live tally moving under it.
     - ``resolved_at`` and the terminal ``resolved`` status.
@@ -248,12 +249,26 @@ async def resolve_duels_at_era_close(
         challenger_character_id = (
             challenger_praxis.created_by_id if challenger_praxis else None
         )
+        opponent_praxis = (
+            praxes_by_id.get(duel.opponent_praxis_id)
+            if duel.opponent_praxis_id is not None
+            else None
+        )
         duel.winner_character_id = (
             duel_winner(
                 challenger_character_id=challenger_character_id,
                 opponent_character_id=duel.opponent_character_id,
                 challenger_points=challenger_points,
                 opponent_points=opponent_points,
+                # The freeze reads moderation for the same reason the live
+                # multiplier does (#1442): a side an admin ruled unscored cannot
+                # win, and this is the write that makes the result permanent.
+                challenger_moderation=(
+                    challenger_praxis.moderation_status if challenger_praxis else None
+                ),
+                opponent_moderation=(
+                    opponent_praxis.moderation_status if opponent_praxis else None
+                ),
                 forfeited_by_character_id=duel.forfeited_by_character_id,
                 tie_break_winner_id=snide_tie_winner_id(
                     faction_by_character.get(challenger_character_id, ""),

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -1803,6 +1803,13 @@ async def moderate_praxis(
     recalc is unconditional rather than gated on "did the scored-ness change":
     it is the same handful of queries the vote path already runs per vote, and
     an admin action is rare.
+
+    A **duel side** also recalcs the *opponent* (#1442). A praxis ruled unscored
+    cannot win its duel, which hands the other side the guaranteed-win modifier —
+    and the opponent is not a member of this praxis, so nothing else would move
+    their score until their own next edit. Same shape as the forfeit recalc in
+    :func:`unsubmit_praxis`, for the same reason: the ruling changes what a second
+    player is worth.
     """
     praxis = await get_praxis(praxis_id, session)
 
@@ -1821,8 +1828,37 @@ async def moderate_praxis(
         praxis.admin_note = None
 
     await session.flush()
-    await recalculate_members_stats(praxis, session, era)
+    era_row = await get_era_row_for_praxis(praxis, session)
+    await recalculate_members_stats(praxis, session, era, era_row=era_row)
+
+    opponent_character_id = await _duel_opponent_character_id(praxis_id, session)
+    if opponent_character_id is not None:
+        await recalculate_character_stats(
+            opponent_character_id, session, era, era_row=era_row
+        )
+        await session.flush()
     return await get_praxis(praxis_id, session)
+
+
+async def _duel_opponent_character_id(
+    praxis_id: int, session: AsyncSession
+) -> Optional[int]:
+    """The other side's character in ``praxis_id``'s live duel, or None.
+
+    None covers every "no second player to move" case: not a duel side, a duel
+    already frozen at era close (``get_duel_for_praxis`` excludes ``resolved``, and
+    ADR-0052 says a frozen outcome never recomputes), or a challenge with no
+    opponent praxis yet.
+    """
+    from services.duel import get_duel_for_praxis
+
+    duel = await get_duel_for_praxis(praxis_id, session)
+    if duel is None:
+        return None
+    if duel.challenger_praxis_id == praxis_id:
+        return duel.opponent_character_id
+    challenger_praxis = await session.get(Praxis, duel.challenger_praxis_id)
+    return challenger_praxis.created_by_id if challenger_praxis else None
 
 
 __all__ = [

--- a/backend/services/praxis_scoring.py
+++ b/backend/services/praxis_scoring.py
@@ -184,30 +184,40 @@ async def compute_contributions(
                 character_faction, task_faction, era,
                 collaboration_mode=COLLABORATION_MODE_SOLO,
             )
-            # One shared rule decides the winner (ADR-0052): forfeit first, then
-            # strictly-greater points_from_votes, else a tie. Read live here; the
-            # same call freezes Duel.winner_character_id at era close — after
-            # which the frozen winner is authoritative and the tally stops moving
-            # the multiplier.
+            # One shared rule decides the winner (ADR-0052): ineligible sides
+            # first (forfeit, or a moderation ruling that the work is unscored —
+            # #1442), then strictly-greater points_from_votes, else a tie. Read
+            # live here; the same call freezes Duel.winner_character_id at era
+            # close — after which the frozen winner is authoritative and the tally
+            # stops moving the multiplier.
             if duel.status == DuelStatus.resolved:
                 winner_character_id: Optional[int] = duel.winner_character_id
             else:
+                opp_moderation: Optional[ModerationStatus] = (
+                    opp_praxis.moderation_status if opp_praxis is not None else None
+                )
                 if duel.challenger_praxis_id == praxis.id:
                     challenger_character_id: Optional[int] = character.id
                     challenger_points = own_tally.points_from_votes
                     opponent_points = opp_tally.points_from_votes
+                    challenger_moderation = praxis.moderation_status
+                    opponent_moderation = opp_moderation
                 else:
                     challenger_character_id = (
                         opp_praxis.created_by_id if opp_praxis is not None else None
                     )
                     challenger_points = opp_tally.points_from_votes
                     opponent_points = own_tally.points_from_votes
+                    challenger_moderation = opp_moderation
+                    opponent_moderation = praxis.moderation_status
 
                 winner_character_id = duel_winner(
                     challenger_character_id=challenger_character_id,
                     opponent_character_id=duel.opponent_character_id,
                     challenger_points=challenger_points,
                     opponent_points=opponent_points,
+                    challenger_moderation=challenger_moderation,
+                    opponent_moderation=opponent_moderation,
                     forfeited_by_character_id=duel.forfeited_by_character_id,
                 )
             duel_multiplier = compute_duel_multiplier(

--- a/backend/tests/integration/test_duel_era_resolution.py
+++ b/backend/tests/integration/test_duel_era_resolution.py
@@ -18,7 +18,13 @@ from models.character_stats import CharacterStats
 from models.duel import Duel, DuelStatus
 from models.era import Era
 from models.faction import Faction
-from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.praxis import (
+    ModerationStatus,
+    Praxis,
+    PraxisMember,
+    PraxisStatus,
+    PraxisType,
+)
 from models.task import Task, TaskStatus
 from models.vote import Vote
 from services.duel_outcome import duel_winner
@@ -80,12 +86,14 @@ async def _make_solo(
     author: Character,
     *,
     status: PraxisStatus = PraxisStatus.submitted,
+    moderation: ModerationStatus = ModerationStatus.visible,
 ) -> Praxis:
     praxis = Praxis(
         task_id=task.id,
         created_by_id=author.id,
         type=PraxisType.solo,
         status=status,
+        moderation_status=moderation,
         title="side",
         body_text="proof",
     )
@@ -122,6 +130,8 @@ async def _make_duel(
     forfeiter: str | None = None,
     challenger_faction: str = "ua",
     opponent_faction: str = "ua",
+    challenger_moderation: ModerationStatus = ModerationStatus.visible,
+    opponent_moderation: ModerationStatus = ModerationStatus.visible,
 ) -> tuple[Duel, Character, Character]:
     """Build a full duel: two characters, two solo praxes, optional votes."""
     challenger = await _make_character(
@@ -136,8 +146,12 @@ async def _make_duel(
         session, era, username=f"{label}_v", email=f"{label}_v@x.com"
     )
     task = await _make_task(session, challenger)
-    challenger_praxis = await _make_solo(session, task, challenger)
-    opponent_praxis = await _make_solo(session, task, opponent)
+    challenger_praxis = await _make_solo(
+        session, task, challenger, moderation=challenger_moderation
+    )
+    opponent_praxis = await _make_solo(
+        session, task, opponent, moderation=opponent_moderation
+    )
 
     if challenger_votes:
         await _cast_vote(session, challenger_praxis, voter, challenger_votes)
@@ -188,6 +202,8 @@ def test_duel_winner_prefers_forfeit_over_the_tally():
             opponent_character_id=2,
             challenger_points=99,
             opponent_points=0,
+            challenger_moderation=ModerationStatus.visible,
+            opponent_moderation=ModerationStatus.visible,
             forfeited_by_character_id=1,
         )
         == 2
@@ -201,6 +217,8 @@ def test_duel_winner_needs_strictly_greater_points():
             opponent_character_id=2,
             challenger_points=4,
             opponent_points=3,
+            challenger_moderation=ModerationStatus.visible,
+            opponent_moderation=ModerationStatus.visible,
         )
         == 1
     )
@@ -210,6 +228,8 @@ def test_duel_winner_needs_strictly_greater_points():
             opponent_character_id=2,
             challenger_points=3,
             opponent_points=3,
+            challenger_moderation=ModerationStatus.visible,
+            opponent_moderation=ModerationStatus.visible,
         )
         is None
     )
@@ -320,6 +340,53 @@ async def test_era_reset_wins_for_the_opponent_side_too(
     assert duel.winner_character_id == opponent.id
     assert duel.challenger_final_points == 1
     assert duel.opponent_final_points == 4
+
+
+@pytest.mark.asyncio
+async def test_era_reset_will_not_freeze_a_win_for_a_failed_side(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """A praxis a moderator ruled failed cannot win the frozen record (#1442).
+
+    The failed side leads 5–1, and still loses: the tally is not the input that
+    decides eligibility. This is the era-close half of the fix — the settlement
+    path is covered in ``test_praxis_card_breakdown``, and the two must agree
+    because they share one rule.
+    """
+    duel, _challenger, opponent = await _make_duel(
+        db_session, era, label="failwin", status=DuelStatus.settled,
+        challenger_votes=5, opponent_votes=1,
+        challenger_moderation=ModerationStatus.failed,
+    )
+
+    await _close_the_era(db_session, account)
+
+    await db_session.refresh(duel)
+    assert duel.status == DuelStatus.resolved
+    assert duel.winner_character_id == opponent.id
+    # The snapshot still records what the tally actually said — the ruling
+    # changes who won, not what the voters did.
+    assert duel.challenger_final_points == 5
+    assert duel.opponent_final_points == 1
+
+
+@pytest.mark.asyncio
+async def test_era_reset_freezes_no_winner_when_both_sides_failed(
+    db_session: AsyncSession, era: Era, account: Account, faction_ua: Faction
+):
+    """Nobody won. A NULL winner, not the higher tally and not the tiebreak."""
+    duel, _challenger, _opponent = await _make_duel(
+        db_session, era, label="bothfail", status=DuelStatus.settled,
+        challenger_votes=5, opponent_votes=1,
+        challenger_moderation=ModerationStatus.failed,
+        opponent_moderation=ModerationStatus.failed,
+    )
+
+    await _close_the_era(db_session, account)
+
+    await db_session.refresh(duel)
+    assert duel.status == DuelStatus.resolved
+    assert duel.winner_character_id is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_duelist_badge.py
+++ b/backend/tests/integration/test_duelist_badge.py
@@ -26,7 +26,13 @@ from models.character_stats import CharacterStats
 from models.duel import Duel, DuelStatus
 from models.era import Era
 from models.faction import Faction
-from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.praxis import (
+    ModerationStatus,
+    Praxis,
+    PraxisMember,
+    PraxisStatus,
+    PraxisType,
+)
 from models.task import Task, TaskStatus
 from models.vote import Vote
 from services.badge import build_badge_contexts, list_badges_for_character
@@ -126,6 +132,8 @@ async def _make_duel(
     winner_character_id: Optional[int] = None,
     challenger_faction: str = "ua",
     opponent_faction: str = "ua",
+    challenger_moderation: ModerationStatus = ModerationStatus.visible,
+    opponent_moderation: ModerationStatus = ModerationStatus.visible,
 ) -> tuple[Duel, Character, Character]:
     """Two fresh characters + their two solo praxes, linked as one duel."""
     challenger = await _make_character(
@@ -138,6 +146,8 @@ async def _make_duel(
     task = await _make_task(session, challenger)
     challenger_praxis = await _make_solo(session, task, challenger)
     opponent_praxis = await _make_solo(session, task, opponent)
+    challenger_praxis.moderation_status = challenger_moderation
+    opponent_praxis.moderation_status = opponent_moderation
 
     if challenger_votes:
         await _cast_vote(session, challenger_praxis, voter, challenger_votes)
@@ -379,6 +389,28 @@ async def test_active_forfeited_duel_still_counts(
     )
     assert await _badge_keys(db_session, challenger) == ["duelist"]
     assert await _badge_keys(db_session, opponent) == []
+
+
+@pytest.mark.asyncio
+async def test_failed_side_is_not_a_duelist_even_while_leading(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """The badge reads the same rule as the multiplier (#1442).
+
+    ``services.badge`` is the third caller of ``duel_winner`` — the issue named
+    two. If it kept deciding on the tally alone, a praxis an admin ruled failed
+    would still wear "Duelist" while its score said it lost.
+    """
+    _, challenger, opponent = await _make_duel(
+        db_session,
+        era,
+        label="failbadge",
+        challenger_votes=9,
+        opponent_votes=1,
+        challenger_moderation=ModerationStatus.failed,
+    )
+    assert await _badge_keys(db_session, challenger) == []
+    assert await _badge_keys(db_session, opponent) == ["duelist"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_failed_praxis.py
+++ b/backend/tests/integration/test_failed_praxis.py
@@ -23,7 +23,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
-from models.praxis import ModerationStatus, Praxis, PraxisStatus
+from models.duel import Duel, DuelStatus
+from models.praxis import (
+    ModerationStatus,
+    Praxis,
+    PraxisMember,
+    PraxisStatus,
+    PraxisType,
+)
 from models.roles import AccountRole, Role
 from models.vote import Vote
 from services.character_stats import recalculate_character_stats
@@ -153,6 +160,82 @@ async def test_restoring_a_failed_praxis_restores_the_score(
         assert response.status_code == 200
 
     assert await _score_of(character.id, db_session) == before
+
+
+@pytest.mark.asyncio
+async def test_failing_a_duel_side_moves_the_opponents_recorded_score(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    account: Account,
+    auth_headers: dict,
+    character: Character,
+    character2: Character,
+    character3: Character,
+    praxis_solo: Praxis,
+):
+    """The second player (#1442): failing one side hands the other the win *now*.
+
+    A duel has an opponent who is not a member of the failed praxis, so the
+    members-only recalc of #1373 would leave their stored score carrying a loss to
+    work an admin ruled did not meet the task — until their own next unrelated
+    edit. The ruling has to reach the opponent's row in the same transaction.
+    """
+    await _make_admin(account, db_session)
+
+    opponent_praxis = Praxis(
+        task_id=praxis_solo.task_id,
+        created_by_id=character2.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.submitted,
+        title="Opponent side",
+        body_text="proof",
+    )
+    db_session.add(opponent_praxis)
+    await db_session.flush()
+    db_session.add(
+        PraxisMember(praxis_id=opponent_praxis.id, character_id=character2.id)
+    )
+    db_session.add(
+        Duel(
+            task_id=praxis_solo.task_id,
+            challenger_praxis_id=praxis_solo.id,
+            opponent_character_id=character2.id,
+            opponent_praxis_id=opponent_praxis.id,
+            status=DuelStatus.settled,
+        )
+    )
+    # Direct inserts: a duel participant may not vote on either side.
+    db_session.add_all(
+        [
+            Vote(
+                praxis_id=praxis_solo.id,
+                voter_character_id=character3.id,
+                voter_account_id=character3.account_id,
+                value=5,
+            ),
+            Vote(
+                praxis_id=opponent_praxis.id,
+                voter_character_id=character3.id,
+                voter_account_id=character3.account_id,
+                value=1,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    # The opponent is behind 1–5, so they are currently the loser.
+    await recalculate_character_stats(character2.id, db_session)
+    losing_score = await _score_of(character2.id, db_session)
+
+    response = await client.patch(
+        f"/admin/praxes/{praxis_solo.id}/moderate",
+        json={"status": "failed", "admin_note": "Proof does not show the task."},
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+
+    # No recalc of character2 here — the moderation transition must do it.
+    assert await _score_of(character2.id, db_session) > losing_score
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_praxis_card_breakdown.py
+++ b/backend/tests/integration/test_praxis_card_breakdown.py
@@ -32,7 +32,13 @@ from models.duel import Duel, DuelStatus
 from models.era import Era
 from models.faction import Faction, FactionStatus
 from models.meta_task import PraxisMetaTask
-from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
+from models.praxis import (
+    ModerationStatus,
+    Praxis,
+    PraxisMember,
+    PraxisStatus,
+    PraxisType,
+)
 from models.task import Task, TaskStatus, TaskType
 from models.vote import Vote
 from services.character_stats import recalculate_character_stats
@@ -441,6 +447,51 @@ async def test_duel_winner_and_loser_scores(
     assert loser_card.display_multiplier == pytest.approx(0.5)
     assert loser_card.score == pytest.approx(7.0)
     assert_invariant(loser_card)
+
+
+@pytest.mark.asyncio
+async def test_failed_duel_side_hands_the_win_to_the_opponent(
+    db_session: AsyncSession, era: Era, faction_ua: Faction
+):
+    """A praxis ruled ``failed`` cannot win, even leading 5–2 on votes (#1442).
+
+    This is the settlement path (``services.praxis_scoring``) of the one duel
+    rule; ``test_duel_era_resolution`` covers the era-close freeze. The opponent
+    wins on the *lower* tally, and still banks the guaranteed-win modifier —
+    they won a duel. #1373 (a failed praxis banks nothing) is about the author's
+    own scoring; this is about the second player.
+    """
+    challenger = await _make_character(
+        db_session, era, faction_slug="ua", username="failedside", email="fs@x.com"
+    )
+    opponent = await _make_character(
+        db_session, era, faction_slug="ua", username="cleanside", email="cs@x.com"
+    )
+    voter = await _make_character(
+        db_session, era, faction_slug="ua", username="failvoter", email="fv@x.com"
+    )
+    task = await _make_task(db_session, challenger, faction_slug="ua", points=10)
+    challenger_praxis = await _make_solo(db_session, task, challenger)
+    opponent_praxis = await _make_solo(db_session, task, opponent)
+
+    await _cast_vote(db_session, challenger_praxis, voter, 5)
+    await _cast_vote(db_session, opponent_praxis, voter, 2)
+    await _make_duel(db_session, task, challenger_praxis, opponent, opponent_praxis)
+
+    challenger_praxis.moderation_status = ModerationStatus.failed
+    await db_session.flush()
+
+    winner_card = await _load_card(db_session, opponent_praxis.id)
+    failed_card = await _load_card(db_session, challenger_praxis.id)
+
+    # Opponent: UA duel_win 1.5 → 10 × 1.5 + 2 = 17.0, off the lower tally.
+    assert winner_card.display_multiplier == pytest.approx(1.5)
+    assert winner_card.score == pytest.approx(17.0)
+    assert_invariant(winner_card)
+
+    # The failed side reads the loss multiplier, not a tie: it lost the duel.
+    # (Its author banks nothing regardless — #1373 keeps it out of the gather.)
+    assert failed_card.display_multiplier == pytest.approx(0.5)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from game_config import ERA_1
+from models.praxis import ModerationStatus
 from services.duel_outcome import duel_winner
 from services.scoring import (
     COLLABORATION_MODE_COLLAB,
@@ -333,39 +334,124 @@ def test_snide_tie_winner_id_resolves_to_the_snide_side():
     assert snide_tie_winner_id("wow", 1, "ua", 2) is None
 
 
+def _winner(**overrides):
+    """``duel_winner`` with two eligible sides — override only what a case is about.
+
+    The moderation arguments are required (#1442), so every call names them; this
+    keeps the cases below about the rule rather than about the signature.
+    """
+    kwargs = dict(
+        challenger_character_id=1,
+        opponent_character_id=2,
+        challenger_points=0,
+        opponent_points=0,
+        challenger_moderation=ModerationStatus.visible,
+        opponent_moderation=ModerationStatus.visible,
+    )
+    kwargs.update(overrides)
+    return duel_winner(**kwargs)
+
+
 def test_duel_winner_returns_tiebreak_on_equal_points():
     # Equal points, no forfeit → the pre-resolved tiebreak winner (Snide's id).
-    assert (
-        duel_winner(
-            challenger_character_id=1,
-            opponent_character_id=2,
-            challenger_points=3,
-            opponent_points=3,
-            tie_break_winner_id=1,
-        )
-        == 1
-    )
+    assert _winner(challenger_points=3, opponent_points=3, tie_break_winner_id=1) == 1
     # A real tie (no tiebreak) is still None.
-    assert (
-        duel_winner(
-            challenger_character_id=1,
-            opponent_character_id=2,
-            challenger_points=3,
-            opponent_points=3,
-        )
-        is None
-    )
+    assert _winner(challenger_points=3, opponent_points=3) is None
     # Forfeit outranks any tiebreak.
     assert (
-        duel_winner(
-            challenger_character_id=1,
-            opponent_character_id=2,
+        _winner(
             challenger_points=3,
             opponent_points=3,
             forfeited_by_character_id=1,
             tie_break_winner_id=1,
         )
         == 2
+    )
+
+
+# ---------------------------------------------------------------------------
+# a side a moderator ruled unscored cannot win (#1442)
+# ---------------------------------------------------------------------------
+
+
+def test_failed_side_loses_even_holding_the_higher_tally():
+    """The intended consequence, not a bug — it only looks wrong at a glance.
+
+    #1373 made a failed praxis bank nothing; letting it still *beat* an opponent
+    put the cost of an admin ruling on the other player.
+    """
+    assert (
+        _winner(
+            challenger_points=99,
+            opponent_points=0,
+            challenger_moderation=ModerationStatus.failed,
+        )
+        == 2
+    )
+
+
+def test_hidden_side_loses_the_same_way_as_a_failed_one():
+    # One set (`UNSCORED_MODERATION_STATUSES`) answers "banks nothing" and
+    # "cannot win", so hidden cannot win either.
+    assert (
+        _winner(
+            challenger_points=0,
+            opponent_points=99,
+            opponent_moderation=ModerationStatus.hidden,
+        )
+        == 1
+    )
+
+
+def test_both_sides_failed_is_nobody_won():
+    # Not even the tiebreak gets to pick one of them.
+    assert (
+        _winner(
+            challenger_points=5,
+            opponent_points=1,
+            challenger_moderation=ModerationStatus.failed,
+            opponent_moderation=ModerationStatus.failed,
+            tie_break_winner_id=1,
+        )
+        is None
+    )
+
+
+def test_failure_and_forfeit_on_opposite_sides_is_nobody_won():
+    # Challenger's work was ruled failed; the opponent walked away. Each is out
+    # for its own reason, so neither wins — no precedence question to get wrong.
+    assert (
+        _winner(
+            challenger_points=7,
+            opponent_points=3,
+            challenger_moderation=ModerationStatus.failed,
+            forfeited_by_character_id=2,
+        )
+        is None
+    )
+
+
+def test_failure_and_forfeit_on_the_same_side_still_names_the_opponent():
+    assert (
+        _winner(
+            challenger_points=7,
+            opponent_points=3,
+            challenger_moderation=ModerationStatus.failed,
+            forfeited_by_character_id=1,
+        )
+        == 2
+    )
+
+
+def test_flagged_side_can_still_win():
+    # `flagged` is merely *awaiting* a ruling — it is not one.
+    assert (
+        _winner(
+            challenger_points=4,
+            opponent_points=1,
+            challenger_moderation=ModerationStatus.flagged,
+        )
+        == 1
     )
 
 


### PR DESCRIPTION
Closes #1442

Owner ruling, built as ruled: **a failed praxis cannot win a duel.** Moderation is now an *input to the shared rule*, not a filter bolted onto each caller.

## Seam under test

`services.duel_outcome.duel_winner` — the one rule — and **all three** of its callers:

| caller | what it decides |
|---|---|
| `services/praxis_scoring.py` | the live duel multiplier at settlement |
| `services/era.py` | the frozen `Duel.winner_character_id` at era close |
| `services/badge.py` | the `duelist` badge over live duels |

**The issue named two callers; there are three.** `services/badge.py` calls the same rule, so a failed praxis was also still wearing "Duelist" while its score said it lost. The moderation arguments are **required keywords** (no default) precisely so a fourth caller cannot quietly assume "it passed" — that defaulting is how this gap opened.

Every new test was run red against the real defect first (moderation ignored in `_can_win`): 4 unit + 4 integration failures, then green.

## The rule now

Forfeit and "ruled unscored" collapse into one eligibility predicate, so there is no precedence question to get wrong:

- exactly one side ineligible → **the other side wins**, on whatever tally it holds;
- both ineligible → **`None`**, and the tiebreak does not get to rescue either.

The two remain distinguishable in the record — `forfeited_by_character_id` is a deliberate player act and is never written from moderation, per the ruling. They are collapsed at the point of *consequence* only.

## Cases decided (as asked)

1. **Both sides failed → nobody won.** `winner_character_id` freezes NULL; the Snide tiebreak is not consulted.
2. **A failed side holding the HIGHER tally → the opponent wins on the lower tally.** Pinned by name in three places because it looks wrong at a glance.
3. **Failure and forfeit on opposite sides → nobody won.** Each side is out for its own reason; asserted rather than left to precedence. Same side (failed *and* forfeited) → the opponent wins, also asserted.
4. **The winner still banks the guaranteed-win modifier** — they won a duel. Test asserts UA ×1.5 for the winner off the *lower* tally. The failed side reads the ×0.5 loss modifier (not a tie): it lost. Its own author banks nothing regardless, since #1373 keeps it out of the gather entirely.
5. **Moderation reversed after settlement does NOT reopen a frozen duel.** Era close writes the winner once (`0007_duel_frozen_outcome`, ADR-0052) and every reader trusts it; restoring a `failed` praxis to `visible` afterwards changes nothing. Written into the `duel_winner` docstring rather than left to be rediscovered.
6. **`hidden` is treated like `failed`** — one `UNSCORED_MODERATION_STATUSES` set (moved from `services/character_stats.py` to `models/praxis.py`) answers both "banks nothing" and "cannot win", so the two cannot drift. Extends the ruling by one status; say the word and it is a one-line narrowing. `flagged` can still win — it is merely *awaiting* a ruling.

## Why this does not contradict #1373

#1373 ruled a failed praxis banks no points *"and that is all it changes"* — about **solo** scoring, where the only person affected is the author. A duel has a **second player** whose recorded result and multiplier follow this function. That reasoning is in the `duel_winner` docstring so the next reader does not "fix" it back.

## The second player actually moves

`moderate_praxis` recalculated only the praxis's **members** (#1373). A duel opponent is not a member, so the ruling would have changed the rule while leaving the opponent's stored `CharacterStats.score` carrying the loss until their own next unrelated edit. It now recalcs the live duel opponent too — same shape, and same reason, as the existing forfeit recalc in `unsubmit_praxis`.

## The forfeit seam (checked, not assumed)

`unsubmit_praxis` and the ban path in `services/character.py` compute "the other side" locally *only to pick a recalc target*; the outcome itself always comes back through `duel_winner`. So a forfeit + failure never double-resolves: the recalc simply runs and `duel_winner` reports nobody won. `get_duel_for_praxis` excludes `resolved`, so a frozen duel is never disturbed.

## Tests

`pytest --cov=. --cov-fail-under=80` from `/backend` (test DB `wz1442_test`) — **1021 passed**, coverage 92.43%.

New: 6 unit cases in `tests/unit/test_scoring.py`; era close in `test_duel_era_resolution.py` (×2); settlement multiplier in `test_praxis_card_breakdown.py`; the opponent's recorded score in `test_failed_praxis.py`; the badge in `test_duelist_badge.py`. The badge query-count guard still passes — the opponent praxis rides an `outerjoin`, not a new query.

No migration. No schema change.

## What to eyeball

- **I did no visual QA.** No browser, no dev stack; this is backend-only and nothing in the API shape changed.
- Whether `hidden` should share `failed`'s fate here (case 6) — the only place I extended past the letter of the ruling.
- Whether the extra opponent recalc on every moderation transition is acceptable cost (one duel lookup + one recalc, admin-only path).
- **#1444** (praxis card still stamps a score on a failed praxis) is untouched and still open — a failed duel side's card now reads a ×0.5 multiplier, which that issue will restyle.
