### PR TITLE
A praxis failed without a note is finally marked on its own page (#1538)

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -30,6 +30,7 @@ import { describe, it, expect } from "vitest";
 // Initialize the i18n catalog so shared-chrome copy keys resolve to English text.
 import "../../../i18n";
 import DefaultPraxisDetail from "../archetypes/DefaultPraxisDetail";
+import { PraxisStatusBanners } from "../shared";
 import type { PraxisDetailState } from "../usePraxisDetail";
 import type { PraxisOut } from "../../../api/praxis";
 import type { TaskOut } from "../../../api/tasks";
@@ -146,6 +147,72 @@ describe("praxis-read Task Crown hero", () => {
       expect(render(<Archetype state={state()} />).text).not.toContain("TASK CROWN");
     });
   }
+});
+
+// ─── The failed mark survives an empty admin note (#1538) ────────────────────
+//
+// #1373 made `failed` a PUBLIC MARK: the praxis keeps its place in the feed and
+// keeps its "marked as failed" banner. The banner used to need an `admin_note`
+// as well as the status, and the note is optional at every layer that sets it —
+// `ModerationAction.admin_note` is `str | None`, and `moderate_praxis` banks
+// `admin_note or ""` on a fail, so leaving the steward's box empty stores the
+// falsy empty string. The card badge next door has always keyed on the status
+// alone, so such a praxis carried a FAILED badge in the feed and (once #1444
+// correctly suppressed its score stamp) nothing at all on its own page.
+//
+// Walked across the whole registry rather than asserted once on the shared slot:
+// the mark has to reach all nine dressed pages, and the empty-note case is
+// exactly the one a skin could quietly stop mounting.
+
+/** The banner's title copy — a whole sentence, so it reads without a note. */
+const FAILED_TITLE = "This praxis was marked as failed.";
+
+describe("failed banner (#1538)", () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} marks a failed praxis with a null, empty, or written note`, () => {
+      for (const note of [null, "", "The photo is of a different ridge."]) {
+        const failed = state();
+        failed.praxis = { ...PRAXIS, moderation_status: "failed", admin_note: note };
+        expect(
+          render(<Archetype state={failed} />).text,
+          `admin_note ${JSON.stringify(note)}`,
+        ).toContain(FAILED_TITLE);
+      }
+      expect(
+        render(<Archetype state={state()} />).text,
+        "a visible praxis carries no mark",
+      ).not.toContain(FAILED_TITLE);
+    });
+  }
+
+  it("prints the note as the banner's body when there is one", () => {
+    const failed = state();
+    failed.praxis = {
+      ...PRAXIS,
+      moderation_status: "failed",
+      admin_note: "The photo is of a different ridge.",
+    };
+    expect(render(<PraxisStatusBanners state={failed} />).text).toContain(
+      "The photo is of a different ridge.",
+    );
+  });
+
+  /**
+   * An optional body must be ABSENT, not empty. Rendering the note's span with
+   * nothing in it would leave a dangling element under the title — the shape
+   * #1444 deleted the headed score panel to avoid.
+   */
+  it("leaves no empty body element when the note is blank", () => {
+    for (const note of [null, ""]) {
+      const failed = state();
+      failed.praxis = { ...PRAXIS, moderation_status: "failed", admin_note: note };
+      const { html } = render(<PraxisStatusBanners state={failed} />);
+      expect(html, `admin_note ${JSON.stringify(note)}`).toContain(FAILED_TITLE);
+      expect(html, "no empty note span").not.toMatch(
+        /<span[^>]*content-text[^>]*><\/span>/,
+      );
+    }
+  });
 });
 
 // ─── Single earned-points breakdown (#641) ───────────────────────────────────

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -55,9 +55,9 @@ import { factionCssVar } from '../../utils/factions'
  * disagree about which praxes have a score to show.
  *
  * The honest signal survives here: {@link PraxisStatusBanners} draws the failed
- * banner on this page too. It needs an `admin_note` to draw, so a praxis failed
- * without one shows no banner AND now no score — a gap that predates this and
- * belongs to the banner, not the stamp.
+ * banner on this page too, keyed on the STATUS alone (#1538) — so suppressing
+ * the stamp never leaves the page silent about a moderation decision, whether or
+ * not the admin wrote a note.
  */
 export function scoreWasBanked(praxis: PraxisOut): boolean {
   return !UNSCORED_MODERATION_STATUSES.has(praxis.moderation_status)
@@ -373,7 +373,20 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
           composer, so neither banner could ever paint again. An open praxis now
           has one owner — the composer's waiting surface (#1071) — instead of two
           that described it differently. */}
-      {praxis.moderation_status === 'failed' && praxis.admin_note && (
+      {/* THE MARK DRAWS ON THE STATUS, NOT ON THE NOTE (#1538).
+          This used to require `praxis.admin_note` as well, and the note is
+          optional everywhere it is set: `ModerationAction.admin_note` is
+          `str | None`, and `moderate_praxis` stores `admin_note or ""` on a
+          fail — so an admin who leaves the box empty banks an EMPTY STRING,
+          falsy here. The card badge next door has always keyed on the status
+          alone, so that praxis carried a "FAILED" badge in the feed and, since
+          #1444 correctly suppressed its score stamp, nothing whatsoever on this
+          page. #1373 made `failed` a PUBLIC MARK — a mark nobody can see is not
+          one. The note is now optional detail INSIDE the banner: its span is
+          omitted entirely when there is nothing to say, so an empty note leaves
+          no dangling element behind the title (which is a whole sentence and
+          reads alone). */}
+      {praxis.moderation_status === 'failed' && (
         <div style={{ background: 'var(--color-danger-veil)', border: '2px solid var(--color-danger-edge)', borderRadius: 8, padding: 'var(--space-sm) var(--space-lg)', marginBottom: 'var(--space-md)', display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
           {/* Ornament: a ✗ dingbat used as an icon, not readable text. Sized
               from the label tier (nearest token to its old 16px), never the
@@ -388,9 +401,11 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
             <span className="font-body content-title" style={{ color: wallInk(praxis, 'alarm'), fontWeight: 700, display: 'block' }}>
               {t('detail.banners.failedTitle')}
             </span>
-            <span className="font-body content-text" style={{ color: wallInk(praxis, 'notice') }}>
-              {praxis.admin_note}
-            </span>
+            {praxis.admin_note && (
+              <span className="font-body content-text" style={{ color: wallInk(praxis, 'notice') }}>
+                {praxis.admin_note}
+              </span>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
Closes #1538

The praxis detail page needed **two** things to draw the "marked as failed" banner — the status *and* an `admin_note`. The card badge next door has only ever needed the status. So a praxis failed with an empty note carried a FAILED badge in the feed and, since #1535 correctly suppressed its score stamp, **nothing at all** on its own page. #1373 made `failed` a public mark; a mark nobody can see is not one.

The banner now draws on `moderation_status` alone, and the note is optional detail *inside* it.

## What the verification turned up

**It is reachable today — this is a live bug, not a latent one.** `ModerationAction.admin_note` is `str | None = Field(None, …)` (`backend/schemas/admin.py`), and `moderate_praxis` banks `praxis.admin_note = admin_note or ""` on a fail (`backend/services/praxis.py`). A steward who leaves the note box empty stores the empty string, which is falsy in the JS guard. The frontend admin client sends `adminNote || null` for the same shape. **No backend behaviour is changed here** — this is a frontend fix, as the issue scoped it.

**`failed` is the only affected status.** The issue asked whether `hidden` or `flagged` carry the same `&& praxis.admin_note` shape. They do not: `flagged`'s notice in `DefaultPraxisDetail` and the flagged/hidden/failed branches of `PraxisAdminBar` all key on the status alone, and there is no `hidden` banner on this page at all. The whole `src/` tree had exactly two `admin_note` reads outside tests, both in the block this PR touches.

**The banner degrades cleanly with no note.** The title copy (`detail.banners.failedTitle` — "This praxis was marked as failed.") is a whole sentence and reads alone; the note's `<span>` is omitted entirely rather than rendered empty, so a blank note leaves no dangling element under the title. That is the same shape #1444 deleted the headed score panel for.

## Tests

Added to `praxisDetail/__tests__/archetypeSlots.test.tsx`, which walks the real `surfaceMap('praxisDetail')` registry, so the claim is made against **all nine dressed pages**, not just the shared slot:

- every archetype marks a failed praxis with `admin_note: null`, `''`, and a written note, and marks nothing on a visible one;
- the note still prints as the banner's body when there is one;
- no empty `content-text` span is emitted when the note is blank.

Ten of these fail against the old guard (verified by reinstating it locally) and pass with the fix.

## Not touched

#1444's suppression of the score stamp on `failed` / `hidden` (shipped in #1535) is correct and untouched. `scoreWasBanked`'s docstring is the one other edit: it described the gap as belonging to the banner, and the banner no longer has it.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` 208 files / 3654 tests pass · `vite build` clean · bundle budget within limits (JS 131.9 KB, CSS 22.3 KB). No colour or type-scale values were added; the banner's tokens are unchanged.

**Visual QA is outstanding** — I have no browser or dev stack in this environment.

## What to eyeball

1. **Praxis detail, `failed` with an empty note** — the banner is the whole point: ✗ ornament, title, and *no* second line or gap under it. This is the case that showed nothing before.
2. **Praxis detail, `failed` with a note** — unchanged from today: title on one line, note under it, both on the faction wall's alarm/notice inks.
3. **The same two states on a non-`na` skin** (Ephemerists or S.N.I.D.E. are the tightest walls, per #1451) — check the note-less banner's vertical rhythm now that the second line can be absent; it is a flex row with `alignItems: center`.
4. **`failed` + crowned** — the crown hero and the failed banner stack in that order; check the two banners' spacing when the failed one is single-line.
5. **The steward path end to end** — admin bar → "Fail" → leave the textarea empty → Confirm, and confirm the page it lands on now says so. Then the same praxis's card in a feed, to see the badge and the banner finally agree.
6. **Mobile form factor** for cases 1 and 2.
7. **Dark mode** for case 1 (the veil/edge rungs are unchanged, but the single-line banner is a new shape on that ground).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
