### PR TITLE
The invitation letter says it is still standing (#1458)

### DIFF
--- a/frontend/src/components/feed/FeedItemSlot.tsx
+++ b/frontend/src/components/feed/FeedItemSlot.tsx
@@ -8,7 +8,7 @@ import i18n from '../../i18n'
 import { extractError } from '../../utils/errors'
 import FeedArchiveButton from './FeedArchiveButton'
 import FeedUndoStrip, { UNDO_WINDOW_MS, type FeedUndoPhase } from './FeedUndoStrip'
-import { feedItemTitle, isArchivable } from './feedItemLabels'
+import { feedDismissedMessage, feedItemTitle, isArchivable } from './feedItemLabels'
 
 /**
  * ONE SLOT IN THE FEED — and the whole of the archive interaction (#1194,
@@ -148,13 +148,17 @@ export default function FeedItemSlot({
 
   // ─── The undo strip, standing in this slot ────────────────────────────────
   if (phase === 'acted') {
-    const title = feedItemTitle(item)
     return (
       <FeedUndoStrip
-        message={i18n.t(
-          archivedView ? 'feed:archive.restored' : 'feed:archive.archived',
-          { title },
-        )}
+        // The dismiss direction takes a per-type line where one is authored
+        // (#1458): the invitation letter's "Not now" is a deferral, and a strip
+        // reading "Archived" would state a decision the player did not make.
+        // Restoring is the same act for every type, so it keeps one sentence.
+        message={
+          archivedView
+            ? i18n.t('feed:archive.restored', { title: feedItemTitle(item) })
+            : feedDismissedMessage(item)
+        }
         actionLabel={i18n.t(
           undoPhase === 'undo'
             ? 'feed:archive.undo'

--- a/frontend/src/components/feed/__tests__/feedDismissedMessage.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedDismissedMessage.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * WHAT THE UNDO STRIP SAYS AFTER A DISMISSAL (#1458).
+ *
+ * `feed:invitationLetter.setAside` — "Set aside — the invitation still stands"
+ * — was authored by #1421 and read by nothing: #1424 routed the letter's
+ * **Not now** through `FeedItemSlot`'s shared strip, which says `Archived
+ * "{title}"`. That routing was the right call (one dismiss implementation for
+ * eight skins), but the shared line states a decision the player did not make:
+ * "Not now" is a deferral and the letter stays valid (ADR-0065/0066). Same
+ * class of defect as #1342.
+ *
+ * The fix is a per-type override, so this pins BOTH halves of it:
+ *
+ *  1. the override fires for `invitation_letter` and only for it — every other
+ *     type still gets the shared archive vocabulary; and
+ *  2. `FeedItemSlot` actually asks for it. The harness has no DOM, so the
+ *     strip's `phase === 'acted'` branch cannot be reached by clicking — the
+ *     wiring is asserted against the source instead. Without that half, a
+ *     correct override wired to nothing would pass the first three tests.
+ *
+ * The strip itself is rendered to prove the sentence survives to markup rather
+ * than only existing as a return value.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import FeedUndoStrip from '../FeedUndoStrip'
+import { feedDismissedMessage } from '../feedItemLabels'
+import type { ActivityFeedItem } from '../../../api/activityFeed'
+
+function item(type: string, payload: Record<string, unknown> = {}): ActivityFeedItem {
+  return {
+    type,
+    item_key: `${type}:1`,
+    timestamp: '2026-01-01T00:00:00Z',
+    actor_display_name: 'Ada',
+    actor_faction_slug: null,
+    actor_avatar_url: null,
+    payload,
+    context_faction_slug: null,
+  }
+}
+
+const LETTER = item('invitation_letter', { faction_slug: 'snide' })
+const NUDGE = item('nudge', { task_title: 'Sweep the yard' })
+
+/** The strip's own markup for a given message — what the reader actually sees. */
+function strip(message: string): string {
+  return renderToStaticMarkup(
+    <FeedUndoStrip
+      message={message}
+      actionLabel={i18n.t('feed:archive.undo')}
+      phase="undo"
+      onAct={() => {}}
+      error={null}
+    />,
+  )
+}
+
+describe('the dismissal line', () => {
+  it('gives the invitation letter its own sentence, not "Archived"', () => {
+    const message = feedDismissedMessage(LETTER)
+
+    // The authored line, resolved — not the key echoed back by a missing
+    // catalog entry, which would make every assertion below pass vacuously.
+    expect(message).not.toBe('feed:invitationLetter.setAside')
+    expect(message).toBe(i18n.t('feed:invitationLetter.setAside'))
+    expect(message).toMatch(/still stands/i)
+
+    // The point of the issue: the word that read as an answer is gone.
+    expect(message).not.toMatch(/archiv/i)
+
+    // ...and it reaches the strip the player is looking at.
+    expect(strip(message)).toContain('still stands')
+  })
+
+  it('leaves every other type on the shared archive line', () => {
+    const message = feedDismissedMessage(NUDGE)
+
+    expect(message).toBe(i18n.t('feed:archive.archived', { title: 'Sweep the yard' }))
+    expect(message).toMatch(/^Archived/)
+    expect(message).toContain('Sweep the yard')
+    expect(strip(message)).toContain('Archived')
+
+    // The override is keyed on one type, not switched on by having a payload.
+    expect(feedDismissedMessage(item('duel_challenge'))).toMatch(/^Archived/)
+    expect(feedDismissedMessage(item('collab_invite'))).toMatch(/^Archived/)
+    expect(feedDismissedMessage(item('era_announcement', { era_name: 'Era Two' }))).toMatch(
+      /^Archived/,
+    )
+  })
+
+  it('overrides the dismissal only — an unknown type still has a line', () => {
+    // A type this build has never heard of must not fall through to an empty
+    // strip; `feedItemTitle` degrades to the fallback kicker.
+    expect(feedDismissedMessage(item('some_future_type'))).toMatch(/^Archived/)
+  })
+})
+
+describe('the slot asks for it', () => {
+  const source = readFileSync(
+    fileURLToPath(new URL('../FeedItemSlot.tsx', import.meta.url)),
+    'utf8',
+  )
+
+  it('builds the dismissal message through the shared override, not inline', () => {
+    expect(source).toContain('feedDismissedMessage(item)')
+    // The old call site read `i18n.t(archivedView ? 'feed:archive.restored' :
+    // 'feed:archive.archived', ...)`. If `feed:archive.archived` is named in
+    // this file again, the letter is back on the shared line.
+    expect(source).not.toContain('feed:archive.archived')
+  })
+
+  it('still restores with one sentence for all fifteen types', () => {
+    // Restoring is the same act whatever the type — the row comes back. Only
+    // the dismiss direction takes overrides.
+    expect(source).toContain("feed:archive.restored")
+  })
+})

--- a/frontend/src/components/feed/__tests__/feedDismissedMessage.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedDismissedMessage.test.tsx
@@ -6,7 +6,7 @@
  * **Not now** through `FeedItemSlot`'s shared strip, which says `Archived
  * "{title}"`. That routing was the right call (one dismiss implementation for
  * eight skins), but the shared line states a decision the player did not make:
- * "Not now" is a deferral and the letter stays valid (ADR-0065/0066). Same
+ * "Not now" is a deferral and the letter stays valid (ADR-0070). Same
  * class of defect as #1342.
  *
  * The fix is a per-type override, so this pins BOTH halves of it:

--- a/frontend/src/components/feed/feedItemLabels.ts
+++ b/frontend/src/components/feed/feedItemLabels.ts
@@ -90,6 +90,48 @@ export function feedKicker(type: string): string {
 }
 
 /**
+ * The types whose dismissal line is NOT `Archived "{title}"` (#1458).
+ *
+ * The shared undo strip is right for fourteen of the fifteen: you filed the
+ * card away and nothing else happened. It is wrong for the invitation letter,
+ * whose dismiss control is labelled **Not now** — a deferral, never an answer
+ * (ADR-0065/0066). "Archived" reads as a decision the player did not make, so
+ * that one type spends its own authored sentence instead:
+ *
+ *   > Set aside — the invitation still stands
+ *
+ * Same class of defect as #1342, where the archive's shared "Still waiting"
+ * tag spoke for a request that had since been answered — one strip asserting
+ * something untrue for one type.
+ *
+ * It is keyed on the TYPE, not on which control was pressed, because both
+ * routes to the write mean the same thing: the ✕ and the swipe archive a
+ * letter that also stays standing.
+ *
+ * Rewording the shared line was rejected on sight: it would be correct here and
+ * wrong for the other fourteen. The map is the override list — deliberately
+ * literal, so an unnamed type falls through to the shared line rather than
+ * printing a raw key.
+ */
+const DISMISSED_MESSAGE_KEY = {
+  invitation_letter: 'feed:invitationLetter.setAside',
+} as const
+
+/**
+ * What the undo strip says after a DISMISSAL — the per-type line where one is
+ * authored, the shared `Archived "{title}"` otherwise.
+ *
+ * Only the dismiss direction takes overrides. Restoring is the same act for
+ * every type (the row comes back), so the archived view keeps
+ * `feed:archive.restored` for all fifteen.
+ */
+export function feedDismissedMessage(item: ActivityFeedItem): string {
+  const override = DISMISSED_MESSAGE_KEY[item.type as keyof typeof DISMISSED_MESSAGE_KEY]
+  if (override) return i18n.t(override)
+  return i18n.t('feed:archive.archived', { title: feedItemTitle(item) })
+}
+
+/**
  * A short human handle for the card, used by the undo strip's
  * `Archived "{title}"`. Falls back to the kicker so the strip never reads
  * `Archived ""`.

--- a/frontend/src/components/feed/feedItemLabels.ts
+++ b/frontend/src/components/feed/feedItemLabels.ts
@@ -95,7 +95,7 @@ export function feedKicker(type: string): string {
  * The shared undo strip is right for fourteen of the fifteen: you filed the
  * card away and nothing else happened. It is wrong for the invitation letter,
  * whose dismiss control is labelled **Not now** — a deferral, never an answer
- * (ADR-0065/0066). "Archived" reads as a decision the player did not make, so
+ * (ADR-0070). "Archived" reads as a decision the player did not make, so
  * that one type spends its own authored sentence instead:
  *
  *   > Set aside — the invitation still stands


### PR DESCRIPTION
`feed:invitationLetter.setAside` — "Set aside — the invitation still stands" — was authored by #1421 and read by nothing. #1424 routed the letter's **Not now** through `FeedItemSlot`'s shared undo strip, which says `Archived "{title}"`.

That routing was the right architectural call and stands: everything about dismissing lives in one place so eight skins inherit it. But the shared line states a decision the player did not make. "Not now" is a deferral — the letter stays valid, the faction is still joinable, nothing was answered (ADR-0065/0066). Same class of defect as #1342, where the archive's shared "Still waiting" tag spoke for a request that had since been answered: one strip asserting something untrue for one type.

Per the owner ruling on the issue: wire it. The key is not deleted and the shared strip is not reworded.

## What changed

- `feedItemLabels.ts` gains `DISMISSED_MESSAGE_KEY` — the override list, one entry — and `feedDismissedMessage(item)`, which returns the per-type line where one is authored and `Archived "{title}"` otherwise. An unnamed type falls through to the shared line rather than printing a raw key.
- `FeedItemSlot.tsx` builds the strip's dismiss message through that function. The **restore** direction is untouched: restoring is the same act for every type (the row comes back), so all fifteen keep `feed:archive.restored`.
- The override is keyed on the item TYPE, not on which control was pressed. The ✕ and the swipe archive a letter that also stays standing, so they get the same sentence as "Not now".

Fourteen types render exactly what they rendered before. No catalog edits, no new endpoints, no backend change.

## Tests

New `feedDismissedMessage.test.tsx`, five cases. It pins both halves, because a correct override wired to nothing would pass the first three:

- the letter's line resolves to the authored sentence, matches `/still stands/`, and no longer matches `/archiv/i` — with an explicit assertion that it is not the key echoed back by a missing catalog entry, which would make the rest pass vacuously;
- `nudge`, `duel_challenge`, `collab_invite`, `era_announcement` and an unknown future type all still get `Archived "..."`;
- the sentence survives into `FeedUndoStrip`'s rendered markup;
- `FeedItemSlot.tsx` names `feedDismissedMessage(item)` and no longer names `feed:archive.archived`. The harness has no DOM, so the strip's `phase === 'acted'` branch is unreachable by clicking; the wiring is asserted against the source, an idiom this tree already uses.

## Verification

`tsc --noEmit` clean · `eslint src` clean · `vitest run` 3648 passing across 209 files · `vite build` clean · bundle budget ok (JS 131.9 KB, CSS 22.3 KB — unchanged).

**Visual QA is outstanding.** I have no browser or dev stack here, and the acted phase cannot be reached in a DOM-less harness, so nobody has seen this strip render.

## What to eyeball

- `/updates` → a faction invitation letter → **Not now**. The strip should read *Set aside — the invitation still stands* with **Undo** beside it, and no title in quotes.
- The same card's **✕** and a left swipe on touch: same sentence, not "Archived".
- Any other card on `/updates` (a nudge, a global task) → still `Archived "<title>"`.
- The Archived tab → **Restore** on that same letter: should still read `Restored "<title>"`, not the set-aside line.
- The letter's line has no interpolated title, so it is much shorter than the shared one — check it sits right in the strip's flex row, which ellipsizes on overflow.
- Wait out the six-second window on the letter: the action degrades to **Restore** while the message stays. "Restore" against "Set aside" is the one wording pair I did not touch — flag it if it reads wrong.

Closes #1458
