### PR TITLE
A stale /tasks bookmark gets the default browse, not an error page (#1537)

### DIFF
--- a/frontend/src/pages/praxes/feedFilterParams.ts
+++ b/frontend/src/pages/praxes/feedFilterParams.ts
@@ -17,6 +17,8 @@
  * the feed URL and the request it makes read alike — and `?task_id=` was
  * already snake_case for the same reason.
  */
+import { readOneOf } from '../../utils/urlParams'
+
 
 /** Account-scoped vote filter. `all` = no filter (#644 §6). */
 export type VotedFilter = 'all' | 'yes' | 'no'
@@ -80,16 +82,9 @@ const ERA_SCOPES: readonly EraScope[] = ['this_era', 'all_eras']
 /**
  * A URL is untrusted input and the list route 422s on an unknown `sort`,
  * `voted` or `era_scope` — so a hand-edited or truncated link degrades to the
- * landing value here rather than turning the feed into an error.
+ * landing value via {@link readOneOf} rather than turning the feed into an
+ * error. That whitelist is now shared with the task browse (#1537).
  */
-function readOneOf<T extends string>(
-  raw: string | null,
-  allowed: readonly T[],
-  fallback: T,
-): T {
-  return allowed.includes(raw as T) ? (raw as T) : fallback
-}
-
 export function readFeedFilters(params: URLSearchParams): PraxisFeedFilters {
   return {
     // Unknown slugs are left alone: `/factions` is fetched separately and a

--- a/frontend/src/pages/tasks/__tests__/taskFilterParams.test.ts
+++ b/frontend/src/pages/tasks/__tests__/taskFilterParams.test.ts
@@ -6,47 +6,93 @@
  * functions of a param set — the repo's harness has no DOM, so the hook itself
  * is not renderable here, and these are deliberately the hook's whole decision.
  *
- * Three decisions:
- *   1. non-default values only — a clean browse has a clean address
- *   2. faction is REPEATED (`?faction=a&faction=b`), the union B2 (#1364) reads
- *   3. "clear all" clears search too, and touches nothing it does not own
+ * Four decisions:
+ *   1. an enumerated axis is WHITELISTED — a value the page cannot serve reads
+ *      as the default rather than riding out to a route that 422s on it (#1537)
+ *   2. non-default values only — a clean browse has a clean address
+ *   3. faction is REPEATED (`?faction=a&faction=b`), the union B2 (#1364) reads
+ *   4. "clear all" clears search too, and touches nothing it does not own
  */
 import { describe, it, expect } from 'vitest'
 import {
   CAN_SIGN_UP_ON,
   TASK_FILTER_PARAMS,
   TASK_SORT_DEFAULT,
-  TASK_STATUS_DEFAULT,
   TASK_TYPE_DEFAULT,
   clearedFilterParams,
   nextFactionParams,
   nextFilterParams,
-  readFilterParam,
+  readTaskFilters,
 } from '../useTasks'
 
 const params = (query: string) => new URLSearchParams(query)
 
-describe('readFilterParam — a missing param IS the default', () => {
-  it('falls back when the axis is absent', () => {
-    expect(
-      readFilterParam(params(''), TASK_FILTER_PARAMS.sort, TASK_SORT_DEFAULT),
-    ).toBe('level')
+describe('readTaskFilters — a missing param IS the default', () => {
+  it('reads a bare URL as the whole default filter set', () => {
+    expect(readTaskFilters(params(''))).toEqual({
+      taskType: 'standard',
+      sort: 'level',
+      status: 'All',
+      factions: [],
+      canSignUp: false,
+    })
   })
 
-  it('falls back when the axis is present but blank', () => {
-    expect(
-      readFilterParam(params('sort='), TASK_FILTER_PARAMS.sort, TASK_SORT_DEFAULT),
-    ).toBe('level')
+  it('falls back when an axis is present but blank', () => {
+    const filters = readTaskFilters(params('sort=&type=&status='))
+    expect(filters.sort).toBe('level')
+    expect(filters.taskType).toBe('standard')
+    expect(filters.status).toBe('All')
   })
 
   it('hydrates a pasted link', () => {
-    expect(
-      readFilterParam(
-        params('sort=oldest&status=retired'),
-        TASK_FILTER_PARAMS.status,
-        TASK_STATUS_DEFAULT,
+    const filters = readTaskFilters(
+      params(
+        `type=metatask&sort=oldest&status=retired&faction=ua&faction=coven&can_sign_up=${CAN_SIGN_UP_ON}`,
       ),
-    ).toBe('retired')
+    )
+    expect(filters).toEqual({
+      taskType: 'metatask',
+      sort: 'oldest',
+      status: 'retired',
+      factions: ['ua', 'coven'],
+      canSignUp: true,
+    })
+  })
+})
+
+describe('readTaskFilters — an unrecognised value CLAMPS (#1537)', () => {
+  it('clamps a sort the list route would 422 on', () => {
+    // `GET /tasks` rejects an unknown sort outright (#1443). A stale bookmark is
+    // not an API caller, so it gets the default browse, not the error state.
+    expect(readTaskFilters(params('sort=bogus')).sort).toBe('level')
+    expect(readTaskFilters(params('sort=most_voted')).sort).toBe('level')
+  })
+
+  it('clamps an unknown browse mode', () => {
+    expect(readTaskFilters(params('type=metatasks')).taskType).toBe('standard')
+  })
+
+  it('clamps an unknown status', () => {
+    expect(readTaskFilters(params('status=archived')).status).toBe('All')
+  })
+
+  it('clamps one axis without disturbing its neighbours', () => {
+    const filters = readTaskFilters(params('sort=bogus&status=retired&faction=ua'))
+    expect(filters.sort).toBe('level')
+    expect(filters.status).toBe('retired')
+    expect(filters.factions).toEqual(['ua'])
+  })
+
+  it('leaves unknown faction slugs alone — /factions is fetched separately', () => {
+    expect(readTaskFilters(params('faction=not-a-faction')).factions).toEqual([
+      'not-a-faction',
+    ])
+  })
+
+  it('reads any eligibility value but the flag as OFF', () => {
+    expect(readTaskFilters(params('can_sign_up=yes')).canSignUp).toBe(false)
+    expect(readTaskFilters(params(`can_sign_up=${CAN_SIGN_UP_ON}`)).canSignUp).toBe(true)
   })
 })
 

--- a/frontend/src/pages/tasks/__tests__/taskFilterParams.test.ts
+++ b/frontend/src/pages/tasks/__tests__/taskFilterParams.test.ts
@@ -90,6 +90,10 @@ describe('readTaskFilters — an unrecognised value CLAMPS (#1537)', () => {
     ])
   })
 
+  it('drops a blank faction, which would filter to no faction at all', () => {
+    expect(readTaskFilters(params('faction=&faction=ua')).factions).toEqual(['ua'])
+  })
+
   it('reads any eligibility value but the flag as OFF', () => {
     expect(readTaskFilters(params('can_sign_up=yes')).canSignUp).toBe(false)
     expect(readTaskFilters(params(`can_sign_up=${CAN_SIGN_UP_ON}`)).canSignUp).toBe(true)

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -41,6 +41,7 @@ import type { FactionConfigOut } from '../../api/gameConfig'
 import { useFactions } from '../../hooks/useFactions'
 import { useGameConfig } from '../../hooks/useGameConfig'
 import { extractError } from '../../utils/errors'
+import { readOneOf } from '../../utils/urlParams'
 import { useAuth } from '../../auth/AuthContext'
 import { computeDisplayPoints, computeFactionMultiplier } from '../../utils/points'
 import { usePagedResource } from '../../hooks/usePagedResource'
@@ -67,6 +68,14 @@ export const TASK_FILTER_PARAMS = {
   canSignUp: 'can_sign_up',
 } as const
 
+/**
+ * The status axis, which is NOT a backend enum: `All` is the page's own "no
+ * status filter" value and the other three are `TaskStatus`. Whether the viewer
+ * may SEE `retired` / `pending` is a separate, server-owned question — see
+ * `statusFilters`, which is what the control offers.
+ */
+export type TaskStatusFilter = 'All' | 'active' | 'retired' | 'pending'
+
 /** Browse mode default: ordinary tasks, metatasks excluded backend-side. */
 export const TASK_TYPE_DEFAULT: TaskType = 'standard'
 /**
@@ -76,20 +85,69 @@ export const TASK_TYPE_DEFAULT: TaskType = 'standard'
  * newest/oldest pair from silently deleting it.
  */
 export const TASK_SORT_DEFAULT: TaskSort = 'level'
-export const TASK_STATUS_DEFAULT = 'All'
+export const TASK_STATUS_DEFAULT: TaskStatusFilter = 'All'
 /** The eligibility axis is a flag; this is its one non-default value. */
 export const CAN_SIGN_UP_ON = '1'
+
+/**
+ * The legal value of each enumerated axis, for {@link readOneOf} (#1537). A URL
+ * is untrusted input: `GET /tasks` 422s on an unknown `sort` (#1443), so a stale
+ * bookmark or a hand-edited link has to degrade to the default view here rather
+ * than surface the browse error state.
+ *
+ * Status is whitelisted against EVERY status, not against the viewer-gated
+ * `statusFilters` — those depend on `/auth/me`, which settles after first
+ * render, so gating the read would flip a shared `?status=retired` link back to
+ * `All` mid-load. A viewer who may not see retired tasks is told so by the
+ * server, which owns that rule.
+ */
+const TASK_TYPES: readonly TaskType[] = ['standard', 'metatask']
+const TASK_SORTS: readonly TaskSort[] = ['newest', 'oldest', 'level']
+const TASK_STATUSES: readonly TaskStatusFilter[] = [
+  'All',
+  'active',
+  'retired',
+  'pending',
+]
 
 /** Navigation options for every filter write: replace, never push. */
 const FILTER_NAV_OPTIONS = { replace: true } as const
 
-/** Read one single-valued axis. A missing or blank param IS the default. */
-export function readFilterParam(
-  params: URLSearchParams,
-  key: string,
-  defaultValue: string,
-): string {
-  return params.get(key) || defaultValue
+/** Every filter axis the browse owns, as read out of the address bar. */
+export interface TaskFilterAxes {
+  taskType: TaskType
+  sort: TaskSort
+  status: TaskStatusFilter
+  factions: string[]
+  canSignUp: boolean
+}
+
+/**
+ * Hydrate the whole filter set from a param set — the hook's entire URL read,
+ * pulled out where the no-DOM harness can drive it. Counterpart to the praxis
+ * feed's `readFeedFilters`.
+ *
+ * The three enumerated axes go through the shared whitelist, so an unknown value
+ * clamps to the default instead of riding out to a route that 422s on it.
+ */
+export function readTaskFilters(params: URLSearchParams): TaskFilterAxes {
+  return {
+    taskType: readOneOf(
+      params.get(TASK_FILTER_PARAMS.taskType),
+      TASK_TYPES,
+      TASK_TYPE_DEFAULT,
+    ),
+    sort: readOneOf(params.get(TASK_FILTER_PARAMS.sort), TASK_SORTS, TASK_SORT_DEFAULT),
+    status: readOneOf(
+      params.get(TASK_FILTER_PARAMS.status),
+      TASK_STATUSES,
+      TASK_STATUS_DEFAULT,
+    ),
+    // Unknown slugs are left alone, as on the praxis feed: `/factions` is
+    // fetched separately and a slug that matches nothing simply returns no rows.
+    factions: params.getAll(TASK_FILTER_PARAMS.faction).filter((slug) => slug !== ''),
+    canSignUp: params.get(TASK_FILTER_PARAMS.canSignUp) === CAN_SIGN_UP_ON,
+  }
 }
 
 /**
@@ -240,24 +298,13 @@ export function useTasks(): TasksState {
   const factionConfigs: FactionConfigOut[] = gameConfig?.factions ?? []
 
   const [searchParams, setSearchParams] = useSearchParams()
-  const taskType = readFilterParam(
-    searchParams,
-    TASK_FILTER_PARAMS.taskType,
-    TASK_TYPE_DEFAULT,
-  ) as TaskType
-  const sort = readFilterParam(
-    searchParams,
-    TASK_FILTER_PARAMS.sort,
-    TASK_SORT_DEFAULT,
-  ) as TaskSort
-  const status = readFilterParam(
-    searchParams,
-    TASK_FILTER_PARAMS.status,
-    TASK_STATUS_DEFAULT,
-  )
-  const selectedFactions = searchParams.getAll(TASK_FILTER_PARAMS.faction)
-  const canSignUp =
-    searchParams.get(TASK_FILTER_PARAMS.canSignUp) === CAN_SIGN_UP_ON
+  const {
+    taskType,
+    sort,
+    status,
+    factions: selectedFactions,
+    canSignUp,
+  } = readTaskFilters(searchParams)
   const [query, setQueryState] = useSearchQueryParam()
   const [signupMsg, setSignupMsg] = useState<SignupMessage | null>(null)
 

--- a/frontend/src/utils/urlParams.ts
+++ b/frontend/src/utils/urlParams.ts
@@ -1,0 +1,29 @@
+/**
+ * Reading untrusted URL params — the one whitelist both browse pages share
+ * (#1537).
+ *
+ * A URL is a user-facing surface, not an API call. The list routes 422 on an
+ * unrecognised enumerated value (`GET /tasks` since #1443, `GET /praxes` from
+ * the start), which is right for a caller sending garbage and wrong for a
+ * player following a link: a bookmark saved before a value was renamed should
+ * degrade to the default view, not to an error page.
+ *
+ * This lived module-private in `pages/praxes/feedFilterParams.ts` while the task
+ * browse read its three axes with a bare `params.get(key) || default` and
+ * forwarded whatever the address bar said. Promoted rather than copied —
+ * a second implementation is how the two pages drifted apart in the first place.
+ */
+
+/**
+ * The value `raw` names, or `fallback` when it names nothing in `allowed`.
+ *
+ * Absent (`null`) and present-but-blank (`?sort=`) both miss the whitelist and
+ * so both land on the fallback, which is what a missing axis has always meant.
+ */
+export function readOneOf<T extends string>(
+  raw: string | null,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return allowed.includes(raw as T) ? (raw as T) : fallback
+}


### PR DESCRIPTION
`GET /tasks` has 422'd on an unrecognised `sort` since #1443 (PR #1534) — the right call for an API caller. But the task browse read three URL params with `params.get(key) || defaultValue` and forwarded whatever the address bar said, so `/tasks?sort=bogus` — a stale bookmark, a shared link, a renamed value — now surfaces the browse error state instead of a list. The praxis feed already clamped, in a module-private helper.

The ruling: **clamp at the URL layer, keep the backend 422 exactly as it is.** A URL is a user-facing surface, not an API call; someone following a link should get the default view, not an error page. Nothing backend changed here.

## What moved

- **`readOneOf` promoted** from `pages/praxes/feedFilterParams.ts` (module-private) to `utils/urlParams.ts`, imported by both browse pages. Promoted rather than copied — a second implementation is how the two pages drifted apart in the first place.
- **`readFilterParam` deleted.** `readTaskFilters(params)` replaces it: one function that hydrates the whole filter set, the counterpart to the feed's `readFeedFilters`, with `type`, `sort` and `status` read through the whitelist.
- `TASK_TYPES` / `TASK_SORTS` / `TASK_STATUSES` name the legal values beside the defaults that already existed; `TaskStatusFilter` gives the status axis a type (`All` + the three `TaskStatus` values).

Two judgements worth reading:

- **Status is whitelisted against every status, not against the viewer-gated `statusFilters`.** Those depend on `/auth/me`, which settles after first render — gating the read would flip a shared `?status=retired` link back to `All` mid-load. Whether a viewer may *see* retired tasks stays a server-owned rule.
- **Faction slugs stay unfiltered**, as on the praxis feed and for the same stated reason: `/factions` is fetched separately, and a slug matching nothing honestly returns no rows. One incidental tightening comes with sharing the feed's read — a *blank* `?faction=` is now dropped instead of sent as `faction=['']`; pinned by a test.

## Tests

`taskFilterParams.test.ts` is rewritten onto the whitelist. Both halves are covered: a missing (and a present-but-blank) param is still the default, **and** an unrecognised value clamps rather than passing through — including `sort=most_voted`, a value that is legal on the *praxis* feed and would 422 here.

Local: `tsc --noEmit` clean, eslint clean, `npm test` 3649 passed / 208 files, `npm run build` and `npm run budget` both green (JS 131.9 KB, CSS 22.3 KB, within budget). Backend untouched.

**Visual QA is outstanding** — this agent has no browser or dev stack.

## What to eyeball

Each of these should render the ordinary task browse, with the affected control sitting on its default, and no error state:

- `/tasks?sort=bogus` — the headline case
- `/tasks?sort=most_voted` — a praxis-feed sort pasted onto tasks
- `/tasks?type=metatasks` (note the plural typo) → should show standard tasks
- `/tasks?status=archived` → should show All
- `/tasks?sort=bogus&status=retired&faction=ua` → sort falls back to level while status and faction survive
- `/tasks?sort=oldest&type=metatask&status=retired&faction=ua&faction=coven&can_sign_up=1` — the control case: a fully legal link must still hydrate every axis
- `/praxis?sort=bogus` — the feed must be unchanged by the promotion

Closes #1537
