### PR TITLE
The reset must not migrate: Render Shell runs the OLD image

### DIFF
--- a/backend/scripts/reset_render_db.py
+++ b/backend/scripts/reset_render_db.py
@@ -1,10 +1,16 @@
 """
-Wipe the database named in DATABASE_URL, rebuild its schema, and clear MEDIA_ROOT.
+Empty the database named in DATABASE_URL and clear MEDIA_ROOT.
 
-Drops and recreates the `public` schema (destroying every table and row), then
-runs `alembic upgrade head` to rebuild from the migration chain, then empties
-the media disk. It does NOT seed — seeding happens on the next deploy, when
-`start.sh` runs `seed.py`.
+Drops and recreates the `public` schema (destroying every table and row) and
+empties the media disk, then **stops**. It deliberately does not migrate and
+does not seed: the following deploy does both, from the new image.
+
+Leaving the database EMPTY is the whole point. Render Shell runs on the
+currently-running instance — the last *successful* deploy — so during a squash
+recovery this image carries the OLD migration chain. Running `alembic upgrade
+head` from here would re-stamp the database at the OLD head, which is precisely
+the stamp the incoming deploy rejects, and every reset would re-create the
+condition it exists to clear.
 
 The media step exists because uploads live on a Render *disk*, which no schema
 drop can reach: every avatar and praxis image would otherwise survive as an
@@ -28,7 +34,6 @@ which this deliberately does not.
 import asyncio
 import os
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -130,35 +135,32 @@ def main() -> None:
     if input(f"\nType the database name ({database_name}) to continue: ").strip() != database_name:
         sys.exit("Aborted.")
 
-    print("\n[1/3] Dropping and recreating public schema...")
+    print("\n[1/2] Dropping and recreating public schema...")
     asyncio.run(drop_and_recreate_public_schema(dsn))
     print("      Done.")
 
-    # scripts/ sits inside the backend package, which is the image's WORKDIR on
-    # Render and `backend/` in a checkout — parent.parent is the alembic root in
-    # both.
-    backend_directory = Path(__file__).resolve().parent.parent
-    print("\n[2/3] Running alembic upgrade head...")
-    result = subprocess.run(
-        [sys.executable, "-m", "alembic", "upgrade", "head"],
-        cwd=backend_directory,
-        env={**os.environ, "DATABASE_URL": database_url},
-    )
-    if result.returncode != 0:
-        # Media is deliberately left alone: the files are already orphaned, and
-        # keeping them means a retry can still report what it is about to delete.
-        sys.exit(result.returncode)
+    # DELIBERATELY NO `alembic upgrade head` HERE. Render Shell runs on the
+    # currently-RUNNING instance — the last *successful* deploy — so during a
+    # squash recovery this image is by definition the OLD one, carrying the OLD
+    # chain. Migrating from here re-stamps the database at the OLD head, which
+    # is exactly the stamp the incoming deploy refuses. That is an unbreakable
+    # loop: every reset re-creates the condition it exists to clear.
+    #
+    # Leaving the database empty is what makes the next deploy work.
+    # `check_db_stamp.stamp_is_known` treats an unstamped DB as fine, so
+    # start.sh proceeds and migrates from the NEW image.
 
     if media_root is None:
-        print("\n[3/3] Media left untouched.")
+        print("\n[2/2] Media left untouched.")
     else:
-        print(f"\n[3/3] Emptying {media_root}...")
+        print(f"\n[2/2] Emptying {media_root}...")
         empty_directory(media_root)
         print("      Done.")
 
     print(
-        "\nSchema rebuilt. Now redeploy (Render → worldzero-backend → Manual Deploy) "
-        "so start.sh runs seed.py — this script does not seed."
+        "\nDatabase is empty and unstamped — that is the point. Do NOT run alembic here.\n"
+        "Redeploy now (Render → worldzero-backend → Manual Deploy → Deploy latest commit); "
+        "start.sh migrates from the new image and seeds."
     )
 
 

--- a/docs/agents/db-migrations.md
+++ b/docs/agents/db-migrations.md
@@ -58,11 +58,19 @@ A squash invalidates the Alembic stamp in **every existing DB**.
 - **Prod / remote:** run `python scripts/reset_render_db.py` from **Render Shell**
   (worldzero-backend → Shell). `render.yaml` already injects `DATABASE_URL` there from the
   `worldzero-db` instance, so no connection string is pasted or stored on a laptop. It drops
-  the public schema and runs `alembic upgrade head`; it does **not** seed — redeploy
-  afterwards so `start.sh` runs `seed.py`. Typed-confirmation gated on the database name,
-  with the target host printed first.
+  the public schema and empties the media disk, then **stops** — redeploy afterwards and
+  `start.sh` migrates and seeds. Typed-confirmation gated on the database name, with the
+  target host printed first.
   (`reset_db.sh --url <connection-string>` still works from a machine that has the `psql`
   client; the prod image does not ship one.)
+
+  ⚠️ **Never run `alembic upgrade head` from Render Shell during a squash recovery.** The
+  Shell attaches to the currently-*running* instance, which is the last **successful**
+  deploy — by definition the image with the OLD chain. Migrating from there stamps the DB
+  at the old head, which is exactly the stamp the incoming deploy refuses, so every reset
+  re-creates the condition it was meant to clear. This cost a live loop on 2026-08-02.
+  An **empty, unstamped** database is the goal: `check_db_stamp.stamp_is_known` passes a
+  fresh DB, so the new image migrates it correctly.
 
 ## CI is never affected
 


### PR DESCRIPTION
**Live bug, hit during the #1398 squash recovery.** The prod reset looped: every run left the deploy failing on the same stamp.

## What happened

`reset_render_db.py` dropped the schema and then ran `alembic upgrade head`.

Render Shell attaches to the **currently-running instance** — the last *successful* deploy. During a squash recovery that is, by definition, the image carrying the **old** chain, because the new one is the deploy that just failed. So the migration ran from `0001_squashed`…`0011` and stamped the database at `0011_vote_unique_per_account` — exactly the stamp the incoming image rejects:

```
DB stamped at unknown revision '0011_vote_unique_per_account' — chain was likely squashed.
```

Reset, redeploy, fail, reset. The recovery tool re-created the condition it exists to clear.

## The fix

Drop the schema, clear media, **stop**. No migration.

An empty, unstamped database is the goal, not an intermediate state: `check_db_stamp.stamp_is_known` returns `True` when there is no `alembic_version` row, so `start.sh` proceeds and migrates from the **new** image, then seeds. That was always the design — `reset_db.sh --url` has only ever dropped the schema and told you to redeploy.

## This was my regression

#1548 moved the script from the repo root into the image. Run from a **local checkout** the alembic step was correct — that checkout is at the new code. Run **in the image** it is guaranteed wrong during the exact scenario the script exists for. Moving it changed which chain `alembic` would find, and I carried the step across without re-examining it.

## Changes

- `backend/scripts/reset_render_db.py` — alembic step removed (2 phases, not 3), `subprocess` import dropped, and the reason recorded at the call site so nobody helpfully adds it back.
- `docs/agents/db-migrations.md` — the prod bullet no longer claims it migrates, plus a ⚠️ never-migrate-from-Shell note.

## Verified

Syntax clean; missing `DATABASE_URL` still guards; no `subprocess` or alembic invocation remains (the two `alembic` hits are the explanatory comments). The media and confirmation paths are untouched from #1548, which were tested against a sandbox.

Not re-run against prod — the operator is mid-recovery and unblocking by hand.