### PR TITLE
A name the board already has is skipped, not a rejection

### DIFF
--- a/backend/services/task_import.py
+++ b/backend/services/task_import.py
@@ -250,10 +250,17 @@ async def resolve_admin_character(
 async def import_tasks_from_csv(
     raw: bytes, admin: Account, session: AsyncSession
 ) -> ImportOutcome:
-    """Create one active task per CSV row, or create nothing at all.
+    """Create one active task per CSV row, skipping names the board already has.
 
     Raises :class:`TaskImportError` with every failing row; the caller maps that
     to a response. Nothing is added to the session unless every row validates.
+
+    A row whose title already exists is **not** a failure — it is skipped and
+    reported as a warning, so re-running the same file is a no-op rather than a
+    rejection. That is what makes a curated sheet safe to re-import after adding
+    a few lines to it. A file that lists the same title twice is still an error
+    (:func:`parse_task_csv`): a collision with the board is expected, a collision
+    inside one file is a mistake in the file.
     """
     rows, warnings = parse_task_csv(raw)
 
@@ -269,6 +276,7 @@ async def import_tasks_from_csv(
     )
 
     errors: list[RowError] = []
+    to_create: list[ParsedRow] = []
     for parsed in rows:
         label = f'Row {parsed.row} ("{parsed.task.title}")'
         if parsed.task.primary_faction_slug not in known_slugs:
@@ -279,12 +287,15 @@ async def import_tasks_from_csv(
                     f"'{parsed.task.primary_faction_slug}'.",
                 )
             )
+            continue
         if parsed.task.title in existing_titles:
-            errors.append(RowError(parsed.row, f"{label}: a task with this name already exists."))
+            warnings.append(f"{label}: a task with this name already exists — skipped.")
+            continue
+        to_create.append(parsed)
     if errors:
         raise TaskImportError(errors)
 
-    for parsed in rows:
+    for parsed in to_create:
         session.add(
             Task(
                 title=parsed.task.title,
@@ -301,6 +312,6 @@ async def import_tasks_from_csv(
     await session.flush()
 
     return ImportOutcome(
-        created_titles=[parsed.task.title for parsed in rows],
+        created_titles=[parsed.task.title for parsed in to_create],
         warnings=warnings,
     )

--- a/backend/tests/integration/test_admin_task_import.py
+++ b/backend/tests/integration/test_admin_task_import.py
@@ -309,7 +309,7 @@ async def test_duplicate_title_within_the_file_is_rejected(
 
 
 @pytest.mark.asyncio
-async def test_title_that_already_exists_is_rejected(
+async def test_title_that_already_exists_is_skipped_not_rejected(
     client: AsyncClient,
     account: Account,
     character: Character,
@@ -317,17 +317,30 @@ async def test_title_that_already_exists_is_rejected(
     auth_headers: dict,
     db_session: AsyncSession,
 ):
-    """Re-uploading a file that was already imported must not duplicate tasks."""
+    """A name the board already has is skipped and reported, never duplicated.
+
+    Re-running a curated sheet after adding a few lines has to be safe, so a
+    collision with the board is a warning rather than a rejection of the file.
+    """
     await _make_admin(account, db_session)
 
     resp = await client.post(
         IMPORT_URL,
         headers=auth_headers,
-        files=_upload(f"{HEADER}\n{active_task.title},ua,Duplicate,1,10\n"),
+        files=_upload(
+            f"{HEADER}\n"
+            f"{active_task.title},ua,Duplicate,1,10\n"
+            "Genuinely New Task,ua,Fresh,1,10\n"
+        ),
     )
 
-    assert resp.status_code == 422, resp.text
-    assert "Row 2" in _messages(resp)[0]
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+
+    # The duplicate is skipped; the new row still lands.
+    assert body["created_titles"] == ["Genuinely New Task"]
+    assert body["created_count"] == 1
+    assert any(active_task.title in w and "skipped" in w for w in body["warnings"])
 
     count = len(
         (
@@ -339,6 +352,30 @@ async def test_title_that_already_exists_is_rejected(
         .all()
     )
     assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_file_of_only_duplicates_creates_nothing_and_still_succeeds(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    active_task: Task,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """Re-importing an unchanged file is a no-op, not an error."""
+    await _make_admin(account, db_session)
+    before = await _task_titles(db_session)
+
+    resp = await client.post(
+        IMPORT_URL,
+        headers=auth_headers,
+        files=_upload(f"{HEADER}\n{active_task.title},ua,Duplicate,1,10\n"),
+    )
+
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["created_count"] == 0
+    assert await _task_titles(db_session) == before
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Requested by the owner while importing a curated task sheet: *"make sure there is a guard such that if we try to import a task with the same name, it will skip the duplicate."*

## The problem

`import_tasks_from_csv` treated a title already in the database as a **row error**, and the import is atomic — so one collision rejected the entire file and nothing landed.

That made the supported route for building a board effectively single-use. A task sheet is a living document; the operation people actually want is "add whatever is new", not "insert these exact rows into an empty table".

## The change

A row whose title already exists is **skipped and reported as a warning**. The rest of the file still imports, the existing task is untouched, and `created_titles` names only what actually landed — so re-running an unchanged file is a no-op returning 201 with `created_count: 0`.

## Deliberately unchanged

- **A file listing the same title twice is still an error.** A collision with the board is expected; a collision inside one file is a mistake in the file, and silently importing one of the two would hide it.
- **Unknown faction slugs stay errors.** That is bad data, not a duplicate.

Both distinctions are written into the function's docstring so the asymmetry is not re-derived as an inconsistency later.

## Tests

`test_title_that_already_exists_is_rejected` pinned the old behaviour and is replaced by two that pin the new one:

- **`test_title_that_already_exists_is_skipped_not_rejected`** — a two-row file with one collision and one new task returns 201, creates only the new one, warns about the skip, and leaves exactly one copy of the existing task.
- **`test_file_of_only_duplicates_creates_nothing_and_still_succeeds`** — re-importing an unchanged file is a no-op, not an error.

All 17 tests in `test_admin_task_import.py` pass.

## Context

This is the guard behind #1376's import path. The owner ruling recorded there was "insert-only, but reject rows whose title already exists, **reported per row**" — this implements the per-row half, which the code had been doing as a whole-file rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)