### PR TITLE
A re-uploaded avatar gets a new path, and the old file goes

### DIFF
--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -199,7 +199,13 @@ async def upload_avatar(
     if current_character.id != character_id:
         raise HTTPException(status_code=403, detail="Cannot update another character's avatar.")
     character = current_character
-    character.avatar_url = await process_and_save_avatar(file, character_id)
+    # Read the outgoing path before overwriting it: the service unlinks it once
+    # the replacement is written, so a per-upload directory (#1565) does not
+    # orphan a file per upload.
+    previous_avatar_url = character.avatar_url
+    character.avatar_url = await process_and_save_avatar(
+        file, character_id, previous_avatar_url=previous_avatar_url
+    )
     await session.flush()
     await session.refresh(character)
     stats = await load_current_era_stats(character_id, session)

--- a/backend/services/media.py
+++ b/backend/services/media.py
@@ -53,6 +53,55 @@ def _sanitize_filename(raw: str) -> str:
     return cleaned
 
 
+def _resolve_stored_media_path(stored_path: str) -> str | None:
+    """Resolve a stored relative media path to an absolute path under MEDIA_ROOT.
+
+    Returns ``None`` for anything this process must not touch on disk, which is
+    the point of the helper: ``Character.avatar_url`` is not always ours.
+    ``POST /characters`` and the admin editor both accept a player-supplied
+    ``avatar_url``, and the upload route's own error text invites pasting a URL,
+    so the column holds either an uploaded relative path *or* a remote
+    ``http(s)`` URL. Absolute filesystem paths and ``..`` escapes are refused
+    for the same reason ``_sanitize_filename`` exists — a value that resolves
+    outside ``MEDIA_ROOT`` is not a file we wrote.
+    """
+    if not stored_path:
+        return None
+    if stored_path.startswith(("http://", "https://")):
+        return None
+    if os.path.isabs(stored_path):
+        return None
+    media_root = os.path.realpath(settings.MEDIA_ROOT)
+    resolved = os.path.realpath(os.path.join(media_root, stored_path))
+    if not resolved.startswith(media_root + os.sep):
+        return None
+    return resolved
+
+
+def _remove_superseded_avatar(previous_avatar_url: str | None) -> None:
+    """Delete the avatar a fresh upload has just replaced, best-effort.
+
+    Called only after the replacement is safely on disk: an upload must never
+    leave a character with a dead ``avatar_url``, so a failure to unlink is
+    logged and swallowed rather than raised.
+    """
+    absolute_path = _resolve_stored_media_path(previous_avatar_url or "")
+    if absolute_path is None:
+        return
+    try:
+        os.remove(absolute_path)
+    except OSError:
+        logger.info("Could not remove superseded avatar %s", absolute_path)
+        return
+    # Each upload owns its directory, so the unlink leaves that directory empty.
+    # rmdir refuses a non-empty one, which is exactly the guard we want for
+    # pre-#1565 avatars still sitting directly in the shared ``<id>/avatar``.
+    try:
+        os.rmdir(os.path.dirname(absolute_path))
+    except OSError:
+        pass
+
+
 def _detect_media_type(content_type: str) -> MediaType:
     """Map a MIME type prefix to a MediaType enum or raise 422."""
     if content_type.startswith("image/"):
@@ -64,19 +113,37 @@ def _detect_media_type(content_type: str) -> MediaType:
     raise HTTPException(status_code=422, detail="Unsupported media type.")
 
 
-async def process_and_save_avatar(upload: UploadFile, character_id: int) -> str:
+async def process_and_save_avatar(
+    upload: UploadFile,
+    character_id: int,
+    previous_avatar_url: str | None = None,
+) -> str:
     """Resize and JPEG-encode an avatar upload; return its relative path.
 
     Router contract: the caller has already validated that the target
     character exists and is owned by the current account. This function
     handles PIL + filesystem concerns only. The returned path is stored on
     ``Character.avatar_url``; the caller commits the session.
+
+    **Every upload gets its own directory** (#1565), the same mechanism #1336
+    gave praxis media one function below. The avatar used to live at the fully
+    deterministic ``<id>/avatar/avatar.jpg``, so a re-upload changed the bytes
+    but not the URL — and the ``/media`` mount sends no ``Cache-Control``, so
+    browsers applied heuristic freshness and kept showing the old photo.
+    Uniquifying the *directory* rather than the basename changes the URL, which
+    (unlike a ``?v=`` token) no proxy can strip. The avatar is the one media
+    route that replaces rather than appends, which is why it is the one where a
+    stale cache was guaranteed rather than incidental.
+
+    ``previous_avatar_url`` is the caller's pre-upload ``Character.avatar_url``;
+    it is unlinked *after* the new file is written, so a unique path per upload
+    does not mean an orphaned file per upload. Paths stay relative (CLAUDE.md).
     """
     content_type = upload.content_type or ""
     if not content_type.startswith("image/"):
         raise HTTPException(status_code=422, detail="Avatar must be an image file.")
 
-    relative_directory = os.path.join(str(character_id), "avatar")
+    relative_directory = os.path.join(str(character_id), "avatar", uuid.uuid4().hex)
     absolute_directory = os.path.join(settings.MEDIA_ROOT, relative_directory)
     filename = "avatar.jpg"
     absolute_path = os.path.join(absolute_directory, filename)
@@ -103,6 +170,9 @@ async def process_and_save_avatar(upload: UploadFile, character_id: int) -> str:
             status_code=500,
             detail="We couldn't save your avatar. Please try again or paste a URL instead.",
         )
+
+    # Only once the replacement is safely on disk.
+    _remove_superseded_avatar(previous_avatar_url)
 
     return relative_path
 

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -1,4 +1,6 @@
 """Integration tests for /characters endpoints."""
+import os
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
@@ -719,6 +721,41 @@ async def test_upload_avatar_success(
     assert data["id"] == character.id
     assert data["avatar_url"] is not None
     assert "avatar" in data["avatar_url"]
+
+
+@pytest.mark.asyncio
+async def test_reuploading_an_avatar_changes_the_url(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    tmp_path,
+    monkeypatch,
+):
+    """A second upload must return a different ``avatar_url`` (#1565).
+
+    Route-level rather than service-level because the defect the route can
+    reintroduce is forgetting to hand the outgoing path to the service: the
+    unit tests pass ``previous_avatar_url`` themselves and so cannot see it.
+    """
+    from config import settings as _settings
+
+    monkeypatch.setattr(_settings, "MEDIA_ROOT", str(tmp_path))
+
+    async def _upload() -> str:
+        resp = await client.post(
+            f"/characters/{character.id}/avatar",
+            files={"file": ("avatar.jpg", _make_jpeg_bytes(), "image/jpeg")},
+            headers=auth_headers,
+        )
+        assert resp.status_code == 200
+        return resp.json()["avatar_url"]
+
+    first_url = await _upload()
+    second_url = await _upload()
+
+    assert first_url != second_url
+    assert not os.path.exists(os.path.join(str(tmp_path), first_url))
+    assert os.path.isfile(os.path.join(str(tmp_path), second_url))
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_media_service.py
+++ b/backend/tests/unit/test_media_service.py
@@ -73,6 +73,101 @@ async def test_non_image_rejected(tmp_path, monkeypatch):
     assert os.listdir(tmp_path) == []
 
 
+@pytest.mark.asyncio
+async def test_reuploaded_avatar_gets_a_new_path_and_drops_the_old_file(
+    tmp_path, monkeypatch
+):
+    """A re-upload must change the URL and leave no orphan (#1565).
+
+    The stale-avatar bug was a deterministic path: new bytes at the same URL,
+    which mobile browsers happily served from cache. Distinct paths alone would
+    not prove the fix is complete — an unlinked-nothing version orphans a file
+    per upload — so this asserts both halves.
+    """
+    monkeypatch.setattr(media.settings, "MEDIA_ROOT", str(tmp_path))
+
+    first_path = await process_and_save_avatar(
+        _make_upload("selfie.jpg", _jpeg_bytes(64, 64), "image/jpeg"),
+        character_id=42,
+    )
+    second_path = await process_and_save_avatar(
+        _make_upload("selfie.jpg", _jpeg_bytes(64, 64), "image/jpeg"),
+        character_id=42,
+        previous_avatar_url=first_path,
+    )
+
+    assert first_path != second_path
+    assert not os.path.isabs(second_path)
+    assert not os.path.exists(os.path.join(str(tmp_path), first_path))
+    assert os.path.isfile(os.path.join(str(tmp_path), second_path))
+    # The replaced upload's directory goes with it; the character's avatar
+    # directory stays, because the new upload lives under it.
+    assert not os.path.exists(os.path.dirname(os.path.join(str(tmp_path), first_path)))
+    assert os.path.isdir(os.path.join(str(tmp_path), "42", "avatar"))
+
+
+@pytest.mark.asyncio
+async def test_legacy_deterministic_avatar_is_replaced_in_place(tmp_path, monkeypatch):
+    """Characters uploaded before #1565 sit at ``<id>/avatar/avatar.jpg``.
+
+    That legacy file must be unlinked without taking the shared ``avatar``
+    directory — which now holds the replacement — down with it.
+    """
+    monkeypatch.setattr(media.settings, "MEDIA_ROOT", str(tmp_path))
+    legacy_relative = os.path.join("42", "avatar", "avatar.jpg")
+    legacy_absolute = os.path.join(str(tmp_path), legacy_relative)
+    os.makedirs(os.path.dirname(legacy_absolute), exist_ok=True)
+    with open(legacy_absolute, "wb") as handle:
+        handle.write(b"OLD-AVATAR-BYTES")
+
+    new_path = await process_and_save_avatar(
+        _make_upload("selfie.jpg", _jpeg_bytes(64, 64), "image/jpeg"),
+        character_id=42,
+        previous_avatar_url=legacy_relative,
+    )
+
+    assert not os.path.exists(legacy_absolute)
+    assert os.path.isfile(os.path.join(str(tmp_path), new_path))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "previous",
+    ["", "https://example.com/photo.jpg", "http://example.com/photo.jpg"],
+)
+async def test_avatar_upload_never_unlinks_a_value_it_did_not_write(
+    tmp_path, monkeypatch, previous
+):
+    """``avatar_url`` may be a pasted remote URL, not a path we own.
+
+    ``POST /characters`` and the admin editor both accept one, and the upload
+    route's own 500 text suggests it. Superseding such a value must be a no-op
+    on disk rather than an error.
+    """
+    monkeypatch.setattr(media.settings, "MEDIA_ROOT", str(tmp_path))
+
+    new_path = await process_and_save_avatar(
+        _make_upload("selfie.jpg", _jpeg_bytes(64, 64), "image/jpeg"),
+        character_id=42,
+        previous_avatar_url=previous,
+    )
+
+    assert os.path.isfile(os.path.join(str(tmp_path), new_path))
+
+
+def test_superseded_avatar_outside_media_root_is_refused(tmp_path, monkeypatch):
+    """A stored path that escapes MEDIA_ROOT is never unlinked."""
+    monkeypatch.setattr(media.settings, "MEDIA_ROOT", str(tmp_path / "media"))
+    os.makedirs(str(tmp_path / "media"), exist_ok=True)
+    outsider = tmp_path / "not-ours.jpg"
+    outsider.write_bytes(b"someone else's file")
+
+    media._remove_superseded_avatar(os.path.join("..", "not-ours.jpg"))
+    media._remove_superseded_avatar(str(outsider))
+
+    assert outsider.exists()
+
+
 def test_filename_sanitization_strips_path_and_unsafe_chars():
     """Path components and special characters are replaced; length capped."""
     # Path traversal attempt collapses to a safe basename.


### PR DESCRIPTION
Closes #1565

The avatar was the one media route #1336 left on a deterministic path. `process_and_save_avatar` wrote `<character_id>/avatar/avatar.jpg` every time, `utils/media.ts` adds no version token, and `main.py`'s `StaticFiles` mount sets no `Cache-Control` — so a re-upload wrote new bytes behind a byte-identical URL and the handset served the copy it already had. It is also the only route that *replaces* rather than appends, which is what made the stale cache guaranteed there rather than incidental.

Per the owner ruling: uniquify the stored path — not a `?v=` token, not cache headers.

## What changed

`process_and_save_avatar` now builds `<character_id>/avatar/<uuid4().hex>/avatar.jpg`. Uniqueness lives in the directory and the filename stays `avatar.jpg`, exactly as `process_and_save_media` does one function below. Paths stay relative.

The previous file is unlinked after a successful upload, so changing your photo no longer orphans one forever. The route reads `character.avatar_url` before overwriting and passes it in; the removal runs **after** the new file is safely written and **outside** the write `try`, so a failed upload never unlinks the live avatar and a failed unlink never fails the upload.

## The judgement call — `avatar_url` is not always a path we wrote

This was not in the ruling and it changes the shape of the delete step.

`POST /characters`, the character update, and the admin editor all accept a **player-supplied** `avatar_url` of up to 500 chars; `utils/media.ts` passes `http(s)://` values through untouched, and the upload route's own 500 message tells you to "paste a URL instead".

So deletion is gated on a new `_resolve_stored_media_path`, which accepts only relative paths that resolve **inside** `MEDIA_ROOT` and refuses `http(s)://`, absolute paths, and anything escaping the root. Unlinking whatever the column happened to hold would have been a path-traversal primitive driven by an attacker-controlled string.

## Tests

Unit (`tests/unit/test_media_service.py`): a re-upload changes the path and removes the old file and its directory; the legacy `<id>/avatar/avatar.jpg` layout is unlinked without taking the shared `avatar` directory with it; remote and empty `avatar_url` values are a disk no-op; an escaping path is refused.

Integration (`tests/integration/test_characters.py`): `test_reuploading_an_avatar_changes_the_url` — route-level, because the unit tests supply `previous_avatar_url` themselves and so cannot catch the router forgetting to.

Both headline tests were mutation-checked: reverting the uuid segment and the unlink makes them fail.

## Verification

`pytest --cov=. --cov-fail-under=80` against a dedicated `wz1565_test` → **1037 passed**, coverage 92.62%.

No migration: `avatar_url` is a free-form `String`. Legacy rows keep their old path, still resolve, and are cleaned up the next time that character uploads. Frontend untouched.

**Visual QA outstanding** — no browser or dev stack here. The mechanism is proven (the URL differs between uploads); confirming on the actual handset is a human step.

## What to eyeball

1. **The reported bug, on your phone.** Change a character photo, then change it again. The new photo should appear immediately both times — this is the case that failed.
2. The old image 404s afterwards rather than lingering, if you kept the previous URL.
3. A character whose `avatar_url` is an external `http(s)://` link still renders and is not disturbed by an upload elsewhere.

## Related

The sibling media-retention issue gets easier: `_resolve_stored_media_path` is the "is this a file we own" predicate a delete-on-character-removal path needs, and `routers/praxes.py:394-404` already hand-rolls the same unlink-then-rmdir pair. Worth promoting both into one shared helper when that lands.
