### PR TITLE
A praxis crop that fails now says which photo it lost (#1545)

### DIFF
--- a/.design-sync/previews/_state.tsx
+++ b/.design-sync/previews/_state.tsx
@@ -231,6 +231,7 @@ export function editPraxisState(slug: string): EditPraxisState {
     pendingImage: null,
     confirmImageEdit: anoop,
     cancelImageEdit: noop,
+    reportImageError: noop,
     switchingMode: null,
     changeMode: anoop,
     inviteQuery: '',

--- a/frontend/src/components/imageEdit/ImageEditModal.tsx
+++ b/frontend/src/components/imageEdit/ImageEditModal.tsx
@@ -58,14 +58,15 @@ export interface ImageEditModalProps {
   /** Dismiss without uploading. */
   onCancel: () => void
   /**
-   * Report a processing failure as a caller-scoped message (#1527). The
-   * character screens pass their picker's `setAvatarError` (#985) so the failure
-   * lands on the same line as an over-size pick, and the modal closes so that
-   * line is visible.
+   * Report a processing failure as a caller-scoped message (#1527). Both call
+   * sites pass one, and both land the failure on the line an over-size pick
+   * already uses — the character screens their picker's `setAvatarError` (#985),
+   * the praxis composer its tray's `fileError` (#1545) — with the modal closing
+   * so that line is visible.
    *
-   * Omit it and a failure keeps the historical behaviour — the untouched file is
-   * uploaded silently. Praxis media is deliberately left on that path for now
-   * (it has no avatar-scoped error line; see the useAvatarPicker docblock).
+   * Still optional, and omitting it still keeps the historical behaviour (the
+   * untouched file is uploaded silently), because that is the fallback
+   * `applyImageEdit` is written around. No caller relies on it.
    */
   onError?: (message: string) => void
 }

--- a/frontend/src/components/imageEdit/imageEditHelpers.ts
+++ b/frontend/src/components/imageEdit/imageEditHelpers.ts
@@ -155,7 +155,7 @@ export interface ApplyImageEditOptions {
  * distinguishing "cropped" from "gave up". The player saw a portrait that never
  * changed and no error anywhere. Failures now report instead of confirming — the
  * caller decides where that shows (the avatar screens use their `avatarError`
- * line, #985).
+ * line, #985; the praxis composer its media tray's `fileError`, #1545).
  *
  * The GIF short-circuit is NOT a failure and keeps its silent pass-through:
  * canvas-encoding a GIF flattens it to its first frame (#569).

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -119,6 +119,7 @@
       "duelUnderway": "This duel is already underway — it can't be cancelled from here.",
       "fileTooLarge_one": "File too large (50 MB limit): {{names}}",
       "fileTooLarge_other": "Files too large (50 MB limit): {{names}}",
+      "imageEditFailed": "{{name}} — {{reason}}",
       "nudge": "Could not nudge {{name}}.",
       "nudgeCrew": "Could not nudge the crew."
     },

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -150,13 +150,15 @@ export default function EditPraxis() {
       )}
       {/* Praxis images crop/rotate in place before upload (#514), free-form so
           nothing is force-cropped. Sequential: keyed on identity so each queued
-          image gets a fresh modal. */}
+          image gets a fresh modal. A failure reports on the tray's file-error
+          line rather than uploading the unprocessed image (#1545). */}
       {state.pendingImage && (
         <ImageEditModal
           key={`${state.pendingImage.name}-${state.pendingImage.lastModified}`}
           file={state.pendingImage}
           onConfirm={(blob) => void state.confirmImageEdit(blob)}
           onCancel={state.cancelImageEdit}
+          onError={state.reportImageError}
         />
       )}
     </>

--- a/frontend/src/pages/editPraxis/__tests__/imageEditFailure.test.tsx
+++ b/frontend/src/pages/editPraxis/__tests__/imageEditFailure.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * A praxis image the edit stage cannot process now says so (#1545).
+ *
+ * #1527/#1543 stopped `applyImageEdit` turning a processing failure into a
+ * silent upload of the unprocessed file — but only where a caller supplied
+ * `onError`, which the four character surfaces did and `EditPraxis` did not.
+ * The helper's fallback is still there (by design: it is what the optional
+ * channel falls back TO), so the only thing keeping praxis media honest is the
+ * prop at the mount. That is what this file pins.
+ *
+ * Why it is reachable at all: `useComposerMedia.handleFileChange` validates
+ * SIZE and nothing else, and `partitionByEditability` sends every non-GIF
+ * `image/*` pick into the modal. Nothing checks that the browser can decode the
+ * image, and "Apply" is enabled from mount — so both `not-ready` (no crop rect
+ * was ever reported) and `render-failed` (the canvas gave up) are ordinary
+ * outcomes here, not theoretical ones.
+ *
+ * Deliberately NOT covered, because neither is a failure: the GIF
+ * short-circuit (#569) and the explicit "use original" button. Both are pinned
+ * as choices in `imageEditHelpers.test.ts`.
+ *
+ * renderToStaticMarkup, no DOM, matching the rest of this suite.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../i18n";
+import i18n from "../../../i18n";
+import type { EditPraxisState } from "../useEditPraxis";
+import { imageEditFailureMessage } from "../useComposerMedia";
+import { FilePicker } from "../archetypes/controls";
+import type { ImageEditModalProps } from "../../../components/imageEdit/ImageEditModal";
+
+const modal = vi.hoisted(() => ({
+  mounts: [] as ImageEditModalProps[],
+}));
+const editState = vi.hoisted(() => ({
+  current: null as EditPraxisState | null,
+}));
+
+vi.mock("../../../hooks/useFormFactor", () => ({
+  useFormFactor: () => "desktop",
+}));
+vi.mock("../useEditPraxis", () => ({
+  useEditPraxis: () => editState.current,
+}));
+// The skin renders null: this file is about the dispatcher's modal wiring.
+vi.mock("../archetypes/DefaultEditPraxis", () => ({ default: () => null }));
+// A probe, so the props the mount actually passes can be inspected.
+vi.mock("../../../components/imageEdit/ImageEditModal", () => ({
+  default: (props: ImageEditModalProps) => {
+    modal.mounts.push(props);
+    return null;
+  },
+}));
+
+// Imported after the mocks are registered.
+import EditPraxis from "../../EditPraxis";
+
+const FILE_NAME = "sunset.heic";
+const REASON = i18n.t("common:imageEdit.errorFailed");
+
+describe("imageEditFailureMessage — the tray names the file it lost", () => {
+  it("carries both the file and the modal's reason", () => {
+    const line = imageEditFailureMessage(FILE_NAME, REASON);
+    expect(line).toContain(FILE_NAME);
+    expect(line).toContain(REASON);
+  });
+
+  it("is the composed catalog line, not a bare concatenation", () => {
+    // The separator is localisable copy, so the shape has to come from the
+    // catalog — a hardcoded " — " in the hook would pass a `toContain` pair.
+    expect(imageEditFailureMessage(FILE_NAME, REASON)).toBe(
+      i18n.t("forms:editPraxis.errors.imageEditFailed", {
+        name: FILE_NAME,
+        reason: REASON,
+      }),
+    );
+  });
+
+  it("falls back to the bare reason when no file is pending", () => {
+    // The modal reports before it cancels, so the queue head is normally still
+    // the failing file. This is the belt-and-braces branch.
+    expect(imageEditFailureMessage(undefined, REASON)).toBe(REASON);
+  });
+});
+
+describe("the failure lands on a line the player can see", () => {
+  it("draws fileError in the picker every archetype mounts", () => {
+    // All nine composer skins reach the media tray through this one control, so
+    // pinning it here covers them without nine fixtures.
+    const line = "sunset.heic — that image could not be processed";
+    const markup = renderToStaticMarkup(
+      <FilePicker
+        state={{ fileError: line, handleFileChange: () => {} } as unknown as EditPraxisState}
+        skin={{ buttonStyle: {}, buttonLabel: "Add proof" }}
+      />,
+    );
+    expect(markup).toContain(line);
+  });
+});
+
+/** Only the fields the dispatcher itself reads; the skin is mocked to null. */
+function stateWithPendingImage(
+  reportImageError: (reason: string) => void,
+): EditPraxisState {
+  return {
+    loading: false,
+    phase: "composing",
+    isPublished: false,
+    error: "",
+    praxis: { id: 55, task_id: 7, task_title: "A Very Human Thing" },
+    task: { primary_faction_slug: "na" },
+    pendingImage: new File(["x"], FILE_NAME, { type: "image/heic" }),
+    confirmImageEdit: async () => {},
+    cancelImageEdit: () => {},
+    reportImageError,
+  } as unknown as EditPraxisState;
+}
+
+/** Mount the dispatcher over a pending image and hand back the modal's props. */
+function mountModal(
+  reportImageError: (reason: string) => void,
+): ImageEditModalProps {
+  modal.mounts.length = 0;
+  editState.current = stateWithPendingImage(reportImageError);
+  renderToStaticMarkup(
+    <MemoryRouter>
+      <EditPraxis />
+    </MemoryRouter>,
+  );
+  const mounted = modal.mounts.at(-1);
+  if (!mounted) throw new Error("EditPraxis mounted no ImageEditModal");
+  return mounted;
+}
+
+describe("EditPraxis hands the modal an error channel (#1545)", () => {
+  it("passes onError, so a failure cannot fall back to the silent upload", () => {
+    // Omitting the prop is exactly the pre-#1545 defect, and it typechecks:
+    // `onError` is optional, and its absence is a behaviour change with no
+    // compile-time tell.
+    const reported: string[] = [];
+    const props = mountModal((reason) => reported.push(reason));
+
+    expect(props.onError).toBeTypeOf("function");
+    props.onError?.(REASON);
+    expect(reported).toEqual([REASON]);
+  });
+
+  it("still lets the player abandon the pick and crop the next one", () => {
+    // `onError` is not a replacement for cancel: the modal calls both, and the
+    // queue only advances on cancel.
+    const props = mountModal(() => {});
+    expect(props.onCancel).toBeTypeOf("function");
+    expect(props.onConfirm).toBeTypeOf("function");
+  });
+});

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -110,6 +110,7 @@ function baseState(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
     pendingImage: null,
     confirmImageEdit: async () => {},
     cancelImageEdit: () => {},
+    reportImageError: () => {},
     switchingMode: null,
     changeMode: async () => {},
     inviteQuery: "",

--- a/frontend/src/pages/editPraxis/editPraxisState.ts
+++ b/frontend/src/pages/editPraxis/editPraxisState.ts
@@ -58,6 +58,17 @@ export interface EditPraxisState {
   pendingImage: File | null;
   confirmImageEdit: (blob: Blob) => Promise<void>;
   cancelImageEdit: () => void;
+  /**
+   * The modal's failure channel (#1545). Before this, a praxis image the browser
+   * could not decode or render was uploaded UNPROCESSED with nothing on screen —
+   * the pass-through #1527 removed from the avatar path but deliberately left
+   * here, because praxis media had no error line of its own to report on.
+   *
+   * It always did: `fileError`, the line a too-large pick already uses. This
+   * reports onto it, named with the file the modal was holding. `EditPraxis.tsx`
+   * passes it as the modal's `onError`.
+   */
+  reportImageError: (reason: string) => void;
 
   // Mode switching
   switchingMode: PraxisType | null;

--- a/frontend/src/pages/editPraxis/useComposerMedia.ts
+++ b/frontend/src/pages/editPraxis/useComposerMedia.ts
@@ -26,6 +26,28 @@ import i18n from "../../i18n";
 
 export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
 
+/**
+ * The tray's line for an image the edit stage could not process (#1545).
+ *
+ * The modal supplies the sentence (it is the only party that knows *why*, and
+ * the copy is already localised there); this names the file it was holding,
+ * because unlike an avatar the tray edits a QUEUE — "that image" is ambiguous
+ * once two of three picks have landed as tiles. Naming the file is also what
+ * every other file-picker error here does (`fileTooLarge`, `upload`).
+ *
+ * Pure so the composition is testable without a DOM.
+ */
+export function imageEditFailureMessage(
+  fileName: string | undefined,
+  reason: string,
+): string {
+  if (!fileName) return reason;
+  return i18n.t("forms:editPraxis.errors.imageEditFailed", {
+    name: fileName,
+    reason,
+  });
+}
+
 export interface ComposerMedia {
   media: MediaItemOut[];
   /** Seed the tray from a freshly loaded praxis, or from a mode switch. */
@@ -37,6 +59,12 @@ export interface ComposerMedia {
   pendingImage: File | null;
   confirmImageEdit: (blob: Blob) => Promise<void>;
   cancelImageEdit: () => void;
+  /**
+   * The edit stage could not process the pending image (#1545). A narrow
+   * reporter rather than the raw `setFileError`, so the tray's one error line
+   * keeps a single owner.
+   */
+  reportImageError: (reason: string) => void;
 }
 
 export function useComposerMedia(
@@ -124,6 +152,16 @@ export function useComposerMedia(
     setImageEditQueue((previous) => previous.slice(1));
   }, []);
 
+  // The modal reports here and then cancels, so the queue head is still the
+  // file that failed when this runs. Lands on the same line a rejected pick
+  // uses, which the next pick clears (see `handleFileChange`).
+  const reportImageError = useCallback(
+    (reason: string) => {
+      setFileError(imageEditFailureMessage(imageEditQueue[0]?.name, reason));
+    },
+    [imageEditQueue],
+  );
+
   const removeMedia = useCallback(
     async (item: MediaItemOut) => {
       if (!idParam) return;
@@ -148,5 +186,6 @@ export function useComposerMedia(
     pendingImage,
     confirmImageEdit,
     cancelImageEdit,
+    reportImageError,
   };
 }

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -138,6 +138,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     pendingImage,
     confirmImageEdit,
     cancelImageEdit,
+    reportImageError,
   } = useComposerMedia(idParam, setError);
 
   // The catalogue of seals this viewer may apply — a viewer-keyed LOAD, so it
@@ -704,6 +705,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     pendingImage,
     confirmImageEdit,
     cancelImageEdit,
+    reportImageError,
 
     switchingMode,
     changeMode,


### PR DESCRIPTION
Closes #1545.

## First: the failure is reachable

The issue asked me to confirm this before building anything. It is, and more easily than on the avatar path:

- `useComposerMedia.handleFileChange` validates **size only** (50 MB). There is no decode check anywhere in the composer.
- `partitionByEditability` routes **every non-GIF `image/*` pick** into the modal. The input's `accept` attribute is a picker hint, not validation.
- react-easy-crop reports the crop rect through `onCropComplete`, which only fires after the image decodes — so an image the browser cannot decode leaves `croppedAreaRef` null forever, while **"Apply" is enabled from mount**. That is `not-ready`.
- `render-failed` covers the rest: `loadImage` rejecting, no 2d context, `getImageData` throwing, or `toBlob` handing back null on an over-large canvas.

Praxis media accepts any image type up to 50 MB, where an avatar is capped at 10 MB. So no, the composer's own validation does not catch this earlier, and the smaller "remove the silent branch" change would have been wrong.

## No design call was needed

The issue framed the error surface as an open design question. It is not — the composer already has one, and it is already the line this class of problem uses:

- `useComposerMedia` holds `fileError`, set when a pick is rejected for size.
- `archetypes/controls.tsx` `FilePicker` renders it, and all nine archetypes mount that one control.
- `fileError` is already in `EditPraxisState` and already stubbed by every archetype test.

The only gap was that nothing outside the hook could write to it. `useComposerMedia` now exposes a narrow `reportImageError(reason)` rather than leaking `setFileError`, so the line keeps a single owner; `EditPraxis.tsx` passes it as the modal's `onError`.

## The message names the file

One deliberate difference from the avatar path. The avatar picker holds one file; the tray holds a **queue**. "That image couldn't be processed" is ambiguous once two of three picks have landed as tiles and one has not. So the modal's sentence (which is where the *reason* is known, and already localised) is composed with the file name through a new catalog key, `forms:editPraxis.errors.imageEditFailed` — the same name-plus-reason shape `uploadNamed` already uses, and the same naming `fileTooLarge` and `upload` already do.

## What was left alone

- **The GIF short-circuit (#569)** — still silent, still uploads the original. Canvas-encoding a GIF flattens it to frame one; that is a choice, not a failure.
- **"Use original"** — untouched. A deliberate user choice.
- **The third silent path**, `renderCroppedBlob` returning null: `applyImageEdit` already routes it through the same `onFailure` as the catch, so all three branches are covered by the one prop. Verified, not assumed.
- The HEIC/format hypothesis from #1527 — still untested on both paths, still out of scope.

## Verification

All six CI steps run locally and green: eslint, `tsc --noEmit`, `vitest run` (212 files / 3713 tests), `vite build`, byte budget (JS 133.7 KB, CSS 22.3 KB — unchanged), and `npm run typecheck:design-sync`, which needed `.design-sync/previews/_state.tsx` updating for the new required state field.

The wiring test is mutation-checked: deleting `onError={state.reportImageError}` from the mount leaves tsc, eslint and the other 3712 tests green and fails only the new test — which is precisely the shape of the defect, since `onError` is optional by design.

No backend change, so pytest was not run.

**Visual QA is outstanding.** I have no browser or dev stack here; the failure line's appearance in each faction's `FilePicker` skin is unverified beyond static markup. No new styling was introduced — the message reuses the existing error paragraph and its `errorColor` skin slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)