### PR TITLE
A Coven collab makes the one fractional multiplier in Era 1 visible in dev (#891)

### DIFF
--- a/backend/scripts/seed_demo_praxes.py
+++ b/backend/scripts/seed_demo_praxes.py
@@ -41,6 +41,11 @@ PLAYERS = [
     ("demo_vesper", "Vesper", "ephemerists"),
     ("demo_unit", "UNIT-7", "singularity"),
     ("demo_almanac", "Almanac Okonkwo", "ephemerists"),  # extra collaborator
+    # Appended, not inserted: the DEMOS loop and the metatask fixture both take
+    # the FIRST n non-member players as voters, so anything added here must go on
+    # the end to leave the existing fixtures' vote tallies untouched.
+    ("demo_kettle", "Kettle", "coven"),      # collab fixture, both sides Coven
+    ("demo_thimble", "Thimble", "coven"),
 ]
 
 # faction -> (author_username, title, body, type, [stars from other players])
@@ -65,9 +70,10 @@ DEMOS = {
                     PraxisType.solo, [4, 3, 4]),
 }
 
-# All demos are solo so each routes to the per-faction PraxisCard (collab praxes
-# render via the separate CollaborationCard, not the faction card under test).
-COLLAB_SECOND_MEMBER: dict[str, str] = {}
+# DEMOS is all-solo on purpose: one praxis per faction so every per-faction
+# praxis card archetype has something to render. The collab case is not missing,
+# it is just seeded separately (COLLAB_* / seed_collab_fixture below) because it
+# exists to exercise a multiplier rather than a card archetype.
 
 
 # ---------------------------------------------------------------------------
@@ -122,6 +128,25 @@ DUEL_WINNER_BODY = "Answered the challenge. Took the room."
 # Unequal on purpose — the duel winner is decided on points_from_votes.
 DUEL_LOSER_STARS = [("demo_quill", 1), ("demo_marigold", 2)]
 DUEL_WINNER_STARS = [("demo_vesper", 5), ("demo_unit", 5), ("demo_almanac", 4)]
+
+# The collab pair. Coven is the only faction in Era 1 with a non-1.0
+# collaboration modifier (era.factions["coven"].collab_own_modifier), and it is
+# also the only Era 1 multiplier that is neither a duel modifier nor a whole
+# number — so it is the one place the score arithmetic can round wrong, and
+# until now the one case with no fixture. Own-faction means the TASK's faction
+# matches the scoring character's (services/scoring.compute_faction_multiplier),
+# so both members are Coven doing a Coven task: whichever member's card you open
+# shows the modifier. The value itself is never written here — it is read off the
+# era at render time.
+COLLAB_TASK_FACTION_SLUG = "coven"
+COLLAB_AUTHOR_USERNAME = "demo_kettle"
+COLLAB_SECOND_USERNAME = "demo_thimble"
+COLLAB_TITLE = TITLE_MARKER + "Collab: proofed the dough in shifts"
+COLLAB_BODY = (
+    "Two of us, one Coven task, one long rise. The multiplier row is the "
+    "own-faction collaboration bonus."
+)
+COLLAB_STARS = [("demo_quill", 5), ("demo_vesper", 4), ("demo_unit", 4)]
 
 
 async def _praxis_exists(session, title: str) -> bool:
@@ -372,12 +397,79 @@ async def seed_duel_fixture(session, players: dict[str, Character]) -> None:
     )
 
 
+async def seed_collab_fixture(session, players: dict[str, Character]) -> None:
+    """One submitted own-faction collab, so the collaboration modifier renders.
+
+    Both members are Coven on a Coven task, which is what makes the multiplier
+    ``collab_own_modifier`` rather than ``collab_other_modifier``. Two members is
+    not decoration: a collab that drops to one member is converted back to solo
+    (ADR-0060), which would take the modifier with it.
+    """
+    if await _praxis_exists(session, COLLAB_TITLE):
+        print("  = collab praxis already present — skipped")
+        return
+
+    # Same contract as the metatask and duel fixtures: ERA_1_TASKS is empty by
+    # design (the board lives only in the DB, see eras/era_1.py), so this fixture
+    # renders only on a database whose board actually has a Coven task. Never
+    # create one here — that would put a task in a code path the era config
+    # deliberately refuses to own.
+    task = await _pick_task(session, COLLAB_TASK_FACTION_SLUG)
+    if task is None:
+        print(
+            f"  ! collab: no {COLLAB_TASK_FACTION_SLUG} task on the board — skipped "
+            f"(import a board first; the collab modifier stays invisible until then)"
+        )
+        return
+
+    author = players[COLLAB_AUTHOR_USERNAME]
+    second = players[COLLAB_SECOND_USERNAME]
+    now = datetime.now(timezone.utc)
+
+    praxis = Praxis(
+        task_id=task.id,
+        type=PraxisType.collab,
+        status=PraxisStatus.submitted,
+        title=COLLAB_TITLE,
+        body_text=COLLAB_BODY,
+        created_by_id=author.id,
+        moderation_status=ModerationStatus.visible,
+        submitted_at=now,
+    )
+    session.add(praxis)
+    await session.flush()
+    # `submitted` means every member submitted (a partial collab is `pending`).
+    for member in (author, second):
+        session.add(PraxisMember(
+            praxis_id=praxis.id, character_id=member.id, has_submitted=True
+        ))
+
+    member_account_ids = {author.account_id, second.account_id}
+    for voter_username, star in COLLAB_STARS:
+        voter = players[voter_username]
+        # Anti-self-voting is per ACCOUNT, not per character (ADR-0041).
+        if voter.account_id in member_account_ids:
+            continue
+        session.add(Vote(
+            praxis_id=praxis.id,
+            voter_character_id=voter.id,
+            voter_account_id=voter.account_id,
+            value=star,
+        ))
+    await session.flush()
+    print(
+        f"  + collab: '{COLLAB_TITLE}' by {author.display_name} + "
+        f"{second.display_name} on a {COLLAB_TASK_FACTION_SLUG} task"
+    )
+
+
 async def seed_score_fixtures(
     session, players: dict[str, Character], era: EraConfig = CURRENT_ERA
 ) -> None:
-    """Everything #891 asks for: a metatask in use and a non-1.0 multiplier."""
+    """Everything #891 asks for: a metatask in use and every non-1.0 multiplier."""
     await seed_metatask_fixture(session, players, era)
     await seed_duel_fixture(session, players)
+    await seed_collab_fixture(session, players)
 
 
 def print_login_recipe(era: EraConfig = CURRENT_ERA) -> None:
@@ -397,6 +489,16 @@ def print_login_recipe(era: EraConfig = CURRENT_ERA) -> None:
     print(
         f"  multiplier row: '{DUEL_LOSER_TITLE}' (losing Snide side) and "
         f"'{DUEL_WINNER_TITLE}'"
+    )
+    collab_modifier = era.factions[COLLAB_TASK_FACTION_SLUG].collab_own_modifier
+    print(
+        f"  collab row    : '{COLLAB_TITLE}' - "
+        f"{COLLAB_TASK_FACTION_SLUG} own-faction collab at x{collab_modifier} "
+        f"(era.factions['{COLLAB_TASK_FACTION_SLUG}'].collab_own_modifier)"
+    )
+    print(
+        f"                  needs a {COLLAB_TASK_FACTION_SLUG} task on the board; "
+        f"if the line above said 'skipped', import one first"
     )
 
 
@@ -466,15 +568,8 @@ async def seed(session, era: EraConfig = CURRENT_ERA) -> None:
         session.add(praxis)
         await session.flush()
 
-        members = [author]
         session.add(PraxisMember(praxis_id=praxis.id, character_id=author.id, has_submitted=True))
-        second = COLLAB_SECOND_MEMBER.get(faction)
-        if second:
-            members.append(players[second])
-            session.add(PraxisMember(praxis_id=praxis.id, character_id=players[second].id, has_submitted=True))
-
-        member_ids = {m.id for m in members}
-        voters = [c for c in players.values() if c.id not in member_ids][: len(stars)]
+        voters = [c for c in players.values() if c.id != author.id][: len(stars)]
         for voter, star in zip(voters, stars):
             session.add(Vote(
                 praxis_id=praxis.id,

--- a/backend/tests/integration/test_seed_score_fixtures.py
+++ b/backend/tests/integration/test_seed_score_fixtures.py
@@ -23,6 +23,10 @@ from models.faction import Faction, FactionStatus
 from models.praxis import Praxis
 from models.task import Task, TaskStatus, TaskType
 from scripts.seed_demo_praxes import (
+    COLLAB_AUTHOR_USERNAME,
+    COLLAB_SECOND_USERNAME,
+    COLLAB_TASK_FACTION_SLUG,
+    COLLAB_TITLE,
     DUEL_LOSER_TITLE,
     DUEL_LOSER_USERNAME,
     DUEL_TASK_FACTION_SLUG,
@@ -47,7 +51,7 @@ async def _board(db_session: AsyncSession, author: Character) -> None:
         if existing is None:
             db_session.add(Faction(slug=slug, status=FactionStatus.visible))
     await db_session.flush()
-    for slug in {METATASK_FACTION_SLUG, DUEL_TASK_FACTION_SLUG}:
+    for slug in {METATASK_FACTION_SLUG, DUEL_TASK_FACTION_SLUG, COLLAB_TASK_FACTION_SLUG}:
         db_session.add(Task(
             title=f"Board task ({slug})",
             description="fixture",
@@ -159,6 +163,87 @@ async def test_seeded_duel_sides_have_non_unit_multipliers(
 
 
 @pytest.mark.asyncio
+async def test_seeded_collab_carries_the_own_faction_collab_modifier(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+):
+    """The seeded collab reports the era's collab_own_modifier, and it is not 1.0.
+
+    This is the fixture's whole reason to exist: Coven's collab_own_modifier is
+    the only Era 1 multiplier that is neither a duel modifier nor a whole number,
+    so it is the one that can round wrong — and it had nothing rendering it.
+    """
+    await _board(db_session, character)
+    players = await get_or_create_players(db_session)
+    await seed_score_fixtures(db_session, players, CURRENT_ERA)
+
+    praxis = await _praxis(db_session, COLLAB_TITLE)
+    expected = CURRENT_ERA.factions[COLLAB_TASK_FACTION_SLUG].collab_own_modifier
+    # Guards the premise, not the value: if a future era neutralises Coven this
+    # fixture stops proving anything and should be re-pointed at whichever
+    # faction carries the non-1.0 modifier then.
+    assert expected != 1.0, (
+        f"'{COLLAB_TASK_FACTION_SLUG}' no longer has a non-1.0 collab_own_modifier "
+        f"— the collab fixture renders nothing"
+    )
+
+    # Both members are Coven on a Coven task, so either side shows the modifier.
+    for username in (COLLAB_AUTHOR_USERNAME, COLLAB_SECOND_USERNAME):
+        member = await _character(db_session, username)
+        contribution = (
+            await compute_contributions([praxis], member, CURRENT_ERA, db_session)
+        )[praxis.id]
+        assert contribution.faction_multiplier == expected, username
+        assert contribution.duel_multiplier == 1.0, username
+
+
+@pytest.mark.asyncio
+async def test_collab_fixture_skips_when_the_board_has_no_coven_task(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+):
+    """No Coven task on the board is a skip, not a crash.
+
+    ERA_1_TASKS is empty by design — the board lives only in the DB — so on a
+    freshly seeded database there may be no Coven task at all. The fixture must
+    behave like its metatask/duel siblings and skip rather than invent one.
+    """
+    for slug in CURRENT_ERA.factions:
+        existing = (
+            await db_session.execute(select(Faction).where(Faction.slug == slug))
+        ).scalar_one_or_none()
+        if existing is None:
+            db_session.add(Faction(slug=slug, status=FactionStatus.visible))
+    await db_session.flush()
+    # Deliberately no COLLAB_TASK_FACTION_SLUG task.
+    for slug in {METATASK_FACTION_SLUG, DUEL_TASK_FACTION_SLUG}:
+        db_session.add(Task(
+            title=f"Board task ({slug})",
+            description="fixture",
+            point_value=100,
+            level_required=0,
+            status=TaskStatus.active,
+            task_type=TaskType.standard,
+            created_by=character.id,
+            primary_faction_slug=slug,
+        ))
+    await db_session.flush()
+
+    players = await get_or_create_players(db_session)
+    await seed_score_fixtures(db_session, players, CURRENT_ERA)
+
+    rows = (
+        await db_session.execute(select(Praxis).where(Praxis.title == COLLAB_TITLE))
+    ).scalars().all()
+    assert rows == []
+    # The siblings still landed — one missing task does not sink the whole seed.
+    await _praxis(db_session, METATASK_PRAXIS_TITLE)
+    await _praxis(db_session, DUEL_LOSER_TITLE)
+
+
+@pytest.mark.asyncio
 async def test_seed_score_fixtures_is_idempotent(
     db_session: AsyncSession,
     era: Era,
@@ -175,6 +260,7 @@ async def test_seed_score_fixtures_is_idempotent(
         METATASK_OPEN_PRAXIS_TITLE,
         DUEL_LOSER_TITLE,
         DUEL_WINNER_TITLE,
+        COLLAB_TITLE,
     ):
         rows = (
             await db_session.execute(select(Praxis).where(Praxis.title == title))


### PR DESCRIPTION
Closes #891.

Five of the six original asks had already shipped. This is the last bullet from the owner's rescope: **seed one Coven own-faction collab praxis so the `collab_own_modifier` renders in dev**, plus deleting the comment that excluded collabs.

## Why this fixture is worth it

`×1.1` is the **only multiplier in Era 1 that is neither a duel modifier nor a whole number**, so it is the one place the score arithmetic can round wrong — and it was the one case invisible in dev. Not hypothetical: `services/character_stats.py:276` carries an explicit `round(), not int()` note citing ADR-0053, because truncation once banked a true 49.9 as 49. A ×1.1 collab is exactly the shape that produces a fractional total.

## What changed

`backend/scripts/seed_demo_praxes.py`
- Two Coven demo players (`demo_kettle`, `demo_thimble`), **appended** to `PLAYERS` — the DEMOS loop and the metatask fixture both take the *first* n non-member players as voters, so inserting rather than appending would have silently rewritten the existing fixtures' vote tallies.
- `seed_collab_fixture()` — one submitted collab, both members Coven on a Coven task. Both members are Coven so whichever member's card you open shows the modifier. Two members is load-bearing: a collab that drops to one member converts back to solo (ADR-0060), taking the modifier with it.
- Wired into `seed_score_fixtures()`; the login recipe now prints the collab row and reads the multiplier off `era.factions["coven"].collab_own_modifier`.
- Deleted the always-empty `COLLAB_SECOND_MEMBER` dict and its dead branch. Its comment justified skipping collabs because they render "via the separate `CollaborationCard`" — that component is retired (`praxisCard/shared.tsx:501` calls it "the retired CollaborationCard"), so the reason was false.

`backend/tests/integration/test_seed_score_fixtures.py` — two new tests, and `COLLAB_TITLE` added to the idempotency loop.

## Constraints honoured

- **Dev-only** — reached only via `seed.py` Phase 5's existing `if env == "dev"` guard, untouched. `seed.py` not edited (it is #1559's file).
- **No hardcoded rule values** — `1.1` appears nowhere in the diff. The seeder names the faction slug; the modifier is read off `era.*` at render time, and the tests assert against `CURRENT_ERA.factions[...].collab_own_modifier` rather than a literal.
- **No scoring semantics touched** — fixture rows and one dead-code deletion only.

## Follows the owner's correction: the fixture is contingent on the board

Per the second comment on #891, `ERA_1_TASKS` is empty by design — the board lives only in the DB. So the fixture looks for a Coven task and **skips with a printed warning** when there is none, exactly like its metatask and duel siblings. It never creates a Coven task. On a freshly wiped DB the only task is the level-0 `na` onboarding task, so this fixture skips until a board is imported (#1376), and the seeder now says so in its output.

## I could not see this render — here is the recipe

I have no browser or dev stack, so **I verified the multiplier through the production scoring path in tests, not on screen.** To see it:

1. `docker-compose up -d` && `alembic upgrade head`
2. Import a board containing at least one **Coven** task (admin CSV import, #1376). Without this the fixture skips and prints `! collab: no coven task on the board — skipped`.
3. `backend/.venv/Scripts/python scripts/seed_demo_praxes.py`
4. `curl -X POST 'http://localhost:8000/auth/dev-login?key=meta'`
5. Open the praxis titled `[demo] Collab: proofed the dough in shifts`. The breakdown's `{base} × {mult}` row shows the Coven collaboration bonus.

## Two observations, deliberately NOT fixed here

Both are pre-existing and out of scope for a fixture change (the issue says to file separately rather than fix in place). Reported for triage:

1. **`Contribution.total` carries binary float error.** With a 100-point board task the seeded collab scores `total=123.00000000000001`, because `100 * 1.1 == 110.00000000000001`. Whether a user ever sees those digits depends on frontend formatting; `character_stats.py` rounds before banking.
2. **`round()` is banker's rounding.** A 35-point Coven collab gives `35 * 1.1 == 38.5`, and Python's `round(38.5) == 38`, not 39 — half-to-even, so it rounds *down*. The `round(), not int()` note at `character_stats.py:276` addresses truncation but not this. Worth a ruling on whether half-up is intended.

## Verification

`pytest --cov=. --cov-fail-under=80` from `backend/` against a dedicated `wz891_test` DB: **1032 passed**, coverage **92.64%**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
