### PR TITLE
The third text tier becomes a temperature, not a weight (#1549)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -62,7 +62,7 @@ All color values are CSS custom properties defined in `index.css`. See that file
 **Key groups:**
 
 - **Page:** `--color-bg-page`, `--color-bg-surface`, `--color-bg-surface-alt`
-- **Text:** `--color-text-primary`, `--color-text-secondary`, `--color-text-tertiary`
+- **Text:** `--color-text-primary`, `--color-text-secondary`, `--color-text-tertiary` — three tiers, and the third one is a **temperature** rather than a weight (see below)
 - **Borders:** `--color-border`, `--color-border-strong`
 - **Factions:** `--faction-{slug}` (primary), `--faction-{slug}-light` (tint), `--faction-{slug}-border`
 - **Faction cards:** `--faction-{slug}-card-bg`, `--faction-{slug}-card-text`, `--faction-{slug}-card-accent`, `--faction-{slug}-card-font`
@@ -73,6 +73,22 @@ All color values are CSS custom properties defined in `index.css`. See that file
 **Dark mode** is handled by `[data-theme="dark"]` overrides in `index.css`. Components should use `var(--faction-everymen-card-bg)` — never `dark ? '#1e1a10' : '#fffef5'`.
 
 **Rule:** If you're about to hardcode a hex value in a component, stop. Add it as a CSS variable first.
+
+### The third text tier is a TEMPERATURE, not a weight (#1549)
+
+The neutral vocabulary is three tiers, and only the first step is a step in contrast. `--color-text-primary` → `--color-text-secondary` is a 3.0× drop in ratio; `--color-text-secondary` → `--color-text-tertiary` is a **hue swing at held weight** — a lavender against warm greys, in both cascades, at essentially the same luminance.
+
+**That is arithmetic, not taste.** Secondary bottoms out at 4.96:1 on `--filter-well` in light and 4.87:1 on `--color-bg-surface-alt` in dark, so a third rung that is genuinely *quieter* than secondary and still clears AA has the band [4.50, 4.96] to live in — a 1.10× span against the 3.0× above it. There is no room below secondary for a step anyone could see. A palette can afford two weight tiers over an AA floor and this one already spends both, so the third tier had to find a different axis or stop claiming to exist.
+
+It had been claiming to exist without one. Light ran `#6b6050` / `#6c6358` — one hex step per channel, **ΔE 3.4**, 5.60:1 against 5.37:1 on the page — so every surface reaching for tertiary to sound quieter than secondary got nothing back, and had every reason to hardcode a grey instead. Dark had already made the right call (a lavender at h 296°, ΔE 38.3) and was left untouched; light was walked to the same hue at h 298°, C 20, weight held to within 0.2 L\*. **The dark cascade was the reference and not the patient** — repointing it would have moved ~460 `.eyebrow` sites for no defect.
+
+Three things worth carrying.
+
+**Cool-on-warm recedes at equal luminance**, so "quieter" survives as a perception after it stops being a ratio. A desaturated cool ink on warm paper reads as further away; that is what buys the hierarchy the contrast ladder could not. Chroma is dialled *down* from dark's 27 to 20 for the same reason in reverse — a mid-tone at C 27 reads as a colour on cream and as a tint on near-black, so matching the number would not have matched the voice.
+
+**Neither cascade makes tertiary dimmer than secondary, and dark makes it louder** (6.21:1 against 5.63:1 on the page). If you find a comment claiming tertiary is "one step down", it predates this and is wrong; the file had two, and both were corrected rather than acted on. A rule that routes *away* from tertiary because it is "too faint" is the tell — measure before you believe it, since the same rule in `.filter-factions` cost contrast in dark while claiming to buy it in light.
+
+**A contrast manifest cannot see this class of bug**, which is why the fix ships with a non-ratio guard beside the ratios. Both inks were comfortably AA-clear on every ground the whole time: the maths knows what an ink sits **on** and never what it sits **beside**. `deltaE76` and a floor of 20 across the three tiers in both cascades is #1449's deferred upgrade — that block guards the card family's alarm/notice split with a hex *inequality* and says in its own ponytail that a distance floor is the real answer, to be minted when a repaint walks two inks apart. This was that repaint. **Two tiers a viewer cannot tell apart are one tier with two names**, and a hex inequality passes them both.
 
 ### Contrast is a pairing, not a property (#1028)
 
@@ -365,6 +381,8 @@ only**: a card, a panel or a rail is not a drawing, and there the doctrine above
 There is deliberately no `.content-heading` / `.content-display` / `.content-score`: each would have a single caller already owned by a component, and a class for one caller is a class for nobody. A score is a title-sized number — `.content-title` plus a `fontWeight`.
 
 **Eyebrow / label text:** Courier Prime, `--text-sm` (9px), uppercase, letter-spacing 0.15em, `var(--color-text-tertiary)`. Use the `.eyebrow` class. Never add an inline `fontSize` to an element that already carries `.eyebrow` — the class owns the size.
+
+That ink is the third text tier, and §3 records what it can and cannot do. The eyebrow clears AA on every neutral stock it lands on — **5.40:1** on the page, 5.78 over the frost, 5.07 on the alt surface, 4.78 on the filter well in light; 6.21 / 5.67 / 5.37 / 5.47 in dark — and it is now visibly a different ink from `--color-text-secondary` rather than the same one under a second name. What it does **not** have is headroom: the tier sits at secondary's weight because the palette has no AA-clear room below secondary, so an eyebrow cannot be made quieter by walking its colour down. If a label rank needs to recede further, the levers left are size, tracking, casing and layout — not ink.
 
 ---
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,10 +12,47 @@
   --color-bg-surface: rgba(255, 255, 255, 0.72);
   --color-bg-surface-alt: #f0ede6;
 
-  /* ── Text ── */
+  /* ── Text ── ─────────────────────────────────────────────────────────────
+     THE THIRD TIER IS A TEMPERATURE, NOT A WEIGHT (#1549).
+
+     `--color-text-tertiary` was #6c6358 against secondary's #6b6050 — one hex
+     step per channel, ΔE 3.4, and 5.37:1 against secondary's 5.60:1 on the
+     page. The vocabulary claimed three inks and rendered two, so anything
+     reaching for tertiary to sound quieter than secondary got nothing back and
+     had every reason to hardcode a grey instead.
+
+     THE WEIGHT RUNG DOES NOT EXIST, and that is a measurement rather than a
+     preference. Secondary bottoms out at 4.96:1 on `--filter-well`, the darkest
+     neutral stock either quiet ink lands on, so a genuinely quieter third rung
+     that still clears AA has the band [4.50, 4.96] to live in — a 1.10x span,
+     against the 3.0x that separates primary from secondary. There is no room
+     below secondary for a rung anyone could see. Walking tertiary down there
+     would buy an invisible step and spend the whole AA margin for it.
+
+     So the axis is the one with room, and DARK ALREADY CHOSE IT: its tertiary
+     is a lavender (h 296°, C 27) against a warm-grey secondary (h 85°), at
+     essentially the same weight — the "this is chrome, not content" signal.
+     Light now says the same thing at the same hue: h 298°, C 20, L* 42.3
+     against the outgoing 42.5. Chroma is dialled back from dark's because a
+     mid-tone at C 27 reads as a COLOUR on cream and as a tint on near-black.
+
+     THE FIX SPENDS NO CONTRAST — every neutral ground gains a little:
+       page 5.37 -> 5.40 · frost 5.74 -> 5.78 · surface-alt 5.04 -> 5.07 ·
+       filter-well 4.75 -> 4.78.  ΔE from secondary 3.4 -> 29.5 (dark: 38.3).
+     All four clear AA for body text at any size, which matters because
+     `.eyebrow` prints this ink at 9px on ~460 sites.
+
+     Cool-on-warm recedes at equal luminance, so "quieter" survives as a
+     perception even though it is no longer a ratio. That is the claim #1307
+     builds its label-tier redesign on: the eyebrow's ink is legible on every
+     neutral stock and is no longer competing with secondary — what it does NOT
+     have is headroom to be walked further down. Measured in
+     `factionContrast.test.ts`, both cascades, with a ΔE floor beside the
+     ratios (#1449's shape: a guard that measures an ink against a ground is
+     blind to an ink measured against its NEIGHBOUR). */
   --color-text-primary: #1a1209;
   --color-text-secondary: #6b6050;
-  --color-text-tertiary: #6c6358;
+  --color-text-tertiary: #656081;
 
   /* ── Borders ── */
   --color-border: rgba(0, 0, 0, 0.07);
@@ -1774,7 +1811,18 @@
   --color-bg-surface: rgba(255, 255, 255, 0.04);
   --color-bg-surface-alt: rgba(255, 255, 255, 0.06);
 
-  /* ── Text ── */
+  /* ── Text ── ─ UNCHANGED BY #1549, AND IT IS THE REFERENCE. This cascade
+     already answered the question the light one was failing to: tertiary is a
+     lavender (h 296°, C 27) against a warm-grey secondary (h 85°) at roughly
+     one weight — ΔE 38.3, and 6.21:1 against 5.63:1 on the page, so if
+     anything it is the LOUDER of the two. Light was brought to this hue rather
+     than this hue being softened toward light, because dark is the cascade
+     that works and a repaint here would move ~460 `.eyebrow` sites for no
+     defect. Note the direction that leaves: neither cascade makes tertiary
+     dimmer than secondary, and dark has even less room to than light does —
+     secondary is 4.87:1 on `--color-bg-surface-alt` here, so a rung below it
+     would be under AA before it was visible. "Tertiary" names a role, not a
+     rank in a contrast ladder; see the `:root` block for the whole argument. */
   --color-text-primary: #f0e6d0;
   --color-text-secondary: #988c78;
   --color-text-tertiary: #9490c0;
@@ -5484,8 +5532,14 @@
    Updates' type counts are the first to ship (#1419 decision 4), so this is the
    rule's first consumer. Undressed it inherited the row's --text-xl primary ink
    and sat flush right at full strength, reading as a second label rather than
-   an annotation on the one beside it. Tertiary and one step down: the count is
-   information about the option, not a peer of it. */
+   an annotation on the one beside it. Tertiary: the count is information about
+   the option, not a peer of it.
+
+   "One step down" is how that used to read here, and #1549 retired the phrase
+   rather than the choice — the third tier is a cooler ink at roughly
+   secondary's weight, not a dimmer one, because the palette has no room below
+   secondary that still clears AA. What sets the count apart from the label is
+   its temperature and its size, and that is the whole of it. */
 .filter-factions__count {
   flex: none;
   font-size: var(--text-lg);
@@ -5493,8 +5547,17 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* A selected row inverts to the thumb fill, which the tertiary ink is too faint
-   against — the count follows the label up to secondary there. */
+/* A selected row inverts to the thumb fill, and the count follows the label
+   into the warm family there so the whole row reads as one selected object.
+
+   ponytail (#1549): the original reason given was "tertiary is too faint
+   against the thumb", and that was never worth much — measured, the thumb
+   (10% primary over `--filter-well`) reads secondary at 4.05:1 and tertiary at
+   3.90:1 in light, and secondary at 3.80:1 against tertiary's 4.19:1 in DARK,
+   where this rule therefore costs contrast rather than buying it. Both inks
+   are under AA on that stock at `--text-lg` in both themes, so the fix is the
+   GROUND (a selected row wants more than a 10% lift) and not the ink, which
+   puts it outside a token-tier change. Left as-is here, measured, and named. */
 .filter-factions__row[data-on] .filter-factions__count {
   color: var(--color-text-secondary);
 }

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -30,7 +30,15 @@ import { fileURLToPath } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { AA_LARGE, AA_NORMAL, compositeOver, contrastRatio, formatRatio, parseColor } from "../contrast";
+import {
+  AA_LARGE,
+  AA_NORMAL,
+  compositeOver,
+  contrastRatio,
+  deltaE76,
+  formatRatio,
+  parseColor,
+} from "../contrast";
 import { readThemes, resolveVar, type Theme } from "./cssVars";
 
 const CSS_PATH = fileURLToPath(new URL("../../index.css", import.meta.url));
@@ -1242,6 +1250,39 @@ const ARCHETYPE_PAIRS: Pair[] = [
     text,
   })),
 
+  // ── THE NEUTRAL TEXT TIERS, ON THE APP'S OWN TWO STOCKS (#1549) ──────────
+  //
+  // The most-painted pairing in the repo and it was not in this manifest. The
+  // rows above reach `--color-text-secondary` / `-tertiary` only THROUGH the
+  // frost, on one card class, on one page — so the bare page ground and the
+  // alt surface, which between them carry every eyebrow, timestamp, byline,
+  // placeholder and inactive nav link in the app, were unmeasured.
+  //
+  // `--color-bg-surface-alt` is opaque in light and rgba(255,255,255,0.06) in
+  // DARK, so it cannot be a `surface` — it is modelled as a veil over the page,
+  // which is exactly what it composites to. Same trick, same reason as the
+  // frost rows above (#1413).
+  //
+  // These are the pairings #1549's repaint moves, so they are the ones that
+  // have to be pinned: light tertiary goes #6c6358 -> #656081, which is a hue
+  // swing at held weight and reads a fraction HIGHER on every one of them
+  // (page 5.37 -> 5.40, alt 5.04 -> 5.07). The tier separation itself is not a
+  // ratio and is asserted at the bottom of this file.
+  ...(
+    [
+      ["secondary", "--color-text-secondary"],
+      ["tertiary", "--color-text-tertiary"],
+    ] as const
+  ).flatMap(([role, text]) => [
+    { what: `app page, ${role} ink`, surface: "--color-bg-page", text },
+    {
+      what: `app alt surface, ${role} ink`,
+      surface: "--color-bg-page",
+      veil: "--color-bg-surface-alt" as Veil,
+      text,
+    },
+  ]),
+
   // ── THE FEED ROW'S ACTOR NAME, on the four chassis #1252 left (#1341) ────
   //
   // `resolveFeedRowInk` defaults `actor` to `factionCssVar(slug)` — the raw
@@ -1475,6 +1516,70 @@ describe("the card sheet's alarm and notice inks stay apart (#1449)", () => {
         `snide (${theme}) prints the destructive and the cautionary mark on the wall in one colour.`,
       ).not.toBe(notice.raw);
     });
+  }
+});
+
+/**
+ * #1549 — THE NEUTRAL TEXT VOCABULARY IS THREE INKS, NOT TWO.
+ *
+ * This is #1449's ponytail collected. That block guards the card family's
+ * alarm/notice split with a hex INEQUALITY, and says so: it cannot see two reds
+ * a viewer could not tell apart, and the upgrade path is a distance floor, to
+ * be minted "when a repaint walks them together, not now". This is that
+ * repaint, one token family over.
+ *
+ * `--color-text-secondary` (#6b6050) and `--color-text-tertiary` (#6c6358) were
+ * one hex step apart per channel in LIGHT — ΔE 3.4, 5.60:1 against 5.37:1 on
+ * the page — so the site advertised a three-tier vocabulary and rendered two.
+ * A hex inequality would have passed that the entire time, and so did every
+ * ratio in this file, because both inks were comfortably AA-clear on every
+ * ground. THE TIERS WERE LEGIBLE AND INDISTINGUISHABLE, which is a defect a
+ * contrast manifest is structurally unable to notice.
+ *
+ * WHY A DISTANCE AND NOT A RATIO-GAP. The obvious guard — "tertiary must be N
+ * ratio points quieter than secondary" — encodes an assumption #1549 measured
+ * and rejected. Secondary bottoms out at 4.96:1 on `--filter-well` in light and
+ * 4.87:1 on `--color-bg-surface-alt` in dark, so a rung genuinely below it and
+ * still above AA has nowhere to stand in either theme. The third tier is a
+ * TEMPERATURE (a lavender against warm greys, in both cascades now), and
+ * temperature is a distance, not a ratio.
+ *
+ * THE FLOOR IS 20, well under the 29.5 the tightest shipped pair measures and
+ * an order of magnitude over the 3.4 that failed. It is deliberately not set
+ * just under today's values: a floor that tracks the current palette turns
+ * every future re-tune into a test edit, and the question being asked here is
+ * "can a viewer tell these apart", to which 20 is a confident yes and 3.4 an
+ * equally confident no.
+ *
+ * ponytail: CIE76 under-reports hue swings very close to neutral, so a pair
+ * this passes is genuinely distinct while a pair it fails MIGHT be. That is the
+ * safe direction for a floor. Swap in CIEDE2000 if a legitimate palette ever
+ * trips it — do not lower the number.
+ */
+describe("the neutral text tiers stay three inks (#1549)", () => {
+  const TIER_DELTA_E = 20;
+  const TIERS = ["--color-text-primary", "--color-text-secondary", "--color-text-tertiary"] as const;
+
+  for (const theme of BOTH_THEMES) {
+    for (let index = 0; index < TIERS.length; index += 1) {
+      for (let other = index + 1; other < TIERS.length; other += 1) {
+        const [first, second] = [TIERS[index], TIERS[other]];
+        it(`${first} is not ${second} (${theme})`, () => {
+          const one = resolveColor(first, theme);
+          const two = resolveColor(second, theme);
+          expect(one.color, `${first} (${theme}) resolved to "${one.raw}"`).not.toBeNull();
+          expect(two.color, `${second} (${theme}) resolved to "${two.raw}"`).not.toBeNull();
+
+          const distance = deltaE76(one.color!, two.color!);
+          expect(
+            distance,
+            `${first} (${one.raw}) and ${second} (${two.raw}) are ΔE ${distance.toFixed(1)} apart in ${theme}, ` +
+              `under the ${TIER_DELTA_E} floor. Two tiers a viewer cannot tell apart are one tier with two names — ` +
+              "that is #1549, and every ratio in this file stays green through it.",
+          ).toBeGreaterThanOrEqual(TIER_DELTA_E);
+        });
+      }
+    }
   }
 });
 

--- a/frontend/src/utils/contrast.ts
+++ b/frontend/src/utils/contrast.ts
@@ -168,6 +168,63 @@ export function contrastRatio(text: Rgba, surface: Rgba): number {
 }
 
 /**
+ * CIE L*a*b* of an opaque sRGB colour, D65 white point.
+ *
+ * Exported only for `deltaE76` below and its tests. Contrast maths lives in
+ * relative luminance; this is the other axis, and the reason the file needs
+ * both is #1549: two inks can be a hair apart in luminance and a whole hue
+ * apart, or a hair apart in both, and a ratio cannot tell you which.
+ */
+export function toLab(color: Rgba): { L: number; a: number; b: number } {
+  const linear = (channel: number): number => {
+    const srgb = channel / 255;
+    return srgb <= 0.04045 ? srgb / 12.92 : ((srgb + 0.055) / 1.055) ** 2.4;
+  };
+  const [r, g, b] = [color.r, color.g, color.b].map(linear);
+  // sRGB -> XYZ (D65), normalised by the D65 white point.
+  const xyz = [
+    (0.4124 * r + 0.3576 * g + 0.1805 * b) / 0.95047,
+    0.2126 * r + 0.7152 * g + 0.0722 * b,
+    (0.0193 * r + 0.1192 * g + 0.9505 * b) / 1.08883,
+  ].map((value) => (value > 0.008856 ? Math.cbrt(value) : 7.787 * value + 16 / 116));
+  const [x, y, z] = xyz;
+  return { L: 116 * y - 16, a: 500 * (x - y), b: 200 * (y - z) };
+}
+
+/**
+ * CIE76 perceptual distance between two opaque colours (#1549).
+ *
+ * WHY THIS EXISTS. `contrastRatio` measures an ink against the GROUND it sits
+ * on. It is blind to the ink sitting BESIDE it — the gap #1449 named when the
+ * card family's alarm and notice roles collapsed onto one hue with every ratio
+ * in the manifest still green. That gap was papered over with a hex inequality
+ * ("these two tokens are not literally the same string"), and the ponytail
+ * there said the upgrade was a distance floor, once a repaint walked two inks
+ * apart. #1549 is that repaint: `--color-text-secondary` and
+ * `--color-text-tertiary` were a hex inequality apart in light and nothing
+ * more, at ΔE 3.4.
+ *
+ * CIE76 ON PURPOSE. It is the crude one — it over-reports distance in
+ * saturated regions and under-reports near-neutral hue swings, and CIEDE2000
+ * is the accurate answer. But every pairing this repo asks about is a
+ * desaturated ink against another desaturated ink, where CIE76 is *pessimistic*
+ * rather than flattering, and a guard that errs toward "these are too close"
+ * is the safe direction for a floor. Forty lines of ΔE2000 to make a threshold
+ * marginally kinder is not a trade worth making.
+ *
+ * Calibration, so a future floor is not picked out of the air: ~2.3 is the
+ * classic just-noticeable difference for adjacent patches, and text tiers are
+ * never adjacent patches — they are small type separated by layout. The shipped
+ * neutral tiers run 29.5 (light secondary/tertiary) to 48.5 (dark
+ * primary/tertiary); the pair this issue fixed was 3.4.
+ */
+export function deltaE76(first: Rgba, second: Rgba): number {
+  const one = toLab(first);
+  const two = toLab(second);
+  return Math.hypot(one.L - two.L, one.a - two.a, one.b - two.b);
+}
+
+/**
  * WCAG "large text": >= 24px, or >= 18.66px when bold (>= 700). Large text
  * only owes 3:1. Several faction surfaces use big display type and would
  * false-positive against the 4.5:1 floor.


### PR DESCRIPTION
Closes #1549

## The premise, verified against `origin/main`

Confirmed, and the real numbers differ from the issue's framing in one way that changed the fix.

**Light** — `--color-text-secondary: #6b6050` / `--color-text-tertiary: #6c6358`. One hex step per channel, **ΔE 3.4**, and on the page ground **5.60:1 against 5.37:1**. Two names, one ink.

**Dark** — `#988c78` / `#9490c0`, **ΔE 38.3**. But the issue calls this cascade "genuinely three" levels, and by *weight* it is not: dark tertiary reads **6.21:1 against secondary's 5.63:1**, so it is the **louder** of the two. Dark's three-ness is entirely hue — a lavender (h 296°) against a warm grey (h 85°). The two cascades did not merely disagree about magnitude; they disagreed about **direction**.

## The decision: the third tier is a temperature, not a weight

The issue asks whether tertiary means *quieter* or *a different hue at similar weight*. I measured whether "quieter" is even available, and it is not — in either theme.

Secondary bottoms out at **4.96:1** on `--filter-well` (light) and **4.87:1** on `--color-bg-surface-alt` (dark). A third rung genuinely below secondary that still clears AA therefore has the band **[4.50, 4.96]** to live in — a **1.10x span, against the 3.0x that separates primary from secondary**. There is no room under secondary for a step anyone could see. Walking tertiary down there buys an invisible rung and spends the whole AA margin for it.

So the axis is the one with room, and **dark had already chosen it**. Light now says the same thing:

```
--color-text-tertiary: #6c6358  ->  #656081     (light only)
```

h 298° against dark's 296°, C 20, **L\* 42.5 -> 42.3** — the weight is held. Chroma is dialled back from dark's 27 because a mid-tone at C 27 reads as *a colour* on cream and as *a tint* on near-black.

**Dark is unchanged, and that is deliberate.** It is the cascade that works; repainting it would move ~460 `.eyebrow` sites for no defect. Prior art #669/#677 lifted dark luminance globally — here dark needed nothing lifted, so nothing was.

## Contrast: the fix spends none, and gains a little

Every neutral ground tertiary actually lands on, in light. All clear **AA 4.5:1 for body text at any size** — which matters, because `.eyebrow` prints this ink at 9px:

| ground | before | after |
|---|---|---|
| `--color-bg-page` | 5.37:1 | **5.40:1** |
| `.sidebar-card` frost over page | 5.74:1 | **5.78:1** |
| `--color-bg-surface-alt` | 5.04:1 | **5.07:1** |
| `--filter-well` | 4.75:1 | **4.78:1** |

Dark, unchanged: 6.21 / 5.67 / 5.37 / 5.47. Tier separation goes **ΔE 3.4 -> 29.5** in light (dark 38.3).

## Token-tier, not per-site

One value moved in `index.css`. No call site was repointed, no `dark ? :` ternary, no new token. The two *comments* in the filter block that asserted tertiary is "one step down" / "too faint" were corrected, because they are now false — see below.

## The guard, because no ratio could have caught this

Every ratio in `factionContrast.test.ts` was green the entire time: both inks were comfortably AA-clear on every ground. **The tiers were legible and indistinguishable**, and contrast maths knows what an ink sits *on* and never what it sits *beside*.

This is #1449's deferred upgrade. That block guards the card family's alarm/notice split with a hex *inequality* and its own ponytail says the real answer is a distance floor, to be minted "when a repaint walks them together, not now". This is that repaint.

- `deltaE76` + `toLab` in `utils/contrast.ts` — CIE76 on purpose: it is *pessimistic* in the desaturated region these tokens live in, and a floor that errs toward "too close" is the safe direction.
- `describe("the neutral text tiers stay three inks (#1549)")` — ΔE floor of **20** across all three tiers, both cascades. Verified red on the old value before shipping: `--color-text-secondary (#6b6050) and --color-text-tertiary (#6c6358) are ΔE 3.4 apart in light, under the 20 floor.`
- Four manifest rows the app's own stocks never had: secondary and tertiary on `--color-bg-page` and `--color-bg-surface-alt`. The existing rows reached these tokens only *through the frost, on one card class, on one page*.

## What this means for `.eyebrow` and #1307

#1307 is blocked by this, so it should start from a measured position rather than re-derive one:

1. **The eyebrow's ink is sound.** 5.40:1 on the page, 4.78:1 on the tightest neutral stock in light; 6.21 / 5.47 in dark. Nothing in the label tier needs rescuing for legibility.
2. **It is now a distinct ink**, so a label reads as chrome beside `--color-text-secondary` instead of matching it. #1307's measurement step will no longer be measuring a degenerate pair.
3. **There is no headroom to walk it quieter.** This is the load-bearing constraint. The tier sits at secondary's weight because the palette has none free below secondary. If a label rank must recede further, the levers are size, tracking, casing and layout — **not ink**. A redesign that assumes it can dim the eyebrow will find the AA floor 0.28 of a contrast point away.
4. **If a neutral ink fails a faction ground**, #1307's per-faction label-ink mint is still the right escape — unchanged by this. The neutral tier got more margin, not less, so the set of grounds needing one can only have shrunk.

## Found while measuring — NOT fixed here

`.filter-factions__row[data-on] .filter-factions__count` bumps tertiary to secondary on a selected row, justified as "the tertiary ink is too faint against the thumb". Measured, that reason does not hold: on `--filter-thumb` (10% primary over `--filter-well`) secondary is **4.05:1** and tertiary **3.90:1** in light — and in **dark** secondary is **3.80:1** against tertiary's **4.19:1**, so the rule *costs* contrast there. Both inks are under AA on that stock at `--text-lg`, in both themes.

That is a **ground** defect (a selected row wants more than a 10% lift), not an ink one, so it is outside a token-tier change, and my edit does not move its arithmetic — tertiary's weight is held. Left in place, measured, and named in a `ponytail:` at the seam. Worth its own issue.

## Verification

All six CI steps run locally and green: `eslint` · `tsc --noEmit` · `vitest run` (**3721 passed / 211 files**) · `vite build` · byte budget (**CSS 22.3 KB, unmoved** — comments minify out) · `typecheck:design-sync`.

Built CSS grepped, not just source: `--color-text-tertiary: #656081` and `#9490c0` each present once, `#6c6358` gone.

**I cannot see this change.** No browser tooling, no dev stack. Every claim above is arithmetic against the declared token values; none of it is a look at a rendered page. The chroma call in particular — C 20 against dark's 27 — is reasoned, not observed.

## What to eyeball

A palette change with no test that can see it. Both themes, every item.

**Light mode is where the change is. Dark mode is the control — it should look pixel-identical.**

1. **Any `.eyebrow`, light** — the biggest surface, ~460 sites. Task cards, praxis cards, admin stat captions, `OverviewTab`. The 9px uppercase label should read as a cool grey with a violet cast, *not* as a purple label. If it reads as a colour rather than an ink, the chroma is too high.
2. **An eyebrow directly beside secondary text, light** — the point of the whole change. `DefaultProfileBody` and `Sidebar` stack both tiers. They should now be tellably different; before they were not.
3. **`.sidebar-card` chrome, light** — the praxis detail's steward bar / report card, over the frost. Quiet inks there, on the ground #1413 fixed.
4. **The filter bar's faction popover, both themes** — `.filter-factions__count` on `--filter-well`, and a **selected** row (the count on the thumb). Unchanged by design, but it is the tightest neutral pairing in the app and the one with the known open defect above.
5. **Nav + footer, light** — inactive nav links and `SiteFooter` print tertiary directly on the page ground.
6. **Singularity and S.N.I.D.E. comment voices, both themes** — both *re-point* `--color-text-tertiary` inside their subtree (`SingularityComment`, `SnideComment`, `SingularityFeedFrame`). They should be completely unaffected; if either shifts, the override is leaking.
7. **The na / Albescent card, light** — `--faction-default-card-muted` is coincidentally the *same hex* as light secondary (`#6b6050`). It is a separate faction token and did not move; check the card's muted text still sits right next to page-level secondary text.
8. **Dark mode, anywhere** — should be byte-identical. Any visible change in dark is a bug in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
