### PR TITLE
A seeded character was wearing a faction nobody gave it

### DIFF
--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -42,7 +42,11 @@ from game_config import (
 #
 # Required system factions (include these in every era):
 #   "ua"       -- an ordinary invite-joinable faction (no starter privilege, ADR-0030)
-#   "na"       -- sentinel for tasks with no faction affiliation
+#   "na"       -- answers two questions at once (see backend/faction_slugs.py):
+#                 the sentinel for a task with no faction affiliation, AND the
+#                 unaffiliated state every character is born into (ADR-0019).
+#                 Omit it and both the default birth faction and every
+#                 cross-faction task lose their FK target.
 #
 # Modifier guide (1.0 = no change, >1.0 = bonus, <1.0 = penalty):
 #   own_task_modifier       -- solo task from your own faction
@@ -229,6 +233,11 @@ ERA_N = EraConfig(
     albescent_level_required=8,
     invitation_point_threshold=50,   # ADR-0022: points from a faction's tasks
     invitation_task_threshold=2,     # ADR-0022: completed tasks for that faction
+    # starting_faction_slug — deliberately OMITTED (#1559). Characters are born
+    # unaffiliated (ADR-0019/ADR-0030) and the EraConfig default already says so,
+    # so name this ONLY if your era wants players pre-sorted into a real faction.
+    # Whatever you name must be a key in ERA_N_FACTIONS above: it is an FK onto a
+    # Faction row and seed.py seeds exactly the era's factions.
 
     reset_score=True,
     reset_level=True,

--- a/backend/faction_slugs.py
+++ b/backend/faction_slugs.py
@@ -1,0 +1,35 @@
+"""Canonical faction-slug sentinels.
+
+A **leaf** module: it imports nothing, so the pure-math layer
+(``services/scoring.py``), the config layer (``game_config.py``), the async
+services, the routers and ``seed.py`` can all name the same string without any
+of them importing each other. Before #1559 the string ``"na"`` was re-declared
+under four different names in six files — including twice under the *same*
+name — so a change of mind about the sentinel had six edit sites.
+
+Two constants below share the value ``"na"``. That is deliberate, and they are
+**not** aliases: they answer different questions about different rows, and an
+era is free to answer them the same way (Era 1 does) without them being one
+concept. Collapsing them would hide the day a task's "no faction" and a
+character's "no faction" need different slugs.
+
+What is *not* here: the faction a character is **born into**. That is a rule,
+not a sentinel, so it lives on ``EraConfig.starting_faction_slug`` (defaulted
+to :data:`UNAFFILIATED_FACTION_SLUG`) where an era can override it — ADR-0042,
+the era doc wins. Services read ``era.starting_faction_slug``; they must not
+read the constant below to answer "what faction does a new character get?".
+"""
+
+#: A **character** has joined no faction — the unaffiliated state every
+#: character is born into by default (ADR-0019 / ADR-0030). This is a real,
+#: seeded ``Faction`` row (hidden, so it never appears in the faction registry)
+#: because ``character.faction_slug`` is a non-nullable FK. It is *not*
+#: :data:`CROSS_FACTION_SLUG`: that one describes a task, this one a player.
+UNAFFILIATED_FACTION_SLUG: str = "na"
+
+#: A **task** belongs to no faction — a generic / cross-faction task that any
+#: character may take without an own-vs-other scoring penalty
+#: (``services.scoring.compute_faction_multiplier``). It is *not*
+#: :data:`UNAFFILIATED_FACTION_SLUG`: a cross-faction task is not "a task that
+#: failed to join a faction", it is a task deliberately open to all of them.
+CROSS_FACTION_SLUG: str = "na"

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -9,6 +9,8 @@ switches all live game mechanics.
 from dataclasses import dataclass, field
 from enum import Enum
 
+from faction_slugs import UNAFFILIATED_FACTION_SLUG
+
 
 class LevelUnlockKind(str, Enum):
     """Whether a level unlock is a rules-backed capability or pure flavor."""
@@ -145,6 +147,20 @@ class EraConfig:
     # ADR-0022: completed-task count (per faction) required to earn that faction's invite.
     # Defaulted so existing EraConfig constructions stay valid.
     invitation_task_threshold: int = 2
+
+    # The faction a character is born into when creation names none (#1559).
+    # ADR-0019 makes characters born unaffiliated and ADR-0030 makes `na` the
+    # site-wide answer, so the default below is already right for every era so
+    # far — an era file declares this ONLY when it wants players pre-sorted into
+    # a real faction. That is ADR-0042's shape: the era doc wins where it
+    # speaks, and stays silent about the obvious.
+    #
+    # Deliberately NOT the era-*reset* faction
+    # (services.era.ERA_RESET_DEFAULT_FACTION). They hold the same value today
+    # and are arguably one knob, but an era may reasonably want players born
+    # unaffiliated and *reset* into something else, so #1559 left them apart
+    # rather than silently unify them.
+    starting_faction_slug: str = UNAFFILIATED_FACTION_SLUG
 
     # Metatask-per-praxis cap (defaulted so bare EraConfig constructions stay valid).
     # A praxis holds metatasks_per_praxis_base metatasks until the applying character

--- a/backend/models/character.py
+++ b/backend/models/character.py
@@ -44,8 +44,11 @@ class Character(TimestampMixin, Base):
     avatar_url: Mapped[str] = mapped_column(String, nullable=False, server_default="")
     location: Mapped[str] = mapped_column(String, nullable=False, server_default="")
     # ADR-0019: characters are born Unaffiliated ("na"); factions are invite-gated.
-    # services.character.create_character always sets this explicitly — the default
-    # is only a backstop for direct inserts, and must not contradict ADR-0019.
+    # services.character.create_character always sets this explicitly, from
+    # era.starting_faction_slug (#1559) — that field, not this literal, is the
+    # live rule. The server_default stays a literal because it is baked into DDL
+    # by the migration: it is only a backstop for direct inserts, and must not
+    # contradict ADR-0019.
     # String FK: faction's primary key is its slug (ADR-0038), not an integer.
     faction_slug: Mapped[str] = mapped_column(
         String, ForeignKey("faction.slug"), nullable=False, server_default="na"

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import selectinload
 from config import settings
 from db import get_db
 from dependencies import require_admin
+from faction_slugs import CROSS_FACTION_SLUG
 from game_config import CURRENT_ERA
 from models.account import Account
 from models.character import Character, CharacterStatus
@@ -582,7 +583,7 @@ async def admin_create_task(
         description=data.description or "",
         point_value=data.point_value,
         level_required=data.level_required,
-        primary_faction_slug=data.primary_faction_slug or "na",
+        primary_faction_slug=data.primary_faction_slug or CROSS_FACTION_SLUG,
         metatask_faction_slug=(
             data.metatask_faction_slug if task_type == TaskType.metatask else None
         ),

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -122,8 +122,11 @@ class AdminCharacterCreate(BaseModel):
     avatar_url: str = Field(default="", max_length=500)
     location: str = Field(default="", max_length=100)
     # Characters start unaffiliated (ADR-0019). An admin who wants to place a
-    # character straight into a faction passes the slug explicitly.
-    faction_slug: str = Field(default="na")
+    # character straight into a faction passes the slug explicitly. Omitted here
+    # rather than defaulted to a literal so the era owns the answer: the service
+    # fills it from era.starting_faction_slug (#1559), which the admin door must
+    # agree with or the two creation paths drift.
+    faction_slug: str | None = Field(default=None)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/schemas/character.py
+++ b/backend/schemas/character.py
@@ -56,9 +56,10 @@ class CharacterCreate(BaseModel):
     bio: str = Field(default="", max_length=500)
     avatar_url: str = Field(default="", max_length=500)
     location: str = Field(default="", max_length=100)
-    # Optional starting faction. Born unaffiliated ("na") by default; a non-None
-    # slug must be one the account holds an invitation for. "albescent" is never
-    # a creation option (join-in-the-field only).
+    # Optional starting faction. Omitted lands era.starting_faction_slug, which
+    # defaults to unaffiliated ("na") — #1559. A non-None slug must be one the
+    # account holds an invitation for. "albescent" is never a creation option
+    # (join-in-the-field only).
     faction_slug: str | None = Field(default=None, max_length=50)
 
 

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -26,6 +26,7 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 from sqlalchemy import func, select
 
+from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA
 from script_utils import add_env_argument, get_settings
 from models.account import Account, OAuthProvider
@@ -42,7 +43,7 @@ from models.task import Task, TaskStatus, TaskType
 # Faction status mapping
 # ---------------------------------------------------------------------------
 # System factions that should be hidden in the UI.
-HIDDEN_FACTION_SLUGS = frozenset({"aged_out", "na"})
+HIDDEN_FACTION_SLUGS = frozenset({"aged_out", UNAFFILIATED_FACTION_SLUG})
 
 
 async def upsert_era_factions(session, era) -> int:
@@ -105,7 +106,12 @@ async def bootstrap_admin(session, era, pixie_acc) -> Character:
         username="pixie",
         display_name="Pixie",
         bio="",
-        faction_slug="ua",
+        # Born unaffiliated like every other character (ADR-0019 / ADR-0030),
+        # read from the era so the fixture cannot contradict the live default.
+        # This said "ua" until #1559 — a bare literal with no reason attached,
+        # which made a freshly seeded prod show the admin as UA · Level 0 and
+        # made the site-wide default look broken on the most-used account.
+        faction_slug=era.starting_faction_slug,
     )
     session.add(pixie_char)
     await session.flush()
@@ -276,7 +282,9 @@ async def seed_dev_demo(session) -> None:
             account_id=dev_acc.id,
             username="dev",
             display_name="Molly",
-            faction_slug="na",  # unaffiliated — everyone starts here (ADR-0030)
+            # unaffiliated — everyone starts here (ADR-0030), read from the era
+            # so the fixture tracks era.starting_faction_slug (#1559).
+            faction_slug=CURRENT_ERA.starting_faction_slug,
         )
         session.add(molly)
         await session.flush()

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -288,7 +288,10 @@ async def admin_create_character(
         bio=data.bio,
         avatar_url=data.avatar_url,
         location=data.location,
-        faction_slug=data.faction_slug,
+        # ADR-0019 read through the era (#1559): omitting a slug lands the era's
+        # starting faction, the same answer services.character.create_character
+        # gives. Two creation doors, one rule.
+        faction_slug=data.faction_slug or era.starting_faction_slug,
     )
     session.add(character)
     await session.flush()

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -7,6 +7,7 @@ from sqlalchemy import case, func, or_, select
 from sqlalchemy.sql import Select, false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.account import Account
 from models.character import Character, CharacterStatus
@@ -78,7 +79,9 @@ async def get_character_by_id(character_id: int, session: AsyncSession) -> Chara
 
 ALBESCENT_FACTION_SLUG = "albescent"
 
-_ALBESCENT_SENTINEL_SLUGS: frozenset[str] = frozenset({"na", "albescent"})
+_ALBESCENT_SENTINEL_SLUGS: frozenset[str] = frozenset(
+    {UNAFFILIATED_FACTION_SLUG, ALBESCENT_FACTION_SLUG}
+)
 
 
 async def account_peak_character_level(
@@ -400,8 +403,10 @@ async def create_character(
 
     # ADR-0019: born unaffiliated by default. A non-None faction must be one the
     # account holds an invitation for. Albescent is never a creation option.
+    # The default is era-owned (ADR-0042) and defaults to `na` on EraConfig, so
+    # this reads era.starting_faction_slug rather than the slug itself.
     if requested_faction_slug is None:
-        starting_faction_slug = "na"
+        starting_faction_slug = era.starting_faction_slug
     elif requested_faction_slug == ALBESCENT_FACTION_SLUG:
         raise HTTPException(
             status_code=400,

--- a/backend/services/character_stats.py
+++ b/backend/services/character_stats.py
@@ -8,6 +8,7 @@ from sqlalchemy import ColumnElement, and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute
 
+from faction_slugs import CROSS_FACTION_SLUG, UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.character_stats import CharacterStats
@@ -22,6 +23,7 @@ from models.praxis import (
 )
 from models.task import Task
 from models.vote import Vote
+from services.character import ALBESCENT_FACTION_SLUG
 from services.era import (
     get_closing_era_id,
     get_current_era_row,
@@ -34,7 +36,9 @@ from services.scoring import compute_level
 from services.taunt_service import emit_recalc_taunts
 
 # Factions that never receive invitation letters (ADR-0022 / ADR-0019 sentinels).
-_NON_INVITE_FACTION_SLUGS: frozenset[str] = frozenset({"na", "albescent"})
+_NON_INVITE_FACTION_SLUGS: frozenset[str] = frozenset(
+    {UNAFFILIATED_FACTION_SLUG, ALBESCENT_FACTION_SLUG}
+)
 
 def _era_window_condition(
     era_row: Era,
@@ -150,7 +154,7 @@ async def _deliver_earned_invitations(
     task_ids_by_faction: dict[str, set[int]] = {}
     points_by_faction: dict[str, float] = {}
     for praxis in praxes:
-        slug = faction_by_task.get(praxis.task_id) or "na"
+        slug = faction_by_task.get(praxis.task_id) or CROSS_FACTION_SLUG
         if slug in uninvitable:
             continue
         task_ids_by_faction.setdefault(slug, set()).add(praxis.task_id)

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -15,6 +15,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.duel import Duel, DuelStatus
@@ -150,7 +151,11 @@ async def get_duel_detail(
             praxis_id=praxis_id,
             character_id=character.id if character is not None else 0,
             display_name=character.display_name if character is not None else "",
-            faction_slug=(character.faction_slug or "na") if character is not None else "na",
+            faction_slug=(
+                (character.faction_slug or UNAFFILIATED_FACTION_SLUG)
+                if character is not None
+                else UNAFFILIATED_FACTION_SLUG
+            ),
             avatar_url=character.avatar_url if character is not None else "",
             points_from_votes=(
                 get_tally(tallies, praxis_id).points_from_votes if praxis_id is not None else 0

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.character_stats import CharacterStats
@@ -14,7 +15,16 @@ from services.duel_outcome import duel_winner
 from services.scoring import snide_tie_winner_id
 from services.vote_tally import get_tally, tally_votes
 
-ERA_RESET_DEFAULT_FACTION: str = "na"
+#: Faction a character is dropped into when ``era.reset_faction`` fires.
+#:
+#: Deliberately its own name, and deliberately NOT ``era.starting_faction_slug``
+#: (#1559): being *born* into a faction and being *returned* to one at era close
+#: are different questions an era may want to answer differently — players born
+#: unaffiliated but reset into a starter faction, say. Today both answer
+#: :data:`~faction_slugs.UNAFFILIATED_FACTION_SLUG`, which is why the two were
+#: easy to mistake for one knob. Promote this to an ``EraConfig`` field the day
+#: an era wants to move it; do not quietly point it at the birth default.
+ERA_RESET_DEFAULT_FACTION: str = UNAFFILIATED_FACTION_SLUG
 
 
 async def get_current_era_row(session: AsyncSession) -> Era:

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.account import Account
 from models.character import Character
@@ -16,7 +17,9 @@ from services.character import ALBESCENT_FACTION_SLUG, can_start_as_albescent
 from services.era import get_current_era_row, get_or_create_stats
 
 UA_FACTION_SLUG: str = "ua"
-UNAFFILIATED_FACTION_SLUG: str = "na"
+
+# UNAFFILIATED_FACTION_SLUG is imported above from faction_slugs, which owns it
+# (#1559). It used to be re-declared here and again in services/scoring.py.
 
 
 # ---------------------------------------------------------------------------

--- a/backend/services/praxis_scoring.py
+++ b/backend/services/praxis_scoring.py
@@ -14,6 +14,7 @@ from typing import Optional
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from faction_slugs import CROSS_FACTION_SLUG, UNAFFILIATED_FACTION_SLUG
 from game_config import EraConfig
 from models.character import Character
 from models.duel import Duel, DuelStatus
@@ -144,14 +145,14 @@ async def compute_contributions(
 
     # ── assemble contributions ───────────────────────────────────────────────
     contributions: dict[int, Contribution] = {}
-    character_faction = character.faction_slug or "na"
+    character_faction = character.faction_slug or UNAFFILIATED_FACTION_SLUG
 
     for praxis in praxes:
         task = tasks_by_id.get(praxis.task_id)
         if task is None:
             continue
 
-        task_faction = task.primary_faction_slug or "na"
+        task_faction = task.primary_faction_slug or CROSS_FACTION_SLUG
         own_tally = get_tally(tallies, praxis.id)
         base_points = task.point_value
         metatask_points = meta_points.get(praxis.id, 0)
@@ -174,11 +175,11 @@ async def compute_contributions(
             opp_tally = get_tally(opp_tallies, opp_id) if opp_id is not None else VoteTally(0, 0)
 
             opp_praxis = opp_praxes_by_id.get(opp_id) if opp_id is not None else None
-            opponent_faction = "na"
+            opponent_faction = UNAFFILIATED_FACTION_SLUG
             if opp_praxis is not None:
                 opp_char = opp_characters_by_id.get(opp_praxis.created_by_id)
                 if opp_char is not None:
-                    opponent_faction = opp_char.faction_slug or "na"
+                    opponent_faction = opp_char.faction_slug or UNAFFILIATED_FACTION_SLUG
 
             faction_multiplier = compute_faction_multiplier(
                 character_faction, task_faction, era,

--- a/backend/services/scoring.py
+++ b/backend/services/scoring.py
@@ -1,6 +1,7 @@
 from math import floor
 from typing import TYPE_CHECKING, Optional
 
+from faction_slugs import CROSS_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 
 if TYPE_CHECKING:
@@ -9,7 +10,6 @@ if TYPE_CHECKING:
 COLLABORATION_MODE_SOLO = "solo"
 COLLABORATION_MODE_COLLAB = "collab"
 COLLABORATION_MODE_DUEL = "duel"
-UNAFFILIATED_FACTION_SLUG = "na"
 SNIDE_FACTION_SLUG = "snide"
 
 
@@ -60,7 +60,8 @@ def compute_faction_multiplier(
 
     For duels, duel outcome is captured separately via compute_duel_multiplier — this
     function returns the own/other task modifier regardless of collaboration mode.
-    Unaffiliated ("na") tasks are treated as own-faction (no penalty).
+    Cross-faction tasks — those carrying CROSS_FACTION_SLUG, i.e. belonging to no
+    faction — are treated as own-faction, so nobody is penalised for generic work.
     Votes are always added flat after all multipliers are applied.
     """
     faction_config = era.factions.get(character_faction_slug)
@@ -69,7 +70,7 @@ def compute_faction_multiplier(
 
     is_own_faction = (
         task_faction_slug == character_faction_slug
-        or task_faction_slug == UNAFFILIATED_FACTION_SLUG
+        or task_faction_slug == CROSS_FACTION_SLUG
         or not task_faction_slug
     )
 

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from faction_slugs import CROSS_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.character_stats import CharacterStats
@@ -84,7 +85,7 @@ async def propose_task(
         description=data.description or "",
         point_value=data.point_value,
         level_required=data.level_required,
-        primary_faction_slug=data.primary_faction_slug or "na",
+        primary_faction_slug=data.primary_faction_slug or CROSS_FACTION_SLUG,
         metatask_faction_slug=(
             data.metatask_faction_slug if task_type == TaskType.metatask else None
         ),
@@ -113,7 +114,7 @@ async def update_task(
     task.description = data.description or ""
     task.point_value = data.point_value
     task.level_required = data.level_required
-    task.primary_faction_slug = data.primary_faction_slug or "na"
+    task.primary_faction_slug = data.primary_faction_slug or CROSS_FACTION_SLUG
     if task.task_type == TaskType.metatask and data.metatask_faction_slug is not None:
         task.metatask_faction_slug = data.metatask_faction_slug
     await session.flush()

--- a/backend/services/task_import.py
+++ b/backend/services/task_import.py
@@ -26,6 +26,7 @@ from pydantic import ValidationError
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from faction_slugs import CROSS_FACTION_SLUG
 from models.account import Account
 from models.character import Character, CharacterStatus
 from models.faction import Faction
@@ -47,9 +48,9 @@ REQUIRED_COLUMNS: tuple[str, ...] = (
     COLUMN_POINTS,
 )
 
-# The sentinel slug for a task no single faction owns. Same default as
+# CROSS_FACTION_SLUG — the sentinel for a task no single faction owns — is
+# imported from faction_slugs, which owns it (#1559). Same default as
 # POST /admin/tasks; `primary_faction_slug` is NOT NULL, so "" can never pass through.
-CROSS_FACTION_SLUG = "na"
 
 # Legacy/typo faction slugs seen in the source spreadsheet → canonical slugs
 # (ADR-0004). Corrections are reported back to the admin, never applied silently.

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -1,9 +1,12 @@
 """Integration tests for /characters endpoints."""
+from dataclasses import replace
+
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from game_config import CURRENT_ERA
 from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
@@ -11,6 +14,8 @@ from models.era import Era
 from models.faction import Faction
 from models.praxis import Praxis
 from models.task import Task, TaskStatus
+from schemas.character import CharacterCreate
+from services.character import create_character
 
 
 @pytest.mark.asyncio
@@ -52,8 +57,9 @@ async def test_create_character(
     assert resp.status_code == 201
     data = resp.json()
     assert data["username"] == "newchar"
-    # ADR-0019: born unaffiliated, not forced into UA.
-    assert data["faction_slug"] == "na"
+    # ADR-0019: born unaffiliated, not forced into UA. Read from the era rather
+    # than spelled "na" (#1559) — tests.unit.test_era_config pins the literal.
+    assert data["faction_slug"] == CURRENT_ERA.starting_faction_slug
     assert "account_id" not in data
 
 
@@ -908,3 +914,27 @@ async def test_faction_slug_db_default_is_unaffiliated(
     await db_session.refresh(bare)
 
     assert bare.faction_slug == "na"
+
+
+@pytest.mark.asyncio
+async def test_starting_faction_is_read_from_the_era_not_hardcoded(
+    db_session: AsyncSession, account: Account, era: Era, faction_ua: Faction
+):
+    """An era that overrides ``starting_faction_slug`` actually moves the birth faction.
+
+    Without this the field would be decorative: ``test_create_character`` passes
+    whether the slug comes from ``era.starting_faction_slug`` or from the literal
+    "na" it used to be (#1559), because Era 1's answer is the same either way.
+    Substituting an era that says "ua" is the only assertion that can tell them
+    apart — and it is deliberately *not* an assertion that new characters are UA.
+    """
+    ua_start = replace(CURRENT_ERA, starting_faction_slug="ua")
+
+    result = await create_character(
+        account_id=account.id,
+        data=CharacterCreate(display_name="Era Says UA", username="erasaysua"),
+        session=db_session,
+        era=ua_start,
+    )
+
+    assert result.character.faction_slug == "ua"

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -8,6 +8,9 @@ from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# These tests set and assert a *task's* primary_faction_slug, so they name the
+# cross-faction sentinel, not the unaffiliated-character one (#1559).
+from faction_slugs import CROSS_FACTION_SLUG
 from game_config import CURRENT_ERA
 from models.account import Account
 from models.character import Character
@@ -17,7 +20,6 @@ from models.faction import Faction, FactionStatus
 from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
 from models.task import Task, TaskStatus
 from schemas.task import TaskSignupOut
-from services.faction_service import UNAFFILIATED_FACTION_SLUG
 
 
 async def _set_character_level(
@@ -248,7 +250,7 @@ async def test_list_tasks_filter_by_multiple_factions(
         level_required=0,
         status=TaskStatus.active,
         created_by=character.id,
-        primary_faction_slug=UNAFFILIATED_FACTION_SLUG,
+        primary_faction_slug=CROSS_FACTION_SLUG,
     )
     ephemerist_task = Task(
         title="Ephemerist Task",
@@ -263,7 +265,7 @@ async def test_list_tasks_filter_by_multiple_factions(
     await db_session.commit()
 
     both = await client.get(
-        "/tasks", params={"faction": ["ua", UNAFFILIATED_FACTION_SLUG]}
+        "/tasks", params={"faction": ["ua", CROSS_FACTION_SLUG]}
     )
     assert both.status_code == 200
     both_ids = {t["id"] for t in both.json()}
@@ -271,7 +273,7 @@ async def test_list_tasks_filter_by_multiple_factions(
     assert ephemerist_task.id not in both_ids
     assert {t["primary_faction_slug"] for t in both.json()} == {
         "ua",
-        UNAFFILIATED_FACTION_SLUG,
+        CROSS_FACTION_SLUG,
     }
 
     one = await client.get("/tasks", params={"faction": "ua"})
@@ -734,7 +736,7 @@ async def test_list_tasks_includes_unaffiliated_tasks(
         level_required=0,
         status=TaskStatus.active,
         created_by=character.id,
-        primary_faction_slug=UNAFFILIATED_FACTION_SLUG,
+        primary_faction_slug=CROSS_FACTION_SLUG,
     )
     hidden_task = Task(
         title="Hidden Faction Task",
@@ -941,7 +943,7 @@ async def test_propose_task_without_faction_is_unaffiliated(
         headers=auth_headers2,
     )
     assert resp.status_code == 201
-    assert resp.json()["primary_faction_slug"] == UNAFFILIATED_FACTION_SLUG
+    assert resp.json()["primary_faction_slug"] == CROSS_FACTION_SLUG
 
 
 @pytest.mark.asyncio
@@ -2474,7 +2476,7 @@ async def test_task_author_faction_is_the_authors_not_the_tasks(
         level_required=0,
         status=TaskStatus.active,
         created_by=character.id,
-        primary_faction_slug=UNAFFILIATED_FACTION_SLUG,
+        primary_faction_slug=CROSS_FACTION_SLUG,
     )
     db_session.add(task)
     await db_session.commit()
@@ -2483,7 +2485,7 @@ async def test_task_author_faction_is_the_authors_not_the_tasks(
     resp = await client.get(f"/tasks/{task.id}")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["primary_faction_slug"] == UNAFFILIATED_FACTION_SLUG
+    assert data["primary_faction_slug"] == CROSS_FACTION_SLUG
     assert data["created_by_faction_slug"] == "ua"
 
 

--- a/backend/tests/unit/test_era_config.py
+++ b/backend/tests/unit/test_era_config.py
@@ -1,4 +1,7 @@
-from game_config import CURRENT_ERA, ERA_1
+import dataclasses
+
+from faction_slugs import UNAFFILIATED_FACTION_SLUG
+from game_config import CURRENT_ERA, ERA_1, EraConfig
 
 
 def test_current_era_is_defined():
@@ -75,6 +78,40 @@ def test_aged_out_faction_removed():
 
 def test_albescent_faction_exists():
     assert "albescent" in ERA_1.factions
+
+
+# ---------------------------------------------------------------------------
+# Starting faction (#1559)
+# ---------------------------------------------------------------------------
+
+
+def test_starting_faction_slug_defaults_to_unaffiliated():
+    """The site-wide invariant lives on the dataclass default (ADR-0019/ADR-0030).
+
+    #1559 opened ADR-0042's seam — an era may pre-sort its players — *without*
+    making every era restate the obvious. This is the one place the literal is
+    pinned; every other assertion in the suite reads ``era.starting_faction_slug``
+    so a future era that overrides it does not have to rewrite them.
+    """
+    field = next(
+        f for f in dataclasses.fields(EraConfig) if f.name == "starting_faction_slug"
+    )
+    assert field.default == UNAFFILIATED_FACTION_SLUG
+
+
+def test_era_1_inherits_the_unaffiliated_start():
+    """Era 1 declares nothing, so it must land on the dataclass default."""
+    assert ERA_1.starting_faction_slug == UNAFFILIATED_FACTION_SLUG
+
+
+def test_starting_faction_is_a_faction_the_era_configures():
+    """An era cannot be born into a faction it does not define.
+
+    ``character.faction_slug`` is an FK onto a seeded ``Faction`` row, and
+    ``seed.py`` seeds exactly the era's factions — so an override naming an
+    unknown slug would fail at insert time on a fresh database.
+    """
+    assert ERA_1.starting_faction_slug in ERA_1.factions
 
 
 def test_vote_budget_base_positive():


### PR DESCRIPTION
Closes #1559.

A fresh production wipe+reseed showed the seeded Pixie character as **UA · Level 0** with UA's orange credential. `seed.py` created her with a bare `faction_slug="ua"` — no comment, no reason — twelve lines above a sibling that created the dev character `na` *and* cited the ADR for it. Whichever account you happened to log in as decided what the site's default looked like.

Real character creation was never broken. This was a fixture contradicting the doctrine on the most-used dev account.

## What changed

**1. The seeder stops contradicting itself.** Pixie is born unaffiliated like everyone else. Both seeded fixtures now read `era.starting_faction_slug` rather than naming a slug, so neither can drift from the live default again.

**2. `EraConfig.starting_faction_slug`, defaulted to `na`.** Per the owner ruling, the birth faction is now an era-overridable default rather than a literal — and *not* a mandatory era field. `era_1.py` declares nothing; the dataclass default already answers correctly. That keeps the site-wide invariant (ADR-0019 / ADR-0030) as the fallback while opening ADR-0042's seam for an era that wants players pre-sorted, without every era restating the obvious. Both creation doors read it: `services/character.py::create_character` and the admin door (`AdminCharacterCreate.faction_slug` becomes `str | None`, resolved in `admin_service` — two doors, one rule).

**3. `na` gets one home.** The literal was declared under four names across six files — including twice under the *same* name, in `services/faction_service.py` and `services/scoring.py`. `backend/faction_slugs.py` is a leaf module (imports nothing) so the pure-math layer, `game_config`, the services, the routers and `seed.py` can all name the same string without importing each other.

It keeps **two** constants, not one, because they are two questions:

- `UNAFFILIATED_FACTION_SLUG` — a *character* joined no faction
- `CROSS_FACTION_SLUG` — a *task* belongs to no faction

Each docstring says why it is not the other. Era 1 answers both with `na`; collapsing them would hide the day it doesn't. The sweep found more sites than the issue listed (12 non-test files, not 6) — including `praxis_scoring.py`, `character_stats.py`, `duel.py`, `services/task.py` and `routers/admin.py`, where the bare literal appeared on *both* sides of the distinction within the same function. Model `server_default`s stay literal: they are baked into DDL by the migration, so pointing them at a constant would be a lie.

## Proof it is a no-op for real creation

- `test_create_character` still asserts a new character is unaffiliated, now by reading `CURRENT_ERA.starting_faction_slug`.
- `test_starting_faction_is_read_from_the_era_not_hardcoded` (new) substitutes an era saying `"ua"` and asserts the character lands there. Without it the field would be decorative — every Era 1 assertion passes whether the slug is read from config or hardcoded, because Era 1's answer is the same either way.
- `test_starting_faction_slug_defaults_to_unaffiliated` (new) pins the literal `na` in exactly **one** place: the `EraConfig` dataclass default. Everything else reads the field.
- Live check: migrated + seeded a scratch database off this branch. `pixie → na`, `dev/Molly → na`. Cross-faction demo players keep their factions (deliberate fixtures).

## Flagged, not changed

`services/era.py:347` sets `character.faction_slug = ERA_RESET_DEFAULT_FACTION` on era reset. Per the issue it is **not** unified with `starting_faction_slug`: being *born* into a faction and being *returned* to one at era close are separable, and an era may reasonably want players born unaffiliated but reset into a starter faction. It now sources its value from `UNAFFILIATED_FACTION_SLUG` and carries a comment saying it is deliberately its own knob and how to promote it to an `EraConfig` field the day an era wants to move it. **Owner call available** if you'd rather they be one field.

## Also worth knowing

`eras/_template.py` described `"na"` as only "sentinel for tasks with no faction affiliation" — half the truth, and the half that made this bug easy to write. It now names both meanings and points at `faction_slugs.py`, and lists `starting_faction_slug` as a deliberate omission with the one constraint an override must satisfy (the slug must be a faction the era configures, since it is an FK onto a seeded row).

No migration. No schema change.

## Testing

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz1559_test \
  pytest --cov=. --cov-fail-under=80
```
**1034 passed**, coverage 92.74% (floor 80%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
