### PR TITLE
A duel card names who is opposite it (#596)

### DIFF
--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -190,6 +190,22 @@ class PraxisCardOut(BaseModel):
     # this, not ``type`` (#992). Precomputed page-wide by the card-list route (no
     # N+1) via ``duel_id_map``; mirrors ``PraxisOut.duel_id``.
     duel_id: Optional[int] = None
+    # ── the other side of the duel (#596) ───────────────────────────────────
+    # A duel is two separate praxis rows joined by a ``Duel`` row (ADR-0011), so
+    # a duel side's own ``members`` holds only its own submitter and the card
+    # cannot name its rival from anything else on this body. Populated page-wide
+    # in one query by the card-list route (no N+1) via ``duel_opponents_for``.
+    #
+    # ALL THREE ARE SET TOGETHER OR NOT AT ALL. They stay None in two cases the
+    # card must not confuse: the praxis is not a duel side, or it IS one and the
+    # duel is still ``pending`` — ``Duel.opponent_praxis_id`` is NULL until the
+    # challenge is accepted, and a challenger has nobody to name until then. The
+    # card falls back to the duel mode chip alone, which is what shipped before
+    # these fields existed. Gate the banner on ``opponent_display_name``, NOT on
+    # ``type == 'duel'``: a duel side is stored ``type='solo'`` (#992).
+    opponent_praxis_id: Optional[int] = None
+    opponent_display_name: Optional[str] = None
+    opponent_faction_slug: Optional[str] = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/services/praxis_out.py
+++ b/backend/services/praxis_out.py
@@ -3,7 +3,8 @@
 Every praxis response body is built here: the single-praxis
 :func:`build_praxis_out`, the list card :func:`build_praxis_card_out`, and the
 page-wide precompute maps (:func:`author_contributions_for`,
-:func:`applied_metatasks_for`, :func:`duel_id_map`, plus the tally/crown/vote
+:func:`applied_metatasks_for`, :func:`duel_id_map`, :func:`duel_opponents_for`,
+plus the tally/crown/vote
 maps gathered in :func:`build_praxis_cards`) that keep a feed from turning into
 an N+1.
 
@@ -14,11 +15,13 @@ the domain predicate a response field reports (``can_flag``), and nothing in
 modules becoming an import cycle.
 """
 
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
@@ -374,6 +377,125 @@ async def duel_id_map(
     return mapping
 
 
+@dataclass(frozen=True)
+class DuelOpponent:
+    """The OTHER side of a duel, as a card names it (#596).
+
+    Identity only — who a duel side is fighting. Deliberately not the other
+    side's score or standing: the card names the opponent, and the duel detail
+    page (``duelCrossLink``) is what reports how the contest is going.
+    """
+
+    #: The other side's praxis, for the card's link through to it.
+    praxis_id: int
+    #: The other side's AUTHOR. A duel side is always solo (ADR-0011), so its
+    #: author is the whole of it — there is no roster to cap.
+    display_name: str
+    #: The author's member faction, for the opponent's avatar. ``None`` for an
+    #: unaffiliated author, which is the `default` sheet's slug (ADR-0039).
+    faction_slug: Optional[str]
+
+
+async def duel_opponents_for(
+    praxes: list[Praxis],
+    session: AsyncSession,
+) -> dict[int, DuelOpponent]:
+    """Praxis id → the OTHER side of its duel, for the whole page in ONE query.
+
+    A duel is two separate ``Praxis`` rows joined by a ``Duel`` row (ADR-0011),
+    not one praxis with two members, so a duel side's own ``members`` contains
+    only its own submitter and the card has no path to the rival's name. This is
+    that path, batched: the same "one query for the page, never one per card"
+    shape as :func:`~services.vote_tally.viewer_votes_for` and
+    :func:`~services.vote_tally.crowned_praxis_ids`. A per-card version of this
+    lookup would be three joins × page size; ``/tasks`` was measured at ~300
+    queries a page once (#1371) and this is exactly how that happens.
+
+    Both sides are resolved in the same statement via aliased joins rather than a
+    second round trip for the ids gathered from the first: a duel row where BOTH
+    sides are on the page (two rivals adjacent in a feed) maps in both directions
+    off the one row.
+
+    THE PENDING WINDOW IS THE CASE THIS GETS RIGHT. ``Duel.opponent_praxis_id``
+    is NULL until the challenge is accepted, so a challenger's card has no
+    opponent praxis to name yet. Such a praxis is simply ABSENT from the map, and
+    the card falls back to the mode chip alone — which is what ships today. The
+    challenged character is knowable (``Duel.opponent_character_id`` is set from
+    the start), but naming someone who has not accepted, on a card that may yet
+    become an ordinary solo praxis if they decline, asserts a contest that does
+    not exist. The outer joins below are what make the absence, rather than a
+    dropped row, the answer.
+
+    Mirrors :func:`duel_id_map`'s status set (incl. ``resolved``, ADR-0052), so a
+    past duel's card still names who it was against after the era froze it.
+    """
+    if not praxes:
+        return {}
+
+    praxis_ids = {p.id for p in praxes}
+
+    challenger_praxis = aliased(Praxis)
+    opponent_praxis = aliased(Praxis)
+    challenger_author = aliased(Character)
+    opponent_author = aliased(Character)
+
+    rows = await session.execute(
+        select(
+            Duel.challenger_praxis_id,
+            Duel.opponent_praxis_id,
+            challenger_author.display_name,
+            challenger_author.faction_slug,
+            opponent_author.display_name,
+            opponent_author.faction_slug,
+        )
+        .join(challenger_praxis, challenger_praxis.id == Duel.challenger_praxis_id)
+        .join(challenger_author, challenger_author.id == challenger_praxis.created_by_id)
+        # Outer, both of them: the opponent side does not exist while the duel is
+        # pending, and an inner join would drop the whole row rather than leave
+        # the challenger unmatched.
+        .outerjoin(opponent_praxis, opponent_praxis.id == Duel.opponent_praxis_id)
+        .outerjoin(opponent_author, opponent_author.id == opponent_praxis.created_by_id)
+        .where(
+            (Duel.challenger_praxis_id.in_(praxis_ids))
+            | (Duel.opponent_praxis_id.in_(praxis_ids)),
+            Duel.status.in_(
+                [
+                    DuelStatus.pending,
+                    DuelStatus.active,
+                    DuelStatus.settled,
+                    DuelStatus.resolved,
+                ]
+            ),
+        )
+    )
+
+    opponents: dict[int, DuelOpponent] = {}
+    for (
+        challenger_praxis_id,
+        opponent_praxis_id,
+        challenger_name,
+        challenger_faction,
+        opponent_name,
+        opponent_faction,
+    ) in rows.all():
+        # The challenger's card names the opponent — only once there IS one.
+        if challenger_praxis_id in praxis_ids and opponent_praxis_id is not None:
+            opponents[challenger_praxis_id] = DuelOpponent(
+                praxis_id=opponent_praxis_id,
+                display_name=opponent_name or "",
+                faction_slug=opponent_faction,
+            )
+        # The opponent's card names the challenger, who always exists: a Duel row
+        # cannot be created without the challenger's praxis.
+        if opponent_praxis_id is not None and opponent_praxis_id in praxis_ids:
+            opponents[opponent_praxis_id] = DuelOpponent(
+                praxis_id=challenger_praxis_id,
+                display_name=challenger_name or "",
+                faction_slug=challenger_faction,
+            )
+    return opponents
+
+
 def _resolve_card_scoring(
     contribution: Optional[Contribution], task_point_value: int, tally_votes_points: int
 ) -> tuple[int, float, int, float]:
@@ -422,6 +544,7 @@ async def build_praxis_card_out(
     applied_metatasks: Optional[dict[int, list[TaskOut]]] = None,
     viewer_can_vote: Optional[dict[int, bool]] = None,
     duel_ids: Optional[dict[int, int]] = None,
+    duel_opponents: Optional[dict[int, DuelOpponent]] = None,
     tallies: Optional[dict[int, VoteTally]] = None,
 ) -> PraxisCardOut:
     """Lightweight card for list views.
@@ -463,6 +586,13 @@ async def build_praxis_card_out(
     the duel lookup is not a per-card query (N+1). When absent, this builder
     loads the single praxis's duel id itself (single-card callers). A missing
     entry means the praxis is not a duel side (``duel_id=None``).
+
+    ``duel_opponents`` maps praxis id → the OTHER side of its duel (#596); list
+    routes precompute it once via :func:`duel_opponents_for` so naming the rival
+    is not a per-card join. When absent, this builder resolves the single
+    praxis's own opponent (single-card callers). A missing entry means there is
+    no opponent to name — either the praxis is not a duel side at all, or its
+    duel is still ``pending`` and nobody has accepted yet.
 
     ``tallies`` maps praxis id → its :class:`~services.vote_tally.VoteTally`;
     list routes precompute it once via :func:`~services.vote_tally.tally_votes`
@@ -525,6 +655,14 @@ async def build_praxis_card_out(
     else:
         praxis_duel_id = (await duel_id_map([praxis], session)).get(praxis.id)
 
+    # The other side of the duel (#596). Reuse the precomputed page-wide map when
+    # the list route supplies it; otherwise resolve this praxis's own. Absent for
+    # a non-duel praxis and for a challenger whose duel is still pending.
+    if duel_opponents is not None:
+        opponent = duel_opponents.get(praxis.id)
+    else:
+        opponent = (await duel_opponents_for([praxis], session)).get(praxis.id)
+
     return PraxisCardOut(
         id=praxis.id,
         task_id=praxis.task_id,
@@ -561,6 +699,9 @@ async def build_praxis_card_out(
             viewer_can_vote.get(praxis.id, True) if viewer_can_vote else True
         ),
         duel_id=praxis_duel_id,
+        opponent_praxis_id=opponent.praxis_id if opponent else None,
+        opponent_display_name=opponent.display_name if opponent else None,
+        opponent_faction_slug=opponent.faction_slug if opponent else None,
     )
 
 
@@ -569,7 +710,7 @@ async def build_praxis_cards(
     session: AsyncSession,
     viewer: Optional[Character],
 ) -> list[PraxisCardOut]:
-    """Enrich a whole page of praxes into cards, seven PAGE-WIDE queries deep.
+    """Enrich a whole page of praxes into cards, eight PAGE-WIDE queries deep.
 
     Every lookup here is deliberately one query for the list rather than one per
     card, and they are listed together so that stays true — an eighth per-card
@@ -611,6 +752,11 @@ async def build_praxis_cards(
     # duel lookup per card. A duel side is stored type='solo' + a non-null
     # duel_id (ADR-0011), so the card mode label/chip gates on this, not type.
     duel_ids = await duel_id_map(praxes, session)
+    # Duel opponents (#596): one three-join query for the whole page — not a join
+    # per card. A duel side's own members list holds only itself (ADR-0011), so
+    # naming the rival needs the Duel row and the other side's author; this is
+    # the only place on a card that reaches across a duel.
+    duel_opponents = await duel_opponents_for(praxes, session)
     # Vote tallies (#1378): one grouped aggregate for the whole page — this was
     # the last per-card query here, a one-element ``tally_votes`` call inside the
     # builder, costing +1 SELECT per row on every list and doubling on each
@@ -626,6 +772,7 @@ async def build_praxis_cards(
             applied_metatasks=applied_metatasks,
             viewer_can_vote=viewer_can_vote,
             duel_ids=duel_ids,
+            duel_opponents=duel_opponents,
             tallies=tallies,
         )
         for praxis in praxes
@@ -639,4 +786,6 @@ __all__ = [
     "build_praxis_cards",
     "build_praxis_out",
     "duel_id_map",
+    "duel_opponents_for",
+    "DuelOpponent",
 ]

--- a/backend/tests/integration/test_duel_opponent_lookup.py
+++ b/backend/tests/integration/test_duel_opponent_lookup.py
@@ -1,0 +1,290 @@
+"""#596 — a duel praxis card names its opponent, without an N+1.
+
+**The seam under test** is :func:`services.praxis_out.duel_opponents_for`: the
+batched other-side lookup that gives a duel side a path to its rival's name.
+A duel is two separate ``Praxis`` rows joined by a ``Duel`` row (ADR-0011), so a
+duel side's own ``members`` holds only its own submitter — there is no path to
+the other side on the praxis row itself.
+
+Three things are pinned here, and they are different kinds of claim:
+
+- **resolution** — a settled duel maps in BOTH directions off one ``Duel`` row,
+  so two rivals adjacent in a feed each name the other.
+- **the pending window** — ``Duel.opponent_praxis_id`` is NULL until the
+  challenge is accepted, so a challenger has nobody to name. The praxis is
+  ABSENT from the map rather than present with a blank name: the card falls back
+  to the duel mode chip alone, which is what shipped before this lookup existed.
+  This is the case the owner ruling called out as the one to get right.
+- **cost** — the whole page costs ONE query, whatever the page size. The ruling
+  was explicit that this must not become an N+1, and this repo has measured
+  ``/tasks`` at ~300 queries a page once (#1371). A count assertion is the only
+  thing that keeps that true, because a per-card version would be invisible at
+  the call site and pass every other test in this file.
+"""
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.duel import Duel, DuelStatus
+from models.era import Era
+from models.praxis import ModerationStatus, Praxis, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from services.praxis_out import duel_opponents_for
+
+
+@contextmanager
+def _count_selects(db_connection):
+    """Collect every SELECT issued on the test connection while the block runs."""
+    selects: list[str] = []
+    sync_connection = db_connection.sync_connection
+
+    def before_cursor_execute(conn, cursor, statement, parameters, context, executemany):
+        if statement.lstrip().upper().startswith("SELECT"):
+            selects.append(statement)
+
+    event.listen(sync_connection, "before_cursor_execute", before_cursor_execute)
+    try:
+        yield selects
+    finally:
+        event.remove(sync_connection, "before_cursor_execute", before_cursor_execute)
+
+
+async def _make_task(db_session: AsyncSession, author: Character) -> Task:
+    task = Task(
+        title="Wheatpaste an original poem on a condemned wall",
+        description="",
+        point_value=10,
+        level_required=1,
+        status=TaskStatus.active,
+        created_by=author.id,
+        # `ua` is the only faction the shared fixtures seed a row for, and the
+        # slug is not what is under test here — the lookup never reads it.
+        primary_faction_slug="ua",
+    )
+    db_session.add(task)
+    await db_session.flush()
+    return task
+
+
+async def _make_praxis(db_session: AsyncSession, task: Task, author: Character) -> Praxis:
+    """A duel side is stored ``type='solo'`` (ADR-0011) — there is no
+    ``type='duel'`` row, which is exactly why the card cannot gate on type."""
+    praxis = Praxis(
+        task_id=task.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        moderation_status=ModerationStatus.visible,
+        created_by_id=author.id,
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+    return praxis
+
+
+@pytest.mark.asyncio
+async def test_settled_duel_maps_both_directions(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    era: Era,
+) -> None:
+    """Each side names the other, off the one Duel row."""
+    task = await _make_task(db_session, character)
+    challenger_praxis = await _make_praxis(db_session, task, character)
+    opponent_praxis = await _make_praxis(db_session, task, character2)
+    db_session.add(
+        Duel(
+            task_id=task.id,
+            challenger_praxis_id=challenger_praxis.id,
+            opponent_character_id=character2.id,
+            opponent_praxis_id=opponent_praxis.id,
+            status=DuelStatus.settled,
+        )
+    )
+    await db_session.flush()
+
+    opponents = await duel_opponents_for(
+        [challenger_praxis, opponent_praxis], db_session
+    )
+
+    assert opponents[challenger_praxis.id].praxis_id == opponent_praxis.id
+    assert opponents[challenger_praxis.id].display_name == character2.display_name
+    assert opponents[challenger_praxis.id].faction_slug == character2.faction_slug
+    assert opponents[opponent_praxis.id].praxis_id == challenger_praxis.id
+    assert opponents[opponent_praxis.id].display_name == character.display_name
+
+
+@pytest.mark.asyncio
+async def test_one_side_on_the_page_still_resolves(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    era: Era,
+) -> None:
+    """The ordinary feed case: only one of the two rivals is on this page."""
+    task = await _make_task(db_session, character)
+    challenger_praxis = await _make_praxis(db_session, task, character)
+    opponent_praxis = await _make_praxis(db_session, task, character2)
+    db_session.add(
+        Duel(
+            task_id=task.id,
+            challenger_praxis_id=challenger_praxis.id,
+            opponent_character_id=character2.id,
+            opponent_praxis_id=opponent_praxis.id,
+            status=DuelStatus.settled,
+        )
+    )
+    await db_session.flush()
+
+    opponents = await duel_opponents_for([challenger_praxis], db_session)
+
+    assert set(opponents) == {challenger_praxis.id}
+    assert opponents[challenger_praxis.id].display_name == character2.display_name
+
+
+@pytest.mark.asyncio
+async def test_pending_duel_names_nobody(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    era: Era,
+) -> None:
+    """THE CASE THE RULING CALLED OUT.
+
+    ``Duel.opponent_praxis_id`` is NULL until the challenge is accepted. The
+    challenged character is knowable — ``opponent_character_id`` is set from the
+    start — but naming someone who has not accepted asserts a contest that does
+    not exist: if they decline, this reverts to an ordinary solo praxis. So the
+    praxis is absent from the map and the card shows the mode chip alone.
+
+    The outer joins in the lookup are what make this an absence rather than a
+    dropped row; an inner join would lose the challenger entirely.
+    """
+    task = await _make_task(db_session, character)
+    challenger_praxis = await _make_praxis(db_session, task, character)
+    db_session.add(
+        Duel(
+            task_id=task.id,
+            challenger_praxis_id=challenger_praxis.id,
+            opponent_character_id=character2.id,
+            opponent_praxis_id=None,
+            status=DuelStatus.pending,
+        )
+    )
+    await db_session.flush()
+
+    opponents = await duel_opponents_for([challenger_praxis], db_session)
+
+    assert challenger_praxis.id not in opponents
+
+
+@pytest.mark.asyncio
+async def test_resolved_duel_still_names_the_opponent(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    era: Era,
+) -> None:
+    """A past duel keeps its rival's name after the era froze it (ADR-0052) —
+    the same status set :func:`services.praxis_out.duel_id_map` uses, so a card
+    that still reads as a duel still says who it was against."""
+    task = await _make_task(db_session, character)
+    challenger_praxis = await _make_praxis(db_session, task, character)
+    opponent_praxis = await _make_praxis(db_session, task, character2)
+    db_session.add(
+        Duel(
+            task_id=task.id,
+            challenger_praxis_id=challenger_praxis.id,
+            opponent_character_id=character2.id,
+            opponent_praxis_id=opponent_praxis.id,
+            status=DuelStatus.resolved,
+        )
+    )
+    await db_session.flush()
+
+    opponents = await duel_opponents_for([challenger_praxis], db_session)
+
+    assert opponents[challenger_praxis.id].display_name == character2.display_name
+
+
+@pytest.mark.asyncio
+async def test_declined_duel_names_nobody(
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    era: Era,
+) -> None:
+    """A declined challenge reverts to a plain solo praxis (ADR-0011), and the
+    Duel row is kept only for history. Excluded from the status set, so the card
+    names nobody — it is not a duel any more."""
+    task = await _make_task(db_session, character)
+    challenger_praxis = await _make_praxis(db_session, task, character)
+    db_session.add(
+        Duel(
+            task_id=task.id,
+            challenger_praxis_id=challenger_praxis.id,
+            opponent_character_id=character2.id,
+            opponent_praxis_id=None,
+            status=DuelStatus.declined,
+        )
+    )
+    await db_session.flush()
+
+    assert await duel_opponents_for([challenger_praxis], db_session) == {}
+
+
+@pytest.mark.asyncio
+async def test_non_duel_praxis_is_absent(
+    db_session: AsyncSession,
+    character: Character,
+    era: Era,
+) -> None:
+    task = await _make_task(db_session, character)
+    solo = await _make_praxis(db_session, task, character)
+
+    assert await duel_opponents_for([solo], db_session) == {}
+
+
+@pytest.mark.asyncio
+async def test_costs_one_query_whatever_the_page_size(
+    db_session: AsyncSession,
+    db_connection,
+    character: Character,
+    character2: Character,
+    era: Era,
+) -> None:
+    """The guard against this re-growing into a per-card join.
+
+    Six duels, twelve sides, one SELECT — and the same one SELECT for a single
+    side. A version that looked up each praxis's opponent individually would
+    pass every other test in this file.
+    """
+    task = await _make_task(db_session, character)
+    sides: list[Praxis] = []
+    for _ in range(6):
+        challenger_praxis = await _make_praxis(db_session, task, character)
+        opponent_praxis = await _make_praxis(db_session, task, character2)
+        db_session.add(
+            Duel(
+                task_id=task.id,
+                challenger_praxis_id=challenger_praxis.id,
+                opponent_character_id=character2.id,
+                opponent_praxis_id=opponent_praxis.id,
+                status=DuelStatus.settled,
+            )
+        )
+        sides.extend([challenger_praxis, opponent_praxis])
+    await db_session.flush()
+
+    with _count_selects(db_connection) as large_page:
+        opponents = await duel_opponents_for(sides, db_session)
+    with _count_selects(db_connection) as small_page:
+        await duel_opponents_for(sides[:1], db_session)
+
+    # Every side resolved — the batch is not trading correctness for the count.
+    assert len(opponents) == len(sides)
+    assert len(large_page) == 1
+    assert len(large_page) == len(small_page)

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -225,6 +225,25 @@ export interface PraxisCardOut {
    * `PraxisOut.duel_id`; precomputed page-wide by the feed route (no N+1).
    */
   duel_id?: number | null
+  /**
+   * The OTHER side of this duel (#596) — who this card is fighting.
+   *
+   * A duel is two separate praxis rows joined by a `Duel` row (ADR-0011), so
+   * `members` on a duel side holds only its own submitter; these three are the
+   * card's only path to the rival's name. Precomputed page-wide by the feed
+   * route (no N+1) via `duel_opponents_for`.
+   *
+   * ALL THREE ARRIVE TOGETHER OR NOT AT ALL, and absent is the ordinary case
+   * twice over: the praxis is not a duel side, or it IS one and the duel is
+   * still `pending` — the opponent praxis does not exist until the challenge is
+   * accepted, so a challenger has nobody to name and the card shows the duel
+   * mode chip alone. Gate the banner on `opponent_display_name`, never on
+   * `type === 'duel'`, which a duel side never has (#992).
+   */
+  opponent_praxis_id?: number | null
+  opponent_display_name?: string | null
+  /** The rival author's member faction; `null` for an unaffiliated author. */
+  opponent_faction_slug?: string | null
 }
 
 export interface PraxisCreate {

--- a/frontend/src/components/praxisCard/__tests__/duelBanner.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/duelBanner.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * #596 — the duel card names its opponent.
+ *
+ * SSR-renders the banner in isolation with the real i18n catalog, so the copy,
+ * the link target and (most of all) the SILENCES are pinned. The three cases
+ * that matter are all cases where the banner draws nothing, because each one is
+ * a different way of having no rival to name and only one of them is "this
+ * isn't a duel".
+ *
+ * The gate under test is `opponent_display_name`, NOT `type === 'duel'` and not
+ * `duel_id`. A duel side is stored `type='solo'` + a non-null `duel_id`
+ * (ADR-0011, #992), so a `type` test would never fire at all; a `duel_id` test
+ * would fire during the pending window, when `Duel.opponent_praxis_id` is still
+ * NULL and there is nobody to print.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { PraxisDuelBanner } from '../shared'
+
+function praxis(overrides: Partial<PraxisCardOut>): PraxisCardOut {
+  return { id: 1, type: 'solo', ...overrides } as PraxisCardOut
+}
+
+/** The banner links, so it needs a router context even under SSR. */
+function render(p: PraxisCardOut): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <PraxisDuelBanner praxis={p} accent="#123456" paper="#ffffff" />
+    </MemoryRouter>,
+  )
+}
+
+const text = (html: string) => html.replace(/<[^>]*>/g, '')
+
+describe('duel banner', () => {
+  it('names the opponent and links to their side', () => {
+    const html = render(
+      praxis({
+        duel_id: 7,
+        opponent_display_name: 'Rax Vandal',
+        opponent_praxis_id: 42,
+        opponent_faction_slug: 'snide',
+      }),
+    )
+    expect(text(html)).toContain('Rax Vandal')
+    expect(text(html)).toContain('vs.')
+    expect(html).toContain('href="/praxis/42"')
+  })
+
+  it('stays silent during the pending window — a duel with no opponent yet', () => {
+    // `duel_id` IS set: this praxis is a duel side. But the challenge has not
+    // been accepted, so `Duel.opponent_praxis_id` is NULL and the wire carries
+    // no name. The mode chip alone is the answer here, which is what shipped
+    // before this banner existed.
+    expect(
+      render(praxis({ duel_id: 7, opponent_display_name: null, opponent_praxis_id: null })),
+    ).toBe('')
+  })
+
+  it('renders nothing on a solo praxis', () => {
+    expect(render(praxis({ duel_id: null }))).toBe('')
+  })
+
+  it('renders nothing on a collab — the roster owns that slot', () => {
+    expect(render(praxis({ type: 'collab', duel_id: null, member_count: 3 }))).toBe('')
+  })
+
+  it('still names the opponent without a link id', () => {
+    // Defensive: an older cached card could carry the name and not the id. A
+    // named rival with no link still says more than the bare chip did.
+    const html = render(
+      praxis({ duel_id: 7, opponent_display_name: 'Rax Vandal', opponent_praxis_id: null }),
+    )
+    expect(text(html)).toContain('Rax Vandal')
+    expect(html).not.toContain('href=')
+  })
+})

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -8,6 +8,7 @@ import {
   PraxisStats,
   PraxisExcerpt,
   PraxisModeChip,
+  PraxisDuelBanner,
   PraxisRoster,
   PraxisMediaGallery,
   PraxisVoteFooter,
@@ -200,6 +201,15 @@ export function PraxisBody({
         fonts={fonts}
       />
       <PraxisModeChip praxis={praxis} fonts={fonts} />
+      {/*
+       * Duel banner (#596) and collab roster are the same slot wearing two
+       * modes, and they are mutually exclusive by construction: the banner
+       * needs an `opponent_display_name` (duel only), the roster needs
+       * `type === 'collab'`. One card can never draw both, so they sit as
+       * siblings rather than behind a ternary that would have to re-derive the
+       * duel test the banner already owns.
+       */}
+      <PraxisDuelBanner praxis={praxis} accent={tint} paper={paper} fonts={fonts} />
       <PraxisRoster praxis={praxis} accent={tint} paper={paper} />
       {/* Every card shows the media slot — a drop target when empty (#821). */}
       <PraxisMediaGallery

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -496,6 +496,93 @@ export function PraxisRoster({
 }
 
 /**
+ * Slot: the duel banner — who this side is fighting (#596).
+ *
+ * ONE SHARED SLOT, NOT NINE TREATMENTS (owner ruling, 2026-08-01). It sits in
+ * the composition where {@link PraxisRoster} sits and is themed the same way —
+ * the frame's own `accent`/`paper` for the avatar, `factionCssVar` off
+ * `task_faction_slug` for the ink — so a faction gets its duel banner from the
+ * archetype it already passes, with no per-archetype edit. The Snide mock in
+ * #596 was reference for tone; it also assumed the rival was findable in
+ * `members`, which the schema never supported.
+ *
+ * NO NEW TOKEN IS MINTED (ADR-0061). The "vs." mark reads in `card-notice`, the
+ * sheet's cautionary ink — the same ink the duel mode chip directly above it
+ * already prints, so the banner reads as that chip's continuation rather than a
+ * second colour language. The rival's NAME takes the frame accent, exactly as a
+ * collaborator's name does in {@link PraxisRoster}.
+ *
+ * SILENT DURING THE PENDING WINDOW. The card names an opponent only when the
+ * wire carries one: `opponent_display_name` is absent both for a non-duel praxis
+ * and for a challenger whose rival has not accepted yet, and in the second case
+ * the mode chip alone is the answer that already shipped. Deliberately gated on
+ * the NAME rather than `isDuelPraxis`: a duel side whose opponent is still
+ * pending IS a duel by `duel_id`, and has nobody to print.
+ */
+export function PraxisDuelBanner({
+  praxis,
+  accent,
+  paper,
+  fonts,
+}: {
+  praxis: PraxisCardOut;
+  accent: string;
+  paper?: string;
+  fonts?: PraxisCardFonts;
+}) {
+  const { t } = useTranslation("praxis");
+  const name = praxis.opponent_display_name;
+  if (!name) return null;
+  const { notice } = sheetInk(praxis.task_faction_slug);
+  // The rival's own praxis, when the payload carries the id. A duel side always
+  // has one once it exists, so the link is the optional half only defensively: a
+  // named opponent with no link still says more than the bare chip did.
+  const rival = (
+    <span
+      className="font-body"
+      style={{ color: accent, fontFamily: fonts?.body, minWidth: 0 }}
+    >
+      {name}
+    </span>
+  );
+  return (
+    <div
+      className="flex items-center flex-wrap"
+      style={{ gap: "var(--space-sm)", marginTop: "var(--space-sm)" }}
+    >
+      <span
+        style={{
+          // A LABEL, not running text — the same tier and tracking the duel mode
+          // chip above it uses, so the two read as one mark.
+          fontSize: "var(--text-sm)",
+          fontFamily: fonts?.display,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: notice,
+          flex: "none",
+        }}
+      >
+        {t("duelBanner.versus")}
+      </span>
+      <RosterAvatar name={name} accent={accent} paper={paper} />
+      <span style={{ fontSize: "var(--text-content)", minWidth: 0 }}>
+        {praxis.opponent_praxis_id != null ? (
+          <Link
+            to={`/praxis/${praxis.opponent_praxis_id}`}
+            className="hover:underline"
+            aria-label={t("duelBanner.readTheirs", { name })}
+          >
+            {rival}
+          </Link>
+        ) : (
+          rival
+        )}
+      </span>
+    </div>
+  );
+}
+
+/**
  * Slot: the mode chip — "Collaboration · {members}" or "Duel", plus a pending
  * marker when a collab's submit window is open. Reuses the shared collaboration
  * copy (`collaborationCard.*`, common ns) the retired CollaborationCard used.

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -243,6 +243,10 @@
       "edited": "amended"
     }
   },
+  "duelBanner": {
+    "versus": "vs.",
+    "readTheirs": "Read {{name}}'s side of the duel"
+  },
   "duelCrossLink": {
     "label": "The duel",
     "readTheirPraxis": "Read their praxis",


### PR DESCRIPTION
Closes #596.

Built to the **owner ruling of 2026-08-01**: one shared, token-themed slot rendered where `PraxisRoster` sits — not nine bespoke treatments. The Snide mock was read as tone, not spec.

## Frontend — one slot, one composition point

`PraxisDuelBanner` lives in shared `praxisCard/shared.tsx` and is composed at the single point in `desktop/shared.tsx`, beside `PraxisModeChip` and `PraxisRoster`. **Zero archetype files changed.** All nine get it: eight compose `PraxisBody` directly and `AlbescentPraxisCard` delegates to `DefaultPraxisCard`.

Banner and roster are mutually exclusive by construction — the banner needs an `opponent_display_name` (duel only), the roster needs `type === 'collab'` — so they sit as siblings rather than behind a ternary that would re-derive the duel test the banner already owns.

## Theming — no token minted (ADR-0061)

Per the ruling's ask to name the accent and justify it: the **"vs." mark reads in `card-notice`**, the sheet's per-faction cautionary ink resolved through `factionCssVar` off `task_faction_slug`. That is not a new token — it is *exactly* the ink the duel mode chip immediately above the banner already prints, so the two read as one continued mark rather than two colour languages. The rival's **name** takes the frame's own `accent`, exactly as a collaborator's name does in `PraxisRoster`, and the avatar reuses `RosterAvatar` with the frame's `accent`/`paper`. Nothing here resolves a colour the roster and chip did not already resolve.

## Backend — one query for the page

`duel_opponents_for` resolves **both** sides in a single statement via aliased joins, so two rivals adjacent in a feed map off the one `Duel` row rather than costing a second pass. It is gathered page-wide in `build_praxis_cards` (now eight page-wide queries, was seven) and handed to the card builder; single-card callers fall back to resolving their own. Same status set as `duel_id_map`, so a `resolved` duel still names who it was against after the era froze it (ADR-0052).

A test asserts **six duels / twelve sides cost the same one SELECT as a single side** — a per-card version would have passed every other test in the file.

## The pending window

`Duel.opponent_praxis_id` is NULL until the challenge is accepted. **The card shows the mode chip alone**, per the ruling — the praxis is simply absent from the map. The challenged character *is* knowable (`opponent_character_id` is set from the start), and that option was deliberately not taken: naming someone who has not accepted asserts a contest that does not exist, and the praxis reverts to an ordinary solo if they decline. The outer joins are what make this an absence rather than a dropped row.

## One divergence from the issue text, resolved in the code's favour

The issue and the ruling both say the new fields are populated "when `type == 'duel'`". **That gate can never fire.** A duel side is stored `type='solo'` + a non-null `duel_id` (ADR-0011), which `#992` already fixed once for the mode chip and which `PraxisCardOut.duel_id`'s own comment states outright. So the wire gates on the resolved duel row, and the banner gates on `opponent_display_name` — which is stricter than `isDuelPraxis` and is what keeps the pending window quiet.

## Verification

- Backend: **1044 passed**, coverage 92.68% (`--cov-fail-under=80`), on a dedicated `wz596_test` DB. Includes `test_praxis_list_query_count.py`, which still shows small and large pages costing the same.
- Frontend, all six CI steps: eslint, `tsc --noEmit`, **3712 tests / 212 files**, `vite build`, byte budget (within: JS 133.7 KB, CSS 22.3 KB), and `typecheck:design-sync`.
- Rebased onto `origin/main` at 28614670 and re-ran everything above.

⚠️ **Visual QA is outstanding** — this environment has no browser or dev stack, so the banner has been verified structurally (SSR markup, link target, silences) but never *seen* on the nine sheets. Worth a look at the duel banner against S.N.I.D.E.'s and Singularity's plates in particular, since those are dark in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)