### PR TITLE
extractError learns the coded-error shape before the backend speaks it

### DIFF
--- a/frontend/src/utils/__tests__/errors.test.ts
+++ b/frontend/src/utils/__tests__/errors.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { extractError } from '../errors'
+
+/**
+ * `extractError` has to read every shape the backend's `detail` field can take.
+ * The coded-object case is the load-bearing one: when the backend starts
+ * emitting `{ code, message }`, a client that only understands strings quietly
+ * falls through to the generic fallback — the player is told "something went
+ * wrong" instead of why, and no test fails, because the fallback is legitimate
+ * behaviour. These cases make that regression loud.
+ */
+
+const axiosError = (status: number, detail?: unknown) => ({
+  message: 'Request failed',
+  response: { status, data: detail === undefined ? {} : { detail } },
+})
+
+const FALLBACK = 'Custom fallback.'
+
+describe('extractError — detail shapes', () => {
+  it('reads a plain string detail', () => {
+    expect(extractError(axiosError(403, 'Task requires level 3'), FALLBACK)).toBe(
+      'Task requires level 3'
+    )
+  })
+
+  it('reads a FastAPI validation array, using the first item', () => {
+    const detail = [
+      { loc: ['body', 'title'], msg: 'Field required', type: 'missing' },
+      { loc: ['body', 'body'], msg: 'String too short', type: 'too_short' },
+    ]
+    expect(extractError(axiosError(422, detail), FALLBACK)).toBe('Field required')
+  })
+
+  it('reads a coded { code, message } object, preferring message', () => {
+    const detail = { code: 'TASK_LEVEL_TOO_LOW', message: 'You need level 3 to claim this task.' }
+    expect(extractError(axiosError(403, detail), FALLBACK)).toBe(
+      'You need level 3 to claim this task.'
+    )
+  })
+
+  it('never shows a bare code to the player', () => {
+    expect(extractError(axiosError(403, { code: 'TASK_LEVEL_TOO_LOW' }), FALLBACK)).toBe(FALLBACK)
+  })
+
+  it('falls back for an unrecognised detail shape', () => {
+    expect(extractError(axiosError(400, 42), FALLBACK)).toBe(FALLBACK)
+    expect(extractError(axiosError(400, {}), FALLBACK)).toBe(FALLBACK)
+    expect(extractError(axiosError(400, []), FALLBACK)).toBe(FALLBACK)
+    expect(extractError(axiosError(400, [{ type: 'missing' }]), FALLBACK)).toBe(FALLBACK)
+    expect(extractError(axiosError(400), FALLBACK)).toBe(FALLBACK)
+  })
+})
+
+describe('extractError — status and network fallbacks', () => {
+  it('skips generic "Internal Server Error" prose in every shape', () => {
+    const serverProse = 'The server ran into an unexpected problem. Try again in a moment.'
+    expect(extractError(axiosError(500, 'Internal Server Error'), FALLBACK)).toBe(serverProse)
+    expect(
+      extractError(axiosError(500, { code: 'UNKNOWN', message: 'Internal Server Error' }), FALLBACK)
+    ).toBe(serverProse)
+  })
+
+  it('reports a 5xx with no detail as a server-side problem', () => {
+    expect(extractError(axiosError(503), FALLBACK)).toBe(
+      'The server ran into an unexpected problem. Try again in a moment.'
+    )
+  })
+
+  it('reports a missing response as a connection failure', () => {
+    expect(extractError({ message: 'Network Error' }, FALLBACK)).toBe(
+      'Unable to reach the server. Check your connection and try again.'
+    )
+    expect(extractError(undefined, FALLBACK)).toBe(
+      'Unable to reach the server. Check your connection and try again.'
+    )
+  })
+
+  it('uses the default fallback when the caller gives none', () => {
+    expect(extractError(axiosError(400))).toBe('Something went wrong. Please try again.')
+  })
+})

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,29 +1,67 @@
 import type { AxiosError } from 'axios'
 
+/** FastAPI validation failures arrive as a list of these. */
+type ValidationDetail = { msg?: string }
+
+/**
+ * A coded backend error: a stable machine-readable `code` plus player-facing
+ * prose in `message`. `message` is what we display; `code` exists so callers
+ * (and, later, an i18n catalog) can branch on the failure without matching prose.
+ */
+type CodedDetail = { code?: string; message?: string }
+
+type ErrorDetail = string | ValidationDetail[] | CodedDetail
+
+/** FastAPI's default 500 body — prose, but useless to a player. */
+const GENERIC_SERVER_PROSE = 'Internal Server Error'
+
+/**
+ * Pulls the displayable prose out of a `detail` body, whatever shape it takes.
+ * Returns null when there is nothing worth showing, so the caller falls through
+ * to its status-based messages.
+ */
+function displayableDetail(detail: ErrorDetail | undefined): string | null {
+  if (!detail) return null
+
+  if (typeof detail === 'string') {
+    return detail === GENERIC_SERVER_PROSE ? null : detail
+  }
+
+  if (Array.isArray(detail)) {
+    return detail[0]?.msg || null
+  }
+
+  // Coded object — `message` carries the prose, `code` is for machines only.
+  // A bare code with no message is not shown; a raw code reads worse to a
+  // player than the caller's fallback does.
+  const message = detail.message
+  if (typeof message !== 'string' || message === GENERIC_SERVER_PROSE) return null
+  return message || null
+}
+
 /**
  * Extracts a user-friendly error message from an axios error.
  *
  * Priority:
- *   1. FastAPI `detail` string from response body (skip generic "Internal Server Error")
- *   2. FastAPI `detail` array (Pydantic validation errors) — uses first item's msg
- *   3. Server error (5xx) with no useful detail — server-side problem message
- *   4. Network error (no response at all) — connection message
- *   5. Caller-provided fallback, or generic default
+ *   1. FastAPI `detail` from the response body (skip generic "Internal Server Error"), as either
+ *      a plain string, a validation array (uses the first item's msg), or a
+ *      coded `{ code, message }` object (uses `message`)
+ *   2. Server error (5xx) with no useful detail — server-side problem message
+ *   3. Network error (no response at all) — connection message
+ *   4. Caller-provided fallback, or generic default
  */
 export function extractError(
   err: unknown,
   fallback = 'Something went wrong. Please try again.'
 ): string {
-  const e = err as AxiosError<{ detail?: string | Array<{ msg: string }> }>
+  const e = err as AxiosError<{ detail?: ErrorDetail }>
 
   const status = e?.response?.status
   const detail = e?.response?.data?.detail
 
-  // Surface meaningful detail strings from the backend (e.g. "Task requires level 3")
-  if (detail) {
-    if (typeof detail === 'string' && detail !== 'Internal Server Error') return detail
-    if (Array.isArray(detail) && detail[0]?.msg) return detail[0].msg
-  }
+  // Surface meaningful detail from the backend (e.g. "Task requires level 3")
+  const message = displayableDetail(detail)
+  if (message) return message
 
   // 5xx with no useful detail — the server hit an unhandled error
   if (status && status >= 500) {


### PR DESCRIPTION
Part of #1401 — the first of the ordering the owner ruled: *"Make `extractError` object-aware FIRST, in its own PR, before any backend change."*

## Why this ships alone

`frontend/src/utils/errors.ts` reads `detail` as `string | Array<{msg}>`. The moment the backend starts emitting `{code, message}`, the `typeof detail === 'string'` branch stops matching and **every converted error falls through to the generic 4xx fallback** — the player is told "something went wrong" instead of "you need level 3" — and **nothing fails**, because the fallback is legitimate behaviour. Landing the client fix first removes that hazard from what will be a large PR.

## What changed

`extractError` now understands a coded `{ code, message }` detail, displaying `message`. String and validation-array paths are untouched in behaviour. A bare `code` with no `message` is *not* shown: a raw machine key reads worse to a player than the caller's fallback, so it falls through.

Shape reading moved into a small `displayableDetail` helper so the three shapes sit in one place and the status/network ladder below stays as it was.

## Strict superset — the proof

This must be a superset of current behaviour; 42 files import `extractError`. The new test file pins all four shapes plus the status and network ladders. Run against `origin/main`'s implementation, **exactly one of the 9 cases fails — the coded-object one** — and the other 8 pass unchanged. That is the superset argument made mechanical rather than asserted.

## Not in this PR (per the owner's ruling)

No `ErrorCode`, no `raise_coded`, no backend change, no `errors.json`, and **no allowlist seed** — that belongs to the first backend PR, seeded with every remaining uncoded raise so "Phase 1 done" is checkable. #1401 stays open.

## Verification

All six CI steps run locally: eslint clean · `tsc --noEmit` clean · `vitest run` 3770 passed (217 files) · `vite build` ok · byte budget within (JS 136.0 KB, CSS 22.3 KB — unchanged) · `typecheck:design-sync` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)