### PR TITLE
The rail's panels fold away and change seats, and the shape follows the account

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,11 +1,18 @@
-import { useState, type CSSProperties } from 'react'
+import { useState, type CSSProperties, type DragEvent, type KeyboardEvent, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../../auth/AuthContext'
 import { relativeTime } from '../../utils/dates'
 import { factionCssVar } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import type { PraxisCardOut } from '../../api/praxis'
 import { useSidebarPanels } from '../../hooks/useSidebarPanels'
+import {
+  SIDEBAR_PANEL_COLLAPSIBLE,
+  useSidebarPanelLayout,
+  type SidebarPanelId,
+} from '../../hooks/useSidebarPanelLayout'
 import { praxisModeLabel } from '../../utils/praxis'
 import { useGameConfig } from '../../hooks/useGameConfig'
 import { useLevelTrack } from '../../hooks/useLevelTrack'
@@ -14,6 +21,19 @@ import { feedKicker, feedItemTitle } from '../feed/feedItemLabels'
 import { normalizeFeedItem } from '../feed/normalizeFeedItem'
 
 const DEFAULT_MAX_TASK_SLOTS = 20
+
+/**
+ * Each reorderable panel's heading key.
+ *
+ * A LOOKUP of whole literal keys, never a `sidebar.${id}.heading` template: a
+ * computed key is invisible to the copy sweep and to the typed `t()`, which is
+ * the same reason `SidebarHandle` writes its four toggle labels out longhand.
+ * Every string here is greppable exactly as it appears in the catalog.
+ */
+const PANEL_HEADING_KEY = {
+  'active-tasks': 'sidebar.activeTasks.heading',
+  'recent-activity': 'sidebar.recentActivity.heading',
+} as const satisfies Record<SidebarPanelId, string>
 
 /**
  * Switch / Edit as REAL controls (#1553). They were bare ~11px caps with no
@@ -71,19 +91,458 @@ const sectionLabel: CSSProperties = {
   color: 'var(--color-text-secondary)',
 }
 
-/** "LABEL ——————" header: eyebrow + a rule that fades out to the right. */
-function SectionHeader({ label }: { label: string }) {
+/** The rule that fades out to the right, in "LABEL ——————". Decorative. */
+function HeaderRule() {
   return (
-    <div className="flex items-center gap-2.5 mb-3.5">
-      <span style={sectionLabel}>{label}</span>
-      <span
-        style={{
-          flex: 1,
-          height: 1,
-          background: 'linear-gradient(90deg, var(--color-border-strong), transparent)',
-        }}
-      />
-    </div>
+    <span
+      aria-hidden="true"
+      style={{
+        flex: 1,
+        height: 1,
+        background: 'linear-gradient(90deg, var(--color-border-strong), transparent)',
+      }}
+    />
+  )
+}
+
+/** Six dots, the conventional "grab me" mark. Inline rather than a font glyph so
+ *  it renders identically everywhere, and `currentColor` so it inherits the
+ *  header's own token instead of naming a colour. */
+function GripMark() {
+  return (
+    <svg width="10" height="16" viewBox="0 0 10 16" aria-hidden="true" focusable="false">
+      <circle cx="2.5" cy="4" r="1.2" fill="currentColor" />
+      <circle cx="7.5" cy="4" r="1.2" fill="currentColor" />
+      <circle cx="2.5" cy="8" r="1.2" fill="currentColor" />
+      <circle cx="7.5" cy="8" r="1.2" fill="currentColor" />
+      <circle cx="2.5" cy="12" r="1.2" fill="currentColor" />
+      <circle cx="7.5" cy="12" r="1.2" fill="currentColor" />
+    </svg>
+  )
+}
+
+/** Reuses the rail's existing glyph rather than introducing a second chevron:
+ *  '›' points right, so a quarter turn down is "open" and no turn is "closed" —
+ *  the design's "rotates −90° when collapsed", read from the open state. */
+const CHEVRON_ROTATION_OPEN = 'rotate(90deg)'
+const CHEVRON_ROTATION_CLOSED = 'rotate(0deg)'
+
+const gripButtonStyle: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  color: 'var(--color-text-tertiary)',
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  cursor: 'grab',
+}
+
+const disclosureButtonStyle: CSSProperties = {
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+  color: 'var(--color-text-secondary)',
+  fontSize: 'var(--text-content)',
+  lineHeight: 1,
+}
+
+interface SidebarPanelProps {
+  readonly id: SidebarPanelId
+  readonly label: string
+  /** 1-based seat, spoken by the grip so a keyboard user hears the move land. */
+  readonly position: number
+  readonly total: number
+  readonly collapsed: boolean
+  readonly onToggleCollapsed: () => void
+  readonly onMoveByStep: (delta: number) => void
+  readonly armed: boolean
+  readonly onArm: (armed: boolean) => void
+  readonly dragging: boolean
+  readonly dropTarget: boolean
+  readonly onDragStart: () => void
+  readonly onDragOverPanel: () => void
+  readonly onDragLeavePanel: () => void
+  readonly onDropPanel: () => void
+  readonly onDragEnd: () => void
+  readonly children: ReactNode
+}
+
+/**
+ * A panel below the character card: its shell, its header row, and the two
+ * gestures the header carries (#1555).
+ *
+ * COLLAPSING HIDES, IT DOES NOT UNMOUNT
+ * -------------------------------------
+ * The body is always rendered and folded away with the `hidden` attribute —
+ * the same instrument, one level down, that `SidebarColumn` uses for the rail
+ * as a whole. #1343 fixed exactly this bug at the rail level: unmounting tore
+ * down the hooks inside, so reopening blinked. `hidden` draws nothing,
+ * contributes no box and takes the subtree out of the accessibility tree, so
+ * "collapsed means gone" holds without costing the reopen.
+ *
+ * WHY THE GRIP IS A BUTTON
+ * ------------------------
+ * Native HTML drag-and-drop is a pointer gesture with no keyboard equivalent,
+ * so a `<div draggable>` would be a control half the site cannot use. The grip
+ * is a real `<button>`: the pointer arms the drag through it, and Arrow Up /
+ * Arrow Down move the panel a seat at a time through the same reorder
+ * primitive. `draggable` is armed by the grip rather than left on permanently
+ * so the panel's own links and text stay selectable and draggable as links.
+ */
+function SidebarPanel({
+  id,
+  label,
+  position,
+  total,
+  collapsed,
+  onToggleCollapsed,
+  onMoveByStep,
+  armed,
+  onArm,
+  dragging,
+  dropTarget,
+  onDragStart,
+  onDragOverPanel,
+  onDragLeavePanel,
+  onDropPanel,
+  onDragEnd,
+  children,
+}: SidebarPanelProps) {
+  const { t } = useTranslation('common')
+  const bodyId = `wz-sidebar-panel-${id}`
+  const collapsible = SIDEBAR_PANEL_COLLAPSIBLE[id]
+
+  function handleGripKeyDown(event: KeyboardEvent<HTMLButtonElement>) {
+    if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      onMoveByStep(-1)
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      onMoveByStep(1)
+    }
+  }
+
+  function handleDragStart(event: DragEvent<HTMLElement>) {
+    // Firefox refuses to start a drag with an empty dataTransfer.
+    event.dataTransfer.setData('text/plain', id)
+    event.dataTransfer.effectAllowed = 'move'
+    onDragStart()
+  }
+
+  function handleDragOver(event: DragEvent<HTMLElement>) {
+    // preventDefault is what marks this element as a valid drop target.
+    event.preventDefault()
+    event.dataTransfer.dropEffect = 'move'
+    onDragOverPanel()
+  }
+
+  function handleDrop(event: DragEvent<HTMLElement>) {
+    event.preventDefault()
+    onDropPanel()
+  }
+
+  return (
+    <section
+      aria-labelledby={`${bodyId}-label`}
+      draggable={armed}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragLeave={onDragLeavePanel}
+      onDrop={handleDrop}
+      onDragEnd={onDragEnd}
+      style={{
+        ...panelStyle,
+        // The drop-target mark: the panel's own hairline, brightened. It is the
+        // border it already has rather than a new outline, so nothing shifts.
+        ...(dropTarget ? { borderColor: 'var(--color-border-strong)' } : null),
+        ...(dragging ? { opacity: 0.5 } : null),
+      }}
+    >
+      <div className="flex items-center gap-2.5 mb-3.5">
+        <button
+          type="button"
+          onPointerDown={() => onArm(true)}
+          onPointerUp={() => onArm(false)}
+          onKeyDown={handleGripKeyDown}
+          aria-label={t('sidebar.panel.reorder', { panel: label, position, total })}
+          title={t('sidebar.panel.reorder', { panel: label, position, total })}
+          aria-keyshortcuts="ArrowUp ArrowDown"
+          className="shrink-0 hover:opacity-80"
+          style={gripButtonStyle}
+        >
+          <GripMark />
+        </button>
+
+        {collapsible ? (
+          <button
+            type="button"
+            onClick={onToggleCollapsed}
+            aria-expanded={!collapsed}
+            aria-controls={bodyId}
+            aria-label={
+              collapsed
+                ? t('sidebar.panel.expand', { panel: label })
+                : t('sidebar.panel.collapse', { panel: label })
+            }
+            className="flex items-center gap-2.5 flex-1 min-w-0 text-left"
+            style={disclosureButtonStyle}
+          >
+            <span id={`${bodyId}-label`} className="truncate" style={sectionLabel}>
+              {label}
+            </span>
+            <HeaderRule />
+            <span
+              aria-hidden="true"
+              className="shrink-0"
+              style={{
+                display: 'inline-block',
+                transform: collapsed ? CHEVRON_ROTATION_CLOSED : CHEVRON_ROTATION_OPEN,
+                transition: 'transform 160ms ease',
+              }}
+            >
+              ›
+            </span>
+          </button>
+        ) : (
+          // Reorderable but not collapsible — the owner ruling's asymmetry. No
+          // disclosure control at all rather than a disabled one.
+          <div className="flex items-center gap-2.5 flex-1 min-w-0">
+            <span id={`${bodyId}-label`} className="truncate" style={sectionLabel}>
+              {label}
+            </span>
+            <HeaderRule />
+          </div>
+        )}
+      </div>
+
+      <div id={bodyId} hidden={collapsed}>
+        {children}
+      </div>
+    </section>
+  )
+}
+
+/** The "In progress tasks" panel's body — everything the header does not own.
+ *  A component of its own since #1555, because the panel is now rendered from an
+ *  ORDER rather than from its position in this file's source. */
+function ActiveTasksBody({
+  activeTasks,
+  maxTaskSlots,
+}: {
+  readonly activeTasks: PraxisCardOut[]
+  readonly maxTaskSlots: number
+}) {
+  const { t } = useTranslation('common')
+  const slotCount = activeTasks.length
+  const slotPercent = Math.min((slotCount / maxTaskSlots) * 100, 100)
+
+  return (
+    <>
+      {activeTasks.length === 0 ? (
+        <p className="font-body content-text" style={{ color: 'var(--color-text-tertiary)' }}>
+          {t('sidebar.activeTasks.empty')}
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {activeTasks.map((praxis) => (
+            <div key={praxis.id} className="flex items-start justify-between gap-3">
+              <Link
+                to={`/praxis/${praxis.id}/edit`}
+                className="font-display min-w-0"
+                style={{ fontSize: 'var(--text-content)', lineHeight: 1.25, color: 'var(--color-text-primary)', textDecoration: 'none' }}
+              >
+                {praxis.task_title}
+              </Link>
+              <span
+                className="shrink-0"
+                style={{
+                  fontFamily: 'var(--font-body)',
+                  fontSize: 'var(--text-sm)',
+                  letterSpacing: '0.16em',
+                  textTransform: 'uppercase',
+                  color: 'var(--faction-default-card-muted)',
+                  padding: 'var(--space-xs) var(--space-sm)',
+                  border: '1px solid var(--color-border-strong)',
+                  borderRadius: 999,
+                }}
+              >
+                {praxisModeLabel(praxis, t)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Slot-usage progress bar — a STATIC window onto one track-wide rainbow
+          (#1128). The spectrum belongs to the TRACK, not to the fill: at 1 of 5
+          slots you see red→orange, at 5 of 5 the whole rainbow, and a visible
+          stop is the same physical width at every fill level. Nothing animates,
+          so there is no motion left for prefers-reduced-motion to gate — which
+          also retires the old drift's un-gated `background-size: 200%`, a
+          permanently half-drawn spectrum for anyone who reduced motion. */}
+      <div className="mt-4">
+        <div className="overflow-hidden" style={{ height: 6, borderRadius: 999, background: 'var(--color-bg-surface-alt)' }}>
+          <div
+            style={{
+              height: '100%',
+              width: `${slotPercent}%`,
+              borderRadius: 999,
+              /* --faction-default-rainbow is the 90deg ramp that runs red 0% →
+                 magenta 100%: exactly ONE pass of the spectrum, which is what a
+                 window wants. Deliberately not -rainbow-loop (eight stops, back
+                 to red at 100% — cut to TILE under a travelling
+                 background-position, and it would seat a second red at the
+                 track's far end), not -rainbow-conic (angular), not
+                 -rainbow-vertical (180deg, for a tall thin rule) and not
+                 -ring (hard wedges). With no repeat and no motion the ramp's
+                 red↔magenta seam never comes into view. */
+              backgroundImage: 'var(--faction-default-rainbow)',
+              backgroundRepeat: 'no-repeat',
+              /* Scale the gradient up by however much the fill is shrunk, so a
+                 fifth-width fill reveals the first fifth of one rainbow rather
+                 than squeezing all seven stops into a fifth of the bar.
+                 A PERCENTAGE is correct here, and this is not the px span
+                 DefaultVote's docstring (#842) argues for: that widget has
+                 five separate dot elements, so a percentage gave each dot its own
+                 restarted ramp. This is ONE fill, so the percentage resolves
+                 against it alone — fill = slotPercent% × track, therefore
+                 backgroundSize = (100/slotPercent)% × fill = track, exactly.
+                 Omitted at zero slots, where the ratio is Infinity (invalid CSS);
+                 the fill is 0%-wide there, so nothing is visible either way. */
+              ...(slotPercent > 0 ? { backgroundSize: `${(100 / slotPercent) * 100}% 100%` } : null),
+              transition: 'width 300ms, background-size 300ms',
+            }}
+          />
+        </div>
+        <p
+          className="font-body text-right"
+          style={{ fontSize: 'var(--text-base)', letterSpacing: '0.08em', color: 'var(--color-text-secondary)', marginTop: 'var(--space-sm)' }}
+        >
+          {t('sidebar.activeTasks.slots', { count: slotCount, max: maxTaskSlots })}
+        </p>
+      </div>
+    </>
+  )
+}
+
+/** The "Recent activity" panel's body. See `ActiveTasksBody` for why it is its
+ *  own component. */
+function RecentActivityBody({ recentActivity }: { readonly recentActivity: ActivityFeedItem[] }) {
+  const { t } = useTranslation('common')
+
+  return (
+    <>
+      {recentActivity.length === 0 ? (
+        <p className="font-body content-text" style={{ color: 'var(--color-text-tertiary)' }}>
+          {t('sidebar.recentActivity.empty')}
+        </p>
+      ) : (
+        <div className="flex flex-col">
+          {recentActivity.map((item, index) => {
+            const isLast = index === recentActivity.length - 1
+            // The SAME vocabulary `/updates` draws its cards from — `feedKicker`
+            // names all fifteen types and `normalizeFeedItem` unpacks the
+            // eleven the faction chassis owns into actor / action / headline /
+            // points. The panel used to hand-roll a two-branch kicker over the
+            // only two types it could ever see; now that it sees eleven, a
+            // second private vocabulary here would be eleven ways to disagree
+            // with the page this panel links to.
+            const row = normalizeFeedItem(item)
+            // `era_announcement` is the one live type the chassis does not own
+            // (epic #1192 decision 6), so `row` is null for it and the shared
+            // title helper answers instead. `friend_defection` has no headline
+            // at all — its substance IS the sentence — so the action line is
+            // the fallback before the title helper.
+            const headline = row?.headline ?? row?.action ?? feedItemTitle(item)
+            const href = row?.headlineHref ?? null
+            const kicker = item.actor_display_name
+              ? `${feedKicker(item.type)} · ${item.actor_display_name}`
+              : feedKicker(item.type)
+            const titleStyle: CSSProperties = {
+              fontSize: 'var(--text-content)',
+              lineHeight: 1.3,
+              color: 'var(--color-text-primary)',
+              textDecoration: 'none',
+            }
+            return (
+              <div
+                key={item.item_key}
+                className="flex gap-3"
+                style={{
+                  padding: 'var(--space-md) 0',
+                  borderBottom: isLast ? undefined : '1px solid var(--color-border)',
+                }}
+              >
+                {/* rainbow bullet — sampled from the default spectrum by position */}
+                <span
+                  className="shrink-0"
+                  style={{
+                    width: 6,
+                    height: 6,
+                    marginTop: 'var(--space-xs)',
+                    borderRadius: 2,
+                    background: 'var(--faction-default-rainbow)',
+                    backgroundSize: '600% 100%',
+                    backgroundPosition: `${index * 20}% 0`,
+                  }}
+                />
+                <div className="min-w-0">
+                  <div
+                    className="truncate"
+                    style={{
+                      fontFamily: 'var(--font-body)',
+                      fontSize: 'var(--text-sm)',
+                      letterSpacing: '0.18em',
+                      textTransform: 'uppercase',
+                      color: 'var(--color-text-secondary)',
+                      marginBottom: 'var(--space-xs)',
+                    }}
+                  >
+                    {kicker}
+                  </div>
+                  {href ? (
+                    <Link to={href} className="font-display block truncate" style={titleStyle}>
+                      {headline}
+                    </Link>
+                  ) : (
+                    <div className="font-display truncate" style={titleStyle}>
+                      {headline}
+                    </div>
+                  )}
+                  <div className="font-body" style={{ marginTop: 'var(--space-xs)', fontSize: 'var(--text-base)', color: 'var(--color-text-tertiary)' }}>
+                    {relativeTime(item.timestamp)}
+                    {row?.points ? ` · ${row.points}` : ''}
+                  </div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+
+      {/* The panel is a WINDOW onto the feed, never a replacement for it: it
+          shows five items and has no paging, no archive gesture and no type
+          facet. `/updates` has all three, so the foot of the panel is a door
+          to it — and it is drawn even when the panel is empty, because "no
+          activity yet" is exactly when a player most needs telling that the
+          full feed exists somewhere. */}
+      <div className="mt-3">
+        <Link
+          to="/updates"
+          className="font-body hover:opacity-80"
+          style={{
+            fontSize: 'var(--text-base)',
+            letterSpacing: '0.16em',
+            textTransform: 'uppercase',
+            color: 'var(--color-text-secondary)',
+            textDecoration: 'none',
+          }}
+        >
+          {t('sidebar.recentActivity.seeMore')}
+        </Link>
+      </div>
+    </>
   )
 }
 
@@ -118,12 +577,48 @@ function SectionHeader({ label }: { label: string }) {
  * The response no longer carries the request items at all (#1456) — only
  * `pending_requests_count`, read by the collapsed handle's badge
  * (`SidebarColumn`), the mobile bell (`MobileHeader`) and the mobile FieldDesk.
+ *
+ * THE PANELS BELOW THE CARD ARE THE PLAYER'S TO ARRANGE (#1555)
+ * -------------------------------------------------------------
+ * Everything under the character card is rendered from an ORDER, not from
+ * source position, and each of those panels can be dragged to a new seat or
+ * moved with the arrow keys from its grip. The two long ones fold away as well.
+ * The character card is pinned above all of it and carries neither gesture:
+ * it is the answer to "who am I playing", which has no useful second position
+ * and nothing worth hiding.
+ *
+ * The shape persists per ACCOUNT (`useSidebarPanelLayout`), never per
+ * character — a rail that rearranged itself as you switched lives would read as
+ * a bug rather than as your own preference.
+ *
+ * Note what does NOT appear in the order: pending requests. The rail stopped
+ * listing them at #1423 (ADR-0070) and the count lives on the handle, so there
+ * is no requests panel here to seat. The ruling that it would be reorderable
+ * but never collapsible is carried by `SIDEBAR_PANEL_COLLAPSIBLE`, which is a
+ * per-panel flag for that reason.
  */
 export default function Sidebar() {
   const { t } = useTranslation('common')
   const { user } = useAuth()
   const character = user?.character
   const [switcherOpen, setSwitcherOpen] = useState(false)
+  const { order, isCollapsed, toggleCollapsed, movePanelOnto, movePanelByStep } =
+    useSidebarPanelLayout(user?.account_id ?? null)
+
+  // Transient drag bookkeeping — the design's `dragKey` / `overKey`. It is
+  // deliberately NOT in the layout hook: nothing about a drag in flight is worth
+  // persisting, and a re-render per pointer move should not touch storage.
+  // `armedId` is the third: `draggable` is switched on only while the pointer is
+  // on that panel's grip, so the panel's own links stay ordinary links.
+  const [armedId, setArmedId] = useState<SidebarPanelId | null>(null)
+  const [draggingId, setDraggingId] = useState<SidebarPanelId | null>(null)
+  const [dropTargetId, setDropTargetId] = useState<SidebarPanelId | null>(null)
+
+  function endDrag() {
+    setArmedId(null)
+    setDraggingId(null)
+    setDropTargetId(null)
+  }
 
   const {
     // The wire field is still named `global_activity`, but since #1556 it
@@ -136,9 +631,15 @@ export default function Sidebar() {
   const track = useLevelTrack(character?.level ?? 0, character?.score ?? 0)
 
   const maxTaskSlots = gameConfig?.max_task_signups ?? DEFAULT_MAX_TASK_SLOTS
-  const slotCount = activeTasks.length
-  const slotPercent = Math.min((slotCount / maxTaskSlots) * 100, 100)
   const eraName = user?.era_name ?? ''
+
+  // Built for EVERY panel on every render, collapsed or not. That is the point:
+  // a collapsed panel is hidden, never unmounted (#1343), so its body is here
+  // waiting rather than being rebuilt when the player opens it again.
+  const panelBodies: Record<SidebarPanelId, ReactNode> = {
+    'active-tasks': <ActiveTasksBody activeTasks={activeTasks} maxTaskSlots={maxTaskSlots} />,
+    'recent-activity': <RecentActivityBody recentActivity={recentActivity} />,
+  }
 
   return (
     // `id` is the target of the fold-away handle's `aria-controls` (#1191).
@@ -307,209 +808,38 @@ export default function Sidebar() {
         </section>
       )}
 
-      {/* ── In Progress Panel ── */}
-      <section style={panelStyle}>
-        <SectionHeader label={t('sidebar.activeTasks.heading')} />
+      {/* ── The panels the player arranges ──
+          Rendered from `order`, and KEYED BY PANEL ID: React then moves the
+          existing DOM node into its new seat instead of rebuilding it, which is
+          what keeps focus on the grip a keyboard user just pressed an arrow on
+          — and what stops a reorder re-mounting a panel it must not unmount. */}
+      {order.map((id, index) => (
+        <SidebarPanel
+          key={id}
+          id={id}
+          label={t(PANEL_HEADING_KEY[id])}
+          position={index + 1}
+          total={order.length}
+          collapsed={isCollapsed(id)}
+          onToggleCollapsed={() => toggleCollapsed(id)}
+          onMoveByStep={(delta) => movePanelByStep(id, delta)}
+          armed={armedId === id}
+          onArm={(next) => setArmedId(next ? id : null)}
+          dragging={draggingId === id}
+          dropTarget={draggingId !== null && draggingId !== id && dropTargetId === id}
+          onDragStart={() => setDraggingId(id)}
+          onDragOverPanel={() => setDropTargetId(id)}
+          onDragLeavePanel={() => setDropTargetId((previous) => (previous === id ? null : previous))}
+          onDropPanel={() => {
+            if (draggingId !== null && draggingId !== id) movePanelOnto(draggingId, id)
+            endDrag()
+          }}
+          onDragEnd={endDrag}
+        >
+          {panelBodies[id]}
+        </SidebarPanel>
+      ))}
 
-        {activeTasks.length === 0 ? (
-          <p className="font-body content-text" style={{ color: 'var(--color-text-tertiary)' }}>
-            {t('sidebar.activeTasks.empty')}
-          </p>
-        ) : (
-          <div className="flex flex-col gap-3">
-            {activeTasks.map((praxis) => (
-              <div key={praxis.id} className="flex items-start justify-between gap-3">
-                <Link
-                  to={`/praxis/${praxis.id}/edit`}
-                  className="font-display min-w-0"
-                  style={{ fontSize: 'var(--text-content)', lineHeight: 1.25, color: 'var(--color-text-primary)', textDecoration: 'none' }}
-                >
-                  {praxis.task_title}
-                </Link>
-                <span
-                  className="shrink-0"
-                  style={{
-                    fontFamily: 'var(--font-body)',
-                    fontSize: 'var(--text-sm)',
-                    letterSpacing: '0.16em',
-                    textTransform: 'uppercase',
-                    color: 'var(--faction-default-card-muted)',
-                    padding: 'var(--space-xs) var(--space-sm)',
-                    border: '1px solid var(--color-border-strong)',
-                    borderRadius: 999,
-                  }}
-                >
-                  {praxisModeLabel(praxis, t)}
-                </span>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {/* Slot-usage progress bar — a STATIC window onto one track-wide rainbow
-            (#1128). The spectrum belongs to the TRACK, not to the fill: at 1 of 5
-            slots you see red→orange, at 5 of 5 the whole rainbow, and a visible
-            stop is the same physical width at every fill level. Nothing animates,
-            so there is no motion left for prefers-reduced-motion to gate — which
-            also retires the old drift's un-gated `background-size: 200%`, a
-            permanently half-drawn spectrum for anyone who reduced motion. */}
-        <div className="mt-4">
-          <div className="overflow-hidden" style={{ height: 6, borderRadius: 999, background: 'var(--color-bg-surface-alt)' }}>
-            <div
-              style={{
-                height: '100%',
-                width: `${slotPercent}%`,
-                borderRadius: 999,
-                /* --faction-default-rainbow is the 90deg ramp that runs red 0% →
-                   magenta 100%: exactly ONE pass of the spectrum, which is what a
-                   window wants. Deliberately not -rainbow-loop (eight stops, back
-                   to red at 100% — cut to TILE under a travelling
-                   background-position, and it would seat a second red at the
-                   track's far end), not -rainbow-conic (angular), not
-                   -rainbow-vertical (180deg, for a tall thin rule) and not
-                   -ring (hard wedges). With no repeat and no motion the ramp's
-                   red↔magenta seam never comes into view. */
-                backgroundImage: 'var(--faction-default-rainbow)',
-                backgroundRepeat: 'no-repeat',
-                /* Scale the gradient up by however much the fill is shrunk, so a
-                   fifth-width fill reveals the first fifth of one rainbow rather
-                   than squeezing all seven stops into a fifth of the bar.
-                   A PERCENTAGE is correct here, and this is not the px span
-                   DefaultVote's docstring (#842) argues for: that widget has
-                   five separate dot elements, so a percentage gave each dot its own
-                   restarted ramp. This is ONE fill, so the percentage resolves
-                   against it alone — fill = slotPercent% × track, therefore
-                   backgroundSize = (100/slotPercent)% × fill = track, exactly.
-                   Omitted at zero slots, where the ratio is Infinity (invalid CSS);
-                   the fill is 0%-wide there, so nothing is visible either way. */
-                ...(slotPercent > 0 ? { backgroundSize: `${(100 / slotPercent) * 100}% 100%` } : null),
-                transition: 'width 300ms, background-size 300ms',
-              }}
-            />
-          </div>
-          <p
-            className="font-body text-right"
-            style={{ fontSize: 'var(--text-base)', letterSpacing: '0.08em', color: 'var(--color-text-secondary)', marginTop: 'var(--space-sm)' }}
-          >
-            {t('sidebar.activeTasks.slots', { count: slotCount, max: maxTaskSlots })}
-          </p>
-        </div>
-      </section>
-
-      {/* ── Recent Activity Panel ── */}
-      <section style={panelStyle}>
-        <SectionHeader label={t('sidebar.recentActivity.heading')} />
-
-        {recentActivity.length === 0 ? (
-          <p className="font-body content-text" style={{ color: 'var(--color-text-tertiary)' }}>
-            {t('sidebar.recentActivity.empty')}
-          </p>
-        ) : (
-          <div className="flex flex-col">
-            {recentActivity.map((item, index) => {
-              const isLast = index === recentActivity.length - 1
-              // The SAME vocabulary `/updates` draws its cards from — `feedKicker`
-              // names all fifteen types and `normalizeFeedItem` unpacks the
-              // eleven the faction chassis owns into actor / action / headline /
-              // points. The panel used to hand-roll a two-branch kicker over the
-              // only two types it could ever see; now that it sees eleven, a
-              // second private vocabulary here would be eleven ways to disagree
-              // with the page this panel links to.
-              const row = normalizeFeedItem(item)
-              // `era_announcement` is the one live type the chassis does not own
-              // (epic #1192 decision 6), so `row` is null for it and the shared
-              // title helper answers instead. `friend_defection` has no headline
-              // at all — its substance IS the sentence — so the action line is
-              // the fallback before the title helper.
-              const headline = row?.headline ?? row?.action ?? feedItemTitle(item)
-              const href = row?.headlineHref ?? null
-              const kicker = item.actor_display_name
-                ? `${feedKicker(item.type)} · ${item.actor_display_name}`
-                : feedKicker(item.type)
-              const titleStyle: CSSProperties = {
-                fontSize: 'var(--text-content)',
-                lineHeight: 1.3,
-                color: 'var(--color-text-primary)',
-                textDecoration: 'none',
-              }
-              return (
-                <div
-                  key={item.item_key}
-                  className="flex gap-3"
-                  style={{
-                    padding: 'var(--space-md) 0',
-                    borderBottom: isLast ? undefined : '1px solid var(--color-border)',
-                  }}
-                >
-                  {/* rainbow bullet — sampled from the default spectrum by position */}
-                  <span
-                    className="shrink-0"
-                    style={{
-                      width: 6,
-                      height: 6,
-                      marginTop: 'var(--space-xs)',
-                      borderRadius: 2,
-                      background: 'var(--faction-default-rainbow)',
-                      backgroundSize: '600% 100%',
-                      backgroundPosition: `${index * 20}% 0`,
-                    }}
-                  />
-                  <div className="min-w-0">
-                    <div
-                      className="truncate"
-                      style={{
-                        fontFamily: 'var(--font-body)',
-                        fontSize: 'var(--text-sm)',
-                        letterSpacing: '0.18em',
-                        textTransform: 'uppercase',
-                        color: 'var(--color-text-secondary)',
-                        marginBottom: 'var(--space-xs)',
-                      }}
-                    >
-                      {kicker}
-                    </div>
-                    {href ? (
-                      <Link to={href} className="font-display block truncate" style={titleStyle}>
-                        {headline}
-                      </Link>
-                    ) : (
-                      <div className="font-display truncate" style={titleStyle}>
-                        {headline}
-                      </div>
-                    )}
-                    <div className="font-body" style={{ marginTop: 'var(--space-xs)', fontSize: 'var(--text-base)', color: 'var(--color-text-tertiary)' }}>
-                      {relativeTime(item.timestamp)}
-                      {row?.points ? ` · ${row.points}` : ''}
-                    </div>
-                  </div>
-                </div>
-              )
-            })}
-          </div>
-        )}
-
-        {/* The panel is a WINDOW onto the feed, never a replacement for it: it
-            shows five items and has no paging, no archive gesture and no type
-            facet. `/updates` has all three, so the foot of the panel is a door
-            to it — and it is drawn even when the panel is empty, because "no
-            activity yet" is exactly when a player most needs telling that the
-            full feed exists somewhere. */}
-        <div className="mt-3">
-          <Link
-            to="/updates"
-            className="font-body hover:opacity-80"
-            style={{
-              fontSize: 'var(--text-base)',
-              letterSpacing: '0.16em',
-              textTransform: 'uppercase',
-              color: 'var(--color-text-secondary)',
-              textDecoration: 'none',
-            }}
-          >
-            {t('sidebar.recentActivity.seeMore')}
-          </Link>
-        </div>
-      </section>
     </aside>
   )
 }

--- a/frontend/src/components/layout/__tests__/sidebarPanelLayout.test.tsx
+++ b/frontend/src/components/layout/__tests__/sidebarPanelLayout.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * #1555 — what the rail RENDERS for a given shape.
+ *
+ * The harness has no DOM, no events and no `localStorage`, so the hook's own
+ * decisions are pinned pure next door (`hooks/__tests__/useSidebarPanelLayout`).
+ * What is left for this file is the half a resolver test cannot see: the markup
+ * each state produces. The hook is mocked so a state can be CHOSEN — under
+ * `renderToStaticMarkup` the real one would read no storage and always answer
+ * with the default rail, so every case below would be the same case.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import type { CurrentUser } from '../../../api/auth'
+import type { SidebarPanelId } from '../../../hooks/useSidebarPanelLayout'
+
+const panelsMock = vi.fn()
+vi.mock('../../../hooks/useSidebarPanels', () => ({
+  useSidebarPanels: () => panelsMock(),
+}))
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: { account_id: 11, character: null } as unknown as CurrentUser }),
+}))
+vi.mock('../../../hooks/useGameConfig', () => ({
+  useGameConfig: () => null,
+}))
+
+const layoutMock = vi.fn()
+vi.mock('../../../hooks/useSidebarPanelLayout', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../hooks/useSidebarPanelLayout')>()
+  return { ...actual, useSidebarPanelLayout: () => layoutMock() }
+})
+
+import Sidebar from '../Sidebar'
+
+const IN_PROGRESS = i18n.t('common:sidebar.activeTasks.heading')
+const RECENT_ACTIVITY = i18n.t('common:sidebar.recentActivity.heading')
+
+function render(
+  order: SidebarPanelId[] = ['active-tasks', 'recent-activity'],
+  collapsed: SidebarPanelId[] = [],
+): string {
+  layoutMock.mockReturnValue({
+    order,
+    isCollapsed: (id: SidebarPanelId) => collapsed.includes(id),
+    toggleCollapsed: vi.fn(),
+    movePanelOnto: vi.fn(),
+    movePanelByStep: vi.fn(),
+  })
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={['/']}>
+      <Sidebar />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  panelsMock.mockReturnValue({
+    pending_requests_count: 0,
+    global_activity: [],
+    active_praxes: [],
+    refetch: vi.fn(),
+    loading: false,
+  })
+})
+
+describe('the order the panels are drawn in', () => {
+  it('follows the stored order, not source position', () => {
+    const defaultOrder = render()
+    expect(defaultOrder.indexOf(IN_PROGRESS)).toBeLessThan(defaultOrder.indexOf(RECENT_ACTIVITY))
+
+    const swapped = render(['recent-activity', 'active-tasks'])
+    expect(swapped.indexOf(RECENT_ACTIVITY)).toBeLessThan(swapped.indexOf(IN_PROGRESS))
+  })
+})
+
+describe('the collapse control', () => {
+  it('is a real button that says whether its panel is open', () => {
+    const html = render()
+    expect(html).toContain(
+      `aria-expanded="true" aria-controls="wz-sidebar-panel-active-tasks" aria-label="${i18n.t('common:sidebar.panel.collapse', { panel: IN_PROGRESS })}"`,
+    )
+  })
+
+  it('flips aria-expanded and the label when the panel is folded', () => {
+    const html = render(['active-tasks', 'recent-activity'], ['active-tasks'])
+    expect(html).toContain('aria-expanded="false"')
+    expect(html).toContain(i18n.t('common:sidebar.panel.expand', { panel: IN_PROGRESS }))
+    // The other panel is untouched — collapsing is per panel.
+    expect(html).toContain(i18n.t('common:sidebar.panel.collapse', { panel: RECENT_ACTIVITY }))
+  })
+
+  /**
+   * THE #1343 CONSTRAINT, one level down. Unmounting the rail made reopening it
+   * refetch and blink; collapsing a PANEL must not reintroduce that. The proof
+   * is that the folded panel's body is still in the markup, behind `hidden`.
+   */
+  it('hides the body rather than unmounting it', () => {
+    const html = render(['active-tasks', 'recent-activity'], ['active-tasks'])
+    expect(html).toContain('id="wz-sidebar-panel-active-tasks" hidden')
+    // Still rendered: the empty-state copy the panel's body owns.
+    expect(html).toContain(i18n.t('common:sidebar.activeTasks.empty'))
+  })
+
+  it('leaves the body unhidden when the panel is open', () => {
+    const html = render()
+    expect(html).toContain('id="wz-sidebar-panel-active-tasks"')
+    expect(html).not.toContain('id="wz-sidebar-panel-active-tasks" hidden')
+  })
+})
+
+describe('the reorder grip', () => {
+  it('gives every panel below the card a keyboard-reachable handle', () => {
+    const html = render()
+    expect(html).toContain(
+      i18n.t('common:sidebar.panel.reorder', { panel: IN_PROGRESS, position: 1, total: 2 }),
+    )
+    expect(html).toContain(
+      i18n.t('common:sidebar.panel.reorder', { panel: RECENT_ACTIVITY, position: 2, total: 2 }),
+    )
+    // Reordering that only works with a mouse is not done: the grip announces
+    // the keys that move it.
+    expect(html).toContain('aria-keyshortcuts="ArrowUp ArrowDown"')
+  })
+
+  it('speaks the seat a panel currently sits in', () => {
+    const html = render(['recent-activity', 'active-tasks'])
+    expect(html).toContain(
+      i18n.t('common:sidebar.panel.reorder', { panel: RECENT_ACTIVITY, position: 1, total: 2 }),
+    )
+  })
+})
+
+describe('the character card', () => {
+  it('is pinned above the order, with neither gesture', () => {
+    panelsMock.mockReturnValue({
+      pending_requests_count: 0,
+      global_activity: [],
+      active_praxes: [],
+      refetch: vi.fn(),
+      loading: false,
+    })
+    const html = render()
+    // It is the first thing in the rail and it is not one of the seats: only
+    // the two ordered panels carry a grip, so there are exactly two.
+    const grips = html.match(/aria-keyshortcuts="ArrowUp ArrowDown"/g) ?? []
+    expect(grips).toHaveLength(2)
+    // The signed-out placeholder card renders before the first panel.
+    expect(html.indexOf(i18n.t('common:sidebar.characterCard.noCharacter'))).toBeLessThan(
+      html.indexOf(IN_PROGRESS),
+    )
+  })
+})

--- a/frontend/src/hooks/__tests__/useSidebarPanelLayout.test.ts
+++ b/frontend/src/hooks/__tests__/useSidebarPanelLayout.test.ts
@@ -1,0 +1,151 @@
+/**
+ * #1555 — the rail's shape below the character card: what collapses, what
+ * moves, and where the answer is remembered.
+ *
+ * The repo's frontend harness is `renderToStaticMarkup` in a node env: no jsdom,
+ * no DOM events, no `localStorage`, and effects never run. So neither the drag
+ * nor the round trip through storage can be exercised here. What CAN be pinned
+ * is every decision the hook makes, extracted pure — exactly as
+ * `resolveInitialCollapsed` is in `useSidebarCollapsed`.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_PANEL_LAYOUT,
+  DEFAULT_PANEL_ORDER,
+  SIDEBAR_PANEL_COLLAPSIBLE,
+  SIDEBAR_PANEL_LAYOUT_STORAGE_KEY,
+  movePanelBy,
+  movePanelTo,
+  resolveInitialPanelLayout,
+  serializePanelLayout,
+  sidebarPanelLayoutStorageKey,
+  type SidebarPanelId,
+} from '../useSidebarPanelLayout'
+
+describe('the storage key', () => {
+  // Owner ruling, 2026-08-02: the rail is chrome, not part of the character. A
+  // player with several lives gets ONE rail shape, so the id in the key is the
+  // account's — a character id here would be the bug the ruling names.
+  it('carries the account id, never a character id', () => {
+    expect(sidebarPanelLayoutStorageKey(7)).toBe(`${SIDEBAR_PANEL_LAYOUT_STORAGE_KEY}:7`)
+    expect(sidebarPanelLayoutStorageKey(8)).not.toBe(sidebarPanelLayoutStorageKey(7))
+  })
+
+  it('falls back to the bare key when no account is known', () => {
+    expect(sidebarPanelLayoutStorageKey(null)).toBe(SIDEBAR_PANEL_LAYOUT_STORAGE_KEY)
+    expect(sidebarPanelLayoutStorageKey(undefined)).toBe(SIDEBAR_PANEL_LAYOUT_STORAGE_KEY)
+  })
+})
+
+describe('which panels may be folded away', () => {
+  // The asymmetry the owner ruled: reordering is pure gain and goes everywhere
+  // below the card; collapsing can swallow an obligation, so it is granted per
+  // panel. This is a flag rather than a blanket `true` precisely so a panel that
+  // must never be hideable can exist.
+  it('is a per-panel decision, not a property of being below the card', () => {
+    expect(Object.keys(SIDEBAR_PANEL_COLLAPSIBLE).sort()).toEqual([...DEFAULT_PANEL_ORDER].sort())
+  })
+
+  it('grants it to the two long panels', () => {
+    expect(SIDEBAR_PANEL_COLLAPSIBLE['active-tasks']).toBe(true)
+    expect(SIDEBAR_PANEL_COLLAPSIBLE['recent-activity']).toBe(true)
+  })
+})
+
+describe('resolveInitialPanelLayout', () => {
+  it('gives a player who has never touched the rail the default shape', () => {
+    expect(resolveInitialPanelLayout(null)).toEqual(DEFAULT_PANEL_LAYOUT)
+    expect(resolveInitialPanelLayout('')).toEqual(DEFAULT_PANEL_LAYOUT)
+  })
+
+  it('honours a stored order and a stored collapse', () => {
+    const stored = serializePanelLayout({
+      order: ['recent-activity', 'active-tasks'],
+      collapsed: ['active-tasks'],
+    })
+    expect(resolveInitialPanelLayout(stored)).toEqual({
+      order: ['recent-activity', 'active-tasks'],
+      collapsed: ['active-tasks'],
+    })
+  })
+
+  it('falls back to the default rail on junk rather than rendering nothing', () => {
+    expect(resolveInitialPanelLayout('chartreuse')).toEqual(DEFAULT_PANEL_LAYOUT)
+    expect(resolveInitialPanelLayout('[]')).toEqual(DEFAULT_PANEL_LAYOUT)
+    expect(resolveInitialPanelLayout('null')).toEqual(DEFAULT_PANEL_LAYOUT)
+    expect(resolveInitialPanelLayout('{"order":"recent-activity"}')).toEqual(DEFAULT_PANEL_LAYOUT)
+  })
+
+  it('drops an id this build no longer has', () => {
+    const stored = '{"order":["pending-requests","recent-activity","active-tasks"]}'
+    expect(resolveInitialPanelLayout(stored).order).toEqual(['recent-activity', 'active-tasks'])
+  })
+
+  it('drops a duplicate rather than drawing a panel twice', () => {
+    const stored = '{"order":["active-tasks","active-tasks","recent-activity"]}'
+    expect(resolveInitialPanelLayout(stored).order).toEqual(['active-tasks', 'recent-activity'])
+  })
+
+  // The one that matters when a panel SHIPS: a stored order written before it
+  // existed must not hide it from every player who ever dragged anything.
+  it('appends a panel the stored order predates', () => {
+    const stored = '{"order":["recent-activity"]}'
+    expect(resolveInitialPanelLayout(stored).order).toEqual(['recent-activity', 'active-tasks'])
+  })
+
+  // And the mirror of it: a ruling can take collapsing AWAY from a panel, and
+  // when it does, nobody may be left with that panel folded shut and no control
+  // to open it.
+  it('expands a panel that is no longer collapsible', () => {
+    const notCollapsible = (Object.keys(SIDEBAR_PANEL_COLLAPSIBLE) as SidebarPanelId[]).filter(
+      (id) => !SIDEBAR_PANEL_COLLAPSIBLE[id],
+    )
+    // Today every registered panel collapses, so the guard is exercised through
+    // an id that is not collapsible because it is not a panel at all.
+    expect(notCollapsible).toEqual([])
+    expect(resolveInitialPanelLayout('{"collapsed":["pending-requests"]}').collapsed).toEqual([])
+  })
+
+  it('round-trips through serialize', () => {
+    const layout = { order: ['recent-activity', 'active-tasks'] as SidebarPanelId[], collapsed: ['recent-activity'] as SidebarPanelId[] }
+    expect(resolveInitialPanelLayout(serializePanelLayout(layout))).toEqual(layout)
+  })
+})
+
+describe('movePanelTo', () => {
+  const order: SidebarPanelId[] = ['active-tasks', 'recent-activity']
+
+  it('moves a panel into the target seat', () => {
+    expect(movePanelTo(order, 'recent-activity', 'active-tasks')).toEqual([
+      'recent-activity',
+      'active-tasks',
+    ])
+  })
+
+  it('returns the very same array for a drop on itself — nothing to persist', () => {
+    expect(movePanelTo(order, 'active-tasks', 'active-tasks')).toBe(order)
+  })
+
+  it('returns the very same array when an id is not in the order', () => {
+    expect(movePanelTo(order, 'active-tasks', 'pending-requests' as SidebarPanelId)).toBe(order)
+  })
+})
+
+describe('movePanelBy — the keyboard path', () => {
+  const order: SidebarPanelId[] = ['active-tasks', 'recent-activity']
+
+  it('moves a panel one seat down', () => {
+    expect(movePanelBy(order, 'active-tasks', 1)).toEqual(['recent-activity', 'active-tasks'])
+  })
+
+  it('moves a panel one seat up', () => {
+    expect(movePanelBy(order, 'recent-activity', -1)).toEqual(['recent-activity', 'active-tasks'])
+  })
+
+  // Clamped, not wrapped: arrowing up at the top must do nothing, or a player
+  // holding the key would find the panel teleporting to the far end.
+  it('does nothing at the ends', () => {
+    expect(movePanelBy(order, 'active-tasks', -1)).toBe(order)
+    expect(movePanelBy(order, 'recent-activity', 1)).toBe(order)
+  })
+})

--- a/frontend/src/hooks/useSidebarPanelLayout.ts
+++ b/frontend/src/hooks/useSidebarPanelLayout.ts
@@ -1,0 +1,260 @@
+import { useCallback, useMemo, useState } from 'react'
+
+/**
+ * The shape of the desktop rail below the character card (#1555): which panels
+ * are collapsed, and in what order they sit.
+ *
+ * WHY THIS IS NOT IN `useSidebarPanels`
+ * -------------------------------------
+ * That provider exists to keep the rail's ONE fetch alive independently of what
+ * is displayed (#1344), and it is mounted above the whole shell. Display
+ * preference put in there would make the data owner re-render every consumer —
+ * the mobile bell included — because somebody folded a panel on the desktop.
+ * This is a viewport preference and it lives with the other viewport
+ * preferences: `useSidebarCollapsed`, which follows `useTheme`.
+ *
+ * WHY IT IS KEYED BY ACCOUNT AND NOT BY CHARACTER
+ * -----------------------------------------------
+ * Owner ruling, 2026-08-02: "a player with several lives gets one rail shape,
+ * not one per life. The rail is chrome, not part of the character." Keying by
+ * character would rearrange the rail as you switch lives, which reads as a bug
+ * rather than as a preference. The account id is safe to read here — it is the
+ * viewer's own, from `/auth/me`, and it never leaves localStorage.
+ *
+ * The storage idiom is `useSidebarCollapsed`'s, unchanged: a pure resolver, a
+ * lazy `useState` initializer that wraps the browser read in try/catch (the
+ * repo's tests render with no DOM), and a write on every change.
+ */
+
+/** Panel ids, in the order a player who has never reordered anything sees. */
+export const SIDEBAR_PANEL_IDS = ['active-tasks', 'recent-activity'] as const
+
+export type SidebarPanelId = (typeof SIDEBAR_PANEL_IDS)[number]
+
+export const DEFAULT_PANEL_ORDER: readonly SidebarPanelId[] = SIDEBAR_PANEL_IDS
+
+/**
+ * Which panels may be folded away — the asymmetry the owner ruled on 2026-08-02.
+ *
+ * Reordering is pure gain: it moves a panel, it never hides one, so every panel
+ * below the character card has a grip. Collapsing is the one gesture that can
+ * silently swallow an obligation, so it is granted only to the two LONG panels.
+ * A panel that exists to tell you somebody is waiting on you is not hideable:
+ * letting a player collapse it re-creates by preference the exact hole #1457 was
+ * filed to close. That is why this is a per-panel flag and not `true` for
+ * everything below the card — the rail's pending-requests panel was deleted by
+ * #1423 (ADR-0070), and if anything of that kind ever returns it registers here
+ * with `false` rather than needing the mechanism rewritten.
+ *
+ * The character card is neither collapsible nor reorderable, so it is not a
+ * panel id at all — it is pinned above this list by `Sidebar`.
+ */
+export const SIDEBAR_PANEL_COLLAPSIBLE: Readonly<Record<SidebarPanelId, boolean>> = {
+  'active-tasks': true,
+  'recent-activity': true,
+}
+
+export interface SidebarPanelLayout {
+  readonly order: readonly SidebarPanelId[]
+  readonly collapsed: readonly SidebarPanelId[]
+}
+
+export const DEFAULT_PANEL_LAYOUT: SidebarPanelLayout = {
+  order: DEFAULT_PANEL_ORDER,
+  collapsed: [],
+}
+
+/** Base key; the account id is appended so two accounts on one browser do not
+ *  inherit each other's rail. */
+export const SIDEBAR_PANEL_LAYOUT_STORAGE_KEY = 'wz-sidebar-panels'
+
+/**
+ * The account's storage key. A signed-out or not-yet-known account falls back to
+ * the bare key — the rail only mounts signed in (`ShellContent`), so this is the
+ * DOM-less-render case, not a state a player reaches.
+ */
+export function sidebarPanelLayoutStorageKey(accountId: number | null | undefined): string {
+  return accountId === null || accountId === undefined
+    ? SIDEBAR_PANEL_LAYOUT_STORAGE_KEY
+    : `${SIDEBAR_PANEL_LAYOUT_STORAGE_KEY}:${accountId}`
+}
+
+function isPanelId(value: unknown): value is SidebarPanelId {
+  return typeof value === 'string' && (SIDEBAR_PANEL_IDS as readonly string[]).includes(value)
+}
+
+/** Known ids only, first occurrence wins. */
+function knownIds(value: unknown): SidebarPanelId[] {
+  if (!Array.isArray(value)) return []
+  const seen: SidebarPanelId[] = []
+  for (const entry of value) {
+    if (isPanelId(entry) && !seen.includes(entry)) seen.push(entry)
+  }
+  return seen
+}
+
+/**
+ * Layout resolution, extracted pure so it is testable in the repo's DOM-less
+ * node env — exactly as `resolveInitialCollapsed` and `resolveInitialTheme` are.
+ *
+ * Every failure mode resolves to "as much of the player's choice as still makes
+ * sense", never to a broken rail:
+ *   - junk, non-JSON, or a non-object → the default rail;
+ *   - an id this build no longer has → dropped;
+ *   - an id this build ADDED since the order was stored → appended in default
+ *     order, so shipping a new panel shows it to everyone rather than hiding it
+ *     from every player who has ever dragged anything;
+ *   - a panel stored as collapsed that is not collapsible → expanded, so a
+ *     ruling change can never leave an un-openable panel behind.
+ */
+export function resolveInitialPanelLayout(stored: string | null): SidebarPanelLayout {
+  if (!stored) return DEFAULT_PANEL_LAYOUT
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stored)
+  } catch {
+    return DEFAULT_PANEL_LAYOUT
+  }
+  if (typeof parsed !== 'object' || parsed === null) return DEFAULT_PANEL_LAYOUT
+
+  const record = parsed as { order?: unknown; collapsed?: unknown }
+  const storedOrder = knownIds(record.order)
+  const order = [
+    ...storedOrder,
+    ...DEFAULT_PANEL_ORDER.filter((id) => !storedOrder.includes(id)),
+  ]
+  const storedCollapsed = knownIds(record.collapsed).filter((id) => SIDEBAR_PANEL_COLLAPSIBLE[id])
+  // Normalized to default order so the serialized value is stable regardless of
+  // the order the player collapsed things in.
+  const collapsed = DEFAULT_PANEL_ORDER.filter((id) => storedCollapsed.includes(id))
+
+  return { order, collapsed }
+}
+
+export function serializePanelLayout(layout: SidebarPanelLayout): string {
+  return JSON.stringify({ order: layout.order, collapsed: layout.collapsed })
+}
+
+/**
+ * Move `movedId` to `targetId`'s seat, sliding everything between them along.
+ * The single reorder primitive: the drop handler calls it with the panel under
+ * the pointer, and the keyboard path calls it with the neighbour.
+ *
+ * Unknown ids and a no-op move return the input order unchanged, so a drop on
+ * the panel being dragged costs nothing and writes nothing.
+ */
+export function movePanelTo(
+  order: readonly SidebarPanelId[],
+  movedId: SidebarPanelId,
+  targetId: SidebarPanelId,
+): readonly SidebarPanelId[] {
+  const from = order.indexOf(movedId)
+  const to = order.indexOf(targetId)
+  if (from === -1 || to === -1 || from === to) return order
+  const next = [...order]
+  next.splice(from, 1)
+  next.splice(to, 0, movedId)
+  return next
+}
+
+/**
+ * The keyboard path: one seat up (-1) or down (+1). Reordering that only works
+ * with a mouse is not reordering, so this is the same primitive the drag uses,
+ * addressed by neighbour instead of by pointer. Clamped at both ends — pressing
+ * up on the top panel is a no-op, not a wrap.
+ */
+export function movePanelBy(
+  order: readonly SidebarPanelId[],
+  movedId: SidebarPanelId,
+  delta: number,
+): readonly SidebarPanelId[] {
+  const from = order.indexOf(movedId)
+  if (from === -1) return order
+  const to = from + delta
+  if (to < 0 || to >= order.length) return order
+  return movePanelTo(order, movedId, order[to])
+}
+
+export interface SidebarPanelLayoutState {
+  readonly order: readonly SidebarPanelId[]
+  readonly isCollapsed: (id: SidebarPanelId) => boolean
+  readonly toggleCollapsed: (id: SidebarPanelId) => void
+  /** Drop `movedId` onto `targetId`'s seat. */
+  readonly movePanelOnto: (movedId: SidebarPanelId, targetId: SidebarPanelId) => void
+  /** Keyboard reorder: `delta` of -1 or +1. */
+  readonly movePanelByStep: (movedId: SidebarPanelId, delta: number) => void
+}
+
+export function useSidebarPanelLayout(accountId: number | null | undefined): SidebarPanelLayoutState {
+  // The rail is mounted only inside `ShellContent`'s `Boolean(user)` gate, so
+  // the account id is already known at mount and cannot change without a
+  // sign-out — which unmounts the rail. That is why the key is read once, in the
+  // lazy initializer, with no effect re-reading it later.
+  const storageKey = sidebarPanelLayoutStorageKey(accountId)
+
+  const [layout, setLayout] = useState<SidebarPanelLayout>(() => {
+    try {
+      return resolveInitialPanelLayout(localStorage.getItem(storageKey))
+    } catch {
+      return DEFAULT_PANEL_LAYOUT
+    }
+  })
+
+  const persist = useCallback(
+    (next: SidebarPanelLayout) => {
+      try {
+        localStorage.setItem(storageKey, serializePanelLayout(next))
+      } catch {
+        // A browser refusing storage (private mode, quota) must not cost the
+        // player the gesture itself — the rail still moves for this session.
+      }
+      return next
+    },
+    [storageKey],
+  )
+
+  const toggleCollapsed = useCallback(
+    (id: SidebarPanelId) => {
+      if (!SIDEBAR_PANEL_COLLAPSIBLE[id]) return
+      setLayout((previous) =>
+        persist({
+          ...previous,
+          collapsed: previous.collapsed.includes(id)
+            ? previous.collapsed.filter((entry) => entry !== id)
+            : DEFAULT_PANEL_ORDER.filter((entry) => entry === id || previous.collapsed.includes(entry)),
+        }),
+      )
+    },
+    [persist],
+  )
+
+  const movePanelOnto = useCallback(
+    (movedId: SidebarPanelId, targetId: SidebarPanelId) => {
+      setLayout((previous) => {
+        const order = movePanelTo(previous.order, movedId, targetId)
+        return order === previous.order ? previous : persist({ ...previous, order })
+      })
+    },
+    [persist],
+  )
+
+  const movePanelByStep = useCallback(
+    (movedId: SidebarPanelId, delta: number) => {
+      setLayout((previous) => {
+        const order = movePanelBy(previous.order, movedId, delta)
+        return order === previous.order ? previous : persist({ ...previous, order })
+      })
+    },
+    [persist],
+  )
+
+  const isCollapsed = useCallback(
+    (id: SidebarPanelId) => layout.collapsed.includes(id),
+    [layout.collapsed],
+  )
+
+  return useMemo(
+    () => ({ order: layout.order, isCollapsed, toggleCollapsed, movePanelOnto, movePanelByStep }),
+    [layout.order, isCollapsed, toggleCollapsed, movePanelOnto, movePanelByStep],
+  )
+}

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -344,6 +344,11 @@
       "heading": "Recent activity",
       "empty": "No activity yet",
       "seeMore": "See more"
+    },
+    "panel": {
+      "collapse": "Collapse {{panel}}",
+      "expand": "Expand {{panel}}",
+      "reorder": "Move {{panel}} — {{position}} of {{total}}. Use the up and down arrow keys."
     }
   },
   "imageEdit": {


### PR DESCRIPTION
Closes #1555. Also completes #1309 — its collapse ruling is built here verbatim, so it can be closed as completed when this merges.

## What the rail does now

Everything below the character card is drawn from an **order**, not from its position in `Sidebar.tsx`, and each of those panels carries a grip. The two long panels also fold away. The character card is pinned above all of it and carries neither gesture.

| Panel | Reorder | Collapse |
|---|---|---|
| Character card | no — pinned | no |
| In progress tasks | yes | yes |
| Recent activity | yes | yes |

**Pending Requests does not appear**, because the rail has had no pending-requests panel since #1423 (ADR-0070) — the count lives on the handle and the cards live in the queue on `/updates`. The ruling's row for it is carried structurally instead of being dropped: `SIDEBAR_PANEL_COLLAPSIBLE` is a **per-panel flag**, not a blanket `true` for "below the card", precisely so a panel that must never be hideable can register with `false`. See "One thing the ruling names that the code no longer has" below.

## Persistence — per account

`localStorage`, key `wz-sidebar-panels:<account_id>`. Owner ruling: a player with several lives gets one rail shape, not one per life. The account id is the viewer's own, from `/auth/me`, and never leaves storage.

**`useSidebarCollapsed` needed no re-keying.** The issue brief flagged it as possibly keyed by character; it is not — it is `wz-sidebar-collapsed`, a per-browser viewport preference, and a test already pins that it is "not keyed by character". Untouched.

## Constraints

- **Collapsing hides, it does not unmount.** The body is always rendered and folded with the `hidden` attribute — the same instrument `SidebarColumn` uses for the whole rail after #1343. Pinned by a test that asserts the folded panel's own copy is still in the markup.
- **Nothing went into `useSidebarPanels`.** That provider stays the data owner; display preference lives beside the other viewport preferences.
- **Storage idiom is `useSidebarCollapsed`'s** (which follows `useTheme`): a pure resolver, a lazy `useState` initializer wrapping the browser read in try/catch, a write on change.
- **Headers are real `<button>`s** with `aria-expanded` + `aria-controls`.
- **The drag has a keyboard path.** The grip is a `<button>`; Arrow Up / Arrow Down move the panel a seat through the *same* reorder primitive the drop handler calls, and it announces `aria-keyshortcuts` and its current seat ("Move Recent activity — 2 of 2"). Panels are keyed by id so React moves the DOM node rather than rebuilding it, which is what keeps focus on the grip across a move.

## Resolver hardening

`resolveInitialPanelLayout` is pure and total. Junk / non-JSON / non-object → the default rail. Unknown id → dropped. Duplicate → deduped. **An id the stored order predates → appended**, so shipping a new panel shows it to everyone rather than hiding it from every player who ever dragged anything. A panel stored collapsed that is no longer collapsible → expanded, so a ruling change can never strand an un-openable panel.

## One thing the ruling names that the code no longer has

The 2026-08-02 ruling's table lists **Pending requests** as reorderable-but-not-collapsible. There is no such panel in the rail to seat — #1423 deleted it and `sidebarPendingRequests.test.tsx` pins that it must not come back. Nothing was guessed: the mechanism is generic over a panel registry and the ruling's asymmetry is encoded in that registry, so if a requests panel ever returns it registers with `collapsible: false` and needs no new code. Flagging it because it means reordering ships over **two** seats today, not three.

## Verification

Six-for-six on the frontend CI job, in the worktree: `eslint src`, `tsc --noEmit`, `vitest run` (218 files / 3787 tests), `vite build`, byte budget (JS 137.6 KB, CSS 22.3 KB — within), and `npm run typecheck:design-sync`. No backend change.

## QA outstanding — please read

**I have no browser and no dev stack, so nothing here was exercised by hand.** Specifically unverified:

- **The drag itself.** Native HTML5 DnD, armed by the grip's `pointerdown` so the panel's own links stay ordinary links. Worth checking: that the drag starts at all, that dropping on the other panel swaps them, and whether `dragleave` bubbling from child elements makes the drop-target highlight flicker.
- **The drop-target affordance** is the panel's own hairline brightened to `--color-border-strong`, plus `opacity: 0.5` on the panel being dragged. That may be too quiet — a real weight decision for `frontend-style` if so.
- **The grip mark** is an inline six-dot SVG in `currentColor` at `--color-text-tertiary` (a font glyph would have risked a missing-glyph box). Its size and placement next to the eyebrow are unreviewed.
- **The chevron** reuses the rail's existing `›`, rotated 90° open / 0° closed — the design's "−90° when collapsed" read from the open state. Whether it reads as a disclosure at this size is untested.
- Dark mode is inherited (tokens only, no ternaries), but unlooked-at.

## Files

- `frontend/src/hooks/useSidebarPanelLayout.ts` (new)
- `frontend/src/components/layout/Sidebar.tsx`
- `frontend/src/hooks/__tests__/useSidebarPanelLayout.test.ts` (new)
- `frontend/src/components/layout/__tests__/sidebarPanelLayout.test.tsx` (new)
- `frontend/src/locales/en/common.json` — three new `sidebar.panel.*` keys

`SidebarColumn.tsx` needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
