### PR TITLE
A cached read names its staleness class, and one era stamp outranks them all

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ identity + era-as-ruleset in ADR-0041 / ADR-0042.
 | API routes + auth guards | `backend/routers/` (source files) |
 | Pages, routing, components | `frontend/src/` (source files) |
 | Frontend API clients | `frontend/src/api/` |
+| How stale a cached read may be — which class, why, and the era epoch | ADR-0072; code in `frontend/src/hooks/cachedResource.ts` + `frontend/src/utils/cacheEpoch.ts` |
 | User-facing frontend copy (i18n catalogs) | `frontend/src/locales/en/*.json` — editor guide: `frontend/src/locales/README.md` |
 | Testing approach | `docs/spec/SPEC-testing.md` |
 | Design intent, UX, faction archetypes | `WORLD_ZERO_STYLE.md` |

--- a/docs/adr/0072-a-cached-read-names-its-staleness-class-and-one-epoch-outranks-them-all.md
+++ b/docs/adr/0072-a-cached-read-names-its-staleness-class-and-one-epoch-outranks-them-all.md
@@ -1,0 +1,162 @@
+# ADR-0072 — A cached read names its staleness class, and one epoch outranks them all
+
+**Status:** Accepted
+**Date:** 2026-08-02
+**Relates to:** ADR-0027 (Albescent is a secret society), ADR-0042 (era as
+ruleset), ADR-0070 (an unanswered obligation lives in the queue, never in the
+stream), #1283 (`/game-config` reads no database), #1284 (the shared read-once
+cache), epic #1346 (the refetch family), #1347 (the query-cache spike, closed
+`wontfix`)
+
+## Context
+
+`hooks/cachedResource.ts` applied one number — `CACHE_TTL_MS = 5 * 60 * 1000` —
+to everything it held, and its docstring argued that number as a *staleness
+bound*: five minutes is short enough that an era transition or a visibility flip
+surfaces on the next navigation, long enough that ordinary browsing is free.
+
+The argument was written for two endpoints and is not portable to a third. Two
+things are wrong with leaving it as the module's default.
+
+**It is meaninglessly conservative at one end.** `/game-config` reads no
+database at all; it serialises the `CURRENT_ERA` module constant (#1283). Its
+answer cannot change while the process is running. Re-reading it every five
+minutes cannot discover anything — it is not a cautious bound, it is a bound over
+data that has no staleness.
+
+**It is catastrophically permissive at the other.** Nothing stopped the next
+author from reaching for the same module for pending collab invites or duel
+challenges. A five-minute-old obligation renders a **live Accept button beside a
+request that has already been answered**. That is not lag, it is an actionable
+lie, and since ADR-0070 the Requests queue is the *single* place an obligation
+gets answered — there is no second surface to correct it.
+
+And underneath both: **an era rollover is not a staleness problem at all.**
+There is no push channel, and no number can express *"everything I hold is wrong
+now"*. Picking a TTL short enough to paper over the rollover was the only tool
+the module had, and it is the wrong tool.
+
+## Decision
+
+**Three classes with their own bounds, plus one global epoch that outranks all
+three.** `ttlMs` becomes a required argument of `createResourceCache` /
+`createCachedResource` — there is no default, so adding a cache forces the author
+to name a class.
+
+### Class A — deploy-scoped. `SESSION_TTL_MS`.
+
+`/game-config` and `/factions`.
+
+**The bound is the session, not five minutes.** Not "a long TTL": within one page
+session this data cannot change, because changing it takes a deploy.
+
+`/game-config` is the clean case — a module constant, no database. `/factions`
+does read the database, and the honest reason it still qualifies is a frontend
+one: **the bundle cannot draw a faction it has never heard of.** A new slug needs
+an entry in `utils/factions.ts`, its CSS variables in `index.css` and its copy in
+`locales/en/factions.json`, all of which ship with the deploy. `POST
+/admin/factions` can insert a row at runtime; it cannot make that row renderable.
+
+The exception that matters is not staleness but **viewer scope**: `/factions`
+omits Albescent until the account has been revealed to it (ADR-0027), and joining
+is what reveals it. That is a mutation, so it is answered as one —
+`chooseFaction()` calls `dropAllCaches()`, and so does sign-out, which must not
+hand the departing viewer's directory to whoever signs in next in this tab. A TTL
+short enough to catch the reveal would have defeated the class.
+
+### Class B — social / ambient. `AMBIENT_TTL_MS`, five minutes.
+
+The leaderboard, another player's profile, the global activity feed.
+
+**Minutes are fine; five is defensible.** What breaks if the bound is exceeded: a
+ranking is a few minutes old. Who notices: nobody. None of it is a control the
+viewer is about to act on, and none of it is a claim about the viewer's own
+obligations. Five is the smallest number that keeps ordinary browsing at zero
+requests and caps the worst case near twelve requests/hour/endpoint.
+
+**Nothing is in this class yet.** The leaderboard, profiles and the feed all read
+through `useResource`, which does not cache; every mount is a request. The bound
+exists so that whoever caches them first does not have to re-derive it — and so
+that reaching for five minutes is a decision rather than a habit.
+
+### Class C — obligations. Never TTL'd. Not in this module at all.
+
+Pending collab invites, duel challenges, awaiting submission, and any number the
+viewer just moved.
+
+**Invalidated on mutation, never aged out.** This is what `utils/requestsBus`
+already does, and it is why it survives #1347's closure rather than being folded
+into a general cache: a twelve-line pub-sub that fires on accept, decline,
+submit, unsubmit, leave and delete is not a poor imitation of a cache, it is the
+correct shape for data whose freshness requirement is *zero*.
+
+### The era rollover — a version key, not a bound
+
+Both `/auth/me` and `/game-config` already carry `era_name`. `utils/cacheEpoch`
+remembers the era last seen and, when a response reports a different one, **drops
+the entire cache** and advances a version counter. A request already in flight is
+stamped with the version it was issued under and refuses to write its answer back
+in behind the drop.
+
+This is orthogonal to staleness, which is exactly why the answer is per-resource
+TTLs **plus** one epoch rather than either alone. It makes the rollover correct
+by construction instead of by choosing a number small enough to hide it.
+
+**Verdict on one-global-policy vs. per-resource policies: both, at different
+levels.** Staleness is per resource, because the three classes disagree by orders
+of magnitude and the disagreement is the whole point. Invalidation is global,
+because an era rollover is a statement about all of it at once.
+
+## Consequences
+
+**Good.** `/game-config` and `/factions` cost one request per page session
+instead of one per five-minute window, and the era case they were being re-read
+*for* is now handled by the instrument that can actually express it. A mounted
+component re-reads on a drop instead of sitting on the old era until something
+remounts it. And a new cache cannot be added without naming a class, so the Class
+C mistake this ADR exists to prevent has to be made deliberately.
+
+**Bad — the stamp is coarser than the event.** `era_name` is `EraConfig.name`, a
+deploy-time constant. `PUT /admin/era/reset` opens a **new `Era` row with the
+same name and the same `config_key`**, so a *same-era reset* — the ordinary
+scores-to-zero rollover — does not move the stamp and does not drop the cache.
+
+This is survivable only because of what the cache currently holds: everything a
+same-era reset changes (scores, levels, vote budgets, resolved duels) reaches the
+client through uncached reads. It stops being survivable the moment a Class B
+resource is cached, since a stale leaderboard would then outlive the reset that
+zeroed it. **The honest key is `Era.id`**, which changes on every reset — and
+today it reaches the client only inside an `era_announcement` feed payload, never
+as a per-response stamp. Adding it to `/auth/me` is the follow-up this ADR
+implies; until then, do not cache anything derived from era-scoped stats.
+
+**Bad — an admin faction-status flip is now invisible until reload.** Under the
+old bound it self-healed in five minutes. The trade is accepted on the argument
+above: a faction the bundle cannot style or name is not usefully visible anyway.
+
+**Unverified by the suite.** The repo has no DOM harness (`SPEC-testing.md`), so
+the mechanics are proved against an injected clock and a hand-built epoch, and
+the React wiring — the `onDrop` re-read, the `dropAllCaches()` on sign-out — is
+not exercised end to end by any test.
+
+## Alternatives considered
+
+**Keep one global TTL and shorten it.** Rejected twice over: no number is short
+enough for Class C (the requirement there is zero, not small), and any number at
+all is wasted on Class A. Shortening it also makes the meaningless re-reads of
+`/game-config` more frequent, which is the opposite of the fix.
+
+**Adopt a query cache (react-query) and inherit its policy.** That was #1347, and
+it is closed `wontfix`. This decision never depended on it: the classes and the
+epoch are statements about the *data*, and would have had to be configured into
+any library exactly as they are configured into `cachedResource` here.
+
+**Give Class C a very short TTL — five seconds, say — instead of a bus.**
+Rejected. It converts a correctness property into a probability, and it costs a
+poll on a surface (the Requests queue) whose entire premise under ADR-0070 is
+that it is the one place the answer is given. The mutation is already observed
+locally; there is nothing to discover by asking again.
+
+**Put the era stamp in `localStorage` so it survives a reload.** Rejected as
+solving nothing: the cache lives in module scope, so a reload already discards
+everything the stamp would have invalidated.

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,4 +1,5 @@
 import api from './axios'
+import { noteEraStamp } from '../utils/cacheEpoch'
 
 /** A badge the character currently holds (ADR-0033). Evaluated on read by the
  *  backend; the image is a bundled frontend asset mapped by `key`. */
@@ -60,6 +61,10 @@ export interface CurrentUser {
 
 export async function getMe(): Promise<CurrentUser> {
   const { data } = await api.get<CurrentUser>('/auth/me')
+  // Every signed-in page load gates on this request, which makes it the earliest
+  // and most frequent era stamp the client gets (ADR-0072). A disagreement with
+  // the era already held drops the whole cache.
+  noteEraStamp(data.era_name)
   return data
 }
 

--- a/frontend/src/api/factions.ts
+++ b/frontend/src/api/factions.ts
@@ -1,4 +1,5 @@
 import api from './axios'
+import { dropAllCaches } from '../utils/cacheEpoch'
 
 // Faction name/description prose is no longer backend-emitted (issue #461): the
 // server sends only the slug, and the frozen English words live in the
@@ -39,5 +40,11 @@ export async function getFactionStatus(): Promise<FactionPageOut> {
 
 export async function chooseFaction(factionSlug: string): Promise<FactionOut> {
   const res = await api.post<FactionOut>('/factions/choose', { faction_slug: factionSlug })
+  // `GET /factions` is viewer-scoped: Albescent is omitted until the account has
+  // been revealed to it (ADR-0027), and joining is what reveals it. The
+  // directory is otherwise deploy-scoped and held for the whole session
+  // (ADR-0072), so the reveal has to be answered as the mutation it is — a timer
+  // short enough to catch it would defeat the class.
+  dropAllCaches()
   return res.data
 }

--- a/frontend/src/api/gameConfig.ts
+++ b/frontend/src/api/gameConfig.ts
@@ -1,4 +1,5 @@
 import api from './axios'
+import { noteEraStamp } from '../utils/cacheEpoch'
 
 // Faction name/description prose moved to the factions.json catalog (issue
 // #461); /game-config emits only the slug + numeric rules. Resolve display copy
@@ -40,5 +41,9 @@ export interface GameConfigOut {
 
 export async function getGameConfig(): Promise<GameConfigOut> {
   const { data } = await api.get<GameConfigOut>('/game-config')
+  // The era stamp: if this disagrees with the era the client already saw, every
+  // rule it holds describes the old world. Dropping the whole cache is the only
+  // honest response, and no TTL can express it (ADR-0072).
+  noteEraStamp(data.era_name)
   return data
 }

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import { getMe, logout, type CurrentUser } from '../api/auth'
+import { dropAllCaches } from '../utils/cacheEpoch'
 
 interface AuthState {
   user: CurrentUser | null
@@ -98,6 +99,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null)
     rememberSession(false)
     setLoading(false)
+    // Deploy-scoped is not viewer-scoped: `/factions` hides Albescent from an
+    // account that has not been revealed to it, and a session-lifetime cache
+    // would hand the departing viewer's directory to whoever signs in next in
+    // this tab (ADR-0072).
+    dropAllCaches()
   })
 
   useEffect(() => {

--- a/frontend/src/hooks/__tests__/cachedResource.test.ts
+++ b/frontend/src/hooks/__tests__/cachedResource.test.ts
@@ -1,15 +1,18 @@
 /**
- * #1284 — the one caching policy behind `useGameConfig` and `useFactions`.
+ * #1284 / #1348 — the shared cache behind `useGameConfig` and `useFactions`,
+ * and the per-resource staleness classes it now takes (ADR-0072).
  *
  * Seam: the extracted staleness predicate (`isFresh`) and the React-free cache
- * mechanics (`createResourceCache`). The hook wrapper is a four-line
- * `useState`/`useEffect` over these; the repo has no DOM harness, so the
- * dedupe and the revalidation are proved here, against an injected `now` and a
- * fake system clock — never by waiting.
+ * mechanics (`createResourceCache`). The hook wrapper is a short
+ * `useState`/`useEffect` over these; the repo has no DOM harness, so the dedupe,
+ * the revalidation and the epoch drop are proved here, against an injected `now`
+ * and a fake system clock — never by waiting.
  */
 import { describe, it, expect, vi, afterEach } from 'vitest'
+import { createCacheEpoch } from '../../utils/cacheEpoch'
 import {
-  CACHE_TTL_MS,
+  AMBIENT_TTL_MS,
+  SESSION_TTL_MS,
   createResourceCache,
   isFresh,
 } from '../cachedResource'
@@ -20,27 +23,37 @@ afterEach(() => {
 
 describe('isFresh', () => {
   it('an absent entry is never fresh', () => {
-    expect(isFresh(null, 0)).toBe(false)
+    expect(isFresh(null, 0, AMBIENT_TTL_MS)).toBe(false)
   })
 
-  it('is fresh right up to the TTL and stale at it', () => {
+  it('is fresh right up to the bound and stale at it', () => {
     const entry = { value: 'x', fetchedAt: 1_000 }
-    expect(isFresh(entry, 1_000)).toBe(true)
-    expect(isFresh(entry, 1_000 + CACHE_TTL_MS - 1)).toBe(true)
-    expect(isFresh(entry, 1_000 + CACHE_TTL_MS)).toBe(false)
-    expect(isFresh(entry, 1_000 + CACHE_TTL_MS * 10)).toBe(false)
+    expect(isFresh(entry, 1_000, AMBIENT_TTL_MS)).toBe(true)
+    expect(isFresh(entry, 1_000 + AMBIENT_TTL_MS - 1, AMBIENT_TTL_MS)).toBe(true)
+    expect(isFresh(entry, 1_000 + AMBIENT_TTL_MS, AMBIENT_TTL_MS)).toBe(false)
+    expect(isFresh(entry, 1_000 + AMBIENT_TTL_MS * 10, AMBIENT_TTL_MS)).toBe(false)
   })
 
-  it('the bound is a few minutes, not seconds — long enough that ordinary navigation is free', () => {
-    expect(CACHE_TTL_MS).toBeGreaterThanOrEqual(60_000)
-    expect(CACHE_TTL_MS).toBeLessThanOrEqual(15 * 60_000)
+  it('a session-scoped entry never goes stale — the bound IS the session', () => {
+    const entry = { value: 'x', fetchedAt: 0 }
+    // A player who leaves the tab open for a week. Class A data cannot have
+    // changed underneath them without a deploy, which ends the session anyway.
+    expect(isFresh(entry, 7 * 24 * 60 * 60 * 1000, SESSION_TTL_MS)).toBe(true)
+    expect(isFresh(entry, Number.MAX_SAFE_INTEGER, SESSION_TTL_MS)).toBe(true)
+    // ...but "never stale" must not degrade into "an empty cache is fine".
+    expect(isFresh(null, 0, SESSION_TTL_MS)).toBe(false)
+  })
+
+  it('the ambient bound is a few minutes, not seconds — ordinary navigation stays free', () => {
+    expect(AMBIENT_TTL_MS).toBeGreaterThanOrEqual(60_000)
+    expect(AMBIENT_TTL_MS).toBeLessThanOrEqual(15 * 60_000)
   })
 })
 
 describe('createResourceCache', () => {
   it('dedupes concurrent consumers into ONE request', async () => {
     const fetchFn = vi.fn(() => Promise.resolve(['ua', 'wow']))
-    const cache = createResourceCache(fetchFn)
+    const cache = createResourceCache(fetchFn, AMBIENT_TTL_MS, createCacheEpoch())
 
     // Five call sites mounting in the same paint.
     const results = await Promise.all([
@@ -57,7 +70,7 @@ describe('createResourceCache', () => {
 
   it('serves later mounts from the cache without a second request', async () => {
     const fetchFn = vi.fn(() => Promise.resolve('config'))
-    const cache = createResourceCache(fetchFn)
+    const cache = createResourceCache(fetchFn, AMBIENT_TTL_MS, createCacheEpoch())
 
     await cache.load()
     // A later navigation mounts another consumer.
@@ -67,36 +80,50 @@ describe('createResourceCache', () => {
   })
 
   it('null until settled: peek is null before the first response', () => {
-    const cache = createResourceCache(() => Promise.resolve('config'))
+    const cache = createResourceCache(() => Promise.resolve('config'), AMBIENT_TTL_MS, createCacheEpoch())
     expect(cache.peek()).toBeNull()
   })
 
-  it('goes stale past the TTL and the next load refetches', async () => {
+  it('goes stale past an ambient bound and the next load refetches', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-07-30T12:00:00Z'))
 
-    let era = 'era_1'
-    const fetchFn = vi.fn(() => Promise.resolve(era))
-    const cache = createResourceCache(fetchFn)
+    let ranking = 'first'
+    const fetchFn = vi.fn(() => Promise.resolve(ranking))
+    const cache = createResourceCache(fetchFn, AMBIENT_TTL_MS, createCacheEpoch())
 
     await cache.load()
 
     // A moment before the bound: zero extra requests, still the old value.
-    vi.setSystemTime(Date.now() + CACHE_TTL_MS - 1)
-    era = 'era_2'
-    expect(await cache.load()).toBe('era_1')
+    vi.setSystemTime(Date.now() + AMBIENT_TTL_MS - 1)
+    ranking = 'second'
+    expect(await cache.load()).toBe('first')
     expect(fetchFn).toHaveBeenCalledTimes(1)
 
-    // Past the bound: the era rolled over server-side and the next mount sees
-    // it, with no reload.
+    // Past the bound: the next mount sees the newer ranking, with no reload.
     vi.setSystemTime(Date.now() + 1)
-    expect(await cache.load()).toBe('era_2')
+    expect(await cache.load()).toBe('second')
     expect(fetchFn).toHaveBeenCalledTimes(2)
 
     // ...and the refreshed entry is itself good for another full window.
-    vi.setSystemTime(Date.now() + CACHE_TTL_MS - 1)
-    expect(await cache.load()).toBe('era_2')
+    vi.setSystemTime(Date.now() + AMBIENT_TTL_MS - 1)
+    expect(await cache.load()).toBe('second')
     expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('a session-scoped resource is never re-read on a timer', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-30T12:00:00Z'))
+
+    const fetchFn = vi.fn(() => Promise.resolve('rules'))
+    const cache = createResourceCache(fetchFn, SESSION_TTL_MS, createCacheEpoch())
+
+    await cache.load()
+    // Long past the five minutes this used to cost a request at. `/game-config`
+    // serialises a module constant: re-reading it could only return `rules`.
+    vi.setSystemTime(Date.now() + 24 * 60 * 60 * 1000)
+    expect(await cache.load()).toBe('rules')
+    expect(fetchFn).toHaveBeenCalledTimes(1)
   })
 
   it('a failed fetch resolves null, keeps the last good value, and lets the next mount retry', async () => {
@@ -107,17 +134,103 @@ describe('createResourceCache', () => {
         ? Promise.reject(new Error('offline'))
         : Promise.resolve(`ok-${attempt}`)
     })
-    const cache = createResourceCache(fetchFn)
+    const cache = createResourceCache(fetchFn, AMBIENT_TTL_MS, createCacheEpoch())
 
     expect(await cache.load()).toBe('ok-1')
 
     vi.useFakeTimers()
-    vi.setSystemTime(Date.now() + CACHE_TTL_MS)
+    vi.setSystemTime(Date.now() + AMBIENT_TTL_MS)
     expect(await cache.load()).toBeNull()
     // The stale-but-real value survives a failed revalidation.
     expect(cache.peek()).toBe('ok-1')
 
     expect(await cache.load()).toBe('ok-3')
     expect(fetchFn).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('the epoch drops what no bound could', () => {
+  it('an era rollover re-reads a session-scoped resource that would otherwise never expire', async () => {
+    const epoch = createCacheEpoch()
+    let era = 'TestEra'
+    const fetchFn = vi.fn(() => Promise.resolve(era))
+    const cache = createResourceCache(fetchFn, SESSION_TTL_MS, epoch)
+
+    epoch.noteEraStamp(era)
+    expect(await cache.load()).toBe('TestEra')
+
+    // The rules changed under a tab that, by its own bound, would hold the old
+    // ones until it was closed.
+    era = 'SecondEra'
+    epoch.noteEraStamp('SecondEra')
+
+    expect(cache.peek()).toBeNull()
+    expect(await cache.load()).toBe('SecondEra')
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('a request already in flight when the era turns cannot write the old world back in', async () => {
+    const epoch = createCacheEpoch()
+    let release: (value: string) => void = () => {}
+    const fetchFn = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          release = resolve
+        }),
+    )
+    const cache = createResourceCache(fetchFn, SESSION_TTL_MS, epoch)
+
+    const pending = cache.load()
+    epoch.noteEraStamp('TestEra')
+    epoch.noteEraStamp('SecondEra')
+    release('rules-from-the-old-era')
+
+    // It resolves null rather than seeding the cache, so the next read refetches
+    // instead of inheriting a value the server has already disowned.
+    expect(await pending).toBeNull()
+    expect(cache.peek()).toBeNull()
+  })
+
+  it('a stale response landing late does not steal the replacement request', async () => {
+    const epoch = createCacheEpoch()
+    const releases: ((value: string) => void)[] = []
+    const fetchFn = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          releases.push(resolve)
+        }),
+    )
+    const cache = createResourceCache(fetchFn, SESSION_TTL_MS, epoch)
+
+    void cache.load()
+    epoch.dropAll()
+    const replacement = cache.load()
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+
+    // The pre-drop request lands first. If it cleared the shared in-flight slot
+    // it would leave the replacement unowned and the next mount would fire a
+    // third request for an answer already on its way.
+    releases[0]('old')
+    releases[1]('new')
+    expect(await replacement).toBe('new')
+    void (await cache.load())
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('drops EVERY cache, not only the one whose response noticed', async () => {
+    const epoch = createCacheEpoch()
+    const gameConfig = createResourceCache(() => Promise.resolve('rules'), SESSION_TTL_MS, epoch)
+    const factions = createResourceCache(() => Promise.resolve(['ua']), SESSION_TTL_MS, epoch)
+
+    await gameConfig.load()
+    await factions.load()
+    expect(factions.peek()).toEqual(['ua'])
+
+    // `/auth/me` is what usually reports the new era, and it feeds neither cache.
+    epoch.noteEraStamp('TestEra')
+    epoch.noteEraStamp('SecondEra')
+
+    expect(gameConfig.peek()).toBeNull()
+    expect(factions.peek()).toBeNull()
   })
 })

--- a/frontend/src/hooks/cachedResource.ts
+++ b/frontend/src/hooks/cachedResource.ts
@@ -1,33 +1,75 @@
 import { useEffect, useState } from 'react'
+import { CACHE_EPOCH, type CacheEpoch } from '../utils/cacheEpoch'
 
 /**
- * The one caching policy shared by every app-wide read-once endpoint
- * (`/game-config`, `/factions`). A single implementation rather than a pair of
- * hand-rolled module caches, because two copies drift into two policies — and
- * the second copy would also trip `sonarjs/no-identical-functions`.
+ * The shared machinery behind every app-wide read-once endpoint — one
+ * implementation rather than a hand-rolled module cache per endpoint, because
+ * two copies drift into two policies (and the second copy would also trip
+ * `sonarjs/no-identical-functions`).
  *
- * Policy: module-level entry + a shared in-flight promise, so N consumers
+ * Mechanics: module-level entry + a shared in-flight promise, so N consumers
  * mounting in the same paint cost ONE request; then stale-while-revalidate past
- * {@link CACHE_TTL_MS}. A hard reload always refetches — the cache lives in
- * module scope, not storage.
+ * the bound the caller names. A hard reload always refetches — the cache lives
+ * in module scope, not storage.
+ *
+ * POLICY IS PER RESOURCE, NOT PER MODULE (ADR-0072). There is no default TTL
+ * here on purpose: `ttlMs` is a required argument, so adding a cache forces you
+ * to name which class the data is in. The three classes:
+ *
+ *  - **A — deploy-scoped.** `/game-config`, `/factions`. {@link SESSION_TTL_MS}.
+ *    Not "a long TTL": the data cannot go stale within a session at all, because
+ *    changing it takes a deploy.
+ *  - **B — social / ambient.** Leaderboard, another player's profile, the global
+ *    activity feed. {@link AMBIENT_TTL_MS}. A minute-old ranking harms nobody.
+ *    Nothing in this class is cached yet; the bound is here for when it is.
+ *  - **C — obligations.** Pending collab invites, duel challenges, awaiting
+ *    submission, and any number the viewer just moved. **These do not belong in
+ *    this module at all.** A live Accept button beside an already-answered
+ *    request is not lag, it is an actionable lie, and ADR-0070 makes the
+ *    Requests queue the single place to answer one — there is no second surface
+ *    to correct it. They are invalidated on mutation via `utils/requestsBus`,
+ *    never aged out.
+ *
+ * Orthogonal to all three: the global epoch in `utils/cacheEpoch` drops
+ * everything held here when a response reports a new era. A TTL cannot express
+ * "everything is wrong now"; a version key can.
  */
 
 /**
- * Staleness bound: **5 minutes**.
+ * **Class A — deploy-scoped. The bound is the session.**
  *
- * There is no push channel from the server, so the client cannot be told that
- * the era rolled over or that an admin flipped a faction's visibility; it can
- * only decide when to stop trusting what it holds. Five minutes is the smallest
- * number that keeps ordinary browsing at zero requests — a player crossing
- * /tasks → /factions → a faction page → /praxes does that in well under five
- * minutes, and pays nothing for it — while bounding staleness to something a
- * player would not sit through: an era transition or a visibility flip surfaces
- * on the next navigation after the window closes, without a reload. It also
- * caps the worst case at ~12 requests/hour/endpoint for someone who idles on a
- * page and navigates once every five minutes, against one request per
- * navigation before this existed.
+ * `/game-config` reads no database at all (it serialises the `CURRENT_ERA`
+ * module constant, #1283) and `/factions` is a directory the frontend cannot
+ * render an addition to anyway — a new slug needs an entry in `utils/factions`,
+ * its CSS variables in `index.css` and its copy in `factions.json`, all of which
+ * ship with the bundle. So there is no staleness to bound: within one page
+ * session the answer cannot change.
+ *
+ * What CAN change mid-session is who is asking. `/factions` hides Albescent
+ * until the account is revealed to it (ADR-0027), and joining reveals it. That
+ * is a mutation, so it is answered like one — `chooseFaction()` calls
+ * `dropAllCaches()` — not by aging the whole class out on a timer in the hope of
+ * catching it.
  */
-export const CACHE_TTL_MS = 5 * 60 * 1000
+export const SESSION_TTL_MS = Number.POSITIVE_INFINITY
+
+/**
+ * **Class B — social / ambient. Five minutes.**
+ *
+ * Rankings, other players' profiles, the global feed. What breaks if the bound
+ * is exceeded: a number is a few minutes old. Who notices: nobody — none of it
+ * is a control the viewer is about to act on, and none of it is a claim about
+ * the viewer's own obligations.
+ *
+ * Five is the smallest number that keeps ordinary browsing at zero requests: a
+ * player crossing /tasks → /players → a profile → /praxes does it in well under
+ * five minutes. It also caps the worst case at ~12 requests/hour/endpoint for
+ * someone idling and navigating once per window.
+ *
+ * Do NOT reach for this because it is the familiar number. If the data is an
+ * obligation, no TTL is short enough — see the Class C note above.
+ */
+export const AMBIENT_TTL_MS = 5 * 60 * 1000
 
 export interface CacheEntry<T> {
   readonly value: T
@@ -36,15 +78,11 @@ export interface CacheEntry<T> {
 }
 
 /**
- * The staleness predicate, extracted so the TTL is provable without waiting on
- * a clock: pass an entry and a `now`, get an answer. An absent entry is never
- * fresh.
+ * The staleness predicate, extracted so a bound is provable without waiting on
+ * a clock: pass an entry, a `now` and a bound, get an answer. An absent entry is
+ * never fresh; a `SESSION_TTL_MS` entry always is.
  */
-export function isFresh(
-  entry: CacheEntry<unknown> | null,
-  now: number,
-  ttlMs: number = CACHE_TTL_MS,
-): boolean {
+export function isFresh(entry: CacheEntry<unknown> | null, now: number, ttlMs: number): boolean {
   return entry !== null && now - entry.fetchedAt < ttlMs
 }
 
@@ -57,34 +95,61 @@ export interface ResourceCache<T> {
    * paint cost one round trip.
    */
   load: () => Promise<T | null>
+  /** Forget everything held. The epoch calls this; call sites should not. */
+  drop: () => void
 }
 
 /**
- * The cache itself, with no React in it — exported so the dedupe and the
- * revalidation are testable directly (the repo has no DOM harness, so hooks are
- * tested through their extracted mechanics).
+ * The cache itself, with no React in it — exported so the dedupe, the
+ * revalidation and the epoch drop are testable directly (the repo has no DOM
+ * harness, so hooks are tested through their extracted mechanics).
+ *
+ * `ttlMs` has no default: naming the class is the point (ADR-0072).
  */
-export function createResourceCache<T>(fetchFn: () => Promise<T>): ResourceCache<T> {
+export function createResourceCache<T>(
+  fetchFn: () => Promise<T>,
+  ttlMs: number,
+  epoch: CacheEpoch = CACHE_EPOCH,
+): ResourceCache<T> {
   let entry: CacheEntry<T> | null = null
   let inFlight: Promise<T | null> | null = null
 
+  const drop = (): void => {
+    entry = null
+    inFlight = null
+  }
+  epoch.register(drop)
+
   return {
     peek: () => entry?.value ?? null,
+    drop,
     load: () => {
       // The freshness gate lives HERE, not in the caller: a consumer that
       // forgot to ask would otherwise refetch on every mount, which is the bug
       // this issue is about.
-      if (entry && isFresh(entry, Date.now())) return Promise.resolve(entry.value)
+      if (entry && isFresh(entry, Date.now(), ttlMs)) return Promise.resolve(entry.value)
+      // Stamped at issue time: if the era rolls over while this is in the air,
+      // the answer describes the old world and must not be written back in
+      // behind the drop that just happened.
+      const issuedAtVersion = epoch.version()
+      // Only the settling of the CURRENT generation may clear `inFlight`: a
+      // pre-drop request landing late would otherwise null out the post-drop
+      // request that replaced it, and the next mount would fire a third.
+      const releaseIfCurrent = (): boolean => {
+        const current = epoch.version() === issuedAtVersion
+        if (current) inFlight = null
+        return current
+      }
       inFlight ??= fetchFn()
         .then((value) => {
+          if (!releaseIfCurrent()) return null
           entry = { value, fetchedAt: Date.now() }
-          inFlight = null
           return value
         })
         .catch(() => {
           // Leave the previous entry in place and drop the promise, so the next
           // consumer to mount retries instead of inheriting the failure.
-          inFlight = null
+          releaseIfCurrent()
           return null
         })
       return inFlight
@@ -93,27 +158,38 @@ export function createResourceCache<T>(fetchFn: () => Promise<T>): ResourceCache
 }
 
 /**
- * Build a hook that reads `fetchFn` once per {@link CACHE_TTL_MS} across the
- * whole app.
+ * Build a hook that reads `fetchFn` once per `ttlMs` across the whole app, and
+ * re-reads when the epoch drops.
  *
  * Returns `null` until the first response lands (the null-until-settled
  * contract every call site already codes against). Once a value exists it stays
- * on screen through revalidation — a TTL expiry must not flash an empty page
+ * on screen through revalidation — an expiry must not flash an empty page
  * mid-session.
  */
-export function createCachedResource<T>(fetchFn: () => Promise<T>): () => T | null {
-  const cache = createResourceCache(fetchFn)
+export function createCachedResource<T>(
+  fetchFn: () => Promise<T>,
+  ttlMs: number,
+  epoch: CacheEpoch = CACHE_EPOCH,
+): () => T | null {
+  const cache = createResourceCache(fetchFn, ttlMs, epoch)
 
   return function useCachedResource(): T | null {
     const [value, setValue] = useState<T | null>(cache.peek)
 
     useEffect(() => {
       let cancelled = false
-      void cache.load().then((fetched) => {
-        if (fetched !== null && !cancelled) setValue(fetched)
-      })
+      const read = (): void => {
+        void cache.load().then((fetched) => {
+          if (fetched !== null && !cancelled) setValue(fetched)
+        })
+      }
+      read()
+      // A drop with nobody listening would leave whatever is on screen showing
+      // the old era until the next navigation remounted it.
+      const unsubscribe = epoch.onDrop(read)
       return () => {
         cancelled = true
+        unsubscribe()
       }
     }, [])
 

--- a/frontend/src/hooks/useFactions.ts
+++ b/frontend/src/hooks/useFactions.ts
@@ -1,5 +1,5 @@
 import { getFactions } from '../api/factions'
-import { createCachedResource } from './cachedResource'
+import { createCachedResource, SESSION_TTL_MS } from './cachedResource'
 
 /**
  * The `/factions` directory — the visible faction slugs, app-wide.
@@ -9,9 +9,13 @@ import { createCachedResource } from './cachedResource'
  * `/factions` cost a round trip on **every** SPA navigation (#1284). One
  * request per page load now covers all five.
  *
- * **Staleness bound: 5 minutes** (`CACHE_TTL_MS`) — the same policy, from the
- * same module, as `useGameConfig`. An admin flipping a faction's visibility
- * surfaces on the first navigation after the bound, without a reload.
+ * **Class A — deploy-scoped; the bound is the session** (`SESSION_TTL_MS`,
+ * ADR-0072). The endpoint does read the database, but a faction the bundle has
+ * never heard of cannot be drawn: a new slug needs its `utils/factions` entry,
+ * its CSS variables and its `factions.json` copy, and all three ship with a
+ * deploy. The one thing that changes mid-session is the Albescent reveal, and
+ * that is a mutation the viewer performs — `chooseFaction()` drops the cache —
+ * not something a timer should be relied on to notice.
  *
  * NOT interchangeable with `useGameConfig()?.factions`: `/factions` returns the
  * VISIBLE factions (slug only), while game-config returns every configured
@@ -22,4 +26,4 @@ import { createCachedResource } from './cachedResource'
  * Returns `null` until the first response lands; call sites that want an empty
  * list while it settles do `useFactions() ?? []`.
  */
-export const useFactions = createCachedResource(getFactions)
+export const useFactions = createCachedResource(getFactions, SESSION_TTL_MS)

--- a/frontend/src/hooks/useGameConfig.ts
+++ b/frontend/src/hooks/useGameConfig.ts
@@ -1,5 +1,5 @@
 import { getGameConfig } from '../api/gameConfig'
-import { createCachedResource } from './cachedResource'
+import { createCachedResource, SESSION_TTL_MS } from './cachedResource'
 
 /**
  * Hook to fetch and cache the current era game config.
@@ -8,14 +8,17 @@ import { createCachedResource } from './cachedResource'
  * same paint cost one `/game-config` request, and navigating between pages
  * costs none.
  *
- * **Staleness bound: 5 minutes** (`CACHE_TTL_MS`). The cache used to be
- * written once and never cleared, so an era transition mid-session served stale
- * rules until a reload (#1284). There is no push channel from the server, so
- * the client cannot be told the era rolled over; instead each entry is stamped
- * when it resolves and the first consumer to mount past the bound refetches.
- * The policy lives in `cachedResource.ts` and is shared verbatim with
- * `useFactions` — one cache story, not two.
+ * **Class A — deploy-scoped; the bound is the session** (`SESSION_TTL_MS`,
+ * ADR-0072). This endpoint touches no database at all: it serialises the
+ * `CURRENT_ERA` module constant (#1283), so its answer can only change when the
+ * process restarts. A five-minute bound was not conservative here, it was
+ * meaningless — nothing it re-read could ever differ.
+ *
+ * The era transition that used to be served stale until a reload (#1284) is
+ * still answered, but by the right instrument: `getGameConfig()` reports its
+ * `era_name` to `utils/cacheEpoch`, and a disagreement drops the whole cache.
+ * That is a version key, not a bound — no TTL can say "everything is wrong now".
  *
  * Returns `null` until the first response lands.
  */
-export const useGameConfig = createCachedResource(getGameConfig)
+export const useGameConfig = createCachedResource(getGameConfig, SESSION_TTL_MS)

--- a/frontend/src/utils/__tests__/cacheEpoch.test.ts
+++ b/frontend/src/utils/__tests__/cacheEpoch.test.ts
@@ -1,0 +1,92 @@
+/**
+ * #1348 — the global cache epoch (ADR-0072).
+ *
+ * The epoch is the answer to the one case a TTL cannot express: an era rollover
+ * means *everything held is wrong*, and there is no push channel to say so. The
+ * client watches the `era_name` every `/auth/me` and `/game-config` response
+ * already carries, and drops the whole cache when it disagrees.
+ *
+ * Tested through `createCacheEpoch()` rather than the `CACHE_EPOCH` singleton so
+ * each case starts from a virgin epoch — module state would otherwise carry the
+ * previous test's era into the next one.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { createCacheEpoch } from '../cacheEpoch'
+
+describe('the era stamp', () => {
+  it('the FIRST era seen only records the stamp — there is nothing held to be wrong yet', () => {
+    const epoch = createCacheEpoch()
+    const drop = vi.fn()
+    epoch.register(drop)
+
+    epoch.noteEraStamp('TestEra')
+
+    expect(drop).not.toHaveBeenCalled()
+    expect(epoch.lastSeenEra()).toBe('TestEra')
+    expect(epoch.version()).toBe(0)
+  })
+
+  it('re-reporting the same era is free — this fires on every /auth/me', () => {
+    const epoch = createCacheEpoch()
+    const drop = vi.fn()
+    epoch.register(drop)
+
+    epoch.noteEraStamp('TestEra')
+    epoch.noteEraStamp('TestEra')
+    epoch.noteEraStamp('TestEra')
+
+    expect(drop).not.toHaveBeenCalled()
+    expect(epoch.version()).toBe(0)
+  })
+
+  it('a DIFFERENT era drops every registered cache at once', () => {
+    const epoch = createCacheEpoch()
+    const gameConfig = vi.fn()
+    const factions = vi.fn()
+    epoch.register(gameConfig)
+    epoch.register(factions)
+
+    epoch.noteEraStamp('TestEra')
+    epoch.noteEraStamp('SecondEra')
+
+    // Not "the one that noticed" — the whole cache. That is the point of a
+    // version key over a per-entry bound.
+    expect(gameConfig).toHaveBeenCalledTimes(1)
+    expect(factions).toHaveBeenCalledTimes(1)
+    expect(epoch.lastSeenEra()).toBe('SecondEra')
+  })
+
+  it('advances the version on every drop, so an in-flight request can tell it is stale', () => {
+    const epoch = createCacheEpoch()
+    expect(epoch.version()).toBe(0)
+    epoch.dropAll()
+    expect(epoch.version()).toBe(1)
+    epoch.dropAll()
+    expect(epoch.version()).toBe(2)
+  })
+
+  it('notifies subscribers AFTER the caches are emptied, never before', () => {
+    const epoch = createCacheEpoch()
+    const order: string[] = []
+    epoch.register(() => order.push('drop'))
+    epoch.onDrop(() => order.push('notify'))
+
+    epoch.dropAll()
+
+    // A listener that re-read first would be served the value just invalidated.
+    expect(order).toEqual(['drop', 'notify'])
+  })
+
+  it('unregisters and unsubscribes', () => {
+    const epoch = createCacheEpoch()
+    const drop = vi.fn()
+    const listener = vi.fn()
+    epoch.register(drop)()
+    epoch.onDrop(listener)()
+
+    epoch.dropAll()
+
+    expect(drop).not.toHaveBeenCalled()
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/utils/cacheEpoch.ts
+++ b/frontend/src/utils/cacheEpoch.ts
@@ -1,0 +1,121 @@
+/**
+ * The global cache epoch — a *version* key, orthogonal to staleness (ADR-0072).
+ *
+ * A TTL answers "how old is too old". It cannot answer "everything I hold is
+ * wrong now", which is what an era rollover means: the level thresholds moved,
+ * the scoring modifiers moved, every score reset. There is no push channel from
+ * the server, so the only way the client can be told is by noticing it in a
+ * response it was already going to read.
+ *
+ * Both `/auth/me` and `/game-config` carry `era_name`. The client remembers the
+ * one it last saw and, when a response reports a different one, drops the ENTIRE
+ * cache rather than aging each entry out. That makes the rollover correct by
+ * construction instead of by picking a TTL short enough to paper over it.
+ *
+ * **What this stamp does NOT catch, and why that is survivable today:**
+ * `era_name` is `EraConfig.name` — a module constant. `PUT /admin/era/reset`
+ * opens a new `Era` row with the *same* name and `config_key`, so a same-era
+ * reset is invisible here. It does not need to be caught: everything a same-era
+ * reset changes (scores, levels, vote budgets) reaches the client through
+ * uncached reads. The moment a score-derived resource is put in this cache, this
+ * stamp stops being sufficient and the honest key becomes `Era.id` — which today
+ * reaches the client only inside an `era_announcement` feed payload, never as a
+ * per-response stamp. See ADR-0072, "Consequences".
+ */
+
+/** A cache that can be emptied when the epoch turns over. */
+type Droppable = () => void
+
+export interface CacheEpoch {
+  /**
+   * Enrol a cache. Returns an unregister function; module-level caches never
+   * call it, but a test-built one should.
+   */
+  register: (drop: Droppable) => () => void
+  /**
+   * Feed the era reported by a response. The first era ever seen only records
+   * the stamp — there is nothing held yet to be wrong. Any *later* disagreement
+   * drops everything.
+   */
+  noteEraStamp: (eraName: string) => void
+  /**
+   * Empty every registered cache and advance the version, so a fetch already in
+   * flight cannot write a pre-drop value back in behind it.
+   */
+  dropAll: () => void
+  /** Subscribe to drops, so a mounted consumer re-reads instead of sitting on a
+   *  value the epoch just invalidated. Returns an unsubscribe function. */
+  onDrop: (listener: () => void) => () => void
+  /** The current version. Only meaningful compared against itself. */
+  version: () => number
+  /** The era last reported by a response; `null` before the first one. */
+  lastSeenEra: () => string | null
+}
+
+/**
+ * Build an epoch. The app uses the {@link CACHE_EPOCH} singleton; this factory
+ * exists so the mechanics are testable without module-scope state leaking
+ * between cases (the repo has no DOM harness — see `SPEC-testing.md`).
+ */
+export function createCacheEpoch(): CacheEpoch {
+  const caches = new Set<Droppable>()
+  const listeners = new Set<() => void>()
+  let version = 0
+  let lastSeenEra: string | null = null
+
+  const dropAll = (): void => {
+    version += 1
+    for (const drop of caches) drop()
+    for (const listener of listeners) listener()
+  }
+
+  return {
+    register: (drop) => {
+      caches.add(drop)
+      return () => {
+        caches.delete(drop)
+      }
+    },
+    noteEraStamp: (eraName) => {
+      if (lastSeenEra === eraName) return
+      const rolled = lastSeenEra !== null
+      lastSeenEra = eraName
+      if (rolled) dropAll()
+    },
+    dropAll,
+    onDrop: (listener) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+    version: () => version,
+    lastSeenEra: () => lastSeenEra,
+  }
+}
+
+/** The one epoch every app-wide cache is enrolled in. */
+export const CACHE_EPOCH: CacheEpoch = createCacheEpoch()
+
+/**
+ * Record the era a response just reported.
+ *
+ * Call from every api client whose payload carries `era_name` — `/auth/me` and
+ * `/game-config` today. Cheap and idempotent: the common case is a string
+ * compare against the era already held.
+ */
+export function noteEraStamp(eraName: string): void {
+  CACHE_EPOCH.noteEraStamp(eraName)
+}
+
+/**
+ * Drop every app-wide cache now.
+ *
+ * For the mutations that change what a deploy-scoped endpoint returns *for this
+ * viewer* — joining Albescent reveals a faction that `/factions` was previously
+ * hiding — and for sign-out, which must not leave the next viewer of this tab
+ * holding the last one's directory.
+ */
+export function dropAllCaches(): void {
+  CACHE_EPOCH.dropAll()
+}


### PR DESCRIPTION
Closes #1348.

Per-resource staleness classes plus one global era epoch, exactly as the owner comment ruled — and an ADR so the next cache author finds the *why*.

## What changed

`hooks/cachedResource.ts` no longer has a default TTL. `ttlMs` is a **required** argument of `createResourceCache` / `createCachedResource`, so adding a cache forces the author to name a class. Two constants replace `CACHE_TTL_MS`:

- `SESSION_TTL_MS` (Class A, deploy-scoped) — `useGameConfig`, `useFactions`.
- `AMBIENT_TTL_MS` = 5 min (Class B, social/ambient) — **nothing uses it yet**; see below.
- Class C is documented in the module header as *not belonging in this module at all*. It stays on `utils/requestsBus`.

New `utils/cacheEpoch.ts`: the client remembers the `era_name` it last saw, and any response reporting a different one drops the **entire** cache and advances a version counter. A request already in flight is stamped at issue time and refuses to write a pre-drop answer back in behind the drop. `getMe()` and `getGameConfig()` report the stamp.

The `cachedResource.ts:30` docstring that argued five minutes as a staleness *bound* is gone; so are the "Staleness bound: 5 minutes" claims in `useGameConfig.ts` and `useFactions.ts`.

## Findings that changed the build — please read

**1. `/factions` is not purely deploy-scoped, and a session TTL would have introduced a bug.** `GET /factions` reads the DB *and is viewer-scoped*: it omits Albescent until `account.albescent_revealed` (ADR-0027), which flips on `POST /factions/choose` mid-session. Today's 5-minute TTL self-heals that within five minutes; a session TTL never would. Handled the ruling's own way — as a mutation, not a timer: `chooseFaction()` calls `dropAllCaches()`, and so does sign-out (otherwise the departing viewer's directory is served to whoever signs in next in this tab). Class A membership for `/factions` is kept, on the argument that the bundle cannot draw a faction it has never heard of (`utils/factions.ts` + `index.css` vars + `factions.json` all ship with the deploy), so `POST /admin/factions` can insert a row it cannot make renderable.

**2. The era stamp is coarser than the era event — `era_name` does not move on a reset.** `PUT /admin/era/reset` opens `Era(name=CURRENT_ERA.name, config_key=CURRENT_ERA.config_key, ...)` — a **new row with the same name**. `era_name` in both `/auth/me` and `/game-config` is `EraConfig.name`, a deploy constant. So the stamp catches a *ruleset change* (a deploy repointing `CURRENT_ERA`) but **not a same-era reset**. Built as ruled, because it is sufficient for what the cache holds today — everything a same-era reset changes (scores, levels, vote budgets) reaches the client through uncached reads — and the limit is written into ADR-0072's Consequences in full. The honest key is `Era.id`, which today reaches the client only inside an `era_announcement` feed payload, never as a per-response stamp. Adding it to `/auth/me` is a backend follow-up, deliberately not done here.

**3. Class B is entirely aspirational today.** The leaderboard, other players' profiles and the activity feed all read through `useResource`, which does not cache at all — every mount is a request. `cachedResource` holds exactly two resources, both Class A. `AMBIENT_TTL_MS` is the written-down bound for whoever caches them first, not a live setting.

**4. Path in the issue/brief was wrong.** The file is `frontend/src/hooks/cachedResource.ts`, not `utils/`. `voteOverrides.ts`, cited in the issue body, does not exist anywhere in the repo.

## Docs

- `docs/adr/0072-a-cached-read-names-its-staleness-class-and-one-epoch-outranks-them-all.md` — three classes with reasons, the explicit one-policy-vs-per-resource verdict (staleness per resource, invalidation global), the era answer, four alternatives considered, and both limits above under Consequences.
- CLAUDE.md routing table gains a row pointing at it.

## Verification

All six frontend CI steps run locally, all green: eslint clean, `tsc --noEmit` clean, `vitest run` **3773 passed / 217 files**, `vite build` ok, byte budget ok (JS 136.3 KB, CSS 22.3 KB), `typecheck:design-sync` clean. No backend changes, so no pytest run.

**What is NOT verified.** Per Hazard 6: there is no browser and no DOM harness here. The mechanics are proved against an injected clock and a hand-built epoch (20 new/rewritten tests across `hooks/__tests__/cachedResource.test.ts` and `utils/__tests__/cacheEpoch.test.ts`), but the React wiring — the `onDrop` re-read in `createCachedResource`, and `dropAllCaches()` firing on sign-out and on `chooseFaction()` — is not exercised end to end by any test in this repo.

## File boundary

No call site in `components/layout/Sidebar.tsx`, `pages/FieldDesk.tsx` or `pages/fieldDesk/mobileArchetypes/*` needed to change — the two cached hooks keep their existing signatures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
