### PR TITLE
The pending row learns to say nothing, and both home verbs land narrowed (#1554)

### DIFF
--- a/.design-sync/previews/_state.tsx
+++ b/.design-sync/previews/_state.tsx
@@ -44,9 +44,10 @@ export function fieldDeskState(slug: string): FieldDeskHomeState {
     // The design's worked example: 320 of 500, 180 short of level 5 (#1553).
     levelTrack: { nextLevel: 5, pointsToNext: 180, nextThreshold: 500, fillPercent: 64 },
     activeTasks: praxisCardsFor(slug),
-    pendingCount: 2,
+    // The pending row's obligation state (#1554) — the one worth previewing,
+    // since the other two are the same pill with less in it.
+    pendingRow: { kind: 'requests', count: 2, to: '/updates#requests-queue' },
     loadingTasks: false,
-    canProposeTask: true,
   }
 }
 

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -154,7 +154,10 @@
       "taskMeta": "{{faction}} · +{{points}} pts",
       "pending_one": "{{count}} pending request",
       "pending_other": "{{count}} pending requests",
-      "browseTasks": "Browse Tasks",
+      "notifications": "New updates",
+      "caughtUp": "All caught up",
+      "findTask": "Find a Task",
+      "castVotes": "Cast Your Votes",
       "coven": {
         "charWindow": "you",
         "questsWindow": "quests",

--- a/frontend/src/pages/fieldDesk/PendingRowPill.tsx
+++ b/frontend/src/pages/fieldDesk/PendingRowPill.tsx
@@ -1,0 +1,81 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import type { PendingRowState } from './useFieldDeskHome'
+
+/**
+ * The summary row under the mobile home's identity card, in all three of its
+ * states (#1554).
+ *
+ * WHY THIS IS SHARED WHEN THE EIGHT HOME SKINS ARE NOT
+ * ----------------------------------------------------
+ * Epic #1552 records that the mobile and desktop homes are deliberately
+ * different screens, and each faction keeps its own dress — so the pill's
+ * ground, border, type and chevron glyph stay with the skin and arrive here as
+ * props. What does NOT vary is the rule: which copy, whether the row is a link,
+ * and whether it draws a chevron at all. That rule was previously restated at
+ * eight call sites as `{pendingCount > 0 && <Link …>}`, and the state this issue
+ * adds is precisely the one a restatement gets wrong — a "nothing waiting" row
+ * that still renders as an anchor is a dead end the player will tap.
+ *
+ * So: one component decides `<Link>` vs `<div>`, one decides the chevron, one
+ * resolves the copy; the caller decides how it all looks. `to === null` is the
+ * whole of the third state — no link, no chevron, and none of the tap-highlight
+ * an anchor gets for free on a phone. It is not a disabled control; it is a
+ * sentence, which is why it is still on screen at all rather than hidden per
+ * CLAUDE.md's "hide unusable controls".
+ */
+export default function PendingRowPill({
+  row,
+  className,
+  style,
+  chevron,
+  glyph,
+}: {
+  row: PendingRowState
+  className?: string
+  style?: CSSProperties
+  /** The faction's own chevron — drawn only when the row leads somewhere. */
+  chevron: ReactNode
+  /** Optional faction mark set before the label (Coven's sigil, WOW's spark). */
+  glyph?: ReactNode
+}) {
+  const { t } = useTranslation('common')
+  const label =
+    row.kind === 'requests'
+      ? t('fieldDesk.home.pending', { count: row.count })
+      : row.kind === 'notifications'
+        ? t('fieldDesk.home.notifications')
+        : t('fieldDesk.home.caughtUp')
+
+  const body = (
+    <>
+      <span style={LABEL_STYLE}>
+        {glyph}
+        {label}
+      </span>
+      {row.to !== null && chevron}
+    </>
+  )
+
+  if (row.to === null) {
+    return (
+      <div className={className} style={style}>
+        {body}
+      </div>
+    )
+  }
+  return (
+    <Link to={row.to} className={className} style={style}>
+      {body}
+    </Link>
+  )
+}
+
+/** Inline-flex so a skin that passes a `glyph` gets it set beside the words;
+ *  with no glyph it renders identically to the bare span it replaces. */
+const LABEL_STYLE: CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 'var(--space-sm)',
+}

--- a/frontend/src/pages/fieldDesk/__tests__/homeDestinations.test.ts
+++ b/frontend/src/pages/fieldDesk/__tests__/homeDestinations.test.ts
@@ -1,0 +1,60 @@
+/**
+ * The mobile home's two CTAs land on a NARROWED view (#1554).
+ *
+ * A link that quietly lands unfiltered is this repo's most expensive class of
+ * frontend bug: the page renders, the request 200s, the list is simply the whole
+ * catalogue, and tsc, eslint, the render assertions and CI all pass over it (see
+ * `FEED_PARAMS_SERIALIZER` in `api/activityFeed` for the version of this that
+ * shipped). Asserting `href="/tasks?can_sign_up=1"` in a skin test only proves
+ * the string was typed correctly — it says nothing about whether the destination
+ * reads that key.
+ *
+ * So each URL is fed back through the very reader its page uses, and the axis is
+ * asserted to come out ON. If `TASK_FILTER_PARAMS.canSignUp` or `VOTED_PARAM`
+ * is ever renamed, or `CAN_SIGN_UP_ON` stops being `'1'`, this fails here rather
+ * than turning the home screen's buttons into a plain browse in production.
+ */
+import { describe, it, expect } from 'vitest'
+import { CAST_VOTES_LINK, FIND_TASK_LINK, UPDATES_LINK } from '../homeDestinations'
+import { readTaskFilters } from '../../tasks/useTasks'
+import { readFeedFilters } from '../../praxes/feedFilterParams'
+
+/** Split a same-origin app link into its path and its parsed query. */
+function parse(link: string): { path: string; params: URLSearchParams } {
+  const [path, query = ''] = link.split('?')
+  return { path, params: new URLSearchParams(query) }
+}
+
+describe('the mobile home CTA destinations', () => {
+  it('sends "Find a Task" to the task browse with the eligibility axis on', () => {
+    const { path, params } = parse(FIND_TASK_LINK)
+    expect(path, 'the task browse').toBe('/tasks')
+    expect(readTaskFilters(params).canSignUp, 'can-sign-up axis').toBe(true)
+  })
+
+  it('does not pin a status alongside eligibility', () => {
+    // `can_sign_up` makes the SERVER run its own predicate, which is what lets a
+    // faction ability bend the level bar (the Ephemerists reach retired tasks).
+    // A `status=active` riding along would cancel that silently.
+    const { params } = parse(FIND_TASK_LINK)
+    const filters = readTaskFilters(params)
+    expect(filters.status, 'no status narrowing').toBe('All')
+    expect(filters.factions, 'no faction narrowing').toEqual([])
+  })
+
+  it('sends "Cast Your Votes" to the praxis feed filtered to needs-my-vote', () => {
+    const { path, params } = parse(CAST_VOTES_LINK)
+    expect(path, 'the praxis feed').toBe('/praxis')
+    expect(readFeedFilters(params).voted, 'needs-my-vote axis').toBe('no')
+  })
+
+  it('leaves the era scope alone so the feed keeps its landing narrowing', () => {
+    const { params } = parse(CAST_VOTES_LINK)
+    expect(readFeedFilters(params).eraScope).toBe('this_era')
+  })
+
+  it('sends the notifications row to Updates with no filter on it', () => {
+    expect(UPDATES_LINK).toBe('/updates')
+    expect(UPDATES_LINK).not.toContain('?')
+  })
+})

--- a/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
@@ -7,6 +7,12 @@
  * and the primary actions. Presentation-only — the skins take state, so no
  * hooks or network are involved.
  *
+ * THE PENDING ROW IS A THREE-STATE SLOT (#1554), and every skin has to hold all
+ * three: an obligation, other news, and a caught-up row that keeps its shape and
+ * stops being a link. The third is asserted per skin rather than once on
+ * `PendingRowPill`, because the failure it guards against is a skin quietly
+ * going back to its own `{pendingCount > 0 && <Link …>}`.
+ *
  * THE FACTION WORD AND THE VOTE COUNT ARE NOT SLOTS ANY MORE (#1553). The
  * identity block dropped "Unaffiliated · Level 4" down to "Level 4" (the art
  * already says the faction) and dropped the votes tile outright — a vote count
@@ -23,6 +29,8 @@ import { describe, it, expect } from 'vitest'
 import '../../../i18n'
 import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
+import { CAST_VOTES_LINK, FIND_TASK_LINK, UPDATES_LINK } from '../homeDestinations'
+import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
 import type { CharacterOut } from '../../../api/auth'
 import type { PraxisCardOut } from '../../../api/praxis'
 
@@ -77,9 +85,8 @@ function baseState(overrides: Partial<FieldDeskHomeState> = {}): FieldDeskHomeSt
     eraName: 'Era 3',
     levelTrack: { nextLevel: 5, pointsToNext: 160, nextThreshold: 500, fillPercent: 68 },
     activeTasks: [ACTIVE_TASK],
-    pendingCount: 2,
+    pendingRow: { kind: 'requests', count: 2, to: REQUESTS_QUEUE_LINK },
     loadingTasks: false,
-    canProposeTask: true,
     ...overrides,
   }
 }
@@ -123,17 +130,66 @@ describe('mobile FieldDesk-home content-slot invariant', () => {
       expect(text.toLowerCase(), 'empty-tasks slot').toContain('nothing in progress')
     })
 
-    it(`${slug} renders the primary Browse Tasks action`, () => {
+    /**
+     * #1554: both CTAs land on an ALREADY-NARROWED view. The hrefs are asserted
+     * rather than the labels alone because "Find a Task" pointing at the whole
+     * catalogue renders identically to one that works — see
+     * `homeDestinations.test.ts`, which proves the two query strings actually
+     * turn the axes on at the destination.
+     */
+    it(`${slug} lands its primary action on the tasks it can sign up for`, () => {
       const { html, text } = render(<Skin state={baseState()} />)
-      expect(text.toLowerCase(), 'browse-tasks slot').toContain('browse tasks')
-      expect(html, 'tasks link slot').toContain('href="/tasks"')
+      expect(text.toLowerCase(), 'find-task slot').toContain('find a task')
+      expect(html, 'eligible-tasks link slot').toContain(`href="${FIND_TASK_LINK}"`)
     })
 
-    it(`${slug} shows the propose action only when permitted`, () => {
-      const permitted = render(<Skin state={baseState({ canProposeTask: true })} />)
-      expect(permitted.html, 'propose shown when permitted').toContain('href="/propose-task"')
-      const denied = render(<Skin state={baseState({ canProposeTask: false })} />)
-      expect(denied.html, 'propose hidden when not permitted').not.toContain('href="/propose-task"')
+    it(`${slug} lands its secondary action on praxes awaiting this vote`, () => {
+      const { html, text } = render(<Skin state={baseState()} />)
+      expect(text.toLowerCase(), 'cast-votes slot').toContain('cast your votes')
+      expect(html, 'needs-my-vote link slot').toContain(`href="${CAST_VOTES_LINK}"`)
+    })
+
+    /**
+     * Proposing has ONE home and it is `/tasks` (#1556 + this issue). The
+     * assertion is on the route, not the label: a link left here would be a
+     * second, ungated entry point to a page that 403s the viewer it lets in.
+     */
+    it(`${slug} offers no propose entry point — /tasks owns it`, () => {
+      const { html } = render(<Skin state={baseState()} />)
+      expect(html, 'propose lives on /tasks now').not.toContain('/propose-task')
+    })
+
+    // ── the pending row's three states (#1554) ──────────────────────────────
+    it(`${slug} points the pending row at the requests queue`, () => {
+      const { html, text } = render(<Skin state={baseState()} />)
+      expect(text, 'requests copy').toContain('2 pending requests')
+      expect(html, 'queue anchor').toContain(`href="${REQUESTS_QUEUE_LINK}"`)
+    })
+
+    it(`${slug} points the pending row at unfiltered Updates when only news waits`, () => {
+      const { html, text } = render(
+        <Skin state={baseState({ pendingRow: { kind: 'notifications', count: 0, to: UPDATES_LINK } })} />,
+      )
+      expect(text, 'notifications copy').toContain('New updates')
+      expect(html, 'unfiltered updates').toContain(`href="${UPDATES_LINK}"`)
+    })
+
+    it(`${slug} dead-ends the pending row rather than linking nowhere`, () => {
+      const { html, text } = render(
+        <Skin state={baseState({ pendingRow: { kind: 'clear', count: 0, to: null } })} />,
+      )
+      // The pill STAYS — it is a sentence, not a control that got hidden.
+      expect(text, 'caught-up copy').toContain('All caught up')
+      // ...and it is not a link at all. A pill that still looks pressable and
+      // goes nowhere is worse than no pill, so neither Updates href survives.
+      expect(html, 'no route out of a caught-up row').not.toContain('/updates')
+    })
+
+    it(`${slug} draws no pending row until the panels land`, () => {
+      const { text } = render(<Skin state={baseState({ pendingRow: null })} />)
+      // Zero-because-unknown must not render as "All caught up" over a queue
+      // with four invites in it, then swap under the reader.
+      expect(text, 'nothing claimed while loading').not.toContain('All caught up')
     })
   }
 })

--- a/frontend/src/pages/fieldDesk/__tests__/pendingRow.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/pendingRow.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * The pending row's three states, at the two places they are decided (#1554):
+ * `selectPendingRow` picks which one, `PendingRowPill` draws it.
+ *
+ * The pair is split that way because the third state is a NEGATIVE — no link, no
+ * chevron, no press state — and a negative is only assertable where the thing
+ * that would have been drawn is in scope. The per-skin copies of these
+ * assertions live in `mobileArchetypeSlots.test.tsx`; these are the rule itself.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so the three copy keys resolve to English text.
+import '../../../i18n'
+import { selectPendingRow } from '../useFieldDeskHome'
+import PendingRowPill from '../PendingRowPill'
+import { UPDATES_LINK } from '../homeDestinations'
+import { REQUESTS_QUEUE_ANCHOR } from '../../updates/requestsQueueAnchor'
+
+describe('selectPendingRow', () => {
+  it('says nothing at all while the panels are still in flight', () => {
+    // Both counts read zero before the response lands. Falling through to
+    // "All caught up" there would claim an empty queue over a full one.
+    expect(selectPendingRow(0, 0, true)).toBeNull()
+    expect(selectPendingRow(4, 9, true)).toBeNull()
+  })
+
+  it('leads with the obligation when one is outstanding', () => {
+    const row = selectPendingRow(3, 0, false)
+    expect(row).toEqual({ kind: 'requests', count: 3, to: expect.any(String) })
+    // ADR-0070 deleted the `requests` filter tab; the row expands the queue.
+    expect(row?.to).toContain(REQUESTS_QUEUE_ANCHOR)
+  })
+
+  it('still leads with the obligation when there is news as well', () => {
+    expect(selectPendingRow(1, 12, false)?.kind).toBe('requests')
+  })
+
+  it('falls to unfiltered Updates when only news is waiting', () => {
+    expect(selectPendingRow(0, 12, false)).toEqual({
+      kind: 'notifications',
+      count: 0,
+      to: UPDATES_LINK,
+    })
+  })
+
+  it('dead-ends with nothing waiting — the row survives, the route does not', () => {
+    expect(selectPendingRow(0, 0, false)).toEqual({ kind: 'clear', count: 0, to: null })
+  })
+})
+
+function draw(row: Parameters<typeof PendingRowPill>[0]['row']): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <PendingRowPill row={row} chevron={<span data-testid="chevron">›</span>} />
+    </MemoryRouter>,
+  )
+}
+
+describe('PendingRowPill', () => {
+  it('draws an obligation as a link with its count and a chevron', () => {
+    const html = draw({ kind: 'requests', count: 2, to: '/updates#requests-queue' })
+    expect(html).toContain('2 pending requests')
+    expect(html).toContain('href="/updates#requests-queue"')
+    expect(html).toContain('data-testid="chevron"')
+  })
+
+  it('pluralises down to a single request', () => {
+    expect(draw({ kind: 'requests', count: 1, to: '/x' })).toContain('1 pending request<')
+  })
+
+  it('draws news as a link, without borrowing the requests copy', () => {
+    const html = draw({ kind: 'notifications', count: 0, to: UPDATES_LINK })
+    expect(html).toContain('New updates')
+    expect(html).toContain(`href="${UPDATES_LINK}"`)
+    expect(html, 'never a count it cannot know').not.toContain('0')
+  })
+
+  it('draws the caught-up state as a sentence: no anchor, no chevron', () => {
+    const html = draw({ kind: 'clear', count: 0, to: null })
+    expect(html).toContain('All caught up')
+    // All three of "the chevron, the link and the press state" go together: an
+    // element that is not an anchor has no tap highlight to drop separately.
+    expect(html, 'not a link').not.toContain('<a ')
+    expect(html, 'no chevron').not.toContain('data-testid="chevron"')
+  })
+
+  it('keeps the faction glyph in every state that has one', () => {
+    for (const row of [
+      { kind: 'requests', count: 1, to: '/x' },
+      { kind: 'clear', count: 0, to: null },
+    ] as const) {
+      const html = renderToStaticMarkup(
+        <MemoryRouter>
+          <PendingRowPill row={row} chevron={null} glyph={<b data-testid="sigil" />} />
+        </MemoryRouter>,
+      )
+      expect(html, `${row.kind} keeps its mark`).toContain('data-testid="sigil"')
+    }
+  })
+})

--- a/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/uaDispatch.test.tsx
@@ -19,6 +19,7 @@ import { surfaceMap } from '../../../factions'
 import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
 import UaFieldDesk from '../mobileArchetypes/UaFieldDesk'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
+import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 import type { CharacterOut } from '../../../api/auth'
 import type { PraxisCardOut } from '../../../api/praxis'
 
@@ -68,9 +69,8 @@ function baseState(overrides: Partial<FieldDeskHomeState> = {}): FieldDeskHomeSt
     eraName: 'Era 1',
     levelTrack: { nextLevel: 5, pointsToNext: 160, nextThreshold: 500, fillPercent: 68 },
     activeTasks: [ACTIVE_TASK],
-    pendingCount: 0,
+    pendingRow: { kind: 'clear', count: 0, to: null },
     loadingTasks: false,
-    canProposeTask: true,
     ...overrides,
   }
 }
@@ -118,8 +118,10 @@ describe('UA mobile home — what it draws', () => {
     expect(text).toContain('Level 2')
     expect(text).toContain('160 to Level 5')
     expect(html).toContain('role="progressbar"')
-    expect(html).toContain('href="/tasks"')
-    expect(html).toContain('href="/propose-task"')
+    // Both verbs now land already narrowed (#1554); proposing lives on /tasks.
+    expect(html).toContain(`href="${FIND_TASK_LINK}"`)
+    expect(html).toContain(`href="${CAST_VOTES_LINK}"`)
+    expect(html).not.toContain('/propose-task')
   })
 
   it('carries no gold: the legacy --ua-* palette and Cinzel are gone here', () => {

--- a/frontend/src/pages/fieldDesk/homeDestinations.ts
+++ b/frontend/src/pages/fieldDesk/homeDestinations.ts
@@ -1,0 +1,55 @@
+/**
+ * Where the mobile home's two big buttons land (#1554).
+ *
+ * BOTH ARE ALREADY-NARROWED VIEWS, and that is the whole point of the issue: a
+ * home screen's buttons should land on what the player can act on, not on the
+ * top of a catalogue they then have to filter by hand. "Find a task" that opens
+ * every task including the ones locked to a higher level is a button that
+ * answers a different question than the one it asks.
+ *
+ * WHY THESE ARE HAND-WRITTEN STRINGS AND NOT BUILT FROM THE READERS' CONSTANTS
+ * ---------------------------------------------------------------------------
+ * `TASK_FILTER_PARAMS` / `CAN_SIGN_UP_ON` live in `pages/tasks/useTasks.ts` and
+ * the voted axis in `pages/praxes/feedFilterParams.ts`. Importing the first from
+ * eight lazily-loaded mobile skins would pull the whole tasks-page module graph
+ * into the field-desk chunk for the sake of two string constants — a real cost
+ * on the one screen the app opens on (`docs/agents/load-time.md`).
+ *
+ * The promise is pinned instead by `__tests__/homeDestinations.test.ts`, which
+ * feeds each URL back through the very readers the destination pages use
+ * (`readTaskFilters`, `readFeedFilters`) and asserts the axis actually comes out
+ * on. A link that lands unfiltered is the failure mode this repo has been bitten
+ * by before — a 200 with an unnarrowed list looks identical to a working one, so
+ * tsc, eslint and a render assertion all pass over it.
+ */
+
+/**
+ * Primary CTA — "tasks I can sign up for" (#1130).
+ *
+ * The SERVER evaluates its own sign-up predicate behind `can_sign_up`, so a
+ * faction ability that bends the level bar (WOW's once-a-level jump, the
+ * Ephemerists' retired-task access) is honoured without this page knowing a
+ * rule. Deliberately carries no `status`: pinning `status=active` alongside it
+ * would quietly cancel the second one.
+ */
+export const FIND_TASK_LINK = '/tasks?can_sign_up=1'
+
+/**
+ * Secondary CTA — praxes awaiting this account's vote.
+ *
+ * `voted=no` is the feed's "needs my vote": votable, unvoted, and never a praxis
+ * the account co-owns (ADR-0013). The era axis is left alone — a bare `/praxis`
+ * lands on `this_era` (#1361 ruling 6), and that is the right scope for work you
+ * are being asked to judge now.
+ */
+export const CAST_VOTES_LINK = '/praxis?voted=no'
+
+/**
+ * Where the pending row goes when what is waiting is news rather than an
+ * obligation: the Updates page with no filter on it.
+ *
+ * Requests get `REQUESTS_QUEUE_LINK` instead (`pages/updates/requestsQueueAnchor`),
+ * which expands and scrolls to the queue — ADR-0070 deleted the `requests`
+ * filter tab, so `/updates?filter=requests` names an axis that no longer exists.
+ */
+export const UPDATES_LINK = '/updates'

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -28,7 +28,8 @@ import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
-import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
+import PendingRowPill from '../PendingRowPill'
+import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /**
  * Cozy Coven MOBILE FieldDesk home (#500, re-dressed by #1209) — the coven's
@@ -159,7 +160,7 @@ const ghostButton: CSSProperties = {
 
 export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
-  const { character, eraName, levelTrack, activeTasks, pendingCount, canProposeTask } = state
+  const { character, eraName, levelTrack, activeTasks, pendingRow } = state
   const [switcherOpen, setSwitcherOpen] = useState(false)
 
   return (
@@ -322,10 +323,10 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
           </div>
         </Plate>
 
-        {/* ── Pending requests ── */}
-        {pendingCount > 0 && (
-          <Link
-            to={REQUESTS_QUEUE_LINK}
+        {/* ── The pending row, in all three of its states (#1554) ── */}
+        {pendingRow && (
+          <PendingRowPill
+            row={pendingRow}
             className="flex items-center justify-between"
             style={{
               background: CARD,
@@ -337,13 +338,9 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
               color: INK,
               textDecoration: 'none',
             }}
-          >
-            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
-              <CovenSigil size={12} color={GOLD} />
-              {t('fieldDesk.home.pending', { count: pendingCount })}
-            </span>
-            <span aria-hidden style={{ color: SOFT }}>›</span>
-          </Link>
+            glyph={<CovenSigil size={12} color={GOLD} />}
+            chevron={<span aria-hidden style={{ color: SOFT }}>›</span>}
+          />
         )}
 
         {/* ── Quests plate ── */}
@@ -408,19 +405,15 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
           )}
         </Plate>
 
-        {/* ── Primary actions ── */}
+        {/* ── Primary actions: both land on an already-narrowed view (#1554) ── */}
         <div className="flex gap-2.5">
-          <Link to="/tasks" style={primaryButton}>
+          <Link to={FIND_TASK_LINK} style={primaryButton}>
             <CovenSigil size={13} color={CTA_INK} />
-            {t('fieldDesk.home.browseTasks')}
+            {t('fieldDesk.home.findTask')}
           </Link>
-          {canProposeTask && (
-            <Link to="/propose-task" style={ghostButton}>
-              {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
-              <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
-              {t('actions.proposeTask')}
-            </Link>
-          )}
+          <Link to={CAST_VOTES_LINK} style={ghostButton}>
+            {t('fieldDesk.home.castVotes')}
+          </Link>
         </div>
 
         {/* The switcher the "Characters" pill opens (#516). */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -6,13 +6,15 @@ import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
-import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
+import PendingRowPill from '../PendingRowPill'
+import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /**
  * Default (na) MOBILE FieldDesk home — the account's carried life at a glance,
  * one-hand and single-column (#500). Character header (avatar in the all-paths
  * rainbow ring + name + level, then the era points figure over a rainbow
- * level track), the in-progress task list, and one or two primary actions. Every faction falls
+ * level track), the pending row, the in-progress task list, and the two
+ * primary actions — both of which land on an already-narrowed view. Every faction falls
  * through here until it registers a bespoke mobile home skin (mirrors the
  * taskDetail mobile Default). Presentation-only: all data arrives via
  * {@link FieldDeskHomeState}; copy resolves from the `common` catalog.
@@ -92,7 +94,7 @@ const secondaryActionStyle: CSSProperties = {
 
 export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
-  const { character, eraName, levelTrack, activeTasks, pendingCount, canProposeTask } = state
+  const { character, eraName, levelTrack, activeTasks, pendingRow } = state
   const [switcherOpen, setSwitcherOpen] = useState(false)
 
   return (
@@ -261,16 +263,15 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
         </div>
       </section>
 
-      {/* ── Pending requests pill (only when there are any) ── */}
-      {pendingCount > 0 && (
-        <Link
-          to={REQUESTS_QUEUE_LINK}
+      {/* ── The pending row: requests, other news, or a dead-ended "all caught
+          up" that keeps the pill and drops the chevron (#1554). ── */}
+      {pendingRow && (
+        <PendingRowPill
+          row={pendingRow}
           className="font-body flex items-center justify-between content-text"
           style={pendingPillStyle}
-        >
-          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
-          <span aria-hidden style={{ color: 'var(--color-text-tertiary)' }}>›</span>
-        </Link>
+          chevron={<span aria-hidden style={{ color: 'var(--color-text-tertiary)' }}>›</span>}
+        />
       )}
 
       {/* ── In-progress tasks ── */}
@@ -355,26 +356,22 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
         )}
       </section>
 
-      {/* ── Primary actions ── */}
+      {/* ── Primary actions: both land on an already-narrowed view (#1554) ── */}
       <div className="flex gap-2.5">
         <Link
-          to="/tasks"
+          to={FIND_TASK_LINK}
           className="font-body flex-1 flex items-center justify-center"
           style={primaryActionStyle}
         >
-          {t('fieldDesk.home.browseTasks')}
+          {t('fieldDesk.home.findTask')}
         </Link>
-        {canProposeTask && (
-          <Link
-            to="/propose-task"
-            className="font-body flex-1 flex items-center justify-center gap-2"
-            style={secondaryActionStyle}
-          >
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
-            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
-            <span>{t('actions.proposeTask')}</span>
-          </Link>
-        )}
+        <Link
+          to={CAST_VOTES_LINK}
+          className="font-body flex-1 flex items-center justify-center"
+          style={secondaryActionStyle}
+        >
+          {t('fieldDesk.home.castVotes')}
+        </Link>
       </div>
 
       {/* Active-character switcher — bottom sheet over Home (#516). */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
@@ -28,7 +28,8 @@ import {
   PLATE as SHEET,
 } from '../../../components/factionMarks/ephemeristsPlate'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
-import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
+import PendingRowPill from '../PendingRowPill'
+import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /**
  * The Ephemerists MOBILE FieldDesk home (#527, swept onto the Valley plate by
@@ -103,7 +104,7 @@ function Leaf({ children }: { children: ReactNode }) {
 
 export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
-  const { character, eraName, levelTrack, activeTasks, pendingCount, canProposeTask } = state
+  const { character, eraName, levelTrack, activeTasks, pendingRow } = state
   const [switcherOpen, setSwitcherOpen] = useState(false)
 
   return (
@@ -248,16 +249,14 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
         </div>
       </Leaf>
 
-      {/* ── Pending requests ── */}
-      {pendingCount > 0 && (
-        <Link
-          to={REQUESTS_QUEUE_LINK}
+      {/* ── The pending row, in all three of its states (#1554) ── */}
+      {pendingRow && (
+        <PendingRowPill
+          row={pendingRow}
           className="flex items-center justify-between"
           style={{ background: SHEET, border: `1px solid ${LINE}`, padding: 'var(--space-md) var(--space-lg)', fontFamily: MARGINALIA, fontStyle: 'italic', fontSize: 'var(--text-content)', color: INK, textDecoration: 'none' }}
-        >
-          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
-          <span aria-hidden style={{ color: NILE }}>›</span>
-        </Link>
+          chevron={<span aria-hidden style={{ color: NILE }}>›</span>}
+        />
       )}
 
       {/* ── Surveys underway ── */}
@@ -311,26 +310,22 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
         )}
       </Leaf>
 
-      {/* ── Primary actions ── */}
+      {/* ── Primary actions: both land on an already-narrowed view (#1554) ── */}
       <div className="flex gap-2.5">
         <Link
-          to="/tasks"
+          to={FIND_TASK_LINK}
           className="flex-1 flex items-center justify-center"
           style={{ ...SMALL_CAPS, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', padding: 'var(--space-lg)', color: CTA_INK, background: CTA_BG, border: `2px solid ${BRASS}`, textDecoration: 'none' }}
         >
-          {t('fieldDesk.home.browseTasks')}
+          {t('fieldDesk.home.findTask')}
         </Link>
-        {canProposeTask && (
-          <Link
-            to="/propose-task"
-            className="flex-1 flex items-center justify-center gap-2"
-            style={{ ...SMALL_CAPS, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', padding: 'var(--space-lg)', color: INK, background: SHEET, border: `1px solid ${BRASS}`, textDecoration: 'none' }}
-          >
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
-            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
-            <span>{t('actions.proposeTask')}</span>
-          </Link>
-        )}
+        <Link
+          to={CAST_VOTES_LINK}
+          className="flex-1 flex items-center justify-center"
+          style={{ ...SMALL_CAPS, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', padding: 'var(--space-lg)', color: INK, background: SHEET, border: `1px solid ${BRASS}`, textDecoration: 'none' }}
+        >
+          {t('fieldDesk.home.castVotes')}
+        </Link>
       </div>
 
       {/* The switcher the "Characters" pill opens (#516). */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
@@ -6,7 +6,8 @@ import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
-import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
+import PendingRowPill from '../PendingRowPill'
+import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /**
  * Everymen MOBILE FieldDesk home (#529) — the union broadsheet on a phone. The
@@ -123,7 +124,7 @@ function SectionHead({ title, trailing }: { title: string; trailing?: ReactNode 
 
 export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
-  const { character, eraName, levelTrack, activeTasks, pendingCount, canProposeTask } = state
+  const { character, eraName, levelTrack, activeTasks, pendingRow } = state
   const [switcherOpen, setSwitcherOpen] = useState(false)
 
   return (
@@ -289,16 +290,14 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
         </div>
       </Plate>
 
-      {/* ── Pending requests ── */}
-      {pendingCount > 0 && (
-        <Link
-          to={REQUESTS_QUEUE_LINK}
+      {/* ── The pending row, in all three of its states (#1554) ── */}
+      {pendingRow && (
+        <PendingRowPill
+          row={pendingRow}
           className="flex items-center justify-between"
           style={{ background: PAPER, border: `1.5px solid ${INK}`, padding: 'var(--space-md) var(--space-lg)', fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', letterSpacing: '0.04em', color: INK, textDecoration: 'none' }}
-        >
-          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
-          <span aria-hidden style={{ color: RED }}>›</span>
-        </Link>
+          chevron={<span aria-hidden style={{ color: RED }}>›</span>}
+        />
       )}
 
       {/* ── On the job ── */}
@@ -349,26 +348,22 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
         )}
       </Plate>
 
-      {/* ── Primary actions ── */}
+      {/* ── Primary actions: both land on an already-narrowed view (#1554) ── */}
       <div className="flex gap-2.5">
         <Link
-          to="/tasks"
+          to={FIND_TASK_LINK}
           className="flex-1 flex items-center justify-center"
           style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.08em', padding: 'var(--space-lg)', color: CREAM, background: RED, border: `2px solid ${INK}`, textDecoration: 'none' }}
         >
-          {t('fieldDesk.home.browseTasks')}
+          {t('fieldDesk.home.findTask')}
         </Link>
-        {canProposeTask && (
-          <Link
-            to="/propose-task"
-            className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.08em', padding: 'var(--space-lg)', color: INK, background: PAPER_DEEP, border: `2px solid ${INK}`, textDecoration: 'none' }}
-          >
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
-            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
-            <span>{t('actions.proposeTask')}</span>
-          </Link>
-        )}
+        <Link
+          to={CAST_VOTES_LINK}
+          className="flex-1 flex items-center justify-center"
+          style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-xl)', letterSpacing: '0.08em', padding: 'var(--space-lg)', color: INK, background: PAPER_DEEP, border: `2px solid ${INK}`, textDecoration: 'none' }}
+        >
+          {t('fieldDesk.home.castVotes')}
+        </Link>
       </div>
 
       {/* The switcher the "Characters" pill opens (#516). */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
@@ -6,7 +6,8 @@ import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
-import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
+import PendingRowPill from '../PendingRowPill'
+import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /**
  * Singularity MOBILE FieldDesk home (#526) — the dark terminal on a phone. The
@@ -123,7 +124,7 @@ function Panel({ children }: { children: ReactNode }) {
 
 export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
-  const { character, eraName, levelTrack, activeTasks, pendingCount, canProposeTask } = state
+  const { character, eraName, levelTrack, activeTasks, pendingRow } = state
   const [switcherOpen, setSwitcherOpen] = useState(false)
 
   return (
@@ -258,16 +259,14 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
         </div>
       </Panel>
 
-      {/* ── Pending requests ── */}
-      {pendingCount > 0 && (
-        <Link
-          to={REQUESTS_QUEUE_LINK}
+      {/* ── The pending row, in all three of its states (#1554) ── */}
+      {pendingRow && (
+        <PendingRowPill
+          row={pendingRow}
           className="flex items-center justify-between"
           style={{ background: VOID, border: `1px solid ${signal(42)}`, padding: 'var(--space-md) var(--space-lg)', fontFamily: FONT, fontSize: 'var(--text-content)', color: PHOSPHOR, textDecoration: 'none' }}
-        >
-          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
-          <span aria-hidden style={{ color: SIGNAL }}>›</span>
-        </Link>
+          chevron={<span aria-hidden style={{ color: SIGNAL }}>›</span>}
+        />
       )}
 
       {/* ── Running functions ── */}
@@ -320,26 +319,22 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
         )}
       </Panel>
 
-      {/* ── Primary actions ── */}
+      {/* ── Primary actions: both land on an already-narrowed view (#1554) ── */}
       <div className="flex gap-2.5">
         <Link
-          to="/tasks"
+          to={FIND_TASK_LINK}
           className="flex-1 flex items-center justify-center"
           style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: VOID, background: PHOSPHOR, border: `1px solid ${PHOSPHOR}`, boxShadow: `0 0 16px ${phosphor(30)}`, textDecoration: 'none' }}
         >
-          {t('fieldDesk.home.browseTasks')}
+          {t('fieldDesk.home.findTask')}
         </Link>
-        {canProposeTask && (
-          <Link
-            to="/propose-task"
-            className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: PHOSPHOR, background: 'transparent', border: `1px solid ${signal(40)}`, textDecoration: 'none' }}
-          >
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
-            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>+</span>
-            <span>{t('actions.proposeTask')}</span>
-          </Link>
-        )}
+        <Link
+          to={CAST_VOTES_LINK}
+          className="flex-1 flex items-center justify-center"
+          style={{ fontFamily: FONT, fontSize: 'var(--text-lg)', letterSpacing: '0.12em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: PHOSPHOR, background: 'transparent', border: `1px solid ${signal(40)}`, textDecoration: 'none' }}
+        >
+          {t('fieldDesk.home.castVotes')}
+        </Link>
       </div>
 
       {/* The switcher the "Characters" pill opens (#516). */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
@@ -6,7 +6,8 @@ import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
-import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
+import PendingRowPill from '../PendingRowPill'
+import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /**
  * S.N.I.D.E. MOBILE FieldDesk home (#530) — the operative's file on a phone.
@@ -112,7 +113,7 @@ function RansomCard({ children, tilt = -1 }: { children: ReactNode; tilt?: numbe
 
 export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
-  const { character, eraName, levelTrack, activeTasks, pendingCount, canProposeTask } = state
+  const { character, eraName, levelTrack, activeTasks, pendingRow } = state
   const [switcherOpen, setSwitcherOpen] = useState(false)
 
   return (
@@ -232,16 +233,14 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
         </div>
       </RansomCard>
 
-      {/* ── Pending requests ── */}
-      {pendingCount > 0 && (
-        <Link
-          to={REQUESTS_QUEUE_LINK}
+      {/* ── The pending row, in all three of its states (#1554) ── */}
+      {pendingRow && (
+        <PendingRowPill
+          row={pendingRow}
           className="flex items-center justify-between"
           style={{ background: INK, color: TEXT, border: `1px solid ${LINE}`, padding: 'var(--space-md) var(--space-lg)', fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.03em', textDecoration: 'none' }}
-        >
-          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
-          <span aria-hidden style={{ color: ACID }}>›</span>
-        </Link>
+          chevron={<span aria-hidden style={{ color: ACID }}>›</span>}
+        />
       )}
 
       {/* ── Jobs in play ── */}
@@ -293,26 +292,22 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
         )}
       </RansomCard>
 
-      {/* ── Primary actions ── */}
+      {/* ── Primary actions: both land on an already-narrowed view (#1554) ── */}
       <div className="flex gap-2.5">
         <Link
-          to="/tasks"
+          to={FIND_TASK_LINK}
           className="flex-1 flex items-center justify-center"
           style={{ fontFamily: BLACK, fontSize: 'var(--text-lg)', letterSpacing: '0.06em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: 'var(--faction-snide-paper)', background: PINK, boxShadow: '2px 3px 0 rgba(0,0,0,.4)', textDecoration: 'none' }}
         >
-          {t('fieldDesk.home.browseTasks')}
+          {t('fieldDesk.home.findTask')}
         </Link>
-        {canProposeTask && (
-          <Link
-            to="/propose-task"
-            className="flex-1 flex items-center justify-center gap-2"
-            style={{ fontFamily: COND, fontSize: 'var(--text-xl)', letterSpacing: '0.06em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: TEXT, background: INK, border: `1px solid ${ACID}`, textDecoration: 'none' }}
-          >
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
-            <span aria-hidden style={{ fontSize: 15, lineHeight: 1, color: ACID }}>+</span>
-            <span>{t('actions.proposeTask')}</span>
-          </Link>
-        )}
+        <Link
+          to={CAST_VOTES_LINK}
+          className="flex-1 flex items-center justify-center"
+          style={{ fontFamily: COND, fontSize: 'var(--text-xl)', letterSpacing: '0.06em', textTransform: 'uppercase', padding: 'var(--space-lg)', color: TEXT, background: INK, border: `1px solid ${ACID}`, textDecoration: 'none' }}
+        >
+          {t('fieldDesk.home.castVotes')}
+        </Link>
       </div>
 
       {/* The switcher the "Characters" pill opens (#516). */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
@@ -8,7 +8,8 @@ import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
-import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
+import PendingRowPill from '../PendingRowPill'
+import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /**
  * University of Asthmatics MOBILE FieldDesk home (#525/#852) — "One mark today.
@@ -92,7 +93,7 @@ function Sheet({ children }: { children: ReactNode }) {
 
 export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation('common')
-  const { character, eraName, levelTrack, activeTasks, pendingCount, canProposeTask } = state
+  const { character, eraName, levelTrack, activeTasks, pendingRow } = state
   const [switcherOpen, setSwitcherOpen] = useState(false)
 
   return (
@@ -250,10 +251,10 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
         </div>
       </Sheet>
 
-      {/* ── Pending requests ── */}
-      {pendingCount > 0 && (
-        <Link
-          to={REQUESTS_QUEUE_LINK}
+      {/* ── The pending row, in all three of its states (#1554) ── */}
+      {pendingRow && (
+        <PendingRowPill
+          row={pendingRow}
           className="flex items-center justify-between"
           style={{
             background: SHEET,
@@ -265,12 +266,12 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
             color: INK,
             textDecoration: 'none',
           }}
-        >
-          <span>{t('fieldDesk.home.pending', { count: pendingCount })}</span>
-          <span aria-hidden style={{ color: ACCENT }}>
-            ›
-          </span>
-        </Link>
+          chevron={
+            <span aria-hidden style={{ color: ACCENT }}>
+              ›
+            </span>
+          }
+        />
       )}
 
       {/* ── What is out on the table ── */}
@@ -323,7 +324,7 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
       {/* ── Begin ── */}
       <div className="flex flex-wrap gap-2.5">
         <Link
-          to="/tasks"
+          to={FIND_TASK_LINK}
           className="flex items-center justify-center"
           style={{
             flex: '1 1 0',
@@ -340,34 +341,28 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
             textDecoration: 'none',
           }}
         >
-          {t('fieldDesk.home.browseTasks')}
+          {t('fieldDesk.home.findTask')}
         </Link>
-        {canProposeTask && (
-          <Link
-            to="/propose-task"
-            className="flex items-center justify-center gap-2"
-            style={{
-              flex: '1 1 0',
-              minWidth: 0,
-              fontFamily: SERIF,
-              fontSize: 'var(--text-xl)',
-              letterSpacing: '0.12em',
-              textTransform: 'uppercase',
-              padding: 'var(--space-lg)',
-              color: INK,
-              background: SHEET,
-              border: `1px solid ${RULE}`,
-              borderRadius: 3,
-              textDecoration: 'none',
-            }}
-          >
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: "+" glyph used as an icon, sized to the button row */}
-            <span aria-hidden style={{ fontSize: 15, lineHeight: 1 }}>
-              +
-            </span>
-            <span>{t('actions.proposeTask')}</span>
-          </Link>
-        )}
+        <Link
+          to={CAST_VOTES_LINK}
+          className="flex items-center justify-center"
+          style={{
+            flex: '1 1 0',
+            minWidth: 0,
+            fontFamily: SERIF,
+            fontSize: 'var(--text-xl)',
+            letterSpacing: '0.12em',
+            textTransform: 'uppercase',
+            padding: 'var(--space-lg)',
+            color: INK,
+            background: SHEET,
+            border: `1px solid ${RULE}`,
+            borderRadius: 3,
+            textDecoration: 'none',
+          }}
+        >
+          {t('fieldDesk.home.castVotes')}
+        </Link>
       </div>
 
       {/* The switcher the "Characters" pill opens (#516). */}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
@@ -56,7 +56,8 @@ import {
 import CharacterSwitcherSheet from "../../../components/CharacterSwitcherSheet";
 import { factionName } from "../../../utils/factions";
 import type { FieldDeskHomeState } from "../useFieldDeskHome";
-import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
+import PendingRowPill from '../PendingRowPill'
+import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /** Every tappable row clears the faction's 46px thumb target. */
 const TAP = 46;
@@ -96,7 +97,7 @@ const trackMetaStyle: CSSProperties = {
 
 export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
   const { t } = useTranslation("common");
-  const { character, eraName, levelTrack, activeTasks, pendingCount, canProposeTask } = state;
+  const { character, eraName, levelTrack, activeTasks, pendingRow } = state;
   const [switcherOpen, setSwitcherOpen] = useState(false);
 
   return (
@@ -255,10 +256,10 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
           {t("fieldDesk.home.wow.masthead")}
         </p>
 
-        {/* ── the herald's pending dispatches ── */}
-        {pendingCount > 0 && (
-          <Link
-            to={REQUESTS_QUEUE_LINK}
+        {/* ── the herald's dispatches, in all three of their states (#1554) ── */}
+        {pendingRow && (
+          <PendingRowPill
+            row={pendingRow}
             style={{
               minHeight: TAP,
               display: "flex",
@@ -274,15 +275,13 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
               color: WOW_INK,
               textDecoration: "none",
             }}
-          >
-            <span style={{ display: "inline-flex", alignItems: "center", gap: "var(--space-sm)" }}>
-              <WowSpark />
-              {t("fieldDesk.home.pending", { count: pendingCount })}
-            </span>
-            <span aria-hidden style={{ color: WOW_DEEP }}>
-              ›
-            </span>
-          </Link>
+            glyph={<WowSpark />}
+            chevron={
+              <span aria-hidden style={{ color: WOW_DEEP }}>
+                ›
+              </span>
+            }
+          />
         )}
 
         {/* ── Thy Open Quests ── */}
@@ -379,15 +378,13 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
 
         {/* ── the two verbs ── */}
         <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-sm)" }}>
-          <Link to="/tasks" className="wow-btn" style={wowGiltButton}>
+          <Link to={FIND_TASK_LINK} className="wow-btn" style={wowGiltButton}>
             <WowSpark color="var(--faction-wow-quest-text)" />
-            {t("fieldDesk.home.browseTasks")}
+            {t("fieldDesk.home.findTask")}
           </Link>
-          {canProposeTask && (
-            <Link to="/propose-task" style={{ ...wowGhostButton, flex: "1 1 auto" }}>
-              {t("actions.proposeTask")}
-            </Link>
-          )}
+          <Link to={CAST_VOTES_LINK} style={{ ...wowGhostButton, flex: "1 1 auto" }}>
+            {t("fieldDesk.home.castVotes")}
+          </Link>
         </div>
       </div>
 

--- a/frontend/src/pages/fieldDesk/useFieldDeskHome.ts
+++ b/frontend/src/pages/fieldDesk/useFieldDeskHome.ts
@@ -4,12 +4,14 @@ import { useSidebarPanels } from '../../hooks/useSidebarPanels'
 import type { CharacterOut } from '../../api/auth'
 import type { PraxisCardOut } from '../../api/praxis'
 import type { LevelTrack } from '../../utils/levelTrack'
+import { REQUESTS_QUEUE_LINK } from '../updates/requestsQueueAnchor'
+import { UPDATES_LINK } from './homeDestinations'
 
 /**
  * Composed read-model for the MOBILE FieldDesk home (#500).
  *
  * Pure composition over the same reads the desktop rail draws from:
- * `useSidebarPanels` for the in-progress tasks and the pending-request count,
+ * `useSidebarPanels` for the in-progress tasks and the pending row,
  * `useLevelTrack` for the identity block's progress read-out, and the carried
  * character from auth. No new data logic — it only bundles what those already
  * return, so the mobile skins stay presentation-only and slot-invariant
@@ -19,6 +21,13 @@ import type { LevelTrack } from '../../utils/levelTrack'
  * stat tile that the identity-block redesign removed — vote count is an input,
  * not an achievement — and this hook was its only consumer, so the
  * `/characters/{id}/stats/votes-received` request left the home screen with it.
+ *
+ * IT NO LONGER CARRIES `canProposeTask` EITHER (#1554). Owner ruling: `/tasks`
+ * is proposing's only home, both form factors. #1556 moved the desktop
+ * affordance onto the tasks page (`ProposeTaskLink`, which owns the
+ * `can_propose_task` gate) but deliberately left the eight mobile skins linking
+ * to `/propose-task` so the control never existed in NEITHER place; taking them
+ * out is the other half of that move, and the flag went with them.
  *
  * It used to compose two hooks of its OWN (`useMyActiveTasks` /
  * `usePendingRequests`) that fetched the same two things the rail was fetching,
@@ -40,12 +49,70 @@ export interface FieldDeskHomeState {
   levelTrack: LevelTrack | null
   /** In-progress praxes (membership-scoped) — the active-tasks list. */
   activeTasks: PraxisCardOut[]
-  /** Count of unanswered requests, straight from `/me/sidebar` (#1456). */
-  pendingCount: number
+  /**
+   * The summary row under the identity card, or `null` while the panels are
+   * still in flight. See {@link selectPendingRow}.
+   */
+  pendingRow: PendingRowState | null
   /** Whether the active-tasks list is still loading. */
   loadingTasks: boolean
-  /** Server-computed: may this life propose a task (drives the secondary CTA)? */
-  canProposeTask: boolean
+}
+
+/**
+ * What the row under the identity card is *saying*, which is not always the same
+ * as what it is *offering* (#1554).
+ *
+ * Three states, and the third is the one worth naming in a type: with nothing
+ * waiting the row stays on screen and stops being a control at all. A dead-ended
+ * pill that still looks pressable is worse than no pill, so `to === null` is the
+ * skins' single instruction to drop the link, the chevron and the press state
+ * together — not to grey one out.
+ */
+export type PendingRowKind = 'requests' | 'notifications' | 'clear'
+
+export interface PendingRowState {
+  kind: PendingRowKind
+  /** Interpolated into the requests copy; 0 for the other two kinds. */
+  count: number
+  /** Where the row leads, or `null` when it is a statement rather than a control. */
+  to: string | null
+}
+
+/**
+ * Which of the three the row is in.
+ *
+ * OBLIGATIONS OUTRANK NEWS, and they are disjoint sets rather than a priority
+ * fudge: ADR-0070 partitions the feed so an unanswered request lives in the
+ * queue and never in the stream, which is why `otherActivity` here is already
+ * "everything that is not a request" without this function subtracting anything.
+ * `pending_requests_count` counts the queue side, `global_activity` carries the
+ * stream side, and both come out of `_visible_types` on the same `/me/sidebar`
+ * response — so the two states cannot double-count one item or lose one.
+ *
+ * `loading` returns `null` rather than falling through to 'clear'. Before the
+ * panels land both numbers are zero, and zero-because-unknown would render "All
+ * caught up" over a queue with four invites in it, then swap under the reader a
+ * moment later. A row that appears late is honest; a row that lies briefly is not.
+ *
+ * THE NOTIFICATIONS STATE CARRIES NO NUMBER, and that is a deliberate shortfall
+ * against the design's `N notifications` — see the copy key's note. `/me/sidebar`
+ * sends the activity panel as a five-item glance (`SIDEBAR_ACTIVITY_LIMIT`), not
+ * a count, so the only number available here is a display cap that would read
+ * "5" for a player with fifty. Restoring the number needs a real count field on
+ * that response; approximating it from the list length would be exactly the
+ * badge-disagrees-with-the-list drift ADR-0036 exists to prevent.
+ */
+export function selectPendingRow(
+  pendingRequests: number,
+  otherActivity: number,
+  loading: boolean,
+): PendingRowState | null {
+  if (loading) return null
+  if (pendingRequests > 0) {
+    return { kind: 'requests', count: pendingRequests, to: REQUESTS_QUEUE_LINK }
+  }
+  if (otherActivity > 0) return { kind: 'notifications', count: 0, to: UPDATES_LINK }
+  return { kind: 'clear', count: 0, to: null }
 }
 
 export function useFieldDeskHome(): FieldDeskHomeState | null {
@@ -57,6 +124,10 @@ export function useFieldDeskHome(): FieldDeskHomeState | null {
   const {
     active_praxes: activeTasks,
     pending_requests_count: pendingCount,
+    // The wire field is still named `global_activity`; since #1556 it carries
+    // the whole live feed minus the obligations, which is precisely the
+    // "notifications that are not requests" side of the row.
+    global_activity: recentActivity,
     loading: loadingTasks,
   } = useSidebarPanels()
   const track = useLevelTrack(character?.level ?? 0, character?.score ?? 0)
@@ -68,8 +139,7 @@ export function useFieldDeskHome(): FieldDeskHomeState | null {
     eraName: user?.era_name ?? '',
     levelTrack: track,
     activeTasks,
-    pendingCount,
+    pendingRow: selectPendingRow(pendingCount, recentActivity.length, loadingTasks),
     loadingTasks,
-    canProposeTask: user?.can_propose_task ?? false,
   }
 }


### PR DESCRIPTION
Closes #1554 (design cards 05 + 06 of epic #1552).

## 1. The pending row gains three states

`PendingRowPill` now owns the rule; each of the eight skins keeps its own dress and passes it in as `style` / `chevron` / `glyph`.

| Condition | Copy | Behaviour |
|---|---|---|
| Requests outstanding | `N pending requests` | `REQUESTS_QUEUE_LINK` |
| No requests, other unread activity | `New updates` | `/updates`, unfiltered |
| Neither | `All caught up` | a `<div>`: no link, no chevron, no tap highlight |
| Panels still loading | — | no row at all |

Two deliberate departures from the issue body, both explained in the code:

- **`/updates?filter=requests` no longer exists.** ADR-0070 / #1421 deleted the `requests` filter tab; the shipped constant `REQUESTS_QUEUE_LINK` (`/updates#requests-queue`) is what every one of the nine pending links already used, and it is what this keeps.
- **The notifications state carries no number.** `/me/sidebar` sends the activity panel as a five-item glance (`SIDEBAR_ACTIVITY_LIMIT`), not a count — the only number available here is a display cap that would read "5" for a player with fifty, which is exactly the badge-disagrees-with-the-list drift ADR-0036 exists to prevent. Restoring `N notifications` needs a real count field on that response. `counts.all` on `/activity-feed` is already the right number (`_visible_types` drops the four request types from the live `all` view), so the backend work is small — but it is a second UNION ALL on a response fetched on every route, and it is outside this PR's file scope.

## 2. Both CTAs land somewhere narrowed

- **Find a Task** → `/tasks?can_sign_up=1` (#1130's server-side predicate; deliberately no `status` alongside it, which would cancel the Ephemerists' retired-task access).
- **Cast Your Votes** → `/praxis?voted=no`, the feed's needs-my-vote axis. The `+` glyph goes with the propose link it belonged to.

Both are single-valued params, so the `faction[]=a` axios/FastAPI trap does not apply here — and `homeDestinations.test.ts` feeds each URL back through `readTaskFilters` / `readFeedFilters` so a link that silently lands unfiltered fails in CI rather than in production.

Copy: `fieldDesk.home.browseTasks` → `findTask` ("Find a Task"), since the button no longer opens the catalogue.

## 3. Propose leaves the mobile skins

`/tasks` was verified to carry it on **both** form factors first (`proposeEntryPoint.test.tsx` runs desktop and mobile, and asserts the `can_propose_task` gate both ways). Only then did the eight `/propose-task` links come out, finishing the move #1556 started. `canProposeTask` left `FieldDeskHomeState` with them.

## Scope

The desktop branch of `FieldDesk.tsx` is **untouched** — #1557/#1560 rebuilt it and nothing here needed it. `Sidebar.tsx` untouched (#1555's file). `.design-sync/previews/_state.tsx` carries the one state-literal update `typecheck:design-sync` requires.

## Verification

`eslint` · `tsc --noEmit` · `vitest run` (218 files, 3816 tests) · `vite build` · byte budget (JS 136.1 KB, CSS 22.3 KB, both ok) · `typecheck:design-sync` — all green.

No browser available in this worktree: **visual QA of the three pill states across the eight skins is outstanding.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)