### PR TITLE
The filter sheet clears the tab bar, and an empty facet draws no trigger

### DIFF
--- a/frontend/src/components/layout/ShellContent.tsx
+++ b/frontend/src/components/layout/ShellContent.tsx
@@ -59,7 +59,10 @@ const DESKTOP_REGION = 'flex-1 relative max-w-[min(92vw,1600px)] mx-auto w-full 
 
 const MOBILE_REGION_STYLE: CSSProperties = {
   zIndex: 5,
-  paddingBottom: 'calc(3.5rem + env(safe-area-inset-bottom))',
+  // The tab bar's height is `--mobile-tabbar-height` in index.css, not a literal
+  // here: the filter sheet needs the same clearance (#1566) and two hardcoded
+  // 3.5rems would drift the first time the bar changes height.
+  paddingBottom: 'calc(var(--mobile-tabbar-height) + env(safe-area-inset-bottom))',
 }
 const DESKTOP_REGION_STYLE: CSSProperties = { zIndex: 5 }
 

--- a/frontend/src/components/ui/FilterBar/OptionPicker.tsx
+++ b/frontend/src/components/ui/FilterBar/OptionPicker.tsx
@@ -39,6 +39,16 @@ export default function OptionPicker({ facet }: { facet: FilterFacet }) {
   const isSheet = useFormFactor() === 'mobile'
   const { label, options, selected, onChange, renderOrnament } = facet
 
+  // A facet with nothing to offer draws no trigger (#1567). Both facets hide a
+  // zero-count row, so on a quiet board — a fresh account, or a freshly reset
+  // one — every row is filtered out and tapping the trigger opened an empty
+  // picker. Hide the unusable control rather than disable it (CLAUDE.md).
+  //
+  // A SELECTED option always keeps its row even at zero, so a deep link like
+  // `?types=nudge` on a view with no nudges still renders the trigger and stays
+  // removable. That is why this tests the option list and not the counts.
+  if (options.length === 0) return null
+
   const panel = (
     <div
       className={isSheet ? 'filter-factions__sheet' : 'filter-factions__popover'}

--- a/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
+++ b/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
@@ -318,3 +318,36 @@ describe('selectedFirst / toggleOption', () => {
     expect(selected).toEqual(['ua'])
   })
 })
+
+describe('a facet with no options draws no trigger (#1567)', () => {
+  const emptyFacet = (selected: string[] = []): FilterFacet => ({
+    key: 'type',
+    label: 'Type',
+    options: [],
+    selected,
+    onChange: () => {},
+  })
+
+  const render = (facet: FilterFacet) =>
+    renderToStaticMarkup(
+      <FilterBar rails={[]} facets={[facet]} onClearAll={() => {}} />,
+    )
+
+  it('hides the trigger when every row was filtered out', () => {
+    // A quiet board: both facets drop zero-count rows, so on a fresh or freshly
+    // reset account the list is empty and the trigger opened an empty picker.
+    expect(render(emptyFacet())).not.toContain('filter-factions__trigger')
+  })
+
+  it('still draws the trigger when a selected option keeps its row', () => {
+    // `?types=nudge` on a view with no nudges: the row survives at zero so the
+    // filter stays removable, which means the picker must stay reachable.
+    const html = render(typeFacet(['praxis']))
+    expect(html).toContain('filter-factions__trigger')
+  })
+
+  it('leaves the rest of the bar alone', () => {
+    // Hiding one facet is not hiding the bar.
+    expect(render(emptyFacet())).toContain('filter-bar')
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1696,6 +1696,11 @@
   /* ── Shared tokens ── */
   --nav-blur: 6px;
   --card-blur: 4px;
+  /* Height of the fixed mobile tab bar. Anything pinned to the bottom of the
+     viewport on a phone has to clear BOTH this and the home-indicator inset, or
+     its last child lands under one of them (#1566). `ShellContent` reserves the
+     same pair for the page region; this token is what stops the two drifting. */
+  --mobile-tabbar-height: 3.5rem;
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
@@ -5437,8 +5442,14 @@
   bottom: 0;
   z-index: 40;
   max-height: 70vh;
-  overflow: auto;
   padding: var(--space-lg);
+  /* The sheet is pinned to the bottom of the viewport, where the fixed tab bar
+     and the home indicator already are. Without this the last child — the Done
+     button — sits under one of them (#1566). The sheet paints ABOVE the tab bar
+     (z-40 vs z-10), so this is clearance, not stacking. */
+  padding-bottom: calc(
+    var(--space-lg) + var(--mobile-tabbar-height) + env(safe-area-inset-bottom)
+  );
   border-top: 1px solid var(--color-border-strong);
   border-radius: var(--space-lg) var(--space-lg) 0 0;
   background: var(--filter-well);
@@ -5446,6 +5457,16 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+}
+
+/* Only the option list scrolls. `overflow` used to sit on the sheet itself, so a
+   long list pushed the heading and the Done button out of view and reaching Done
+   meant scrolling past every option (#1566). `min-height: 0` is what lets a flex
+   child shrink below its content and actually scroll. Scoped to the sheet: the
+   desktop popover has no height cap and should keep growing to fit. */
+.filter-factions__sheet .filter-factions__rows {
+  overflow-y: auto;
+  min-height: 0;
 }
 
 .filter-factions__scrim {

--- a/frontend/src/pages/updates/__tests__/updatesFilterBar.test.tsx
+++ b/frontend/src/pages/updates/__tests__/updatesFilterBar.test.tsx
@@ -72,14 +72,29 @@ describe('the Updates page mounts the shared FilterBar', () => {
     mocks.formFactor = 'desktop'
   })
 
-  it('draws the state segment and the type facet', () => {
+  it('draws the state segment', () => {
     const { text } = render('/updates')
     expect(text).toContain(INBOX)
     expect(text).toContain(ARCHIVED)
+  })
+
+  it('draws the type facet once it has a row to show', () => {
+    // The facet drops zero-count rows, and this harness runs no effects, so the
+    // counts never arrive and every row is filtered out. A SELECTED type keeps
+    // its row at zero — that is what a `?types=` deep link relies on — so it is
+    // also what makes the trigger reachable here.
+    const { text } = render(`/updates?types=nudge`)
     // "Type", not "Kicker" — a kicker is a typography term for the eyebrow
     // above a headline (epic decision 5).
     expect(text).toContain(TYPE)
     expect(text).not.toContain('Kicker')
+  })
+
+  it('hides the type facet on a board with nothing in it (#1567)', () => {
+    // No counts and nothing selected: every row is filtered out, so the trigger
+    // would open an empty picker. Hide the unusable control instead. This is
+    // what a fresh or freshly reset account sees.
+    expect(render('/updates').text).not.toContain(TYPE)
   })
 
   it('draws the five relationship segments, localized', () => {


### PR DESCRIPTION
Fixes #1566 and #1567 — two faults in the same widget, both reported from a phone. Neither screenshot attached, so both were diagnosed from the code.

## #1566 — the Done button was clipped

`.filter-factions__sheet` is `position: fixed; bottom: 0` and reserved nothing for the two things already living at the bottom of a phone viewport: the **3.5rem fixed tab bar** and the **home-indicator inset**. `ShellContent` computes exactly that clearance for the page region; the sheet did not, so its last child — Done — landed under one of them. There was no `env(safe-area-inset-bottom)` anywhere in `index.css`.

`overflow: auto` also sat on the sheet rather than on the option list, so a long list scrolled the heading and the Done button out of view, and reaching Done meant scrolling past every option. The scroll moves to `__rows`, **scoped to the sheet** so the desktop popover — which has no height cap — keeps growing to fit.

The tab bar's height becomes **`--mobile-tabbar-height`**. It was a bare `3.5rem` in `ShellContent`, and this is its second consumer; two literals would drift the first time the bar changed height.

## #1567 — the type picker opened empty

Both facets drop a zero-count row, so on a quiet board — a fresh account, or a freshly reset one — every row is filtered out and the trigger opened a picker with nothing in it. Working as written, but a dead end.

`OptionPicker` now returns `null` when it has no options: **hide the unusable control rather than disable it** (CLAUDE.md).

It tests the option *list*, not the counts, because a **selected** option keeps its row at zero — a `?types=nudge` deep link on a view with no nudges must stay removable, so its trigger must stay reachable.

The fix lands in `OptionPicker` rather than `FilterBar`'s facet loop: the component knows when it has nothing to offer, and the **faction facet gets it for free**.

## One existing test pinned the old behaviour

`updatesFilterBar` asserted the Type trigger renders on a bare `/updates`. But that harness runs no effects, so the counts never arrive and the facet is *always* empty there — the assertion only passed because the trigger drew unconditionally. It becomes two tests: the trigger appears with a selected type, and is absent on an empty board.

Three new tests in `filterState` cover the widget directly: no trigger when every row is filtered out, a trigger when a selected option keeps its row, and the rest of the bar untouched.

## Blast radius

`OptionPicker` is the shared `FilterBar` picker (#1365/#1446), so both fixes land on **tasks, praxes and updates** at once. Worth a look at all three at mobile width.

## Verified

- **3,868 tests** across 222 files pass
- `tsc --noEmit` clean, `eslint` clean
- `npm run build` succeeds; bundle budget **within limits** — though CSS is at 22.4 KB against a 22.5 KB warn line, so this leaves ~0.1 KB of headroom. That is #1325's territory, not something this PR should move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)