### PR TITLE
An empty facet stops drawing a trigger it cannot fill (#1567)

### DIFF
--- a/frontend/src/components/ui/FilterBar/OptionPicker.tsx
+++ b/frontend/src/components/ui/FilterBar/OptionPicker.tsx
@@ -32,12 +32,32 @@ const CHECK_GLYPH = '✓'
  * Dismissal is the trigger, the Done button, and Escape. Deliberately no
  * document-level click-outside listener: three routes is enough, and an effect
  * here would be untestable in a harness with no DOM.
+ *
+ * **An option-less facet draws nothing at all** (#1567). A facet may legitimately
+ * narrow itself to nothing — Updates' type facet hides zero-count rows, so on a
+ * quiet board every row drops off — and the trigger was still rendering, opening
+ * a panel with no rows in it and no explanation. That is a control that cannot
+ * be used, and this repo hides those rather than showing them disabled
+ * (CLAUDE.md; STYLE §1.4). It lives here rather than in `FilterBar`'s facet loop
+ * because this component is the one that knows whether it has anything to offer;
+ * the bar maps facets to pickers and should not reason about their contents.
+ *
+ * The control therefore comes and goes with activity. That cost is accepted: on
+ * a board with traffic it is always present, and it vanishes exactly when it had
+ * nothing to offer. A SELECTED value always keeps its row (see
+ * `typeFacetOptions` and `factionFacet`), so a deep link like `?types=nudge`
+ * leaves a non-empty list and the trigger still renders — the chip it raises
+ * stays removable both from the panel and from the applied-chip row.
  */
 export default function OptionPicker({ facet }: { facet: FilterFacet }) {
   const { t } = useTranslation('common')
   const [open, setOpen] = useState(false)
   const isSheet = useFormFactor() === 'mobile'
   const { label, options, selected, onChange, renderOrnament } = facet
+
+  // After the hooks, never before: an early return above them is a conditional
+  // hook call, and `options` is a prop that changes as counts arrive.
+  if (options.length === 0) return null
 
   const panel = (
     <div

--- a/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
+++ b/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
@@ -16,6 +16,8 @@
  *     hardcoded roster (#1361 ruling 4)
  *   - factionFacet — the faction axis expressed in the generic shape: rows in
  *     roster order, selected first, named, and NO counts (#1361 ruling 3)
+ *   - an option-less facet drawing no trigger at all (#1567), which IS reachable
+ *     here: it is the absence of markup, not the contents of the panel
  *
  * The picker's rows are not reachable here: the panel is behind `open`, which
  * only a click sets. The option list they render is what `factionFacet` and
@@ -301,6 +303,72 @@ describe('factionFacet — the faction axis as one configuration of the widget',
     for (const place of ['row', 'trigger', 'chip'] as const) {
       expect(facet.renderOrnament?.('ua', place)).toBeTruthy()
     }
+  })
+})
+
+describe('an option-less facet draws no trigger (#1567)', () => {
+  // A facet is allowed to narrow itself to nothing: Updates' type facet hides
+  // zero-count rows, so a quiet board leaves it empty. `OptionPicker` returns
+  // null rather than opening a panel with no rows in it. `FilterBar` maps facets
+  // to pickers unconditionally and is deliberately not the place this lives.
+  const emptyFacet: FilterFacet = {
+    key: 'type',
+    label: 'Type',
+    options: [],
+    selected: [],
+    onChange: () => {},
+  }
+
+  const render = (facets: FilterFacet[], summary?: string) =>
+    renderToStaticMarkup(
+      <FilterBar
+        rails={[eraRail('current')]}
+        facets={facets}
+        onClearAll={() => {}}
+        summary={summary}
+      />,
+    )
+
+  it('hides the trigger when the facet has no options', () => {
+    expect(render([emptyFacet])).not.toContain('filter-factions')
+  })
+
+  it('leaves the rails, the summary and the bar itself alone', () => {
+    const html = render([emptyFacet], 'Showing 0 updates')
+    expect(html).toContain('filter-bar')
+    expect(html).toContain('filter-rail')
+    expect(html).toContain('Showing 0 updates')
+  })
+
+  it('hides only the empty facet, not its populated neighbour', () => {
+    const html = render([emptyFacet, factionFacet([{ slug: 'ua' }], [], () => {})])
+    // One trigger, not two: the faction facet still draws.
+    expect(html.match(/filter-factions__trigger/g)).toHaveLength(1)
+  })
+
+  it('KEEPS the trigger for a facet whose only row is a selected zero', () => {
+    // The shape `typeFacetOptions` returns for a deep link like `?types=nudge`
+    // on a board with no nudges. Hiding it would strand the chip.
+    const html = render([
+      {
+        ...emptyFacet,
+        options: [{ value: 'nudge', label: 'Nudge', count: 0 }],
+        selected: ['nudge'],
+      },
+    ])
+    expect(html).toContain('filter-factions__trigger')
+    expect(html).toContain('Nudge')
+  })
+
+  it('never hides the FACTION facet — its roster is not count-filtered', () => {
+    // #1567 guessed this was the same bug; it is not. `factionFacet` carries no
+    // counts at all (#1361 ruling 3) and `filterRoster` always appends the `na`
+    // sentinel, so its option list is non-empty even before GET /factions
+    // answers. Nothing to fix, and nothing to "restore" either.
+    expect(factionFacet([], [], () => {}).options).not.toHaveLength(0)
+    expect(render([factionFacet([], [], () => {})])).toContain(
+      'filter-factions__trigger',
+    )
   })
 })
 

--- a/frontend/src/pages/updates/__tests__/updatesFilterBar.test.tsx
+++ b/frontend/src/pages/updates/__tests__/updatesFilterBar.test.tsx
@@ -37,6 +37,7 @@ const ARCHIVED = i18n.t('feed:filter.state.archived')
 const FOES = i18n.t('feed:filter.relationship.foes')
 const YOUR_STUFF = i18n.t('feed:filter.relationship.yourStuff')
 const TYPE = i18n.t('feed:filter.type')
+const NUDGE = i18n.t('feed:kicker.nudge')
 const FILTERING_BY = i18n.t('common:filters.bar.filteringBy')
 
 function render(entry: string): { html: string; text: string } {
@@ -72,10 +73,17 @@ describe('the Updates page mounts the shared FilterBar', () => {
     mocks.formFactor = 'desktop'
   })
 
-  it('draws the state segment and the type facet', () => {
+  it('draws the state segment', () => {
     const { text } = render('/updates')
     expect(text).toContain(INBOX)
     expect(text).toContain(ARCHIVED)
+  })
+
+  it('draws the type facet when it has rows to offer', () => {
+    // The harness runs no effects, so `counts.by_type` is the hook's empty seed
+    // and the facet has no rows — see the #1567 block below. A selected type
+    // keeps its row, which is the one way to get a populated facet from here.
+    const { text } = render('/updates?types=nudge')
     // "Type", not "Kicker" — a kicker is a typography term for the eyebrow
     // above a headline (epic decision 5).
     expect(text).toContain(TYPE)
@@ -130,5 +138,45 @@ describe('the relationship rail is hidden on the archive', () => {
 
   it('brings it back in the inbox', () => {
     expect(render('/updates?state=inbox').text).toContain(FOES)
+  })
+})
+
+describe('the type facet on an empty board (#1567)', () => {
+  // `typeFacetOptions` hides zero-count rows on purpose, so on a wiped board
+  // every row drops off and the facet has nothing to offer. The trigger used to
+  // render anyway and opened a sheet with nothing in it. `OptionPicker` now
+  // returns null for an option-less facet — the same rule the relationship rail
+  // above follows (CLAUDE.md: hide unusable controls, don't show them disabled).
+  //
+  // This harness runs no effects, so `counts.by_type` never leaves `useUpdates`'
+  // empty seed: the wiped board IS the default render here.
+  it('draws no Type trigger when every count is zero', () => {
+    const { html, text } = render('/updates')
+    expect(html).not.toContain('filter-factions__trigger')
+    expect(text).not.toContain(TYPE)
+  })
+
+  it('still draws the rest of the bar — hiding one facet is not hiding the bar', () => {
+    const { html, text } = render('/updates')
+    expect(html).toContain('filter-bar')
+    expect(text).toContain(INBOX)
+    expect(text).toContain(FOES)
+  })
+
+  it('KEEPS the trigger for a type selected by deep link, so it can be un-ticked', () => {
+    // The regression most likely to bite: a selected type keeps its row at zero,
+    // so the list is non-empty and the picker must still render. Hiding it here
+    // would strand the chip's only other removal route.
+    const { html } = render('/updates?types=nudge')
+    expect(html).toContain('filter-factions__trigger')
+  })
+
+  it('and the chip that names it stays removable and NAMED', () => {
+    // `deriveChips` reads the label off the same option list, so an emptied list
+    // would print the raw slug.
+    const { text } = render('/updates?types=nudge')
+    expect(text).toContain(FILTERING_BY)
+    expect(text).toContain(NUDGE)
+    expect(text).not.toContain('nudge')
   })
 })

--- a/frontend/src/pages/updates/__tests__/updatesFilters.test.ts
+++ b/frontend/src/pages/updates/__tests__/updatesFilters.test.ts
@@ -238,6 +238,17 @@ describe('the type facet', () => {
     expect(options[0].label).not.toBe('nudge')
   })
 
+  it('offers nothing at all on a wiped board (#1567)', () => {
+    // Every count is zero, so every row drops off — and `OptionPicker` renders
+    // no trigger for an option-less facet rather than opening an empty sheet.
+    expect(typeFacetOptions({}, [])).toEqual([])
+    expect(typeFacet({}, [], () => {}).options).toHaveLength(0)
+  })
+
+  it('but a deep-linked selection keeps the facet non-empty, so it still draws', () => {
+    expect(typeFacet({}, ['nudge'], () => {}).options).toHaveLength(1)
+  })
+
   it('sorts selected rows to the top', () => {
     const options = typeFacetOptions({ vote_on_mine: 2, nudge: 1, global_task: 4 }, ['global_task'])
     expect(options.map((option) => option.value)).toEqual([

--- a/frontend/src/pages/updates/updatesFilters.ts
+++ b/frontend/src/pages/updates/updatesFilters.ts
@@ -302,6 +302,10 @@ export function feedTypeLabel(type: string): string {
  * leave an un-removable filter and — because `deriveChips` reads chip labels off
  * this list — print the raw slug `nudge` on the chip. The faction facet solves
  * the same problem the same way, for the same reason.
+ *
+ * On a quiet board this returns NOTHING, which is a legal answer: `OptionPicker`
+ * draws no trigger for an option-less facet (#1567), so the control disappears
+ * rather than opening a sheet with no rows in it.
  */
 export function typeFacetOptions(
   byType: Record<string, number>,


### PR DESCRIPTION
Closes #1567.

## The defect

Tapping **Type** on `/updates` opened a picker with nothing in it and no explanation.

The menu was behaving as written. `typeFacetOptions` keeps a row only when its count is above zero **or** the type is already selected — deliberate, and documented: a selected type must keep its row at zero so it can be un-ticked, and otherwise the list fills with dead options. The board was wiped, so almost every type counted zero and every row dropped off. The trigger rendered anyway.

## The fix

`OptionPicker` returns `null` when `facet.options` is empty — after its hooks, before its markup.

It lives there rather than in `FilterBar`'s facet loop, per the owner ruling: the component is the one that knows whether it has anything to offer; the bar maps facets to pickers and should not have to reason about each facet's contents. Not "list every type at zero" and not "list them disabled" — the standing rule is *hide unusable controls, don't show them disabled* (CLAUDE.md / STYLE §1.4), the same rule the relationship rail already follows on the archive.

Accepted cost, already weighed by the ruling: the control comes and goes with activity. On a board with traffic it is always present; it vanishes on an empty board, which is exactly when it had nothing to offer.

## The two things to confirm

**1. The faction facet does NOT have this bug.** The issue guessed it was the same defect built on the same widget; it is not. `factionFacet` carries no counts at all (#1361 ruling 3, so there is nothing to filter by), and `filterRoster` always appends the `na` sentinel — so its option list holds at least one row even before `GET /factions` answers. It was never reachable in the empty state and it stays visible after this change. One `null` return fixes one facet, not two. That is now **pinned by a test**, so nobody "restores" symmetry that was never there.

**2. The applied-chip row is untouched, and the deep link still works.** `?types=nudge` on a board with no nudges keeps that type's row (at zero), so the list is non-empty, the trigger **still renders**, and `deriveChips` still reads a real label off it rather than printing the raw slug. Removing the filter works from the panel and from the chip. This is the case pinned hardest — three assertions across two files.

`FilterBarEmpty` and the "Showing N updates" summary render normally; hiding one facet is not hiding the bar. Pinned too.

## Tests

- `FilterBar/__tests__/filterState.test.tsx` — an option-less facet draws no `filter-factions` markup; the rails, summary and bar survive it; a populated *neighbour* facet still draws (exactly one trigger, not zero and not two); a facet whose only row is a selected zero keeps its trigger; the faction facet is never empty.
- `pages/updates/__tests__/updatesFilterBar.test.tsx` — the harness runs no effects, so `counts.by_type` never leaves `useUpdates`' empty seed: **the wiped board is the default render here.** A bare `/updates` draws no Type trigger; `/updates?types=nudge` does, with a named removable chip.
- `pages/updates/__tests__/updatesFilters.test.ts` — the pure half: `typeFacetOptions({}, [])` is `[]`, `typeFacet({}, ['nudge'])` is one row.

One existing assertion moved rather than broke: `draws the state segment and the type facet` asserted the Type trigger on a bare `/updates`, which under this fix is precisely the state where it must not draw. It is split into the state segments plus a Type-facet check on the deep-linked render, keeping the "Type, not Kicker" guard (epic decision 5).

## Verification

All six frontend CI steps green locally: `eslint src` (0 warnings), `tsc --noEmit`, `vitest run` (3875 passed / 222 files), `vite build`, byte budget (JS 137.9 KB, CSS 22.3 KB — unchanged), `typecheck:design-sync`. Frontend-only, so `api-schema` and the pytest job are untouched.

**Visual QA is outstanding** — I have no browser or dev stack here. What no test in this repo can see: the bar's spacing once one control leaves the row.

No CSS touched. `index.css` belongs to #1566 (the same picker's Done-button clearance, different layer) and was not opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
