### PR TITLE
The bottom strip the shell already reserved gets a name, and the filter sheet reads it (#1566)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -494,6 +494,16 @@ A faction skin that wants a full-page ground reaches for `position: fixed; inset
 
 `z-index: 0` is neither, and it reads as if it were both. When an ornament lands over copy, the bug is almost always here rather than in the opacity.
 
+### The phone's bottom edge is spoken for, and `position: fixed` does not escape it (#1566)
+
+Two separate rules meet at the bottom 3.5rem of a phone viewport, and the filter bottom sheet broke both at once — on every filter surface in the app, since `OptionPicker` is shared by tasks, praxes and updates.
+
+**A fixed child cannot climb out of an ancestor's stacking context, and `z-index` is what makes that invisible.** The sheet sits at `z-index: 40` and `MobileTabBar` at `10`, so the sheet looks like it wins. It does not: `ShellContent`'s mobile region is `relative` with `z-index: 5`, which opens a stacking context, so *everything* inside it — the sheet at 40, its scrim at 39 — composites at 5 against a bar sitting at 10 in the **root** context. The bar paints over the sheet. That is why the report was "Done is cut off" rather than "Done is behind the tab bar": the number in the rule says the opposite of what renders. **When two fixed elements disagree about who is on top, read the ancestors before you read the z-indexes** — and note that raising the region's z-index is the wrong lever, because it puts ordinary page content over the bar.
+
+**Bottom chrome is a reservation, not a paint order.** The right fix is for anything pinned to the bottom of a phone viewport to reserve the strip the tab bar occupies. That strip is two things summed — the bar's height, then the home-indicator inset beneath it — and it was written out longhand as `calc(3.5rem + env(safe-area-inset-bottom))` in four files with no name before the sheet became the fifth consumer and reserved nothing at all. It is `--tab-bar-clearance` now, composed from `--tab-bar-height`. Two properties of it are worth knowing. **The height is measured, not declared** — the bar has no height rule for the token to read, so it is five `py-2` tabs at `--text-lg` under a 2px rule, and if that type moves nothing catches the drift. And **the `env()` half is currently inert**: without `viewport-fit=cover` on the viewport meta the browser already excludes the safe area from the layout viewport, so the inset resolves to `0px` — correct today, and correct on the day someone sets `viewport-fit`, which is exactly why it stays in the sum.
+
+The corollary at the sheet: **a `max-height` measured from `bottom: 0` is not the height it claims.** `70vh` was spending its last 3.5rem on chrome, so it grows by the clearance to go back to meaning 70vh of *usable* panel. And a panel with a pinned action gives the scroll to the **list**, not to itself — the label row and the Done button stay put, a long facet can never push the action below the fold, and the bottom padding stays out of a scrollport, where browsers have a long history of dropping it on a flex column.
+
 ---
 
 ## 6. Faction Card Archetypes

--- a/frontend/src/components/layout/ShellContent.tsx
+++ b/frontend/src/components/layout/ShellContent.tsx
@@ -59,7 +59,7 @@ const DESKTOP_REGION = 'flex-1 relative max-w-[min(92vw,1600px)] mx-auto w-full 
 
 const MOBILE_REGION_STYLE: CSSProperties = {
   zIndex: 5,
-  paddingBottom: 'calc(3.5rem + env(safe-area-inset-bottom))',
+  paddingBottom: 'var(--tab-bar-clearance)',
 }
 const DESKTOP_REGION_STYLE: CSSProperties = { zIndex: 5 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1725,6 +1725,23 @@
   --space-5xl: 64px;
   --space-6xl: 96px;
 
+  /* ── Mobile bottom-chrome clearance (#1566) ──
+     `MobileTabBar` is `fixed bottom-0` and ~3.5rem tall, and it pads ITSELF by
+     the home indicator. Anything else pinned to the bottom of a phone viewport
+     therefore owes that strip twice over — the bar's height, then the inset
+     beneath it — and the sum was written out by hand in four files with no
+     name: the shell's content region, the two character-path action bars and
+     the faction-detail action bar. A fifth surface (the filter bottom sheet)
+     reserved nothing at all and put its Done button behind the bar. One name
+     so the two halves of the sum can never disagree.
+     Theme-invariant, :root only, like --space-*.
+     ponytail: 3.5rem is the bar's MEASURED height (five `py-2` tabs set in
+     --text-lg under a 2px active rule), not a declared one — the bar has no
+     height property for this to read. If its type or padding moves, re-measure
+     here; nothing enforces the match. */
+  --tab-bar-height: 3.5rem;
+  --tab-bar-clearance: calc(var(--tab-bar-height) + env(safe-area-inset-bottom));
+
   /* ── Leaderboard rank colors (podium — stable across themes) ── */
   --rank-gold: #f59e0b;
   --rank-silver: #c49a3a;
@@ -5429,16 +5446,35 @@
 
 /* Same panel, anchored to the viewport instead of the trigger. One conditional
    in FactionPicker picks between these two classes; there is no second
-   component (#1313's precedent). */
+   component (#1313's precedent).
+
+   The bottom edge is the whole of #1566. Anchored at `bottom: 0` the sheet's
+   last child — Done — landed inside the tab bar's strip, and the sheet's
+   z-index does NOT save it: `ShellContent`'s mobile region is `relative` with
+   `z-index: 5`, which opens a stacking context, so 40 here is composited at 5
+   against a tab bar sitting at 10 in the ROOT context. The bar paints over the
+   sheet (and over the scrim), and Done reads as cut off. Reserving the strip is
+   the fix at this layer; raising the region's z-index would only put page
+   content over the bar.
+
+   `max-height` grows by the same clearance on purpose: 70vh measured from
+   `bottom: 0` was already spending its last 3.5rem on chrome, so the sheet
+   claimed a height it did not have. Adding the strip back keeps 70vh meaning
+   70vh of USABLE panel.
+
+   The rows region owns the scroll rather than the sheet, so head and Done are
+   pinned and a long facet can never push Done below the fold — and the bottom
+   padding stays out of a scrollport, where browsers have historically dropped
+   it on a flex column. */
 .filter-factions__sheet {
   position: fixed;
   left: 0;
   right: 0;
   bottom: 0;
   z-index: 40;
-  max-height: 70vh;
-  overflow: auto;
-  padding: var(--space-lg);
+  max-height: calc(70vh + var(--tab-bar-clearance));
+  padding: var(--space-lg) var(--space-lg)
+    calc(var(--space-lg) + var(--tab-bar-clearance));
   border-top: 1px solid var(--color-border-strong);
   border-radius: var(--space-lg) var(--space-lg) 0 0;
   background: var(--filter-well);
@@ -5468,6 +5504,16 @@
 .filter-factions__rows {
   display: flex;
   flex-direction: column;
+}
+
+/* Sheet-only: the option list is the scrolling part, so the label row and Done
+   stay put (#1566). `min-height: 0` is load-bearing — a flex item's default
+   `min-height: auto` refuses to shrink below its content, which would push the
+   sheet past its own max-height and take Done off-screen again. The popover has
+   no max-height and therefore nothing to scroll, so this stays scoped. */
+.filter-factions__sheet .filter-factions__rows {
+  min-height: 0;
+  overflow-y: auto;
 }
 
 .filter-factions__row {

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
@@ -217,7 +217,7 @@ const errorBox: CSSProperties = {
 }
 const stickyBar: CSSProperties = {
   position: 'sticky',
-  bottom: 'calc(3.5rem + env(safe-area-inset-bottom))',
+  bottom: 'var(--tab-bar-clearance)',
   marginTop: 'auto',
   paddingTop: 'var(--space-sm)',
 }

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
@@ -253,7 +253,7 @@ const errorBox: CSSProperties = {
 }
 const stickyBar: CSSProperties = {
   position: 'sticky',
-  bottom: 'calc(3.5rem + env(safe-area-inset-bottom))',
+  bottom: 'var(--tab-bar-clearance)',
   marginTop: 'auto',
   paddingTop: 'var(--space-sm)',
 }

--- a/frontend/src/pages/factionDetail/mobileArchetypes/shared.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/shared.tsx
@@ -28,9 +28,10 @@ import type { CSSProperties, ReactNode } from "react";
  */
 
 /**
- * Sticky bottom action bar. Pins just above the fixed {@link MobileTabBar}
- * (~3.5rem) and clears the home-indicator safe area; goes full-bleed by
- * cancelling the mobile shell's 16px gutter. Stacks its children in a column so
+ * Sticky bottom action bar. Pins just above the fixed {@link MobileTabBar} and
+ * clears the home-indicator safe area — both halves of that sum live in
+ * `--tab-bar-clearance` (#1566). Goes full-bleed by cancelling the mobile
+ * shell's 16px gutter. Stacks its children in a column so
  * a skin can drop an error line or caption above the action row.
  */
 export function MobileStickyBar({
@@ -44,7 +45,7 @@ export function MobileStickyBar({
     <div
       style={{
         position: "sticky",
-        bottom: "calc(3.5rem + env(safe-area-inset-bottom))",
+        bottom: "var(--tab-bar-clearance)",
         marginLeft: "calc(-1 * var(--space-lg))",
         marginRight: "calc(-1 * var(--space-lg))",
         marginTop: "var(--space-xl)",


### PR DESCRIPTION
Closes #1566.

## What was wrong

`.filter-factions__sheet` is `position: fixed; bottom: 0` and reserved nothing for `MobileTabBar`, so its last child — the **Done** button — landed inside the bar's 3.5rem strip. `OptionPicker` is the shared `FilterBar` picker (#1365/#1446), so this was every filter surface: **tasks, praxes and updates**.

## One correction to the diagnosis

The issue reasons that the sheet's `z-index: 40` beats the bar's `10`, "which is why it reads as cut off rather than hidden". It is the other way round, and the mechanism matters for anyone who touches this next: `ShellContent`'s mobile region is `relative` with `z-index: 5` (`ShellContent.tsx:56,61`), which **opens a stacking context**. Everything inside it — the sheet at 40, its scrim at 39 — composites at 5 against a bar sitting at 10 in the *root* context, so the bar genuinely paints **over** the sheet. The prescribed fix is unaffected: reserving the strip is the right lever at this layer, and raising the region's z-index would only put ordinary page content over the bar.

## The fix

- **`--tab-bar-height: 3.5rem`** and **`--tab-bar-clearance: calc(var(--tab-bar-height) + env(safe-area-inset-bottom))`** in `:root`. The sum was written longhand in **four** files, not the two the issue names — `ShellContent`, `DefaultCreateCharacter`, `DefaultEditCharacter`, `factionDetail/mobileArchetypes/shared` — and the sheet was the fifth consumer. All five read the token now; the four existing sites are a pure rename with no rendered change.
- **The sheet reserves the strip** as bottom padding, so Done clears both the bar and the home indicator.
- **`max-height` grows by the same clearance.** `70vh` measured from `bottom: 0` was already spending its last 3.5rem on chrome; now 70vh means 70vh of *usable* panel.
- **The rows region takes the scroll, not the sheet.** The label row and Done are pinned, so a long facet can never push Done below the fold — and the new bottom padding stays out of a scrollport, where browsers have historically dropped it on a flex column.

## What to eyeball

I have no browser and no dev stack, so **none of this has been seen** — it is a bug about pixels at a screen edge, verified only through `tsc`/`eslint`/`vitest`/`vite build` and by grepping the built stylesheet. Please check, at mobile width (≤ the `useFormFactor` breakpoint), on a device **with** a home indicator and one **without**:

1. `/tasks`, `/praxis`, `/updates` — open each filter facet's sheet. Done should sit fully above the tab bar, and the tab bar should still be visible below the sheet.
2. Open the facet with the most options (factions on `/tasks`) — the list should scroll *inside* the sheet while the label row and Done stay put.
3. Light and dark, both.
4. Regression check on the four renamed sites: the character create/edit sticky action bars, the faction-detail sticky action bar, and general page-bottom padding on any mobile page.

## Known adjacent, not fixed here

- **`env(safe-area-inset-bottom)` resolves to `0px` today** — `frontend/index.html` has no `viewport-fit=cover`, so the browser already excludes the safe area from the layout viewport. The inset half of the token is correct-and-inert rather than load-bearing; the 3.5rem is doing the work. Setting `viewport-fit` is a whole-app decision, not a filter-sheet one.
- **The scrim is trapped in the same stacking context**, so the tab bar stays undimmed and tappable while a sheet is open. Fixing that needs a portal or a `.tsx` change to the shell.
- `CharacterSwitcherSheet.tsx:176` is a second bottom sheet that pads by `env()` alone with no tab-bar clearance. It escapes the symptom only because it is mounted outside the trapped region at `z-index: 41`.

`OptionPicker.tsx` is untouched (#1567 owns it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)