### PR TITLE
The avatar goes with the life that ends it, and the disk learns what the database forgot (#1568)

### DIFF
--- a/backend/scripts/reset_render_db.py
+++ b/backend/scripts/reset_render_db.py
@@ -14,9 +14,18 @@ condition it exists to clear.
 
 The media step exists because uploads live on a Render *disk*, which no schema
 drop can reach: every avatar and praxis image would otherwise survive as an
-orphan pointing at a row that no longer exists. Pass `--keep-media` to skip it.
-Only the disk's CONTENTS are removed, never MEDIA_ROOT itself — that is the
-mount point, and removing it would break the mount.
+orphan pointing at a row that no longer exists — and character ids restart at 1,
+so a new character then writes into the previous occupant's directory. Pass
+`--keep-media` to skip it. Only the disk's CONTENTS are removed, never
+MEDIA_ROOT itself — that is the mount point, and removing it would break the
+mount.
+
+`--keep-media`, or any environment wiped by other means (a reset predating this
+step, a local `reset_db.sh`), leaves that accumulation behind. `scripts/
+sweep_orphan_media.py` is what clears it after the fact: it deletes only files
+no database row claims, so it is safe to run on a live disk, and reports before
+it touches anything. This script is the blunt instrument for a disk that is
+*meant* to be empty; the sweep is the selective one.
 
 Designed to run from **Render Shell** (worldzero-backend → Shell), where
 `DATABASE_URL` and `MEDIA_ROOT` are already injected by `render.yaml`. Nothing

--- a/backend/scripts/reset_render_db.py
+++ b/backend/scripts/reset_render_db.py
@@ -21,11 +21,11 @@ MEDIA_ROOT itself — that is the mount point, and removing it would break the
 mount.
 
 `--keep-media`, or any environment wiped by other means (a reset predating this
-step, a local `reset_db.sh`), leaves that accumulation behind. `scripts/
-sweep_orphan_media.py` is what clears it after the fact: it deletes only files
-no database row claims, so it is safe to run on a live disk, and reports before
-it touches anything. This script is the blunt instrument for a disk that is
-*meant* to be empty; the sweep is the selective one.
+step, a local `reset_db.sh`), leaves that accumulation behind.
+`scripts/sweep_orphan_media.py` is what clears it after the fact: it deletes
+only files no database row claims, so it is safe to run on a live disk, and
+reports before it touches anything. This script is the blunt instrument for a
+disk that is *meant* to be empty; the sweep is the selective one.
 
 Designed to run from **Render Shell** (worldzero-backend → Shell), where
 `DATABASE_URL` and `MEDIA_ROOT` are already injected by `render.yaml`. Nothing

--- a/backend/scripts/sweep_orphan_media.py
+++ b/backend/scripts/sweep_orphan_media.py
@@ -1,0 +1,202 @@
+"""
+Report — and optionally unlink — media files that no database row points at.
+
+A thin CLI over ``services.media_sweep``. The reconciliation rules, and why the
+disk is read before the database, live in that module's docstring; do not grow a
+second copy of them here.
+
+    python scripts/sweep_orphan_media.py                  # dry run, dev
+    python scripts/sweep_orphan_media.py --env prod       # dry run, prod
+    python scripts/sweep_orphan_media.py --apply          # actually unlink
+    python scripts/sweep_orphan_media.py --apply --yes    # skip the confirmation
+    python scripts/sweep_orphan_media.py --min-age-minutes 0   # judge fresh files too
+
+**Dry run is the default and unlinking is opt-in**, because this deletes user
+data that no undo exists for: the file is the artefact, and MEDIA_ROOT has no
+version history. Every run prints counts and total bytes before it is asked
+whether to act, so ``--apply`` is only ever the second thing you type.
+
+WHY THIS EXISTS BEYOND ROUTINE HYGIENE
+--------------------------------------
+``MEDIA_ROOT`` is a separate disk that a database wipe cannot reach, and
+character ids restart at 1. So after a reset every file on disk is an orphan,
+and a *new* character writes into the previous occupant's directory. This sweep
+is what clears the accumulation. ``scripts/reset_render_db.py`` empties the disk
+as part of a Render reset, which handles the case going forward — this handles
+everything the resets before it left behind, and any local or self-managed
+environment that was wiped by other means. See docs/agents/db-migrations.md.
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine  # noqa: E402
+
+from script_utils import add_env_argument, get_settings  # noqa: E402
+from services.media_sweep import (  # noqa: E402
+    DEFAULT_MIN_AGE_SECONDS,
+    MediaPathShape,
+    SweepReport,
+    find_orphans,
+    load_known_paths,
+    media_root_is_sweepable,
+    prune_empty_directories,
+    scan_media_root,
+    summarise_by_shape,
+    total_bytes,
+    unlink_orphans,
+)
+
+MEBIBYTE = 1024 * 1024
+# Enough to see the pattern without paging thousands of lines past an operator
+# who is about to make an irreversible decision.
+PATHS_LISTED = 40
+
+SHAPE_LABELS = {
+    MediaPathShape.avatar: "avatar   <character_id>/avatar/...",
+    MediaPathShape.praxis: "praxis   <character_id>/<praxis_id>/...",
+    MediaPathShape.unrecognised: "other    (neither shape)",
+}
+
+
+def format_size(size_bytes: int) -> str:
+    return f"{size_bytes / MEBIBYTE:.1f} MiB"
+
+
+def print_report(report: SweepReport, min_age_seconds: float) -> None:
+    """Everything an operator needs before deciding whether to --apply."""
+    print(f"Scanned     : {len(report.scanned)} file(s), {format_size(total_bytes(report.scanned))}")
+    # ASCII arrows on purpose: this prints to a Windows console under cp1252 as
+    # readily as to a Render shell, and a report that raises UnicodeEncodeError
+    # halfway through is a report an operator acts on without having read.
+    print(
+        f"Claimed by  : {report.known.avatar_rows} character row(s) "
+        f"-> {len(report.known.avatar_paths)} avatar path(s), "
+        f"{report.known.media_item_rows} media_item row(s) "
+        f"-> {len(report.known.media_item_paths)} media path(s)"
+    )
+    if report.known.avatar_rows and not report.known.claimed_paths:
+        print("              (no row claims any file on this disk - a wiped or foreign database?)")
+
+    if report.escaping:
+        print(f"\nSkipped     : {len(report.escaping)} path(s) resolving outside MEDIA_ROOT (never ours):")
+        for path in report.escaping[:PATHS_LISTED]:
+            print(f"  {path}")
+
+    if report.too_recent:
+        print(
+            f"\nHeld back   : {len(report.too_recent)} unclaimed file(s), "
+            f"{format_size(total_bytes(report.too_recent))} - younger than "
+            f"{min_age_seconds / 60:.0f} min, so possibly an upload mid-flight. "
+            f"Use --min-age-minutes 0 to include them."
+        )
+
+    print(
+        f"\nOrphans     : {len(report.orphans)} file(s), "
+        f"{format_size(total_bytes(report.orphans))}"
+    )
+    summary = summarise_by_shape(report.orphans)
+    for shape in MediaPathShape:
+        count, size_bytes = summary[shape]
+        print(f"  {SHAPE_LABELS[shape]:<40} {count:>6} file(s)  {format_size(size_bytes):>12}")
+
+    if report.orphans:
+        print()
+        for scanned_file in report.orphans[:PATHS_LISTED]:
+            print(f"  {scanned_file.relative_path}")
+        if len(report.orphans) > PATHS_LISTED:
+            print(f"  ... and {len(report.orphans) - PATHS_LISTED} more")
+
+
+async def run(env: str, apply: bool, yes: bool, min_age_seconds: float) -> int:
+    settings = get_settings(env)
+    media_root = settings.MEDIA_ROOT
+
+    print(f"Environment : {env}")
+    print(f"Database    : {settings.DATABASE_URL.split('@')[-1]}")  # host/db only, no creds
+    print(f"Media root  : {os.path.realpath(media_root)}")
+    print(f"Mode        : {'APPLY - files WILL be unlinked' if apply else 'dry run'}\n")
+
+    if not media_root_is_sweepable(media_root):
+        print(f"ERROR: refusing to sweep MEDIA_ROOT={media_root!r} - that is not a media disk.")
+        return 1
+    if not os.path.isdir(os.path.realpath(media_root)):
+        print("MEDIA_ROOT does not exist - nothing to sweep.")
+        return 0
+
+    # Disk first, database second: see services/media_sweep.py.
+    scanned, escaping = scan_media_root(media_root)
+
+    engine = create_async_engine(settings.DATABASE_URL, echo=False)
+    async_session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with async_session() as session:
+            known = await load_known_paths(session, media_root)
+    finally:
+        await engine.dispose()
+
+    report = find_orphans(media_root, scanned, escaping, known, min_age_seconds)
+    print_report(report, min_age_seconds)
+
+    if not report.orphans:
+        print("\nNothing to remove.")
+        return 0
+
+    if not apply:
+        print("\nDry run - nothing was deleted. Re-run with --apply to unlink.")
+        return 0
+
+    if not yes:
+        answer = input(f"\nType 'delete' to unlink {len(report.orphans)} file(s): ").strip()
+        if answer != "delete":
+            print("Aborted.")
+            return 1
+
+    removed, freed, failures = unlink_orphans(report.orphans)
+    pruned = prune_empty_directories(media_root)
+    print(f"\nRemoved {removed} file(s), freed {format_size(freed)}; pruned {pruned} empty directory(ies).")
+    if failures:
+        print(f"{len(failures)} file(s) could not be removed:")
+        for failure in failures[:PATHS_LISTED]:
+            print(f"  {failure}")
+        return 1
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Report media files with no database row behind them; --apply to unlink."
+    )
+    add_env_argument(parser)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Actually unlink the orphans. Without this the script only reports.",
+    )
+    parser.add_argument(
+        "--yes", "-y",
+        action="store_true",
+        help="Skip the typed confirmation (for non-interactive runs). Only meaningful with --apply.",
+    )
+    parser.add_argument(
+        "--min-age-minutes",
+        type=float,
+        default=DEFAULT_MIN_AGE_SECONDS / 60,
+        help=(
+            "Hold back unclaimed files younger than this, since an upload writes its "
+            "file before its row commits. 0 disables the grace period."
+        ),
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(run(args.env, args.apply, args.yes, args.min_age_minutes * 60)))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -17,6 +17,7 @@ from models.praxis import ModerationStatus, Praxis, PraxisMember, PraxisStatus
 from models.task import Task
 from schemas.character import BadgeOut, CharacterCreate, CharacterOut, CharacterUpdate
 from services.era import get_current_era_row, get_current_era_row_safe, get_or_create_stats
+from services.media import delete_stored_avatar
 
 # Status set for the account-scoped roster: a player's own lives, excluding
 # banned. Kept as a set even though `active` is currently its only member — the
@@ -476,10 +477,39 @@ async def soft_delete_character(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> None:
+    """End a life at the player's own request, and erase its avatar (#1568).
+
+    "Soft" is literal: there is no hard delete anywhere in the codebase, and
+    this sets ``status = banned`` — the same *state* an admin ban lands in.
+    The two paths are nevertheless split on media, and this is the erasing one:
+
+    * **Self-deletion** (``DELETE /characters/{id}``, which 403s on anyone
+      else's, so the caller is always ending their own life) unlinks the
+      avatar file and clears the column.
+    * **Moderator ban** (``POST /admin/characters/{id}/ban``) deletes nothing.
+      Moderation must not shred the evidence it is acting on, and a ban is a
+      reversible toggle — destroying files on it would restore a character
+      with holes in it. That route sets ``status`` directly and deliberately
+      does not call this function; keep it that way.
+
+    **Praxis media survives both.** It is the public artefact of work other
+    players have voted on and built feeds around; removing it retroactively
+    would leave praxis cards with missing images across other people's history.
+
+    The column is cleared before the unlink so the row never points at a file
+    that is gone. The unlink itself is the last thing this function does, and
+    is deliberately *not* transactional — the router owns the commit (``db.get_db``),
+    so a commit that failed after the unlink would leave a file deleted and a
+    row rolled back. Doing it last makes that window as small as it can be
+    without moving filesystem I/O into the route handler; the failure mode is a
+    dead ``avatar_url``, which the next upload overwrites.
+    """
     character = await get_character_by_id(character_id, session)
     if character is None:
         raise HTTPException(status_code=404, detail="Character not found.")
     character.status = CharacterStatus.banned
+    erased_avatar_url = character.avatar_url
+    character.avatar_url = ""
 
     # ADR-0011 §Forfeit (#307): a ban forfeits every *settled* duel the banned
     # character is a side of — the opponent wins by default. Sticky: leave duels
@@ -523,6 +553,10 @@ async def soft_delete_character(
                 winner_id, session, era, era_row=era_row
             )
         await session.flush()
+
+    # Last, and only after the cleared column has been flushed: see the docstring.
+    # A no-op when the column held a pasted remote URL rather than a path we wrote.
+    delete_stored_avatar(erased_avatar_url)
 
 
 def _character_stats_era_join(era_id: int | None) -> Select:

--- a/backend/services/media.py
+++ b/backend/services/media.py
@@ -53,7 +53,9 @@ def _sanitize_filename(raw: str) -> str:
     return cleaned
 
 
-def _resolve_stored_media_path(stored_path: str) -> str | None:
+def resolve_stored_media_path(
+    stored_path: str, media_root: str | None = None
+) -> str | None:
     """Resolve a stored relative media path to an absolute path under MEDIA_ROOT.
 
     Returns ``None`` for anything this process must not touch on disk, which is
@@ -64,6 +66,17 @@ def _resolve_stored_media_path(stored_path: str) -> str | None:
     ``http(s)`` URL. Absolute filesystem paths and ``..`` escapes are refused
     for the same reason ``_sanitize_filename`` exists — a value that resolves
     outside ``MEDIA_ROOT`` is not a file we wrote.
+
+    This is the single "is this a file we own?" predicate. Every caller that
+    turns a stored column value into a filesystem operation goes through it —
+    the upload path, character self-deletion (#1568) and the orphan sweep
+    (``services.media_sweep``) — because unlinking whatever a 500-char
+    player-supplied column happens to hold is a path-traversal primitive.
+
+    ``media_root`` overrides ``settings.MEDIA_ROOT`` for callers that resolve
+    settings themselves rather than from the process environment: the sweep
+    script loads a ``Settings`` for ``--env prod`` and must ask about *that*
+    disk, not this process's.
     """
     if not stored_path:
         return None
@@ -71,27 +84,36 @@ def _resolve_stored_media_path(stored_path: str) -> str | None:
         return None
     if os.path.isabs(stored_path):
         return None
-    media_root = os.path.realpath(settings.MEDIA_ROOT)
-    resolved = os.path.realpath(os.path.join(media_root, stored_path))
-    if not resolved.startswith(media_root + os.sep):
+    resolved_root = os.path.realpath(media_root or settings.MEDIA_ROOT)
+    resolved = os.path.realpath(os.path.join(resolved_root, stored_path))
+    if not resolved.startswith(resolved_root + os.sep):
         return None
     return resolved
 
 
-def _remove_superseded_avatar(previous_avatar_url: str | None) -> None:
-    """Delete the avatar a fresh upload has just replaced, best-effort.
+def delete_stored_avatar(stored_avatar_url: str | None) -> None:
+    """Unlink an avatar file we wrote, best-effort. Two callers, one rule.
 
-    Called only after the replacement is safely on disk: an upload must never
-    leave a character with a dead ``avatar_url``, so a failure to unlink is
-    logged and swallowed rather than raised.
+    1. A fresh upload has superseded it (``process_and_save_avatar``). Called
+       only once the replacement is safely on disk — an upload must never leave
+       a character with a dead ``avatar_url``.
+    2. The player has ended this life (``services.character.soft_delete_character``,
+       #1568). Self-deletion is the *only* path that erases: an admin ban leaves
+       every file alone, because moderation must not shred the evidence it is
+       acting on and a ban is a reversible toggle.
+
+    Best-effort in both: a failure to unlink is logged and swallowed rather than
+    raised, so a filesystem problem can never block the state change the caller
+    is really making. The residue is an orphan, which
+    ``scripts/sweep_orphan_media.py`` exists to collect.
     """
-    absolute_path = _resolve_stored_media_path(previous_avatar_url or "")
+    absolute_path = resolve_stored_media_path(stored_avatar_url or "")
     if absolute_path is None:
         return
     try:
         os.remove(absolute_path)
     except OSError:
-        logger.info("Could not remove superseded avatar %s", absolute_path)
+        logger.info("Could not remove avatar file %s", absolute_path)
         return
     # Each upload owns its directory, so the unlink leaves that directory empty.
     # rmdir refuses a non-empty one, which is exactly the guard we want for
@@ -172,7 +194,7 @@ async def process_and_save_avatar(
         )
 
     # Only once the replacement is safely on disk.
-    _remove_superseded_avatar(previous_avatar_url)
+    delete_stored_avatar(previous_avatar_url)
 
     return relative_path
 
@@ -243,6 +265,8 @@ __all__ = [
     "AVATAR_MAX_SIZE",
     "MEDIA_FILENAME_MAX_LEN",
     "MEDIA_MAX_BYTES",
+    "delete_stored_avatar",
     "process_and_save_avatar",
     "process_and_save_media",
+    "resolve_stored_media_path",
 ]

--- a/backend/services/media_sweep.py
+++ b/backend/services/media_sweep.py
@@ -1,0 +1,318 @@
+"""Find media files on disk that no database row points at (#1568).
+
+``MEDIA_ROOT`` is a disk, not a table. Nothing in the request path is
+transactional across the two, so files outlive rows in several ordinary ways:
+an upload that is written and then fails to commit, a praxis whose media rows
+are deleted, a character who ends their own life while an avatar upload is in
+flight — and, most sweepingly, a database wipe, which cannot reach the disk at
+all and therefore orphans *every* file on it in one move.
+
+This module is the read side of that reconciliation. It walks the disk, asks
+the database which paths it still claims, and returns the difference.
+``scripts/sweep_orphan_media.py`` is the thin CLI over it (dry run by default).
+
+WHAT COUNTS AS "CLAIMED"
+------------------------
+The **stored path**, and only the stored path. ``MediaItem.file_path`` and
+``Character.avatar_url`` are the sole records of where a file lives; inferring
+ownership from the directory layout would drift the moment a path shape
+changes — which it has done twice inside a year (#1336 gave praxis media a uuid
+directory, #1565 gave avatars one). :class:`MediaPathShape` exists purely to
+group the *report* into the two shapes an operator recognises; it is never
+consulted when deciding whether a file is an orphan, and an ``unrecognised``
+shape is not by itself evidence of anything.
+
+Every stored value is passed through ``services.media.resolve_stored_media_path``
+— the same "is this a file we own?" predicate the upload and deletion paths
+use — so a row holding a player-supplied ``http(s)`` URL contributes no claim
+and a row holding ``../../etc/passwd`` cannot make one either.
+
+WHY THE DISK IS READ BEFORE THE DATABASE
+----------------------------------------
+An upload writes its file *before* its row commits, so a file seen mid-upload
+looks unclaimed. Walking the disk first and querying afterwards means any row
+that commits during the scan is still in the claim set, which closes most of
+that window; ``min_age_seconds`` closes the rest by refusing to consider a file
+younger than the operator's chosen threshold. Neither is a lock — the honest
+statement is that a sweep run against a busy instance can still race, and the
+mitigations make the window small rather than zero.
+"""
+
+import dataclasses
+import enum
+import os
+import time
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.praxis import MediaItem
+from services.media import resolve_stored_media_path
+
+
+# Directories that are obviously not a media disk. A sweep resolves "orphan" as
+# "no database row claims it", so pointed at ``/etc`` it would find that nothing
+# is claimed and offer to delete the lot. ``scripts/reset_render_db.py`` keeps
+# its own copy of this list on purpose: that script imports nothing from the app
+# so it can run on a Render instance whose image predates the current chain.
+FORBIDDEN_MEDIA_ROOTS = frozenset({"/", "/app", "/usr", "/etc", "/var", "/home", "/root"})
+
+# Default grace period for the disk/database race described in the module
+# docstring. Tunable per run; this is an operational safety margin, not a rule,
+# so it lives here rather than in EraConfig.
+DEFAULT_MIN_AGE_SECONDS = 3600.0
+
+
+class MediaPathShape(enum.Enum):
+    """How a path under MEDIA_ROOT reads. Report grouping only — never matching."""
+
+    avatar = "avatar"
+    praxis = "praxis"
+    unrecognised = "unrecognised"
+
+
+@dataclasses.dataclass(frozen=True)
+class ScannedFile:
+    """One file found under MEDIA_ROOT, with everything the report needs."""
+
+    absolute_path: str
+    relative_path: str
+    size_bytes: int
+    shape: MediaPathShape
+    age_seconds: float
+
+
+@dataclasses.dataclass(frozen=True)
+class KnownPaths:
+    """The paths the database still claims, already resolved to absolute form.
+
+    Row counts are kept alongside the path sets because they differ, and the
+    difference is worth printing: a row whose value is a remote URL is a real
+    row that claims no file.
+    """
+
+    avatar_paths: frozenset[str]
+    media_item_paths: frozenset[str]
+    avatar_rows: int
+    media_item_rows: int
+
+    @property
+    def claimed_paths(self) -> frozenset[str]:
+        return self.avatar_paths | self.media_item_paths
+
+
+@dataclasses.dataclass(frozen=True)
+class SweepReport:
+    """Everything the CLI prints, computed before anything is unlinked."""
+
+    media_root: str
+    scanned: tuple[ScannedFile, ...]
+    orphans: tuple[ScannedFile, ...]
+    too_recent: tuple[ScannedFile, ...]
+    escaping: tuple[str, ...]
+    known: KnownPaths
+
+
+def media_root_is_sweepable(media_root: str) -> bool:
+    """False for a path no sweep should ever be pointed at. See FORBIDDEN_MEDIA_ROOTS."""
+    if not media_root.strip():
+        return False
+    resolved = os.path.realpath(media_root)
+    normalised = "/" + media_root.replace("\\", "/").strip("/") if media_root.strip("/") else "/"
+    if normalised in FORBIDDEN_MEDIA_ROOTS or resolved in FORBIDDEN_MEDIA_ROOTS:
+        return False
+    return os.path.dirname(resolved) != resolved
+
+
+def classify_shape(relative_path: str) -> MediaPathShape:
+    """Group a relative path for the report. Not used to decide orphanhood.
+
+    ``<character_id>/avatar/...`` is an avatar; ``<character_id>/<praxis_id>/...``
+    with two numeric segments is praxis media. Anything else is reported as
+    ``unrecognised`` rather than guessed at — including the shapes a future
+    change introduces, which is the point of not matching on this.
+    """
+    segments = [segment for segment in relative_path.replace("\\", "/").split("/") if segment]
+    if len(segments) < 2 or not segments[0].isdigit():
+        return MediaPathShape.unrecognised
+    if segments[1] == "avatar":
+        return MediaPathShape.avatar
+    if segments[1].isdigit():
+        return MediaPathShape.praxis
+    return MediaPathShape.unrecognised
+
+
+def scan_media_root(
+    media_root: str, now: float | None = None
+) -> tuple[tuple[ScannedFile, ...], tuple[str, ...]]:
+    """Walk MEDIA_ROOT and describe every file under it.
+
+    Returns ``(files, escaping)``. ``escaping`` holds paths whose symlinks
+    resolve outside the root: those are not files we wrote, so they are
+    reported and then left entirely alone.
+    """
+    now = time.time() if now is None else now
+    root = os.path.realpath(media_root)
+    files: list[ScannedFile] = []
+    escaping: list[str] = []
+
+    for directory_path, _directory_names, file_names in os.walk(root):
+        for file_name in file_names:
+            joined = os.path.join(directory_path, file_name)
+            absolute_path = os.path.realpath(joined)
+            if not absolute_path.startswith(root + os.sep):
+                escaping.append(joined)
+                continue
+            try:
+                stat_result = os.lstat(joined)
+            except OSError:
+                continue
+            relative_path = os.path.relpath(absolute_path, root)
+            files.append(
+                ScannedFile(
+                    absolute_path=absolute_path,
+                    relative_path=relative_path,
+                    size_bytes=stat_result.st_size,
+                    shape=classify_shape(relative_path),
+                    age_seconds=now - stat_result.st_mtime,
+                )
+            )
+
+    return tuple(files), tuple(escaping)
+
+
+async def load_known_paths(session: AsyncSession, media_root: str) -> KnownPaths:
+    """Resolve every stored media value in the database to an absolute path.
+
+    Values the app does not own — empty strings, pasted ``http(s)`` URLs,
+    anything that resolves outside ``media_root`` — claim nothing, exactly as
+    they unlink nothing elsewhere. That is ``resolve_stored_media_path``'s
+    contract and this module does not restate it.
+    """
+    avatar_values = (
+        await session.execute(select(Character.avatar_url))
+    ).scalars().all()
+    file_path_values = (
+        await session.execute(select(MediaItem.file_path))
+    ).scalars().all()
+
+    def resolved(values: list[str]) -> frozenset[str]:
+        return frozenset(
+            path
+            for path in (
+                resolve_stored_media_path(value or "", media_root) for value in values
+            )
+            if path is not None
+        )
+
+    return KnownPaths(
+        avatar_paths=resolved(list(avatar_values)),
+        media_item_paths=resolved(list(file_path_values)),
+        avatar_rows=len(avatar_values),
+        media_item_rows=len(file_path_values),
+    )
+
+
+def find_orphans(
+    media_root: str,
+    scanned: tuple[ScannedFile, ...],
+    escaping: tuple[str, ...],
+    known: KnownPaths,
+    min_age_seconds: float = DEFAULT_MIN_AGE_SECONDS,
+) -> SweepReport:
+    """Split the scan into claimed, orphaned, and too-recent-to-judge."""
+    claimed = known.claimed_paths
+    orphans: list[ScannedFile] = []
+    too_recent: list[ScannedFile] = []
+
+    for scanned_file in scanned:
+        if scanned_file.absolute_path in claimed:
+            continue
+        if scanned_file.age_seconds < min_age_seconds:
+            too_recent.append(scanned_file)
+        else:
+            orphans.append(scanned_file)
+
+    return SweepReport(
+        media_root=os.path.realpath(media_root),
+        scanned=scanned,
+        orphans=tuple(sorted(orphans, key=lambda item: item.relative_path)),
+        too_recent=tuple(sorted(too_recent, key=lambda item: item.relative_path)),
+        escaping=escaping,
+        known=known,
+    )
+
+
+def summarise_by_shape(
+    files: tuple[ScannedFile, ...]
+) -> dict[MediaPathShape, tuple[int, int]]:
+    """``{shape: (file count, total bytes)}`` for every shape, including zeroes."""
+    summary = {shape: (0, 0) for shape in MediaPathShape}
+    for scanned_file in files:
+        count, total = summary[scanned_file.shape]
+        summary[scanned_file.shape] = (count + 1, total + scanned_file.size_bytes)
+    return summary
+
+
+def total_bytes(files: tuple[ScannedFile, ...]) -> int:
+    return sum(scanned_file.size_bytes for scanned_file in files)
+
+
+def unlink_orphans(orphans: tuple[ScannedFile, ...]) -> tuple[int, int, tuple[str, ...]]:
+    """Unlink the given files. Returns ``(removed, bytes freed, failures)``.
+
+    One failure does not abort the rest: a sweep that stops halfway leaves the
+    operator with a report that no longer describes the disk.
+    """
+    removed = 0
+    freed = 0
+    failures: list[str] = []
+    for scanned_file in orphans:
+        try:
+            os.remove(scanned_file.absolute_path)
+        except OSError as error:
+            failures.append(f"{scanned_file.relative_path}: {error}")
+            continue
+        removed += 1
+        freed += scanned_file.size_bytes
+    return removed, freed, tuple(failures)
+
+
+def prune_empty_directories(media_root: str) -> int:
+    """Remove directories left empty beneath MEDIA_ROOT; never the root itself.
+
+    Both media shapes give every upload its own directory, so unlinking the
+    files leaves a tree of empty ones behind. Bottom-up so a directory whose
+    only contents were empty directories also goes.
+    """
+    root = os.path.realpath(media_root)
+    removed = 0
+    for directory_path, _directory_names, _file_names in os.walk(root, topdown=False):
+        if os.path.realpath(directory_path) == root:
+            continue
+        try:
+            os.rmdir(directory_path)
+        except OSError:
+            continue  # Not empty, or not ours to remove.
+        removed += 1
+    return removed
+
+
+__all__ = [
+    "DEFAULT_MIN_AGE_SECONDS",
+    "FORBIDDEN_MEDIA_ROOTS",
+    "KnownPaths",
+    "MediaPathShape",
+    "ScannedFile",
+    "SweepReport",
+    "classify_shape",
+    "find_orphans",
+    "load_known_paths",
+    "media_root_is_sweepable",
+    "prune_empty_directories",
+    "scan_media_root",
+    "summarise_by_shape",
+    "total_bytes",
+    "unlink_orphans",
+]

--- a/backend/tests/integration/test_admin.py
+++ b/backend/tests/integration/test_admin.py
@@ -432,6 +432,51 @@ async def test_admin_ban_character(
     assert resp.json()["banned"] is False
 
 
+@pytest.mark.asyncio
+async def test_admin_ban_deletes_no_media(
+    client: AsyncClient,
+    account: Account,
+    character2: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    tmp_path,
+    monkeypatch,
+):
+    """A ban destroys nothing on disk (#1568).
+
+    Self-deletion erases the avatar; moderation does not. Two reasons, both
+    load-bearing: moderation must not shred the evidence it is acting on, and a
+    ban is a reversible toggle — un-banning would otherwise restore a character
+    with holes in it. The two paths land in the same ``status = banned`` state,
+    so nothing but a test distinguishes them.
+    """
+    import os
+
+    from config import settings as _settings
+
+    monkeypatch.setattr(_settings, "MEDIA_ROOT", str(tmp_path))
+    await _make_admin(account, db_session)
+
+    relative_path = os.path.join(str(character2.id), "avatar", "abc", "avatar.jpg")
+    absolute_path = os.path.join(str(tmp_path), relative_path)
+    os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
+    with open(absolute_path, "wb") as handle:
+        handle.write(b"avatar bytes")
+    character2.avatar_url = relative_path
+    await db_session.flush()
+
+    resp = await client.post(
+        f"/admin/characters/{character2.id}/ban",
+        json={"banned": True},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+
+    await db_session.refresh(character2)
+    assert os.path.isfile(absolute_path)
+    assert character2.avatar_url == relative_path
+
+
 # ---------------------------------------------------------------------------
 # Accounts & roles
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -842,6 +842,121 @@ async def test_delete_character_wrong_owner(
 
 
 # ---------------------------------------------------------------------------
+# DELETE erases the avatar (#1568)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_delete_character_erases_the_avatar_file_and_the_column(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    tmp_path,
+    monkeypatch,
+):
+    """Ending your own life takes your photo with it (#1568).
+
+    Route-level because the erasure is a property of the *self-deletion path*,
+    not of the state it lands in: the admin ban reaches the identical
+    ``status = banned`` and must leave the file alone.
+
+    Both halves are asserted. Unlinking without clearing the column leaves the
+    row pointing at a file that is gone; clearing without unlinking leaves an
+    orphan nothing will ever reference again.
+    """
+    from config import settings as _settings
+
+    monkeypatch.setattr(_settings, "MEDIA_ROOT", str(tmp_path))
+
+    upload = await client.post(
+        f"/characters/{character.id}/avatar",
+        files={"file": ("avatar.jpg", _make_jpeg_bytes(), "image/jpeg")},
+        headers=auth_headers,
+    )
+    assert upload.status_code == 200
+    avatar_url = upload.json()["avatar_url"]
+    assert os.path.isfile(os.path.join(str(tmp_path), avatar_url))
+
+    resp = await client.delete(f"/characters/{character.id}", headers=auth_headers)
+    assert resp.status_code == 204
+
+    assert not os.path.exists(os.path.join(str(tmp_path), avatar_url))
+    await db_session.refresh(character)
+    assert character.avatar_url == ""
+
+
+@pytest.mark.asyncio
+async def test_delete_character_leaves_praxis_media_on_disk(
+    client: AsyncClient,
+    character: Character,
+    praxis_solo,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    tmp_path,
+    monkeypatch,
+):
+    """Praxis media is other people's history, not the departing player's alone.
+
+    It is the public artefact of work others have voted on and built feeds
+    around; removing it retroactively would leave praxis cards with missing
+    images across those feeds (#1568).
+    """
+    from config import settings as _settings
+    from models.praxis import MediaItem, MediaType
+
+    monkeypatch.setattr(_settings, "MEDIA_ROOT", str(tmp_path))
+
+    relative_path = os.path.join(str(character.id), str(praxis_solo.id), "abc", "proof.jpg")
+    absolute_path = os.path.join(str(tmp_path), relative_path)
+    os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
+    with open(absolute_path, "wb") as handle:
+        handle.write(b"proof bytes")
+    db_session.add(
+        MediaItem(
+            praxis_id=praxis_solo.id,
+            type=MediaType.image,
+            file_path=relative_path,
+            display_order=0,
+        )
+    )
+    await db_session.flush()
+
+    resp = await client.delete(f"/characters/{character.id}", headers=auth_headers)
+    assert resp.status_code == 204
+
+    assert os.path.isfile(absolute_path)
+
+
+@pytest.mark.asyncio
+async def test_delete_character_with_a_pasted_avatar_url_deletes_nothing(
+    client: AsyncClient,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+    tmp_path,
+    monkeypatch,
+):
+    """``avatar_url`` may hold a remote URL a player typed, not a path we wrote.
+
+    Unlinking whatever that column holds would be a path-traversal primitive;
+    the guard lives in ``services.media.resolve_stored_media_path`` and this is
+    the deletion path's proof that it goes through it.
+    """
+    from config import settings as _settings
+
+    monkeypatch.setattr(_settings, "MEDIA_ROOT", str(tmp_path))
+    character.avatar_url = "https://example.com/photo.jpg"
+    await db_session.flush()
+
+    resp = await client.delete(f"/characters/{character.id}", headers=auth_headers)
+
+    assert resp.status_code == 204
+    await db_session.refresh(character)
+    assert character.avatar_url == ""
+
+
+# ---------------------------------------------------------------------------
 # Relationships endpoint — deleted, see below
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/integration/test_media_sweep_db.py
+++ b/backend/tests/integration/test_media_sweep_db.py
@@ -1,0 +1,78 @@
+"""The orphan sweep's database side, against real rows (#1568).
+
+``load_known_paths`` is the half that decides what the sweep will *not* delete,
+and it can only be wrong in ways that need a database: a column type, a row
+holding a value the app did not write, a second table nobody remembered. The
+disk half is unit-tested in ``tests/unit/test_media_sweep.py``.
+"""
+
+import os
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.character import Character
+from models.praxis import MediaItem, MediaType, Praxis
+from services.media_sweep import find_orphans, load_known_paths, scan_media_root
+
+
+def _write(root, relative_path: str) -> str:
+    absolute_path = os.path.join(str(root), relative_path)
+    os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
+    with open(absolute_path, "wb") as handle:
+        handle.write(b"bytes")
+    return os.path.realpath(absolute_path)
+
+
+@pytest.mark.asyncio
+async def test_both_shapes_are_claimed_and_an_unmatched_file_is_not(
+    db_session: AsyncSession,
+    character: Character,
+    praxis_solo: Praxis,
+    tmp_path,
+):
+    """An avatar row and a media_item row each protect their file; nothing else does."""
+    avatar_relative = os.path.join(str(character.id), "avatar", "abc123", "avatar.jpg")
+    media_relative = os.path.join(str(character.id), str(praxis_solo.id), "def456", "proof.jpg")
+    avatar_absolute = _write(tmp_path, avatar_relative)
+    media_absolute = _write(tmp_path, media_relative)
+    orphan_absolute = _write(tmp_path, os.path.join("999", "1", "old", "gone.jpg"))
+
+    character.avatar_url = avatar_relative
+    db_session.add(
+        MediaItem(
+            praxis_id=praxis_solo.id,
+            type=MediaType.image,
+            file_path=media_relative,
+            display_order=0,
+        )
+    )
+    await db_session.flush()
+
+    known = await load_known_paths(db_session, str(tmp_path))
+    scanned, escaping = scan_media_root(str(tmp_path))
+    report = find_orphans(str(tmp_path), scanned, escaping, known, min_age_seconds=0)
+
+    assert avatar_absolute in known.avatar_paths
+    assert media_absolute in known.media_item_paths
+    assert [item.absolute_path for item in report.orphans] == [orphan_absolute]
+
+
+@pytest.mark.asyncio
+async def test_a_pasted_remote_avatar_url_claims_nothing_and_breaks_nothing(
+    db_session: AsyncSession,
+    character: Character,
+    tmp_path,
+):
+    """``avatar_url`` is a 500-char free-text column: most rows are not paths.
+
+    A remote URL must contribute no claim (there is no file to protect) without
+    the sweep treating it as an error or, worse, resolving it against the disk.
+    """
+    character.avatar_url = "https://example.com/photo.jpg"
+    await db_session.flush()
+
+    known = await load_known_paths(db_session, str(tmp_path))
+
+    assert known.avatar_rows >= 1
+    assert known.avatar_paths == frozenset()

--- a/backend/tests/unit/test_media_service.py
+++ b/backend/tests/unit/test_media_service.py
@@ -162,8 +162,8 @@ def test_superseded_avatar_outside_media_root_is_refused(tmp_path, monkeypatch):
     outsider = tmp_path / "not-ours.jpg"
     outsider.write_bytes(b"someone else's file")
 
-    media._remove_superseded_avatar(os.path.join("..", "not-ours.jpg"))
-    media._remove_superseded_avatar(str(outsider))
+    media.delete_stored_avatar(os.path.join("..", "not-ours.jpg"))
+    media.delete_stored_avatar(str(outsider))
 
     assert outsider.exists()
 

--- a/backend/tests/unit/test_media_sweep.py
+++ b/backend/tests/unit/test_media_sweep.py
@@ -164,3 +164,51 @@ def test_obviously_wrong_media_roots_are_refused():
 
 def test_a_real_media_directory_is_sweepable(tmp_path):
     assert media_root_is_sweepable(str(tmp_path)) is True
+
+
+def test_the_report_prints_whole_on_a_cp1252_console(tmp_path, capsys):
+    """The report is the only thing between an operator and an irreversible flag.
+
+    It is printed to a Windows console as often as to a Render shell, and a
+    ``UnicodeEncodeError`` halfway through leaves a half-read report and a
+    non-zero exit — so the printer is exercised over every branch (held-back
+    files, escaping paths, all three shapes) and its output is asserted to
+    survive a cp1252 encode.
+    """
+    from scripts.sweep_orphan_media import print_report
+
+    _write(tmp_path, os.path.join("42", "avatar", "abc", "avatar.jpg"))
+    _write(tmp_path, os.path.join("42", "7", "def", "proof.jpg"))
+    _write(tmp_path, "stray.bin")
+    scanned, _escaping = scan_media_root(str(tmp_path))
+    report = find_orphans(
+        str(tmp_path),
+        scanned,
+        ("/somewhere/else/link.jpg",),
+        KnownPaths(frozenset(), frozenset(), avatar_rows=3, media_item_rows=0),
+        min_age_seconds=3600,
+    )
+
+    print_report(report, min_age_seconds=3600)
+
+    printed = capsys.readouterr().out
+    printed.encode("cp1252")
+    assert "Held back" in printed
+    assert "Skipped" in printed
+    assert "Orphans     : 0 file(s)" in printed
+
+    # The same report with nothing held back: the orphan listing and the
+    # per-shape summary are the lines the operator actually reads counts off.
+    listing = find_orphans(
+        str(tmp_path),
+        scanned,
+        (),
+        KnownPaths(frozenset(), frozenset(), avatar_rows=3, media_item_rows=0),
+        min_age_seconds=0,
+    )
+    print_report(listing, min_age_seconds=0)
+
+    printed = capsys.readouterr().out
+    printed.encode("cp1252")
+    assert "Orphans     : 3 file(s)" in printed
+    assert "stray.bin" in printed

--- a/backend/tests/unit/test_media_sweep.py
+++ b/backend/tests/unit/test_media_sweep.py
@@ -1,0 +1,166 @@
+"""Unit tests for the orphan sweep's disk side (#1568).
+
+The sweep deletes user data that has no undo, so the properties worth pinning
+are the ones that decide *not* to delete something:
+
+  1. A file a database row claims is never an orphan — including a file at a
+     path shape the code no longer produces, because matching is on the stored
+     path and not on directory arithmetic.
+  2. A file too young to judge is held back rather than deleted, since an
+     upload writes its file before its row commits.
+  3. A media root that is obviously not a media disk is refused outright.
+
+The database side (``load_known_paths``) is exercised in
+``tests/integration/test_media_sweep_db.py``, where real rows exist.
+"""
+
+import os
+
+from services.media_sweep import (
+    KnownPaths,
+    MediaPathShape,
+    classify_shape,
+    find_orphans,
+    media_root_is_sweepable,
+    prune_empty_directories,
+    scan_media_root,
+    summarise_by_shape,
+    total_bytes,
+    unlink_orphans,
+)
+
+
+def _write(root, relative_path: str, contents: bytes = b"bytes") -> str:
+    """Create a file under ``root`` and return its absolute realpath."""
+    absolute_path = os.path.join(str(root), relative_path)
+    os.makedirs(os.path.dirname(absolute_path), exist_ok=True)
+    with open(absolute_path, "wb") as handle:
+        handle.write(contents)
+    return os.path.realpath(absolute_path)
+
+
+def _known(*absolute_paths: str) -> KnownPaths:
+    """A claim set with everything attributed to media items; shape is irrelevant."""
+    return KnownPaths(
+        avatar_paths=frozenset(),
+        media_item_paths=frozenset(absolute_paths),
+        avatar_rows=0,
+        media_item_rows=len(absolute_paths),
+    )
+
+
+def test_classify_shape_reads_both_shapes_and_guesses_at_neither():
+    assert classify_shape("42/avatar/deadbeef/avatar.jpg") is MediaPathShape.avatar
+    assert classify_shape("42/avatar/avatar.jpg") is MediaPathShape.avatar
+    assert classify_shape("42/7/deadbeef/proof.jpg") is MediaPathShape.praxis
+    assert classify_shape("42/7/proof.jpg") is MediaPathShape.praxis
+    # Anything that is not one of the two known layouts is reported as-is rather
+    # than assigned to the nearest match.
+    assert classify_shape("stray.jpg") is MediaPathShape.unrecognised
+    assert classify_shape("exports/2026/report.csv") is MediaPathShape.unrecognised
+    assert classify_shape("42/thumbnails/x.jpg") is MediaPathShape.unrecognised
+
+
+def test_scan_reports_every_file_with_its_size(tmp_path):
+    _write(tmp_path, os.path.join("42", "avatar", "abc", "avatar.jpg"), b"1234")
+    _write(tmp_path, os.path.join("42", "7", "def", "proof.jpg"), b"123456")
+
+    scanned, escaping = scan_media_root(str(tmp_path))
+
+    assert escaping == ()
+    assert len(scanned) == 2
+    assert total_bytes(scanned) == 10
+    assert all(not os.path.isabs(item.relative_path) for item in scanned)
+
+
+def test_a_claimed_file_is_never_an_orphan_whatever_shape_it_has(tmp_path):
+    """Matching is on the stored path (#1568), not on the directory layout.
+
+    The legacy pre-#1565 avatar path is the case that proves it: it is still a
+    perfectly valid ``Character.avatar_url`` value, and a sweep that recognised
+    only the current uuid layout would delete a live avatar.
+    """
+    legacy_avatar = _write(tmp_path, os.path.join("42", "avatar", "avatar.jpg"))
+    odd_shape = _write(tmp_path, os.path.join("archive", "legacy-import.jpg"))
+    orphan = _write(tmp_path, os.path.join("42", "7", "gone", "deleted.jpg"))
+
+    scanned, escaping = scan_media_root(str(tmp_path))
+    report = find_orphans(
+        str(tmp_path), scanned, escaping, _known(legacy_avatar, odd_shape), min_age_seconds=0
+    )
+
+    assert [item.absolute_path for item in report.orphans] == [orphan]
+
+
+def test_a_file_younger_than_the_grace_period_is_held_back(tmp_path):
+    """An upload writes its file before its row commits — do not judge it yet."""
+    fresh = _write(tmp_path, os.path.join("42", "7", "new", "in-flight.jpg"))
+
+    scanned, escaping = scan_media_root(str(tmp_path))
+    report = find_orphans(
+        str(tmp_path), scanned, escaping, _known(), min_age_seconds=3600
+    )
+
+    assert report.orphans == ()
+    assert [item.absolute_path for item in report.too_recent] == [fresh]
+
+
+def test_every_file_is_an_orphan_when_the_database_claims_nothing(tmp_path):
+    """The post-wipe case: MEDIA_ROOT survives a schema drop, ids restart at 1."""
+    _write(tmp_path, os.path.join("1", "avatar", "abc", "avatar.jpg"))
+    _write(tmp_path, os.path.join("1", "2", "def", "proof.jpg"))
+
+    scanned, escaping = scan_media_root(str(tmp_path))
+    report = find_orphans(str(tmp_path), scanned, escaping, _known(), min_age_seconds=0)
+
+    assert len(report.orphans) == 2
+    summary = summarise_by_shape(report.orphans)
+    assert summary[MediaPathShape.avatar][0] == 1
+    assert summary[MediaPathShape.praxis][0] == 1
+    assert summary[MediaPathShape.unrecognised][0] == 0
+
+
+def test_unlink_removes_only_the_orphans_and_prunes_what_it_emptied(tmp_path):
+    keeper = _write(tmp_path, os.path.join("42", "avatar", "keep", "avatar.jpg"))
+    doomed = _write(tmp_path, os.path.join("42", "7", "gone", "deleted.jpg"), b"1234")
+
+    scanned, escaping = scan_media_root(str(tmp_path))
+    report = find_orphans(
+        str(tmp_path), scanned, escaping, _known(keeper), min_age_seconds=0
+    )
+    removed, freed, failures = unlink_orphans(report.orphans)
+    pruned = prune_empty_directories(str(tmp_path))
+
+    assert (removed, freed, failures) == (1, 4, ())
+    assert not os.path.exists(doomed)
+    assert os.path.isfile(keeper)
+    # The emptied upload directory and its praxis directory both go; the root
+    # and everything still holding a file stay.
+    assert pruned >= 2
+    assert not os.path.exists(os.path.join(str(tmp_path), "42", "7"))
+    assert os.path.isdir(str(tmp_path))
+
+
+def test_unlink_reports_a_failure_instead_of_stopping(tmp_path):
+    """A report the operator has already read must describe the whole run."""
+    first = _write(tmp_path, os.path.join("42", "7", "a", "one.jpg"))
+    _write(tmp_path, os.path.join("42", "7", "b", "two.jpg"))
+
+    scanned, escaping = scan_media_root(str(tmp_path))
+    report = find_orphans(str(tmp_path), scanned, escaping, _known(), min_age_seconds=0)
+    os.remove(first)  # Vanishes between the report and the unlink.
+
+    removed, _freed, failures = unlink_orphans(report.orphans)
+
+    assert removed == 1
+    assert len(failures) == 1
+
+
+def test_obviously_wrong_media_roots_are_refused():
+    """"Orphan" means "no row claims it", so a wrong root offers to delete everything."""
+    for forbidden in ("/", "/etc", "/usr", "/app", ""):
+        assert media_root_is_sweepable(forbidden) is False
+
+
+def test_a_real_media_directory_is_sweepable(tmp_path):
+    assert media_root_is_sweepable(str(tmp_path)) is True

--- a/docs/agents/db-migrations.md
+++ b/docs/agents/db-migrations.md
@@ -72,6 +72,25 @@ A squash invalidates the Alembic stamp in **every existing DB**.
   An **empty, unstamped** database is the goal: `check_db_stamp.stamp_is_known` passes a
   fresh DB, so the new image migrates it correctly.
 
+## The media disk survives every wipe ⚠️
+
+`MEDIA_ROOT` is a separate volume. Nothing above touches it — dropping the public schema,
+`reset_db.sh`, `alembic downgrade base`. So after any wipe **every file on disk is
+orphaned**, and because character ids restart at 1 the next character to sign up writes
+into the previous occupant's directory. That surprise is what produced #1565.
+
+Two tools, different jobs:
+
+- `backend/scripts/reset_render_db.py` **empties** `MEDIA_ROOT` as part of a Render reset
+  (`--keep-media` skips it). Blunt: it assumes the disk is meant to be empty, which is true
+  only in lockstep with the schema drop it accompanies.
+- `backend/scripts/sweep_orphan_media.py` **reconciles** disk against database — it removes
+  only files no `Character.avatar_url` or `MediaItem.file_path` row claims, so it is safe to
+  run against a live disk. Dry run by default; `--apply` to unlink.
+
+Use the sweep for anything a past wipe left behind, and for any environment (local,
+self-managed) reset by other means.
+
 ## CI is never affected
 
 Tests do **not** use migrations. `tests/integration/conftest.py` builds the schema


### PR DESCRIPTION
Closes #1568.

Two halves of the same gap: media files outlive the rows that name them, and nothing existed to notice.

## 1. Self-deletion erases the avatar; a ban does not

Per the owner ruling, erasure and moderation are split.

| Path | Media |
|---|---|
| `DELETE /characters/{id}` → `soft_delete_character` | avatar file unlinked, `avatar_url` cleared |
| `POST /admin/characters/{id}/ban` | nothing deleted, nothing cleared |

The two land in the same `status = banned` state — there is no hard delete anywhere in the codebase — so the split is implemented where they actually differ: the hook is inside `soft_delete_character`, and the ban route, which sets `status` directly, is untouched. Moderation must not shred the evidence it is acting on, and a ban is a reversible toggle.

**Praxis media survives both.** The ruling flagged this as its author's recommendation rather than a ruling. Nothing in the code argues against it: `MediaItem` rows belong to a praxis that other characters may co-own (ADR-0013) and that other players have voted on, so an erasure keyed on one character would punch holes in other people's history. Pinned by `test_delete_character_leaves_praxis_media_on_disk`.

`avatar_url` is a 500-char free-text column that may hold a pasted `http(s)` URL, so the unlink goes through #1565's `resolve_stored_media_path` — the one "is this a file we own?" predicate — rather than a second copy of that guard. It is now public and takes an optional `media_root`, and `_remove_superseded_avatar` became `delete_stored_avatar`: one function, three callers.

The column is cleared and flushed *before* the unlink, and the unlink is the last statement in the function. The router owns the commit, so this is not atomic; the docstring says so and names the residue (an orphan, which part 2 collects).

## 2. An orphan sweep

`backend/services/media_sweep.py` + `backend/scripts/sweep_orphan_media.py` (thin CLI, per `import_tasks_csv.py`).

- **Dry run by default**, `--apply` to unlink, typed `delete` confirmation (`--yes` for non-interactive).
- Counts and total bytes, split by shape, printed **before** anything happens.
- Reads DB and `MEDIA_ROOT` from the environment via `script_utils.get_settings`.
- **Matching is on the stored path**, never directory arithmetic. `MediaPathShape` groups the *report* only. The layout has changed twice in a year (#1336, #1565); a sweep that recognised only the current shape would have deleted every pre-#1565 avatar, which is a live case and is the test that proves the rule.
- **Disk is walked before the database is queried**, because an upload writes its file before its row commits — that ordering keeps a row that lands mid-scan in the claim set. `--min-age-minutes` (default 60) covers the remainder. Neither is a lock; the residual race is stated in the module docstring.
- Refuses `/`, `/etc`, `/app`, … : "orphan" means "no row claims it", so a wrong root would offer to delete everything.
- Prunes directories it emptied; never `MEDIA_ROOT` itself.

## What was and was not exercised

This deletes user data, so, precisely:

**Exercised for real** — the CLI was run end-to-end against the live dev Postgres and a scratch `MEDIA_ROOT`:
- dry run, orphans listed, exit 0, nothing removed;
- default grace period holding fresh files back;
- `--apply --yes`, 3 files removed, 6 empty directories pruned, `MEDIA_ROOT` itself intact;
- **a file claimed by a real `character.avatar_url` row survived an `--apply` run** while an unclaimed sibling went (the row was set and restored to `''` afterwards; the dev DB is unchanged);
- `MEDIA_ROOT=/etc` and `MEDIA_ROOT=/` both refused, exit 1.

Development found one real defect this way: the report died with `UnicodeEncodeError` on a cp1252 console, i.e. a half-printed report followed by a crash. Fixed, and pinned by a test that encodes the printed output.

**Not exercised**: no run against production or the Render disk; no symlink case (needs privileges the dev box does not have, so `scan_media_root`'s escaping branch is code-reviewed only); `run()`/`main()` argument wiring is manual-only, not unit-tested.

## Out of scope, flagged

The unauthenticated `/media` mount on a guessable id-keyed path is in the issue title and is **not** touched here — the ruling does not cover it. It is real: `app.mount("/media", StaticFiles(...))` serves every avatar and every praxis image to anyone who can guess `<character_id>/<praxis_id>/`, and the uuid directories added by #1336/#1565 now make guessing much harder by accident rather than by design. Worth triaging separately.

## Not done — outside this agent's write scope

The ruling asks for the wipe hazard to be documented in `docs/agents/db-migrations.md`. That file is outside `backend/`, which this agent may not edit. The hazard is documented where it can be: `scripts/sweep_orphan_media.py`'s docstring, and a new paragraph in `scripts/reset_render_db.py` relating the two tools. **The `db-migrations.md` note still needs applying** — text handed back with the task result.

## Tests

`pytest --cov=. --cov-fail-under=80` from `backend/`: **1070 passed**, coverage 92.70%.

New: `tests/unit/test_media_sweep.py` (10), `tests/integration/test_media_sweep_db.py` (2), 3 in `test_characters.py`, 1 in `test_admin.py`.

`backend/openapi.json` regenerated: no drift (no route shape changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
