### PR TITLE
Four mutations answer with what the caller was about to re-ask for (#1383)

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -3569,6 +3569,25 @@
         "title": "InviteResponse",
         "type": "object"
       },
+      "InviteResponseOut": {
+        "description": "Acknowledgement for answering a collab invite (#1383).\n\nDeliberately an ack and not the praxis. This route used to answer a full\ntally-bearing `PraxisOut`, which meant a `selectinload` of the invites and\nmedia plus the whole `build_praxis_out` fan-out — and every caller discarded\nit, then navigated or refreshed the feed. The two facts a responder actually\nneeds are which praxis was answered and which way.\n\nWidening this to the updated feed row instead is the better end state, but it\nwaits on #1419/ADR-0070 to settle what a request row is once requests leave\nthe stream.",
+        "properties": {
+          "accepted": {
+            "title": "Accepted",
+            "type": "boolean"
+          },
+          "praxis_id": {
+            "title": "Praxis Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "praxis_id",
+          "accepted"
+        ],
+        "title": "InviteResponseOut",
+        "type": "object"
+      },
       "LevelProfileOut": {
         "properties": {
           "rank_key": {
@@ -4990,45 +5009,6 @@
           "display_status"
         ],
         "title": "RelationshipListItem",
-        "type": "object"
-      },
-      "RelationshipOut": {
-        "properties": {
-          "created_at": {
-            "format": "date-time",
-            "title": "Created At",
-            "type": "string"
-          },
-          "from_character_id": {
-            "title": "From Character Id",
-            "type": "integer"
-          },
-          "id": {
-            "title": "Id",
-            "type": "integer"
-          },
-          "status": {
-            "title": "Status",
-            "type": "string"
-          },
-          "to_character_id": {
-            "title": "To Character Id",
-            "type": "integer"
-          },
-          "type": {
-            "title": "Type",
-            "type": "string"
-          }
-        },
-        "required": [
-          "id",
-          "from_character_id",
-          "to_character_id",
-          "type",
-          "status",
-          "created_at"
-        ],
-        "title": "RelationshipOut",
         "type": "object"
       },
       "RelationshipTypeEnum": {
@@ -9419,7 +9399,7 @@
     },
     "/factions/choose": {
       "post": {
-        "description": "Choose or defect to a new faction.\n\nWorks for the initial faction join and later defections.\nPlayers cannot rejoin factions they have left, except UA Masters and Albescent.",
+        "description": "Choose or defect to a new faction.\n\nWorks for the initial faction join and later defections.\nPlayers cannot rejoin factions they have left, except UA Masters and Albescent.\n\nAnswers the refreshed `CurrentUser`, not the faction row (#1383). Membership\ndresses the whole site off `/auth/me` — the faction slug, the level-jump\nallowance, the capability flags and the sticky `albescent_revealed` reveal\nmove together — so all four callers threw the `{slug}` away and re-asked\n`/auth/me` for the object this handler is already positioned to build.",
         "operationId": "choose_faction_factions_choose_post",
         "parameters": [
           {
@@ -9454,7 +9434,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/FactionOut"
+                  "$ref": "#/components/schemas/CurrentUser"
                 }
               }
             },
@@ -10812,6 +10792,7 @@
     },
     "/praxes/{praxis_id}/invite/{invite_id}/respond": {
       "post": {
+        "description": "Accept or decline a collab invite; answer an ack (#1383).\n\nSee `InviteResponseOut` for why this is an ack rather than the praxis.",
         "operationId": "respond_to_invite_route_praxes__praxis_id__invite__invite_id__respond_post",
         "parameters": [
           {
@@ -10864,7 +10845,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PraxisOut"
+                  "$ref": "#/components/schemas/InviteResponseOut"
                 }
               }
             },
@@ -11861,7 +11842,7 @@
         ]
       },
       "post": {
-        "description": "Declare a friend or foe relationship (instant, no pending state).",
+        "description": "Declare a friend or foe relationship (instant, no pending state).\n\nAnswers the enriched item, not the bare row (#1383): the display name,\navatar, faction and derived ``display_status`` are what the profile draws,\nand it used to re-list every relationship the viewer holds to get them.",
         "operationId": "create_relationship_route_relationships_post",
         "parameters": [
           {
@@ -11896,7 +11877,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationshipOut"
+                  "$ref": "#/components/schemas/RelationshipListItem"
                 }
               }
             },
@@ -12015,7 +11996,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationshipOut"
+                  "$ref": "#/components/schemas/RelationshipListItem"
                 }
               }
             },
@@ -12079,7 +12060,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/RelationshipOut"
+                  "$ref": "#/components/schemas/RelationshipListItem"
                 }
               }
             },

--- a/backend/routers/factions.py
+++ b/backend/routers/factions.py
@@ -10,6 +10,7 @@ from dependencies import (
 from models.account import Account
 from models.character import Character
 from models.faction import Faction, FactionStatus
+from schemas.auth import CurrentUser
 from schemas.faction import (
     FactionChoiceRequest,
     FactionOut,
@@ -19,6 +20,7 @@ from schemas.faction import (
 )
 from services.auth import get_current_account
 from services.character import ALBESCENT_FACTION_SLUG
+from services.current_user import build_current_user
 from services.era import get_current_era_row
 from services.faction_service import (
     defect_to_faction,
@@ -51,9 +53,10 @@ async def list_factions(
     ]
 
 
-@router.post("/choose", response_model=FactionOut)
+@router.post("/choose", response_model=CurrentUser)
 async def choose_faction(
     data: FactionChoiceRequest,
+    account: Account = Depends(get_current_account),
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
@@ -61,12 +64,15 @@ async def choose_faction(
 
     Works for the initial faction join and later defections.
     Players cannot rejoin factions they have left, except UA Masters and Albescent.
+
+    Answers the refreshed `CurrentUser`, not the faction row (#1383). Membership
+    dresses the whole site off `/auth/me` — the faction slug, the level-jump
+    allowance, the capability flags and the sticky `albescent_revealed` reveal
+    move together — so all four callers threw the `{slug}` away and re-asked
+    `/auth/me` for the object this handler is already positioned to build.
     """
-    updated_character = await defect_to_faction(
-        character, data.faction_slug, session
-    )
-    faction = await session.get(Faction, updated_character.faction_slug)
-    return FactionOut.model_validate(faction)
+    await defect_to_faction(character, data.faction_slug, session)
+    return await build_current_user(account, session)
 
 
 @router.get("/status", response_model=FactionPageOut)

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -47,6 +47,24 @@ class InviteResponse(BaseModel):
     accept: bool
 
 
+class InviteResponseOut(BaseModel):
+    """Acknowledgement for answering a collab invite (#1383).
+
+    Deliberately an ack and not the praxis. This route used to answer a full
+    tally-bearing `PraxisOut`, which meant a `selectinload` of the invites and
+    media plus the whole `build_praxis_out` fan-out — and every caller discarded
+    it, then navigated or refreshed the feed. The two facts a responder actually
+    needs are which praxis was answered and which way.
+
+    Widening this to the updated feed row instead is the better end state, but it
+    waits on #1419/ADR-0070 to settle what a request row is once requests leave
+    the stream.
+    """
+
+    praxis_id: int
+    accepted: bool
+
+
 class MetataskApply(BaseModel):
     task_id: int
 from schemas.nudge import NudgeOut, NudgeResultOut
@@ -433,7 +451,7 @@ async def invite_member_route(
     return _build_invite_out(invite)
 
 
-@router.post("/{praxis_id}/invite/{invite_id}/respond", response_model=PraxisOut)
+@router.post("/{praxis_id}/invite/{invite_id}/respond", response_model=InviteResponseOut)
 async def respond_to_invite_route(
     praxis_id: int,
     invite_id: int,
@@ -441,6 +459,10 @@ async def respond_to_invite_route(
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
 ):
+    """Accept or decline a collab invite; answer an ack (#1383).
+
+    See `InviteResponseOut` for why this is an ack rather than the praxis.
+    """
     invite = await respond_to_invite(
         invite_id=invite_id,
         character_id=character.id,
@@ -448,15 +470,7 @@ async def respond_to_invite_route(
         session=session,
         era=CURRENT_ERA,
     )
-    result = await session.execute(
-        select(Praxis)
-        .options(selectinload(Praxis.invites), selectinload(Praxis.media_items))
-        .where(Praxis.id == invite.praxis_id)
-    )
-    praxis = result.scalar_one_or_none()
-    if praxis is None:
-        raise HTTPException(status_code=404, detail="Praxis not found.")
-    return await build_praxis_out(praxis, session, viewer=character)
+    return InviteResponseOut(praxis_id=invite.praxis_id, accepted=data.accept)
 
 
 @router.delete("/{praxis_id}/invite/{invite_id}", status_code=204)

--- a/backend/routers/relationships.py
+++ b/backend/routers/relationships.py
@@ -7,9 +7,10 @@ from db import get_db
 from dependencies import get_current_character
 from models.character import Character
 from models.relationship import RelationshipType
-from schemas.relationship import RelationshipCreate, RelationshipListItem, RelationshipOut
+from schemas.relationship import RelationshipCreate, RelationshipListItem
 from services.relationship_service import (
     block_relationship,
+    build_relationship_item,
     create_relationship,
     list_relationships,
     unblock_relationship,
@@ -34,43 +35,48 @@ async def list_my_relationships(
     )
 
 
-@router.post("", response_model=RelationshipOut, status_code=201)
+@router.post("", response_model=RelationshipListItem, status_code=201)
 async def create_relationship_route(
     data: RelationshipCreate,
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
-) -> RelationshipOut:
-    """Declare a friend or foe relationship (instant, no pending state)."""
+) -> RelationshipListItem:
+    """Declare a friend or foe relationship (instant, no pending state).
+
+    Answers the enriched item, not the bare row (#1383): the display name,
+    avatar, faction and derived ``display_status`` are what the profile draws,
+    and it used to re-list every relationship the viewer holds to get them.
+    """
     relationship = await create_relationship(
         from_character=character,
         to_character_id=data.to_character_id,
         rel_type=RelationshipType[data.type],
         session=session,
     )
-    return RelationshipOut.model_validate(relationship)
+    return await build_relationship_item(relationship, session)
 
 
-@router.put("/{relationship_id}", response_model=RelationshipOut)
+@router.put("/{relationship_id}", response_model=RelationshipListItem)
 async def block_relationship_route(
     relationship_id: int,
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
-) -> RelationshipOut:
+) -> RelationshipListItem:
     """Block a relationship. Either party can block."""
     relationship = await block_relationship(
         relationship_id=relationship_id,
         character=character,
         session=session,
     )
-    return RelationshipOut.model_validate(relationship)
+    return await build_relationship_item(relationship, session)
 
 
-@router.post("/{relationship_id}/unblock", response_model=RelationshipOut)
+@router.post("/{relationship_id}/unblock", response_model=RelationshipListItem)
 async def unblock_relationship_route(
     relationship_id: int,
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
-) -> RelationshipOut:
+) -> RelationshipListItem:
     """Reverse a block (ADR-0009). Either party can unblock; the edge returns to
     active. Separate route from PUT /{id} (block) so the two actions don't
     collide."""
@@ -79,7 +85,7 @@ async def unblock_relationship_route(
         character=character,
         session=session,
     )
-    return RelationshipOut.model_validate(relationship)
+    return await build_relationship_item(relationship, session)
 
 
 @router.delete("/{relationship_id}", status_code=204)

--- a/backend/schemas/relationship.py
+++ b/backend/schemas/relationship.py
@@ -23,17 +23,6 @@ RelationshipDisplayStatus = Literal[
 ]
 
 
-class RelationshipOut(BaseModel):
-    model_config = ConfigDict(from_attributes=True)
-
-    id: int
-    from_character_id: int
-    to_character_id: int
-    type: str
-    status: str
-    created_at: datetime
-
-
 class RelationshipCreate(BaseModel):
     to_character_id: int
     type: RelationshipTypeEnum

--- a/backend/services/relationship_service.py
+++ b/backend/services/relationship_service.py
@@ -60,6 +60,68 @@ def compute_display_status(
     return DISPLAY_STATUS_UNKNOWN
 
 
+def _to_list_item(
+    relationship: Relationship,
+    target_character: Character,
+    incoming_type: Optional[str],
+    incoming_status: Optional[str],
+) -> RelationshipListItem:
+    """Assemble one display-ready edge.
+
+    The item describes THE EDGE, not the viewer: ``to_*`` always names
+    ``relationship.to_character_id`` and ``display_status`` is computed with this
+    edge as the outgoing side. Block and unblock may be performed by either party
+    (ADR-0009), so a viewer-relative shape would hand back the same row mirrored
+    depending on who acted.
+    """
+    outgoing_type = relationship.type.value
+    outgoing_status = relationship.status.value
+    return RelationshipListItem(
+        id=relationship.id,
+        from_character_id=relationship.from_character_id,
+        to_character_id=relationship.to_character_id,
+        type=outgoing_type,
+        status=outgoing_status,
+        created_at=relationship.created_at,
+        to_display_name=target_character.display_name,
+        to_avatar_url=target_character.avatar_url,
+        to_faction_slug=target_character.faction_slug,
+        display_status=compute_display_status(
+            outgoing_type, outgoing_status, incoming_type, incoming_status
+        ),
+    )
+
+
+async def build_relationship_item(
+    relationship: Relationship,
+    session: AsyncSession,
+) -> RelationshipListItem:
+    """Enrich one freshly-written edge into the shape the list route emits.
+
+    The three mutation routes answer with this rather than the bare row (#1383):
+    every caller of add / block / unblock immediately re-ran
+    ``GET /relationships`` for exactly these display fields, so the write already
+    held the answer to the read that chased it.
+    """
+    target_character = await session.get(Character, relationship.to_character_id)
+    if target_character is None:
+        raise HTTPException(status_code=404, detail="Target character not found.")
+
+    reverse_result = await session.execute(
+        select(Relationship).where(
+            Relationship.from_character_id == relationship.to_character_id,
+            Relationship.to_character_id == relationship.from_character_id,
+        )
+    )
+    reverse = reverse_result.scalar_one_or_none()
+    return _to_list_item(
+        relationship,
+        target_character,
+        reverse.type.value if reverse else None,
+        reverse.status.value if reverse else None,
+    )
+
+
 async def create_relationship(
     from_character: Character,
     to_character_id: int,
@@ -176,24 +238,12 @@ async def list_relationships(
 
     items = []
     for relationship, target_character in rows:
-        outgoing_type = relationship.type.value
-        outgoing_status = relationship.status.value
         incoming = reverse_map.get(target_character.id)
-        incoming_type = incoming[0] if incoming else None
-        incoming_status = incoming[1] if incoming else None
-        items.append(RelationshipListItem(
-            id=relationship.id,
-            from_character_id=relationship.from_character_id,
-            to_character_id=relationship.to_character_id,
-            type=outgoing_type,
-            status=outgoing_status,
-            created_at=relationship.created_at,
-            to_display_name=target_character.display_name,
-            to_avatar_url=target_character.avatar_url,
-            to_faction_slug=target_character.faction_slug,
-            display_status=compute_display_status(
-                outgoing_type, outgoing_status, incoming_type, incoming_status
-            ),
+        items.append(_to_list_item(
+            relationship,
+            target_character,
+            incoming[0] if incoming else None,
+            incoming[1] if incoming else None,
         ))
 
     return items

--- a/backend/tests/integration/test_collab_invite_bypass.py
+++ b/backend/tests/integration/test_collab_invite_bypass.py
@@ -198,7 +198,14 @@ async def test_wrong_faction_low_level_character_can_be_invited_and_submit(
         headers=invitee_headers,
     )
     assert accept_resp.status_code == 200, accept_resp.text
-    assert invitee.id in [m["character_id"] for m in accept_resp.json()["members"]]
+    # The respond route answers an ack (#1383). The Easter egg's claim is that
+    # the invitee BECAME A MEMBER of a task they could not claim, so that still
+    # has to be read off the praxis rather than inferred from the 200.
+    assert accept_resp.json() == {"praxis_id": praxis_id, "accepted": True}
+
+    detail_resp = await client.get(f"/praxes/{praxis_id}", headers=inviter_headers)
+    assert detail_resp.status_code == 200, detail_resp.text
+    assert invitee.id in [m["character_id"] for m in detail_resp.json()["members"]]
 
     # ...and they may submit, which is the whole point of the carve-out.
     submit_resp = await client.post(

--- a/backend/tests/integration/test_factions.py
+++ b/backend/tests/integration/test_factions.py
@@ -198,7 +198,9 @@ async def test_choose_faction_with_invitation_succeeds(
         headers=auth_headers,
     )
     assert resp.status_code == 200
-    assert resp.json()["slug"] == "wow"
+    # The choose POST answers the refreshed CurrentUser, so the caller never has
+    # to re-ask /auth/me for the membership it just caused (#1383).
+    assert resp.json()["character"]["faction_slug"] == "wow"
 
 
 @pytest.mark.asyncio
@@ -337,7 +339,13 @@ async def test_choose_albescent_eligible_succeeds(
         headers=auth_headers,
     )
     assert resp.status_code == 200
-    assert resp.json()["slug"] == "albescent"
+    body = resp.json()
+    assert body["character"]["faction_slug"] == "albescent"
+    # The sticky ADR-0027 reveal arrives in the SAME answer as the join. This is
+    # the case that most needed the widened response (#1383): joining is what
+    # reveals the secret society, and the client used to learn that only on the
+    # follow-up /auth/me.
+    assert body["albescent_revealed"] is True
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_multi_character.py
+++ b/backend/tests/integration/test_multi_character.py
@@ -135,7 +135,12 @@ async def test_other_account_character_collaborates_on_praxis(
         headers=auth_headers,
     )
     assert accept.status_code == 200, accept.text
-    member_ids = {m["character_id"] for m in accept.json()["members"]}
+    # The respond route answers an ack (#1383); membership is read off the praxis.
+    assert accept.json() == {"praxis_id": praxis_id, "accepted": True}
+
+    detail = await client.get(f"/praxes/{praxis_id}", headers=auth_headers2)
+    assert detail.status_code == 200, detail.text
+    member_ids = {m["character_id"] for m in detail.json()["members"]}
     assert member_ids == {character.id, character2.id}
 
 
@@ -436,7 +441,12 @@ async def test_second_life_collaborates_on_praxis(
         headers=auth_headers,
     )
     assert accept.status_code == 200, accept.text
-    member_ids = {m["character_id"] for m in accept.json()["members"]}
+    # The respond route answers an ack (#1383); membership is read off the praxis.
+    assert accept.json() == {"praxis_id": praxis_id, "accepted": True}
+
+    detail = await client.get(f"/praxes/{praxis_id}", headers=auth_headers2)
+    assert detail.status_code == 200, detail.text
+    member_ids = {m["character_id"] for m in detail.json()["members"]}
     assert second.id in member_ids, (
         "Collab accept did not add the carried second life as a member: "
         f"expected {second.id} in {member_ids}."

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -1077,8 +1077,13 @@ async def test_collab_invite_and_accept(
         headers=auth_headers,
     )
     assert respond_resp.status_code == 200
-    data = respond_resp.json()
-    member_ids = [m["character_id"] for m in data["members"]]
+    # The respond route answers an ack, not the praxis (#1383).
+    assert respond_resp.json() == {"praxis_id": praxis_id, "accepted": True}
+
+    # Membership is the real effect, so read it off the praxis itself.
+    praxis_resp = await client.get(f"/praxes/{praxis_id}", headers=auth_headers2)
+    assert praxis_resp.status_code == 200
+    member_ids = [m["character_id"] for m in praxis_resp.json()["members"]]
     assert character.id in member_ids
     assert character2.id in member_ids
 
@@ -1387,9 +1392,14 @@ async def test_collab_invite_decline(
         headers=auth_headers,
     )
     assert respond_resp.status_code == 200
+    # The respond route answers an ack, not the praxis (#1383). A decline is
+    # still an answer, so `accepted` reports which way it went.
+    assert respond_resp.json() == {"praxis_id": praxis_id, "accepted": False}
+
     # character should NOT be a member
-    data = respond_resp.json()
-    member_ids = [m["character_id"] for m in data["members"]]
+    praxis_resp = await client.get(f"/praxes/{praxis_id}", headers=auth_headers2)
+    assert praxis_resp.status_code == 200
+    member_ids = [m["character_id"] for m in praxis_resp.json()["members"]]
     assert character.id not in member_ids
 
 

--- a/frontend/src/__tests__/rootLandingChunks.test.tsx
+++ b/frontend/src/__tests__/rootLandingChunks.test.tsx
@@ -70,7 +70,7 @@ function withSessionHint(hint: string | null): void {
 function renderRoot(session: { user: CurrentUser | null; loading: boolean }): string {
   return renderToStaticMarkup(
     <MemoryRouter>
-      <AuthContext.Provider value={{ ...session, refetch: async () => {}, signOut: async () => {} }}>
+      <AuthContext.Provider value={{ ...session, refetch: async () => {}, applyUser: () => {}, signOut: async () => {} }}>
         {/* Stands in for App's one Suspense boundary. A distinctive fallback so
             "chunk still in flight" is never mistaken for a rendered page. */}
         <Suspense fallback={<div data-page="suspended" />}>

--- a/frontend/src/api/factions.ts
+++ b/frontend/src/api/factions.ts
@@ -1,4 +1,5 @@
 import api from './axios'
+import type { CurrentUser } from './auth'
 import { dropAllCaches } from '../utils/cacheEpoch'
 
 // Faction name/description prose is no longer backend-emitted (issue #461): the
@@ -38,8 +39,16 @@ export async function getFactionStatus(): Promise<FactionPageOut> {
   return res.data
 }
 
-export async function chooseFaction(factionSlug: string): Promise<FactionOut> {
-  const res = await api.post<FactionOut>('/factions/choose', { faction_slug: factionSlug })
+/**
+ * Join or defect to a faction; answers the refreshed `CurrentUser` (#1383).
+ *
+ * Membership moves the faction slug, the level-jump allowance, the capability
+ * flags and the sticky `albescent_revealed` reveal together, and all of those
+ * ride on `/auth/me`. The POST now carries that whole object, so callers hand
+ * it straight to `applyUser()` instead of chasing it with `refetch()`.
+ */
+export async function chooseFaction(factionSlug: string): Promise<CurrentUser> {
+  const res = await api.post<CurrentUser>('/factions/choose', { faction_slug: factionSlug })
   // `GET /factions` is viewer-scoped: Albescent is omitted until the account has
   // been revealed to it (ADR-0027), and joining is what reveals it. The
   // directory is otherwise deploy-scoped and held for the whole session

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -1085,6 +1085,12 @@ export interface paths {
          *
          *     Works for the initial faction join and later defections.
          *     Players cannot rejoin factions they have left, except UA Masters and Albescent.
+         *
+         *     Answers the refreshed `CurrentUser`, not the faction row (#1383). Membership
+         *     dresses the whole site off `/auth/me` — the faction slug, the level-jump
+         *     allowance, the capability flags and the sticky `albescent_revealed` reveal
+         *     move together — so all four callers threw the `{slug}` away and re-asked
+         *     `/auth/me` for the object this handler is already positioned to build.
          */
         post: operations["choose_faction_factions_choose_post"];
         delete?: never;
@@ -1411,7 +1417,12 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Respond To Invite Route */
+        /**
+         * Respond To Invite Route
+         * @description Accept or decline a collab invite; answer an ack (#1383).
+         *
+         *     See `InviteResponseOut` for why this is an ack rather than the praxis.
+         */
         post: operations["respond_to_invite_route_praxes__praxis_id__invite__invite_id__respond_post"];
         delete?: never;
         options?: never;
@@ -1734,6 +1745,10 @@ export interface paths {
         /**
          * Create Relationship Route
          * @description Declare a friend or foe relationship (instant, no pending state).
+         *
+         *     Answers the enriched item, not the bare row (#1383): the display name,
+         *     avatar, faction and derived ``display_status`` are what the profile draws,
+         *     and it used to re-list every relationship the viewer holds to get them.
          */
         post: operations["create_relationship_route_relationships_post"];
         delete?: never;
@@ -3489,6 +3504,26 @@ export interface components {
             /** Accept */
             accept: boolean;
         };
+        /**
+         * InviteResponseOut
+         * @description Acknowledgement for answering a collab invite (#1383).
+         *
+         *     Deliberately an ack and not the praxis. This route used to answer a full
+         *     tally-bearing `PraxisOut`, which meant a `selectinload` of the invites and
+         *     media plus the whole `build_praxis_out` fan-out — and every caller discarded
+         *     it, then navigated or refreshed the feed. The two facts a responder actually
+         *     needs are which praxis was answered and which way.
+         *
+         *     Widening this to the updated feed row instead is the better end state, but it
+         *     waits on #1419/ADR-0070 to settle what a request row is once requests leave
+         *     the stream.
+         */
+        InviteResponseOut: {
+            /** Accepted */
+            accepted: boolean;
+            /** Praxis Id */
+            praxis_id: number;
+        };
         /** LevelProfileOut */
         LevelProfileOut: {
             /** Rank Key */
@@ -4109,24 +4144,6 @@ export interface components {
             to_display_name: string;
             /** To Faction Slug */
             to_faction_slug: string;
-            /** Type */
-            type: string;
-        };
-        /** RelationshipOut */
-        RelationshipOut: {
-            /**
-             * Created At
-             * Format: date-time
-             */
-            created_at: string;
-            /** From Character Id */
-            from_character_id: number;
-            /** Id */
-            id: number;
-            /** Status */
-            status: string;
-            /** To Character Id */
-            to_character_id: number;
             /** Type */
             type: string;
         };
@@ -6406,7 +6423,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FactionOut"];
+                    "application/json": components["schemas"]["CurrentUser"];
                 };
             };
             /** @description Validation Error */
@@ -7070,7 +7087,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PraxisOut"];
+                    "application/json": components["schemas"]["InviteResponseOut"];
                 };
             };
             /** @description Validation Error */
@@ -7582,7 +7599,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RelationshipOut"];
+                    "application/json": components["schemas"]["RelationshipListItem"];
                 };
             };
             /** @description Validation Error */
@@ -7615,7 +7632,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RelationshipOut"];
+                    "application/json": components["schemas"]["RelationshipListItem"];
                 };
             };
             /** @description Validation Error */
@@ -7679,7 +7696,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["RelationshipOut"];
+                    "application/json": components["schemas"]["RelationshipListItem"];
                 };
             };
             /** @description Validation Error */

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -478,12 +478,25 @@ export async function inviteToPraxis(id: number, inviteeId: number): Promise<Pra
   return data
 }
 
+/** Acknowledgement for answering a collab invite (#1383). */
+export interface InviteResponseOut {
+  praxis_id: number
+  accepted: boolean
+}
+
+/**
+ * Accept or decline a collab invite.
+ *
+ * Answers an ack, not the praxis (#1383). This route used to return a full
+ * tally-bearing `PraxisOut` — mistyped here as `PraxisInviteOut` — and every
+ * caller discarded it, then navigated or refreshed the feed.
+ */
 export async function respondToInvite(
   praxisId: number,
   inviteId: number,
   accept: boolean,
-): Promise<PraxisInviteOut> {
-  const { data } = await api.post<PraxisInviteOut>(
+): Promise<InviteResponseOut> {
+  const { data } = await api.post<InviteResponseOut>(
     `/praxes/${praxisId}/invite/${inviteId}/respond`,
     { accept },
   )

--- a/frontend/src/api/relationships.ts
+++ b/frontend/src/api/relationships.ts
@@ -16,16 +16,6 @@ export interface RelationshipListItem {
   display_status: 'Mutual Friends' | 'Rivals' | 'Tsundere' | 'One-sided Friend' | 'One-sided Foe' | 'Secret Admirer' | 'Targeted' | 'Blocked' | 'Unknown'
 }
 
-/** Matches backend RelationshipOut (basic create/update response) */
-export interface RelationshipOut {
-  id: number
-  from_character_id: number
-  to_character_id: number
-  type: 'friend' | 'foe'
-  status: 'active' | 'blocked'
-  created_at: string
-}
-
 export interface RelationshipFilters {
   status?: string
   type?: string
@@ -36,20 +26,27 @@ export async function listRelationships(filters?: RelationshipFilters): Promise<
   return data
 }
 
-export async function createRelationship(to_character_id: number, type: 'friend' | 'foe'): Promise<RelationshipOut> {
-  const { data } = await api.post<RelationshipOut>('/relationships', { to_character_id, type })
+// The three mutations below answer the same enriched item the list emits
+// (#1383). They used to answer the bare row, so every caller re-ran
+// `listRelationships()` and searched it for the edge it had just written.
+//
+// The item describes THE EDGE, not the viewer: `to_*` always names
+// `to_character_id`, and either party may block or unblock (ADR-0009).
+
+export async function createRelationship(to_character_id: number, type: 'friend' | 'foe'): Promise<RelationshipListItem> {
+  const { data } = await api.post<RelationshipListItem>('/relationships', { to_character_id, type })
   return data
 }
 
 /** Block a relationship. Either party can block. */
-export async function blockRelationship(id: number): Promise<RelationshipOut> {
-  const { data } = await api.put<RelationshipOut>(`/relationships/${id}`)
+export async function blockRelationship(id: number): Promise<RelationshipListItem> {
+  const { data } = await api.put<RelationshipListItem>(`/relationships/${id}`)
   return data
 }
 
 /** Reverse a block (ADR-0009) — restores the edge to active. Either party can unblock. */
-export async function unblockRelationship(id: number): Promise<RelationshipOut> {
-  const { data } = await api.post<RelationshipOut>(`/relationships/${id}/unblock`)
+export async function unblockRelationship(id: number): Promise<RelationshipListItem> {
+  const { data } = await api.post<RelationshipListItem>(`/relationships/${id}/unblock`)
   return data
 }
 

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -7,6 +7,20 @@ interface AuthState {
   loading: boolean
   refetch: () => Promise<void>
   /**
+   * Adopt a `CurrentUser` a mutation just handed back, with no `/auth/me` trip.
+   *
+   * The same move as `signOut` (#1349), pointed the other way: when the client
+   * has *caused* the new state and the server has already answered with it,
+   * re-asking is a round trip for a value we are already holding.
+   * `POST /factions/choose` and `POST /me/active-character` both answer the
+   * refreshed `CurrentUser` (#1383) — every caller used to discard it and
+   * `refetch()`.
+   *
+   * Only for a WHOLE, freshly-built `CurrentUser`. Anything partial belongs on
+   * `refetch`, or the context starts drifting from what `/auth/me` would say.
+   */
+  applyUser: (user: CurrentUser) => void
+  /**
    * End the session and drop the app to its logged-out state.
    *
    * Exists so that signing out does not have to `logout()` and then `refetch()`
@@ -25,6 +39,7 @@ export const AuthContext = createContext<AuthState>({
   user: null,
   loading: true,
   refetch: async () => {},
+  applyUser: () => {},
   signOut: async () => {},
 })
 
@@ -93,6 +108,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  // See `AuthState.applyUser`. `rememberSession(true)` because being handed a
+  // built `CurrentUser` is itself proof the session is live — the same fact
+  // `fetchUser` records on a successful `/auth/me`.
+  const applyUser = (me: CurrentUser) => {
+    setUser(me)
+    rememberSession(true)
+    setLoading(false)
+  }
+
   // No `/auth/me` follow-up: ending the session IS the new state, and the
   // provider owns both halves of it — see `AuthState.signOut`.
   const signOut = runSignOut(logout, () => {
@@ -111,7 +135,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [])
 
   return (
-    <AuthContext.Provider value={{ user, loading, refetch: fetchUser, signOut }}>
+    <AuthContext.Provider value={{ user, loading, refetch: fetchUser, applyUser, signOut }}>
       {children}
     </AuthContext.Provider>
   )

--- a/frontend/src/auth/__tests__/authRefetchLedger.test.ts
+++ b/frontend/src/auth/__tests__/authRefetchLedger.test.ts
@@ -5,9 +5,10 @@
  * era stats, its invitation letters, and a dozen server-computed capability
  * flags. The refetch family (#1346) has been closing it down one reason at a
  * time — #1382 retired the per-star reload, #1390 stopped a fresh `CurrentUser`
- * object fanning out into unrelated reads — and this is the closing sweep: an
- * inventory in which every surviving call site is written down with the reason
- * it survives.
+ * object fanning out into unrelated reads, #1349 deleted the post-`logout()`
+ * pair, and #1383 had the six sites that discarded a `CurrentUser` the server
+ * had already built consume it instead. What is left is an inventory in which
+ * every surviving call site is written down with the reason it survives.
  *
  * WHAT THIS PROVES, AND WHAT IT CANNOT
  * ------------------------------------
@@ -29,9 +30,7 @@ const SOURCE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '
 
 type Verdict =
   /** The mutation genuinely changed `CurrentUser` and nothing cheaper exists. */
-  | 'identity-changed'
-  /** The server already handed the client the answer; consuming it is #1383. */
-  | 'response-in-hand'
+  'identity-changed'
 
 interface LedgerEntry {
   file: string
@@ -43,46 +42,24 @@ interface LedgerEntry {
 /**
  * Every `useAuth().refetch()` in the tree, with its justification.
  *
- * The classification the sweep landed on, from tracing each mutation into the
- * service that answers it:
+ * #1383 closed the ledger's second class out. Every entry that survives is
+ * `identity-changed`: the mutation really did move `CurrentUser` and no response
+ * carries the new one. Publishing, withdrawing or leaving a praxis each run a
+ * stats recalc (points, level, and on publish the delivery of newly-earned
+ * invitation letters); creating, editing and deleting a life change or
+ * re-resolve the carried one; dev-login has no other way to learn who signed in.
  *
- *  - 8 calls are `identity-changed` — publishing, withdrawing or leaving a
- *    praxis all run a stats recalc (points, level, and on publish the delivery
- *    of newly-earned invitation letters); creating, editing and deleting a life
- *    all change or re-resolve the carried one; dev-login has no other way to
- *    learn who just signed in.
- *  - 6 calls are `response-in-hand`, and are #1383's to delete, not this
- *    sweep's: two discard the `CurrentUser` that `POST /me/active-character`
- *    already returns, and four follow `POST /factions/choose`, which #1383
- *    item 1 widens to return `CurrentUser` too.
- *  - The 2 that were neither — the post-`logout()` reloads in `NavBar` and
- *    `Settings` — are gone. See the `signOut` rule below.
+ * The two classes that are gone, and why they are not coming back:
+ *
+ *  - `response-in-hand` — 6 calls across 4 files that discarded a `CurrentUser`
+ *    the server had already built. #1383 widened `POST /factions/choose` to
+ *    answer one and had those callers, plus the three `POST /me/active-character`
+ *    callers, adopt it via `applyUser()`. A mutation that answers the whole
+ *    viewer should be consumed, never chased with `/auth/me`.
+ *  - Merely redundant — the post-`logout()` reloads in `NavBar` and `Settings`,
+ *    deleted by #1349. See the `signOut` rule below.
  */
 const LEDGER: LedgerEntry[] = [
-  {
-    file: 'components/CharacterSwitcherSheet.tsx',
-    calls: 1,
-    verdict: 'response-in-hand',
-    why: 'POST /me/active-character already returns the refreshed CurrentUser (#1383 item 4).',
-  },
-  {
-    file: 'components/InvitationLetterPopup.tsx',
-    calls: 1,
-    verdict: 'response-in-hand',
-    why: 'Accepting a letter joins the faction; POST /factions/choose returns {slug,status} (#1383 item 1).',
-  },
-  {
-    file: 'components/feed/FeedCardInvitationLetter.tsx',
-    calls: 1,
-    verdict: 'response-in-hand',
-    why: 'The feed-row twin of the popup — same join, same narrow response (#1383 item 1).',
-  },
-  {
-    file: 'pages/FieldDesk.tsx',
-    calls: 2,
-    verdict: 'response-in-hand',
-    why: 'Life switch (#1383 item 4) and the Albescent join (#1383 item 1).',
-  },
   {
     file: 'pages/Home.tsx',
     calls: 1,
@@ -106,12 +83,6 @@ const LEDGER: LedgerEntry[] = [
     calls: 3,
     verdict: 'identity-changed',
     why: 'publish / pullBack / leaveCollab each run a backend stats recalc; publish also delivers invitation letters.',
-  },
-  {
-    file: 'pages/factionDetail/useFactionDetail.ts',
-    calls: 1,
-    verdict: 'response-in-hand',
-    why: 'Join or defect; POST /factions/choose returns {slug,status} (#1383 item 1).',
   },
   {
     file: 'pages/praxisDetail/usePraxisDetail.ts',
@@ -185,20 +156,20 @@ describe('the useAuth().refetch() inventory matches the ledger', () => {
   })
 
   it('totals the count this sweep reports', () => {
-    // 16 before, in 12 files — the same headline figure the issue was filed
-    // with, though not the same sixteen: #1382 had already deleted the per-star
-    // reload it named, and a faction letter gained an Accept button (#1424)
-    // that added one back.
+    // 16 before #1349, in 12 files; 14 in 10 after it; 8 in 5 once #1383 had
+    // the six `response-in-hand` sites consume the response instead.
     const total = [...measured.values()].reduce((sum, calls) => sum + calls, 0)
-    expect(total).toBe(14)
-    expect(measured.size).toBe(10)
+    expect(total).toBe(8)
+    expect(measured.size).toBe(5)
   })
 
-  it('leaves nothing classified as merely redundant', () => {
-    // The two that were — `logout()` then `refetch()` — are deleted. Anything
-    // that lands in this state again should be deleted, not written down.
+  it('leaves only identity reloads', () => {
+    // Both other classes are closed: merely-redundant (#1349) and
+    // response-in-hand (#1383). A new call site belongs here only if the
+    // mutation moved the whole viewer AND no response carries it — otherwise
+    // consume the response, or delete the call.
     const verdicts = new Set(LEDGER.map((entry) => entry.verdict))
-    expect([...verdicts].sort()).toEqual(['identity-changed', 'response-in-hand'])
+    expect([...verdicts]).toEqual(['identity-changed'])
   })
 })
 

--- a/frontend/src/auth/__tests__/protectedRoute.test.tsx
+++ b/frontend/src/auth/__tests__/protectedRoute.test.tsx
@@ -76,7 +76,7 @@ function renderGuard(
 ): string {
   const { warm = async () => {}, adminOnly = false } = props
   return renderToStaticMarkup(
-    <AuthContext.Provider value={{ ...session, refetch: async () => {}, signOut: async () => {} }}>
+    <AuthContext.Provider value={{ ...session, refetch: async () => {}, applyUser: () => {}, signOut: async () => {} }}>
       <ProtectedRoute warm={warm} adminOnly={adminOnly}>
         {PAGE}
       </ProtectedRoute>

--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -1,6 +1,7 @@
 import { useState, type CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { CharacterOut } from '../api/auth'
+import { useAuth } from '../auth/AuthContext'
 import { setActiveCharacter } from '../api/me'
 import { chooseFaction } from '../api/factions'
 import { extractError } from '../utils/errors'
@@ -62,12 +63,17 @@ const PERK_KEYS: ReadonlyArray<string> = [
 export interface AlbescentInvitationProps {
   /** The account's roster (active + paused lives). */
   lives: CharacterOut[]
-  /** Called after a successful join — refetch auth + roster so the UI reflects it. */
+  /**
+   * Called after a successful join, to refresh what the PARENT owns — the
+   * roster. The viewer half is no longer the parent's job: the join POST
+   * answers the refreshed `CurrentUser` and this component adopts it (#1383).
+   */
   onJoined: () => Promise<void> | void
 }
 
 export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvitationProps) {
   const { t } = useTranslation('factions')
+  const { applyUser } = useAuth()
   // Dynamic term/perk keys are data-driven; resolve them through a plain
   // string view of `t` (the typed union can't see the interpolated key).
   const tDynamic = t as unknown as (key: string) => string
@@ -89,8 +95,13 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
     try {
       // Existing character-switch flow, then the plain defection endpoint —
       // /factions/choose acts on the account's active character.
+      //
+      // Both POSTs answer a `CurrentUser` (#1383), but only the second is worth
+      // keeping: it is built AFTER the defection, so it supersedes the switch's
+      // answer. Adopting the first as well would only be overwritten a line
+      // later. Neither call is followed by an `/auth/me` any more.
       await setActiveCharacter(picked.id)
-      await chooseFaction(ALBESCENT_SLUG)
+      applyUser(await chooseFaction(ALBESCENT_SLUG))
       setJoined(true)
       await onJoined()
     } catch (err) {

--- a/frontend/src/components/CharacterSwitcherSheet.tsx
+++ b/frontend/src/components/CharacterSwitcherSheet.tsx
@@ -10,7 +10,8 @@ import { mediaUrl } from '../utils/media'
 /**
  * MOBILE active-character switcher (#516) — a bottom sheet over Home. Lists the
  * account's lives (active one checkmarked), swaps the carried life on tap
- * (`POST /me/active-character` then refetch), and holds the two path actions:
+ * (one `POST /me/active-character`, whose answer IS the new viewer — #1383),
+ * and holds the two path actions:
  * Create new character and Edit this character. Opened from the Home character
  * card's Switch / avatar caret. Presentation-only over existing endpoints.
  */
@@ -28,7 +29,7 @@ export default function CharacterSwitcherSheet({
   onClose: () => void
 }) {
   const { t } = useTranslation('common')
-  const { refetch } = useAuth()
+  const { applyUser } = useAuth()
   const navigate = useNavigate()
   const [lives, setLives] = useState<CharacterOut[]>([])
   const [switching, setSwitching] = useState<number | null>(null)
@@ -47,11 +48,10 @@ export default function CharacterSwitcherSheet({
     }
     setSwitching(id)
     try {
-      await setActiveCharacter(id)
-      // Carrying a different life changes the whole of `CurrentUser`. This POST
-      // already RETURNS that object and we throw it away — adopting it instead
-      // is #1383's item 4, not this sweep's (#1349 ledger).
-      await refetch()
+      // Carrying a different life changes the whole of `CurrentUser`, and this
+      // POST already answers that object — so adopt it rather than throwing it
+      // away and re-asking `/auth/me` (#1383).
+      applyUser(await setActiveCharacter(id))
       onClose()
     } finally {
       setSwitching(null)

--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -61,7 +61,7 @@ export default function InvitationLetterPopup({
   onClose,
 }: InvitationLetterPopupProps) {
   const { t } = useTranslation('factions')
-  const { user, refetch } = useAuth()
+  const { user, applyUser } = useAuth()
   const currentSlug = user?.character?.faction_slug
   const isSwitch = !!currentSlug && currentSlug !== 'na'
   const [confirming, setConfirming] = useState(false)
@@ -91,12 +91,12 @@ export default function InvitationLetterPopup({
     setJoining(true)
     setJoinError(null)
     try {
-      await chooseFaction(factionSlug)
-      // Same as the faction page's join: the choose response is `{slug, status}`,
-      // and membership moves faction slug + capability flags together. Also what
-      // clears this letter out of `user.character.invitations` so the watcher
-      // stops re-opening the prospectus (#1383 item 1 would make it cheaper).
-      await refetch()
+      // Same as the faction page's join: membership moves the faction slug and
+      // the capability flags together, and this is also what clears the letter
+      // out of `user.character.invitations` so the watcher stops re-opening the
+      // prospectus. The POST answers that whole viewer now (#1383), so adopting
+      // it does the job the follow-up `/auth/me` used to.
+      applyUser(await chooseFaction(factionSlug))
       onClose() // advance the queue; watcher keys the popup per slug so state resets
     } catch (err) {
       setJoinError(extractError(err, t('detail.errors.join')))

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -109,7 +109,7 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
   // there on purpose (ADR-0039 §2), and the cascade owns the dark half.
   const color = factionCssVar(faction_slug);
 
-  const { user, refetch } = useAuth();
+  const { user, applyUser } = useAuth();
   const mode = acceptMode(user?.character?.faction_slug, faction_slug);
   const currentName = factionName(user?.character?.faction_slug ?? UNAFFILIATED_FACTION_SLUG);
   const letterName = factionName(faction_slug);
@@ -124,13 +124,13 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
     setJoining(true);
     setError(null);
     try {
-      await chooseFaction(faction_slug);
+      // The character's faction is on /auth/me and dresses most of the site, so
+      // the feed alone is not enough — but the join POST now answers the whole
+      // refreshed viewer (#1383), so adopting it replaces the /auth/me that
+      // used to chase it. The bell and the queue count still follow.
+      applyUser(await chooseFaction(faction_slug));
       setJoined(true);
       setConfirming(false);
-      // The character's faction is on /auth/me and dresses most of the site, so
-      // the feed alone is not enough — refresh the character context, then let
-      // the bell and the queue count follow.
-      await refetch();
       notifyRequestsChanged();
     } catch (err) {
       // `extractError` returns the backend `detail` verbatim, which is what

--- a/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
+++ b/frontend/src/components/feed/__tests__/invitationLetterAccept.test.tsx
@@ -44,7 +44,7 @@ function viewer(factionSlug: string | null): CurrentUser {
 
 function render(factionSlug: string | null, onNotNow?: () => void): string {
   return renderToStaticMarkup(
-    <AuthContext.Provider value={{ user: viewer(factionSlug), loading: false, refetch: async () => {}, signOut: async () => {} }}>
+    <AuthContext.Provider value={{ user: viewer(factionSlug), loading: false, refetch: async () => {}, applyUser: () => {}, signOut: async () => {} }}>
       <MemoryRouter>
         <FeedCardInvitationLetter item={letter} onNotNow={onNotNow} />
       </MemoryRouter>

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -96,15 +96,14 @@ export default function CharacterProfile() {
     setRelationshipLoading(true);
     setRelationshipError(null);
     try {
-      await createRelationship(character.id, type);
-      // Re-fetch to get the properly typed RelationshipListItem with display data
-      const rels = await listRelationships();
-      const match = rels.find(
-        (r) => r.to_character_id === character.id,
-      );
-      setRelationship(match ?? null);
+      // The POST answers the enriched item, display data and all (#1383) —
+      // it used to answer the bare row, so this re-listed every relationship
+      // the viewer holds just to find the one it had written.
+      setRelationship(await createRelationship(character.id, type));
     } catch (err: unknown) {
-      // Handle 409 (already exists) gracefully — re-fetch existing relationship
+      // Handle 409 (already exists) gracefully — re-fetch existing relationship.
+      // This one stays a list read: the write FAILED, so there is no response
+      // body carrying the edge that already existed.
       if (err && typeof err === "object" && "response" in err) {
         const axiosErr = err as { response?: { status?: number } };
         if (axiosErr.response?.status === 409) {
@@ -143,12 +142,9 @@ export default function CharacterProfile() {
     setRelationshipLoading(true);
     setRelationshipError(null);
     try {
-      await unblockRelationship(relationship.id);
-      // Re-fetch to get the re-derived display status (Blocked → type label).
-      const rels = await listRelationships();
-      setRelationship(
-        rels.find((r) => r.to_character_id === character.id) ?? null,
-      );
+      // The re-derived display status (Blocked → type label) comes back on the
+      // unblock itself (#1383); it used to cost a full re-list.
+      setRelationship(await unblockRelationship(relationship.id));
     } catch {
       setRelationshipError("Could not unblock.");
     } finally {

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -89,7 +89,7 @@ export default function FieldDesk() {
   // what `/` renders for a signed-in viewer, and `home.json` is documented as
   // "Home / landing page copy". `common:fieldDesk.*` stays the roster's.
   const { t: tHome } = useTranslation('home')
-  const { user, refetch } = useAuth()
+  const { user, applyUser } = useAuth()
   const navigate = useNavigate()
   // `null` until the roster lands — "not known yet" and "known to be empty" are
   // different answers to the gate below, and one state cannot say both.
@@ -114,10 +114,9 @@ export default function FieldDesk() {
   const enterLife = async (id: number) => {
     setSwitching(id)
     try {
-      await setActiveCharacter(id)
-      // As in CharacterSwitcherSheet: the POST already returns the refreshed
-      // `CurrentUser`; consuming it instead of re-asking is #1383 item 4.
-      await refetch()
+      // As in CharacterSwitcherSheet: the POST already answers the refreshed
+      // `CurrentUser`, so consume it rather than re-asking `/auth/me` (#1383).
+      applyUser(await setActiveCharacter(id))
       navigate(`/characters/${id}`)
     } finally {
       setSwitching(null)
@@ -231,11 +230,11 @@ export default function FieldDesk() {
         <AlbescentInvitation
           lives={lives}
           onJoined={async () => {
-            // Joining Albescent moves `faction_slug`, `albescent_revealed` and
-            // the capability flags at once, and `POST /factions/choose` returns
-            // only `{slug, status}` — so the whole object has to be re-read
-            // until #1383 item 1 widens that response.
-            await refetch()
+            // Only the roster now: joining Albescent moves `faction_slug`,
+            // `albescent_revealed` and the capability flags at once, but they
+            // all ride back on the join POST and AlbescentInvitation adopts
+            // that directly (#1383). The roster still has to be re-read — the
+            // joined life's faction changed, and the rows above draw it.
             setLives(await getMyCharacters())
           }}
         />

--- a/frontend/src/pages/factionDetail/useFactionDetail.ts
+++ b/frontend/src/pages/factionDetail/useFactionDetail.ts
@@ -116,7 +116,7 @@ export function useFactionDetail(
   slug: string | undefined,
 ): FactionDetailState {
   const { t } = useTranslation("factions");
-  const { user, refetch } = useAuth();
+  const { user, applyUser } = useAuth();
   const characterId = user?.character?.id;
 
   // Section ③ — the viewer's relationship to this faction. Raw status ("member"
@@ -223,18 +223,17 @@ export function useFactionDetail(
     setJoining(true);
     setJoinError(null);
     try {
-      await chooseFaction(slug);
       // Membership dresses the whole site off `/auth/me` — faction slug, the
-      // level-jump allowance, `albescent_revealed`. `POST /factions/choose`
-      // answers `{slug, status}`, so nothing cheaper exists yet (#1383 item 1).
-      await refetch();
+      // level-jump allowance, `albescent_revealed`. The POST now answers that
+      // whole object, so adopting it replaces the follow-up `/auth/me` (#1383).
+      applyUser(await chooseFaction(slug));
       setRawStatus("member");
     } catch (err) {
       setJoinError(extractError(err, t("detail.errors.join")));
     } finally {
       setJoining(false);
     }
-  }, [slug, refetch, t]);
+  }, [slug, applyUser, t]);
 
   return {
     slug,

--- a/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
@@ -151,7 +151,7 @@ function state(user: CurrentUser | null, viewerCanVote: boolean): PraxisDetailSt
 
 function render(element: ReactElement, user: CurrentUser | null): string {
   const html = renderToStaticMarkup(
-    <AuthContext.Provider value={{ user, loading: false, refetch: async () => {}, signOut: async () => {} }}>
+    <AuthContext.Provider value={{ user, loading: false, refetch: async () => {}, applyUser: () => {}, signOut: async () => {} }}>
       <MemoryRouter>{element}</MemoryRouter>
     </AuthContext.Provider>,
   );


### PR DESCRIPTION
Closes #1383.

Four mutations returned something the client threw away and then refetched. Now they answer with the thing the caller was about to ask for, and the caller consumes it.

## What changed

**Instance 1 — `POST /factions/choose` answers `CurrentUser`, not `{slug}`.** Membership dresses the whole site off `/auth/me` — faction slug, level-jump allowance, capability flags, the sticky `albescent_revealed` reveal — so every caller discarded the slug and re-asked. Albescent is the sharpest case: joining is what *reveals* the secret society (ADR-0027), and the client used to learn that only on the follow-up.

**Instance 2 — the three relationship mutations answer `RelationshipListItem`.** Every caller of add / block / unblock immediately re-ran `GET /relationships` purely for the display name, avatar, faction and derived `display_status`. The item describes **the edge, not the viewer**: either party may block or unblock (ADR-0009), so a viewer-relative shape would hand back the same row mirrored depending on who acted. `list_relationships` shares the field mapping and keeps its batched reverse-edge query, so the list path gains no N+1.

**Instance 3 — `POST .../invite/{id}/respond` shrinks to `{praxis_id, accepted}`.** It declared `response_model=PraxisOut` and built a full tally-bearing payload behind a `selectinload` of invites and media; both call sites discarded it. Per the owner's ruling, this is the ack — widening it to the updated feed row is the better end state but collides with #1419/ADR-0070, which moves requests out of the stream. Revisit once that settles what a request row is.

**Instance 4 — `setActiveCharacter`'s `CurrentUser` is consumed.** Purely frontend; the route already returned it.

`AuthContext` gains `applyUser(user)` — the same move as `signOut` (#1349) pointed the other way.

## Corrections to the issue

- **`chooseFaction` has FOUR call sites, not one.** The issue named only `useFactionDetail`. Also `InvitationLetterPopup`, `FeedCardInvitationLetter` and `AlbescentInvitation`.
- **The owner's flagged check is clean.** `AlbescentInvitation` does not read the `FactionOut` shape — it discards the return entirely. No caller depended on it.
- **`RelationshipOut` had no reader left** once the mutations were widened, backend or frontend, so it is deleted.

`AlbescentInvitation` is where instances 1 and 4 collide: it chains `setActiveCharacter` then `chooseFaction`, and only the **second** response is adopted — it is built after the defection and supersedes the first.

## Load-time

**Six `/auth/me` round trips removed**, one per: joining a faction from the faction page, from the prospectus popup, from the feed letter, from the Albescent letter, and switching lives from either home screen. Each rebuilt the carried character, its era stats, its invitation letters and a dozen capability flags. Plus **two full `GET /relationships` list reads** (add, unblock) and the `PraxisOut` fan-out on every invite response. Entry bundle unchanged at 138.0 KB gzipped.

## Ledger

The #1349 `refetch()` ledger had already written these down in advance as `response-in-hand` — "#1383's to delete". This closes that class out: **14 calls in 10 files become 8 in 5**, and every survivor is now `identity-changed`. The verdict variant is removed with its entries, so a future call site can only be justified by the whole viewer really having moved with no response carrying it.

## Verification

All three CI jobs run locally end to end:

- **`test`** — 1054 passed, coverage 92.88% (fail-under 80).
- **`frontend`** — all six steps: eslint, `tsc --noEmit`, 3858 vitest tests, `vite build`, byte budget (JS 138.0 KB / CSS 22.3 KB, within budget), `typecheck:design-sync`.
- **`api-schema`** — `python scripts/regen_api_client.py`; both artifacts committed, re-run confirms **zero drift**.

The ADR-0071 collab-invite Easter-egg test keeps its claim intact: that the invitee *became a member* of a task they could not claim is still asserted, just sourced from `GET /praxes/{id}` rather than inferred from the respond body.

**Visual QA is outstanding** — this environment has no browser tools and no dev stack, so the join / life-switch / relationship surfaces were verified by tests, types and lint only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)