### PR TITLE
The label tier splits into a region name and a small fact, and its ink becomes a seam (#1307)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -331,7 +331,7 @@ Three things that ruling turns up. **Adding a face can retire one**: Lora uprigh
 
 | Tier        | Tokens                                                                     | Rule                    |
 | ----------- | -------------------------------------------------------------------------- | ----------------------- |
-| **Label**   | `--text-xs` 8 · `--text-sm` 9 · `--text-base` 10 · `--text-md` 11 · `--text-lg` 12 · `--text-xl` 14 | Stays small. Scanned, not read. |
+| **Label**   | `--text-xs` 8 · `--text-sm` 9 · `--text-base` 10 · `--text-md` 11 · `--text-lg` 12 · `--text-xl` 14 | Stays small. Scanned, not read — **except the caption role**, below. |
 | **Content** | `--text-content` 18 · `--text-title` 24 · `--text-heading` 32 · `--text-display` 42 | The floor and up. Read for meaning. |
 
 The content tier is a clean **4:3 ramp** — each step is exactly a third bigger than the last, so it needs no table to reproduce.
@@ -350,7 +350,7 @@ The content tier is a clean **4:3 ramp** — each step is exactly a third bigger
 Classify every string against these three roles. This is the vocabulary the sweeps work from.
 
 - **Content → the floor.** User-authored free text (`praxis.body`, `task.description`, `admin_note`, comments). Titles (`h1`–`h3`, `font-display`, `task.title`). Numbers a player cares about (points, votes, level). Full sentences from the i18n catalog — banner prose, status explanations.
-- **Label → stays small.** `.eyebrow` (and anything uppercase + letter-spacing, which is the same thing hand-rolled). Button and link chrome. Pills, badges, stamps, corner counters. Bylines, timestamps, metadata.
+- **Label → stays small,** and splits in two (#1307). `.label-heading` for a region name; `.label-caption` for a small fact about the thing. `.eyebrow` (and anything uppercase + letter-spacing, which is the same thing hand-rolled) is the retiring form of both. Button and link chrome. Pills, badges, stamps, corner counters. Bylines, timestamps, metadata.
 - **Ornament → exempt.** Glyphs used as icons (a `✗` dingbat is not text). Text that is part of the illustration — stamp text, tape-strip labels, punch-card headers.
 
 ### The geometry doctrine
@@ -359,7 +359,7 @@ Classify every string against these three roles. This is the vocabulary the swee
 > Type wins; geometry yields. A cramped card is not a reason to shrink readable text —
 > it is a reason to widen the card.
 
-Both of the floor's original exceptions came from treating a fixed container as immovable. It is not.
+Both of the floor's original exceptions came from treating a fixed container as immovable. It is not. (The floor now carries **one standing exception**, `.label-caption` at 12px — stated below, because it is a tier rather than a site and the doctrine above cannot be acted on for a timestamp.)
 
 **One container really is immovable: a drawn one (#1147).** When ornament type sits *inside a mark* — a
 figure in UA's ensō, a total in Everymen's roundel — the container is an illustration, and widening it
@@ -380,9 +380,30 @@ only**: a card, a panel or a rail is not a drawing, and there the doctrine above
 
 There is deliberately no `.content-heading` / `.content-display` / `.content-score`: each would have a single caller already owned by a component, and a class for one caller is a class for nobody. A score is a title-sized number — `.content-title` plus a `fontWeight`.
 
-**Eyebrow / label text:** Courier Prime, `--text-sm` (9px), uppercase, letter-spacing 0.15em, `var(--color-text-tertiary)`. Use the `.eyebrow` class. Never add an inline `fontSize` to an element that already carries `.eyebrow` — the class owns the size.
+**Eyebrow / label text:** Courier Prime, `--text-sm` (9px), uppercase, letter-spacing 0.15em, `var(--color-text-tertiary)`. Use the `.eyebrow` class. Never add an inline `fontSize` to an element that already carries `.eyebrow` — the class owns the size. **`.eyebrow` is being retired** — see the split below; it stays declared and correct until the last sweep moves off it.
 
 That ink is the third text tier, and §3 records what it can and cannot do. The eyebrow clears AA on every neutral stock it lands on — **5.40:1** on the page, 5.78 over the frost, 5.07 on the alt surface, 4.78 on the filter well in light; 6.21 / 5.67 / 5.37 / 5.47 in dark — and it is now visibly a different ink from `--color-text-secondary` rather than the same one under a second name. What it does **not** have is headroom: the tier sits at secondary's weight because the palette has no AA-clear room below secondary, so an eyebrow cannot be made quieter by walking its colour down. If a label rank needs to recede further, the levers left are size, tracking, casing and layout — not ink.
+
+### The label tier is TWO tiers, and the content floor has one exception (#1307)
+
+One class covered five jobs — section headings, metadata captions, status chips, counts, bylines — at 9px uppercase on 0.15em tracking in the weakest neutral, on 461 sites. Four legibility costs on the same string, and the treatment had already been found not to survive real content once: `.eyebrow-sentence` existed because *"a sentence set that way is a wall"*, which is a caption wearing a heading's clothes and a variant standing in for a rethink. **Owner ruling: two intents, not five treatments and not one.**
+
+| Class | Intent | Size | Casing | Tracking |
+| --- | --- | --- | --- | --- |
+| `.label-heading` | **This names a region.** "COLLABORATORS · 4", "WRITE-UP", "IN PROGRESS TASKS" | `--text-md` (11px) | uppercase | 0.15em |
+| `.label-caption` | **This is a small fact about the thing.** "5d ago", "5 / 20 slots", a byline, a status | `--text-lg` (12px) | normal | normal |
+
+Being hard to read as prose is acceptable for a heading, whose job is marking where a region starts and which is one or two words by construction. It is not acceptable for a caption, which is genuinely read. `.eyebrow-sentence` is **deleted**, absorbed by the caption tier rather than kept in sync.
+
+**The caption is nominally larger than the heading on purpose.** Uppercase reads optically larger than its nominal size, so 11px caps and 12px lowercase land at about the same weight while doing different jobs. Do not "fix" the inversion by pulling the caption to 11px: the casing is what the size is compensating for. And note where the win actually comes from — **dropping the casing and the tracking is the larger half**, since uppercase removes the ascender/descender shape that carries word recognition at small sizes and wide tracking works against reading the run as a word at all. The step from 9px is the smaller half.
+
+**The content floor's one exception is a tier, not a site.** §4's geometry doctrine says nothing readable may sit below `--text-content` and that a container which cannot hold it is too small; the label ramp says the tier is scanned, not read. Both cannot hold for a caption carrying text people read. The floor governs **content** — the thing a container exists to hold, and the thing that can run to any length. "Make the container bigger" is an instruction you can act on for a paragraph and meaningless for a timestamp: a caption does not size its container, it rides along beside something that does. So the floor could only ever have been enforced on captions by deleting them. What the caption tier owes instead is legibility per glyph, which it buys with casing and tracking rather than with size. **The boundary is a role test, not a length test:** anything that *can* become a paragraph is content and takes `--text-content`. When a caption starts wrapping to three lines it was content in a caption's clothes, which is the mistake `.eyebrow-sentence` was minted to paper over.
+
+**The ink is a SEAM, and it is the token — never the component (#1252).** `--label-ink` is what both classes paint; unset it is `--color-text-tertiary`, so a label outside a faction frame renders exactly what `.eyebrow` renders today. Both tiers sit under WCAG's large-text threshold, so both owe 4.5:1 and one measurement serves the pair. Measured on the #1549 instrument, the neutral clears on every neutral stock in both cascades and on all eight card sheets in **dark** — and fails on three in **light**, for a reason that is polarity rather than taste: S.N.I.D.E. **3.18:1** and Singularity **3.29:1** are near-black sheets in *both* themes (§6), so no light-cascade neutral can clear them, and Ephemerists' vellum is the darkest light sheet at **4.36:1** (its praxis plate 4.35). That is §3's "a colour that must differ between two factions within one theme is a faction token" arriving on the label tier. A faction frame therefore sets `--label-ink` **once on its own root** and every label underneath follows; a faction does not restyle the tier in its own component, because eight bespoke components quietly contradicting a shared class is the problem the shared class exists to prevent.
+
+**Nothing new was minted for it, and that is the measurement's finding rather than a shortcut.** `--faction-{key}-card-muted` is already the quiet ink for this role on that sheet and clears on all eight in both cascades (worst **4.70:1**, the Ephemerists plate), gated by rows `factionContrast.test.ts` has carried since #651. A second name for a value that is already measured is a name pretending to be a value (#1213), and #1302 reached the same conclusion for the praxis card's shared inks. What the guard gained instead is **structural**: every ratio in the file stays green through a `.label-caption` that hardcodes the neutral (which puts 3.18:1 back on S.N.I.D.E. with no faction able to reach it) and through one that goes back to uppercase on 0.15em (which is `.eyebrow` under a new name). Both are asserted on the declaration text, in the shape #1449 and #1413 set — a guard that measures an ink against a ground is blind to the ink not being reachable.
+
+**Retiring it is a foundation plus per-area sweeps, and the sweeps are free.** A sweep swaps class names in `.tsx` and adds no CSS; the whole issue's stylesheet cost is the foundation's **+39 bytes gzip**, and the last sweep gets some of it back by deleting `.eyebrow`. Classify each site by asking which of the two sentences it says — *this names a region* or *this is a small fact about the thing* — not by how long the string is.
 
 ---
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -54,6 +54,37 @@
   --color-text-secondary: #6b6050;
   --color-text-tertiary: #656081;
 
+  /* ── The label tier's ink is a SEAM, not a constant (#1307) ───────────────
+     Read by .label-heading and .label-caption and by nothing else. Declared
+     here rather than left to a `var(--label-ink, …)` fallback for the reason
+     the ep* motion knobs give further down: a fallback-only property is a
+     token nobody can find, and `factionTokensDeclared.test.ts` is right to
+     police it. Declared as an INDIRECTION rather than a hex, so it follows
+     --color-text-tertiary through the dark cascade and needs no counterpart
+     there — and so there is still exactly one place the neutral's value lives.
+
+     WHY IT IS A SEAM. Measured on the #1549 instrument, the neutral clears at
+     the tier's floor (both tiers are under WCAG's large-text threshold, so
+     both owe 4.5:1) on every neutral stock in both cascades and on all eight
+     card sheets in DARK — but it fails on three sheets in LIGHT, and the
+     reason is polarity rather than taste. S.N.I.D.E. 3.18:1 and Singularity
+     3.29:1 are near-black in BOTH themes (§6), so no light-cascade neutral can
+     clear them; Ephemerists' vellum is the darkest light sheet at 4.36:1 (its
+     praxis plate 4.35). That is #694's shape exactly: a colour that must
+     differ between two factions WITHIN one theme is a faction question, not a
+     global one.
+
+     A faction frame therefore sets this ONCE on its own root and every label
+     underneath follows — no per-label style, and no faction contradicting the
+     shared class in its own component (#1252: the seam is the token, not the
+     component). NOTHING NEW IS MINTED FOR IT: --faction-{key}-card-muted is
+     already the measured quiet ink for this role on that sheet, and it clears
+     on all eight in both cascades (worst 4.70:1, the Ephemerists plate), so a
+     frame points at its own rather than at a fresh hex. #1302 made the same
+     call for the same reason, and a second name for a value that is already
+     measured is a name pretending to be a value (#1213). */
+  --label-ink: var(--color-text-tertiary);
+
   /* ── Borders ── */
   --color-border: rgba(0, 0, 0, 0.07);
   --color-border-strong: rgba(0, 0, 0, 0.15);
@@ -2639,10 +2670,17 @@
 
 /* ── Type Scale + Font Families ── */
 :root {
-  /* ── Label tier (issue #627) ──
-     A size ramp, deliberately t-shirt-named. Backs .eyebrow and every
-     label-tier surface: pills, badges, stamps, bylines, button chrome.
-     Small on purpose — this text is scanned, not read. */
+  /* ── Label tier (issue #627, split in two by #1307) ──
+     A size ramp, deliberately t-shirt-named. Backs .label-heading and
+     .label-caption below, the legacy .eyebrow, and every label-tier surface:
+     pills, badges, stamps, bylines, button chrome.
+
+     "Small on purpose — this text is scanned, not read" was the rule for the
+     whole tier and is now the HEADING half's alone. A caption is a small FACT
+     about the thing beside it — a timestamp, a count, a byline — and those are
+     genuinely read. The split, the sizes and the ink seam are documented at
+     .label-heading / .label-caption; the content-floor exception it forces is
+     on the content tier below. */
   --text-xs: 8px;
   --text-sm: 9px;
   --text-base: 10px;
@@ -2655,7 +2693,35 @@
      "--text-content is the floor" needs no doc to explain. A clean 4:3
      ramp: each step is exactly a third bigger than the last.
      Nothing readable may sit below --text-content. If the type doesn't
-     fit, the container is too small — see WORLD_ZERO_STYLE.md §4. */
+     fit, the container is too small — see WORLD_ZERO_STYLE.md §4.
+
+     THE ONE EXCEPTION IS A TIER, NOT A SITE: .label-caption, --text-lg
+     (12px), #1307. State it here or the next reader files a 12px caption as a
+     violation to be fixed.
+
+     The floor governs CONTENT — the thing a container exists to hold, and the
+     thing that can run to any length. "The container is too small" is an
+     instruction you can act on for a paragraph and meaningless for a
+     timestamp: a caption does not size its container, it rides along beside
+     something that does, and widening the card gives it nothing. So the floor
+     could only ever have been enforced on captions by deleting them.
+
+     What the caption tier owes instead is legibility per glyph, and #1307
+     measured where that actually comes from. Against `.eyebrow`'s 9px
+     uppercase on 0.15em tracking, dropping the casing and the tracking is the
+     larger half of the fix — uppercase removes the ascender/descender shape
+     that carries word recognition at small sizes, and wide tracking works
+     against reading the run as a word at all. The size step is the smaller
+     half and 12px is where it stops, because past that the tier stops reading
+     as subordinate to the 18px it annotates and the hierarchy has to be
+     restated.
+
+     The boundary is a role test, not a length test: anything that CAN become a
+     paragraph is content and takes --text-content. A caption is bounded by
+     what it is — a date, a count, a name, a status. When one starts wrapping
+     to three lines, it was content wearing a caption's clothes, which is
+     exactly the mistake .eyebrow-sentence was minted to paper over (#850) and
+     #1307 deleted rather than kept in sync. */
   --text-content: 18px; /* body copy, descriptions, admin notes — the floor */
   --text-title: 24px; /* titles, scores */
   --text-heading: 32px; /* section and page headings */
@@ -3041,17 +3107,83 @@
     color: var(--color-text-tertiary);
   }
 
-  /* A label slot whose content is a SENTENCE rather than a word.
-     `.eyebrow`'s uppercase + 0.15em tracking is tuned for one or two words; a
-     sentence set that way is a wall. The propose-task faction descriptors are
-     the live case — six factions answer with one word and UA answers with
-     "Practise with us — one true mark a day." (#850). Same size and colour, so
-     the row still reads as one rank of labels; only the casing gives way. */
-  .eyebrow-sentence {
+  /* ── The label tier is TWO roles, not one (#1307) ──────────────────────────
+     `.eyebrow` above covers five jobs — section headings, metadata captions,
+     status chips, counts, bylines — at 9px uppercase on 0.15em tracking in the
+     weakest neutral. Four legibility costs stacked on one string, and the file
+     had already admitted the stack half-fails: `.eyebrow-sentence` lived here
+     (deleted by #1307) precisely because "a sentence set that way is a wall".
+     That was a CAPTION wearing a heading's clothes, and a variant rather than
+     the rethink it should have had. The five jobs are two intents:
+
+       .label-heading   THIS NAMES A REGION. "COLLABORATORS · 4", "WRITE-UP",
+                        "IN PROGRESS TASKS". 11px, uppercase, tracked. Being
+                        hard to read as prose is acceptable here — the job is
+                        marking where a region starts, and a region name is one
+                        or two words by construction.
+
+       .label-caption   THIS IS A SMALL FACT ABOUT THE THING. "5d ago",
+                        "5 / 20 slots", a byline, a status. 12px, normal case,
+                        normal tracking. It is genuinely read, so it may not be
+                        hard to read.
+
+     THE CAPTION IS NOMINALLY LARGER THAN THE HEADING, ON PURPOSE. Uppercase
+     reads optically larger than its nominal size, so 11px caps and 12px
+     lowercase land at about the same weight while doing different jobs. Do not
+     "fix" the inversion by pulling the caption to 11px: the casing is what the
+     size is compensating for, and matching the numbers un-matches the voices.
+
+     COLOUR IS `--label-ink`, WHICH IS NOT DECLARED HERE. Its measurement and
+     the reason a faction repoints it (three light-mode sheets the neutral
+     cannot clear) are at its declaration, up with the text tiers. Unset it is
+     `--color-text-tertiary`, so a label outside a faction frame renders what
+     `.eyebrow` renders today. Both tiers read the SAME property: they land on
+     one AA floor, so one measurement serves the pair, and a frame that had to
+     repoint two properties would eventually repoint one.
+
+     PURGE, AND ONE FRAGILE THING ABOUT IT. These live in @layer components, so
+     Tailwind emits a class only once it sees the literal string in a scanned
+     file — same as `.content-text` and `.eyebrow`, and it means a name
+     assembled at runtime is a name that never ships. Write both as literals.
+     `.label-caption` has real callers from the day it landed (the four sites
+     `.eyebrow-sentence` used to hold). `.label-heading` HAS NONE YET and is in
+     the bundle only because `factionContrast.test.ts` quotes it and Tailwind's
+     content glob scans every .ts and .tsx under src — so moving that spec out
+     of src would silently delete the class. Its first sweep is what makes it
+     load-bearing; until then, check the built stylesheet rather than the source
+     if it appears to do nothing. (Do not write that glob out here. It contains
+     a star-slash, which ENDS a CSS comment, and postcss then fails on the
+     remains of the sentence rather than on the thing you typed.)
+
+     `.eyebrow` stays declared and in use; #1307's per-area sweeps are what
+     retire it, and deleting it is the last of them. */
+
+  /* Written as two whole rules rather than a grouped selector plus two
+     role rules: the shared face and ink LOOK like 29 raw bytes of duplication,
+     and hoisting them measured 6 bytes gzip WORSE on the day (22,968 against
+     22,962, warn line 23,000). gzip had already collapsed the repetition and
+     the second selector list is new text. Measure a de-duplication in the
+     BUILT stylesheet before believing it — the raw file is not the payload. */
+
+  .label-heading {
     @apply font-body;
-    font-size: var(--text-sm);
-    letter-spacing: 0.02em;
-    color: var(--color-text-tertiary);
+    font-size: var(--text-md);
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    color: var(--label-ink);
+  }
+
+  /* `text-transform: none` is not redundant. A caption inherits its casing, and
+     several faction frames uppercase whole regions — a swept caption without
+     this line renders as the wall the split exists to remove, silently, at the
+     one size that makes it worse. `.eyebrow` never needed the reset because it
+     sets uppercase itself. */
+  .label-caption {
+    @apply font-body;
+    font-size: var(--text-lg);
+    text-transform: none;
+    letter-spacing: normal;
+    color: var(--label-ink);
   }
 
   /* ── Level gem (issue #728) ──

--- a/frontend/src/pages/editPraxis/blocks/HoldoutPublishNotice.tsx
+++ b/frontend/src/pages/editPraxis/blocks/HoldoutPublishNotice.tsx
@@ -91,7 +91,7 @@ export default function HoldoutPublishNotice({
       {/* The way out, said in the same breath as the deadline: submitting ends
           it, and an edit cancels it outright (ADR-0012). A countdown with no
           stated escape reads as a threat rather than a rule. */}
-      <span className="font-body eyebrow-sentence">
+      <span className="font-body label-caption">
         {collabCopy(factionSlug, "holdoutClockCaption")}
       </span>
     </div>

--- a/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
+++ b/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
@@ -831,7 +831,7 @@ export default function PraxisWaitingSurface({
                     {crewNudge != null && (
                       <span
                         role="status"
-                        className="eyebrow-sentence"
+                        className="label-caption"
                         style={{
                           textAlign: "right",
                           maxWidth: 420,
@@ -877,7 +877,7 @@ export default function PraxisWaitingSurface({
                     (`cancel_pending_publish_on_edit`, ADR-0012) — the countdown
                     drawn a few blocks up. */}
                 <span
-                  className="eyebrow-sentence"
+                  className="label-caption"
                   style={{ textAlign: "right", maxWidth: 420, ...dress.quietStyle }}
                 >
                   {collabCopy(

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -302,7 +302,7 @@ export default function DefaultProposeTask({
                     {/* Sentence-case: the descriptors are no longer uniformly
                         one word (#850 gave UA a full sentence), and 0.15em
                         all-caps is a wall at that length. */}
-                    <span className="eyebrow-sentence">
+                    <span className="label-caption">
                       {factionDescriptor(slug)}
                     </span>
                   </button>

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1392,6 +1392,23 @@ function resolveColor(name: string, theme: Theme) {
   return { raw, color: raw === null ? null : parseColor(raw) };
 }
 
+/**
+ * The stylesheet as text, and one rule out of it.
+ *
+ * Two blocks at the bottom of this file assert on DECLARATIONS rather than on
+ * ratios (#1413, #1307), because the bugs they guard are structural: a ground
+ * that is not a ground, an ink that is not reachable. Every ratio above stays
+ * green through both, which is the whole reason source assertions belong in a
+ * contrast spec at all. Shared so there is one reader of the file.
+ */
+const CSS_TEXT = readFileSync(CSS_PATH, "utf8");
+
+function ruleBody(selector: string): string {
+  const at = CSS_TEXT.indexOf(`${selector} {`);
+  expect(at, `index.css declares no \`${selector}\` rule`).toBeGreaterThan(-1);
+  return CSS_TEXT.slice(at, CSS_TEXT.indexOf("}", at));
+}
+
 describe("faction token contrast (WCAG AA)", () => {
   for (const theme of BOTH_THEMES) {
     describe(theme, () => {
@@ -1610,14 +1627,6 @@ describe("the neutral text tiers stay three inks (#1549)", () => {
  * would still pass here; `e2e/contrast.spec.ts` measures the real composite.
  */
 describe("the frost is a layer, not a ground (#1413)", () => {
-  const CSS = readFileSync(CSS_PATH, "utf8");
-
-  function ruleBody(selector: string): string {
-    const at = CSS.indexOf(`${selector} {`);
-    expect(at, `index.css declares no \`${selector}\` rule`).toBeGreaterThan(-1);
-    return CSS.slice(at, CSS.indexOf("}", at));
-  }
-
   for (const theme of BOTH_THEMES) {
     it(`--color-bg-surface is alpha in ${theme}, which is why it cannot be a Pair surface`, () => {
       const surface = resolveColor("--color-bg-surface", theme);
@@ -1646,5 +1655,103 @@ describe("the frost is a layer, not a ground (#1413)", () => {
       ruleBody(".card-on-page"),
       "`.card-on-page` is what the praxis detail's steward bar and report card wear (#1118: a block whose ink you do not control gets the stock that ink was measured on).",
     ).toContain("--card-ground: var(--color-bg-page)");
+  });
+});
+
+/**
+ * #1307 — THE LABEL TIER IS TWO TIERS, AND ITS INK IS A SEAM.
+ *
+ * WHY THERE ARE NO NEW `Pair` ROWS BELOW, which is a finding rather than an
+ * omission and is the whole reason this block is shaped the way it is.
+ *
+ * #1307 ruled "measure first, per tier, on all eight faction grounds; where the
+ * neutral fails a ground, mint a per-faction label ink". The measurement was
+ * done and it says the family gains no member. Both tiers sit under WCAG's
+ * large-text threshold (11px and 12px), so both owe 4.5:1 and ONE measurement
+ * serves the pair. `--color-text-tertiary` clears that floor on the app's two
+ * stocks — already gated above, "app page / app alt surface, tertiary ink"
+ * (#1549) — and on all eight card sheets in dark. It fails on three sheets in
+ * LIGHT, and the reason is polarity rather than taste: S.N.I.D.E. 3.18:1 and
+ * Singularity 3.29:1 are near-black sheets in BOTH themes, and Ephemerists'
+ * vellum is the darkest light sheet at 4.36:1 (its praxis plate 4.35). No
+ * light-cascade neutral clears a near-black sheet, so this is #694's shape: a
+ * colour that must differ between two factions within one theme is a faction
+ * question.
+ *
+ * And that faction question already has an answer with a name and a row.
+ * `--faction-{key}-card-muted` IS the measured quiet ink for this role on that
+ * sheet — 4.70:1 at worst, the Ephemerists plate — gated by `{key} card muted
+ * text` above and, for the four keys whose sheet is a different token, by
+ * `{key} praxis card sheet, muted ink`. Adding `{key} label ink on its sheet`
+ * beside those would be a second name for one measurement, which is what this
+ * file keeps warning about. So the frame points `--label-ink` at its own
+ * `-card-muted` and nothing is minted, exactly as #1302 concluded for the
+ * praxis card's shared inks.
+ *
+ * WHAT IS LEFT IS STRUCTURAL, and it is the #1449 / #1413 shape: a guard that
+ * measures an ink against a ground is blind to the ink not being reachable.
+ * Every ratio in this file stays green through a `.label-caption` that
+ * hardcodes `--color-text-tertiary` — and that version puts 3.18:1 back on the
+ * S.N.I.D.E. sheet with no faction able to do anything about it, because the
+ * seam a frame repoints would no longer be read. Likewise every ratio stays
+ * green through a `.label-caption` that goes back to uppercase on 0.15em
+ * tracking, which is `.eyebrow` again under a new name and the collapse #1307
+ * undid.
+ */
+describe("the label tier stays two tiers on one seam (#1307)", () => {
+  for (const selector of [".label-heading", ".label-caption"]) {
+    it(`${selector} paints the seam, not a hardcoded neutral`, () => {
+      expect(
+        ruleBody(selector),
+        `${selector} must read \`var(--label-ink)\`. Hardcoding the neutral is invisible to every ratio in this file and leaves S.N.I.D.E. (3.18:1), Singularity (3.29:1) and Ephemerists (4.36:1) in light with no way to fix their own sheet.`,
+      ).toContain("color: var(--label-ink)");
+    });
+  }
+
+  for (const theme of BOTH_THEMES) {
+    it(`--label-ink unset is the measured neutral (${theme})`, () => {
+      const seam = resolveColor("--label-ink", theme);
+      const neutral = resolveColor("--color-text-tertiary", theme);
+      expect(seam.color, `--label-ink (${theme}) resolved to "${seam.raw}"`).not.toBeNull();
+      expect(
+        seam.raw,
+        "a label outside a faction frame must render what `.eyebrow` renders today — that is what makes the sweeps a size-and-casing change rather than a repaint.",
+      ).toBe(neutral.raw);
+    });
+  }
+
+  it("the caption tier does not collapse back into the heading tier", () => {
+    const caption = ruleBody(".label-caption");
+    expect(
+      caption,
+      "the caption is normal-case on purpose: uppercase removes the ascender/descender shape that carries word recognition, and dropping it is the LARGER half of #1307's legibility fix.",
+    ).not.toContain("text-transform: uppercase");
+    expect(
+      caption,
+      "the caption carries no tracking: 0.15em works against reading the run as a word, which is why `.eyebrow-sentence` had to exist and why it does not any more.",
+    ).toContain("letter-spacing: normal");
+    expect(
+      ruleBody(".label-heading"),
+      "the heading tier keeps the caps — it names a region, and being hard to read as prose is acceptable for one or two words.",
+    ).toContain("text-transform: uppercase");
+  });
+
+  it("the two tiers take the sizes the split was measured at", () => {
+    expect(ruleBody(".label-heading"), "11px — see the ruling on #1307").toContain(
+      "font-size: var(--text-md)",
+    );
+    expect(
+      ruleBody(".label-caption"),
+      "12px, and nominally LARGER than the heading on purpose: uppercase reads optically larger, so 11px caps and 12px lowercase land at about the same weight doing different jobs. Matching the numbers un-matches the voices.",
+    ).toContain("font-size: var(--text-lg)");
+  });
+
+  it("the variant the split absorbed is gone, not kept in sync", () => {
+    // The SELECTOR, not the string: the block above still names the class in
+    // prose, and a comment is not a declaration.
+    expect(
+      CSS_TEXT.includes(".eyebrow-sentence {"),
+      "`.eyebrow-sentence` was a caption wearing a heading's clothes (#850). The two-tier split is the rethink it should have had; keeping it is keeping a second thing to sync.",
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
**Part of #1307** — the foundation only. The 461-site sweep is deliberately not here; the issue stays open for the per-area sweeps.

## What landed

**Two tiers, per the owner ruling.**

| class | intent | size | casing | tracking |
|---|---|---|---|---|
| `.label-heading` | *this names a region* | `--text-md` 11px | uppercase | 0.15em |
| `.label-caption` | *this is a small fact about the thing* | `--text-lg` 12px | normal | normal |

The caption being nominally larger is deliberate: uppercase reads optically larger, so 11px caps and 12px lowercase land at about the same weight doing different jobs.

**`.eyebrow-sentence` is deleted** and its **4** call sites (5 grep hits including the declaration — count verified) take the caption tier: `PraxisWaitingSurface` ×2, `HoldoutPublishNotice`, `DefaultProposeTask`. `.eyebrow` itself is untouched and still in use.

**The ink was measured, not assigned** — on the `#1549` instrument, per tier, on all eight faction grounds in both cascades. Both tiers sit under WCAG's large-text threshold, so both owe 4.5:1 and one measurement serves the pair.

`--color-text-tertiary` clears on every neutral stock in both cascades and on all eight card sheets in **dark** (worst 5.50:1). In **light** it fails three, and the reason is polarity rather than taste:

| sheet | light |
|---|---|
| S.N.I.D.E. `#14110b` | **3.18:1** |
| Singularity `#050f08` | **3.29:1** |
| Ephemerists vellum `#e9dcbf` | **4.36:1** |
| Ephemerists plate `#eadcb6` | **4.35:1** |

S.N.I.D.E. and Singularity are near-black in *both* themes, so no light-cascade neutral can clear them. That is #694's shape: a colour that must differ between two factions within one theme is a faction question.

So the colour is a seam — `--label-ink`, declared in `:root` as an indirection to the neutral (so dark needs no counterpart, and `factionTokensDeclared` has a declaration to find). A faction frame sets it **once on its own root**; factions do not restyle the tier in their own components (#1252).

## The one deviation from the ruling, and why

The ruling said *"where the neutral fails a ground, mint a per-faction label ink — eight keys, both cascades"*. **The measurement says the family gains no member, so nothing is minted.** `--faction-{key}-card-muted` is already the measured quiet ink for this role on that sheet and clears on **all eight in both cascades, worst 4.70:1** (the Ephemerists plate) — gated by `{key} card muted text` and `{key} praxis card sheet, muted ink`, rows this file has carried since #651. Adding `{key} label ink on its sheet` beside them is the "second name for one measurement" the file explicitly warns against, and #1302 reached the same conclusion for the praxis card's shared inks. Reversing this is a one-line-per-frame change if the owner disagrees.

**What the guard gained instead is structural**, in the #1449 / #1413 shape — every ratio in the file stays green through both of these:

- a `.label-caption` that hardcodes `--color-text-tertiary` (puts 3.18:1 back on S.N.I.D.E. with no faction able to reach it),
- a `.label-caption` that goes back to uppercase on 0.15em (that is `.eyebrow` under a new name).

Plus: `--label-ink` unset resolves to the neutral in both cascades, the two tiers hold their measured sizes, and `.eyebrow-sentence` is gone rather than kept in sync.

## Doctrine amendment

`index.css` said *"nothing readable may sit below `--text-content` (18px); if the type doesn't fit, the container is too small"* while the label ramp said *"scanned, not read"*. Both cannot hold for a 12px caption. The exception is stated **at the tier, not at a site**, in `index.css` and in `WORLD_ZERO_STYLE.md` §4: the floor governs *content* — the thing a container exists to hold and the thing that can run to any length. "Make the container bigger" is actionable for a paragraph and meaningless for a timestamp, so the floor could only ever have been enforced on captions by deleting them. The boundary is a **role test, not a length test**: anything that *can* become a paragraph is content.

## Budget

| | gzip |
|---|---|
| baseline (`origin/main`) | 22,923 |
| this branch | **22,962** |
| warn | 23,000 |

**+39 bytes, 38 left.** Under the line, and it is the whole issue's stylesheet cost — a sweep swaps class names in `.tsx` and adds no CSS, and the last sweep gets bytes back by deleting `.eyebrow`.

Hoisting the two classes' shared `font-family` + `color` into a grouped selector was measured and is **6 bytes gzip worse** (22,968) despite 29 fewer raw bytes — gzip had already collapsed the repetition and the second selector list is new text. Recorded at the declaration.

## Two things worth knowing

- **`.label-heading` has no `.tsx` caller yet** and is in the bundle only because the contrast spec quotes it as a literal and Tailwind scans `src`. Verified present in the built stylesheet. Moving that spec out of `src` would silently delete the class; its first sweep makes it load-bearing.
- A CSS comment that writes Tailwind's content glob out longhand **closes the comment early** (it contains a star-slash) and postcss then fails somewhere else. Hit and fixed; noted in the comment so the next editor doesn't.

## What to eyeball (both themes)

No browser here, and axe cannot measure the gradient / `background-clip` surfaces (#651). Four rendered sites changed, all 9px → 12px, uppercase-off, tracking-off:

1. `/tasks/propose` — the faction descriptor under each faction pill (the UA sentence "Practise with us — one true mark a day." is the case the deleted class existed for). Check it still reads as one rank of labels beside the `.eyebrow` region label above it.
2. `/praxes/:id/edit` waiting surface — the "nudge crew" result line and the pull-back / awaiting-edit description, both right-aligned at `maxWidth: 420`. Both spread `dress.quietStyle` inline, so the **inline colour still wins** over the tier; confirm nothing went louder.
3. The holdout publish notice — the caption under the deadline. The parent sets `color: notice` and the class overrides it to the neutral, as `.eyebrow-sentence` did; confirm that is unchanged.

Also worth a look on a faction-skinned page: the caption tier is 3px larger, so any row that was tightly packed at 9px may now wrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)