### PR TITLE
A bottom sheet leaves the shell so its scrim can cover the tab bar

### DIFF
--- a/frontend/src/components/CharacterSwitcherSheet.tsx
+++ b/frontend/src/components/CharacterSwitcherSheet.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from 'react-i18next'
 import { useAuth } from '../auth/AuthContext'
 import { getMyCharacters, setActiveCharacter } from '../api/me'
 import type { CharacterOut } from '../api/auth'
+import { useFormFactor } from '../hooks/useFormFactor'
 import { factionCssVar, factionName } from '../utils/factions'
 import { mediaUrl } from '../utils/media'
+import { drawAtRoot } from './ui/drawAtRoot'
 
 /**
  * MOBILE active-character switcher (#516) — a bottom sheet over Home. Lists the
@@ -14,6 +16,13 @@ import { mediaUrl } from '../utils/media'
  * and holds the two path actions:
  * Create new character and Edit this character. Opened from the Home character
  * card's Switch / avatar caret. Presentation-only over existing endpoints.
+ *
+ * **Drawn at the document root** (#1591). Every caller — the desktop rail's
+ * Characters pill (`layout/Sidebar`) and all eight mobile field desks — mounts
+ * this from inside `ShellContent`, whose `position: relative` + `z-index: 5`
+ * opens a stacking context that no descendant can escape by declaring a bigger
+ * number. On the phone that put the tab bar over the sheet and left it tappable
+ * behind the scrim. `drawAtRoot` carries the full argument.
  */
 
 // Decorative edit glyph (aria-hidden icon); a const so the jsx-text-only literal
@@ -31,6 +40,7 @@ export default function CharacterSwitcherSheet({
   const { t } = useTranslation('common')
   const { applyUser } = useAuth()
   const navigate = useNavigate()
+  const isMobile = useFormFactor() === 'mobile'
   const [lives, setLives] = useState<CharacterOut[]>([])
   const [switching, setSwitching] = useState<number | null>(null)
 
@@ -58,10 +68,10 @@ export default function CharacterSwitcherSheet({
     }
   }
 
-  return (
+  return drawAtRoot(
     <div role="dialog" aria-modal="true" aria-label={t('fieldDesk.home.switcher.title')}>
       <button type="button" aria-label={t('fieldDesk.home.switcher.close')} onClick={onClose} style={scrim} />
-      <div style={sheet}>
+      <div style={{ ...sheet, paddingBottom: bottomRest(isMobile) }}>
         <span style={grab} />
         <div style={sheetTitle}>{t('fieldDesk.home.switcher.title')}</div>
 
@@ -166,15 +176,38 @@ export function CharacterSwitcherRows({
 
 // --- token-driven styles ----------------------------------------------------
 
+/**
+ * What sits under the last action before the screen ends.
+ *
+ * On the phone that is the mobile tab bar, and `--tab-bar-clearance` is the one
+ * token that says how tall it is (#1590) — the filter sheet already reads it,
+ * so both sheets now agree about where the bottom of the screen is. On desktop
+ * there is no bar to clear and the sheet keeps its own breathing room.
+ *
+ * ponytail: the clearance folds in `env(safe-area-inset-bottom)`, which
+ * resolves to `0px` app-wide today because `index.html` sets no
+ * `viewport-fit=cover`. Correct-but-inert, and live the day someone sets it.
+ */
+function bottomRest(isMobile: boolean): string {
+  return isMobile ? 'calc(var(--space-xl) + var(--tab-bar-clearance))' : 'var(--space-xl)'
+}
+
+// Bottom-sheet band, shared with `.filter-factions__scrim` / `__sheet` in
+// index.css: scrim 39, sheet 40. Read in the ROOT stacking context now that
+// both sheets portal out of the shell (#1591) — above the chrome at 10, below
+// ConfirmDialog's 50 and the full-screen modals at 1000, which is the order a
+// confirm raised from inside this sheet needs.
 const scrim: CSSProperties = {
-  position: 'fixed', inset: 0, zIndex: 40, border: 'none', padding: 0,
-  background: 'rgba(0,0,0,0.45)', cursor: 'pointer',
+  position: 'fixed', inset: 0, zIndex: 39, border: 'none', padding: 0,
+  background: 'var(--color-overlay-strong)', cursor: 'pointer',
 }
 const sheet: CSSProperties = {
-  position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 41,
+  position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 40,
   background: 'var(--color-bg-surface)', borderRadius: '22px 22px 0 0',
-  padding: 'var(--space-md) var(--space-lg) calc(var(--space-xl) + env(safe-area-inset-bottom))',
-  boxShadow: '0 -12px 34px rgba(0,0,0,0.3)', maxHeight: '80vh', overflowY: 'auto',
+  padding: 'var(--space-md) var(--space-lg)',
+  // No --shadow-* token exists; the colour half is the half that would drift
+  // between themes, so it is the half that comes from a token (ConfirmDialog).
+  boxShadow: '0 -12px 34px var(--color-overlay-strong)', maxHeight: '80vh', overflowY: 'auto',
 }
 const grab: CSSProperties = {
   display: 'block', width: 38, height: 4, borderRadius: 999,

--- a/frontend/src/components/__tests__/sheetsEscapeShell.test.tsx
+++ b/frontend/src/components/__tests__/sheetsEscapeShell.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * Bottom sheets escape the shell's stacking context (#1591).
+ *
+ * WHAT THIS CAN AND CANNOT PROVE
+ * ------------------------------
+ * The defect is an INTERACTION: the mobile tab bar stayed tappable behind an
+ * open sheet's scrim, because `ShellContent`'s `position: relative` +
+ * `z-index: 5` opens a stacking context that caps every descendant below the
+ * chrome at 10. Tapping a bar through a scrim needs a real browser with real
+ * hit-testing, and this harness is `renderToStaticMarkup` in node — no DOM, no
+ * pointer, no effects. **The interaction itself is not exercised here and
+ * cannot be**; it is on the eyeball list in the PR.
+ *
+ * What IS mechanically checkable is the thing the fix turns on: whether each
+ * sheet hands its overlay to `createPortal(…, document.body)`. Two facts make
+ * that assertable without a DOM:
+ *
+ *   1. `drawAtRoot` is a plain function, so it can be called directly — with
+ *      no `document` (the harness) and with an element-like stub (the browser).
+ *   2. `react-dom/server` REFUSES to render a portal. So "this component
+ *      portals when a document exists" reads as `renderToStaticMarkup` raising
+ *      the server renderer's own portal error, and "this path does not portal"
+ *      reads as the same render returning markup. The throw is the proof, not
+ *      an accident.
+ *
+ * The mirror case matters as much: with no `document` the guard keeps the tree
+ * inline, which is what stops this change from silently blanking every other
+ * suite's markup assertions.
+ */
+import type { ReactElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+
+// factionName and the sheet copy read the raw i18n instance, not a provider.
+import '../../i18n'
+
+const formFactorMock = vi.fn(() => 'desktop')
+vi.mock('../../hooks/useFormFactor', () => ({
+  useFormFactor: () => formFactorMock(),
+}))
+
+vi.mock('../../auth/AuthContext', () => ({
+  useAuth: () => ({ applyUser: () => {} }),
+}))
+
+// Fetched in an effect the static renderer never runs; mocked so the module
+// graph does not drag an axios client in behind it.
+vi.mock('../../api/me', () => ({
+  getMyCharacters: async () => [],
+  setActiveCharacter: async () => ({}),
+}))
+
+import CharacterSwitcherSheet from '../CharacterSwitcherSheet'
+import { OptionOverlay } from '../ui/FilterBar/OptionPicker'
+import { drawAtRoot } from '../ui/drawAtRoot'
+import type { FilterFacet } from '../ui/FilterBar/filterState'
+
+const REACT_PORTAL = Symbol.for('react.portal')
+
+/**
+ * A portal's runtime fields. `@types/react`'s `ReactPortal` describes what you
+ * may PASS to React, not the tagged object `createPortal` hands back, so the
+ * two fields that identify a portal are not on it.
+ */
+interface PortalShape {
+  $$typeof: symbol
+  containerInfo: unknown
+}
+
+/**
+ * The smallest thing React accepts as a portal container: `isValidContainer`
+ * reads `nodeType`, nothing more. A real Element would need jsdom, which this
+ * harness deliberately does not have.
+ */
+const FAKE_BODY = { nodeType: 1 } as unknown as HTMLElement
+
+function withDocument<T>(run: () => T): T {
+  vi.stubGlobal('document', { body: FAKE_BODY })
+  try {
+    return run()
+  } finally {
+    vi.unstubAllGlobals()
+  }
+}
+
+const FACET: FilterFacet = {
+  key: 'type',
+  label: 'Type',
+  options: [
+    { value: 'nudge', label: 'Nudge' },
+    { value: 'notice', label: 'Notice' },
+  ],
+  selected: ['nudge'],
+  onChange: () => {},
+}
+
+function switcher(formFactor: 'mobile' | 'desktop'): string {
+  formFactorMock.mockReturnValue(formFactor)
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <CharacterSwitcherSheet open activeCharacterId={1} onClose={() => {}} />
+    </MemoryRouter>,
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  formFactorMock.mockReturnValue('desktop')
+})
+
+describe('drawAtRoot', () => {
+  it('hands the overlay back untouched when there is no document', () => {
+    const overlay = <div data-test="overlay" />
+    expect(drawAtRoot(overlay)).toBe(overlay)
+    expect(renderToStaticMarkup(drawAtRoot(overlay) as ReactElement)).toContain('data-test="overlay"')
+  })
+
+  it('portals the overlay to document.body when there is one', () => {
+    const portal = withDocument(() => drawAtRoot(<div />)) as unknown as PortalShape
+    expect(portal.$$typeof).toBe(REACT_PORTAL)
+    expect(portal.containerInfo).toBe(FAKE_BODY)
+  })
+})
+
+describe('CharacterSwitcherSheet', () => {
+  it('portals — the shell can no longer cap it under the tab bar', () => {
+    expect(() => withDocument(() => switcher('mobile'))).toThrow(/[Pp]ortal/)
+  })
+
+  it('still renders its markup inline in the DOM-less harness', () => {
+    const html = switcher('mobile')
+    expect(html).toContain('role="dialog"')
+    expect(html).toContain('aria-modal="true"')
+    // The roster arrives in an effect the static renderer never runs, so the
+    // rows are `CharacterSwitcherRows`' business (characterPaths.test.tsx);
+    // what is here is the sheet's own chrome.
+    expect(html).toContain('Your characters')
+    expect(html).toContain('Create new character')
+  })
+
+  it('clears the tab bar on the phone and nothing on the desktop rail', () => {
+    // Both sheets read the one token that says how tall the bar is, so they
+    // agree about where the bottom of the screen is. The desktop rail opens
+    // the same sheet with no bar under it (#1591).
+    expect(switcher('mobile')).toContain('padding-bottom:calc(var(--space-xl) + var(--tab-bar-clearance))')
+    const desktop = switcher('desktop')
+    expect(desktop).toContain('padding-bottom:var(--space-xl)')
+    expect(desktop).not.toContain('--tab-bar-clearance')
+  })
+
+  it('takes its scrim and shadow from a token, never a raw rgba', () => {
+    const html = switcher('mobile')
+    expect(html).toContain('var(--color-overlay-strong)')
+    expect(html).not.toMatch(/rgba\(/)
+  })
+})
+
+describe('OptionOverlay', () => {
+  it('portals the phone sheet', () => {
+    expect(() =>
+      withDocument(() =>
+        renderToStaticMarkup(<OptionOverlay facet={FACET} isSheet onDone={() => {}} />),
+      ),
+    ).toThrow(/[Pp]ortal/)
+  })
+
+  it('leaves the desktop popover exactly where its anchor is', () => {
+    // Not merely "no portal needed": the popover is positioned against the
+    // trigger, so moving it to document.body would tear it off its anchor.
+    const html = withDocument(() =>
+      renderToStaticMarkup(<OptionOverlay facet={FACET} isSheet={false} onDone={() => {}} />),
+    )
+    expect(html).toContain('filter-factions__popover')
+    expect(html).not.toContain('filter-factions__scrim')
+  })
+
+  it('still renders the sheet and its scrim inline in the DOM-less harness', () => {
+    const html = renderToStaticMarkup(<OptionOverlay facet={FACET} isSheet onDone={() => {}} />)
+    expect(html).toContain('filter-factions__scrim')
+    expect(html).toContain('filter-factions__sheet')
+    expect(html).toContain('aria-checked="true"')
+  })
+})

--- a/frontend/src/components/ui/FilterBar/OptionPicker.tsx
+++ b/frontend/src/components/ui/FilterBar/OptionPicker.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useState, type ReactElement } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useFormFactor } from '../../../hooks/useFormFactor'
+import { drawAtRoot } from '../drawAtRoot'
 import { toggleOption, type FilterFacet } from './filterState'
 
 /** The trigger stacks at most three ornaments; the badge carries the rest. */
@@ -31,7 +32,9 @@ const CHECK_GLYPH = '✓'
  *
  * Dismissal is the trigger, the Done button, and Escape. Deliberately no
  * document-level click-outside listener: three routes is enough, and an effect
- * here would be untestable in a harness with no DOM.
+ * here would be untestable in a harness with no DOM. Escape still works with
+ * the sheet portalled out (#1591): a portal moves the DOM node, not the React
+ * tree, so the keydown still bubbles to the wrapper's handler below.
  *
  * **An option-less facet draws nothing at all** (#1567). A facet may legitimately
  * narrow itself to nothing — Updates' type facet hides zero-count rows, so on a
@@ -50,14 +53,76 @@ const CHECK_GLYPH = '✓'
  * stays removable both from the panel and from the applied-chip row.
  */
 export default function OptionPicker({ facet }: { facet: FilterFacet }) {
-  const { t } = useTranslation('common')
   const [open, setOpen] = useState(false)
   const isSheet = useFormFactor() === 'mobile'
-  const { label, options, selected, onChange, renderOrnament } = facet
+  const { label, options, selected, renderOrnament } = facet
 
   // After the hooks, never before: an early return above them is a conditional
   // hook call, and `options` is a prop that changes as counts arrive.
   if (options.length === 0) return null
+
+  return (
+    <div
+      className="filter-factions"
+      onKeyDown={(event) => {
+        if (event.key === 'Escape' && open) setOpen(false)
+      }}
+    >
+      <button
+        type="button"
+        className="filter-factions__trigger"
+        aria-expanded={open}
+        data-on={open ? 'true' : undefined}
+        onClick={() => setOpen(!open)}
+      >
+        <span>{label}</span>
+        {renderOrnament && (
+          <span className="filter-factions__stack" aria-hidden="true">
+            {selected.slice(0, TRIGGER_STACK_MAX).map((value) => (
+              <span key={value} className="filter-factions__stack-sigil">
+                {renderOrnament(value, 'trigger')}
+              </span>
+            ))}
+          </span>
+        )}
+        {selected.length > 0 && (
+          <span className="filter-bar__badge">{selected.length}</span>
+        )}
+      </button>
+      {open && (
+        <OptionOverlay facet={facet} isSheet={isSheet} onDone={() => setOpen(false)} />
+      )}
+    </div>
+  )
+}
+
+/**
+ * The open panel: a popover anchored to the trigger at tablet and up, a
+ * scrimmed bottom sheet on the phone.
+ *
+ * Exported so the sheet path is reachable in a harness with no DOM — `open` is
+ * local state that only a click sets, so a test rendering `OptionPicker` can
+ * never see this markup at all. `CharacterSwitcherRows` is the precedent.
+ *
+ * **The sheet half draws at the document root** (#1591). Rendered in place it
+ * was trapped in the content region's stacking context, which capped it below
+ * the mobile tab bar: the bar painted over the sheet and stayed tappable behind
+ * the scrim. `drawAtRoot` is where the whole argument lives. The popover is
+ * deliberately NOT portalled — it is `position: absolute` against the trigger,
+ * so moving it to `document.body` would tear it off its anchor, and there is no
+ * tab bar on the desktop it renders on.
+ */
+export function OptionOverlay({
+  facet,
+  isSheet,
+  onDone,
+}: {
+  facet: FilterFacet
+  isSheet: boolean
+  onDone: () => void
+}): ReactElement {
+  const { t } = useTranslation('common')
+  const { label, options, selected, onChange, renderOrnament } = facet
 
   const panel = (
     <div
@@ -104,53 +169,23 @@ export default function OptionPicker({ facet }: { facet: FilterFacet }) {
           )
         })}
       </div>
-      <button
-        type="button"
-        className="filter-factions__done"
-        onClick={() => setOpen(false)}
-      >
+      <button type="button" className="filter-factions__done" onClick={onDone}>
         {t('filters.bar.done')}
       </button>
     </div>
   )
 
-  return (
-    <div
-      className="filter-factions"
-      onKeyDown={(event) => {
-        if (event.key === 'Escape' && open) setOpen(false)
-      }}
-    >
+  if (!isSheet) return panel
+
+  return drawAtRoot(
+    <>
       <button
         type="button"
-        className="filter-factions__trigger"
-        aria-expanded={open}
-        data-on={open ? 'true' : undefined}
-        onClick={() => setOpen(!open)}
-      >
-        <span>{label}</span>
-        {renderOrnament && (
-          <span className="filter-factions__stack" aria-hidden="true">
-            {selected.slice(0, TRIGGER_STACK_MAX).map((value) => (
-              <span key={value} className="filter-factions__stack-sigil">
-                {renderOrnament(value, 'trigger')}
-              </span>
-            ))}
-          </span>
-        )}
-        {selected.length > 0 && (
-          <span className="filter-bar__badge">{selected.length}</span>
-        )}
-      </button>
-      {open && isSheet && (
-        <button
-          type="button"
-          className="filter-factions__scrim"
-          aria-label={t('filters.bar.done')}
-          onClick={() => setOpen(false)}
-        />
-      )}
-      {open && panel}
-    </div>
+        className="filter-factions__scrim"
+        aria-label={t('filters.bar.done')}
+        onClick={onDone}
+      />
+      {panel}
+    </>,
   )
 }

--- a/frontend/src/components/ui/drawAtRoot.ts
+++ b/frontend/src/components/ui/drawAtRoot.ts
@@ -1,0 +1,39 @@
+import { createPortal } from 'react-dom'
+import type { ReactElement } from 'react'
+
+/**
+ * Draw an overlay at the document root instead of where it was mounted.
+ *
+ * WHY (#1591) — the shell composites in three deliberate bands: backdrop `0`
+ * (`WatercolorBackground`), content `5` (`ShellContent`'s two regions and
+ * `SiteFooter`), chrome `10` (`MobileHeader`, `MobileTabBar`). That is the
+ * right order, and it is also the trap: `position: relative` + `z-index: 5` on
+ * the content region OPENS A STACKING CONTEXT, so everything rendered inside
+ * page content composites at 5 and can never rise above the chrome — whatever
+ * z-index it declares for itself. The mobile tab bar therefore painted OVER an
+ * open bottom sheet and stayed tappable behind its scrim, which breaks the one
+ * promise a scrim makes: nothing behind it is available.
+ *
+ * The bands must stay. Deleting the content region's z-index drops content
+ * behind the backdrop; raising it lifts ordinary content over the chrome. The
+ * overlay is what has to leave, and a portal to `document.body` is how it
+ * leaves — the same escape `ConfirmDialog` (#1082) and `FeedBankFullModal`
+ * (#1148) already make. Factored here so the two bottom sheets that needed it
+ * next did not become copies three and four of the same ternary.
+ *
+ * ALTITUDE, once out: an overlay portalled to `document.body` competes in the
+ * ROOT stacking context, where its own z-index finally means something. The
+ * ladder there reads backdrop `0` < content `5` < chrome `10` < bottom sheets
+ * `39`/`40` < `ConfirmDialog` `50` < the full-screen modals at `1000`. A sheet
+ * belongs below a confirm raised from inside it, so the sheets keep their
+ * existing numbers rather than joining the `1000` band — those numbers were
+ * only ever fiction because of the trap, not because they were wrong.
+ *
+ * THE GUARD is this repo's test harness. Tests render with
+ * `renderToStaticMarkup` and no DOM, and the server renderer cannot render a
+ * portal at all, so with no `document` the tree stays inline and the markup
+ * stays assertable. In a browser that branch is never taken.
+ */
+export function drawAtRoot(overlay: ReactElement): ReactElement {
+  return typeof document === 'undefined' ? overlay : createPortal(overlay, document.body)
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5622,7 +5622,12 @@
   z-index: 39;
   border: 0;
   padding: 0;
-  background: rgba(0, 0, 0, 0.55);
+  /* One scrim for every overlay. This was the outlier at 0.55 while
+     ConfirmDialog, FeedBankFullModal and (as of #1591) CharacterSwitcherSheet
+     all dimmed at --color-overlay-strong. Two modal sheets disagreeing about
+     how dark "the page behind is unavailable" looks is the drift a token
+     exists to stop. Costs 0 bytes gzip — measured against the built sheet. */
+  background: var(--color-overlay-strong);
   cursor: pointer;
 }
 


### PR DESCRIPTION
Closes #1591

The mobile tab bar stayed **tappable** behind an open sheet's scrim — you could navigate away from behind a scrim telling you the page was unavailable — and the scrim never covered the bar.

## The cause is not a wrong z-index

The shell's bands are coherent: backdrop `0` (`WatercolorBackground`), content `5` (`ShellContent`, `SiteFooter`), chrome `10` (`MobileHeader`, `MobileTabBar`).

But `position: relative` + `z-index: 5` on the content region **opens a stacking context**, so anything rendered inside page content is capped at 5 and can never rise above chrome at 10 — whatever it declares. The filter sheet's `40` and the switcher's `41` were fiction.

So neither raising the sheets nor deleting the region's z-index would work. The sheets have to leave the region.

## Two sheets were trapped, not one

An earlier note on the issue said `CharacterSwitcherSheet` escaped by being mounted outside the region. **It does not.** Its callers are `components/layout/Sidebar.tsx:799` and all eight `pages/fieldDesk/mobileArchetypes/*FieldDesk.tsx` — every one inside `ShellContent`. (`pages/FieldDesk.tsx:117` only *mentions* it in a comment.)

## The fix reuses the house pattern

New `components/ui/drawAtRoot.ts` carries `ConfirmDialog`'s exact shape, including the guard this harness needs:

```ts
return typeof document === 'undefined' ? overlay : createPortal(overlay, document.body)
```

That ternary is load-bearing — the test harness is `renderToStaticMarkup` with no DOM, and a bare portal makes the markup unassertable. Factored into one function rather than pasted a third and fourth time.

- **`OptionPicker`** — panel + scrim extracted to `OptionOverlay`; the **sheet** branch portals, the **desktop popover does not**. The popover is `position: absolute` against its trigger, so portalling would tear it off its anchor.
- **`CharacterSwitcherSheet`** — portals, and its bottom padding becomes `calc(var(--space-xl) + var(--tab-bar-clearance))` **on mobile only**. The conditional is load-bearing: the desktop rail's Characters pill opens this same sheet, where an unconditional 3.5rem would be dead space.

Escape still works portalled — a portal moves the DOM node, not the React tree, so the keydown still bubbles to the wrapper's handler.

## Altitude: 39/40, deliberately not 1000

The brief suggested matching `FeedBankFullModal` at 1000. Kept at 39/40 instead, because once portalled those numbers compete in the root context and stop being fiction. The resulting ladder reads:

`0` backdrop → `5` content → `10` chrome → **`39/40` sheets** → `50` ConfirmDialog → `1000` full-screen modals

Raising sheets to 1000 would put a bottom sheet *above* a confirm dialog or level-up popup raised from inside it.

## One scrim token

`.filter-factions__scrim` was the outlier at `rgba(0,0,0,.55)` while every other overlay dimmed at `--color-overlay-strong`. Since this PR moves the switcher onto that token, leaving the filter sheet at 0.55 would have shipped two sheets disagreeing about how dark "unavailable" looks — drift introduced by this very change. Both now read the token.

**Zero bytes gzip**, verified against a **rebuilt** stylesheet. Worth recording: the first measurement read a stale `dist/` whose scrim still compiled to `#0000008c`, and reported "within budget" for a change that was not in the bundle. CSS 22.4 KB against a 22.5 KB warn line — unmoved.

## Tests

`components/__tests__/sheetsEscapeShell.test.tsx`, 9 cases: `drawAtRoot` returns the node unchanged with no `document` and produces a `react.portal` aimed at `document.body` when one exists; both sheets throw the server renderer's portal error once a document is present (that refusal *is* the proof they portal); the desktop popover renders inline with no scrim; both sheets still render assertable markup in the DOM-less harness; the mobile/desktop padding split; and no raw `rgba(` survives in the switcher's output.

**The interaction itself — tapping the bar through a scrim — needs real hit-testing and is NOT exercised.** The test file says so in its opening docstring.

## Verification

`eslint src` · `tsc --noEmit` · `vitest run` (223 files / 3886 tests) · `vite build` · byte budget · `typecheck:design-sync` — all green. Backend untouched.

## What to eyeball (mobile width, < 768px)

1. **Filter sheet** — `/tasks`, `/updates`, `/players`, `/requests`. Tap a facet: the scrim must now cover the tab bar, the bar must be **untappable**, and **Done** must still clear the bar (#1590's clearance, preserved).
2. **Character switcher** — mobile home, all nine skins, via the character card. Same two checks, plus its bottom action should now clear the tab bar, which it never did.
3. **Character switcher on desktop** — the rail's Characters pill. Should look exactly as before: no extra gap under the last action.
4. **Scrim darkness** — every scrim is now 0.25. The filter sheet's was 0.55, so it is lighter than yesterday. If it no longer reads as "the page behind is unavailable", the alternative is minting `--color-scrim` at 0.55 for all four (+3 bytes, measured).
5. **Dark mode**, both sheets — portalled to `document.body` while `data-theme` lives on `documentElement`, so inheritance should be intact.
6. **Escape**, and the tablet-and-up **popover** still anchored under its trigger.
