### PR TITLE
Backend errors answer with a code beside the prose, and a ratchet counts what is left (#1401)

### DIFF
--- a/backend/errors.py
+++ b/backend/errors.py
@@ -1,0 +1,186 @@
+"""Machine-readable error codes for API failures (#1401).
+
+## The shape
+
+FastAPI's envelope is unchanged — a failure is still ``{"detail": ...}`` with an
+HTTP status. What changes is ``detail``: instead of a bare prose string it
+becomes an object::
+
+    {"detail": {"code": "VOTE_BUDGET_EXHAUSTED",
+                "message": "No votes remaining in your budget."}}
+
+``code`` is the stable machine-readable identifier — the thing a client may
+branch on. ``message`` is **exactly the prose that raise site has always
+emitted**, kept as a fallback so no player-visible copy changes when a raise is
+converted. ``frontend/src/utils/errors.ts::extractError`` reads ``message`` for
+display and deliberately shows nothing for a bare ``code``, so the two halves
+can be adopted independently.
+
+The i18n catalog lookup (``code`` -> ``errors.json``, the ADR-0031 emit-keys
+half of #1401) is a **later slice**. Nothing here reads a catalog.
+
+## Why a helper and not an exception hierarchy
+
+``SPEC-backend-architecture.md`` §5 blesses ``HTTPException`` raised straight
+from services, and ADR-0045 explains why this codebase does not carry a parallel
+domain-exception hierarchy with a router-side translator. :func:`raise_coded` is
+the smallest thing that adds a code without disturbing that posture: same
+exception type, same status codes, same call site.
+
+## The ratchet
+
+``tests/unit/test_uncoded_error_ratchet.py`` inventories every remaining
+``HTTPException(...)`` construction in the shipped backend against a shrink-only
+allowlist. This module is the one place allowed to construct one directly — it
+is the blessed constructor, so it is excluded from the scan. Everywhere else,
+"has a code" is definitionally "went through :func:`raise_coded` or
+:func:`coded_error`".
+"""
+
+from __future__ import annotations
+
+import enum
+from typing import Any, Mapping, NoReturn, Optional
+
+from fastapi import HTTPException
+
+
+class ErrorCode(str, enum.Enum):
+    """Stable identifiers for the failures a client may want to branch on.
+
+    A member's **value** is the wire contract: renaming one is a breaking change
+    for any client (or, later, any ``errors.json`` key) that matches on it. The
+    member *name* is internal and may be refactored freely.
+
+    Grouped by the gate that raises it. Phase 1 (#1401) covers the errors
+    players actually hit: the vote budget, level gates, signup caps,
+    collab/duel eligibility, and media limits.
+    """
+
+    # -- Voting -------------------------------------------------------------
+    vote_budget_exhausted = "VOTE_BUDGET_EXHAUSTED"
+
+    # -- Level gates --------------------------------------------------------
+    task_level_too_low = "TASK_LEVEL_TOO_LOW"
+    collaboration_level_too_low = "COLLABORATION_LEVEL_TOO_LOW"
+    duel_level_too_low = "DUEL_LEVEL_TOO_LOW"
+    flag_level_too_low = "FLAG_LEVEL_TOO_LOW"
+    comment_level_too_low = "COMMENT_LEVEL_TOO_LOW"
+    task_proposal_level_too_low = "TASK_PROPOSAL_LEVEL_TOO_LOW"
+    metatask_proposal_level_too_low = "METATASK_PROPOSAL_LEVEL_TOO_LOW"
+    second_character_level_too_low = "SECOND_CHARACTER_LEVEL_TOO_LOW"
+    praxis_mode_unavailable = "PRAXIS_MODE_UNAVAILABLE"
+
+    # -- Signup caps and task-signup eligibility ----------------------------
+    task_bank_full = "TASK_BANK_FULL"
+    task_already_active_member = "TASK_ALREADY_ACTIVE_MEMBER"
+    task_not_open_for_signup = "TASK_NOT_OPEN_FOR_SIGNUP"
+    task_is_metatask = "TASK_IS_METATASK"
+
+    # -- Duel eligibility ---------------------------------------------------
+    duel_self_challenge = "DUEL_SELF_CHALLENGE"
+    duel_requires_solo_praxis = "DUEL_REQUIRES_SOLO_PRAXIS"
+    duel_requires_in_progress_praxis = "DUEL_REQUIRES_IN_PROGRESS_PRAXIS"
+    duel_already_exists = "DUEL_ALREADY_EXISTS"
+    duel_opponent_has_active_praxis = "DUEL_OPPONENT_HAS_ACTIVE_PRAXIS"
+
+    # -- Collab-invite eligibility ------------------------------------------
+    invite_self = "INVITE_SELF"
+    invite_already_member = "INVITE_ALREADY_MEMBER"
+    invite_already_pending = "INVITE_ALREADY_PENDING"
+    invite_target_has_active_praxis = "INVITE_TARGET_HAS_ACTIVE_PRAXIS"
+    invite_faction_not_permitted = "INVITE_FACTION_NOT_PERMITTED"
+    invite_praxis_submitted = "INVITE_PRAXIS_SUBMITTED"
+
+    # -- Media limits -------------------------------------------------------
+    media_type_unsupported = "MEDIA_TYPE_UNSUPPORTED"
+    media_too_large = "MEDIA_TOO_LARGE"
+    avatar_must_be_image = "AVATAR_MUST_BE_IMAGE"
+    avatar_too_large = "AVATAR_TOO_LARGE"
+
+
+#: The two keys of a coded ``detail`` body. Named so the frontend contract is
+#: greppable from Python and no raise site spells them as bare literals.
+DETAIL_CODE_KEY = "code"
+DETAIL_MESSAGE_KEY = "message"
+
+
+def coded_detail(code: ErrorCode, message: str) -> dict[str, str]:
+    """Build the ``detail`` body for a coded failure."""
+    return {DETAIL_CODE_KEY: code.value, DETAIL_MESSAGE_KEY: message}
+
+
+def coded_error(
+    status_code: int,
+    code: ErrorCode,
+    message: str,
+    headers: Optional[dict[str, str]] = None,
+) -> HTTPException:
+    """Build — but do not raise — a coded :class:`HTTPException`.
+
+    Most call sites want :func:`raise_coded`. This exists for the two helpers
+    that *return* an exception for a caller to raise or to report per-item:
+    ``services.praxis._signup_denial_to_http`` and ``services.nudge._refuse``.
+    Those are exactly the shapes a ``raise HTTPException`` regex cannot see,
+    which is why the ratchet's scan is AST-based and matches construction.
+    """
+    return HTTPException(
+        status_code=status_code, detail=coded_detail(code, message), headers=headers
+    )
+
+
+def raise_coded(
+    status_code: int,
+    code: ErrorCode,
+    message: str,
+    headers: Optional[dict[str, str]] = None,
+) -> NoReturn:
+    """Raise a coded failure. The blessed replacement for ``raise HTTPException``.
+
+    ``message`` stays the prose the raise site already emitted — this helper
+    adds a code, it does not rewrite copy.
+    """
+    raise coded_error(status_code, code, message, headers=headers)
+
+
+def detail_message(detail: Any) -> str:
+    """The displayable prose of any ``detail``, coded or not.
+
+    Two endpoints flatten a per-item :class:`HTTPException` into a plain string
+    field rather than returning it as the response body — the batch media upload
+    (``schemas.praxis.MediaUploadResultOut.error``) and the crew nudge
+    (``schemas.nudge.NudgeResultOut.error``). Both used to call ``str(detail)``,
+    which on a coded detail would render the *dict repr* into a field a player
+    reads. They call this instead, so those two envelopes keep carrying prose
+    exactly as before while the raise sites behind them gain codes.
+    """
+    if isinstance(detail, Mapping):
+        message = detail.get(DETAIL_MESSAGE_KEY)
+        if isinstance(message, str):
+            return message
+    return str(detail)
+
+
+def detail_code(detail: Any) -> Optional[str]:
+    """The :class:`ErrorCode` value carried by a ``detail``, or ``None``.
+
+    The read side of :func:`coded_detail`, for tests and for any caller that
+    wants to branch on a code without knowing the body's shape.
+    """
+    if isinstance(detail, Mapping):
+        code = detail.get(DETAIL_CODE_KEY)
+        if isinstance(code, str):
+            return code
+    return None
+
+
+__all__ = [
+    "DETAIL_CODE_KEY",
+    "DETAIL_MESSAGE_KEY",
+    "ErrorCode",
+    "coded_detail",
+    "coded_error",
+    "detail_code",
+    "detail_message",
+    "raise_coded",
+]

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -7,6 +7,7 @@ from sqlalchemy import case, func, or_, select
 from sqlalchemy.sql import Select, false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode, raise_coded
 from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.account import Account
@@ -394,9 +395,10 @@ async def create_character(
         # Need level >= era.second_character_level_required on at least one
         # character to create another.
         if not await can_create_additional_character(account_id, session, era):
-            raise HTTPException(
-                status_code=403,
-                detail=(
+            raise_coded(
+                403,
+                ErrorCode.second_character_level_too_low,
+                (
                     f"Must reach level {era.second_character_level_required} "
                     "before creating additional characters."
                 ),

--- a/backend/services/comment.py
+++ b/backend/services/comment.py
@@ -12,6 +12,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from errors import ErrorCode, raise_coded
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.comment import MAX_COMMENT_BODY, Comment, CommentMention
@@ -156,9 +157,10 @@ async def create_comment(
     era: EraConfig = CURRENT_ERA,
 ) -> Comment:
     if not await can_comment(author, session, era):
-        raise HTTPException(
-            status_code=403,
-            detail=f"Must be level {era.comment_level_required} or above to comment.",
+        raise_coded(
+            403,
+            ErrorCode.comment_level_too_low,
+            f"Must be level {era.comment_level_required} or above to comment.",
         )
     body_text = _clean_body(body_text)
     await _assert_commentable_target(praxis_id, task_id, session)
@@ -252,9 +254,10 @@ async def flag_comment(
     if flagged_by.id == comment.created_by_id:
         raise HTTPException(status_code=403, detail="Cannot flag your own comment.")
     if await _character_level(flagged_by.id, session) < era.flag_level_required:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Must be level {era.flag_level_required} or above to flag a comment.",
+        raise_coded(
+            403,
+            ErrorCode.flag_level_too_low,
+            f"Must be level {era.flag_level_required} or above to flag a comment.",
         )
     session.add(
         Flag(

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -15,6 +15,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode, raise_coded
 from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
@@ -206,26 +207,27 @@ async def issue_duel_challenge(
     if await _characters_share_account(
         challenger_character_id, opponent_character_id, session
     ):
-        raise HTTPException(status_code=400, detail=SELF_DUEL_DETAIL)
+        raise_coded(400, ErrorCode.duel_self_challenge, SELF_DUEL_DETAIL)
 
     challenger_praxis = await get_praxis(challenger_praxis_id, session)
     if challenger_praxis.created_by_id != challenger_character_id:
         raise HTTPException(status_code=403, detail="You do not own this praxis.")
     if challenger_praxis.status != PraxisStatus.in_progress:
-        raise HTTPException(
-            status_code=422,
-            detail="A duel can only start from an in-progress praxis.",
+        raise_coded(
+            422,
+            ErrorCode.duel_requires_in_progress_praxis,
+            "A duel can only start from an in-progress praxis.",
         )
     # A duel side is a solo praxis (ADR-0011); duel and collab are mutually exclusive.
     if challenger_praxis.type != PraxisType.solo:
-        raise HTTPException(
-            status_code=422,
-            detail="Only a solo praxis can issue a duel challenge.",
+        raise_coded(
+            422,
+            ErrorCode.duel_requires_solo_praxis,
+            "Only a solo praxis can issue a duel challenge.",
         )
     if await get_duel_for_praxis(challenger_praxis_id, session) is not None:
-        raise HTTPException(
-            status_code=409,
-            detail="This praxis is already part of a duel.",
+        raise_coded(
+            409, ErrorCode.duel_already_exists, "This praxis is already part of a duel."
         )
 
     task = await session.get(Task, challenger_praxis.task_id)
@@ -241,18 +243,20 @@ async def issue_duel_challenge(
     # carve-out (#1511); dropping it silently resolved against CURRENT_ERA no
     # matter what this function was passed.
     if await is_active_member_of_task(opponent, task, session, era):
-        raise HTTPException(
-            status_code=409,
-            detail="The opponent already has an active praxis for this task.",
+        raise_coded(
+            409,
+            ErrorCode.duel_opponent_has_active_praxis,
+            "The opponent already has an active praxis for this task.",
         )
 
     # Challenger must meet duel level requirement.
     era_row = await get_current_era_row(session)
     challenger_stats = await get_or_create_stats(session, challenger_character_id, era_row.id)
     if challenger_stats.level < era.duel_level_required:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Duels require level {era.duel_level_required}.",
+        raise_coded(
+            403,
+            ErrorCode.duel_level_too_low,
+            f"Duels require level {era.duel_level_required}.",
         )
 
     # Create only the pending Duel row, pointing at the existing praxis.
@@ -316,7 +320,7 @@ async def respond_to_duel_challenge(
     if challenger_praxis is not None and await _characters_share_account(
         challenger_praxis.created_by_id, character_id, session
     ):
-        raise HTTPException(status_code=400, detail=SELF_DUEL_DETAIL)
+        raise_coded(400, ErrorCode.duel_self_challenge, SELF_DUEL_DETAIL)
 
     task = await session.get(Task, duel.task_id)
     if task is None:
@@ -326,17 +330,19 @@ async def respond_to_duel_challenge(
     # in the window between challenge and accept). `era` threaded for the same
     # reason as in `issue_duel_challenge` above (#1511).
     if await is_active_member_of_task(opponent, task, session, era):
-        raise HTTPException(
-            status_code=409,
-            detail="You already have an active praxis for this task.",
+        raise_coded(
+            409,
+            ErrorCode.task_already_active_member,
+            "You already have an active praxis for this task.",
         )
 
     # Opponent bank cap check.
     in_progress_count = await _count_in_progress_praxes(character_id, session)
     if in_progress_count >= era.max_task_signups:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Task bank is full ({era.max_task_signups} in-progress praxes).",
+        raise_coded(
+            400,
+            ErrorCode.task_bank_full,
+            f"Task bank is full ({era.max_task_signups} in-progress praxes).",
         )
 
     # Opponent level check.
@@ -348,9 +354,10 @@ async def respond_to_duel_challenge(
     era_row = await get_current_era_row(session)
     opponent_stats = await get_or_create_stats(session, character_id, era_row.id)
     if opponent_stats.level < era.duel_level_required:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Duels require level {era.duel_level_required}.",
+        raise_coded(
+            403,
+            ErrorCode.duel_level_too_low,
+            f"Duels require level {era.duel_level_required}.",
         )
 
     # Create the opponent's solo praxis.

--- a/backend/services/media.py
+++ b/backend/services/media.py
@@ -16,6 +16,7 @@ from fastapi import HTTPException, UploadFile
 from PIL import Image
 
 from config import settings
+from errors import ErrorCode, raise_coded
 from models.praxis import MediaItem, MediaType
 
 
@@ -132,7 +133,7 @@ def _detect_media_type(content_type: str) -> MediaType:
         return MediaType.video
     if content_type.startswith("audio/"):
         return MediaType.audio
-    raise HTTPException(status_code=422, detail="Unsupported media type.")
+    raise_coded(422, ErrorCode.media_type_unsupported, "Unsupported media type.")
 
 
 async def process_and_save_avatar(
@@ -163,7 +164,7 @@ async def process_and_save_avatar(
     """
     content_type = upload.content_type or ""
     if not content_type.startswith("image/"):
-        raise HTTPException(status_code=422, detail="Avatar must be an image file.")
+        raise_coded(422, ErrorCode.avatar_must_be_image, "Avatar must be an image file.")
 
     relative_directory = os.path.join(str(character_id), "avatar", uuid.uuid4().hex)
     absolute_directory = os.path.join(settings.MEDIA_ROOT, relative_directory)
@@ -175,7 +176,7 @@ async def process_and_save_avatar(
         os.makedirs(absolute_directory, exist_ok=True)
         contents = await upload.read()
         if len(contents) > AVATAR_MAX_BYTES:
-            raise HTTPException(status_code=413, detail="Avatar too large (max 10 MB).")
+            raise_coded(413, ErrorCode.avatar_too_large, "Avatar too large (max 10 MB).")
 
         image = Image.open(io.BytesIO(contents))
         image = image.convert("RGB")
@@ -239,7 +240,7 @@ async def process_and_save_media(
         os.makedirs(absolute_directory, exist_ok=True)
         contents = await upload.read()
         if len(contents) > MEDIA_MAX_BYTES:
-            raise HTTPException(status_code=413, detail="File too large (max 100 MB).")
+            raise_coded(413, ErrorCode.media_too_large, "File too large (max 100 MB).")
         with open(absolute_path, "wb") as file_handle:
             file_handle.write(contents)
     except HTTPException:

--- a/backend/services/nudge.py
+++ b/backend/services/nudge.py
@@ -33,6 +33,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import detail_message
 from models.duel import Duel, DuelStatus
 from models.nudge import Nudge
 from models.praxis import Praxis, PraxisMember, PraxisStatus, PraxisType
@@ -318,7 +319,11 @@ async def _send_nudges(
                 else None
             ),
             error=(
-                str(refusals[to_character_id].detail)
+                # `detail_message`, not `str(...)`: `_refuse`'s bodies are not
+                # coded yet (#1401 phase 1 does not reach them), but the day one
+                # is, `str()` on a `{code, message}` dict would render its repr
+                # into a field a player reads.
+                detail_message(refusals[to_character_id].detail)
                 if to_character_id in refusals
                 else None
             ),

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -14,6 +14,7 @@ from sqlalchemy import and_, exists, func, not_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from errors import ErrorCode, coded_error, detail_message, raise_coded
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.flag import Flag, FlagReason, stored_flag_reason
@@ -717,15 +718,24 @@ async def signup_reason(
 def _signup_denial_to_http(
     reason: Optional[SignupDenialReason], task: Task, era: EraConfig
 ) -> HTTPException:
-    """Map a :class:`SignupDenialReason` to the route error it has always raised."""
+    """Map a :class:`SignupDenialReason` to the route error it has always raised.
+
+    Every branch carries an :class:`ErrorCode` (#1401). This helper *returns*
+    rather than raises, which is exactly the shape a ``raise HTTPException``
+    text scan cannot see — hence :func:`errors.coded_error` and hence the
+    ratchet's AST scan.
+    """
     if reason == SignupDenialReason.is_metatask:
-        return HTTPException(
-            status_code=400,
-            detail="Metatasks are applied to a praxis, not signed up for.",
+        return coded_error(
+            400,
+            ErrorCode.task_is_metatask,
+            "Metatasks are applied to a praxis, not signed up for.",
         )
     if reason == SignupDenialReason.below_level:
-        return HTTPException(
-            status_code=403, detail=f"This task requires level {task.level_required}."
+        return coded_error(
+            403,
+            ErrorCode.task_level_too_low,
+            f"This task requires level {task.level_required}.",
         )
     if reason == SignupDenialReason.task_status_closed:
         detail = (
@@ -733,15 +743,18 @@ def _signup_denial_to_http(
             if task.status == TaskStatus.retired
             else "This task is pending and is not open for new praxes."
         )
-        return HTTPException(status_code=403, detail=detail)
+        return coded_error(403, ErrorCode.task_not_open_for_signup, detail)
     if reason == SignupDenialReason.already_active_member:
-        return HTTPException(
-            status_code=409, detail="You have already submitted a praxis for this task."
+        return coded_error(
+            409,
+            ErrorCode.task_already_active_member,
+            "You have already submitted a praxis for this task.",
         )
     # bank_full (and the anonymous/None fallback, which create_praxis never hits).
-    return HTTPException(
-        status_code=400,
-        detail=f"Task bank is full ({era.max_task_signups} in-progress praxes). Complete or withdraw one first.",
+    return coded_error(
+        400,
+        ErrorCode.task_bank_full,
+        f"Task bank is full ({era.max_task_signups} in-progress praxes). Complete or withdraw one first.",
     )
 
 
@@ -778,12 +791,17 @@ async def _check_create_preconditions(
     stats = await get_or_create_stats(session, character_id, era_row.id)
     allowed = allowed_praxis_modes(character, stats.level, era)
     if praxis_type not in allowed:
-        _denial: dict[PraxisType, str] = {
-            PraxisType.collab: f"Collaborations require level {era.collaboration_level_required}.",
-        }
-        raise HTTPException(
-            status_code=403,
-            detail=_denial.get(praxis_type, "Praxis mode not available."),
+        # Only collab has prose of its own; anything else is a mode the era does
+        # not offer this character at all, and says so generically (#1401 keeps
+        # both strings byte-identical — it adds the code, not new copy).
+        if praxis_type == PraxisType.collab:
+            raise_coded(
+                403,
+                ErrorCode.collaboration_level_too_low,
+                f"Collaborations require level {era.collaboration_level_required}.",
+            )
+        raise_coded(
+            403, ErrorCode.praxis_mode_unavailable, "Praxis mode not available."
         )
 
     return task
@@ -997,9 +1015,10 @@ async def change_praxis_type(
         era_row = await get_current_era_row(session)
         stats = await get_or_create_stats(session, character_id, era_row.id)
         if stats.level < era.collaboration_level_required:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Collaborations require level {era.collaboration_level_required}.",
+            raise_coded(
+                403,
+                ErrorCode.collaboration_level_too_low,
+                f"Collaborations require level {era.collaboration_level_required}.",
             )
         praxis.type = PraxisType.collab
     else:
@@ -1108,7 +1127,10 @@ async def add_media_batch(
             results.append(
                 MediaUploadResultOut(
                     filename=filename,
-                    error=str(exception.detail),
+                    # `detail_message`, not `str(...)`: since #1401 the media
+                    # limits raise a coded `{code, message}` body, and `str()`
+                    # on that renders a dict repr into a field a player reads.
+                    error=detail_message(exception.detail),
                     status_code=exception.status_code,
                 )
             )
@@ -1446,9 +1468,10 @@ async def flag_praxis(
         )
 
     if not await can_flag_praxis(flagged_by, praxis, session, era):
-        raise HTTPException(
-            status_code=403,
-            detail=f"Must be level {era.flag_level_required} or above to flag a praxis.",
+        raise_coded(
+            403,
+            ErrorCode.flag_level_too_low,
+            f"Must be level {era.flag_level_required} or above to flag a praxis.",
         )
 
     praxis.moderation_status = ModerationStatus.flagged
@@ -1503,16 +1526,20 @@ async def invite_to_praxis(
             detail="Invites are only for collab praxes. Duels use the challenge endpoint.",
         )
     if praxis.status == PraxisStatus.submitted:
-        raise HTTPException(status_code=400, detail="Cannot invite to a submitted praxis.")
+        raise_coded(
+            400, ErrorCode.invite_praxis_submitted, "Cannot invite to a submitted praxis."
+        )
 
     member_ids = {m.character_id for m in praxis.members}
     if inviter_id not in member_ids:
         raise HTTPException(status_code=403, detail="Only members can send invites.")
 
     if invitee_id == inviter_id:
-        raise HTTPException(status_code=400, detail="Cannot invite yourself.")
+        raise_coded(400, ErrorCode.invite_self, "Cannot invite yourself.")
     if invitee_id in member_ids:
-        raise HTTPException(status_code=409, detail="Player is already a member.")
+        raise_coded(
+            409, ErrorCode.invite_already_member, "Player is already a member."
+        )
 
     # Check for duplicate pending invite
     existing_result = await session.execute(
@@ -1524,9 +1551,10 @@ async def invite_to_praxis(
         )
     )
     if existing_result.scalar_one_or_none() is not None:
-        raise HTTPException(
-            status_code=409,
-            detail="A pending invite already exists. Resolve it before sending another.",
+        raise_coded(
+            409,
+            ErrorCode.invite_already_pending,
+            "A pending invite already exists. Resolve it before sending another.",
         )
 
     invitee = await session.get(Character, invitee_id)
@@ -1534,9 +1562,10 @@ async def invite_to_praxis(
         raise HTTPException(status_code=404, detail="Invitee not found.")
 
     if await is_active_member_of_task(invitee, praxis.task, session, era):
-        raise HTTPException(
-            status_code=409,
-            detail="This player already has an active praxis for this task and cannot be invited.",
+        raise_coded(
+            409,
+            ErrorCode.invite_target_has_active_praxis,
+            "This player already has an active praxis for this task and cannot be invited.",
         )
 
     # The two eligibility axes, each read from the era rather than skipped by
@@ -1550,16 +1579,18 @@ async def invite_to_praxis(
         # it. Upgrade path if an era ever wants it: pass available_level_reach(...)
         # here and consume_level_jump on accept, as create_praxis does.
         if not meets_task_level(invitee_stats.level, praxis.task):
-            raise HTTPException(
-                status_code=403,
-                detail=f"This task requires level {praxis.task.level_required}.",
+            raise_coded(
+                403,
+                ErrorCode.task_level_too_low,
+                f"This task requires level {praxis.task.level_required}.",
             )
     if not era.collab_invite_bypasses_faction and not faction_permits(
         invitee, praxis.task, era
     ):
-        raise HTTPException(
-            status_code=403,
-            detail="This player's faction may not act on this task.",
+        raise_coded(
+            403,
+            ErrorCode.invite_faction_not_permitted,
+            "This player's faction may not act on this task.",
         )
 
     invite = PraxisInvite(
@@ -1611,16 +1642,19 @@ async def respond_to_invite(
         raise HTTPException(status_code=404, detail="Praxis no longer exists.")
 
     if praxis.status == PraxisStatus.submitted:
-        raise HTTPException(status_code=400, detail="Cannot join a submitted praxis.")
+        raise_coded(
+            400, ErrorCode.invite_praxis_submitted, "Cannot join a submitted praxis."
+        )
 
     # Check bank capacity — unless this era's collab door lifts it too (#1511).
     already_member = any(m.character_id == character_id for m in praxis.members)
     if not era.collab_invite_bypasses_task_bank and not already_member:
         in_progress_count = await _count_in_progress_praxes(character_id, session)
         if in_progress_count >= era.max_task_signups:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Task bank is full ({era.max_task_signups} in-progress praxes).",
+            raise_coded(
+                409,
+                ErrorCode.task_bank_full,
+                f"Task bank is full ({era.max_task_signups} in-progress praxes).",
             )
 
     # Add member

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -1651,10 +1651,20 @@ async def respond_to_invite(
     if not era.collab_invite_bypasses_task_bank and not already_member:
         in_progress_count = await _count_in_progress_praxes(character_id, session)
         if in_progress_count >= era.max_task_signups:
-            raise_coded(
-                409,
-                ErrorCode.task_bank_full,
-                f"Task bank is full ({era.max_task_signups} in-progress praxes).",
+            # DELIBERATELY UNCODED, and the only phase-1 gate left behind
+            # (#1401). `FeedCardCollabInvite` reads this response's `detail`
+            # RAW — `typeof detail === "string" && detail.includes("Task bank
+            # is full")` — outside `extractError`, which is the only reader
+            # #1581 taught to understand a coded body. Coding this here turns
+            # that check false and the drop-a-praxis-and-retry modal silently
+            # stops opening, with no test failing. Client first, then this.
+            #
+            # The duel twin (`respond_to_duel_challenge`) IS coded: its card
+            # reads the detail through `useRespondToRequest` -> `extractError`,
+            # which hands back `message`, so its substring match still holds.
+            raise HTTPException(
+                status_code=409,
+                detail=f"Task bank is full ({era.max_task_signups} in-progress praxes).",
             )
 
     # Add member

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode, raise_coded
 from faction_slugs import CROSS_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
@@ -64,9 +65,10 @@ async def propose_task(
 
     if task_type == TaskType.metatask:
         if not skip_level_check and stats.level < era.level_to_propose_metatask:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Must be level {era.level_to_propose_metatask} or above to propose metatasks.",
+            raise_coded(
+                403,
+                ErrorCode.metatask_proposal_level_too_low,
+                f"Must be level {era.level_to_propose_metatask} or above to propose metatasks.",
             )
         if not data.metatask_faction_slug:
             raise HTTPException(
@@ -75,9 +77,10 @@ async def propose_task(
             )
     else:
         if not skip_level_check and stats.level < era.level_to_propose_task:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Must be level {era.level_to_propose_task} or above to propose tasks.",
+            raise_coded(
+                403,
+                ErrorCode.task_proposal_level_too_low,
+                f"Must be level {era.level_to_propose_task} or above to propose tasks.",
             )
 
     task = Task(

--- a/backend/services/vote.py
+++ b/backend/services/vote.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode, raise_coded
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.character_stats import CharacterStats
@@ -139,8 +140,10 @@ async def cast_or_update_vote(
     else:
         # New vote — deduct from budget via CharacterStats (on-read recomputation).
         if compute_votes_available(stats, era) <= 0:
-            raise HTTPException(
-                status_code=403, detail="No votes remaining in your budget."
+            raise_coded(
+                403,
+                ErrorCode.vote_budget_exhausted,
+                "No votes remaining in your budget.",
             )
 
         cast = Vote(

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode
 from game_config import CURRENT_ERA
 from models.account import Account
 from models.character import Character
@@ -530,8 +531,11 @@ async def test_second_character_blocked_below_level4(
         headers=auth_headers,
     )
     assert resp.status_code == 403
-    # The error message must explicitly name the level-4 requirement
-    assert "4" in resp.json()["detail"]
+    # A code the client can branch on, plus prose that still names the level-4
+    # requirement — #1401 added the code without rewriting the copy.
+    detail = resp.json()["detail"]
+    assert detail["code"] == ErrorCode.second_character_level_too_low.value
+    assert "4" in detail["message"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_collab_invite_bypass.py
+++ b/backend/tests/integration/test_collab_invite_bypass.py
@@ -266,8 +266,10 @@ async def test_full_task_bank_still_refuses_on_accept(
             era=tight_bank,
         )
     assert excinfo.value.status_code == 409
-    assert excinfo.value.detail["code"] == ErrorCode.task_bank_full.value
-    assert "bank" in excinfo.value.detail["message"].lower()
+    # Still plain prose, not a coded body: this one raise is held back from
+    # #1401 phase 1 because `FeedCardCollabInvite` substring-matches it outside
+    # `extractError`. The rationale is at the raise in `services/praxis.py`.
+    assert "bank" in excinfo.value.detail.lower()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_collab_invite_bypass.py
+++ b/backend/tests/integration/test_collab_invite_bypass.py
@@ -23,6 +23,7 @@ from fastapi import HTTPException
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode
 from game_config import CURRENT_ERA
 from models.account import Account
 from models.character import Character
@@ -180,7 +181,9 @@ async def test_wrong_faction_low_level_character_can_be_invited_and_submit(
         headers=invitee_headers,
     )
     assert signup_resp.status_code == 403, signup_resp.text
-    assert str(TASK_LEVEL_REQUIRED) in signup_resp.json()["detail"]
+    signup_detail = signup_resp.json()["detail"]
+    assert signup_detail["code"] == ErrorCode.task_level_too_low.value
+    assert str(TASK_LEVEL_REQUIRED) in signup_detail["message"]
 
     # The door that is open: invited into someone else's collab on it.
     praxis_id = await _create_collab(client, high_level_task, inviter_headers)
@@ -263,7 +266,8 @@ async def test_full_task_bank_still_refuses_on_accept(
             era=tight_bank,
         )
     assert excinfo.value.status_code == 409
-    assert "bank" in excinfo.value.detail.lower()
+    assert excinfo.value.detail["code"] == ErrorCode.task_bank_full.value
+    assert "bank" in excinfo.value.detail["message"].lower()
 
 
 @pytest.mark.asyncio
@@ -306,7 +310,9 @@ async def test_existing_active_membership_still_refuses_the_invite(
         headers=second_inviter_headers,
     )
     assert refused.status_code == 409, refused.text
-    assert "active praxis" in refused.json()["detail"].lower()
+    refused_detail = refused.json()["detail"]
+    assert refused_detail["code"] == ErrorCode.invite_target_has_active_praxis.value
+    assert "active praxis" in refused_detail["message"].lower()
 
 
 @pytest.mark.asyncio
@@ -335,7 +341,8 @@ async def test_level_bypass_flag_off_refuses_the_invite(
             era=strict,
         )
     assert excinfo.value.status_code == 403
-    assert str(TASK_LEVEL_REQUIRED) in excinfo.value.detail
+    assert excinfo.value.detail["code"] == ErrorCode.task_level_too_low.value
+    assert str(TASK_LEVEL_REQUIRED) in excinfo.value.detail["message"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_duel_self_duel.py
+++ b/backend/tests/integration/test_duel_self_duel.py
@@ -29,6 +29,7 @@ from models.praxis import (
     PraxisStatus,
     PraxisType,
 )
+from errors import ErrorCode
 from models.task import Task
 from services.duel import (
     SELF_DUEL_DETAIL,
@@ -132,7 +133,10 @@ async def test_challenging_an_alt_on_the_same_account_is_rejected(
         )
 
     assert exception_info.value.status_code == 400
-    assert exception_info.value.detail == SELF_DUEL_DETAIL
+    assert exception_info.value.detail == {
+        "code": ErrorCode.duel_self_challenge.value,
+        "message": SELF_DUEL_DETAIL,
+    }
 
     # No Duel row was created.
     result = await db_session.execute(
@@ -161,7 +165,10 @@ async def test_challenging_your_own_character_is_still_rejected(
         )
 
     assert exception_info.value.status_code == 400
-    assert exception_info.value.detail == SELF_DUEL_DETAIL
+    assert exception_info.value.detail == {
+        "code": ErrorCode.duel_self_challenge.value,
+        "message": SELF_DUEL_DETAIL,
+    }
 
 
 @pytest.mark.asyncio
@@ -240,7 +247,10 @@ async def test_accepting_a_challenge_from_your_own_character_is_rejected(
         await respond_to_duel_challenge(duel.id, alt.id, True, db_session)
 
     assert exception_info.value.status_code == 400
-    assert exception_info.value.detail == SELF_DUEL_DETAIL
+    assert exception_info.value.detail == {
+        "code": ErrorCode.duel_self_challenge.value,
+        "message": SELF_DUEL_DETAIL,
+    }
     assert duel.status == DuelStatus.pending
     assert duel.opponent_praxis_id is None
 

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -15,6 +15,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode
 from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
@@ -104,7 +105,9 @@ async def test_create_solo_praxis_on_metatask_rejected(
         headers=auth_headers,
     )
     assert resp.status_code == 400
-    assert "metatask" in resp.json()["detail"].lower()
+    detail = resp.json()["detail"]
+    assert detail["code"] == ErrorCode.task_is_metatask.value
+    assert "metatask" in detail["message"].lower()
 
 
 @pytest.mark.asyncio
@@ -1036,7 +1039,9 @@ async def test_create_collab_praxis_on_metatask_rejected(
         headers=auth_headers2,
     )
     assert resp.status_code == 400
-    assert "metatask" in resp.json()["detail"].lower()
+    detail = resp.json()["detail"]
+    assert detail["code"] == ErrorCode.task_is_metatask.value
+    assert "metatask" in detail["message"].lower()
 
 
 @pytest.mark.asyncio
@@ -2045,7 +2050,9 @@ async def test_create_praxis_below_required_level_returns_403(
     )
     assert resp.status_code == 403
     # Error message must name the required level
-    assert "5" in resp.json()["detail"]
+    detail = resp.json()["detail"]
+    assert detail["code"] == ErrorCode.task_level_too_low.value
+    assert "5" in detail["message"]
 
 
 
@@ -2219,7 +2226,9 @@ async def test_create_praxis_duplicate_blocked_non_analog(
         headers=auth_headers,
     )
     assert second_resp.status_code == 409
-    assert "already submitted" in second_resp.json()["detail"].lower()
+    detail = second_resp.json()["detail"]
+    assert detail["code"] == ErrorCode.task_already_active_member.value
+    assert "already submitted" in detail["message"].lower()
 
 
 @pytest.mark.asyncio
@@ -2386,7 +2395,9 @@ async def test_create_minimal_draft_blocks_duplicate_non_analog(
         headers=auth_headers,
     )
     assert second_resp.status_code == 409
-    assert "already submitted" in second_resp.json()["detail"].lower()
+    detail = second_resp.json()["detail"]
+    assert detail["code"] == ErrorCode.task_already_active_member.value
+    assert "already submitted" in detail["message"].lower()
 
 
 # ---------------------------------------------------------------------------
@@ -2423,7 +2434,9 @@ async def test_create_praxis_non_active_task_returns_403(
         headers=auth_headers,
     )
     assert resp.status_code == 403
-    assert task_status.value in resp.json()["detail"].lower()
+    detail = resp.json()["detail"]
+    assert detail["code"] == ErrorCode.task_not_open_for_signup.value
+    assert task_status.value in detail["message"].lower()
 
 
 @pytest.mark.asyncio
@@ -2688,7 +2701,9 @@ async def test_in_progress_collab_member_cannot_be_invited_again(
         headers=headers4,
     )
     assert re_invite.status_code == 409
-    assert "active praxis" in re_invite.json()["detail"].lower()
+    detail = re_invite.json()["detail"]
+    assert detail["code"] == ErrorCode.invite_target_has_active_praxis.value
+    assert "active praxis" in detail["message"].lower()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_praxis_media_batch.py
+++ b/backend/tests/integration/test_praxis_media_batch.py
@@ -135,7 +135,11 @@ async def test_one_bad_file_fails_only_itself(
     failed = results[1]
     assert failed["media_item"] is None
     assert failed["status_code"] == 422
-    assert failed["error"]
+    # Exact prose, not just truthiness (#1401). `error` flattens an
+    # `HTTPException` whose `detail` is now a `{code, message}` object, and a
+    # truthiness check passes just as happily on a stringified dict — which is
+    # what the player would have read.
+    assert failed["error"] == "Unsupported media type."
 
     # The two survivors persisted; the reject wrote nothing.
     detail = await client.get(f"/praxes/{praxis_id}", headers=auth_headers)

--- a/backend/tests/integration/test_viewer_can_vote.py
+++ b/backend/tests/integration/test_viewer_can_vote.py
@@ -17,6 +17,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode
 from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
@@ -240,7 +241,9 @@ async def test_out_of_budget_viewer_still_shows_module(
         f"/praxes/{praxis_id}/vote", json={"value": 3}, headers=auth_headers2
     )
     assert vote.status_code == 403
-    assert "budget" in vote.json()["detail"].lower()
+    detail = vote.json()["detail"]
+    assert detail["code"] == ErrorCode.vote_budget_exhausted.value
+    assert "budget" in detail["message"].lower()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_errors.py
+++ b/backend/tests/unit/test_errors.py
@@ -1,0 +1,125 @@
+"""The coded-error shape (#1401).
+
+These pin the wire contract that ``frontend/src/utils/errors.ts::extractError``
+was taught to read in #1581: ``detail`` is ``{"code": ..., "message": ...}``,
+the client displays ``message``, and ``code`` is the machine-readable half.
+
+The pairing matters more than either half alone. #1581 deliberately made
+``extractError`` show *nothing* for a bare ``code`` — a player reading
+``TASK_LEVEL_TOO_LOW`` is worse than the caller's own fallback — so a coded
+error that forgot its ``message`` would degrade silently to "something went
+wrong". :func:`test_every_error_code_is_emitted_with_prose` is the guard.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from errors import (
+    DETAIL_CODE_KEY,
+    DETAIL_MESSAGE_KEY,
+    ErrorCode,
+    coded_detail,
+    coded_error,
+    detail_code,
+    detail_message,
+    raise_coded,
+)
+from tests.unit.uncoded_error_scan import scan_coded_backend
+
+
+def test_coded_detail_is_the_two_key_object_the_client_reads() -> None:
+    detail = coded_detail(ErrorCode.vote_budget_exhausted, "No votes remaining.")
+    assert detail == {
+        DETAIL_CODE_KEY: "VOTE_BUDGET_EXHAUSTED",
+        DETAIL_MESSAGE_KEY: "No votes remaining.",
+    }
+
+
+def test_raise_coded_raises_an_http_exception_with_the_status_it_was_given() -> None:
+    with pytest.raises(HTTPException) as raised:
+        raise_coded(403, ErrorCode.duel_level_too_low, "Duels require level 3.")
+
+    assert raised.value.status_code == 403
+    assert raised.value.detail[DETAIL_CODE_KEY] == "DUEL_LEVEL_TOO_LOW"
+    assert raised.value.detail[DETAIL_MESSAGE_KEY] == "Duels require level 3."
+
+
+def test_coded_error_builds_without_raising() -> None:
+    """The shape ``_signup_denial_to_http`` and ``_refuse`` need."""
+    error = coded_error(409, ErrorCode.task_bank_full, "Task bank is full.")
+    assert isinstance(error, HTTPException)
+    assert error.status_code == 409
+
+
+def test_error_code_values_are_stable_screaming_snake() -> None:
+    """A code's *value* is the wire contract; renaming one breaks clients."""
+    for code in ErrorCode:
+        assert code.value == code.value.upper()
+        assert code.value.replace("_", "").isalnum()
+        assert " " not in code.value
+
+
+def test_error_codes_are_unique() -> None:
+    values = [code.value for code in ErrorCode]
+    assert len(values) == len(set(values))
+
+
+def test_detail_message_reads_prose_from_either_shape() -> None:
+    assert detail_message("Task not found.") == "Task not found."
+    assert (
+        detail_message(coded_detail(ErrorCode.media_too_large, "File too large."))
+        == "File too large."
+    )
+
+
+def test_detail_message_never_leaks_a_dict_repr() -> None:
+    """The bug the two flattening endpoints would otherwise have shipped."""
+    rendered = detail_message(coded_detail(ErrorCode.media_too_large, "File too large."))
+    assert "{" not in rendered
+    assert DETAIL_CODE_KEY not in rendered
+
+
+def test_detail_code_reads_the_code_or_none() -> None:
+    assert detail_code(coded_detail(ErrorCode.invite_self, "no")) == "INVITE_SELF"
+    assert detail_code("plain prose") is None
+    assert detail_code([{"msg": "field required"}]) is None
+
+
+# ---------------------------------------------------------------------------
+# Every code, at a real raise site, with prose
+# ---------------------------------------------------------------------------
+
+
+def test_every_error_code_is_emitted_with_prose() -> None:
+    """No coded raise may omit its ``message``.
+
+    #1581 pinned that ``extractError`` shows nothing for a bare ``code`` — a raw
+    ``TASK_LEVEL_TOO_LOW`` reads worse to a player than the caller's own
+    fallback. So a message-less coded raise is a silent downgrade to "something
+    went wrong", with no test failing and no error in any log.
+    """
+    missing = [
+        f"{site.module_path}:{site.line}"
+        for site in scan_coded_backend()
+        if not site.has_message
+    ]
+    assert not missing, (
+        "Coded raises with no `message`:\n  "
+        + "\n  ".join(missing)
+        + "\n\nThe client displays `message`; a bare code renders nothing."
+    )
+
+
+def test_every_error_code_has_a_raise_site() -> None:
+    """An ``ErrorCode`` nothing raises is a name a client would wait forever for."""
+    emitted = {
+        site.code_member for site in scan_coded_backend() if site.code_member is not None
+    }
+    orphans = sorted(code.name for code in ErrorCode if code.name not in emitted)
+    assert not orphans, (
+        "ErrorCode members no raise site emits:\n  "
+        + "\n  ".join(orphans)
+        + "\n\nEither convert the raise that needs it or drop the member."
+    )

--- a/backend/tests/unit/test_uncoded_error_ratchet.py
+++ b/backend/tests/unit/test_uncoded_error_ratchet.py
@@ -1,0 +1,213 @@
+"""The ratchet: uncoded ``HTTPException`` raises may only shrink (#1401, phase 2).
+
+Two halves, and both matter.
+
+:func:`test_uncoded_raises_match_the_allowlist` is the ratchet proper. It scans
+the shipped backend and compares the inventory to ``uncoded_error_allowlist``
+in **both directions**, because a one-directional check is not a ratchet:
+
+* the code grew a raise the allowlist does not know about — a regression;
+* the allowlist claims raises the code no longer has — the pawl slipped, and
+  "phase 1 shrank the list by N" stops being a fact about the code.
+
+The rest of the file tests the *instrument*. The frontend style ratchet was
+defeated five separate ways by patterns a text scan could not see, and this
+codebase already contains the same class of pattern: nine ``HTTPException``s
+that are built and **returned** rather than raised. So the shapes below are
+pinned as fixtures — if the scanner ever stops seeing one of them, the ratchet
+silently under-reports and a "clean" file may not be clean at all.
+"""
+
+from __future__ import annotations
+
+from tests.unit.uncoded_error_allowlist import (
+    UNCODED_RAISE_ALLOWLIST,
+    UNCODED_RAISE_TOTAL,
+)
+from tests.unit.uncoded_error_scan import (
+    MODULE_SCOPE,
+    scan_backend,
+    scan_source,
+    tally,
+)
+
+
+# ---------------------------------------------------------------------------
+# The ratchet
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_total_matches_its_entries() -> None:
+    """The headline number is the sum of the entries, not a separate claim."""
+    assert UNCODED_RAISE_TOTAL == sum(UNCODED_RAISE_ALLOWLIST.values())
+
+
+def test_uncoded_raises_match_the_allowlist() -> None:
+    actual = tally(scan_backend())
+
+    appeared = sorted(set(actual) - set(UNCODED_RAISE_ALLOWLIST))
+    assert not appeared, (
+        "New uncoded HTTPException raises in scopes the allowlist does not cover:\n  "
+        + "\n  ".join(appeared)
+        + "\n\nRaise these with `errors.raise_coded(status, ErrorCode.x, message)`"
+        " instead of adding them to tests/unit/uncoded_error_allowlist.py — the"
+        " allowlist only shrinks."
+    )
+
+    grew = sorted(
+        f"{key}: {UNCODED_RAISE_ALLOWLIST[key]} allowed, {count} found"
+        for key, count in actual.items()
+        if count > UNCODED_RAISE_ALLOWLIST[key]
+    )
+    assert not grew, (
+        "Uncoded HTTPException raises increased:\n  "
+        + "\n  ".join(grew)
+        + "\n\nUse `errors.raise_coded` for the new one. The allowlist only shrinks."
+    )
+
+    shrank = sorted(
+        f"{key}: {allowed} allowed, {actual.get(key, 0)} found"
+        for key, allowed in UNCODED_RAISE_ALLOWLIST.items()
+        if actual.get(key, 0) < allowed
+    )
+    assert not shrank, (
+        "The allowlist is stale — these raises are coded (or gone) now:\n  "
+        + "\n  ".join(shrank)
+        + "\n\nLower or delete the entries in tests/unit/uncoded_error_allowlist.py"
+        " and update UNCODED_RAISE_TOTAL. Shrinking it is the point; leaving it"
+        " oversized is what makes 'the list got smaller by N' stop meaning anything."
+    )
+
+
+def test_scan_covers_the_routers_and_services_layers() -> None:
+    """A smoke test on the scan's reach, so an exclusion bug cannot read as progress.
+
+    If someone widened ``EXCLUDED_DIRECTORIES`` the inventory would drop and the
+    ratchet would look like it had been ratcheted.
+    """
+    scanned = {site.module_path.split("/")[0] for site in scan_backend()}
+    assert "routers" in scanned
+    assert "services" in scanned
+
+
+# ---------------------------------------------------------------------------
+# The instrument: launderable shapes the scanner must still see
+# ---------------------------------------------------------------------------
+
+DIRECT_RAISE = """
+from fastapi import HTTPException
+
+def gate():
+    raise HTTPException(status_code=403, detail="no")
+"""
+
+BUILT_THEN_RAISED = """
+from fastapi import HTTPException
+
+def gate():
+    exception = HTTPException(status_code=403, detail="no")
+    raise exception
+"""
+
+RETURNED_FROM_HELPER = """
+from fastapi import HTTPException
+
+def _refuse():
+    return HTTPException(status_code=403, detail="no")
+"""
+
+ALIASED_IMPORT = """
+from fastapi import HTTPException as Boom
+
+def gate():
+    raise Boom(status_code=403, detail="no")
+"""
+
+MODULE_ATTRIBUTE = """
+import fastapi
+
+def gate():
+    raise fastapi.HTTPException(status_code=403, detail="no")
+"""
+
+SUBCLASSED = """
+from fastapi import HTTPException
+
+class Denied(HTTPException):
+    pass
+
+def gate():
+    raise Denied(status_code=403, detail="no")
+"""
+
+REBOUND_NAME = """
+from fastapi import HTTPException
+
+Denied = HTTPException
+
+def gate():
+    raise Denied(status_code=403, detail="no")
+"""
+
+STARLETTE_IMPORT = """
+from starlette.exceptions import HTTPException
+
+def gate():
+    raise HTTPException(status_code=403, detail="no")
+"""
+
+
+def test_scanner_sees_every_launderable_shape() -> None:
+    launderings = {
+        "direct raise": DIRECT_RAISE,
+        "built then raised": BUILT_THEN_RAISED,
+        "returned from a helper": RETURNED_FROM_HELPER,
+        "aliased import": ALIASED_IMPORT,
+        "module attribute": MODULE_ATTRIBUTE,
+        "subclassed": SUBCLASSED,
+        "rebound name": REBOUND_NAME,
+        "starlette import": STARLETTE_IMPORT,
+    }
+    for label, source in launderings.items():
+        sites = scan_source(source, "fixture.py")
+        assert len(sites) == 1, f"scanner missed the {label} shape"
+        assert sites[0].scope == "gate" or sites[0].scope == "_refuse"
+
+
+def test_bare_reraise_is_not_a_new_raise() -> None:
+    """Re-raising something someone else built is not a new uncoded error."""
+    source = """
+from fastapi import HTTPException
+
+def gate():
+    try:
+        work()
+    except HTTPException:
+        raise
+"""
+    assert scan_source(source, "fixture.py") == []
+
+
+def test_coded_helper_calls_are_invisible_to_the_scan() -> None:
+    """`raise_coded` is the conversion: a converted site leaves the inventory."""
+    source = """
+from errors import ErrorCode, raise_coded
+
+def gate():
+    raise_coded(403, ErrorCode.vote_budget_exhausted, "no")
+"""
+    assert scan_source(source, "fixture.py") == []
+
+
+def test_scope_is_the_innermost_function_and_names_its_class() -> None:
+    source = """
+from fastapi import HTTPException
+
+class Gate:
+    def check(self):
+        raise HTTPException(status_code=403, detail="no")
+
+raise HTTPException(status_code=500, detail="at import")
+"""
+    scopes = [site.scope for site in scan_source(source, "fixture.py")]
+    assert scopes == ["Gate.check", MODULE_SCOPE]

--- a/backend/tests/unit/uncoded_error_allowlist.py
+++ b/backend/tests/unit/uncoded_error_allowlist.py
@@ -1,0 +1,162 @@
+"""The shrink-only allowlist of uncoded ``HTTPException`` raises (#1401).
+
+Every entry is a place in the shipped backend that still builds an
+``HTTPException`` without an :class:`errors.ErrorCode`. It is **seeded with all
+of them** — that is the point. Without a complete seed, "phase 1 is done" is a
+sentence someone has to agree with; with one, it is arithmetic: the allowlist
+got smaller by N.
+
+THE RULE
+--------
+**This mapping may only shrink.** Two directions, two meanings:
+
+* A number that goes **up**, or a key that appears, means a new uncoded raise
+  landed. Convert it with :func:`errors.raise_coded` instead of editing this
+  file. ``tests/unit/test_uncoded_error_ratchet.py`` fails either way.
+* A number that goes **down**, or a key that disappears, is a conversion. Lower
+  or delete the entry in the same commit — the test requires the allowlist to
+  match reality exactly, so it cannot quietly stop describing the code.
+
+There is deliberately no escape hatch for "this one is fine uncoded". A 404 for
+a missing row is a perfectly reasonable thing to leave uncoded forever; leaving
+it *here* costs nothing and keeps one number honest, whereas a second
+"permanently exempt" list would need its own guard against growth.
+
+KEY SHAPE
+---------
+``"<path relative to backend/>::<qualified name of the enclosing function>"``
+mapped to how many constructions that scope holds. Line numbers are not part of
+the key — they churn on every edit above the raise, which would turn this file
+into a merge-conflict generator instead of a ratchet.
+
+The scan that produces these keys is in ``uncoded_error_scan.py``, and it is AST
+-based on purpose: nine of the entries seeded here were invisible to
+``grep "raise HTTPException"`` because they are *returned*, not raised. See that
+module's docstring.
+"""
+
+from __future__ import annotations
+
+#: Sum of :data:`UNCODED_RAISE_ALLOWLIST`. Duplicated on purpose: this is the
+#: one number a reviewer reads to see how far a PR moved the ratchet, and the
+#: test asserts the two agree so it cannot drift.
+UNCODED_RAISE_TOTAL = 164
+
+#: ``"file::scope" -> count``. Grouped by file, sorted; see the module docstring.
+UNCODED_RAISE_ALLOWLIST: dict[str, int] = {
+    "dependencies.py::get_current_character": 1,
+    "dependencies.py::require_admin": 1,
+
+    "routers/admin.py::admin_cli_token": 3,
+    "routers/admin.py::admin_create_task": 3,
+    "routers/admin.py::admin_import_tasks_csv": 1,
+    "routers/admin.py::ban_character": 1,
+
+    "routers/auth.py::dev_login": 3,
+
+    "routers/characters.py::delete_character_route": 1,
+    "routers/characters.py::get_character": 1,
+    "routers/characters.py::update_character_route": 1,
+    "routers/characters.py::upload_avatar": 1,
+
+    "routers/comments.py::list_praxis_comments": 1,
+
+    "routers/praxes.py::delete_media_route": 2,
+    "routers/praxes.py::get_praxis_route": 1,
+    "routers/praxes.py::kick_member_route": 1,
+    "routers/praxes.py::list_praxes_route": 5,
+    "routers/praxes.py::upload_media_batch_route": 1,
+    "routers/praxes.py::upload_media_route": 1,
+
+    "routers/relationships.py::delete_relationship": 2,
+
+    "routers/tasks.py::get_task": 1,
+    "routers/tasks.py::list_tasks": 1,
+    "routers/tasks.py::update_task_route": 1,
+
+    "routers/votes.py::list_voters": 1,
+
+    "services/activity_feed.py::parse_archivable_item_key": 1,
+    "services/activity_feed.py::parse_item_key": 2,
+
+    "services/admin_service.py::admin_create_character": 2,
+    "services/admin_service.py::admin_edit_task": 2,
+    "services/admin_service.py::archive_message": 1,
+    "services/admin_service.py::assign_or_revoke_role": 2,
+    "services/admin_service.py::create_faction": 1,
+    "services/admin_service.py::get_account_detail": 1,
+    "services/admin_service.py::reactivate_task": 2,
+    "services/admin_service.py::suspend_account": 1,
+    "services/admin_service.py::update_task_status": 2,
+
+    "services/auth.py::decode_jwt": 2,
+    "services/auth.py::get_current_account": 2,
+
+    "services/character.py::create_character": 3,
+    "services/character.py::set_active_character": 2,
+    "services/character.py::soft_delete_character": 1,
+    "services/character.py::update_character": 1,
+
+    "services/character_stats.py::recompute_votes_spent_this_era": 1,
+
+    "services/comment.py::_assert_commentable_target": 5,
+    "services/comment.py::_clean_body": 2,
+    "services/comment.py::edit_comment": 1,
+    "services/comment.py::flag_comment": 1,
+    "services/comment.py::get_comment": 1,
+    "services/comment.py::moderate_comment": 1,
+    "services/comment.py::withdraw_comment": 1,
+
+    "services/duel.py::cancel_duel_challenge": 2,
+    "services/duel.py::get_duel": 1,
+    "services/duel.py::issue_duel_challenge": 3,
+    "services/duel.py::respond_to_duel_challenge": 4,
+
+    "services/era.py::get_current_era_row": 1,
+
+    "services/faction_service.py::defect_to_faction": 6,
+
+    "services/media.py::process_and_save_avatar": 1,
+    "services/media.py::process_and_save_media": 1,
+
+    "services/nudge.py::_authorize_collab": 2,
+    "services/nudge.py::_authorize_duel": 3,
+    "services/nudge.py::_load_praxis_with_members": 1,
+    "services/nudge.py::_refuse": 4,
+    "services/nudge.py::_send_nudges": 1,
+    "services/nudge.py::send_nudge": 1,
+
+    "services/praxis.py::_check_create_preconditions": 3,
+    "services/praxis.py::_require_member": 1,
+    "services/praxis.py::cancel_invite": 2,
+    "services/praxis.py::change_praxis_type": 3,
+    "services/praxis.py::delete_praxis": 2,
+    "services/praxis.py::flag_praxis": 2,
+    "services/praxis.py::get_praxis": 1,
+    "services/praxis.py::invite_to_praxis": 3,
+    "services/praxis.py::kick_member": 3,
+    "services/praxis.py::leave_praxis": 1,
+    "services/praxis.py::moderate_praxis": 1,
+    "services/praxis.py::respond_to_invite": 4,
+    "services/praxis.py::submit_praxis": 1,
+    "services/praxis.py::unsubmit_praxis": 2,
+
+    "services/praxis_metatask.py::apply_metatask": 8,
+    "services/praxis_metatask.py::remove_metatask": 2,
+
+    "services/relationship_service.py::block_relationship": 2,
+    "services/relationship_service.py::build_relationship_item": 1,
+    "services/relationship_service.py::create_relationship": 3,
+    "services/relationship_service.py::unblock_relationship": 2,
+
+    "services/task.py::list_signups_for_task": 1,
+    "services/task.py::list_tasks": 2,
+    "services/task.py::propose_task": 2,
+    "services/task.py::update_task": 1,
+
+    "services/vote.py::cast_or_update_vote": 3,
+    "services/vote.py::cast_vote_on_praxis": 1,
+}
+
+
+__all__ = ["UNCODED_RAISE_ALLOWLIST", "UNCODED_RAISE_TOTAL"]

--- a/backend/tests/unit/uncoded_error_allowlist.py
+++ b/backend/tests/unit/uncoded_error_allowlist.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 #: Sum of :data:`UNCODED_RAISE_ALLOWLIST`. Duplicated on purpose: this is the
 #: one number a reviewer reads to see how far a PR moved the ratchet, and the
 #: test asserts the two agree so it cannot drift.
-UNCODED_RAISE_TOTAL = 164
+UNCODED_RAISE_TOTAL = 165
 
 #: ``"file::scope" -> count``. Grouped by file, sorted; see the module docstring.
 UNCODED_RAISE_ALLOWLIST: dict[str, int] = {
@@ -137,7 +137,9 @@ UNCODED_RAISE_ALLOWLIST: dict[str, int] = {
     "services/praxis.py::kick_member": 3,
     "services/praxis.py::leave_praxis": 1,
     "services/praxis.py::moderate_praxis": 1,
-    "services/praxis.py::respond_to_invite": 4,
+    # 5, not 4: the bank-full 409 here is deliberately uncoded until a client
+    # site that reads `detail` raw is fixed. The reason is at the raise.
+    "services/praxis.py::respond_to_invite": 5,
     "services/praxis.py::submit_praxis": 1,
     "services/praxis.py::unsubmit_praxis": 2,
 

--- a/backend/tests/unit/uncoded_error_scan.py
+++ b/backend/tests/unit/uncoded_error_scan.py
@@ -1,0 +1,225 @@
+"""AST inventory of ``HTTPException`` construction sites (#1401, phase 2).
+
+This is the measuring instrument behind the shrink-only allowlist in
+``uncoded_error_allowlist.py``. It answers exactly one question about the
+shipped backend: **where is an ``HTTPException`` still built without a code?**
+
+WHY AST AND NOT A REGEX
+-----------------------
+The repo has been here before. The frontend style ratchet was defeated five
+separate ways by patterns that a text scan could not see, and the same shapes
+exist here today: ``git grep -c "raise HTTPException"`` over ``routers/`` +
+``services/`` reports 190, while this scan reports 201 over the same files. The
+nine it cannot see are not raised at all at the point they are built —
+``services/praxis.py::_signup_denial_to_http`` and ``services/nudge.py::_refuse``
+*return* an ``HTTPException`` for a caller to raise or to report per-item. A
+scan that matched the word ``raise`` would have declared those nine already
+clean. (The other two are ``dependencies.py``, which the grep above simply did
+not cover.)
+
+So the unit of measurement is **construction**, not raising:
+
+* ``raise HTTPException(...)``                      — the common shape
+* ``exception = HTTPException(...); raise exception`` — built, then raised
+* ``def _refuse(...) -> HTTPException: return HTTPException(...)`` — returned
+* ``from fastapi import HTTPException as Http`` + ``Http(...)`` — aliased
+* ``import fastapi`` + ``fastapi.HTTPException(...)``  — module attribute
+* ``class Denied(HTTPException)`` + ``Denied(...)``    — subclassed
+
+all count. A bare ``raise exception`` with no construction does not: re-raising
+an exception someone else built is not a new error.
+
+"Has a code" is definitionally "was built by ``errors.raise_coded`` /
+``errors.coded_error``", because those are the only two functions that put a
+``code`` into ``detail``. That makes the inventory a pure structural property —
+no prose, no status codes, nothing a refactor can launder.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Iterator
+
+#: ``backend/``. The scan root, resolved from this file rather than the cwd so
+#: it does not matter where pytest was invoked from.
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+#: Directories under ``backend/`` that ship no HTTP surface, plus the tests
+#: themselves — a test that asserts on an ``HTTPException`` has to build one.
+EXCLUDED_DIRECTORIES = frozenset({"tests", "alembic", "scripts", ".venv", "__pycache__"})
+
+#: ``errors.py`` is the blessed constructor: ``coded_error`` is the one place in
+#: the shipped backend allowed to call ``HTTPException(...)`` directly.
+EXCLUDED_FILES = frozenset({"errors.py"})
+
+#: Modules whose ``HTTPException`` export is the same class.
+HTTP_EXCEPTION_MODULES = frozenset(
+    {"fastapi", "fastapi.exceptions", "starlette.exceptions"}
+)
+
+HTTP_EXCEPTION_NAME = "HTTPException"
+
+#: What an entry in the allowlist is keyed on: the file, then the qualified name
+#: of the enclosing function. Line numbers are deliberately *not* part of the
+#: key — they churn on every edit above the raise, which would make the
+#: allowlist a merge-conflict generator rather than a ratchet.
+MODULE_SCOPE = "<module>"
+
+
+@dataclass(frozen=True)
+class UncodedSite:
+    """One ``HTTPException(...)`` construction that carries no error code."""
+
+    #: POSIX-style path relative to ``backend/``, e.g. ``services/praxis.py``.
+    module_path: str
+    #: Qualified name of the enclosing function, e.g. ``TaskRouter.get_task``,
+    #: or :data:`MODULE_SCOPE` for a construction at import time.
+    scope: str
+    #: 1-based line of the construction. Reported in failure messages so a
+    #: developer can find it; never part of the allowlist key.
+    line: int
+
+    @property
+    def key(self) -> str:
+        return f"{self.module_path}::{self.scope}"
+
+
+def shipped_modules(root: Path = BACKEND_ROOT) -> Iterator[Path]:
+    """Every ``.py`` file in the shipped backend, sorted for stable output."""
+    for path in sorted(root.rglob("*.py")):
+        relative = path.relative_to(root)
+        if EXCLUDED_DIRECTORIES.intersection(relative.parts):
+            continue
+        if relative.as_posix() in EXCLUDED_FILES or relative.name in EXCLUDED_FILES:
+            continue
+        yield path
+
+
+def _bound_names(tree: ast.Module) -> set[str]:
+    """Every local name in this module that resolves to ``HTTPException``.
+
+    Covers the import spellings, plain aliasing (``Denied = HTTPException``) and
+    subclassing (``class Denied(HTTPException)``). Subclass and alias chains are
+    resolved to a fixed point so a two-step launder does not escape.
+    """
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module in HTTP_EXCEPTION_MODULES:
+            for alias in node.names:
+                if alias.name == HTTP_EXCEPTION_NAME:
+                    names.add(alias.asname or alias.name)
+
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            derived: set[str] = set()
+            if isinstance(node, ast.ClassDef):
+                bases = {base.id for base in node.bases if isinstance(base, ast.Name)}
+                if bases & names:
+                    derived.add(node.name)
+            elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Name):
+                if node.value.id in names:
+                    derived.update(
+                        target.id
+                        for target in node.targets
+                        if isinstance(target, ast.Name)
+                    )
+            if derived - names:
+                names |= derived
+                changed = True
+    return names
+
+
+def _is_http_exception_call(node: ast.Call, bound_names: set[str]) -> bool:
+    """Does this call construct an ``HTTPException``?
+
+    ``ast.Attribute`` is matched on the attribute name alone (``fastapi.HTTPException``,
+    ``exceptions.HTTPException``, ``starlette.exceptions.HTTPException``) rather
+    than by resolving the module: the name is distinctive enough that a false
+    positive would itself be a thing worth looking at.
+    """
+    function = node.func
+    if isinstance(function, ast.Name):
+        return function.id in bound_names
+    if isinstance(function, ast.Attribute):
+        return function.attr == HTTP_EXCEPTION_NAME
+    return False
+
+
+class _ScopeWalker(ast.NodeVisitor):
+    """Walks a module tracking the qualified name of the enclosing scope."""
+
+    def __init__(self, module_path: str, bound_names: set[str]) -> None:
+        self.module_path = module_path
+        self.bound_names = bound_names
+        self.sites: list[UncodedSite] = []
+        self._scope: list[str] = []
+
+    def _current_scope(self) -> str:
+        return ".".join(self._scope) if self._scope else MODULE_SCOPE
+
+    def _visit_scoped(self, node: ast.AST, name: str) -> None:
+        self._scope.append(name)
+        self.generic_visit(node)
+        self._scope.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._visit_scoped(node, node.name)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if _is_http_exception_call(node, self.bound_names):
+            self.sites.append(
+                UncodedSite(
+                    module_path=self.module_path,
+                    scope=self._current_scope(),
+                    line=node.lineno,
+                )
+            )
+        self.generic_visit(node)
+
+
+def scan_source(source: str, module_path: str) -> list[UncodedSite]:
+    """Inventory one module's source. Exposed so the scanner can be tested."""
+    tree = ast.parse(source)
+    walker = _ScopeWalker(module_path, _bound_names(tree))
+    walker.visit(tree)
+    return walker.sites
+
+
+def scan_backend(root: Path = BACKEND_ROOT) -> list[UncodedSite]:
+    """Inventory every shipped backend module."""
+    sites: list[UncodedSite] = []
+    for path in shipped_modules(root):
+        module_path = path.relative_to(root).as_posix()
+        sites.extend(scan_source(path.read_text(encoding="utf-8"), module_path))
+    return sites
+
+
+def tally(sites: Iterable[UncodedSite]) -> dict[str, int]:
+    """Collapse sites into the allowlist's ``"file::scope" -> count`` shape."""
+    counts: dict[str, int] = {}
+    for site in sites:
+        counts[site.key] = counts.get(site.key, 0) + 1
+    return counts
+
+
+__all__ = [
+    "BACKEND_ROOT",
+    "EXCLUDED_DIRECTORIES",
+    "EXCLUDED_FILES",
+    "MODULE_SCOPE",
+    "UncodedSite",
+    "scan_backend",
+    "scan_source",
+    "shipped_modules",
+    "tally",
+]

--- a/backend/tests/unit/uncoded_error_scan.py
+++ b/backend/tests/unit/uncoded_error_scan.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 import ast
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Iterator
+from typing import Iterable, Iterator, Optional
 
 #: ``backend/``. The scan root, resolved from this file rather than the cwd so
 #: it does not matter where pytest was invoked from.
@@ -212,7 +212,73 @@ def tally(sites: Iterable[UncodedSite]) -> dict[str, int]:
     return counts
 
 
+#: The two blessed constructors in ``errors.py``. A call to either is what "has
+#: a code" means.
+CODED_CONSTRUCTORS = frozenset({"raise_coded", "coded_error"})
+
+
+@dataclass(frozen=True)
+class CodedSite:
+    """One ``raise_coded`` / ``coded_error`` call in the shipped backend."""
+
+    module_path: str
+    line: int
+    #: The :class:`errors.ErrorCode` *member name* (not its value) this site
+    #: passes, or ``None`` if it passes something the AST cannot resolve.
+    code_member: Optional[str]
+    #: Whether a third positional argument (the prose ``message``) was supplied.
+    has_message: bool
+
+
+def scan_coded_source(source: str, module_path: str) -> list[CodedSite]:
+    """Find the coded raises in one module."""
+    sites: list[CodedSite] = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        name = (
+            function.id
+            if isinstance(function, ast.Name)
+            else function.attr if isinstance(function, ast.Attribute) else None
+        )
+        if name not in CODED_CONSTRUCTORS:
+            continue
+        code_member: Optional[str] = None
+        if len(node.args) >= 2:
+            code_argument = node.args[1]
+            if (
+                isinstance(code_argument, ast.Attribute)
+                and isinstance(code_argument.value, ast.Name)
+                and code_argument.value.id == "ErrorCode"
+            ):
+                code_member = code_argument.attr
+        sites.append(
+            CodedSite(
+                module_path=module_path,
+                line=node.lineno,
+                code_member=code_member,
+                has_message=len(node.args) >= 3
+                or any(keyword.arg == "message" for keyword in node.keywords),
+            )
+        )
+    return sites
+
+
+def scan_coded_backend(root: Path = BACKEND_ROOT) -> list[CodedSite]:
+    """Find every coded raise in the shipped backend."""
+    sites: list[CodedSite] = []
+    for path in shipped_modules(root):
+        module_path = path.relative_to(root).as_posix()
+        sites.extend(scan_coded_source(path.read_text(encoding="utf-8"), module_path))
+    return sites
+
+
 __all__ = [
+    "CODED_CONSTRUCTORS",
+    "CodedSite",
+    "scan_coded_backend",
+    "scan_coded_source",
     "BACKEND_ROOT",
     "EXCLUDED_DIRECTORIES",
     "EXCLUDED_FILES",


### PR DESCRIPTION
Part of #1401.

Backend errors grow a machine-readable half. `detail` becomes `{code, message}`
at the gates players actually hit, and the remaining uncoded raises are seeded
into a shrink-only allowlist so "phase 1 done" is arithmetic rather than
assertion.

## The shape

FastAPI's envelope is unchanged; `detail` becomes an object:

```json
{"detail": {"code": "VOTE_BUDGET_EXHAUSTED", "message": "No votes remaining in your budget."}}
```

`message` is **byte-identical to the prose that raise site already emitted** —
this PR adds a code, it does not rewrite copy. New module `backend/errors.py`
holds an `ErrorCode` enum plus `raise_coded(status, ErrorCode.x, message)` and
`coded_error(...)` (the build-don't-raise twin, for the two helpers that
*return* an exception). No exception hierarchy, no router-side translator —
`SPEC-backend-architecture.md` §5 / ADR-0045 keep `HTTPException`-in-services.

**`errors.json` and the catalog lookup are deliberately not here.** #1581 left
`extractError` preferring `message` and pinned that a bare `code` falls through
to the caller's fallback; that test is the seam a later slice hooks into.

## The frontend contract

`frontend/src/utils/errors.ts::extractError` reads `detail.message` for the
object branch, so every converted error displays exactly the string it did
before. Three readers of a raw error body exist in `frontend/src` and all three
were checked:

| Reader | Verdict |
|---|---|
| `utils/errors.ts::extractError` (43 importers) | object-aware since #1581; prefers `message`. Safe. |
| `api/admin.ts::taskImportRowErrors` | requires `Array.isArray(detail)`; the CSV-import raise is untouched. Safe. |
| `components/feed/FeedCardCollabInvite.tsx:86` | reads `err.response.data.detail` **raw** and tests `typeof detail === "string" && detail.includes("Task bank is full")`. **Would have broken.** |

So `services/praxis.py::respond_to_invite`'s bank-full 409 is the one phase-1
gate left uncoded, with the reason written at the raise and echoed in the
allowlist. Coding it would have turned that check false and the
drop-a-praxis-and-retry modal would have silently stopped opening, with nothing
failing. Its duel twin (`respond_to_duel_challenge`) **is** coded — that card
reads the detail through `useRespondToRequest` → `extractError`, which hands
back `message`, so its substring match still holds. Follow-up: move
`FeedCardCollabInvite` onto `detail.code === 'TASK_BANK_FULL'`, then code the
last raise and drop the allowlist entry from 5 to 4.

The two endpoints that *flatten* a per-item `HTTPException` into a string field
— `MediaUploadResultOut.error` and `NudgeResultOut.error` — called
`str(detail)`, which on a coded body renders a dict repr into a field a player
reads. Both now call `errors.detail_message`. The batch-upload test asserted
only `assert failed["error"]`, which a stringified dict satisfies, so it is now
an exact-prose assertion.

## Phase 1: 36 raises converted, 29 codes

Vote budget · level gates (task, collab, duel, flag, comment, task/metatask
proposal, second character) · signup caps and the whole `_signup_denial_to_http`
mapper · duel and collab-invite eligibility · media limits.

## The ratchet

`backend/tests/unit/test_uncoded_error_ratchet.py` inventories every remaining
`HTTPException` construction against `uncoded_error_allowlist.py`, seeded with
**all** of them: `UNCODED_RAISE_TOTAL = 165`, 88 entries keyed
`"file.py::enclosing.scope"` (not line numbers — those churn). It fails in both
directions: a key that appears or a count that rises is a new uncoded raise; a
count that is *too high* means the allowlist stopped describing the code, which
is what would let "the list got smaller by N" quietly stop meaning anything.

**The scan is AST-based and matches construction, not the word `raise`** — the
issue asked for this explicitly, citing the style ratchet that was defeated five
ways. It pays for itself immediately: `git grep -c "raise HTTPException"` over
`routers/` + `services/` reports **190**; the AST scan over the same files
reports **199**. The nine it cannot see are not raised where they are built —
`services/praxis.py::_signup_denial_to_http` (5) and `services/nudge.py::_refuse`
(4) *return* an `HTTPException` for a caller to raise or report per-item. A
`raise`-matching scan would have called those nine already clean. (The scan's
full footprint is 201, adding `dependencies.py`'s 2, which the `git grep` above
did not cover.)

`test_scanner_sees_every_launderable_shape` pins eight shapes as fixtures —
direct raise, built-then-raised, returned-from-helper, aliased import, module
attribute, subclass, rebound name, starlette import — so the instrument cannot
quietly go blind and read as progress.

Two further guards in `tests/unit/test_errors.py`: every coded raise must supply
a `message` (a bare code renders nothing on the client, per #1581), and every
`ErrorCode` member must have a raise site.

## Not in this PR

`errors.json` / catalog lookup · RFC-7807 · status-code changes · the Pydantic
422 array shape.

## Verification

```
cd backend && pytest --cov=. --cov-report=term-missing --cov-fail-under=80
```
→ **1087 passed**, coverage 92.86% (`errors.py` 100%).

`python backend/scripts/dump_openapi.py` produces **no diff**: FastAPI does not
document non-422 error bodies and no response schema gained a field, so
`backend/openapi.json` and `frontend/src/api/generated/schema.d.ts` are
unchanged and the `api-schema` job has nothing to catch.

**Unverified:** no browser or dev stack here. No player-visible copy changes by
construction (every `message` is the prior string verbatim, pinned by tests), but
nothing was rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
