### PR TITLE
The collab-invite card branches on the error code, and the last phase-1 raise gets one

### DIFF
--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -1651,20 +1651,10 @@ async def respond_to_invite(
     if not era.collab_invite_bypasses_task_bank and not already_member:
         in_progress_count = await _count_in_progress_praxes(character_id, session)
         if in_progress_count >= era.max_task_signups:
-            # DELIBERATELY UNCODED, and the only phase-1 gate left behind
-            # (#1401). `FeedCardCollabInvite` reads this response's `detail`
-            # RAW — `typeof detail === "string" && detail.includes("Task bank
-            # is full")` — outside `extractError`, which is the only reader
-            # #1581 taught to understand a coded body. Coding this here turns
-            # that check false and the drop-a-praxis-and-retry modal silently
-            # stops opening, with no test failing. Client first, then this.
-            #
-            # The duel twin (`respond_to_duel_challenge`) IS coded: its card
-            # reads the detail through `useRespondToRequest` -> `extractError`,
-            # which hands back `message`, so its substring match still holds.
-            raise HTTPException(
-                status_code=409,
-                detail=f"Task bank is full ({era.max_task_signups} in-progress praxes).",
+            raise_coded(
+                409,
+                ErrorCode.task_bank_full,
+                f"Task bank is full ({era.max_task_signups} in-progress praxes).",
             )
 
     # Add member

--- a/backend/tests/integration/test_collab_invite_bypass.py
+++ b/backend/tests/integration/test_collab_invite_bypass.py
@@ -266,10 +266,14 @@ async def test_full_task_bank_still_refuses_on_accept(
             era=tight_bank,
         )
     assert excinfo.value.status_code == 409
-    # Still plain prose, not a coded body: this one raise is held back from
-    # #1401 phase 1 because `FeedCardCollabInvite` substring-matches it outside
-    # `extractError`. The rationale is at the raise in `services/praxis.py`.
-    assert "bank" in excinfo.value.detail.lower()
+    # Coded as of #1598 — the last phase-1 raise, held back only until the
+    # client stopped substring-matching this response's prose.
+    # `FeedCardCollabInvite` opens its drop-to-accept modal off this code now,
+    # so the code is the contract and the prose is the fallback, not the
+    # reverse. The prose is still asserted because it is what a player reads
+    # on any client that does not know the code.
+    assert excinfo.value.detail["code"] == ErrorCode.task_bank_full.value
+    assert "bank" in excinfo.value.detail["message"].lower()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/uncoded_error_allowlist.py
+++ b/backend/tests/unit/uncoded_error_allowlist.py
@@ -40,7 +40,7 @@ from __future__ import annotations
 #: Sum of :data:`UNCODED_RAISE_ALLOWLIST`. Duplicated on purpose: this is the
 #: one number a reviewer reads to see how far a PR moved the ratchet, and the
 #: test asserts the two agree so it cannot drift.
-UNCODED_RAISE_TOTAL = 165
+UNCODED_RAISE_TOTAL = 164
 
 #: ``"file::scope" -> count``. Grouped by file, sorted; see the module docstring.
 UNCODED_RAISE_ALLOWLIST: dict[str, int] = {
@@ -137,9 +137,7 @@ UNCODED_RAISE_ALLOWLIST: dict[str, int] = {
     "services/praxis.py::kick_member": 3,
     "services/praxis.py::leave_praxis": 1,
     "services/praxis.py::moderate_praxis": 1,
-    # 5, not 4: the bank-full 409 here is deliberately uncoded until a client
-    # site that reads `detail` raw is fixed. The reason is at the raise.
-    "services/praxis.py::respond_to_invite": 5,
+    "services/praxis.py::respond_to_invite": 4,
     "services/praxis.py::submit_praxis": 1,
     "services/praxis.py::unsubmit_praxis": 2,
 

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -14,6 +14,7 @@ import {
 } from "../../api/praxis";
 import { extractError } from "../../utils/errors";
 import { factionFill } from "../../utils/factions";
+import { isTaskBankFull } from "./bankFull";
 import FeedBadge from "./FeedBadge";
 import FeedBankFullModal from "./FeedBankFullModal";
 
@@ -74,16 +75,14 @@ export default function FeedCardCollabInvite({ item }: Props) {
     // hand back the raw axios error, and its `error` state is stale this tick.
     // Re-issue the accept directly so we can inspect the backend detail: when
     // the invitee's task bank is full, offer to drop one praxis and retry.
-    // Match on the detail SUBSTRING (bank-full is 409 on collab, 400 on the
-    // duel twin) — not the status code. Other errors stay on the hook's `error`.
+    // Match on the FAILURE, not the status code (bank-full is 409 on collab,
+    // 400 on the duel twin). Other errors stay on the hook's `error`.
     try {
       await respondToInvite(praxis_id, invite_id, true);
       // Raced free between the two calls — land on the collab like happy path.
       navigate(`/praxis/${praxis_id}/edit`);
     } catch (err) {
-      const detail = (err as { response?: { data?: { detail?: unknown } } })
-        ?.response?.data?.detail;
-      if (typeof detail === "string" && detail.includes("Task bank is full")) {
+      if (isTaskBankFull(err)) {
         setDropError("");
         refetchActiveTasks();
         setShowDropModal(true);

--- a/frontend/src/components/feed/__tests__/bankFull.test.ts
+++ b/frontend/src/components/feed/__tests__/bankFull.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { isTaskBankFull } from '../bankFull'
+
+/**
+ * #1598 — the drop-to-accept trigger stops depending on English prose.
+ *
+ * THE BUG THIS PINS. `FeedCardCollabInvite` decided whether to open the
+ * drop-a-praxis modal by reading `err.response.data.detail` raw and asking
+ * `typeof detail === "string" && detail.includes("Task bank is full")`. The
+ * moment that raise gained a `{code, message}` body the test suite stayed
+ * green and the modal stopped opening: the player hit a full bank, got a bare
+ * error, and had no way forward. Nothing failed because the branch is a UI
+ * affordance rather than an assertion.
+ *
+ * WHAT THIS HARNESS CAN PROVE. `renderToStaticMarkup` in the `node`
+ * environment has no DOM and runs no effects, so the click that reaches this
+ * predicate cannot be driven here — the modal actually opening is hand-
+ * verified. What *is* mechanical is the decision itself, which is why it is a
+ * standalone exported function: every `detail` shape the backend can answer
+ * with, in and out.
+ */
+
+const axiosError = (status: number, detail?: unknown) => ({
+  message: 'Request failed',
+  response: { status, data: detail === undefined ? {} : { detail } },
+})
+
+const BANK_FULL_PROSE = 'Task bank is full (20 in-progress praxes).'
+
+describe('isTaskBankFull', () => {
+  it('recognises the coded body every live backend path now sends', () => {
+    // `services/praxis.py::respond_to_invite` — the collab accept this card drives.
+    expect(
+      isTaskBankFull(axiosError(409, { code: 'TASK_BANK_FULL', message: BANK_FULL_PROSE }))
+    ).toBe(true)
+    // The duel twin and the shared signup denial answer 400, same code. The
+    // status is not part of the decision and must not become part of it.
+    expect(
+      isTaskBankFull(axiosError(400, { code: 'TASK_BANK_FULL', message: BANK_FULL_PROSE }))
+    ).toBe(true)
+  })
+
+  it('recognises the code even with no prose attached', () => {
+    expect(isTaskBankFull(axiosError(409, { code: 'TASK_BANK_FULL' }))).toBe(true)
+  })
+
+  it('still recognises the bare-string body, for the deploy-skew window', () => {
+    // Frontend and API deploy separately. Until no running API predates the
+    // coded raise, this bundle can be talking to one that answers prose — the
+    // window #1401 is sequenced client-first to survive.
+    expect(isTaskBankFull(axiosError(409, BANK_FULL_PROSE))).toBe(true)
+  })
+
+  it('does not fire on some other failure', () => {
+    expect(
+      isTaskBankFull(
+        axiosError(400, { code: 'INVITE_PRAXIS_SUBMITTED', message: 'Cannot join a submitted praxis.' })
+      )
+    ).toBe(false)
+    expect(isTaskBankFull(axiosError(403, 'This invite is not for you.'))).toBe(false)
+    expect(isTaskBankFull(axiosError(404, { code: 'TASK_LEVEL_TOO_LOW' }))).toBe(false)
+    expect(isTaskBankFull(axiosError(500))).toBe(false)
+    expect(isTaskBankFull({ message: 'Network Error' })).toBe(false)
+    expect(isTaskBankFull(undefined)).toBe(false)
+  })
+})
+
+describe('the card decides through the predicate, not a raw body read', () => {
+  it('FeedCardCollabInvite holds no second reader of response.data.detail', () => {
+    const text = readFileSync(
+      new URL('../FeedCardCollabInvite.tsx', import.meta.url),
+      'utf8'
+    )
+    // The literal shape of the bug: any reach past utils/errors for the body.
+    expect(text).not.toContain('response?: { data?: { detail?: unknown } }')
+    expect(text).not.toContain('data?.detail')
+    expect(text).toContain('isTaskBankFull(err)')
+  })
+})

--- a/frontend/src/components/feed/bankFull.ts
+++ b/frontend/src/components/feed/bankFull.ts
@@ -1,0 +1,36 @@
+import { ErrorCode, extractError, extractErrorCode } from '../../utils/errors'
+
+/**
+ * "Was this failure a full task bank?" — the trigger for the drop-to-accept
+ * flow (#322, #314).
+ *
+ * WHY THIS IS A FUNCTION AND NOT AN INLINE `if`. It used to be inline, and it
+ * read `err.response.data.detail` raw, outside `extractError`, asking
+ * `typeof detail === "string"`. When #1401 turned that `detail` into
+ * `{code, message}` the test stayed green — the branch that dies is a UI
+ * affordance, not an assertion — and the modal would simply have stopped
+ * opening (#1598). Here it is one exported predicate with its own tests, so
+ * the next shape change fails loudly.
+ *
+ * TWO ACCEPTED SHAPES, and the second is not legacy-for-its-own-sake:
+ *
+ *  - the code, which is what every live backend path now sends. All three
+ *    bank-full raise sites are coded — `services/praxis.py::respond_to_invite`
+ *    (409, the collab accept this card drives), the shared signup denial
+ *    `_signup_denial_to_http` (400), and `services/duel.py` (400).
+ *  - the prose, which survives a **deploy skew**. Frontend and API ship
+ *    separately, so between the two deploys this bundle talks to a backend
+ *    that still answers a bare string. That window is exactly why #1401 is
+ *    sequenced client-first, and dropping the prose arm would reintroduce the
+ *    outage it is sequenced to avoid — for the same flow, in the same window.
+ *    Deletable once no deployed API predates the coded raise.
+ *
+ * The prose arm reads through `extractError` rather than the response body, so
+ * this module never grows the second raw `detail` reader again.
+ */
+const BANK_FULL_PROSE = 'Task bank is full'
+
+export function isTaskBankFull(err: unknown): boolean {
+  if (extractErrorCode(err) === ErrorCode.taskBankFull) return true
+  return extractError(err, '').includes(BANK_FULL_PROSE)
+}

--- a/frontend/src/utils/__tests__/errors.test.ts
+++ b/frontend/src/utils/__tests__/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { extractError } from '../errors'
+import { ErrorCode, extractError, extractErrorCode } from '../errors'
 
 /**
  * `extractError` has to read every shape the backend's `detail` field can take.
@@ -78,5 +78,35 @@ describe('extractError — status and network fallbacks', () => {
 
   it('uses the default fallback when the caller gives none', () => {
     expect(extractError(axiosError(400))).toBe('Something went wrong. Please try again.')
+  })
+})
+
+/**
+ * `extractErrorCode` exists so a caller can branch on *which* failure happened
+ * without reaching past this module for a raw `detail` and matching English
+ * prose — the exact drift that made a coded raise a silent UI break (#1598).
+ */
+describe('extractErrorCode', () => {
+  it('reads the code off a coded detail', () => {
+    const detail = { code: 'TASK_BANK_FULL', message: 'Task bank is full (20 in-progress praxes).' }
+    expect(extractErrorCode(axiosError(409, detail))).toBe(ErrorCode.taskBankFull)
+  })
+
+  it('reads a bare code, which extractError deliberately will not show', () => {
+    expect(extractErrorCode(axiosError(409, { code: 'TASK_BANK_FULL' }))).toBe(
+      ErrorCode.taskBankFull
+    )
+    expect(extractError(axiosError(409, { code: 'TASK_BANK_FULL' }), FALLBACK)).toBe(FALLBACK)
+  })
+
+  it('returns null for every uncoded shape, so callers need no narrowing', () => {
+    expect(extractErrorCode(axiosError(409, 'Task bank is full (20 in-progress praxes).'))).toBeNull()
+    expect(extractErrorCode(axiosError(422, [{ msg: 'Field required' }]))).toBeNull()
+    expect(extractErrorCode(axiosError(400, {}))).toBeNull()
+    expect(extractErrorCode(axiosError(400, { message: 'no code here' }))).toBeNull()
+    expect(extractErrorCode(axiosError(400, { code: 42 }))).toBeNull()
+    expect(extractErrorCode(axiosError(400))).toBeNull()
+    expect(extractErrorCode({ message: 'Network Error' })).toBeNull()
+    expect(extractErrorCode(undefined)).toBeNull()
   })
 })

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -16,6 +16,18 @@ type ErrorDetail = string | ValidationDetail[] | CodedDetail
 const GENERIC_SERVER_PROSE = 'Internal Server Error'
 
 /**
+ * The `backend/errors.py::ErrorCode` values this client actually branches on.
+ *
+ * A mirror, not a copy: only the codes some component switches behaviour on
+ * belong here, and each one's string is the wire contract (renaming it on
+ * either side is a break). Codes that are merely *displayed* need no entry —
+ * `extractError` shows their `message` without knowing what they are.
+ */
+export const ErrorCode = {
+  taskBankFull: 'TASK_BANK_FULL',
+} as const
+
+/**
  * Pulls the displayable prose out of a `detail` body, whatever shape it takes.
  * Returns null when there is nothing worth showing, so the caller falls through
  * to its status-based messages.
@@ -79,4 +91,24 @@ export function extractError(
   }
 
   return fallback
+}
+
+/**
+ * Extracts the machine-readable `code` from an axios error, or null.
+ *
+ * The read side of `extractError`: that one answers "what do I show the
+ * player", this one answers "which failure was it". Both go through the same
+ * `detail` typing on purpose — the collab-invite card once reached past
+ * `extractError` for a raw `detail` and substring-matched English prose, which
+ * meant coding that raise would have silently killed its retry flow (#1598).
+ * A second reader is how that drifted, so there is one, here.
+ *
+ * Returns null for every uncoded shape (string, validation array, absent), so
+ * callers can compare against `ErrorCode.*` without narrowing first.
+ */
+export function extractErrorCode(err: unknown): string | null {
+  const detail = (err as AxiosError<{ detail?: ErrorDetail }>)?.response?.data
+    ?.detail
+  if (!detail || typeof detail === 'string' || Array.isArray(detail)) return null
+  return typeof detail.code === 'string' ? detail.code : null
 }


### PR DESCRIPTION
Closes #1598

`FeedCardCollabInvite` decided whether to open the drop-to-accept modal (#322) by reading `err.response.data.detail` **raw** — past `extractError`, the one reader #1581 taught to understand a coded body — and asking `typeof detail === "string" && detail.includes("Task bank is full")`. Coding that raise turns the check false: no modal, no way forward for a player whose bank is full, and no test failing, because the branch that dies is a UI affordance rather than an assertion.

Client first, then the raise — the ordering the owner ruled for #1401, for exactly this reason.

## The client

`extractErrorCode` joins `extractError` in `utils/errors.ts`, reading the same `detail` typing: one answers *what do I show the player*, the other *which failure was it*. A second raw reader is how this drifted in the first place, so there is one reader and the prose arm goes through `extractError` too.

The decision itself moves out of the component into `feed/bankFull.ts::isTaskBankFull` — a standalone exported predicate, which is what makes it testable at all in a `renderToStaticMarkup` harness with no DOM and no effects.

**The string arm is kept, and step 3 of the issue said to check rather than assume.** Checked: all three "Task bank is full" raise sites are coded after this PR — `respond_to_invite` (409, the one this card drives), the shared `_signup_denial_to_http` (400), and `services/duel.py` (400) — so no *live* server path emits the prose form to this card. It is kept for the **deploy-skew window**: the frontend and API deploy separately, so between the two deploys this bundle talks to an API that still answers a bare string. That is the same window the 2026-08-02 prod incident opened, for the same flow. Deletable once no deployed API predates the coded raise; the test that covers it says so.

## The raise

`services/praxis.py::respond_to_invite` converts to `raise_coded`, and the twelve-line comment above it is deleted — it documented the client state that this PR removes, and a comment describing a state that no longer exists is worse than no comment.

Allowlist entry `services/praxis.py::respond_to_invite` 5 → 4 and `UNCODED_RAISE_TOTAL` 165 → 164, in the same commit. The ratchet compares in both directions and fails on a stale entry as loudly as on a new raise.

## Tests

- `bankFull.test.ts` — new. Every `detail` shape in and out: coded at 409 and at 400 (the status is not part of the decision and must not become part of it), bare code with no prose, the deploy-skew string, and four near-misses. Plus a source assertion that the card holds no second raw body read.
- `errors.test.ts` — `extractErrorCode` across coded / bare-code / string / validation-array / absent, including the pairing that a bare code is *readable* but deliberately *not displayable*.
- `test_collab_invite_bypass.py::test_full_task_bank_still_refuses_on_accept` — was asserting the prose, which is precisely the assertion this change invalidates. Now reads `detail["code"]`, and still asserts the message, since that is what a player sees on a client that does not know the code.

**One correction to the brief:** it said the card's existing test asserts the modal opens on a string detail, and that this assertion becomes wrong. No such test existed. `feedBankFullModal.test.tsx` only asserts the modal's structure and portal, and it still passes untouched — which is the issue's own point restated: *no test failed*. `bankFull.test.ts` is the coverage that was missing.

## Verification

Full local CI: backend `pytest --cov-fail-under=80` (1087 passed, 92.87%) and all six frontend steps — eslint, `tsc --noEmit`, vitest (3894 passed), `vite build`, the initial-load budget (JS 138.1 KB, CSS 22.4 KB, both within budget), and `typecheck:design-sync`. Backend ran against a dedicated `wz1598_test`.

Out of scope and untouched, per the issue: `code` on `MediaUploadResultOut` / `NudgeResultOut`, any `errors.json` catalog work, and `backend/routers/`, `backend/schemas/`, `backend/openapi.json`, `frontend/src/api/generated/`.

`FeedCardDuelChallenge` is deliberately **not** changed. Its raise is already coded and its `BANK_FULL_MARKER` still matches, because it reads through `useRespondToRequest` → `extractError` → `message`. It is the natural second adopter of `isTaskBankFull`, but it is not broken and this PR is not the place.

## What to eyeball

I have no browser and no dev stack, so the modal actually opening is **not** verified here — the harness has no DOM and runs no effects. A human needs to click:

1. Sign in as a character whose **task bank is full** (`max_task_signups` in-progress praxes).
2. Have another character invite them to a **collab**, on a task the invitee is not already an active member of.
3. Open Updates / the feed and hit **Accept** on that collab invite.
4. **The drop-a-praxis modal must still open** — full-viewport, unclipped, listing the in-progress praxes. This is the branch that would have silently died.
5. Pick one to drop. An authored-solo praxis is deleted, a joined collab is left. **The retry must then succeed** and land on the collab.
6. Cancel out of the modal instead, and confirm the card falls back to the ordinary inline error rather than getting stuck.
7. Worth a glance in passing: the **duel** challenge card's bank-full flow, which this PR does not touch but which shares the modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
