### PR TITLE
Twelve routes stop answering with an untyped dict, and a ratchet keeps them honest

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -12,6 +12,7 @@ from starlette.middleware.sessions import SessionMiddleware
 from config import settings
 from routers import activity_feed, admin, auth, characters, duel, factions, game_config, leaderboard, praxes, relationships, tasks, votes
 from routers import comments, contact, me
+from schemas.system import HealthOut
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +93,6 @@ app.include_router(contact.router, prefix="/contact", tags=["contact"])
 app.include_router(activity_feed.router, prefix="/activity-feed", tags=["activity-feed"])
 
 
-@app.get("/health")
-async def health():
-    return {"status": "ok"}
+@app.get("/health", response_model=HealthOut)
+async def health() -> HealthOut:
+    return HealthOut(status="ok")

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -233,6 +233,51 @@
         "title": "AdminCharacterCreate",
         "type": "object"
       },
+      "AdminCharacterOut": {
+        "description": "The character an admin just minted (``POST /admin/characters``).\n\nCarries ``account_id`` on purpose. The \"never expose account_id\" rule\n(SPEC-backend-architecture.md §4) governs the *public* API; the admin router\nis the operator surface and already answers with raw account identity and\ne-mail (``AccountSummary``). An admin who creates a character for an account\nneeds to see which account it landed on.\n\nDeliberately not ``CharacterOut``: that shape is the player-facing profile\n(score, level, badges, faction display), none of which exists yet at\ncreation time. This is the insert receipt.",
+        "properties": {
+          "account_id": {
+            "title": "Account Id",
+            "type": "integer"
+          },
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "faction_slug": {
+            "title": "Faction Slug",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "username",
+          "display_name",
+          "faction_slug",
+          "status",
+          "created_at"
+        ],
+        "title": "AdminCharacterOut",
+        "type": "object"
+      },
       "AdminFactionOut": {
         "properties": {
           "created_at": {
@@ -462,6 +507,25 @@
           "banned"
         ],
         "title": "BanAction",
+        "type": "object"
+      },
+      "BanActionOut": {
+        "description": "Result of ``POST /admin/characters/{id}/ban``.\n\nCharacter-scoped: a ban lands on one character, not the account behind it\n(ADR-0041). Suspending the account is the other endpoint.",
+        "properties": {
+          "banned": {
+            "title": "Banned",
+            "type": "boolean"
+          },
+          "character_id": {
+            "title": "Character Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "character_id",
+          "banned"
+        ],
+        "title": "BanActionOut",
         "type": "object"
       },
       "Body_admin_import_tasks_csv_admin_tasks_import_csv_post": {
@@ -1624,6 +1688,58 @@
         "title": "CurrentUser",
         "type": "object"
       },
+      "DevLoginOut": {
+        "description": "Result of the dev-only bot login (``POST /auth/dev-login``).\n\nExposes ``account_id``, which the public API never does — and this is not a\nsecond exception beside ``/auth/me``. The endpoint 404s outside development\n(``settings.ENVIRONMENT``), and the ids exist so e2e fixtures can invite and\ncredit by id without a second round trip. If this route ever becomes\nreachable in production the leak is the route, not the field.",
+        "properties": {
+          "account_id": {
+            "title": "Account Id",
+            "type": "integer"
+          },
+          "character_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Character Id"
+          },
+          "character_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Character Name"
+          },
+          "faction_slug": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Faction Slug"
+          },
+          "message": {
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message",
+          "account_id"
+        ],
+        "title": "DevLoginOut",
+        "type": "object"
+      },
       "DuelChallengeIn": {
         "description": "Body for POST /duels/challenge — attach a duel to an existing praxis.",
         "properties": {
@@ -2082,6 +2198,25 @@
           "config_key"
         ],
         "title": "EraAnnouncementPayload",
+        "type": "object"
+      },
+      "EraResetOut": {
+        "description": "Readout for ``PUT /admin/era/reset``: the new era row and who it touched.",
+        "properties": {
+          "characters_reset": {
+            "title": "Characters Reset",
+            "type": "integer"
+          },
+          "era_id": {
+            "title": "Era Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "era_id",
+          "characters_reset"
+        ],
+        "title": "EraResetOut",
         "type": "object"
       },
       "FactionChoiceRequest": {
@@ -3441,6 +3576,21 @@
         "title": "HTTPValidationError",
         "type": "object"
       },
+      "HealthOut": {
+        "description": "``GET /health`` — the liveness probe the host polls.\n\n``status`` is a ``Literal`` rather than a bare ``str`` because the endpoint\nhas exactly one success answer: it either returns ``\"ok\"`` or it does not\nreturn. Typing it as an open string would put a value in the generated\nclient that nothing can ever produce, and invite a caller to branch on it.",
+        "properties": {
+          "status": {
+            "const": "ok",
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "HealthOut",
+        "type": "object"
+      },
       "InvitationLetterItem": {
         "properties": {
           "actor_avatar_url": {
@@ -3625,6 +3775,20 @@
           "key"
         ],
         "title": "LevelUnlockOut",
+        "type": "object"
+      },
+      "LogoutOut": {
+        "description": "Acknowledgement for ``POST /auth/logout``.\n\nThe work of logging out is the ``Set-Cookie`` header that clears the JWT,\nnot the body; this exists so the body is a declared shape in the schema\nrather than an untyped object the generated client cannot check.",
+        "properties": {
+          "message": {
+            "title": "Message",
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "title": "LogoutOut",
         "type": "object"
       },
       "MediaItemOut": {
@@ -5043,6 +5207,34 @@
         "title": "RoleAction",
         "type": "object"
       },
+      "RoleActionOut": {
+        "description": "Echo of an applied ``POST /admin/accounts/{id}/role``.\n\nAn echo rather than the account's full role set: the service applies one\ngrant/revoke and does not read the rest back, and inventing a fuller shape\nhere would mean a second query whose only consumer is the confirmation.",
+        "properties": {
+          "account_id": {
+            "title": "Account Id",
+            "type": "integer"
+          },
+          "action": {
+            "enum": [
+              "grant",
+              "revoke"
+            ],
+            "title": "Action",
+            "type": "string"
+          },
+          "role": {
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "account_id",
+          "role",
+          "action"
+        ],
+        "title": "RoleActionOut",
+        "type": "object"
+      },
       "SidebarOut": {
         "description": "Everything the rail's three data panels draw, in one response.\n\nOne field per panel, and nothing else. Identity is deliberately absent: the\ncharacter card reads ``user.character`` from ``/auth/me``, which ~20 call\nsites already refetch, and fattening that payload would make every one of\nthem heavier (#1349). This carries only what the panels need.\n\nRequests are a NUMBER, not a list (#1456). The rail listed them until\n#1423; under ADR-0070 the Requests queue on ``/updates`` is the only\nsurface a request can be answered on, so all that is left here is the\nbadge on the collapsed handle, the mobile bell and the mobile FieldDesk —\nthree consumers of one integer. Shipping up to a hundred hydrated feed\nitems on a page-load path to produce it was the whole of the cost.\n\nThe count is the same one ``counts.requests`` reports, so the badge and\nthe queue's card list cannot disagree — see\n:func:`services.activity_feed.get_sidebar_feed`.",
         "properties": {
@@ -5139,6 +5331,20 @@
         "title": "SidebarOut",
         "type": "object"
       },
+      "StatsBackfillOut": {
+        "description": "Readout for ``POST /admin/characters/backfill-stats``.\n\n``recalculated`` counts *active* characters — banned ones are skipped — so\nit will not match a headcount of the accounts table.",
+        "properties": {
+          "recalculated": {
+            "title": "Recalculated",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "recalculated"
+        ],
+        "title": "StatsBackfillOut",
+        "type": "object"
+      },
       "SuspendAction": {
         "properties": {
           "suspended": {
@@ -5150,6 +5356,25 @@
           "suspended"
         ],
         "title": "SuspendAction",
+        "type": "object"
+      },
+      "SuspendActionOut": {
+        "description": "Result of ``POST /admin/accounts/{id}/suspend``.\n\n``status`` is the account's resulting ``AccountStatus`` value, read back from\nthe row rather than echoed from the request — suspension is idempotent, so\nthe stored value is the one worth reporting.",
+        "properties": {
+          "account_id": {
+            "title": "Account Id",
+            "type": "integer"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "account_id",
+          "status"
+        ],
+        "title": "SuspendActionOut",
         "type": "object"
       },
       "TaskCreate": {
@@ -5523,6 +5748,33 @@
         "title": "ViewerStatsOut",
         "type": "object"
       },
+      "VoteBudgetBackfillOut": {
+        "description": "Readout for ``POST /admin/characters/backfill-vote-budget``.\n\n``changes`` is the whole point of the endpoint's ``dry_run`` mode: an admin\n``votes_available`` grant writes the same counter a recompute rebuilds, and\nnothing records that a row was hand-set, so an operator reads these\nbefore/after pairs to spot a grant this pass would revert.",
+        "properties": {
+          "changed": {
+            "title": "Changed",
+            "type": "integer"
+          },
+          "changes": {
+            "items": {
+              "$ref": "#/components/schemas/VoteSpendRepairOut"
+            },
+            "title": "Changes",
+            "type": "array"
+          },
+          "dry_run": {
+            "title": "Dry Run",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "dry_run",
+          "changed",
+          "changes"
+        ],
+        "title": "VoteBudgetBackfillOut",
+        "type": "object"
+      },
       "VoteCastOut": {
         "description": "The complete post-cast truth: everything the client used to reconstruct.\n\nExtends ``VoteOut`` rather than nesting it — the vote's own fields stay at\nthe top level so existing readers keep working — and adds the three facts\nthat a bare ``VoteOut`` forced the client to fake or refetch:\n\n* ``tally`` — retired the client-side overlay's delta arithmetic (#626,\n  stale-bugged twice as #1142 and #1239).\n* ``viewer_vote`` — the star that now stands for the viewer's carried\n  character. Same name and meaning as ``PraxisCardOut.viewer_vote``.\n* ``viewer_stats`` — retired the ``/auth/me`` reload fired per star.",
         "properties": {
@@ -5699,6 +5951,30 @@
         "title": "VoteOnMinePayload",
         "type": "object"
       },
+      "VoteSpendRepairOut": {
+        "description": "One character's ``votes_spent_this_era`` before and after a recompute.\n\nThe wire mirror of ``services.character_stats.VoteSpendRepair``. It is a\nseparate declaration rather than the dataclass itself because the response\nshape is a published contract and the dataclass is an internal return type;\ntying them together would make an internal rename a wire break.",
+        "properties": {
+          "after": {
+            "title": "After",
+            "type": "integer"
+          },
+          "before": {
+            "title": "Before",
+            "type": "integer"
+          },
+          "character_id": {
+            "title": "Character Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "character_id",
+          "before",
+          "after"
+        ],
+        "title": "VoteSpendRepairOut",
+        "type": "object"
+      },
       "VoteTallyOut": {
         "description": "A praxis's vote aggregate, in the field names every praxis payload uses.\n\nDeliberately the same two names as ``PraxisOut`` / ``PraxisCardOut`` carry\n(``points_from_votes``, ``voter_count``) rather than a third vocabulary for\nthe same numbers. The retired ``VoteSummary`` used ``total_score`` /\n``total_votes``, which is why the client needed a *separate* merge function\nfor it — one shape, one merge (#1382).",
         "properties": {
@@ -5749,6 +6025,25 @@
           "value"
         ],
         "title": "VoterDetail",
+        "type": "object"
+      },
+      "VotesReceivedOut": {
+        "description": "Votes received on the praxes a character **authored**.\n\nAuthor-scoped, not membership-scoped (ADR-0053) — see the route docstring in\n``routers/characters.py`` for why the two must not be conflated. It echoes\n``character_id`` so a caller batching several of these can tell the answers\napart.",
+        "properties": {
+          "character_id": {
+            "title": "Character Id",
+            "type": "integer"
+          },
+          "votes_received": {
+            "title": "Votes Received",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "character_id",
+          "votes_received"
+        ],
+        "title": "VotesReceivedOut",
         "type": "object"
       },
       "routers__admin__ContactMessageOut": {
@@ -6394,9 +6689,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Admin Manage Role Admin Accounts  Account Id  Role Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/RoleActionOut"
                 }
               }
             },
@@ -6469,9 +6762,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Admin Suspend Account Admin Accounts  Account Id  Suspend Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/SuspendActionOut"
                 }
               }
             },
@@ -6623,9 +6914,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Admin Create Character Endpoint Admin Characters Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/AdminCharacterOut"
                 }
               }
             },
@@ -6680,9 +6969,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Backfill All Character Stats Admin Characters Backfill Stats Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/StatsBackfillOut"
                 }
               }
             },
@@ -6747,9 +7034,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Backfill Vote Budget Admin Characters Backfill Vote Budget Post",
-                  "type": "object"
+                  "$ref": "#/components/schemas/VoteBudgetBackfillOut"
                 }
               }
             },
@@ -6821,7 +7106,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/BanActionOut"
+                }
               }
             },
             "description": "Successful Response"
@@ -7123,9 +7410,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response Admin Era Reset Admin Era Reset Put",
-                  "type": "object"
+                  "$ref": "#/components/schemas/EraResetOut"
                 }
               }
             },
@@ -8119,7 +8404,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/DevLoginOut"
+                }
               }
             },
             "description": "Successful Response"
@@ -8146,12 +8433,7 @@
         "description": "Redirect the browser to Google's OAuth consent screen.",
         "operationId": "auth_google_auth_google_get",
         "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
+          "302": {
             "description": "Successful Response"
           }
         },
@@ -8163,15 +8445,10 @@
     },
     "/auth/google/callback": {
       "get": {
-        "description": "Exchange the OAuth code for a token, create/get the Account, set JWT cookie.",
+        "description": "Exchange the OAuth code for a token, create/get the Account, set JWT cookie.\n\nRedirects to ``settings.FRONTEND_URL`` carrying the session cookie.",
         "operationId": "auth_google_callback_auth_google_callback_get",
         "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
+          "302": {
             "description": "Successful Response"
           }
         },
@@ -8189,7 +8466,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/LogoutOut"
+                }
               }
             },
             "description": "Successful Response"
@@ -8803,11 +9082,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": {
-                    "type": "integer"
-                  },
-                  "title": "Response Get Votes Received Count Characters  Character Id  Stats Votes Received Get",
-                  "type": "object"
+                  "$ref": "#/components/schemas/VotesReceivedOut"
                 }
               }
             },
@@ -9546,7 +9821,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/HealthOut"
+                }
               }
             },
             "description": "Successful Response"
@@ -10656,6 +10933,7 @@
     },
     "/praxes/{praxis_id}/invite": {
       "post": {
+        "description": "Invite a character onto this praxis; answer the invite row.\n\nThe ``response_model=None`` this replaced (#1400) was a suppression, not a\ndescription: ``_build_invite_out`` has always returned a ``PraxisInviteOut``,\nso the only thing the annotation achieved was keeping the shape out of the\nschema. Not to be confused with the *respond* route below, which answers an\nack rather than an invite.",
         "operationId": "invite_member_route_praxes__praxis_id__invite_post",
         "parameters": [
           {
@@ -10698,7 +10976,9 @@
           "200": {
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "$ref": "#/components/schemas/PraxisInviteOut"
+                }
               }
             },
             "description": "Successful Response"

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -21,21 +21,30 @@ from schemas.admin import (
     AccountDetail,
     AccountSummary,
     AdminCharacterCreate,
+    AdminCharacterOut,
     AdminTaskPatch,
+    BanAction,
+    BanActionOut,
     CharacterStatsPatch,
     AdminFactionOut,
     CharacterStatsOut,
     CharacterSummary,
     CliTokenResponse,
+    EraResetOut,
     FactionCreate,
     FlaggedCommentOut,
     FlaggedPraxisOut,
     ModerationAction,
     OverviewStats,
     RoleAction,
+    RoleActionOut,
+    StatsBackfillOut,
     SuspendAction,
+    SuspendActionOut,
     TaskImportResult,
     TaskStatusAction,
+    VoteBudgetBackfillOut,
+    VoteSpendRepairOut,
 )
 from schemas.task import TaskCreate, TaskOut
 from schemas.praxis import PraxisOut
@@ -80,10 +89,6 @@ from services.scoring import compute_votes_available
 from services.auth import create_jwt
 
 router = APIRouter()
-
-
-class BanAction(BaseModel):
-    banned: bool
 
 
 class ContactMessageOut(BaseModel):
@@ -177,22 +182,22 @@ async def admin_create_faction(
     )
 
 
-@router.post("/characters", status_code=201)
+@router.post("/characters", response_model=AdminCharacterOut, status_code=201)
 async def admin_create_character_endpoint(
     data: AdminCharacterCreate,
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> AdminCharacterOut:
     character = await admin_create_character(data, session)
-    return {
-        "id": character.id,
-        "account_id": character.account_id,
-        "username": character.username,
-        "display_name": character.display_name,
-        "faction_slug": character.faction_slug,
-        "status": character.status.value,
-        "created_at": character.created_at,
-    }
+    return AdminCharacterOut(
+        id=character.id,
+        account_id=character.account_id,
+        username=character.username,
+        display_name=character.display_name,
+        faction_slug=character.faction_slug,
+        status=character.status.value,
+        created_at=character.created_at,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -219,12 +224,16 @@ async def admin_patch_character_stats(
     )
 
 
-@router.post("/characters/backfill-vote-budget", status_code=200)
+@router.post(
+    "/characters/backfill-vote-budget",
+    response_model=VoteBudgetBackfillOut,
+    status_code=200,
+)
 async def backfill_vote_budget(
     dry_run: bool = False,
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> VoteBudgetBackfillOut:
     """Rebuild ``votes_spent_this_era`` for the live era from the vote table (#1531).
 
     The repair half of the 2026-08-02 vote dedupe: migration
@@ -247,18 +256,22 @@ async def backfill_vote_budget(
     interleaving them risks one pass overwriting the other.
     """
     repairs = await recompute_votes_spent_this_era(session, dry_run=dry_run)
-    return {
-        "dry_run": dry_run,
-        "changed": len(repairs),
-        "changes": [dataclasses.asdict(repair) for repair in repairs],
-    }
+    return VoteBudgetBackfillOut(
+        dry_run=dry_run,
+        changed=len(repairs),
+        changes=[
+            VoteSpendRepairOut(**dataclasses.asdict(repair)) for repair in repairs
+        ],
+    )
 
 
-@router.post("/characters/backfill-stats", status_code=200)
+@router.post(
+    "/characters/backfill-stats", response_model=StatsBackfillOut, status_code=200
+)
 async def backfill_all_character_stats(
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> StatsBackfillOut:
     """Recompute CharacterStats for every character using current vote data.
 
     **Consumer-less on purpose — do not delete it (owner ruling, 2026-07-31).**
@@ -296,21 +309,21 @@ async def backfill_all_character_stats(
             character.id, session, era_row=era_row, emit_taunts=False
         )
     await session.flush()
-    return {"recalculated": len(characters)}
+    return StatsBackfillOut(recalculated=len(characters))
 
 
-@router.put("/era/reset", status_code=200)
+@router.put("/era/reset", response_model=EraResetOut, status_code=200)
 async def admin_era_reset(
     admin: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> EraResetOut:
     """Trigger an era reset: new Era row + reset stats per EraConfig flags."""
     new_era_row = Era(name=CURRENT_ERA.name, config_key=CURRENT_ERA.config_key, started_by=admin.id)
     session.add(new_era_row)
     await session.flush()
     characters = await list_active_characters(session)
     await apply_era_reset(characters, new_era_row, session)
-    return {"era_id": new_era_row.id, "characters_reset": len(characters)}
+    return EraResetOut(era_id=new_era_row.id, characters_reset=len(characters))
 
 
 @router.post("/tasks/{task_id}/reactivate", response_model=TaskOut)
@@ -328,13 +341,13 @@ async def admin_reactivate_task(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/accounts/{account_id}/role", status_code=200)
+@router.post("/accounts/{account_id}/role", response_model=RoleActionOut, status_code=200)
 async def admin_manage_role(
     account_id: int,
     data: RoleAction,
     admin: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> RoleActionOut:
     await assign_or_revoke_role(
         account_id=account_id,
         role_name=data.role,
@@ -342,18 +355,20 @@ async def admin_manage_role(
         admin_account_id=admin.id,
         session=session,
     )
-    return {"account_id": account_id, "role": data.role, "action": data.action}
+    return RoleActionOut(account_id=account_id, role=data.role, action=data.action)
 
 
-@router.post("/accounts/{account_id}/suspend", status_code=200)
+@router.post(
+    "/accounts/{account_id}/suspend", response_model=SuspendActionOut, status_code=200
+)
 async def admin_suspend_account(
     account_id: int,
     data: SuspendAction,
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
-) -> dict:
+) -> SuspendActionOut:
     account = await suspend_account(account_id, data.suspended, session)
-    return {"account_id": account.id, "status": account.status.value}
+    return SuspendActionOut(account_id=account.id, status=account.status.value)
 
 
 # ---------------------------------------------------------------------------
@@ -538,19 +553,21 @@ async def retire_task(
     return await build_task_out(task, session)
 
 
-@router.post("/characters/{character_id}/ban", status_code=200)
+@router.post(
+    "/characters/{character_id}/ban", response_model=BanActionOut, status_code=200
+)
 async def ban_character(
     character_id: int,
     data: BanAction,
     _: Account = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
-):
+) -> BanActionOut:
     character = await session.get(Character, character_id)
     if character is None:
         raise HTTPException(status_code=404, detail="Character not found.")
     character.status = CharacterStatus.banned if data.banned else CharacterStatus.active
     await session.flush()
-    return {"character_id": character_id, "banned": data.banned}
+    return BanActionOut(character_id=character_id, banned=data.banned)
 
 
 @router.post("/tasks", response_model=TaskOut, status_code=201)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -3,13 +3,14 @@ from typing import Optional
 from authlib.integrations.starlette_client import OAuth
 from fastapi import APIRouter, Depends, HTTPException, Response
 from fastapi import Request
+from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from db import get_db
 from game_config import CURRENT_ERA
 from models.account import Account
-from schemas.auth import CurrentUser
+from schemas.auth import CurrentUser, DevLoginOut, LogoutOut
 from schemas.character import CharacterCreate
 from services.auth import create_jwt, create_or_get_account, get_current_account
 from services.character import create_character, resolve_active_character
@@ -32,18 +33,32 @@ _OAUTH.register(
 _COOKIE_MAX_AGE = 7 * 24 * 60 * 60  # 7 days in seconds
 
 
-@router.get("/google")
+# The two OAuth legs answer with a redirect, not JSON, so they carry
+# `response_class=RedirectResponse` and a 302 instead of a `response_model`
+# (#1400). A model here would be a lie the generated client believes: without
+# it FastAPI documents a 200 with an empty JSON schema, which is exactly the
+# untyped success shape the contract gate exists to remove. Declaring the
+# redirect is the honest version — there is no body to type.
+#
+# The decorator's `status_code` does not touch runtime behaviour: both handlers
+# return a Response object, which FastAPI passes through untouched.
+
+
+@router.get("/google", response_class=RedirectResponse, status_code=302)
 async def auth_google(request: Request):
     """Redirect the browser to Google's OAuth consent screen."""
     return await _OAUTH.google.authorize_redirect(request, settings.GOOGLE_REDIRECT_URI)
 
 
-@router.get("/google/callback")
+@router.get("/google/callback", response_class=RedirectResponse, status_code=302)
 async def auth_google_callback(
     request: Request,
     session: AsyncSession = Depends(get_db),
 ):
-    """Exchange the OAuth code for a token, create/get the Account, set JWT cookie."""
+    """Exchange the OAuth code for a token, create/get the Account, set JWT cookie.
+
+    Redirects to ``settings.FRONTEND_URL`` carrying the session cookie.
+    """
     token = await _OAUTH.google.authorize_access_token(request)
     user_info = token.get("userinfo") or await _OAUTH.google.userinfo(token=token)
 
@@ -85,8 +100,8 @@ async def auth_me(
     return await build_current_user(account, session)
 
 
-@router.post("/logout")
-async def auth_logout(response: Response):
+@router.post("/logout", response_model=LogoutOut)
+async def auth_logout(response: Response) -> LogoutOut:
     """Clear the JWT cookie."""
     response.delete_cookie(
         "access_token",
@@ -95,10 +110,10 @@ async def auth_logout(response: Response):
         secure=settings.ENVIRONMENT == "production",
         domain=settings.COOKIE_DOMAIN,
     )
-    return {"message": "Logged out"}
+    return LogoutOut(message="Logged out")
 
 
-@router.post("/dev-login")
+@router.post("/dev-login", response_model=DevLoginOut)
 async def dev_login(
     response: Response,
     session: AsyncSession = Depends(get_db),
@@ -175,10 +190,10 @@ async def dev_login(
         secure=False,
         max_age=_COOKIE_MAX_AGE,
     )
-    return {
-        "message": "Dev login successful",
-        "account_id": account.id,
-        "character_id": character.id if character else None,
-        "character_name": character.display_name if character else None,
-        "faction_slug": character.faction_slug if character else None,
-    }
+    return DevLoginOut(
+        message="Dev login successful",
+        account_id=account.id,
+        character_id=character.id if character else None,
+        character_name=character.display_name if character else None,
+        faction_slug=character.faction_slug if character else None,
+    )

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -14,7 +14,12 @@ from models.account import Account
 from models.character import Character, CharacterStatus
 from models.praxis import Praxis, PraxisStatus
 from models.vote import Vote
-from schemas.character import CharacterCreate, CharacterOut, CharacterUpdate
+from schemas.character import (
+    CharacterCreate,
+    CharacterOut,
+    CharacterUpdate,
+    VotesReceivedOut,
+)
 from schemas.praxis import PraxisOut
 from services.auth import get_current_account
 from services.badge import list_badges_for_character
@@ -212,11 +217,11 @@ async def upload_avatar(
     return build_character_out(character, stats)
 
 
-@router.get("/{character_id}/stats/votes-received")
+@router.get("/{character_id}/stats/votes-received", response_model=VotesReceivedOut)
 async def get_votes_received_count(
     character_id: int,
     session: AsyncSession = Depends(get_db),
-) -> dict[str, int]:
+) -> VotesReceivedOut:
     """Votes received on the praxes this character **authored**.
 
     Deliberately still ``created_by_id`` after #1112 moved the praxis *record*
@@ -235,4 +240,4 @@ async def get_votes_received_count(
         .where(Praxis.created_by_id == character_id)
     )
     count = result.scalar_one()
-    return {"character_id": character_id, "votes_received": count}
+    return VotesReceivedOut(character_id=character_id, votes_received=count)

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -36,6 +36,7 @@ from schemas.praxis import (
     PraxisCardOut,
     PraxisCreate,
     PraxisInviteCreate,
+    PraxisInviteOut,
     PraxisOut,
     PraxisTypeChange,
     PraxisUpdate,
@@ -434,13 +435,21 @@ async def delete_media_route(
 # ---------------------------------------------------------------------------
 
 
-@router.post("/{praxis_id}/invite", response_model=None)
+@router.post("/{praxis_id}/invite", response_model=PraxisInviteOut)
 async def invite_member_route(
     praxis_id: int,
     data: PraxisInviteCreate,
     character: Character = Depends(get_current_character),
     session: AsyncSession = Depends(get_db),
-):
+) -> PraxisInviteOut:
+    """Invite a character onto this praxis; answer the invite row.
+
+    The ``response_model=None`` this replaced (#1400) was a suppression, not a
+    description: ``_build_invite_out`` has always returned a ``PraxisInviteOut``,
+    so the only thing the annotation achieved was keeping the shape out of the
+    schema. Not to be confused with the *respond* route below, which answers an
+    ack rather than an invite.
+    """
     invite = await invite_to_praxis(
         praxis_id=praxis_id,
         invitee_id=data.invitee_id,

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -129,9 +129,79 @@ class AdminCharacterCreate(BaseModel):
     faction_slug: str | None = Field(default=None)
 
 
+class AdminCharacterOut(BaseModel):
+    """The character an admin just minted (``POST /admin/characters``).
+
+    Carries ``account_id`` on purpose. The "never expose account_id" rule
+    (SPEC-backend-architecture.md §4) governs the *public* API; the admin router
+    is the operator surface and already answers with raw account identity and
+    e-mail (``AccountSummary``). An admin who creates a character for an account
+    needs to see which account it landed on.
+
+    Deliberately not ``CharacterOut``: that shape is the player-facing profile
+    (score, level, badges, faction display), none of which exists yet at
+    creation time. This is the insert receipt.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    account_id: int
+    username: str
+    display_name: str
+    faction_slug: str
+    status: str
+    created_at: datetime
+
+
 # ---------------------------------------------------------------------------
 # Adjust Game State
 # ---------------------------------------------------------------------------
+
+
+class VoteSpendRepairOut(BaseModel):
+    """One character's ``votes_spent_this_era`` before and after a recompute.
+
+    The wire mirror of ``services.character_stats.VoteSpendRepair``. It is a
+    separate declaration rather than the dataclass itself because the response
+    shape is a published contract and the dataclass is an internal return type;
+    tying them together would make an internal rename a wire break.
+    """
+
+    character_id: int
+    before: int
+    after: int
+
+
+class VoteBudgetBackfillOut(BaseModel):
+    """Readout for ``POST /admin/characters/backfill-vote-budget``.
+
+    ``changes`` is the whole point of the endpoint's ``dry_run`` mode: an admin
+    ``votes_available`` grant writes the same counter a recompute rebuilds, and
+    nothing records that a row was hand-set, so an operator reads these
+    before/after pairs to spot a grant this pass would revert.
+    """
+
+    dry_run: bool
+    changed: int
+    changes: list[VoteSpendRepairOut]
+
+
+class StatsBackfillOut(BaseModel):
+    """Readout for ``POST /admin/characters/backfill-stats``.
+
+    ``recalculated`` counts *active* characters — banned ones are skipped — so
+    it will not match a headcount of the accounts table.
+    """
+
+    recalculated: int
+
+
+class EraResetOut(BaseModel):
+    """Readout for ``PUT /admin/era/reset``: the new era row and who it touched."""
+
+    era_id: int
+    characters_reset: int
 
 
 class CharacterStatsPatch(BaseModel):
@@ -198,6 +268,46 @@ class RoleAction(BaseModel):
 
 class SuspendAction(BaseModel):
     suspended: bool
+
+
+class BanAction(BaseModel):
+    banned: bool
+
+
+class RoleActionOut(BaseModel):
+    """Echo of an applied ``POST /admin/accounts/{id}/role``.
+
+    An echo rather than the account's full role set: the service applies one
+    grant/revoke and does not read the rest back, and inventing a fuller shape
+    here would mean a second query whose only consumer is the confirmation.
+    """
+
+    account_id: int
+    role: str
+    action: Literal["grant", "revoke"]
+
+
+class SuspendActionOut(BaseModel):
+    """Result of ``POST /admin/accounts/{id}/suspend``.
+
+    ``status`` is the account's resulting ``AccountStatus`` value, read back from
+    the row rather than echoed from the request — suspension is idempotent, so
+    the stored value is the one worth reporting.
+    """
+
+    account_id: int
+    status: str
+
+
+class BanActionOut(BaseModel):
+    """Result of ``POST /admin/characters/{id}/ban``.
+
+    Character-scoped: a ban lands on one character, not the account behind it
+    (ADR-0041). Suspending the account is the other endpoint.
+    """
+
+    character_id: int
+    banned: bool
 
 
 # ---------------------------------------------------------------------------

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -36,3 +36,33 @@ class CurrentUser(BaseModel):
     # is_admin — the jump is a faction perk, not a level gate.
     level_jump_reach: int = 0
     level_jump_available: bool = False
+
+
+class LogoutOut(BaseModel):
+    """Acknowledgement for ``POST /auth/logout``.
+
+    The work of logging out is the ``Set-Cookie`` header that clears the JWT,
+    not the body; this exists so the body is a declared shape in the schema
+    rather than an untyped object the generated client cannot check.
+    """
+
+    message: str
+
+
+class DevLoginOut(BaseModel):
+    """Result of the dev-only bot login (``POST /auth/dev-login``).
+
+    Exposes ``account_id``, which the public API never does — and this is not a
+    second exception beside ``/auth/me``. The endpoint 404s outside development
+    (``settings.ENVIRONMENT``), and the ids exist so e2e fixtures can invite and
+    credit by id without a second round trip. If this route ever becomes
+    reachable in production the leak is the route, not the field.
+    """
+
+    message: str
+    account_id: int
+    # None whenever the dev account carries no character yet — passing `name=`
+    # on the first call is what creates one.
+    character_id: Optional[int] = None
+    character_name: Optional[str] = None
+    faction_slug: Optional[str] = None

--- a/backend/schemas/character.py
+++ b/backend/schemas/character.py
@@ -67,6 +67,19 @@ class ActiveCharacterIn(BaseModel):
     character_id: int
 
 
+class VotesReceivedOut(BaseModel):
+    """Votes received on the praxes a character **authored**.
+
+    Author-scoped, not membership-scoped (ADR-0053) — see the route docstring in
+    ``routers/characters.py`` for why the two must not be conflated. It echoes
+    ``character_id`` so a caller batching several of these can tell the answers
+    apart.
+    """
+
+    character_id: int
+    votes_received: int
+
+
 class CharacterUpdate(BaseModel):
     display_name: str | None = Field(None, max_length=50)
     bio: str | None = Field(None, max_length=500)

--- a/backend/schemas/system.py
+++ b/backend/schemas/system.py
@@ -1,0 +1,17 @@
+"""Response shapes for the app-level routes that belong to no router."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class HealthOut(BaseModel):
+    """``GET /health`` — the liveness probe the host polls.
+
+    ``status`` is a ``Literal`` rather than a bare ``str`` because the endpoint
+    has exactly one success answer: it either returns ``"ok"`` or it does not
+    return. Typing it as an open string would put a value in the generated
+    client that nothing can ever produce, and invite a caller to branch on it.
+    """
+
+    status: Literal["ok"]

--- a/backend/tests/test_openapi_response_shapes.py
+++ b/backend/tests/test_openapi_response_shapes.py
@@ -1,0 +1,99 @@
+"""Every success body in the contract is a named shape, or there is no body (#1400).
+
+A committed schema and a CI drift gate (``test_openapi_dump.py``) make the
+frontend's types *track* the backend. They do not make those types **say**
+anything. A route that returns a hand-built ``dict`` regenerates perfectly
+cleanly and lands in ``schema.d.ts`` as ``unknown`` — the gate is green, the
+codegen is honest, and the caller is back to guessing. Twelve routes were in
+exactly that state before this test existed.
+
+So this is the other half of the gate, and it is a ratchet rather than a
+one-time sweep: it fails the moment a *new* route reaches the wire with an
+undescribed success body.
+
+WHAT COUNTS AS DESCRIBED
+------------------------
+A 2xx response passes if it is one of:
+
+- **No content at all.** The seven ``204`` deletes and the two OAuth ``302``
+  redirects. Forcing a ``response_model`` onto a no-body status would document
+  a body that is never sent, which is worse than silence, not better. This is
+  why the rule is written against *content* rather than against
+  ``response_model``.
+- **A ``$ref``**, or an array of ``$ref``s — a named Pydantic model.
+- **An array of a declared primitive**, e.g. ``list[str]``. ``string[]`` is
+  fully checkable by the generated client; a wrapper model would add a name
+  and no information.
+
+Everything else fails, and the two shapes that actually occur are worth naming:
+``{}`` (an unannotated handler → ``unknown``) and an object carrying only
+``additionalProperties`` (``dict`` / ``dict[str, int]`` → an index signature).
+Both type a *bag*, not a response.
+
+It reads the committed ``openapi.json`` rather than importing the app, so it
+needs no environment; ``test_openapi_dump.py`` is what proves that file is the
+one the app serves.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+COMMITTED_SCHEMA = BACKEND_ROOT / "openapi.json"
+
+# Response media type the rule applies to. A future binary/stream route would
+# carry its own media type and is deliberately not this test's business.
+JSON_MEDIA_TYPE = "application/json"
+
+PRIMITIVE_TYPES = frozenset({"boolean", "integer", "number", "string"})
+
+
+def _describes_a_shape(schema: dict[str, Any]) -> bool:
+    """True when this success schema tells a client what it is getting."""
+    if "$ref" in schema:
+        return True
+    if schema.get("type") == "array":
+        items = schema.get("items")
+        if not isinstance(items, dict):
+            return False
+        return "$ref" in items or items.get("type") in PRIMITIVE_TYPES
+    return schema.get("type") in PRIMITIVE_TYPES
+
+
+def _undescribed_success_bodies() -> list[str]:
+    """Return one ``METHOD /path -> status`` line per offending response."""
+    document = json.loads(COMMITTED_SCHEMA.read_text(encoding="utf-8"))
+    offenders: list[str] = []
+
+    for path, operations in document["paths"].items():
+        for method, operation in operations.items():
+            for status, response in operation.get("responses", {}).items():
+                if not status.startswith("2"):
+                    continue
+                content = response.get("content")
+                if not content:
+                    continue  # 204 / 302 — no body by definition.
+                body = content.get(JSON_MEDIA_TYPE)
+                if body is None:
+                    continue
+                if not _describes_a_shape(body.get("schema", {})):
+                    offenders.append(f"{method.upper()} {path} -> {status}")
+
+    return sorted(offenders)
+
+
+def test_every_success_body_is_a_named_shape() -> None:
+    offenders = _undescribed_success_bodies()
+
+    assert not offenders, (
+        "These routes answer with an undescribed success body, so the generated "
+        "frontend client sees `unknown` or an index signature and the compiler "
+        "cannot check a single field of them (#1400):\n  "
+        + "\n  ".join(offenders)
+        + "\n\nGive each one a Pydantic model in backend/schemas/ and declare it "
+        "as `response_model=`, then run `python scripts/regen_api_client.py`. "
+        "If the route genuinely has no body, give it a no-content status "
+        "(204) or an explicit `response_class` — do NOT invent a model for it, "
+        "and do not relax this test."
+    )

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -720,6 +720,8 @@ export interface paths {
         /**
          * Auth Google Callback
          * @description Exchange the OAuth code for a token, create/get the Account, set JWT cookie.
+         *
+         *     Redirects to ``settings.FRONTEND_URL`` carrying the session cookie.
          */
         get: operations["auth_google_callback_auth_google_callback_get"];
         put?: never;
@@ -1383,7 +1385,16 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Invite Member Route */
+        /**
+         * Invite Member Route
+         * @description Invite a character onto this praxis; answer the invite row.
+         *
+         *     The ``response_model=None`` this replaced (#1400) was a suppression, not a
+         *     description: ``_build_invite_out`` has always returned a ``PraxisInviteOut``,
+         *     so the only thing the annotation achieved was keeping the shape out of the
+         *     schema. Not to be confused with the *respond* route below, which answers an
+         *     ack rather than an invite.
+         */
         post: operations["invite_member_route_praxes__praxis_id__invite_post"];
         delete?: never;
         options?: never;
@@ -1957,6 +1968,39 @@ export interface components {
             /** Username */
             username: string;
         };
+        /**
+         * AdminCharacterOut
+         * @description The character an admin just minted (``POST /admin/characters``).
+         *
+         *     Carries ``account_id`` on purpose. The "never expose account_id" rule
+         *     (SPEC-backend-architecture.md §4) governs the *public* API; the admin router
+         *     is the operator surface and already answers with raw account identity and
+         *     e-mail (``AccountSummary``). An admin who creates a character for an account
+         *     needs to see which account it landed on.
+         *
+         *     Deliberately not ``CharacterOut``: that shape is the player-facing profile
+         *     (score, level, badges, faction display), none of which exists yet at
+         *     creation time. This is the insert receipt.
+         */
+        AdminCharacterOut: {
+            /** Account Id */
+            account_id: number;
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /** Display Name */
+            display_name: string;
+            /** Faction Slug */
+            faction_slug: string;
+            /** Id */
+            id: number;
+            /** Status */
+            status: string;
+            /** Username */
+            username: string;
+        };
         /** AdminFactionOut */
         AdminFactionOut: {
             /**
@@ -2051,6 +2095,19 @@ export interface components {
         BanAction: {
             /** Banned */
             banned: boolean;
+        };
+        /**
+         * BanActionOut
+         * @description Result of ``POST /admin/characters/{id}/ban``.
+         *
+         *     Character-scoped: a ban lands on one character, not the account behind it
+         *     (ADR-0041). Suspending the account is the other endpoint.
+         */
+        BanActionOut: {
+            /** Banned */
+            banned: boolean;
+            /** Character Id */
+            character_id: number;
         };
         /** Body_admin_import_tasks_csv_admin_tasks_import_csv_post */
         Body_admin_import_tasks_csv_admin_tasks_import_csv_post: {
@@ -2593,6 +2650,28 @@ export interface components {
             second_character_level_required: number;
         };
         /**
+         * DevLoginOut
+         * @description Result of the dev-only bot login (``POST /auth/dev-login``).
+         *
+         *     Exposes ``account_id``, which the public API never does — and this is not a
+         *     second exception beside ``/auth/me``. The endpoint 404s outside development
+         *     (``settings.ENVIRONMENT``), and the ids exist so e2e fixtures can invite and
+         *     credit by id without a second round trip. If this route ever becomes
+         *     reachable in production the leak is the route, not the field.
+         */
+        DevLoginOut: {
+            /** Account Id */
+            account_id: number;
+            /** Character Id */
+            character_id?: number | null;
+            /** Character Name */
+            character_name?: string | null;
+            /** Faction Slug */
+            faction_slug?: string | null;
+            /** Message */
+            message: string;
+        };
+        /**
          * DuelChallengeIn
          * @description Body for POST /duels/challenge — attach a duel to an existing praxis.
          */
@@ -2786,6 +2865,16 @@ export interface components {
             era_name: string;
             /** Era Notes */
             era_notes: string;
+        };
+        /**
+         * EraResetOut
+         * @description Readout for ``PUT /admin/era/reset``: the new era row and who it touched.
+         */
+        EraResetOut: {
+            /** Characters Reset */
+            characters_reset: number;
+            /** Era Id */
+            era_id: number;
         };
         /** FactionChoiceRequest */
         FactionChoiceRequest: {
@@ -3440,6 +3529,22 @@ export interface components {
             /** Detail */
             detail?: components["schemas"]["ValidationError"][];
         };
+        /**
+         * HealthOut
+         * @description ``GET /health`` — the liveness probe the host polls.
+         *
+         *     ``status`` is a ``Literal`` rather than a bare ``str`` because the endpoint
+         *     has exactly one success answer: it either returns ``"ok"`` or it does not
+         *     return. Typing it as an open string would put a value in the generated
+         *     client that nothing can ever produce, and invite a caller to branch on it.
+         */
+        HealthOut: {
+            /**
+             * Status
+             * @constant
+             */
+            status: "ok";
+        };
         /** InvitationLetterItem */
         InvitationLetterItem: {
             /** Actor Avatar Url */
@@ -3537,6 +3642,18 @@ export interface components {
             key: string;
             /** Kind */
             kind: string;
+        };
+        /**
+         * LogoutOut
+         * @description Acknowledgement for ``POST /auth/logout``.
+         *
+         *     The work of logging out is the ``Set-Cookie`` header that clears the JWT,
+         *     not the body; this exists so the body is a declared shape in the schema
+         *     rather than an untyped object the generated client cannot check.
+         */
+        LogoutOut: {
+            /** Message */
+            message: string;
         };
         /** MediaItemOut */
         MediaItemOut: {
@@ -4163,6 +4280,25 @@ export interface components {
             role: string;
         };
         /**
+         * RoleActionOut
+         * @description Echo of an applied ``POST /admin/accounts/{id}/role``.
+         *
+         *     An echo rather than the account's full role set: the service applies one
+         *     grant/revoke and does not read the rest back, and inventing a fuller shape
+         *     here would mean a second query whose only consumer is the confirmation.
+         */
+        RoleActionOut: {
+            /** Account Id */
+            account_id: number;
+            /**
+             * Action
+             * @enum {string}
+             */
+            action: "grant" | "revoke";
+            /** Role */
+            role: string;
+        };
+        /**
          * SidebarOut
          * @description Everything the rail's three data panels draw, in one response.
          *
@@ -4190,10 +4326,35 @@ export interface components {
             /** Pending Requests Count */
             pending_requests_count: number;
         };
+        /**
+         * StatsBackfillOut
+         * @description Readout for ``POST /admin/characters/backfill-stats``.
+         *
+         *     ``recalculated`` counts *active* characters — banned ones are skipped — so
+         *     it will not match a headcount of the accounts table.
+         */
+        StatsBackfillOut: {
+            /** Recalculated */
+            recalculated: number;
+        };
         /** SuspendAction */
         SuspendAction: {
             /** Suspended */
             suspended: boolean;
+        };
+        /**
+         * SuspendActionOut
+         * @description Result of ``POST /admin/accounts/{id}/suspend``.
+         *
+         *     ``status`` is the account's resulting ``AccountStatus`` value, read back from
+         *     the row rather than echoed from the request — suspension is idempotent, so
+         *     the stored value is the one worth reporting.
+         */
+        SuspendActionOut: {
+            /** Account Id */
+            account_id: number;
+            /** Status */
+            status: string;
         };
         /** TaskCreate */
         TaskCreate: {
@@ -4392,6 +4553,23 @@ export interface components {
             votes_available: number;
         };
         /**
+         * VoteBudgetBackfillOut
+         * @description Readout for ``POST /admin/characters/backfill-vote-budget``.
+         *
+         *     ``changes`` is the whole point of the endpoint's ``dry_run`` mode: an admin
+         *     ``votes_available`` grant writes the same counter a recompute rebuilds, and
+         *     nothing records that a row was hand-set, so an operator reads these
+         *     before/after pairs to spot a grant this pass would revert.
+         */
+        VoteBudgetBackfillOut: {
+            /** Changed */
+            changed: number;
+            /** Changes */
+            changes: components["schemas"]["VoteSpendRepairOut"][];
+            /** Dry Run */
+            dry_run: boolean;
+        };
+        /**
          * VoteCastOut
          * @description The complete post-cast truth: everything the client used to reconstruct.
          *
@@ -4484,6 +4662,23 @@ export interface components {
             vote_id: number;
         };
         /**
+         * VoteSpendRepairOut
+         * @description One character's ``votes_spent_this_era`` before and after a recompute.
+         *
+         *     The wire mirror of ``services.character_stats.VoteSpendRepair``. It is a
+         *     separate declaration rather than the dataclass itself because the response
+         *     shape is a published contract and the dataclass is an internal return type;
+         *     tying them together would make an internal rename a wire break.
+         */
+        VoteSpendRepairOut: {
+            /** After */
+            after: number;
+            /** Before */
+            before: number;
+            /** Character Id */
+            character_id: number;
+        };
+        /**
          * VoteTallyOut
          * @description A praxis's vote aggregate, in the field names every praxis payload uses.
          *
@@ -4511,6 +4706,21 @@ export interface components {
             faction_slug: string;
             /** Value */
             value: number;
+        };
+        /**
+         * VotesReceivedOut
+         * @description Votes received on the praxes a character **authored**.
+         *
+         *     Author-scoped, not membership-scoped (ADR-0053) — see the route docstring in
+         *     ``routers/characters.py`` for why the two must not be conflated. It echoes
+         *     ``character_id`` so a caller batching several of these can tell the answers
+         *     apart.
+         */
+        VotesReceivedOut: {
+            /** Character Id */
+            character_id: number;
+            /** Votes Received */
+            votes_received: number;
         };
         /** ContactMessageOut */
         routers__admin__ContactMessageOut: {
@@ -4818,9 +5028,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["RoleActionOut"];
                 };
             };
             /** @description Validation Error */
@@ -4857,9 +5065,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["SuspendActionOut"];
                 };
             };
             /** @description Validation Error */
@@ -4928,9 +5134,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["AdminCharacterOut"];
                 };
             };
             /** @description Validation Error */
@@ -4961,9 +5165,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["StatsBackfillOut"];
                 };
             };
             /** @description Validation Error */
@@ -4996,9 +5198,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["VoteBudgetBackfillOut"];
                 };
             };
             /** @description Validation Error */
@@ -5035,7 +5235,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["BanActionOut"];
                 };
             };
             /** @description Validation Error */
@@ -5202,9 +5402,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["EraResetOut"];
                 };
             };
             /** @description Validation Error */
@@ -5712,7 +5910,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["DevLoginOut"];
                 };
             };
             /** @description Validation Error */
@@ -5736,13 +5934,11 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            200: {
+            302: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": unknown;
-                };
+                content?: never;
             };
         };
     };
@@ -5756,13 +5952,11 @@ export interface operations {
         requestBody?: never;
         responses: {
             /** @description Successful Response */
-            200: {
+            302: {
                 headers: {
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": unknown;
-                };
+                content?: never;
             };
         };
     };
@@ -5781,7 +5975,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["LogoutOut"];
                 };
             };
         };
@@ -6079,9 +6273,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: number;
-                    };
+                    "application/json": components["schemas"]["VotesReceivedOut"];
                 };
             };
             /** @description Validation Error */
@@ -6503,7 +6695,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["HealthOut"];
                 };
             };
         };
@@ -7017,7 +7209,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": unknown;
+                    "application/json": components["schemas"]["PraxisInviteOut"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
Part of #1400

One slice: **Build step 1 — close the `response_model` gap**. No client migration, no axios changes, no `package.json` edits, no SPEC doctrine paragraph. Those are later slices.

## What the audit actually found

The issue body predates PR #1584, which already shipped step 2 (`backend/openapi.json`, `scripts/regen_api_client.py`, the `api-schema` CI job, and `frontend/src/api/generated/schema.d.ts`). So the question this PR answers is narrower than the issue's text: **with the gate in place, what does the schema still fail to say?**

Introspecting the live app rather than grepping decorators: **22 routes** had no *usable* response model. Several of the seven admin offenders do carry a `response_model` — FastAPI infers one from a `-> dict` return annotation, which lands in the schema as `{"type":"object","additionalProperties":true}` and in `schema.d.ts` as an index signature. Grepping for `response_model=` misses those.

They split three ways:

**Fixed — 12 routes, each now a named Pydantic model:**

| Route | Was |
|---|---|
| `POST /admin/characters` | `-> dict` |
| `POST /admin/characters/backfill-vote-budget` | `-> dict` |
| `POST /admin/characters/backfill-stats` | `-> dict` |
| `PUT /admin/era/reset` | `-> dict` |
| `POST /admin/accounts/{id}/role` | `-> dict` |
| `POST /admin/accounts/{id}/suspend` | `-> dict` |
| `POST /admin/characters/{id}/ban` | unannotated |
| `POST /auth/logout` | unannotated |
| `POST /auth/dev-login` | unannotated |
| `GET /characters/{id}/stats/votes-received` | `-> dict[str, int]` |
| `POST /praxes/{id}/invite` | explicit `response_model=None` |
| `GET /health` | unannotated |

`/health` is **not** on the brief's list; it is a genuine hand-built-dict route in `main.py` that a routers-only sweep does not see.

**Fixed differently — the two OAuth legs.** `GET /auth/google` and `/auth/google/callback` return redirects, and were documenting a `200 application/json` with an empty schema. They now declare `response_class=RedirectResponse, status_code=302`, so the schema carries a bodyless 302. No model, because there is no body. The decorator's `status_code` does not change runtime behaviour — both handlers return a `Response` object, which FastAPI passes through untouched.

**Left alone — the seven `status_code=204` deletes.** I checked the committed schema before touching anything: FastAPI already emits them as `"204": {"description": ...}` with no `content` key. They were never the untyped-200 failure mode, so there is nothing to fix and no `response_class` to add.

One more, deliberately untouched: `GET /me/invited-factions` returns `list[str]`, which generates as `string[]`. Fully checkable; a wrapper model would add a name and no information.

## Two things worth flagging

**`invite_member_route` is not what the issue implies.** The issue names it as an offender that "returns an untyped dict". It does not — `_build_invite_out` has always returned a `PraxisInviteOut`. The `response_model=None` was pure suppression, and the fix was to name the model that was already there, not to write a new one. The frontend's hand-written `PraxisInviteOut` in `api/praxis.ts` matches the generated one field for field, so **no hand-written interface was caught lying by this slice.** (The audit's original mistype, `respondToInvite`, was already fixed by #1383.)

**`dev_login` publishes `account_id`.** It always did; making the shape explicit puts it in the schema for the first time. This is not a second exception to the "never expose `account_id`" rule beside `/auth/me` — the endpoint 404s outside development. The reasoning is written into `DevLoginOut`'s docstring so the next reader does not have to re-derive it. Admin responses carrying `account_id` follow the existing `AccountSummary`/`CharacterSummary` precedent: the admin router is the operator surface, not the public API.

## The ratchet

`backend/tests/test_openapi_response_shapes.py` is new, and it is the reason this slice does not silently un-ship.

The #1584 drift gate proves the committed schema *matches* the app. It cannot prove the schema *says* anything: a new route returning a hand-built dict regenerates perfectly cleanly, lands in `schema.d.ts` as `unknown`, and CI is green end to end. That is exactly the state 12 routes were in. The new test asserts every 2xx JSON body is a `$ref`, an array of `$ref`s, or an array of a declared primitive — and allows no-content responses, so 204s and 302s pass without needing a fictional model.

It reads the committed `openapi.json` rather than importing the app, so it needs no environment; `test_openapi_dump.py` is what proves that file is current.

## Artifacts

Both regenerated through `python scripts/regen_api_client.py` — never a second code path, never hand-edited. The generated diff removes eleven `"application/json": unknown` bodies, one `{ [key: string]: number }`, and one index-signature object.

Note that `backend/openapi.json` was byte-identical on the second run one commit later, which is the determinism the gate rests on.

## Verification

- `pytest --cov=. --cov-report=term-missing --cov-fail-under=80` from `backend/` (against a dedicated `wz1400_test` DB): **1088 passed**, coverage 92.88%. Re-run green after rebasing onto `origin/main` at #1599.
- All six frontend CI steps run locally and green: `lint`, `typecheck`, `typecheck:design-sync`, `vitest` (223 files / 3886 tests), `vite build`, and the byte budget (JS 138.0 KB, CSS 22.4 KB — unchanged, this PR ships no runtime code to the browser).

**Visual QA is outstanding** — I have no browser tooling here.

## What to eyeball

Every changed response is one a human can only confirm by using it. tsc cannot see these callers: the frontend discards most of these bodies today, so a wrong field name would fail silently rather than at compile time.

- **Admin → Characters:** create a character (the 201 body is now `AdminCharacterOut`); ban and unban one, and confirm the row's state flips in the list.
- **Admin → Accounts:** suspend and unsuspend an account; grant and revoke a role. Both now echo through a model rather than a dict.
- **Admin → break-glass ops:** `POST /admin/characters/backfill-vote-budget?dry_run=true` — check the `changes` array still lists every `{character_id, before, after}` triple, since reading that list before applying is the endpoint's whole purpose. Then `POST /admin/characters/backfill-stats`.
- **Admin → era reset** (on a throwaway DB): confirm the response still carries the new `era_id` and the reset headcount.
- **Sign in with Google, end to end.** This is the highest-risk item: the two OAuth legs changed decorators. Confirm the consent screen still appears, the callback still lands you back on the frontend signed in, and the `access_token` cookie is set. Then sign out.
- **Dev login** (`POST /auth/dev-login`), including the `?name=`/`?level=`/`?faction=` fixture params the e2e suite drives.
- **Collab invite:** invite a player onto a praxis and confirm the invite appears in their requests bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
