### PR TITLE
Propose-task labels split into region names and small facts (#1307)

### DIFF
--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -256,8 +256,9 @@ export default function DefaultProposeTask({
         <div>
           {/* Faction Selector (§20.2) */}
           <div style={{ marginBottom: "var(--space-lg)" }}>
+            {/* A full sentence, not a region name — caption tier (#1307). */}
             <span
-              className="eyebrow"
+              className="label-caption"
               style={{ display: "block", marginBottom: "var(--space-sm)" }}
             >
               {t("proposeTask.factionSelectorLabel")}
@@ -328,7 +329,7 @@ export default function DefaultProposeTask({
               {/* Task Name (§20.4) */}
               <div style={{ marginBottom: "var(--space-lg)" }}>
                 <span
-                  className="eyebrow"
+                  className="label-heading"
                   style={{ display: "block", marginBottom: "var(--space-sm)" }}
                 >
                   {t("proposeTask.fields.name.label")}
@@ -364,7 +365,7 @@ export default function DefaultProposeTask({
                   }}
                 />
                 <span
-                  className={`eyebrow self-end ${title.length >= 180 ? "text-red-600" : ""}`}
+                  className={`label-caption self-end ${title.length >= 180 ? "text-red-600" : ""}`}
                   style={{ marginTop: "var(--space-xs)" }}
                 >
                   {title.length}/200
@@ -382,7 +383,7 @@ export default function DefaultProposeTask({
               {/* Description (§20.4) */}
               <div style={{ marginBottom: "var(--space-lg)" }}>
                 <span
-                  className="eyebrow"
+                  className="label-heading"
                   style={{ display: "block", marginBottom: "var(--space-sm)" }}
                 >
                   {t("proposeTask.fields.description.label")}
@@ -398,7 +399,7 @@ export default function DefaultProposeTask({
                   style={descriptionTextareaStyle}
                 />
                 <span
-                  className={`eyebrow self-end ${description.length >= 4500 ? "text-red-600" : ""}`}
+                  className={`label-caption self-end ${description.length >= 4500 ? "text-red-600" : ""}`}
                   style={{ marginTop: "var(--space-xs)" }}
                 >
                   {description.length}/5000
@@ -425,7 +426,7 @@ export default function DefaultProposeTask({
                 {!isMetatask && (
                   <div>
                     <span
-                      className="eyebrow"
+                      className="label-heading"
                       style={{ display: "block", marginBottom: "var(--space-sm)" }}
                     >
                       {t("proposeTask.fields.basePoints.label")}
@@ -443,7 +444,7 @@ export default function DefaultProposeTask({
                       style={basePointsInputStyle}
                     />
                     <span
-                      className="eyebrow"
+                      className="label-caption"
                       style={{ display: "block", marginTop: "var(--space-xs)" }}
                     >
                       {t("proposeTask.fields.basePoints.hint")}
@@ -453,7 +454,7 @@ export default function DefaultProposeTask({
                 {isMetatask && (
                   <div>
                     <span
-                      className="eyebrow"
+                      className="label-heading"
                       style={{ display: "block", marginBottom: "var(--space-sm)" }}
                     >
                       {t("proposeTask.fields.bonusPoints.label")}
@@ -474,7 +475,7 @@ export default function DefaultProposeTask({
                       }}
                     />
                     <span
-                      className="eyebrow"
+                      className="label-caption"
                       style={{ display: "block", marginTop: "var(--space-xs)" }}
                     >
                       {t("proposeTask.fields.bonusPoints.hint")}
@@ -483,7 +484,7 @@ export default function DefaultProposeTask({
                 )}
                 <div>
                   <span
-                    className="eyebrow"
+                    className="label-heading"
                     style={{ display: "block", marginBottom: "var(--space-sm)" }}
                   >
                     {t("proposeTask.fields.minimumLevel.label")}
@@ -494,7 +495,7 @@ export default function DefaultProposeTask({
                     onChange={setLevelRequired}
                   />
                   <span
-                    className="eyebrow"
+                    className="label-caption"
                     style={{ display: "block", marginTop: "var(--space-xs)" }}
                   >
                     {t("proposeTask.fields.minimumLevel.hint")}
@@ -538,12 +539,7 @@ export default function DefaultProposeTask({
                     >
                       {t("proposeTask.metaToggle.label")}
                     </span>
-                    <span
-                      className="eyebrow"
-                      style={{
-                        color: "var(--color-text-tertiary)",
-                      }}
-                    >
+                    <span className="label-caption">
                       {isKnownFaction(factionSlug)
                         ? t("proposeTask.metaToggle.hint", {
                             faction: factionName(factionSlug),
@@ -559,7 +555,7 @@ export default function DefaultProposeTask({
             {!isMetatask && (
               <div style={{ marginBottom: "var(--space-lg)" }}>
                 <span
-                  className="eyebrow"
+                  className="label-heading"
                   style={{ display: "block", marginBottom: "var(--space-sm)" }}
                 >
                   {t("proposeTask.fields.notes.label")}
@@ -599,8 +595,12 @@ export default function DefaultProposeTask({
                   marginBottom: "var(--space-lg)",
                 }}
               >
+                {/* Caption, not a heading: the faction name is interpolated in,
+                    so "Task preview — University of Asthmatics — Pending" is a
+                    run of prose the moment a long slug is selected (#1307). The
+                    faction accent stays — ink is measured separately. */}
                 <span
-                  className="eyebrow"
+                  className="label-caption"
                   style={{ color, marginBottom: "var(--space-xs)", display: "block" }}
                 >
                   {isMetatask
@@ -635,7 +635,7 @@ export default function DefaultProposeTask({
                 <div style={{ display: "flex", gap: "var(--space-sm)", marginTop: "var(--space-sm)" }}>
                   {isMetatask ? (
                     <span
-                      className="eyebrow"
+                      className="label-caption"
                       style={{ color: "var(--color-success)" }}
                     >
                       {t("proposeTask.preview.bonusPoints", {
@@ -643,19 +643,19 @@ export default function DefaultProposeTask({
                       })}
                     </span>
                   ) : (
-                    <span className="eyebrow">
+                    <span className="label-caption">
                       {t("proposeTask.preview.points", {
                         points: pointValue || "?",
                       })}
                     </span>
                   )}
-                  <span className="eyebrow">
+                  <span className="label-caption">
                     {t("proposeTask.preview.level", {
                       level: levelRequired === "" ? 0 : levelRequired,
                     })}
                   </span>
                   {!isMetatask && (
-                    <span className="eyebrow" style={{ color }}>
+                    <span className="label-caption" style={{ color }}>
                       {t("proposeTask.preview.pending")}
                     </span>
                   )}
@@ -729,7 +729,11 @@ export default function DefaultProposeTask({
         {/* ── Right: Tips Column (§20.8) ── */}
         <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-md)" }}>
           <div className="sidebar-card" style={{ padding: "var(--space-md) var(--space-lg)" }}>
-            <p className="eyebrow mb-2">
+            {/* Both tips-card titles are prose phrases rather than region
+                names ("What makes a good task"), so they take the caption tier
+                — and they take the SAME one, or two sibling cards disagree
+                about what a card title is. */}
+            <p className="label-caption mb-2">
               {t("proposeTask.tips.goodTaskHeading")}
             </p>
             <ul
@@ -747,7 +751,7 @@ export default function DefaultProposeTask({
           </div>
 
           <div className="sidebar-card" style={{ padding: "var(--space-md) var(--space-lg)" }}>
-            <p className="eyebrow mb-2">{t("proposeTask.tips.nextHeading")}</p>
+            <p className="label-caption mb-2">{t("proposeTask.tips.nextHeading")}</p>
             <p
               className="content-text font-body"
               style={tipsBodyStyle}


### PR DESCRIPTION
Sweeps the `.eyebrow` label tier off `frontend/src/pages/proposeTask/archetypes/` and onto the two tiers that shipped with the #1307 foundation. One file, `DefaultProposeTask.tsx` — it is the only archetype in the directory, and every faction without a bespoke propose-task skin renders through it, so this changes the propose form for all eight.

Part of #1307

## The count

`grep` finds **20** `className`-borne `.eyebrow` sites here, matching the state-check comment's table. All 20 moved; **zero** `eyebrow` occurrences remain anywhere under `pages/proposeTask/`. The file also already carried one `.label-caption` (the faction descriptor, moved when `.eyebrow-sentence` was deleted), so the file now reads 6 × `label-heading` + 15 × `label-caption`.

## The split, and why

**`.label-heading` — 6 sites, all of them form-field labels.** "Task name", "Description", "Base points", "Bonus points", "Minimum level", "Notes to admin (optional)". These are the grill's "form-section names": each marks where a field's region starts, and each is one to three words by construction.

The one judgement call is **"Notes to admin (optional)"** — four words, so the ">3 words is a caption" heuristic points the other way. It is a heading here because its role is unambiguous and identical to the other five (the parenthetical is a qualifier on a three-word region name), and because splitting one label out of a column of five would read as a rendering bug rather than a distinction. Flagged for eyeball below.

**`.label-caption` — 14 sites.** Everything that is a small fact rather than a region name:

- the faction-selector prompt — *"Choose a faction for this task, or leave it open to everyone"*, a full sentence
- the two character counters (`123/200`, `4200/5000`)
- the three field hints — "Admin may adjust", "Flat bonus added to score", "Level 0 = anyone can attempt"
- the meta-task toggle hint — *"applies as a bonus to all {faction} submissions"* / *"pick a faction above (Unaffiliated = anyone)"*
- the four preview-strip chips: the strip heading, the points chip, the level chip, the "Pending review" status
- both tips-card titles in the right rail

Two of those deserve a note:

- **The preview-strip heading** interpolates the faction name: *"Task preview — University of Asthmatics — Pending"*. Set as a heading that is a ~48-character all-caps run on 0.15em tracking, which is the exact wall #850 minted `.eyebrow-sentence` to paper over. It is a caption.
- **Both tips-card titles** ("What makes a good task", "What happens next") are prose phrases, not region names, so both are captions — and deliberately the *same* tier, because two sibling cards in one rail cannot disagree about what a card title is.

## Inline overrides

**Deleted (1):** the meta-toggle hint carried `color: 'var(--color-text-tertiary)'`, which is exactly what unset `--label-ink` resolves to — pure noise, and the whole `style` prop went with it.

No `letterSpacing` or `textTransform` override existed at any site in this file, so nothing else was redundant. Layout-only overrides (`display: 'block'`, `marginTop`/`marginBottom` on `--space-*`) were kept as-is.

**Colour overrides left standing (3)** — per the ruling that ink is measured per tier against all eight grounds, not assigned here:

| site | override |
|---|---|
| preview-strip heading | `color` = the selected faction's accent (`factionCssVar(factionSlug)`) |
| preview bonus-points chip | `color: 'var(--color-success)'` |
| preview "Pending review" chip | `color` = the selected faction's accent |

Also untouched, and **not** label-tier sites, but worth naming for whoever sweeps next: the two character counters still append the Tailwind `text-red-600` when they near the cap, and `tooLongStyle` (a `.content-text` span) hardcodes `#dc2626`. Both are raw colour outside `index.css`; both predate this PR and are out of its scope.

## What I did not touch

`frontend/src/index.css` (including `.eyebrow`, which stays declared and in use until the last sweep retires it) and `frontend/src/utils/__tests__/factionContrast.test.ts` (shared registry — it already asserts both tiers). No file outside `pages/proposeTask/archetypes/`.

## Verification

All six CI frontend steps run locally and green: `eslint src`, `tsc --noEmit`, `vitest run` (224 files / 3894 tests), `vite build`, the initial-load byte budget (CSS 22.4 KB, JS 138.1 KB — unchanged, this PR ships no CSS), `typecheck:design-sync`.

Purge check: both class names are written as literals and both survive into the built stylesheet —

```
.label-heading{...font-size:var(--text-md);text-transform:uppercase;letter-spacing:.15em;color:var(--label-ink)}
.label-caption{...font-size:var(--text-lg);text-transform:none;letter-spacing:normal;color:var(--label-ink)}
```

This is the first sweep to give `.label-heading` real callers, so it is now load-bearing rather than test-quoted.

**Visual QA is outstanding.** I have no browser and no dev stack; nothing below was seen by a human or a machine.

## What to eyeball

`/propose-task`, in **both themes**, cycling the faction picker through every option — the page has one archetype, so each faction only changes the accent, the pennant fills and the frame, but the label tiers land on all eight grounds:

1. **Unaffiliated (`na`)** — the opening state, and the only one wearing the rainbow `frame`/`pill` rather than a solid hue. Check the preview-strip heading (a caption now) against the neutral interior.
2. **UA — the descriptor sentence.** *"Practise with us — one true mark a day."* is the reason `.eyebrow-sentence` ever existed. It was already on `.label-caption` before this PR, but it now sits directly beneath a caption-tier selector prompt and beside six one-word descriptors ("Anyone", "Circle", "Mobilize", "Mischief", "Record", "Discover") — confirm the picker still reads as a row of peers and the UA button does not blow out the flex-wrap. WOW's descriptor is a second full sentence.
3. **The preview strip, with a long faction selected (UA or Singularity)** — *"Task preview — {faction} — Pending"* in the faction accent at 12px sentence case. This is the site that most changed shape; confirm the accent ink is still legible on the faction-tinted strip in dark mode.
4. **The form-field label column** — five headings down the left plus "Notes to admin (optional)". Confirm they still read as a consistent ladder of region names, and specifically that the four-word one does not look out of place.
5. **The right-hand tips rail** — two card titles now in 12px sentence case instead of 9px caps. This is the biggest visual departure on the page; if they no longer read as titles, the fix is the tier assignment, not a per-site override.
6. **The character counters** at 180+/4500+ characters, where they take `text-red-600` on top of the caption tier.

