### PR TITLE
The admin queue's ten eyebrows split into a region name and nine small facts

### DIFF
--- a/frontend/src/pages/admin/AccountsTab.tsx
+++ b/frontend/src/pages/admin/AccountsTab.tsx
@@ -184,10 +184,7 @@ export default function AccountsTab() {
               {/* Expanded: characters */}
               {expandedId === account.id && detail && (
                 <div className="mt-3 ml-4 border-l-2 border-border pl-4">
-                  <p
-                    className="eyebrow mb-2"
-                    style={{ color: "var(--color-text-tertiary)" }}
-                  >
+                  <p className="label-heading mb-2">
                     {t("accounts.charactersHeading", {
                       count: detail.characters.length,
                     })}

--- a/frontend/src/pages/admin/ModerationTab.tsx
+++ b/frontend/src/pages/admin/ModerationTab.tsx
@@ -100,7 +100,7 @@ interface ActionLogEntry {
 function ReasonBadge({ reason }: { reason: string }) {
   return (
     <span
-      className="eyebrow"
+      className="label-caption"
       style={{
         border: '1.5px solid var(--color-danger)',
         color: 'var(--color-danger)',
@@ -113,7 +113,9 @@ function ReasonBadge({ reason }: { reason: string }) {
 }
 
 /** Segmented content-type filter over the merged queue (#576). Mirrors the
- *  admin tab-bar's underline eyebrow language rather than the mobile pill. */
+ *  admin tab-bar's underline label language rather than the mobile pill — each
+ *  option names a region of the queue, so it is the heading tier (#1307) and
+ *  has to stay on whatever tier `pages/Admin.tsx`'s tab bar lands on. */
 function QueueFilterBar({
   value,
   onChange,
@@ -133,7 +135,7 @@ function QueueFilterBar({
           role="tab"
           aria-selected={value === option}
           onClick={() => onChange(option)}
-          className="eyebrow pb-1 transition-colors"
+          className="label-heading pb-1 transition-colors"
           style={{
             background: 'none',
             border: 'none',
@@ -164,7 +166,7 @@ function QueueCardFrame({
     <div className="card px-4 py-3">
       <div className="flex items-center gap-3 mb-2">
         <ReasonBadge reason={badgeReason} />
-        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+        <span className="label-caption">
           {typeLabel} &middot; {relativeTime(when)}
         </span>
       </div>
@@ -302,11 +304,11 @@ export default function ModerationTab() {
       <div className="flex gap-4">
         <div className="card px-5 py-3" style={{ minWidth: 140 }}>
           <p className="font-display text-2xl font-bold">{queue.length}</p>
-          <p className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t('moderation.stats.openReports')}</p>
+          <p className="label-caption">{t('moderation.stats.openReports')}</p>
         </div>
         <div className="card px-5 py-3" style={{ minWidth: 140 }}>
           <p className="font-display text-2xl font-bold">{activeMembers ?? '—'}</p>
-          <p className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t('moderation.stats.activeMembers')}</p>
+          <p className="label-caption">{t('moderation.stats.activeMembers')}</p>
         </div>
       </div>
 
@@ -362,7 +364,7 @@ export default function ModerationTab() {
                       )}
                       <Link
                         to={`/praxis/${item.praxis.id}`}
-                        className="eyebrow"
+                        className="label-caption"
                         style={{ display: 'inline-block', marginTop: 'var(--space-sm)' }}
                       >
                         {t('moderation.queue.viewPraxis')}
@@ -443,7 +445,7 @@ export default function ModerationTab() {
                         to={item.comment.praxis_id != null
                           ? `/praxis/${item.comment.praxis_id}`
                           : `/tasks/${item.comment.task_id}`}
-                        className="eyebrow"
+                        className="label-caption"
                         style={{ display: 'inline-block', marginTop: 'var(--space-sm)' }}
                       >
                         {t('moderation.queue.viewThread')}

--- a/frontend/src/pages/admin/OverviewTab.tsx
+++ b/frontend/src/pages/admin/OverviewTab.tsx
@@ -42,7 +42,9 @@ export default function OverviewTab() {
           >
             {value}
           </p>
-          <p className="eyebrow mt-1" style={{ color: 'var(--color-text-tertiary)' }}>
+          {/* A stat card's label is a small fact about the figure above it, not
+              a region name (#1307) — caption tier. */}
+          <p className="label-caption mt-1">
             {label}
           </p>
         </div>

--- a/frontend/src/pages/admin/TasksTab.tsx
+++ b/frontend/src/pages/admin/TasksTab.tsx
@@ -239,7 +239,7 @@ export default function TasksTab() {
                         {task.title}
                       </p>
                       <span
-                        className="eyebrow"
+                        className="label-caption"
                         style={{
                           padding: "var(--space-xs) var(--space-sm)",
                           border: "1px solid var(--color-border)",


### PR DESCRIPTION
`#1307`'s foundation has shipped; this is the **`frontend/src/pages/admin/` sweep**. No CSS changes — ten class swaps in four `.tsx` files.

Part of #1307

## The count

My own grep found **10** `className`-borne `.eyebrow` sites in the directory, matching the orchestrator's figure. All ten are moved; `grep -rn eyebrow frontend/src/pages/admin/` now returns nothing.

## Classification

Each site was classified by which sentence it says, not by string length.

### `.label-heading` — *this names a region* (2)

| site | text |
|---|---|
| `AccountsTab.tsx:187` | "Characters (N)" — the rule over an expanded account's character list |
| `ModerationTab.tsx:138` | the queue's All / Praxes / Comments filter — each option names a slice of the queue |

The filter bar is drawn deliberately to mirror `pages/Admin.tsx`'s tab bar (its own doc comment says so). **That tab bar is outside this PR's scope** — it is the last `.eyebrow` in `pages/` top level. If the sibling sweeping `pages/` puts it on `.label-caption`, the two bars diverge; the comment in `QueueFilterBar` now records the dependency.

### `.label-caption` — *this is a small fact about the thing* (8)

| site | text |
|---|---|
| `ModerationTab.tsx:103` | the flag-reason badge (a status chip) |
| `ModerationTab.tsx:169` | "Praxis · 5d ago" — type + timestamp |
| `ModerationTab.tsx:307` | "Open reports" under its figure |
| `ModerationTab.tsx:311` | "Active members" under its figure |
| `ModerationTab.tsx:367` | "View praxis" linkback |
| `ModerationTab.tsx:448` | "View thread" linkback |
| `OverviewTab.tsx:47` | the seven stat-card labels under their figures |
| `TasksTab.tsx:242` | the task status chip (Active / Pending / …) |

Two judgement calls worth stating. **A stat-card label is a caption, not a heading** — the card holds one figure, and the label says what the figure is, which is a fact about it rather than the name of a region. **The two linkbacks are genuinely ambiguous** — link chrome is neither sentence exactly — and went to caption on the standing tie-break, which suits them: a call to action is read, not scanned.

## Inline overrides

**Deleted — 5 redundant colour restatements.** `color: 'var(--color-text-tertiary)'` is now exactly what unset `--label-ink` resolves to, so these were restating the tier: `ModerationTab.tsx` (queue stamp, both stat labels), `OverviewTab.tsx`, `AccountsTab.tsx`.

**Left standing — colour overrides, per the sweep rules:**

| site | override | why it stays |
|---|---|---|
| `ModerationTab.tsx:103` | `color: 'var(--color-danger)'` + `border` + `padding` | the badge's alarm ink, nothing to do with the tier |
| `ModerationTab.tsx:143` | `value === option ? 'var(--color-text-primary)' : 'var(--color-text-tertiary)'` | a **selected-state ternary**, not a static override — the tertiary is one branch of a two-state expression, and dropping it to `undefined` would leave a half-expression whose other branch still hardcodes a colour |
| `TasksTab.tsx:246-251` | `active → success`, `pending → warning`, else `tertiary` | same shape: a three-way **status** ramp whose neutral default happens to be tertiary |

No `letterSpacing` or `textTransform` overrides existed at any of the ten sites, so nothing was deleted on that count. The `display: inline-block` / `marginTop` / `padding` overrides are geometry and are untouched.

## Verification

All six frontend CI steps run locally and green: `eslint src`, `tsc --noEmit`, `vitest run` (224 files / 3894 tests), `vite build`, the byte budget (JS 138.1 KB, CSS **22.4 KB** — unchanged, this PR adds no CSS), and `typecheck:design-sync`.

**Purge check on the built stylesheet**, since both tiers are `@layer components`: `dist/assets/index-*.css` contains both rules, `.label-heading` at `--text-md`/uppercase/`.15em` and `.label-caption` at `--text-lg`/none/normal, both painting `var(--label-ink)`. Both names are written as literals.

## What to eyeball

I have no browser and no dev stack, so **visual QA is outstanding on all of it**, in both themes, at `/admin`:

1. **Overview tab** — the seven stat labels go 9px uppercase to 12px sentence case. This is the biggest visible change in the PR: seven captions in a grid all growing and un-shouting at once. Check the cards do not now feel bottom-heavy against their `text-3xl` figures.
2. **Moderation stat strip** — same change on "Open reports" / "Active members", but only two cards, side by side, at `minWidth: 140`. Confirm neither label wraps at 12px.
3. **The queue filter bar** — the only heading-tier control. It grows 9px to 11px and keeps its caps, so the underline it wears and the gap to the cards below both shift a little. Confirm the selected underline still sits right under the word.
4. **The flag-reason badge** — it is a bordered chip that has *lost its uppercase*, so reasons now read "Spam" rather than "SPAM" (whatever `flagReasonLabel` returns). This is the intended caption treatment but it is the most opinionated single change here; it also gets wider, beside the "Praxis · 5d ago" stamp on the same row. Check the row still fits and the badge's 1.5px danger border still reads as an alarm at sentence case.
5. **The task status chip** on the Tasks tab — same shape as the badge, three colours, and it sits inline beside a `text-lg` bold title. Check the baseline alignment survives the size bump.
6. **"View praxis" / "View thread"** — these are links, now sentence case at 12px. Confirm they still read as links and not as body text.
7. **"Characters (N)"** — the one heading in the set, on the expanded account row. Confirm it still reads as a rule over the list rather than as a list item.

Unrelated, spotted while sweeping and deliberately **not** fixed here: `OverviewTab.tsx:41` paints a raw hex `#dc2626` for the highlight figure. That is `--color-danger`'s light value hardcoded, invisible to `local/no-raw-style-values` (which does not cover colour), and it cannot flip with the theme. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
