### PR TITLE
The praxis detail's 41 eyebrows become three headings and thirty-eight captions

### DIFF
--- a/frontend/src/pages/praxisDetail/DuelCard.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCard.tsx
@@ -369,7 +369,7 @@ export function DuelCard({ state, style, heading, ink }: DuelCardProps) {
       ink={paint}
       subtitle={
         rival.praxis_id != null ? (
-          <span className="eyebrow" style={{ color: paint.muted }}>
+          <span className="label-caption" style={{ color: paint.muted }}>
             {t('duelCrossLink.readTheirPraxis')}
           </span>
         ) : undefined

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -351,7 +351,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
             flexWrap: 'wrap',
           }}
         >
-          <span className="eyebrow" style={{ color: 'var(--color-warning)' }}>
+          <span className="label-caption" style={{ color: 'var(--color-warning)' }}>
             {t('detail.banners.flaggedLabel')}
           </span>
           <span className="font-body content-text" style={{ color: 'var(--color-text-secondary)' }}>

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -222,7 +222,7 @@ export default function DefaultPraxisDetail({
       }}
     >
       <span
-        className="eyebrow"
+        className="label-heading"
         style={{ letterSpacing: '0.22em', color: 'var(--color-text-primary)' }}
       >
         {label}
@@ -263,33 +263,31 @@ export default function DefaultPraxisDetail({
     >
       <Link
         to="/tasks"
-        className="eyebrow"
+        className="label-caption"
         style={{
-          letterSpacing: '0.2em',
           color: 'var(--faction-default-card-accent)',
           textDecoration: 'none',
         }}
       >
         {t('detail.breadcrumb.tasks')}
       </Link>
-      <span aria-hidden className="eyebrow">
+      <span aria-hidden className="label-caption">
         ›
       </span>
       <Link
         to={`/tasks/${praxis.task_id}`}
-        className="eyebrow"
+        className="label-caption"
         style={{
-          letterSpacing: '0.2em',
           color: 'var(--faction-default-card-accent)',
           textDecoration: 'none',
         }}
       >
         {praxis.task_title}
       </Link>
-      <span aria-hidden className="eyebrow">
+      <span aria-hidden className="label-caption">
         ›
       </span>
-      <span className="eyebrow" style={{ letterSpacing: '0.2em' }}>
+      <span className="label-caption">
         {t('detail.breadcrumb.current')}
       </span>
     </nav>
@@ -309,9 +307,8 @@ export default function DefaultPraxisDetail({
     >
       <Link
         to="/praxis"
-        className="eyebrow"
+        className="label-caption"
         style={{
-          letterSpacing: '0.2em',
           color: 'var(--faction-default-card-accent)',
           textDecoration: 'none',
         }}
@@ -320,8 +317,8 @@ export default function DefaultPraxisDetail({
         {t('detail.back')}
       </Link>
       <span
-        className="eyebrow"
-        style={{ flex: 1, textAlign: 'center', letterSpacing: '0.2em' }}
+        className="label-caption"
+        style={{ flex: 1, textAlign: 'center' }}
       >
         {t('detail.breadcrumb.current')}
       </span>
@@ -351,7 +348,7 @@ export default function DefaultPraxisDetail({
             flexWrap: 'wrap',
           }}
         >
-          <span className="eyebrow" style={{ color: 'var(--color-warning)' }}>
+          <span className="label-caption" style={{ color: 'var(--color-warning)' }}>
             {t('detail.banners.flaggedLabel')}
           </span>
           <span className="font-body content-text" style={{ color: 'var(--color-text-secondary)' }}>
@@ -410,7 +407,7 @@ export default function DefaultPraxisDetail({
               textDecoration: 'none',
             }}
           />
-          <div className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
+          <div className="label-caption" style={{ color: 'var(--faction-default-card-muted)' }}>
             {t('detail.filed', {
               date: formatTimestamp(praxis.submitted_at ?? praxis.created_at),
             })}
@@ -447,7 +444,7 @@ export default function DefaultPraxisDetail({
           marginBottom: 'var(--space-xl)',
         }}
       >
-        <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
+        <span className="label-caption" style={{ color: 'var(--faction-default-card-muted)' }}>
           {t('detail.taskRef.label')}
         </span>
         <Link
@@ -457,7 +454,7 @@ export default function DefaultPraxisDetail({
         >
           {praxis.task_title}
         </Link>
-        <span className="eyebrow" style={{ marginLeft: 'auto', color: 'var(--faction-default-card-muted)' }}>
+        <span className="label-caption" style={{ marginLeft: 'auto', color: 'var(--faction-default-card-muted)' }}>
           {t('detail.taskRef.level', { level: praxis.task_level_required })}
           {' · '}
           {t('detail.taskRef.points', { points: praxis.task_point_value })}
@@ -555,7 +552,7 @@ export default function DefaultPraxisDetail({
     <section style={panel}>
       {sectionHead(
         t('detail.voters.heading'),
-        <span className="eyebrow" style={{ color: 'var(--faction-default-card-muted)' }}>
+        <span className="label-caption" style={{ color: 'var(--faction-default-card-muted)' }}>
           {t('detail.voters.count', { count: voters.length })}
         </span>,
       )}

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -486,7 +486,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
             flexWrap: "wrap",
           }}
         >
-          <span className="eyebrow" style={{ color: "var(--color-warning)" }}>
+          <span className="label-caption" style={{ color: "var(--color-warning)" }}>
             {t("detail.banners.flaggedLabel")}
           </span>
           <span className="font-body content-text" style={{ color: "var(--color-text-secondary)" }}>

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -120,7 +120,8 @@ const TRACK = "var(--everymen-paper)";
 
 const BEBAS = "var(--font-accent)";
 // Courier Prime is the sheet's chrome face and is never named here: every label
-// on this page carries `.eyebrow`, which owns the family AND the size (§4).
+// on this page carries `.label-heading` or `.label-caption`, which own the
+// family AND the size (§4).
 /** Special Elite — what the report was typed on. */
 const TYPED = "var(--font-faction-typewriter)";
 /** Lora — the article face; the write-up and the standfirst read in it. */
@@ -290,33 +291,31 @@ export default function EverymenPraxisDetail({
     >
       <Link
         to="/tasks"
-        className="eyebrow"
+        className="label-caption"
         style={{
-          letterSpacing: "0.2em",
           color: ACCENT,
           textDecoration: "none",
         }}
       >
         {t("detail.breadcrumb.tasks")}
       </Link>
-      <span aria-hidden className="eyebrow" style={{ color: MUTED }}>
+      <span aria-hidden className="label-caption" style={{ color: MUTED }}>
         /
       </span>
       <Link
         to={`/tasks/${praxis.task_id}`}
-        className="eyebrow"
+        className="label-caption"
         style={{
-          letterSpacing: "0.2em",
           color: ACCENT,
           textDecoration: "none",
         }}
       >
         {praxis.task_title}
       </Link>
-      <span aria-hidden className="eyebrow" style={{ color: MUTED }}>
+      <span aria-hidden className="label-caption" style={{ color: MUTED }}>
         /
       </span>
-      <span className="eyebrow" style={{ letterSpacing: "0.2em", color: MUTED }}>
+      <span className="label-caption" style={{ color: MUTED }}>
         {t("detail.breadcrumb.current")}
       </span>
     </nav>
@@ -335,9 +334,8 @@ export default function EverymenPraxisDetail({
     >
       <Link
         to="/praxis"
-        className="eyebrow"
+        className="label-caption"
         style={{
-          letterSpacing: "0.2em",
           color: ACCENT,
           textDecoration: "none",
         }}
@@ -346,11 +344,10 @@ export default function EverymenPraxisDetail({
         {t("detail.back")}
       </Link>
       <span
-        className="eyebrow"
+        className="label-caption"
         style={{
           flex: 1,
           textAlign: "center",
-          letterSpacing: "0.2em",
           color: MUTED,
         }}
       >
@@ -423,7 +420,7 @@ export default function EverymenPraxisDetail({
             flexWrap: "wrap",
           }}
         >
-          <span className="eyebrow" style={{ color: "var(--color-warning)" }}>
+          <span className="label-caption" style={{ color: "var(--color-warning)" }}>
             {t("detail.banners.flaggedLabel")}
           </span>
           <span
@@ -490,7 +487,7 @@ export default function EverymenPraxisDetail({
               color: MUTED,
             }}
           />
-          <div className="eyebrow" style={{ color: MUTED }}>
+          <div className="label-caption" style={{ color: MUTED }}>
             {t("detail.filed", {
               date: formatTimestamp(praxis.submitted_at ?? praxis.created_at),
             })}
@@ -528,7 +525,7 @@ export default function EverymenPraxisDetail({
           marginBottom: "var(--space-xl)",
         }}
       >
-        <span className="eyebrow" style={{ color: MUTED }}>
+        <span className="label-caption" style={{ color: MUTED }}>
           {t("detail.taskRef.label")}
         </span>
         <Link
@@ -544,7 +541,7 @@ export default function EverymenPraxisDetail({
           {praxis.task_title}
         </Link>
         <span
-          className="eyebrow"
+          className="label-caption"
           style={{ marginLeft: "auto", color: OLIVE }}
         >
           {t("detail.taskRef.level", { level: praxis.task_level_required })}
@@ -638,7 +635,7 @@ export default function EverymenPraxisDetail({
     <section style={panel}>
       {sectionHead(
         t("detail.voters.heading"),
-        <span className="eyebrow" style={{ color: MUTED }}>
+        <span className="label-caption" style={{ color: MUTED }}>
           {t("detail.voters.count", { count: voters.length })}
         </span>,
       )}

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -412,7 +412,7 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
             flexWrap: "wrap",
           }}
         >
-          <span className="eyebrow" style={{ color: "var(--color-warning)" }}>
+          <span className="label-caption" style={{ color: "var(--color-warning)" }}>
             {t("detail.banners.flaggedLabel")}
           </span>
           <span className="font-body content-text" style={{ color: "var(--color-warning)" }}>

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -434,7 +434,7 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
             flexWrap: "wrap",
           }}
         >
-          <span className="eyebrow" style={{ color: "var(--color-warning)" }}>
+          <span className="label-caption" style={{ color: "var(--color-warning)" }}>
             {t("detail.banners.flaggedLabel")}
           </span>
           <span

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -431,7 +431,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
             flexWrap: "wrap",
           }}
         >
-          <span className="eyebrow" style={{ color: "var(--color-warning)" }}>
+          <span className="label-caption" style={{ color: "var(--color-warning)" }}>
             {t("detail.banners.flaggedLabel")}
           </span>
           <span

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -401,7 +401,7 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
             flexWrap: 'wrap',
           }}
         >
-          <span className="eyebrow" style={{ color: 'var(--color-warning)' }}>
+          <span className="label-caption" style={{ color: 'var(--color-warning)' }}>
             {t('detail.banners.flaggedLabel')}
           </span>
           <span

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -219,11 +219,11 @@ export function PraxisAdminBar({ state }: { state: PraxisDetailState }) {
   return (
     <div className="sidebar-card card-on-page mb-4" style={{ padding: 'var(--space-md) var(--space-lg)' }}>
       <div className="flex items-center gap-3 flex-wrap">
-        <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+        <span className="label-heading">
           {t('detail.admin.eyebrow')}
         </span>
         <span
-          className="eyebrow"
+          className="label-caption"
           style={{
             padding: 'var(--space-xs) var(--space-sm)',
             border: '1px solid var(--color-border)',
@@ -361,7 +361,7 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
         >
           <TaskCrown size={34} ringInset={3} />
           <div>
-            <span className="eyebrow" style={{ display: 'block' }}>{t('detail.banners.crownLabel')}</span>
+            <span className="label-heading" style={{ display: 'block' }}>{t('detail.banners.crownLabel')}</span>
             <span className="font-body content-text" style={{ color: 'var(--color-text-secondary)' }}>
               {t('detail.banners.crownBody')}
             </span>
@@ -461,7 +461,7 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
     <div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
         {!handsOff && (
-          <Link to={`/praxis/${praxis.id}/edit`} className="font-body eyebrow hover:underline" style={{ color: 'var(--color-text-tertiary)' }}>
+          <Link to={`/praxis/${praxis.id}/edit`} className="font-body label-caption hover:underline">
             {t('detail.owner.edit')}
           </Link>
         )}
@@ -586,7 +586,7 @@ export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
        dialog mounts over it as a fixed overlay. Skinned by the TASK's
        faction, matching the composer's own dispatch. */
     <>
-      <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: wallInk(praxis, 'alarm') }}>
+      <button onClick={() => setShowWithdrawConfirm(true)} className="font-body label-caption" style={{ background: 'none', border: 'none', cursor: 'pointer', color: wallInk(praxis, 'alarm') }}>
         {t('duelForfeit.action')}
       </button>
       {showWithdrawConfirm && (
@@ -603,12 +603,12 @@ export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
       )}
     </>
   ) : !showWithdrawConfirm ? (
-    <button onClick={() => setShowWithdrawConfirm(true)} className="font-body eyebrow" style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--color-text-tertiary)' }}>
+    <button onClick={() => setShowWithdrawConfirm(true)} className="font-body label-caption" style={{ background: 'none', border: 'none', cursor: 'pointer' }}>
       {t(unsubmitCopy.trigger)}
     </button>
   ) : (
     <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', flexWrap: 'wrap' }}>
-      <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>{t(unsubmitCopy.prompt)}</span>
+      <span className="label-caption">{t(unsubmitCopy.prompt)}</span>
       <button
         onClick={handleWithdraw}
         disabled={withdrawing}
@@ -639,10 +639,24 @@ export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
  *
  * That is enforced structurally rather than by convention: this component takes
  * `state` and nothing else, so there is no `style` seam to dress it through, and
- * every text node inside carries an explicit `--color-*` token or `.eyebrow`'s
- * own neutral colour — so it cannot inherit a skin's sheet colour by accident.
+ * every text node inside carries an explicit `--color-*` token or the label
+ * tier's neutral — so it cannot inherit a skin's sheet colour by accident.
  * `PraxisAdminBar` above is built the same way for the same reason. If a skin
  * ever needs this card to look different, that is an ADR change, not a prop.
+ *
+ * ONE THING THE #1307 SWEEP CHANGED ABOUT THAT LAST CLAUSE, AND IT IS A LOADED
+ * GUN RATHER THAN A BUG TODAY. `.eyebrow` HARDCODED `--color-text-tertiary`, so
+ * a label in here was neutral no matter what it was mounted inside.
+ * `.label-caption` reads `--label-ink`, which is a SEAM a faction frame is meant
+ * to set once on its own root (see its declaration in `index.css`) — and this
+ * card renders INSIDE that root. Nothing sets it yet, so every one of these
+ * labels still resolves to the same neutral; the moment a praxis-detail skin
+ * repoints it, the steward bar and the report card inherit the skin's quiet ink
+ * and ADR-0061's promise quietly breaks. The fix belongs to the token, not here:
+ * `.card-on-page` already names the stock these inks were measured on (#1413)
+ * and is the right place to pin `--label-ink` back to the neutral. Do not paper
+ * over it with an inline colour on each label — that is the per-component
+ * contradiction #1252 exists to stop.
  */
 export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
   const { t } = useTranslation('praxis')
@@ -653,7 +667,7 @@ export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
     return (
       <div className="sidebar-card card-on-page flex items-center gap-3" style={{ padding: 'var(--space-md) var(--space-lg)' }}>
         <div style={{ width: 32, height: 32, borderRadius: '50%', border: '1.5px solid var(--color-success)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-          <span className="eyebrow" style={{ color: 'var(--color-success)' }}>{t('detail.flag.flaggedOk')}</span>
+          <span className="label-caption" style={{ color: 'var(--color-success)' }}>{t('detail.flag.flaggedOk')}</span>
         </div>
         <div className="flex-1">
           <p className="font-body" style={{ fontSize: 'var(--text-base)', fontWeight: 700, color: 'var(--color-text-secondary)' }}>{t('detail.flag.flaggedTitle')}</p>
@@ -669,7 +683,7 @@ export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
     <div className="sidebar-card card-on-page" style={{ padding: 'var(--space-md) var(--space-lg)' }}>
       <div className="flex items-center gap-3">
         <div style={{ width: 32, height: 32, borderRadius: '50%', border: '1.5px solid var(--color-danger-edge)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-          <span className="eyebrow">{t('detail.flag.badge')}</span>
+          <span className="label-caption">{t('detail.flag.badge')}</span>
         </div>
         <div className="flex-1">
           <p className="font-body" style={{ fontSize: 'var(--text-base)', fontWeight: 700, color: 'var(--color-text-secondary)' }}>{t('detail.flag.title')}</p>


### PR DESCRIPTION
Part of #1307

The praxis detail's 41 `.eyebrow` call sites move onto the two label tiers that already ship in `index.css`. Nothing is created here: `.label-heading` (11px, uppercase, tracked) and `.label-caption` (12px, normal case, normal tracking) were declared by the foundation, and this is one of its per-area sweeps. `index.css` and `factionContrast.test.ts` are untouched, and `.eyebrow` stays declared — retiring it is the last sweep, not this one.

## What moved, and on what judgement

**`.label-heading` — 3 sites.** Only the marks that name a region:

| site | string |
|---|---|
| `shared.tsx` steward bar | `ADMIN · Status:` |
| `shared.tsx` Task Crown banner | `TASK CROWN` |
| `DefaultPraxisDetail` `sectionHead()` | Proof · Write-up · Members · Discussion · Score · Who voted · Metatasks |

That last one is a single call site that paints seven region names, which is why the heading tier's whole job is visible on the na page and essentially invisible on the other eight — the seven themed skins draw their section heads with a bespoke inline label object (Everymen's cog rule, S.N.I.D.E.'s wall stencil, UA's `UA_EYEBROW`), not with `.eyebrow`.

**`.label-caption` — 38 sites.** Breadcrumbs and their `›` / `/` separators, the mobile back link and its centred label, the `Submitted <date>` byline, `Completing task`, `Level N · N pts`, the vote count beside a section head, the `FLAGGED` banner chip, the moderation status chip, the `FLAG` and `OK` report-card badges, `edit this praxis`, the unsubmit/forfeit triggers and the confirm prompt, and the duel card's `read their praxis`.

Two of those are worth naming because the tier changes their rendered *casing*, which is the point of the split: the moderation status chip (`flagged` / `hidden` / `visible` / `failed`) and every breadcrumb crumb now read in their own case instead of uppercase. `FLAGGED`, `FLAG`, `OK` and `TASK CROWN` are uppercase in the catalogue, so they render unchanged.

## The overrides

**Deleted — tracking that existed to fight `.eyebrow` (10):** `letterSpacing: '0.2em'` on all five Default breadcrumb/mobile-bar sites and all five Everymen ones. The caption tier sets `letter-spacing: normal`; leaving these in would have rebuilt the wall the split exists to remove. The one tracking override kept is `DefaultPraxisDetail`'s `0.22em` on `sectionHead`, which is a *heading* — that tier keeps its tracking, and the wider value is the na skin's dress rather than a fight with the tier.

**Deleted — colour that is now pure noise (4):** `color: 'var(--color-text-tertiary)'` in `shared.tsx` on the steward-bar label, `edit this praxis`, the unsubmit trigger and the unsubmit confirm prompt. Unset, `--label-ink` resolves to exactly that token, so these render byte-identically.

**Left standing — every other colour override.** Per the ruling that label ink is measured per tier against all eight faction grounds, not reassigned in a sweep:

- `var(--color-warning)` — the `FLAGGED` banner chip, in all eight archetypes (8)
- `var(--faction-default-card-muted)` — Default's byline date, `Completing task`, level/points, vote count (4)
- `var(--faction-default-card-accent)` — Default's two breadcrumb links and the mobile back link (3)
- `var(--color-text-primary)` — Default's `sectionHead` ink (1)
- Everymen's `ACCENT` (3), `MUTED` (7), `OLIVE` (1)
- `paint.muted` — `DuelCard`'s rival cross-link (1)
- `wallInk(praxis, 'alarm')` — the forfeit trigger (1)
- `var(--color-success)` — the report card's `OK` disc (1)
- `shared.tsx`'s moderation-status ternary, which resolves to danger / warning / success / tertiary (1)

## One thing the sweep loads for a later PR

`.eyebrow` **hardcoded** `--color-text-tertiary`; the tiers read `--label-ink`, which is a seam a faction frame is meant to set once on its own root. ADR-0061 puts the steward bar and the report card *inside* that root deliberately undressed, and their neutrality was resting on that hardcoded ink. Nothing sets `--label-ink` today, so this PR changes no colour anywhere — but the first praxis-detail skin that repoints it will tint neutral moderation chrome. The remedy belongs to the token, not to these components: `.card-on-page` already names the stock these inks were measured on (#1413) and is where `--label-ink` should be pinned back to the neutral. `index.css` is out of this PR's scope, so it is written down at `PraxisFlagBlock`'s docstring instead.

## Still on `.eyebrow`-shaped inline objects (out of this sweep, worth an issue)

`EphemeristsPraxisDetail` (`eyebrow` / `plateEyebrow`, 9 uses) and `SnidePraxisDetail` (`eyebrow`, 12 uses) declare a local `CSSProperties` label voice at `var(--text-sm)` — 9px, uppercase, tracked, in a faction FACE. They carry the identical legibility cost #1307 is about, but neither tier sets a face, so moving them is a design decision rather than a class swap. Untouched here, and not part of the 241-site `className` census either.

## Verification

`tsc --noEmit`, `eslint src`, `vitest run` (224 files / 3894 tests), `vite build`, the initial-load byte budget (JS 138.1 KB, CSS 22.4 KB — both unchanged and within budget) and `typecheck:design-sync` all pass locally. Both tier names are written as literals and both are confirmed present in the BUILT stylesheet, so nothing is purged.

**Visual QA is outstanding** — this branch was built with no browser and no dev stack.

## What to eyeball

Each of these in **both themes**, since `--label-ink` follows `--color-text-tertiary` through the dark cascade:

1. **Unaffiliated / `na`** — the whole page is the reference: the desktop breadcrumb (`Tasks › <task> › Praxis`, now mixed-case and untracked), the mobile back-link bar, the byline's `Submitted …` line, the `Completing task` / `Level N · N pts` rule, and every `sectionHead`. This is the only skin where `.label-heading` renders at all, so it is the one place to judge 11px-caps against 12px-lowercase side by side.
2. **Albescent** — renders the na component under its drift overlay, so it inherits all of the above; check the shimmer over the new sizes.
3. **Everymen** — the broadsheet's breadcrumb, mobile bar, byline date, standfirst row (`Completing task`, olive level/points) and the voters-block count. Its section heads are its own inline label and are deliberately unchanged, so check that the two voices still sit together.
4. **All eight skins, flagged state** — the `FLAGGED` chip in the amber banner, now 12px normal-tracked in `--color-warning`.
5. **Report card, two states** — the `FLAG` prompt and the post-submit `OK`. Both badges are single marks centred in a 32px ring; the tier trades 9px+tracking for 12px+none, so the width barely moves in theory and `FLAG` is the one to confirm has not grown out of its circle.
6. **Steward bar, signed in as an admin** — `ADMIN · Status:` (heading) beside the status chip (caption), which now reads `flagged` / `hidden` / `visible` / `failed` in lower case inside its bordered pill.
7. **Owner actions** — `edit this praxis`, `unsubmit to edit`, and the confirm prompt sentence, which is the longest caption on the page and the clearest read on whether 12px normal case fixed the wall.
8. **A settled duel** — `DuelCard`'s `read their praxis` cross-link under the rival's row, on each of the nine walls.
9. **Task Crown hero** — `TASK CROWN` over its body line, the second heading-tier site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
