### PR TITLE
Task detail's archetypes move off .eyebrow onto the two label tiers

### DIFF
--- a/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/AlbescentTaskDetail.tsx
@@ -97,9 +97,7 @@ export default function AlbescentTaskDetail({
           flexWrap: "wrap",
         }}
       >
-        <span className="eyebrow" style={{ letterSpacing: "0.16em" }}>
-          {t("detail.points.base")}
-        </span>
+        <span className="label-caption">{t("detail.points.base")}</span>
         <span
           style={{
             fontFamily: "var(--font-accent)",
@@ -146,9 +144,8 @@ export default function AlbescentTaskDetail({
             {modifiedPoints}
           </span>
           <span
-            className="eyebrow"
+            className="label-caption"
             style={{
-              fontSize: "var(--text-xs)",
               marginTop: "var(--space-xs)",
               color: "var(--faction-default-gold)",
             }}

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -177,7 +177,7 @@ export default function DefaultTaskDetail({
       }}
     >
       <span
-        className="eyebrow"
+        className="label-heading"
         style={{ letterSpacing: "0.22em", color: "var(--color-text-primary)" }}
       >
         {label}
@@ -193,7 +193,7 @@ export default function DefaultTaskDetail({
           opacity: 0.55,
         }}
       />
-      {gloss !== undefined && <span className="eyebrow">{gloss}</span>}
+      {gloss !== undefined && <span className="label-caption">{gloss}</span>}
     </div>
   );
 
@@ -201,9 +201,7 @@ export default function DefaultTaskDetail({
   const scoreBody = (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
       <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
-        <span className="eyebrow" style={{ letterSpacing: "0.16em" }}>
-          {t("detail.points.base")}
-        </span>
+        <span className="label-caption">{t("detail.points.base")}</span>
         <span
           style={{
             fontFamily: "var(--font-accent)",
@@ -455,9 +453,8 @@ export default function DefaultTaskDetail({
       >
         <Link
           to="/tasks"
-          className="eyebrow"
+          className="label-caption"
           style={{
-            letterSpacing: "0.2em",
             color: "var(--faction-default-card-accent)",
             textDecoration: "none",
           }}
@@ -485,12 +482,7 @@ export default function DefaultTaskDetail({
             backgroundImage: SPECTRUM,
           }}
         />
-        <span
-          className="eyebrow"
-          style={{ fontSize: "var(--text-base)", letterSpacing: "0.2em" }}
-        >
-          {factionName(slug)}
-        </span>
+        <span className="label-caption">{factionName(slug)}</span>
         {isMetatask && (
           <span
             className="font-body"
@@ -528,7 +520,7 @@ export default function DefaultTaskDetail({
 
       {isMetatask && (
         <p
-          className="eyebrow"
+          className="label-caption"
           style={{
             marginTop: 0,
             marginBottom: "var(--space-md)",
@@ -609,7 +601,7 @@ export default function DefaultTaskDetail({
               {authorName}
             </span>
           </Link>
-          <span className="eyebrow">
+          <span className="label-caption">
             {t("detail.author", { level: task.created_by_level ?? 0 })}
           </span>
         </div>
@@ -626,7 +618,7 @@ export default function DefaultTaskDetail({
         }}
       >
         <div style={{ display: "flex", flexDirection: "column", lineHeight: 1 }}>
-          <span className="eyebrow" style={{ marginBottom: "var(--space-xs)" }}>
+          <span className="label-caption" style={{ marginBottom: "var(--space-xs)" }}>
             {t("detail.stats.level")}
           </span>
           <span
@@ -651,7 +643,7 @@ export default function DefaultTaskDetail({
           }}
         />
         <div style={{ display: "flex", flexDirection: "column", lineHeight: 1 }}>
-          <span className="eyebrow" style={{ marginBottom: "var(--space-xs)" }}>
+          <span className="label-caption" style={{ marginBottom: "var(--space-xs)" }}>
             {t("detail.stats.inProgress")}
           </span>
           <span
@@ -703,7 +695,7 @@ export default function DefaultTaskDetail({
         }}
       >
         <span
-          className="eyebrow"
+          className="label-heading"
           style={{ letterSpacing: "0.22em", color: "var(--color-text-primary)" }}
         >
           {t("detail.gallery.heading", { count: submissions.length })}
@@ -732,7 +724,7 @@ export default function DefaultTaskDetail({
             <button
               key={sort}
               onClick={() => setSubmissionSort(sort)}
-              className="eyebrow"
+              className="label-caption"
               style={{
                 cursor: "pointer",
                 border: "none",

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -293,9 +293,8 @@ export default function EverymenTaskDetail({
       >
         <Link
           to="/tasks"
-          className="eyebrow"
+          className="label-caption"
           style={{
-            letterSpacing: "0.2em",
             color: ACCENT,
             textDecoration: "none",
           }}
@@ -365,7 +364,7 @@ export default function EverymenTaskDetail({
 
       {isMetatask && (
         <p
-          className="eyebrow"
+          className="label-caption"
           style={{
             marginTop: 0,
             marginBottom: "var(--space-md)",
@@ -446,7 +445,7 @@ export default function EverymenTaskDetail({
               {authorName}
             </span>
           </Link>
-          <span className="eyebrow" style={{ color: MUTED }}>
+          <span className="label-caption" style={{ color: MUTED }}>
             {t("detail.author", { level: task.created_by_level ?? 0 })}
           </span>
         </div>
@@ -537,10 +536,7 @@ export default function EverymenTaskDetail({
           gap: "var(--space-sm)",
         }}
       >
-        <span
-          className="eyebrow"
-          style={{ letterSpacing: "0.16em", color: MUTED }}
-        >
+        <span className="label-caption" style={{ color: MUTED }}>
           {t("detail.points.base")}
         </span>
         <span

--- a/frontend/src/pages/taskDetail/archetypes/shared.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/shared.tsx
@@ -49,7 +49,7 @@ export function LevelJumpBanner({ state }: { state: TaskDetailState }) {
       }}
     >
       <span
-        className="eyebrow"
+        className="label-caption"
         style={{ color: "var(--color-text-primary)" }}
       >
         {t("detail.levelJump.tag")}


### PR DESCRIPTION
Part of #1307

The label-tier sweep for `frontend/src/pages/taskDetail/archetypes/`. The foundation
(`.label-heading`, `.label-caption`, `--label-ink`, the doctrine amendment, the contrast
assertions) already shipped; this PR only moves call sites onto it. **`index.css` and
`factionContrast.test.ts` are untouched** — `.eyebrow` stays declared and in use, and the
shared registry is left alone so parallel area sweeps cannot red `main` after squash.

## What moved

**18 `className`-borne `.eyebrow` sites → 2 `.label-heading` + 16 `.label-caption`.**
Verified with `grep -rn 'className="eyebrow"' frontend/src/pages/taskDetail/archetypes/` →
no matches remain.

| file | sites | tier |
|---|---|---|
| `DefaultTaskDetail.tsx` | 2 | `.label-heading` — the `sectionHead()` label and the praxis-gallery heading |
| `DefaultTaskDetail.tsx` | 9 | `.label-caption` |
| `EverymenTaskDetail.tsx` | 4 | `.label-caption` |
| `AlbescentTaskDetail.tsx` | 2 | `.label-caption` |
| `archetypes/shared.tsx` | 1 | `.label-caption` |

### Why only two headings

`.label-heading` is *"this names a region."* On this page exactly two strings do that, and both
live in Default: `sectionHead()` (which draws `Task Description` and the comments head, each
followed by the spectrum hairline) and the gallery head `{count} completed praxis`. Everything
else on a task-detail page is a **small fact about the task** — breadcrumb, faction line,
`Metatask for {faction}`, `author · lvl N`, `Level` / `In progress` stat labels, `base`,
`POINTS`, the `Level-jump` tag, the `Top rated` / `Recent` sort toggles. Those are captions,
including the several that were genuinely ambiguous (breadcrumb, sort buttons, faction line) —
the brief's tiebreak is caption, and the point of the split is that unreadable-as-prose is the
exception.

This is `.label-heading`'s **first production caller**; until now it was in the bundle only
because the contrast spec quoted it. Confirmed emitted in the built stylesheet, not just the
source:

```
.label-heading{font-family:Courier Prime,monospace;font-size:var(--text-md);text-transform:uppercase;letter-spacing:.15em;color:var(--label-ink)}
.label-caption{font-family:Courier Prime,monospace;font-size:var(--text-lg);text-transform:none;letter-spacing:normal;color:var(--label-ink)}
```

## Inline overrides DELETED (7)

Every one of these existed to fight `.eyebrow`'s treatment and now contradicts the caption tier:

- `letterSpacing: "0.16em"` — `AlbescentTaskDetail`, `DefaultTaskDetail`, `EverymenTaskDetail` (the `base` points label ×3)
- `letterSpacing: "0.2em"` — `DefaultTaskDetail` and `EverymenTaskDetail` (the `Tasks` breadcrumb ×2)
- `letterSpacing: "0.2em"` **and** `fontSize: "var(--text-base)"` — `DefaultTaskDetail` (the faction line)
- `fontSize: "var(--text-xs)"` — `AlbescentTaskDetail` (`POINTS` inside the prism ring)

The two `fontSize` deletions are the ones that visibly change size, and they are deliberate: both
were bumps applied *to `.eyebrow`'s 9px*, and the tier's 12px supersedes them. `--text-xs` is
**8px** — leaving it would have kept the worse half of the wall at the one place it is smallest.

`letterSpacing: "0.22em"` on the two `.label-heading` sites is **kept**. Headings retain tracking
by design, so a slightly wider value is na's dress rather than a fight with the tier; only the
caption sites, where the tier sets `normal`, had a contradiction to remove.

## Colour overrides LEFT STANDING (10) — per the brief, ink is a separate measured change

None of these are `--color-text-tertiary`, so none qualified for the noise exception:

| site | override |
|---|---|
| `shared.tsx` (`Level-jump` tag) | `var(--color-text-primary)` |
| `DefaultTaskDetail` (`sectionHead` label) | `var(--color-text-primary)` |
| `DefaultTaskDetail` (gallery heading) | `var(--color-text-primary)` |
| `DefaultTaskDetail` (breadcrumb) | `var(--faction-default-card-accent)` |
| `DefaultTaskDetail` (`Metatask for …`) | `factionCssVar(metatask_faction_slug)` |
| `DefaultTaskDetail` (sort buttons) | ternary `var(--color-bg-page)` / `var(--color-text-tertiary)` |
| `AlbescentTaskDetail` (`POINTS`) | `var(--faction-default-gold)` |
| `EverymenTaskDetail` (breadcrumb) | `ACCENT` = `var(--faction-everymen-sheet-accent)` |
| `EverymenTaskDetail` (`Metatask for …`) | `factionCssVar(metatask_faction_slug)` |
| `EverymenTaskDetail` (byline, `base`) | `MUTED` = `var(--everymen-muted)` |

The sort-button one is worth a note: its tertiary arm looks like the deletable noise case, but it
is **half of a selected/unselected ternary** whose other arm is `--color-bg-page`. Removing half a
ternary is not a no-op, so the whole expression stays.

Since no faction frame repoints `--label-ink` yet, it resolves to `--color-text-tertiary`
everywhere — i.e. exactly what `.eyebrow` painted. **This PR changes no ink.** None of the three
light-cascade sheets the neutral cannot clear (S.N.I.D.E., Singularity, Ephemerists) is touched
here: those three archetypes never used the class (see below).

## Not swept, and why

`CovenTaskDetail`, `EphemeristsTaskDetail` and `SnideTaskDetail` each declare a **local
`const eyebrow: CSSProperties`** and spread it inline. Those are bespoke faction inline styles that
never referenced the `.eyebrow` class, so deleting `.eyebrow` in the final sweep will not touch
them and they are outside this issue's `className` measurement. Converting them is a real change
(each carries its own faction ink and would need `--label-ink` repointed on that frame first) and
belongs with the per-faction ink work in the #1307 grill's section 4.

## Checks

All six frontend CI steps run locally and green: `eslint src`, `tsc --noEmit`, `vitest run`
(224 files / 3894 tests), `vite build`, `npm run budget` (JS 138.1 KB, CSS 22.4 KB — both ok;
CSS unchanged, `index.css` not edited), `npm run typecheck:design-sync`.

**Visual QA is outstanding** — I have no browser and no dev stack.

## What to eyeball

Task detail at `/tasks/:id`, **both themes**:

1. **na / Unaffiliated (`DefaultTaskDetail`)** — the header row (spectrum dot, faction name, META
   pill): the faction line dropped from 10px tracked caps to 12px sentence case and now sits beside
   an 8px `META` pill. That size relationship is the single most likely thing to look wrong.
2. **na** — the `Tasks` breadcrumb now reads `Tasks`, not `TASKS`.
3. **na** — `Task Description` and `{n} completed praxis` section heads: still caps + hairline,
   now 11px instead of 9px. Check the hairline still baselines against them.
4. **na** — the `Level` / `In progress` stat pair under the byline, and the `author · lvl N`
   byline itself, all sentence case at 12px.
5. **na** — the `Top rated` / `Recent` sort toggles inside their bordered pill, **selected and
   unselected**, at 12px sentence case: check the pill still fits and the selected fill still
   contains its label.
6. **Albescent** — the prism-ring worth readout: `POINTS` inside the ring went 8px → 12px. Ring is
   92px desktop / **74px mobile** (inner face inset 7px), so check the mobile ring first — that is
   the tightest geometry in the change.
7. **Everymen** — the newsprint header: breadcrumb, `author · lvl N` byline, and the `base` label
   beside the Bebas figure. Everymen's own masthead and section heads are bespoke and unchanged, so
   check the swept captions do not now out-shout them.
8. **Metatask task, any faction** — `Metatask for {faction}` under the title on both na and
   Everymen, still painted in the target faction's hue.
9. **A level-jump task** (WOW member, task one rung up) — the `Level-jump` tag in the shared
   banner, sentence case at 12px next to its 9px note.
10. **Mobile** for 1–7; every one of these strings is in the collapsed single-column header.

Coven, Ephemerists, S.N.I.D.E., Singularity, UA and WOW task details are **unchanged** by this PR.
