### PR TITLE
The feed's 28 label sites split into region names and small facts (#1307)

### DIFF
--- a/frontend/src/components/feed/CovenFeedFrame.tsx
+++ b/frontend/src/components/feed/CovenFeedFrame.tsx
@@ -34,8 +34,8 @@ import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
  *                     re-inked here — hence no padding on the body wrapper.
  *
  * The four slots are placed by hand rather than through `FeedChassisBand`,
- * because the band's `.eyebrow` sets the kicker at the label ramp's floor and
- * this sheet wants it in the display face. Nothing is dropped: kicker · tag ·
+ * because the band's `.label-heading` sets the kicker in the shared label face
+ * and this sheet wants it in the display face. Nothing is dropped: kicker · tag ·
  * time · archive all ride the head, and the head is tinted `--faction-coven-
  * slip-ink` so the archive control — which paints in `currentColor` — comes out
  * in the slip's own ink.

--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -190,8 +190,9 @@ export default function EphemeristsFeedFrame({
 
         {/* The four chrome slots, placed by hand rather than through
             `FeedChassisBand`: this band sets the kicker in incised small caps and
-            the time in the reading face, which the shared arrangement's uniform
-            `.eyebrow` would flatten. All four are still drawn — a swallowed slot
+            the time in the reading face, which the shared arrangement's
+            `.label-heading` / `.label-caption` pair would flatten. All four are
+            still drawn — a swallowed slot
             loses a feature, not a decoration. */}
         <div
           style={{

--- a/frontend/src/components/feed/EverymenFeedFrame.tsx
+++ b/frontend/src/components/feed/EverymenFeedFrame.tsx
@@ -140,11 +140,14 @@ export default function EverymenFeedFrame({
         >
           {/* Left flank — the status tag ("Still waiting"), or nothing. Drawn as
               an overprinted chip: a currentColor hairline box, so it reads as a
-              stamp struck onto the band rather than a second colour on it. */}
+              stamp struck onto the band rather than a second colour on it.
+              A status and a dateline are both small FACTS about the slip, so
+              both flanks are `.label-caption` (#1307); the masthead between
+              them is the kicker and already carries its own poster face. */}
           <span style={{ justifySelf: 'start', minWidth: 0, display: 'inline-flex' }}>
             {tag && (
               <span
-                className="eyebrow"
+                className="label-caption"
                 style={{
                   color: 'inherit',
                   border: '1px solid currentColor',
@@ -193,7 +196,7 @@ export default function EverymenFeedFrame({
             }}
           >
             <span
-              className="eyebrow"
+              className="label-caption"
               style={{ color: 'inherit', whiteSpace: 'nowrap', minWidth: 0 }}
             >
               {time}

--- a/frontend/src/components/feed/FeedBankFullModal.tsx
+++ b/frontend/src/components/feed/FeedBankFullModal.tsx
@@ -118,9 +118,13 @@ export default function FeedBankFullModal({
         }}
         onClick={(event) => event.stopPropagation()}
       >
+        {/* The dialog's accessible name, and the one site in the feed that
+            unambiguously NAMES A REGION — so it takes `.label-heading` while
+            the failure line below, which is genuinely read, takes the caption
+            tier (#1307). */}
         <p
           id={titleId}
-          className="eyebrow"
+          className="label-heading"
           style={{ marginBottom: 'var(--space-sm)' }}
         >
           {title}
@@ -167,7 +171,7 @@ export default function FeedBankFullModal({
         </div>
         {error && (
           <p
-            className="eyebrow"
+            className="label-caption"
             style={{
               color: 'var(--color-danger)',
               marginTop: 'var(--space-md)',

--- a/frontend/src/components/feed/FeedBulkArchiveButton.tsx
+++ b/frontend/src/components/feed/FeedBulkArchiveButton.tsx
@@ -27,7 +27,7 @@ export default function FeedBulkArchiveButton({
     <button
       type="button"
       onClick={onAct}
-      className="eyebrow"
+      className="label-caption"
       data-feed-bulk={archivedView ? 'restore-all' : 'archive-all'}
       style={{
         cursor: pending ? 'progress' : 'pointer',

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -204,10 +204,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
           >
             {task_title}
           </span>
-          <span
-            className="eyebrow"
-            style={{ color: "var(--color-text-tertiary)" }}
-          >
+          <span className="label-caption">
             {i18n.t("feed:collabInvite.taskMeta", {
               points: task_point_value,
               level: task_level_required,
@@ -265,7 +262,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
               {i18n.t("feed:collabInvite.decline")}
             </button>
             {error && (
-              <span className="eyebrow" style={{ color: "var(--color-danger)" }}>
+              <span className="label-caption" style={{ color: "var(--color-danger)" }}>
                 {error}
               </span>
             )}
@@ -276,7 +273,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
           <div style={{ marginTop: "var(--space-sm)", marginLeft: "var(--space-3xl)" }}>
             <Link
               to={`/praxis/${praxis_id}`}
-              className="eyebrow"
+              className="label-caption"
               style={{ color: "var(--badge-collab)", textDecoration: "none" }}
             >
               {i18n.t("feed:collabInvite.accepted")}
@@ -285,10 +282,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
         )}
         {status === "declined" && (
           <div style={{ marginTop: "var(--space-sm)", marginLeft: "var(--space-3xl)" }}>
-            <span
-              className="eyebrow"
-              style={{ color: "var(--color-text-tertiary)" }}
-            >
+            <span className="label-caption">
               {i18n.t("feed:collabInvite.declined")}
             </span>
           </div>

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -236,10 +236,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
           >
             {task_title}
           </span>
-          <span
-            className="eyebrow"
-            style={{ color: "var(--color-text-tertiary)" }}
-          >
+          <span className="label-caption">
             {i18n.t("feed:duelChallenge.taskMeta", { points: task_point_value })}
           </span>
           {/* eslint-disable-next-line local/no-raw-style-values -- ornament: crossed-swords dingbat used as an icon */}
@@ -316,7 +313,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
             </button>
             {error && !showDropModal && (
               <span
-                className="eyebrow"
+                className="label-caption"
                 style={{ color: "var(--color-danger)" }}
               >
                 {error}
@@ -324,7 +321,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
             )}
             {withdrawError && (
               <span
-                className="eyebrow"
+                className="label-caption"
                 style={{ color: "var(--color-danger)" }}
               >
                 {withdrawError}
@@ -335,10 +332,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
 
         {withdrawn && (
           <div style={{ marginTop: "var(--space-sm)", marginLeft: "var(--space-3xl)" }}>
-            <span
-              className="eyebrow"
-              style={{ color: "var(--color-text-tertiary)" }}
-            >
+            <span className="label-caption">
               {i18n.t("feed:duelChallenge.withdrawn")}
             </span>
           </div>
@@ -348,7 +342,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
           <div style={{ marginTop: "var(--space-sm)", marginLeft: "var(--space-3xl)" }}>
             <Link
               to={`/praxis/${challenger_praxis_id}`}
-              className="eyebrow"
+              className="label-caption"
               style={{ color: "var(--badge-duel)", textDecoration: "none" }}
             >
               {i18n.t("feed:duelChallenge.accepted")}
@@ -357,10 +351,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
         )}
         {status === "declined" && (
           <div style={{ marginTop: "var(--space-sm)", marginLeft: "var(--space-3xl)" }}>
-            <span
-              className="eyebrow"
-              style={{ color: "var(--color-text-tertiary)" }}
-            >
+            <span className="label-caption">
               {i18n.t("feed:duelChallenge.declined")}
             </span>
           </div>

--- a/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
+++ b/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
@@ -32,8 +32,11 @@ export default function FeedCardEraAnnouncement({ item, archive }: Props) {
       }}
     >
       <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)', marginBottom: 'var(--space-md)' }}>
-        <span className="eyebrow">{i18n.t('feed:eraAnnouncement.kicker')}</span>
-        <span className="eyebrow" style={{ color: 'var(--rank-silver)' }}>
+        {/* The masthead pair (#1307): "ERA" names the card, so it is the
+            heading tier; "Era Announcement" beside it is a fact about the card
+            and takes the caption's sentence case. */}
+        <span className="label-heading">{i18n.t('feed:eraAnnouncement.kicker')}</span>
+        <span className="label-caption" style={{ color: 'var(--rank-silver)' }}>
           {i18n.t('feed:eraAnnouncement.label')}
         </span>
         <span style={{ marginLeft: 'auto' }}>

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -269,7 +269,7 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
         >
           {joined ? (
             <span
-              className="eyebrow"
+              className="label-caption"
               style={{ color }}
               data-invitation-accepted
             >

--- a/frontend/src/components/feed/FeedChassisBand.tsx
+++ b/frontend/src/components/feed/FeedChassisBand.tsx
@@ -16,6 +16,13 @@ import type { ReactNode } from 'react'
  * Everything here paints in `color: inherit` / `currentColor`, so a frame tints
  * the whole band (the archive control included) by setting `color` on whatever
  * it places this inside.
+ *
+ * THE BAND SPENDS BOTH LABEL TIERS (#1307), and the split is the slot's job
+ * rather than its position. The kicker NAMES THE REGION — it is the card's kind,
+ * one or two words by construction, and every faction sheet that places the four
+ * slots by hand draws it as a masthead — so it is `.label-heading`. The tag and
+ * the time are small FACTS about the card, genuinely read, so they take
+ * `.label-caption` and its sentence case.
  */
 export default function FeedChassisBand({
   kicker,
@@ -39,7 +46,7 @@ export default function FeedChassisBand({
       }}
     >
       <span
-        className="eyebrow"
+        className="label-heading"
         style={{
           color: 'inherit',
           minWidth: 0,
@@ -52,7 +59,7 @@ export default function FeedChassisBand({
       </span>
       {tag && (
         <span
-          className="eyebrow"
+          className="label-caption"
           style={{
             color: 'inherit',
             opacity: 0.8,
@@ -65,7 +72,7 @@ export default function FeedChassisBand({
         </span>
       )}
       <span
-        className="eyebrow"
+        className="label-caption"
         style={{
           marginLeft: 'auto',
           color: 'inherit',

--- a/frontend/src/components/feed/FeedRowActions.tsx
+++ b/frontend/src/components/feed/FeedRowActions.tsx
@@ -24,6 +24,10 @@ import type { FeedRowAction } from './normalizeFeedItem'
  * longer describes reality (you have left the collab), so the button is replaced
  * by nothing rather than left clickable. `notifyRequestsChanged()` makes the
  * surrounding feed refetch, which is what actually removes the row.
+ *
+ * The labels and the failure line are `.label-caption` (#1307): an action label
+ * and an error are both genuinely read, so neither may wear the heading tier's
+ * caps and tracking. Nothing here names a region.
  */
 export default function FeedRowActions({ actions }: { actions: FeedRowAction[] }) {
   const [pendingId, setPendingId] = useState<string | null>(null)
@@ -59,14 +63,14 @@ export default function FeedRowActions({ actions }: { actions: FeedRowAction[] }
     >
       {visible.map((action) =>
         action.href ? (
-          <Link key={action.id} to={action.href} className="eyebrow" style={buttonStyle(action.tone)}>
+          <Link key={action.id} to={action.href} className="label-caption" style={buttonStyle(action.tone)}>
             {action.label}
           </Link>
         ) : (
           <button
             key={action.id}
             type="button"
-            className="eyebrow"
+            className="label-caption"
             onClick={() => runCall(action)}
             style={{
               ...buttonStyle(action.tone),
@@ -78,7 +82,7 @@ export default function FeedRowActions({ actions }: { actions: FeedRowAction[] }
         ),
       )}
       {error && (
-        <span className="eyebrow" style={{ color: 'var(--color-danger)' }}>
+        <span className="label-caption" style={{ color: 'var(--color-danger)' }}>
           {error}
         </span>
       )}

--- a/frontend/src/components/feed/FeedRowContent.tsx
+++ b/frontend/src/components/feed/FeedRowContent.tsx
@@ -202,13 +202,18 @@ export default function FeedRowContent({
                 crooked gold plaque, the Everymen's stamped circular seal — and
                 a chassis had no way to reach it, nor any value to strike one
                 with. A frame that publishes no `points` renderer gets the
-                eyebrow line below, unchanged; the gate is shared, so a skin
+                caption line below, unchanged; the gate is shared, so a skin
                 never has to guard for an empty figure. */}
             {(row.points || row.level != null) &&
               (skin.points ? (
                 skin.points({ points: row.points, level: row.level })
               ) : (
-                <span className="eyebrow" style={{ color: 'var(--color-text-tertiary)' }}>
+                {/* A points/level figure is a small fact about the row, so it
+                    is `.label-caption` (#1307). The inline tertiary is gone
+                    rather than restated: unset, `--label-ink` resolves to
+                    exactly that token, and pinning it here would be the one
+                    thing that stops a faction frame repointing the label ink. */}
+                <span className="label-caption">
                   {row.points}
                   {row.points && row.level != null ? ' · ' : ''}
                   {row.level != null ? i18n.t('feed:row.level', { level: row.level }) : ''}

--- a/frontend/src/components/feed/FeedRowContent.tsx
+++ b/frontend/src/components/feed/FeedRowContent.tsx
@@ -203,16 +203,18 @@ export default function FeedRowContent({
                 a chassis had no way to reach it, nor any value to strike one
                 with. A frame that publishes no `points` renderer gets the
                 caption line below, unchanged; the gate is shared, so a skin
-                never has to guard for an empty figure. */}
+                never has to guard for an empty figure.
+
+                That line is `.label-caption` (#1307) — a points/level figure is
+                a small fact about the row, not a region name. Its inline
+                tertiary is gone rather than restated: unset, `--label-ink`
+                resolves to exactly that token, and pinning it here is the one
+                thing that would stop a faction frame repointing the label
+                ink. */}
             {(row.points || row.level != null) &&
               (skin.points ? (
                 skin.points({ points: row.points, level: row.level })
               ) : (
-                {/* A points/level figure is a small fact about the row, so it
-                    is `.label-caption` (#1307). The inline tertiary is gone
-                    rather than restated: unset, `--label-ink` resolves to
-                    exactly that token, and pinning it here would be the one
-                    thing that stops a faction frame repointing the label ink. */}
                 <span className="label-caption">
                   {row.points}
                   {row.points && row.level != null ? ' · ' : ''}

--- a/frontend/src/components/feed/FeedUndoStrip.tsx
+++ b/frontend/src/components/feed/FeedUndoStrip.tsx
@@ -69,7 +69,7 @@ export default function FeedUndoStrip({
       <button
         type="button"
         onClick={onAct}
-        className="eyebrow"
+        className="label-caption"
         style={{
           flexShrink: 0,
           background: 'transparent',

--- a/frontend/src/components/feed/UaFeedFrame.tsx
+++ b/frontend/src/components/feed/UaFeedFrame.tsx
@@ -36,8 +36,14 @@ import type { FeedFrameProps } from './feedFrameProps'
  * functional control sits under an ornament.
  *
  * TYPE. Kicker in Cormorant Garamond (the display cut), uppercase and widely
- * tracked; the time in the EB Garamond eyebrow, the pairing the sheet draws.
- * Both are label tier — a kind label and a timestamp are scanned, not read (§4).
+ * tracked; the tag and the time in the EB Garamond label face, the pairing the
+ * sheet draws. Both are label tier, but #1307 split that tier in two and this
+ * band has NOT been swept: the kicker is heading work (it names the card) while
+ * the tag and the time are captions (small facts, genuinely read), and both of
+ * the latter wear `UA_EYEBROW` — a hand-rolled label style in
+ * `components/factionMarks/uaAtoms.ts`, outside this directory. Moving it is
+ * that atom's sweep, not this file's; until then the old "scanned, not read"
+ * reading still describes what renders here, and it is no longer the doctrine.
  *
  * NO COPY. Every string on this card arrives as a prop from the neutral `feed`
  * catalog; the sheet's own dialect is discarded (epic #1192), and there is no

--- a/frontend/src/components/feed/WowFeedFrame.tsx
+++ b/frontend/src/components/feed/WowFeedFrame.tsx
@@ -50,7 +50,7 @@ import type { FeedFrameProps } from './feedFrameProps'
  *
  * #1252 grew the body the slot this note asked for: publish a
  * {@link FeedRowSkin} with a `points` renderer and it draws the figure INSTEAD
- * of the shared eyebrow line, with the row's own values. Striking the plaque is
+ * of the shared caption line, with the row's own values. Striking the plaque is
  * dress and belongs to #1204's own follow-up; what this file claims today is
  * the ink half of that seam, below.
  *
@@ -157,8 +157,12 @@ export default function WowFeedFrame({
           ✦
         </span>
 
+        {/* The proclamation head NAMES the card, so it is `.label-heading`
+            (#1307) — the tier the decree's own caps and tracking already agree
+            with, and the faction dress below only re-tunes. The chip beside it
+            is a status, which is caption work. */}
         <span
-          className="eyebrow"
+          className="label-heading"
           style={{
             fontFamily: MED,
             fontSize: size.kicker,
@@ -175,14 +179,15 @@ export default function WowFeedFrame({
 
         {/* "Still waiting" — an archived challenge or invite is still open, since
             archiving never answers anything (ADR-0070). Struck as the decree's
-            own plum lozenge, the one WOW chip pairing measured in both themes. */}
+            own plum lozenge, the one WOW chip pairing measured in both themes.
+            Its 11px and its 0.1em tracking are gone rather than restated: both
+            existed to lift the chip off `.eyebrow`'s 9px caps, and the caption
+            tier now carries that job further than the overrides did. */}
         {tag && (
           <span
-            className="eyebrow"
+            className="label-caption"
             style={{
               fontFamily: MED,
-              fontSize: 'var(--text-md)',
-              letterSpacing: '0.1em',
               color: 'var(--faction-wow-on-plum)',
               background: 'var(--faction-wow-plum-surface)',
               borderRadius: 4,

--- a/frontend/src/components/feed/feedRowSkin.ts
+++ b/frontend/src/components/feed/feedRowSkin.ts
@@ -122,7 +122,7 @@ export function resolveFeedRowInk(
   }
 }
 
-/** The figure the row would otherwise print in its own eyebrow voice. */
+/** The figure the row would otherwise print in its own caption voice. */
 export interface FeedRowPoints {
   /** Pre-formatted points string, e.g. "40 pts" / "+12 pts", or null. */
   points: string | null
@@ -133,7 +133,7 @@ export interface FeedRowSkin {
   /** Re-point the body's inks for this chassis's ground. */
   ink?: FeedRowInk
   /**
-   * Draw the points/level figure instead of the shared eyebrow line.
+   * Draw the points/level figure instead of the shared caption line.
    *
    * A renderer rather than a style bag because the four asks are STRUCTURE, not
    * colour: WOW's sheet strikes a crooked gold plaque (`rotate(-2deg)`) with a ✦


### PR DESCRIPTION
Part of #1307

The label-tier sweep for `frontend/src/components/feed/`. The foundation (`.label-heading`, `.label-caption`, `--label-ink`, the doctrine amendment, the contrast rows) already shipped in `index.css`; this PR only moves call sites onto it. **Nothing outside `components/feed/` is touched** — not `index.css`, not `factionContrast.test.ts`, not `.eyebrow` itself, which stays declared and in use for the areas the sibling sweeps own.

## The count

28 `className`-borne `.eyebrow` sites, which is exactly the orientation figure. They land **24 caption / 4 heading**, and zero `.eyebrow` class sites remain in the directory.

## Where the heading tier went, and why so few

`.label-heading` had no callers at all before this PR (it was in the bundle only because a spec file quotes the literal). It gets four, all the same judgement — **this string names the region, and the region is the card**:

| site | string |
|---|---|
| `FeedChassisBand.tsx` kicker | the card's kind, in the shared four-slot band |
| `FeedCardEraAnnouncement.tsx` kicker | `ERA` |
| `WowFeedFrame.tsx` proclamation head | the kicker in MedievalSharp caps |
| `FeedBankFullModal.tsx` title | `Task bank full` / `Task list full` — the dialog's `aria-labelledby` |

The kicker is a region name by the ruling's own test: one or two words by construction, and every faction sheet that declines `FeedChassisBand` and places the four slots by hand draws it as a **masthead** (Everymen's poster face, WOW's decree, UA's Cormorant caps, Coven's display face). Making it a caption would have flattened four sheets' mastheads to sentence case, which is the opposite of what the split is for. Everything else on a feed card is a small fact about the card, so everything else is a caption.

Note the two mastheads that were *never* `.eyebrow` — Everymen's and UA's — are untouched by this PR; they draw their own display type.

## Overrides deleted

**Six inline `color: 'var(--color-text-tertiary)'`**, per the sweep brief: unset, `--label-ink` resolves to exactly that token, so these were noise, and pinning it at the call site is the one thing that would stop a faction frame ever repointing the label ink.

- `FeedRowContent.tsx` — the points/level line
- `FeedCardCollabInvite.tsx` — task meta, `declined`
- `FeedCardDuelChallenge.tsx` — task meta, `withdrawn`, `declined`

**WOW's "Still waiting" chip loses `fontSize: 'var(--text-md)'` and `letterSpacing: '0.1em'`.** Both existed to lift the chip off `.eyebrow`'s 9px caps; the caption tier carries that job further than the overrides did (12px, `letter-spacing: normal`), so restating them would re-impose the wall at the one size that makes it worse. The chip keeps its MedievalSharp face and its measured plum pairing. This is the only geometry change in the PR.

## Colour overrides LEFT STANDING

Ink is a separate, measured change. Every one of these survives untouched:

| file | override | why it stays |
|---|---|---|
| `FeedChassisBand.tsx` x3 | `color: 'inherit'` | load-bearing — a frame tints the whole band, archive control included, via `currentColor` |
| `EverymenFeedFrame.tsx` x2 | `color: 'inherit'` | same, on the red masthead |
| `WowFeedFrame.tsx` kicker | `color: 'inherit'` | the head's plum ink |
| `WowFeedFrame.tsx` chip | `var(--faction-wow-on-plum)` | the one WOW chip pairing measured in both themes (5.16:1) |
| `FeedCardEraAnnouncement.tsx` | `var(--rank-silver)` | on the always-dark admin card |
| `FeedRowActions.tsx` | `var(--color-danger)`, plus `buttonStyle()`'s `--color-bg-page` / `--color-text-secondary` | |
| `FeedUndoStrip.tsx` | `var(--color-text-primary)` | |
| `FeedBulkArchiveButton.tsx` | `var(--color-text-secondary)` | |
| `FeedCardCollabInvite.tsx` | `var(--color-danger)`, `var(--badge-collab)` | |
| `FeedCardDuelChallenge.tsx` | `var(--color-danger)` x2, `var(--badge-duel)` | |
| `FeedBankFullModal.tsx` | `var(--color-danger)` | |
| `FeedCardInvitationLetter.tsx` | `{ color }` | dynamic faction letter colour |

The heading sites that inherit rather than override render whatever their frame tints the band, exactly as before. Only the era card's `ERA` and the bank-full dialog title now read bare `--label-ink`, which is the same value `.eyebrow` painted them.

## Left for another sweep

- **`UA_EYEBROW`** (`components/factionMarks/uaAtoms.ts`) is a hand-rolled label style spread into `UaFeedFrame`'s tag and time. It is caption work and it is **outside this directory**, so it is untouched; the file's docstring now says so rather than repeating the retired "scanned, not read" line.
- Six raw button styles in `FeedCardCollabInvite` / `FeedCardDuelChallenge` / `FeedBankFullModal` hand-roll the tier inline (`Courier Prime` + `var(--text-sm)` + `uppercase` + `0.1em`) without ever naming `.eyebrow`, so no grep for the class finds them. They are 9px uppercase label text and belong on the caption tier, but tokenising them is a behaviour change beyond a class move.

## Verification

All six frontend CI steps run clean locally: eslint (0), `tsc --noEmit` (0), vitest (**3894 passed / 224 files**), `vite build`, initial-load budget (JS 138.1 KB, CSS 22.4 KB — both `ok`, CSS unchanged), `typecheck:design-sync`.

Both tiers are confirmed present in the **built** stylesheet, not just the source — the purge hazard is real and both names are written as literals:

```
.label-heading{font-family:Courier Prime,monospace;font-size:var(--text-md);text-transform:uppercase;letter-spacing:.15em;color:var(--label-ink)}
.label-caption{font-family:Courier Prime,monospace;font-size:var(--text-lg);text-transform:none;letter-spacing:normal;color:var(--label-ink)}
```

**Visual QA is outstanding.** I have no browser and no dev stack; the harness has no DOM, so nothing above proves a rendered pixel.

## What to eyeball

Both themes for every line.

**Card types** — walk the feed with each of these present:

1. **Collab invite** — pending (Accept/Decline + task meta), accepted, declined, and the error line. The task-bank-full modal too: its title is now the only `.label-heading` in a dialog, and the drop error is a caption.
2. **Duel challenge** — pending (Accept/Decline/Withdraw), withdrawn, accepted, declined, both error lines, plus its own bank-full modal.
3. **Invitation letter** — the `joined` state, whose "You have joined X" now reads sentence case in the faction's own colour.
4. **Era announcement** — the always-dark admin card. `ERA` (heading) sits directly beside `Era Announcement` (caption, silver) — this pair is the clearest place to judge whether the 11px-caps / 12px-lowercase inversion actually lands.
5. **Ordinary rows** — the points/level line under a headline, on a frame that publishes no `points` renderer. Also the row action buttons and the undo strip's `Undo`, both now sentence case.
6. **Archive header** — `Archive all` (pill) and `Restore all` (underlined), both now sentence case.

**Faction skins** — the chassis band renders under every frame, so the kicker/tag/time trio wants a look on each:

- **WOW** — the most changed skin. The decree head is a heading; the plum "Still waiting" lozenge is now 12px sentence-case MedievalSharp instead of 11px tracked caps, and the lozenge's padding was tuned around the old size.
- **Everymen** — the red masthead's two flanks (status chip left, dateline right) are captions now; check they still balance the `1fr auto 1fr` grid and still ellipsise rather than shoving the masthead.
- **S.N.I.D.E., Singularity, Albescent, na/Default** — these take `FeedChassisBand` wholesale, so they show the plain kicker-heading / tag-caption / time-caption arrangement.
- **Coven, Ephemerists, UA** — place the four slots by hand and should be **unchanged**; they are in the diff for comment corrections only. Worth confirming they really did not move.

Singularity and S.N.I.D.E. are dark sheets in *both* themes, so they are where an unset `--label-ink` is most worth a second look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
