### PR TITLE
The frontend stops offering a life state the backend can no longer enter

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -19,7 +19,9 @@ export interface CharacterOut {
   score: number
   all_time_score: number
   faction_slug: string | null
-  /** "active" | "paused" | "banned" — the roster includes paused lives (#270). */
+  /** "active" | "banned" (`CharacterStatus`). The roster is every life of the
+   *  account with banned excluded (#270), which since #1550 is simply the
+   *  active ones — `paused` was deleted, nothing ever wrote it. */
   status: string
   created_at: string
   /** Evaluated on read (ADR-0033). Populated by GET /characters/{id} and, since

--- a/frontend/src/api/me.ts
+++ b/frontend/src/api/me.ts
@@ -1,7 +1,8 @@
 import api from './axios'
 import type { CharacterOut, CurrentUser } from './auth'
 
-/** The account's own roster — active + paused lives, carried life first (#270). */
+/** The account's own roster — every life but the banned ones, carried life
+ *  first (#270). It used to read "active + paused"; `paused` is gone (#1550). */
 export async function getMyCharacters(): Promise<CharacterOut[]> {
   const { data } = await api.get<CharacterOut[]>('/me/characters')
   return data

--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -61,7 +61,7 @@ const PERK_KEYS: ReadonlyArray<string> = [
 ]
 
 export interface AlbescentInvitationProps {
-  /** The account's roster (active + paused lives). */
+  /** The account's roster (every life but the banned ones). */
   lives: CharacterOut[]
   /**
    * Called after a successful join, to refresh what the PARENT owns — the

--- a/frontend/src/components/__tests__/albescentInvitation.test.ts
+++ b/frontend/src/components/__tests__/albescentInvitation.test.ts
@@ -1,8 +1,8 @@
 /**
  * The Albescent invitation's life chooser (#395) only offers active,
- * non-Albescent lives — paused/banned lives can't be carried, and a life
- * already of the Order has nothing left to accept. Pure filter, tested
- * directly (no jsdom in this repo — see vite.config.ts).
+ * non-Albescent lives — a banned life can't be carried, and a life already of
+ * the Order has nothing left to accept. Pure filter, tested directly (no jsdom
+ * in this repo — see vite.config.ts).
  */
 import { describe, it, expect } from 'vitest'
 import { eligibleLives } from '../AlbescentInvitation'
@@ -32,8 +32,12 @@ describe('eligibleLives', () => {
     expect(eligibleLives(lives).map((l) => l.id)).toEqual([1, 2])
   })
 
-  it('drops paused lives — the roster includes them, the order will not', () => {
-    const lives = [life({ id: 1, status: 'paused' }), life({ id: 2 })]
+  // Was written against `paused`, the one status the roster carried and the
+  // order refused. That value is gone (#1550), so the mixed-list case — one
+  // life dropped, its sibling kept — is asserted on the surviving non-active
+  // status instead of deleted with it.
+  it('drops a non-active life while keeping its sibling', () => {
+    const lives = [life({ id: 1, status: 'banned' }), life({ id: 2 })]
     expect(eligibleLives(lives).map((l) => l.id)).toEqual([2])
   })
 

--- a/frontend/src/locales/en/admin.json
+++ b/frontend/src/locales/en/admin.json
@@ -42,8 +42,7 @@
     "status": {
       "active": "active",
       "suspended": "suspended",
-      "banned": "banned",
-      "paused": "paused"
+      "banned": "banned"
     }
   },
   "tasks": {

--- a/frontend/src/pages/admin/AccountsTab.tsx
+++ b/frontend/src/pages/admin/AccountsTab.tsx
@@ -10,13 +10,16 @@ import type { AccountSummary, AccountDetail } from "../../api/admin";
 import { extractError } from "../../utils/errors";
 import { formatTimestamp } from "../../utils/dates";
 
-type AccountStatus = "active" | "suspended" | "banned" | "paused";
-const ACCOUNT_STATUSES: AccountStatus[] = [
-  "active",
-  "suspended",
-  "banned",
-  "paused",
-];
+/** Every status this tab renders a label for — the UNION of two backend enums,
+ *  not one of them. `statusLabel` below is called on `account.status`
+ *  (`AccountStatus`: active | suspended) and on `character.status`
+ *  (`CharacterStatus`: active | banned) alike, so the name understates it: no
+ *  account is ever `banned` and no life is ever `suspended`. Left as one list
+ *  because it is a label lookup rather than a set of offerable values, and the
+ *  fallback renders anything unmapped verbatim. Splitting it in two is a
+ *  separate decision (#1551). `paused` is gone from both enums (#1550). */
+type LabelledStatus = "active" | "suspended" | "banned";
+const ACCOUNT_STATUSES: LabelledStatus[] = ["active", "suspended", "banned"];
 
 export default function AccountsTab() {
   const { t } = useTranslation(["admin", "common"]);
@@ -217,9 +220,7 @@ export default function AccountsTab() {
                                 color:
                                   character.status === "banned"
                                     ? "var(--color-danger)"
-                                    : character.status === "paused"
-                                      ? "var(--color-warning)"
-                                      : "var(--color-success)",
+                                    : "var(--color-success)",
                                 fontWeight: 700,
                               }}
                             >


### PR DESCRIPTION
Closes #1551

Dead code, not a defect: the value is never sent to the API, so it could only ever have rendered a label and a colour for a status the backend can no longer return.

## The care note's answer, first — the two ARE conflated

The issue asked to confirm whether `ACCOUNT_STATUSES` models **account** status or **character** status before deleting anything. **It models neither — it is the union of both.**

- `AccountStatus` (`backend/models/account.py`) = `active | suspended`
- `CharacterStatus` (`backend/models/character.py`) = `active | banned`
- `ACCOUNT_STATUSES` was `active | suspended | banned | paused`, and `statusLabel` is called on **`account.status`** (`AccountsTab.tsx:152`) *and* on **`character.status`** (`AccountsTab.tsx:226`).

So no account is ever `banned` and no life is ever `suspended`; the list's name understates what it covers, and the same is true of the `accounts.status.*` catalog block.

**This did not change which entry to remove** — `paused` is absent from *both* enums, so it goes regardless of which one the list is taken to model, and nothing here is a guess. What I have **not** done is act on the conflation: the list is left as one list, and the finding is now recorded in a comment at its declaration instead of being left to the next reader's assumption. Splitting it into an account list and a character list (or renaming `statusLabel` to say it is a shared label lookup) is a separate decision and is called out as such in the comment. **Flagging it here so it can be filed if wanted.**

The local type alias is renamed `AccountStatus` → `LabelledStatus`, which is file-local: the name had one declaration and one use, and it was the thing asserting the untrue claim. `frontend/src/api/generated/schema.d.ts` mentions the backend's real `AccountStatus` in a docstring and is untouched.

## What changed

| file | change |
|---|---|
| `frontend/src/pages/admin/AccountsTab.tsx` | `"paused"` out of the union and the list; the dead `character.status === "paused" → --color-warning` branch removed; the conflation written down at the declaration |
| `frontend/src/locales/en/admin.json` | `accounts.status.paused` deleted |
| `frontend/src/api/auth.ts` | `CharacterOut.status` documented as `"active" \| "banned"` |
| `frontend/src/components/__tests__/albescentInvitation.test.ts` | the mixed-list case re-asserted on `banned` |

**The vitest fixture was retargeted, not deleted.** `it('drops paused lives …')` proves one life is dropped *while its sibling is kept* — a different claim from `it('returns empty when nobody is fit to answer')` below it, which uses `banned` already. Only the status value it happened to use is dead, so the case now runs on `banned` and the coverage shape survives. Deleting it would have quietly dropped the only mixed-list assertion on `eligibleLives`.

**The catalog key is dead the way the tests see it, not just to `git grep`.** `src/locales/__tests__/catalog.test.ts` asserts nothing about `accounts.status.*` (its explicit lists are the vote-voice factions and the `forms.charLimit` keys), and no negative assertion names the key. The one thing that *did* read it is the typed-key check: `statusLabel` calls ``t(`accounts.status.${known}`)`` over the union, so the JSON key and the union member have to go together or `tsc` fails — which is a guard, and it passes.

## Two edits beyond the issue's list — please sanity-check the scope

The issue named four sites. Two more prose mentions were left saying the roster carries "active + paused lives", which after this PR would be documentation of a state that does not exist:

- `frontend/src/api/me.ts:4` — `getMyCharacters`'s doc comment
- `frontend/src/components/AlbescentInvitation.tsx:64` — the `lives` prop's doc comment

Both are **comment-only, zero behaviour**. I took them because leaving them is the half-job that generates the follow-up issue, but they are outside the issue's enumeration; revert those two hunks if they collide with concurrent work.

## Verification

All six frontend CI steps run locally and green: `eslint src`, `tsc --noEmit`, `vitest run` (224 files / **3894** tests — same count as `main`, since the retargeted case is still one test), `vite build`, the byte budget (JS 138.1 KB, CSS 22.4 KB), and `typecheck:design-sync`. No backend and no generated file is touched, so the `api-schema` job is unaffected.

## What to eyeball

I have no browser or dev stack, so **visual QA is outstanding**. There should be nothing to see, and that is the claim to check — at `/admin` → **Accounts**:

1. **Expand an account and read the character rows.** The status word beside each life is rendered by the same `statusLabel`, and its colour ternary lost a branch. An `active` life must still read green and a `banned` life red — the deleted branch was amber and unreachable, so any colour change here means I read the ternary wrong.
2. **The account row's own status** (green/red beside the email) and the suspend/unsuspend button are untouched; confirm `active` and `suspended` still label correctly.
3. **Nothing should read as a raw lowercase string in a different style** — `statusLabel` falls back to rendering the backend's value verbatim for anything unmapped, so if a status suddenly looks unstyled or oddly cased, a value I removed is still arriving from the API.

Worth knowing for (3): every catalog value in this block is identical to its key (`"active": "active"`), so a stale `paused` row in a database would have rendered the same string before and after this PR. There is no rendering difference available to find, only the dropdown-shaped lie the issue describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
