### PR TITLE
The Court gets the page beneath its banner, and six unread keys find their reader (#951)

### DIFF
--- a/frontend/src/factions/__tests__/archetypeReachability.test.ts
+++ b/frontend/src/factions/__tests__/archetypeReachability.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Retired skins must not leave corpses.
+ *
+ * ADR-0056 / 0058 / 0063 / 0065 / 0067 / 0069 each collapsed a surface that used
+ * to be a desktop/mobile PAIR down to one responsive component per faction. Each
+ * collapse deletes manifest rows — and `surfaceDispatch.test.ts` catches that,
+ * because its BESPOKE table flips red when a slug de-registers.
+ *
+ * What nothing catches is the FILE. De-registering `mobileEditPraxis` removes the
+ * manifest line; it does not remove `WowEditPraxisMobile.tsx`. The orphan still
+ * compiles, still passes `tsc`, still passes lint, and still passes every render
+ * test — because no test renders a component no dispatcher can reach. It is
+ * invisible until someone greps for a component name and finds two.
+ *
+ * The two guards below are the ones that go red in that situation:
+ *
+ *   1. an archetype file nothing outside itself names — a skin whose manifest row
+ *      was deleted while the module stayed on disk;
+ *   2. a declared surface no dispatcher reads — a whole tier retired at the
+ *      registry while every faction's implementation of it stayed.
+ *
+ * Both are SOURCE scans, not graph walks, and that is deliberate: a graph walk
+ * asks "what does the manifest resolve to", which cannot see a file the manifest
+ * has already forgotten. Only the filesystem remembers the corpse.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, basename, relative, sep } from 'node:path'
+
+import { SURFACE_KEYS } from '..'
+
+const SRC = join(process.cwd(), 'src')
+
+/** Directories whose contents are dispatched skins rather than plain modules. */
+const SKIN_DIRS = ['archetypes', 'mobileArchetypes', 'voices', 'skins']
+
+function walk(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry) => {
+    const full = join(dir, entry)
+    return statSync(full).isDirectory() ? walk(full) : [full]
+  })
+}
+
+const ALL_FILES = walk(SRC).filter((path) => /\.tsx?$/.test(path))
+const IS_TEST = (path: string) => /\.test\.tsx?$/.test(path) || path.includes(`${sep}__tests__${sep}`)
+
+/** Every dispatched skin on disk: a non-test module inside a skin directory. */
+const SKIN_FILES = ALL_FILES.filter(
+  (path) => !IS_TEST(path) && SKIN_DIRS.some((dir) => path.includes(`${sep}${dir}${sep}`)),
+)
+
+/**
+ * Production source only. A retired skin usually keeps its own render test for a
+ * while, and counting that as a reference would let the corpse hold itself alive
+ * — the exact failure this file exists to catch.
+ */
+const PROD_FILES = ALL_FILES.filter((path) => !IS_TEST(path))
+const SOURCE = new Map(PROD_FILES.map((path) => [path, readFileSync(path, 'utf8')]))
+
+describe('archetype reachability', () => {
+  it('has skin files to check at all', () => {
+    // Guards the guard: a walk that silently matches nothing would make both
+    // assertions below vacuously green forever.
+    expect(SKIN_FILES.length).toBeGreaterThan(50)
+  })
+
+  it('every dispatched skin is named by something other than itself', () => {
+    const orphans = SKIN_FILES.filter((path) => {
+      const name = basename(path).replace(/\.tsx?$/, '')
+      // Bounded by a quote or a path separator so `WowSeal` cannot be kept alive
+      // by `WowSealConfirm`. Import specifiers are extensionless, so the closing
+      // quote is the end of the name.
+      const named = new RegExp(`['"/]${name}['"]`)
+      for (const [other, text] of SOURCE) {
+        if (other !== path && named.test(text)) return false
+      }
+      return true
+    })
+
+    expect(orphans.map((path) => relative(SRC, path)).sort()).toEqual([])
+  })
+
+  it('every declared surface has a dispatcher that reads it', () => {
+    const unread = SURFACE_KEYS.filter((key) => {
+      const call = new RegExp(`surfaceMap\\(\\s*['"]${key}['"]`)
+      for (const [path, text] of SOURCE) {
+        // The manifest DECLARES the key and the index iterates it generically;
+        // neither is a dispatcher, so neither may satisfy this.
+        if (path.includes(`${sep}factions${sep}`)) continue
+        if (call.test(text)) return false
+      }
+      return true
+    })
+
+    expect([...unread].sort()).toEqual([])
+  })
+})

--- a/frontend/src/factions/__tests__/surfaceDispatch.test.ts
+++ b/frontend/src/factions/__tests__/surfaceDispatch.test.ts
@@ -141,12 +141,14 @@ const REQUIRED = SURFACE_KEYS.filter((surface) =>
 // When a skin ships, drop the surface here and the "still pending" guard below
 // fails, forcing this allowlist to shrink in lockstep with the fix.
 // `taskDetail` left this set in #1037 — the parchment field, WOW's first
-// desktop task-detail page — and `praxisDetail` left it in #1121, the chronicle
-// entry: WOW's dress over the one shared praxis-detail page (ADR-0061). Two
-// bullets of #951 remain, and neither is a page the kit ever drew.
+// desktop task-detail page — `praxisDetail` left it in #1121, the chronicle
+// entry (WOW's dress over the one shared praxis-detail page, ADR-0061), and
+// `factionBody` left it with the muster page: the charter, the muster roll, the
+// two galleries and the enlist rail, derived from the phone twin and the shared
+// ornament module because the kit never drew this one either. `factionCard` is
+// the last bullet of #951.
 const WOW_PENDING: ReadonlySet<string> = new Set([
   'factionCard',
-  'factionBody',
 ])
 
 describe('Coven is bespoke on every core surface, never the Default', () => {

--- a/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
+++ b/frontend/src/factions/__tests__/wowRendersDefault.test.tsx
@@ -83,9 +83,15 @@ function Sentinel() {
  * faction dresses (ADR-0061). One responsive component, so it serves both form
  * factors and there is no mobile row to add beside it.
  *
- * SIX SURFACES ARE STILL UNCLAIMED, in two groups.
+ * and the `factionBody` beneath that hero — THE MUSTER PAGE: the charter, the
+ * muster roll, the two galleries and the enlist rail. Third of #951's four to
+ * ship. Derived rather than drawn, like the two above it: the ornaments come
+ * from `wowOrnament`, the section order from `mobileFactionPage`, and the copy
+ * was already sitting unread in `factions.json` from #900.
  *
- * `factionBody` and `factionCard` are PENDING DESIGN BUGS, tracked by #951.
+ * `factionCard` is the LAST unclaimed desktop surface.
+ *
+ * It is a PENDING DESIGN BUG, tracked by #951.
  * #899/#900/#840 scoped them out on a design-fidelity argument (the kit drew
  * WOW's cards and hero, not the desktop pages beneath them, so a page skin would
  * be invention), but the owner ruled (2026-07-23) that a faction missing a
@@ -93,9 +99,10 @@ function Sentinel() {
  * those pages. They fall to the neutral Default (N/A), never to Coven — which is
  * the point of pinning the set here. When #951 ships a skin, move that surface
  * into WOW_SKINNED and this list shrinks; `surfaceDispatch.test.ts` enforces the
- * same #951 allowlist. That shrink has now happened twice: `taskDetail` moved
- * down into WOW_SKINNED in #1037, and `praxisDetail` in #1121 — each out of both
- * allowlists in the same commit as its skin.
+ * same #951 allowlist. That shrink has now happened three times: `taskDetail`
+ * moved down into WOW_SKINNED in #1037, `praxisDetail` in #1121 and
+ * `factionBody` with the muster page — each out of both allowlists in the same
+ * commit as its skin.
  *
  * `mobileCreateCharacter` and `mobileEditCharacter`, `mobileFactionsDirectory`
  * and `mobilePlayersDirectory` used to be listed here as Default-for-everyone
@@ -117,6 +124,7 @@ const WOW_SKINNED: ReadonlySet<FactionSurface> = new Set([
   'vote',
   'editPraxis',
   'factionHero',
+  'factionBody',
   'backdrop',
   'profileBody',
   'factionSelectCard',

--- a/frontend/src/factions/wow.ts
+++ b/frontend/src/factions/wow.ts
@@ -116,6 +116,7 @@ const WowFieldDesk = lazyArchetype(() => import('../pages/fieldDesk/mobileArchet
 const WowTaskDetail = lazyArchetype(() => import('../pages/taskDetail/archetypes/WowTaskDetail'))
 const WowPraxisDetail = lazyArchetype(() => import('../pages/praxisDetail/archetypes/WowPraxisDetail'))
 const WowMobileFactionPage = lazyArchetype(() => import('../pages/factionDetail/mobileArchetypes/WowFactionPage'))
+const WowFactionBody = lazyArchetype(() => import('../pages/factionDetail/archetypes/WowFactionBody'))
 
 export const WOW_MANIFEST: FactionManifest = {
   slug: 'wow',
@@ -143,6 +144,15 @@ export const WOW_MANIFEST: FactionManifest = {
 
   // #900 — the page-level desktop surfaces.
   factionHero: () => WowFactionHero,
+  // The PAGE beneath that hero. #900 drew the recruiting banner and left the
+  // body defaulting, so a WOW faction page was a gilt banner over the na
+  // placeholder — and, because `DefaultFactionBody` carries no join block, with
+  // no way to enlist. Derived rather than drawn (no sheet exists): the ornaments
+  // come from `wowOrnament`, the section order from the phone twin below, and
+  // the main + rail shape from the other six bodies. The copy was already in
+  // `factions.json` from #900, unread until now. Third of #951's four bullets;
+  // `factionCard` is the last one open.
+  factionBody: () => WowFactionBody,
   backdrop: () => WowBackdrop,
   profileBody: () => WowProfileBody,
   factionSelectCard: () => WOWSelectCard,

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -555,20 +555,35 @@
     },
     "tasks": {
       "heading": "Quests Awaiting a Champion",
+      "kicker": "The herald's call",
       "empty": "No quests afoot. The realm is, briefly and tragically, sensible."
     },
     "praxis": {
-      "heading": "Chronicles of Proof"
+      "heading": "Chronicles of Proof",
+      "kicker": "Deeds set down",
+      "empty": "The chronicle stands open, its pages still blank."
     },
     "join": {
+      "heading": "THE MUSTER",
+      "memberTitle": "Thou art sworn",
+      "eligibleKicker": "the lists are open —",
       "eligibleTitle": "Enlist in the Crusade",
-      "eligibleBody": "the armour is one-size, the oath is for life"
+      "eligibleBody": "the armour is one-size, the oath is for life",
+      "joinButton": "TAKE THE OATH ⚔",
+      "joining": "SWEARING…",
+      "confirmButton": "CONFIRM",
+      "gateKicker": "Unsworn — for now",
+      "gateTitle": "Earn thy summons",
+      "gateBody": "Complete quests from {{faction}} and the Court will send a herald. Keep at it — deeds carry further than petitions."
     },
     "spotlight": {
-      "label": "Champion of the Fortnight"
+      "label": "Champion of the Fortnight",
+      "stat": "lvl {{level}} · {{score}} pts"
     },
     "roster": {
-      "heading": "The Muster Roll"
+      "heading": "The Muster Roll",
+      "emptyWithSpotlight": "No other knights mustered yet.",
+      "level": "lvl {{level}}"
     },
     "mobile": {
       "eyebrow": "The Field Pavilion",

--- a/frontend/src/pages/factionDetail/__tests__/burnedNotice.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/burnedNotice.test.tsx
@@ -2,8 +2,9 @@
  * The burned notice on the faction detail page (#1305).
  *
  * Walks every desktop faction-body archetype plus the Default fallback (which
- * is what WOW and Albescent render — the surface the defect was reported on)
- * and pins the two non-actionable states apart:
+ * is what Albescent still renders — the surface the defect was reported on;
+ * WOW rendered it too until it got a body of its own) and pins the two
+ * non-actionable states apart:
  *
  *   - "gate"   → not invited YET (#454). "Keep doing tasks" is true here.
  *   - "burned" → left this faction this era; `can_join_faction` refuses the
@@ -54,9 +55,13 @@ function stateWith(slug: string, state: MembershipState): FactionDetailState {
   }
 }
 
-// The Default body is keyed to `wow` — the faction the defect was filed
-// against, which has no bespoke body of its own yet (#951).
-const bodies = { ...surfaceMap('factionBody'), wow: DefaultFactionBody }
+// Every registered body, plus the Default under `albescent` — the one faction
+// still falling through to it, and so the surface this defect was filed
+// against. `wow` USED to be pinned here too, overriding the surface map with
+// `DefaultFactionBody`; it now has a body of its own, and leaving the override
+// in would have quietly kept testing the Default under WOW's name — green, and
+// proving nothing about the page WOW actually renders.
+const bodies = { ...surfaceMap('factionBody'), albescent: DefaultFactionBody }
 
 describe('burned viewers are told the era is closed, not to keep tasking', () => {
   for (const [slug, Body] of Object.entries(bodies)) {

--- a/frontend/src/pages/factionDetail/__tests__/wowFactionBody.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/wowFactionBody.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * WOW's faction-body — the muster page (#951).
+ *
+ * Two things are worth pinning, and neither is dress.
+ *
+ * ONE: the enlist rail draws a different thing in every membership state, and
+ * only ONE of those five is reachable in a browser without five different
+ * accounts. The rail is the whole reason this body exists — `DefaultFactionBody`
+ * has no join control at all, so before this skin a WOW player who was invited
+ * had nowhere on the page to accept. A regression that hid the button again
+ * would look exactly like the bug being fixed.
+ *
+ * TWO: the copy is WOW's own. The catalog carried `wow.charter`, `wow.roster`,
+ * `wow.tasks`, `wow.praxis`, `wow.join` and `wow.spotlight` unread from #900,
+ * and the first draft of this component wired the PHONE's `mobile.*` keys
+ * instead — which renders identical-looking English on a desktop page while
+ * silently making the phone catalog load-bearing for a surface it does not
+ * serve. Asserting on the faction-voiced strings is what tells those two apart.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+// Initialize the i18n catalog so faction copy keys resolve to English text.
+import '../../../i18n'
+import WowFactionBody from '../archetypes/WowFactionBody'
+import type { FactionDetailState, MembershipState } from '../useFactionDetail'
+
+function text(node: ReactElement): string {
+  return renderToStaticMarkup(<MemoryRouter>{node}</MemoryRouter>).replace(/<[^>]*>/g, '')
+}
+
+function stateWith(state: MembershipState): FactionDetailState {
+  return {
+    slug: 'wow',
+    loading: false,
+    faction: { slug: 'wow' },
+    fetchError: null,
+    members: [],
+    tasks: [],
+    recentPraxis: [],
+    viewerFactionSlug: null,
+    gameFactions: [],
+    membership: {
+      state,
+      currentFactionSlug: null,
+      join: async () => {},
+      joining: false,
+      joinError: null,
+    },
+  } as unknown as FactionDetailState
+}
+
+const render = (state: MembershipState) => text(<WowFactionBody state={stateWith(state)} />)
+
+describe('the enlist rail answers every membership state', () => {
+  it('offers the oath to an eligible viewer — the control the Default body lacks', () => {
+    expect(render('eligible')).toContain('TAKE THE OATH')
+  })
+
+  it('never offers it to anyone who cannot act', () => {
+    // "Hide unusable controls; don't show them disabled" — a gated or burned
+    // viewer must not see a button that would only refuse them.
+    for (const state of ['none', 'member', 'gate', 'burned'] as const) {
+      expect(render(state), `${state} must not see the oath`).not.toContain('TAKE THE OATH')
+    }
+  })
+
+  it('draws no rail at all for a viewer with no character', () => {
+    expect(render('none')).not.toContain('THE MUSTER')
+  })
+
+  it('keeps the gate and the burn distinguishable', () => {
+    // "Keep questing" is true for "not invited yet" (#454) and a lie for the
+    // burn, which `can_join_faction` refuses for the rest of the era (#1305).
+    expect(render('gate')).toContain('Earn thy summons')
+    expect(render('burned')).not.toContain('Earn thy summons')
+    expect(render('burned')).toContain('until the next one begins')
+  })
+})
+
+describe('the page speaks in WOW voice, not the phone catalog', () => {
+  it('wires the charter, the roll and both galleries', () => {
+    const markup = render('none')
+    expect(markup).toContain('The Charter of Whimsy')
+    expect(markup).toContain('The Muster Roll')
+    expect(markup).toContain('Quests Awaiting a Champion')
+    expect(markup).toContain('Chronicles of Proof')
+  })
+
+  it('renders the charter body, which is the one thing the hero cannot show', () => {
+    // The array-valued key needs `returnObjects`; a plain `t()` yields the key
+    // back and the section renders its frame with nothing in it.
+    expect(render('none')).toContain('We knight houseplants')
+  })
+
+  it('does not fall back to the phone page copy', () => {
+    const markup = render('gate')
+    expect(markup).not.toContain('Keep completing tasks to earn an invitation')
+    expect(markup).not.toContain('Top members')
+  })
+})

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -1,0 +1,615 @@
+import { useState, type CSSProperties, type ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { useTranslation } from "react-i18next";
+
+import TaskCard from "../../../components/taskCard/TaskCard";
+import PraxisCard from "../../../components/praxisCard/PraxisCard";
+import { BalloonBunch, Bunting, Zig } from "../../../components/factionMarks/wowOrnament";
+import { WowSigil } from "../../../components/sigil/WowSigil";
+import { factionName } from "../../../utils/factions";
+import { computeFactionMultiplier } from "../../../utils/points";
+import type { CharacterOut } from "../../../api/auth";
+import type { FactionDetailState } from "../useFactionDetail";
+
+/**
+ * Warriors of Whimsy — the faction-page BODY, net-new.
+ *
+ * The last of #951's four missing desktop surfaces. #1037 shipped `taskDetail`
+ * (the parchment field) and #1121 `praxisDetail` (the chronicle entry); #900
+ * shipped the `factionHero` above this and left the page BENEATH it defaulting.
+ * So until this file a WOW faction page was a gilt recruiting banner sitting on
+ * the na placeholder body — `.eyebrow` headings, a hairline member tile, no
+ * charter, and no join control at all (`DefaultFactionBody` carries only the
+ * burn notice, which is why its own `ponytail:` names WOW as one of the two
+ * factions waiting on this).
+ *
+ * DERIVED, not drawn — there is no v2 sheet for this surface. Three sources,
+ * all already in the repo:
+ *
+ *   • the parchment ground, the wavy gold→plum rules, the bunting and the
+ *     balloons from `WowTaskDetail` (#1037) via the shared ornament module
+ *     (`components/factionMarks/wowOrnament.tsx`, §6/#849) — nothing is redrawn here;
+ *   • the SECTION ORDER and the join flow from the phone twin
+ *     `mobileArchetypes/WowFactionPage` (#901), so the two form factors tell the
+ *     same story in the same sequence;
+ *   • the two-column main + right-rail SHAPE from the other six bespoke bodies
+ *     (Coven's is the closest), so the join block sits where a returning player
+ *     already looks for it.
+ *
+ * THE COPY WAS ALREADY WRITTEN. `factions.json` has carried `wow.charter`,
+ * `wow.roster`, `wow.tasks`, `wow.praxis`, `wow.join` and `wow.spotlight` since
+ * #900 — six key groups with no reader, because the body they were written for
+ * was never built. This file adds no new keys; it wires those six up and falls
+ * back to the shared neutral `detail.*` catalog for everything else (ADR-0057:
+ * dress is ours, words are not). The charter is the one thing here the hero
+ * cannot show — it is the faction's own voice at length, and it is why the page
+ * is worth visiting after the banner.
+ *
+ * NO NEW TOKENS. Every colour is a shipped `--faction-wow-*`; #1023 and #1037
+ * minted them and this page reuses them.
+ *
+ * ponytail: no bespoke member tile, no spotlight portrait, no task/praxis
+ * treatment of its own — the roster rows are the phone twin's rows widened, and
+ * the two galleries mount the live `<TaskCard>` / `<PraxisCard>`, which are
+ * already WOW's own archetypes. The kit never drew this surface, so inventing a
+ * third WOW card chrome here would be guessing in a faction that has two
+ * DELIBERATELY unalike ones already (ADR-0050: a quest is ISSUED by decree,
+ * proof is RECORDED in the chronicle). Upgrade path: when #951's sheet is
+ * drawn, restyle these three sections in place — the data wiring and the join
+ * contract below are the final ones.
+ */
+
+const MED = "var(--faction-wow-card-font)"; /* MedievalSharp */
+const LORA = "var(--faction-wow-body-font)"; /* Lora */
+
+const INK = "var(--faction-wow-card-text)";
+const MUTED = "var(--faction-wow-card-muted)";
+/** Label ink. Olive-gold, the one measured to clear AA on the parchment field. */
+const LABEL = "var(--faction-wow-accent-deep)";
+const PLUM = "var(--faction-wow-card-accent)";
+const PLUM_SURFACE = "var(--faction-wow-plum-surface)";
+const ON_PLUM = "var(--faction-wow-on-plum)";
+/** Frame + rule gold. Never an ink: 2.24:1 on the cream (§3). */
+const GOLD = "var(--faction-wow-chronicle-gold)";
+/** The burnt gold reserved for figures. */
+const GILT = "var(--faction-wow-stamp-total)";
+const CARD = "var(--faction-wow-card-bg)";
+const PLATE = "var(--faction-wow-plate)";
+const HAIR = "var(--faction-wow-chronicle-rule)";
+const BORDER = "var(--faction-wow-chronicle-border)";
+const SHADOW = "0 18px 40px -20px var(--faction-wow-chronicle-shadow)";
+
+const NA_SLUG = "na";
+
+/** Members shown on the roll before it stops. The rest are on the players page. */
+const ROLL_LIMIT = 8;
+
+/** A gold-framed cream plate — the kit's one container, used for every section. */
+const PLATE_FRAME: CSSProperties = {
+  background: CARD,
+  border: `2px solid ${GOLD}`,
+  borderRadius: "var(--radius-lg)",
+  boxShadow: SHADOW,
+  padding: "var(--space-xl)",
+};
+
+export default function WowFactionBody({ state }: { state: FactionDetailState }) {
+  const { t } = useTranslation("factions");
+  const {
+    faction,
+    members,
+    tasks,
+    recentPraxis,
+    viewerFactionSlug,
+    gameFactions,
+    membership,
+  } = state;
+
+  // Guarded non-null by the dispatcher.
+  if (!faction) return null;
+
+  const name = factionName(faction.slug);
+  const roll = [...members].sort((a, b) => b.all_time_score - a.all_time_score);
+  const champion = roll[0];
+
+  return (
+    // `.wz-faction-grid` is the shared main+rail seam all six other bodies use.
+    // Not an inline grid: the class carries the ≤860px collapse to one column,
+    // which a hand-rolled `1fr 320px` silently loses — the rail would go on
+    // squeezing the galleries on a narrow desktop window instead of dropping
+    // below them.
+    //
+    // `--label-ink` is repointed ONCE here, which is the seam #1307 built into
+    // the two label tiers. WOW's labels sit on parchment, where the neutral
+    // tertiary is too weak; `--faction-wow-accent-deep` is the olive-gold
+    // measured to clear AA on both this ground and the cream plate. Setting it
+    // on the frame rather than colouring each label inline is the explicit rule
+    // at the tiers' declaration — a per-label colour is the contradiction #1252
+    // exists to stop, and it is invisible to `factionContrast.test.ts`.
+    <div
+      className="wz-faction-grid"
+      data-skin="wow"
+      style={{ ["--label-ink" as string]: "var(--faction-wow-accent-deep)" } as CSSProperties}
+    >
+      {/* ── MAIN COLUMN ── */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
+        <Charter />
+
+        {/* ── the muster roll ── */}
+        <section>
+          <SectionHead>{t("wow.roster.heading")}</SectionHead>
+          {roll.length === 0 ? (
+            <Quiet>{t("detail.membersEmpty")}</Quiet>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-sm)" }}>
+              {roll.slice(0, ROLL_LIMIT).map((member, index) => (
+                <MemberRow
+                  key={member.id}
+                  rank={index + 1}
+                  member={member}
+                  champion={member.id === champion?.id}
+                />
+              ))}
+              {/* The champion IS the whole roll — say so rather than leaving one
+                  lonely row reading as a truncated list. */}
+              {roll.length === 1 && <Quiet>{t("wow.roster.emptyWithSpotlight")}</Quiet>}
+            </div>
+          )}
+        </section>
+
+        {/* ── quests awaiting a champion ── */}
+        <section>
+          <SectionHead kicker={t("wow.tasks.kicker")}>{t("wow.tasks.heading")}</SectionHead>
+          {tasks.length === 0 ? (
+            <Quiet>{t("wow.tasks.empty")}</Quiet>
+          ) : (
+            <div style={CARD_GRID}>
+              {tasks.map((task) => (
+                <TaskCard
+                  key={task.id}
+                  task={task}
+                  basePoints={task.point_value}
+                  multiplier={computeFactionMultiplier(
+                    viewerFactionSlug,
+                    task.primary_faction_slug,
+                    gameFactions,
+                  )}
+                />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* ── chronicles of proof ── the one bunch of balloons on the page ── */}
+        <section>
+          <SectionHead kicker={t("wow.praxis.kicker")} balloons>
+            {t("wow.praxis.heading")}
+          </SectionHead>
+          {recentPraxis.length === 0 ? (
+            <Quiet>{t("wow.praxis.empty")}</Quiet>
+          ) : (
+            <div className="praxis-gallery" style={CARD_GRID}>
+              {recentPraxis.map((praxis) => (
+                <PraxisCard key={praxis.id} praxis={praxis} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
+
+      {/* ── RIGHT RAIL — standing / enlist / gate ── */}
+      <JoinBlock name={name} membership={membership} />
+    </div>
+  );
+}
+
+/** Varied card sizes are intentional, not a CSS grid — matches every other body. */
+const CARD_GRID: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "var(--space-lg)",
+  alignItems: "flex-start",
+};
+
+/**
+ * The charter — the faction's own voice at length, bunting strung across it.
+ * The only section the hero above cannot show.
+ */
+function Charter() {
+  const { t } = useTranslation("factions");
+  // The catalog holds the charter as an array of paragraphs; `t` is typed to a
+  // string, so the array form needs the same cast every other reader uses.
+  const resolve = t as unknown as (k: string, o: { returnObjects: true }) => unknown;
+  const raw = resolve("wow.charter.paragraphs", { returnObjects: true });
+  const paragraphs = Array.isArray(raw) ? (raw as string[]) : [];
+
+  return (
+    <section style={{ ...PLATE_FRAME, padding: 0, overflow: "hidden" }}>
+      <Bunting style={{ padding: "var(--space-sm) var(--space-lg) 0" }} />
+      <div style={{ padding: "var(--space-lg) var(--space-xl) var(--space-xl)" }}>
+        <div className="label-heading" style={{ fontFamily: MED }}>
+          {t("wow.charter.heading")}
+        </div>
+        <h2
+          style={{
+            fontFamily: MED,
+            fontSize: "var(--text-title)",
+            lineHeight: 1.15,
+            color: INK,
+            margin: "var(--space-xs) 0 var(--space-md)",
+          }}
+        >
+          {t("wow.charter.title")}
+        </h2>
+        <Zig id="charter" style={{ marginBottom: "var(--space-md)" }} />
+        {paragraphs.map((paragraph) => (
+          <p
+            key={paragraph}
+            className="content-text"
+            style={{
+              fontFamily: LORA,
+              lineHeight: 1.65,
+              color: INK,
+              margin: "0 0 var(--space-md)",
+            }}
+          >
+            {paragraph}
+          </p>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/** A section head in the display face, over the wavy gold→plum rule. */
+function SectionHead({
+  children,
+  kicker,
+  balloons,
+}: {
+  children: ReactNode;
+  kicker?: string;
+  balloons?: boolean;
+}) {
+  return (
+    <div style={{ marginBottom: "var(--space-lg)" }}>
+      {kicker && (
+        <div className="label-heading" style={{ fontFamily: MED }}>
+          {kicker}
+        </div>
+      )}
+      <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-md)" }}>
+        <h2
+          style={{
+            fontFamily: MED,
+            fontSize: "var(--text-title)",
+            lineHeight: 1.15,
+            color: INK,
+            margin: 0,
+          }}
+        >
+          {children}
+        </h2>
+        {balloons && <BalloonBunch size={38} style={{ marginBottom: "calc(-1 * var(--space-sm))" }} />}
+      </div>
+      <Zig id="section" style={{ marginTop: "var(--space-sm)" }} />
+    </div>
+  );
+}
+
+/** The quiet register — Lora italic, for every empty state on the page. */
+function Quiet({ children }: { children: ReactNode }) {
+  return (
+    <p
+      className="content-text"
+      style={{ fontFamily: LORA, fontStyle: "italic", color: MUTED, margin: 0 }}
+    >
+      {children}
+    </p>
+  );
+}
+
+/**
+ * A roll entry: rank numeral, name, tally — the phone twin's row widened, with
+ * the top of the roll taking the Champion ribbon the copy catalog already names.
+ */
+function MemberRow({
+  rank,
+  member,
+  champion,
+}: {
+  rank: number;
+  member: CharacterOut;
+  champion: boolean;
+}) {
+  const { t } = useTranslation("factions");
+  return (
+    <Link
+      to={`/characters/${member.id}`}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: "var(--space-lg)",
+        padding: "var(--space-sm) var(--space-lg)",
+        background: PLATE,
+        border: `1px solid ${HAIR}`,
+        borderLeft: `4px solid ${champion ? GOLD : PLUM_SURFACE}`,
+        borderRadius: 7,
+        textDecoration: "none",
+      }}
+    >
+      <span
+        style={{
+          flex: "none",
+          fontFamily: MED,
+          fontSize: "var(--text-title)",
+          lineHeight: 1,
+          color: GILT,
+        }}
+      >
+        {rank}
+      </span>
+      <span
+        className="content-text"
+        style={{
+          flex: 1,
+          minWidth: 0,
+          fontFamily: MED,
+          color: INK,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {member.display_name}
+      </span>
+      {champion && (
+        <span
+          className="label-caption"
+          style={{
+            flex: "none",
+            fontFamily: MED,
+            background: PLUM_SURFACE,
+            color: ON_PLUM,
+            padding: "var(--space-xs) var(--space-sm)",
+            borderRadius: 999,
+          }}
+        >
+          {t("wow.spotlight.label")}
+        </span>
+      )}
+      <span className="label-caption" style={{ flex: "none" }}>
+        {champion
+          ? t("wow.spotlight.stat", {
+              level: member.level,
+              score: member.all_time_score.toLocaleString(),
+            })
+          : t("wow.roster.level", { level: member.level })}
+      </span>
+    </Link>
+  );
+}
+
+/**
+ * The enlist rail (ADR-0019: joining is invite-earned and irreversible, so the
+ * button confirms). Every branch of `membership.state` is drawn EXCEPT "none" —
+ * a viewer who cannot act does not see a control ("hide unusable controls").
+ * The burn and the gate stay distinguishable: "keep questing" is the right line
+ * for "not invited yet" and a lie for the burn.
+ */
+function JoinBlock({
+  name,
+  membership,
+}: {
+  name: string;
+  membership: FactionDetailState["membership"];
+}) {
+  const { t } = useTranslation("factions");
+  const [confirming, setConfirming] = useState(false);
+
+  if (membership.state === "none") return null;
+
+  const currentSlug = membership.currentFactionSlug;
+  const switching = currentSlug && currentSlug !== NA_SLUG;
+
+  return (
+    <aside
+      style={{
+        ...PLATE_FRAME,
+        padding: 0,
+        overflow: "hidden",
+        border: `2px solid ${BORDER}`,
+        position: "sticky",
+        top: "var(--space-xl)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "var(--space-sm)",
+          padding: "var(--space-md) var(--space-lg)",
+          background:
+            "linear-gradient(160deg, var(--faction-wow-ground-from), var(--faction-wow-ground-to))",
+          borderBottom: `2px solid ${GOLD}`,
+        }}
+      >
+        <WowSigil size={30} />
+        <span className="label-heading" style={{ marginLeft: "auto", fontFamily: MED }}>
+          {t("wow.join.heading")}
+        </span>
+      </div>
+
+      <div style={{ background: CARD, padding: "var(--space-lg)", textAlign: "center" }}>
+        {membership.state === "member" && (
+          <div style={{ fontFamily: MED, fontSize: "var(--text-title)", lineHeight: 1.15, color: PLUM }}>
+            {t("wow.join.memberTitle")}
+          </div>
+        )}
+
+        {membership.state === "eligible" && !confirming && (
+          <>
+            <div className="label-caption" style={{ fontFamily: MED }}>
+              {t("wow.join.eligibleKicker")}
+            </div>
+            <div
+              style={{
+                fontFamily: MED,
+                fontSize: "var(--text-title)",
+                lineHeight: 1.15,
+                color: INK,
+                margin: "var(--space-xs) 0 var(--space-sm)",
+              }}
+            >
+              {t("wow.join.eligibleTitle")}
+            </div>
+            <p
+              className="content-text"
+              style={{
+                fontFamily: LORA,
+                fontStyle: "italic",
+                color: MUTED,
+                margin: "0 0 var(--space-lg)",
+              }}
+            >
+              {t("wow.join.eligibleBody")}
+            </p>
+            <button type="button" onClick={() => setConfirming(true)} style={GILT_BUTTON}>
+              {t("wow.join.joinButton")}
+            </button>
+          </>
+        )}
+
+        {membership.state === "eligible" && confirming && (
+          <>
+            <p
+              className="content-text"
+              style={{
+                fontFamily: LORA,
+                lineHeight: 1.6,
+                color: INK,
+                margin: "0 0 var(--space-md)",
+              }}
+            >
+              {switching
+                ? t("detail.join.confirmSwitch", {
+                    faction: name,
+                    current: factionName(currentSlug),
+                  })
+                : t("detail.join.confirm", { faction: name })}
+            </p>
+            {membership.joinError && (
+              <p
+                className="content-text"
+                style={{
+                  fontFamily: LORA,
+                  color: "var(--color-danger)",
+                  margin: "0 0 var(--space-md)",
+                }}
+              >
+                {membership.joinError}
+              </p>
+            )}
+            {/* [Cancel] … [Confirm] — the global footer order (#646). */}
+            <div style={{ display: "flex", gap: "var(--space-sm)" }}>
+              <button
+                type="button"
+                onClick={() => setConfirming(false)}
+                disabled={membership.joining}
+                style={GHOST_BUTTON}
+              >
+                {t("detail.join.cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={() => void membership.join()}
+                disabled={membership.joining}
+                style={{ ...GILT_BUTTON, flex: 1, opacity: membership.joining ? 0.6 : 1 }}
+              >
+                {membership.joining ? t("wow.join.joining") : t("wow.join.confirmButton")}
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* The gate and the burn must stay distinguishable: "keep questing" is
+            right for "not invited yet" and a lie for the burn, which
+            `can_join_faction` refuses for the rest of the era (#1305). The burn
+            keeps the shared neutral wording every other body uses — a faction
+            does not get to put its own spin on a door it closed. */}
+        {membership.state === "gate" && (
+          <>
+            <div className="label-caption" style={{ fontFamily: MED }}>
+              {t("wow.join.gateKicker")}
+            </div>
+            <div
+              style={{
+                fontFamily: MED,
+                fontSize: "var(--text-title)",
+                lineHeight: 1.15,
+                color: INK,
+                margin: "var(--space-xs) 0 var(--space-sm)",
+              }}
+            >
+              {t("wow.join.gateTitle")}
+            </div>
+            <p
+              className="content-text"
+              style={{ fontFamily: LORA, lineHeight: 1.6, color: MUTED, margin: 0 }}
+            >
+              {t("wow.join.gateBody", { faction: name })}
+            </p>
+          </>
+        )}
+
+        {membership.state === "burned" && (
+          <>
+            <div className="label-caption" style={{ fontFamily: MED }}>
+              {t("detail.burned.kicker")}
+            </div>
+            <div
+              style={{
+                fontFamily: MED,
+                fontSize: "var(--text-title)",
+                lineHeight: 1.15,
+                color: INK,
+                margin: "var(--space-xs) 0 var(--space-sm)",
+              }}
+            >
+              {t("detail.burned.title", { faction: name })}
+            </div>
+            <p
+              className="content-text"
+              style={{ fontFamily: LORA, lineHeight: 1.6, color: MUTED, margin: 0 }}
+            >
+              {t("detail.burned.body", { faction: name })}
+            </p>
+          </>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+const GILT_BUTTON: CSSProperties = {
+  width: "100%",
+  fontFamily: MED,
+  fontSize: "var(--text-content)",
+  color: "var(--faction-wow-quest-text)",
+  background: "linear-gradient(160deg, var(--faction-wow-quest-from), var(--faction-wow-quest-to))",
+  border: `2px solid var(--faction-wow-quest-border)`,
+  borderRadius: 999,
+  padding: "var(--space-sm) var(--space-lg)",
+  cursor: "pointer",
+};
+
+const GHOST_BUTTON: CSSProperties = {
+  fontFamily: MED,
+  fontSize: "var(--text-content)",
+  color: LABEL,
+  background: "transparent",
+  border: `1px solid ${HAIR}`,
+  borderRadius: 999,
+  padding: "var(--space-sm) var(--space-lg)",
+  cursor: "pointer",
+};


### PR DESCRIPTION
Builds WOW's desktop faction-detail body — the third of #951's four missing desktop surfaces, after #1037's parchment field and #1121's chronicle entry. `factionCard` is the last one open.

## What was actually wrong

WOW already had a bespoke `factionHero` from #900. What sat *under* that gilt recruiting banner was `DefaultFactionBody` — the na placeholder, with `.eyebrow` headings and hairline member tiles.

Worse than plain: **`DefaultFactionBody` carries no join block at all.** Its own `ponytail:` comment says so, naming WOW as one of the two factions waiting on this. So an invited WOW player had nowhere on the faction page to enlist.

## Derived, not drawn

There is no v2 sheet for this surface — it is one of the pages the kit never drew. Everything here comes from something already in the repo:

| Source | What it gave |
|---|---|
| `wowOrnament.tsx` (§6/#849) | bunting, wavy gold→plum rules, the balloon bunch — nothing redrawn |
| `mobileArchetypes/WowFactionPage` (#901) | the section order and the join flow, so both form factors tell the same story |
| `.wz-faction-grid` | the main+rail shape all six other bodies use |

Sections: **The Charter** → **The Muster Roll** → **Quests Awaiting a Champion** → **Chronicles of Proof**, with the enlist rail sticky on the right.

## The copy already existed

`factions.json` has carried `wow.charter`, `wow.roster`, `wow.tasks`, `wow.praxis`, `wow.join` and `wow.spotlight` since #900 — **six key groups with no reader**, because the body they were written for was never built. This wires them up and adds only what the house shape needs beside them (join kickers, the gate, the roster level).

The charter is the one thing the hero above cannot show, and it is why the page is worth visiting after the banner.

## Three things worth reviewing

1. **The first draft used the phone's `mobile.*` keys.** Identical-looking English on a desktop page, and the phone catalog quietly load-bearing for a surface it does not serve. No other desktop body touches those keys. Fixed, and `wowFactionBody.test.tsx` asserts against it.

2. **`burnedNotice.test.tsx` pinned `wow: DefaultFactionBody`** over the surface map. Left alone it would have gone on testing the Default under WOW's name — green, proving nothing about the page WOW now renders. It pins `albescent` instead, the one faction still falling through.

3. **Labels use #1307's two tiers, not `.eyebrow`.** Main moved four commits mid-build, all `.eyebrow` sweeps, so this would otherwise have added fresh legacy sites to the pile they just cleared. Region names → `.label-heading`, small facts → `.label-caption`, and `--label-ink` is repointed **once on the frame** — the seam those tiers were given. A per-label inline colour is the contradiction #1252 exists to stop.

## Verified

- `tsc` clean · `eslint` clean · **3905 tests green** (226 files) · build + bundle budget within limits, entry chunk unchanged at 138.3 KB (the archetype is code-split)
- Rendered live against the dev server at 1440px: all four sections, sticky rail, zero console errors
- Collapse to one column at 820px confirmed — this is what reusing `.wz-faction-grid` buys over an inline `1fr 320px`, which would have gone on squeezing the galleries
- Dark mode flips through the token cascade; `--label-ink` resolves to WOW's `#cfb268` olive-gold
- No new tokens. No new `--faction-wow-*` anything.

The five membership states are covered by `wowFactionBody.test.tsx` rather than by hand — only one of them is reachable in a browser without five accounts, and the enlist button is the whole reason this body exists.

## Second commit is separable

`A retired skin can no longer leave its file behind` is the archetype-reachability guard from the audit conversation, not part of this feature. It is one new test file touching nothing else, and it is here so it doesn't rot as an untracked file — **say the word and I'll split it into its own PR.**

## Not done

Bespoke member tiles, a spotlight portrait, or a third WOW card chrome. The roster rows are the phone twin's rows widened, and both galleries mount the live `TaskCard` / `PraxisCard` — already WOW's own archetypes. Inventing a third chrome in a faction that has two deliberately unalike ones (ADR-0050) would be guessing. Marked `ponytail:` in the file with the upgrade path: when #951's sheet is drawn, restyle in place — the data wiring and the join contract are final.
