### PR TITLE
Two label-tier comments stop describing a state that ended this morning

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3145,13 +3145,15 @@
      Tailwind emits a class only once it sees the literal string in a scanned
      file — same as `.content-text` and `.eyebrow`, and it means a name
      assembled at runtime is a name that never ships. Write both as literals.
-     `.label-caption` has real callers from the day it landed (the four sites
-     `.eyebrow-sentence` used to hold). `.label-heading` HAS NONE YET and is in
-     the bundle only because `factionContrast.test.ts` quotes it and Tailwind's
-     content glob scans every .ts and .tsx under src — so moving that spec out
-     of src would silently delete the class. Its first sweep is what makes it
-     load-bearing; until then, check the built stylesheet rather than the source
-     if it appears to do nothing. (Do not write that glob out here. It contains
+     Both tiers now have real callers across propose-task, praxis detail, task
+     detail, the feed and admin (#1601, #1603, #1604, #1605, #1602), so neither
+     depends any longer on `factionContrast.test.ts` quoting it to survive the
+     purge — which it did, for `.label-heading`, between landing and its first
+     sweep. Worth knowing that this was ever true: a class held in the bundle
+     only by a spec is one `src`-relative move away from silently vanishing, and
+     the symptom is a rule that does nothing rather than a build that fails. If
+     either tier ever appears inert, check the BUILT stylesheet rather than the
+     source before believing the source. (Do not write that glob out here. It contains
      a star-slash, which ENDS a CSS comment, and postcss then fails on the
      remains of the sentence rather than on the thing you typed.)
 

--- a/frontend/src/pages/admin/AccountsTab.tsx
+++ b/frontend/src/pages/admin/AccountsTab.tsx
@@ -17,7 +17,8 @@ import { formatTimestamp } from "../../utils/dates";
  *  account is ever `banned` and no life is ever `suspended`. Left as one list
  *  because it is a label lookup rather than a set of offerable values, and the
  *  fallback renders anything unmapped verbatim. Splitting it in two is a
- *  separate decision (#1551). `paused` is gone from both enums (#1550). */
+ *  separate decision, tracked in #1610 — #1551 is the `paused` removal that
+ *  surfaced it, not the split. `paused` is gone from both enums (#1550). */
 type LabelledStatus = "active" | "suspended" | "banned";
 const ACCOUNT_STATUSES: LabelledStatus[] = ["active", "suspended", "banned"];
 


### PR DESCRIPTION
Comment-only. No rule, no selector, no behaviour — `index.css`'s built output is byte-identical.

## What was stale

`frontend/src/index.css` said of `.label-heading`:

> `.label-heading` HAS NONE YET and is in the bundle only because `factionContrast.test.ts` quotes it […] Its first sweep is what makes it load-bearing; **until then**, check the built stylesheet rather than the source if it appears to do nothing.

That "until then" passed today. Five #1307 sweeps landed in the last few hours — #1601 (propose-task), #1603 (praxis detail), #1604 (task detail), #1605 (the feed), #1602 (admin) — and between them both tiers now have real callers. `.eyebrow` is down from 241 `className` sites to 124.

No sweep agent could correct it: `index.css` was explicitly off-limits to all five, precisely because it is the shared file that reds `main` when parallel PRs restate it.

## What this keeps

The hazard, minus the state. A class held in the bundle only by a spec quoting it really is one `src`-relative move away from silently vanishing, and it fails as *a rule that does nothing* rather than as a build that breaks — so "check the BUILT stylesheet before believing the source" is worth keeping even though neither tier depends on that any more.

## Second fix

`pages/admin/AccountsTab.tsx`'s status-union comment credited #1551 with the "split it in two" decision. #1551 is the `paused` removal that *surfaced* the conflation; the split is #1610. Repointed.

## What to eyeball

Nothing. Both hunks are inside comments. The CSS comment change is worth one glance for the postcss trap it warns about in its own next sentence — a `*/` inside that block ends the comment early and postcss then fails on the remains — but `vite build` passing is the real proof, and it does.