### PR TITLE
errors.json owns the words, and coded errors carry the numbers the words need

### DIFF
--- a/backend/errors.py
+++ b/backend/errors.py
@@ -12,12 +12,28 @@ becomes an object::
 ``code`` is the stable machine-readable identifier — the thing a client may
 branch on. ``message`` is **exactly the prose that raise site has always
 emitted**, kept as a fallback so no player-visible copy changes when a raise is
-converted. ``frontend/src/utils/errors.ts::extractError`` reads ``message`` for
-display and deliberately shows nothing for a bare ``code``, so the two halves
-can be adopted independently.
+converted. ``frontend/src/utils/errors.ts::extractError`` resolves the catalog
+first and falls back to ``message``, so the two halves stay independently
+adoptable: a code the catalog does not know still renders its prose.
 
-The i18n catalog lookup (``code`` -> ``errors.json``, the ADR-0031 emit-keys
-half of #1401) is a **later slice**. Nothing here reads a catalog.
+## ``params``: the numbers the catalog cannot know
+
+Fifteen raise sites interpolate a runtime value into their prose — the level
+gates, the signup caps, the media ceilings. ``frontend/src/locales/en/errors.json``
+owns the words (ADR-0031), but it cannot reproduce *"level 3"* from the key
+alone, and dropping the number makes the message unactionable. So a coded
+detail may carry a third member::
+
+    {"detail": {"code": "TASK_LEVEL_TOO_LOW",
+                "message": "This task requires level 3.",
+                "params": {"level": 3}}}
+
+``params`` is **additive and optional** — omitted entirely when a raise site has
+nothing to interpolate, so the non-interpolating sites' bodies are unchanged and
+a client that ignores the field is unaffected. Its keys are the i18next
+placeholder names used in ``errors.json``.
+
+One key is special: see :data:`DETAIL_CONTEXT_PARAM`.
 
 ## Why a helper and not an exception hierarchy
 
@@ -99,21 +115,56 @@ class ErrorCode(str, enum.Enum):
     avatar_too_large = "AVATAR_TOO_LARGE"
 
 
-#: The two keys of a coded ``detail`` body. Named so the frontend contract is
+#: The keys of a coded ``detail`` body. Named so the frontend contract is
 #: greppable from Python and no raise site spells them as bare literals.
 DETAIL_CODE_KEY = "code"
 DETAIL_MESSAGE_KEY = "message"
+DETAIL_PARAMS_KEY = "params"
+
+#: The one ``params`` entry that is not interpolated into copy.
+#:
+#: Five codes are raised with genuinely different prose at different sites:
+#: ``FLAG_LEVEL_TOO_LOW`` reads "…to flag a comment" in :mod:`services.comment`
+#: and "…to flag a praxis" in :mod:`services.praxis`; ``TASK_BANK_FULL`` gains
+#: "Complete or withdraw one first." on the signup path only. A single catalog
+#: key per code cannot render both variants, and #1401 adds a machine-readable
+#: channel — it does not restyle copy. So the raise site names its variant here
+#: and the catalog carries a ``<CODE>_<context>`` sibling key, which is
+#: i18next's native ``context`` feature rather than anything bespoke.
+#:
+#: Prefer *not* reaching for this. A new code is the better answer whenever the
+#: two messages describe genuinely different failures; ``context`` is for one
+#: failure worded for its surface.
+DETAIL_CONTEXT_PARAM = "context"
+
+#: What a ``params`` mapping may carry: interpolation values (ints for levels
+#: and caps) plus the string :data:`DETAIL_CONTEXT_PARAM` discriminator.
+ErrorParams = Mapping[str, Any]
 
 
-def coded_detail(code: ErrorCode, message: str) -> dict[str, str]:
-    """Build the ``detail`` body for a coded failure."""
-    return {DETAIL_CODE_KEY: code.value, DETAIL_MESSAGE_KEY: message}
+def coded_detail(
+    code: ErrorCode, message: str, params: Optional[ErrorParams] = None
+) -> dict[str, Any]:
+    """Build the ``detail`` body for a coded failure.
+
+    ``params`` is omitted from the body entirely when absent or empty, so a
+    raise site with nothing to interpolate produces the exact two-key body it
+    produced before #1401's catalog slice.
+    """
+    detail: dict[str, Any] = {
+        DETAIL_CODE_KEY: code.value,
+        DETAIL_MESSAGE_KEY: message,
+    }
+    if params:
+        detail[DETAIL_PARAMS_KEY] = dict(params)
+    return detail
 
 
 def coded_error(
     status_code: int,
     code: ErrorCode,
     message: str,
+    params: Optional[ErrorParams] = None,
     headers: Optional[dict[str, str]] = None,
 ) -> HTTPException:
     """Build — but do not raise — a coded :class:`HTTPException`.
@@ -125,7 +176,9 @@ def coded_error(
     which is why the ratchet's scan is AST-based and matches construction.
     """
     return HTTPException(
-        status_code=status_code, detail=coded_detail(code, message), headers=headers
+        status_code=status_code,
+        detail=coded_detail(code, message, params),
+        headers=headers,
     )
 
 
@@ -133,14 +186,16 @@ def raise_coded(
     status_code: int,
     code: ErrorCode,
     message: str,
+    params: Optional[ErrorParams] = None,
     headers: Optional[dict[str, str]] = None,
 ) -> NoReturn:
     """Raise a coded failure. The blessed replacement for ``raise HTTPException``.
 
     ``message`` stays the prose the raise site already emitted — this helper
-    adds a code, it does not rewrite copy.
+    adds a code and (since the catalog slice) the values that prose interpolates.
+    It does not rewrite copy.
     """
-    raise coded_error(status_code, code, message, headers=headers)
+    raise coded_error(status_code, code, message, params, headers=headers)
 
 
 def detail_message(detail: Any) -> str:
@@ -174,13 +229,31 @@ def detail_code(detail: Any) -> Optional[str]:
     return None
 
 
+def detail_params(detail: Any) -> dict[str, Any]:
+    """The interpolation ``params`` carried by a ``detail``, or an empty mapping.
+
+    Absent ``params`` reads the same as empty ``params`` on purpose: a caller
+    can splat the result into a catalog lookup without branching on whether the
+    raise site had anything to interpolate.
+    """
+    if isinstance(detail, Mapping):
+        params = detail.get(DETAIL_PARAMS_KEY)
+        if isinstance(params, Mapping):
+            return dict(params)
+    return {}
+
+
 __all__ = [
     "DETAIL_CODE_KEY",
+    "DETAIL_CONTEXT_PARAM",
     "DETAIL_MESSAGE_KEY",
+    "DETAIL_PARAMS_KEY",
     "ErrorCode",
+    "ErrorParams",
     "coded_detail",
     "coded_error",
     "detail_code",
     "detail_message",
+    "detail_params",
     "raise_coded",
 ]

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -402,6 +402,7 @@ async def create_character(
                     f"Must reach level {era.second_character_level_required} "
                     "before creating additional characters."
                 ),
+                {"level": era.second_character_level_required},
             )
 
     # ADR-0019: born unaffiliated by default. A non-None faction must be one the

--- a/backend/services/comment.py
+++ b/backend/services/comment.py
@@ -12,7 +12,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from errors import ErrorCode, raise_coded
+from errors import DETAIL_CONTEXT_PARAM, ErrorCode, raise_coded
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.comment import MAX_COMMENT_BODY, Comment, CommentMention
@@ -161,6 +161,7 @@ async def create_comment(
             403,
             ErrorCode.comment_level_too_low,
             f"Must be level {era.comment_level_required} or above to comment.",
+            {"level": era.comment_level_required},
         )
     body_text = _clean_body(body_text)
     await _assert_commentable_target(praxis_id, task_id, session)
@@ -258,6 +259,7 @@ async def flag_comment(
             403,
             ErrorCode.flag_level_too_low,
             f"Must be level {era.flag_level_required} or above to flag a comment.",
+            {"level": era.flag_level_required, DETAIL_CONTEXT_PARAM: "comment"},
         )
     session.add(
         Flag(

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -15,7 +15,7 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from errors import ErrorCode, raise_coded
+from errors import DETAIL_CONTEXT_PARAM, ErrorCode, raise_coded
 from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
@@ -257,6 +257,7 @@ async def issue_duel_challenge(
             403,
             ErrorCode.duel_level_too_low,
             f"Duels require level {era.duel_level_required}.",
+            {"level": era.duel_level_required},
         )
 
     # Create only the pending Duel row, pointing at the existing praxis.
@@ -334,6 +335,7 @@ async def respond_to_duel_challenge(
             409,
             ErrorCode.task_already_active_member,
             "You already have an active praxis for this task.",
+            {DETAIL_CONTEXT_PARAM: "duel"},
         )
 
     # Opponent bank cap check.
@@ -343,6 +345,7 @@ async def respond_to_duel_challenge(
             400,
             ErrorCode.task_bank_full,
             f"Task bank is full ({era.max_task_signups} in-progress praxes).",
+            {"limit": era.max_task_signups},
         )
 
     # Opponent level check.
@@ -358,6 +361,7 @@ async def respond_to_duel_challenge(
             403,
             ErrorCode.duel_level_too_low,
             f"Duels require level {era.duel_level_required}.",
+            {"level": era.duel_level_required},
         )
 
     # Create the opponent's solo praxis.

--- a/backend/services/media.py
+++ b/backend/services/media.py
@@ -23,13 +23,20 @@ from models.praxis import MediaItem, MediaType
 logger = logging.getLogger(__name__)
 
 
+#: Named so the size ceilings can state their limit in megabytes to both the
+#: prose and the ``params`` the copy catalog interpolates (#1401), instead of
+#: repeating the number as a bare literal in three places.
+BYTES_PER_MEGABYTE = 1024 * 1024
+
 # Avatar pipeline tunables — kept here so the whole avatar contract lives in one place.
 AVATAR_MAX_SIZE = 512
 AVATAR_JPEG_QUALITY = 85
-AVATAR_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+AVATAR_MAX_MEGABYTES = 10
+AVATAR_MAX_BYTES = AVATAR_MAX_MEGABYTES * BYTES_PER_MEGABYTE
 
 # Praxis-media tunables.
-MEDIA_MAX_BYTES = 100 * 1024 * 1024  # 100 MB
+MEDIA_MAX_MEGABYTES = 100
+MEDIA_MAX_BYTES = MEDIA_MAX_MEGABYTES * BYTES_PER_MEGABYTE
 MEDIA_FILENAME_MAX_LEN = 100
 
 
@@ -176,7 +183,12 @@ async def process_and_save_avatar(
         os.makedirs(absolute_directory, exist_ok=True)
         contents = await upload.read()
         if len(contents) > AVATAR_MAX_BYTES:
-            raise_coded(413, ErrorCode.avatar_too_large, "Avatar too large (max 10 MB).")
+            raise_coded(
+                413,
+                ErrorCode.avatar_too_large,
+                f"Avatar too large (max {AVATAR_MAX_MEGABYTES} MB).",
+                {"max_megabytes": AVATAR_MAX_MEGABYTES},
+            )
 
         image = Image.open(io.BytesIO(contents))
         image = image.convert("RGB")
@@ -240,7 +252,12 @@ async def process_and_save_media(
         os.makedirs(absolute_directory, exist_ok=True)
         contents = await upload.read()
         if len(contents) > MEDIA_MAX_BYTES:
-            raise_coded(413, ErrorCode.media_too_large, "File too large (max 100 MB).")
+            raise_coded(
+                413,
+                ErrorCode.media_too_large,
+                f"File too large (max {MEDIA_MAX_MEGABYTES} MB).",
+                {"max_megabytes": MEDIA_MAX_MEGABYTES},
+            )
         with open(absolute_path, "wb") as file_handle:
             file_handle.write(contents)
     except HTTPException:
@@ -263,9 +280,12 @@ async def process_and_save_media(
 __all__ = [
     "AVATAR_JPEG_QUALITY",
     "AVATAR_MAX_BYTES",
+    "AVATAR_MAX_MEGABYTES",
     "AVATAR_MAX_SIZE",
+    "BYTES_PER_MEGABYTE",
     "MEDIA_FILENAME_MAX_LEN",
     "MEDIA_MAX_BYTES",
+    "MEDIA_MAX_MEGABYTES",
     "delete_stored_avatar",
     "process_and_save_avatar",
     "process_and_save_media",

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -14,7 +14,13 @@ from sqlalchemy import and_, exists, func, not_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from errors import ErrorCode, coded_error, detail_message, raise_coded
+from errors import (
+    DETAIL_CONTEXT_PARAM,
+    ErrorCode,
+    coded_error,
+    detail_message,
+    raise_coded,
+)
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.flag import Flag, FlagReason, stored_flag_reason
@@ -736,25 +742,34 @@ def _signup_denial_to_http(
             403,
             ErrorCode.task_level_too_low,
             f"This task requires level {task.level_required}.",
+            {"level": task.level_required},
         )
     if reason == SignupDenialReason.task_status_closed:
-        detail = (
-            "This task is retired and is not open for new praxes."
-            if task.status == TaskStatus.retired
-            else "This task is pending and is not open for new praxes."
+        # The status word is the only thing that varies, and it is also the
+        # catalog discriminator — so the branch picks a context and the prose
+        # follows from it rather than the two being spelled out twice.
+        status_context = (
+            "retired" if task.status == TaskStatus.retired else "pending"
         )
-        return coded_error(403, ErrorCode.task_not_open_for_signup, detail)
+        return coded_error(
+            403,
+            ErrorCode.task_not_open_for_signup,
+            f"This task is {status_context} and is not open for new praxes.",
+            {DETAIL_CONTEXT_PARAM: status_context},
+        )
     if reason == SignupDenialReason.already_active_member:
         return coded_error(
             409,
             ErrorCode.task_already_active_member,
             "You have already submitted a praxis for this task.",
+            {DETAIL_CONTEXT_PARAM: "signup"},
         )
     # bank_full (and the anonymous/None fallback, which create_praxis never hits).
     return coded_error(
         400,
         ErrorCode.task_bank_full,
         f"Task bank is full ({era.max_task_signups} in-progress praxes). Complete or withdraw one first.",
+        {"limit": era.max_task_signups, DETAIL_CONTEXT_PARAM: "signup"},
     )
 
 
@@ -799,6 +814,7 @@ async def _check_create_preconditions(
                 403,
                 ErrorCode.collaboration_level_too_low,
                 f"Collaborations require level {era.collaboration_level_required}.",
+                {"level": era.collaboration_level_required},
             )
         raise_coded(
             403, ErrorCode.praxis_mode_unavailable, "Praxis mode not available."
@@ -1019,6 +1035,7 @@ async def change_praxis_type(
                 403,
                 ErrorCode.collaboration_level_too_low,
                 f"Collaborations require level {era.collaboration_level_required}.",
+                {"level": era.collaboration_level_required},
             )
         praxis.type = PraxisType.collab
     else:
@@ -1472,6 +1489,7 @@ async def flag_praxis(
             403,
             ErrorCode.flag_level_too_low,
             f"Must be level {era.flag_level_required} or above to flag a praxis.",
+            {"level": era.flag_level_required, DETAIL_CONTEXT_PARAM: "praxis"},
         )
 
     praxis.moderation_status = ModerationStatus.flagged
@@ -1527,7 +1545,10 @@ async def invite_to_praxis(
         )
     if praxis.status == PraxisStatus.submitted:
         raise_coded(
-            400, ErrorCode.invite_praxis_submitted, "Cannot invite to a submitted praxis."
+            400,
+            ErrorCode.invite_praxis_submitted,
+            "Cannot invite to a submitted praxis.",
+            {DETAIL_CONTEXT_PARAM: "invite"},
         )
 
     member_ids = {m.character_id for m in praxis.members}
@@ -1583,6 +1604,7 @@ async def invite_to_praxis(
                 403,
                 ErrorCode.task_level_too_low,
                 f"This task requires level {praxis.task.level_required}.",
+                {"level": praxis.task.level_required},
             )
     if not era.collab_invite_bypasses_faction and not faction_permits(
         invitee, praxis.task, era
@@ -1643,7 +1665,10 @@ async def respond_to_invite(
 
     if praxis.status == PraxisStatus.submitted:
         raise_coded(
-            400, ErrorCode.invite_praxis_submitted, "Cannot join a submitted praxis."
+            400,
+            ErrorCode.invite_praxis_submitted,
+            "Cannot join a submitted praxis.",
+            {DETAIL_CONTEXT_PARAM: "join"},
         )
 
     # Check bank capacity — unless this era's collab door lifts it too (#1511).
@@ -1655,6 +1680,7 @@ async def respond_to_invite(
                 409,
                 ErrorCode.task_bank_full,
                 f"Task bank is full ({era.max_task_signups} in-progress praxes).",
+                {"limit": era.max_task_signups},
             )
 
     # Add member

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -69,6 +69,7 @@ async def propose_task(
                 403,
                 ErrorCode.metatask_proposal_level_too_low,
                 f"Must be level {era.level_to_propose_metatask} or above to propose metatasks.",
+                {"level": era.level_to_propose_metatask},
             )
         if not data.metatask_faction_slug:
             raise HTTPException(
@@ -81,6 +82,7 @@ async def propose_task(
                 403,
                 ErrorCode.task_proposal_level_too_low,
                 f"Must be level {era.level_to_propose_task} or above to propose tasks.",
+                {"level": era.level_to_propose_task},
             )
 
     task = Task(

--- a/backend/tests/unit/test_i18n_catalog_coverage.py
+++ b/backend/tests/unit/test_i18n_catalog_coverage.py
@@ -7,12 +7,15 @@ this coverage test lives here. It reads the English catalog JSON directly (no
 running frontend) and fails if config references a key the catalog is missing.
 """
 import json
+import re
 from pathlib import Path
 
 import pytest
 
+from errors import ErrorCode
 from game_config import CURRENT_ERA
 from models.taunt_message import TauntTriggerType
+from tests.unit.uncoded_error_scan import scan_coded_backend
 
 # backend/tests/unit/ -> worktree root -> frontend/src/locales/en/
 LOCALES_DIR = Path(__file__).resolve().parents[3] / "frontend" / "src" / "locales" / "en"
@@ -111,3 +114,87 @@ def test_every_config_faction_taunt_combo_resolves(taunts):
                 f"taunts for ({faction_slug}, {trigger.value}) resolve to nothing "
                 f"— no faction variant and no default fallback"
             )
+
+
+# ---------------------------------------------------------------------------
+# Error codes (#1401)
+# ---------------------------------------------------------------------------
+
+#: i18next interpolation placeholders, as written in an ``errors.json`` value.
+PLACEHOLDER_PATTERN = re.compile(r"\{\{(\w+)\}\}")
+
+
+@pytest.fixture(scope="module")
+def error_codes() -> dict:
+    return _load("errors")["codes"]
+
+
+def test_every_error_code_resolves(error_codes):
+    """Every ``ErrorCode`` the backend can emit has words in the catalog.
+
+    ``extractError`` falls back to the backend's own ``message`` for a code the
+    catalog does not carry, so a gap here is silent at runtime — the player sees
+    Python's prose and ADR-0031 quietly stops holding for that failure. This is
+    the only thing that makes it loud.
+    """
+    for code in ErrorCode:
+        assert code.value in error_codes, (
+            f"errors:codes.{code.value} not in catalog "
+            f"(ErrorCode.{code.name}) — add the key or the failure renders "
+            f"backend prose instead of catalog copy"
+        )
+
+
+def test_every_raise_site_context_resolves(error_codes):
+    """A raise site naming a ``context`` has a ``<CODE>_<context>`` sibling.
+
+    A typo'd or uncatalogued context is the quiet failure this guards: i18next
+    silently falls back to the base key, so the player gets the generic wording
+    for their surface and nothing anywhere complains.
+    """
+    for site in scan_coded_backend():
+        if site.context is None or site.code_member is None:
+            continue
+        code_value = ErrorCode[site.code_member].value
+        sibling = f"{code_value}_{site.context}"
+        assert sibling in error_codes, (
+            f"errors:codes.{sibling} not in catalog — raised at "
+            f"{site.module_path}:{site.line}. i18next would fall back to the "
+            f"base key and render the wrong surface's wording."
+        )
+
+
+def test_every_catalog_placeholder_is_supplied_by_a_raise_site(error_codes):
+    """No catalog value interpolates a value no raise site sends.
+
+    The other half of the ``params`` contract. ``extractError`` refuses to
+    render a half-interpolated string, so a placeholder nothing supplies does
+    not garble copy — it silently disables the catalog for that code, which is
+    just as invisible and just as wrong.
+    """
+    supplied: dict[str, set[str]] = {}
+    for site in scan_coded_backend():
+        if site.code_member is None:
+            continue
+        code_value = ErrorCode[site.code_member].value
+        supplied.setdefault(code_value, set()).update(site.param_names)
+
+    for key, value in error_codes.items():
+        placeholders = set(PLACEHOLDER_PATTERN.findall(value))
+        if not placeholders:
+            continue
+        # A key is either a code or a ``<CODE>_<context>`` sibling, and a
+        # sibling is rendered with its base code's params. Underscores are in
+        # the code values themselves, so match the longest code that prefixes
+        # this key rather than splitting on "_".
+        base = max(
+            (code for code in supplied if key == code or key.startswith(f"{code}_")),
+            key=len,
+            default=key,
+        )
+        missing = placeholders - supplied.get(base, set())
+        assert not missing, (
+            f"errors:codes.{key} interpolates {sorted(missing)}, which no "
+            f"raise site for {base} passes in params — extractError will skip "
+            f"the catalog entirely and fall back to backend prose"
+        )

--- a/backend/tests/unit/uncoded_error_scan.py
+++ b/backend/tests/unit/uncoded_error_scan.py
@@ -228,6 +228,47 @@ class CodedSite:
     code_member: Optional[str]
     #: Whether a third positional argument (the prose ``message``) was supplied.
     has_message: bool
+    #: The interpolation placeholder names this site passes in ``params``,
+    #: excluding the :data:`errors.DETAIL_CONTEXT_PARAM` discriminator.
+    param_names: frozenset[str] = frozenset()
+    #: The literal ``context`` value this site passes, or ``None``. Drives the
+    #: ``<CODE>_<context>`` sibling lookup in the catalog-coverage guard.
+    context: Optional[str] = None
+
+
+def _read_params(node: ast.Call) -> tuple[frozenset[str], Optional[str]]:
+    """The ``params`` mapping a coded raise passes, as (placeholders, context).
+
+    Only a dict literal is readable, which is every site in the codebase and
+    the shape the convention wants: a raise site that computes its params
+    dynamically would be invisible to the catalog-coverage guard, so keeping
+    them literal is what keeps that guard honest.
+    """
+    params: Optional[ast.expr] = None
+    if len(node.args) >= 4:
+        params = node.args[3]
+    else:
+        for keyword in node.keywords:
+            if keyword.arg == "params":
+                params = keyword.value
+    if not isinstance(params, ast.Dict):
+        return frozenset(), None
+
+    names: set[str] = set()
+    context: Optional[str] = None
+    for key, value in zip(params.keys, params.values):
+        # The context key is spelled as the DETAIL_CONTEXT_PARAM constant, not
+        # a bare literal, so match the Name as well as the string.
+        is_context = (isinstance(key, ast.Name) and key.id == "DETAIL_CONTEXT_PARAM") or (
+            isinstance(key, ast.Constant) and key.value == "context"
+        )
+        if is_context:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                context = value.value
+            continue
+        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+            names.add(key.value)
+    return frozenset(names), context
 
 
 def scan_coded_source(source: str, module_path: str) -> list[CodedSite]:
@@ -253,6 +294,7 @@ def scan_coded_source(source: str, module_path: str) -> list[CodedSite]:
                 and code_argument.value.id == "ErrorCode"
             ):
                 code_member = code_argument.attr
+        param_names, context = _read_params(node)
         sites.append(
             CodedSite(
                 module_path=module_path,
@@ -260,6 +302,8 @@ def scan_coded_source(source: str, module_path: str) -> list[CodedSite]:
                 code_member=code_member,
                 has_message=len(node.args) >= 3
                 or any(keyword.arg == "message" for keyword in node.keywords),
+                param_names=param_names,
+                context=context,
             )
         )
     return sites

--- a/frontend/scripts/i18nKeyRefs.py
+++ b/frontend/scripts/i18nKeyRefs.py
@@ -24,12 +24,21 @@ Exit code 1 if anything is deletable, so it can gate a commit.
 
 DELETABLE IS A CANDIDATE LIST, NEVER A DELETE ORDER. A key composed at runtime
 has no literal anywhere and reads as deletable while being very much alive.
-There is a live example in this repo: `components/duel/wowLists.tsx` calls
-``t(`duelSeal.wow.${scope}.sub`)``, so all six `duelSeal.wow.*` keys report
-DELETABLE and must NOT be removed. Before deleting anything, grep the source for
-template-literal `t(` calls and check none of them can build the key. The useful
-signal is the DIFF of this report before and after a change — the keys a change
-newly orphaned — not its absolute output.
+Two live examples in this repo:
+
+* `components/duel/wowLists.tsx` calls ``t(`duelSeal.wow.${scope}.sub`)``, so
+  all six `duelSeal.wow.*` keys report DELETABLE and must NOT be removed.
+* **The whole `errors` namespace.** `utils/errors.ts` builds its key from the
+  backend's wire `code` (``t(`errors:codes.${code}`)``, #1401), so this script
+  reports *every* key in `errors.json` as deletable — "0 kept, 38 deletable" is
+  the expected output there, not a finding. The real guard for that namespace is
+  `backend/tests/unit/test_i18n_catalog_coverage.py`, which holds the keys level
+  with the `ErrorCode` enum, the raise sites' contexts, and their `params`.
+
+Before deleting anything, grep the source for template-literal `t(` calls and
+check none of them can build the key. The useful signal is the DIFF of this
+report before and after a change — the keys a change newly orphaned — not its
+absolute output.
 """
 from __future__ import annotations
 

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -3,6 +3,7 @@ import { initReactI18next } from 'react-i18next'
 
 import admin from './locales/en/admin.json'
 import common from './locales/en/common.json'
+import errors from './locales/en/errors.json'
 import factions from './locales/en/factions.json'
 import feed from './locales/en/feed.json'
 import forms from './locales/en/forms.json'
@@ -19,6 +20,7 @@ export const resources = {
   en: {
     admin,
     common,
+    errors,
     factions,
     feed,
     forms,

--- a/frontend/src/i18next.d.ts
+++ b/frontend/src/i18next.d.ts
@@ -13,6 +13,7 @@ declare module 'i18next' {
     resources: {
       admin: typeof import('./locales/en/admin.json')
       common: typeof import('./locales/en/common.json')
+      errors: typeof import('./locales/en/errors.json')
       factions: typeof import('./locales/en/factions.json')
       feed: typeof import('./locales/en/feed.json')
       forms: typeof import('./locales/en/forms.json')

--- a/frontend/src/locales/README.md
+++ b/frontend/src/locales/README.md
@@ -29,6 +29,7 @@ locales/
 | `admin.json` | Admin and moderation screens |
 | `progression.json` | Level-up ranks + unlock names/descriptions (backend emits keys — ADR-0031) |
 | `taunts.json` | Foe-taunt templates per faction/trigger (backend emits keys — ADR-0031) |
+| `errors.json` | What a failed request tells the player, keyed by error code (backend emits keys — ADR-0031) |
 
 ## How a key works
 
@@ -126,6 +127,28 @@ never sends prose for taunts or ranks/unlocks.
   modulo pick means reordering silently reassigns which taunt an existing row
   renders, and deleting one shifts every later index. Adding to the end is safe.
 
+### Error messages (`errors.json`)
+
+When a request fails, the backend sends a machine-readable **error code** plus
+the runtime values its message needs; this catalog owns the wording (#1401).
+
+- **`codes.<ERROR_CODE>`** — the message for one failure, e.g.
+  `codes.TASK_BANK_FULL`. The key is the code exactly as the backend spells it,
+  in capitals; **never rename one** — it is a wire contract, not a label.
+- Placeholders are the values the backend sends: `{{level}}`, `{{limit}}`,
+  `{{max_megabytes}}`. **A placeholder with no value disables the whole entry** —
+  the player then sees the backend's plainer English instead. So keep every
+  placeholder that is already in a value, and never invent a new one.
+- **`codes.<ERROR_CODE>_<context>`** — a variant for one surface, where the same
+  failure needs different words in different places. `FLAG_LEVEL_TOO_LOW_comment`
+  and `FLAG_LEVEL_TOO_LOW_praxis` are the same gate worded for what you were
+  flagging. The plain `codes.<ERROR_CODE>` is the fallback for any surface with
+  no variant of its own, so it must stay, and it should stay generic.
+
+Reword any value freely. Adding or removing a key here needs a backend change
+too — `backend/tests/unit/test_i18n_catalog_coverage.py` fails if this catalog
+and the backend's error codes disagree.
+
 ### Faction names/descriptions (`factions.json`)
 
 Faction **name/description** prose is also backend-emitted-as-slug (ADR-0038):
@@ -144,9 +167,10 @@ add an entry when a new faction ships; don't drop a slug that config still emits
 
 A backend drift-guard test (`backend/tests/unit/test_i18n_catalog_coverage.py`)
 fails if the era config references a rank/unlock key, a
-`(faction_slug, trigger_type)` taunt combo, or a faction slug whose
-`names`/`descriptions` entry this catalog can't resolve — so a missing key is
-caught in CI, not at render time.
+`(faction_slug, trigger_type)` taunt combo, a faction slug whose
+`names`/`descriptions` entry this catalog can't resolve, or an error code whose
+`errors.json` entry is missing — so a missing key is caught in CI, not at render
+time.
 
 ## Rules of the road
 

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -15,16 +15,16 @@
     "FLAG_LEVEL_TOO_LOW_comment": "Must be level {{level}} or above to flag a comment.",
     "FLAG_LEVEL_TOO_LOW_praxis": "Must be level {{level}} or above to flag a praxis.",
 
-    "TASK_BANK_FULL": "Task bank is full ({{limit}} in-progress praxes).",
-    "TASK_BANK_FULL_signup": "Task bank is full ({{limit}} in-progress praxes). Complete or withdraw one first.",
+    "TASK_BANK_FULL": "Task bank is full ({{limit}} in-progress praxis).",
+    "TASK_BANK_FULL_signup": "Task bank is full ({{limit}} in-progress praxis). Complete or withdraw one first.",
 
     "TASK_ALREADY_ACTIVE_MEMBER": "You already have an active praxis for this task.",
     "TASK_ALREADY_ACTIVE_MEMBER_duel": "You already have an active praxis for this task.",
     "TASK_ALREADY_ACTIVE_MEMBER_signup": "You have already submitted a praxis for this task.",
 
-    "TASK_NOT_OPEN_FOR_SIGNUP": "This task is not open for new praxes.",
-    "TASK_NOT_OPEN_FOR_SIGNUP_retired": "This task is retired and is not open for new praxes.",
-    "TASK_NOT_OPEN_FOR_SIGNUP_pending": "This task is pending and is not open for new praxes.",
+    "TASK_NOT_OPEN_FOR_SIGNUP": "This task is not open for new praxis.",
+    "TASK_NOT_OPEN_FOR_SIGNUP_retired": "This task is retired and is not open for new praxis.",
+    "TASK_NOT_OPEN_FOR_SIGNUP_pending": "This task is pending and is not open for new praxis.",
 
     "TASK_IS_METATASK": "Metatasks are applied to a praxis, not signed up for.",
 

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -1,0 +1,52 @@
+{
+  "codes": {
+    "VOTE_BUDGET_EXHAUSTED": "No votes remaining in your budget.",
+
+    "TASK_LEVEL_TOO_LOW": "This task requires level {{level}}.",
+    "COLLABORATION_LEVEL_TOO_LOW": "Collaborations require level {{level}}.",
+    "DUEL_LEVEL_TOO_LOW": "Duels require level {{level}}.",
+    "COMMENT_LEVEL_TOO_LOW": "Must be level {{level}} or above to comment.",
+    "TASK_PROPOSAL_LEVEL_TOO_LOW": "Must be level {{level}} or above to propose tasks.",
+    "METATASK_PROPOSAL_LEVEL_TOO_LOW": "Must be level {{level}} or above to propose metatasks.",
+    "SECOND_CHARACTER_LEVEL_TOO_LOW": "Must reach level {{level}} before creating additional characters.",
+    "PRAXIS_MODE_UNAVAILABLE": "Praxis mode not available.",
+
+    "FLAG_LEVEL_TOO_LOW": "Must be level {{level}} or above to flag.",
+    "FLAG_LEVEL_TOO_LOW_comment": "Must be level {{level}} or above to flag a comment.",
+    "FLAG_LEVEL_TOO_LOW_praxis": "Must be level {{level}} or above to flag a praxis.",
+
+    "TASK_BANK_FULL": "Task bank is full ({{limit}} in-progress praxes).",
+    "TASK_BANK_FULL_signup": "Task bank is full ({{limit}} in-progress praxes). Complete or withdraw one first.",
+
+    "TASK_ALREADY_ACTIVE_MEMBER": "You already have an active praxis for this task.",
+    "TASK_ALREADY_ACTIVE_MEMBER_duel": "You already have an active praxis for this task.",
+    "TASK_ALREADY_ACTIVE_MEMBER_signup": "You have already submitted a praxis for this task.",
+
+    "TASK_NOT_OPEN_FOR_SIGNUP": "This task is not open for new praxes.",
+    "TASK_NOT_OPEN_FOR_SIGNUP_retired": "This task is retired and is not open for new praxes.",
+    "TASK_NOT_OPEN_FOR_SIGNUP_pending": "This task is pending and is not open for new praxes.",
+
+    "TASK_IS_METATASK": "Metatasks are applied to a praxis, not signed up for.",
+
+    "DUEL_SELF_CHALLENGE": "You cannot duel your own character.",
+    "DUEL_REQUIRES_SOLO_PRAXIS": "Only a solo praxis can issue a duel challenge.",
+    "DUEL_REQUIRES_IN_PROGRESS_PRAXIS": "A duel can only start from an in-progress praxis.",
+    "DUEL_ALREADY_EXISTS": "This praxis is already part of a duel.",
+    "DUEL_OPPONENT_HAS_ACTIVE_PRAXIS": "The opponent already has an active praxis for this task.",
+
+    "INVITE_SELF": "Cannot invite yourself.",
+    "INVITE_ALREADY_MEMBER": "Player is already a member.",
+    "INVITE_ALREADY_PENDING": "A pending invite already exists. Resolve it before sending another.",
+    "INVITE_TARGET_HAS_ACTIVE_PRAXIS": "This player already has an active praxis for this task and cannot be invited.",
+    "INVITE_FACTION_NOT_PERMITTED": "This player's faction may not act on this task.",
+
+    "INVITE_PRAXIS_SUBMITTED": "Cannot act on a submitted praxis.",
+    "INVITE_PRAXIS_SUBMITTED_invite": "Cannot invite to a submitted praxis.",
+    "INVITE_PRAXIS_SUBMITTED_join": "Cannot join a submitted praxis.",
+
+    "MEDIA_TYPE_UNSUPPORTED": "Unsupported media type.",
+    "MEDIA_TOO_LARGE": "File too large (max {{max_megabytes}} MB).",
+    "AVATAR_MUST_BE_IMAGE": "Avatar must be an image file.",
+    "AVATAR_TOO_LARGE": "Avatar too large (max {{max_megabytes}} MB)."
+  }
+}

--- a/frontend/src/utils/__tests__/errors.test.ts
+++ b/frontend/src/utils/__tests__/errors.test.ts
@@ -82,6 +82,94 @@ describe('extractError — status and network fallbacks', () => {
 })
 
 /**
+ * The ADR-0031 half of #1401: `errors.json` owns the words, the backend emits a
+ * `code` plus the `params` its prose interpolates, and `message` is what a code
+ * the catalog has never heard of still renders.
+ */
+describe('extractError — the errors.json catalog', () => {
+  it('renders catalog copy for a code, interpolating params', () => {
+    const detail = {
+      code: 'TASK_LEVEL_TOO_LOW',
+      message: 'This task requires level 3.',
+      params: { level: 3 },
+    }
+    expect(extractError(axiosError(403, detail), FALLBACK)).toBe(
+      'This task requires level 3.'
+    )
+  })
+
+  it('prefers the catalog over the backend prose', () => {
+    // Same code, deliberately divergent prose: whichever string comes back
+    // proves which side won.
+    const detail = {
+      code: 'VOTE_BUDGET_EXHAUSTED',
+      message: 'BACKEND PROSE',
+    }
+    expect(extractError(axiosError(403, detail), FALLBACK)).toBe(
+      'No votes remaining in your budget.'
+    )
+  })
+
+  it('resolves the context sibling when the raise site names one', () => {
+    const flagged = (context: string) => ({
+      code: 'FLAG_LEVEL_TOO_LOW',
+      message: 'BACKEND PROSE',
+      params: { level: 2, context },
+    })
+    expect(extractError(axiosError(403, flagged('comment')), FALLBACK)).toBe(
+      'Must be level 2 or above to flag a comment.'
+    )
+    expect(extractError(axiosError(403, flagged('praxis')), FALLBACK)).toBe(
+      'Must be level 2 or above to flag a praxis.'
+    )
+  })
+
+  it('falls back to the base key for an unknown context', () => {
+    const detail = {
+      code: 'FLAG_LEVEL_TOO_LOW',
+      message: 'BACKEND PROSE',
+      params: { level: 2, context: 'nonesuch' },
+    }
+    expect(extractError(axiosError(403, detail), FALLBACK)).toBe(
+      'Must be level 2 or above to flag.'
+    )
+  })
+
+  it('falls back to message for a code the catalog does not carry', () => {
+    const detail = { code: 'NOT_IN_THE_CATALOG', message: 'Backend prose wins.' }
+    expect(extractError(axiosError(403, detail), FALLBACK)).toBe('Backend prose wins.')
+  })
+
+  /**
+   * The deploy-skew guard. A backend that predates the `params` channel sends
+   * `{code, message}` for a code whose catalog entry interpolates — rendering
+   * it would produce "This task requires level ." at the player.
+   */
+  it('falls back to message when params for a placeholder are missing', () => {
+    const detail = {
+      code: 'TASK_LEVEL_TOO_LOW',
+      message: 'This task requires level 3.',
+    }
+    expect(extractError(axiosError(403, detail), FALLBACK)).toBe(
+      'This task requires level 3.'
+    )
+    expect(
+      extractError(
+        axiosError(403, { code: 'TASK_BANK_FULL', message: 'Task bank is full (20).' }),
+        FALLBACK
+      )
+    ).toBe('Task bank is full (20).')
+  })
+
+  it('never renders a half-interpolated catalog string', () => {
+    // No message either — the caller's fallback beats broken copy.
+    expect(extractError(axiosError(403, { code: 'TASK_LEVEL_TOO_LOW' }), FALLBACK)).toBe(
+      FALLBACK
+    )
+  })
+})
+
+/**
  * `extractErrorCode` exists so a caller can branch on *which* failure happened
  * without reaching past this module for a raw `detail` and matching English
  * prose — the exact drift that made a coded raise a silent UI break (#1598).

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -42,6 +42,44 @@ function isCataloged(code: string): code is CatalogedCode {
   return code in errorsCatalog.codes
 }
 
+/** i18next interpolation placeholders, as written in the catalog values. */
+const PLACEHOLDER_PATTERN = /\{\{(\w+)\}\}/g
+
+/**
+ * The catalog value i18next will resolve for this code and context.
+ *
+ * Read so {@link hasEveryPlaceholder} can inspect the template *before*
+ * rendering it. Mirrors i18next's own context resolution: prefer the
+ * `<CODE>_<context>` sibling, fall back to the base key.
+ */
+function catalogTemplate(code: CatalogedCode, context: unknown): string {
+  if (typeof context === 'string' && context) {
+    const contextual = `${code}_${context}`
+    if (isCataloged(contextual)) return errorsCatalog.codes[contextual]
+  }
+  return errorsCatalog.codes[code]
+}
+
+/**
+ * Does `params` supply every value this catalog string interpolates?
+ *
+ * The guard that makes the catalog safe during a deploy skew. A backend that
+ * predates the `params` channel still sends `{code, message}`, and a catalog
+ * entry like "This task requires level {{level}}." would render as "This task
+ * requires level ." — strictly worse than the prose it replaced, and on the
+ * frontend-deploys-first path that has taken this site down before. When a
+ * value is missing the catalog simply does not apply and `message` wins.
+ */
+function hasEveryPlaceholder(
+  template: string,
+  params: Record<string, unknown> | undefined
+): boolean {
+  for (const [, name] of template.matchAll(PLACEHOLDER_PATTERN)) {
+    if (params?.[name] === undefined) return false
+  }
+  return true
+}
+
 type ErrorDetail = string | ValidationDetail[] | CodedDetail
 
 /** FastAPI's default 500 body — prose, but useless to a player. */
@@ -82,6 +120,9 @@ export const ErrorCode = {
 function catalogMessage(detail: CodedDetail): string | null {
   const { code, params } = detail
   if (typeof code !== 'string' || !isCataloged(code)) return null
+  if (!hasEveryPlaceholder(catalogTemplate(code, params?.context), params)) {
+    return null
+  }
 
   const rendered = i18n.t(`${ERRORS_NAMESPACE}:${CODE_KEY_PREFIX}.${code}`, {
     ...params,

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,14 +1,46 @@
 import type { AxiosError } from 'axios'
 
+import i18n from '../i18n'
+import errorsCatalog from '../locales/en/errors.json'
+
 /** FastAPI validation failures arrive as a list of these. */
 type ValidationDetail = { msg?: string }
 
 /**
- * A coded backend error: a stable machine-readable `code` plus player-facing
- * prose in `message`. `message` is what we display; `code` exists so callers
- * (and, later, an i18n catalog) can branch on the failure without matching prose.
+ * A coded backend error: a stable machine-readable `code`, player-facing prose
+ * in `message`, and the runtime values that prose interpolates in `params`.
+ *
+ * `code` is what the copy catalog is keyed by and what callers branch on.
+ * `message` is the backend's own prose, kept as the fallback for any code the
+ * catalog does not know. `params` is absent whenever the raise site had nothing
+ * to interpolate — see `backend/errors.py`.
  */
-type CodedDetail = { code?: string; message?: string }
+type CodedDetail = {
+  code?: string
+  message?: string
+  params?: Record<string, unknown>
+}
+
+/** Where `backend/errors.py::ErrorCode` values are keyed in the copy catalog. */
+const ERRORS_NAMESPACE = 'errors'
+const CODE_KEY_PREFIX = 'codes'
+
+/**
+ * The codes `errors.json` actually carries — read off the catalog itself.
+ *
+ * i18next types keys as a literal union built from the resources, so a key
+ * composed from an unconstrained `string` does not compile (the problem
+ * `components/feed/feedItemLabels.ts` solves with a hand-written map of its 15
+ * types). Deriving the union from the imported JSON solves it without a second
+ * copy of the code list to drift: the catalog stays the single frontend
+ * inventory, and `backend/tests/unit/test_i18n_catalog_coverage.py` is what
+ * holds it level with the backend enum.
+ */
+type CatalogedCode = keyof typeof errorsCatalog.codes
+
+function isCataloged(code: string): code is CatalogedCode {
+  return code in errorsCatalog.codes
+}
 
 type ErrorDetail = string | ValidationDetail[] | CodedDetail
 
@@ -28,6 +60,36 @@ export const ErrorCode = {
 } as const
 
 /**
+ * The catalog's words for a coded error, or null if it has none (ADR-0031).
+ *
+ * This is the emit-keys half of #1401: the backend sends `code` + the `params`
+ * its prose interpolates, and `errors.json` owns the wording. A code the
+ * catalog has never heard of returns null so the caller falls back to the
+ * backend's own `message` — which is how a newly-coded raise can ship before
+ * its catalog entry does, and how a deploy-skewed client stays useful.
+ *
+ * Membership is checked before `t` rather than letting the lookup miss, because
+ * `i18n.ts` installs a `missingKeyHandler` that THROWS in dev and test. An
+ * unknown code here is an ordinary runtime condition — an older client meeting
+ * a newer backend — not a build defect, so it must not take the error path down
+ * with it.
+ *
+ * `params.context` is i18next's discriminator, not an interpolation value: it
+ * resolves `<CODE>_<context>` for the handful of codes whose prose differs by
+ * the surface that raised them, falling back to the base key when the catalog
+ * has no such sibling. Spreading `params` passes both at once.
+ */
+function catalogMessage(detail: CodedDetail): string | null {
+  const { code, params } = detail
+  if (typeof code !== 'string' || !isCataloged(code)) return null
+
+  const rendered = i18n.t(`${ERRORS_NAMESPACE}:${CODE_KEY_PREFIX}.${code}`, {
+    ...params,
+  })
+  return typeof rendered === 'string' && rendered ? rendered : null
+}
+
+/**
  * Pulls the displayable prose out of a `detail` body, whatever shape it takes.
  * Returns null when there is nothing worth showing, so the caller falls through
  * to its status-based messages.
@@ -43,9 +105,13 @@ function displayableDetail(detail: ErrorDetail | undefined): string | null {
     return detail[0]?.msg || null
   }
 
-  // Coded object — `message` carries the prose, `code` is for machines only.
-  // A bare code with no message is not shown; a raw code reads worse to a
-  // player than the caller's fallback does.
+  // Coded object. The catalog owns the words when it knows this code; the
+  // backend's own prose is the fallback for every code it does not.
+  const fromCatalog = catalogMessage(detail)
+  if (fromCatalog) return fromCatalog
+
+  // A bare code with no message is still not shown: a raw code reads worse to
+  // a player than the caller's fallback does.
   const message = detail.message
   if (typeof message !== 'string' || message === GENERIC_SERVER_PROSE) return null
   return message || null
@@ -57,7 +123,9 @@ function displayableDetail(detail: ErrorDetail | undefined): string | null {
  * Priority:
  *   1. FastAPI `detail` from the response body (skip generic "Internal Server Error"), as either
  *      a plain string, a validation array (uses the first item's msg), or a
- *      coded `{ code, message }` object (uses `message`)
+ *      coded `{ code, message, params }` object — which resolves the `errors.json`
+ *      catalog by `code` first (interpolated with `params`) and falls back to
+ *      `message` for any code the catalog does not carry
  *   2. Server error (5xx) with no useful detail — server-side problem message
  *   3. Network error (no response at all) — connection message
  *   4. Caller-provided fallback, or generic default


### PR DESCRIPTION
Part of #1401

Build step 2's frontend half — the ADR-0031 emit-keys part. `backend/errors.py` said the catalog lookup was "a later slice. Nothing here reads a catalog." This is that slice: `frontend/src/locales/en/errors.json` now owns the words, and `extractError` resolves it by `code` before falling back to backend prose.

## What changed

1. **`coded_detail` / `coded_error` / `raise_coded` grow an optional `params`.** The wire body becomes `{code, message, params}`. `params` is **omitted entirely** when a raise site has nothing to interpolate, so the non-interpolating sites' bodies are byte-identical to before and a client that ignores the field is unaffected.
2. **The interpolating raise sites pass their values as `params`.** No player-facing prose was restyled — the `message` each site emits is unchanged (one exception, below).
3. **`errors.json`** — 38 keys covering all 29 `ErrorCode` members.
4. **`extractError` resolves catalog → `message` → existing heuristics.** The whole existing chain is intact; a new first step was inserted.

## Two things the brief's numbers missed

**It is 15 interpolating sites, not 14.** From an AST inventory rather than a grep. Two *further* sites (`AVATAR_TOO_LARGE`, `MEDIA_TOO_LARGE`) carried their limits as **literal** prose rather than f-strings — `"Avatar too large (max 10 MB)."` — so a scan for interpolation misses them entirely while the catalog still cannot reproduce the number. Those now read from new `AVATAR_MAX_MEGABYTES` / `MEDIA_MAX_MEGABYTES` constants and render identical prose. 22 sites carry `params` in total (15 + 2 + 5 context-only).

**Five codes are raised with genuinely different prose at different sites.** This is the one thing the brief did not anticipate, and it changes the catalog's shape, so flagging it explicitly:

| code | site A | site B |
|---|---|---|
| `FLAG_LEVEL_TOO_LOW` | "…to flag a **comment**" | "…to flag a **praxis**" |
| `INVITE_PRAXIS_SUBMITTED` | "Cannot **invite to** a submitted praxis." | "Cannot **join** a submitted praxis." |
| `TASK_ALREADY_ACTIVE_MEMBER` | "You already **have an active** praxis…" | "You have already **submitted** a praxis…" |
| `TASK_BANK_FULL` | "…praxis)." | "…praxis). **Complete or withdraw one first.**" |
| `TASK_NOT_OPEN_FOR_SIGNUP` | "…is **retired** and…" | "…is **pending** and…" |

One key per code cannot render both, and dropping a variant *is* a copy rewrite. Resolved with **i18next's native `context`**: the raise site names its variant in `params.context`, the catalog carries a `<CODE>_<context>` sibling, and the base key stays as the generic fallback. No new `ErrorCode` members, no wire change beyond `params`, every byte of copy preserved.

If you would rather these became **separate error codes**, that is a reasonable alternative and a small follow-up — `context` is deliberately documented in `errors.py` as the lesser tool ("a new code is the better answer whenever the two messages describe genuinely different failures").

## Decisions you asked me to make deliberately

**`detail_message` / `detail_code`: `params` does NOT reach them — prose-only is still right there.** `MediaUploadResultOut.error` and `NudgeResultOut.error` are plain string fields inside a **200 OK** body, not the `detail` envelope; the frontend renders them directly and never through `extractError`. Reaching `params` in would mean changing two response schemas (and their generated artifacts) for zero player-visible gain, since the prose is identical either way. Nudge's `_refuse` builds *uncoded* exceptions anyway. Left alone.

**The i18n sweep script.** `python scripts/i18nKeyRefs.py errors` reports **"0 kept, 38 deletable"** — every key, because `utils/errors.ts` composes the key from the wire code at runtime. That is the documented false positive, not a finding. I added the `errors` namespace to the script's docstring beside the existing `duelSeal.wow` example, so the next reader is not misled into deleting a live catalog.

**`openapi.json` did not move.** `detail` bodies are runtime dicts, not Pydantic schemas, so the `api-schema` job has nothing to regenerate. Verified by running `scripts/regen_api_client.py` and getting a clean `git status`.

## One deliberate copy change, forced by an existing rule

#1136 rules that **the plural of *praxis* is *praxis***, CI-enforced by `src/__tests__/praxisPlural.test.ts` — but only over the *catalog*. Error prose lived in Python and had escaped that rule, so five values arrived saying "praxes" and failed the test the moment they became catalog copy. They now read "praxis", matching the house voice already in `tasks.json` ("{{count}} completed praxis").

**Player-visible consequence:** a full task bank now reads "Task bank is full (20 in-progress **praxis**)". The backend `message` fallback still says "praxes" — I did not touch prose beyond the catalog, and that string is now only reachable during a deploy skew or for an uncatalogued code. Worth a follow-up to align it.

## Guards added

`backend/tests/unit/test_i18n_catalog_coverage.py` gains three, reusing the ratchet's existing AST scanner (`CodedSite` grew `param_names` / `context` fields rather than a second scanner being written):

- every `ErrorCode` has a catalog key;
- every `context` a raise site names has a `<CODE>_<context>` sibling;
- every catalog placeholder is a param some raise site actually sends.

**All three were mutation-tested** — I broke the catalog three ways (dropped a code, typo'd a context sibling, typo'd a `{{level}}` placeholder), confirmed each guard fails, then restored. A guard that has only ever passed proves nothing.

There is also a **deploy-skew guard** in `extractError`: if a catalog entry interpolates a placeholder that `params` does not supply, the catalog is skipped and `message` wins. Without it a backend predating `params` would render "This task requires level ." — worse than the prose it replaced, and on the frontend-deploys-first path that has taken this site down before. Every pre-existing test in `errors.test.ts` passes **unmodified**, which is the evidence that the new first step is genuinely additive.

## Verification

- backend `pytest`: **1091 passed**, coverage **92.87%** (gate 80)
- frontend: eslint clean, `tsc --noEmit` clean, **3903 tests passed**, `vite build` ok, initial-load budget **139.2 KB JS / 22.4 KB CSS** (within), `typecheck:design-sync` clean
- `api-schema`: regenerated, no diff
- rebased onto `origin/main` @ f1b63a18 and re-ran all of the above

**Visual QA is outstanding** — I have no browser or dev stack in this worktree, so nothing here was seen rendered.

## What to eyeball

Each of these should now render **catalog** copy with the number filled in:

1. **A full task bank** — sign up until you hit the cap, then try one more. Expect "Task bank is full (N in-progress praxis). Complete or withdraw one first." (the `_signup` variant). Then accept a **duel** at a full bank: same code, the shorter sentence, no "Complete or withdraw".
2. **A level-gated signup** — a task above your level: "This task requires level N." Then the same gate via a **collab invite**, which raises the same code from a different site.
3. **An oversized upload** — a >100 MB praxis file ("File too large (max 100 MB)") and a >10 MB avatar ("Avatar too large (max 10 MB)").
4. **The context split** — flag a **comment** vs. flag a **praxis** while below the flag level. They must read "…to flag a comment." and "…to flag a praxis." If both say the same thing, context resolution is broken.
5. **A retired vs. pending task** signup — "This task is retired/pending and is not open for new praxis."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
