### PR TITLE
A typed openapi-fetch client, installed and proven, with nothing calling it yet

### DIFF
--- a/backend/models/task.py
+++ b/backend/models/task.py
@@ -59,7 +59,7 @@ class Task(TimestampMixin, Base):
     metatask_faction_slug: Mapped[Optional[str]] = mapped_column(
         String, ForeignKey("faction.slug"), nullable=True
     )
-    # Parked v2 feature (SPEC-backend-architecture §9 "Intentional v2
+    # Parked v2 feature (SPEC-backend-architecture §10 "Intentional v2
     # deferrals"): Task Vision would let Ephemerists see retired tasks. The
     # column and its TaskDef writer stay so an era can mark tasks eligible;
     # nothing reads it yet and it is deliberately NOT on the wire (#1471) —

--- a/docs/adr/0045-pragmatic-ddd-posture.md
+++ b/docs/adr/0045-pragmatic-ddd-posture.md
@@ -48,6 +48,6 @@ a domain-exception hierarchy translated to HTTP in the router layer. Rejected be
 ## Consequences
 
 - "Refactor this to real DDD" is a **non-goal** — point here when it comes up.
-- **Revisit triggers are explicit** (`SPEC-backend-architecture.md §10`): add a repository layer
+- **Revisit triggers are explicit** (`SPEC-backend-architecture.md §11`): add a repository layer
   only if query duplication grows; add an event bus only if service-call chains grow.
 - New logic goes in a **service**, not on a model — models stay anemic by rule.

--- a/docs/agents/load-time.md
+++ b/docs/agents/load-time.md
@@ -146,7 +146,7 @@ landed somewhere they had not asked for.
 No bundle work would ever have found that, and no byte budget would have flagged
 it. When a page feels slow, check what it actually *did* — a waterfall showing
 the document requested twice is a different bug from a waterfall that is simply
-wide. `shouldReturnToLanding` in `api/axios.ts` is now unit-tested for it.
+wide. `shouldReturnToLanding` in `api/sessionRedirect.ts` is now unit-tested for it.
 
 ## Preloading can make things much worse
 

--- a/docs/spec/SPEC-backend-architecture.md
+++ b/docs/spec/SPEC-backend-architecture.md
@@ -31,7 +31,7 @@ Each layer has one job.
 models. Services may import models, `scoring`, and `game_config`. Models
 import nothing from `services/` or `routers/`. A module-level import inside
 `services/` that points at another `services/` file is OK *if it doesn't
-create a cycle*; see §9 for what to do when it does.
+create a cycle*; see §10 for what to do when it does.
 
 ---
 
@@ -98,7 +98,7 @@ themselves are frozen dataclasses.
 ### What we deliberately skip
 
 - No repository abstraction. Services issue SQLAlchemy queries directly.
-  Revisit if query duplication grows (see §10).
+  Revisit if query duplication grows (see §11).
 - No behavior on models. `Character.level_up()` would be nice in theory;
   in practice, `recalculate_character_stats` is where level transitions
   happen. Leave models anemic.
@@ -197,7 +197,48 @@ use the canonical one.
 
 ---
 
-## 7. Patterns to follow
+## 7. The API is a private BFF
+
+This is not a public API. It is a backend-for-frontend with exactly one
+consumer — `frontend/` — which is developed in the same repository, reviewed in
+the same PR, and deployed alongside it. Every design argument that starts "but a
+REST API should…" has to answer that first, because the constraints those
+arguments exist to satisfy — unknown clients, clients you cannot upgrade,
+clients that outlive your deploy — are not constraints we have.
+
+Three things follow, and they are the reason this section is written down at
+all.
+
+**Screen-shaped endpoints are correct here.** `GET /me/sidebar` returns the
+rail's panels: a compound read assembled for one piece of UI, named after that
+UI rather than after a resource. Under public-API doctrine that is a smell, and
+the cure is to expose the underlying resources and let the client compose them.
+Here the cure is the disease — it turns one round trip into several, on the
+first wave of every page load, to serve a caller we control and can see. Build
+the endpoint the screen needs. The pressure to resist is the opposite one: a
+compound endpoint that no screen uses.
+
+**There is no versioning, and there should not be.** No `/v1`, no version
+header, no deprecation window, no parallel old-and-new shape. Both halves ship
+together, so a wire change is a single atomic edit across the seam — and since
+#1400 the seam is checked: `backend/openapi.json` is regenerated in CI and the
+frontend's types are generated from it, so a shape that changes on one side and
+not the other fails the build instead of failing a user. The moment a second
+consumer appears that we cannot deploy in lockstep, this paragraph is wrong and
+the posture has to be revisited (§11); until then, versioning buys nothing and
+costs every change twice.
+
+**Verb and URL aesthetics are opportunistic only.** Some routes are tidier than
+others, and the untidy ones are not bugs. Rename a path or straighten a verb
+when you are already editing that router for another reason and the change is
+free; never open a PR to do it, and never make one a precondition of shipping
+something else. A rename costs a backend edit, a frontend edit, a regenerated
+schema and a review — and buys a nicer-looking string that no one outside this
+repository will ever read.
+
+---
+
+## 8. Patterns to follow
 
 - **Service signature**: `async def verb_noun(session: AsyncSession, ...,
   era: EraConfig = CURRENT_ERA) -> Orm | Dataclass`. Example:
@@ -220,7 +261,7 @@ use the canonical one.
 
 ---
 
-## 8. Patterns to avoid
+## 9. Patterns to avoid
 
 - Business logic inside route handlers. If a handler has more than a few
   lines after `Depends`, it likely owes work to a service.
@@ -248,7 +289,7 @@ use the canonical one.
 
 ---
 
-## 9. Intentional v2 deferrals
+## 10. Intentional v2 deferrals
 
 These features are **parked, not built** — deliberately deferred until v2. Do not "fix" them.
 
@@ -265,7 +306,7 @@ Only the exotic cases in the table above remain deferred.
 
 ---
 
-## 10. When to revisit this posture
+## 11. When to revisit this posture
 
 The current posture is sized for a ~20-model codebase with a single bounded
 context. Signs it's time to revisit:
@@ -279,9 +320,9 @@ context. Signs it's time to revisit:
 - A second bounded context emerging (e.g. a distinct moderation/admin
   domain that is no longer a thin overlay on the game model).
 
-Until then, the rules in §1–§8 are enough.
+Until then, the rules in §1–§9 are enough.
 
-## 11. When in doubt
+## 12. When in doubt
 
 - Start at `CLAUDE.md`'s "Where to look for X" table.
 - For game rule values: `backend/eras/era_1.py`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.7.2",
         "i18next": "^26.3.6",
+        "openapi-fetch": "^0.17.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-easy-crop": "^6.2.2",
@@ -4744,6 +4745,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/openapi-fetch": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.17.0.tgz",
+      "integrity": "sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.1.0"
+      }
+    },
     "node_modules/openapi-typescript": {
       "version": "7.13.0",
       "resolved": "https://registry.npmjs.org/openapi-typescript/-/openapi-typescript-7.13.0.tgz",
@@ -4764,6 +4774,12 @@
       "peerDependencies": {
         "typescript": "^5.x"
       }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.1.0.tgz",
+      "integrity": "sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==",
+      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "axios": "^1.7.2",
     "i18next": "^26.3.6",
+    "openapi-fetch": "^0.17.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-easy-crop": "^6.2.2",

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1,0 +1,236 @@
+/**
+ * #1400 — the openapi-fetch transport, tested at the seam it actually owns:
+ * the `Request` the configured client hands to `fetch`, and the error it hands
+ * back to the caller.
+ *
+ * Both halves are invisible to the type checker. `schema.d.ts` says `faction`
+ * is a `string[]`; it says nothing about how that array reaches the wire, and
+ * the wrong answer 200s with the filter silently dropped. Likewise nothing in
+ * the types distinguishes a client that throws on a 403 from one that returns
+ * `{ error }` — but ninety-odd call sites sit inside `try`/`catch` blocks that
+ * only one of those two behaviours reaches.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+import { ApiError, ApiNetworkError, apiGet, apiPost } from '../client'
+import { extractError, extractErrorCode } from '../../utils/errors'
+
+const JSON_HEADERS = { 'content-type': 'application/json' }
+
+const jsonReply = (status: number, body: string) => () =>
+  Promise.resolve(new Response(body, { status, headers: JSON_HEADERS }))
+
+/**
+ * The fetch stub goes in via `vi.hoisted`, not `beforeEach`, because
+ * `openapi-fetch` binds `globalThis.fetch` when the client is CREATED — which
+ * happens at `../client`'s top level, i.e. during this file's imports. A later
+ * `vi.stubGlobal('fetch', …)` is simply not consulted, and the failure is not a
+ * failure: the suite issues REAL requests to whatever is listening on
+ * localhost:8000 and asserts against its answers.
+ */
+const wire = vi.hoisted(() => {
+  const ok = () =>
+    Promise.resolve(
+      new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } }),
+    )
+
+  const sent: Request[] = []
+  let reply: () => Promise<Response> = ok
+
+  globalThis.fetch = (async (input: Request) => {
+    sent.push(input)
+    return reply()
+  }) as unknown as typeof globalThis.fetch
+
+  return {
+    sent,
+    reset() {
+      sent.length = 0
+      reply = ok
+    },
+    replyWith(next: () => Promise<Response>) {
+      reply = next
+    },
+  }
+})
+
+const sent = wire.sent
+
+beforeEach(() => {
+  wire.reset()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/** The URL of the single request the last call made. */
+const sentUrl = () => new URL(sent[0].url)
+
+describe('the request the client builds', () => {
+  it('sends the httpOnly JWT cookie', async () => {
+    // Without this the backend sees an anonymous caller on every authenticated
+    // read, and answers 401 — or worse, answers a guest's version of the page.
+    await apiGet('/tasks', {})
+    expect(sent[0].credentials).toBe('include')
+  })
+
+  it('resolves paths against the configured base URL', async () => {
+    await apiGet('/tasks', {})
+    expect(sentUrl().origin).toBe('http://localhost:8000')
+    expect(sentUrl().pathname).toBe('/tasks')
+  })
+
+  /**
+   * The one that has bitten this repo before (#1366). `GET /tasks` declares
+   * `faction: list[str] = Query(None)`, which FastAPI reads from REPEATED bare
+   * keys. Axios' default writes `faction[]=ua`, from which FastAPI reads
+   * nothing at all: the request succeeds, the filter vanishes, and no test,
+   * type or log says a word. `api/tasks.ts` carries `REPEATED_QUERY_PARAMS`
+   * purely to undo that.
+   *
+   * openapi-fetch defaults to `style: "form", explode: true`, which is the
+   * shape FastAPI wants — but "the library's default happens to be right" is a
+   * claim, and this is the assertion that makes it a checked one. If a
+   * `querySerializer` is ever added to `client.ts` for some other reason, this
+   * fails rather than the filters going quiet.
+   */
+  it('writes an array param as repeated bare keys', async () => {
+    await apiGet('/tasks', { params: { query: { faction: ['ua', 'wow'] } } })
+    expect(sentUrl().search).toBe('?faction=ua&faction=wow')
+    expect(sentUrl().searchParams.getAll('faction')).toEqual(['ua', 'wow'])
+  })
+
+  it('writes a union of one exactly as a single-slug caller would', async () => {
+    await apiGet('/tasks', { params: { query: { faction: ['ua'] } } })
+    expect(sentUrl().search).toBe('?faction=ua')
+  })
+
+  it('omits an absent filter rather than sending an empty one', async () => {
+    // `?status=` is not "no filter" to FastAPI, it is the empty string.
+    await apiGet('/tasks', {
+      params: { query: { faction: undefined, status: undefined, sort: 'newest' } },
+    })
+    expect(sentUrl().search).toBe('?sort=newest')
+  })
+
+  it('sends a JSON body on a write', async () => {
+    wire.replyWith(jsonReply(201, '{"id":1}'))
+
+    await apiPost('/tasks', { body: { title: 'Sweep', point_value: 3, level_required: 0 } })
+
+    expect(sent[0].method).toBe('POST')
+    expect(sent[0].headers.get('content-type')).toContain('application/json')
+    expect(await sent[0].json()).toEqual({ title: 'Sweep', point_value: 3, level_required: 0 })
+  })
+})
+
+describe('what the client does with a failure', () => {
+  const CODED_409 = '{"detail":{"code":"TASK_BANK_FULL","message":"Task bank is full."}}'
+
+  /**
+   * The load-bearing decision. openapi-fetch reports a failure by RESOLVING
+   * with `{ data, error }` where axios rejected, and every consumer in this app
+   * is a `try`/`catch` that calls `extractError`. A client that returns instead
+   * of throwing turns a transport swap into an app-wide rewrite, and — far
+   * worse — turns every unmigrated `catch` into dead code that reports a failed
+   * request as a success.
+   */
+  it('throws on a non-2xx instead of returning an error branch', async () => {
+    wire.replyWith(jsonReply(409, CODED_409))
+
+    await expect(apiGet('/tasks', {})).rejects.toBeInstanceOf(ApiError)
+  })
+
+  it('carries the status and the parsed body on what it throws', async () => {
+    wire.replyWith(jsonReply(403, '{"detail":"Task requires level 3"}'))
+
+    const error = await apiGet('/tasks', {}).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect((error as ApiError).status).toBe(403)
+    expect((error as ApiError).data).toEqual({ detail: 'Task requires level 3' })
+  })
+
+  /**
+   * The point of throwing that particular shape: the app's existing error
+   * readers must understand it without a call-site change.
+   */
+  it('is readable by extractError and extractErrorCode unchanged', async () => {
+    wire.replyWith(jsonReply(409, CODED_409))
+
+    const error = await apiGet('/tasks', {}).catch((caught: unknown) => caught)
+
+    expect(extractError(error, 'FALLBACK')).toBe('Task bank is full.')
+    expect(extractErrorCode(error)).toBe('TASK_BANK_FULL')
+  })
+
+  /**
+   * A proxy's HTML error page is not JSON. That is no reason to throw something
+   * the caller cannot read: the status still tells the truth, and `extractError`
+   * falls through to its 5xx prose exactly as it does for an axios failure with
+   * an unparseable body.
+   */
+  it('still throws with a status when the body is not JSON', async () => {
+    wire.replyWith(() => Promise.resolve(new Response('<html>502</html>', { status: 502 })))
+
+    const error = await apiGet('/tasks', {}).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect((error as ApiError).status).toBe(502)
+    expect(extractError(error, 'FALLBACK')).toBe(
+      'The server ran into an unexpected problem. Try again in a moment.',
+    )
+  })
+
+  /**
+   * `fetch` rejects — DNS failure, offline, connection refused. There is no
+   * response and no status, which is a different thing from a 500 and reads as
+   * different words to the player. `extractError`'s network branch keys off
+   * exactly this.
+   */
+  it('distinguishes a network failure from a server failure', async () => {
+    wire.replyWith(() => Promise.reject(new TypeError('Failed to fetch')))
+
+    const error = await apiGet('/tasks', {}).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(ApiNetworkError)
+    expect(extractError(error, 'FALLBACK')).toBe(
+      'Unable to reach the server. Check your connection and try again.',
+    )
+  })
+})
+
+/**
+ * The rule `sessionRedirect.ts` owns, exercised through the NEW transport. Its
+ * predicate has its own tests; what is unproven there is that this client
+ * consults it at all, and that it hands over a URL the probe check can match —
+ * openapi-fetch's `Request.url` is absolute where axios' `config.url` was not.
+ */
+describe('the 401 landing redirect', () => {
+  const NOT_AUTHENTICATED = '{"detail":"Not authenticated"}'
+
+  const stubLocation = (pathname: string) => {
+    const location = { pathname, href: pathname }
+    vi.stubGlobal('window', { location })
+    return location
+  }
+
+  it('bounces a session that expires while the app is in use', async () => {
+    const location = stubLocation('/tasks/46')
+    wire.replyWith(jsonReply(401, NOT_AUTHENTICATED))
+
+    await apiGet('/tasks', {}).catch(() => undefined)
+
+    expect(location.href).toBe('/')
+  })
+
+  it('leaves a guest on the deep link they asked for when a probe 401s', async () => {
+    const location = stubLocation('/tasks/46')
+    wire.replyWith(jsonReply(401, NOT_AUTHENTICATED))
+
+    await apiGet('/auth/me', {}).catch(() => undefined)
+
+    expect(location.href).toBe('/tasks/46')
+  })
+})

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -12,7 +12,8 @@
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-import { ApiError, ApiNetworkError, apiGet, apiPost } from '../client'
+import { ApiError, ApiNetworkError } from '../apiError'
+import { apiGet, apiPost } from '../client'
 import { extractError, extractErrorCode } from '../../utils/errors'
 
 const JSON_HEADERS = { 'content-type': 'application/json' }
@@ -111,6 +112,24 @@ describe('the request the client builds', () => {
     await apiGet('/tasks', {
       params: { query: { faction: undefined, status: undefined, sort: 'newest' } },
     })
+    expect(sentUrl().search).toBe('?sort=newest')
+  })
+
+  /**
+   * `undefined` is not the only way this filter arrives empty, and the other two
+   * are the ones a caller actually produces. `schema.d.ts` types the union as
+   * `string[] | null`, so `null` is what an explicitly-cleared filter has every
+   * right to be; `[]` is what clearing the last faction chip leaves behind.
+   *
+   * Both must vanish from the URL entirely. `?faction=null` and `?faction=` are
+   * each a slug FastAPI will dutifully match nothing against — the #1366 failure
+   * again, arriving as an empty list rather than an unfiltered one.
+   */
+  it('omits a null filter and an empty union, not just an undefined one', async () => {
+    await apiGet('/tasks', { params: { query: { faction: null, sort: 'newest' } } })
+    expect(sentUrl().search).toBe('?sort=newest')
+
+    await apiGet('/tasks', { params: { query: { faction: [], sort: 'newest' } } })
     expect(sentUrl().search).toBe('?sort=newest')
   })
 

--- a/frontend/src/api/__tests__/sessionRedirect.test.ts
+++ b/frontend/src/api/__tests__/sessionRedirect.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { shouldReturnToLanding } from '../axios'
+import { shouldReturnToLanding } from '../sessionRedirect'
 
 /**
  * Guard for the guest deep-link bounce.

--- a/frontend/src/api/apiError.ts
+++ b/frontend/src/api/apiError.ts
@@ -1,0 +1,62 @@
+/**
+ * What the `openapi-fetch` transport throws (#1400).
+ *
+ * Its own module, and deliberately free of any import, because `utils/errors.ts`
+ * reads these and `utils/errors.ts` is imported by most of the app. Declaring
+ * them inside `client.ts` would put `openapi-fetch` — and the whole generated
+ * schema module — on the initial-load path of every page, to carry two class
+ * declarations.
+ */
+
+/**
+ * A non-2xx answer from the API.
+ *
+ * `openapi-fetch` reports failures by RETURNING `{ data, error, response }`
+ * where axios rejected. Every consumer in this app is a `try`/`catch` around
+ * `extractError`, so the helpers in `client.ts` throw this instead: a returning
+ * client would not merely need ninety-odd call sites rewritten, it would leave
+ * every un-rewritten `catch` unreachable — a failed request reported as a
+ * success, with no error anywhere to notice.
+ *
+ * `data` is the parsed JSON body, or undefined when there wasn't one (a 204, or
+ * an HTML error page from a proxy). `status` is always the truth either way.
+ */
+export class ApiError<TBody = unknown> extends Error {
+  readonly status: number
+  readonly data: TBody | undefined
+  readonly response: Response
+
+  constructor(response: Response, data: TBody | undefined) {
+    super(`Request failed with status ${response.status}`)
+    this.name = 'ApiError'
+    this.status = response.status
+    this.data = data
+    this.response = response
+  }
+}
+
+/**
+ * The request never got an answer — offline, DNS failure, connection refused,
+ * CORS preflight rejected.
+ *
+ * A separate class rather than an {@link ApiError} with a made-up status,
+ * because there genuinely is no status and the player is told something else
+ * ("check your connection", not "the server had a problem"). The message is
+ * `'Network Error'` to match what axios sets on the same condition, so
+ * `extractError`'s existing branch reads both transports without a special case.
+ */
+export class ApiNetworkError extends Error {
+  /**
+   * Whatever `fetch` rejected with — a `TypeError` in every browser, but not
+   * worth insisting on. Declared as an own field rather than passed to
+   * `super(message, { cause })`, because `Error.cause` arrived in ES2022 and
+   * this project's `lib` is ES2020.
+   */
+  readonly cause: unknown
+
+  constructor(cause: unknown) {
+    super('Network Error')
+    this.name = 'ApiNetworkError'
+    this.cause = cause
+  }
+}

--- a/frontend/src/api/apiError.ts
+++ b/frontend/src/api/apiError.ts
@@ -3,9 +3,14 @@
  *
  * Its own module, and deliberately free of any import, because `utils/errors.ts`
  * reads these and `utils/errors.ts` is imported by most of the app. Declaring
- * them inside `client.ts` would put `openapi-fetch` — and the whole generated
- * schema module — on the initial-load path of every page, to carry two class
- * declarations.
+ * them inside `client.ts` would put `openapi-fetch` — and the `createClient`
+ * call at that module's top level — on the initial-load path of every page, to
+ * carry two class declarations. Not the generated schema: `generated/schema.d.ts`
+ * is a declaration file, imported `import type`, and weighs nothing at runtime
+ * wherever it lands. `openapi-fetch` is the weight.
+ *
+ * Which is why `client.ts` does not re-export these. One import path, and it is
+ * the one that stays cheap.
  */
 
 /**

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -1,73 +1,16 @@
 import axios from 'axios'
 
+import { returnToLandingIfSessionExpired } from './sessionRedirect'
+
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL ?? 'http://localhost:8000',
   withCredentials: true, // send httpOnly JWT cookie automatically
 })
 
-/**
- * The session probes. A 401 from one of these is not a failure — it is the
- * answer "nobody is logged in", which is what the app's first wave asks on every
- * page load.
- *
- * There are two, because the first wave asks two things before it knows who the
- * viewer is: `AuthProvider` asks for the identity, and `SidebarProvider` asks
- * for the rail's panels (#1344). Both go out unconditionally — the JWT is an
- * httpOnly cookie, so the client cannot know synchronously whether anyone is
- * signed in, and asking is the only way to find out.
- *
- * A SET, and matched whole — deliberately not a `/me` prefix. `/me/sidebar` is a
- * probe; `/me/characters` is not, and a 401 from that one really is an expired
- * session and must still bounce.
- */
-const SESSION_PROBES = ['/auth/me', '/me/sidebar']
-
-/**
- * If the server says the session has expired, send the user back to the landing
- * page.
- *
- * WHY THE PROBES ARE EXCLUDED
- * ---------------------------
- * The first wave asks whether anyone is signed in, and for a guest the answer is
- * 401. Treating that as an expired session meant every logged-out visitor who
- * opened any URL other than `/` was immediately thrown back to `/` — so no deep
- * link worked for a guest. A shared task link, a praxis permalink, a bookmarked
- * faction page: all of them landed on the homepage instead.
- *
- * It was also expensive. `window.location.href` is a full document navigation,
- * so the visitor paid for the entire bundle, the fonts and every API call a
- * second time before seeing a page they had not asked for.
- *
- * Every future unconditional first-wave fetch has to join `SESSION_PROBES` for
- * the same reason. Adding one without doing so silently restores the bug for
- * every guest, on every URL.
- *
- * The redirect still fires for a session that expires while the app is in use,
- * which is what it was written for.
- */
-export function shouldReturnToLanding(
-  status: number | undefined,
-  requestUrl: string,
-  pathname: string,
-): boolean {
-  if (status !== 401) return false
-  if (SESSION_PROBES.some((probe) => requestUrl.includes(probe))) return false
-  if (pathname.startsWith('/auth')) return false
-  return pathname !== '/'
-}
-
 api.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (
-      shouldReturnToLanding(
-        error?.response?.status,
-        error?.config?.url ?? '',
-        window.location.pathname,
-      )
-    ) {
-      window.location.href = '/'
-    }
+    returnToLandingIfSessionExpired(error?.response?.status, error?.config?.url ?? '')
     return Promise.reject(error)
   },
 )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -21,8 +21,6 @@ import { ApiError, ApiNetworkError } from './apiError'
 import type { paths } from './generated/schema'
 import { returnToLandingIfSessionExpired } from './sessionRedirect'
 
-export { ApiError, ApiNetworkError } from './apiError'
-
 const client = createClient<paths>({
   baseUrl: import.meta.env.VITE_API_URL ?? 'http://localhost:8000',
   // The JWT is an httpOnly cookie. Without this every authenticated call goes
@@ -122,5 +120,3 @@ export const apiPost = throwOnFailure<'post'>(client.POST)
 export const apiPut = throwOnFailure<'put'>(client.PUT)
 export const apiPatch = throwOnFailure<'patch'>(client.PATCH)
 export const apiDelete = throwOnFailure<'delete'>(client.DELETE)
-
-export default client

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,126 @@
+/**
+ * The typed API transport (#1400).
+ *
+ * `openapi-fetch` over the `paths` in `./generated/schema`, which is generated
+ * from `backend/openapi.json` by `scripts/regen_api_client.py` and gated in CI.
+ * That is the whole point: a route whose shape changes stops being a runtime
+ * surprise and becomes a compile error.
+ *
+ * It carries every convention `./axios.ts` carries, because during the
+ * migration both are live and a request must not mean two different things
+ * depending on which one issued it — see `credentials`, the 401 rule below, and
+ * the query serialization proven in `__tests__/client.test.ts`.
+ */
+import createClient, {
+  type ClientPathsWithMethod,
+  type MaybeOptionalInit,
+  type MethodResponse,
+} from 'openapi-fetch'
+
+import { ApiError, ApiNetworkError } from './apiError'
+import type { paths } from './generated/schema'
+import { returnToLandingIfSessionExpired } from './sessionRedirect'
+
+export { ApiError, ApiNetworkError } from './apiError'
+
+const client = createClient<paths>({
+  baseUrl: import.meta.env.VITE_API_URL ?? 'http://localhost:8000',
+  // The JWT is an httpOnly cookie. Without this every authenticated call goes
+  // out anonymous and comes back as a guest's answer — which is not an error,
+  // just quietly the wrong page.
+  credentials: 'include',
+})
+
+/**
+ * The 401 → landing rule, applied to this transport (`./sessionRedirect.ts`
+ * owns it; `./axios.ts` applies the same one).
+ *
+ * Middleware rather than the helpers below, to match where axios puts it: on
+ * the client, so it holds for anything issued through it. `request.url` is
+ * absolute here where axios recorded a relative one, which the probe check
+ * tolerates because it matches by substring.
+ */
+client.use({
+  onResponse({ request, response }) {
+    returnToLandingIfSessionExpired(response.status, request.url)
+  },
+})
+
+/** The methods this app issues. */
+type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete'
+
+/**
+ * `init` is optional exactly when the path needs nothing in it — no params, no
+ * body. `MaybeOptionalInit` already encodes that by unioning `undefined` in, so
+ * this reads the answer back off it rather than restating the rule.
+ */
+type InitArgs<Init> = undefined extends Init ? [init?: Init] : [init: Init]
+
+/**
+ * One method of the throwing client: same call signature as `client.GET` and
+ * friends, but resolving to the success branch alone.
+ *
+ * `MethodResponse` is `openapi-fetch`'s own "the data for this path, this
+ * method, these options" type, so the payload stays inferred from the schema —
+ * narrowed here only by dropping the `{ data?: never, error }` half of the
+ * union, which is unreachable once a failure throws.
+ */
+interface ThrowingMethod<Method extends HttpMethod> {
+  <
+    Path extends ClientPathsWithMethod<typeof client, Method>,
+    Init extends MaybeOptionalInit<paths[Path], Method>,
+  >(
+    url: Path,
+    ...init: InitArgs<Init>
+  ): Promise<{
+    data: MethodResponse<typeof client, Method, Path, Init>
+    response: Response
+  }>
+}
+
+/** What every `openapi-fetch` method resolves to, before the union is narrowed. */
+type SettledResult = { data?: unknown; error?: unknown; response: Response }
+
+/**
+ * Turn one returning method into a throwing one.
+ *
+ * WHY THROW
+ * ---------
+ * `openapi-fetch` reports a failure by RESOLVING with `{ error }`. Every
+ * consumer in this app is a `try`/`catch` that calls `extractError`. If this
+ * transport returned, the migration would not merely be ninety-odd call-site
+ * rewrites — every `catch` not yet rewritten would become unreachable, and a
+ * failed request would be handled as a successful one with an undefined body.
+ * Silent, and everywhere. So the shape callers already understand wins, and the
+ * openapi-fetch result shape stops at this function.
+ *
+ * The cast is the seam: the runtime is untyped inside (it is the same three
+ * lines for all five methods), and `ThrowingMethod` states the contract that
+ * holds outside. Nothing downstream is widened.
+ */
+function throwOnFailure<Method extends HttpMethod>(
+  call: (url: never, init?: never) => Promise<SettledResult>,
+): ThrowingMethod<Method> {
+  return (async (url: never, init?: never) => {
+    let settled: SettledResult
+    try {
+      settled = await call(url, init)
+    } catch (cause) {
+      // `fetch` itself rejected: no response, no status, and different words
+      // for the player than any server failure.
+      throw new ApiNetworkError(cause)
+    }
+    if (!settled.response.ok) {
+      throw new ApiError(settled.response, settled.error)
+    }
+    return { data: settled.data, response: settled.response }
+  }) as ThrowingMethod<Method>
+}
+
+export const apiGet = throwOnFailure<'get'>(client.GET)
+export const apiPost = throwOnFailure<'post'>(client.POST)
+export const apiPut = throwOnFailure<'put'>(client.PUT)
+export const apiPatch = throwOnFailure<'patch'>(client.PATCH)
+export const apiDelete = throwOnFailure<'delete'>(client.DELETE)
+
+export default client

--- a/frontend/src/api/sessionRedirect.ts
+++ b/frontend/src/api/sessionRedirect.ts
@@ -1,0 +1,84 @@
+/**
+ * The 401 → landing rule, kept apart from any one transport.
+ *
+ * It lived inside `axios.ts` until #1400 started replacing axios with an
+ * `openapi-fetch` client. Both transports are live during that migration, and
+ * both have to bounce an expired session the same way — so the rule is stated
+ * once, here, and imported by each. A second copy is how it drifts, and the
+ * failure mode of drift is silent: guests stop being able to open any URL but
+ * `/`, and nothing throws.
+ */
+
+/**
+ * The session probes. A 401 from one of these is not a failure — it is the
+ * answer "nobody is logged in", which is what the app's first wave asks on every
+ * page load.
+ *
+ * There are two, because the first wave asks two things before it knows who the
+ * viewer is: `AuthProvider` asks for the identity, and `SidebarProvider` asks
+ * for the rail's panels (#1344). Both go out unconditionally — the JWT is an
+ * httpOnly cookie, so the client cannot know synchronously whether anyone is
+ * signed in, and asking is the only way to find out.
+ *
+ * A SET, and matched whole — deliberately not a `/me` prefix. `/me/sidebar` is a
+ * probe; `/me/characters` is not, and a 401 from that one really is an expired
+ * session and must still bounce.
+ */
+const SESSION_PROBES = ['/auth/me', '/me/sidebar']
+
+/**
+ * If the server says the session has expired, send the user back to the landing
+ * page.
+ *
+ * WHY THE PROBES ARE EXCLUDED
+ * ---------------------------
+ * The first wave asks whether anyone is signed in, and for a guest the answer is
+ * 401. Treating that as an expired session meant every logged-out visitor who
+ * opened any URL other than `/` was immediately thrown back to `/` — so no deep
+ * link worked for a guest. A shared task link, a praxis permalink, a bookmarked
+ * faction page: all of them landed on the homepage instead.
+ *
+ * It was also expensive. `window.location.href` is a full document navigation,
+ * so the visitor paid for the entire bundle, the fonts and every API call a
+ * second time before seeing a page they had not asked for.
+ *
+ * Every future unconditional first-wave fetch has to join `SESSION_PROBES` for
+ * the same reason. Adding one without doing so silently restores the bug for
+ * every guest, on every URL.
+ *
+ * The redirect still fires for a session that expires while the app is in use,
+ * which is what it was written for.
+ *
+ * `requestUrl` is matched by substring, so it may be either the relative URL
+ * axios records in `config.url` or the absolute one `openapi-fetch` puts on its
+ * `Request`. Both contain the probe path.
+ */
+export function shouldReturnToLanding(
+  status: number | undefined,
+  requestUrl: string,
+  pathname: string,
+): boolean {
+  if (status !== 401) return false
+  if (SESSION_PROBES.some((probe) => requestUrl.includes(probe))) return false
+  if (pathname.startsWith('/auth')) return false
+  return pathname !== '/'
+}
+
+/**
+ * Apply the rule above to a failed response, reading the current location and
+ * navigating if it says so.
+ *
+ * The half {@link shouldReturnToLanding} cannot cover: it is a pure predicate
+ * precisely so the DOM-less test harness can reach it, which leaves the two
+ * `window` touches to live somewhere. They live here, once, rather than in each
+ * transport's error path.
+ */
+export function returnToLandingIfSessionExpired(
+  status: number | undefined,
+  requestUrl: string,
+): void {
+  if (typeof window === 'undefined') return
+  if (shouldReturnToLanding(status, requestUrl, window.location.pathname)) {
+    window.location.href = '/'
+  }
+}

--- a/frontend/src/api/sidebar.ts
+++ b/frontend/src/api/sidebar.ts
@@ -53,7 +53,7 @@ export interface SidebarPanels {
  * `/auth/me` rather than behind it.
  *
  * Rejects with 401 for a guest. That is an answer, not a failure — see
- * `SESSION_PROBES` in `./axios`.
+ * `SESSION_PROBES` in `./sessionRedirect`.
  */
 export async function getSidebar(): Promise<SidebarPanels> {
   const { data } = await api.get<SidebarPanels>('/me/sidebar')

--- a/frontend/src/auth/AuthContext.tsx
+++ b/frontend/src/auth/AuthContext.tsx
@@ -26,8 +26,9 @@ interface AuthState {
    * Exists so that signing out does not have to `logout()` and then `refetch()`
    * (#1349). That second call was a request whose answer the client already
    * held: the cookie is gone, so `/auth/me` can only 401, and `/auth/me` is a
-   * `SESSION_PROBE` (`api/axios.ts`) precisely so that 401 is swallowed. It cost
-   * a round trip to reach the `user = null` the caller had already caused.
+   * `SESSION_PROBE` (`api/sessionRedirect.ts`) precisely so that 401 is
+   * swallowed. It cost a round trip to reach the `user = null` the caller had
+   * already caused.
    */
   signOut: () => Promise<void>
 }

--- a/frontend/src/auth/__tests__/authRefetchLedger.test.ts
+++ b/frontend/src/auth/__tests__/authRefetchLedger.test.ts
@@ -188,7 +188,7 @@ describe('signing out never re-asks who the viewer is', () => {
   })
 
   it('clears the viewer locally instead of refetching a guaranteed 401', () => {
-    // `/auth/me` is a SESSION_PROBE (`api/axios.ts`), so the post-logout 401 was
+    // `/auth/me` is a SESSION_PROBE (`api/sessionRedirect.ts`), so the 401 was
     // swallowed rather than fatal — it just cost a round trip to arrive at the
     // `null` the caller had already caused. What keeps the client honest without
     // it: the provider sets the same `null` and the same session hint that a

--- a/frontend/src/hooks/useSidebarPanels.tsx
+++ b/frontend/src/hooks/useSidebarPanels.tsx
@@ -48,8 +48,8 @@ const UNSETTLED = Symbol('auth-unsettled')
  *    resolves the viewer from the JWT cookie, so there is nothing to wait for.
  *
  *    The client therefore asks before it knows whether anyone is signed in, and
- *    a guest's answer is 401. `SESSION_PROBES` in `api/axios` excludes this URL
- *    from the expired-session redirect for exactly that reason — without it,
+ *    a guest's answer is 401. `SESSION_PROBES` in `api/sessionRedirect` excludes
+ *    this URL from the expired-session redirect for exactly that reason — without it,
  *    every guest opening any deep link would be thrown to `/` by a full document
  *    navigation, from chrome that mounts on every route.
  *

--- a/frontend/src/utils/__tests__/errors.test.ts
+++ b/frontend/src/utils/__tests__/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { ApiError, ApiNetworkError } from '../../api/apiError'
 import { ErrorCode, extractError, extractErrorCode } from '../errors'
 
 /**
@@ -196,5 +197,80 @@ describe('extractErrorCode', () => {
     expect(extractErrorCode(axiosError(400))).toBeNull()
     expect(extractErrorCode({ message: 'Network Error' })).toBeNull()
     expect(extractErrorCode(undefined)).toBeNull()
+  })
+})
+
+/**
+ * #1400 — the same reader, fed the other live transport.
+ *
+ * `api/*.ts` migrates off axios module by module, so for the length of that
+ * migration a `catch` block may receive either shape and must not care which.
+ * The cases above stay exactly as they were; these assert the openapi-fetch
+ * client's `ApiError` reads identically.
+ */
+const apiError = (status: number, detail?: unknown) =>
+  new ApiError(
+    new Response(null, { status }),
+    detail === undefined ? {} : { detail }
+  )
+
+describe('extractError — the openapi-fetch transport', () => {
+  it('reads every detail shape off an ApiError', () => {
+    expect(extractError(apiError(403, 'Task requires level 3'), FALLBACK)).toBe(
+      'Task requires level 3'
+    )
+    expect(extractError(apiError(422, [{ msg: 'Field required' }]), FALLBACK)).toBe(
+      'Field required'
+    )
+    expect(
+      extractError(
+        apiError(403, { code: 'NOT_IN_THE_CATALOG', message: 'Backend prose wins.' }),
+        FALLBACK
+      )
+    ).toBe('Backend prose wins.')
+  })
+
+  it('resolves the errors.json catalog off an ApiError too', () => {
+    expect(
+      extractError(apiError(403, { code: 'VOTE_BUDGET_EXHAUSTED', message: 'BACKEND PROSE' }), FALLBACK)
+    ).toBe('No votes remaining in your budget.')
+  })
+
+  /**
+   * The trap this shape sets. `ApiError` carries a `response` — a fetch
+   * `Response`, which has a `status` and no `data`. Read through the axios lens
+   * the status looks right and `detail` is silently always absent, so every
+   * coded backend error degrades to the caller's fallback and nothing fails.
+   * This is the case that catches it.
+   */
+  it('does not lose the detail to the axios lens', () => {
+    const error = apiError(409, { code: 'TASK_BANK_FULL', message: 'Task bank is full.' })
+    expect(error.response.status).toBe(409)
+    expect(extractError(error, FALLBACK)).toBe('Task bank is full.')
+    expect(extractError(error, FALLBACK)).not.toBe(FALLBACK)
+  })
+
+  it('keeps the status and suppression branches', () => {
+    expect(extractError(apiError(503), FALLBACK)).toBe(
+      'The server ran into an unexpected problem. Try again in a moment.'
+    )
+    expect(extractError(apiError(500, 'Internal Server Error'), FALLBACK)).toBe(
+      'The server ran into an unexpected problem. Try again in a moment.'
+    )
+    expect(extractError(apiError(400), FALLBACK)).toBe(FALLBACK)
+    expect(extractError(apiError(403, { code: 'TASK_LEVEL_TOO_LOW' }), FALLBACK)).toBe(FALLBACK)
+  })
+
+  it('reports an unanswered request as a connection failure', () => {
+    expect(extractError(new ApiNetworkError(new TypeError('Failed to fetch')), FALLBACK)).toBe(
+      'Unable to reach the server. Check your connection and try again.'
+    )
+  })
+
+  it('reads the code off an ApiError, and null off every uncoded shape', () => {
+    expect(extractErrorCode(apiError(409, { code: 'TASK_BANK_FULL' }))).toBe(ErrorCode.taskBankFull)
+    expect(extractErrorCode(apiError(409, 'Task bank is full.'))).toBeNull()
+    expect(extractErrorCode(apiError(400))).toBeNull()
+    expect(extractErrorCode(new ApiNetworkError(new TypeError('Failed to fetch')))).toBeNull()
   })
 })

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,5 +1,6 @@
 import type { AxiosError } from 'axios'
 
+import { ApiError } from '../api/apiError'
 import i18n from '../i18n'
 import errorsCatalog from '../locales/en/errors.json'
 
@@ -158,8 +159,44 @@ function displayableDetail(detail: ErrorDetail | undefined): string | null {
   return message || null
 }
 
+/** The body every failing route answers with — FastAPI's `detail` envelope. */
+type ErrorBody = { detail?: ErrorDetail }
+
 /**
- * Extracts a user-friendly error message from an axios error.
+ * What a failed request tells us, whichever transport issued it (#1400).
+ *
+ * Two are live at once while `api/*.ts` migrates off axios module by module, so
+ * both readers below go through this rather than each growing a second branch.
+ * The transports agree on everything that matters here and disagree on where it
+ * sits: axios hangs `status` and the parsed body off `err.response`, the
+ * openapi-fetch client puts them on {@link ApiError} directly.
+ *
+ * `ApiError` is checked FIRST and deliberately. It carries a `response` too — a
+ * fetch `Response`, which has a `status` and no `data` — so the axios lens would
+ * half-read it: right status, `detail` silently always absent, and every coded
+ * backend error degraded to the caller's generic fallback with nothing failing.
+ */
+function failureOf(err: unknown): {
+  status: number | undefined
+  body: ErrorBody | undefined
+  unreachable: boolean
+} {
+  if (err instanceof ApiError) {
+    return { status: err.status, body: err.data as ErrorBody | undefined, unreachable: false }
+  }
+  const axiosError = err as AxiosError<ErrorBody>
+  return {
+    status: axiosError?.response?.status,
+    body: axiosError?.response?.data,
+    // `ApiNetworkError` sets this exact message for this exact reason, so a
+    // `fetch` that never got an answer reads the same as an axios one.
+    unreachable: axiosError?.message === 'Network Error' || !axiosError?.response,
+  }
+}
+
+/**
+ * Extracts a user-friendly error message from a failed request — an axios
+ * error, or an {@link ApiError} from the openapi-fetch client.
  *
  * Priority:
  *   1. FastAPI `detail` from the response body (skip generic "Internal Server Error"), as either
@@ -175,13 +212,10 @@ export function extractError(
   err: unknown,
   fallback = 'Something went wrong. Please try again.'
 ): string {
-  const e = err as AxiosError<{ detail?: ErrorDetail }>
-
-  const status = e?.response?.status
-  const detail = e?.response?.data?.detail
+  const { status, body, unreachable } = failureOf(err)
 
   // Surface meaningful detail from the backend (e.g. "Task requires level 3")
-  const message = displayableDetail(detail)
+  const message = displayableDetail(body?.detail)
   if (message) return message
 
   // 5xx with no useful detail — the server hit an unhandled error
@@ -195,7 +229,7 @@ export function extractError(
   }
 
   // No response object at all — genuine network failure
-  if (e?.message === 'Network Error' || !e?.response) {
+  if (unreachable) {
     return 'Unable to reach the server. Check your connection and try again.'
   }
 
@@ -203,7 +237,7 @@ export function extractError(
 }
 
 /**
- * Extracts the machine-readable `code` from an axios error, or null.
+ * Extracts the machine-readable `code` from a failed request, or null.
  *
  * The read side of `extractError`: that one answers "what do I show the
  * player", this one answers "which failure was it". Both go through the same
@@ -216,8 +250,7 @@ export function extractError(
  * callers can compare against `ErrorCode.*` without narrowing first.
  */
 export function extractErrorCode(err: unknown): string | null {
-  const detail = (err as AxiosError<{ detail?: ErrorDetail }>)?.response?.data
-    ?.detail
+  const detail = failureOf(err).body?.detail
   if (!detail || typeof detail === 'string' || Array.isArray(detail)) return null
   return typeof detail.code === 'string' ? detail.code : null
 }


### PR DESCRIPTION
The transport half of #1400: `openapi-fetch` is installed, configured and proven, and nothing calls it yet. The app's behaviour is unchanged — every `api/*.ts` module still goes through axios.

## The seam I tested at

**The `Request` the configured client hands to `fetch`, and the error it hands back to the caller.** Both halves are invisible to the type checker, which is the whole reason they need a test:

- `schema.d.ts` says `faction` is a `string[]`. It says nothing about how that array reaches the wire, and the wrong answer 200s with the filter silently dropped (#1366 — axios writes `faction[]=ua`, from which FastAPI reads *nothing*).
- Nothing in the types distinguishes a client that throws on a 403 from one that returns `{ error }`. Ninety-odd call sites sit in `try`/`catch` blocks that only one of those two behaviours ever reaches.

`frontend/src/api/__tests__/client.test.ts` (13 cases) stubs `fetch` and asserts on the real configured client.

**The stub has to go in via `vi.hoisted`, not `beforeEach`** — `openapi-fetch` binds `globalThis.fetch` when the client is *created*, which happens at `client.ts`'s top level. With a `beforeEach` stub the suite issued real requests to whatever was listening on `localhost:8000` and asserted against its answers. That is written down in the test file so the next person does not rediscover it.

## What is here

- **`openapi-fetch@^0.17.0`** as a runtime dependency (pairs with the pinned `openapi-typescript@^7`).
- **`api/sessionRedirect.ts`** — the 401→landing rule and its `SESSION_PROBES` set, lifted out of `axios.ts` with its comments intact. Both transports now call the one copy; two copies is how it drifts, and drift here means no guest can open any URL but `/`. `sessionRedirect.test.ts` keeps its assertions, only its import path moved. `openapi-fetch`'s `Request.url` is absolute where axios' `config.url` was relative — the probe check matches by substring, so both work, and there is now a case pinning that.
- **`api/client.ts`** — typed against `paths`, `baseUrl` from `VITE_API_URL`, `credentials: 'include'`, the 401 rule as middleware. Exports `apiGet/apiPost/apiPut/apiPatch/apiDelete`.
- **`api/apiError.ts`** — `ApiError { status, data, response }` and `ApiNetworkError`. Its own module, and import-free, so `utils/errors.ts` can read these without putting `openapi-fetch` and the generated schema on every page's initial-load path.
- **`utils/errors.ts`** reads both transports through one `failureOf()` lens. Every existing branch survives — coded catalog, validation array, `GENERIC_SERVER_PROSE` suppression, 5xx, network. `errors.test.ts`'s 19 original cases are untouched; 6 new ones cover the `ApiError` shape.
- **`SPEC-backend-architecture.md` §7** — the BFF doctrine paragraph (step 6).

## Two decisions worth reviewing

**The helpers throw.** `openapi-fetch` reports failure by *resolving* with `{ data, error }`. If this transport returned, the migration would not just be ninety-odd rewrites — every `catch` not yet rewritten would become unreachable, and a failed request would be handled as a success with an undefined body. Silent, and everywhere. So `ApiError` is thrown and the openapi-fetch result shape stops at one function.

**The helpers resolve to `{ data, response }`, not bare `data`.** Call sites today read `const { data } = await api.get<TaskOut[]>('/tasks')`. Keeping that shape makes the later per-module slices a near-mechanical swap. `data` is non-optional and still inferred from the schema via `openapi-fetch`'s own `MethodResponse` — not widened to `any`.

**Query serialization:** `openapi-fetch`'s default is `style: "form", explode: true`, which is already what FastAPI wants. No `querySerializer` was needed — but "the library's default happens to be right" is a claim, so there are assertions for `faction=ua&faction=wow` and for an `undefined` value being omitted rather than sent empty. If anyone ever adds a `querySerializer` for another reason, those fail instead of the filters going quiet.

## Section renumbering

The new spec section is §7, which pushed the old §7–§11 down to §8–§12. Five pointers were updated: two inside the spec, plus `backend/models/task.py:62` (§9→§10) and `docs/adr/0045:51` (§10→§11). The `§4` references in code docstrings — the only ones that reach `openapi.json` and `schema.d.ts` — are before the insertion point and did not move, so `api-schema` is unaffected. Verified by grepping `backend/openapi.json`: it carries `§4` and nothing else.

## Checks

All six `frontend` CI steps run locally and green: eslint, `tsc --noEmit`, `vitest run` (**227 files / 3933 tests**), `vite build`, budget, `typecheck:design-sync`. No backend behaviour changed (one `#` comment).

**Byte budget: 139.4 KB → 139.6 KB gzipped JS (+0.2 KB), CSS unchanged at 22.4 KB. Within budget** (warn at 146.5 KB).

The delta is **not** `openapi-fetch`, which tree-shakes out completely — `client.ts` has no importers yet, and no `openapi-fetch` symbol appears anywhere in `dist/`. The +0.2 KB is the `ApiError` class alone, which reaches the initial chunk because `utils/errors.ts` does `instanceof` against it. `ApiNetworkError` shook out too. The real transport cost lands with the first module migration, not here.

**Visual QA is outstanding** — I have no browser or dev stack in this worktree. Nothing renders differently by construction (no component, style or copy changed), but that is an argument, not an observation.

Part of #1400.
