### PR TITLE
The axios ban reaches the directory the last axios dependent was hiding in

### DIFF
--- a/frontend/.ds-kit/provider.tsx
+++ b/frontend/.ds-kit/provider.tsx
@@ -85,8 +85,13 @@ function softenMissingKeys(): void {
 }
 
 export function DSProvider({ children }: { children: ReactNode }) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const preview = typeof window !== "undefined" && Boolean((window as any).__dsPreview);
+  // The preview harness sets this flag on `window` before evaluating the kit.
+  // Narrowed rather than `any`: this file is now linted (#1400 put the axios ban
+  // on `.ds-kit/`, which is where the last hidden axios dependent was hiding),
+  // and a one-property cast says what is being read without disabling a rule.
+  const preview =
+    typeof window !== "undefined" &&
+    Boolean((window as unknown as { __dsPreview?: unknown }).__dsPreview);
   if (preview) softenMissingKeys();
   // ThemeProvider backs useTheme() — NavBar and the shell chrome throw without
   // it. It also owns the [data-theme] cascade the whole kit styles against.

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -279,9 +279,49 @@ const LEGACY_RAW_STYLE_FILES = fs
   .map((line) => line.trim())
   .filter(Boolean)
 
+/**
+ * #1400: axios is gone. An import of it would install a SECOND transport that
+ * misses everything `api/client.ts` carries — the JWT cookie, the 401→landing
+ * rule, the array-param serialization FastAPI actually reads — and every one of
+ * those failures is a 200 with the wrong answer rather than a crash. Cheaper as
+ * a lint line than as a bug report.
+ */
+const NO_AXIOS_IMPORT = [
+  'error',
+  {
+    paths: [
+      {
+        name: 'axios',
+        message:
+          'axios was retired in #1400 — issue requests through api/client.ts (apiGet/apiPost/...).',
+      },
+    ],
+  },
+]
+
 export default [
   {
     ignores: ['dist/**', 'node_modules/**', 'playwright-report/**', 'test-results/**'],
+  },
+  /**
+   * The axios ban reaches past `src/`, because the one hidden axios dependent
+   * this migration turned up was OUTSIDE it: `.ds-kit/provider.tsx` faked
+   * `GET /auth/me` by swapping `api.defaults.adapter`, and nothing but
+   * `typecheck:design-sync` ever looked at it — `npm run lint` was `eslint src`.
+   *
+   * These directories get the import ban and nothing else. Widening the whole
+   * rule set to them would surface a backlog that has nothing to do with #1400,
+   * so this block is deliberately one rule wide.
+   */
+  {
+    files: ['.ds-kit/**/*.{ts,tsx}', 'e2e/**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    rules: {
+      'no-restricted-imports': NO_AXIOS_IMPORT,
+    },
   },
   {
     files: ['src/**/*.{ts,tsx}'],
@@ -307,23 +347,7 @@ export default [
       ],
       'local/no-raw-style-values': 'error',
       'sonarjs/no-identical-functions': 'error',
-      // #1400: axios is gone. An import of it would install a SECOND transport
-      // that misses everything `api/client.ts` carries — the JWT cookie, the
-      // 401→landing rule, the array-param serialization FastAPI actually reads
-      // — and every one of those failures is a 200 with the wrong answer rather
-      // than a crash. Cheaper as a lint line than as a bug report.
-      'no-restricted-imports': [
-        'error',
-        {
-          paths: [
-            {
-              name: 'axios',
-              message:
-                'axios was retired in #1400 — issue requests through api/client.ts (apiGet/apiPost/...).',
-            },
-          ],
-        },
-      ],
+      'no-restricted-imports': NO_AXIOS_IMPORT,
     },
   },
   // Ratchet: existing violations are grandfathered until migrated. Spread

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:design-sync": "tsc -p tsconfig.design-sync.json --noEmit",
     "test": "vitest run",
-    "lint": "eslint src",
+    "lint": "eslint src .ds-kit e2e",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui"
   },

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -187,8 +187,8 @@ describe('what the client does with a failure', () => {
   /**
    * A proxy's HTML error page is not JSON. That is no reason to throw something
    * the caller cannot read: the status still tells the truth, and `extractError`
-   * falls through to its 5xx prose exactly as it does for an axios failure with
-   * an unparseable body.
+   * falls through to its 5xx prose, which is what it does for any failure whose
+   * body it cannot make sense of.
    */
   it('still throws with a status when the body is not JSON', async () => {
     wire.replyWith(() => Promise.resolve(new Response('<html>502</html>', { status: 502 })))


### PR DESCRIPTION
#1631 deleted axios and added a `no-restricted-imports` guard so it cannot come back. The guard was scoped to `src/**`, and `npm run lint` was `eslint src`.

The one hidden axios dependent that whole migration turned up sat outside both. `.ds-kit/provider.tsx` faked `GET /auth/me` by swapping `api.defaults.adapter`; nothing but `typecheck:design-sync` ever looked at it, because eslint had no config block matching that directory at all. A ban that does not cover the place the problem actually occurred is a ban that would not have caught it.

So the rule is hoisted to a constant and applied a second time to `.ds-kit/` and `e2e/`, and `npm run lint` now visits them. Deliberately **one rule wide**: those directories have never been linted, and widening the whole rule set to them would surface a backlog with nothing to do with #1400.

Making `.ds-kit/` linted for the first time cost one real fix. `provider.tsx` read `(window as any).__dsPreview` behind a disable comment for `@typescript-eslint/no-explicit-any` — a rule the new block does not register, so the stale directive itself became an error. A one-property cast says what is being read and needs no rule disabled.

## Seam

The lint run, verified by probe rather than by reading the config. With a probe file in `.ds-kit/`, both `import axios from 'axios'` and `import type { AxiosError } from 'axios'` report `error no-restricted-imports` (type-only imports are the easy one to miss). Removing the probe returns the suite to clean.

## Provenance

This work was written during #1631's review and pushed as `4e474562`, but that PR had already been squash-merged at `6cf94e9e`, so the commit was orphaned rather than shipped. Cherry-picked here unchanged, re-verified against current `main`.

## Verification

`eslint src .ds-kit e2e` clean · `tsc --noEmit` clean · `typecheck:design-sync` clean · `vitest run` 3936 tests pass. No runtime code changed, so nothing renders differently — visual QA is not applicable here beyond the design-sync previews, which typecheck.

Part of #1400.