### PR TITLE
Two Ephemerists card bugs: a shaved byline letter and colliding vote bursts

### DIFF
--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -123,6 +123,41 @@ describe('the byline portrait (#888)', () => {
   })
 })
 
+/**
+ * #1633 — the byline name was losing a letter against its own portrait.
+ *
+ * The seam is the NAME LINK's own declaration, and it has to be, because the
+ * clip is unobservable in this harness: renderToStaticMarkup gives no DOM, no
+ * fonts and no layout, so nothing here can see a glyph get shaved. What these
+ * pin is the pair of properties that decides it — how far the clip box runs
+ * past the text, and whether the name still yields when it genuinely does not
+ * fit. Both halves matter: the second is what the Ephemerists kit's own fix
+ * (`overflow: visible`) would have given away.
+ */
+describe('the byline name is not shaved against its portrait (#1633)', () => {
+  const nameLink = (html: string) => html.match(/<a [^>]*>/)?.[0] ?? ''
+  const byline = (name: string) =>
+    nameLink(render(<PraxisByline praxis={praxis({ created_by_display_name: name })} />))
+
+  it('carries the portrait separation as padding, so the clip box outruns the text', () => {
+    // `overflow: hidden` clips at the PADDING box while `text-overflow`
+    // measures the CONTENT box. With the 8px living on the row as `gap` the
+    // two edges coincided, so a display face's last glyph — the Ephemerists
+    // card sets this line in Poiret One — was cut off at the portrait.
+    expect(byline('Isolde')).toContain('padding-inline-end:var(--space-sm)')
+  })
+
+  it('still yields a long name to an ellipsis rather than over the portrait', () => {
+    const link = byline('Bartholomew Featherstonehaugh-Wentworth')
+    expect(link).toContain('overflow:hidden')
+    expect(link).toContain('text-overflow:ellipsis')
+    // The kit patched this to `visible`, which restores min-width:auto to
+    // min-content — the name then stops shrinking and paints over the portrait
+    // and the faction tag, which is the reported symptom, deliberately caused.
+    expect(link).not.toContain('overflow:visible')
+  })
+})
+
 describe('the meta line (#888)', () => {
   it('shows the level on a level-0 task, so the segment count never varies', () => {
     const zero = text(render(<PraxisStats praxis={praxis({ task_level_required: 0 })} />))

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -289,7 +289,11 @@ export function PraxisByline({
         ...style,
       }}
     >
-      <span className="flex items-center" style={{ gap: "var(--space-sm)", minWidth: 0 }}>
+      {/*
+       * No `gap` here on purpose (#1633) — the separation from the portrait is
+       * carried as padding on the name itself. See the link below.
+       */}
+      <span className="flex items-center" style={{ minWidth: 0 }}>
         <Link
           to={`/characters/${praxis.created_by_id}`}
           // A person's name is readable text, not scanned chrome: content tier
@@ -298,9 +302,34 @@ export function PraxisByline({
           className="content-text font-semibold hover:underline"
           style={{
             fontFamily: fonts?.display,
+            /*
+             * The truncation pair, and the padding that keeps it off the
+             * glyphs (#1633). `overflow: hidden` is doing two jobs: it clips,
+             * and it is what makes this a shrinkable flex item at all
+             * (min-width: auto resolves to 0 rather than to the whole nowrap
+             * string), so a name too long for the card ellipsizes instead of
+             * shoving the portrait out of the frame.
+             *
+             * But it clips at the PADDING box while `text-overflow` measures
+             * the CONTENT box, and the two coincided while the 8px lived on
+             * the row as `gap`. A display face's final glyph can carry ink
+             * past its own advance width — the Ephemerists card sets this line
+             * in Poiret One — so that overhang was shaved off flush against
+             * the portrait beside it, with no ellipsis to explain it, which is
+             * what "a letter clipped behind its own avatar" looks like.
+             * Carrying the same 8px as padding here renders identically and
+             * gives the ink somewhere to land.
+             *
+             * The Ephemerists kit's own fix was `overflow: visible` +
+             * `text-overflow: clip`. It does not port: visible overflow
+             * restores min-width: auto to min-content, the name stops yielding,
+             * and a long one paints straight over the portrait and the faction
+             * tag. That is the symptom, caused on purpose.
+             */
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
+            paddingInlineEnd: "var(--space-sm)",
           }}
         >
           {praxis.created_by_display_name || `#${praxis.created_by_id}`}

--- a/frontend/src/components/vote/EphemeristsVote.tsx
+++ b/frontend/src/components/vote/EphemeristsVote.tsx
@@ -118,8 +118,23 @@ export default function EphemeristsVote({
           position: 'relative',
           display: 'flex',
           alignItems: 'center',
-          gap: 'var(--space-md)',
-          padding: 'var(--space-md) var(--space-lg)',
+          /*
+           * The gap holds the BURSTS apart, not the discs (#1633). A ray leaves
+           * the rim at `radius + 3` and runs `rayLength` further, so the
+           * ornament reaches 11.5px past an ordinary disc and 14.5px past rank
+           * 5, whose filings also orbit 13px out — two neighbours want ~24px of
+           * clear rim-to-rim, and at `--space-md` (12) they had half that, so
+           * the bursts and the sheens ran into each other. `--space-xl` is the
+           * rung that clears it. The Ephemerists kit asked for 22px; the token
+           * scale has no 22, and this is the direction to round in — the raw
+           * value would also have failed the no-raw-style-values ratchet.
+           *
+           * The horizontal padding matches the gap for the same reason: rank 1
+           * and rank 5 burst toward the plate's border rather than toward a
+           * neighbour, and owe it the same room.
+           */
+          gap: 'var(--space-xl)',
+          padding: 'var(--space-md) var(--space-xl)',
           background:
             'radial-gradient(130% 170% at 50% -20%, var(--faction-ephemerists-vote-plate-from), var(--faction-ephemerists-vote-plate-to))',
           border: `1px solid ${BRASS}`,

--- a/frontend/src/components/vote/EphemeristsVote.tsx
+++ b/frontend/src/components/vote/EphemeristsVote.tsx
@@ -119,19 +119,26 @@ export default function EphemeristsVote({
           display: 'flex',
           alignItems: 'center',
           /*
-           * The gap holds the BURSTS apart, not the discs (#1633). A ray leaves
-           * the rim at `radius + 3` and runs `rayLength` further, so the
-           * ornament reaches 11.5px past an ordinary disc and 14.5px past rank
-           * 5, whose filings also orbit 13px out — two neighbours want ~24px of
-           * clear rim-to-rim, and at `--space-md` (12) they had half that, so
-           * the bursts and the sheens ran into each other. `--space-xl` is the
-           * rung that clears it. The Ephemerists kit asked for 22px; the token
-           * scale has no 22, and this is the direction to round in — the raw
-           * value would also have failed the no-raw-style-values ratchet.
+           * The gap holds the BURSTS apart, not the discs (#1633). What matters
+           * is each burst's HORIZONTAL projection, not its longest ray — a ray
+           * pointing straight up costs a neighbour nothing.
            *
-           * The horizontal padding matches the gap for the same reason: rank 1
-           * and rank 5 burst toward the plate's border rather than toward a
-           * neighbour, and owe it the same room.
+           * An ordinary disc's 10 rays sit at 36° steps, so the one nearest
+           * horizontal is index 2 at 72°: `33.5·sin72° − 22 = 9.86`. Rank 5
+           * carries 16 rays, which puts index 4 at exactly 90°: `39.5 − 25 =
+           * 14.5`. Side by side they want `9.86 + 14.5 = 24.36`px rim-to-rim,
+           * and at `--space-md` (12) they had half that, so the bursts and the
+           * sheens ran into each other. `--space-xl` (24) is the rung that
+           * clears it, and the 0.36px it does not cover falls inside the rays'
+           * own taper. The Ephemerists kit asked for 22px; the token scale has
+           * no 22, up is the direction to round (`WORLD_ZERO_STYLE.md`), and a
+           * raw 22 would have failed the no-raw-style-values ratchet anyway.
+           *
+           * The horizontal padding matches the gap because rank 1 and rank 5
+           * burst toward the plate's border rather than toward a neighbour. The
+           * BLOCK padding deliberately does not: rank 5's index-0 ray points
+           * straight up and reaches 14.5px, which `stepClip(7)` already cuts.
+           * Giving it room is a dressing question and belongs to #1638.
            */
           gap: 'var(--space-xl)',
           padding: 'var(--space-md) var(--space-xl)',

--- a/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
@@ -135,6 +135,30 @@ describe('EphemeristsVote markup', () => {
     expect(html).toContain('width:50px;height:50px')
   })
 
+  /**
+   * #1633 — the bursts and sheens were colliding at the default gap.
+   *
+   * The seam is the plate's own declaration, because the collision itself is
+   * unobservable here: this harness has no DOM and no layout. What IS decidable
+   * from the component's constants is the CLEARANCE each disc's ornament needs,
+   * and the plate has to be at least that wide between rims.
+   *
+   * A ray starts at `radius + 3` from the disc centre and runs `rayLength` past
+   * that, so the ornament reaches `3 + 8.5` = 11.5px beyond an ordinary disc's
+   * rim and `3 + 11.5` = 14.5px beyond rank 5's; rank 5's filings orbit 13px
+   * out. Two neighbours therefore need roughly 24px between rims, and they had
+   * `--space-md` (12). The same figure has to hold at the plate's own edges, or
+   * the outermost bursts collide with the border instead of with each other.
+   */
+  it('holds the metals far enough apart for their bursts to clear (#1633)', () => {
+    mocks.user = currentUser()
+    const plate = render(5).match(/<div style="position:relative;display:flex[^"]*"/)?.[0] ?? ''
+    expect(plate).toContain('gap:var(--space-xl)')
+    // The side padding matches the gap: the end discs get the same room as the
+    // ones in the middle.
+    expect(plate).toContain('padding:var(--space-md) var(--space-xl)')
+  })
+
   it('lights only the reached discs, and leaves the rest idle', () => {
     mocks.user = currentUser()
     const html = render(3)

--- a/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
@@ -143,12 +143,14 @@ describe('EphemeristsVote markup', () => {
    * from the component's constants is the CLEARANCE each disc's ornament needs,
    * and the plate has to be at least that wide between rims.
    *
-   * A ray starts at `radius + 3` from the disc centre and runs `rayLength` past
-   * that, so the ornament reaches `3 + 8.5` = 11.5px beyond an ordinary disc's
-   * rim and `3 + 11.5` = 14.5px beyond rank 5's; rank 5's filings orbit 13px
-   * out. Two neighbours therefore need roughly 24px between rims, and they had
-   * `--space-md` (12). The same figure has to hold at the plate's own edges, or
-   * the outermost bursts collide with the border instead of with each other.
+   * What costs a neighbour room is each burst's HORIZONTAL projection, not its
+   * longest ray — a ray pointing straight up reaches nothing sideways. An
+   * ordinary disc's 10 rays sit at 36° steps, so the one nearest horizontal is
+   * index 2 at 72°: `33.5·sin72° − 22 = 9.86`. Rank 5 carries 16, putting index
+   * 4 at exactly 90°: `39.5 − 25 = 14.5`. Side by side they need
+   * `9.86 + 14.5 = 24.36`px between rims and they had `--space-md` (12). The
+   * same figure has to hold at the plate's own edges, or the outermost bursts
+   * collide with the border instead of with each other.
    */
   it('holds the metals far enough apart for their bursts to clear (#1633)', () => {
     mocks.user = currentUser()


### PR DESCRIPTION
Two live Ephemerists defects, split out of the re-skin epic (#1632) so they ship ahead of it. No dressing: the design's conic-ring burst redraw belongs to #1638, and the `--faction-ephemerists-*` token block is #1627's and is untouched here.

## The seam

Both fixes are pinned at **the element's own rendered style declaration** — the byline name link, and the vote plate's flex row. That is a deliberate ceiling, not a convenience. This repo's frontend harness is `renderToStaticMarkup`: no DOM, no fonts, no layout, effects never run. **Neither defect is observable in a test.** Nothing here has seen a glyph get shaved or two bursts overlap; what the tests assert is the property that decides it, and the arithmetic that fixes the value is in the comment beside it. **The visual behaviour of both fixes is unverified and needs a human** — see the reproductions at the bottom.

## Bug 1 — which of the two candidate causes is real

**Conclusion: the byline clip is its own defect. The `flex-basis` is behaving in the shipped layout, and its fix must not ship.**

Evidence — I walked every `<PraxisCard>` mount in `frontend/src`:

| shape | mounts |
|---|---|
| wrapping flex row (`flex flex-wrap`) | `/praxes` desktop + mobile, Home, both profile galleries, all 8 task-detail `.praxis-gallery` rows, the faction bodies |
| CSS grid | FieldDesk, `DefaultFactionBody`, `WowFactionBody` |
| flex **column**, card as a direct item | all 8 mobile faction pages, `WowProfileBody` |

Two things follow.

**No mount gives the container a definite height.** A column flex container with an indefinite main size resolves its size from the items' max-content contributions (Flexbox §9.9.1), so `flex-grow: 1` inflates every card to the tallest card's content height — the cards are all *taller* than they need to be, and nothing is cut. The design's canvas stacks cards in a column that *does* have a definite height, so the same basis shrinks them and `overflow: hidden` on the card root eats the bottom. That is where "clipped the byline and vote row" came from, and it does not reproduce here.

**And the design's fix would be a fresh regression.** `frameBase` also sets `width: 100%`, so `flex: 0 0 auto` resolves the basis to `auto` → `100%`, and every wrapping-row mount — the whole feed — collapses to one card per row.

So the byline clip stands on its own. Its cause, in the shared byline:

- `overflow: hidden` on the name link is doing **two** jobs. It clips, and it is what makes the link a shrinkable flex item at all (`min-width: auto` resolves to `0` instead of to the whole `nowrap` string), which is why a long name ellipsizes rather than shoving the portrait out of the frame.
- It clips at the **padding** box, while `text-overflow` measures the **content** box. The 8px separation from the portrait lived on the row as `gap`, so the two edges coincided — the clip box ended exactly where the text did.
- A display face's final glyph can carry ink past its own advance width. The Ephemerists card sets this line in **Poiret One**. That overhang was cut flush, with no ellipsis to explain it, immediately left of the portrait. "A letter clipped behind its own avatar."

**The fix moves the same 8px from the row's `gap` onto `padding-inline-end` on the link.** Identical rendering, and the clip box now outruns the text. Fixed once in `PraxisByline`, so all nine archetypes get it — this slot is the only byline any of them has.

**Why not the design's literal fix.** `overflow: visible` + `text-overflow: clip` restores `min-width: auto` to `min-content`. The name then stops yielding and a long one paints straight over the portrait and the faction tag — the reported symptom, caused on purpose. The test asserts `overflow:visible` never reaches this link, so that door stays shut.

## Bug 2 — the vote metals

Spacing only. The gap holds the **bursts** apart, not the discs: a ray leaves the rim at `radius + 3` and runs `rayLength` further, reaching 11.5px past an ordinary disc and 14.5px past rank 5, whose iron filings orbit another 13px out. Two neighbours want ~24px rim-to-rim and had `--space-md` (12), so the bursts and sheens overlapped by roughly a ray's length. The plate's horizontal padding moves with it, because rank 1 and rank 5 burst toward the border rather than toward a neighbour.

**`gap: 22px` did not survive the ratchet, and should not have.** `local/no-raw-style-values` has an empty grandfather list, so a raw 22 is a lint failure. **`var(--space-xl)` (24px)** is the rung, and rounding up is the right direction anyway — at rank 4 ↔ rank 5 the two bursts reach 24.4px combined, which 22 leaves overlapping and 24 clears to within half a pixel.

## Noted for the epic, not fixed here

The eight **mobile faction pages** and `WowProfileBody` stack `<PraxisCard>` as direct children of a flex **column**, where its 394px basis is read on the main axis. It does not clip (above), but it does stretch every card to the tallest one's height — blank plate under the short ones. `MobilePraxisFeed`'s own header comment already says a wrapping row is the shape this geometry expects. Out of scope: those are page files, and the fix is a mount change rather than a style one.

## Verification

`eslint` · `tsc --noEmit` · `vitest run` (229 files, 3963 tests) · `vite build` · initial-load budget (JS 127.9 KB, CSS 22.4 KB, both ok) · `typecheck:design-sync` — all green locally. No `index.css` change, so no built-CSS brace hazard.

**Visual QA is outstanding, and it is load-bearing on this PR — both defects are visual and neither can be seen from a static render.** What a human should look at:

1. **The byline.** Any Ephemerists praxis card (`/praxes` filtered to the faction, or an Ephemerists task detail). Use an author whose display name is **long enough to reach the ellipsis** and one that sits just short of it — the second is the case that was losing a glyph. Confirm the last letter is whole, the spacing to the portrait is unchanged at 8px, and the long name still ends in `…` rather than running under the portrait. Worth a glance at one non-Ephemerists card too, since the slot is shared.
2. **The vote metals.** The same card, signed in, hovering rank 5 so every disc is lit. Confirm no ray or sheen from one disc reaches its neighbour, and that rank 1's and rank 5's bursts clear the plate's border. Check dark mode as well — the plate is a fixed night surface, but the sheen is `mix-blend-mode: screen`.

Closes #1633.
