### PR TITLE
A bio and a location a player can take back

### DIFF
--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -1182,3 +1182,32 @@ async def test_tagline_and_bio_are_independent(
     data = resp.json()
     assert data["bio"] == "b" * 500
     assert data["tagline"] == "Evidence first. Apologies never."
+
+
+@pytest.mark.asyncio
+async def test_update_character_clears_bio_and_location(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    """An explicit "" clears the column — setting a field must be undoable (#1644).
+
+    The seam is which keys reach the body, so it can only be guarded here: the
+    client used to send ``value || undefined``, ``exclude_unset=True`` read the
+    omission as "leave it alone", and the save appeared to succeed while the old
+    text survived. The empty PUT below is the request the form now makes.
+    """
+    resp = await client.put(
+        f"/characters/{character.id}",
+        json={"bio": "Once wrote this down.", "location": "Portland"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+
+    resp = await client.put(
+        f"/characters/{character.id}",
+        json={"bio": "", "location": ""},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["bio"] == ""
+    assert data["location"] == ""

--- a/frontend/src/pages/characterPaths/useEditCharacter.ts
+++ b/frontend/src/pages/characterPaths/useEditCharacter.ts
@@ -112,16 +112,18 @@ export function useEditCharacter(): EditCharacterState {
       }
     }
     try {
+      // Every editable field is sent unconditionally, empty or not. `|| undefined`
+      // omits the key, and an omitted key is "leave it alone" server-side
+      // (`exclude_unset=True`), so a field sent that way can be set but never
+      // cleared — #1644, which is how a player emptied a bio, saved, and got the
+      // old one back. Emptying these three is a state the player is entitled to,
+      // so "" has to reach the server as "". `exclude_unset` stays: it is what
+      // makes a partial update partial for callers that genuinely send a subset.
       const updated = await updateCharacter(characterId, {
         display_name: displayName,
-        bio: bio || undefined,
-        // Sent unconditionally, unlike its neighbours: `|| undefined` omits the
-        // key, and an omitted key is "leave it alone" server-side, so a field
-        // sent that way can be set but never cleared. An empty tagline is a
-        // state the player is entitled to — the header hides the slot rather
-        // than filling it (#1628) — so "" has to reach the server as "".
+        bio: bio.trim(),
         tagline: tagline.trim(),
-        location: location || undefined,
+        location: location.trim(),
       })
       setCharacter(updated)
       // The edited life may BE the carried one, whose name/bio/avatar the rail


### PR DESCRIPTION
Closes #1644.

Setting a bio or a location was already possible. Clearing one was not. `useEditCharacter` sent `value || undefined`, which omits the key entirely on an empty box, and an omitted key reaches `update_character`'s `model_dump(exclude_unset=True)` as "leave this column alone". The form cleared, the PUT returned 200, and the old text was still there on reload.

All three editable fields now send unconditionally and trimmed, as `tagline` already did — #1643 wrote it that way deliberately to avoid inheriting this, and its comment named the neighbours it could not fix without burying a behaviour change inside a field addition. That comment is now the rule for the whole payload rather than an exception carved out of it.

## What the issue asked me to check first

**Nothing relies on the omit behaviour.** `updateCharacter` has exactly one caller — this hook. There is no partial-update caller anywhere on this resource, so `exclude_unset=True` has no client depending on it today.

**`exclude_unset=True` stays.** It is not the bug; it is what makes a partial update partial, and the issue is right that each field wants its own decision about whether "absent" and "empty" genuinely differ. For bio and location they do not.

**Both skins go through the one hook.** `EditCharacter.tsx` and `mobileArchetypes/DefaultEditCharacter.tsx` are presentation-only, so both are fixed at once. Worth knowing: the mobile skin has no `location` input at all, so on a phone `location` echoes the loaded value straight back — a no-op write, not a clear.

**`useCreateCharacter` keeps `|| undefined`** for the same reason in reverse: on create, absent means "take the default" and there is nothing to take back. The remaining `|| undefined` sites in the codebase are query params or other resources; per the issue, each wants its own decision rather than a sweep.

## The test

At the wire, because the defect is which keys reach the request body and the frontend harness renders to static markup with no DOM — it can never run a submit handler. `test_update_character_clears_bio_and_location` sets both fields, PUTs `""`, and asserts `""` comes back. It pins the server half the client now depends on.

## Verified locally

- `pytest tests/integration/test_characters.py` — 54 passed, against a real Postgres
- `tsc --noEmit` — clean
- `vitest` characterPaths + authRefetchLedger — 37 passed

One thing found in passing, not fixed here: `frontend/node_modules` in my checkout was stale — `openapi-fetch` has been in `package.json` since #1641 but was not installed, so `tsc` and `vitest` both failed on `Cannot find module 'openapi-fetch'` until I ran `npm install`. Until then tsc was typechecking the request body as `any` and would not have caught a bad payload. CI does a fresh install so it is unaffected, but anyone pulling since #1641 needs an install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)