### PR TITLE
Era 1 becomes Renaissance, Era 2 is authored, and each announcement gets its own era's name

### DIFF
--- a/backend/eras/_template.py
+++ b/backend/eras/_template.py
@@ -40,8 +40,7 @@ from game_config import (
 # Config owns which factions exist + their mechanics; add matching name/description
 # entries there for every slug below.
 #
-# Required system factions (include these in every era):
-#   "ua"       -- an ordinary invite-joinable faction (no starter privilege, ADR-0030)
+# The one structurally required faction:
 #   "na"       -- answers two questions at once (see backend/faction_slugs.py):
 #                 the sentinel for a task with no faction affiliation, AND the
 #                 unaffiliated state every character is born into (ADR-0019).
@@ -60,18 +59,11 @@ from game_config import (
 #                              (no ability). Era 1 gives wow 1; everyone else 0.
 
 ERA_N_FACTIONS = {
-    # --- Required system factions (copy and customize) ---
+    # --- Required system faction (copy and customize) ---
     #
-    # "ua": FactionConfig(
-    #     slug="ua",
-    #     can_always_rejoin=False,
-    #     own_task_modifier=1.0,
-    #     other_task_modifier=1.0,
-    #     collab_own_modifier=1.0,
-    #     collab_other_modifier=1.0,
-    #     duel_win_modifier=1.0,
-    #     duel_loss_modifier=1.0,
-    # ),
+    # Every OTHER faction is this era's own choice: Era 2 drops "ua" entirely
+    # (#1618) and nothing structural objects.
+    #
     # "na": FactionConfig(
     #     slug="na",
     #     can_always_rejoin=False,

--- a/backend/eras/era_1.py
+++ b/backend/eras/era_1.py
@@ -245,7 +245,10 @@ ERA_1_LEVEL_PROFILES = (
 # =============================================================================
 
 ERA_1 = EraConfig(
-    name="TestEra",
+    name="Renaissance",
+    # Display prose above, identity below: `config_key` is matched against
+    # Era.config_key in the database (seed.py, routers/admin.py on rollover), so
+    # renaming it would orphan the existing row. Rename the era, never the key.
     config_key="era_1",
     max_task_signups=20,
     vote_budget_base=100,

--- a/backend/eras/era_2.py
+++ b/backend/eras/era_2.py
@@ -1,0 +1,184 @@
+"""
+Era 2 — Metamorphosis.
+
+Authored, not activated: ``CURRENT_ERA`` still resolves to Era 1. This file
+exists so that everything which varies by era has a second ruleset to be tested
+against, and so the rollover has somewhere to go when it happens.
+
+The one rule Metamorphosis actually changes is the own/other split — 1.2 / 0.8
+on solo and duel — plus a smaller roster. Everything else is Era 1's, unchanged.
+"""
+from eras.era_1 import ERA_1_LEVEL_PROFILES
+from game_config import EraConfig, FactionConfig, TaskDef
+
+
+# =============================================================================
+# FACTIONS
+# =============================================================================
+
+# Five factions, and **no UA** — deliberate, not an oversight. Existing UA
+# characters are not stranded: reset_faction=True below sweeps everyone to `na`
+# at rollover. (`ua` is not a structurally required slug — only `na` is, as the
+# FK target for the born-unaffiliated state and for cross-faction tasks. See
+# faction_slugs.py; _template.py claimed otherwise until #1618 and is corrected.)
+#
+# Faction names/descriptions are NOT config-owned (ADR-0038): the English words
+# live in frontend/src/locales/en/factions.json (names.<slug>, descriptions.<slug>).
+#
+# THE POINT OF THIS ERA — the own/other split, applied to all five factions:
+#
+#   own_task_modifier    = 1.2   solo/duel task from your own faction
+#   other_task_modifier  = 0.8   solo/duel task from another faction
+#   collab_own_modifier  = 1.0   \  collaborations deliberately stay flat
+#   collab_other_modifier= 1.0   /
+#
+# The 120/80 rule is **solo and duel only** (owner ruling). A collaboration on
+# your own faction's task must not be worth less than doing it alone, which is
+# what a 1.2 solo beside a 1.0 collab would mean if the collab pair were lifted
+# too — and a cross-faction collab is the behaviour this game wants to
+# encourage, so it is not penalised either. The asymmetry between the two pairs
+# is intentional: this is exactly the shape a later "make these consistent"
+# cleanup would flatten. Do not.
+#
+# Each faction's Era 1 ability is carried across unchanged: Snide's duel
+# gamble, WOW's level jump, Everymen's Double Dipper, Albescent's rejoin.
+# Note that Coven's +10% collab bonus has no counterpart here — Coven is not in
+# Metamorphosis, so this is the first era with no non-1.0 collab modifier at all.
+ERA_2_FACTIONS = {
+    "snide": FactionConfig(
+        slug="snide",
+        can_always_rejoin=False,
+        own_task_modifier=1.2,
+        other_task_modifier=0.8,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=2.0,        # duel win: 200% of base (Snide high-risk bonus)
+        duel_loss_modifier=0.0,       # duel loss: 0% of base (Snide high-risk penalty)
+    ),
+    "wow": FactionConfig(
+        slug="wow",
+        can_always_rejoin=False,
+        own_task_modifier=1.2,
+        other_task_modifier=0.8,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
+        level_jump_reach=1,           # once per level, claim ONE task 1 level up
+    ),
+    "everymen": FactionConfig(
+        slug="everymen",
+        can_always_rejoin=False,
+        own_task_modifier=1.2,
+        other_task_modifier=0.8,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
+        can_hold_multiple_memberships=True,   # Double Dipper
+    ),
+    "albescent": FactionConfig(
+        slug="albescent",
+        can_always_rejoin=True,       # can always be rejoined after defecting
+        own_task_modifier=1.2,
+        other_task_modifier=0.8,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
+    ),
+    "na": FactionConfig(
+        slug="na",
+        can_always_rejoin=False,
+        own_task_modifier=1.2,
+        other_task_modifier=0.8,
+        collab_own_modifier=1.0,
+        collab_other_modifier=1.0,
+        duel_win_modifier=1.5,
+        duel_loss_modifier=0.5,
+    ),
+}
+
+
+# =============================================================================
+# TASKS
+# =============================================================================
+
+# Empty, for the same reason Era 1's is (era_1.py:140-152): `seed.py::sync_era_tasks`
+# re-adds every config task missing from the DB and `start.sh` seeds on EVERY
+# deploy, so a task listed here would resurrect itself the next deploy after an
+# admin deleted it. The board is authored in the admin UI; a config list and a
+# hand-curated board cannot both own the same table.
+ERA_2_TASKS: tuple[TaskDef, ...] = ()
+
+
+# =============================================================================
+# LEVEL PROFILES
+# =============================================================================
+
+# Shared with Era 1 rather than copied. Level profiles are the *announcement* of
+# the capability gates (ADR-0031: copy keys, resolved by the frontend), and
+# every gate below is Era 1's value unchanged — so a divergent tuple here could
+# only ever be a typo. The day Metamorphosis re-tunes a gate, fork this into its
+# own ERA_2_LEVEL_PROFILES rather than editing Era 1's.
+ERA_2_LEVEL_PROFILES = ERA_1_LEVEL_PROFILES
+
+
+# =============================================================================
+# ERA DEFINITION
+# =============================================================================
+
+ERA_2 = EraConfig(
+    name="Metamorphosis",
+    config_key="era_2",
+    # Everything from here down is Era 1's value, deliberately unchanged: the
+    # only rule Metamorphosis re-tunes is the own/other split above.
+    max_task_signups=20,
+    vote_budget_base=100,
+    vote_budget_multiplier=2.0,
+    level_thresholds=(0, 10, 70, 170, 330, 610, 1090, 1840, 3040),
+    # Capability level gates (see SPEC-game-rules.md "Level privileges")
+    level_to_propose_task=3,
+    level_to_propose_metatask=5,
+    level_to_see_metatasks=5,
+    level_to_see_retired_tasks=2,
+    level_to_see_pending_tasks=3,
+    # Praxis / moderation / metatask gates
+    duel_level_required=2,
+    collaboration_level_required=1,
+    collab_auto_submit_days=10,
+    metatask_apply_level=5,
+    flag_level_required=4,
+    # Metatask-per-praxis cap: 1 until L7, then up to 3.
+    metatasks_per_praxis_base=1,
+    metatasks_per_praxis_max=3,
+    metatasks_per_praxis_max_level=7,
+    # Comment gates (ADR-0006)
+    comment_level_required=2,
+    comment_flag_review_threshold=1,
+    # Character account / faction gates
+    second_character_level_required=4,
+    # Inherited from Era 1 on purpose, and it means something different here.
+    # The Albescent unlock has two halves (services/character.py): this level,
+    # AND a submitted praxis covering every non-sentinel faction in the era.
+    # That is seven factions in Era 1 but only THREE here — `na` and `albescent`
+    # are the sentinels — so the coverage half becomes dramatically cheaper
+    # while the level half does not. Knowingly accepted; not a bug to file.
+    albescent_level_required=8,
+    invitation_point_threshold=50,   # ADR-0022: 50 points from a faction's tasks
+    invitation_task_threshold=2,     # ADR-0022: 2 completed tasks for that faction
+    reset_score=True,
+    reset_level=True,
+    reset_faction=True,              # sweeps ex-UA characters to `na` at rollover
+    reset_vote_budget=True,
+    reset_all_time_score=False,
+    factions=ERA_2_FACTIONS,
+    tasks=ERA_2_TASKS,
+    level_profiles=ERA_2_LEVEL_PROFILES,
+    # No Ephemerists in this era, so nobody carries the Task Vision perk:
+    # allow_praxis_on_retired_task_factions stays empty.
+    # Collab invites reach across levels and factions (#1511), as in Era 1.
+    collab_invite_bypasses_level=True,
+    collab_invite_bypasses_faction=True,
+    collab_invite_bypasses_task_bank=False,
+)

--- a/backend/game_config.py
+++ b/backend/game_config.py
@@ -225,4 +225,40 @@ def __getattr__(name: str):
         globals()["ERA_1_FACTIONS"] = _factions
         globals()["CURRENT_ERA"] = _era_1
         return globals()[name]
+    if name in ("ERA_2", "ERA_2_FACTIONS"):
+        # Era 2 (Metamorphosis) is authored, not activated: CURRENT_ERA stays
+        # Era 1 above.
+        from eras.era_2 import ERA_2 as _era_2
+        from eras.era_2 import ERA_2_FACTIONS as _factions
+        globals()["ERA_2"] = _era_2
+        globals()["ERA_2_FACTIONS"] = _factions
+        return globals()[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# The config_key -> EraConfig registry (#1623). A stored ``Era`` row records
+# which ruleset governed it via ``Era.config_key``; this is the only way back
+# from that key to the rules, and the reason the era announcement can label a
+# *past* era correctly instead of relabelling it with whatever CURRENT_ERA is.
+#
+# Deliberately a key -> ATTRIBUTE-NAME map rather than key -> EraConfig: reading
+# the config_key off an era file means importing every era file at module load,
+# which is exactly the eager import the __getattr__ above exists to avoid. The
+# duplication is one string per era, and a unit test asserts the two agree.
+_ERA_ATTRIBUTE_BY_CONFIG_KEY: dict[str, str] = {
+    "era_1": "ERA_1",
+    "era_2": "ERA_2",
+}
+
+
+def era_config_for_key(config_key: str) -> EraConfig | None:
+    """The EraConfig a stored ``Era.config_key`` names, or ``None`` if unknown.
+
+    ``None`` for an era whose config file has been deleted, or for a row written
+    by a newer version of the app. Callers own the fallback; the era announcement
+    falls back to the ``Era.name`` recorded on the row.
+    """
+    attribute_name = _ERA_ATTRIBUTE_BY_CONFIG_KEY.get(config_key)
+    if attribute_name is None:
+        return None
+    return globals().get(attribute_name) or __getattr__(attribute_name)

--- a/backend/models/era.py
+++ b/backend/models/era.py
@@ -10,7 +10,15 @@ class Era(Base):
     __tablename__ = "era"
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(), primary_key=True)
+    #: DELIBERATELY WRITTEN, DELIBERATELY NOT READ on the happy path (#1623).
+    #: The era's display name comes from its config — ``config_key`` below
+    #: resolves it via ``game_config.era_config_for_key`` — so this column is
+    #: the *historical fallback*: the name the era shipped under, shown only
+    #: when the key no longer matches any config (a deleted era file, or a row
+    #: written by a newer version). That is the whole reason ``seed.py`` and
+    #: ``routers/admin.py`` keep writing it. Not a dead field; do not sweep it.
     name: Mapped[str] = mapped_column(String, nullable=False)
+    #: Identity, not prose: the link to the EraConfig that governed this era.
     config_key: Mapped[str] = mapped_column(String, nullable=False)
     started_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=func.now()

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -34,6 +34,7 @@ from sqlalchemy.dialects.postgresql import insert as postgres_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import InstrumentedAttribute, aliased
 
+from game_config import era_config_for_key
 from models.character import Character
 from models.comment import Comment, CommentMention
 from models.era import Era
@@ -484,6 +485,16 @@ def _era_announcements_query(ctx: FeedContext) -> Select:
 
 def _era_announcement_item(row: Any) -> ActivityFeedItemDC:
     era: Era = row[0]
+    # The era's display name comes from its CONFIG, resolved through the row's
+    # own config_key (#1623) — not from the Era.name column, and not from
+    # CURRENT_ERA. This query emits announcements for PAST eras too, so
+    # CURRENT_ERA would relabel Era 1's historical announcement with Era 2's
+    # name the day Metamorphosis starts.
+    #
+    # The stored name is the fallback for a config_key with no config left:
+    # a deleted era file, or a row written by a newer version. An old
+    # announcement showing the name it shipped under beats showing "era_1".
+    era_config = era_config_for_key(era.config_key)
     return ActivityFeedItemDC(
         type=FEED_ITEM_TYPE_ERA_ANNOUNCEMENT,
         item_key=build_item_key(FEED_ITEM_TYPE_ERA_ANNOUNCEMENT, era.id),
@@ -493,7 +504,7 @@ def _era_announcement_item(row: Any) -> ActivityFeedItemDC:
         actor_avatar_url=None,
         payload=EraAnnouncementPayload(
             era_id=era.id,
-            era_name=era.name,
+            era_name=era_config.name if era_config is not None else era.name,
             era_notes=era.notes,
             config_key=era.config_key,
         ),

--- a/backend/tests/unit/test_era_announcement_name.py
+++ b/backend/tests/unit/test_era_announcement_name.py
@@ -1,0 +1,57 @@
+"""The era announcement labels each era from ITS OWN config (#1623).
+
+The seam under test is ``services.activity_feed._era_announcement_item``, the
+row-to-item mapper: it takes an ``Era`` row and decides what name players read.
+It used to emit ``Era.name`` — a hand-editable column that had already drifted
+from the config in production — and the query it serves emits announcements for
+*past* eras too, so neither the column nor ``CURRENT_ERA`` is the right answer.
+
+Unit-level on purpose: the mapper is a pure function of the row, so the whole
+rule is reachable without a database.
+"""
+from datetime import datetime, timezone
+
+from game_config import ERA_1, ERA_2
+from models.era import Era
+from services.activity_feed import _era_announcement_item
+
+
+def _era_row(config_key: str, name: str) -> tuple[Era, ...]:
+    """One row shaped the way ``_era_announcements_query`` returns it."""
+    return (
+        Era(
+            id=1,
+            name=name,
+            config_key=config_key,
+            started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            notes="",
+        ),
+    )
+
+
+def test_announcement_reads_the_config_not_the_stored_name():
+    item = _era_announcement_item(_era_row("era_1", "TestEra"))
+    assert item.payload.era_name == ERA_1.name
+
+
+def test_each_announcement_carries_its_own_eras_name():
+    """The regression this issue exists to prevent.
+
+    Two rows, two config_keys. If the mapper resolved through CURRENT_ERA both
+    would read "Renaissance", and Era 1's historical announcement would be
+    relabelled the day Metamorphosis starts.
+    """
+    first = _era_announcement_item(_era_row("era_1", "whatever"))
+    second = _era_announcement_item(_era_row("era_2", "whatever"))
+
+    assert first.payload.era_name == ERA_1.name
+    assert second.payload.era_name == ERA_2.name
+    assert first.payload.era_name != second.payload.era_name
+
+
+def test_an_unknown_config_key_falls_back_to_the_stored_name():
+    """A deleted era file, or a row from a newer version — the one reason the
+    ``Era.name`` column is still written."""
+    item = _era_announcement_item(_era_row("era_99", "The Long Winter"))
+    assert item.payload.era_name == "The Long Winter"
+    assert item.payload.config_key == "era_99"

--- a/backend/tests/unit/test_era_config.py
+++ b/backend/tests/unit/test_era_config.py
@@ -13,6 +13,17 @@ def test_era1_config_key():
     assert ERA_1.config_key == "era_1"
 
 
+def test_era1_is_named_renaissance():
+    """The live era's player-visible name (#1620).
+
+    Pinned as a literal on purpose: every surface that shows it — the character
+    card's era stat, GET /game-config, the era announcement — asserts against
+    ``.name`` rather than prose, so without this one assertion the rename has no
+    test that can fail.
+    """
+    assert ERA_1.name == "Renaissance"
+
+
 def test_level_thresholds_count():
     # Levels 0–8 = 9 entries
     assert len(ERA_1.level_thresholds) == 9

--- a/backend/tests/unit/test_era_config.py
+++ b/backend/tests/unit/test_era_config.py
@@ -1,7 +1,14 @@
 import dataclasses
 
 from faction_slugs import UNAFFILIATED_FACTION_SLUG
-from game_config import CURRENT_ERA, ERA_1, EraConfig
+from game_config import (
+    CURRENT_ERA,
+    ERA_1,
+    ERA_2,
+    EraConfig,
+    _ERA_ATTRIBUTE_BY_CONFIG_KEY,
+    era_config_for_key,
+)
 
 
 def test_current_era_is_defined():
@@ -210,3 +217,111 @@ def test_era1_level_profiles_use_slug_keys():
         for unlock in profile.unlocks:
             assert unlock.key and unlock.key.islower()
             assert " " not in unlock.key
+
+
+# ---------------------------------------------------------------------------
+# Era 2 — Metamorphosis, authored but not activated (#1618)
+# ---------------------------------------------------------------------------
+
+
+def test_era_2_is_authored_not_activated():
+    assert ERA_2.name == "Metamorphosis"
+    assert ERA_2.config_key == "era_2"
+    assert CURRENT_ERA is ERA_1, "Metamorphosis is authored, not activated"
+
+
+def test_era_2_roster_is_five_factions_and_no_ua():
+    """No UA is deliberate. Nobody is stranded: reset_faction sweeps to `na`."""
+    assert set(ERA_2.factions) == {"na", "snide", "wow", "everymen", "albescent"}
+    assert ERA_2.starting_faction_slug in ERA_2.factions
+    assert ERA_2.reset_faction is True
+
+
+def test_era_2_own_other_split_applies_to_every_faction():
+    for slug, faction in ERA_2.factions.items():
+        assert faction.own_task_modifier == 1.2, slug
+        assert faction.other_task_modifier == 0.8, slug
+
+
+def test_era_2_collab_modifiers_stay_flat():
+    """The asymmetry is the owner ruling, not an oversight (#1618).
+
+    A collaboration on your own faction's task must not be worth less than doing
+    it alone, and cross-faction collaboration is not something this game
+    penalises — so the 120/80 rule is solo and duel only. This test exists to
+    fail the "make these consistent" cleanup.
+    """
+    for slug, faction in ERA_2.factions.items():
+        assert faction.collab_own_modifier == 1.0, slug
+        assert faction.collab_other_modifier == 1.0, slug
+
+
+def test_era_2_carries_era_1_faction_abilities_across():
+    assert ERA_2.factions["snide"].duel_win_modifier == ERA_1.factions["snide"].duel_win_modifier
+    assert ERA_2.factions["snide"].duel_loss_modifier == ERA_1.factions["snide"].duel_loss_modifier
+    assert ERA_2.factions["wow"].level_jump_reach == ERA_1.factions["wow"].level_jump_reach
+    assert ERA_2.factions["everymen"].can_hold_multiple_memberships is True
+    assert ERA_2.factions["albescent"].can_always_rejoin is True
+
+
+def test_era_2_ships_no_config_tasks():
+    """Same reason as Era 1's empty roster: a config task resurrects itself on
+    the next deploy after an admin deletes it."""
+    assert ERA_2.tasks == ()
+
+
+def test_era_2_inherits_every_other_rule_from_era_1():
+    """The own/other split and the roster are the ONLY things Metamorphosis
+    re-tunes. Compare the whole dataclass rather than a hand-listed subset, so a
+    field added later cannot silently diverge unnoticed."""
+    diverged = {
+        field.name
+        for field in dataclasses.fields(EraConfig)
+        if getattr(ERA_1, field.name) != getattr(ERA_2, field.name)
+    }
+    assert diverged == {
+        "name",
+        "config_key",
+        "factions",
+        # Era 1 grants Ephemerists the retired-task perk; Metamorphosis has no
+        # Ephemerists, so the set is empty rather than differently populated.
+        "allow_praxis_on_retired_task_factions",
+    }
+
+
+def test_era_2_albescent_gate_is_inherited_knowingly():
+    """The level half is Era 1's, but the coverage half is far cheaper here.
+
+    ``services.character._account_covers_every_faction`` requires a submitted
+    praxis for every NON-SENTINEL faction in the era — seven in Era 1, three
+    here. Accepted deliberately (#1618); asserted so the difference is visible
+    rather than rediscovered as a bug.
+    """
+    assert ERA_2.albescent_level_required == ERA_1.albescent_level_required
+    sentinels = {"na", "albescent"}
+    assert len(set(ERA_2.factions) - sentinels) == 3
+    assert len(set(ERA_1.factions) - sentinels) == 7
+
+
+# ---------------------------------------------------------------------------
+# config_key -> EraConfig registry (#1623)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_resolves_each_key_to_its_own_config():
+    assert era_config_for_key("era_1") is ERA_1
+    assert era_config_for_key("era_2") is ERA_2
+
+
+def test_registry_keys_agree_with_the_configs_they_name():
+    """The registry restates each config_key as a string so the era files are
+    not all imported at module load. This is the guard on that duplication."""
+    for config_key in _ERA_ATTRIBUTE_BY_CONFIG_KEY:
+        assert era_config_for_key(config_key).config_key == config_key
+
+
+def test_registry_returns_none_for_an_unknown_key():
+    """A deleted era file, or a row from a newer version. The caller owns the
+    fallback — the era announcement uses the name stored on the row."""
+    assert era_config_for_key("era_99") is None
+    assert era_config_for_key("") is None

--- a/backend/tests/unit/test_scoring.py
+++ b/backend/tests/unit/test_scoring.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 
-from game_config import ERA_1
+from game_config import ERA_1, ERA_2
 from models.praxis import ModerationStatus
 from services.duel_outcome import duel_winner
 from services.scoring import (
@@ -262,6 +262,61 @@ def test_collab_unaffiliated_task():
         collaboration_mode=COLLABORATION_MODE_COLLAB,
     )
     assert result == ERA_1.factions["wow"].collab_own_modifier
+
+
+# ---------------------------------------------------------------------------
+# Era 2 (Metamorphosis): the 120/80 split is solo + duel, never collab (#1618)
+# ---------------------------------------------------------------------------
+# The same function under a second ruleset — the reason a second era exists at
+# all. Era 1 flattens every modifier to 1.0, so nothing above can tell "reads
+# the era's own/other fields" apart from "returns 1.0".
+
+
+def test_era_2_own_other_split_lands_on_solo_and_duel():
+    for mode in (COLLABORATION_MODE_SOLO, COLLABORATION_MODE_DUEL):
+        own = compute_faction_multiplier(
+            "snide", "snide", ERA_2, collaboration_mode=mode
+        )
+        other = compute_faction_multiplier(
+            "snide", "wow", ERA_2, collaboration_mode=mode
+        )
+        assert own == 1.2, mode
+        assert other == 0.8, mode
+
+
+def test_era_2_cross_faction_task_is_not_penalised():
+    """A `na` task belongs to no faction, so it takes the OWN modifier — the
+    0.8 is for another faction's work, not for generic work."""
+    assert compute_faction_multiplier("snide", "na", ERA_2) == 1.2
+
+
+def test_era_2_collab_stays_flat_both_ways():
+    """Deliberately asymmetric with the solo/duel pair above (owner ruling): a
+    collaboration on your own faction's task must not be worth less than doing
+    it alone, and a cross-faction collab is not penalised."""
+    for character_faction, task_faction in (("wow", "wow"), ("wow", "snide")):
+        assert compute_faction_multiplier(
+            character_faction, task_faction, ERA_2,
+            collaboration_mode=COLLABORATION_MODE_COLLAB,
+        ) == 1.0, (character_faction, task_faction)
+
+
+def test_era_2_duel_outcome_multiplies_on_top_of_the_split():
+    """The two multipliers are separate inputs to compute_praxis_score, so a
+    Snide duel win on another faction's task is base × 0.8 × 2.0."""
+    faction_multiplier = compute_faction_multiplier(
+        "snide", "wow", ERA_2, collaboration_mode=COLLABORATION_MODE_DUEL
+    )
+    duel_multiplier = compute_duel_multiplier(
+        "snide", "wow", is_winner=True, is_tied=False, era=ERA_2
+    )
+    score = compute_praxis_score(
+        task_point_value=10,
+        faction_multiplier=faction_multiplier,
+        total_stars=0,
+        duel_multiplier=duel_multiplier,
+    )
+    assert score == 10 * 0.8 * 2.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1620
Closes #1623
Closes #1618

Three issues, one PR: all three edit the same seam, and #1623's registry would
otherwise be built twice and tested nowhere.

## The seam

`services/activity_feed._era_announcement_item` — the row-to-item mapper that
decides what era name a player reads in the feed. It took `Era.name` (a
hand-editable column that had already drifted from the config in production);
it now resolves the row's own `config_key` through a new
`game_config.era_config_for_key` registry, falling back to the stored name when
the key names no config. The test at that seam goes red on the real defect: I
reverted the one line and two of the three cases failed.

## What changed

**#1620 — Era 1 is `Renaissance`.** One line in `eras/era_1.py`, plus a comment
next to `config_key` saying it is identity, not prose. The character card
(`CurrentUser.era_name`) and `GET /game-config` both read `CURRENT_ERA.name`,
so they follow automatically; both already have tests asserting against
`CURRENT_ERA.name`, which is why the literal is now pinned once in
`test_era_config.py` — without it the rename had no test that could fail.

**#1623 — the announcement reads the config.** `era_config_for_key` maps
`config_key -> EraConfig`. It is deliberately a key -> *attribute-name* map, not
a key -> config map: reading `config_key` off an era file would mean importing
every era file at module load, which is exactly the eager import the
`game_config` docstring's lazy `__getattr__` exists to avoid. That restated
string is guarded by a test asserting each registry key equals the
`config_key` of the config it names. `models/era.py` now documents `name` as the
historical fallback — deliberately written, deliberately not read on the happy
path — so the next dead-field sweep leaves it alone.

**#1618 — `eras/era_2.py`, Metamorphosis.** Five factions (`na`, `snide`, `wow`,
`everymen`, `albescent`), 1.2/0.8 on solo and duel, collab modifiers flat at 1.0
on all five with a comment saying the asymmetry is the owner ruling and not
something to "make consistent", `ERA_2_TASKS = ()`, Era 1 abilities carried
across, `albescent_level_required=8` inherited with a comment on why three
non-sentinel factions makes the coverage half far cheaper. `CURRENT_ERA` stays
Era 1 — authored, not activated.

## Verified against the code, not the issue text

- Every path and line number in the three issues checked out (`era_1.py:248`,
  `activity_feed.py:485-499`, `current_user.py:36,85`, `routers/game_config.py:42`,
  `character.py`'s non-sentinel coverage rule). One drift: the rollover write is
  `routers/admin.py:322`, not `:321`.
- **`eras/_template.py` was wrong** and this PR corrects it: it listed `ua` as a
  "required system faction … include in every era". Nothing requires it —
  `UA_FACTION_SLUG` in `services/faction_service.py` is declared and never
  referenced anywhere. Only `na` is structural (FK target for the
  born-unaffiliated state and for cross-faction tasks). Left uncorrected, the
  template would have argued against #1618's deliberate no-UA roster.
- `ERA_2` shares Era 1's `level_profiles` tuple rather than copying it — the
  profiles are the *announcement* of the capability gates, and every gate is
  Era 1's value unchanged, so a divergent copy could only be a typo. Commented,
  with the instruction to fork it the day a gate is re-tuned. The issue was
  silent on this; flagging it as a judgement call.
- The only other `TestEra` strings in the repo are two frontend cache-epoch
  tests using it as an arbitrary stamp literal. Not coupled to this value, not
  touched.

## Tests

`cd backend && pytest --cov=. --cov-fail-under=80` → **1118 passed**, coverage
92.95%, against a dedicated `wz1623_test` database.

- `tests/unit/test_era_announcement_name.py` (new): reads the config not the
  stored name; two rows with different `config_key`s each carrying **its own**
  era's name; an unknown key falling back to the stored name.
- `test_era_config.py`: the Renaissance literal; the Era 2 roster, split and
  flat-collab pair; a whole-dataclass comparison asserting the *only* fields
  Era 2 diverges on are `name`, `config_key`, `factions` and the (empty)
  Ephemerists perk set, so a field added later cannot silently diverge; the
  registry's three cases.
- `test_scoring.py`: 1.2/0.8 on solo **and** duel, 1.0 on collab both ways,
  `na` tasks taking the own modifier, and a Snide duel win landing
  `base × 0.8 × 2.0`. Era 1 flattens every modifier to 1.0, so nothing in the
  existing suite could tell "reads the era's fields" apart from "returns 1.0".

No migration, no data change, no schema change (`era_name` is the same wire
field with a different source), so `api-schema` is unaffected. No frontend file
is touched.

Not run: the frontend CI job's six steps, because the diff contains zero
frontend files. Visual QA is outstanding — I have no browser.

## Out of scope, worth knowing

`services/faction_service.py:19` declares `UA_FACTION_SLUG` and nothing in the
codebase reads it. Left alone here; it is a candidate for the next dead-code
sweep.

## What to eyeball

- **The character card's era stat** — it should now read `Renaissance`. The name
  goes from 7 characters to 11 and that stat sits in a **fixed-width slot**, so
  this is the one place a length change can look wrong.
- **The era-announcement row in the activity feed** — should still read
  `Renaissance`, now sourced from the config rather than the hand-edited
  production row. Same words, different origin: if it changes, something is
  wrong.
