### PR TITLE
An era rollover retires the board it closes, and the first task stops taxing the factionless

### DIFF
--- a/backend/alembic/versions/0004_onboarding_cross_faction.py
+++ b/backend/alembic/versions/0004_onboarding_cross_faction.py
@@ -1,0 +1,54 @@
+"""Move the onboarding task off Albescent onto the cross-faction sentinel (#1619 B5).
+
+A **data** migration, not a schema one. ``seed.ensure_onboarding_task`` is keyed
+on **title**: it creates the row when the title is absent and returns early when
+it is present, so it will never update an existing row's
+``primary_faction_slug``. Production already holds this task at ``albescent``,
+which means the code change alone would only ever reach a fresh database — and
+the whole point of the change is the newcomer already playing on production, who
+is charged ``other_task_modifier`` for the one task on the board.
+
+Deliberately written with literal strings rather than by importing
+``seed.ONBOARDING_TASK_TITLE`` / ``faction_slugs.CROSS_FACTION_SLUG``: a
+migration describes a moment in time and must keep describing it after those
+constants move again.
+
+Idempotent, and a no-op on a fresh database — ``0002_squashed`` builds the
+schema before ``seed.py`` has inserted any task, so there is nothing to match.
+
+Revision ID: 0004_onboarding_cross_faction
+Revises: 0003_character_tagline
+Create Date: 2026-08-03
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0004_onboarding_cross_faction"
+down_revision: Union[str, None] = "0003_character_tagline"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# The onboarding task as it exists on any database stamped at 0003 (#511).
+ONBOARDING_TITLE = 'Take a Picture of "Yourself"'
+CROSS_FACTION = "na"
+PREVIOUS_FACTION = "albescent"
+
+
+def _repoint(from_slug: str, to_slug: str) -> None:
+    op.get_bind().execute(
+        sa.text(
+            "UPDATE task SET primary_faction_slug = :to_slug "
+            "WHERE title = :title AND primary_faction_slug = :from_slug"
+        ),
+        {"to_slug": to_slug, "title": ONBOARDING_TITLE, "from_slug": from_slug},
+    )
+
+
+def upgrade() -> None:
+    _repoint(PREVIOUS_FACTION, CROSS_FACTION)
+
+
+def downgrade() -> None:
+    _repoint(CROSS_FACTION, PREVIOUS_FACTION)

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -26,7 +26,7 @@ from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 
 from sqlalchemy import func, select
 
-from faction_slugs import UNAFFILIATED_FACTION_SLUG
+from faction_slugs import CROSS_FACTION_SLUG, UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA
 from script_utils import add_env_argument, get_settings
 from models.account import Account, OAuthProvider
@@ -191,10 +191,7 @@ async def sync_era_tasks(session, era, created_by_id: int) -> int:
 # The single game-wide level-0 task (#511). It is NOT era content — it lives in
 # no `era_N.tasks` list — so it is seeded here on every run and exists in every
 # era regardless of era config. Level 0 is reserved for this one task; every
-# faction's roster content lives in levels 1-7 (#904). Faction is Albescent
-# (owner's call): task signup is gated on level only (`meets_task_level`), never
-# faction, so a brand-new unaffiliated (na) player can sign up, and Albescent
-# renders neutral/rainbow (#783/#794) so it reads as neutral to a newcomer.
+# faction's roster content lives in levels 1-7 (#904).
 ONBOARDING_TASK_TITLE = "Take a Picture of \"Yourself\""
 ONBOARDING_TASK_DESCRIPTION = (
     "Point a camera at yourself — but the quotation marks are doing work. "
@@ -203,7 +200,24 @@ ONBOARDING_TASK_DESCRIPTION = (
     "carried you, the desk that's unmistakably yours. Show us who you are. A "
     "literal selfie is allowed, but never required."
 )
-ONBOARDING_TASK_FACTION_SLUG = "albescent"
+# Cross-faction, not Albescent (#1619 B5). It was Albescent by the owner's call
+# and for good reasons that all still hold — signup is gated on level only
+# (`meets_task_level`), never faction, so an unaffiliated player could always
+# take it, and Albescent renders neutral/rainbow (#783/#794) so it *reads*
+# neutral. What changed is that a second era makes a faction slug carry
+# arithmetic it did not carry before: `compute_faction_multiplier` treats a task
+# as own-faction only when its slug matches the character's or the task is
+# cross-faction, so an Albescent task charged a brand-new `na` character
+# `other_task_modifier`. In Era 1 that is 1.0 and nothing happens; at 0.8 the
+# first act of an era pays a newcomer 8 points instead of 10 for not having a
+# faction yet, on what may be the only task on the board. Cross-faction keeps
+# every property the original call wanted and adds era-independence: it pays the
+# same to everyone, in every era, whatever the modifiers are.
+#
+# CROSS_FACTION_SLUG, not UNAFFILIATED_FACTION_SLUG — they share the value "na"
+# and are not aliases (see faction_slugs). This is a task belonging to no
+# faction, not a player who has joined none.
+ONBOARDING_TASK_FACTION_SLUG = CROSS_FACTION_SLUG
 ONBOARDING_TASK_POINT_VALUE = 10
 
 

--- a/backend/services/era.py
+++ b/backend/services/era.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from faction_slugs import UNAFFILIATED_FACTION_SLUG
@@ -11,6 +11,12 @@ from models.character_stats import CharacterStats
 from models.duel import Duel, DuelStatus
 from models.era import Era
 from models.praxis import Praxis
+from models.task import Task, TaskStatus
+# ``seed`` is a leaf as far as services go — it imports models, game_config and
+# config, never a service — so naming the one task both modules must agree on
+# costs no cycle. The seeder owns the title because the seeder is what keeps the
+# task alive in every era (#511); the sweep below only has to recognise it.
+from seed import ONBOARDING_TASK_TITLE
 from services.duel_outcome import duel_winner
 from services.scoring import snide_tie_winner_id
 from services.vote_tally import get_tally, tally_votes
@@ -300,6 +306,50 @@ async def resolve_duels_at_era_close(
     return duels
 
 
+async def retire_board_at_era_close(session: AsyncSession) -> int:
+    """Retire every task except the onboarding one. Returns how many rows moved.
+
+    An era's board belongs to that era. Before #1619 ``apply_era_reset`` had no
+    ``Task`` reference at all, so a rollover left the whole board active and
+    claimable; an empty ``ERA_2_TASKS`` only stops the *seeder* adding more, it
+    says nothing about what is already there.
+
+    **Retire, not delete.** ``praxis.task_id`` is NOT NULL, so deleting a task
+    would strand or destroy every praxis written against it. Retiring preserves
+    every reference — the row keeps answering "what was this proof *for*".
+
+    The onboarding self-portrait is spared: ``seed.ensure_onboarding_task`` keeps
+    it alive in every era by design (#511), so re-retiring it each rollover would
+    only fight the seeder on the next deploy. Everything else goes, including
+    ``pending`` proposals — a proposal from a closed era is that era's content,
+    and leaving it approvable would let the board the sweep just cleared come
+    back one admin click at a time.
+
+    Two consequences, neither a blocker and both certain to be re-discovered as
+    bugs otherwise:
+
+    1. **Retired titles stay taken.** ``services.task_import`` dedupes on
+       ``select(Task.title)`` with no status filter, so a retired task still
+       occupies its name. From here every title from every past era is reserved
+       forever — and once #1563 lands, a colliding import row is *silently
+       skipped* rather than rejected, so re-using a task name across eras yields
+       a successful-looking import that quietly drops rows.
+    2. **The board un-hides itself as players climb.** ``level_to_see_retired_tasks``
+       is 2, so retired tasks return to browse for anyone past that level.
+       ``reset_level`` puts everyone at 0 on rollover, so "only the photo task"
+       is true on day one and decays from there. (An era listing a faction in
+       ``allow_praxis_on_retired_task_factions`` — Era 1 lists Ephemerists —
+       leaks a second way, for that faction only.)
+    """
+    result = await session.execute(
+        update(Task)
+        .where(Task.title != ONBOARDING_TASK_TITLE)
+        .where(Task.status != TaskStatus.retired)
+        .values(status=TaskStatus.retired)
+    )
+    return result.rowcount
+
+
 async def apply_era_reset(
     characters: list[Character],
     new_era_row: Era,
@@ -310,7 +360,8 @@ async def apply_era_reset(
 
     Preserves historical stats rows for prior eras. Also freezes every unresolved
     duel outcome — era close is the moment a duel acquires a definitive winner
-    (ADR-0011 / ADR-0052).
+    (ADR-0011 / ADR-0052) — and retires the closing era's board
+    (:func:`retire_board_at_era_close`, #1619).
 
     Defection history is **not** purged. ``reset_faction`` returns everyone to
     ``na``, and a fresh start on the join gate falls out of era scoping alone:
@@ -325,6 +376,10 @@ async def apply_era_reset(
     # tell "last era" from "this era" without comparing timestamps (#823).
     closing_era_id = await get_closing_era_id(new_era_row, session)
     await resolve_duels_at_era_close(session, closing_era_id=closing_era_id)
+
+    # The closing era's board closes with it. Order does not matter to the duel
+    # freeze above — a duel's outcome is a vote tally, never a task status.
+    await retire_board_at_era_close(session)
 
     for character in characters:
         # Find previous stats to carry all_time_score forward

--- a/backend/tests/integration/test_era_reset_retires_board.py
+++ b/backend/tests/integration/test_era_reset_retires_board.py
@@ -1,0 +1,168 @@
+"""An era rollover retires the board, and history survives it (#1619 B4).
+
+Seam under test: ``services.era.apply_era_reset`` → ``task.status``. Before this
+change the function had no ``Task`` reference at all, so every task — active,
+pending, metatask — survived a rollover fully claimable. An empty
+``ERA_2_TASKS`` only stops the *seeder* adding more; it says nothing about what
+is already there.
+
+Retire, not delete: ``praxis.task_id`` is NOT NULL, so a delete would strand or
+destroy history. These tests pin both halves — the board goes dark, and a praxis
+authored against a now-retired task still resolves its task.
+"""
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.account import Account
+from models.character import Character
+from models.era import Era
+from models.faction import Faction
+from models.praxis import Praxis, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus, TaskType
+from seed import ONBOARDING_TASK_TITLE, ensure_onboarding_task
+from services.era import apply_era_reset
+
+
+async def _close_era(
+    session: AsyncSession, account: Account, characters: list[Character]
+) -> Era:
+    """Append the next Era row and run the reset — what ``PUT /admin/era/reset`` does."""
+    new_era_row = Era(
+        name=CURRENT_ERA.name,
+        config_key=CURRENT_ERA.config_key,
+        started_by=account.id,
+    )
+    session.add(new_era_row)
+    await session.flush()
+    await apply_era_reset(characters, new_era_row, session)
+    return new_era_row
+
+
+async def _seed_board(session: AsyncSession, character: Character) -> dict[str, Task]:
+    """Every task shape a rollover can find: active, pending, metatask, retired."""
+    board = {
+        "active": Task(
+            title="Board Active",
+            description="claimable today",
+            point_value=10,
+            level_required=1,
+            status=TaskStatus.active,
+            created_by=character.id,
+            primary_faction_slug="ua",
+        ),
+        "pending": Task(
+            title="Board Pending",
+            description="a proposal awaiting approval",
+            point_value=10,
+            level_required=1,
+            status=TaskStatus.pending,
+            created_by=character.id,
+            primary_faction_slug="ua",
+        ),
+        "metatask": Task(
+            title="Board Metatask",
+            description="applied to another praxis",
+            point_value=5,
+            level_required=1,
+            status=TaskStatus.active,
+            task_type=TaskType.metatask,
+            created_by=character.id,
+            primary_faction_slug="ua",
+            metatask_faction_slug="ua",
+        ),
+        "already_retired": Task(
+            title="Board Already Retired",
+            description="retired last era",
+            point_value=10,
+            level_required=1,
+            status=TaskStatus.retired,
+            created_by=character.id,
+            primary_faction_slug="ua",
+        ),
+    }
+    for task in board.values():
+        session.add(task)
+    await session.flush()
+    return board
+
+
+async def _statuses_by_title(session: AsyncSession) -> dict[str, TaskStatus]:
+    result = await session.execute(select(Task.title, Task.status))
+    return {title: status for title, status in result.all()}
+
+
+@pytest.mark.asyncio
+async def test_era_reset_retires_every_task_but_the_onboarding_one(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+):
+    """The board goes dark; the one task a newcomer needs stays lit."""
+    await _seed_board(db_session, character)
+    assert await ensure_onboarding_task(db_session, character.id) is True
+
+    await _close_era(db_session, account, [character])
+
+    statuses = await _statuses_by_title(db_session)
+    assert statuses[ONBOARDING_TASK_TITLE] == TaskStatus.active
+    retired = {
+        title: status
+        for title, status in statuses.items()
+        if title != ONBOARDING_TASK_TITLE
+    }
+    assert retired, "the fixture board must not be empty"
+    assert all(status == TaskStatus.retired for status in retired.values()), retired
+
+
+@pytest.mark.asyncio
+async def test_era_reset_leaves_the_onboarding_task_untouched_on_a_second_rollover(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+):
+    """Re-running the sweep must not fight the seeder (#511)."""
+    await ensure_onboarding_task(db_session, character.id)
+
+    first_era = await _close_era(db_session, account, [character])
+    await _close_era(db_session, account, [character])
+
+    statuses = await _statuses_by_title(db_session)
+    assert statuses[ONBOARDING_TASK_TITLE] == TaskStatus.active
+    assert first_era.id  # the two rollovers really were distinct rows
+
+
+@pytest.mark.asyncio
+async def test_praxis_on_a_retired_task_still_resolves_its_task(
+    db_session: AsyncSession,
+    account: Account,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    active_task: Task,
+):
+    """Retire, not delete: ``praxis.task_id`` is NOT NULL and must stay resolvable."""
+    praxis = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.submitted,
+        title="Proof from the old era",
+        body_text="proof",
+    )
+    db_session.add(praxis)
+    await db_session.flush()
+
+    await _close_era(db_session, account, [character])
+    await db_session.refresh(praxis)
+
+    task = (
+        await db_session.execute(select(Task).where(Task.id == praxis.task_id))
+    ).scalar_one()
+    assert task.status == TaskStatus.retired
+    assert praxis.task_id == active_task.id

--- a/backend/tests/integration/test_seed_task_sync.py
+++ b/backend/tests/integration/test_seed_task_sync.py
@@ -22,6 +22,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from faction_slugs import CROSS_FACTION_SLUG
 from game_config import TaskDef
 from models.character import Character
 from models.era import Era
@@ -89,15 +90,8 @@ async def test_onboarding_task_seeded_once_and_is_the_only_level_zero_task(
     faction_ua: Faction,
 ):
     """The game-wide L0 onboarding task is seeded on every run, idempotently (#511)."""
-    # The onboarding task is faction="albescent"; seed that FK target.
-    from models.faction import FactionStatus
-
-    if (
-        await db_session.execute(select(Faction).where(Faction.slug == "albescent"))
-    ).scalar_one_or_none() is None:
-        db_session.add(Faction(slug="albescent", status=FactionStatus.visible))
-        await db_session.flush()
-
+    # The onboarding task is cross-faction (#1619 B5), so its FK target is the
+    # ``na`` row the ``faction_ua`` fixture already seeds.
     # Simulate a populated DB with era content (none of it level 0 anymore).
     await sync_era_tasks(
         db_session, _era_with_tasks(_standard_task("Alpha Task")), character.id
@@ -120,7 +114,7 @@ async def test_onboarding_task_seeded_once_and_is_the_only_level_zero_task(
     ).scalars().all()
     assert len(onboarding_rows) == 1
     assert onboarding_rows[0].level_required == 0
-    assert onboarding_rows[0].primary_faction_slug == "albescent"
+    assert onboarding_rows[0].primary_faction_slug == CROSS_FACTION_SLUG
     assert onboarding_rows[0].task_type == TaskType.standard
 
     # It is the only standard level-0 task in the database.

--- a/backend/tests/unit/test_onboarding_task_faction.py
+++ b/backend/tests/unit/test_onboarding_task_faction.py
@@ -1,0 +1,72 @@
+"""The onboarding task pays the same to everyone, in every era (#1619 B5).
+
+Seam under test: ``seed.ONBOARDING_TASK_FACTION_SLUG`` read through
+``services.scoring.compute_faction_multiplier``. That pair is the whole rule —
+the slug on the one task every brand-new player starts on decides whether an
+unaffiliated character is charged ``other_task_modifier`` for it.
+
+Era 1 sets every modifier to 1.0, so the defect is invisible against the live
+era. The 1.2/0.8 config below is what a second era looks like; it is built
+inline rather than imported so this test keeps failing on the real defect
+whatever the era files happen to hold.
+"""
+from dataclasses import replace
+
+import pytest
+
+from faction_slugs import UNAFFILIATED_FACTION_SLUG
+from game_config import ERA_1, EraConfig
+from seed import ONBOARDING_TASK_FACTION_SLUG
+from services.scoring import compute_faction_multiplier
+
+#: Every faction slug an era knows, including the unaffiliated sentinel.
+ALL_FACTION_SLUGS: tuple[str, ...] = tuple(ERA_1.factions)
+
+
+def _era_with_modifiers(own: float, other: float) -> EraConfig:
+    """ERA_1's shape with every faction's solo modifiers pinned to (own, other)."""
+    return replace(
+        ERA_1,
+        factions={
+            slug: replace(
+                faction, own_task_modifier=own, other_task_modifier=other
+            )
+            for slug, faction in ERA_1.factions.items()
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "own,other",
+    [
+        (1.0, 1.0),   # Era 1: the defect is silent here
+        (1.2, 0.8),   # a second era: the slug starts carrying arithmetic
+    ],
+)
+@pytest.mark.parametrize("character_faction_slug", ALL_FACTION_SLUGS)
+def test_onboarding_task_pays_everyone_the_same(
+    character_faction_slug: str, own: float, other: float
+):
+    """No faction — least of all none at all — is penalised for the first act."""
+    era = _era_with_modifiers(own, other)
+    multiplier = compute_faction_multiplier(
+        character_faction_slug=character_faction_slug,
+        task_faction_slug=ONBOARDING_TASK_FACTION_SLUG,
+        era=era,
+    )
+    assert multiplier == own
+
+
+def test_unaffiliated_newcomer_is_not_charged_the_other_faction_modifier():
+    """The case that motivated #1619 B5, stated on its own.
+
+    A brand-new character is unaffiliated, and the onboarding task may be the
+    only thing on the board the day an era opens. Under a 0.8 other-modifier a
+    faction-carrying onboarding task pays them 8 points for a 10-point task.
+    """
+    era = _era_with_modifiers(own=1.2, other=0.8)
+    assert compute_faction_multiplier(
+        character_faction_slug=UNAFFILIATED_FACTION_SLUG,
+        task_faction_slug=ONBOARDING_TASK_FACTION_SLUG,
+        era=era,
+    ) != era.factions[UNAFFILIATED_FACTION_SLUG].other_task_modifier


### PR DESCRIPTION
Closes #1619

Two independent changes from the era grill, one commit each.

## B4 — an era rollover retires the board

`services/era.py` gains `retire_board_at_era_close`, called from `apply_era_reset` right after the duel freeze. Every task moves to `retired` except the onboarding self-portrait.

**Seam under test:** `apply_era_reset` → `task.status`. Before this, the function had no `Task` reference at all, so a rollover left the whole board active and claimable — an empty `ERA_2_TASKS` only stops the *seeder* adding more.

Retire, not delete: `praxis.task_id` is NOT NULL, so a delete would strand or destroy history.

Two judgement calls inside the ruling:

- **Pending proposals are retired too.** The ruling says "every task except the onboarding one" and a pending proposal is the closing era's content; leaving it approvable would let the cleared board come back one admin click at a time. Say the word if proposals should instead survive a rollover and I'll add the carve-out.
- **The onboarding task is spared by title.** `seed.ensure_onboarding_task` is the thing that keeps it alive in every era (#511), so the sweep recognises it by the constant the seeder owns. `services/era.py` now imports `ONBOARDING_TASK_TITLE` from `seed` — no cycle, `seed` imports models/config and never a service, and there's a comment saying so.

Both consequences from the grill are in the `retire_board_at_era_close` docstring, not just here: retired titles stay taken (`task_import` dedupes on `select(Task.title)` with no status filter, and once #1563 lands a colliding row is *silently skipped*), and the board un-hides itself as players climb past `level_to_see_retired_tasks=2` with `reset_level=True`.

## B5 — the onboarding task becomes cross-faction

`ONBOARDING_TASK_FACTION_SLUG` is now `CROSS_FACTION_SLUG` from `faction_slugs` — not the literal `"na"`, and not `UNAFFILIATED_FACTION_SLUG`, which shares the value and answers a different question.

**Seam under test:** `seed.ONBOARDING_TASK_FACTION_SLUG` read through `services.scoring.compute_faction_multiplier`. The unit test builds a **1.2/0.8 era config inline** (via `dataclasses.replace` on `ERA_1`) rather than importing Era 2, so it keeps failing on the real defect whatever the era files hold. It went red 9/19 before the fix.

The `seed.py:190-197` comment's reasons for Albescent all still held; the comment is rewritten rather than deleted, because the reason it changed (a second era makes the slug carry arithmetic) is the part worth keeping.

## The data-fix decision: **a migration ships**

`ensure_onboarding_task` is keyed on **title** and returns early when the row exists, so it will never repoint a deployed row — the code change alone would only reach fresh databases, and the newcomer this fixes is already playing on production.

`backend/alembic/versions/0004_onboarding_cross_faction.py` is a **data** migration: one parameterised `UPDATE task SET primary_faction_slug='na' WHERE title=… AND primary_faction_slug='albescent'`. Idempotent, reversible, and a no-op on a fresh DB (`0002_squashed` builds the schema before `seed.py` has inserted any task). It uses literal strings rather than importing `seed`/`faction_slugs` constants, because a migration describes a moment in time.

Verified by hand against real Postgres, since CI builds from `Base.metadata.create_all` and proves nothing about migrations: `upgrade 0003` → insert the task at `albescent` → `upgrade head` → `na` → `downgrade 0003` → `albescent` → `upgrade head` → `na`, then `alembic check` reports no drift.

## Verified against the code, not taken on trust

Every claim in the issue checked out:

- `apply_era_reset` at `services/era.py:303`; `grep -n "Task" services/era.py` returned nothing (exit 1). ✅
- `ONBOARDING_TASK_FACTION_SLUG = "albescent"` at `seed.py:206`. ✅
- `services/task_import.py:276` — `select(Task.title)`, no status filter. ✅
- `eras/era_1.py` — `level_to_see_retired_tasks=2`, `reset_level=True`, `allow_praxis_on_retired_task_factions={"ephemerists"}`. ✅
- `faction_slugs.CROSS_FACTION_SLUG` exists and its docstring says exactly what the issue says it says. ✅

One correction to the issue's parenthetical: it says "Ephemerists is not in Metamorphosis", but **Era 1** *does* list Ephemerists in `allow_praxis_on_retired_task_factions`, so on the live era that leak is real today. The docstring states it as an era-dependent leak rather than an Era-2 aside.

## Tests

```
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz1619_test \
  pytest -q --cov=. --cov-fail-under=80
```
→ **1121 passed**, coverage **92.93%** (dedicated DB `wz1619_test`; parallel agents share `worldzero_test`).

New:
- `backend/tests/integration/test_era_reset_retires_board.py` — seeds a board of every task shape (active / pending / metatask / already-retired), rolls the era, asserts everything but the onboarding task is `retired`; a second rollover still leaves the onboarding task active; and a praxis on a now-retired task still resolves its `task_id`.
- `backend/tests/unit/test_onboarding_task_faction.py` — the onboarding task pays the same multiplier to every faction slug including `na`, under 1.0/1.0 and 1.2/0.8.

Updated: `test_seed_task_sync.py` asserted `"albescent"` and hand-seeded that FK target; it now asserts `CROSS_FACTION_SLUG` and drops the extra faction row.

Backend-only — no frontend, no Pydantic model, so no `api-schema` or `frontend` surface is touched. No visual QA applies.

## What to eyeball

1. **Pending proposals get retired.** The most debatable line in the diff. Deliberate, argued above — override me if a proposal should outlive its era.
2. **`services/era.py` imports from `seed.py`.** A service importing the seed script. It is acyclic today and commented, but if it reads wrong the alternative is a third leaf module for the onboarding-task identity.
3. **The migration revision id.** `0004_onboarding_cross_faction`, `down_revision = 0003_character_tagline`. #1620/#1623/#1618 are in flight on `models/era.py` — if that work also adds an `0004_*`, the chain branches and one of the two needs re-pointing at the other.
4. **The `alembic check` claim.** Verified locally against Postgres; CI cannot see it.
5. **The `retire_board_at_era_close` docstring** — it is where the two grill consequences now live, so it is the artifact, not prose around it.
6. **The onboarding task's faction on production after deploy.** `start.sh` runs the migration then `seed.py`; the task should read `na`, and browse should still show it to a level-0 unaffiliated character.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
