### PR TITLE
Ephemerists score labels read in kanji; the numerals stay Western

### DIFF
--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import {
@@ -56,6 +57,67 @@ import type { ScoreStampProps } from "./ScoreStamp";
 const MEDALLION = 104;
 const MEDALLION_INSET = 6;
 
+/**
+ * The glyph's own voice, over whatever label voice it sits in (#1637).
+ *
+ * Three of the four properties exist to UNDO the surrounding voice rather than
+ * to dress the glyph:
+ *  • `textTransform` — `SMALL_CAPS` uppercases the plate's whole label tier, and
+ *    uppercasing a kanji costs a `text-transform` and buys nothing. The design
+ *    names this one out loud.
+ *  • `fontStyle` — the tally line is set in italic Spectral, and a CJK fallback
+ *    face has no italic, so the browser synthesises a slant. Undo it.
+ *  • `fontSize` — the label tier is `--text-xs` (8px). A Latin label is scanned
+ *    at that size; 基 is eleven strokes and simply fills in. `--text-xl` is the
+ *    smallest token inside the 13-16px band the issue names as legible, and the
+ *    labels are the only thing that grows: every figure keeps its own size.
+ * `letterSpacing` is the design's 0.06em.
+ */
+const GLYPH: CSSProperties = {
+  fontSize: "var(--text-xl)",
+  lineHeight: 1,
+  letterSpacing: "0.06em",
+  textTransform: "none",
+  fontStyle: "normal",
+};
+
+/**
+ * A label the reader decodes (#1637): the kanji is what shows, and the English
+ * is one gesture away on `title`.
+ *
+ * ONE attribute carries the whole reveal — a pointer opens it as a tooltip and
+ * assistive tech reads it out — which is the owner's ruling and not an
+ * incidental choice: a visually-hidden twin would be a second copy of the same
+ * fact, free to drift from the one on screen. The gloss handed in here is
+ * always the very string another faction's stamp prints, so the two cannot
+ * disagree about what the row is called.
+ *
+ * `<abbr>` is the element for "short form, expansion available", and it is what
+ * draws the native dotted underline — the only hint that there is anything to
+ * look up. `tabIndex` is what makes FOCUS one of the gestures; without it the
+ * glyph is pointer-only and the ruling's keyboard half is a word.
+ *
+ * ponytail: the reveal is the browser's own tooltip, so a sighted keyboard user
+ * gets it only where focus tooltips are implemented. The upgrade is a
+ * `:focus-visible` gloss reading `attr(title)` — that lives in `index.css`, is a
+ * styling decision, and is not taken here.
+ */
+function GlossedGlyph({
+  glyph,
+  gloss,
+  style,
+}: {
+  glyph: string;
+  gloss: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <abbr title={gloss} tabIndex={0} style={{ ...style, ...GLYPH }}>
+      {glyph}
+    </abbr>
+  );
+}
+
 export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
@@ -99,7 +161,11 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
             gap: "var(--space-sm)",
           }}
         >
-          <span style={label}>{t("card.stamp.base")}</span>
+          <GlossedGlyph
+            glyph={t("card.stamp.ephemerists.base")}
+            gloss={t("card.stamp.base")}
+            style={label}
+          />
           <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", lineHeight: 0.8, color: INK }}>
             {base}
           </span>
@@ -156,7 +222,11 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
         </div>
       )}
 
-      {/* The tally, always drawn — `+ 0 from votes` is a fact, not a gap. */}
+      {/* The tally, always drawn — `+ 0 票` is a fact, not a gap. The `+` and
+          the figure are arithmetic, not copy, so they are set here rather than
+          interpolated into a sentence: this is the one line where a label and a
+          numeral sit together, and #1637's whole bound is that only the label
+          is encoded. */}
       <div
         style={{
           fontFamily: READING,
@@ -166,7 +236,11 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
           marginTop: "var(--space-sm)",
         }}
       >
-        {t("card.stamp.fromVotes", { votes })}
+        + {votes}{" "}
+        <GlossedGlyph
+          glyph={t("card.stamp.ephemerists.fromVotes")}
+          gloss={t("card.stamp.ephemerists.fromVotesGloss")}
+        />
       </div>
 
       {/* The total, struck in the stepped octagon on its lotus base. */}
@@ -214,17 +288,11 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
             <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", color: OCHRE }}>
               {total.toFixed(1)}
             </span>
-            <span
-              style={{
-                ...SMALL_CAPS,
-                fontSize: "var(--text-xs)",
-                letterSpacing: "0.2em",
-                color: CAPTION,
-                marginTop: "var(--space-xs)",
-              }}
-            >
-              {t("card.stamp.points")}
-            </span>
+            <GlossedGlyph
+              glyph={t("card.stamp.ephemerists.points")}
+              gloss={t("card.stamp.points")}
+              style={{ ...SMALL_CAPS, color: CAPTION, marginTop: "var(--space-xs)" }}
+            />
           </div>
         </div>
         {/* The lotus itself, closing the cell. */}

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -292,10 +292,19 @@ const STATES = [
  * Every stamp labels the row from the same key, so one assertion covers all
  * eight: the label is present exactly when the resolver kept the figure.
  */
-function expectBaseRow(html: string, showsBase: boolean) {
-  if (showsBase) expect(html).toContain('base')
-  else expect(html).not.toContain('base')
+function expectBaseRow(html: string, showsBase: boolean, baseLabel = 'base') {
+  if (showsBase) expect(html).toContain(baseLabel)
+  else expect(html).not.toContain(baseLabel)
 }
+
+/**
+ * The Ephemerists' rows are the same rows under different NAMES (#1637): the
+ * labels are kanji and the English rides on `title`, which `text()` strips with
+ * the tag it lives on. So every shared row assertion below hands in the glyph
+ * the reader actually sees — passing the English would go quietly green on the
+ * NEGATIVE half ("no base row") while proving nothing about the positive one.
+ */
+const EPHEMERISTS_LABEL = { base: '基', points: '点', fromVotes: '票' } as const
 
 /**
  * The five conditional states of design v2, on both #841 stamps. The failure
@@ -322,8 +331,8 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
       const html = text(
         renderToStaticMarkup(<EphemeristsScoreStamp praxis={praxis({ ...fields })} />),
       )
-      expectBaseRow(html, showsBase)
-      expect(html).toContain('from votes')
+      expectBaseRow(html, showsBase, EPHEMERISTS_LABEL.base)
+      expect(html).toContain(EPHEMERISTS_LABEL.fromVotes)
       expect(html).toContain(fields.score.toFixed(1))
       expect(html).not.toMatch(HEX)
     })
@@ -496,15 +505,21 @@ describe('#842 stamps across the conditional states (ADR-0047)', () => {
  * waiting surface shows the moment you submit.
  */
 describe('the base row leaves every stamp when it restates the total (#1131)', () => {
+  /**
+   * Each stamp with the two words this case reads off it — the base label it
+   * would print, and the votes label it must still print. Seven say them in
+   * English; the Ephemerists say them in kanji (#1637), and handing in 'base'
+   * there would assert nothing at all.
+   */
   const STAMPS = [
-    ['the unaffiliated sheet', DefaultScoreStamp],
-    ['Everymen', EverymenScoreStamp],
-    ['the Ephemerists', EphemeristsScoreStamp],
-    ['S.N.I.D.E.', SnideScoreStamp],
-    ['Singularity', SingularityScoreStamp],
-    ['WOW', WowScoreStamp],
-    ['Coven', CovenScoreStamp],
-    ['UA', UaScoreStamp],
+    ['the unaffiliated sheet', DefaultScoreStamp, 'base', /votes/],
+    ['Everymen', EverymenScoreStamp, 'base', /votes/],
+    ['the Ephemerists', EphemeristsScoreStamp, EPHEMERISTS_LABEL.base, /票/],
+    ['S.N.I.D.E.', SnideScoreStamp, 'base', /votes/],
+    ['Singularity', SingularityScoreStamp, 'base', /votes/],
+    ['WOW', WowScoreStamp, 'base', /votes/],
+    ['Coven', CovenScoreStamp, 'base', /votes/],
+    ['UA', UaScoreStamp, 'base', /votes/],
   ] as const
 
   /** No multiplier, no metatask, no votes: base IS the total. */
@@ -516,17 +531,17 @@ describe('the base row leaves every stamp when it restates the total (#1131)', (
     score: 10,
   })
 
-  for (const [name, Stamp] of STAMPS) {
+  for (const [name, Stamp, baseLabel, votesLabel] of STAMPS) {
     it(`${name} states the figure once, and still says nobody has voted`, () => {
       const html = text(renderToStaticMarkup(<Stamp praxis={bare} />))
-      expect(html).not.toContain('base')
+      expect(html).not.toContain(baseLabel)
       // The total mark stays — under ADR-0049 it is the faction's signature
       // device, so it is the one number that never drops out. Singularity's
       // two-decimal `10.00` contains this too.
       expect(html).toContain('10.0')
       // And the votes row stays at +0: ADR-0047's declared exception, which the
       // owner re-affirmed against hiding it alongside base.
-      expect(html).toMatch(/votes/)
+      expect(html).toMatch(votesLabel)
       // The label is gone, not blanked: no orphaned figure left behind.
       expect(html).not.toMatch(/\b10\b(?!\.)/)
     })
@@ -686,5 +701,84 @@ describe('PraxisOut satisfies the stamp contract without a cast (#1079)', () => 
         pickVariant(surfaceMap('scoreStamp'), covenDetail.task_faction_slug, DefaultScoreStamp),
       ),
     ).toBe(CovenScoreStamp)
+  })
+})
+
+/**
+ * #1637 — the Ephemerists label their score in kanji, and ONLY the labels.
+ *
+ * The seam under test is the rendered label markup of the Ephemerists stamp:
+ * which string reaches the glyph slot, and what the reader can get back out of
+ * it. It is an i18n change, not a DOM one — the design walks every text node
+ * with a `TreeWalker` because a canvas cannot reach the components, and a sweep
+ * built from that would rewrite the word "base" anywhere on the page.
+ *
+ * The bound that makes the puzzle acceptable is asserted here as its own case:
+ * the cost of not decoding is losing a LABEL, never a number. So the numerals
+ * assertion is not a nicety — it is the rule. A future skin that renders 四 for
+ * a vote count would render fine, read beautifully, and be the defect.
+ */
+describe('the Ephemerists label their score in kanji (#1637)', () => {
+  /** A praxis with every row live, so all three substituted labels are drawn. */
+  const full = () =>
+    renderToStaticMarkup(
+      <EphemeristsScoreStamp
+        praxis={praxis({
+          task_point_value: 40,
+          display_multiplier: 1.2,
+          metatask_points: 0,
+          points_from_votes: 4,
+          score: 52,
+        })}
+      />,
+    )
+
+  it('prints the glyphs, and none of the English, in the visible text', () => {
+    const html = text(full())
+    expect(html).toContain('基')
+    expect(html).toContain('点')
+    expect(html).toContain('票')
+    expect(html).not.toContain('base')
+    expect(html).not.toContain('points')
+    expect(html).not.toContain('from votes')
+  })
+
+  it('leaves every numeral Western — undecoded, the arithmetic still checks out', () => {
+    const html = text(full())
+    expect(html).toContain('40')
+    expect(html).toContain('×1.20')
+    expect(html).toContain('+ 4 ')
+    expect(html).toContain('52.0')
+    // The one thing that would break the bound: a number written as a glyph.
+    expect(html).not.toMatch(/[〇一二三四五六七八九十百千万]/)
+  })
+
+  it('carries the English on one attribute, for hover, focus and assistive tech', () => {
+    const markup = full()
+    // `title` is the whole reveal: a pointer opens it as a tooltip and AT reads
+    // it out, so there is no second accessibility path that could drift.
+    for (const gloss of ['base', 'points', 'from votes']) {
+      expect(markup).toContain(`title="${gloss}"`)
+    }
+    // …and every substituted label is reachable, so FOCUS is a real gesture and
+    // not just a word in the ruling.
+    expect(markup.match(/tabindex="0"/g)).toHaveLength(3)
+    // `<abbr>` is the element that says "short form, expansion available" — it
+    // is what draws the native dotted underline hinting there is a lookup here.
+    expect(markup.match(/<abbr /g)).toHaveLength(3)
+  })
+
+  it('never uppercases a kanji, whatever voice the surrounding label wears', () => {
+    // SMALL_CAPS sets `text-transform: uppercase` for the plate's whole label
+    // voice; uppercasing does nothing to a kanji but cost it the override.
+    expect(full().match(/text-transform:none/g)).toHaveLength(3)
+  })
+
+  it('leaves every other faction reading in English', () => {
+    const html = text(renderToStaticMarkup(<DefaultScoreStamp praxis={praxis({})} />))
+    expect(html).toContain('base')
+    expect(html).toContain('points')
+    expect(html).toContain('from votes')
+    expect(html).not.toMatch(/[基点票計]/)
   })
 })

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -50,7 +50,13 @@
       "pointsShort": "pts",
       "tally": "TALLY",
       "group": "group",
-      "onTheRecord": "★ VERIFIED ★ ON THE RECORD "
+      "onTheRecord": "★ VERIFIED ★ ON THE RECORD ",
+      "ephemerists": {
+        "base": "基",
+        "points": "点",
+        "fromVotes": "票",
+        "fromVotesGloss": "from votes"
+      }
     },
     "mediaEmpty": "no proof attached",
     "adminStatus": {


### PR DESCRIPTION
The four score-breakdown labels are substituted where they are **authored** — a
`card.stamp.ephemerists` block in `praxis.json`, read by the one component that
already dispatches on the task's faction. No `TreeWalker`, no DOM sweep: the
design walks text nodes because a canvas cannot reach the components that render
the labels, and a sweep built from that would also rewrite the word "base"
wherever else it appears on the page.

## Seam under test

The **rendered label markup of `EphemeristsScoreStamp`** — which string reaches
the glyph slot, and what a reader can get back out of it. The loop went red on
that seam first (three of five new cases failed: no glyphs, no `title=`, no
`text-transform:none`), then green.

## What changed

- `frontend/src/locales/en/praxis.json` — new `card.stamp.ephemerists` block:
  `基` / `点` / `票`, plus one English gloss (`fromVotesGloss`) for the label half
  of the shared `"+ {{votes}} from votes"` sentence, which has no bare key.
- `frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx` —
  a local `GlossedGlyph`, and three call sites.
- `frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx` —
  a new `#1637` describe, and six pre-existing shared assertions made
  faction-aware.

## Decisions worth arguing with

**Three labels, not four.** `基` (base), `点` (points) and `票` (from votes) all
render. `計` (total) has **no render site** — `card.stamp.total` is unused
repo-wide (only Singularity's `totalShort`, and it is not an Ephemerists
surface), so adding a variant for it would be dead copy. Say the word if you'd
rather it land now against the masthead work.

**`mult` and `meta` stay English.** They are not in the specified set of four,
and encoding them is a set the issue reserves. The cell currently reads
`基 40 · MULT ×1.20 · META +20 · + 4 票 · 52.0 点`, which is mixed. Happy to
extend it — that is a one-line follow-up — but it is a wider ruling than the
issue makes.

**One attribute, and `<abbr>`.** `title` is the whole reveal: a pointer opens it
as a native tooltip and assistive tech reads it out. No visually-hidden twin, per
the ruling — a second copy of the same fact is a second copy free to drift. The
gloss handed in is literally the string another faction's stamp prints
(`t("card.stamp.base")`), so the two cannot disagree about what the row is
called. `<abbr>` is the element for "short form, expansion available" and is what
draws the native dotted underline — the only hint that there *is* a lookup here.
`tabIndex={0}` makes **focus** a real gesture; without it the glyph is
pointer-only and the keyboard half of the ruling is just a word. Cost: three
extra tab stops per stamp.

**`ponytail`** in the file: the reveal is the *browser's* tooltip, so a sighted
keyboard user gets it only where focus tooltips are implemented. The upgrade is a
`:focus-visible` gloss reading `attr(title)` — that lives in `index.css`, which
is `frontend-style`'s file and a styling decision, so it is not taken here.

**No webfont.** `基` `点` `票` are common CJK Unified Ideographs, covered by the
system stack everywhere (Yu Gothic UI / Microsoft YaHei on Windows, PingFang on
Apple, Noto CJK on Android). Per-character fallback carries them through the
plate's Cinzel/Spectral stacks. `docs/agents/load-time.md` is satisfied by adding
nothing: **initial-load budget unchanged, JS 127.9 KB / CSS 22.2 KB, within
budget.**

**The labels grew to `--text-xl` (14px).** The plate's label tier is `--text-xs`
= **8px**. A Latin label is *scanned* at 8px; `基` is eleven strokes and simply
fills in. `--text-xl` is the smallest existing token inside the 13-16px band the
issue names. Only the labels grow — every figure keeps its size. This is the one
thing here that is really a **styling** call, so flagging it for `frontend-style`
rather than assuming.

Also carried: the design's `text-transform: none` (the plate's `SMALL_CAPS`
uppercases the whole label tier) and `letter-spacing: 0.06em`, plus a
`font-style: normal` the design did not need — the tally line is italic Spectral,
and a CJK fallback face has no italic, so the browser would synthesise a slant.

## Surfaces

One component, two mounts: the **praxis card** (feed, `/praxis`, task detail,
faction pages) and the **praxis detail** score rail — `EphemeristsPraxisDetail`
renders `<ScoreStamp>` rather than its own breakdown, so both are fixed once
where they route through. The composer's waiting slip mounts it too.

## Verification

`eslint` · `tsc --noEmit` · `vitest run` (**229 files, 3985 tests, all pass**) ·
`vite build` · initial-load budget · `typecheck:design-sync` — all green locally.
No API touched, so `schema.d.ts` is unchanged. **I have no browser: visual QA is
outstanding.**

## What to eyeball

1. **Praxis card, Ephemerists task** (feed / `/praxis`) — the tally cell should
   read `基 40`, `+ 4 票`, `52.0 点`, with `MULT`/`META` still in English.
2. **Praxis detail score rail** for the same praxis — same cell, no crown.
3. **Hover a glyph.** The native tooltip should say `base` / `points` /
   `from votes`. Note the dotted underline under each kanji — that is `<abbr>`'s
   native affordance and is meant to stay.
4. **Tab to a glyph.** It takes focus. Whether your browser pops the `title` on
   focus is the `ponytail` above — if it doesn't, that is the known ceiling and
   the CSS upgrade is the fix.
5. **Legibility at 14px**, light and dark. `基` is the busy one; if it mushes,
   the size call is the thing to move.
6. **The empty state** (fresh praxis, no votes, ×1.0): base row drops, cell reads
   `+ 0 票` then `10.0 点`. No orphaned glyph.
7. **Any non-Ephemerists card** — must be untouched English.

Closes #1637
