### PR TITLE
CredentialCard: drop the kicker and bio, grow the portrait, and swap the faction label for a labelled sigil

### DIFF
--- a/.design-sync/previews/CredentialCard.tsx
+++ b/.design-sync/previews/CredentialCard.tsx
@@ -1,7 +1,8 @@
 // CredentialCard preview cells — the skinnable faction "passport" card (#271):
 // one structure re-skinned per faction via the --faction-<slug>-card-* tokens.
-// Portrait ring, name, clamped bio, faction pill, level + score. Cells sweep a
-// couple of faction skins plus the neutral (unaffiliated) treatment.
+// Portrait ring, name, a labelled faction sigil, level + score (#1626 dropped
+// the kicker and the clamped bio; the bio lives on the profile's About block).
+// Cells sweep a couple of faction skins plus the neutral (unaffiliated) one.
 import { CredentialCard } from 'worldzero-frontend'
 import { mockCredential } from './_fixtures'
 
@@ -23,7 +24,6 @@ export function FactionSkins() {
       <CredentialCard
         displayName="node_44"
         handle="node_44"
-        bio="Instruments the self. Publishes the raw series, not the story."
         factionSlug="singularity"
         level={6}
         score={512}
@@ -32,7 +32,6 @@ export function FactionSkins() {
       <CredentialCard
         displayName="Pip Marigold"
         handle="pip_marigold"
-        bio="Chalk on every sidewalk. Believes joy is a public work."
         factionSlug="wow"
         level={3}
         score={140}
@@ -42,14 +41,13 @@ export function FactionSkins() {
   )
 }
 
-/** Unaffiliated — the neutral field treatment: no faction pill, blank-passport bio. */
+/** Unaffiliated — the neutral field treatment: spectrum ring, spectrum sigil. */
 export function Unaffiliated() {
   return (
     <div style={wrap}>
       <CredentialCard
         displayName="New Recruit"
         handle="new_recruit"
-        bio={null}
         factionSlug={null}
         level={0}
         score={0}

--- a/.design-sync/previews/_fixtures.tsx
+++ b/.design-sync/previews/_fixtures.tsx
@@ -105,7 +105,8 @@ export function makeCharacter(overrides: Partial<CharacterOut> = {}): CharacterO
     id: 7,
     username: 'ada_reed',
     display_name: 'Ada Reed',
-      // Deliberately a slogan, not the bio's first sentence — the two fields are
+    bio: 'Cartographer of small kindnesses. Plants trees she will not sit beneath.',
+    // Deliberately a slogan, not the bio's first sentence — the two fields are
     // separate jobs (#1628), and a fixture that blurred them would let a design
     // be built against a distinction the product does not make.
     tagline: 'Slow spells, strong tea.',

--- a/.design-sync/previews/_fixtures.tsx
+++ b/.design-sync/previews/_fixtures.tsx
@@ -105,8 +105,7 @@ export function makeCharacter(overrides: Partial<CharacterOut> = {}): CharacterO
     id: 7,
     username: 'ada_reed',
     display_name: 'Ada Reed',
-    bio: 'Cartographer of small kindnesses. Plants trees she will not sit beneath.',
-    // Deliberately a slogan, not the bio's first sentence — the two fields are
+      // Deliberately a slogan, not the bio's first sentence — the two fields are
     // separate jobs (#1628), and a fixture that blurred them would let a design
     // be built against a distinction the product does not make.
     tagline: 'Slow spells, strong tea.',
@@ -368,7 +367,6 @@ export const mockCollaboration: PraxisCardOut = {
 export const mockCredential: CredentialCardProps = {
   displayName: 'Ada Reed',
   handle: 'ada_reed',
-  bio: 'Cartographer of small kindnesses. Plants trees she will not sit beneath.',
   factionSlug: 'ua',
   level: 4,
   score: 320,

--- a/frontend/src/components/CredentialCard.tsx
+++ b/frontend/src/components/CredentialCard.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
+import FactionSigil from './sigil/FactionSigil'
 import { factionName, isKnownFaction } from '../utils/factions'
 
 /**
@@ -13,7 +14,6 @@ import { factionName, isKnownFaction } from '../utils/factions'
 export interface CredentialCardProps {
   displayName: string
   handle: string
-  bio?: string | null
   factionSlug?: string | null
   level: number
   score: number
@@ -75,7 +75,6 @@ const NEUTRAL: Skin = {
 export default function CredentialCard({
   displayName,
   handle,
-  bio,
   factionSlug,
   level,
   score,
@@ -88,7 +87,6 @@ export default function CredentialCard({
   const skinned = skinFor(factionSlug)
   const skin = skinned ?? NEUTRAL
   const name = displayName.trim() || t('credential.fallbackName')
-  const cardBio = (bio ?? '').trim()
 
   const cardStyle: CSSProperties = {
     // Local skin vars consumed by descendants.
@@ -115,7 +113,10 @@ export default function CredentialCard({
 
   return (
     <div style={cardStyle}>
-      {/* eyebrow: @handle + credential / unaffiliated tag */}
+      {/* eyebrow: @handle. The "CREDENTIAL" / "UNAFFILIATED" kicker that used to
+          sit opposite it is gone (#1626) — it named the object the reader is
+          already holding, and its unaffiliated variant said a second time what
+          the footer sigil says. */}
       <div
         style={{
           display: 'flex',
@@ -128,7 +129,6 @@ export default function CredentialCard({
         }}
       >
         <span>@{handle}</span>
-        <span>{skinned ? t('credential.credential') : t('credential.unaffiliated')}</span>
       </div>
 
       {/* portrait ring. Rendered as a <button> only when it's an upload affordance —
@@ -138,8 +138,9 @@ export default function CredentialCard({
         {(() => {
           const ringStyle: CSSProperties = {
             position: 'relative',
-            width: 96,
-            height: 96,
+            // The portrait is the card's subject, not one of its fields (#1626).
+            width: 136,
+            height: 136,
             borderRadius: '50%',
             padding: 'var(--space-xs)',
             boxSizing: 'border-box',
@@ -207,26 +208,11 @@ export default function CredentialCard({
         {name}
       </div>
 
-      {/* bio (clamped to 2 lines) */}
-      <div
-        style={{
-          fontFamily: 'var(--font-body)',
-          fontSize: 'var(--text-content)',
-          lineHeight: 1.55,
-          color: 'var(--fc-muted)',
-          margin: 'var(--space-sm) auto 0',
-          maxWidth: 210,
-          display: '-webkit-box',
-          WebkitLineClamp: 2,
-          WebkitBoxOrient: 'vertical',
-          overflow: 'hidden',
-          minHeight: cardBio ? undefined : 12,
-        }}
-      >
-        {cardBio || (skinned ? '' : t('credential.blankPassport'))}
-      </div>
+      {/* No bio slot. A two-line clamp could only ever show the first sentence
+          of a 500-character field, so the bio moved to the profile's ② About
+          block, where it is read whole (#1626, `archetypes/profileSkin.tsx`). */}
 
-      {/* footer: pill + level + score */}
+      {/* footer: sigil + level + score */}
       <div
         style={{
           display: 'flex',
@@ -238,35 +224,34 @@ export default function CredentialCard({
           paddingTop: 'var(--space-md)',
         }}
       >
-        {skinned ? (
-          <span
-            style={{
-              background: 'var(--fc-accent)',
-              color: 'var(--fc-bg)',
-              fontFamily: 'var(--fc-font)',
-              fontSize: 'var(--text-md)',
-              padding: 'var(--space-xs) var(--space-md)',
-              borderRadius: 4,
-              lineHeight: 1.3,
-            }}
-          >
-            {factionName(factionSlug)}
-          </span>
-        ) : (
-          <span
-            style={{
-              fontStyle: 'italic',
-              fontFamily: 'var(--font-display)',
-              fontSize: 'var(--text-sm)',
-              color: 'var(--fc-muted)',
-            }}
-          >
-            {t('credential.factionToBeChosen')}
-          </span>
-        )}
+        {/* The faction is the sigil now — the name is spoken, never printed
+            (#1626). `role="img"` + the catalog name is the whole accessible
+            name: it makes the mark a labelled image rather than decoration, so
+            a screen reader still gets "Cozy Coven" where a sighted reader gets
+            the mark. Unaffiliated and unknown slugs are not a hole — they get
+            `FactionSigil`'s spectrum `DefaultSigil` and the name `na` resolves
+            to. The card stays slug-blind: which sigil belongs to which slug is
+            `FactionSigil`'s dispatch to answer, including albescent's. */}
+        <span
+          role="img"
+          aria-label={factionName(factionSlug)}
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flex: 'none',
+            width: 42,
+            height: 42,
+            borderRadius: '50%',
+            border: '2px solid var(--fc-accent)',
+            background: 'transparent',
+          }}
+        >
+          <FactionSigil slug={factionSlug} size={28} />
+        </span>
         <span
           style={{
-            fontSize: 'var(--text-xs)',
+            fontSize: 'var(--text-lg)',
             letterSpacing: '0.1em',
             textTransform: 'uppercase',
             color: 'var(--fc-muted)',

--- a/frontend/src/components/__tests__/credentialCard.test.tsx
+++ b/frontend/src/components/__tests__/credentialCard.test.tsx
@@ -1,34 +1,39 @@
 /**
  * CredentialCard skin contract (#271). One structure, color + font only:
  * a faction with card tokens skins via --faction-<slug>-card-*; everything else
- * (na, factionless) falls to the neutral field treatment with no faction pill.
+ * (na, factionless) falls to the neutral field treatment.
+ *
+ * #1626 trimmed that structure to the three facts a credential carries — who,
+ * which faction, how far along — so the assertions below are as much about what
+ * the card no longer prints as about what it does.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect } from 'vitest'
 // Initialize the i18n catalog so the copy keys resolve to English text.
 import '../../i18n'
 import CredentialCard from '../CredentialCard'
+import { factionName } from '../../utils/factions'
+
+/** What a sighted reader can actually read: markup minus every tag/attribute. */
+const visibleText = (html: string) => html.replace(/<[^>]*>/g, ' ')
 
 describe('CredentialCard', () => {
-  it('skins to the faction token set and shows the faction pill', () => {
+  it('skins to the faction token set', () => {
     const html = renderToStaticMarkup(
-      <CredentialCard displayName="Marlow Quill" handle="marlowquill" bio="x" factionSlug="coven" level={3} score={42} />,
+      <CredentialCard displayName="Marlow Quill" handle="marlowquill" factionSlug="coven" level={3} score={42} />,
     )
     expect(html).toContain('--faction-coven-card-bg')
     expect(html).toContain('Marlow Quill')
     expect(html).toContain('@marlowquill')
-    expect(html).toContain('Cozy Coven') // faction pill label
     expect(html).toContain('42')
   })
 
-  it('renders the neutral UNAFFILIATED treatment for na (not aliased to ua)', () => {
+  it('renders the neutral treatment for na (not aliased to ua)', () => {
     const html = renderToStaticMarkup(
       <CredentialCard displayName="Wren" handle="wren" factionSlug="na" level={1} score={0} />,
     )
     expect(html).toContain('--color-bg-surface-alt')
     expect(html).not.toContain('--faction-ua-card-bg')
-    expect(html).toContain('unaffiliated')
-    expect(html).toContain('faction to be chosen')
   })
 
   it('falls back to "Wanderer" when the name is blank', () => {
@@ -36,6 +41,127 @@ describe('CredentialCard', () => {
       <CredentialCard displayName="   " handle="wanderer" factionSlug={null} level={1} score={0} />,
     )
     expect(html).toContain('Wanderer')
+  })
+})
+
+/**
+ * #1626 delta 1. The kicker printed "CREDENTIAL" opposite the handle — the
+ * card naming the object the reader is already holding — and "UNAFFILIATED" for
+ * everyone else, which the footer sigil says again. The handle is the half of
+ * that row that identifies anyone, so it stays.
+ */
+describe('CredentialCard eyebrow — the kicker is gone, the handle is not', () => {
+  it('keeps the @handle', () => {
+    const html = renderToStaticMarkup(
+      <CredentialCard displayName="Marlow Quill" handle="marlowquill" factionSlug="coven" level={3} score={42} />,
+    )
+    expect(visibleText(html)).toContain('@marlowquill')
+  })
+
+  it.each(['coven', 'na', null])('prints no kicker for %s', (slug) => {
+    const html = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" factionSlug={slug} level={1} score={0} />,
+    )
+    const text = visibleText(html).toLowerCase()
+    expect(text, 'the CREDENTIAL kicker').not.toContain('credential')
+    expect(text, 'the UNAFFILIATED kicker').not.toContain('unaffiliated')
+  })
+})
+
+/**
+ * #1626 delta 4 + the owner ruling: "I want screen readers to have the faction
+ * name, but for the name to not show up on the screen." The footer pill (a
+ * faction name in the faction's own font) became a 42px hoop around a 28px
+ * sigil, so the mark carries the identity and `aria-label` carries the word.
+ *
+ * The card stays SLUG-BLIND: it asks `FactionSigil` for a sigil by slug and
+ * takes what it is given. There is no `if (slug === ...)` here to drift.
+ */
+describe('CredentialCard footer sigil — spoken, never printed', () => {
+  const label = (html: string) => /aria-label="([^"]*)"/.exec(html)?.[1]
+
+  it.each(['coven', 'ua', 'snide', 'everymen', 'singularity', 'wow', 'ephemerists', 'albescent'])(
+    'names %s to assistive tech and to nobody else',
+    (slug) => {
+      const html = renderToStaticMarkup(
+        <CredentialCard displayName="Wren" handle="wren" factionSlug={slug} level={1} score={0} />,
+      )
+      expect(label(html), 'the sigil is a labelled image').toBe(factionName(slug))
+      expect(html).toContain('role="img"')
+      expect(visibleText(html), 'no faction name on screen').not.toContain(factionName(slug))
+    },
+  )
+
+  it('drops the "faction to be chosen" placeholder for the spectrum sigil', () => {
+    const html = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" factionSlug="na" level={1} score={0} />,
+    )
+    expect(visibleText(html)).not.toContain('faction to be chosen')
+    expect(label(html)).toBe(factionName('na'))
+  })
+
+  it.each([
+    ['na', 'na'],
+    ['a slug no manifest knows', 'totally-unknown'],
+    ['no slug at all', null],
+  ])('draws the DefaultSigil ring for %s rather than a hole', (_case, slug) => {
+    const html = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" factionSlug={slug} level={1} score={0} />,
+    )
+    expect(html, 'the unaffiliated spectrum ring').toContain('--faction-default-rainbow-conic')
+  })
+
+  // The one named hazard (#783): albescent registers no `sigil` row, so the
+  // dispatcher used to hand it the unaffiliated ring while its own cross-hair
+  // sat in components/sigil/. Resolved inside FactionSigil, not here — this
+  // asserts the card GETS the right mark, which is all the card may know.
+  it('gets albescent its own cross-hair, without a branch in the card', () => {
+    const rings = (html: string) => html.split('--faction-default-rainbow-conic').length - 1
+    const albescent = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" factionSlug="albescent" level={1} score={0} />,
+    )
+    const unaffiliated = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" factionSlug="na" level={1} score={0} />,
+    )
+    expect(albescent, "albescent's always-light reveal ink").toContain('--albescent-reveal-text')
+    // na wears the spectrum TWICE — portrait hoop and sigil. Albescent keeps the
+    // hoop (it is unthemed on purpose, #783) and the sigil is the one thing that
+    // differs, so counting the ring is what tells the two apart.
+    expect(rings(unaffiliated), 'na: hoop + sigil').toBe(2)
+    expect(rings(albescent), 'albescent: hoop only, the sigil is its own').toBe(1)
+  })
+})
+
+/**
+ * #1626 delta 3. A two-line clamp on a 500-character field only ever showed its
+ * first sentence, so the bio moved to the profile's ② About block. The card
+ * cannot render it at ANY mount because it no longer accepts it — this pins the
+ * runtime half of that (no clamp, no blank-passport filler); the compiler pins
+ * the rest at the four call sites.
+ */
+describe('CredentialCard has no bio slot', () => {
+  it('prints no bio and no placeholder for it', () => {
+    const html = renderToStaticMarkup(
+      <CredentialCard displayName="Wren" handle="wren" factionSlug="coven" level={1} score={0} />,
+    )
+    expect(html, 'the two-line clamp').not.toContain('-webkit-line-clamp')
+    expect(visibleText(html), 'the blank-passport filler').not.toContain('blank passport')
+  })
+})
+
+/** #1626 deltas 2 + 5: the portrait is the subject; the level is a footnote. */
+describe('CredentialCard proportions', () => {
+  const html = renderToStaticMarkup(
+    <CredentialCard displayName="Wren" handle="wren" factionSlug="coven" level={4} score={9} />,
+  )
+
+  it('gives the portrait ring 136px, not 96', () => {
+    expect(html).toContain('width:136px')
+    expect(html).not.toContain('width:96px')
+  })
+
+  it('sets the level readout at the 12px step', () => {
+    expect(html).toMatch(/font-size:var\(--text-lg\)[^"]*"[^>]*>lvl 4/)
   })
 })
 

--- a/frontend/src/components/sigil/FactionSigil.tsx
+++ b/frontend/src/components/sigil/FactionSigil.tsx
@@ -2,6 +2,7 @@ import type { } from "react";
 import { pickVariant } from "../../utils/factionDispatch";
 import { surfaceMap } from "../../factions";
 import { factionCssVar } from "../../utils/factions";
+import AlbescentSigil from "./AlbescentSigil";
 import { SingularitySigil } from "./SingularitySigil";
 import { UaSigil } from "./UaSigil";
 import DefaultSigil from "./DefaultSigil";
@@ -36,6 +37,29 @@ export function SingularitySigilAdapter({ size, color }: SigilVariantProps) {
   );
 }
 
+/**
+ * Albescent's surveyor's cross-hair (#1626). It is the faction's only mark and
+ * it is drawn everywhere else it appears — the invitation, the faction-select
+ * tile — but `factions/albescent.ts` registers no `sigil` row, so asking this
+ * dispatcher for `albescent` handed back the unaffiliated spectrum ring while a
+ * finished `AlbescentSigil` sat one directory over. Every caller that hit it
+ * (the faction filter facet, the mobile players chip row, the requests-queue
+ * tray, and now the credential footer) had to either live with the wrong mark
+ * or branch on the slug itself — four copies of one gap.
+ *
+ * WHY THE ADAPTER AND NOT THE MANIFEST. `albescent.ts`'s contract is explicit:
+ * anything added there must be "a flourish LAYERED OVER Default's structure",
+ * because a surface that repaints Albescent in its own colours un-hides the
+ * society (#783). A bespoke emblem drawn on the always-light
+ * `--albescent-reveal-*` register is not Default-plus-a-flourish, so it is not a
+ * manifest row. It resolves here instead, where the mark→slug question already
+ * lives — and it sits BEFORE the spread, so the day albescent does declare a
+ * `sigil` the manifest wins and this line quietly stops mattering.
+ */
+function AlbescentSigilAdapter({ size, color }: SigilVariantProps) {
+  return <AlbescentSigil size={size ?? 22} color={color} />;
+}
+
 function DefaultSigilAdapter({ size }: SigilVariantProps) {
   // The default ring has no color prop — it draws
   // --faction-default-rainbow-conic.
@@ -43,6 +67,10 @@ function DefaultSigilAdapter({ size }: SigilVariantProps) {
 }
 
 export default function FactionSigil({ slug, size, color }: FactionSigilProps) {
-  const Variant = pickVariant(surfaceMap('sigil'), slug, DefaultSigilAdapter);
+  const Variant = pickVariant(
+    { albescent: AlbescentSigilAdapter, ...surfaceMap("sigil") },
+    slug,
+    DefaultSigilAdapter,
+  );
   return <Variant size={size} color={color} />;
 }

--- a/frontend/src/components/sigil/__tests__/factionSigil.test.tsx
+++ b/frontend/src/components/sigil/__tests__/factionSigil.test.tsx
@@ -51,6 +51,17 @@ describe("FactionSigil dispatcher (#659)", () => {
     expect(html).toContain("var(--everymen-cream)");
   });
 
+  // #1626. `factions/albescent.ts` registers no `sigil` row — and must not,
+  // since its manifest takes only Default-plus-a-flourish surfaces (#783) — so
+  // the dispatcher used to hand albescent the unaffiliated ring while its own
+  // cross-hair sat one directory over. Resolved HERE, once, rather than by a
+  // slug branch in each of the four callers.
+  it("renders the surveyor's cross-hair for the albescent slug", () => {
+    const html = renderToStaticMarkup(<FactionSigil slug="albescent" />);
+    expect(html, "the always-light reveal ink").toContain("var(--albescent-reveal-text)");
+    expect(html, "not the unaffiliated ring").not.toContain("var(--faction-default-rainbow-conic)");
+  });
+
   it("falls back to the unaffiliated ring for an unknown slug", () => {
     const html = renderToStaticMarkup(<FactionSigil slug="totally-unknown" />);
     expect(html).toContain("var(--faction-default-rainbow-conic)");

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -29,6 +29,7 @@
     "ptsThisLevel": "{{current}} / {{span}} pts this level",
     "nextLevel": "next · lvl {{level}}",
     "ptsToNext": "{{score}} / {{threshold}} pts",
+    "aboutHeading": "About",
     "badgesHeading": "Badges",
     "badgesEarned": "{{count}} earned",
     "mobile": {
@@ -117,11 +118,7 @@
   },
   "credential": {
     "fallbackName": "Wanderer",
-    "credential": "credential",
-    "unaffiliated": "unaffiliated",
     "uploadTitle": "Click to upload a photo",
-    "blankPassport": "A blank passport, waiting for its first stamp.",
-    "factionToBeChosen": "— faction to be chosen —",
     "lvl": "lvl {{level}}",
     "pts": "pts"
   },

--- a/frontend/src/pages/CreateCharacter.tsx
+++ b/frontend/src/pages/CreateCharacter.tsx
@@ -187,7 +187,6 @@ function DesktopCreateCharacter({ state }: { state: CreateCharacterState }) {
           <CredentialCard
             displayName={displayName || t('createCharacter.previewFallbackName')}
             handle={handle}
-            bio={bio}
             factionSlug={factionSlug || null}
             level={1}
             score={0}

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -202,7 +202,6 @@ export default function FieldDesk() {
                   <CredentialCard
                     displayName={life.display_name}
                     handle={life.username}
-                    bio={life.bio}
                     factionSlug={life.faction_slug}
                     level={life.level}
                     score={life.score}

--- a/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/factionProfileBody.test.tsx
@@ -86,7 +86,18 @@ describe("FactionProfileBody dispatch", () => {
     expect(skinOf("albescent").length).toBeGreaterThan(0);
     // And no trace of the deleted token block. This is the assertion that
     // caught CredentialCard still painting from --faction-albescent-card-bg.
-    expect(renderBody({ faction_slug: "albescent" })).not.toContain("albescent");
+    //
+    // #1626 narrowed it by ONE register, and only that one. The credential
+    // footer's faction label became a sigil, and `FactionSigil` now resolves
+    // albescent to its own cross-hair — which draws in `--albescent-reveal-*`,
+    // the always-light REVEAL register #783 deliberately kept alive (it is what
+    // the invitation letter, the faction-select tile and the metatask seal are
+    // drawn in). The deleted THEME block `--faction-albescent-*` is what "no
+    // trace" was written about, and it is still absolutely forbidden here, as is
+    // any other albescent-shaped class, attribute or token: the substitution
+    // below permits the reveal register and nothing else.
+    const html = renderBody({ faction_slug: "albescent" });
+    expect(html.replace(/--albescent-reveal-[a-z-]+/g, "")).not.toContain("albescent");
   });
 
   // Unaffiliated is the slug `na`, not a missing one (ADR-0030), and since

--- a/frontend/src/pages/characterProfile/__tests__/profileAbout.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileAbout.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * The seam: `FactionProfileBody` × `character.bio` (#1626) — where a bio is
+ * READ, now that the credential card no longer prints it.
+ *
+ * The card carried the bio as a two-line clamp, which on a 500-character field
+ * showed its first sentence and hid the rest. #1626 deleted that slot, so the
+ * field would have been editable in Settings and rendered NOWHERE unless the
+ * profile picked it up. The ② About block is that pickup, and it has to reach
+ * three renderers, not one:
+ *
+ *   · `DefaultProfileBody` → `DesktopProfile`   (na, albescent, any unskinned)
+ *   · `DefaultProfileBody` → `MobileProfile`    (the phone stack — a separate
+ *                                                component, not a media query)
+ *   · `ProfileSkin`                             (the seven faction kits)
+ *
+ * The counting assertions are the load-bearing ones: a bio that appears exactly
+ * once proves the About block picked it up AND that the card put it down. Before
+ * this issue the same render carried it twice.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import '../../../i18n'
+import type { CharacterOut } from '../../../api/auth'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+import FactionProfileBody, { type ProfileBodyProps } from '../FactionProfileBody'
+
+const BIO = 'Keeps a field notebook.\nWalks the same three streets on purpose.'
+
+function makeCharacter(overrides: Partial<CharacterOut> = {}): CharacterOut {
+  return {
+    id: 7,
+    username: 'reza',
+    display_name: 'Reza',
+    bio: BIO,
+    tagline: '',
+    avatar_url: '',
+    location: '',
+    level: 7,
+    score: 1880,
+    all_time_score: 2400,
+    faction_slug: 'na',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    badges: [],
+    invitations: [],
+    ...overrides,
+  }
+}
+
+function renderBody(overrides: Partial<CharacterOut> = {}): string {
+  const props: ProfileBodyProps = {
+    character: makeCharacter(overrides),
+    submissions: [],
+    proposedTasks: [],
+    progression: {
+      nextLevel: 8,
+      currentThreshold: 1500,
+      nextThreshold: 2000,
+      progressPercent: 76,
+    },
+    identityActions: null,
+  }
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <FactionProfileBody {...props} />
+    </MemoryRouter>,
+  )
+}
+
+/** How many times the bio's text appears in the render. */
+const bioCount = (html: string) => html.split('Keeps a field notebook.').length - 1
+
+beforeEach(() => {
+  mocks.formFactor = 'desktop'
+})
+
+/** The three renderers, at both widths — `[case, slug, form factor]`. */
+const BRANCHES: Array<[string, string, 'desktop' | 'mobile']> = [
+  ['the na desktop grid', 'na', 'desktop'],
+  ['the MobileProfile phone stack', 'na', 'mobile'],
+  ['a faction kit through ProfileSkin', 'coven', 'desktop'],
+  ['a faction kit on a phone', 'coven', 'mobile'],
+]
+
+describe.each(BRANCHES)('② About on %s', (_case, slug, formFactor) => {
+  const render = (bio: string) => {
+    mocks.formFactor = formFactor
+    return renderBody({ faction_slug: slug, bio })
+  }
+
+  it('renders the heading and the bio when there is one', () => {
+    const html = render(BIO)
+    expect(html, 'the section heading').toMatch(/>About</)
+    expect(html, 'the bio itself').toContain('Keeps a field notebook.')
+  })
+
+  it('reads the bio exactly once — the card no longer carries it', () => {
+    expect(bioCount(render(BIO))).toBe(1)
+  })
+
+  it('keeps the line breaks a player typed', () => {
+    // Plain text, not markdown (#523 owns rich text): a typed newline survives
+    // only because the paragraph is pre-wrap.
+    expect(render(BIO)).toContain('white-space:pre-wrap')
+  })
+
+  // `CharacterOut.bio` is `string | undefined` on the wire, so "" and a
+  // whitespace-only draft are the two blanks a player can actually produce.
+  it.each([['empty', ''], ['whitespace only', '   \n '], ['absent', undefined]])(
+    'hides the whole block — heading included — when the bio is %s',
+    (_kind, bio) => {
+      mocks.formFactor = formFactor
+      const html = renderBody({ faction_slug: slug, bio })
+      expect(html, 'no bio').not.toContain('Keeps a field notebook.')
+      expect(html, 'no heading over nothing').not.toMatch(/>About</)
+    },
+  )
+})

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -44,6 +44,10 @@ import { useFormFactor } from '../../../hooks/useFormFactor'
 import { factionFill, factionName, isKnownFaction } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import type { ProfileBodyProps } from '../FactionProfileBody'
+// The ② About block is shared with every faction kit — see profileSkin.tsx. This
+// is the one profile that does NOT delegate to `ProfileSkin`, so it mounts that
+// component itself rather than growing a second copy of the rule.
+import { AboutBlock } from './profileSkin'
 
 type Segment = 'praxis' | 'tasks'
 
@@ -340,7 +344,6 @@ function DesktopProfile({
             <CredentialCard
               displayName={character.display_name}
               handle={character.username}
-              bio={character.bio}
               factionSlug={character.faction_slug}
               level={character.level}
               score={character.score}
@@ -525,7 +528,8 @@ function DesktopProfile({
         </div>
       </div>
 
-      {/* ── ② About: skipped in v1 (no long-form field; contract hides empty) ── */}
+      {/* ── ② About — the long-form field arrived with #1626 ── */}
+      <AboutBlock bio={character.bio} heading={<SectionHeading title={t('profile.aboutHeading')} />} />
 
       {badges.length > 0 ? (
         <div
@@ -678,7 +682,6 @@ function MobileProfile({
             <CredentialCard
               displayName={character.display_name}
               handle={character.username}
-              bio={character.bio}
               factionSlug={character.faction_slug}
               level={character.level}
               score={character.score}
@@ -805,6 +808,9 @@ function MobileProfile({
             )}
           </div>
         </div>
+
+        {/* ── ② About — same block as the desktop branch and every kit ── */}
+        <AboutBlock bio={character.bio} heading={<SectionHeading title={t('profile.aboutHeading')} />} />
 
         {/* ── ③ Badges — hidden entirely when empty ── */}
         {badges.length > 0 && (

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -228,6 +228,63 @@ export function LaurelGlyph({ size = 18 }: { size?: number }) {
   )
 }
 
+/**
+ * ② About — the profile's home for `character.bio` (#1626).
+ *
+ * The bio used to live in the credential card as a two-line clamp, which could
+ * only ever show its first sentence: the field takes 500 characters and is
+ * explicitly not guaranteed to be a blurb. Deleting that slot without this
+ * block would have left `bio` editable in Settings and rendered nowhere.
+ *
+ * ONE BLOCK, NOT NINE. The seven factions that delegate to {@link ProfileSkin}
+ * inherit it without touching their kits; `DefaultProfileBody` mounts the same
+ * component in each of its two branches. A kit dresses it through `heading` and
+ * `style` — it never re-implements it, and nothing here is per-faction.
+ *
+ * PLAIN TEXT. `pre-wrap` so the line breaks a player typed survive, and no
+ * markdown: nothing on the profile renders markdown today and rich text is its
+ * own epic (#523). The paragraph is content, so `--text-content` is its floor —
+ * a kit may hand it ink and a font, never a size.
+ *
+ * Hidden when empty, per the house rule — a heading over nothing is chrome.
+ */
+export function AboutBlock({
+  bio,
+  heading,
+  style,
+}: {
+  bio?: string | null
+  /** The section heading, dressed by the caller (kit heading / na's rule). */
+  heading: ReactNode
+  /** Ink + font for the paragraph. */
+  style?: CSSProperties
+}) {
+  const text = (bio ?? '').trim()
+  if (!text) return null
+  return (
+    <section style={{ marginTop: 'var(--space-2xl)', marginBottom: 'var(--space-2xl)' }}>
+      {heading}
+      <p
+        style={{
+          fontFamily: 'var(--font-body)',
+          color: 'var(--color-text-secondary)',
+          ...style,
+          fontSize: 'var(--text-content)',
+          lineHeight: 1.6,
+          whiteSpace: 'pre-wrap',
+          overflowWrap: 'anywhere',
+          // A measure, so a 500-character paragraph is not one long line on a
+          // laptop. `ch` rather than px: it follows the kit's own body font.
+          maxWidth: '68ch',
+          margin: 0,
+        }}
+      >
+        {text}
+      </p>
+    </section>
+  )
+}
+
 /** Shared badge-row primitive: a skinnable medallion + the badge name. Kits
  *  pass their medallion chrome; the glyph is mapped client-side by badge key. */
 export function BadgeRow({
@@ -317,7 +374,6 @@ export function ProfileSkin({
     <CredentialCard
       displayName={character.display_name}
       handle={character.username}
-      bio={character.bio}
       factionSlug={character.faction_slug}
       level={character.level}
       score={character.score}
@@ -601,7 +657,12 @@ export function ProfileSkin({
           </div>
         </header>
 
-        {/* ── ② About: skipped in v1 (no long-form field) ── */}
+        {/* ── ② About — the field arrived (#1626); the kit only dresses it ── */}
+        <AboutBlock
+          bio={character.bio}
+          heading={kit.sectionHeading(t('profile.aboutHeading'), '')}
+          style={{ fontFamily: kit.bodyFont ?? kit.eyebrowFont, color: kit.muted }}
+        />
 
         {badges.length > 0 ? (
           <div


### PR DESCRIPTION
Closes #1626

Five deltas on the shared `CredentialCard`, the dispatch fix that lets it stay slug-blind, and the About block that gives the bio somewhere to live.

## The seam

`CredentialCard`'s rendered markup (`renderToStaticMarkup`), and `FactionProfileBody` × `character.bio` — where a bio is *read* now that the card no longer prints it. Both suites were written against the defect first: the About tests fail on `main` (nothing renders `>About<`), and the card's kicker/sigil/bio assertions fail against the old structure.

## What changed

| # | delta | where |
|---|---|---|
| 1 | "CREDENTIAL" / "UNAFFILIATED" kicker deleted, `@handle` stays | `CredentialCard.tsx` |
| 2 | portrait ring 96px → 136px | `CredentialCard.tsx` |
| 3 | bio slot deleted — **and the `bio` prop with it** | `CredentialCard.tsx` + its 4 call sites |
| 4 | footer faction label → 42px hoop (2px accent border) around a 28px `FactionSigil`, no visible name | `CredentialCard.tsx` |
| 5 | footer level readout → `var(--text-lg)` (the 12px step) | `CredentialCard.tsx` |
| — | ② About block, shared | `archetypes/profileSkin.tsx` (`AboutBlock`), mounted 3× |

**The accessible name.** The hoop is `role="img" aria-label={factionName(slug)}`, so the mark is a labelled image: a screen reader gets "Cozy Coven" where a sighted reader gets the mark, and no faction name is printed anywhere on the card. `na`, an unknown slug and a null slug all get `DefaultSigil`'s spectrum ring plus the name `na` resolves to — no hole.

**The bio's new home.** `AboutBlock` in `profileSkin.tsx`: hidden when empty, plain text with `white-space: pre-wrap` (typed line breaks survive; no markdown — #523 owns rich text), `--text-content` floor, `68ch` measure. A kit dresses it via `heading` + `style` and never re-implements it. Mounted in `ProfileSkin` (all seven faction kits inherit it — **none of the seven `*ProfileBody` files were touched**) and in `DefaultProfileBody`'s two branches.

**The `bio` prop is gone, not just the markup.** A card that accepts a field it ignores is where the next copy of this bug starts. `tsc` now enforces at all four call sites what the runtime test can only assert at one.

## Where I departed from the issue — please read these three

**1. `DefaultProfileBody` had to be edited, despite "no per-archetype work".** The ruling says do not add the block to the eight `*ProfileBody` files. Seven of them delegate to `ProfileSkin` and are untouched, exactly as intended. `DefaultProfileBody` is the one that does **not** delegate — it is its own `DesktopProfile` + `MobileProfile` — and it is the profile `na`, `albescent` and any unregistered faction get. Leaving it out would have deleted the bio for the most common profile on the site, so it mounts the *same shared component*, one line per branch, with no dress of its own.

**2. I narrowed a shipped #783 guard, and this is the thing to overrule me on.** `factionProfileBody.test.tsx` asserted an albescent profile contains *no trace of the string "albescent"* — and the albescent sigil ruling breaks it, because the cross-hair draws in `--albescent-reveal-text`. The two registers are not the same thing:

- `--faction-albescent-*` — the deleted theme block. Still absolutely forbidden.
- `--albescent-reveal-*` — the always-light reveal register #783 *kept*, already drawn by `AlbescentInvitation`, `FactionSelectCard` and `AlbescentSeal`.

The guard's own comment says it was written about the deleted token block, so I restated it as "strip `--albescent-reveal-*`, then no trace of albescent" — which still catches any other albescent-shaped class, attribute or token. The `--fc-*` skin-equality half is untouched and still passes: albescent keeps the neutral card skin and the spectrum portrait hoop.

**But the test's stated rationale is "that is what would make a member visually identifiable in a list of players"**, and a cross-hair where every other unskinned player has a rainbow ring is exactly that. The counter-argument is that the profile header already prints `Player · /Albescent` in its eyebrow, so the mark reveals nothing that page did not already say. **The design and the ruling both call for the cross-hair; if the #783 doctrine outranks them, revert `AlbescentSigilAdapter` in `FactionSigil.tsx` and albescent falls back to the spectrum ring with no other change needed.**

**3. Albescent resolves in the adapter, not the manifest** — the escape hatch the issue offered. `factions/albescent.ts` states its own contract: anything added there must be "a flourish LAYERED OVER Default's structure". A bespoke emblem on its own register is not Default-plus-a-flourish, so it is not a manifest row. It sits in `FactionSigil` *before* the `surfaceMap('sigil')` spread, so if albescent ever does declare a `sigil` the manifest wins and the line stops mattering.

Note this is a **global** dispatch change, not a card-local one: the three other `FactionSigil` callers — the faction filter facet, the mobile players chip row, the requests-queue tray — now draw the cross-hair for albescent too. All three are faction-*identity* displays that already name the faction beside the mark, so none of them outs an individual player.

## Claims from the issue I checked

- `CredentialCard.tsx:131 / :141 / :210-226` and the four mount line numbers: **all accurate.**
- "the bio is rendered nowhere else": **confirmed** — the only readers were the three `CredentialCard` mounts.
- `credential.blankPassport` had exactly one reader: **confirmed, removed.** Three *more* keys died with the same two spans and went with it: `credential.credential`, `credential.unaffiliated`, `credential.factionToBeChosen`. The last is the one to sanity-check — "— faction to be chosen —" was the na footer's placeholder, and the ruling that the sigil owns that slot for every slug retires it.
- `factions/albescent.ts` registers no `sigil` while `components/sigil/AlbescentSigil.tsx` exists: **confirmed.**
- Ephemerists: **not special-cased**, inherits `card-*`.

## Verification

`tsc --noEmit` clean · `eslint src .ds-kit e2e` clean · `vitest run` **230 files / 4025 tests green** · `vite build` green · `typecheck:design-sync` green (the `bio` prop removal reached `previews/CredentialCard.tsx` and `_fixtures.tsx`; this step is what caught a global replace that had also eaten `makeCharacter`'s bio) · budget **127.9 KB JS / 22.2 KB CSS — byte-identical to a build of `origin/main@ab836940`**, so `FactionSigil` in the card costs the initial load nothing.

**No visual QA — I have no browser or dev stack.** Everything below is unverified pixels.

## What to eyeball

1. **`/characters/create` live preview** — the card with a portrait but no bio; then type into the bio textarea and confirm you are happy that **nothing echoes it any more** (the field still posts; the preview simply no longer mirrors it).
2. **`/` FieldDesk roster**, 2+ lives at the tilt: the 136px portrait inside the 266px card, and the sigil hoop sitting on the footer rule.
3. **Profile header, all seven skinned factions** (`ProfileSkin`) — the hoop's `2px solid var(--fc-accent)` on each faction's card ground, and each sigil at 28px inside 42px. Ephemerists especially, since its `card-*` was just repointed in #1645.
4. **Profile header, `na` and `albescent`** — spectrum portrait hoop both; `na` gets the rainbow sigil, albescent the cross-hair (see departure 2).
5. **② About, desktop `na`** (`DefaultProfileBody` → `DesktopProfile`): heading with the rainbow rule, paragraph at 68ch, between the identity band and the badge grid.
6. **② About, phone `na`** (`MobileProfile`, the separate component): same block above the badge stack, single-column.
7. **② About, phone + desktop for a faction kit** (Coven and Snide are the useful pair — Snide is always-dark, so check the paragraph's ink on the kit ground).
8. **A bio with typed line breaks** — blank lines must survive; and **a bio of exactly nothing**, where the heading must not appear.
9. **Dark mode on 3, 4 and 7** — nothing here branches on theme, but the hoop border is a token that flips.
10. **The three other sigil callers**, for the albescent regression surface: the `/tasks` faction filter facet, the mobile players chip row, and the Updates requests-queue tray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
