### PR TITLE
The Ephemerists sigil becomes the kite, and the ephemeris grid becomes a token

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -593,6 +593,26 @@ Two rules follow, and UA is the worked example:
 
 Where a mark ships as an inline SVG and where as a masked `public/` asset is a **weight** decision, not a style one — see `components/factionMarks/index.ts`. Both are token-tinted, so both follow the dark cascade. The same faction can legitimately carry two versions of one device at different sizes for different consumers; do not consolidate them on sight.
 
+### A mark below the size of its own line is a different drawing (#1635)
+
+The paragraph above allows two versions of a device at two sizes. This is the case where you owe one, and the threshold is arithmetic rather than taste.
+
+Every faction sigil renders in `BadgedAvatar`'s membership badge, whose glyph is `badge - 5` px — **7px at the small avatar**, and 12–14px in a masthead datum row. The Ephemerists' kite is drawn on a 486×560 frame with a 26-unit stroke, so its rule is 2.9 rendered px at page scale and **0.6px at 13**. Sub-pixel geometry does not get finer, it gets grey: the crossed axes and four of the five discs stopped being detail and became a smudge, which is why "just scale it down" is the failure the reduced cut exists to prevent. So `EphemeristsSigil` draws the kite and the apex point alone below 20px, and 20 is not a round number — **it is where the design's own stroke crosses one device pixel** (20 × 26 / 560 = 0.93px), i.e. the mark is cut at the size where its line stops being drawable. Two floors do the rest: the rule and the point are each clamped to a device pixel, expressed once as user-units-per-rendered-pixel, so the small cut thickens rather than fades.
+
+**A caller hands a mark one number, so the mark owns its ratio.** The kite is not square. Passing `size` through to both `width` and `height` would have stretched it on every mount, and asking each mount for two numbers puts the design's aspect ratio in eight call sites where it can drift. `size` is the **height** and the width follows the frame — which is what makes a masthead's 54×62, 38×44 and inline mounts one prop apart.
+
+**And a prop whose every existing value became wrong is deleted, not reinterpreted.** The old mark took `stroke` in a 24-unit space, where `1.4` was right; in a 560-unit space it is a hairline, so every caller's number was wrong and none of them knew. Keeping the prop and quietly ignoring it is worse than removing it: the component derives a better weight from `size` than any call site can, and a knob nothing turns is scaffolding.
+
+### A published ornament GROUND carries no opacity (#1635)
+
+`--faction-ephemerists-grid` is the faction hero's ruled graticule, published so the surfaces queued behind it borrow it instead of each re-typing the crossed gradients. Two things about publishing a **ground** rather than a colour.
+
+**The wash belongs to the mount.** The hero wears the grid at `.10` and a card at `.17`; an opacity baked into the image cannot be dialled back by whatever sits on it, and the second consumer then forks the token. Publish the marks, let the surface decide how far back they sit.
+
+**A decorative ground goes in an ISOLATED negative layer, not on top with the content lifted over it.** The obvious shape — a `::before` at `z-index: 0` with the card's content lifted to `1` — needs a `> *` rule strong enough to lift *static* children, which means setting `position: relative`, which overrides any absolutely-positioned ornament the card already had. The plate skins are full of those. `isolation: isolate` on the host plus `z-index: -1` on the layer renders identically and asks the adopter for nothing: the host becomes a stacking context, so the negative layer paints after the host's own fill and before every descendant, and a card adopting `.eph-grid-ground` changes one class and nothing else. This is the same family as #1148 and #1255 — the question is never "may this element clip or stack?", it is "what is downstream of it?"
+
+**Size it `100% 100% / no-repeat` even when that is a no-op.** It is, for a repeating gradient. It is exactly what a warped SVG needs, and it is the difference between swapping the warp in later as one declaration and revisiting every consumer.
+
 ---
 
 ## 7. Components

--- a/frontend/src/components/avatar/EphemeristsAvatar.tsx
+++ b/frontend/src/components/avatar/EphemeristsAvatar.tsx
@@ -5,7 +5,9 @@ import { BAND, BRASS, CAPS, DISC, GOLD, INK, PLATE } from "../factionMarks/ephem
 /**
  * The Ephemerists avatar — the plate's medallion field ruled in brass, with the
  * night band's disc as the membership badge carrying the faction sigil (the
- * watching wanderer).
+ * kite). The badge glyph is 7-11px, so the sigil serves it with its
+ * reduced-detail cut (#1635); it no longer passes a stroke, because the mark
+ * floors its own rule at a device pixel from `size`.
  *
  * The one Ephemerists mark that renders inside components this faction does not
  * own — the praxis card's byline, rosters, the feed, the constellation — which
@@ -29,7 +31,7 @@ export default function EphemeristsAvatar({ character, size }: FactionAvatarProp
       initialFontSize={[11, 14]}
       badgeBg={BAND}
       badgeRing={PLATE}
-      glyph={(s, _color) => <EphemeristsSigil size={s} color={GOLD} stroke={1.4} />}
+      glyph={(s, _color) => <EphemeristsSigil size={s} color={GOLD} />}
     />
   );
 }

--- a/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
+++ b/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
@@ -10,6 +10,7 @@ import {
   DECO,
   EmblemOctagon,
   GOLD,
+  GRID,
   GlyphRegister,
   MARGINALIA,
   READING,
@@ -40,8 +41,9 @@ function HeroGrids() {
           position: "absolute",
           inset: 0,
           opacity: 0.1,
-          backgroundImage:
-            `repeating-linear-gradient(0deg, ${BRASS_LIGHT} 0 1px, transparent 1px 26px), repeating-linear-gradient(90deg, ${BRASS_LIGHT} 0 1px, transparent 1px 26px)`,
+          // The graticule is the published token now (#1635) — this hero is
+          // where it was drawn, and it is the first thing to borrow it back.
+          backgroundImage: GRID,
         }}
       />
       <svg viewBox="0 0 1000 320" preserveAspectRatio="none" style={{ position: "absolute", inset: 0, width: "100%", height: "100%", opacity: 0.16 }}>

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsGrid.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsGrid.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * The ephemeris grid (#1635) — the faction hero's ruled ground, published as a
+ * token so surfaces that ship ruled notepaper borrow it.
+ *
+ * Two seams, because the token has two halves and only one of them renders.
+ * The JS half is the hero: it is where the graticule was drawn and the first
+ * thing to borrow it back, so if it stops reading the token the token has no
+ * live consumer and nobody would notice. The CSS half is the contract the
+ * queued surfaces adopt — `.eph-grid-ground` promises an INERT ground under the
+ * card's content, and every property in that promise (inert, behind, sized to
+ * the box) is invisible to markup and to `renderToStaticMarkup`, so it is
+ * asserted against the stylesheet on disk.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import "../../../i18n";
+import EphemeristsFactionHero from "../../factionHero/EphemeristsFactionHero";
+
+const CSS = readFileSync(fileURLToPath(new URL("../../../index.css", import.meta.url)), "utf8");
+
+/** The declaration body of one rule, by selector. */
+function ruleFor(selector: string): string {
+  const match = CSS.match(new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`));
+  if (!match) throw new Error(`no rule for ${selector} in index.css`);
+  return match[1];
+}
+
+describe("the ephemeris grid token", () => {
+  it("is declared once, from the plate's own brass rather than a raw hue", () => {
+    const declaration = CSS.match(/--faction-ephemerists-grid:([^;]*);/g) ?? [];
+    expect(declaration).toHaveLength(1);
+    expect(declaration[0]).toContain("var(--faction-ephemerists-plate-brass-light)");
+    // No wash in the token — the mount decides how far back the ruling sits.
+    expect(declaration[0]).not.toContain("opacity");
+  });
+
+  it("carries no opacity and no colour of its own, so it costs the critical path nothing", () => {
+    // `docs/agents/load-time.md`: index.css is on every page, not just the
+    // Ephemerists ones. A warped SVG data URI would be kilobytes here.
+    expect(CSS.match(/--faction-ephemerists-grid:[\s\S]*?;/)?.[0].length).toBeLessThan(400);
+  });
+});
+
+describe("the hero borrows the token back", () => {
+  const html = renderToStaticMarkup(
+    <EphemeristsFactionHero name="The Ephemerists" description={null} members={4} tasks={9} praxes={2} />,
+  );
+
+  it("draws its ruled ground from the token, not a hand-typed gradient pair", () => {
+    expect(html).toContain("var(--faction-ephemerists-grid)");
+    expect(html).not.toContain("repeating-linear-gradient(0deg");
+  });
+});
+
+describe(".eph-grid-ground — the card contract", () => {
+  const ground = ruleFor(".eph-grid-ground::before");
+
+  it("is a ground, not a veil: inert, full-bleed, and behind the card's content", () => {
+    expect(ground).toContain("inset: 0");
+    expect(ground).toContain("pointer-events: none");
+    expect(ground).toContain("opacity: 0.17");
+    // Behind everything printed on the card, and the host isolates so the
+    // negative layer cannot escape below the card's own fill.
+    expect(ground).toContain("z-index: -1");
+    expect(ruleFor(".eph-grid-ground")).toContain("isolation: isolate");
+  });
+
+  it("stretches to the box rather than tiling, which is what a warped SVG will need", () => {
+    expect(ground).toContain("background-size: 100% 100%");
+    expect(ground).toContain("background-repeat: no-repeat");
+    expect(ground).toContain("background-image: var(--faction-ephemerists-grid)");
+  });
+});

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -64,6 +64,15 @@ export const RULE = "var(--faction-ephemerists-plate-rule)";
 export const LINE = "var(--faction-ephemerists-plate-line)";
 export const SHADOW = "var(--faction-ephemerists-plate-shadow)";
 export const WASH = "var(--faction-ephemerists-plate-wash)";
+/**
+ * The EPHEMERIS GRID (#1635) — the surveyor's graticule, as a `background-image`.
+ * A published ground rather than a colour: any surface shipping ruled notepaper
+ * takes this instead of re-typing the crossed gradients, and it carries no
+ * opacity of its own, so the mount decides how far back it sits. Cards want the
+ * `.eph-grid-ground` class in `index.css`, which lays it in an inert layer under
+ * the card's content; this constant is for the surfaces that draw it themselves.
+ */
+export const GRID = "var(--faction-ephemerists-grid)";
 
 /**
  * The plate's STEPPED CORNER — top-left and bottom-right chamfered, so a cell

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -234,7 +234,7 @@ export function EphemeristsSelectCard({ state = "locked", members, onVisit }: Om
       <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-xl) 0" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)" }}>
           <span style={{ width: 46, height: 46, borderRadius: "50%", border: `1.5px solid ${eph.BRASS}`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-            <EphemeristsSigil size={26} color={eph.GOLD} stroke={1.4} />
+            <EphemeristsSigil size={26} color={eph.GOLD} />
           </span>
           <div>
             <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-sm)", letterSpacing: "0.24em", color: eph.GOLD }}>{i18n.t("feed:factionSelect.ephemerists.eyebrow")}</div>

--- a/frontend/src/components/sigil/EphemeristsSigil.tsx
+++ b/frontend/src/components/sigil/EphemeristsSigil.tsx
@@ -1,42 +1,97 @@
 /**
- * The Ephemerists' mark — the watching wanderer: an eye on an orbital ring.
+ * The Ephemerists' mark — the KITE: a plumb-bob quartered by its own axes,
+ * struck under a single point (#1635).
  *
- * Moved here from the deleted `ephemeristsAtoms.tsx` (#1208), which puts it
- * where every sibling already lives — one dedicated file per faction sigil
- * (`UaSigil`, `SnideSigil`, `WowSigil`, `EverymenSigil`, `SingularitySigil`,
- * `AlbescentSigil`). It is the component `factions/ephemerists.ts` registers as
- * the `sigil` archetype.
+ * It replaces the watching wanderer, the eye-on-an-orbital-ring that had been
+ * the faction's sigil since `ephemeristsAtoms.tsx` was deleted (#1208). That
+ * mark was drawn on the same 24-unit square as the Valley plate's glyph library
+ * and read as one more sign out of the register; this one is the faction's own
+ * device, on the design's 486x560 frame, and it is deliberately NOT square.
+ * Callers hand it one number and get the design's ratio back, which is what
+ * makes the masthead's three mounts (54x62, 38x44, and the datum row's 12-14px)
+ * one prop apart. It is not UA's lotus — that mark is untouched.
  *
- * It survived the codex sweep unchanged and painted, because it never carried
- * codex colour: it is stroke-only geometry on the same 24-unit square the Valley
- * plate's whole glyph library is drawn on, and its ink arrives as a prop. Read
- * beside `GLYPHS.planet` (Saturn's ring) and `GLYPHS.openEye`, it is the plate's
- * own two signs fused, so it needs no re-cutting to sit on papyrus.
+ * ONE INK, WHOLESALE. Stroked geometry and filled discs take the same `color`,
+ * defaulting to `currentColor`, so the mark recolours from whatever token the
+ * mount sets. There is no light/dark pair: the whole
+ * `--faction-ephemerists-plate-*` register is theme-invariant (#1627) and every
+ * surface this sigil renders on is one of its night grounds, so a token that
+ * flipped with the theme would move the mark off a ground that does not.
+ *
+ * THE REDUCED CUT. Below `REDUCED_BELOW_PX` the five discs and the crossed axes
+ * stop being detail and become mud — at 13px the axes are 0.6 rendered pixels
+ * and the four vertex discs sit inside the kite's own stroke. Small sizes
+ * therefore draw a DIFFERENT mark rather than the same one scaled: the kite and
+ * the apex point, with both the rule and the point floored at a device pixel.
+ * The threshold is 20px because that is where the design's 26-unit stroke
+ * crosses 1 rendered pixel (20 x 26 / 560 = 0.93px) — i.e. the mark is cut at
+ * the size where its own line stops being drawable, not at a round number.
  */
+
+/** The design's frame. The mark is 486 wide and 560 tall; `size` is the HEIGHT. */
+const VIEW_W = 486;
+const VIEW_H = 560;
+/** The design's stroke, in user units. */
+const DESIGN_STROKE = 26;
+/** The design's point above the apex: r 26 centred at 243,22 — so its top edge
+ *  sits 4 units ABOVE the frame and the point is struck flat by it. That crop is
+ *  the design's, and `APEX_TOP` is what keeps it when the reduced cut grows the
+ *  disc: the point is pinned by its top edge rather than its centre, so it opens
+ *  downward instead of eating further into the frame. */
+const DESIGN_APEX_R = 26;
+const APEX_TOP = 22 - DESIGN_APEX_R;
+/** See the reduced-cut note above — this is where a 26-unit stroke hits 1px. */
+const REDUCED_BELOW_PX = 20;
+
+const KITE = "M243 120 L55 272 L243 490 L425 272 Z";
+const AXIS_V = "M243 120 L243 490";
+const AXIS_H = "M100 272 L392 272";
+/** The four kite vertices, in path order: apex, left, foot, right. */
+const VERTEX_DISCS = [
+  { cx: 243, cy: 120, r: 56 },
+  { cx: 55, cy: 272, r: 56 },
+  { cx: 243, cy: 490, r: 50 },
+  { cx: 425, cy: 272, r: 54 },
+];
+
 export function EphemeristsSigil({
   size = 22,
   color = "currentColor",
-  stroke = 1.4,
 }: {
+  /** Rendered HEIGHT in px; the width follows the design's 486:560 ratio. */
   size?: number;
   color?: string;
-  stroke?: number;
 }) {
+  const reduced = size < REDUCED_BELOW_PX;
+  // User units per rendered pixel — the conversion both floors are expressed in.
+  const perPixel = VIEW_H / size;
+  const strokeWidth = Math.max(DESIGN_STROKE, perPixel);
+  const apexRadius = Math.max(DESIGN_APEX_R, perPixel * 0.8);
+
   return (
     <svg
-      width={size}
+      width={Math.round((size * VIEW_W) / VIEW_H)}
       height={size}
-      viewBox="0 0 24 24"
+      viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
       fill="none"
       stroke={color}
-      strokeWidth={stroke}
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
       style={{ display: "block" }}
       aria-hidden="true"
     >
-      <ellipse cx="12" cy="12" rx="11" ry="4.4" transform="rotate(-24 12 12)" />
-      <path d="M4 12 C7.5 8.2 16.5 8.2 20 12 C16.5 15.8 7.5 15.8 4 12 Z" />
-      <circle cx="12" cy="12" r="2.7" />
-      <circle cx="12" cy="12" r="0.6" fill={color} stroke="none" />
+      <path d={KITE} />
+      {!reduced && (
+        <>
+          <path d={AXIS_V} />
+          <path d={AXIS_H} />
+          {VERTEX_DISCS.map((disc) => (
+            <circle key={`${disc.cx}-${disc.cy}`} {...disc} fill={color} stroke="none" />
+          ))}
+        </>
+      )}
+      <circle cx="243" cy={APEX_TOP + apexRadius} r={apexRadius} fill={color} stroke="none" />
     </svg>
   );
 }

--- a/frontend/src/components/sigil/__tests__/ephemeristsSigil.test.tsx
+++ b/frontend/src/components/sigil/__tests__/ephemeristsSigil.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * The Ephemerists sigil (#1635) — the kite mark, and its REDUCED-DETAIL CUT.
+ *
+ * The seam is the rendered SVG: a sigil has no behaviour, so the only thing
+ * that can be wrong about it is the geometry it emits at a given `size`. Two
+ * claims are worth a test rather than an eyeball. The mark is **not square**,
+ * so a caller that hands it one number must still get the design's 486:560
+ * frame back — that is what makes the masthead's 54x62 and 38x44 mounts
+ * (#1634) buildable from `size` alone. And below the threshold the component
+ * must draw a DIFFERENT mark, not the same one smaller; a scaled-down full cut
+ * is exactly the failure this cut exists to prevent, and it looks identical to
+ * a working one in any snapshot that does not count elements.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import { EphemeristsSigil } from "../EphemeristsSigil";
+
+const KITE = "M243 120 L55 272 L243 490 L425 272 Z";
+const AXIS_V = "M243 120 L243 490";
+const AXIS_H = "M100 272 L392 272";
+
+const discCount = (html: string) => (html.match(/<circle/g) ?? []).length;
+const pathCount = (html: string) => (html.match(/<path/g) ?? []).length;
+
+describe("EphemeristsSigil — the full cut", () => {
+  const html = renderToStaticMarkup(<EphemeristsSigil size={62} />);
+
+  it("draws the design's kite, crossed axes and five discs", () => {
+    expect(html).toContain('viewBox="0 0 486 560"');
+    expect(html).toContain(KITE);
+    expect(html).toContain(AXIS_V);
+    expect(html).toContain(AXIS_H);
+    expect(discCount(html)).toBe(5);
+    expect(pathCount(html)).toBe(3);
+  });
+
+  it("keeps the design's stroke weight and round caps at page scale", () => {
+    expect(html).toContain('stroke-width="26"');
+    expect(html).toContain('stroke-linecap="round"');
+    expect(html).toContain('stroke-linejoin="round"');
+  });
+
+  it("is no longer the watching wanderer — the eye and its orbital ring are gone", () => {
+    expect(html).not.toContain("<ellipse");
+    expect(html).not.toContain('viewBox="0 0 24 24"');
+  });
+});
+
+describe("EphemeristsSigil — the frame", () => {
+  it("returns the design's 486:560 box from a single size, at every mount the masthead uses", () => {
+    // #1634 mounts it at a page scale, a card scale and inline; all three are
+    // one `size` away, which is why the component owns the ratio.
+    expect(renderToStaticMarkup(<EphemeristsSigil size={62} />)).toContain('width="54" height="62"');
+    expect(renderToStaticMarkup(<EphemeristsSigil size={44} />)).toContain('width="38" height="44"');
+    expect(renderToStaticMarkup(<EphemeristsSigil size={13} />)).toContain('width="11" height="13"');
+  });
+});
+
+describe("EphemeristsSigil — the reduced cut", () => {
+  const small = renderToStaticMarkup(<EphemeristsSigil size={13} />);
+
+  it("drops the crossed axes and the four vertex discs below the threshold", () => {
+    expect(small).toContain(KITE);
+    expect(small).not.toContain(AXIS_V);
+    expect(small).not.toContain(AXIS_H);
+    expect(pathCount(small)).toBe(1);
+    // The apex disc survives: it is the silhouette's distinguishing feature.
+    expect(discCount(small)).toBe(1);
+  });
+
+  it("thickens the stroke rather than scaling it, so the kite never goes sub-pixel", () => {
+    // 26 units at 13px is 0.6 rendered px — a grey smear. The cut floors both
+    // the rule and the disc at a device pixel instead.
+    const width = Number(small.match(/stroke-width="([\d.]+)"/)?.[1]);
+    expect(width).toBeGreaterThan(26);
+    expect((width * 13) / 560).toBeGreaterThanOrEqual(1);
+  });
+
+  it("switches on the threshold, not on the caller", () => {
+    expect(renderToStaticMarkup(<EphemeristsSigil size={20} />)).toContain(AXIS_H);
+    expect(renderToStaticMarkup(<EphemeristsSigil size={19} />)).not.toContain(AXIS_H);
+  });
+});
+
+describe("EphemeristsSigil — ink", () => {
+  it("takes one colour for the whole mark and hardcodes no hex", () => {
+    const html = renderToStaticMarkup(
+      <EphemeristsSigil size={62} color="var(--faction-ephemerists-plate-gold)" />,
+    );
+    expect(html).not.toContain("#");
+    // Stroked geometry and filled discs are the same ink — it recolours whole.
+    expect(html).toContain('stroke="var(--faction-ephemerists-plate-gold)"');
+    expect(html).toContain('fill="var(--faction-ephemerists-plate-gold)"');
+  });
+
+  it("inherits from the cascade when no colour is given", () => {
+    expect(renderToStaticMarkup(<EphemeristsSigil size={62} />)).toContain('stroke="currentColor"');
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1582,6 +1582,27 @@
   --faction-ephemerists-plate-rule: rgba(201, 162, 75, 0.12); /* journal ruling */
   --faction-ephemerists-plate-line: rgba(201, 162, 75, 0.28); /* hairline borders */
 
+  /* ── THE EPHEMERIS GRID (#1635) ──
+     The faction hero's ruled ground, published so the surfaces queued behind it
+     borrow the graticule instead of each re-typing the pair. Opacity is
+     deliberately NOT in the token: the hero wears it at .10 and a card at .17,
+     and a wash baked into the image cannot be dialled by its mount.
+
+     It is the STRAIGHT ruling, which is a decision and not an oversight. The
+     design canvas draws a warped `0 0 1000 600` survey graticule; nothing in
+     this app has ever drawn it, and inlining a multi-kilobyte data URI here
+     would put it on every page's critical path rather than on the Ephemerists
+     surfaces that want it (`docs/agents/load-time.md`). Publishing what ships
+     today costs ~250 bytes and buys the seam.
+
+     ponytail: two crossed repeating gradients — ceiling is no warp and one
+     pitch. Upgrade path: point this at a `url()` of a hosted SVG. Every
+     consumer already sizes it `100% 100%` / `no-repeat`, so a stretched image
+     lands exactly where the tiling gradient sat, and no consumer changes. */
+  --faction-ephemerists-grid:
+    repeating-linear-gradient(0deg, var(--faction-ephemerists-plate-brass-light) 0 1px, transparent 1px 26px),
+    repeating-linear-gradient(90deg, var(--faction-ephemerists-plate-brass-light) 0 1px, transparent 1px 26px);
+
   /* ══ Everymen — the rainbow's missing red (union/WW2 poster) ══
      Constants (cream/gold/ink) keep their role in both themes; the paper
      surface + its text FLIP in dark; accent red stays vivid; field is the
@@ -3567,6 +3588,43 @@
     repeating-linear-gradient(0deg, var(--faction-ephemerists-plate-rule) 0 1px, transparent 1px 26px),
     linear-gradient(170deg, var(--faction-ephemerists-plate-bg), var(--faction-ephemerists-plate-page));
   background-size: 100% 100%, 100% 100%, 100% 100%, 100% 100%, 5px 5px, 100% 100%, 100% 100%;
+}
+
+/* ══════════════════════════════════════════════════════════════
+   THE EPHEMERIS GRID, as a card ground (#1635)
+
+   "The ruling is a ground, not a veil" — so it sits between the card's
+   own fill and everything printed on it, and it is inert: no hit
+   testing, no contribution to any ink's contrast reading.
+
+   The design lifts the card's content to `z-index: 1` over a `z-index: 0`
+   ::before. This does the same render with `isolation: isolate` and a
+   NEGATIVE layer instead, because the lift is the half that costs: a
+   `> *` rule strong enough to lift static children has to set
+   `position: relative`, which overrides any absolutely-positioned
+   ornament the card already had — and the plate skins are full of them.
+   Isolating makes the host a stacking context, so `-1` paints after the
+   host's own background and before every descendant, and an adopting
+   card adds one class and changes nothing else.
+
+   Sized `100% 100%` / `no-repeat` per the design, which is a no-op for a
+   repeating gradient and is exactly what a warped SVG would need — see
+   the token's upgrade path beside its declaration.
+   ══════════════════════════════════════════════════════════════ */
+.eph-grid-ground {
+  position: relative;
+  isolation: isolate;
+}
+.eph-grid-ground::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  opacity: 0.17;
+  background-image: var(--faction-ephemerists-grid);
+  background-size: 100% 100%;
+  background-repeat: no-repeat;
 }
 
 /* Homepage activity ticker — horizontal marquee + blinking "LIVE" dot. */


### PR DESCRIPTION
Two shared marks the rest of the Ephemerists re-skin sits on.

Closes #1635

## The seam

**The sigil:** the rendered SVG. A sigil has no behaviour, so the only thing that can be wrong about it is the geometry it emits at a given `size`. `frontend/src/components/sigil/__tests__/ephemeristsSigil.test.tsx` went red on the real defect first — nine assertions, all failing against the old ellipse-and-eye mark.

**The grid:** two halves, only one of which renders. The JS half is the hero (if it stops reading the token, the token has no live consumer and nobody notices); the CSS half is the contract the queued surfaces adopt, every property of which — inert, behind, sized to the box — is invisible to `renderToStaticMarkup`, so it is asserted against the stylesheet on disk.

## 1. The sigil

New geometry in `EphemeristsSigil.tsx`, built to the issue's numbers: `0 0 486 560`, the kite `M243 120 L55 272 L243 490 L425 272 Z`, both axes, five discs at r 56/56/50/54 on the vertices in path order and r 26 at `243,22`, stroke-width 26, round caps and joins.

Three decisions worth reading.

**`size` is the HEIGHT and the mark owns its ratio.** The kite is not square. Passing one number through to both `width` and `height` stretches it on every mount, and asking each mount for two puts the aspect ratio in eight call sites where it can drift. `size` 62 gives `54x62`, 44 gives `38x44`, 13 gives `11x13` — so #1634's page, card and inline scales are one prop apart, and there is a test that says so by those exact numbers.

**The reduced cut switches at 20px, and 20 is arithmetic.** It is where the design's own 26-unit stroke crosses one device pixel (20 x 26 / 560 = 0.93px) — i.e. the mark is cut at the size where its line stops being drawable, rather than at a round number. Below it the component draws the kite and the apex point alone; the axes and the four vertex discs go. Two floors do the rest, both expressed once as user-units-per-rendered-pixel: the rule and the point are each clamped to a device pixel, so the small cut **thickens rather than fades**. This is not theoretical — `BadgedAvatar`'s glyph is `badge - 5`, i.e. **7px** at the small avatar, and `EphemeristsFactionBody` plus the two mobile skins already mount it at 13-15px.

The apex point is pinned by its **top edge**, not its centre. The design centres r 26 at `243,22`, so 4 units of it sit above the frame and the point is struck flat by it; keeping that crop means the floored disc opens downward instead of eating further in.

**`stroke` is deleted, not reinterpreted.** `1.4` was correct in the old 24-unit space and is a hairline in a 560-unit one, so every existing caller's value was wrong and none of them knew. Keeping the prop and quietly ignoring it is worse than removing it. Two call sites drop it (`EphemeristsAvatar`, `FactionSelectCard`); `FactionSigil` and the design-sync preview only ever passed `{ size, color }`, so the dispatcher and `typecheck:design-sync` are untouched.

`color` stays a prop and no colour token was minted — see the correction below.

## 2. The ephemeris grid

`--faction-ephemerists-grid` publishes the hero's ruled graticule; `.eph-grid-ground` is the card contract (`inset: 0`, `pointer-events: none`, `opacity: .17`, `background-size: 100% 100%`, `no-repeat`). The plate module exports it as `GRID` for surfaces that draw it themselves, and **the hero is rewired to borrow it back** — the token has a live consumer today rather than waiting for the queue.

**It publishes the straight ruling, and that is a decision.** The warped `0 0 1000 600` SVG lives only on the design canvas; nothing in this app has ever drawn it. `index.css` sits on every page's critical path, not just the Ephemerists surfaces, so a multi-kilobyte data URI there is weight charged to everyone (`docs/agents/load-time.md`). **CSS budget: 22.2 KB to 22.3 KB gzipped** (measured both ways by stashing; warn is 22.5, fail 24.4). Because it is a token and every consumer already stretches rather than tiles, swapping the warp in later is one declaration and no consumer changes — that is written down at the declaration as a `ponytail:` with the upgrade path.

**Opacity is deliberately not in the token.** The hero wears it at `.10` and a card at `.17`; a wash baked into the image cannot be dialled by its mount, and the second consumer then forks the token.

**The ground uses `isolation: isolate` plus `z-index: -1`, not the design's `z-index: 0` plus a content lift.** This is the one place I departed from the spec'd mechanism, and the render is identical. Lifting *static* children needs a `> *` rule that sets `position: relative`, which overrides any absolutely-positioned ornament the card already had — and the plate skins are full of them. Isolating makes the host a stacking context, so the negative layer paints after the host's own fill and before every descendant. An adopting card adds one class and changes nothing else. Same family as #1148 / #1255: the question is never "may this element stack?", it is "what is downstream of it?"

The task brief's ruled notepaper is **not** rewired — that is a `repeating-linear-gradient` inside a surface this PR does not otherwise touch, and the issue marks it optional.

## Corrections to the issue

Three, each verified against the code rather than worked around.

**The sigil did not replace "the lotus sign".** That is the design canvas's own naming. The shipped mark was *"the watching wanderer: an eye on an orbital ring"* on a 24-unit square. That is what this replaces; its docstring is rewritten so it no longer describes a mark that does not exist. UA's lotus is untouched.

**"Plate brass in light, a pale gold in dark" contradicts the shipped register, so no token was minted.** #1627 took the whole `--faction-ephemerists-plate-*` register **theme-invariant** — `[data-theme="dark"]` declares nothing for it, deliberately, and `WORLD_ZERO_STYLE.md` section 3 records why. Every ground this sigil renders on is one of those night values in both themes, so a token that flipped with the theme would move the mark off a ground that does not. The "recolours wholesale" property is already how it works: one `color` for stroke and fill together, defaulting to `currentColor`, chosen by the mount (`GOLD` on the band, `BRASS` on the plate). There is no hex in the component and a test asserts it.

**The dispatcher's file reference was half right.** `EphemeristsFactionHero.tsx:44` is exactly the gradient pair, confirmed. `index.css:3566-3567` is not "the plate" — it is inside `.eph-backdrop`, the fixed page ground, and it is a single `0deg` ruling in `-plate-rule` plus the papyrus grain. The hero's crossed pair in `-plate-brass-light` is the thing the issue names ("the ruled ground from the faction hero"), so that is what the token publishes.

## Verification

All six `frontend` CI steps run locally and green, post-rebase onto `origin/main` @ `b1dc226b` (all four parallel PRs landed first):

- `eslint` — clean
- `tsc --noEmit` — clean
- `vitest run` — **4044 passed / 232 files**
- `vite build` — ok
- `budget` — JS 127.9 KB (warn 130.9), CSS 22.3 KB (warn 22.5)
- `typecheck:design-sync` — clean

The built stylesheet was grepped for both new selectors at top-level depth, per the style guide's brace rule. No backend or `schema.d.ts` change, so `test` and `api-schema` are untouched.

**Visual QA is outstanding.** I have no browser and no dev stack. A sigil at five sizes in two themes is precisely what a markup assertion cannot see.

## What to eyeball

- **The sigil at every size it renders, in both themes.** `EphemeristsAvatar` badge glyph (**7px** at `sm`, ~11px at `md` — the reduced cut's worst case), `EphemeristsFactionPage` and `EphemeristsFieldDesk` running heads (13px, reduced), `EphemeristsFactionBody`'s apparatus heading (15px, reduced), `CredentialCard` via `FactionSigil` (28px, full cut), `FactionSelectCard`'s 46px brass disc (26px, full cut), and the design-sync `FactionSigil` sweep (56px).
- **The 20px boundary specifically** — 19 against 20 should read as the same mark, not as two.
- **The full cut's proportions.** The four vertex discs at r 56/56/50/54 sit partly inside the kite's own 26-unit stroke; that is the design's drawing, but it is the first thing to check against the canvas.
- **The apex point's crop.** r 26 at `cy 22` puts 4 units of it above the frame in the full cut. If the canvas does not show a flat-topped point, the viewBox needs headroom the issue did not specify — say so and it is a one-line change.
- **The non-square frame in a flex row.** Every current mount centres it, but the width is now ~13% narrower than the height at the same `size`; check the gap beside the running heads.
- **The faction hero's graticule should be byte-identical to before** — same token, same `.10`. If it moved, the rewire is wrong.
- **`.eph-grid-ground` has no consumer yet**, so nothing renders it. Worth mounting on one Ephemerists card by hand before the queue adopts it, to confirm the ruling sits under the content and over the fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
