### PR TITLE
The Ephemerists masthead: an engraved title replaces the deco wordmark, and the winged sun disc retires

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -613,6 +613,20 @@ Every faction sigil renders in `BadgedAvatar`'s membership badge, whose glyph is
 
 **Size it `100% 100% / no-repeat` even when that is a no-op.** It is, for a repeating gradient. It is exactly what a warped SVG needs, and it is the difference between swapping the warp in later as one declaration and revisiting every consumer.
 
+### A faction's HEAD is a component, and the fifth copy is what proves it (#1634)
+
+The Ephemerists drew one masthead — a winged sun disc over the faction's name in letterspaced Poiret One, centred on a night band — on four surfaces, in four copies that could not see each other: the praxis card, the praxis detail, the task detail and the composer. The task detail carried a *fifth* copy, of the disc itself, byte-identical to the shared kit's and invisible to it. §6's rule above says a device is drawn once; this is the same rule one level up, where what repeats is not a mark but **an arrangement of marks plus type**. `EphemeristsMasthead` is that arrangement, and the four skins now mount it.
+
+Four things generalise off it, none of them Ephemerists-specific.
+
+**A masthead's TWO SCALES are one prop, and everything else is a table.** `page` heads a page, `card` heads a sheet — and because #1635 made the sigil own its 486:560 ratio, the two scales differ by exactly one number per row. A `compact` boolean would have forked every internal (§1.2's rejected escape); a size *record* keyed by scale keeps them side by side where a typo in one is visible against the other.
+
+**A band that held a fixed-height stack becomes a FLOOR when the stack starts sizing itself.** All four mounts pinned their band (110 / 84 / 108 / 84–68 px) around content whose height they knew. A masthead built from its own padding does not fit inside a number chosen for something else, so `height` becomes `minHeight` and the band's background register moves to `height: 100%`. Where the band is a *shared* block — `ComposerMasthead`, mounted by eight composers — the skin relaxes it through `style`, which is spread after `height`, rather than the shared block growing a second prop for one caller.
+
+**A DATUM ROW is honest data or an honest egg, and never the thing in between.** The design hardcoded a plausible date and a plausible right ascension and declination *per surface*, which is decoration wearing the appearance of data — worse than either half. Owner ruling: the date is the surface's own (a praxis's submission, a task's filing), and the coordinates are **fixed**, pointing at one real place, derived rather than picked. Two consequences worth carrying. The derivation belongs in a comment at the constants, including the sign convention, or the next reader deletes two arbitrary numbers. And an egg is never labelled — a caption spends what noticing was supposed to buy. The corollary on the real half: a date formatter that renders a missing timestamp as the literal string `Invalid Date` puts an *invention* on the one row a player reads as data, so the guard belongs in the component rather than at each mount.
+
+**Retiring a mark is finished when its LAST caller is gone, and the last caller is rarely on the list.** The issue named the winged sun disc through one class (`.eph-plate-crown`) on one surface. Four of the disc's five call sites were the mastheads it crowned and went with them; the fifth was a feed row's 14px band ornament, on nobody's list, and leaving it would have shipped a faction wearing two marks with no way for a reader to tell which was deliberate. Grep for the *component*, not for the symptom the issue named. The mirror of that: `WingedDiscSign` is a **different drawing** on a 24-unit square for the metatask seal, and a retirement stops at the edge of a drawing it is not about.
+
 ---
 
 ## 7. Components

--- a/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
@@ -1,0 +1,244 @@
+import { useTranslation } from "react-i18next";
+import { EphemeristsSigil } from "../sigil/EphemeristsSigil";
+import {
+  BAND_INK,
+  BAND_QUIET,
+  BRASS,
+  CAPS,
+  GOLD,
+  GlossedGlyph,
+  READING,
+} from "./ephemeristsPlate";
+import { factionName } from "../../utils/factions";
+
+/**
+ * THE ENGRAVED MASTHEAD (#1634) — the head of every Ephemerists surface, and the
+ * end of the deco wordmark it replaces.
+ *
+ * A row: the kite sigil on the left, and a column holding three stacked bands —
+ * the wordmark in incised small caps, a four-kanji register ruled off above and
+ * below, and a datum row of date, right ascension and declination closed by the
+ * sigil again at inline scale.
+ *
+ * WHAT IT REPLACED, AND WHY IT IS ONE COMPONENT. Four surfaces each drew the
+ * same centred stack — a 150–176px winged sun disc over the faction's name in
+ * letterspaced Poiret One — in four copies that could not see each other
+ * (WORLD_ZERO_STYLE §6, "duplication is discovered by the next consumer"). The
+ * masthead is the fifth consumer arriving, so the stack becomes a component
+ * rather than a fifth copy. The winged disc goes with it: #1634's ruling is that
+ * the sigil is the only mark, and the disc was only ever the wordmark's crown.
+ *
+ * IT MOUNTS ON THE CORNICE BAND. Its two inks — {@link BAND_INK} for the
+ * wordmark, {@link BAND_QUIET} for the datum row — are the pair measured against
+ * `--faction-ephemerists-plate-band`, and all four mounts are that band. A plate
+ * mount would be a different (ink, ground) pairing and therefore a prop, not an
+ * assumption to leave standing: WORLD_ZERO_STYLE §3's rule is that a component's
+ * inks belong to the sheet they were measured on. Nothing here flips with the
+ * theme; the whole plate register is theme-invariant (#1627).
+ *
+ * TWO SCALES, ONE PROP. `page` heads a whole page, `card` heads a sheet. The
+ * design carries both, and every rung of both tables below is on the type or
+ * spacing scale — see {@link SIZES} for the three places the scale had no step.
+ */
+
+/** The design's grid, shared by the glyph row and the datum row so their cells
+ *  line up. The fourth column is narrower and right-aligned: it is the row's
+ *  closing mark rather than a fourth reading. */
+const COLUMNS = "1.1fr 1fr 1fr 0.9fr";
+
+/**
+ * THE DATUM ROW'S COORDINATES — an easter egg, and a fixed pair.
+ *
+ * The design hardcoded a different plausible pair per surface, which is
+ * decoration wearing the appearance of data. Owner ruling: the date is real (the
+ * surface's own) and the coordinates point at one real place — the Oregon
+ * Country Fairgrounds, Veneta, Oregon, at 44.0534° N, 123.3704° W. Both cells
+ * name the same spot in the datum row's own units, so neither is invented:
+ *
+ *  • DECLINATION is the fairgrounds' LATITUDE. A star at declination +44° 03′
+ *    passes through the zenith there — that is the definition of declination,
+ *    not a fudge. 0.0534° × 60 = 3.2′, so 44° 03′.
+ *  • RIGHT ASCENSION is the fairgrounds' LONGITUDE in RA's own unit. Right
+ *    ascension runs 24ʰ to the circle, so 123.3704 / 15 = 8.2247ʰ and
+ *    0.2247 × 60 = 13.5ᵐ, giving 8ʰ 13ᵐ. The sign convention is WEST longitude
+ *    as a POSITIVE hour angle, which is what keeps the figure inside 0–24ʰ;
+ *    measured eastward the same place reads 15ʰ 47ᵐ.
+ *
+ * It is never labelled in user-visible copy, and it must not become one. An egg
+ * rewards noticing; a caption spends it.
+ */
+const RIGHT_ASCENSION = "8ʰ 13ᵐ";
+const DECLINATION = "+44° 03′";
+
+/**
+ * The four-kanji register — 星 暦 観 録, "star · almanac · observation · record".
+ *
+ * The design set this row in cuneiform; the owner replaced cuneiform with kanji
+ * across the kit, and the four chosen here read top-to-bottom as what an
+ * ephemeris IS: the thing watched, the table it is kept in, the act of watching,
+ * and what survives the watcher. 暦 is the load-bearing one — an ephemeris is
+ * literally an almanac of positions, so the faction's name is in its own
+ * masthead a second time in a script most readers cannot spend.
+ *
+ * Each is a {@link GlossedGlyph}: the English is on `title`, so hover and focus
+ * reveal it and assistive tech reads it out. Pairs rather than a template
+ * literal, so every key survives a grep.
+ */
+const REGISTER: readonly (readonly [mark: string, gloss: string])[] = [
+  ["ephemerists.masthead.starMark", "ephemerists.masthead.star"],
+  ["ephemerists.masthead.almanacMark", "ephemerists.masthead.almanac"],
+  ["ephemerists.masthead.observationMark", "ephemerists.masthead.observation"],
+  ["ephemerists.masthead.recordMark", "ephemerists.masthead.record"],
+];
+
+export type MastheadScale = "page" | "card";
+
+interface MastheadSize {
+  /** The sigil's HEIGHT; the mark owns its 486:560 ratio (#1635). Ornament. */
+  sigil: number;
+  wordmark: string;
+  glyph: string;
+  datum: string;
+  padding: string;
+  gap: string;
+  /** The grid's own column gap. Ornament geometry rounded to the scale. */
+  columnGap: string;
+  /** The datum row's closing sigil, below the reduced cut's 20px (#1635). */
+  inlineSigil: number;
+}
+
+/**
+ * The design's two size tables, mapped onto the type and spacing scales.
+ *
+ * The sigil sizes stay raw: a drawn mark's dimensions are ornament geometry and
+ * never spacing (§4a). Everything else takes a rung, and three of them needed a
+ * decision because the scale has no step at the design's number:
+ *
+ *  • the page glyph row is drawn at 16px, which sits exactly between `--text-xl`
+ *    (14) and `--text-content` (18). It rounds UP, for #1637's reason rather
+ *    than §4a's: a kanji at 14px is at the bottom of the legible band and these
+ *    four are the row, not a caption beside one.
+ *  • the card glyph row is drawn at 13 and takes `--text-xl` (14), the same
+ *    rung #1637 already chose for a glossed kanji.
+ *  • the wordmarks are drawn at 26 and 19 and take `--text-title` (24) and
+ *    `--text-content` (18) — the rungs the composer's own wordmark comment
+ *    already picked for 19.
+ *
+ * The four spacing values are all ties (20, 14, 14, 10) and all round UP, per
+ * §4a. The paddings are asymmetric, so they are checked against §4a's carve-out
+ * and kept: `24 24 16` and `12 16 8` both preserve the design's top-heavier
+ * shape, which rounding down would flatten.
+ */
+const SIZES: Record<MastheadScale, MastheadSize> = {
+  page: {
+    sigil: 62,
+    wordmark: "var(--text-title)",
+    glyph: "var(--text-content)",
+    datum: "var(--text-md)",
+    padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
+    gap: "var(--space-xl)",
+    columnGap: "var(--space-lg)",
+    inlineSigil: 14,
+  },
+  card: {
+    sigil: 44,
+    wordmark: "var(--text-content)",
+    glyph: "var(--text-xl)",
+    datum: "var(--text-base)",
+    padding: "var(--space-md) var(--space-lg) var(--space-sm)",
+    gap: "var(--space-lg)",
+    columnGap: "var(--space-md)",
+    inlineSigil: 12,
+  },
+};
+
+export function EphemeristsMasthead({ slug, scale, date }: {
+  /** The faction whose name the wordmark carries — the mounts' own slug. */
+  slug: string | null | undefined;
+  scale: MastheadScale;
+  /**
+   * The surface's OWN date, already formatted. Optional because a surface may
+   * genuinely have none (the composer drafting a praxis that does not exist
+   * yet); the cell is then left empty rather than filled with an invention.
+   */
+  date?: string;
+}) {
+  const { t } = useTranslation("factions");
+  const size = SIZES[scale];
+  const grid = { display: "grid", gridTemplateColumns: COLUMNS, gap: `0 ${size.columnGap}` } as const;
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: size.gap,
+        padding: size.padding,
+        borderBottom: `1px solid ${BRASS}`,
+        boxSizing: "border-box",
+      }}
+    >
+      <EphemeristsSigil size={size.sigil} color={GOLD} />
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontFamily: CAPS,
+            fontVariant: "small-caps",
+            fontSize: size.wordmark,
+            letterSpacing: "0.12em",
+            lineHeight: 1,
+            color: BAND_INK,
+          }}
+        >
+          {factionName(slug)}
+        </div>
+
+        {/* The register, ruled 1px above and 3px double below. The double rule
+            is the design's, and it is what makes the row read as an engraved
+            band rather than a line of type with a border. */}
+        <div
+          style={{
+            ...grid,
+            marginTop: "var(--space-xs)",
+            padding: "var(--space-sm) 0",
+            borderTop: `1px solid ${BRASS}`,
+            borderBottom: `3px double ${BRASS}`,
+            color: GOLD,
+          }}
+        >
+          {REGISTER.map(([mark, gloss], index) => (
+            <span key={mark} style={{ textAlign: index === REGISTER.length - 1 ? "right" : "left" }}>
+              <GlossedGlyph glyph={t(mark)} gloss={t(gloss)} size={size.glyph} />
+            </span>
+          ))}
+        </div>
+
+        {/* The datum row. `tabular-nums` is the design's, and it is doing real
+            work: three of the four cells are figures that must not shimmy as the
+            date changes underneath them. */}
+        <div
+          style={{
+            ...grid,
+            marginTop: "var(--space-xs)",
+            fontFamily: READING,
+            fontSize: size.datum,
+            fontVariantNumeric: "tabular-nums",
+            color: BAND_QUIET,
+            lineHeight: 1,
+            alignItems: "center",
+          }}
+        >
+          <span>{date}</span>
+          <span>{RIGHT_ASCENSION}</span>
+          <span>{DECLINATION}</span>
+          <span style={{ justifySelf: "end" }}>
+            <EphemeristsSigil size={size.inlineSigil} color={GOLD} />
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default EphemeristsMasthead;

--- a/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
@@ -10,6 +10,7 @@ import {
   READING,
 } from "./ephemeristsPlate";
 import { factionName } from "../../utils/factions";
+import { formatDate } from "../../utils/dates";
 
 /**
  * THE ENGRAVED MASTHEAD (#1634) — the head of every Ephemerists surface, and the
@@ -81,15 +82,16 @@ const DECLINATION = "+44° 03′";
  * masthead a second time in a script most readers cannot spend.
  *
  * Each is a {@link GlossedGlyph}: the English is on `title`, so hover and focus
- * reveal it and assistive tech reads it out. Pairs rather than a template
- * literal, so every key survives a grep.
+ * reveal it and assistive tech reads it out. Written as literal pairs — never a
+ * template literal — so every key survives both a grep and the catalog's own
+ * key types, which a computed key silently widens out of.
  */
-const REGISTER: readonly (readonly [mark: string, gloss: string])[] = [
+const REGISTER = [
   ["ephemerists.masthead.starMark", "ephemerists.masthead.star"],
   ["ephemerists.masthead.almanacMark", "ephemerists.masthead.almanac"],
   ["ephemerists.masthead.observationMark", "ephemerists.masthead.observation"],
   ["ephemerists.masthead.recordMark", "ephemerists.masthead.record"],
-];
+] as const;
 
 export type MastheadScale = "page" | "card";
 
@@ -152,16 +154,32 @@ const SIZES: Record<MastheadScale, MastheadSize> = {
   },
 };
 
+/**
+ * The datum row's date cell, from the surface's own timestamp.
+ *
+ * Owner ruling: the date is REAL — a praxis's submission, a task's filing —
+ * where the surface has one, and the cell is left EMPTY where it has none. So
+ * the guard is not defensive tidiness, it is the ruling: `formatDate` renders an
+ * absent or malformed timestamp as the literal string "Invalid Date", which is
+ * an invention rather than a blank, and the masthead is exactly the surface a
+ * player would read it off as data. Guarded here rather than at each mount,
+ * because four mounts guarding separately is three chances to forget.
+ */
+function datumDate(iso: string | null | undefined): string | undefined {
+  if (!iso || Number.isNaN(new Date(iso).getTime())) return undefined;
+  return formatDate(iso);
+}
+
 export function EphemeristsMasthead({ slug, scale, date }: {
   /** The faction whose name the wordmark carries — the mounts' own slug. */
   slug: string | null | undefined;
   scale: MastheadScale;
   /**
-   * The surface's OWN date, already formatted. Optional because a surface may
-   * genuinely have none (the composer drafting a praxis that does not exist
-   * yet); the cell is then left empty rather than filled with an invention.
+   * The surface's OWN timestamp, ISO. Optional because a surface may genuinely
+   * have none (the composer drafting a praxis that does not exist yet); the cell
+   * is then left empty rather than filled with an invention.
    */
-  date?: string;
+  date?: string | null;
 }) {
   const { t } = useTranslation("factions");
   const size = SIZES[scale];
@@ -229,7 +247,7 @@ export function EphemeristsMasthead({ slug, scale, date }: {
             alignItems: "center",
           }}
         >
-          <span>{date}</span>
+          <span>{datumDate(date)}</span>
           <span>{RIGHT_ASCENSION}</span>
           <span>{DECLINATION}</span>
           <span style={{ justifySelf: "end" }}>

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsMasthead.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsMasthead.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * THE ENGRAVED MASTHEAD (#1634).
+ *
+ * The seam is the component's rendered markup given props — a masthead has no
+ * behaviour, so what can be wrong about it is what it emits. Four claims are
+ * worth a test rather than an eyeball, and the first two are the ones a
+ * screenshot would pass:
+ *
+ *  • THE TWO SCALES MUST DIFFER. `page` and `card` are one prop apart and every
+ *    value in both tables is a `var()`, so a table typo renders a perfectly
+ *    plausible masthead at the wrong size on half the surfaces. Pin the sigil's
+ *    emitted box, which is a NUMBER and therefore the one thing here a
+ *    stylesheet cannot silently absorb.
+ *  • THE DATUM ROW'S INLINE SIGIL MUST TAKE THE REDUCED CUT. Both inline sizes
+ *    (14 and 12) sit under #1635's 20px threshold, so the mark must arrive
+ *    without its crossed axes. A full cut at 12px still renders — as a smudge —
+ *    which is exactly what no markup assertion catches unless it counts.
+ *  • THE COORDINATES ARE FIXED AND THE DATE IS THE SURFACE'S. The easter egg is
+ *    only an egg if both cells point at the same real place on every surface;
+ *    the moment one of them starts varying it is decoration again.
+ *  • EVERY KANJI CARRIES ITS ENGLISH. The row is unreadable to most players by
+ *    design, and `title` is the whole of the reveal (#1637).
+ *
+ * SSR-only harness (renderToStaticMarkup, no DOM, effects never run).
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import "../../../i18n";
+import { EphemeristsMasthead } from "../EphemeristsMasthead";
+
+const AXIS_H = "M100 272 L392 272";
+const render = (scale: "page" | "card", date?: string) =>
+  renderToStaticMarkup(<EphemeristsMasthead slug="ephemerists" scale={scale} date={date} />);
+
+describe("EphemeristsMasthead — the two scales", () => {
+  it("hands the sigil one number and gets the design's frame back at each scale", () => {
+    expect(render("page")).toContain('width="54" height="62"');
+    expect(render("card")).toContain('width="38" height="44"');
+  });
+
+  it("draws the datum row's closing sigil at its own inline size, below the reduced cut", () => {
+    expect(render("page")).toContain('width="12" height="14"');
+    expect(render("card")).toContain('width="10" height="12"');
+    // One kite each — the full cut's crossed axes would be a smear at 12-14px.
+    for (const scale of ["page", "card"] as const) {
+      expect(render(scale).match(new RegExp(AXIS_H, "g")) ?? []).toHaveLength(1);
+    }
+  });
+
+  it("carries the wordmark at a different rung on each scale", () => {
+    expect(render("page")).toContain("font-size:var(--text-title)");
+    expect(render("card")).toContain("font-size:var(--text-content)");
+  });
+});
+
+describe("EphemeristsMasthead — the datum row", () => {
+  it("prints the surface's own date and leaves the cell empty when there is none", () => {
+    expect(render("page", "Aug 2, 2026")).toContain("Aug 2, 2026");
+    expect(render("page")).not.toContain("Aug 2, 2026");
+  });
+
+  it("points both coordinates at one place, on every surface and both scales", () => {
+    // 44.0534 N / 123.3704 W — the fairgrounds. Never labelled, never varied.
+    for (const scale of ["page", "card"] as const) {
+      expect(render(scale)).toContain("8ʰ 13ᵐ");
+      expect(render(scale)).toContain("+44° 03′");
+    }
+  });
+});
+
+describe("EphemeristsMasthead — the register", () => {
+  const html = render("page");
+
+  it("sets four kanji, each with its English one gesture away", () => {
+    for (const [mark, gloss] of [
+      ["星", "Star"],
+      ["暦", "Almanac"],
+      ["観", "Observation"],
+      ["録", "Record"],
+    ]) {
+      expect(html).toContain(`title="${gloss}"`);
+      expect(html).toContain(`>${mark}</abbr>`);
+    }
+  });
+
+  it("reaches the focus gloss the tooltip cannot give a keyboard user", () => {
+    expect((html.match(/class="eph-gloss"/g) ?? []).length).toBe(4);
+    expect((html.match(/tabindex="0"/g) ?? []).length).toBe(4);
+  });
+});
+
+describe("EphemeristsMasthead — ink", () => {
+  it("hardcodes no colour and no raw size", () => {
+    const html = render("card", "Aug 2, 2026");
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+    // The retired illuminated-codex family may never reach a plate surface.
+    expect(html).not.toMatch(/--eph-[a-z]/);
+    // Every ink is a band-measured token; nothing here flips with the theme.
+    expect(html).toContain("--faction-ephemerists-plate-band-ink");
+    expect(html).toContain("--faction-ephemerists-plate-band-quiet");
+  });
+});

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsMasthead.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsMasthead.test.tsx
@@ -29,7 +29,7 @@ import "../../../i18n";
 import { EphemeristsMasthead } from "../EphemeristsMasthead";
 
 const AXIS_H = "M100 272 L392 272";
-const render = (scale: "page" | "card", date?: string) =>
+const render = (scale: "page" | "card", date?: string | null) =>
   renderToStaticMarkup(<EphemeristsMasthead slug="ephemerists" scale={scale} date={date} />);
 
 describe("EphemeristsMasthead — the two scales", () => {
@@ -55,8 +55,18 @@ describe("EphemeristsMasthead — the two scales", () => {
 
 describe("EphemeristsMasthead — the datum row", () => {
   it("prints the surface's own date and leaves the cell empty when there is none", () => {
-    expect(render("page", "Aug 2, 2026")).toContain("Aug 2, 2026");
-    expect(render("page")).not.toContain("Aug 2, 2026");
+    expect(render("page", "2026-08-02T09:00:00Z")).toContain("2026");
+    expect(render("page")).not.toContain("2026");
+    expect(render("page", null)).not.toContain("2026");
+  });
+
+  it("prints nothing rather than 'Invalid Date' for a timestamp it cannot read", () => {
+    // The owner's ruling is that the date is REAL or the cell is empty, and
+    // `formatDate` renders an unparseable value as that literal string — an
+    // invention, on the one row a player would read as data.
+    for (const bad of ["", "not a date"]) {
+      expect(render("page", bad)).not.toContain("Invalid Date");
+    }
   });
 
   it("points both coordinates at one place, on every surface and both scales", () => {

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -246,60 +246,18 @@ export function GlyphRegister({ width, y, strength, keyPrefix }: {
   );
 }
 
-/** One wing of the sun disc, drawn as deco stepped bars. */
-function Wing({ flip }: { flip?: boolean }) {
-  return (
-    <g transform={flip ? "scale(-1,1)" : undefined}>
-      {[0, 1, 2, 3, 4].map((i) => (
-        <rect
-          key={i}
-          x={13 + i * 11.4}
-          y={-6 + i * 1.5}
-          width={9.6}
-          height={8.4 - i * 1.4}
-          rx={1.4}
-          fill={GOLD}
-          opacity={0.9 - i * 0.13}
-        />
-      ))}
-      {[0, 1, 2, 3].map((i) => (
-        <rect
-          key={`covert-${i}`}
-          x={15 + i * 11.4}
-          y={4.2 + i * 1.6}
-          width={8}
-          height={3.4 - i * 0.5}
-          rx={1}
-          fill={BRASS_LIGHT}
-          opacity={0.62 - i * 0.11}
-        />
-      ))}
-    </g>
-  );
-}
+/* `Wing` and `WingedDisc` stood here — the winged sun disc, the mark that headed
+   every Ephemerists band and crowned the task detail's action panel.
 
-/** The winged sun disc, at whatever width it is asked for. */
-export function WingedDisc({ width, height, className }: {
-  width: number
-  height: number
-  className?: string
-}) {
-  return (
-    <svg
-      className={className}
-      width={width}
-      height={height}
-      viewBox="-88 -20 176 40"
-      aria-hidden="true"
-      style={{ display: "block", flex: "0 0 auto" }}
-    >
-      <Wing />
-      <Wing flip />
-      <circle r={11} fill={DISC} stroke={BRASS} strokeWidth="1.6" />
-      <circle r={5.5} fill={GOLD} opacity={0.85} />
-    </svg>
-  );
-}
+   #1634 retired it: the engraved masthead carries the kite SIGIL, and the kit
+   shows one mark rather than two. Its last caller was the feed row's band, which
+   is the shape WORLD_ZERO_STYLE §6 names — a device is drawn once and consumed
+   everywhere, so retiring it is one delete rather than five.
+
+   `WingedDiscSign` below is NOT this mark scaled down and does not go with it:
+   it is a separate drawing on the plate's 24-unit square, read by
+   `EmblemOctagon` for the metatask seal's indigo disc (#1207). That surface is
+   the seal epic's, not this one's. */
 
 /**
  * The cavetto cornice: fluted strokes under a stepped double rule.
@@ -378,12 +336,14 @@ export function LotusSign({ width, color }: { width: number; color: string }) {
 }
 
 /**
- * The winged sun disc at SIGN scale — the same emblem {@link WingedDisc} draws
- * across a masthead, redrawn on the plate's 24-unit square so it can sit in a
- * badge. Not a scaled-down copy: the masthead's is 176 units wide and would
- * come out a hairline at 24, so the wings are cut to three stepped bars a side.
+ * The winged sun disc at SIGN scale — redrawn on the plate's 24-unit square so
+ * it can sit in a badge. Never a scaled-down copy of the masthead's disc: that
+ * one was 176 units wide and would have come out a hairline at 24, so the wings
+ * are cut to three stepped bars a side.
  *
- * Its one reader today is the metatask seal's indigo disc (#1207).
+ * Its one reader is the metatask seal's indigo disc (#1207), and that is why it
+ * survived #1634's retirement of the full-size disc: the seal's mark is a
+ * different drawing on a surface this issue does not own.
  */
 export function WingedDiscSign({ size, color }: { size: number; color: string }) {
   return (

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -75,6 +75,73 @@ export const WASH = "var(--faction-ephemerists-plate-wash)";
 export const GRID = "var(--faction-ephemerists-grid)";
 
 /**
+ * The glyph's own voice, over whatever label voice it sits in (#1637).
+ *
+ * Three of the four properties exist to UNDO the surrounding voice rather than
+ * to dress the glyph:
+ *  • `textTransform` — {@link SMALL_CAPS} uppercases the plate's whole label
+ *    tier, and uppercasing a kanji costs a `text-transform` and buys nothing.
+ *  • `fontStyle` — the score stamp's tally line is set in italic Spectral, and a
+ *    CJK fallback face has no italic, so the browser synthesises a slant.
+ *  • `fontSize` — the label tier is `--text-xs` (8px). A Latin label is scanned
+ *    at that size; 基 is eleven strokes and simply fills in. `--text-xl` is the
+ *    smallest token inside the 13–16px band #1637 names as legible, so it is the
+ *    DEFAULT rather than the only value — a caller with its own ramp (the
+ *    masthead's two scales) passes `size` and keeps the three undos.
+ * `letterSpacing` is the design's 0.06em.
+ */
+const GLYPH_VOICE: CSSProperties = {
+  lineHeight: 1,
+  letterSpacing: "0.06em",
+  textTransform: "none",
+  fontStyle: "normal",
+};
+
+/**
+ * A label the reader decodes (#1637): the kanji is what shows, and the English
+ * is one gesture away on `title`.
+ *
+ * ONE attribute carries the whole reveal — a pointer opens it as a tooltip and
+ * assistive tech reads it out — which is the owner's ruling and not an
+ * incidental choice: a visually-hidden twin would be a second copy of the same
+ * fact, free to drift from the one on screen. The gloss handed in here is always
+ * the very string another surface prints in English, so the two cannot disagree
+ * about what the mark is called.
+ *
+ * `<abbr>` is the element for "short form, expansion available", and it is what
+ * draws the native dotted underline — the only hint that there is anything to
+ * look up. `tabIndex` is what makes FOCUS one of the gestures; without it the
+ * glyph is pointer-only and the ruling's keyboard half is a word.
+ *
+ * `.eph-gloss` in index.css is #1637's own ponytail taken up now that the
+ * component has a second consumer: a `:focus-visible` panel reading
+ * `attr(title)`, because the native tooltip is a POINTER affordance and a
+ * sighted keyboard user got nothing from it.
+ *
+ * The caller's `style` is overridden by the voice, not the other way round —
+ * every consumer hands in a label style whose casing, slant and size are exactly
+ * what the three undos exist to cancel.
+ */
+export function GlossedGlyph({ glyph, gloss, size, style }: {
+  glyph: string
+  gloss: string
+  /** The glyph's own optical size. Defaults to the smallest legible rung. */
+  size?: string
+  style?: CSSProperties
+}) {
+  return (
+    <abbr
+      className="eph-gloss"
+      title={gloss}
+      tabIndex={0}
+      style={{ ...style, ...GLYPH_VOICE, fontSize: size ?? "var(--text-xl)" }}
+    >
+      {glyph}
+    </abbr>
+  );
+}
+
+/**
  * The plate's STEPPED CORNER — top-left and bottom-right chamfered, so a cell
  * reads as cut from stone rather than rounded. The design draws it on the score
  * box (7), the ratio chip inside it (5), the byline cartouche (7) and the vote

--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -24,8 +24,14 @@
  * one surface — so the codex atoms leave the file rather than sit under the new
  * band.
  *
- * Every mark is REUSED from `ephemeristsPlate`, never redrawn: `WingedDisc`,
+ * Every mark is REUSED from the kit, never redrawn: `EphemeristsSigil`,
  * `Cornice`, `GlyphRegister`. No new SVG.
+ *
+ * The band's mark was the winged sun disc until #1634 retired it kit-wide — the
+ * sigil is the only mark, and this row was its last caller anywhere. It takes
+ * the sigil at the disc's own height, which is under #1635's 20px threshold, so
+ * what lands here is the reduced cut: the kite and its apex point, with the rule
+ * floored at a device pixel rather than fading to a grey smear.
  *
  * ## Two things the sheet draws that this card deliberately does not
  *
@@ -67,8 +73,8 @@ import {
   SHADOW,
   SMALL_CAPS,
   WASH,
-  WingedDisc,
 } from '../factionMarks/ephemeristsPlate'
+import { EphemeristsSigil } from '../sigil/EphemeristsSigil'
 import { useFormFactor } from '../../hooks/useFormFactor'
 import type { FeedFrameProps } from './feedFrameProps'
 import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
@@ -101,8 +107,8 @@ interface BandSize {
   /** Masthead height, and the width its register is drawn to fill. Geometry. */
   height: number
   view: number
-  /** The winged disc crowning the band. Geometry. */
-  disc: number
+  /** The sigil at the head of the band. Its HEIGHT — the mark owns its ratio
+   *  (#1635) — so there is one number, not two. */
   discHeight: number
   /** Strength of the incised register behind the label. */
   register: number
@@ -116,7 +122,6 @@ const SIZES: Record<'desktop' | 'mobile', BandSize> = {
   desktop: {
     height: 30,
     view: 452,
-    disc: 58,
     discHeight: 14,
     register: 0.24,
     bandPadding: 'var(--space-xs) var(--space-md)',
@@ -125,7 +130,6 @@ const SIZES: Record<'desktop' | 'mobile', BandSize> = {
   mobile: {
     height: 26,
     view: 360,
-    disc: 42,
     discHeight: 10,
     register: 0.2,
     bandPadding: 'var(--space-xs) var(--space-sm)',
@@ -210,7 +214,7 @@ export default function EphemeristsFeedFrame({
             minWidth: 0,
           }}
         >
-          <WingedDisc width={size.disc} height={size.discHeight} />
+          <EphemeristsSigil size={size.discHeight} color={BAND_INK} />
           <span
             style={{
               ...SMALL_CAPS,

--- a/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
+++ b/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
@@ -88,12 +88,22 @@ describe('EphemeristsFeedFrame — the Valley plate ground', () => {
     expect(frame()).not.toMatch(/#[0-9a-fA-F]{3,8}\b/)
   })
 
-  it('reuses the plate ornament rather than drawing new marks', () => {
+  it('reuses the kit ornament rather than drawing new marks', () => {
     const html = frame()
-    // The winged disc's medallion (a `plate-disc` fill) and the incised register
-    // (`epg-glyph`, whose breathe cycle + reduced-motion gate live in index.css).
-    expect(html).toContain('--faction-ephemerists-plate-disc')
+    // The kite sigil (#1635) and the incised register (`epg-glyph`, whose
+    // breathe cycle + reduced-motion gate live in index.css). The band's mark
+    // was the winged sun disc until #1634 retired it kit-wide; this row was its
+    // last caller anywhere, so the disc's own `plate-disc` medallion fill must
+    // not survive here.
+    expect(html).toContain('M243 120 L55 272 L243 490 L425 272 Z')
+    expect(html).not.toContain('--faction-ephemerists-plate-disc')
     expect(html).toContain('epg-glyph')
+  })
+
+  it('takes the sigil at the REDUCED cut, since the band is 10-14px tall', () => {
+    // Both band heights sit under #1635's 20px threshold, so the mark drops its
+    // crossed axes and vertex discs rather than drawing them at half a pixel.
+    expect(frame()).not.toContain('M100 272 L392 272')
   })
 
   it('keeps its ornament stacking inside the card', () => {

--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -104,15 +104,28 @@ describe('the Ephemerists praxis card wears the Valley plate (#1207)', () => {
     // belongs to the sweep, not to this card.
   })
 
-  it('carries the night-band masthead: winged disc over an incised register', () => {
+  it('carries the night-band masthead: the engraved title over an incised register', () => {
     const markup = html()
     // The register's signs and the cornice are the kit's, not a second copy.
     expect(markup).toContain('class="epg-glyph"')
     expect(markup).toContain('var(--faction-ephemerists-plate-band)')
   })
 
-  it('heads the record with the cartouche, ruled off at both ends', () => {
-    expect(text(html())).toContain(i18n.t('praxis:card.masthead.ephemerists'))
+  it('heads the record with the engraved masthead, and says the wordmark ONCE', () => {
+    // #1634 replaced the winged disc + Poiret One wordmark with the engraved
+    // masthead, and retired the brass cartouche pill that repeated the faction's
+    // name 40px below it. Both halves are asserted here because a mount that
+    // adds the masthead and leaves the pill is the failure that still renders:
+    // it looks like a masthead with a subtitle.
+    const rendered = text(html())
+    expect(rendered).toContain(i18n.t('factions:names.ephemerists'))
+    // The pill's own copy, spelled out: `praxis:card.masthead.ephemerists` was
+    // deleted with the pill, and a key kept alive by a negative assertion is a
+    // key the next dead-key sweep cannot tell from a live one.
+    expect(rendered).not.toContain('Ephemeris · sealed entry')
+    // The masthead's own register, at the card scale's rung.
+    expect(rendered).toContain('星')
+    expect(html()).toContain('var(--faction-ephemerists-plate-band-quiet)')
   })
 
   it('reads the task through the plate gloss rather than as a bare reference', () => {

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -17,19 +17,21 @@ import {
   READING,
   SHADOW,
   SMALL_CAPS,
-  WASH,
-  WingedDisc,
 } from "../../factionMarks/ephemeristsPlate";
-import { factionName } from "../../../utils/factions";
+import { EphemeristsMasthead } from "../../factionMarks/EphemeristsMasthead";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
 /**
  * The Ephemerists — THE FIELD-JOURNAL PLATE (#1207, the Valley plate at card
- * size). A papyrus leaf under a night-band masthead: a winged sun disc over an
- * incised register of glyphs, a cavetto cornice ruling it off, the entry's
- * cartouche, the Poiret One title over its Spectral gloss, and the tally cell
- * cut into the right column.
+ * size). A papyrus leaf under a night-band masthead: the ENGRAVED MASTHEAD at
+ * card scale (#1634) over an incised register of glyphs, a cavetto cornice
+ * ruling it off, the Poiret One title over its Spectral gloss, and the tally
+ * cell cut into the right column.
+ *
+ * The masthead replaced two things at once: the winged sun disc over a
+ * letterspaced Poiret One wordmark that headed the band, and the brass cartouche
+ * pill below the cornice that said "THE EPHEMERISTS" a second time.
  *
  * It replaces THE CODEX (#841) — the vellum folio painted out of the retired
  * `--eph-*` family. That family is still declared and still worn by every other
@@ -61,11 +63,11 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  *    8 the codex folio used.
  */
 
-/** Masthead band, and the field its register is drawn across. Geometry (§4a). */
+/** Masthead band, and the field its register is drawn across. Geometry (§4a).
+ *  A FLOOR since #1634, not a height: the engraved masthead sizes itself from
+ *  its own padding, and a fixed band would crop it. */
 const MASTHEAD = 110;
 const MASTHEAD_VIEW = 340;
-/** The wordmark's winged disc, at the design's own span. Geometry. */
-const WORDMARK_DISC = 176;
 
 /**
  * The drifting strip above the vote block — a run of marks from the plate's
@@ -77,9 +79,6 @@ const DRIFT = [
   "‖", "ψ", "⟩", "∝", "Σ", "μ", "ν", "·", "⊗", "Δ", "λ", "≥", "ϖ", "·", "∫",
   "ρ", "∂",
 ];
-
-/** The cartouche's end rules. Ornament geometry, so it is shared, not repeated. */
-const cartoucheTick: CSSProperties = { width: 1.5, height: 12, background: BRASS };
 
 export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   const { t } = useTranslation("praxis");
@@ -101,19 +100,19 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
         transition: "background 150ms, color 150ms",
       }}
     >
-      {/* The masthead: the winged sun disc over an incised register, on night. */}
+      {/* The masthead: the engraved title over an incised register, on night. */}
       <div
         style={{
           position: "relative",
           overflow: "hidden",
-          height: MASTHEAD,
+          minHeight: MASTHEAD,
           background: BAND,
           color: BAND_INK,
         }}
       >
         <svg
           width="100%"
-          height={MASTHEAD}
+          height="100%"
           viewBox={`0 0 ${MASTHEAD_VIEW} ${MASTHEAD}`}
           preserveAspectRatio="xMidYMid slice"
           aria-hidden="true"
@@ -127,31 +126,12 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
           />
           <GlyphRegister width={MASTHEAD_VIEW} y={97} strength={0.3} keyPrefix="card" />
         </svg>
-        <div
-          style={{
-            position: "relative",
-            zIndex: 2,
-            height: "100%",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "var(--space-xs)",
-          }}
-        >
-          <WingedDisc width={WORDMARK_DISC} height={40} />
-          <span
-            style={{
-              fontFamily: DECO,
-              fontSize: "var(--text-content)",
-              letterSpacing: "0.3em",
-              textTransform: "uppercase",
-              color: BAND_INK,
-              whiteSpace: "nowrap",
-            }}
-          >
-            {factionName(praxis.task_faction_slug)}
-          </span>
+        <div style={{ position: "relative", zIndex: 2 }}>
+          <EphemeristsMasthead
+            slug={praxis.task_faction_slug}
+            scale="card"
+            date={praxis.submitted_at ?? praxis.created_at}
+          />
         </div>
       </div>
       <Cornice />
@@ -165,34 +145,10 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
       >
         <AdminOverlay {...adminProps} />
 
-        {/* The entry's cartouche, ruled off at both ends. */}
-        <div style={{ display: "flex", justifyContent: "center", padding: "var(--space-md) 0 var(--space-sm)" }}>
-          <span
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: "var(--space-sm)",
-              padding: "var(--space-xs) var(--space-md)",
-              border: `1.5px solid ${BRASS}`,
-              borderRadius: 12,
-              background: WASH,
-            }}
-          >
-            <span aria-hidden style={cartoucheTick} />
-            <span
-              style={{
-                ...SMALL_CAPS,
-                fontWeight: 700,
-                fontSize: "var(--text-sm)",
-                color: INK,
-                whiteSpace: "nowrap",
-              }}
-            >
-              {t("card.masthead.ephemerists")}
-            </span>
-            <span aria-hidden style={cartoucheTick} />
-          </span>
-        </div>
+        {/* The entry's cartouche stood here, a pill reading "THE EPHEMERISTS"
+            ruled off at both ends. #1634 retired it: the masthead directly above
+            now carries that wordmark in the engraved title, so the pill was the
+            same word said twice within 40px. */}
 
         <PraxisBody
           praxis={praxis}

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import {
@@ -7,6 +6,7 @@ import {
   CAPTION,
   DECO,
   DISC,
+  GlossedGlyph,
   INK,
   INNER,
   LotusSign,
@@ -56,67 +56,6 @@ import type { ScoreStampProps } from "./ScoreStamp";
 /** The octagon medallion, and its inner rule. Ornament geometry (§4a). */
 const MEDALLION = 104;
 const MEDALLION_INSET = 6;
-
-/**
- * The glyph's own voice, over whatever label voice it sits in (#1637).
- *
- * Three of the four properties exist to UNDO the surrounding voice rather than
- * to dress the glyph:
- *  • `textTransform` — `SMALL_CAPS` uppercases the plate's whole label tier, and
- *    uppercasing a kanji costs a `text-transform` and buys nothing. The design
- *    names this one out loud.
- *  • `fontStyle` — the tally line is set in italic Spectral, and a CJK fallback
- *    face has no italic, so the browser synthesises a slant. Undo it.
- *  • `fontSize` — the label tier is `--text-xs` (8px). A Latin label is scanned
- *    at that size; 基 is eleven strokes and simply fills in. `--text-xl` is the
- *    smallest token inside the 13-16px band the issue names as legible, and the
- *    labels are the only thing that grows: every figure keeps its own size.
- * `letterSpacing` is the design's 0.06em.
- */
-const GLYPH: CSSProperties = {
-  fontSize: "var(--text-xl)",
-  lineHeight: 1,
-  letterSpacing: "0.06em",
-  textTransform: "none",
-  fontStyle: "normal",
-};
-
-/**
- * A label the reader decodes (#1637): the kanji is what shows, and the English
- * is one gesture away on `title`.
- *
- * ONE attribute carries the whole reveal — a pointer opens it as a tooltip and
- * assistive tech reads it out — which is the owner's ruling and not an
- * incidental choice: a visually-hidden twin would be a second copy of the same
- * fact, free to drift from the one on screen. The gloss handed in here is
- * always the very string another faction's stamp prints, so the two cannot
- * disagree about what the row is called.
- *
- * `<abbr>` is the element for "short form, expansion available", and it is what
- * draws the native dotted underline — the only hint that there is anything to
- * look up. `tabIndex` is what makes FOCUS one of the gestures; without it the
- * glyph is pointer-only and the ruling's keyboard half is a word.
- *
- * ponytail: the reveal is the browser's own tooltip, so a sighted keyboard user
- * gets it only where focus tooltips are implemented. The upgrade is a
- * `:focus-visible` gloss reading `attr(title)` — that lives in `index.css`, is a
- * styling decision, and is not taken here.
- */
-function GlossedGlyph({
-  glyph,
-  gloss,
-  style,
-}: {
-  glyph: string;
-  gloss: string;
-  style?: CSSProperties;
-}) {
-  return (
-    <abbr title={gloss} tabIndex={0} style={{ ...style, ...GLYPH }}>
-      {glyph}
-    </abbr>
-  );
-}
 
 export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3913,13 +3913,49 @@
   transition: background-color 300ms;
 }
 
-/* The winged disc crowning the action panel (#1032). The design lifted the gold
-   off the PAPYRUS with a hard night-blue offset plus a soft cast, and dropped to
-   a plain soft cast on the dark plate where the hard edge would only smear. Only
-   the second case survives #1627: there is no papyrus plate in either cascade
-   now, and a hard navy offset against a navy ground draws nothing. */
-.eph-plate-crown {
-  filter: drop-shadow(0 3px 7px rgba(0, 0, 0, 0.6));
+/* `.eph-plate-crown` stood here — the drop-shadow lifting the winged sun disc
+   off the task detail's action panel (#1032). #1634 retired the disc across the
+   kit ("the sigil is the only mark"), so the shadow has nothing left to lift.
+
+   THE GLOSS PANEL (#1634, taking up #1637's ponytail). Every glossed kanji is an
+   `<abbr title>`, and a title is a POINTER affordance: hovering opens the
+   browser's tooltip and focusing opens nothing. `tabIndex={0}` put the glyph in
+   the tab order, which without this rule buys a focus ring around a mark whose
+   expansion the keyboard user still cannot read. The panel is the expansion,
+   drawn from `attr(title)` so it cannot drift from the tooltip beside it.
+
+   `:focus-visible` rather than `:focus`, so a pointer user who clicks a glyph
+   gets the tooltip they were already getting and not two copies of it.
+
+   The panel is theme-INVARIANT because every surface it can appear on is one of
+   the plate register's night grounds (#1627) — the score stamp's cut cell and
+   the masthead's cornice band. `-band` under `-band-ink` is the pairing the
+   masthead's own wordmark already runs at 14.00:1.
+
+   `white-space: nowrap` plus `pointer-events: none` keep it a readout: it never
+   wraps to two lines over the row beneath, and it cannot swallow a click meant
+   for whatever it is covering. */
+.eph-gloss {
+  position: relative;
+}
+.eph-gloss:focus-visible::after {
+  content: attr(title);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + var(--space-xs));
+  transform: translateX(-50%);
+  z-index: 6;
+  padding: 0 var(--space-xs);
+  border: 1px solid var(--faction-ephemerists-plate-brass);
+  background: var(--faction-ephemerists-plate-band);
+  color: var(--faction-ephemerists-plate-band-ink);
+  font-family: var(--font-body);
+  font-size: var(--text-lg);
+  font-style: normal;
+  letter-spacing: normal;
+  text-transform: none;
+  white-space: nowrap;
+  pointer-events: none;
 }
 
 /* Ephemerists — THE SLOW GLOW ON THE CORNICE (praxis detail v2, #1120). A gold

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -96,6 +96,16 @@
     }
   },
   "ephemerists": {
+    "masthead": {
+      "starMark": "星",
+      "star": "Star",
+      "almanacMark": "暦",
+      "almanac": "Almanac",
+      "observationMark": "観",
+      "observation": "Observation",
+      "recordMark": "録",
+      "record": "Record"
+    },
     "apparatus": {
       "heading": "The Apparatus",
       "empty": "No apparatus recorded yet."

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -74,7 +74,6 @@
     },
     "masthead": {
       "ua": "Acquisition · filed",
-      "ephemerists": "Ephemeris · sealed entry",
       "everymen": "The Everymen",
       "snide": "evidence locker",
       "albescent": "Account · filed",

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -35,14 +35,18 @@
  * because it is not composer page copy but `collabCopy`'s override table, read
  * by `CollabRoster` on `/praxis/:id` too. The masthead's one word is the
  * faction's NAME out of `factions.json` (`factionName`), the same string the
- * praxis-detail masthead sets — a name, not a voice.
+ * praxis-detail masthead sets — a name, not a voice. Since #1634 that name is
+ * set by `EphemeristsMasthead` rather than here, which is the same string
+ * through the same lookup on one more surface.
  *
  * ## Marks: reused, not redrawn (WORLD_ZERO_STYLE §6, "one primitive")
  *
- * The winged disc, the cornice, the fluted rule, the incised signs and the
- * stepped octagon are all `components/factionMarks/ephemeristsPlate` — the module
- * #1120 extracted so the plate's ornament is shared rather than copied. This
- * file draws no new SVG apart from the two marks' arrangement.
+ * The engraved masthead, the cornice, the fluted rule, the incised signs and the
+ * stepped octagon are all `components/factionMarks` — the module #1120 extracted
+ * so the plate's ornament is shared rather than copied. This file draws no new
+ * SVG apart from the two marks' arrangement. The winged sun disc that headed the
+ * sky band was retired kit-wide by #1634: the sigil is the only mark, and it
+ * arrives inside the masthead.
  *
  * `RingMark` is deliberately NOT used for either mark. It is a ring with a
  * circular punch, and both of this design's marks are octagons — a stepped
@@ -79,7 +83,6 @@
 import { useState, type CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { mediaUrl } from "../../../utils/media";
-import { factionName } from "../../../utils/factions";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
 import { pickArtKey } from "../blocks/useMediaArt";
@@ -139,8 +142,8 @@ import {
   SHADOW,
   SMALL_CAPS,
   Sign,
-  WingedDisc,
 } from "../../../components/factionMarks/ephemeristsPlate";
+import { EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
 import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -159,12 +162,12 @@ const CTA_INK = "var(--faction-ephemerists-plate-cta-ink)";
 
 /* ── Ornament geometry (WORLD_ZERO_STYLE §4a: not layout spacing) ──
  *
- * `EPH_BAND` is the design's own name for the sky band's height. The pairs
- * below are its desktop / mobile values, and the praxis-detail masthead's — one
- * plate, one masthead, drawn at the same two sizes on both surfaces. */
+ * `EPH_BAND` is the design's own name for the sky band's height, and since #1634
+ * it is a FLOOR rather than a height — the engraved masthead sizes the band from
+ * its own padding. The pair is its desktop / mobile values, and the
+ * praxis-detail masthead's: one plate, one masthead, at the same two sizes on
+ * both surfaces. `WORDMARK_DISC` went with the winged disc it measured. */
 const EPH_BAND = { desktop: 84, mobile: 68 };
-const WORDMARK_DISC = { desktop: 150, mobile: 124 };
-const WORDMARK_DISC_HEIGHT = 32;
 /** The journal ruling's leading, and where the ochre margin rule is struck. */
 const RULING = 25;
 const MARGIN_RULE = { desktop: 22, mobile: 13 };
@@ -374,36 +377,21 @@ export default function EphemeristsEditPraxis({ state }: Props) {
               height={EPH_BAND[factor]}
               background={`linear-gradient(180deg, color-mix(in srgb, var(--faction-ephemerists-plate-band) 82%, ${NILE}) 0%, var(--faction-ephemerists-plate-band) 100%)`}
               style={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                gap: "var(--space-xs)",
+                // The engraved masthead sizes itself from its own padding, so
+                // the shared band's `height` becomes a FLOOR. `style` is spread
+                // after `height` in `ComposerMasthead`, which is what lets a skin
+                // relax it without the shared block growing a second prop.
+                height: "auto",
+                minHeight: EPH_BAND[factor],
                 overflow: "hidden",
                 color: BAND_INK,
               }}
             >
-              <WingedDisc
-                width={WORDMARK_DISC[factor]}
-                height={WORDMARK_DISC_HEIGHT}
+              <EphemeristsMasthead
+                slug={praxis.task_faction_slug}
+                scale={sizes.isMobile ? "card" : "page"}
+                date={praxis.submitted_at ?? praxis.created_at}
               />
-              <span
-                style={{
-                  fontFamily: DECO,
-                  // Chrome, not content: a wordmark is scanned. The design's
-                  // 19/16 land on the two nearest rungs.
-                  fontSize: sizes.isMobile
-                    ? "var(--text-xl)"
-                    : "var(--text-content)",
-                  letterSpacing: "0.3em",
-                  textTransform: "uppercase",
-                  lineHeight: 1,
-                  color: BAND_INK,
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {factionName(praxis.task_faction_slug)}
-              </span>
             </ComposerMasthead>
             {/* The cavetto cornice, beneath the band, carrying the one motion. */}
             <Cornice glow />

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -7,7 +7,10 @@
  * re-deriving it here. What this file adds is the Valley plate at record size:
  * the same Deco × Egypt metaphor the v2 task card (#1023) and task detail
  * (#1032) wear, turned from a posting into the account of a deed done. A cavetto
- * cornice under a night band of incised registers, a winged sun disc, stepped
+ * cornice under a night band of incised registers, the ENGRAVED MASTHEAD (#1634,
+ * page scale on desktop and card scale on a phone, in place of the winged sun
+ * disc and the Poiret One wordmark it replaced, and in place of the brass
+ * cartouche that used to frame the breadcrumb's last crumb), stepped
  * octagon bylines, small caps for every label, and the write-up on a leaf with
  * an ochre margin rule. Poiret One display, Cinzel small caps, Spectral reading,
  * EB Garamond marginalia — the issue's four faces, all four already in the
@@ -114,16 +117,14 @@ import {
   SHADOW,
   SMALL_CAPS,
   Sign,
-  WASH,
-  WingedDisc,
   BAND,
   BAND_INK,
   BRASS_LIGHT,
 } from "../../../components/factionMarks/ephemeristsPlate";
+import { EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
 import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
-import { factionName } from "../../../utils/factions";
 import {
   PraxisAdminBar,
   PraxisStatusBanners,
@@ -144,8 +145,6 @@ interface SizeSet {
   /** Masthead band height, and the width its registers are drawn to fill. */
   masthead: number
   mastheadView: number
-  /** The masthead's winged disc. Geometry. */
-  wordmarkDisc: number
   /** A byline octagon. Geometry. */
   disc: number
   titleSize: string
@@ -161,7 +160,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   desktop: {
     masthead: 84,
     mastheadView: 1200,
-    wordmarkDisc: 150,
     disc: 46,
     titleSize: "var(--text-display)",
     pagePadding: "var(--space-2xl)",
@@ -172,7 +170,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   mobile: {
     masthead: 68,
     mastheadView: 440,
-    wordmarkDisc: 124,
     disc: 40,
     titleSize: "var(--text-heading)",
     pagePadding: "var(--space-lg)",
@@ -330,7 +327,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
     </div>
   );
 
-  // ── The masthead: night band, one incised register, the winged disc ───────
+  // ── The masthead: night band, one incised register, the engraved title ────
   //
   // Shorter than the task page's: a record is filed ON the plate, not the plate
   // itself, so it carries one register rather than two.
@@ -340,14 +337,14 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
         style={{
           position: "relative",
           overflow: "hidden",
-          height: size.masthead,
+          minHeight: size.masthead,
           background: BAND,
           color: BAND_INK,
         }}
       >
         <svg
           width="100%"
-          height={size.masthead}
+          height="100%"
           viewBox={`0 0 ${size.mastheadView} 84`}
           preserveAspectRatio="xMidYMid slice"
           aria-hidden="true"
@@ -361,31 +358,12 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
           />
           <GlyphRegister width={size.mastheadView} y={72} strength={0.3} keyPrefix="rec" />
         </svg>
-        <div
-          style={{
-            position: "relative",
-            zIndex: 2,
-            height: "100%",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "var(--space-xs)",
-          }}
-        >
-          <WingedDisc width={size.wordmarkDisc} height={32} />
-          <span
-            style={{
-              fontFamily: DECO,
-              fontSize: "var(--text-lg)",
-              letterSpacing: "0.3em",
-              textTransform: "uppercase",
-              color: BAND_INK,
-              whiteSpace: "nowrap",
-            }}
-          >
-            {factionName(praxis.task_faction_slug)}
-          </span>
+        <div style={{ position: "relative", zIndex: 2 }}>
+          <EphemeristsMasthead
+            slug={praxis.task_faction_slug}
+            scale={desktop ? "page" : "card"}
+            date={praxis.submitted_at ?? praxis.created_at}
+          />
         </div>
       </div>
       <Cornice glow />
@@ -421,24 +399,13 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
       <span aria-hidden style={eyebrow}>
         /
       </span>
-      {/* The cartouche — this record, ruled off at both ends. */}
-      <span
-        style={{
-          display: "inline-flex",
-          alignItems: "center",
-          gap: "var(--space-sm)",
-          padding: "var(--space-xs) var(--space-md)",
-          border: `1.5px solid ${BRASS}`,
-          borderRadius: 12,
-          background: WASH,
-        }}
-      >
-        <span aria-hidden style={{ width: 1.5, height: 12, background: BRASS }} />
-        <span style={{ ...SMALL_CAPS, fontWeight: 700, fontSize: "var(--text-base)", color: INK }}>
-          {t("detail.breadcrumb.current")}
-        </span>
-        <span aria-hidden style={{ width: 1.5, height: 12, background: BRASS }} />
-      </span>
+      {/* The last crumb was a brass CARTOUCHE pill, ruled off at both ends.
+          #1634 retired it: the engraved masthead directly above the crumb row
+          carries this record's own identity now, and a framed pill under it read
+          as a second masthead rather than as where-you-are. The crumb stays —
+          the trail's last step is still a fact — in the plain eyebrow its
+          siblings wear. */}
+      <span style={{ ...eyebrow, color: INK }}>{t("detail.breadcrumb.current")}</span>
     </nav>
   );
 

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -131,16 +131,27 @@ describe("Ephemerists task detail — the Valley plate", () => {
     }
   });
 
-  it("wears the Valley dress — masthead band, incised registers, crowned panel", () => {
+  it("wears the Valley dress — masthead band, incised registers, engraved title", () => {
     const { html, text } = render(<EphemeristsTaskDetail state={baseState()} />);
     expect(html, "papyrus page sheet").toContain("eph-plate-sheet");
     expect(html, "cornice masthead band").toContain("--faction-ephemerists-plate-band");
     expect(html, "incised glyph registers").toContain("epg-glyph");
-    expect(html, "the disc crowning the action panel").toContain("eph-plate-crown");
     expect(html, "the stepped octagon medallion").toContain("M30 4 L70 4 L96 30");
     expect(text, "the masthead wordmark").toContain("The Ephemerists");
+    expect(html, "the masthead's kite sigil").toContain("M243 120 L55 272 L243 490 L425 272 Z");
+    expect(text, "the masthead's four-kanji register").toContain("星暦観録");
     // The codex ground belongs to the OTHER Ephemerists surfaces now.
     expect(html, "retired illuminated-codex ground").not.toContain("--eph-vellum");
+  });
+
+  it("crowns the action panel with nothing — the sigil is the only mark (#1634)", () => {
+    // A 400px winged sun disc used to hang over the panel in reserved space, on
+    // this page's own LOCAL copy of the shared kit's disc. Both halves of that
+    // are asserted, because deleting the mark and leaving the reserve renders as
+    // a plate floating below a gap that nothing explains.
+    const { html } = render(<EphemeristsTaskDetail state={baseState()} />);
+    expect(html, "the retired crown's shadow class").not.toContain("eph-plate-crown");
+    expect(html, "the disc's own wing geometry").not.toContain('viewBox="-88 -20 176 40"');
   });
 
   it("renders the in-progress population as a header count", () => {

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -2,6 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
+import { EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { factionCssVar, factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
@@ -21,11 +22,17 @@ import type { TaskDetailState } from "../useTaskDetail";
  *
  * Deco × Egypt, the same metaphor the v2 task card ships (#1023): a papyrus
  * field journal out of the Valley. A cavetto-cornice masthead whose night band
- * holds a winged sun disc between two incised registers of glyphs; the task
- * number in a cartouche; the level a numeral over tally strokes; the worth on a
- * stepped octagon medallion inside a panel crowned by a second winged disc; the
- * brief on a ruled leaf with a red margin rule. Poiret One display, Cinzel small
- * caps, Spectral reading.
+ * holds the ENGRAVED MASTHEAD (#1634, page scale on desktop and card scale on a
+ * phone) between two incised registers of glyphs; the level a numeral over tally
+ * strokes; the worth on a stepped octagon medallion; the brief on a ruled leaf
+ * with a red margin rule. Poiret One display, Cinzel small caps, Spectral
+ * reading.
+ *
+ * The winged sun disc appeared TWICE on this page — over the wordmark, and 400px
+ * wide crowning the action panel — from a local copy of the shared kit's mark.
+ * #1634 retired the disc across the kit: the sigil is the only mark, and it is
+ * in the masthead. The panel's reserved space and the `collapsedMinWidth` that
+ * kept the column from narrowing under it went with the crown.
  *
  * This REPLACES "The Discordant Map" — the 909-line illuminated-codex archetype
  * built on `credenceHeading` / `ephemeridesHeading` / `cartographersHeading` /
@@ -208,60 +215,11 @@ function GlyphRegister({ width, y, strength, keyPrefix }: {
   );
 }
 
-/** One wing of the sun disc, drawn as deco stepped bars. */
-function Wing({ flip }: { flip?: boolean }) {
-  return (
-    <g transform={flip ? "scale(-1,1)" : undefined}>
-      {[0, 1, 2, 3, 4].map((i) => (
-        <rect
-          key={i}
-          x={13 + i * 11.4}
-          y={-6 + i * 1.5}
-          width={9.6}
-          height={8.4 - i * 1.4}
-          rx={1.4}
-          fill={GOLD}
-          opacity={0.9 - i * 0.13}
-        />
-      ))}
-      {[0, 1, 2, 3].map((i) => (
-        <rect
-          key={`covert-${i}`}
-          x={15 + i * 11.4}
-          y={4.2 + i * 1.6}
-          width={8}
-          height={3.4 - i * 0.5}
-          rx={1}
-          fill={BRASS_LIGHT}
-          opacity={0.62 - i * 0.11}
-        />
-      ))}
-    </g>
-  );
-}
-
-/** The winged sun disc, at whatever width it is asked for. */
-function WingedDisc({ width, height, className }: {
-  width: number
-  height: number
-  className?: string
-}) {
-  return (
-    <svg
-      className={className}
-      width={width}
-      height={height}
-      viewBox="-88 -20 176 40"
-      aria-hidden="true"
-      style={{ display: "block", flex: "0 0 auto" }}
-    >
-      <Wing />
-      <Wing flip />
-      <circle r={11} fill={DISC} stroke={BRASS} strokeWidth="1.6" />
-      <circle r={5.5} fill={GOLD} opacity={0.85} />
-    </svg>
-  );
-}
+/* `Wing` and `WingedDisc` stood here — this page's LOCAL copy of the shared
+   kit's winged sun disc (the two were byte-identical, which is how a duplicate
+   survives review). #1634 retired the mark across the kit: the sigil is the only
+   one now, and it arrives through `EphemeristsMasthead`. The copy goes with the
+   original rather than outliving it. */
 
 /** A stepped octagon, inset from the medallion's edge. */
 function Octagon({ inset, stroke, width, fill }: {
@@ -369,9 +327,6 @@ interface SizeSet {
   /** The wordmark's winged disc. Geometry. */
   wordmarkDisc: number
   /** The disc crowning the action panel, and the room reserved above it. */
-  crownWidth: number
-  crownHeight: number
-  crownReserve: number
   /** The points medallion, and the ledger cell that holds it. Geometry. */
   medallion: number
   ledgerWidth: number
@@ -399,9 +354,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
     masthead: 108,
     mastheadView: 1200,
     wordmarkDisc: 176,
-    crownWidth: 400,
-    crownHeight: 91,
-    crownReserve: 96,
     medallion: 104,
     ledgerWidth: 150,
     tapTarget: 32,
@@ -417,9 +369,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
     masthead: 92,
     mastheadView: 440,
     wordmarkDisc: 150,
-    crownWidth: 290,
-    crownHeight: 66,
-    crownReserve: 74,
     medallion: 88,
     ledgerWidth: 116,
     tapTarget: 44,
@@ -597,21 +546,21 @@ export default function EphemeristsTaskDetail({
     </div>
   );
 
-  // ── The masthead: the night band, its two registers, the winged disc ──
+  // ── The masthead: the night band, its two registers, the engraved title ──
   const masthead = (
     <div style={{ marginBottom: desktop ? "var(--space-xl)" : "var(--space-lg)" }}>
       <div
         style={{
           position: "relative",
           overflow: "hidden",
-          height: size.masthead,
+          minHeight: size.masthead,
           background: BAND,
           color: BAND_INK,
         }}
       >
         <svg
           width="100%"
-          height={size.masthead}
+          height="100%"
           viewBox={`0 0 ${size.mastheadView} 108`}
           preserveAspectRatio="xMidYMid slice"
           aria-hidden="true"
@@ -626,31 +575,12 @@ export default function EphemeristsTaskDetail({
           <GlyphRegister width={size.mastheadView} y={13} strength={0.34} keyPrefix="top" />
           <GlyphRegister width={size.mastheadView} y={95} strength={0.3} keyPrefix="bottom" />
         </svg>
-        <div
-          style={{
-            position: "relative",
-            zIndex: 2,
-            height: "100%",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: "var(--space-xs)",
-          }}
-        >
-          <WingedDisc width={size.wordmarkDisc} height={38} />
-          <span
-            style={{
-              fontFamily: DECO,
-              fontSize: "var(--text-xl)",
-              letterSpacing: "0.3em",
-              textTransform: "uppercase",
-              color: BAND_INK,
-              whiteSpace: "nowrap",
-            }}
-          >
-            {factionName(slug)}
-          </span>
+        <div style={{ position: "relative", zIndex: 2 }}>
+          <EphemeristsMasthead
+            slug={slug}
+            scale={desktop ? "page" : "card"}
+            date={task.created_at}
+          />
         </div>
       </div>
       <Cornice />
@@ -858,10 +788,12 @@ export default function EphemeristsTaskDetail({
       style={{
         ...cell,
         // Alone on the plate — no move for this viewer (#1138) — the ledger
-        // takes the width the crown reserves rather than sitting in one corner
-        // of it. The crown cannot narrow with the plate: it is absolutely
-        // positioned, so it adds nothing to a shrink-to-fit width and would
-        // overhang both edges. Hence `collapsedMinWidth` at the column below.
+        // spreads to the plate rather than sitting in one corner of it. Until
+        // #1634 the plate could not narrow to it: a 400px winged disc hung over
+        // the panel, absolutely positioned, so it added nothing to a
+        // shrink-to-fit width and would have overhung both edges. With the crown
+        // gone the panel really can go to its contents, so `collapsedMinWidth`
+        // at the column below is dropped rather than re-pointed.
         flex: hasAction ? "0 0 auto" : "1 1 auto",
         width: hasAction ? size.ledgerWidth : "auto",
         display: "flex",
@@ -988,23 +920,15 @@ export default function EphemeristsTaskDetail({
     </>
   );
 
-  // The worth beside the summons, one plate, crowned by a winged disc.
+  // The worth beside the summons, on one plate.
+  //
+  // A 400px winged sun disc used to hang over it, absolutely positioned in
+  // reserved space above the plate. #1634 retired it — the sigil is the kit's
+  // only mark, and it is in the masthead at the head of this page — which takes
+  // `crownWidth`/`crownHeight`/`crownReserve` with it. The panel is now an
+  // ordinary block: no reserve to pad, and nothing overhanging its edges.
   const actionPanel = (
-    <div style={{ position: "relative", paddingTop: size.crownReserve }}>
-      <div
-        aria-hidden
-        style={{
-          position: "absolute",
-          top: 0,
-          left: "50%",
-          transform: "translateX(-50%)",
-          zIndex: 2,
-          pointerEvents: "none",
-          maxWidth: "100%",
-        }}
-      >
-        <WingedDisc className="eph-plate-crown" width={size.crownWidth} height={size.crownHeight} />
-      </div>
+    <div style={{ position: "relative" }}>
       <div
         style={{
           ...plate,
@@ -1197,16 +1121,11 @@ export default function EphemeristsTaskDetail({
             <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
             <div
               style={{
-                // 420 with a summons to answer; with none, the plate narrows to
-                // its crown (#1138) — the only skin in the set that cannot go to
-                // its contents' intrinsic width, because the winged disc is
-                // drawn 400 wide and does not participate in the layout.
-                ...actionColumnSize({
-                  desktop,
-                  hasAction,
-                  width: PANEL_WIDTH,
-                  collapsedMinWidth: size.crownWidth,
-                }),
+                // 420 with a summons to answer; with none, the plate goes to its
+                // contents like every other skin (#1138). This was the one
+                // exception, and only because a 400px winged disc hung over the
+                // panel without participating in the layout; #1634 retired it.
+                ...actionColumnSize({ desktop, hasAction, width: PANEL_WIDTH }),
                 maxWidth: "100%",
               }}
             >


### PR DESCRIPTION
The Ephemerists' four surfaces each drew the same head — a winged sun disc over the faction's name in letterspaced Poiret One, centred on a night band — in four copies that could not see each other. This replaces all four with one engraved masthead: the kite sigil, the wordmark in incised small caps, a four-kanji register ruled 1px above and 3px double below, and a datum row of date, right ascension and declination closed by the sigil at inline scale.

Closes #1634

## The seam I tested at

`EphemeristsMasthead`'s **rendered markup given props** — a masthead has no behaviour, so what can be wrong about it is what it emits. The four claims worth a test rather than an eyeball, and the first two are the ones a screenshot passes:

- **The two scales must differ.** Every value in both tables is a `var()`, so a table typo renders a perfectly plausible masthead at the wrong size on half the surfaces. The test pins the sigil's emitted box, which is a *number* and therefore the one thing a stylesheet cannot silently absorb.
- **The datum row's inline sigil must take the reduced cut.** 14 and 12 are both under #1635's 20px threshold, so the mark must arrive without its crossed axes. A full cut at 12px still renders — as a smudge — which no markup assertion catches unless it counts.
- **The coordinates are fixed and the date is the surface's.** The egg is only an egg if both cells point at the same place on every surface.
- **Every kanji carries its English.**

The mount tests found a real defect: the praxis-card fixture omits `created_at`, and `formatDate(undefined)` renders the literal string **"Invalid Date"** into the datum row. That is an *invention* on the one row a player reads as data, so the guard went into the component (one place) rather than into four mounts (three chances to forget), and it has its own test.

## The datum row — the owner's ruling, built

**The date is real.** The praxis's `submitted_at ?? created_at` on the card, the detail and the composer; `task.created_at` on the task detail. **No surface came out dateless** — all four had one. Formatting goes through the repo's existing `formatDate` rather than the design's `2 aug 2026`, so it stays locale-aware.

**The coordinates are a fixed egg**, and both cells point at the Oregon Country Fairgrounds, Veneta, Oregon (44.0534 N, 123.3704 W):

- **`+44 03'`** is the fairgrounds' *latitude*. A star at that declination transits its zenith — that is the definition of declination, not a fudge. 0.0534 x 60 = 3.2'.
- **`8h 13m`** is the fairgrounds' *longitude* in RA's own unit: 24h to the circle, so 123.3704 / 15 = 8.2247h and 0.2247 x 60 = 13.5m. **Sign convention: west longitude as a positive hour angle**, which keeps the figure inside 0-24h; measured eastward the same place reads 15h 47m.

The derivation and the convention are a comment at the constants. Nothing user-visible names it — an egg rewards noticing, and a caption spends that.

## The kanji

**星 暦 観 録** — *star, almanac, observation, record.* They read as what an ephemeris **is**: the thing watched, the table it is kept in, the act of watching, and what survives the watcher. **暦 is the load-bearing one** — an ephemeris is literally an almanac of positions, so the faction names itself twice in its own masthead, once in a script most readers cannot spend.

Each is a `GlossedGlyph`, **reused, not re-invented**. #1637 built it local to `EphemeristsScoreStamp` and named this issue as its likely second consumer; it moves to `ephemeristsPlate` (the faction's one vocabulary module). One thing changed on the way: the `fontSize` fixed inside the voice constant is now a `size` prop defaulting to the same `--text-xl`. The three *undos* — casing, slant, line-height — still beat the caller, because that is what the constant is for; the size does not, because this component has two scales and the stamp has one.

**I took #1637's ponytail.** `title` is a *pointer* affordance: hovering opens the tooltip and focusing opens nothing, so `tabIndex={0}` was buying a focus ring around a mark whose expansion a keyboard user still could not read. `.eph-gloss:focus-visible::after` reads `attr(title)`, so it cannot drift from the tooltip beside it. It benefits both consumers. `:focus-visible` rather than `:focus`, so a pointer user does not get two copies.

## Where the brief's measurements were wrong

Verified against the code, as asked:

- **Six of the eleven files on the cartouche/crown list are false positives.** `EphemeristsFactionHero`, `EphemeristsTaskCard`, `EphemeristsVote`, `EphemeristsFactionBody`, `EphemeristsFactionPage` and `ephemeristsPlate` match on the *word* "cartouche" in comments, used for the **octagon monogram shape** (`AuthorOctagon`, `EmblemOctagon`) — a different thing entirely, and not something the masthead makes redundant. The task card's is a comment recording that #1020's cartouche already went. Two real cartouche pills existed: the praxis card's `THE EPHEMERISTS` pill and the praxis detail's breadcrumb frame. Both are gone.
- **The list missed `components/feed/EphemeristsFeedFrame.tsx`**, which turned out to be the winged sun disc's *last* caller anywhere once the four mastheads landed. Leaving it would have shipped a faction wearing two marks with no way to tell which was deliberate, so the feed band takes the sigil at its own height (14 / 10, both under the reduced cut) and `Wing` / `WingedDisc` are deleted. **`WingedDiscSign` does not go with them** — it is a separate drawing on a 24-unit square, read by `EmblemOctagon` for the metatask seal (#1207), which is another epic's surface.
- **The task detail carried a fifth copy of the disc**, local to the file and byte-identical to the shared kit's. It also drew the disc **twice**: over the wordmark, and 400px wide crowning the action panel.

## The size tables on the scales

Both tables are mapped rather than typed as pixels. Sigil sizes stay raw — a drawn mark's dimensions are ornament geometry (§4a), never spacing.

Three places **the scale had no step**:

| design | shipped | why |
|---|---|---|
| page glyphs 16px | `--text-content` (18) | 16 sits exactly between `--text-xl` and `--text-content`; rounds **up** for #1637's reason rather than §4a's — a kanji at 14 is at the floor of the legible band, and these four *are* the row |
| card glyphs 13px | `--text-xl` (14) | the rung #1637 already picked for a glossed kanji |
| wordmarks 26 / 19 | `--text-title` (24) / `--text-content` (18) | the composer's own wordmark comment already picked `--text-content` for 19 |

The datum rows (11 / 10) land exactly on `--text-md` / `--text-base`. **All four spacing values are ties** (20, 14, 14, 10) and all round **up** per §4a. The paddings are asymmetric, so they were checked against §4a's carve-out and kept: `24 24 16` and `12 16 8` both preserve the design's top-heavier shape, which rounding down would flatten. The glyph row's `7px 0 6px` became `var(--space-sm) 0` — 1px of asymmetry is not a designed shape, and an on-scale value beats a hatch.

## Two things that fell out

**A fixed band height becomes a floor.** All four mounts pinned their band (110 / 84 / 108 / 84-68) around content whose height they knew. A masthead sized from its own padding does not fit a number chosen for something else, so `height` becomes `minHeight` and the register SVG takes `height: 100%`. For the *shared* `ComposerMasthead` (eight composers mount it) the skin relaxes it through `style`, which is spread after `height` — no second prop on a shared block for one caller.

**Deleting the crown collapses a #1138 exception.** The task detail's action column could not narrow to its contents because a 400-wide absolutely-positioned disc would overhang both edges, so it carried a `collapsedMinWidth` of the crown's width — the only skin in the set that needed one. With no crown there is nothing to clear, so the argument is dropped and `crownWidth` / `crownHeight` / `crownReserve` leave the size sets. **`actionColumnSize`'s optional `collapsedMinWidth` in `pages/taskDetail/archetypes/shared.tsx` is now callerless** and left untouched — it is a layout helper nine skins mount, and deleting a dead knob there belongs to its owner, not to a style PR.

`praxis:card.masthead.ephemerists` is deleted with the pill it labelled. Its test assertion spells the copy out rather than reading the key, because a key kept alive only by a negative assertion reads as dead to the next sweep.

## Verification

`tsc --noEmit`, `eslint src .ds-kit e2e`, `typecheck:design-sync`, `vite build` and the byte budget all clean. **4054 tests / 233 files green.** CSS budget unchanged at 22.4 KB gzip (`.eph-gloss` in, `.eph-plate-crown` out); JS 128.0 KB. The emitted stylesheet was grepped and `.eph-gloss` sits at **brace depth 0** — top level, not reparented into a media or theme block. Rebased onto `main` after #1655 (the eyebrow half) landed.

**Visual QA is outstanding, and this one owes it more than most.** I have no browser and no dev stack. A masthead at two scales on five surfaces in two themes is exactly what a markup assertion cannot see.

## What to eyeball

- **Both scales side by side.** Page: `/tasks/:id` and `/praxis/:id` on desktop, and `/praxis/:id/edit`. Card: an Ephemerists praxis card in a gallery, and the same two pages on a phone. The wordmark, glyph and datum rungs should step down visibly and the sigil should not stretch.
- **Every surface that mounts it** — `EphemeristsPraxisCard`, `EphemeristsPraxisDetail`, `EphemeristsTaskDetail`, `EphemeristsEditPraxis` — specifically that the **band no longer crops it**, and that the masthead's 1px brass bottom rule sits legibly above the cavetto cornice rather than fighting it.
- **Both themes.** Nothing here should move: the plate register is theme-invariant since #1627, and every ink (`-band-ink`, `-band-quiet`, `-brass`, `-gold`) is measured on the band. If anything flips, that is the bug.
- **The datum row's inline sigil at its reduced cut** — 14px page, 12px card. It should read as a kite with a point above it, not a grey smudge, and it should sit on the datum row's baseline rather than riding above it.
- **The glyph row's focus gloss.** Tab into a kanji on the masthead *and* on the score stamp: the panel should open above the glyph, not wrap, not clip at the band's edge, and not swallow a click.
- **The two deletions in place.** The praxis card should say "The Ephemerists" once, not twice; the praxis detail's last breadcrumb crumb should read as a crumb; and the task detail's action panel should sit flush with the column beside it, with no leftover gap where the crown's reserved space used to be.
- **The feed row's band** at both form factors — the sigil should be legible at 10px and the row's vertical rhythm unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
