### PR TITLE
The Ephemerists' marks get one home: eleven transcriptions become eleven imports

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -644,6 +644,16 @@ A vote plate is a scale, and a scale that has to be captioned is not one yet. Th
 
 **A decorative mark's accessible name is a different question from a decodable one's.** The kit's `GlossedGlyph` hides its English on `title`, and that is right *because* the English is a bonus already printed somewhere on screen: the tooltip is a convenience over a fact the reader can otherwise obtain. Where the glyph is the **only** carrier of its information, `title` is not an option — it is a pointer affordance, unreliably announced and unreachable on touch. That case takes a visually-hidden label (`sr-only`, already in the bundle). The test is one question, *is this word printed anywhere else on the surface?*, and it is worth asking out loud, because the two cases look identical in a design.
 
+### Two designs drawing one ornament at two densities is not drift (#1654)
+
+The Ephemerists' mark vocabulary lived in three files: the kit, plus a transcription in the task card and another in the task page — eleven local redefinitions, and a twelfth written out inline so no grep for a component *name* could see it. #849 above says why that happens; this is what to do when you find one, and the trap is in the second paragraph.
+
+**Diff every copy against the kit's before deleting it, because a copy that has drifted is a live defect and the kit's version may be the stale one.** Here nothing had: all sixteen glyph paths were byte-identical in all three tables, and both membership differences traced to a shipped issue.
+
+**But two numbers really did differ, and neither was wrong.** The card struck 40 cornice flutes and the page 52 — and the flutes are `flex: 1`, so the count *is* the fluting's pitch rather than a detail. Neither had drifted from the other: 40 came out of the task-card design and 52 out of the task-details design, months apart, and no shared source ever existed for them to diverge from. **A de-duplication that also picks a winner is a redesign wearing a refactor's clothes.** The count became a prop and both surfaces kept their drawing — which is #849's "parameterize what genuinely differs", with *genuinely* meaning traced to two designs rather than inferred from two numbers.
+
+**Sweep the PATH STRINGS, not the component names.** A transcription is invisible to the import graph and invisible to markup — both copies render perfectly — so the only seam that can hold it is the source tree, and a name check misses a copy that has been renamed, inlined or split up. The `d` string cannot be smuggled: `ephemeristsPlateSurfaces.test.tsx` asserts that each of the kit's glyph paths appears in exactly **one** file. The corollary for a reviewer is that a green suite proves nothing here — 118 tests passed over the eleven copies and passed again over the imports.
+
 ---
 
 ## 7. Components

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -15,12 +15,13 @@
  * dark override tuned for the plate's night-blue, and the plate's brass is a
  * rule colour that is never an ink.
  *
- * `EphemeristsTaskCard` and `EphemeristsTaskDetail` still carry their own copies
- * of the glyph library and the cornice; both are migration targets for a
- * follow-up whose whole diff is a delete and an import. They are deliberately
- * NOT rewired here — three faction skins are being built over the same shared
- * layout in parallel, and a same-wave edit to two files this issue does not own
- * is how a wave collides.
+ * `EphemeristsTaskCard` and `EphemeristsTaskDetail` carried their own copies of
+ * the glyph library, the cornice, the octagon and the tally — eleven local
+ * redefinitions of things declared here, transcribed rather than imported, so
+ * nothing failed when a mark was redrawn in one file and left standing in the
+ * others. #1654 collapsed all eleven. There is no second declaration of any of
+ * this vocabulary left in `src/`, and `ephemeristsPlateSurfaces.test.tsx` pins
+ * that against the SOURCE tree, because an import-graph sweep cannot see a copy.
  *
  * Every colour is a `--faction-ephemerists-plate-*` token; light/dark flips
  * through the `[data-theme="dark"]` cascade, never a ternary.
@@ -160,9 +161,76 @@ export const SMALL_CAPS: CSSProperties = {
 };
 
 /**
+ * THE FIVE METALS, and everything three surfaces need to strike one (#1638).
+ *
+ * Classical alchemical sigils on the plate's 24-unit square — Saturn for lead,
+ * Venus for copper, the crescent for silver, the sun for gold, and the
+ * moon-and-Mercury compound for platinum. They lived in `EphemeristsVote` while
+ * the ladder was their only reader; #1660 gave them two more (the voters panel
+ * strikes one per vote, and the sign-up summons strikes platinum), which is the
+ * threshold the kit exists for.
+ *
+ * `burstStep` is the DEGREE PITCH of the conic ring around a reached disc, and
+ * it is the ladder's whole legibility: the ring densifies as the metal improves
+ * (60° → 22.5°), so rank reads off the spoke count without a numeral. Geometry
+ * rather than style, which is why it is a number here and arrives at CSS as a
+ * custom property.
+ *
+ * Ordered exactly as `VOTE_REFRAMES.ephemerists.tiers`: index is `value - 1`.
+ *
+ * This block sits ABOVE {@link GLYPHS} only because that table files the
+ * platinum sigil under a sign name, and a const may not read a const declared
+ * below it.
+ */
+export const METAL_SIGILS = [
+  {
+    name: "lead",
+    color: "var(--faction-ephemerists-metal-lead)",
+    glyph: "M6.2 7.4 C7.4 4.6 10.2 4.8 10.2 7.8 C10.2 10.8 9 14.6 9.4 17.6 C9.8 20.4 11.8 21 13.8 19.4 M6.4 10.8 H13.4",
+    weight: 1.5,
+    burstStep: 60,
+  },
+  {
+    name: "copper",
+    color: "var(--faction-ephemerists-metal-copper)",
+    glyph: "M12 4.4 a4.4 4.4 0 1 0 0.01 0 Z M12 13.2 V20.6 M8.8 17.4 H15.2",
+    weight: 1.5,
+    burstStep: 45,
+  },
+  {
+    name: "silver",
+    color: "var(--faction-ephemerists-metal-silver)",
+    glyph: "M15.8 4.4 A8 8 0 1 0 15.8 19.6 A6.3 6.3 0 1 1 15.8 4.4 Z",
+    weight: 1.3,
+    burstStep: 36,
+  },
+  {
+    name: "gold",
+    color: "var(--faction-ephemerists-metal-gold)",
+    glyph: "M12 5 a7 7 0 1 0 0.01 0 Z M12 10.4 a1.7 1.7 0 1 0 0.01 0 Z",
+    weight: 1.5,
+    burstStep: 30,
+  },
+  {
+    name: "platinum",
+    color: "var(--faction-ephemerists-metal-platinum)",
+    glyph: "M10.6 5.2 A7 7 0 1 0 10.6 18.8 A5.5 5.5 0 1 1 10.6 5.2 Z M15.6 7.6 a4.4 4.4 0 1 0 0.01 0 Z M15.6 11.2 a0.9 0.9 0 1 0 0.01 0 Z",
+    weight: 1.3,
+    burstStep: 22.5,
+  },
+] as const;
+
+/** The top of the ladder — the mark the summons is struck with (#1638). */
+export const PLATINUM = METAL_SIGILS[4];
+
+/**
  * The glyph library — Egyptian signs beside later-era marks, drawn as deco
  * geometry on a 24-unit square, stroke-only so they read as incised rather than
  * illustrated.
+ *
+ * The ONE home for the set since #1654. The task card and the task page each
+ * carried a transcription of it, so a sign could be redrawn in one file and
+ * left standing in two with nothing failing; both now read this table.
  */
 export const GLYPHS: Record<string, string> = {
   ankh: "M12 22 V10 M6 15 H18 M12 10 a4 4 0 1 0 0.001 0 Z",
@@ -180,6 +248,11 @@ export const GLYPHS: Record<string, string> = {
   hourglass: "M5 3 H19 M5 21 H19 M6.5 3 L12 12 L6.5 21 M17.5 3 L12 12 L17.5 21",
   openEye: "M2 12 C6 5.4 18 5.4 22 12 M2 12 C6 18.6 18 18.6 22 12 M8.4 12 a3.6 3.6 0 1 0 7.2 0 a3.6 3.6 0 1 0 -7.2 0 M10.7 12 a1.3 1.3 0 1 0 2.6 0 a1.3 1.3 0 1 0 -2.6 0 M12 2.8 V5 M5 4.6 L6.8 6.6 M19 4.6 L17.2 6.6",
   planet: "M5.8 12 a6.2 6.2 0 1 0 12.4 0 a6.2 6.2 0 1 0 -12.4 0 M1.8 16.2 A10.8 3.7 -22 0 1 22.2 7.8 A10.8 3.7 -22 0 1 1.8 16.2", // Saturn
+  /* The summons mark since #1638 — the ladder's top metal, filed here under a
+     sign name rather than re-drawn, so `Sign name="platinum"` resolves on every
+     surface and the mark the vote plate strikes and the mark the summons wears
+     cannot drift apart. Both consumers already kept this entry privately. */
+  platinum: PLATINUM.glyph,
 };
 
 /** The order the signs march in — the design's own register. */
@@ -192,8 +265,15 @@ export const REGISTER = [
 const GLYPH_PITCH = 27.5;
 const GLYPH_SIZE = 13;
 
-/** One incised sign, at its own strength and its own phase in the cycle. */
-function Glyph({ name, x, y, strength, delay, color }: {
+/**
+ * One incised sign, at its own strength and its own phase in the cycle.
+ *
+ * Exported for the ONE caller that composes its own register rather than taking
+ * {@link GlyphRegister}: the task card's masthead marches two named 12-sign
+ * rows at its own pitch, which is the card design's drawing and not the page's.
+ * Everything else wants the register.
+ */
+export function Glyph({ name, x, y, strength, delay, color }: {
   name: string
   x: number
   y: number
@@ -254,65 +334,6 @@ export function GlyphRegister({ width, y, strength, keyPrefix, color }: {
   );
 }
 
-/**
- * THE FIVE METALS, and everything three surfaces need to strike one (#1638).
- *
- * Classical alchemical sigils on the plate's 24-unit square — Saturn for lead,
- * Venus for copper, the crescent for silver, the sun for gold, and the
- * moon-and-Mercury compound for platinum. They lived in `EphemeristsVote` while
- * the ladder was their only reader; this issue gave them two more (the voters
- * panel strikes one per vote, and the sign-up summons strikes platinum), which
- * is the threshold the kit exists for.
- *
- * `burstStep` is the DEGREE PITCH of the conic ring around a reached disc, and
- * it is the ladder's whole legibility: the ring densifies as the metal improves
- * (60° → 22.5°), so rank reads off the spoke count without a numeral. Geometry
- * rather than style, which is why it is a number here and arrives at CSS as a
- * custom property.
- *
- * Ordered exactly as `VOTE_REFRAMES.ephemerists.tiers`: index is `value - 1`.
- */
-export const METAL_SIGILS = [
-  {
-    name: "lead",
-    color: "var(--faction-ephemerists-metal-lead)",
-    glyph: "M6.2 7.4 C7.4 4.6 10.2 4.8 10.2 7.8 C10.2 10.8 9 14.6 9.4 17.6 C9.8 20.4 11.8 21 13.8 19.4 M6.4 10.8 H13.4",
-    weight: 1.5,
-    burstStep: 60,
-  },
-  {
-    name: "copper",
-    color: "var(--faction-ephemerists-metal-copper)",
-    glyph: "M12 4.4 a4.4 4.4 0 1 0 0.01 0 Z M12 13.2 V20.6 M8.8 17.4 H15.2",
-    weight: 1.5,
-    burstStep: 45,
-  },
-  {
-    name: "silver",
-    color: "var(--faction-ephemerists-metal-silver)",
-    glyph: "M15.8 4.4 A8 8 0 1 0 15.8 19.6 A6.3 6.3 0 1 1 15.8 4.4 Z",
-    weight: 1.3,
-    burstStep: 36,
-  },
-  {
-    name: "gold",
-    color: "var(--faction-ephemerists-metal-gold)",
-    glyph: "M12 5 a7 7 0 1 0 0.01 0 Z M12 10.4 a1.7 1.7 0 1 0 0.01 0 Z",
-    weight: 1.5,
-    burstStep: 30,
-  },
-  {
-    name: "platinum",
-    color: "var(--faction-ephemerists-metal-platinum)",
-    glyph: "M10.6 5.2 A7 7 0 1 0 10.6 18.8 A5.5 5.5 0 1 1 10.6 5.2 Z M15.6 7.6 a4.4 4.4 0 1 0 0.01 0 Z M15.6 11.2 a0.9 0.9 0 1 0 0.01 0 Z",
-    weight: 1.3,
-    burstStep: 22.5,
-  },
-] as const;
-
-/** The top of the ladder — the mark the summons is struck with (#1638). */
-export const PLATINUM = METAL_SIGILS[4];
-
 /* `Wing` and `WingedDisc` stood here — the winged sun disc, the mark that headed
    every Ephemerists band and crowned the task detail's action panel.
 
@@ -332,8 +353,16 @@ export const PLATINUM = METAL_SIGILS[4];
  * `glow` washes a slow gold bloom along the band — the praxis record's one piece
  * of motion. The pigment, the cycle and the reduced-motion gate all live on
  * `.eph-cornice-glow` in index.css; this only reserves the layer.
+ *
+ * `flutes` is the number of strokes, and it is a PROP because the two designs
+ * this cornice came out of drew different densities: the task-card design
+ * (#1023) struck 40 across a 384px card and the task-details design (#1041)
+ * struck 52 across the page. The flutes are `flex: 1`, so the count is the
+ * fluting's pitch — 52 on a card would close it up. Neither number drifted from
+ * the other; they were never the same drawing, and #1654 collapsed the two
+ * transcriptions without picking a winner.
  */
-export function Cornice({ glow }: { glow?: boolean }) {
+export function Cornice({ glow, flutes = 52 }: { glow?: boolean; flutes?: number }) {
   return (
     // `overflow: hidden` is load-bearing when `glow` is on: the bloom drifts on
     // a translate, so an unclipped band would wash gold past the sheet's edges.
@@ -344,7 +373,7 @@ export function Cornice({ glow }: { glow?: boolean }) {
       {glow && <span className="eph-cornice-glow" />}
       {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the lead between cornice flutes; rounding it to a rung reflows the fluting. */}
       <div style={{ position: "relative", display: "flex", height: 7, alignItems: "flex-end", gap: 3, padding: "0 var(--space-sm)", overflow: "hidden" }}>
-        {Array.from({ length: 52 }).map((_, i) => (
+        {Array.from({ length: flutes }).map((_, i) => (
           <span
             key={i}
             style={{ flex: 1, height: i % 2 ? 6 : 3.5, background: BRASS_LIGHT, opacity: i % 2 ? 0.5 : 0.28 }}

--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -23,6 +23,7 @@ import i18n from '../../../i18n'
 import type { PraxisCardOut } from '../../../api/praxis'
 import type { TaskOut } from '../../../api/tasks'
 import EphemeristsPraxisCard from '../desktop/EphemeristsPraxisCard'
+import { GLYPHS } from '../../factionMarks/ephemeristsPlate'
 import MetataskSeal from '../../metataskSeal/MetataskSeal'
 
 /** The retired illuminated-codex family. None of it may reach a plate surface. */
@@ -187,37 +188,39 @@ describe('one card, both form factors (ADR-0067)', () => {
  * ornament; grepping the tree costs nothing and catches the case rendering
  * cannot see, which is a NEW hand-copy appearing later.
  */
-describe('the fluted rule is retired kit-wide (#1638)', () => {
-  const SKINS = fileURLToPath(new URL('../../..', import.meta.url))
+const SKINS = fileURLToPath(new URL('../../..', import.meta.url))
+const KIT = fileURLToPath(new URL('../../factionMarks/ephemeristsPlate.tsx', import.meta.url))
 
-  /**
-   * Every shipped `.ts`/`.tsx` under `src/`, with comments stripped and tests
-   * skipped. Both exclusions matter: the files that RETIRED the flute name it
-   * in prose so the next reader knows it was deleted rather than mislaid, and
-   * this very file names it in the assertions below.
-   */
-  const sources = (): string[] => {
-    const found: string[] = []
-    const walk = (dir: string) => {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (entry.name === '__tests__') continue
-        const full = join(dir, entry.name)
-        if (entry.isDirectory()) walk(full)
-        else if (/\.tsx?$/.test(entry.name)) {
-          found.push(
-            readFileSync(full, 'utf8')
-              .replace(/\/\*[\s\S]*?\*\//g, '')
-              .replace(/^\s*\/\/.*$/gm, ''),
-          )
-        }
+/**
+ * Every shipped `.ts`/`.tsx` under `src/`, with comments stripped and tests
+ * skipped. Both exclusions matter: the files that RETIRED a mark name it in
+ * prose so the next reader knows it was deleted rather than mislaid, and this
+ * very file names them in the assertions below.
+ */
+function sources(): { path: string; source: string }[] {
+  const found: { path: string; source: string }[] = []
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === '__tests__') continue
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (/\.tsx?$/.test(entry.name)) {
+        found.push({
+          path: full,
+          source: readFileSync(full, 'utf8')
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/^\s*\/\/.*$/gm, ''),
+        })
       }
     }
-    walk(SKINS)
-    return found
   }
+  walk(SKINS)
+  return found
+}
 
+describe('the fluted rule is retired kit-wide (#1638)', () => {
   it('leaves no FlutedRule anywhere — not a mount, not a second declaration', () => {
-    expect(sources().filter((file) => file.includes('FlutedRule'))).toEqual([])
+    expect(sources().filter(({ source }) => source.includes('FlutedRule'))).toEqual([])
   })
 
   it('mounts the rune band on all seven surfaces the flute had', () => {
@@ -225,23 +228,74 @@ describe('the fluted rule is retired kit-wide (#1638)', () => {
     // shared one. Counted as FILES rather than mounts because the task page
     // draws it twice, and the number that can silently drift is how many
     // surfaces reach the kit at all.
-    const mounts = sources().filter((file) => file.includes('<RuneRule'))
+    const mounts = sources().filter(({ source }) => source.includes('<RuneRule'))
     expect(mounts.length).toBe(7)
   })
 
   it('draws the band out of the kit register, in brass rather than gold', () => {
     // Gold is the masthead's ink on a night band; on the papyrus page it is a
     // stain. `-brass` is the plate's rule colour and never an ink.
-    const kit = readFileSync(
-      fileURLToPath(new URL('../../factionMarks/ephemeristsPlate.tsx', import.meta.url)),
-      'utf8',
-    )
+    const kit = readFileSync(KIT, 'utf8')
     const rule = kit.slice(kit.indexOf('export function RuneRule'))
     expect(rule).toContain('<GlyphRegister')
     expect(rule).toContain('color={BRASS}')
     // The shift is the register's own `.epg-glyph` cycle, already gated on
     // reduced-motion — the band declares no animation of its own.
     expect(rule.slice(0, rule.indexOf('\n}'))).not.toContain('animation')
+  })
+})
+
+/**
+ * #1654 — the mark vocabulary has ONE home, and this is what says so.
+ *
+ * The task card and the task page each carried a transcription of the plate's
+ * marks: eleven local redefinitions between them, plus the tally written out
+ * inline. Nothing imported them, so nothing linked the copies — a sign redrawn
+ * in the kit left the other two standing, and every test stayed green while one
+ * surface drew last month's mark. That is the failure this pins, and it can
+ * only be pinned against the SOURCE tree: a second declaration is invisible to
+ * the import graph and invisible to markup, which renders perfectly either way.
+ *
+ * The path strings are the sharper half. A copy can be renamed, inlined, or
+ * split up and the component-name sweep below misses it; the ankh's `d` is the
+ * same 44 characters however it is smuggled.
+ */
+describe('the Ephemerists mark vocabulary is declared once (#1654)', () => {
+  it('draws each sign in exactly one file', () => {
+    const files = sources()
+    for (const [name, path] of Object.entries(GLYPHS)) {
+      const drawn = files.filter(({ source }) => source.includes(path))
+      expect(drawn.map((file) => file.path), `${name} is transcribed`).toEqual([KIT])
+    }
+  })
+
+  it('declares each mark COMPONENT once, and in the kit', () => {
+    // `Glyph` is exported for the task card, which composes its own register
+    // out of the sign rather than taking `GlyphRegister` — so the sign is kit
+    // and the ORDER is the card's. Word-bounded, or `AuthorOctagon`,
+    // `GlossedGlyph` and `LotusSign` would each answer for their base name.
+    const files = sources()
+    for (const mark of ['Glyph', 'GlyphRegister', 'Octagon', 'Cornice', 'Tally', 'Sign']) {
+      const declared = files.filter(({ source }) =>
+        new RegExp(`\\b(?:function|const)\\s+${mark}\\b`).test(source),
+      )
+      expect(declared.map((file) => file.path), `${mark} is redeclared`).toEqual([KIT])
+    }
+  })
+
+  it('keeps the two cornice densities apart — a prop, not two components', () => {
+    // 40 flutes is the task-card design's (#1023) across a 384px band and 52
+    // the task-details design's (#1041) across the page. The flutes are
+    // `flex: 1`, so the count IS the pitch and the two are not interchangeable.
+    // Neither drifted from the other — they were never one drawing — which is
+    // why the collapse parameterised the count instead of picking a winner.
+    const kit = readFileSync(KIT, 'utf8')
+    expect(kit).toContain('flutes = 52')
+    const card = readFileSync(
+      fileURLToPath(new URL('../../taskCard/EphemeristsTaskCard.tsx', import.meta.url)),
+      'utf8',
+    )
+    expect(card).toContain('<Cornice flutes={40} />')
   })
 })
 

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -4,7 +4,13 @@ import type { CardProps } from "./TaskCard";
 import i18n from "../../i18n";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
-import { PLATINUM } from "../factionMarks/ephemeristsPlate";
+import {
+  Cornice,
+  Glyph,
+  GLYPHS,
+  Octagon,
+  Tally,
+} from "../factionMarks/ephemeristsPlate";
 
 /**
  * The Ephemerists — THE VALLEY PLATE (task card v2, #1023). Deco × Egypt: the
@@ -89,32 +95,15 @@ const SMALL_CAPS: CSSProperties = {
   textTransform: "uppercase",
 };
 
-/**
- * The glyph library. Egyptian signs beside later-era marks, all drawn as deco
- * geometry on a 24-unit square. Stroke-only, so they read as incised rather than
- * as illustration.
+/*
+ * The glyph library stood here — a 15-key transcription of the kit's own table,
+ * identical path for identical path. #1654 collapsed it: `GLYPHS` is imported
+ * from `factionMarks/ephemeristsPlate`, which is where the signs are drawn.
+ *
+ * The card's registers are still the CARD's, and deliberately: the design
+ * marches two named 12-sign rows here where the page cycles one 16-sign
+ * register to fill its width. Those orders are composition, not vocabulary.
  */
-const GLYPHS: Record<string, string> = {
-  ankh: "M12 22 V10 M6 15 H18 M12 10 a4 4 0 1 0 0.001 0 Z",
-  eye: "M3 12 C7 7 17 7 21 12 C17 16 7 16 3 12 M12 10.2 a1.8 1.8 0 1 0 .01 0 Z M15 15 L18 20 M8 15 L5 19",
-  feather: "M12 22 V4 M12 6 C15 7 17 10 17 13 M12 6 C9 7 7 10 7 13 M12 12 C14.6 12.8 16 14.6 16 17 M12 12 C9.4 12.8 8 14.6 8 17",
-  water: "M2 9 l4 3 4-3 4 3 4-3 4 3 M2 15 l4 3 4-3 4 3 4-3 4 3",
-  djed: "M12 22 V8 M6 8 H18 M6 12 H18 M7.5 4.6 H16.5 M9 2 H15",
-  reed: "M12 22 V7 C12 4 14 2.6 17 2.6 C17 6 15 7.4 12 7.4",
-  sun: "M12 12 a5 5 0 1 0 .01 0 Z M12 3 V6 M12 18 V21 M3 12 H6 M18 12 H21",
-  offering: "M4 8 H20 M6 8 V14 H18 V8 M9 14 V20 M15 14 V20 M4 20 H20",
-  scarab: "M12 4 C15.5 4 17.5 7 17.5 11 C17.5 16.6 15 20 12 20 C9 20 6.5 16.6 6.5 11 C6.5 7 8.5 4 12 4 M12 4 V20 M6.5 9 L2.5 6 M17.5 9 L21.5 6 M6.5 15 L2.5 18 M17.5 15 L21.5 18",
-  greekKey: "M2 20 V6 H16 V16 H8 V11 H12", // meander — Greek, c. 700 BC
-  chevrons: "M3 8 L12 3 L21 8 M3 14 L12 9 L21 14 M3 20 L12 15 L21 20", // deco, 1925
-  alchemy: "M12 3 L21 19 H3 Z M6.6 13.6 H17.4", // alchemical fire — medieval
-  hourglass: "M5 3 H19 M5 21 H19 M6.5 3 L12 12 L6.5 21 M17.5 3 L12 12 L17.5 21",
-  /* The summons mark since #1638 — the ladder's top metal, read from the kit
-     rather than copied, so the sign the vote plate strikes and the sign the
-     summons wears cannot drift apart. It replaced the open eye, which had no
-     other reader on this card and went with it. */
-  platinum: PLATINUM.glyph,
-  planet: "M5.8 12 a6.2 6.2 0 1 0 12.4 0 a6.2 6.2 0 1 0 -12.4 0 M1.8 16.2 A10.8 3.7 -22 0 1 22.2 7.8 A10.8 3.7 -22 0 1 1.8 16.2", // Saturn
-};
 
 const REGISTER_TOP = [
   "ankh", "water", "feather", "eye", "djed", "greekKey",
@@ -125,35 +114,10 @@ const REGISTER_BOTTOM = [
   "water", "djed", "eye", "alchemy", "offering", "feather",
 ];
 
-const GLYPH_SIZE = 13;
-
-/** One incised sign, at its own strength and its own phase in the cycle. */
-function Glyph({ name, x, y, strength, delay }: {
-  name: string
-  x: number
-  y: number
-  strength: number
-  delay: number
-}) {
-  return (
-    <g
-      className="epg-glyph"
-      transform={`translate(${x} ${y}) scale(${GLYPH_SIZE / 24}) translate(-12 -12)`}
-      style={{ ["--epg-op"]: strength, ["--epg-delay"]: `${delay}s` } as CSSProperties}
-    >
-      <path
-        d={GLYPHS[name]}
-        fill="none"
-        stroke="var(--faction-ephemerists-plate-gold)"
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </g>
-  );
-}
-
-/** A register of signs marching across the band. */
+/**
+ * A register of signs marching across the band. The SIGN is the kit's `Glyph`;
+ * only the order, the 20px lead-in and the 0.72 off-beat are this card's.
+ */
 function register(names: string[], y: number, strength: number, keyPrefix: string) {
   return names.map((name, index) => (
     <Glyph
@@ -199,48 +163,11 @@ function Wing({ flip }: { flip?: boolean }) {
   );
 }
 
-/** A stepped octagon, inset from the medallion's edge. */
-function Octagon({ inset, stroke, width, fill }: {
-  inset: number
-  stroke: string
-  width: number
-  fill?: string
-}) {
-  return (
-    <path
-      d="M30 4 L70 4 L96 30 L96 70 L70 96 L30 96 L4 70 L4 30 Z"
-      fill={fill ?? "none"}
-      stroke={stroke}
-      strokeWidth={width}
-      transform={`translate(50,50) scale(${(100 - inset * 2) / 100}) translate(-50,-50)`}
-    />
-  );
-}
-
-/** The cavetto cornice: fluted strokes under a stepped double rule. */
-function Cornice() {
-  return (
-    <div aria-hidden="true" style={{ position: "relative", zIndex: 3, background: "var(--faction-ephemerists-plate-band)" }}>
-      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the lead between cornice flutes; rounding it to a rung reflows the fluting. */}
-      <div style={{ display: "flex", height: 7, alignItems: "flex-end", gap: 3, padding: "0 var(--space-sm)", overflow: "hidden" }}>
-        {Array.from({ length: 40 }).map((_, i) => (
-          <span
-            key={i}
-            style={{
-              flex: 1,
-              height: i % 2 ? 6 : 3.5,
-              background: "var(--faction-ephemerists-plate-brass-light)",
-              opacity: i % 2 ? 0.5 : 0.28,
-            }}
-          />
-        ))}
-      </div>
-      <div style={{ height: 2, background: "var(--faction-ephemerists-plate-brass)", opacity: 0.9 }} />
-      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the gap in the cornice's stepped double rule. */}
-      <div style={{ height: 1, marginTop: 2, background: "var(--faction-ephemerists-plate-brass-light)", opacity: 0.55 }} />
-    </div>
-  );
-}
+/* The stepped `Octagon` and the cavetto `Cornice` stood here — the octagon
+   identical to the kit's, the cornice identical but for its FLUTE COUNT. Both
+   are imported from `factionMarks/ephemeristsPlate` since #1654; the count is
+   now `<Cornice flutes={40} />`, which is the task-card design's density on a
+   384px band and always was. */
 
 /* `JournalRule` stood here — this card's own fluted band, bleeding past the text
    column between the description and the in-progress line.
@@ -262,7 +189,6 @@ export default function EphemeristsTaskCard({
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
   const showMultiplier = !isNeutralMultiplier(multiplier);
-  const tallyStrokes = Math.min(9, Math.max(1, Math.round(task.level_required)));
 
   return (
     <div
@@ -344,7 +270,7 @@ export default function EphemeristsTaskCard({
             </span>
           </div>
         </div>
-        <Cornice />
+        <Cornice flutes={40} />
 
         {/* The journal leaf. */}
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
@@ -362,22 +288,12 @@ export default function EphemeristsTaskCard({
                 <span style={{ fontFamily: DECO, fontSize: size.levelSize, lineHeight: 0.8 }}>
                   {task.level_required}
                 </span>
-                {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the pitch of the tally strokes, drawn at 1.6px wide. */}
-                <span aria-hidden="true" style={{ display: "flex", alignItems: "flex-end", gap: 2.5, height: 11 }}>
-                  {Array.from({ length: tallyStrokes }).map((_, i) => (
-                    <span
-                      key={i}
-                      style={{
-                        width: 1.6,
-                        height: 11 - (i % 3) * 2,
-                        opacity: 0.85,
-                        background: i === 4
-                          ? "var(--faction-ephemerists-plate-ochre)"
-                          : "var(--faction-ephemerists-plate-brass)",
-                      }}
-                    />
-                  ))}
-                </span>
+                {/* The kit's `Tally` — this was the same strokes written out
+                    inline, which is a copy no grep for a component NAME could
+                    have found (#1654's table listed four here; this is a
+                    fifth). Its `Math.min(9, Math.max(1, Math.round(level)))`
+                    clamp came with it. */}
+                <Tally level={task.level_required} />
               </div>
 
               {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the lead between three 1px hairlines. */}

--- a/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
@@ -286,3 +286,42 @@ describe('albescent task card is na + drift, never a repaint (ADR-0048)', () => 
       .not.toContain('--faction-albescent')
   })
 })
+
+/**
+ * #1654 — the Ephemerists card draws the kit's marks, at the CARD's densities.
+ *
+ * Its glyph table, its `Glyph`, its `Octagon` and its `Cornice` were local
+ * copies of the plate's, and its tally strokes were the plate's `Tally` written
+ * out inline. `ephemeristsPlateSurfaces.test.tsx` pins that none of them may be
+ * declared twice again; what is left, and what only rendering can say, is that
+ * the collapse kept the two numbers the card did NOT share with the page.
+ *
+ * Both are counts of ornament, so they are legible in the markup and nowhere
+ * else: neither is a token, neither is text, and a wrong one still renders a
+ * perfectly good cornice.
+ */
+describe('the Ephemerists card keeps its own ornament densities (#1654)', () => {
+  const card = () => render(SKINS.find((skin) => skin.slug === 'ephemerists')!).html
+
+  it('strikes 40 cornice flutes, not the page kit default of 52', () => {
+    // The flutes are `flex: 1`, so the count is the fluting's pitch: 52 across
+    // a 384px band closes it up. 40 is the task-card design's (#1023); 52 is
+    // the task-details design's (#1041). Counted on the SHORT flute, which the
+    // cornice alternates in and nothing else on the card draws — every other
+    // stroke, so 20 of them.
+    expect(card().match(/height:3\.5px/g)).toHaveLength(20)
+  })
+
+  it('marches two registers of 12 signs — the card order, not the page cycle', () => {
+    // The page fills its width from a cycled 16-sign register; the card names
+    // its two rows. `Glyph` is shared, the ORDER is not, which is why the kit
+    // exports the sign as well as the register.
+    expect(card().match(/class="epg-glyph"/g)).toHaveLength(24)
+  })
+
+  it('draws the level as the kit tally, one stroke per level', () => {
+    // TASK is level 2, and `Tally` clamps to 1..9. The inline copy this
+    // replaced carried the same clamp, and it came across with it.
+    expect(card().match(/width:1\.6px/g)).toHaveLength(2)
+  })
+})

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -34,6 +34,7 @@ import { MemoryRouter } from "react-router-dom";
 import type { ReactElement } from "react";
 import { describe, it, expect } from "vitest";
 import EphemeristsTaskDetail from "../archetypes/EphemeristsTaskDetail";
+import { PLATINUM } from "../../../components/factionMarks/ephemeristsPlate";
 import { surfaceMap } from "../../../factions";
 import { resolvedArchetype } from "../../../factions/lazyArchetype";
 import { readThemes } from "../../../utils/__tests__/cssVars";
@@ -226,4 +227,44 @@ describe("the Valley plate's tokens", () => {
       ).toBe(false);
     });
   }
+});
+
+/**
+ * #1654 — the page draws the kit's marks, at the PAGE's densities.
+ *
+ * Seven of this file's declarations were transcriptions of `ephemeristsPlate`'s
+ * — `GLYPHS`, `Glyph`, `GlyphRegister`, `Octagon`, `Cornice`, `Tally`, `Sign` —
+ * so a mark redrawn in the kit left this page on the old one, silently. The
+ * source-tree guard against a fresh copy lives in
+ * `praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx`; what only rendering
+ * can say is that the collapse changed no ornament, and these are the counts a
+ * wrong import or a lost prop would move while everything still built.
+ */
+describe("the Valley page's ornament comes from the kit unchanged (#1654)", () => {
+  const page = () => render(<EphemeristsTaskDetail state={baseState()} />).html;
+
+  it("strikes the page cornice's 52 flutes", () => {
+    // Counted on the short flute the band alternates in — half of 52. The task
+    // CARD strikes 40 of them across its 384px band; the two densities are the
+    // two designs' and neither drifted from the other, so `Cornice` takes the
+    // count as a prop and this page takes the default.
+    expect(page().match(/height:3\.5px/g)).toHaveLength(26);
+  });
+
+  it("fills both masthead registers from the width, not a fixed 16", () => {
+    // `Math.ceil(1200 / 27.5)` = 44 signs a row, twice. A fixed count would
+    // stop short of the page edge at the 1200 cap; the design's own 16 is the
+    // number the local copy documented itself as NOT using. Sliced to the
+    // masthead's own svg so the page's rune bands — one per section head, and
+    // a section count this has no opinion about — cannot move it.
+    const masthead = page().slice(0, page().indexOf("</svg>"));
+    expect(masthead.match(/class="epg-glyph"/g)).toHaveLength(44 * 2);
+  });
+
+  it("strikes the summons in platinum, off the shared sign table", () => {
+    // The one entry the kit's `GLYPHS` did not have before this issue: both
+    // copies filed `PLATINUM.glyph` under a sign name privately, so the table
+    // took it in rather than the two call sites reaching around `Sign`.
+    expect(page()).toContain(PLATINUM.glyph);
+  });
 });

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -13,7 +13,14 @@ import {
   LevelJumpBanner,
   TaskDetailComments,
 } from "./shared";
-import { PLATINUM, RuneRule } from "../../../components/factionMarks/ephemeristsPlate";
+import {
+  Cornice,
+  GlyphRegister,
+  Octagon,
+  RuneRule,
+  Sign,
+  Tally,
+} from "../../../components/factionMarks/ephemeristsPlate";
 import { signupCtaKey } from "../signupCta";
 import type { TaskDetailState } from "../useTaskDetail";
 
@@ -83,7 +90,10 @@ const QUIET = "var(--faction-ephemerists-plate-quiet)";
 const CAPTION = "var(--faction-ephemerists-plate-caption)";
 const BRASS = "var(--faction-ephemerists-plate-brass)";
 const BRASS_LIGHT = "var(--faction-ephemerists-plate-brass-light)";
-const GOLD = "var(--faction-ephemerists-plate-gold)";
+/* `GOLD` stood here. Its one reader was this page's copy of the kit's `Glyph`,
+   which #1654 deleted — and the kit's own already defaults its ink to the same
+   gold, so nothing has to hand it in. Gold is the masthead's ink on a night
+   band and a stain on the papyrus page; nothing else here wants it. */
 const BAND = "var(--faction-ephemerists-plate-band)";
 const BAND_INK = "var(--faction-ephemerists-plate-band-ink)";
 const DISC = "var(--faction-ephemerists-plate-disc)";
@@ -115,47 +125,13 @@ const GALLERY_PREVIEW = 3;
  */
 const BRIEF_LEADING = 32;
 
-/**
- * The glyph library — Egyptian signs beside later-era marks, drawn as deco
- * geometry on a 24-unit square, stroke-only so they read as incised rather than
- * illustrated.
- *
- * Duplicated from `components/taskCard/EphemeristsTaskCard.tsx`, which owns the
- * same set for the card. Deliberate under this issue's two-file scope; the
- * extraction target is `components/factionMarks/ephemeristsPlate.tsx`, and until the
- * two are merged a change to one sign has to be made twice.
- */
-const GLYPHS: Record<string, string> = {
-  ankh: "M12 22 V10 M6 15 H18 M12 10 a4 4 0 1 0 0.001 0 Z",
-  eye: "M3 12 C7 7 17 7 21 12 C17 16 7 16 3 12 M12 10.2 a1.8 1.8 0 1 0 .01 0 Z M15 15 L18 20 M8 15 L5 19",
-  feather: "M12 22 V4 M12 6 C15 7 17 10 17 13 M12 6 C9 7 7 10 7 13 M12 12 C14.6 12.8 16 14.6 16 17 M12 12 C9.4 12.8 8 14.6 8 17",
-  water: "M2 9 l4 3 4-3 4 3 4-3 4 3 M2 15 l4 3 4-3 4 3 4-3 4 3",
-  djed: "M12 22 V8 M6 8 H18 M6 12 H18 M7.5 4.6 H16.5 M9 2 H15",
-  reed: "M12 22 V7 C12 4 14 2.6 17 2.6 C17 6 15 7.4 12 7.4",
-  sun: "M12 12 a5 5 0 1 0 .01 0 Z M12 3 V6 M12 18 V21 M3 12 H6 M18 12 H21",
-  offering: "M4 8 H20 M6 8 V14 H18 V8 M9 14 V20 M15 14 V20 M4 20 H20",
-  scarab: "M12 4 C15.5 4 17.5 7 17.5 11 C17.5 16.6 15 20 12 20 C9 20 6.5 16.6 6.5 11 C6.5 7 8.5 4 12 4 M12 4 V20 M6.5 9 L2.5 6 M17.5 9 L21.5 6 M6.5 15 L2.5 18 M17.5 15 L21.5 18",
-  greekKey: "M2 20 V6 H16 V16 H8 V11 H12", // meander — Greek, c. 700 BC
-  chevrons: "M3 8 L12 3 L21 8 M3 14 L12 9 L21 14 M3 20 L12 15 L21 20", // deco, 1925
-  alchemy: "M12 3 L21 19 H3 Z M6.6 13.6 H17.4", // alchemical fire — medieval
-  hourglass: "M5 3 H19 M5 21 H19 M6.5 3 L12 12 L6.5 21 M17.5 3 L12 12 L17.5 21",
-  openEye: "M2 12 C6 5.4 18 5.4 22 12 M2 12 C6 18.6 18 18.6 22 12 M8.4 12 a3.6 3.6 0 1 0 7.2 0 a3.6 3.6 0 1 0 -7.2 0 M10.7 12 a1.3 1.3 0 1 0 2.6 0 a1.3 1.3 0 1 0 -2.6 0 M12 2.8 V5 M5 4.6 L6.8 6.6 M19 4.6 L17.2 6.6",
-  planet: "M5.8 12 a6.2 6.2 0 1 0 12.4 0 a6.2 6.2 0 1 0 -12.4 0 M1.8 16.2 A10.8 3.7 -22 0 1 22.2 7.8 A10.8 3.7 -22 0 1 1.8 16.2", // Saturn
-  /* The summons mark since #1638 — the ladder's top metal, read from the kit
-     rather than copied, so the sign the vote plate strikes and the sign the
-     summons wears cannot drift apart. */
-  platinum: PLATINUM.glyph,
-};
-
-/** The order the signs march in — the design's own register. */
-const REGISTER = [
-  "ankh", "water", "feather", "eye", "djed", "greekKey", "reed", "offering",
-  "alchemy", "chevrons", "scarab", "sun", "ankh", "water", "djed", "eye",
-];
-
-/** Distance between two signs in a register, in viewBox units. */
-const GLYPH_PITCH = 27.5;
-const GLYPH_SIZE = 13;
+/* The glyph library, its 16-sign register and their pitch stood here — a
+   transcription of the kit's, path for path, which is exactly the shape that
+   lets one surface keep drawing last month's mark. #1654 collapsed it along
+   with `Glyph`, `GlyphRegister`, `Octagon`, `Cornice`, `Tally` and `Sign`: all
+   seven now come from `factionMarks/ephemeristsPlate`, imported at the top of
+   this file. Nothing on this page draws differently — the kit's `GlyphRegister`
+   defaults its ink to the same gold the local one hardcoded. */
 
 /** Incised small caps — the plate's whole label voice. */
 const SMALL_CAPS: CSSProperties = {
@@ -165,154 +141,19 @@ const SMALL_CAPS: CSSProperties = {
   textTransform: "uppercase",
 };
 
-/** One incised sign, at its own strength and its own phase in the cycle. */
-function Glyph({ name, x, y, strength, delay }: {
-  name: string
-  x: number
-  y: number
-  strength: number
-  delay: number
-}) {
-  return (
-    <g
-      className="epg-glyph"
-      transform={`translate(${x} ${y}) scale(${GLYPH_SIZE / 24}) translate(-12 -12)`}
-      style={{ ["--epg-op"]: strength, ["--epg-delay"]: `${delay}s` } as CSSProperties}
-    >
-      <path
-        d={GLYPHS[name]}
-        fill="none"
-        stroke={GOLD}
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </g>
-  );
-}
-
-/**
- * A register of signs marching the full width of the band. The count follows the
- * viewBox rather than the design's fixed 16: the masthead is page-wide here (up
- * to the 1200 cap) and a fixed count would either stop short of the edge or,
- * under `slice`, blow every sign up to a cartoon.
- */
-function GlyphRegister({ width, y, strength, keyPrefix }: {
-  width: number
-  y: number
-  strength: number
-  keyPrefix: string
-}) {
-  const count = Math.ceil(width / GLYPH_PITCH);
-  return (
-    <>
-      {Array.from({ length: count }).map((_, index) => (
-        <Glyph
-          key={`${keyPrefix}${index}`}
-          name={REGISTER[index % REGISTER.length]}
-          x={18 + index * GLYPH_PITCH}
-          y={y}
-          strength={strength * (index % 3 === 0 ? 1 : 0.7)}
-          delay={((index * 7) % 12) * 1.6}
-        />
-      ))}
-    </>
-  );
-}
-
 /* `Wing` and `WingedDisc` stood here — this page's LOCAL copy of the shared
    kit's winged sun disc (the two were byte-identical, which is how a duplicate
    survives review). #1634 retired the mark across the kit: the sigil is the only
    one now, and it arrives through `EphemeristsMasthead`. The copy goes with the
    original rather than outliving it. */
 
-/** A stepped octagon, inset from the medallion's edge. */
-function Octagon({ inset, stroke, width, fill }: {
-  inset: number
-  stroke: string
-  width: number
-  fill?: string
-}) {
-  return (
-    <path
-      d="M30 4 L70 4 L96 30 L96 70 L70 96 L30 96 L4 70 L4 30 Z"
-      fill={fill ?? "none"}
-      stroke={stroke}
-      strokeWidth={width}
-      transform={`translate(50,50) scale(${(100 - inset * 2) / 100}) translate(-50,-50)`}
-    />
-  );
-}
-
-/** The cavetto cornice: fluted strokes under a stepped double rule. */
-function Cornice() {
-  return (
-    <div aria-hidden="true" style={{ position: "relative", zIndex: 3, background: BAND }}>
-      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the lead between cornice flutes; rounding it to a rung reflows the fluting. */}
-      <div style={{ display: "flex", height: 7, alignItems: "flex-end", gap: 3, padding: "0 var(--space-sm)", overflow: "hidden" }}>
-        {Array.from({ length: 52 }).map((_, i) => (
-          <span
-            key={i}
-            style={{ flex: 1, height: i % 2 ? 6 : 3.5, background: BRASS_LIGHT, opacity: i % 2 ? 0.5 : 0.28 }}
-          />
-        ))}
-      </div>
-      <div style={{ height: 2, background: BRASS, opacity: 0.9 }} />
-      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the gap in the cornice's stepped double rule. */}
-      <div style={{ height: 1, marginTop: 2, background: BRASS_LIGHT, opacity: 0.55 }} />
-    </div>
-  );
-}
-
 /* The page's own hand-copied `FlutedRule` stood here — a second, byte-identical
    declaration of the kit's divider that no import-following sweep could see, so
    #1638's "fluted rules become shifting runes" would have converted six mounts
    and silently left this page's two on the old drawing. The rule is now
    `RuneRule` from `factionMarks/ephemeristsPlate`, imported at the top of this
-   file: one divider, seven mounts, one place to change it. The rest of this
-   file's local glyph library is still a copy and is still #1654's shape. */
-
-/** The level, struck as tally marks — every fifth stroke in ochre. */
-function Tally({ level }: { level: number }) {
-  const strokes = Math.min(9, Math.max(1, Math.round(level)));
-  return (
-    // eslint-disable-next-line local/no-raw-style-values -- ornament: the pitch of the tally strokes, drawn 1.6px wide.
-    <span aria-hidden="true" style={{ display: "flex", alignItems: "flex-end", gap: 2.5, height: 11 }}>
-      {Array.from({ length: strokes }).map((_, i) => (
-        <span
-          key={i}
-          style={{
-            width: 1.6,
-            height: 11 - (i % 3) * 2,
-            opacity: 0.85,
-            background: i === 4 ? OCHRE : BRASS,
-          }}
-        />
-      ))}
-    </span>
-  );
-}
-
-/** One incised sign at label scale, set beside a line of type. */
-function Sign({ name, size, color, weight }: {
-  name: string
-  size: number
-  color: string
-  weight?: number
-}) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
-      <path
-        d={GLYPHS[name]}
-        fill="none"
-        stroke={color}
-        strokeWidth={weight ?? 1.5}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
+   file: one divider, seven mounts, one place to change it. #1654 did the same
+   for the other eleven, so nothing in this file declares a mark any more. */
 
 interface SizeSet {
   /** Masthead band height. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */


### PR DESCRIPTION
`components/factionMarks/ephemeristsPlate.tsx` exports the Ephemerists' mark vocabulary. The task card and the task page each transcribed it instead of importing it — **eleven local redefinitions**, plus a twelfth written out inline. Nothing imported them from the plate, so a mark redrawn in the kit left the other copies standing and **nothing failed**.

This is a pure de-duplication. Nothing renders differently.

## The seam, and the proof

The seam is **the rendered markup of each affected surface**. Twelve renders (task card and task page × desktop/mobile × four state combinations, 10,305 markup lines) were captured at `origin/main` @ `4697612b` and again on this branch and compared line for line.

**48 of 10,305 lines differ, and all 48 are the same four declarations.** The plate's `Cornice` carries `overflow: hidden` on the band and `position: relative` on its three children so `glow` can clip and layer; the two local copies did not. With `glow` off — which is every mount here — both are inert: nothing overflows the 12px band, and `position: relative` at `z-index: auto` with no positioned descendants shifts nothing and creates no stacking context. **Every glyph path, every register, every flute, every tally stroke and every octagon is byte-identical.**

The committed guard is a **source-tree sweep**, because that is the only place a second declaration exists — it is invisible to the import graph and invisible to markup, which renders perfectly either way. 118 tests passed over the eleven copies and passed again over the imports, so the existing suites were never going to say anything. Added:

- each of the kit's **16 glyph path strings** must appear in exactly one file. Sharper than a name check: a copy can be renamed, inlined or split up, and the `d` string still cannot be smuggled.
- each of `Glyph`, `GlyphRegister`, `Octagon`, `Cornice`, `Tally`, `Sign` declared once, word-bounded so `AuthorOctagon` / `GlossedGlyph` / `LotusSign` do not answer for their base names.
- the render-level counts only markup can see: 40 flutes and two 12-sign registers on the card, 52 flutes and two width-filled 44-sign rows on the page.

Both sweeps were mutation-tested — re-adding one transcribed path and one `function Tally` to the card fails them by name.

## Did anything drift? No.

All three `GLYPHS` tables were compared entry by entry. **Every shared path is byte-identical.** The only differences were membership, and both are explained:

- the card had no `openEye` — #1638 struck its summons with platinum and the eye had no other reader on that card.
- neither the card's nor the page's `platinum` entry was in the plate; both filed `PLATINUM.glyph` under a sign name privately. The plate's `GLYPHS` takes it in, so `Sign name="platinum"` resolves off one table.

**Two numbers really did differ, and neither is wrong.** The card's cornice struck **40** flutes, the page's **52**. The flutes are `flex: 1`, so the count is the fluting's pitch, not a detail — 52 across a 384px band closes it up. `git log -S` puts 40 in #1027 (the task-card design, #1023) and 52 in #1041 (the task-details design), months apart, with no shared source to diverge from. That is two designs, not drift, so `Cornice` takes `flutes` (default 52) and both surfaces keep their drawing. Absorbing one into the other would have been a redesign wearing a refactor's clothes.

Likewise the card keeps its own two named 12-sign registers rather than the page's cycled 16 — which is why `Glyph` is now exported alongside `GlyphRegister`.

## Corrections to the issue

- **`Glyph` was not exported.** The table in the issue comment lists it as "a local redefinition of something the plate already exports"; it was module-private. Collapsing it required exporting it. The other ten were exported as stated, and the table is otherwise exact.
- **There was a twelfth.** `EphemeristsTaskCard` wrote `Tally`'s strokes out **inline**, clamp and all — no grep for a component name could have found it. Collapsed here.
- **Two more found, not collapsed, deliberately.** The task page's local `SMALL_CAPS` is byte-identical to the plate's export, and its local `initialsOf` differs from the plate's in one edge case (a whitespace-only name gives `""` where the plate gives `"·"`). Both are outside "the mark vocabulary" and collapsing the second would absorb a behaviour change. Worth a follow-up; not this issue.

## Order note (#1638)

`Cornice` is collapsed, **not retired** — that is #1638's call. Its cavetto retirement now deletes one definition instead of hunting three.

## Bundle

`npm run budget`, before → after:

```
JS   128.0 KB → 128.0 KB   (warn >130.9, fail >175.8)
CSS   21.5 KB →  21.5 KB   (warn >22.5,  fail >24.4)
```

Initial load is unchanged — these surfaces are lazy chunks. Total gzipped JS across all chunks: **592,364 → 590,011 bytes, −2,353**. No CSS touched.

## Verified locally

eslint (`src .ds-kit e2e`), `tsc --noEmit`, `vitest run` (233 files, 4200 tests), `vite build`, `npm run budget`, `npm run typecheck:design-sync` — all clean.

## What to eyeball

I have no browser tools, so visual QA is outstanding — but the bar here is genuinely low: the markup is provably unchanged apart from four inert style declarations, so there should be nothing to find. Confirming that is the whole check.

- **Task card**, light and dark — the cornice under the masthead (40 flutes, same density as `main`), the two glyph registers on the night band, the tally strokes under the level numeral, the platinum sign in the sign-up band.
- **Task detail**, light and dark — the cornice under the masthead (52 flutes), both masthead registers reaching the page edge at the 1200 cap, the octagon medallion, the ankh and hourglass beside the header rows, the platinum + Saturn signs on the summons.

Closes #1654
