### PR TITLE
Fourteen security findings, fixed: arbitrary media deletion, HTML on the API origin, and four ways moderated content stayed readable

### DIFF
--- a/.claude/agents/backend.md
+++ b/.claude/agents/backend.md
@@ -21,6 +21,7 @@ You are the backend specialist for World Zero. You own everything under `backend
 ## Scope
 
 - Edit and create files under `backend/` only. Read anywhere; never edit outside `backend/`.
+- **Never edit `.github/`.** CI config is what gates merges to a branch that auto-deploys to production (`render.yaml` sets `autoDeploy: true`), so a job quietly weakened while keeping its name reports green and ships. A `PreToolUse` hook enforces this — the line here is the explanation, the hook is the control. If a task seems to need a workflow change, stop and say so.
 - Run `pytest`, `alembic`, `uvicorn` via Bash. Test env notes live in `docs/spec/SPEC-testing.md`.
 
 ## Build conventions

--- a/.claude/agents/frontend-feature.md
+++ b/.claude/agents/frontend-feature.md
@@ -28,6 +28,7 @@ If a change needs real styling/design decisions beyond "reuse existing component
 - Reuse shared classes (`.card-footer`, `.card-meta`, `.card-description`) instead of inventing new ones. Each faction keeps its own card archetype — don't unify.
 - Hide controls a user can't use; don't render them disabled.
 - TypeScript: proper types for API responses; no unexplained `any`.
+- **Never edit `.github/`.** CI config is what gates merges to a branch that auto-deploys to production (`render.yaml` sets `autoDeploy: true`), so a job quietly weakened while keeping its name reports green and ships. A `PreToolUse` hook enforces this — the line here is the explanation, the hook is the control. If a task seems to need a workflow change, stop and say so.
 
 ## Reporting back
 

--- a/.claude/agents/frontend-style.md
+++ b/.claude/agents/frontend-style.md
@@ -19,6 +19,7 @@ You are the frontend design-system specialist for World Zero. You own how the si
 - Edit: `frontend/src/index.css`, `frontend/src/utils/factions.ts`, any `*.css` under `frontend/`, files under `frontend/src/components/cards/`, and `WORLD_ZERO_STYLE.md` when design decisions change.
 - Run `npm run dev` / `npm run build` via Bash to verify rendering.
 - Do NOT edit `.tsx` files carrying business logic, API calls, or state. If a style change needs that, raise it back to the dispatcher for `frontend-feature`.
+- **Never edit `.github/`.** CI config is what gates merges to a branch that auto-deploys to production (`render.yaml` sets `autoDeploy: true`), so a job quietly weakened while keeping its name reports green and ships. A `PreToolUse` hook enforces this — the line here is the explanation, the hook is the control. If a task seems to need a workflow change, stop and say so.
 
 ## Build conventions
 

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -114,6 +114,12 @@ class ErrorCode(str, enum.Enum):
     avatar_must_be_image = "AVATAR_MUST_BE_IMAGE"
     avatar_too_large = "AVATAR_TOO_LARGE"
 
+    # -- Sign-in ------------------------------------------------------------
+    #: The provider returned an address it does not vouch for. Refused because
+    #: an unseen OAuth identity is linked to an existing account BY EMAIL, which
+    #: makes the claim an authentication decision rather than a profile detail.
+    oauth_email_unverified = "OAUTH_EMAIL_UNVERIFIED"
+
 
 #: The keys of a coded ``detail`` body. Named so the frontend contract is
 #: greppable from Python and no raise site spells them as bare literals.

--- a/backend/main.py
+++ b/backend/main.py
@@ -72,6 +72,28 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+@app.middleware("http")
+async def add_content_type_options(request: Request, call_next):
+    """Send ``X-Content-Type-Options: nosniff`` on everything.
+
+    The mount below serves player-uploaded bytes from the API's own origin, and
+    Starlette derives their ``Content-Type`` from the stored filename. Uploads
+    now get a server-chosen extension off an allow-list
+    (``services.media._with_safe_extension``), which is the actual fix; this is
+    the second lock. Without it a browser is still free to disregard a declared
+    ``image/jpeg`` and sniff HTML out of the bytes — and a script that runs here
+    runs same-origin with the session cookie, which `.worldzero.org` scoping
+    sends to every host under the domain.
+
+    Applied app-wide rather than to the mount alone: nothing this API serves
+    should ever be content-sniffed, and a header that covers one path is a
+    header someone has to remember to extend.
+    """
+    response = await call_next(request)
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    return response
+
+
 # Static file serving for local media uploads
 app.mount("/media", StaticFiles(directory=settings.MEDIA_ROOT, check_dir=False), name="media")
 

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5582,6 +5582,7 @@
           "description": {
             "anyOf": [
               {
+                "maxLength": 5000,
                 "type": "string"
               },
               {
@@ -5635,6 +5636,8 @@
             "title": "Task Type"
           },
           "title": {
+            "maxLength": 200,
+            "minLength": 1,
             "title": "Title",
             "type": "string"
           }
@@ -12203,6 +12206,7 @@
     },
     "/praxes/{praxis_id}/voters": {
       "get": {
+        "description": "The voter roster for a praxis the caller may see.\n\nVisibility is :func:`can_view_praxis`, the same predicate the praxis detail\nroute runs, so the two doors cannot drift.",
         "operationId": "list_voters_praxes__praxis_id__voters_get",
         "parameters": [
           {
@@ -12212,6 +12216,22 @@
             "schema": {
               "title": "Praxis Id",
               "type": "integer"
+            }
+          },
+          {
+            "in": "cookie",
+            "name": "access_token",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Access Token"
             }
           }
         ],
@@ -12241,6 +12261,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
         "summary": "List Voters",
         "tags": [
           "votes"

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -1,3 +1,4 @@
+import hmac
 import dataclasses
 from datetime import datetime
 
@@ -383,9 +384,19 @@ async def admin_cli_token(
     session: AsyncSession = Depends(get_db),
 ) -> CliTokenResponse:
     """Return a JWT for the first admin account when the CLI secret matches."""
-    if not settings.ADMIN_CLI_SECRET:
-        raise HTTPException(status_code=403, detail="CLI token endpoint is disabled.")
-    if x_admin_cli_secret != settings.ADMIN_CLI_SECRET:
+    # One indistinguishable refusal for both "not configured" and "wrong
+    # secret". Two different messages told an unauthenticated prober whether
+    # ADMIN_CLI_SECRET is set at all, which is the reconnaissance step before
+    # attacking it — and this one header is the ENTIRE authentication boundary
+    # for a 7-day full-admin JWT.
+    #
+    # compare_digest, not `!=`: Python string comparison short-circuits on
+    # length and on the first differing block, so `!=` leaks the secret's shape
+    # through response timing. Impractical over a network, but the whole
+    # privilege of the endpoint rests on this single comparison.
+    if not settings.ADMIN_CLI_SECRET or not hmac.compare_digest(
+        x_admin_cli_secret, settings.ADMIN_CLI_SECRET
+    ):
         raise HTTPException(status_code=403, detail="Invalid CLI secret.")
 
     admins = await find_admin_accounts(session)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -115,7 +115,9 @@ async def auth_google_callback(
         # Fail closed: Secure unless we KNOW this is local development.
         secure=not _is_development(),
         max_age=_COOKIE_MAX_AGE,
-        domain=settings.COOKIE_DOMAIN,
+        # `or None`: an unset COOKIE_DOMAIN arrives as "" from a .env line with
+        # no value, and "" is not None — Starlette would emit a bare `Domain=`.
+        domain=settings.COOKIE_DOMAIN or None,
     )
     return response
 
@@ -143,7 +145,9 @@ async def auth_logout(response: Response) -> LogoutOut:
         samesite="lax",
         # Fail closed, and must match the flags the cookie was set with.
         secure=not _is_development(),
-        domain=settings.COOKIE_DOMAIN,
+        # `or None`: an unset COOKIE_DOMAIN arrives as "" from a .env line with
+        # no value, and "" is not None — Starlette would emit a bare `Domain=`.
+        domain=settings.COOKIE_DOMAIN or None,
     )
     return LogoutOut(message="Logged out")
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -7,6 +7,7 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
+from errors import ErrorCode, raise_coded
 from db import get_db
 from game_config import CURRENT_ERA
 from models.account import Account
@@ -19,7 +20,23 @@ from services.era import get_current_era_row, get_or_create_stats
 
 router = APIRouter()
 
-_ENV_PRODUCTION = "production"
+#: The ONE value that unlocks the dev seams below. `ENVIRONMENT` is a free-form
+#: `str` defaulting to "development" (`config.py`), and the guards here used to
+#: be deny-lists against the literal "production" — so every value that was not
+#: exactly that ("prod", "Production", a trailing space, an env var dropped when
+#: a Render service is re-created, unset) simultaneously enabled an
+#: unauthenticated JWT mint AND stripped `Secure` from the session cookie. Both
+#: now fail closed: anything unrecognised is treated as production.
+#:
+#: Safe to invert — `.github/workflows/e2e.yml:42` sets `ENVIRONMENT: development`
+#: explicitly ("dev-login must be enabled"), the config default is "development",
+#: and `render.yaml:34` is "production".
+_ENV_DEVELOPMENT = "development"
+
+
+def _is_development() -> bool:
+    return settings.ENVIRONMENT == _ENV_DEVELOPMENT
+
 
 _OAUTH = OAuth()
 _OAUTH.register(
@@ -62,6 +79,22 @@ async def auth_google_callback(
     token = await _OAUTH.google.authorize_access_token(request)
     user_info = token.get("userinfo") or await _OAUTH.google.userinfo(token=token)
 
+    # An unseen OAuth identity is attached to any EXISTING account holding the
+    # same email (`create_or_get_account`), which makes the email claim an
+    # authentication decision — so it has to be one the provider vouches for.
+    # Nothing checked `email_verified`, so any condition under which Google
+    # emits an address the bearer does not control (an unverified Workspace
+    # identity; a Workspace domain changing hands, letting a new admin mint
+    # `victim@thatdomain` with a fresh `sub`) linked a new provider row to the
+    # victim's account and minted a full session for it — their characters,
+    # their score — with no re-authentication and no notification.
+    if user_info.get("email_verified") is not True:
+        raise_coded(
+            403,
+            ErrorCode.oauth_email_unverified,
+            "Your Google account's email address is not verified.",
+        )
+
     # Google's access token is used here and then discarded (#1374): it proves
     # this sign-in, and nothing afterwards calls a Google API as the player. The
     # session that follows is World Zero's own JWT.
@@ -79,7 +112,8 @@ async def auth_google_callback(
         value=jwt_token,
         httponly=True,
         samesite="lax",
-        secure=settings.ENVIRONMENT == _ENV_PRODUCTION,
+        # Fail closed: Secure unless we KNOW this is local development.
+        secure=not _is_development(),
         max_age=_COOKIE_MAX_AGE,
         domain=settings.COOKIE_DOMAIN,
     )
@@ -107,7 +141,8 @@ async def auth_logout(response: Response) -> LogoutOut:
         "access_token",
         httponly=True,
         samesite="lax",
-        secure=settings.ENVIRONMENT == "production",
+        # Fail closed, and must match the flags the cookie was set with.
+        secure=not _is_development(),
         domain=settings.COOKIE_DOMAIN,
     )
     return LogoutOut(message="Logged out")
@@ -139,7 +174,7 @@ async def dev_login(
 
     Returns account_id + character_id so tests can invite/credit by id.
     """
-    if settings.ENVIRONMENT == _ENV_PRODUCTION:
+    if not _is_development():
         raise HTTPException(status_code=404, detail="Not found.")
 
     provider_user_id = "dev-user-1" if key == "1" else f"dev-{key}"

--- a/backend/routers/characters.py
+++ b/backend/routers/characters.py
@@ -12,7 +12,7 @@ from db import get_db
 from dependencies import get_current_character, get_current_character_optional
 from models.account import Account
 from models.character import Character, CharacterStatus
-from models.praxis import Praxis, PraxisStatus
+from models.praxis import ModerationStatus, Praxis, PraxisStatus
 from models.vote import Vote
 from schemas.character import (
     CharacterCreate,
@@ -178,6 +178,12 @@ async def get_character_praxes(
             praxis_membership_condition(character_id),
             Praxis.status == PraxisStatus.submitted,
             praxis_visibility_condition(viewer.id if viewer else None),
+            # The docstring above promises this stays in step with
+            # ``list_praxes``; it did not. ``list_praxes`` excludes
+            # moderation-hidden rows, this did not, so content an admin had
+            # taken off the site stayed readable — unauthenticated — from the
+            # author's own profile. The two spellings CAN drift, and did.
+            Praxis.moderation_status != ModerationStatus.hidden,
         )
         .order_by(Praxis.created_at.desc())
         .limit(limit)

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -100,7 +100,7 @@ from services.praxis_out import (
     build_praxis_cards,
     build_praxis_out,
 )
-from services.media import process_and_save_media
+from services.media import process_and_save_media, resolve_stored_media_path
 from services.nudge import nudge_the_crew, send_nudge
 from services.vote import cast_vote_on_praxis
 
@@ -410,9 +410,19 @@ async def delete_media_route(
     if media_item is None or media_item.praxis_id != praxis_id:
         raise HTTPException(status_code=404, detail="Media item not found.")
 
-    abs_path = os.path.join(settings.MEDIA_ROOT, media_item.file_path)
+    # Through the shared predicate, not a bare join. `resolve_stored_media_path`
+    # is documented as the one "is this a file we own?" gate every
+    # column-value-to-filesystem operation passes; this route bypassed it and
+    # joined MEDIA_ROOT to `file_path` directly. `file_path` is server-generated
+    # today so there is no live traversal — but `os.path.join` with an absolute
+    # or `..`-bearing value escapes MEDIA_ROOT entirely, so the day any other
+    # writer touches that column (an import, an admin editor, a migration) this
+    # silently becomes an arbitrary-unlink primitive. Same two lines as
+    # `delete_stored_avatar`.
+    abs_path = resolve_stored_media_path(media_item.file_path)
     try:
-        os.remove(abs_path)
+        if abs_path is not None:
+            os.remove(abs_path)
     except OSError:
         pass
     # Each upload owns its directory (#1336), so removing the file leaves that

--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -91,6 +91,7 @@ async def list_tasks(
         offset=offset,
         viewer=viewer,
         skip_level_check=is_admin,
+        is_admin=is_admin,
     )
     # One grouped query for the whole page (#1021) — never a per-task count.
     in_progress_counts = await in_progress_counts_for_tasks(

--- a/backend/routers/votes.py
+++ b/backend/routers/votes.py
@@ -28,19 +28,17 @@ async def list_voters(
     session: AsyncSession = Depends(get_db),
     viewer: Character | None = Depends(get_current_character_optional),
 ):
-    """The voter roster for a praxis the caller may actually see.
+    """The voter roster for a praxis the caller may see.
 
-    The existence check alone used to be the whole guard, so this answered for a
-    moderation-hidden praxis and for another character's ``in_progress`` draft or
-    a pre-seal duel side — all of which the detail route 404s. Votes *can* land on
-    a non-submitted praxis (``cast_vote_on_praxis`` refuses only ``hidden``), so
-    the roster was not empty in those cases. The 200/404 split also made it a
-    praxis-existence oracle for ids the detail door hides.
-
-    Gated on :func:`can_view_praxis` — the same predicate the detail route runs,
-    so the two cannot drift — and 404, not 403, so it says nothing the detail
-    route would not.
+    Visibility is :func:`can_view_praxis`, the same predicate the praxis detail
+    route runs, so the two doors cannot drift.
     """
+    # NB: this docstring is published verbatim into `backend/openapi.json`, which
+    # is a committed artifact in a public repo — keep it a description of what the
+    # endpoint does, not a history of what it used to do wrong.
+    #
+    # Votes can land on a non-submitted praxis (`cast_vote_on_praxis` refuses only
+    # `hidden`), so an ungated roster here was not merely theoretical.
     # One raise, deliberately: "no such praxis" and "not yours to see" must be
     # the same answer, or the difference between them is the oracle.
     praxis = await session.get(Praxis, praxis_id)

--- a/backend/routers/votes.py
+++ b/backend/routers/votes.py
@@ -3,10 +3,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_db
+from dependencies import get_current_character_optional
 from models.character import Character
 from models.praxis import Praxis
 from models.vote import Vote
 from schemas.vote import VoterDetail
+from services.praxis import can_view_praxis
 
 # Read-only vote surfaces. The write surface (POST /praxes/{id}/vote) lives in
 # ``routers/praxes.py`` -- it enforces the hidden-praxis 404 guard. A duplicate
@@ -24,9 +26,25 @@ router = APIRouter()
 async def list_voters(
     praxis_id: int,
     session: AsyncSession = Depends(get_db),
+    viewer: Character | None = Depends(get_current_character_optional),
 ):
+    """The voter roster for a praxis the caller may actually see.
+
+    The existence check alone used to be the whole guard, so this answered for a
+    moderation-hidden praxis and for another character's ``in_progress`` draft or
+    a pre-seal duel side — all of which the detail route 404s. Votes *can* land on
+    a non-submitted praxis (``cast_vote_on_praxis`` refuses only ``hidden``), so
+    the roster was not empty in those cases. The 200/404 split also made it a
+    praxis-existence oracle for ids the detail door hides.
+
+    Gated on :func:`can_view_praxis` — the same predicate the detail route runs,
+    so the two cannot drift — and 404, not 403, so it says nothing the detail
+    route would not.
+    """
+    # One raise, deliberately: "no such praxis" and "not yours to see" must be
+    # the same answer, or the difference between them is the oracle.
     praxis = await session.get(Praxis, praxis_id)
-    if praxis is None:
+    if praxis is None or not await can_view_praxis(viewer, praxis, session):
         raise HTTPException(status_code=404, detail="Praxis not found.")
 
     result = await session.execute(

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -71,9 +71,21 @@ class TaskOut(WireModel):
     signup_reason: Optional[str] = None
 
 
+#: Trust-boundary caps on the two free-text fields a player writes, matching the
+#: convention `CommentIn` already follows (ADR-0006). Both were unbounded, and
+#: the DB columns behind them are `String`/`Text` with no length either — so a
+#: task proposal could carry an arbitrarily long body. That body is read back by
+#: the admin moderation queue and by `mcp/worldzero-admin`'s `wz_list_pending_-
+#: tasks`, which returns it into an agent context that also holds `wz_manage_-
+#: role`. A cap is not a defence against prompt injection, but an unbounded
+#: field is a comfortable place to hide one.
+MAX_TASK_TITLE = 200
+MAX_TASK_DESCRIPTION = 5000
+
+
 class TaskCreate(WireModel):
-    title: str
-    description: Optional[str] = None
+    title: str = Field(..., min_length=1, max_length=MAX_TASK_TITLE)
+    description: Optional[str] = Field(None, max_length=MAX_TASK_DESCRIPTION)
     point_value: int = Field(..., gt=0)
     level_required: int = Field(0, ge=0)
     primary_faction_slug: Optional[str] = None

--- a/backend/services/activity_feed.py
+++ b/backend/services/activity_feed.py
@@ -45,6 +45,7 @@ from models.nudge import Nudge
 from models.relationship import Relationship, RelationshipStatus, RelationshipType
 from models.duel import Duel, DuelStatus
 from models.praxis import ModerationStatus, Praxis, PraxisInvite, PraxisInviteStatus, PraxisMember, PraxisStatus, PraxisType
+from services.praxis import praxis_visibility_condition
 from models.task import Task, TaskStatus
 from models.taunt_message import TauntMessage
 from models.vote import Vote
@@ -368,6 +369,20 @@ def _completions_query_factory(character_ids_attr: str) -> Callable[[FeedContext
             .where(
                 Praxis.created_by_id.in_(character_ids),
                 Praxis.status == PraxisStatus.submitted,
+                # The feed is a read-time projection (ADR-0023), and a projection
+                # that forgets a visibility filter re-publishes what every other
+                # door refuses. Both doors this used to bypass matter, because a
+                # friend/foe edge is unilateral and instant — anyone can declare
+                # you a foe and then read this source:
+                #   * moderation `hidden` is "off the site entirely", stripped by
+                #     `list_praxes` and 404'd by the detail route — but the
+                #     `praxis_title` selected above shipped it verbatim, so
+                #     whatever got a praxis taken down came back in the title.
+                #   * a submitted side of a live duel is author-only until the
+                #     seal (#999); this handed the opponent the title the detail
+                #     route answers 404 for.
+                Praxis.moderation_status != ModerationStatus.hidden,
+                praxis_visibility_condition(ctx.character_id),
             )
         )
         if ctx.before is not None:

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -140,7 +140,15 @@ async def find_admin_accounts(session: AsyncSession) -> list[Account]:
         select(Account)
         .join(AccountRole, AccountRole.account_id == Account.id)
         .join(Role, Role.id == AccountRole.role_id)
-        .where(Role.name == "admin")
+        # Active only. `/admin/cli-token` mints its JWT for `admins[0]`, so
+        # without this a SUSPENDED admin still yields a token. Nothing is
+        # exploitable today — `get_current_account` rejects a non-active account
+        # at token USE — but that means this fails closed only because a check
+        # in another module happens to catch it, and suspending a compromised
+        # admin would still hand out tokens bearing their `sub`. The CLI helper
+        # `import_tasks_csv._first_admin_account` already filters; these two
+        # disagreed.
+        .where(Role.name == "admin", Account.status == AccountStatus.active)
         .order_by(Account.id.asc())
     )
     return list(result.scalars().all())

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -560,8 +560,10 @@ async def soft_delete_character(
         await session.flush()
 
     # Last, and only after the cleared column has been flushed: see the docstring.
-    # A no-op when the column held a pasted remote URL rather than a path we wrote.
-    delete_stored_avatar(erased_avatar_url)
+    # A no-op when the column held a pasted remote URL rather than a path we wrote,
+    # and — since the column is player-writable — also when it points at a file
+    # belonging to some other character.
+    delete_stored_avatar(erased_avatar_url, character.id)
 
 
 def _character_stats_era_join(era_id: int | None) -> Select:

--- a/backend/services/comment.py
+++ b/backend/services/comment.py
@@ -21,6 +21,7 @@ from models.praxis import ModerationStatus, Praxis
 from models.task import Task, TaskStatus
 from schemas.comment import CommentAuthor, CommentMentionOut, CommentOut
 from services.era import get_current_era_row, get_or_create_stats
+from services.praxis import can_view_praxis
 
 # @handle mentions: word chars matching Character.username. Unresolved handles
 # stay plain text — linkify at render runs against the resolved set only.
@@ -117,7 +118,10 @@ def _clean_body(body_text: str) -> str:
 
 
 async def _assert_commentable_target(
-    praxis_id: Optional[int], task_id: Optional[int], session: AsyncSession
+    praxis_id: Optional[int],
+    task_id: Optional[int],
+    session: AsyncSession,
+    author: Optional[Character] = None,
 ) -> None:
     """Exactly one target, and it must be open for comments.
 
@@ -132,6 +136,15 @@ async def _assert_commentable_target(
     if praxis_id is not None:
         praxis = await session.get(Praxis, praxis_id)
         if praxis is None:
+            raise HTTPException(status_code=404, detail="Praxis not found.")
+        # The write door must ask the same question as the read door. It used to
+        # check only `moderation_status`, so any player could POST a comment into
+        # someone else's `in_progress` draft (ADR-0024 makes those private) or a
+        # live duel side (#999) — content they cannot themselves read back. That
+        # also made this an existence oracle: 201 for a draft, 404 only when the
+        # row was absent. `list_praxis_comments` already gates on can_view_praxis;
+        # now both doors share the predicate, and 404 matches what a reader gets.
+        if author is not None and not await can_view_praxis(author, praxis, session):
             raise HTTPException(status_code=404, detail="Praxis not found.")
         if praxis.moderation_status != ModerationStatus.visible:
             raise HTTPException(
@@ -164,7 +177,7 @@ async def create_comment(
             {"level": era.comment_level_required},
         )
     body_text = _clean_body(body_text)
-    await _assert_commentable_target(praxis_id, task_id, session)
+    await _assert_commentable_target(praxis_id, task_id, session, author=author)
 
     comment = Comment(
         praxis_id=praxis_id,

--- a/backend/services/comment.py
+++ b/backend/services/comment.py
@@ -134,17 +134,21 @@ async def _assert_commentable_target(
             detail="A comment targets exactly one of a praxis or a task.",
         )
     if praxis_id is not None:
-        praxis = await session.get(Praxis, praxis_id)
-        if praxis is None:
-            raise HTTPException(status_code=404, detail="Praxis not found.")
         # The write door must ask the same question as the read door. It used to
         # check only `moderation_status`, so any player could POST a comment into
         # someone else's `in_progress` draft (ADR-0024 makes those private) or a
         # live duel side (#999) — content they cannot themselves read back. That
-        # also made this an existence oracle: 201 for a draft, 404 only when the
+        # also made it an existence oracle: 201 for a draft, 404 only when the
         # row was absent. `list_praxis_comments` already gates on can_view_praxis;
-        # now both doors share the predicate, and 404 matches what a reader gets.
-        if author is not None and not await can_view_praxis(author, praxis, session):
+        # now both doors share the predicate.
+        #
+        # Absent and invisible collapse into ONE raise on purpose — two raises
+        # with the same status still differ in reachability, and that difference
+        # is the oracle we are closing.
+        praxis = await session.get(Praxis, praxis_id)
+        if praxis is None or (
+            author is not None and not await can_view_praxis(author, praxis, session)
+        ):
             raise HTTPException(status_code=404, detail="Praxis not found.")
         if praxis.moderation_status != ModerationStatus.visible:
             raise HTTPException(

--- a/backend/services/media.py
+++ b/backend/services/media.py
@@ -61,6 +61,48 @@ def _sanitize_filename(raw: str) -> str:
     return cleaned
 
 
+#: Extensions we are willing to let a player put on a file that ``/media``
+#: serves from the API's own origin, keyed by the type we detected.
+#:
+#: This exists because the served ``Content-Type`` is guessed from the stored
+#: filename (Starlette's ``FileResponse`` calls ``mimetypes.guess_type``), and
+#: the filename used to be the player's, verbatim. Uploading ``pwn.html`` while
+#: declaring ``Content-Type: image/png`` passed ``_detect_media_type`` — which
+#: reads only the declared string — and then came back off ``/media`` as
+#: ``text/html``, executing on the API origin with the session cookie attached.
+#:
+#: ``.svg`` is deliberately absent from the image set: SVG carries script.
+_SAFE_EXTENSIONS: dict[MediaType, frozenset[str]] = {
+    MediaType.image: frozenset(
+        {".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif", ".heic", ".heif", ".bmp"}
+    ),
+    MediaType.video: frozenset({".mp4", ".webm", ".mov", ".m4v", ".ogv"}),
+    MediaType.audio: frozenset({".mp3", ".m4a", ".aac", ".ogg", ".oga", ".wav", ".flac"}),
+}
+
+#: What we fall back to when the player's extension is not on the list above.
+_CANONICAL_EXTENSION: dict[MediaType, str] = {
+    MediaType.image: ".jpg",
+    MediaType.video: ".mp4",
+    MediaType.audio: ".mp3",
+}
+
+
+def _with_safe_extension(filename: str, media_type: MediaType) -> str:
+    """Force ``filename``'s extension onto the allow-list for ``media_type``.
+
+    An allow-list rather than a deny-list of dangerous extensions: the set of
+    things a browser will execute is not fixed, and a deny-list is a promise to
+    keep up with it. The stem is preserved because it is player-visible — the
+    composer renders it as the attachment caption and as the remove button's
+    accessible name — so only the extension is rewritten.
+    """
+    stem, extension = os.path.splitext(filename)
+    if extension.lower() in _SAFE_EXTENSIONS[media_type]:
+        return filename
+    return f"{stem or 'upload'}{_CANONICAL_EXTENSION[media_type]}"
+
+
 def resolve_stored_media_path(
     stored_path: str, media_root: str | None = None
 ) -> str | None:
@@ -99,8 +141,8 @@ def resolve_stored_media_path(
     return resolved
 
 
-def delete_stored_avatar(stored_avatar_url: str | None) -> None:
-    """Unlink an avatar file we wrote, best-effort. Two callers, one rule.
+def delete_stored_avatar(stored_avatar_url: str | None, character_id: int) -> None:
+    """Unlink an avatar file **this character owns**, best-effort. Two callers, one rule.
 
     1. A fresh upload has superseded it (``process_and_save_avatar``). Called
        only once the replacement is safely on disk — an upload must never leave
@@ -114,9 +156,36 @@ def delete_stored_avatar(stored_avatar_url: str | None) -> None:
     raised, so a filesystem problem can never block the state change the caller
     is really making. The residue is an orphan, which
     ``scripts/sweep_orphan_media.py`` exists to collect.
+
+    ``character_id`` is the ownership half of the predicate, and it is the whole
+    point of this function. ``resolve_stored_media_path`` answers only "does this
+    resolve inside MEDIA_ROOT?" — it cannot answer "is this *ours*?", because it
+    is also used by the orphan sweep, which legitimately resolves every
+    character's paths. Containment alone was not enough: ``avatar_url`` is a
+    free-form, player-writable column (``update_character`` ``setattr``s whatever
+    ``CharacterUpdate`` carries), and victims' paths are public — ``CharacterOut.
+    avatar_url`` and ``MediaItemOut.file_path`` both ship the raw relative path.
+    So a player could point their own column at anyone's file and make the next
+    avatar upload, or their own account deletion, unlink it. Traversal was never
+    the gap; the guard correctly refuses ``..``, absolute paths and remote URLs.
+    Ownership was.
     """
     absolute_path = resolve_stored_media_path(stored_avatar_url or "")
     if absolute_path is None:
+        return
+    # Every avatar this server writes lands under `<character_id>/avatar/<uuid>/`
+    # (`process_and_save_avatar`). Anything else in the column came from a player,
+    # and is not ours to delete.
+    owner_directory = os.path.realpath(
+        os.path.join(settings.MEDIA_ROOT, str(character_id), "avatar")
+    )
+    if not absolute_path.startswith(owner_directory + os.sep):
+        logger.warning(
+            "Refusing to unlink %s for character %s: outside that character's "
+            "avatar directory.",
+            absolute_path,
+            character_id,
+        )
         return
     try:
         os.remove(absolute_path)
@@ -207,7 +276,7 @@ async def process_and_save_avatar(
         )
 
     # Only once the replacement is safely on disk.
-    delete_stored_avatar(previous_avatar_url)
+    delete_stored_avatar(previous_avatar_url, character_id)
 
     return relative_path
 
@@ -244,7 +313,12 @@ async def process_and_save_media(
         str(character_id), str(praxis_id), uuid.uuid4().hex
     )
     absolute_directory = os.path.join(settings.MEDIA_ROOT, relative_directory)
-    filename = _sanitize_filename(upload.filename or "upload")
+    # Sanitize the name, then force the extension onto the allow-list: `/media`
+    # serves these from the API's own origin and derives Content-Type from the
+    # stored filename, so the extension is a security decision, not cosmetics.
+    filename = _with_safe_extension(
+        _sanitize_filename(upload.filename or "upload"), media_type
+    )
     absolute_path = os.path.join(absolute_directory, filename)
     relative_path = os.path.join(relative_directory, filename)
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -405,14 +405,25 @@ async def list_praxes(
             )
             query = query.where(~account_voted, ~account_member)
 
+    # Hidden is excluded unconditionally, and the caller's filter may only narrow
+    # within what is left. This used to sit in an `else`, so *any* value for the
+    # ungated `moderation_status` query param removed the exclusion — and
+    # `?moderation_status=hidden` then selected exactly the content an admin had
+    # taken off the site. An invalid value was worse: `except ValueError: pass`
+    # dropped the caller's filter *and* the default, so a typo also published it.
+    # The detail door (`can_view_praxis`) always refused hidden; only this list
+    # door leaked. Asking for `hidden` now yields an empty page, not a 422 —
+    # a distinguishable error would answer "does hidden content exist here?".
+    query = query.where(Praxis.moderation_status != ModerationStatus.hidden)
     if moderation_status is not None:
         try:
             mod_enum = ModerationStatus(moderation_status)
-            query = query.where(Praxis.moderation_status == mod_enum)
         except ValueError:
-            pass
-    else:
-        query = query.where(Praxis.moderation_status != ModerationStatus.hidden)
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid moderation status: {moderation_status}",
+            )
+        query = query.where(Praxis.moderation_status == mod_enum)
 
     if task_id is not None:
         query = query.where(Praxis.task_id == task_id)

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -417,13 +417,13 @@ async def list_praxes(
     query = query.where(Praxis.moderation_status != ModerationStatus.hidden)
     if moderation_status is not None:
         try:
-            mod_enum = ModerationStatus(moderation_status)
-        except ValueError:
-            raise HTTPException(
-                status_code=422,
-                detail=f"Invalid moderation status: {moderation_status}",
+            query = query.where(
+                Praxis.moderation_status == ModerationStatus(moderation_status)
             )
-        query = query.where(Praxis.moderation_status == mod_enum)
+        except ValueError:
+            # Still ignored, as before — but now it only costs the caller their
+            # own filter. It used to also discard the hidden exclusion above.
+            pass
 
     if task_id is not None:
         query = query.where(Praxis.task_id == task_id)

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Collection, Optional
 
 from fastapi import HTTPException
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, false, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from errors import ErrorCode, raise_coded
@@ -457,6 +457,10 @@ async def list_tasks(
     offset: int = 0,
     viewer: Optional[Character] = None,
     skip_level_check: bool = False,
+    # Deliberately not folded into `skip_level_check`: that one answers "may this
+    # viewer see tasks above their level", this one answers "may they see the
+    # moderation queue". They happen to be true together today.
+    is_admin: bool = False,
     era: EraConfig = CURRENT_ERA,
 ) -> list[Task]:
     """Query tasks with optional filters, excluding hidden-faction tasks.
@@ -507,9 +511,20 @@ async def list_tasks(
 
     if status and status != "all":
         try:
-            query = query.where(Task.status == TaskStatus[status])
+            requested_status = TaskStatus[status]
         except KeyError:
             raise HTTPException(status_code=422, detail=f"Invalid status: {status}")
+        # The comment below used to promise pending "stays hidden from all
+        # viewers", and that held only on the `created_by` branch — an explicit
+        # `?status=pending` routed straight around it and served the whole
+        # admin-review queue of player-written proposals to anyone, signed in or
+        # not. The guarantee now lives on the path that can actually enforce it.
+        if requested_status == TaskStatus.pending and not is_admin:
+            # An empty page rather than a 403: no new error code for a filter no
+            # legitimate client sends, and it says nothing about what is queued.
+            query = query.where(false())
+        else:
+            query = query.where(Task.status == requested_status)
     elif not status:
         if created_by is not None:
             # Proposer's profile: show approved tasks (active + retired); pending
@@ -517,7 +532,10 @@ async def list_tasks(
             query = query.where(Task.status != TaskStatus.pending)
         else:
             query = query.where(Task.status == TaskStatus.active)
-    # status == "all" -> no status filter, return tasks of every status
+    elif not is_admin:
+        # status == "all" is the other door onto the same rows: every status for
+        # an admin, everything-but-the-review-queue for everyone else.
+        query = query.where(Task.status != TaskStatus.pending)
 
     # Task type filter — default (None) means STANDARD-ONLY so metatasks never
     # leak into the ordinary browse (#1001); pass "all" to get every type, or

--- a/backend/tests/unit/test_media_service.py
+++ b/backend/tests/unit/test_media_service.py
@@ -14,6 +14,7 @@ import pytest
 from fastapi import HTTPException, UploadFile
 from PIL import Image
 
+from models.praxis import MediaType
 from services import media
 from services.media import (
     AVATAR_MAX_SIZE,
@@ -162,10 +163,52 @@ def test_superseded_avatar_outside_media_root_is_refused(tmp_path, monkeypatch):
     outsider = tmp_path / "not-ours.jpg"
     outsider.write_bytes(b"someone else's file")
 
-    media.delete_stored_avatar(os.path.join("..", "not-ours.jpg"))
-    media.delete_stored_avatar(str(outsider))
+    media.delete_stored_avatar(os.path.join("..", "not-ours.jpg"), 42)
+    media.delete_stored_avatar(str(outsider), 42)
 
     assert outsider.exists()
+
+
+def test_avatar_belonging_to_another_character_is_refused(tmp_path, monkeypatch):
+    """Inside MEDIA_ROOT is not enough — it has to be OURS.
+
+    ``avatar_url`` is a free-form, player-writable column and every victim's
+    path is public (``CharacterOut.avatar_url``, ``MediaItemOut.file_path``), so
+    without this a player could point their own column at anyone's file and let
+    the next upload — or their own account deletion — unlink it. Traversal was
+    always refused; ownership was not checked at all.
+    """
+    monkeypatch.setattr(media.settings, "MEDIA_ROOT", str(tmp_path / "media"))
+    victim_directory = tmp_path / "media" / "7" / "avatar" / "deadbeef"
+    os.makedirs(str(victim_directory), exist_ok=True)
+    victim_avatar = victim_directory / "avatar.jpg"
+    victim_avatar.write_bytes(b"character 7's avatar")
+
+    # Character 42 asks for character 7's file. Resolves cleanly inside
+    # MEDIA_ROOT — the old predicate would have unlinked it.
+    media.delete_stored_avatar("7/avatar/deadbeef/avatar.jpg", 42)
+    assert victim_avatar.exists()
+
+    # The owner may still delete their own.
+    media.delete_stored_avatar("7/avatar/deadbeef/avatar.jpg", 7)
+    assert not victim_avatar.exists()
+
+
+def test_uploaded_extension_cannot_make_the_api_serve_active_content():
+    """A player picks the stem; the server picks the extension.
+
+    ``/media`` is mounted on the API's own origin and Starlette guesses
+    Content-Type from the stored filename, so ``pwn.html`` declared as
+    ``image/png`` used to come back as ``text/html`` and execute same-origin.
+    """
+    assert media._with_safe_extension("pwn.html", MediaType.image) == "pwn.jpg"
+    # SVG carries script, so it is deliberately off the image allow-list.
+    assert media._with_safe_extension("logo.svg", MediaType.image) == "logo.jpg"
+    # Legitimate uploads keep their own extension, case-insensitively.
+    assert media._with_safe_extension("photo.JPG", MediaType.image) == "photo.JPG"
+    assert media._with_safe_extension("clip.mov", MediaType.video) == "clip.mov"
+    # The player-visible stem survives — the composer renders it as the caption.
+    assert media._with_safe_extension("holiday.html", MediaType.image) == "holiday.jpg"
 
 
 def test_filename_sanitization_strips_path_and_unsafe_chars():

--- a/backend/tests/unit/uncoded_error_allowlist.py
+++ b/backend/tests/unit/uncoded_error_allowlist.py
@@ -40,14 +40,14 @@ from __future__ import annotations
 #: Sum of :data:`UNCODED_RAISE_ALLOWLIST`. Duplicated on purpose: this is the
 #: one number a reviewer reads to see how far a PR moved the ratchet, and the
 #: test asserts the two agree so it cannot drift.
-UNCODED_RAISE_TOTAL = 164
+UNCODED_RAISE_TOTAL = 163
 
 #: ``"file::scope" -> count``. Grouped by file, sorted; see the module docstring.
 UNCODED_RAISE_ALLOWLIST: dict[str, int] = {
     "dependencies.py::get_current_character": 1,
     "dependencies.py::require_admin": 1,
 
-    "routers/admin.py::admin_cli_token": 3,
+    "routers/admin.py::admin_cli_token": 2,
     "routers/admin.py::admin_create_task": 3,
     "routers/admin.py::admin_import_tasks_csv": 1,
     "routers/admin.py::ban_character": 1,

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -1732,7 +1732,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List Voters */
+        /**
+         * List Voters
+         * @description The voter roster for a praxis the caller may see.
+         *
+         *     Visibility is :func:`can_view_praxis`, the same predicate the praxis detail
+         *     route runs, so the two doors cannot drift.
+         */
         get: operations["list_voters_praxes__praxis_id__voters_get"];
         put?: never;
         post?: never;
@@ -7738,7 +7744,9 @@ export interface operations {
             path: {
                 praxis_id: number;
             };
-            cookie?: never;
+            cookie?: {
+                access_token?: string | null;
+            };
         };
         requestBody?: never;
         responses: {

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -47,6 +47,7 @@
     "MEDIA_TYPE_UNSUPPORTED": "Unsupported media type.",
     "MEDIA_TOO_LARGE": "File too large (max {{max_megabytes}} MB).",
     "AVATAR_MUST_BE_IMAGE": "Avatar must be an image file.",
-    "AVATAR_TOO_LARGE": "Avatar too large (max {{max_megabytes}} MB)."
+    "AVATAR_TOO_LARGE": "Avatar too large (max {{max_megabytes}} MB).",
+    "OAUTH_EMAIL_UNVERIFIED": "Google hasn't verified that email address, so we can't sign you in with it. Verify it with Google and try again."
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -32,8 +32,21 @@ services:
         value: https://worldzero.org,https://www.worldzero.org
       - key: ENVIRONMENT
         value: production
-      - key: COOKIE_DOMAIN
-        value: .worldzero.org
+      # COOKIE_DOMAIN is deliberately UNSET, so the session cookie is host-only
+      # on api.worldzero.org.
+      #
+      # It used to be `.worldzero.org`, which attaches a live 7-day JWT to every
+      # request to every host under the domain — present and future, including
+      # any preview/CDN/status subdomain and any dangling DNS record someone
+      # else can claim. A wildcard here buys nothing: the browser decides what
+      # to send from the REQUEST host, and the frontend's credentialed XHR goes
+      # to api.worldzero.org, which a host-only cookie still covers.
+      # worldzero.org and api.worldzero.org share a registrable domain, so
+      # SameSite=Lax treats them as same-site and does not block it either.
+      #
+      # Changing this logs everyone out once — the old `.worldzero.org` cookie
+      # and the new host-only one are different cookies. That is expected and
+      # was accepted deliberately.
 
   - type: web
     name: worldzero-frontend


### PR DESCRIPTION
Fourteen findings from a seven-agent security review of the whole repo, fixed rather than filed so nothing exploitable sat in a public issue while it was still live. Every finding was verified against the code by hand before a line was changed.

**Merge promptly.** These commits describe each defect in order to justify the fix, and the repo is public — the exposure window is this PR's lifetime. `main` auto-deploys, so landing it closes the window.

## High

**Any signed-in player could delete other players' media.** `resolve_stored_media_path` asked *"is this inside MEDIA_ROOT?"* and never *"is this ours?"*. `avatar_url` is a free-form player-writable column (`update_character` `setattr`s whatever `CharacterUpdate` carries) and victim paths are public — `CharacterOut.avatar_url` and `MediaItemOut.file_path` both ship the raw relative path. So a player pointed their own column at anyone's file and let the next avatar upload, or their own account deletion, unlink it. Path traversal was always correctly refused; ownership was never asked. `delete_stored_avatar` now takes the character id and requires the resolved path to sit under that character's own avatar directory.

**Player-uploaded HTML executed on the API origin.** `_detect_media_type` read only the *client-declared* `Content-Type`, `_sanitize_filename` preserved the client's extension, and `/media` is StaticFiles-mounted on the API itself — so `pwn.html` declared as `image/png` came back as `text/html` from the API origin and ran with the session cookie attached. Extensions now come off a per-type allow-list (`.svg` deliberately excluded — it carries script) with the player's stem preserved, plus `X-Content-Type-Options: nosniff` app-wide.

## Medium

- **`GET /praxes?moderation_status=hidden` served moderated-off content to anyone, unauthenticated.** The `!= hidden` exclusion sat in an `else`, so any value removed it — and `except ValueError: pass` meant a *typo* dropped the filter and the default together. Exclusion is now unconditional; a caller's filter may only narrow within it.
- **`GET /characters/{id}/praxes` never applied the moderation filter**, despite a docstring promising it stayed "byte-for-byte in step with" `list_praxes`.
- **The activity feed republished hidden and duel-sealed praxis titles.** Friend/foe edges are unilateral and instant, so anyone could declare a player a foe and read titles the detail route 404s. Now built off the shared `praxis_visibility_condition`.
- **Comments were writable into other players' private drafts.** The write door checked `moderation_status` but never `can_view_praxis`, so a player could post into an `in_progress` draft they cannot read back — and use the 201/404 split as an existence oracle.
- **OAuth linked accounts by email with no `email_verified` check**, making an address the provider does not vouch for an authentication decision.
- **`dev-login` and the cookie's `Secure` flag failed *open*.** Both were deny-lists against the literal `"production"`, so every other value — `"prod"`, unset, an env var lost in a service re-create — simultaneously enabled an unauthenticated JWT mint and stripped `Secure`. Inverted to an allow-list on `"development"`.
- **The session cookie was scoped `.worldzero.org`**, attaching a live 7-day JWT to every host under the domain, including future and dangling ones. Now host-only on the API. **This logs everyone out once** — accepted deliberately.

## Low / hardening

Voter-roster visibility gate · `?status=pending` no longer serves the admin review queue publicly · `hmac.compare_digest` on the CLI-token secret with one indistinguishable refusal · `find_admin_accounts` filters to active · praxis media unlink routed through the shared ownership predicate · `TaskCreate` title/description bounded.

## Notes for review

**Two of these were shaped by the repo's own guards, not by me.**

The uncoded-error ratchet rejected my new `HTTPException`s, and it was right for a reason I had not seen: a *coded* error looks different from the neighbouring plain 404, which would have reopened the very oracle I was closing. The fix was to merge existence and visibility into a single raise. `uncoded_error_allowlist.py` shrinks 164 → 163 accordingly.

Route docstrings are copied verbatim into `backend/openapi.json`, a committed artifact on a public repo. The first version of the voter-roster docstring narrated the defect into the public API spec; it now describes the endpoint, with the history in a non-published comment. Verified zero net increase in sensitive text.

**Also here:** `.github/` is now off-limits to the three scoped subagents, because `render.yaml` has `autoDeploy: true` and all three required CI jobs live in a file the gated PR can edit. The line in each definition is the explanation; the control is a `PreToolUse` hook. CODEOWNERS was considered and rejected — GitHub forbids self-approval, so with a single owner and `enforce_admins: true` it would make workflow files permanently unmergeable rather than merely reviewed.

## Verification

- **1151 backend tests pass**, 93% coverage (gate is 80%) — unit *and* integration, against a real Postgres.
- Both API artifacts regenerated; `api-schema` should be clean.
- Not covered: no live exploitation was attempted against a deployment, and the frontend was not re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
