### PR TITLE
The habit bonus reaches the stamp: one flat term, eight voices, and no +0 noise

### DIFF
--- a/frontend/src/components/praxisCard/scoreStamp/CovenScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/CovenScoreStamp.tsx
@@ -50,7 +50,7 @@ import type { ScoreStampProps } from "./ScoreStamp";
 export default function CovenScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
-  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   /** The working's voice — the coven's hand, in the margin. */
@@ -152,6 +152,14 @@ export default function CovenScoreStamp({ praxis, showCrown }: ScoreStampProps) 
       >
         {t("card.stamp.fromVotes", { votes })}
       </div>
+
+      {/* The habit bonus, written after the tally: flat, outside the multiplier
+          (#1617). It always has a line above it, so it always keeps its lead. */}
+      {habit !== null && (
+        <div style={workingStyle}>
+          {t("card.stamp.habit")} +{habit}
+        </div>
+      )}
 
       {/* The braid — what rules a Coven surface. */}
       <Braid style={{ margin: "var(--space-sm) 0 var(--space-xs)" }} />

--- a/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
@@ -38,6 +38,9 @@ import type { ScoreStampProps } from "./ScoreStamp";
  *     neutralises it to 1.0 for every faction, so the row is dark today and
  *     lights up on its own if an era ever configures one.
  *   - the META row appears only when metatask points are > 0.
+ *   - the HABIT row appears only when a habit bonus was banked (#1617), and sits
+ *     under the tally's rule with the votes — both are flat terms added after
+ *     the multiplier, never inside it.
  *   - the VOTES tally is drawn ALWAYS, including `+0` — an absent row cannot
  *     say "nobody has voted yet".
  * Nothing is derived by subtraction; that was the bug ADR-0053 retired.
@@ -69,7 +72,7 @@ const STAMP_WIDTH = 150;
 export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
-  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   /** The working out, in reading order. Selection belongs to scoreBreakdown. */
@@ -239,7 +242,12 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
       {/* The tally, under a rule of its own. Always drawn: `+ 0 from votes` is a
           fact about this praxis, not a missing row. Its rule separates it from
           the working above — with no working (the #1131 empty state) there is
-          nothing to separate, and the rule would hang under the disc alone. */}
+          nothing to separate, and the rule would hang under the disc alone.
+
+          The habit bonus joins it BELOW that rule rather than in the ruled rows
+          above, because the rule is the multiplier's edge: everything over it is
+          inside `(base + meta) × mult` and everything under it is flat (#1617).
+          Unlike the tally it goes when it is 0 — the vast majority of praxes. */}
       <div
         style={{
           borderTop: rows.length > 0 ? "1px solid var(--faction-default-card-line)" : undefined,
@@ -251,7 +259,8 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
           color: "var(--faction-default-card-muted)",
         }}
       >
-        {t("card.stamp.fromVotes", { votes })}
+        <div>{t("card.stamp.fromVotes", { votes })}</div>
+        {habit !== null && <div>{t("card.stamp.habitBonus", { points: habit })}</div>}
       </div>
     </div>
   );

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -60,7 +60,7 @@ const MEDALLION_INSET = 6;
 export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
-  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   /** The cell's label voice: incised caps, at the plate's caption gold. */
@@ -181,6 +181,23 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
           gloss={t("card.stamp.ephemerists.fromVotesGloss")}
         />
       </div>
+
+      {/* The habit bonus (#1617), cut after the tally: flat, outside the ratio.
+          Labelled 習 like every other row of this cell — the #1637 bound holds,
+          so the LABEL is encoded and the figure stays a Western numeral. */}
+      {habit !== null && (
+        <div
+          style={{
+            fontFamily: READING,
+            fontStyle: "italic",
+            fontSize: "var(--text-md)",
+            color: QUIET,
+            marginTop: "var(--space-xs)",
+          }}
+        >
+          + {habit} <GlossedGlyph glyph={t("card.stamp.ephemerists.habit")} gloss={t("card.stamp.habit")} />
+        </div>
+      )}
 
       {/* The total, struck in the stepped octagon on its lotus base. */}
       <div

--- a/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
@@ -35,7 +35,7 @@ const FIELD_WIDTH = 38;
 export default function EverymenScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
-  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   /** Rows in working order. `ruled` draws the subtotal rule above the row. */
@@ -56,6 +56,12 @@ export default function EverymenScoreStamp({ praxis, showCrown }: ScoreStampProp
     rows.push({ key: "mult", label: t("card.stamp.mult"), value: formatMult(mult), gold: true });
   }
   rows.push({ key: "votes", label: t("card.stamp.votes"), value: `+${votes}` });
+  // The habit bonus is filled in AFTER the multiplier and after the subtotal
+  // rule, beside votes, because it is flat and outside the parentheses (#1617).
+  // Unlike votes it leaves the form entirely at 0 — the form is still complete.
+  if (habit !== null) {
+    rows.push({ key: "habit", label: t("card.stamp.habit"), value: `+${habit}` });
+  }
 
   return (
     <div

--- a/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
@@ -25,7 +25,7 @@ import type { ScoreStampProps } from "./ScoreStamp";
 export default function SingularityScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
-  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   const rowStyle = {
@@ -77,6 +77,18 @@ export default function SingularityScoreStamp({ praxis, showCrown }: ScoreStampP
     value: `+${String(votes).padStart(2, "0")}`,
     valueColor: "var(--faction-singularity-terminal-ink)",
   });
+  // The habit bonus prints after the multiplier and beside votes — it is flat,
+  // outside the parentheses (#1617) — and pads like every other line the machine
+  // writes. It is the one line below `BASE` that is also optional: the read-out
+  // omits a register the era never wrote to rather than printing `+00`.
+  if (habit !== null) {
+    lines.push({
+      key: "habit",
+      label: t("card.stamp.habit"),
+      value: `+${String(habit).padStart(2, "0")}`,
+      valueColor: "var(--faction-singularity-terminal-ink)",
+    });
+  }
 
   return (
     <div

--- a/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
@@ -23,8 +23,20 @@ import type { ScoreStampProps } from "./ScoreStamp";
 export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
-  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
+
+  /** The tag's typed working line — meta, the tally, and the habit bonus. */
+  const typedLine = {
+    fontFamily: "var(--font-body)",
+    fontWeight: 700,
+    // eslint-disable-next-line local/no-raw-style-values -- ornament: typewriter working on the tag, the design's 11 (§4a)
+    fontSize: 11,
+    letterSpacing: "0.06em",
+    textTransform: "uppercase" as const,
+    color: "var(--faction-snide-acid)",
+    marginTop: "var(--space-xs)",
+  };
 
   return (
     <div
@@ -100,39 +112,26 @@ export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) 
         </div>
       )}
 
-      {meta !== null && (
-        <div
-          style={{
-            fontFamily: "var(--font-body)",
-            fontWeight: 700,
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: typewriter working on the tag, the design's 11 (§4a)
-            fontSize: 11,
-            letterSpacing: "0.06em",
-            textTransform: "uppercase",
-            color: "var(--faction-snide-acid)",
-            marginTop: "var(--space-xs)",
-          }}
-        >
-          {t("card.stamp.meta")} +{meta}
-        </div>
-      )}
+      {meta !== null && <div style={typedLine}>{t("card.stamp.meta")} +{meta}</div>}
 
       <div
         style={{
-          fontFamily: "var(--font-body)",
-          fontWeight: 700,
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: typewriter working on the tag, the design's 11 (§4a)
-          fontSize: 11,
-          letterSpacing: "0.06em",
-          textTransform: "uppercase",
-          color: "var(--faction-snide-acid)",
+          ...typedLine,
           // The lead is between typed LINES: none when the tally is the first
           // one on the tag (#1131).
-          marginTop: base !== null ? "var(--space-xs)" : undefined,
+          marginTop: base !== null ? typedLine.marginTop : undefined,
         }}
       >
         {t("card.stamp.fromVotes", { votes })}
       </div>
+
+      {/* The habit bonus, typed after the tally: flat, outside the multiplier
+          (#1617). It always has a line above it, so it always keeps its lead. */}
+      {habit !== null && (
+        <div style={typedLine}>
+          {t("card.stamp.habit")} +{habit}
+        </div>
+      )}
 
       {/* Torn-off perforation, then the total mark. */}
       <div

--- a/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
@@ -83,7 +83,7 @@ function MultChip({ children }: { children: ReactNode }) {
 export default function UaScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
-  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   return (
@@ -225,6 +225,26 @@ export default function UaScoreStamp({ praxis, showCrown }: ScoreStampProps) {
         >
           {t("card.stamp.fromVotes", { votes })}
         </div>
+
+        {/*
+         * The habit bonus (#1617) — UA's own ability, and the one plate on the
+         * site that routinely carries this line. It is written UNDER the tally
+         * and outside the grouped subtotal on purpose: the bonus is flat, and
+         * the plate's rule is where the multiplier stops applying. Vermilion
+         * like the metatask working, because both are points the sheet ADDS.
+         */}
+        {habit !== null && (
+          <div
+            style={{
+              ...workingStyle,
+              color: "var(--faction-ua-card-accent)",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: the plate's lead between working lines.
+              marginTop: 3,
+            }}
+          >
+            + {habit} {t("card.stamp.habit")}
+          </div>
+        )}
       </div>
 
       {/*

--- a/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
@@ -27,7 +27,7 @@ import type { ScoreStampProps } from "./ScoreStamp";
 export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
-  const { base, mult, meta, votes, total } = scoreBreakdown(praxis);
+  const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   /** The working's voice: Lora italic, the chronicle's quiet secondary face. */
@@ -132,6 +132,14 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
       >
         {t("card.stamp.fromVotes", { votes })}
       </div>
+
+      {/* The habit bonus, entered after the tally: flat, outside the multiplier
+          (#1617). It always has a line above it, so it always keeps its lead. */}
+      {habit !== null && (
+        <div style={workingStyle}>
+          {t("card.stamp.habit")} +{habit}
+        </div>
+      )}
 
       {/* The gold→plum hairline, then the total and its star. */}
       <div

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -60,6 +60,7 @@ describe('scoreBreakdown row selection (ADR-0053)', () => {
       base: 12,
       mult: 0.8,
       meta: null,
+      habit: null,
       votes: 4,
       total: 13.6,
     })
@@ -104,6 +105,7 @@ describe('scoreBreakdown row selection (ADR-0053)', () => {
       base: null,
       mult: null,
       meta: null,
+      habit: null,
       votes: 0,
       total: 10,
     })
@@ -144,12 +146,58 @@ describe('scoreBreakdown row selection (ADR-0053)', () => {
       scoreBreakdown(
         praxis({ task_point_value: null, points_from_votes: null, score: null }),
       ),
-    ).toEqual({ base: 0, mult: 0.8, meta: null, votes: 0, total: 0 })
+    ).toEqual({ base: 0, mult: 0.8, meta: null, habit: null, votes: 0, total: 0 })
   })
 
   it('formats the multiplier to two decimals', () => {
     expect(formatMult(0.8)).toBe('×0.80')
     expect(formatMult(2)).toBe('×2.00')
+  })
+})
+
+/**
+ * #1617 — UA's habit bonus, at the SHARED seam: `scoreBreakdown` row selection.
+ *
+ * The backend half (PR #1659) stamps `habit_bonus_points` at seal time and puts
+ * it on the wire; nothing read it. The issue's §4 is why that is a defect and
+ * not a nicety — *"a term that scores without appearing there is how a card and
+ * a detail page start disagreeing"*. A praxis whose total is 5 higher than its
+ * own working is a stamp that cannot be checked.
+ *
+ * The bonus is FLAT and sits OUTSIDE the multiplier (owner ruling, restated at
+ * `backend/schemas/praxis.py:173`): `(base + meta) × mult + votes + habit`. So
+ * it is its own term here, never folded into `base` and never multiplied.
+ */
+describe('the habit bonus is a term of the breakdown (#1617)', () => {
+  it('reads the bonus through as its own row', () => {
+    expect(scoreBreakdown(praxis({ habit_bonus_points: 5, score: 18.6 })).habit).toBe(5)
+  })
+
+  /**
+   * The meta rule, not the votes one. `+0 from votes` is ADR-0047's single
+   * declared exception because an absent row cannot say "nobody has voted yet";
+   * the habit bonus has no such statement to make. It is 0 for every faction
+   * but UA and for every character's FIRST praxis, so a permanent `+0 habit`
+   * would print on all but a handful of cards on the site and mean nothing.
+   */
+  it('hides the row at 0 or below — the default on every faction but UA', () => {
+    expect(scoreBreakdown(praxis({ habit_bonus_points: 0 })).habit).toBeNull()
+    expect(scoreBreakdown(praxis({ habit_bonus_points: null })).habit).toBeNull()
+    expect(scoreBreakdown(praxis({ habit_bonus_points: 5 })).habit).toBe(5)
+  })
+
+  it('brings the base row back when the bonus is the only term moving the figure', () => {
+    const habitOnly = praxis({
+      task_point_value: 10,
+      display_multiplier: 1,
+      metatask_points: 0,
+      points_from_votes: 0,
+      habit_bonus_points: 5,
+      score: 15,
+    })
+    // Without the base row the sheet would state 15 over `+ 5 habit bonus` and
+    // leave the other 10 unaccounted for.
+    expect(scoreBreakdown(habitOnly).base).toBe(10)
   })
 })
 
@@ -786,5 +834,79 @@ describe('the Ephemerists label their score in kanji (#1637)', () => {
     expect(html).toContain('points')
     expect(html).toContain('from votes')
     expect(html).not.toMatch(/[基点票計]/)
+  })
+})
+
+/**
+ * #1617 at the OTHER seam: the eight skins' rendered markup.
+ *
+ * `scoreBreakdown` deciding the row is only half of it — #1131 is the standing
+ * proof that each skin still has to ACT on the resolver, and a skin that ignores
+ * the term renders perfectly while stamping a total 5 points above its own
+ * working. So every registered stamp is asserted, not just UA's: the bonus is a
+ * `FactionConfig` field defaulted to 0, and the faction that holds it is an ERA's
+ * choice. UA is the only one in Era 1.
+ */
+describe('every stamp shows the habit bonus when one is banked (#1617)', () => {
+  /**
+   * Each stamp with the label it prints and the figure it prints. Seven label it
+   * in English; the Ephemerists label it in kanji like every other row of theirs
+   * (#1637), and handing in 'habit' there would assert nothing. Singularity pads
+   * to two digits (`+05`) — the declared terminal notation, same as its votes row
+   * — which is why the figure is matched as a pattern rather than a literal.
+   */
+  const STAMPS = [
+    ['the unaffiliated sheet', DefaultScoreStamp, 'habit'],
+    ['Everymen', EverymenScoreStamp, 'habit'],
+    ['the Ephemerists', EphemeristsScoreStamp, '習'],
+    ['S.N.I.D.E.', SnideScoreStamp, 'habit'],
+    ['Singularity', SingularityScoreStamp, 'habit'],
+    ['WOW', WowScoreStamp, 'habit'],
+    ['Coven', CovenScoreStamp, 'habit'],
+    ['UA', UaScoreStamp, 'habit'],
+  ] as const
+
+  /** `12 × 0.8 + 4 votes + 5 habit = 18.6`. The multiplier is live on purpose. */
+  const banked = praxis({ habit_bonus_points: 5, score: 18.6 })
+  /** The same praxis without the bonus — the state of nearly every praxis. */
+  const none = praxis({ habit_bonus_points: 0, score: 13.6 })
+
+  for (const [name, Stamp, label] of STAMPS) {
+    it(`${name} prints the bonus, and drops the row at 0`, () => {
+      const html = text(renderToStaticMarkup(<Stamp praxis={banked} />))
+      expect(html).toContain(label)
+      // `+5`, `+ 5` or `+05` depending on the faction's notation — never `+4`,
+      // which is what folding the bonus inside the ×0.80 would print.
+      expect(html).toMatch(/\+ ?0?5\b/)
+      // The total mark never moves off the payload's own figure.
+      expect(html).toContain('18.6')
+
+      expect(text(renderToStaticMarkup(<Stamp praxis={none} />))).not.toContain(label)
+    })
+  }
+
+  /**
+   * The flat-vs-multiplied ruling, asserted on whole lines rather than numerals:
+   * `5 × 0.80 = 4` and 4 is already on this sheet as the votes figure, so a
+   * numeral assertion would go green on the bug.
+   */
+  it('prints the bonus flat — the multiplier never reaches it', () => {
+    const html = text(renderToStaticMarkup(<DefaultScoreStamp praxis={banked} />))
+    expect(html).toContain('+ 5 habit bonus')
+    expect(html).not.toContain('+ 4 habit bonus')
+    // …and it is not quietly rolled into the base figure either.
+    expect(html).toContain('base')
+    expect(html).not.toMatch(/\b17\b/)
+  })
+
+  it('leaves the Ephemerists numeral Western, like every other figure of theirs', () => {
+    const html = text(renderToStaticMarkup(<EphemeristsScoreStamp praxis={banked} />))
+    expect(html).toContain('+ 5')
+    expect(html).not.toMatch(/[〇一二三四五六七八九十百千万]/)
+  })
+
+  it('carries the English gloss on the kanji, for hover, focus and assistive tech', () => {
+    const markup = renderToStaticMarkup(<EphemeristsScoreStamp praxis={banked} />)
+    expect(markup).toContain('title="habit"')
   })
 })

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -849,21 +849,25 @@ describe('the Ephemerists label their score in kanji (#1637)', () => {
  */
 describe('every stamp shows the habit bonus when one is banked (#1617)', () => {
   /**
-   * Each stamp with the label it prints and the figure it prints. Seven label it
-   * in English; the Ephemerists label it in kanji like every other row of theirs
-   * (#1637), and handing in 'habit' there would assert nothing. Singularity pads
-   * to two digits (`+05`) — the declared terminal notation, same as its votes row
-   * — which is why the figure is matched as a pattern rather than a literal.
+   * Each stamp with the LABEL it prints and the whole LINE it prints.
+   *
+   * The line is spelled out per faction rather than pattern-matched, because
+   * `5 × 0.80 = 4` is the bug this guards and 4 is already on every one of these
+   * sheets as the votes figure — a bare numeral assertion would go green on it.
+   * Seven label the row in English; the Ephemerists label it in kanji like every
+   * other row of theirs (#1637), and handing in 'habit' there would assert
+   * nothing. Singularity zero-pads (`+05`) — its declared terminal notation,
+   * the same one its votes row already uses.
    */
   const STAMPS = [
-    ['the unaffiliated sheet', DefaultScoreStamp, 'habit'],
-    ['Everymen', EverymenScoreStamp, 'habit'],
-    ['the Ephemerists', EphemeristsScoreStamp, '習'],
-    ['S.N.I.D.E.', SnideScoreStamp, 'habit'],
-    ['Singularity', SingularityScoreStamp, 'habit'],
-    ['WOW', WowScoreStamp, 'habit'],
-    ['Coven', CovenScoreStamp, 'habit'],
-    ['UA', UaScoreStamp, 'habit'],
+    ['the unaffiliated sheet', DefaultScoreStamp, 'habit', '+ 5 habit bonus'],
+    ['Everymen', EverymenScoreStamp, 'habit', 'habit+5'],
+    ['the Ephemerists', EphemeristsScoreStamp, '習', '+ 5 習'],
+    ['S.N.I.D.E.', SnideScoreStamp, 'habit', 'habit +5'],
+    ['Singularity', SingularityScoreStamp, 'habit', 'habit+05'],
+    ['WOW', WowScoreStamp, 'habit', 'habit +5'],
+    ['Coven', CovenScoreStamp, 'habit', 'habit +5'],
+    ['UA', UaScoreStamp, 'habit', '+ 5 habit'],
   ] as const
 
   /** `12 × 0.8 + 4 votes + 5 habit = 18.6`. The multiplier is live on purpose. */
@@ -871,33 +875,19 @@ describe('every stamp shows the habit bonus when one is banked (#1617)', () => {
   /** The same praxis without the bonus — the state of nearly every praxis. */
   const none = praxis({ habit_bonus_points: 0, score: 13.6 })
 
-  for (const [name, Stamp, label] of STAMPS) {
-    it(`${name} prints the bonus, and drops the row at 0`, () => {
+  for (const [name, Stamp, label, line] of STAMPS) {
+    it(`${name} prints the bonus flat, and drops the row at 0`, () => {
       const html = text(renderToStaticMarkup(<Stamp praxis={banked} />))
-      expect(html).toContain(label)
-      // `+5`, `+ 5` or `+05` depending on the faction's notation — never `+4`,
-      // which is what folding the bonus inside the ×0.80 would print.
-      expect(html).toMatch(/\+ ?0?5\b/)
+      expect(html).toContain(line)
       // The total mark never moves off the payload's own figure.
       expect(html).toContain('18.6')
+      // …and the bonus is not quietly rolled into the base figure either: the
+      // sheet still states the task's own 12.
+      expect(html).not.toContain('17')
 
       expect(text(renderToStaticMarkup(<Stamp praxis={none} />))).not.toContain(label)
     })
   }
-
-  /**
-   * The flat-vs-multiplied ruling, asserted on whole lines rather than numerals:
-   * `5 × 0.80 = 4` and 4 is already on this sheet as the votes figure, so a
-   * numeral assertion would go green on the bug.
-   */
-  it('prints the bonus flat — the multiplier never reaches it', () => {
-    const html = text(renderToStaticMarkup(<DefaultScoreStamp praxis={banked} />))
-    expect(html).toContain('+ 5 habit bonus')
-    expect(html).not.toContain('+ 4 habit bonus')
-    // …and it is not quietly rolled into the base figure either.
-    expect(html).toContain('base')
-    expect(html).not.toMatch(/\b17\b/)
-  })
 
   it('leaves the Ephemerists numeral Western, like every other figure of theirs', () => {
     const html = text(renderToStaticMarkup(<EphemeristsScoreStamp praxis={banked} />))

--- a/frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts
+++ b/frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts
@@ -21,6 +21,8 @@ export interface ScoredPraxis {
   metatask_points: number;
   display_multiplier: number;
   points_from_votes: number;
+  /** UA's habit bonus — flat, OUTSIDE the multiplier (#1617). See below. */
+  habit_bonus_points: number;
   score: number;
 }
 
@@ -39,6 +41,15 @@ export interface ScoreBreakdown {
   mult: number | null;
   /** Metatask points, or null when the meta row is hidden (`≤ 0`). */
   meta: number | null;
+  /**
+   * The habit bonus, or null when the row is hidden (`≤ 0`) — #1617.
+   *
+   * It is a FLAT term outside the multiplier, so a skin adds it beside `votes`
+   * and never inside the `(base + meta) × mult` group. Multiplying it would make
+   * the same faction ability worth more under an era with a non-neutral modifier
+   * than under Era 1's 1.0, which is the owner ruling this null carries.
+   */
+  habit: number | null;
   votes: number;
   total: number;
 }
@@ -53,6 +64,10 @@ export interface ScoreBreakdown {
  *    print the total a second time (#1131)
  *  - mult row only when `display_multiplier !== 1` (×1.0 moves nothing)
  *  - meta row only when `metatask_points > 0` (`+0` moves nothing)
+ *  - habit row only when `habit_bonus_points > 0`, by the same rule (#1617). It
+ *    is 0 for every faction but UA and for every character's FIRST praxis, so a
+ *    row drawn at 0 would print "+0 habit" on nearly every card on the site and
+ *    tell the viewer nothing the total does not already say.
  *  - votes row ALWAYS, `+0` included — the exception, re-affirmed in ADR-0047:
  *    an absent row cannot say "nobody has voted yet"
  *  - total to 1 decimal at the render sites
@@ -64,26 +79,29 @@ export function scoreBreakdown(praxis: ScoredPraxis): ScoreBreakdown {
   const rawBase = praxis.task_point_value ?? 0;
   const rawMult = praxis.display_multiplier ?? 1;
   const rawMeta = praxis.metatask_points ?? 0;
+  const rawHabit = praxis.habit_bonus_points ?? 0;
   const mult = rawMult !== 1 ? rawMult : null;
   const meta = rawMeta > 0 ? rawMeta : null;
+  const habit = rawHabit > 0 ? rawHabit : null;
   const votes = praxis.points_from_votes ?? 0;
   const total = praxis.score ?? 0;
 
   /**
    * #1131 — the empty state said `10.0 POINTS` and then `BASE 10`. Both halves
-   * of this test are load-bearing: the three terms decide whether any row could
+   * of this test are load-bearing: the terms decide whether any row could
    * explain a difference between base and total, and `total === rawBase` refuses
    * to hide a figure the payload itself disagrees with — a `score` that has
    * drifted from its terms must stay legible, not collapse silently into the
    * faction's total mark.
    */
   const baseRestatesTotal =
-    mult === null && meta === null && votes === 0 && total === rawBase;
+    mult === null && meta === null && habit === null && votes === 0 && total === rawBase;
 
   return {
     base: baseRestatesTotal ? null : rawBase,
     mult,
     meta,
+    habit,
     votes,
     total,
   };

--- a/frontend/src/components/vote/__tests__/applyCastTally.test.ts
+++ b/frontend/src/components/vote/__tests__/applyCastTally.test.ts
@@ -181,6 +181,7 @@ describe('applyCastTally on a detail payload (#1142)', () => {
       base: 12,
       mult: null,
       meta: null,
+      habit: null,
       votes: 9,
       total: 21,
     })
@@ -206,6 +207,7 @@ describe('applyCastTally on a detail payload (#1142)', () => {
       metatask_points: 0,
       display_multiplier: 1.0,
       points_from_votes: 4,
+      habit_bonus_points: 0,
       score: 16,
     }
     const voted = applyCastTally(scoreOnly, firstCastOfFive())

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -42,6 +42,8 @@
       "base": "base",
       "mult": "mult",
       "meta": "meta",
+      "habit": "habit",
+      "habitBonus": "+ {{points}} habit bonus",
       "votes": "votes",
       "total": "total",
       "totalShort": "tot",
@@ -55,7 +57,8 @@
         "base": "基",
         "points": "点",
         "fromVotes": "票",
-        "fromVotesGloss": "from votes"
+        "fromVotesGloss": "from votes",
+        "habit": "習"
       }
     },
     "mediaEmpty": "no proof attached",


### PR DESCRIPTION
The backend half (PR #1659) stamps `habit_bonus_points` at seal time and puts it on the wire. Nothing read it: every frontend occurrence was a test fixture pinned to `0`, so a UA praxis that earned the bonus stamped a total 5 points above its own visible working. That PR said so itself — *"the score stamp does not yet render the term; #1617 closes when a player can see it."*

This is that half. **No backend file is touched** and no schema is regenerated: the field already exists on `PraxisCardOut`, `PraxisOut` and `FlaggedPraxisOut` in `schema.d.ts`.

Closes #1617

## The seam

**`scoreBreakdown()` — the single row-selection authority (ADR-0053) — and then each skin's rendered markup.** Both halves, because #1131 is the standing proof that they are two seams: the resolver deciding a row exists does not make a skin draw it, and a skin that ignores the term renders perfectly while contradicting its own total.

The loop went red there first: 16 failures across the resolver's contract and all eight stamps, then green.

## Two calls worth stating

**The bonus is flat and outside the multiplier.** `(base + meta) × mult + votes + habit`, per the owner ruling restated at `backend/schemas/praxis.py:173`. So `habit` is its own term in the breakdown, never folded into `base` and never multiplied, and every skin places it *after* the multiplier beside the votes — under the Default sheet's tally rule, after Everymen's subtotal rule, under UA's plate rule. The test asserts whole lines rather than numerals, because `5 × 0.80 = 4` and 4 is already on each of these sheets as the votes figure: a bare numeral assertion would have gone green on exactly the bug.

**A zero habit bonus does not render.** It takes the META rule, not the votes one. ADR-0047's always-draw exception exists because an absent votes row cannot say "nobody has voted yet"; the habit bonus has no such statement to make, and it is `0` for every faction but UA and for every character's *first* praxis. A row drawn at 0 would print "+0 habit" on all but a handful of cards on the site.

## All eight skins, not just UA's

`habit_bonus_points` is a `FactionConfig` field defaulted to 0 — *which* faction holds it is an era's choice, and UA is merely the one in Era 1. A stamp that ignores the term would be wrong the day an era grants it elsewhere, and ADR-0053 already says a faction that disagrees with the shared rows is wrong, not different. Each draws it in its own voice:

| stamp | line |
|---|---|
| unaffiliated / Default | `+ 5 habit bonus`, under the tally rule |
| Everymen | a filled `HABIT +5` tally field |
| Ephemerists | `+ 5 習`, glossed "habit" |
| S.N.I.D.E. | `HABIT +5`, typed |
| Singularity | `habit +05` — the register's declared zero-padding, same as its votes row |
| WOW / Coven | `habit +5` in the working hand |
| UA | `+ 5 habit` in vermilion, under the plate's rule |

Copy is in `frontend/src/locales/en/praxis.json` (`card.stamp.habit`, `card.stamp.habitBonus`, `card.stamp.ephemerists.habit`) — no bare literals.

**One thing to rule on:** the Ephemerists kanji `習` is my pick, following #1637's established pattern (the glyph is the label, the English rides on the `title` gloss, the numeral stays Western). If a different character is wanted it is a one-line catalog change.

## Also here

`ScoredPraxis` gains `habit_bonus_points`, so the one bare `ScoredPraxis` literal in `applyCastTally.test.ts` and three `toEqual` breakdown assertions grow the field. S.N.I.D.E.'s two copy-pasted working-line style literals become one hoisted const rather than a third copy.

## Verification

Every CI step run locally in the worktree: `eslint` clean · `tsc --noEmit` clean · `typecheck:design-sync` clean (the `.design-sync` fixtures already carry the field) · `vitest run` **4213 passed / 233 files** · `vite build` ok · initial-load budget ok (JS 128.1 KB, CSS 21.5 KB, both within). `api-schema` is untouched — no route, `response_model` or Pydantic schema changed.

**Visual QA is outstanding.** I have no browser and no dev stack; everything above is markup assertions.

## What to eyeball

The bonus only appears on a UA praxis whose author filed another submitted praxis within the last 7 days, so seed two UA praxes a few days apart and look at the second one:

- **UA praxis card** in the feed, and the **UA praxis detail** page — the vermilion `+ 5 habit` under the plate's rule, and that the ensō still overlaps the plate's foot by its 6px rather than colliding with the new line.
- **UA card on mobile** — same component, narrower column.
- **The composer's waiting surface** right after submitting a qualifying UA praxis.
- A **UA praxis with a metatask applied**, where the grouped `(base + meta)` subtotal and the habit line are both live — that the bonus reads as being *outside* the group.
- **Any non-UA praxis** (Coven, WOW, Snide, Singularity, Everymen, Ephemerists, unaffiliated): the row must be absent, and each stamp must look exactly as it does on `main`.
- If you can force a non-zero bonus on another faction, check **Singularity's `+05`** and the **Ephemerists' `習`** — the latter's dotted `<abbr>` underline and its "habit" tooltip on hover/focus.
- **Dark mode** on the UA and Ephemerists stamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
