### PR TITLE
Three prod bugs, one disease: a rule stated twice and never reconciled

### DIFF
--- a/backend/alembic/versions/0006_praxis_child_fk_cascade.py
+++ b/backend/alembic/versions/0006_praxis_child_fk_cascade.py
@@ -1,0 +1,83 @@
+"""Put ``ON DELETE CASCADE`` on every FK into ``praxis.id`` that is part of the praxis.
+
+Dropping a praxis was impossible the moment anything hung off it. All ten FKs
+into ``praxis.id`` were NO ACTION, so ``services.praxis.delete_praxis``'s
+``session.delete(praxis)`` failed two different ways:
+
+* For a child the session had **not** loaded (``vote``, ``nudge``,
+  ``praxis_meta_task``, ``comment``, ``flag``) Postgres refused the parent
+  DELETE outright with a foreign-key violation.
+* For ``media_item`` — which ``get_praxis`` eagerly loads for the detail view
+  and which carries no ``delete-orphan`` cascade — SQLAlchemy's default is to
+  *de-associate* the child, i.e. ``UPDATE media_item SET praxis_id = NULL``.
+  That column is NOT NULL, so the transaction died on a not-null violation and
+  the player saw the raw asyncpg error while the drop silently did nothing.
+
+The rule belongs in the database rather than in eight ``cascade='all,
+delete-orphan'`` declarations: those only fire for collections already loaded in
+the session, which would mean six more ``selectinload``s in ``get_praxis`` — paid
+by every praxis *detail view* — purely so that delete would work. The FK covers
+every caller and costs no reads. The mappings carry ``passive_deletes=True`` to
+match (``models/praxis.py``).
+
+``duel.challenger_praxis_id`` and ``duel.opponent_praxis_id`` are deliberately
+left NO ACTION. A duel is a contract between two players, not a component of
+either side; it should refuse the delete rather than disappear with it.
+
+``0002_squashed`` builds a fresh database straight from the ORM models, so CI and
+local resets already land on this shape from ``models/`` alone. A deployed
+database is stamped at a later revision and never re-runs it — hence this one.
+Idempotent either way: each constraint is dropped ``IF EXISTS`` before being
+recreated under the same ``models/base.py`` naming convention.
+
+Revision ID: 0006_praxis_child_fk_cascade
+Revises: 0005_praxis_member_habit_bonus
+Create Date: 2026-08-14
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0006_praxis_child_fk_cascade"
+down_revision: Union[str, None] = "0005_praxis_member_habit_bonus"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+#: ``(table, column)`` for every FK into ``praxis.id`` that names a *part* of the
+#: praxis. Constraint names follow ``models/base.py``'s ``fk_`` convention, so
+#: they are derivable rather than spelled out.
+PRAXIS_CHILDREN: tuple[tuple[str, str], ...] = (
+    ("comment", "praxis_id"),
+    ("flag", "praxis_id"),
+    ("media_item", "praxis_id"),
+    ("nudge", "praxis_id"),
+    ("praxis_invite", "praxis_id"),
+    ("praxis_member", "praxis_id"),
+    ("praxis_meta_task", "praxis_id"),
+    ("vote", "praxis_id"),
+)
+
+
+def _constraint_name(table: str, column: str) -> str:
+    return f"fk_{table}_{column}_praxis"
+
+
+def _repoint(table: str, column: str, ondelete: str | None) -> None:
+    name = _constraint_name(table, column)
+    op.execute(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {name}")
+    clause = f" ON DELETE {ondelete}" if ondelete else ""
+    op.execute(
+        f"ALTER TABLE {table} ADD CONSTRAINT {name} "
+        f"FOREIGN KEY ({column}) REFERENCES praxis (id){clause}"
+    )
+
+
+def upgrade() -> None:
+    for table, column in PRAXIS_CHILDREN:
+        _repoint(table, column, "CASCADE")
+
+
+def downgrade() -> None:
+    for table, column in PRAXIS_CHILDREN:
+        _repoint(table, column, None)

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,13 +37,28 @@ app = FastAPI(title="World Zero", version="1.0.0", lifespan=lifespan)
 
 @app.exception_handler(IntegrityError)
 async def integrity_error_handler(request: Request, exc: IntegrityError) -> JSONResponse:
+    """Turn a constraint violation into something a player can read.
+
+    The ``else`` branch used to be ``detail = msg`` — the lower-cased driver
+    exception, shipped verbatim to the browser. A "drop task" that tripped the
+    praxis-delete bug answered with the asyncpg exception class, the statement,
+    and the failing row's column values. That is unreadable *and* a disclosure:
+    the message names tables, columns and stored data.
+
+    Only the two recognised shapes get bespoke copy; everything else is a bug in
+    us, not a mistake by the player, so it reads like one and the real exception
+    goes to the log where it belongs.
+    """
     msg = str(exc.orig).lower()
     if "username" in msg:
         detail = "That username is already taken. Please choose a different one."
     elif "unique" in msg or "duplicate" in msg:
         detail = "That value is already in use. Please try a different one."
     else:
-        detail = msg
+        logger.exception(
+            "Unhandled integrity error on %s %s", request.method, request.url.path
+        )
+        detail = "That didn't go through — something on our end refused it. Please try again."
     return JSONResponse(status_code=409, content={"detail": detail})
 
 

--- a/backend/models/comment.py
+++ b/backend/models/comment.py
@@ -58,8 +58,10 @@ class Comment(TimestampMixin, Base):
     )
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(), primary_key=True)
+    # ON DELETE CASCADE: a comment on a praxis is part of that praxis. See the
+    # note on ``MediaItem.praxis_id`` for why every such FK carries it.
     praxis_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("praxis.id"), nullable=True
+        BigInteger, ForeignKey("praxis.id", ondelete="CASCADE"), nullable=True
     )
     task_id: Mapped[Optional[int]] = mapped_column(
         BigInteger, ForeignKey("task.id"), nullable=True

--- a/backend/models/flag.py
+++ b/backend/models/flag.py
@@ -76,8 +76,9 @@ class Flag(CreatedAtMixin, Base):
     )
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(), primary_key=True)
+    # ON DELETE CASCADE — see the note on ``MediaItem.praxis_id``.
     praxis_id: Mapped[Optional[int]] = mapped_column(
-        BigInteger, ForeignKey("praxis.id"), nullable=True
+        BigInteger, ForeignKey("praxis.id", ondelete="CASCADE"), nullable=True
     )
     comment_id: Mapped[Optional[int]] = mapped_column(
         BigInteger, ForeignKey("comment.id"), nullable=True

--- a/backend/models/meta_task.py
+++ b/backend/models/meta_task.py
@@ -19,8 +19,9 @@ class PraxisMetaTask(Base):
 
     # The only composite primary key in the schema, and so the only table with
     # no `Identity()`: both halves are foreign keys, and the pair IS the fact.
+    # ON DELETE CASCADE — see the note on ``MediaItem.praxis_id``.
     praxis_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("praxis.id"), primary_key=True
+        BigInteger, ForeignKey("praxis.id", ondelete="CASCADE"), primary_key=True
     )
     task_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("task.id"), primary_key=True

--- a/backend/models/nudge.py
+++ b/backend/models/nudge.py
@@ -47,8 +47,9 @@ class Nudge(CreatedAtMixin, Base):
         BigInteger, ForeignKey("character.id"), nullable=False
     )
     # The praxis the recipient still owes — see the module docstring.
+    # ON DELETE CASCADE — see the note on ``MediaItem.praxis_id``.
     praxis_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("praxis.id"), nullable=False
+        BigInteger, ForeignKey("praxis.id", ondelete="CASCADE"), nullable=False
     )
 
     __table_args__ = (

--- a/backend/models/praxis.py
+++ b/backend/models/praxis.py
@@ -159,6 +159,7 @@ class Praxis(TimestampMixin, Base):
         back_populates="praxis",
         lazy="selectin",
         cascade="all, delete-orphan",
+        passive_deletes=True,
     )
     # invites, votes, media_items, and flags are load-on-demand. Only the
     # praxis detail view and admin-moderation flows read them, so the list
@@ -166,23 +167,41 @@ class Praxis(TimestampMixin, Base):
     # sites that need them must use ``.options(selectinload(Praxis.foo))``;
     # accessing these attributes on an un-loaded Praxis raises.
     #
-    # CASCADE INVARIANT: any relationship declared with
-    # ``cascade='all, delete-orphan'`` MUST be eagerly loaded wherever
-    # ``session.delete(praxis)`` is called (see ``services/praxis.get_praxis``).
-    # Otherwise SQLAlchemy cannot cascade the delete and the orphaned rows
-    # remain. If you add a new cascade, update ``get_praxis`` to selectin-load
-    # it too.
+    # DELETE INVARIANT: every collection here is ``cascade='all, delete-orphan'``
+    # + ``passive_deletes=True``, and every FK behind them is ``ON DELETE
+    # CASCADE`` (see ``MediaItem.praxis_id``). Both halves are load-bearing, and
+    # they answer different halves of the question:
+    #
+    # * ``delete-orphan`` says what a child *is* — a part of the praxis, not an
+    #   independent row that outlives it. Without it SQLAlchemy's default for a
+    #   loaded collection is to de-associate: ``UPDATE ... SET praxis_id = NULL``,
+    #   which is what "drop task" used to write into ``media_item``'s NOT NULL
+    #   column. ``passive_deletes=True`` does NOT prevent that on its own — it
+    #   stops SQLAlchemy *loading* a collection in order to null it, but a
+    #   collection already in the session (``get_praxis`` selectin-loads
+    #   ``media_items`` for the detail view) is still processed.
+    # * ``passive_deletes=True`` then says the database will handle the children
+    #   SQLAlchemy has *not* loaded, so ``lazy='raise'`` collections are left
+    #   alone instead of being fetched to be deleted one by one.
+    #
+    # ``members`` and ``invites`` additionally rely on orphan-removal in place —
+    # ``kick_member`` and ``leave_praxis`` do ``praxis.members.remove(...)`` and
+    # expect the DELETE to follow. That is a separate mechanism from the
+    # parent-delete one and is unaffected by ``passive_deletes``.
     invites: Mapped[List["PraxisInvite"]] = relationship(
         "PraxisInvite",
         back_populates="praxis",
         lazy="raise",
         cascade="all, delete-orphan",
+        passive_deletes=True,
     )
     votes: Mapped[List["Vote"]] = relationship(
         "Vote",
         foreign_keys="Vote.praxis_id",
         back_populates="praxis",
         lazy="raise",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
     media_items: Mapped[List["MediaItem"]] = relationship(
         "MediaItem",
@@ -190,12 +209,16 @@ class Praxis(TimestampMixin, Base):
         back_populates="praxis",
         order_by="MediaItem.display_order",
         lazy="raise",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
     flags: Mapped[List["Flag"]] = relationship(
         "Flag",
         foreign_keys="Flag.praxis_id",
         back_populates="praxis",
         lazy="raise",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )
 
 
@@ -206,8 +229,9 @@ class PraxisMember(Base):
     )
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(), primary_key=True)
+    # ON DELETE CASCADE — see the note on ``MediaItem.praxis_id``.
     praxis_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("praxis.id"), nullable=False
+        BigInteger, ForeignKey("praxis.id", ondelete="CASCADE"), nullable=False
     )
     character_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("character.id"), nullable=False
@@ -258,8 +282,31 @@ class MediaItem(CreatedAtMixin, Base):
     __table_args__ = (Index("ix_media_item_praxis_id", "praxis_id"),)
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(), primary_key=True)
+    # ON DELETE CASCADE, and the reference note for every other FK into
+    # ``praxis.id`` that carries it (comment, flag, nudge, praxis_meta_task,
+    # praxis_member, praxis_invite, vote).
+    #
+    # Deleting a praxis used to be impossible once anything hung off it. Every
+    # one of these FKs was NO ACTION, so ``session.delete(praxis)`` in
+    # ``services.praxis.delete_praxis`` either hit a foreign-key violation (for
+    # a child the session had not loaded) or — for THIS column, which
+    # ``get_praxis`` eagerly loads for the detail view and which has no
+    # ``delete-orphan`` cascade — made SQLAlchemy try to de-associate the child
+    # by writing ``praxis_id = NULL``, straight into this NOT NULL. Players got
+    # a raw asyncpg not-null violation from "drop task" and the drop silently
+    # failed.
+    #
+    # The rule is in the DB rather than in eight ``cascade='all,
+    # delete-orphan'`` declarations because those only fire for collections the
+    # session has already loaded — which would mean six more ``selectinload``s
+    # in ``get_praxis``, paid by every praxis *detail view*, to make delete
+    # work. The FK covers every caller and costs no reads.
+    #
+    # ``duel.challenger_praxis_id`` / ``opponent_praxis_id`` are deliberately
+    # NOT in the set: a duel is a contract between two players, not a part of
+    # either side, and it should refuse the delete rather than vanish with it.
     praxis_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("praxis.id"), nullable=False
+        BigInteger, ForeignKey("praxis.id", ondelete="CASCADE"), nullable=False
     )
     type: Mapped[MediaType] = mapped_column(
         Enum(MediaType, create_type=False), nullable=False
@@ -276,8 +323,9 @@ class PraxisInvite(CreatedAtMixin, Base):
     __tablename__ = "praxis_invite"
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(), primary_key=True)
+    # ON DELETE CASCADE — see the note on ``MediaItem.praxis_id``.
     praxis_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("praxis.id"), nullable=False
+        BigInteger, ForeignKey("praxis.id", ondelete="CASCADE"), nullable=False
     )
     inviter_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("character.id"), nullable=False

--- a/backend/models/vote.py
+++ b/backend/models/vote.py
@@ -33,8 +33,9 @@ class Vote(Base):
     )
 
     id: Mapped[int] = mapped_column(BigInteger, Identity(), primary_key=True)
+    # ON DELETE CASCADE — see the note on ``MediaItem.praxis_id``.
     praxis_id: Mapped[int] = mapped_column(
-        BigInteger, ForeignKey("praxis.id"), nullable=False
+        BigInteger, ForeignKey("praxis.id", ondelete="CASCADE"), nullable=False
     )
     voter_character_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("character.id"), nullable=False

--- a/backend/services/comment.py
+++ b/backend/services/comment.py
@@ -12,6 +12,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from dependencies import account_has_admin_role
 from errors import DETAIL_CONTEXT_PARAM, ErrorCode, raise_coded
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
@@ -20,6 +21,7 @@ from models.flag import Flag, FlagReason, stored_flag_reason
 from models.praxis import ModerationStatus, Praxis
 from models.task import Task, TaskStatus
 from schemas.comment import CommentAuthor, CommentMentionOut, CommentOut
+from services.character_capabilities import compute_capabilities
 from services.era import get_current_era_row, get_or_create_stats
 from services.praxis import can_view_praxis
 
@@ -46,13 +48,29 @@ async def can_comment(
     session: AsyncSession,
     era: EraConfig = CURRENT_ERA,
 ) -> bool:
-    """True if viewer is authenticated and at/above era.comment_level_required.
+    """Whether ``viewer`` may post a comment — the enforcement half of the
+    ``can_comment`` flag ``/auth/me`` carries.
 
-    Mirrors :func:`services.praxis.can_flag_praxis`.
+    Derived from :func:`services.character_capabilities.compute_capabilities`
+    rather than restated, because restating it is what broke. This used to read
+    the level alone, while the flag the frontend gates the composer on
+    short-circuits to True for admins. An admin below
+    ``era.comment_level_required`` was therefore shown a comment box and got a
+    403 from every submit — which is how a production database reached zero
+    comments with an admin repeatedly trying to leave one.
+
+    That is the same trap :func:`services.praxis.can_sign_up_for_task` is built
+    to avoid ("one predicate, so the can_sign_up flag can't drift from
+    enforcement"). One predicate here too.
     """
     if viewer is None:
         return False
-    return await _character_level(viewer.id, session) >= era.comment_level_required
+    capabilities = compute_capabilities(
+        await _character_level(viewer.id, session),
+        await account_has_admin_role(viewer.account_id, session),
+        era,
+    )
+    return capabilities.can_comment
 
 
 async def get_comment(comment_id: int, session: AsyncSession) -> Comment:

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -105,12 +105,13 @@ async def get_praxis(
     this helper ultimately feeds a ``build_praxis_out`` caller. The list
     endpoint uses :func:`list_praxes` which loads only what the card needs.
 
-    INVARIANT: must eagerly load every Praxis relationship with
-    ``cascade='all, delete-orphan'`` — currently just ``invites`` — because
-    :func:`delete_praxis` does ``session.delete(praxis)`` which needs those
-    collections loaded in the session for the cascade to fire. The other
-    relationships are ``lazy='raise'`` (see ``models/praxis.py``); dropping a
-    ``selectinload`` here silently breaks delete.
+    The loads here are for the *detail view* only. Deleting a praxis no longer
+    depends on them: the FKs into ``praxis.id`` are ``ON DELETE CASCADE`` and
+    the collections are ``passive_deletes=True``, so :func:`delete_praxis`
+    works whether or not a collection is loaded. It is the inverse that used to
+    bite — eagerly loading ``media_items``, which has no ``delete-orphan``
+    cascade, is what made ``session.delete(praxis)`` try to write
+    ``praxis_id = NULL`` into a NOT NULL column. See ``MediaItem.praxis_id``.
     """
     result = await session.execute(
         select(Praxis)
@@ -834,6 +835,51 @@ async def _check_create_preconditions(
     return task
 
 
+#: Namespace for :func:`_lock_signups_for_character`'s advisory lock. Postgres
+#: advisory locks share one global 64-bit space across the whole database, so a
+#: bare ``character_id`` would collide with any other feature that ever locks on
+#: an id. The two-argument form takes an explicit namespace instead.
+#:
+#: ponytail: that form is ``(int4, int4)``, so it presumes ``character.id`` fits
+#: in 32 bits. It is a BIGINT column; past 2^31 characters this needs the
+#: one-argument int8 form with the namespace folded into the high half.
+_SIGNUP_LOCK_NAMESPACE = 0x5A19
+
+
+async def _lock_signups_for_character(character_id: int, session: AsyncSession) -> None:
+    """Serialise one character's task signups for the rest of this transaction.
+
+    :func:`_check_create_preconditions` is a read-then-write: it SELECTs whether
+    the character already holds an active membership on the task (and how full
+    their bank is), then INSERTs on the strength of that answer. Nothing in the
+    schema can catch a second signup that slips between the two — the
+    "one active membership per character per task" rule spans ``praxis_member``
+    and ``praxis.status``/``task_id``, so it is not expressible as a unique
+    index without denormalising ``task_id`` onto the membership.
+
+    That gap is not theoretical. In production four praxes were created for one
+    character on one task inside 110 milliseconds — two of them 2ms apart — by a
+    single tap on a phone that fired four requests. All four ran the membership
+    check before any of them committed, so all four were told they were the
+    first.
+
+    An advisory lock rather than ``SELECT ... FOR UPDATE`` on the character row:
+    the thing being serialised is a *decision spanning several tables*, not a
+    mutation of ``character``, and taking a row lock for it would mean anything
+    else touching that row inherits the contention. ``xact`` releases at
+    commit or rollback, so no path can leak it. Contention is per character, so
+    two different players never wait on each other.
+
+    ponytail: the client is not fixed here — four ``handleSignup`` copies would
+    each need an in-flight guard, and every one of them would still be advisory.
+    The server has to refuse regardless. Add the client guard when the wasted
+    round-trips are worth four diffs.
+    """
+    await session.execute(
+        select(func.pg_advisory_xact_lock(_SIGNUP_LOCK_NAMESPACE, character_id))
+    )
+
+
 async def create_praxis(
     task_id: int,
     praxis_type: PraxisType,
@@ -851,7 +897,12 @@ async def create_praxis(
     - Bank cap: era.max_task_signups = max concurrent in_progress praxes per character
     - Duel/collab type requires minimum level
     - Spends the faction level-jump allowance if the claim needed it (#811)
+
+    Every one of those gates is a *read* followed by a write, so they only hold
+    against one signup at a time — see :func:`_lock_signups_for_character`.
     """
+    await _lock_signups_for_character(character_id, session)
+
     task = await _check_create_preconditions(
         task_id, praxis_type, character_id, session, era
     )

--- a/backend/tests/integration/test_comments.py
+++ b/backend/tests/integration/test_comments.py
@@ -10,11 +10,13 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.comment import MAX_COMMENT_BODY, Comment
 from models.era import Era
 from models.praxis import Praxis
+from models.roles import AccountRole, Role
 from models.task import Task
 from services.comment import create_comment
 
@@ -519,3 +521,48 @@ async def test_body_stored_over_the_cap_still_reads_in_full(
     resp = await client.get(f"/praxes/{praxis_solo.id}/comments")
     assert resp.status_code == 200, resp.text
     assert [len(c["body_text"]) for c in resp.json()] == [legacy_length]
+
+
+@pytest.mark.asyncio
+async def test_an_admin_below_the_level_gate_can_actually_post(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    praxis_solo: Praxis,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """The ``can_comment`` flag and the enforcement behind it must agree.
+
+    ``compute_capabilities`` short-circuits every flag to True for an admin, and
+    the composer is shown on exactly that flag — but ``services.comment.
+    can_comment`` used to restate the rule as a bare level check with no admin
+    branch. An admin below ``comment_level_required`` was therefore given a
+    comment box and a 403 from every submit. That is not hypothetical: it is why
+    a production database held zero comments while an admin kept trying to leave
+    one.
+
+    ``character`` is level 0 here, well under the gate, which is the whole point
+    — the admin short-circuit is the only thing that can make this pass.
+    """
+    role = Role(name="admin", description="Administrator")
+    db_session.add(role)
+    await db_session.flush()
+    db_session.add(
+        AccountRole(account_id=account.id, role_id=role.id, granted_by=account.id)
+    )
+    await db_session.commit()
+
+    me_response = await client.get("/auth/me", headers=auth_headers)
+    assert me_response.status_code == 200, me_response.text
+    assert me_response.json()["can_comment"] is True
+
+    post_response = await client.post(
+        f"/praxes/{praxis_solo.id}/comments",
+        json={"body_text": "the box said I could"},
+        headers=auth_headers,
+    )
+    assert post_response.status_code == 201, (
+        "the /auth/me flag says this viewer may comment and the write door "
+        f"disagreed: {post_response.text}"
+    )

--- a/backend/tests/integration/test_praxis_delete_and_signup_race.py
+++ b/backend/tests/integration/test_praxis_delete_and_signup_race.py
@@ -1,0 +1,151 @@
+"""Two production bugs that both came down to "the database was not asked to help".
+
+**Dropping a task.** Every FK into ``praxis.id`` was NO ACTION, so
+``DELETE /praxes/{id}`` failed the moment anything hung off the praxis — in two
+different ways depending on whether the session had the child loaded. Both are
+covered here in one delete, because a fix for one does not imply the other:
+
+* ``media_item`` is eagerly loaded by ``get_praxis`` for the detail view and has
+  no ``delete-orphan`` cascade, so SQLAlchemy tried to *de-associate* it —
+  ``UPDATE media_item SET praxis_id = NULL`` into a NOT NULL column. This is the
+  reported bug: a raw asyncpg not-null violation shown to the player, and the
+  drop silently not happening.
+* ``vote`` is ``lazy='raise'`` and never loaded, so Postgres refused the parent
+  DELETE outright with a foreign-key violation.
+
+**Signing up twice.** The "already an active member of this task" gate is a read
+followed by a write with nothing in the schema behind it. In production one tap
+on a phone fired four requests 2–100ms apart and created four praxes on one task,
+because all four ran the check before any of them committed.
+"""
+
+import io
+
+import pytest
+from httpx import AsyncClient
+from PIL import Image
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.account import Account
+from models.character import Character
+from models.praxis import MediaItem, Praxis
+from models.task import Task
+from models.vote import Vote
+from services import media as media_service
+from services.praxis import _SIGNUP_LOCK_NAMESPACE
+
+
+@pytest.fixture(autouse=True)
+def media_root(tmp_path, monkeypatch):
+    """Point the media pipeline at a throwaway directory."""
+    monkeypatch.setattr(media_service.settings, "MEDIA_ROOT", str(tmp_path))
+    return tmp_path
+
+
+def _jpeg_bytes() -> bytes:
+    image = Image.new("RGB", (16, 16), color=(10, 120, 200))
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_drop_a_task_that_has_media_and_a_vote_on_it(
+    client: AsyncClient,
+    character: Character,
+    account: Account,
+    active_task: Task,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """The praxis and both kinds of child row go, and the player gets a 204."""
+    create_response = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Drop me"},
+        headers=auth_headers,
+    )
+    assert create_response.status_code == 201, create_response.text
+    praxis_id = create_response.json()["id"]
+
+    # The loaded-child failure mode: media, through the real upload route.
+    upload_response = await client.post(
+        f"/praxes/{praxis_id}/media",
+        files={"file": ("IMG_0951.jpg", _jpeg_bytes(), "image/jpeg")},
+        headers=auth_headers,
+    )
+    assert upload_response.status_code == 201, upload_response.text
+
+    # The unloaded-child failure mode. Written straight to the session rather
+    # than through the vote service, which would first require submitting the
+    # praxis — and a submitted praxis cannot be dropped at all. Unsubmitting
+    # preserves votes, so this state is reachable in the app.
+    db_session.add(
+        Vote(
+            praxis_id=praxis_id,
+            voter_character_id=character.id,
+            voter_account_id=account.id,
+            value=3,
+        )
+    )
+    await db_session.flush()
+
+    delete_response = await client.delete(f"/praxes/{praxis_id}", headers=auth_headers)
+    assert delete_response.status_code == 204, delete_response.text
+
+    assert await db_session.get(Praxis, praxis_id) is None
+    assert await db_session.scalar(
+        select(func.count()).select_from(MediaItem).where(MediaItem.praxis_id == praxis_id)
+    ) == 0
+    assert await db_session.scalar(
+        select(func.count()).select_from(Vote).where(Vote.praxis_id == praxis_id)
+    ) == 0
+
+
+@pytest.mark.asyncio
+async def test_signing_up_holds_a_lock_keyed_on_the_character(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    auth_headers: dict,
+    db_connection,
+):
+    """A signup takes the advisory lock for its transaction, keyed on the character.
+
+    What this asserts is that the lock is *taken* and *correctly keyed* — that
+    a second signup by this character would have to wait, and that a signup by
+    anyone else would not. It deliberately does not assert that Postgres blocks
+    on a held lock; that is Postgres's job, not this codebase's.
+
+    A genuinely concurrent version is not possible here: the whole suite shares
+    one connection inside one transaction (see ``conftest``), and advisory locks
+    are re-entrant within a transaction, so two "concurrent" signups would both
+    sail through and prove nothing.
+    """
+    response = await client.post(
+        "/praxes",
+        json={"task_id": active_task.id, "type": "solo", "title": "Lock me"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 201, response.text
+
+    # `pg_try_advisory_xact_lock` never waits: False means someone else holds it.
+    probe = text("SELECT pg_try_advisory_xact_lock(:namespace, :key)")
+
+    async with db_connection.engine.connect() as other_connection:
+        held_by_signup = await other_connection.scalar(
+            probe, {"namespace": _SIGNUP_LOCK_NAMESPACE, "key": character.id}
+        )
+        assert held_by_signup is False, (
+            "create_praxis did not hold the signup lock — concurrent signups can "
+            "each read 'not yet a member' and each insert one"
+        )
+
+        free_for_others = await other_connection.scalar(
+            probe, {"namespace": _SIGNUP_LOCK_NAMESPACE, "key": character2.id}
+        )
+        assert free_for_others is True, (
+            "the lock is not keyed on the character — one player signing up "
+            "would serialise every other player's signups too"
+        )


### PR DESCRIPTION
Reported as three unrelated things — a raw asyncpg error on "drop task", four identical praxes on one task, and a comment box that refused every comment. All three are the same defect: a rule written in two places that drifted apart. Diagnosed against production data (read-only).

| | stated in | also stated in | how they disagreed |
|---|---|---|---|
| Drop task | the FK (`NO ACTION`) | the ORM relationship | ORM nulled a NOT NULL column |
| Sign up | `evaluate_signup`'s SELECT | nothing | four parallel reads, four inserts |
| Comment | `compute_capabilities` | `services.comment` | flag said yes, door said no |

## Drop task could not delete a praxis that anything hung off

All ten FKs into `praxis.id` were `NO ACTION`, so `session.delete(praxis)` failed two different ways depending on whether the session had the child loaded:

- **`media_item`** — eagerly loaded by `get_praxis` for the detail view, and carrying no `delete-orphan` cascade — so SQLAlchemy's default is to *de-associate*: `UPDATE media_item SET praxis_id = NULL`, straight into a NOT NULL column. This is the reported bug.
- **`vote`, `nudge`, `comment`, `flag`, `praxis_meta_task`** — `lazy='raise'`, never loaded, so Postgres refused the parent DELETE outright with a foreign-key violation.

Either way the player got a raw driver exception and the drop silently did not happen.

The eight FKs naming a *part* of a praxis are now `ON DELETE CASCADE`, with matching `cascade='all, delete-orphan'` + `passive_deletes=True` on the mappings. **Both halves are load-bearing**, and they answer different questions — `passive_deletes=True` alone does not fix this, because it stops SQLAlchemy *loading* a collection in order to null it but still processes one already in the session, which `media_items` always is.

In the database rather than in six more `selectinload`s in `get_praxis`, which every praxis *detail view* would pay for purely so that delete would work.

`duel`'s two FKs stay `NO ACTION` deliberately: a duel is a contract between two players, not a component of either side, and should refuse the delete rather than vanish with it.

## Signing up was a read-then-write with nothing behind it

Production, one character, one task:

| praxis | created_at |
|---|---|
| 6 | 02:43:51.**433** |
| 7 | 02:43:51.**435** |
| 8 | 02:43:51.**536** |
| 9 | 02:43:51.**542** |

Four praxes in 110ms, two of them 2ms apart — one tap on a phone that fired four requests. All four ran the "already an active member" check before any of them committed, so all four were told they were first. The character's faction is `na`, so the Everymen Double Dipper carve-out is not involved.

`create_praxis` now takes a transaction-scoped advisory lock keyed on the character. Not a unique index — the rule spans `praxis_member` and `praxis.status`/`task_id`, and is not expressible as one without denormalising `task_id` onto the membership. Not `SELECT ... FOR UPDATE` — what is being serialised is a decision across several tables, not a mutation of `character`, and a row lock would make anything else touching that row inherit the contention.

The client is deliberately not changed: four `handleSignup` copies would each need an in-flight guard and every one would still be advisory. The server has to refuse regardless.

## An admin was shown a comment box that refused every comment

`compute_capabilities` short-circuits `can_comment` — along with every flag — to `True` for an admin, and `CommentThread` shows the composer on exactly that flag. `services.comment.can_comment` restated the rule as a bare level check with no admin branch. An admin below `era.comment_level_required` got the box and a 403 from every submit.

Production holds **zero comments**, an admin account at level 1 under a gate of 2, and a player who kept pressing send.

`can_comment` now derives from `compute_capabilities` rather than restating it. `can_flag_praxis` was checked for the same drift and does not have it — there is no `can_flag` in `CharacterCapabilities`.

## The raw error was a code path, not an accident

`main.py`'s `IntegrityError` handler pattern-matched for `username`/`unique`/`duplicate` and its `else` was `detail = str(exc.orig).lower()` — shipping the driver exception, the SQL, and the failing row's column values to the browser. That is unreadable and a disclosure. Unrecognised violations now log and answer in English.

## Verification

- **1178 tests pass.** Three new ones; each was confirmed to fail on the old code first.
- The delete test reproduced the production error verbatim before the fix, down to the SQL: `UPDATE media_item SET praxis_id=$1` → `NotNullViolationError`.
- Migration verified against a database in production's shape: flips the eight to CASCADE, leaves both `duel` FKs alone, round-trips through `downgrade`, and `alembic check` reports no drift.
- The signup test asserts the lock is taken *and* keyed on the character (a second connection probes with `pg_try_advisory_xact_lock`). It does not assert that Postgres blocks on a held lock — that is Postgres's job. A genuinely concurrent test is not possible in this harness, which shares one connection inside one transaction.

## After deploy

Praxes 7, 8 and 9 are the duplicate Pixie's Promises and can be dropped from the UI once this lands (6 is the original — keep it). Praxis 11 becomes droppable too. Orphaned media files on disk are left to `scripts/sweep_orphan_media.py`, which exists for exactly that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
