### PR TITLE
Two advertised level unlocks start meaning something: the archive gate exists, the review queue reopens to level 3

### DIFF
--- a/backend/services/character_capabilities.py
+++ b/backend/services/character_capabilities.py
@@ -86,7 +86,21 @@ def compute_capabilities(
     return CharacterCapabilities(
         can_propose_task=character_level >= era.level_to_propose_task,
         can_propose_metatask=character_level >= era.level_to_propose_metatask,
-        can_see_retired_tasks=character_level >= era.level_to_see_retired_tasks,
+        # Both thresholds are enforced by ``services.task.list_tasks``, which is
+        # what makes these two flags honest. They were not: retired was gated
+        # here and by nothing there (anonymous callers could read the archive),
+        # and pending was gated here by level but there by ``is_admin`` alone
+        # (#1672), so a level-3 player was offered a filter tab that always
+        # answered nothing.
+        #
+        # The faction clause mirrors the same clause in ``list_tasks`` — a
+        # faction the era lets work retired tasks can reach them from level 0,
+        # so the tab must be offered from level 0 too, or the flag is lying
+        # again in the other direction.
+        can_see_retired_tasks=(
+            character_level >= era.level_to_see_retired_tasks
+            or faction_slug in era.allow_praxis_on_retired_task_factions
+        ),
         can_see_pending_tasks=character_level >= era.level_to_see_pending_tasks,
         can_comment=character_level >= era.comment_level_required,
         level_jump_reach=granted_reach,

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -452,6 +452,15 @@ async def list_tasks(
     spec's "below level 6 cannot see the metatask list". ``skip_level_check``
     is the admin escape hatch, mirroring :func:`propose_task`.
 
+    ``retired`` and ``pending`` rows are gated the same way, by
+    ``era.level_to_see_retired_tasks`` and ``era.level_to_see_pending_tasks``.
+    Both are advertised level unlocks, and both were out of step with what this
+    function did — retired was withheld from nobody, pending from everybody
+    below admin. They are enforced at every door here, and
+    :func:`services.character_capabilities.compute_capabilities` states the same
+    two thresholds for the ``/auth/me`` flags the UI gates its filter tabs on, so
+    a tab is offered exactly when the query behind it will answer.
+
     ``q`` is a free-text ``ilike`` over the task title, its description (#661),
     AND the proposing character's handle / display name (#681), mirroring the
     praxis-feed search in :func:`services.praxis.list_praxes`. A leading ``@``
@@ -486,19 +495,70 @@ async def list_tasks(
     if created_by is not None:
         query = query.where(Task.created_by == created_by)
 
+    # The viewer's current-era stats, read ONCE for the whole request: the two
+    # status gates below want the level, the metatask visibility gate wants the
+    # level, and the can_sign_up filter wants the level plus the level-jump
+    # stamp. Several consumers, one query — the admin browse with the filter off
+    # still reads nothing.
+    viewer_stats: Optional[CharacterStats] = None
+    if viewer is not None and (can_sign_up or not skip_level_check):
+        era_row = await get_current_era_row(session)
+        viewer_stats = await get_or_create_stats(session, viewer.id, era_row.id)
+    # Anonymous viewers sit below every gate, which is the point: both abilities
+    # below are things a *character* earns, so there is no level to read.
+    viewer_level = viewer_stats.level if viewer_stats is not None else -1
+
+    # The two status gates, stated once and applied at BOTH doors — an explicit
+    # `?status=X` and the `?status=all` catch-all reach the same rows, and a gate
+    # written at only one of them is not a gate. That is exactly how the pending
+    # queue leaked before #1672: the promise lived on a branch an explicit status
+    # routed around.
+    #
+    # `retired` is the level-2 "the archive opens" unlock (`era_1.py`,
+    # `progression.json`). It had NO enforcement at all — anonymous callers could
+    # read the whole archive — so the ability was advertised and never withheld,
+    # and `services.era.retire_all_tasks`'s "the board un-hides itself as players
+    # climb" was describing a gate that did not exist. It is a level gate, so
+    # `skip_level_check` is what bypasses it.
+    #
+    # `pending` is the level-3 "watch proposals move through review" unlock, and
+    # is the moderation queue, so `is_admin` bypasses it rather than
+    # `skip_level_check` (the two answer different questions — see the parameter
+    # docs). #1672 made it admin-ONLY, which silently killed the level-3 reward
+    # while `/auth/me` went on advertising it; the level is restored here as a
+    # deliberate decision, NOT as a revert of that fix. What #1672 closed was
+    # "anyone, signed in or not". Level 3 is 170 points of investment and an
+    # account, so pre-moderation proposals are still withheld from the anonymous
+    # web — but they ARE now visible to established players before an admin has
+    # ruled on them, and that is the trade being made.
+    # The faction clause is not an exception to the archive gate, it is the only
+    # way the perk means anything: a faction the era lets work retired tasks
+    # cannot be forbidden from finding them. Without it an Ephemerist below level
+    # 2 lost their faction's entire reason for existing, and the ``can_sign_up``
+    # parity suite catches it. ``services.era.retire_all_tasks`` already names
+    # this interaction — "an era listing a faction in
+    # allow_praxis_on_retired_task_factions leaks a second way, for that faction
+    # only" — so it is stated here rather than left to be rediscovered.
+    viewer_sees_retired = (
+        skip_level_check
+        or viewer_level >= era.level_to_see_retired_tasks
+        or (viewer is not None
+            and viewer.faction_slug in era.allow_praxis_on_retired_task_factions)
+    )
+    viewer_sees_pending = is_admin or viewer_level >= era.level_to_see_pending_tasks
+
     if status and status != "all":
         try:
             requested_status = TaskStatus[status]
         except KeyError:
             raise HTTPException(status_code=422, detail=f"Invalid status: {status}")
-        # The comment below used to promise pending "stays hidden from all
-        # viewers", and that held only on the `created_by` branch — an explicit
-        # `?status=pending` routed straight around it and served the whole
-        # admin-review queue of player-written proposals to anyone, signed in or
-        # not. The guarantee now lives on the path that can actually enforce it.
-        if requested_status == TaskStatus.pending and not is_admin:
+        gate_closed = (
+            requested_status == TaskStatus.pending and not viewer_sees_pending
+        ) or (requested_status == TaskStatus.retired and not viewer_sees_retired)
+        if gate_closed:
             # An empty page rather than a 403: no new error code for a filter no
-            # legitimate client sends, and it says nothing about what is queued.
+            # legitimate client sends, and it says nothing about what is behind
+            # the gate.
             query = query.where(false())
         else:
             query = query.where(Task.status == requested_status)
@@ -506,13 +566,22 @@ async def list_tasks(
         if created_by is not None:
             # Proposer's profile: show approved tasks (active + retired); pending
             # rows are admin-review submissions and stay hidden from all viewers.
+            #
+            # Deliberately NOT gated on `viewer_sees_retired`. The level-2 unlock
+            # opens *the archive* — the browse — not every mention of a retired
+            # task anywhere on the site. This surface is one character's own
+            # proposals, reached by knowing their id, and hiding a proposer's
+            # accepted work from newcomers reads as a bug rather than a reward.
             query = query.where(Task.status != TaskStatus.pending)
         else:
             query = query.where(Task.status == TaskStatus.active)
-    elif not is_admin:
-        # status == "all" is the other door onto the same rows: every status for
-        # an admin, everything-but-the-review-queue for everyone else.
-        query = query.where(Task.status != TaskStatus.pending)
+    else:
+        # status == "all" is the other door onto the same rows. Whatever a gate
+        # withholds from an explicit status it must withhold here too.
+        if not viewer_sees_pending:
+            query = query.where(Task.status != TaskStatus.pending)
+        if not viewer_sees_retired:
+            query = query.where(Task.status != TaskStatus.retired)
 
     # Task type filter — default (None) means STANDARD-ONLY so metatasks never
     # leak into the ordinary browse (#1001); pass "all" to get every type, or
@@ -529,22 +598,10 @@ async def list_tasks(
     else:
         query = query.where(Task.task_type == TaskType.standard)
 
-    # The viewer's current-era stats, read ONCE for the whole request: the
-    # metatask visibility gate wants the level and the can_sign_up filter wants
-    # the level plus the level-jump stamp. Two consumers, one query — the admin
-    # browse with the filter off still reads nothing.
-    viewer_stats: Optional[CharacterStats] = None
-    if viewer is not None and (can_sign_up or not skip_level_check):
-        era_row = await get_current_era_row(session)
-        viewer_stats = await get_or_create_stats(session, viewer.id, era_row.id)
-
     # Metatask visibility gate (#453): the metatask list only opens at
     # era.level_to_see_metatasks. Anonymous viewers are always below the gate.
     if not skip_level_check:
-        viewer_sees_metatasks = (
-            viewer_stats is not None
-            and viewer_stats.level >= era.level_to_see_metatasks
-        )
+        viewer_sees_metatasks = viewer_level >= era.level_to_see_metatasks
         if not viewer_sees_metatasks:
             query = query.where(Task.task_type != TaskType.metatask)
 

--- a/backend/tests/integration/test_task_list_query_count.py
+++ b/backend/tests/integration/test_task_list_query_count.py
@@ -184,7 +184,11 @@ async def test_batched_flags_equal_the_per_task_predicates(
     per row rather than uniformly.
     """
     stats = await get_or_create_stats(db_session, character.id, era.id)
-    stats.level = 1
+    # At (not above) era.level_to_see_retired_tasks: the page below deliberately
+    # includes a retired row, and the archive gate would otherwise withhold it
+    # before any flag could be compared. Still well under `too_hard`'s level 99,
+    # so the above-your-level row it is mixed with still answers differently.
+    stats.level = CURRENT_ERA.level_to_see_retired_tasks
     await db_session.commit()
 
     plain = await _add_tasks(db_session, character2, 3)

--- a/backend/tests/integration/test_task_visibility_gates.py
+++ b/backend/tests/integration/test_task_visibility_gates.py
@@ -1,0 +1,133 @@
+"""The retired/pending filter tabs are offered exactly when the query will answer.
+
+Two advertised level unlocks — level 2 "the archive opens" (`retired_tasks`) and
+level 3 "watch proposals move through review" (`pending_tasks`) — are stated in
+two places that had drifted apart in *opposite* directions:
+
+* `can_see_retired_tasks` was gated on the `/auth/me` flag and by nothing at all
+  in `list_tasks`. Anonymous callers could read the whole archive, so the level-2
+  ability was advertised and never actually withheld.
+* `can_see_pending_tasks` was gated by level on the flag but by `is_admin` alone
+  in `list_tasks` (#1672), so a level-3 player was offered a filter tab that
+  always came back empty.
+
+`useTasks.ts` pushes a status tab for each flag, so the flag *is* the promise and
+the query has to keep it. This asserts the two agree — for both statuses, at both
+doors (`?status=X` and the `?status=all` catch-all), which is the pairing that
+matters: a gate written at only one door is not a gate, and that is exactly how
+the pending queue leaked before #1672.
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from game_config import CURRENT_ERA
+from models.character import Character
+from models.character_stats import CharacterStats
+from models.era import Era
+from models.faction import Faction
+from models.task import Task, TaskStatus, TaskType
+
+
+async def _set_level_and_faction(
+    session: AsyncSession, character: Character, era: Era, level: int, faction: str
+) -> None:
+    stats = (
+        await session.execute(
+            select(CharacterStats).where(
+                CharacterStats.character_id == character.id,
+                CharacterStats.era_id == era.id,
+            )
+        )
+    ).scalar_one()
+    stats.level = level
+    character.faction_slug = faction
+    await session.commit()
+
+
+async def _gated_task(session: AsyncSession, author: Character, status: TaskStatus) -> Task:
+    task = Task(
+        title=f"{status.value} row",
+        description="",
+        point_value=10,
+        level_required=0,
+        primary_faction_slug="na",
+        task_type=TaskType.standard,
+        created_by=author.id,
+        status=status,
+    )
+    session.add(task)
+    await session.commit()
+    return task
+
+
+async def _ids(client: AsyncClient, query: str, headers: dict | None) -> set[int]:
+    response = await client.get(query, headers=headers or {})
+    assert response.status_code == 200, response.text
+    return {row["id"] for row in response.json()}
+
+
+@pytest.mark.parametrize(
+    "level, faction, sees_retired, sees_pending",
+    [
+        (0, "ua", False, False),
+        (CURRENT_ERA.level_to_see_retired_tasks, "ua", True, False),
+        (CURRENT_ERA.level_to_see_pending_tasks, "ua", True, True),
+        # The faction whose perk is working retired tasks reaches the archive
+        # from level 0 — a perk you cannot find the rows for is not a perk.
+        (0, "ephemerists", True, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_the_flag_and_the_query_agree(
+    level: int,
+    faction: str,
+    sees_retired: bool,
+    sees_pending: bool,
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    era: Era,
+    faction_ua: Faction,
+    faction_ephemerists: Faction,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    retired = await _gated_task(db_session, character2, TaskStatus.retired)
+    pending = await _gated_task(db_session, character2, TaskStatus.pending)
+    await _set_level_and_faction(db_session, character, era, level, faction)
+
+    me = (await client.get("/auth/me", headers=auth_headers)).json()
+    assert me["can_see_retired_tasks"] is sees_retired
+    assert me["can_see_pending_tasks"] is sees_pending
+
+    # Door one: the explicit status the flag's filter tab sends.
+    assert (retired.id in await _ids(client, "/tasks?status=retired", auth_headers)) is sees_retired
+    assert (pending.id in await _ids(client, "/tasks?status=pending", auth_headers)) is sees_pending
+
+    # Door two: the catch-all reaches the same rows and must withhold the same.
+    everything = await _ids(client, "/tasks?status=all&limit=200", auth_headers)
+    assert (retired.id in everything) is sees_retired
+    assert (pending.id in everything) is sees_pending
+
+
+@pytest.mark.asyncio
+async def test_the_anonymous_web_gets_neither(
+    client: AsyncClient,
+    character2: Character,
+    db_session: AsyncSession,
+):
+    """No character, no level, so both abilities are unearned — at both doors.
+
+    Retired is the regression that matters here: it used to come back 200 with
+    the rows on it, to callers with no account at all.
+    """
+    retired = await _gated_task(db_session, character2, TaskStatus.retired)
+    pending = await _gated_task(db_session, character2, TaskStatus.pending)
+
+    for query in ("/tasks?status=retired", "/tasks?status=pending", "/tasks?status=all&limit=200"):
+        visible = await _ids(client, query, None)
+        assert retired.id not in visible, query
+        assert pending.id not in visible, query


### PR DESCRIPTION
Follow-up sweep of the four remaining admin-short-circuited capability flags, after #1692 found `can_comment` promising something the write door refused.

| flag | `/auth/me` says | server actually did | verdict |
|---|---|---|---|
| `can_propose_task` | level ≥ 3, admin bypass | same, via `skip_level_check=is_admin` | **clean** |
| `can_propose_metatask` | level ≥ 5, admin bypass | same | **clean** |
| `can_see_retired_tasks` | level ≥ 2 | **nothing** — anonymous got them | under-enforced |
| `can_see_pending_tasks` | level ≥ 3 | **admin only** — level 3 got 0 rows | over-promised |

Two clean, two drifted — in opposite directions, so they needed opposite fixes. Measured, not inferred: a throwaway probe established each behaviour before anything was changed.

Neither is merely a flag. Both are **advertised rewards** with progression copy:

- Level 2 "ranger" → `retired_tasks`: *"The archive opens — browse tasks the board has since retired."*
- Level 3 "surveyor" → `pending_tasks`: *"Watch proposals move through review before they go live."*

## Retired: the archive was never shut

`list_tasks` gated retired rows on no condition at all. `curl "/tasks?status=retired"` with no account returned the archive. So the level-2 ability was announced and never withheld, and `services.era.retire_all_tasks`'s docstring — "the board un-hides itself as players climb", reasoning carefully about `level_to_see_retired_tasks` being 2 — was describing a gate that did not exist.

Now enforced. Anonymous visitors and level 0–1 players stop seeing retired tasks; the level-2 unlock becomes real.

## Pending: a security fix quietly ate a level-3 reward

#1672 closed a genuine hole — `?status=pending` served the whole review queue of player-written proposals to anyone, signed in or not — by restricting it to admins. That silently killed the level-3 reward, and nobody noticed **because the flag kept saying yes**: `/auth/me` advertised it, `useTasks.ts` rendered the tab, and the tab always came back empty.

Restoring the level here is a **deliberate owner decision, not a revert of #1672**. What that fix closed was "anyone, signed in or not". Level 3 is 170 points and an account. Pre-moderation proposals stay off the anonymous web — but they are now visible to established players before an admin has ruled on them, and that is the trade being made knowingly.

## Both doors, or it is not a gate

Each gate is applied to the explicit `?status=X` **and** the `?status=all` catch-all. A gate written at one door is not a gate — that exact asymmetry is how the queue leaked before #1672, and the comment there says so.

## The faction clause is the point, not an exception

A faction the era lets *work* retired tasks cannot be forbidden from *finding* them. Without this, an Ephemerist below level 2 lost their faction's entire reason for existing. The `can_sign_up` parity suite caught it on the first run — the check that exists precisely because "the filtered browse and `evaluate_signup` must never disagree". `services.era` already names this interaction as a known second path, so it is now stated in both the query and the flag rather than left to be rediscovered.

## Verification

- **1183 tests pass.**
- New `test_task_visibility_gates.py` asserts the flag and the query agree — per level, per faction, per status, at both doors — because `useTasks.ts` pushes a tab per flag, so the flag *is* the promise. **4 of its 5 cases fail on the old code.**
- One existing test changed: `test_task_list_query_count` pinned its viewer at level 1 while expecting a retired row on the page. It now sits at `level_to_see_retired_tasks`. Its intent (mix rows so the predicate answers differently per row) is untouched — the level-99 `too_hard` row still towers over it.

## Reviewer's attention, please

The pending decision is the one worth a second opinion — it widens who can see unmoderated player proposals. Everything else is closing a gap between what the site promises and what it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
