### PR TITLE
Neutral moderation chrome keeps the app's label ink, not just its ground

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3011,9 +3011,31 @@
      the case that forced it: ADR-0061 mounts them BARE on nine faction walls
      precisely so moderation chrome reads the same everywhere, which is a promise
      the frost was quietly breaking. Worst reading on this ground is 4.71:1
-     (danger, light), against 2.54 on the terminal. */
+     (danger, light), against 2.54 on the terminal.
+
+     THE INK IS THE SAME PROMISE, ONE PROPERTY OVER (#1606). The ground was only
+     half of what kept these cards neutral. `.eyebrow` HARDCODED
+     `--color-text-tertiary`, so a label in the steward bar read the app's own
+     quiet ink whatever it was mounted inside; #1307 retired it into
+     `.label-heading` / `.label-caption`, which read `--label-ink` — a SEAM a
+     faction frame is meant to set ONCE on its own root, and these cards render
+     inside that root. So the neutral survived the sweep by accident, and the
+     first praxis-detail skin to repoint the seam (three light sheets cannot
+     clear the neutral, so one is coming) would tint moderation chrome on its
+     wall and nowhere else. `WowFactionBody` already repoints it — on the
+     faction detail page, which mounts no neutral chrome, so nothing renders
+     wrong today and this is pre-emptive.
+
+     Pinning it HERE is what the tiers' own declaration asks for: the alternative
+     is an inline colour on each label, which is the per-component contradiction
+     #1252 exists to stop and is invisible to every ratio in
+     `factionContrast.test.ts`. The neutral is already measured on this exact
+     ground for the tier's floor — both tiers sit under WCAG's large-text
+     threshold and so owe 4.5:1; tertiary on the page reads 5.40:1 light and
+     6.21:1 dark. Gated beside the ground, in the same file. */
   .card-on-page {
     --card-ground: var(--color-bg-page);
+    --label-ink: var(--color-text-tertiary);
   }
 
   .card {

--- a/frontend/src/pages/praxisDetail/__tests__/detailWallAlarmInk.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/detailWallAlarmInk.test.tsx
@@ -219,9 +219,16 @@ describe('the praxis detail wall carries its own alarm ink (#1451)', () => {
     // nine skins. The INK claim is unchanged and is the half that matters here:
     // a later skin reaching for `wallInk` in these two blocks would be undoing
     // both issues at once.
-    expect(SHARED_SOURCE).toContain(
-      "className=\"sidebar-card card-on-page mb-4\" style={{ padding: 'var(--space-md) var(--space-lg)' }}",
-    )
+    // Every neutral-chrome mount in this file, not just the steward bar's:
+    // `PraxisFlagBlock` has two, and a new one added without the class is the
+    // silent way back to the old ground. #1606 made the class carry
+    // `--label-ink` as well, so a mount that drops it now loses the INK too —
+    // which is why this counts mounts rather than quoting one of them.
+    const mounts = SHARED_SOURCE.match(/className="sidebar-card[^"]*"/g) ?? []
+    expect(mounts.length).toBeGreaterThan(0)
+    for (const mount of mounts) {
+      expect(mount, 'a `.sidebar-card` here is moderation chrome and owes ADR-0061 the app\'s own ground AND ink').toContain('card-on-page')
+    }
     for (const block of ['PraxisAdminBar', 'PraxisFlagBlock']) {
       const body = SHARED_SOURCE.slice(SHARED_SOURCE.indexOf(`export function ${block}`))
       expect(body.slice(0, body.indexOf('\n}\n'))).toContain('var(--color-danger)')

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1705,6 +1705,27 @@ describe("the frost is a layer, not a ground (#1413)", () => {
       "`.card-on-page` is what the praxis detail's steward bar and report card wear (#1118: a block whose ink you do not control gets the stock that ink was measured on).",
     ).toContain("--card-ground: var(--color-bg-page)");
   });
+
+  /**
+   * #1606 — the same promise, second property. `.eyebrow` HARDCODED
+   * `--color-text-tertiary`, so a label inside the steward bar or the report
+   * card was neutral whatever it was mounted in. #1307 replaced it with two
+   * tiers that read `--label-ink`, a SEAM a faction frame is meant to set once
+   * on its own root — and ADR-0061 mounts both of those cards BARE inside that
+   * root. `WowFactionBody` already repoints the seam (on the faction detail
+   * page, which holds no neutral chrome); the first praxis-detail skin to do
+   * the same would tint moderation chrome on its wall and nowhere else.
+   *
+   * Pinning it here rather than colouring each label is the rule at the tiers'
+   * own declaration: a per-label colour is the per-component contradiction
+   * #1252 exists to stop, and it is invisible to every ratio in this file.
+   */
+  it("the neutral chrome keeps the app's own label ink too (#1606)", () => {
+    expect(
+      ruleBody(".card-on-page"),
+      "`.card-on-page` must pin `--label-ink` back to the neutral. Without it, the first faction frame to repoint the seam tints the praxis detail's steward bar and report card — which ADR-0061 mounts bare on nine walls precisely so moderation chrome reads the same everywhere.",
+    ).toContain("--label-ink: var(--color-text-tertiary)");
+  });
 });
 
 /**


### PR DESCRIPTION
`.card-on-page` pinned the app's own *ground* back under neutral moderation chrome (#1413). It did not pin the *ink*, and since #1307 that is a second way the same promise can break.

`.eyebrow` **hardcoded** `--color-text-tertiary`, so a label inside the steward bar or the report card was neutral whatever it was mounted in. The two tiers that replaced it read `--label-ink` — a seam a faction frame is meant to set once on its own root — and ADR-0061 mounts both of those cards **bare** inside that root. The neutral survived the sweep by accident.

```css
.card-on-page {
  --card-ground: var(--color-bg-page);
  --label-ink: var(--color-text-tertiary);   /* new */
}
```

## Seam tested at

`index.css`'s `.card-on-page` **rule body**, read through `factionContrast.test.ts`'s `ruleBody()` parser — the same seam its ground half is already gated at, one `it` above. This is a source assertion rather than a ratio for the reason that block already states: the bug is structural, and every ratio in the file stays green through it. The harness is `renderToStaticMarkup` with no DOM, so a rendered-cascade check was never available; the CSS text is the reachable seam.

The new test went **red on the real defect** before the change (`expected '.card-on-page {\n --card-ground: v…' to contain '--label-ink: var(--color-text-tertiar…'`), then green.

A second guard in `detailWallAlarmInk.test.tsx`: the token only helps if the cards still *wear* the class, and only one of the three mounts was asserted (the steward bar's, quoted as a literal). It now matches all `className="sidebar-card…"` values in `praxisDetail/shared.tsx` and requires `card-on-page` on each — 3 mounts today, and a fourth added without it fails.

## What I re-verified vs. what the brief claimed

| Claim | Result |
|---|---|
| `.card-on-page` at `index.css:3015`, sets only `--card-ground` | **True** (line 3015 on `origin/main`) |
| `.label-heading` / `.label-caption` read `color: var(--label-ink)` | **True** (3175, 3188) |
| `.eyebrow` is deleted; only comments reference it | **True** — no `.eyebrow` rule in `index.css` |
| `--label-ink` declared once, at `:root` ~line 89 | **True** |
| **"No faction frame repoints it yet"** | **FALSE** |

`frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx:132` already repoints the seam:

```tsx
style={{ ["--label-ink" as string]: "var(--faction-wow-accent-deep)" } as CSSProperties}
```

**It is still not a live rendering bug, and I checked rather than assumed.** That repoint is on `.wz-faction-grid` on the **faction detail** page. The praxis detail's steward bar and report card are not mounted under it, and the only `sidebar-card` mounts anywhere in `pages/factionDetail` are in `DefaultFactionBody` / the mobile `DefaultFactionPage` — neither of which is under WOW's frame, and neither of which carries `card-on-page` at all. No praxis-detail archetype sets `--label-ink` (it is the only live repoint in the whole of `frontend/src`). So this stays pre-emptive and a no-op on the current render; what WOW proves is that the seam is in use, so the first praxis-detail skin to follow was a matter of time rather than a hypothetical.

Contrast re-check the issue asked for: both tiers sit under WCAG's large-text threshold and owe 4.5:1, and the neutral on `--color-bg-page` reads **5.40:1 light / 6.21:1 dark**. Already gated by the "app page / app alt surface, tertiary ink" rows (#1549); no new `Pair` needed.

Sourcing: the comment cites the `.card-on-page` block itself (#1118) and #1252. **ADR-0061's withdrawn "voice returns to the content slots" amendment is not cited anywhere.**

## Verification

Every step named in `.github/workflows/test.yml`'s `frontend` job, run locally: `lint`, `typecheck`, `typecheck:design-sync`, `test` (**4244 passed / 235 files**), `build`, `budget` (CSS 21.5 KB, within budget). Backend untouched, so `api-schema` has nothing to regenerate.

Built stylesheet grepped rather than trusting the source — braces prove nothing:

```
.card-on-page{--card-ground: var(--color-bg-page);--label-ink: var(--color-text-tertiary)}
```

**Visual QA is outstanding.** I have no browser and did not run a dev server; nothing here was seen rendered.

## What to eyeball

The chrome this protects, on the praxis detail:

- **Steward bar** (`PraxisAdminBar`) and **report card** (`PraxisFlagBlock`, both its states — the flag prompt and the "flagged" acknowledgement) mounted on **faction walls**, light **and** dark. Their labels must read the same neutral on all nine as they do on the app's page.
- WOW's **faction detail** page, both themes — its olive-gold label repoint must be **unchanged**; this PR must not have reached it.
- Any surface using `.card-on-page` elsewhere — there is none outside `praxisDetail/shared.tsx` today, so a diff against production on those two cards is the whole visible surface.

## Note for a follow-up (not this PR)

`--label-ink` on a faction's praxis-detail wall is #1608/#1307's per-faction ink work and is deliberately untouched here. Worth knowing when it lands: this PR is what lets it be done safely, and whoever ships the first praxis-detail repoint should eyeball the two cards above on that wall.

Closes #1606
