### PR TITLE
A name a player cannot be given at birth, they could still rename themselves to

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -827,6 +827,7 @@
         "type": "object"
       },
       "CharacterUpdate": {
+        "description": "A partial edit. Absent fields are left alone (``exclude_unset`` downstream).\n\n``display_name`` is the one field that cannot be blanked (#1686): omitting it\nand sending an explicit ``null`` both mean \"leave unchanged\", and ``\"\"``,\n``\"   \"`` and ``\"\\t\"`` are rejected here rather than stored. The other fields\nkeep their existing semantics, where a ``null`` clears the value — a player\nis allowed to have no bio, and is not allowed to have no name.",
         "properties": {
           "avatar_url": {
             "anyOf": [
@@ -856,6 +857,7 @@
             "anyOf": [
               {
                 "maxLength": 50,
+                "minLength": 1,
                 "type": "string"
               },
               {

--- a/backend/schemas/character.py
+++ b/backend/schemas/character.py
@@ -1,7 +1,25 @@
 from datetime import datetime
+from typing import Annotated, Any
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, StringConstraints, model_validator
 from schemas.base import WireModel
+
+# The one statement of what a display name may be (#1686). Creation and renaming
+# used to say it separately, and the renaming one forgot ``min_length`` — so a
+# character created as "Molly" could be renamed to "" or "   " and the server
+# stored it, leaving every byline, roster, comment attribution and avatar
+# monogram to invent its own answer for what a blank name looks like.
+#
+# ponytail: the strip is on this alias rather than ``str_strip_whitespace`` on
+# WireModel. That flag would be the fix-once seam if display names were the only
+# strings on this wire, but WireModel is the base for *every* request and
+# response model — praxis bodies, comment bodies, search terms — and response
+# models validate from ORM attributes, so it would also rewrite text on read.
+# Upgrade path if more identity-ish fields want this: widen the alias's reach,
+# not WireModel's.
+DisplayName = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=50)
+]
 
 
 class BadgeOut(WireModel):
@@ -54,7 +72,7 @@ class CharacterCreate(WireModel):
     # username is optional: the server derives a unique @handle from display_name
     # when absent (ADR-0019). An explicit one is still accepted for back-compat.
     username: str | None = Field(default=None, min_length=3, max_length=30)
-    display_name: str = Field(..., min_length=1, max_length=50)
+    display_name: DisplayName
     bio: str = Field(default="", max_length=500)
     tagline: str = Field(default="", max_length=140)
     avatar_url: str = Field(default="", max_length=500)
@@ -71,8 +89,33 @@ class ActiveCharacterIn(WireModel):
 
 
 class CharacterUpdate(WireModel):
-    display_name: str | None = Field(None, max_length=50)
+    """A partial edit. Absent fields are left alone (``exclude_unset`` downstream).
+
+    ``display_name`` is the one field that cannot be blanked (#1686): omitting it
+    and sending an explicit ``null`` both mean "leave unchanged", and ``""``,
+    ``"   "`` and ``"\\t"`` are rejected here rather than stored. The other fields
+    keep their existing semantics, where a ``null`` clears the value — a player
+    is allowed to have no bio, and is not allowed to have no name.
+    """
+
+    display_name: DisplayName | None = None
     bio: str | None = Field(None, max_length=500)
     tagline: str | None = Field(None, max_length=140)
     avatar_url: str | None = Field(None, max_length=500)
     location: str | None = Field(None, max_length=100)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _null_display_name_means_unchanged(cls, data: Any) -> Any:
+        """Drop an explicit ``display_name: null`` so it reads as omitted.
+
+        The update service coerces every ``None`` it is handed to ``""``, so a
+        client sending an explicit null blanked the name by the back door. Making
+        the field simply *unset* is what routes both spellings of "I am not
+        editing this" through the same ``exclude_unset`` gate — and it keeps the
+        rule in the schema, where the wire can enforce it, rather than adding a
+        second statement of it in the service.
+        """
+        if isinstance(data, dict) and data.get("display_name", ...) is None:
+            data = {key: value for key, value in data.items() if key != "display_name"}
+        return data

--- a/backend/tests/integration/test_characters.py
+++ b/backend/tests/integration/test_characters.py
@@ -88,6 +88,77 @@ async def test_update_character(
 
 
 @pytest.mark.asyncio
+async def test_update_character_trims_display_name(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    """Creation strips before storing; the update path now agrees (#1686)."""
+    resp = await client.put(
+        f"/characters/{character.id}",
+        json={"display_name": "  Padded Name  "},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == "Padded Name"
+
+
+@pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+@pytest.mark.asyncio
+async def test_update_character_blank_display_name_rejected(
+    client: AsyncClient, character: Character, auth_headers: dict, blank: str
+):
+    """A rename to whitespace is refused at the wire, as creation already refuses it.
+
+    A display name is drawn on bylines, rosters, comment attributions and avatar
+    monograms; a blank one makes every one of those surfaces invent a fallback
+    (#1686).
+    """
+    original = character.display_name
+    resp = await client.put(
+        f"/characters/{character.id}",
+        json={"display_name": blank},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+    read_back = await client.get(f"/characters/{character.id}")
+    assert read_back.json()["display_name"] == original
+
+
+@pytest.mark.asyncio
+async def test_update_character_explicit_null_display_name_leaves_it_unchanged(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    """An explicit ``null`` means "leave unchanged", not "blank it" (#1686).
+
+    Before the fix the service coerced every ``None`` in the body to ``""``, so
+    this stored an empty name — the same defect as the blank-string case wearing
+    a different hat.
+    """
+    original = character.display_name
+    resp = await client.put(
+        f"/characters/{character.id}",
+        json={"display_name": None, "bio": "still edited"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == original
+    assert resp.json()["bio"] == "still edited"
+
+
+@pytest.mark.asyncio
+async def test_update_character_omitted_display_name_leaves_it_unchanged(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    original = character.display_name
+    resp = await client.put(
+        f"/characters/{character.id}",
+        json={"bio": "only the bio moved"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["display_name"] == original
+
+
+@pytest.mark.asyncio
 async def test_update_character_wrong_owner(
     client: AsyncClient,
     character: Character,

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -1953,7 +1953,16 @@ export interface components {
             /** Votes Available */
             votes_available: number;
         };
-        /** CharacterUpdate */
+        /**
+         * CharacterUpdate
+         * @description A partial edit. Absent fields are left alone (``exclude_unset`` downstream).
+         *
+         *     ``display_name`` is the one field that cannot be blanked (#1686): omitting it
+         *     and sending an explicit ``null`` both mean "leave unchanged", and ``""``,
+         *     ``"   "`` and ``"\t"`` are rejected here rather than stored. The other fields
+         *     keep their existing semantics, where a ``null`` clears the value — a player
+         *     is allowed to have no bio, and is not allowed to have no name.
+         */
         CharacterUpdate: {
             /** Avatar Url */
             avatar_url?: string | null;


### PR DESCRIPTION
Closes #1686

`CharacterUpdate.display_name` had no `min_length` and `WireModel` does not strip, so a character created as "Molly" could be renamed to `""` or `"   "` and the server stored it. Every byline, roster, comment attribution, duel challenge, players-grid cell and avatar monogram then had to invent its own answer for what a blank name looks like — #1664 found the monogram helpers alone disagreeing 13 ways.

## The seam I tested at

The wire: `PUT /characters/{character_id}` in `backend/tests/integration/test_characters.py`, driven through the real app via the `client` fixture. The constraint lives in the schema, but the thing the issue is about is what the *server accepts*, so the test asserts the status code and then re-reads the character to prove nothing was stored.

(The issue says PATCH; the route is a `PUT` with PATCH semantics — `update_character` does `model_dump(exclude_unset=True)`. The semantics ruled on below are the ones that route actually implements.)

Six tests went red on the real defect before the fix, four green after, plus a trim case and an omitted-field case.

## Did explicit null really coerce to `""`?

**Yes — confirmed, not assumed.** The pre-fix run failed with:

```
assert resp.json()["display_name"] == original
E   AssertionError: assert '' == 'Test Character'
```

`update_character` does `if value is None: value = ""` over every field in the dump, so `{"display_name": null}` blanked the name by the back door. That made this one fix with two spellings, not two fixes.

## PATCH semantics, now stated in the schema

| body | meaning |
|---|---|
| `display_name` omitted | leave unchanged |
| `"display_name": null` | leave unchanged (**not** "blank it") |
| `""`, `"   "`, `"\t"` | **rejected**, 422 |
| `"  Padded  "` | stored as `"Padded"` |

The null case is implemented as a `model_validator(mode="before")` on `CharacterUpdate` that drops a null `display_name` from the incoming body, so it arrives at the service *unset* and falls through the same `exclude_unset` gate that omission does. That keeps the rule in the schema rather than adding a second statement of it in `services/character.py` — which also kept this PR out of a file a sibling agent owns this batch.

The other fields keep their existing "null clears it" behaviour on purpose: a player is entitled to have no bio (#1644 is about exactly that), and is not entitled to have no name.

## `WireModel` or per-field? Per-field, deliberately.

The issue asked whether stripping belongs on `WireModel` generally. It does not, and the blast radius is why: `WireModel` is the base for *every* request **and** response model in the app — praxis bodies, comment bodies, search terms — and response models validate `from_attributes`, so `str_strip_whitespace` there would also rewrite text on the way **out**. That is a far larger change than this issue asked for.

I did still fix once rather than per-symptom, one level down: there is now a single `DisplayName` annotated type (`strip_whitespace=True, min_length=1, max_length=50`) and **both** `CharacterCreate` and `CharacterUpdate` use it. The bug was one rule stated in two places where the second copy forgot half of it; two corrected copies would have been the same disease. The narrow choice carries a `ponytail:` comment naming the ceiling and the upgrade path (widen the alias's reach, not `WireModel`'s).

I checked the siblings before choosing: the only other `*Update(WireModel)` is `PraxisUpdate` (`title`, `body_text`), which is prose, not identity, and is not the same shape.

## Contract artifacts

`backend/openapi.json` and `frontend/src/api/generated/schema.d.ts` are regenerated and committed, produced by `python scripts/regen_api_client.py` from the repo root — never hand-edited. The diff is `minLength: 1` on `CharacterUpdate.display_name` plus the new model description. `CharacterCreate` is byte-identical: `StringConstraints` renders the same JSON Schema the old `Field(min_length=1, max_length=50)` did, and `strip_whitespace` has no JSON Schema representation.

`typecheck:design-sync` passes — no contract the preview kit constructs gained a required field.

## What to eyeball (visual QA is outstanding — I have no browser)

1. **The edit-character form's rename path** (`/characters/{id}/edit`). Clear the name field and save. Expect the save to fail and the character to keep its old name.
2. **What a rejected blank name looks like to the player.** `useEditCharacter` sends `display_name: displayName` **raw and unconditionally**, and its submit button is not gated on the name being non-empty — so this path is genuinely reachable, and the 422 lands in the form's bottom error slot via `extractError`, which reads `detail[0].msg` for a validation array. The player will see Pydantic's prose: **"String should have at least 1 character"**. Honest, but developer-ish and outside the i18n catalogue. Fixing that is a frontend change (mirror the create form, which already trims client-side and disables submit on an empty trimmed name) and is not in this PR's scope.
3. **The create form is unaffected in practice.** `useCreateCharacter` already sends `displayName.trim()` and blocks submit when it is empty, so its server-side whitespace branch is unreachable from the UI. It is worth knowing that a *direct API* create with `"   "` now 422s at the wire instead of reaching the service's nicer 400 "A chosen name is required." — the empty-string spelling already 422'd before this PR, so this makes creation uniform rather than newly ugly.
4. **A rename that only pads** — save `"  Molly  "` and confirm the roster/byline shows `Molly` with no leading gap.

## One thing I could not check

The issue asks whether prod already holds a blank display name. I have no prod credentials in this worktree, so I could not count them. It does not gate this change either way: the constraint is on the request schema only, `CharacterOut.display_name` still accepts `""`, and a character with a blank name can still edit its bio (omit `display_name`) or fix its name (send a non-blank one). Worth a read-only `SELECT count(*) FROM characters WHERE trim(display_name) = ''` before merge if you want the number.

## Verification

- `pytest --cov=. --cov-fail-under=80` from `backend/` against a dedicated `wz1686_test` — **1185 passed**, 93.12% coverage.
- `npm run lint`, `typecheck`, `typecheck:design-sync`, `test` (4243 passed), `build`, `budget` (within budget) — all green.
- Visual QA is outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
