### PR TITLE
Twenty-one refusals a player reads gain a code, and the prose stops disagreeing with the catalog

### DIFF
--- a/backend/errors.py
+++ b/backend/errors.py
@@ -73,7 +73,9 @@ class ErrorCode(str, enum.Enum):
     collab/duel eligibility, and media limits. #1652 adds the read-path
     rejections a player reaches by URL rather than by button — the praxis
     filters, the two 404s that share ``DELETE /praxes/{id}/media/{id}``, the
-    relationship-delete guard, and the feed-item key parser.
+    relationship-delete guard, and the feed-item key parser — and then, in its
+    second slice, the service-layer gates behind the buttons themselves:
+    defection, commenting, duel challenge and response, character creation.
     """
 
     # -- Voting -------------------------------------------------------------
@@ -127,6 +129,46 @@ class ErrorCode(str, enum.Enum):
     #: /praxes/{id}/media/{id}`` can 404 for either reason, and which one it was
     #: is the difference between a dead link and a stale media list.
     media_item_not_found = "MEDIA_ITEM_NOT_FOUND"
+
+    # -- Tasks and characters as targets (#1652 slice two) -------------------
+    #: A task id that resolves to nothing. Distinct from
+    #: :attr:`praxis_not_found` because ``POST /praxes/{id}/comments`` and
+    #: ``POST /tasks/{id}/comments`` are sibling routes answering the same 404
+    #: for different reasons — the code is what says which id was wrong.
+    task_not_found = "TASK_NOT_FOUND"
+    character_not_found = "CHARACTER_NOT_FOUND"
+
+    # -- Factions: joining, defecting, and the letters that gate both --------
+    faction_not_found = "FACTION_NOT_FOUND"
+    faction_already_member = "FACTION_ALREADY_MEMBER"
+    #: The unaffiliated sentinel is a start state, not a destination
+    #: (ADR-0019/0030).
+    faction_not_selectable = "FACTION_NOT_SELECTABLE"
+    faction_rejoin_forbidden = "FACTION_REJOIN_FORBIDDEN"
+    #: #454. Raised from two surfaces — defecting and character creation —
+    #: because it is one rule: you hold the current era's letter or you do not.
+    faction_invitation_required = "FACTION_INVITATION_REQUIRED"
+    #: ADR-0021. Albescent is joined in the field once the *account* qualifies…
+    faction_albescent_not_eligible = "FACTION_ALBESCENT_NOT_ELIGIBLE"
+    #: …and never at character creation, which is a different answer to a
+    #: different question and so a different code.
+    faction_albescent_not_at_creation = "FACTION_ALBESCENT_NOT_AT_CREATION"
+
+    # -- Character creation --------------------------------------------------
+    character_name_required = "CHARACTER_NAME_REQUIRED"
+
+    # -- Praxis ownership and comment threads --------------------------------
+    praxis_not_owner = "PRAXIS_NOT_OWNER"
+    praxis_not_open_for_comments = "PRAXIS_NOT_OPEN_FOR_COMMENTS"
+    task_not_open_for_comments = "TASK_NOT_OPEN_FOR_COMMENTS"
+    #: The service's exactly-one-target guard. Unreachable from the two comment
+    #: routes, which each pass one target; it answers any future caller that
+    #: passes both or neither, and the DB CHECK behind it.
+    comment_target_ambiguous = "COMMENT_TARGET_AMBIGUOUS"
+
+    # -- Duel challenge lifecycle --------------------------------------------
+    duel_challenge_not_yours = "DUEL_CHALLENGE_NOT_YOURS"
+    duel_challenge_already_resolved = "DUEL_CHALLENGE_ALREADY_RESOLVED"
 
     # -- Relationships ------------------------------------------------------
     relationship_not_found = "RELATIONSHIP_NOT_FOUND"

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -379,7 +379,9 @@ async def create_character(
 
     display_name = (data.display_name or "").strip()
     if not display_name:
-        raise HTTPException(status_code=400, detail="A chosen name is required.")
+        raise_coded(
+            400, ErrorCode.character_name_required, "A chosen name is required."
+        )
 
     requested_faction_slug = (data.faction_slug or "").strip().lower() or None
 
@@ -413,16 +415,18 @@ async def create_character(
     if requested_faction_slug is None:
         starting_faction_slug = era.starting_faction_slug
     elif requested_faction_slug == ALBESCENT_FACTION_SLUG:
-        raise HTTPException(
-            status_code=400,
-            detail="Albescent is joined in the field, not chosen at creation.",
+        raise_coded(
+            400,
+            ErrorCode.faction_albescent_not_at_creation,
+            "Albescent is joined in the field, not chosen at creation.",
         )
     else:
         invited = await get_account_invited_faction_slugs(account_id, session, era)
         if requested_faction_slug not in invited:
-            raise HTTPException(
-                status_code=400,
-                detail="You don't hold an invitation for that faction.",
+            raise_coded(
+                400,
+                ErrorCode.faction_invitation_required,
+                "You don't hold an invitation for that faction.",
             )
         starting_faction_slug = requested_faction_slug
 

--- a/backend/services/comment.py
+++ b/backend/services/comment.py
@@ -147,9 +147,10 @@ async def _assert_commentable_target(
     The DB CHECK also guards exactly-one; this gives a clean 4xx before the insert.
     """
     if (praxis_id is None) == (task_id is None):
-        raise HTTPException(
-            status_code=422,
-            detail="A comment targets exactly one of a praxis or a task.",
+        raise_coded(
+            422,
+            ErrorCode.comment_target_ambiguous,
+            "A comment targets exactly one of a praxis or a task.",
         )
     if praxis_id is not None:
         # The write door must ask the same question as the read door. It used to
@@ -167,18 +168,22 @@ async def _assert_commentable_target(
         if praxis is None or (
             author is not None and not await can_view_praxis(author, praxis, session)
         ):
-            raise HTTPException(status_code=404, detail="Praxis not found.")
+            raise_coded(404, ErrorCode.praxis_not_found, "Praxis not found.")
         if praxis.moderation_status != ModerationStatus.visible:
-            raise HTTPException(
-                status_code=403, detail="This praxis is not open for comments."
+            raise_coded(
+                403,
+                ErrorCode.praxis_not_open_for_comments,
+                "This praxis is not open for comments.",
             )
     else:
         task = await session.get(Task, task_id)
         if task is None:
-            raise HTTPException(status_code=404, detail="Task not found.")
+            raise_coded(404, ErrorCode.task_not_found, "Task not found.")
         if task.status != TaskStatus.active:
-            raise HTTPException(
-                status_code=403, detail="This task is not open for comments."
+            raise_coded(
+                403,
+                ErrorCode.task_not_open_for_comments,
+                "This task is not open for comments.",
             )
 
 

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -352,7 +352,7 @@ async def respond_to_duel_challenge(
         raise_coded(
             400,
             ErrorCode.task_bank_full,
-            f"Task bank is full ({era.max_task_signups} in-progress praxes).",
+            f"Task bank is full ({era.max_task_signups} in-progress praxis).",
             {"limit": era.max_task_signups},
         )
 

--- a/backend/services/duel.py
+++ b/backend/services/duel.py
@@ -211,7 +211,7 @@ async def issue_duel_challenge(
 
     challenger_praxis = await get_praxis(challenger_praxis_id, session)
     if challenger_praxis.created_by_id != challenger_character_id:
-        raise HTTPException(status_code=403, detail="You do not own this praxis.")
+        raise_coded(403, ErrorCode.praxis_not_owner, "You do not own this praxis.")
     if challenger_praxis.status != PraxisStatus.in_progress:
         raise_coded(
             422,
@@ -232,11 +232,13 @@ async def issue_duel_challenge(
 
     task = await session.get(Task, challenger_praxis.task_id)
     if task is None:
-        raise HTTPException(status_code=404, detail="Task no longer exists.")
+        raise_coded(404, ErrorCode.task_not_found, "Task no longer exists.")
 
     opponent = await session.get(Character, opponent_character_id)
     if opponent is None:
-        raise HTTPException(status_code=404, detail="Opponent character not found.")
+        raise_coded(
+            404, ErrorCode.character_not_found, "Opponent character not found."
+        )
 
     # Opponent eligibility: must not already have an active praxis for this task.
     # `era` is threaded through because the predicate carries the Double Dipper
@@ -291,10 +293,16 @@ async def respond_to_duel_challenge(
     duel = await get_duel(duel_id, session)
 
     if duel.opponent_character_id != character_id:
-        raise HTTPException(status_code=403, detail="This challenge is not for you.")
+        raise_coded(
+            403, ErrorCode.duel_challenge_not_yours, "This challenge is not for you."
+        )
 
     if duel.status != DuelStatus.pending:
-        raise HTTPException(status_code=400, detail="Challenge has already been resolved.")
+        raise_coded(
+            400,
+            ErrorCode.duel_challenge_already_resolved,
+            "Challenge has already been resolved.",
+        )
 
     now = datetime.now(timezone.utc)
 
@@ -306,7 +314,7 @@ async def respond_to_duel_challenge(
 
     opponent = await session.get(Character, character_id)
     if opponent is None:
-        raise HTTPException(status_code=404, detail="Character not found.")
+        raise_coded(404, ErrorCode.character_not_found, "Character not found.")
 
     # Account-level self-duel guard (ADR-0041, #1237). The invitation check above
     # only proves the responder is the invited *character*; it says nothing about
@@ -325,7 +333,7 @@ async def respond_to_duel_challenge(
 
     task = await session.get(Task, duel.task_id)
     if task is None:
-        raise HTTPException(status_code=404, detail="Task no longer exists.")
+        raise_coded(404, ErrorCode.task_not_found, "Task no longer exists.")
 
     # Opponent must still be eligible (they could have signed up for the task
     # in the window between challenge and accept). `era` threaded for the same

--- a/backend/services/faction_service.py
+++ b/backend/services/faction_service.py
@@ -1,9 +1,9 @@
 """Faction lifecycle: defection and invitation letters."""
 
-from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode, raise_coded
 from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA, EraConfig
 from models.account import Account
@@ -147,30 +147,33 @@ async def defect_to_faction(
     bar (level + full faction coverage).
     """
     if character.faction_slug == target_slug:
-        raise HTTPException(
-            status_code=422,
-            detail="Already a member of this faction.",
+        raise_coded(
+            422,
+            ErrorCode.faction_already_member,
+            "Already a member of this faction.",
         )
 
     # `na` is the unaffiliated sentinel, not a joinable destination (ADR-0019/0030).
     if target_slug == UNAFFILIATED_FACTION_SLUG:
-        raise HTTPException(
-            status_code=422,
-            detail="This faction cannot be chosen directly.",
+        raise_coded(
+            422,
+            ErrorCode.faction_not_selectable,
+            "This faction cannot be chosen directly.",
         )
 
     faction_config = era.factions.get(target_slug)
     if faction_config is None:
-        raise HTTPException(status_code=404, detail="Faction not found.")
+        raise_coded(404, ErrorCode.faction_not_found, "Faction not found.")
 
     era_row = await get_current_era_row(session)
 
     if not await can_join_faction(
         character.id, target_slug, era_row.id, session, era
     ):
-        raise HTTPException(
-            status_code=403,
-            detail="Cannot rejoin a faction you have left.",
+        raise_coded(
+            403,
+            ErrorCode.faction_rejoin_forbidden,
+            "Cannot rejoin a faction you have left.",
         )
 
     # #454: switching into a faction requires holding that faction's invitation
@@ -181,9 +184,10 @@ async def defect_to_faction(
     if not faction_config.can_always_rejoin and not await has_invitation(
         character.id, target_slug, era_row.id, session
     ):
-        raise HTTPException(
-            status_code=403,
-            detail="You don't hold an invitation for that faction.",
+        raise_coded(
+            403,
+            ErrorCode.faction_invitation_required,
+            "You don't hold an invitation for that faction.",
         )
 
     # ADR-0021: Albescent is joined in the field via defection, but only once the
@@ -192,9 +196,10 @@ async def defect_to_faction(
     if target_slug == ALBESCENT_FACTION_SLUG and not await can_start_as_albescent(
         character.account_id, session, era
     ):
-        raise HTTPException(
-            status_code=403,
-            detail="The order has not extended its hand to you.",
+        raise_coded(
+            403,
+            ErrorCode.faction_albescent_not_eligible,
+            "The order has not extended its hand to you.",
         )
 
     # Record defection from current faction (if it's a real faction, not na)

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -766,7 +766,7 @@ def _signup_denial_to_http(
         return coded_error(
             403,
             ErrorCode.task_not_open_for_signup,
-            f"This task is {status_context} and is not open for new praxes.",
+            f"This task is {status_context} and is not open for new praxis.",
             {DETAIL_CONTEXT_PARAM: status_context},
         )
     if reason == SignupDenialReason.already_active_member:
@@ -780,7 +780,7 @@ def _signup_denial_to_http(
     return coded_error(
         400,
         ErrorCode.task_bank_full,
-        f"Task bank is full ({era.max_task_signups} in-progress praxes). Complete or withdraw one first.",
+        f"Task bank is full ({era.max_task_signups} in-progress praxis). Complete or withdraw one first.",
         {"limit": era.max_task_signups, DETAIL_CONTEXT_PARAM: "signup"},
     )
 
@@ -1603,7 +1603,7 @@ async def invite_to_praxis(
     if praxis.type != PraxisType.collab:
         raise HTTPException(
             status_code=400,
-            detail="Invites are only for collab praxes. Duels use the challenge endpoint.",
+            detail="Invites are only for collab praxis. Duels use the challenge endpoint.",
         )
     if praxis.status == PraxisStatus.submitted:
         raise_coded(
@@ -1741,7 +1741,7 @@ async def respond_to_invite(
             raise_coded(
                 409,
                 ErrorCode.task_bank_full,
-                f"Task bank is full ({era.max_task_signups} in-progress praxes).",
+                f"Task bank is full ({era.max_task_signups} in-progress praxis).",
                 {"limit": era.max_task_signups},
             )
 

--- a/backend/services/praxis_metatask.py
+++ b/backend/services/praxis_metatask.py
@@ -93,7 +93,7 @@ async def apply_metatask(
     if praxis.status != PraxisStatus.in_progress:
         raise HTTPException(
             status_code=422,
-            detail="Metatasks can only be applied to in-progress praxes.",
+            detail="Metatasks can only be applied to in-progress praxis.",
         )
 
     character = await session.get(Character, character_id)

--- a/backend/tests/integration/test_player_facing_error_codes.py
+++ b/backend/tests/integration/test_player_facing_error_codes.py
@@ -17,8 +17,12 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from errors import DETAIL_CONTEXT_PARAM, ErrorCode
+from faction_slugs import UNAFFILIATED_FACTION_SLUG
 from models.character import Character
-from models.praxis import Praxis, PraxisStatus, PraxisType
+from models.duel import Duel, DuelStatus
+from models.praxis import ModerationStatus, Praxis, PraxisStatus, PraxisType
+from models.task import Task, TaskStatus
+from services.character import ALBESCENT_FACTION_SLUG
 
 
 # ---------------------------------------------------------------------------
@@ -154,3 +158,319 @@ async def test_deleting_a_missing_relationship_is_coded(
     )
     assert response.status_code == 404, response.text
     assert response.json()["detail"]["code"] == ErrorCode.relationship_not_found.value
+
+
+# ---------------------------------------------------------------------------
+# Slice two (#1652): the service-layer gates a player walks into
+#
+# The route sweep above missed these because they live one layer down — in
+# services/, behind a thin handler. They are still things a player does and
+# reads the rejection of, which is the same argument, so they get the same
+# treatment.
+# ---------------------------------------------------------------------------
+
+# POST /factions/choose — six refusals on one button
+#
+# ``character`` starts in ``ua``, so every case below is a real defection
+# attempt. Six different reasons answer three statuses; before #1652 the prose
+# was the only thing telling them apart.
+
+
+@pytest.mark.asyncio
+async def test_defecting_to_your_current_faction_is_coded(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    response = await client.post(
+        "/factions/choose", json={"faction_slug": "ua"}, headers=auth_headers
+    )
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"]["code"] == ErrorCode.faction_already_member.value
+
+
+@pytest.mark.asyncio
+async def test_defecting_to_the_unaffiliated_sentinel_is_coded(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    """``na`` is a start state, not a destination (ADR-0019/0030)."""
+    response = await client.post(
+        "/factions/choose",
+        json={"faction_slug": UNAFFILIATED_FACTION_SLUG},
+        headers=auth_headers,
+    )
+    assert response.status_code == 422, response.text
+    assert response.json()["detail"]["code"] == ErrorCode.faction_not_selectable.value
+
+
+@pytest.mark.asyncio
+async def test_defecting_to_an_unknown_faction_is_coded(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    response = await client.post(
+        "/factions/choose",
+        json={"faction_slug": "no-such-faction"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"]["code"] == ErrorCode.faction_not_found.value
+
+
+@pytest.mark.asyncio
+async def test_defecting_without_an_invitation_is_coded(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    """#454: switching in needs that faction's current-era invitation letter."""
+    response = await client.post(
+        "/factions/choose", json={"faction_slug": "snide"}, headers=auth_headers
+    )
+    assert response.status_code == 403, response.text
+    assert (
+        response.json()["detail"]["code"]
+        == ErrorCode.faction_invitation_required.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_defecting_to_albescent_unqualified_is_coded(
+    client: AsyncClient, character: Character, auth_headers: dict
+):
+    """ADR-0021: Albescent skips the invitation gate and has its own bar."""
+    response = await client.post(
+        "/factions/choose",
+        json={"faction_slug": ALBESCENT_FACTION_SLUG},
+        headers=auth_headers,
+    )
+    assert response.status_code == 403, response.text
+    assert (
+        response.json()["detail"]["code"]
+        == ErrorCode.faction_albescent_not_eligible.value
+    )
+
+
+# POST /praxes/{id}/comments and /tasks/{id}/comments — two 404s that are not
+# the same 404. ``character2`` is level 5, clearing era.comment_level_required.
+
+
+@pytest.mark.asyncio
+async def test_commenting_on_a_missing_praxis_and_task_are_coded_apart(
+    client: AsyncClient, character2: Character, auth_headers2: dict
+):
+    on_praxis = await client.post(
+        f"/praxes/{MISSING_ID}/comments",
+        json={"body_text": "hello"},
+        headers=auth_headers2,
+    )
+    assert on_praxis.status_code == 404, on_praxis.text
+    assert on_praxis.json()["detail"]["code"] == ErrorCode.praxis_not_found.value
+
+    on_task = await client.post(
+        f"/tasks/{MISSING_ID}/comments",
+        json={"body_text": "hello"},
+        headers=auth_headers2,
+    )
+    assert on_task.status_code == 404, on_task.text
+    assert on_task.json()["detail"]["code"] == ErrorCode.task_not_found.value
+
+
+@pytest.mark.asyncio
+async def test_commenting_on_a_hidden_praxis_is_coded(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    praxis_solo: Praxis,
+    character2: Character,
+    auth_headers2: dict,
+):
+    praxis_solo.moderation_status = ModerationStatus.hidden
+    await db_session.commit()
+
+    response = await client.post(
+        f"/praxes/{praxis_solo.id}/comments",
+        json={"body_text": "hello"},
+        headers=auth_headers2,
+    )
+    assert response.status_code == 403, response.text
+    assert (
+        response.json()["detail"]["code"]
+        == ErrorCode.praxis_not_open_for_comments.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_commenting_on_a_retired_task_is_coded(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    active_task: Task,
+    character2: Character,
+    auth_headers2: dict,
+):
+    """ADR-0006: only an active task carries a comment thread."""
+    active_task.status = TaskStatus.retired
+    await db_session.commit()
+
+    response = await client.post(
+        f"/tasks/{active_task.id}/comments",
+        json={"body_text": "hello"},
+        headers=auth_headers2,
+    )
+    assert response.status_code == 403, response.text
+    assert (
+        response.json()["detail"]["code"] == ErrorCode.task_not_open_for_comments.value
+    )
+
+
+# POST /duels/challenge and /duels/{id}/respond
+
+
+@pytest.mark.asyncio
+async def test_challenging_with_someone_elses_praxis_is_coded(
+    client: AsyncClient,
+    praxis_solo: Praxis,
+    character: Character,
+    character2: Character,
+    auth_headers2: dict,
+):
+    response = await client.post(
+        "/duels/challenge",
+        json={
+            "challenger_praxis_id": praxis_solo.id,
+            "opponent_character_id": character.id,
+        },
+        headers=auth_headers2,
+    )
+    assert response.status_code == 403, response.text
+    assert response.json()["detail"]["code"] == ErrorCode.praxis_not_owner.value
+
+
+@pytest.mark.asyncio
+async def test_challenging_a_missing_character_is_coded(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    active_task: Task,
+    character: Character,
+    auth_headers: dict,
+):
+    draft = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        title="Draft",
+        body_text="wip",
+    )
+    db_session.add(draft)
+    await db_session.commit()
+
+    response = await client.post(
+        "/duels/challenge",
+        json={
+            "challenger_praxis_id": draft.id,
+            "opponent_character_id": MISSING_ID,
+        },
+        headers=auth_headers,
+    )
+    assert response.status_code == 404, response.text
+    assert response.json()["detail"]["code"] == ErrorCode.character_not_found.value
+
+
+@pytest.mark.asyncio
+async def test_responding_to_someone_elses_challenge_is_coded(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    active_task: Task,
+    praxis_solo: Praxis,
+    character2: Character,
+    character3: Character,
+    auth_headers3: dict,
+):
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=praxis_solo.id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.pending,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    response = await client.post(
+        f"/duels/{duel.id}/respond", json={"accept": True}, headers=auth_headers3
+    )
+    assert response.status_code == 403, response.text
+    assert (
+        response.json()["detail"]["code"] == ErrorCode.duel_challenge_not_yours.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_responding_to_a_resolved_challenge_is_coded(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    active_task: Task,
+    praxis_solo: Praxis,
+    character2: Character,
+    auth_headers2: dict,
+):
+    duel = Duel(
+        task_id=active_task.id,
+        challenger_praxis_id=praxis_solo.id,
+        opponent_character_id=character2.id,
+        status=DuelStatus.declined,
+    )
+    db_session.add(duel)
+    await db_session.commit()
+
+    response = await client.post(
+        f"/duels/{duel.id}/respond", json={"accept": True}, headers=auth_headers2
+    )
+    assert response.status_code == 400, response.text
+    assert (
+        response.json()["detail"]["code"]
+        == ErrorCode.duel_challenge_already_resolved.value
+    )
+
+
+# POST /characters — the three refusals on the creation form. ``account2`` holds
+# no character yet, so the second-character level gate is not what answers.
+
+
+@pytest.mark.asyncio
+async def test_creating_a_character_with_a_blank_name_is_coded(
+    client: AsyncClient, account2, era, faction_ua, auth_headers2: dict
+):
+    """Whitespace clears Pydantic's min_length; the service is what refuses."""
+    response = await client.post(
+        "/characters", json={"display_name": "   "}, headers=auth_headers2
+    )
+    assert response.status_code == 400, response.text
+    assert response.json()["detail"]["code"] == ErrorCode.character_name_required.value
+
+
+@pytest.mark.asyncio
+async def test_creating_a_character_in_albescent_is_coded(
+    client: AsyncClient, account2, era, faction_ua, auth_headers2: dict
+):
+    response = await client.post(
+        "/characters",
+        json={"display_name": "Newcomer", "faction_slug": ALBESCENT_FACTION_SLUG},
+        headers=auth_headers2,
+    )
+    assert response.status_code == 400, response.text
+    assert (
+        response.json()["detail"]["code"]
+        == ErrorCode.faction_albescent_not_at_creation.value
+    )
+
+
+@pytest.mark.asyncio
+async def test_creating_a_character_in_an_uninvited_faction_is_coded(
+    client: AsyncClient, account2, era, faction_ua, auth_headers2: dict
+):
+    """The same failure as defecting without a letter, and the same code."""
+    response = await client.post(
+        "/characters",
+        json={"display_name": "Newcomer", "faction_slug": "snide"},
+        headers=auth_headers2,
+    )
+    assert response.status_code == 400, response.text
+    assert (
+        response.json()["detail"]["code"]
+        == ErrorCode.faction_invitation_required.value
+    )

--- a/backend/tests/integration/test_player_facing_error_codes.py
+++ b/backend/tests/integration/test_player_facing_error_codes.py
@@ -435,14 +435,29 @@ async def test_responding_to_a_resolved_challenge_is_coded(
 
 @pytest.mark.asyncio
 async def test_creating_a_character_with_a_blank_name_is_coded(
-    client: AsyncClient, account2, era, faction_ua, auth_headers2: dict
+    db_session: AsyncSession, account2, era, faction_ua
 ):
-    """Whitespace clears Pydantic's min_length; the service is what refuses."""
-    response = await client.post(
-        "/characters", json={"display_name": "   "}, headers=auth_headers2
-    )
-    assert response.status_code == 400, response.text
-    assert response.json()["detail"]["code"] == ErrorCode.character_name_required.value
+    """Tested at the service, because the wire now refuses first.
+
+    ``schemas.character.DisplayName`` strips and enforces ``min_length=1`` as of
+    #1696, so ``POST /characters`` answers 422 for a blank name and never
+    reaches this raise. The service keeps its own guard anyway — ``seed.py`` and
+    the scripts call ``create_character`` directly, with no Pydantic in front —
+    so it is coded like the rest of the scope and pinned where it is reachable.
+    """
+    from fastapi import HTTPException
+
+    from schemas.character import CharacterCreate
+    from services.character import create_character
+
+    # model_construct skips validation, which is exactly the door a non-HTTP
+    # caller comes through.
+    blank = CharacterCreate.model_construct(display_name="   ")
+    with pytest.raises(HTTPException) as raised:
+        await create_character(account2.id, blank, db_session)
+
+    assert raised.value.status_code == 400
+    assert raised.value.detail["code"] == ErrorCode.character_name_required.value
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_player_facing_error_codes.py
+++ b/backend/tests/integration/test_player_facing_error_codes.py
@@ -272,14 +272,16 @@ async def test_commenting_on_a_missing_praxis_and_task_are_coded_apart(
 
 
 @pytest.mark.asyncio
-async def test_commenting_on_a_hidden_praxis_is_coded(
+async def test_commenting_on_a_flagged_praxis_is_coded(
     client: AsyncClient,
     db_session: AsyncSession,
     praxis_solo: Praxis,
     character2: Character,
     auth_headers2: dict,
 ):
-    praxis_solo.moderation_status = ModerationStatus.hidden
+    """``flagged``, not ``hidden``: a hidden praxis is unviewable, so it answers
+    the 404 above — this 403 is the one a player can actually reach."""
+    praxis_solo.moderation_status = ModerationStatus.flagged
     await db_session.commit()
 
     response = await client.post(

--- a/backend/tests/unit/test_errors.py
+++ b/backend/tests/unit/test_errors.py
@@ -112,6 +112,60 @@ def test_every_error_code_is_emitted_with_prose() -> None:
     )
 
 
+def test_signup_denial_prose_matches_the_catalog_copy() -> None:
+    """#1614: both halves of the same failure must read the same.
+
+    The backend ``message`` is not decorative — ``extractError`` falls back to
+    it whenever the catalog has no entry, which in practice means the window
+    between the API deploying and the frontend deploying. When the catalog copy
+    moved to "praxis" (``praxisPlural.test.ts``, CONTEXT.md: *one praxis, many
+    praxis*) the Python prose stayed on "praxes", so a player hitting a full
+    task bank read one plural or the other depending on which half of the
+    deploy they were on.
+
+    Pinned on the two branches that say it — the bank-full denial and the
+    closed-task denial — by rendering the catalog entry with this raise site's
+    own ``params`` and demanding the two strings agree.
+    """
+    import json
+    import re
+    from pathlib import Path
+
+    from game_config import CURRENT_ERA
+    from models.task import Task, TaskStatus
+    from services.praxis import SignupDenialReason, _signup_denial_to_http
+    from errors import DETAIL_CONTEXT_PARAM, DETAIL_PARAMS_KEY
+
+    catalog = json.loads(
+        (
+            Path(__file__).resolve().parents[3]
+            / "frontend" / "src" / "locales" / "en" / "errors.json"
+        ).read_text(encoding="utf-8")
+    )["codes"]
+
+    def rendered(error: HTTPException) -> str:
+        """The catalog string the client would show, interpolated as i18next does."""
+        detail = error.detail
+        params = dict(detail.get(DETAIL_PARAMS_KEY, {}))
+        context = params.pop(DETAIL_CONTEXT_PARAM, None)
+        code = detail[DETAIL_CODE_KEY]
+        key = f"{code}_{context}" if context and f"{code}_{context}" in catalog else code
+        return re.sub(
+            r"\{\{(\w+)\}\}", lambda match: str(params[match.group(1)]), catalog[key]
+        )
+
+    retired_task = Task(status=TaskStatus.retired, level_required=0)
+    for reason, task in (
+        (SignupDenialReason.bank_full, retired_task),
+        (SignupDenialReason.task_status_closed, retired_task),
+    ):
+        error = _signup_denial_to_http(reason, task, CURRENT_ERA)
+        assert error.detail[DETAIL_MESSAGE_KEY] == rendered(error), (
+            f"{reason} renders differently depending on whether the catalog "
+            f"resolved — the fallback prose and the catalog copy disagree"
+        )
+
+
 def test_every_error_code_has_a_raise_site() -> None:
     """An ``ErrorCode`` nothing raises is a name a client would wait forever for."""
     emitted = {

--- a/backend/tests/unit/uncoded_error_allowlist.py
+++ b/backend/tests/unit/uncoded_error_allowlist.py
@@ -49,12 +49,24 @@ judgement, not by fatigue — so the next reader does not re-derive it:
 * **Auth and dependency plumbing.** ``services/auth.py``, ``dependencies.py``:
   401/403 with a status the client already switches on before it ever looks at
   a body.
-* **Service-layer gates whose surface is unsettled.** ``services/praxis.py``,
+* **Service-layer gates behind a button.** ``services/praxis.py``,
   ``services/comment.py``, ``services/duel.py``, ``services/nudge.py`` and
-  friends still hold the bulk of the list. These *are* player-facing and are
-  the next slice worth taking; they are here because they need per-code
-  judgement about which failures a client should branch on, not because they
-  were judged fine.
+  friends still hold the bulk of the list. Slice two took the five heaviest —
+  ``faction_service.py::defect_to_faction``,
+  ``comment.py::_assert_commentable_target``, both duel challenge scopes and
+  ``character.py::create_character``, 21 raises — on the argument the issue
+  body makes for ``list_praxes_route``, applied one layer down: defection,
+  commenting, duel challenge/response and character creation are all things a
+  player does and reads the rejection of. What is left in these files is the
+  tail: scopes where the status already says everything a client needs, or
+  where nothing renders the prose as its own failure (``nudge.py::_refuse``
+  reports per item into a plain string field). They want per-code judgement one
+  at a time, and none is a failure a player currently tells apart by reading.
+
+**Where that leaves the number.** 164 at #1401, 137 after slice one, 116 after
+slice two. #1652 closes here rather than at zero: converting the rest would
+mean minting a code for every missing-row 404 in the app, which no client
+branches on and no catalog would word differently.
 
 KEY SHAPE
 ---------
@@ -74,7 +86,7 @@ from __future__ import annotations
 #: Sum of :data:`UNCODED_RAISE_ALLOWLIST`. Duplicated on purpose: this is the
 #: one number a reviewer reads to see how far a PR moved the ratchet, and the
 #: test asserts the two agree so it cannot drift.
-UNCODED_RAISE_TOTAL = 137
+UNCODED_RAISE_TOTAL = 116
 
 #: ``"file::scope" -> count``. Grouped by file, sorted; see the module docstring.
 UNCODED_RAISE_ALLOWLIST: dict[str, int] = {
@@ -109,14 +121,12 @@ UNCODED_RAISE_ALLOWLIST: dict[str, int] = {
     "services/auth.py::decode_jwt": 2,
     "services/auth.py::get_current_account": 2,
 
-    "services/character.py::create_character": 3,
     "services/character.py::set_active_character": 2,
     "services/character.py::soft_delete_character": 1,
     "services/character.py::update_character": 1,
 
     "services/character_stats.py::recompute_votes_spent_this_era": 1,
 
-    "services/comment.py::_assert_commentable_target": 5,
     "services/comment.py::_clean_body": 2,
     "services/comment.py::edit_comment": 1,
     "services/comment.py::flag_comment": 1,
@@ -126,12 +136,8 @@ UNCODED_RAISE_ALLOWLIST: dict[str, int] = {
 
     "services/duel.py::cancel_duel_challenge": 2,
     "services/duel.py::get_duel": 1,
-    "services/duel.py::issue_duel_challenge": 3,
-    "services/duel.py::respond_to_duel_challenge": 4,
 
     "services/era.py::get_current_era_row": 1,
-
-    "services/faction_service.py::defect_to_faction": 6,
 
     "services/media.py::process_and_save_avatar": 1,
     "services/media.py::process_and_save_media": 1,

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -53,6 +53,26 @@
 
     "PRAXIS_NOT_FOUND": "Praxis not found.",
     "MEDIA_ITEM_NOT_FOUND": "Media item not found.",
+    "TASK_NOT_FOUND": "Task not found.",
+    "CHARACTER_NOT_FOUND": "Character not found.",
+
+    "FACTION_NOT_FOUND": "Faction not found.",
+    "FACTION_ALREADY_MEMBER": "Already a member of this faction.",
+    "FACTION_NOT_SELECTABLE": "This faction cannot be chosen directly.",
+    "FACTION_REJOIN_FORBIDDEN": "Cannot rejoin a faction you have left.",
+    "FACTION_INVITATION_REQUIRED": "You don't hold an invitation for that faction.",
+    "FACTION_ALBESCENT_NOT_ELIGIBLE": "The order has not extended its hand to you.",
+    "FACTION_ALBESCENT_NOT_AT_CREATION": "Albescent is joined in the field, not chosen at creation.",
+
+    "CHARACTER_NAME_REQUIRED": "A chosen name is required.",
+
+    "PRAXIS_NOT_OWNER": "You do not own this praxis.",
+    "PRAXIS_NOT_OPEN_FOR_COMMENTS": "This praxis is not open for comments.",
+    "TASK_NOT_OPEN_FOR_COMMENTS": "This task is not open for comments.",
+    "COMMENT_TARGET_AMBIGUOUS": "A comment targets exactly one of a praxis or a task.",
+
+    "DUEL_CHALLENGE_NOT_YOURS": "This challenge is not for you.",
+    "DUEL_CHALLENGE_ALREADY_RESOLVED": "Challenge has already been resolved.",
 
     "RELATIONSHIP_NOT_FOUND": "Relationship not found.",
     "RELATIONSHIP_NOT_DECLARER": "Only the declaring party can delete a relationship.",


### PR DESCRIPTION
Two issues folded into one PR because both edit `backend/services/praxis.py` and `backend/services/duel.py`; splitting them means a rebase.

Closes #1652
Closes #1614

## The seam I tested at

**#1652 — the HTTP error body, not the raise statement.** What #1401 promises a client is that `detail` carries a stable `code` beside the prose; that promise is only observably kept through the app, so the new cases live in `backend/tests/integration/test_player_facing_error_codes.py` and drive the real routes (`POST /factions/choose`, `POST /praxes/{id}/comments`, `POST /tasks/{id}/comments`, `POST /duels/challenge`, `POST /duels/{id}/respond`, `POST /characters`). 15 new cases, all red before the fix (`ErrorCode` had no member for any of these 21 raises).

**#1614 — the fallback `message` against the catalog string.** `test_signup_denial_prose_matches_the_catalog_copy` in `backend/tests/unit/test_errors.py` renders the `errors.json` entry with the raise site's own `params` and demands the two strings agree. That is exactly the defect the issue describes — the same failure reading two different plurals depending on which half of a deploy you are on — and it failed on it first:

```
- Task bank is full (20 in-progress praxis). Complete or withdraw one first.
+ Task bank is full (20 in-progress praxes). Complete or withdraw one first.
```

## `UNCODED_RAISE_TOTAL`: 137 → 116

Both numbers re-derived from the tool, not from the issue:

```
before:  scan total: 137 | allowlist total: 137
after:   scan total: 116 | allowlist total: 116
```

The five scopes were present at exactly the counts the issue comment gave (6/5/4/3/3 = 21), and all five are now gone from the allowlist entirely rather than lowered.

| scope | raises | codes |
|---|---|---|
| `services/faction_service.py::defect_to_faction` | 6 | `FACTION_ALREADY_MEMBER`, `FACTION_NOT_SELECTABLE`, `FACTION_NOT_FOUND`, `FACTION_REJOIN_FORBIDDEN`, `FACTION_INVITATION_REQUIRED`, `FACTION_ALBESCENT_NOT_ELIGIBLE` |
| `services/comment.py::_assert_commentable_target` | 5 | `COMMENT_TARGET_AMBIGUOUS`, `PRAXIS_NOT_FOUND` (reused), `PRAXIS_NOT_OPEN_FOR_COMMENTS`, `TASK_NOT_FOUND`, `TASK_NOT_OPEN_FOR_COMMENTS` |
| `services/duel.py::respond_to_duel_challenge` | 4 | `DUEL_CHALLENGE_NOT_YOURS`, `DUEL_CHALLENGE_ALREADY_RESOLVED`, `CHARACTER_NOT_FOUND`, `TASK_NOT_FOUND` |
| `services/duel.py::issue_duel_challenge` | 3 | `PRAXIS_NOT_OWNER`, `TASK_NOT_FOUND`, `CHARACTER_NOT_FOUND` |
| `services/character.py::create_character` | 3 | `CHARACTER_NAME_REQUIRED`, `FACTION_ALBESCENT_NOT_AT_CREATION`, `FACTION_INVITATION_REQUIRED` |

16 new `ErrorCode` members for 21 raises: `FACTION_INVITATION_REQUIRED` is shared by defection and character creation because it is one rule (#454 — you hold the current era's letter or you do not), `TASK_NOT_FOUND` / `CHARACTER_NOT_FOUND` are shared across the duel scopes, and `PRAXIS_NOT_FOUND` already existed. Every one has its `errors.json` key; every raise keeps its own prose as `message`.

**The trap was respected.** `list_praxes_route`'s five filter raises are untouched — still five inline `raise_coded` calls with literal `context` strings — and none of the conversions introduces the pattern: no shared raise helper, `context` stays a literal at each site. `test_every_raise_site_context_resolves` still sees every sibling.

The *"WHAT #1652 LEFT, AND WHY"* section of the allowlist docstring now records what slice two took, what the tail is, and why the issue closes at 116 rather than at zero.

## #1614: the six prose strings

The issue names two files. There are three — `services/praxis_metatask.py` it never saw. All six, verified with an AST scan for non-docstring string literals containing "praxes":

| file:line | before → after |
|---|---|
| `services/duel.py:355` | `Task bank is full ({n} in-progress praxes).` → `…in-progress praxis).` |
| `services/praxis.py:769` | `This task is {status} and is not open for new praxes.` → `…for new praxis.` |
| `services/praxis.py:783` | `Task bank is full ({n} in-progress praxes). Complete or withdraw one first.` → `…in-progress praxis). …` |
| `services/praxis.py:1606` | `Invites are only for collab praxes. Duels use the challenge endpoint.` → `…collab praxis. …` |
| `services/praxis.py:1744` | `Task bank is full ({n} in-progress praxes).` → `…in-progress praxis).` |
| `services/praxis_metatask.py:96` | `Metatasks can only be applied to in-progress praxes.` → `…in-progress praxis.` |

After the change, the only remaining "praxes" in shipped backend code are the things that must stay: the `/praxes/...` API paths, the `Character.praxes` / `Task.praxes` relationship names, `list_praxes` in `__all__`, and comments/docstrings. Option 2 (an AST guard scanning `backend/`) is deliberately **not** built.

One thing worth knowing: `isTaskBankFull` and `FeedCardDuelChallenge`'s deploy-skew prose arm both match on the prefix `"Task bank is full"`, so the drop-to-accept flow is unaffected by the plural change. I checked before editing.

## Not in this PR

- `backend/schemas/character.py` — untouched (sibling work, #1686/#1696).
- **No schema movement.** `scripts/regen_api_client.py` run after the work leaves `backend/openapi.json` and `frontend/src/api/generated/schema.d.ts` byte-identical, as expected for an `HTTPException` → `raise_coded` conversion.
- Only frontend file: `frontend/src/locales/en/errors.json`.

**One mid-flight interaction.** #1696 merged while this branch was open and made `display_name` strip + `min_length=1` at the wire, so `POST /characters` now answers 422 for a blank name and never reaches `create_character`'s own guard. The guard stays (seed and scripts call the service with no Pydantic in front) and stays coded; its test moved to the service seam, because asserting it through the route would have been asserting #1696's 422 instead.

## Verification

```
# backend (dedicated DB, parallel-agent safe)
cd backend
TEST_DATABASE_URL=postgresql+asyncpg://worldzero:localdev@localhost:5432/wz1652_test \
  python -m pytest --cov=. --cov-fail-under=80 -q
→ 1206 passed, coverage 93.23% (floor 80%)

# every step .github/workflows/test.yml names, run locally
npm run lint                  → clean
npm run typecheck             → clean
npm run typecheck:design-sync → clean
npm test                      → 235 files, 4243 tests passed
npm run build                 → built
npm run budget                → within budget (JS 128.8 KB, CSS 21.5 KB)
python scripts/regen_api_client.py && git status → no artifact drift
```

## Visual QA is outstanding

I have no browser and no dev stack; everything above is tests, typecheck, lint and build. Nothing here changes a component, a style or a route shape — the failures listed below previously rendered backend prose and now render the `errors.json` copy for the same code, which for every key in this PR is the *same sentence*. So the expected visual result is **no visible change**, and the thing to eyeball is that each error still appears at all.

### What to eyeball

- **Defection** — `/factions`, pick a faction: your current one (already a member), one you hold no invitation for, and Albescent while unqualified. Three different refusals, three different codes, same words as before.
- **Commenting** — comment on a flagged praxis, and on a retired task. Both should still refuse with their own message rather than a blank error.
- **Duel challenge** — challenge someone with a praxis that is not yours, and challenge a character that no longer exists.
- **Duel response** — open a challenge that is not addressed to you, and respond to one that is already declined/accepted.
- **Character creation** — create a second character asking for Albescent, and asking for a faction you were not invited to.
- **The bank-full message** — the one place copy actually changed. Fill your task bank and then accept a collab invite and a duel challenge: the modal should read **"Task bank is full (20 in-progress praxis)."** with the drop-a-praxis flow still opening. Also sign up for a task with a full bank — same sentence plus "Complete or withdraw one first."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
