### PR TITLE
An admin can move a task to another faction, under the name the model actually uses

### DIFF
--- a/backend/errors.py
+++ b/backend/errors.py
@@ -137,6 +137,12 @@ class ErrorCode(str, enum.Enum):
     #: for different reasons — the code is what says which id was wrong.
     task_not_found = "TASK_NOT_FOUND"
     character_not_found = "CHARACTER_NOT_FOUND"
+    #: #1714. An admin edit naming a faction slug the current era does not
+    #: define. Config owns which factions exist (ADR-0042), so this is a
+    #: config-membership answer, not a row lookup — hence not
+    #: :attr:`faction_not_found`, which reports a missing ``Faction`` row to a
+    #: player joining one.
+    task_faction_unknown = "TASK_FACTION_UNKNOWN"
 
     # -- Factions: joining, defecting, and the letters that gate both --------
     faction_not_found = "FACTION_NOT_FOUND"

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -216,6 +216,19 @@
             ],
             "title": "Point Value"
           },
+          "primary_faction_slug": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Primary Faction Slug"
+          },
           "title": {
             "anyOf": [
               {

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -135,6 +135,14 @@ class AdminTaskPatch(WireModel):
     description: str | None = None
     point_value: int | None = Field(None, ge=1)
     level_required: int | None = Field(None, ge=0)
+    #: The task's own faction — which kit renders it and who earns the
+    #: own-faction modifier (#1714). Validated against the era's factions in
+    #: :func:`services.admin_service.admin_edit_task`, not here, because the
+    #: allowed set is era config and a schema cannot read it (ADR-0042).
+    #: Deliberately NOT ``metatask_faction_slug``: that field answers a
+    #: different question (which faction may *apply* a metatask) and is bound
+    #: to ``task_type`` on create, so moving it is its own decision.
+    primary_faction_slug: str | None = Field(None, min_length=1, max_length=50)
 
 
 class TaskStatusAction(WireModel):

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode, raise_coded
 from game_config import CURRENT_ERA, EraConfig
 from models.account import Account, AccountStatus
 from models.character import Character, CharacterStatus
@@ -404,6 +405,7 @@ async def admin_edit_task(
     task_id: int,
     data: AdminTaskPatch,
     session: AsyncSession,
+    era: EraConfig = CURRENT_ERA,
 ) -> Task:
     """Edit editable fields on a pending or retired task. Active tasks are locked."""
     task = await session.get(Task, task_id)
@@ -414,6 +416,18 @@ async def admin_edit_task(
             status_code=400,
             detail="Active tasks cannot be edited. Retire the task first.",
         )
+    if data.primary_faction_slug is not None:
+        # Config owns which factions exist (ADR-0042), so membership of
+        # ``era.factions`` is the question — including the cross-faction
+        # sentinel, which is one of its keys. Without this the unknown slug
+        # reaches the FK and surfaces as a 500.
+        if data.primary_faction_slug not in era.factions:
+            raise_coded(
+                422,
+                ErrorCode.task_faction_unknown,
+                f"Unknown faction: {data.primary_faction_slug}.",
+            )
+        task.primary_faction_slug = data.primary_faction_slug
     if data.title is not None:
         task.title = data.title
     if data.description is not None:

--- a/backend/tests/integration/test_admin.py
+++ b/backend/tests/integration/test_admin.py
@@ -4,6 +4,8 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from errors import ErrorCode
+from faction_slugs import CROSS_FACTION_SLUG
 from models.account import Account
 from models.character import Character
 from models.character_stats import CharacterStats
@@ -756,6 +758,87 @@ async def test_admin_edit_pending_task(
     data = resp.json()
     assert data["title"] == "Updated Title"
     assert data["point_value"] == 20
+
+
+@pytest.mark.asyncio
+async def test_admin_edit_task_faction(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """Admin can move a task to another of the era's factions (#1714).
+
+    ``primary_faction_slug`` decides which kit renders the task and who earns
+    the own-faction modifier, so a task filed against the wrong faction was
+    unfixable short of SQL before this.
+    """
+    await _make_admin(account, db_session)
+
+    task = Task(
+        title="Filed Against The Wrong Faction",
+        point_value=5,
+        level_required=0,
+        status=TaskStatus.pending,
+        created_by=character.id,
+        primary_faction_slug=CROSS_FACTION_SLUG,
+    )
+    db_session.add(task)
+    await db_session.commit()
+
+    resp = await client.patch(
+        f"/admin/tasks/{task.id}",
+        json={"primary_faction_slug": "ua"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["primary_faction_slug"] == "ua"
+
+    await db_session.refresh(task)
+    assert task.primary_faction_slug == "ua"
+
+    # …and back to the cross-faction sentinel, which is a real slug in config.
+    back = await client.patch(
+        f"/admin/tasks/{task.id}",
+        json={"primary_faction_slug": CROSS_FACTION_SLUG},
+        headers=auth_headers,
+    )
+    assert back.status_code == 200
+    assert back.json()["primary_faction_slug"] == CROSS_FACTION_SLUG
+
+
+@pytest.mark.asyncio
+async def test_admin_edit_task_unknown_faction_rejected(
+    client: AsyncClient,
+    account: Account,
+    character: Character,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """An unknown slug is a coded 422, not a 500 from the FK (#1714)."""
+    await _make_admin(account, db_session)
+
+    task = Task(
+        title="Untouched",
+        point_value=5,
+        level_required=0,
+        status=TaskStatus.pending,
+        created_by=character.id,
+    )
+    db_session.add(task)
+    await db_session.commit()
+
+    resp = await client.patch(
+        f"/admin/tasks/{task.id}",
+        json={"primary_faction_slug": "not-a-faction"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["code"] == ErrorCode.task_faction_unknown.value
+
+    await db_session.refresh(task)
+    assert task.primary_faction_slug == CROSS_FACTION_SLUG
 
 
 @pytest.mark.asyncio

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -112,12 +112,10 @@ export async function updateTaskStatus(id: number, status: AdminTaskStatus): Pro
   return data
 }
 
-interface AdminTaskPatch {
-  title?: string
-  description?: string
-  point_value?: number
-  level_required?: number
-}
+/** Aliased to the generated schema (#1400) rather than restated: a hand-written
+ *  copy is how the wire and the client drift, and it did — the backend's
+ *  `primary_faction_slug` (#1714) was invisible to this file. */
+type AdminTaskPatch = components['schemas']['AdminTaskPatch']
 
 export async function adminPatchTask(id: number, patch: AdminTaskPatch): Promise<TaskOut> {
   const { data } = await apiPatch('/admin/tasks/{task_id}', {

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -1678,6 +1678,8 @@ export interface components {
             level_required?: number | null;
             /** Point Value */
             point_value?: number | null;
+            /** Primary Faction Slug */
+            primary_faction_slug?: string | null;
             /** Title */
             title?: string | null;
         };

--- a/frontend/src/locales/en/admin.json
+++ b/frontend/src/locales/en/admin.json
@@ -60,6 +60,7 @@
     "descriptionPlaceholder": "Description",
     "pointsLabel": "Points",
     "levelLabel": "Level req.",
+    "factionLabel": "Faction",
     "meta": "{{points}} pts · lvl {{level}} · {{faction}}",
     "crossFaction": "cross-faction",
     "proposedBy": "Proposed by {{name}}",

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -55,6 +55,7 @@
     "MEDIA_ITEM_NOT_FOUND": "Media item not found.",
     "TASK_NOT_FOUND": "Task not found.",
     "CHARACTER_NOT_FOUND": "Character not found.",
+    "TASK_FACTION_UNKNOWN": "That faction is not part of the current era.",
 
     "FACTION_NOT_FOUND": "Faction not found.",
     "FACTION_ALREADY_MEMBER": "Already a member of this faction.",

--- a/frontend/src/pages/admin/TasksTab.tsx
+++ b/frontend/src/pages/admin/TasksTab.tsx
@@ -12,6 +12,8 @@ import { mergeAdminTaskRows } from "./adminTaskRows";
 import type { AdminTaskRow } from "./adminTaskRows";
 import TaskImportPanel from "./TaskImportPanel";
 import { extractError } from "../../utils/errors";
+import { useGameConfig } from "../../hooks/useGameConfig";
+import { factionName, UNAFFILIATED_FACTION_SLUG } from "../../utils/factions";
 
 type StatusFilter = "all" | "pending" | "active" | "retired";
 
@@ -22,6 +24,10 @@ interface EditState {
   description: string;
   point_value: string;
   level_required: string;
+  /** The task's OWN faction — which kit renders it and who earns the
+   *  own-faction modifier (#1714). Not the metatask faction, which answers a
+   *  different question and has no admin edit. */
+  primary_faction_slug: string;
 }
 
 const TASK_STATUSES = ["active", "pending", "retired"] as const;
@@ -37,6 +43,18 @@ export default function TasksTab() {
       | undefined;
     return known ? t(`tasks.status.${known}`) : status;
   };
+  const gameConfig = useGameConfig();
+  // The era's factions, in config order. `na` is among them and is a legitimate
+  // choice for a task: for a TASK the slug means cross-faction (open to all),
+  // not "unaffiliated player", so it gets the tab's existing cross-faction
+  // wording rather than the faction catalog's player-facing name.
+  const factionOptions = (gameConfig?.factions ?? []).map(
+    (faction) => faction.slug,
+  );
+  const factionOptionLabel = (slug: string): string =>
+    slug === UNAFFILIATED_FACTION_SLUG
+      ? t("tasks.crossFaction")
+      : factionName(slug);
   const [tasks, setTasks] = useState<AdminTaskRow[]>([]);
   const [filter, setFilter] = useState<StatusFilter>("all");
   const [loading, setLoading] = useState(true);
@@ -80,6 +98,8 @@ export default function TasksTab() {
       description: task.description ?? "",
       point_value: String(task.point_value),
       level_required: String(task.level_required),
+      primary_faction_slug:
+        task.primary_faction_slug ?? UNAFFILIATED_FACTION_SLUG,
     });
   };
 
@@ -104,6 +124,7 @@ export default function TasksTab() {
           editState.level_required !== ""
             ? Number(editState.level_required)
             : undefined,
+        primary_faction_slug: editState.primary_faction_slug || undefined,
       });
       setEditingId(null);
       setEditState(null);
@@ -214,6 +235,30 @@ export default function TasksTab() {
                         }
                       />
                     </label>
+                    {/* Options come from the era config the app already loads
+                        — no admin-only endpoint for the list. Hidden while it
+                        is in flight rather than shown empty. */}
+                    {factionOptions.length > 0 && (
+                      <label className="font-body text-xs text-muted flex items-center gap-1">
+                        {t("tasks.factionLabel")}
+                        <select
+                          className="font-body content-text border border-border bg-surface px-2 py-1"
+                          value={editState.primary_faction_slug}
+                          onChange={(e) =>
+                            setEditState({
+                              ...editState,
+                              primary_faction_slug: e.target.value,
+                            })
+                          }
+                        >
+                          {factionOptions.map((slug) => (
+                            <option key={slug} value={slug}>
+                              {factionOptionLabel(slug)}
+                            </option>
+                          ))}
+                        </select>
+                      </label>
+                    )}
                   </div>
                   <div className="flex gap-2">
                     <button


### PR DESCRIPTION
Closes #1714

An admin could fix a task's title, description, points and level, but not the one field that decides which kit renders it and who earns the own-faction modifier. Now they can.

## The field is `primary_faction_slug`, not `faction_slug`

The issue proposed `faction_slug: str | None`. **There is no `faction_slug` on a Task.** `backend/models/task.py` carries two separate columns, and I confirmed both by reading the model and every writer:

- `primary_faction_slug` — NOT NULL, `server_default="na"`, FK to `faction.slug`. This is the task's own faction. It is what `services/scoring.py::compute_faction_multiplier` compares against and what the kit dispatches on. **This is what the patch adds.**
- `metatask_faction_slug` — nullable, set only for metatask proposals. `services/task.py::propose_task` requires it when `task_type == metatask` and forces it to `None` otherwise.

The new field is named after the model.

## Ruling on `metatask_faction_slug`: not in this patch

Only `primary_faction_slug` is editable. `metatask_faction_slug` answers a different question — not "whose task is this" but "which faction's members may *apply* this metatask to their praxes" — and on create it is bound to `task_type`: required for a metatask, forced null for a standard task. An admin patch of it would need its own task_type-dependent rule (refuse on a standard task; refuse nulling it on a metatask), and nothing in the issue asks for it. Narrow thing done; noted here rather than silently.

## Seam I tested at

`PATCH /admin/tasks/{task_id}` — the HTTP route, in `backend/tests/integration/test_admin.py`, alongside the existing `test_admin_edit_pending_task`. That covers the schema, the service and the route in one, which matters here because the pre-fix defect was **silent**: the extra field was dropped by Pydantic and the endpoint answered `200` with nothing changed. Both new tests went red on the real behaviour first (`assert 200 == 422`, and the faction unchanged) before the implementation.

- `test_admin_edit_task_faction` — cross-faction → `ua` → back, asserting the response body *and* the DB row.
- `test_admin_edit_task_unknown_faction_rejected` — `422` with `detail.code == TASK_FACTION_UNKNOWN`, and the row untouched.

## Validation is against the era, not a list

`admin_edit_task` now takes `era: EraConfig = CURRENT_ERA` as a parameter and checks membership of `era.factions`. Config owns which factions exist (ADR-0042); `na` is one of its keys, so the cross-faction sentinel is accepted with no special case. Without the check an unknown slug reaches the FK and surfaces as a 500.

New `ErrorCode.task_faction_unknown` = `TASK_FACTION_UNKNOWN`, with its `frontend/src/locales/en/errors.json` key. It is deliberately not `FACTION_NOT_FOUND`: that one reports a missing `Faction` **row** to a player joining one; this is a config-membership answer. `context` is not used, so the catalog guard's AST scan has nothing extra to read.

## Frontend

- `TasksTab.tsx` — a faction `<select>` on the existing inline edit form, options from `useGameConfig()` (already loaded, session-cached, no new endpoint). Hidden while the config is in flight rather than rendered empty.
- `na` is offered under the tab's existing `tasks.crossFaction` wording rather than the faction catalog's "Unaffiliated": for a **task** the slug means open-to-all, which is exactly the distinction `backend/faction_slugs.py` documents between `CROSS_FACTION_SLUG` and `UNAFFILIATED_FACTION_SLUG`.
- `api/admin.ts` — its hand-written `AdminTaskPatch` interface is now an alias of `components['schemas']['AdminTaskPatch']`. It had already drifted: it was a private restatement of the wire, and `tsc` rejected the new field until it was aliased. That is the drift the alias prevents recurring.

## Not done, deliberately

- **The `text-xs` labels.** The issue offered this as a while-you-are-here. `TasksTab.tsx` has 14 `text-xs` sites spanning labels, buttons and read-view meta — that is a sweep, not a small change, and re-tiering buttons is a visual change I cannot QA here. Skipped per the issue's own "skip it if it turns into a sweep". The new label matches its two siblings.
- **No praxis backfill or re-scoring.** Praxis already filed against the task keeps whatever multiplier it earned under the old faction. The issue calls this a separate decision; flagging it, not doing it.
- No new frontend test: the select is state plumbing, and the harness has no DOM (effects never run), so a mounted `TasksTab` renders only its loading branch. The runnable check for the real logic is the pair of backend integration tests.

## Verification

Every step in `.github/workflows/test.yml`, run locally:

- `pytest --cov=. --cov-report=term-missing --cov-fail-under=80` (test DB `wz1714_test`) — **1208 passed**, coverage 93.24%.
- `python scripts/regen_api_client.py` — `backend/openapi.json` + `frontend/src/api/generated/schema.d.ts` committed as produced by the script. Re-run after rebasing onto `395e3046`: no drift.
- `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (**235 files, 4244 tests passed**), `npm run build`, `npm run budget` (within budget; no initial-load change).

**Visual QA is outstanding** — I have no browser and no dev stack. Nothing below has been seen rendered.

## What to eyeball

1. Admin → Tasks tab → **edit** on a pending or retired task. A **Faction** select appears next to Points and Level req., preselected to the task's current faction.
2. The option list is the era's nine factions, with `na` reading **"cross-faction"** — not "Unaffiliated".
3. Change it, **save**. The row's meta line (`… pts · lvl … · <faction>`) shows the new slug, and it survives a reload.
4. Open that task on the public task list / task detail — it should now render in the **new faction's kit**, which is the whole point of the fix.
5. The other four fields still save, alone and together with the faction.
6. Active tasks still show no edit button (unchanged: active tasks are locked, retire first).
7. The failure path has no UI trigger — the select cannot emit a bad slug — so the coded 422 is exercised by test, not by eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
