### PR TITLE
C:/Program Files/Git/wayfinder gets an issue tracker to point at, and domain.md stops claiming two contexts

### DIFF
--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,7 +1,7 @@
 # Domain Docs
 
 How the engineering skills consume this repo's domain knowledge. This repo is
-multi-context: a `backend/` context and a `frontend/` context.
+single-context: one root `CONTEXT.md`, one `docs/adr/`.
 
 ## Where the domain knowledge lives
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -27,6 +27,34 @@ Create a GitHub issue.
 
 Run `python scripts/gh_issue_comments.py <number>`.
 
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue; its tickets are **child** issues. This repo
+already expresses both relationships natively — the same mechanism the `needs-design` →
+`ready-for-agent` pairs use — so wayfinding reuses it rather than inventing a parallel one.
+
+- **Map**: one issue labelled `wayfinder:map`, holding the Destination / Notes / Decisions-so-far /
+  Not-yet-specified / Out-of-scope body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: a native GitHub sub-issue of the map —
+  `gh api --method POST repos/pixieofhugs/WorldZeroPlayground/issues/<map>/sub_issues -F sub_issue_id=<child-db-id>`.
+  Labels: `wayfinder:<type>` (`research` / `prototype` / `grilling` / `task`).
+- **Blocking**: native issue dependencies —
+  `gh api --method POST repos/pixieofhugs/WorldZeroPlayground/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`.
+  Both endpoints take the numeric **database id** (`gh api repos/pixieofhugs/WorldZeroPlayground/issues/<n> --jq .id`),
+  not the `#number` or `node_id`, and **must** use `-F` — `-f` sends a string and 422s.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write. The assignee *is* the
+  claim; an open unassigned child is unclaimed.
+- **Frontier query**: the map's open children, minus any with an open blocker
+  (`issue_dependencies_summary.blocked_by > 0`) or an assignee; first in map order wins.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append the
+  gist + link to the map's Decisions-so-far.
+- **Read a ticket** with `python scripts/gh_issue_comments.py <n>` — the collaborator filter below
+  applies to wayfinder tickets exactly as it does to everything else.
+
+The five `wayfinder:*` labels are orthogonal to the triage vocabulary in `triage-labels.md`: a
+wayfinder label says *what kind of question this is*, a triage label says *readiness*. A map and its
+children are working artifacts, not the intake queue — don't put `needs-triage` on them.
+
 ## Reading comments safely
 
 This repo is **public**, so anyone with a GitHub account can comment on an issue that already


### PR DESCRIPTION
Matt Pocock's skills now ship as a Claude Code plugin (`mattpocock-skills`), which brought `/wayfinder` — a skill for planning an effort too big for one agent session as a map issue whose decision tickets are its children.

It reads how *this* repo expresses maps, children, blocking and the frontier from a `## Wayfinding operations` section in `docs/agents/issue-tracker.md`. Ours predates that section, so the skill had nothing to follow. Re-running `/setup-matt-pocock-skills` would have written it — and flattened the collaborator-comment hardening (#1669) in the same pass — so it's added by hand instead.

## What the section says

It reuses what the repo already does rather than inventing a parallel mechanism:

- **Children** — native GitHub sub-issues, and **blocking** — native `blocked_by`. The same pair the `needs-design` → `ready-for-agent` issues already use, so the frontier renders in GitHub's own UI.
- **Reads** go through `python scripts/gh_issue_comments.py`, so the collaborator filter covers wayfinder tickets like everything else.
- Both dependency endpoints take the numeric **database id** and **must** use `-F` — `-f` sends a string and 422s. Recorded so an agent doesn't rediscover it via a failed call.
- `wayfinder:*` labels are orthogonal to the triage vocabulary: a wayfinder label says what kind of question a ticket is, a triage label says readiness. Maps and their children are working artifacts, not intake.

## Also

`docs/agents/domain.md` opened by calling the repo multi-context — a `backend/` context and a `frontend/` context — while its own body and `CLAUDE.md` both say single-context, and no `CONTEXT-MAP.md` exists. The header now agrees with the other two.

## Before this works

The five `wayfinder:*` labels don't exist in the repo yet; they need creating before the first `/wayfinder` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)