### PR TITLE
The frontier query reads the endpoint, not a field this repo's issues don't carry

### DIFF
--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -44,8 +44,14 @@ already expresses both relationships natively — the same mechanism the `needs-
   not the `#number` or `node_id`, and **must** use `-F` — `-f` sends a string and 422s.
 - **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write. The assignee *is* the
   claim; an open unassigned child is unclaimed.
-- **Frontier query**: the map's open children, minus any with an open blocker
-  (`issue_dependencies_summary.blocked_by > 0`) or an assignee; first in map order wins.
+- **Frontier query**: the map's open children, minus any with an open blocker or an assignee; first
+  in map order wins. Read both relationships back with the **GET** side of the same two endpoints —
+  `gh api repos/pixieofhugs/WorldZeroPlayground/issues/<map>/sub_issues` returns the children as
+  full issue objects (`state`, `assignee`), and `.../issues/<n>/dependencies/blocked_by` returns the
+  blockers, so "open blocker" is a `state` check on that list. Do **not** reach for the
+  `issue_dependencies_summary` / `sub_issues_summary` fields some GitHub docs describe: this repo's
+  issue payload does not carry them, so `.issue_dependencies_summary.blocked_by > 0` reads as `null`
+  on every ticket and quietly reports a blocked frontier as takeable.
 - **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append the
   gist + link to the map's Decisions-so-far.
 - **Read a ticket** with `python scripts/gh_issue_comments.py <n>` — the collaborator filter below


### PR DESCRIPTION
`/wayfinder` decides what work is takeable by asking which of a map's child tickets
still have an open blocker. The Wayfinding-operations section added in #1728 told it
to read `issue_dependencies_summary.blocked_by` -- a field that is simply absent from
this repo's issue payload. The predicate reads `null` on every ticket, so a blocked
frontier reports as entirely takeable: silent, and wrong in the one direction that
matters, since a session then picks up a decision whose input has not been made yet.

The GET side of the two endpoints the section already POSTs to does carry it.
`/sub_issues` returns the children as full issue objects (`state`, `assignee`) and
`/dependencies/blocked_by` returns the blockers, and both answer 200 on this repo
today -- so "open blocker" becomes a state check on a list rather than a field lookup
that fails open.

Verified against the live API before and after: the issue payload's key list contains
neither `issue_dependencies_summary` nor `sub_issues_summary`, while both GET
endpoints return `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
