### PR TITLE
Dark is the default theme; the OS scheme no longer decides

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -10,20 +10,22 @@
       // Applies the persisted [data-theme] before first paint so a mobile
       // refresh (MobileLayout never mounts useTheme) doesn't revert to light,
       // and desktop doesn't flash light before React hydrates. Keep this in
-      // sync with THEME_STORAGE_KEY ('wz-theme') in src/hooks/useTheme.ts.
+      // sync with THEME_STORAGE_KEY ('wz-theme') and DEFAULT_THEME in
+      // src/hooks/useTheme.tsx — a disagreement is a visible flip on hydration.
+      // Dark is the default and light is opt-in via the toggle (#1698), so the
+      // OS scheme is deliberately not consulted. The attribute must be written
+      // even when storage throws: the CSS default is light, so leaving it unset
+      // would hand a private-mode visitor the theme this bootstrap exists to
+      // prevent.
       (function () {
+        var theme = 'dark'
         try {
           var stored = localStorage.getItem('wz-theme')
-          var theme =
-            stored === 'light' || stored === 'dark'
-              ? stored
-              : window.matchMedia('(prefers-color-scheme: dark)').matches
-                ? 'dark'
-                : 'light'
-          document.documentElement.setAttribute('data-theme', theme)
+          if (stored === 'light' || stored === 'dark') theme = stored
         } catch (error) {
-          /* localStorage/matchMedia can throw; fall back to CSS default. */
+          /* localStorage can throw (private mode, blocked storage) — keep the default. */
         }
+        document.documentElement.setAttribute('data-theme', theme)
       })()
     </script>
     <!-- The API is a separate origin in production, so the first data request

--- a/frontend/src/hooks/__tests__/useTheme.test.tsx
+++ b/frontend/src/hooks/__tests__/useTheme.test.tsx
@@ -8,9 +8,23 @@
  * propagates to every consumer by construction, so asserting it would be
  * testing React, not this codebase.
  */
+import { existsSync, readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect } from 'vitest'
-import { resolveInitialTheme, nextTheme, ThemeProvider, useTheme } from '../useTheme'
+import {
+  resolveInitialTheme,
+  nextTheme,
+  ThemeProvider,
+  useTheme,
+  THEME_STORAGE_KEY,
+} from '../useTheme'
+
+const INDEX_HTML = readFileSync(
+  fileURLToPath(new URL('../../../index.html', import.meta.url)),
+  'utf8',
+)
 
 describe('nextTheme — the toggle flip', () => {
   it('returns the opposite theme', () => {
@@ -19,19 +33,54 @@ describe('nextTheme — the toggle flip', () => {
   })
 })
 
-describe('resolveInitialTheme — unchanged resolution order', () => {
-  it('honours a stored choice over the system preference', () => {
-    expect(resolveInitialTheme('light', true)).toBe('light')
-    expect(resolveInitialTheme('dark', false)).toBe('dark')
+/**
+ * #1698 — dark is the default, light is opt-in. The OS preference is no longer
+ * an input at all, which is why these cases take one argument: "no stored value
+ * + a light-mode OS" is expressible only as "no stored value", because there is
+ * nowhere left for the OS to enter. The other half of that claim — that the
+ * pre-paint bootstrap doesn't read the OS either — is the mirror suite below.
+ */
+describe('resolveInitialTheme — dark unless the visitor chose light', () => {
+  it('honours a stored choice', () => {
+    expect(resolveInitialTheme('light')).toBe('light')
+    expect(resolveInitialTheme('dark')).toBe('dark')
   })
 
-  it('falls back to the system preference when nothing is stored', () => {
-    expect(resolveInitialTheme(null, true)).toBe('dark')
-    expect(resolveInitialTheme(null, false)).toBe('light')
+  it('defaults to dark when nothing is stored, whatever the OS prefers', () => {
+    expect(resolveInitialTheme(null)).toBe('dark')
   })
 
-  it('ignores a junk stored value and asks the system', () => {
-    expect(resolveInitialTheme('chartreuse', true)).toBe('dark')
+  it('ignores a junk stored value and defaults to dark', () => {
+    expect(resolveInitialTheme('chartreuse')).toBe('dark')
+  })
+})
+
+/**
+ * The inline bootstrap in `index.html` runs before React exists, so nothing in
+ * the bundle can observe it — but it decides the same question this module
+ * does, and a disagreement is a visible theme flip on hydration. It is a string
+ * to us, so a string is what we assert on.
+ */
+describe('index.html pre-paint bootstrap — mirrors this module', () => {
+  it('reads the same storage key', () => {
+    expect(INDEX_HTML).toContain(`'${THEME_STORAGE_KEY}'`)
+  })
+
+  it('does not consult the OS colour scheme', () => {
+    expect(INDEX_HTML).not.toContain('prefers-color-scheme')
+  })
+
+  it('defaults to dark', () => {
+    expect(INDEX_HTML).toMatch(/theme\s*=\s*'dark'/)
+    expect(INDEX_HTML, 'no light fallback left in the bootstrap').not.toMatch(
+      /theme\s*=\s*'light'/,
+    )
+  })
+
+  it('names the sibling it mirrors by a filename that exists', () => {
+    const named = /src\/hooks\/useTheme\.tsx?/.exec(INDEX_HTML)?.[0]
+    expect(named, 'bootstrap points at its sibling').toBeTruthy()
+    expect(existsSync(new URL(`../../../${named}`, import.meta.url))).toBe(true)
   })
 })
 

--- a/frontend/src/hooks/useTheme.tsx
+++ b/frontend/src/hooks/useTheme.tsx
@@ -23,28 +23,31 @@ export function applyTheme(theme: Theme): void {
   document.documentElement.setAttribute('data-theme', theme)
 }
 
+/** What a visitor who has never touched the toggle gets (#1698). */
+export const DEFAULT_THEME: Theme = 'dark'
+
 /**
  * Theme resolution, extracted pure so it is testable in the repo's DOM-less node
- * env: a stored choice wins, otherwise fall back to the system preference.
- * Unchanged semantics — only the browser reads moved out to `getInitialTheme`.
+ * env: a stored choice wins, otherwise dark.
+ *
+ * The OS `prefers-color-scheme` used to decide the unstored case; #1698 removed
+ * it, so light is reachable only through the toggle. That is why there is no
+ * system-preference argument to pass — a light-mode OS is not an input.
  */
-export function resolveInitialTheme(stored: string | null, prefersDark: boolean): Theme {
+export function resolveInitialTheme(stored: string | null): Theme {
   if (stored === 'light' || stored === 'dark') return stored
-  return prefersDark ? 'dark' : 'light'
+  return DEFAULT_THEME
 }
 
-/** Read the browser's answer for the initial theme (localStorage → system pref). */
+/** Read the browser's answer for the initial theme (localStorage → default). */
 export function getInitialTheme(): Theme {
   // Defensive so the provider can also be mounted in a DOM-less render (SSR,
-  // node tests). In a browser both reads always succeed, so behaviour is
+  // node tests). In a browser the read always succeeds, so behaviour is
   // identical to the pre-provider hook.
   try {
-    return resolveInitialTheme(
-      localStorage.getItem(THEME_STORAGE_KEY),
-      window.matchMedia('(prefers-color-scheme: dark)').matches,
-    )
+    return resolveInitialTheme(localStorage.getItem(THEME_STORAGE_KEY))
   } catch {
-    return 'light'
+    return DEFAULT_THEME
   }
 }
 


### PR DESCRIPTION
Closes #1698

A visitor with no stored `wz-theme` now gets dark regardless of the OS. Light is opt-in through the toggle, which still persists exactly as before.

## What moved

Both halves that answer "which theme?" mirror each other, so both change here:

- `frontend/index.html` — the pre-paint bootstrap drops the `matchMedia('(prefers-color-scheme: dark)')` branch and starts from `'dark'`.
- `frontend/src/hooks/useTheme.tsx` — `resolveInitialTheme` loses its `prefersDark` parameter entirely and falls back to a new `DEFAULT_THEME = 'dark'`; `getInitialTheme` no longer reads `matchMedia`.

Two things worth calling out beyond the literal swap:

1. **The bootstrap's `catch` used to bail without setting the attribute**, on the reasoning "fall back to the CSS default". The CSS default (`:root`) is light. Under the old rule that was harmless-ish; under the new one it would hand a private-mode / blocked-storage visitor precisely the theme this issue removes. So the attribute is now written unconditionally and only the `localStorage` read sits inside the `try`. `getInitialTheme`'s `catch` returns `DEFAULT_THEME` for the same reason (it returned `'light'`).
2. Dropping the parameter rather than passing a dead `false` is deliberate — it makes "the OS is not an input" a type-level fact instead of a convention.

The comment naming the sibling file is corrected to `src/hooks/useTheme.tsx` (it said `.ts`), and now also names `DEFAULT_THEME` as a second thing to keep in sync.

`Leaderboard.tsx` is untouched — the theme-bound Players visualisation is #1700's.

## Seam and test

The seam is **`resolveInitialTheme(stored)`** in `frontend/src/hooks/useTheme.tsx` — already exported and pure precisely so it is assertable in this repo's DOM-less harness (`renderToStaticMarkup`, no jsdom, effects never run). `frontend/src/hooks/__tests__/useTheme.test.tsx` covers stored `light` → `light`, stored `dark` → `dark`, `null` → `dark`, junk → `dark`.

Note the shape of "no stored value + light OS → dark": after this change there is nowhere for the OS to enter the function, so that case *is* `resolveInitialTheme(null)`. Asserting on a light-OS input would mean re-adding the input.

That leaves the bootstrap, which runs before React exists and is unreachable from the bundle. Rather than invent a DOM harness for it, the test reads `index.html` as a string (same posture as `faviconSpectrum.test.ts` reading `favicon.svg`) and asserts the mirror holds: same storage key, no `prefers-color-scheme` anywhere, defaults to `'dark'` with no `'light'` fallback left, and the sibling filename it names actually exists on disk. That last one is the check that would have caught the stale `.ts` in the first place.

The loop went red first: 5 of 10 failing on the real defect, then green.

## Verification

Frontend CI job run locally, every step in `.github/workflows/test.yml`:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — 236 files, 4254 tests, all passing
- `npm run build` — clean
- `npm run budget` — within budget (JS 129.0 KB, CSS 21.5 KB)

No backend change, so no `api-schema` regeneration.

## What to eyeball

I have no browser here, so visual QA is outstanding on all of this:

- **Theme flash between the pre-paint bootstrap and React hydration.** This is the one I cannot verify at all. Hard-refresh with `wz-theme` cleared and watch for a light frame before the app mounts, then again with `wz-theme=light` stored and watch for a dark frame. Both halves are supposed to agree now; a flicker means they don't.
- A first visit on a **light-mode OS** with no `wz-theme` in localStorage lands on dark.
- The toggle still switches to light, and light survives a refresh (including a mobile refresh, where `MobileLayout` never mounts `useTheme` and the bootstrap is the only thing running).
- A private / storage-blocked window renders dark rather than light.
- The Players page under the new default — expected to be the dark visualisation; the light-mode Meadow becoming near-unreachable is the accepted knock-on that #1700 handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
