### PR TITLE
The mode picker asks the task, and shows nothing until it answers

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -443,7 +443,6 @@ export default function CovenEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 
-  const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
   const modeOptions: Array<{ key: PraxisType; label: string }> = [
     { key: "solo", label: t("editPraxis.composer.modeSolo") },
     { key: "collab", label: t("editPraxis.composer.modeCollab") },
@@ -712,7 +711,6 @@ export default function CovenEditPraxis({ state }: Props) {
                   flexWrap: "wrap",
                 },
                 options: modeOptions,
-                allowedModes,
                 renderOption: (option, { active, disabled, onSelect }) => (
                   <button
                     key={option.key}

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -230,7 +230,6 @@ export default function DefaultEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 
-  const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
   const modeOptions: Array<{ key: PraxisType; label: string }> = [
     { key: "solo", label: t("editPraxis.composer.modeSolo") },
     { key: "collab", label: t("editPraxis.composer.modeCollab") },
@@ -350,7 +349,6 @@ export default function DefaultEditPraxis({ state }: Props) {
                   flexWrap: "wrap",
                 },
                 options: modeOptions,
-                allowedModes,
                 renderOption: (option, { active, disabled, onSelect }) => (
                   <button
                     key={option.key}

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -307,7 +307,6 @@ export default function EphemeristsEditPraxis({ state }: Props) {
   const task = state.task;
   const factor = sizes.isMobile ? "mobile" : "desktop";
 
-  const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
   const modeOptions: Array<{ key: PraxisType; label: string }> = [
     { key: "solo", label: t("editPraxis.composer.modeSolo") },
     { key: "collab", label: t("editPraxis.composer.modeCollab") },
@@ -553,7 +552,6 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                   flexWrap: "wrap",
                 },
                 options: modeOptions,
-                allowedModes,
                 renderOption: (option, { active, disabled, onSelect }) => (
                   <button
                     key={option.key}

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -247,7 +247,6 @@ export default function EverymenEditPraxis({ state }: Props) {
   const task = state.task;
   const slug = task?.primary_faction_slug ?? praxis.task_faction_slug;
 
-  const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
   const modeOptions: Array<{ key: PraxisType; label: string }> = [
     { key: "solo", label: t("editPraxis.composer.modeSolo") },
     { key: "collab", label: t("editPraxis.composer.modeCollab") },
@@ -533,7 +532,6 @@ export default function EverymenEditPraxis({ state }: Props) {
                   flexWrap: "wrap",
                 },
                 options: modeOptions,
-                allowedModes,
                 renderOption: (option, { active, disabled, onSelect }) => (
                   <button
                     key={option.key}

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -206,7 +206,6 @@ export default function SingularityEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 
-  const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
   const modeOptions: Array<{ key: PraxisType; label: string }> = [
     { key: "solo", label: t("editPraxis.composer.modeSolo") },
     { key: "collab", label: t("editPraxis.composer.modeCollab") },
@@ -516,7 +515,6 @@ export default function SingularityEditPraxis({ state }: Props) {
                   flexWrap: "wrap",
                 },
                 options: modeOptions,
-                allowedModes,
                 renderOption: (option, { active, disabled, onSelect }) => (
                   <button
                     key={option.key}

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -217,7 +217,6 @@ export default function SnideEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 
-  const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
   const modeOptions: Array<{ key: PraxisType; label: string }> = [
     { key: "solo", label: t("editPraxis.composer.modeSolo") },
     { key: "collab", label: t("editPraxis.composer.modeCollab") },
@@ -497,7 +496,6 @@ export default function SnideEditPraxis({ state }: Props) {
                   flexWrap: "wrap",
                 },
                 options: modeOptions,
-                allowedModes,
                 renderOption: (option, { active, disabled, onSelect }) => (
                   <button
                     key={option.key}

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -166,7 +166,6 @@ export default function UaEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 
-  const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
   const modeOptions: Array<{ key: PraxisType; label: string }> = [
     { key: "solo", label: t("editPraxis.composer.modeSolo") },
     { key: "collab", label: t("editPraxis.composer.modeCollab") },
@@ -375,7 +374,6 @@ export default function UaEditPraxis({ state }: Props) {
                   flexWrap: "wrap",
                 },
                 options: modeOptions,
-                allowedModes,
                 renderOption: (option, { active, disabled, onSelect }) => (
                   <button
                     key={option.key}

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -235,7 +235,6 @@ export default function WowEditPraxis({ state }: Props) {
   const praxis = state.praxis!;
   const task = state.task;
 
-  const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
   const modeOptions: Array<{ key: PraxisType; label: string }> = [
     { key: "solo", label: t("editPraxis.composer.modeSolo") },
     { key: "collab", label: t("editPraxis.composer.modeCollab") },
@@ -446,7 +445,6 @@ export default function WowEditPraxis({ state }: Props) {
                   flexWrap: "wrap",
                 },
                 options: modeOptions,
-                allowedModes,
                 renderOption: (option, { active, disabled, onSelect }) => (
                   <button
                     key={option.key}

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -367,6 +367,28 @@ describe("mode picker gates, unchanged by the collapse (#311, #877)", () => {
     expect(markup).not.toContain(DUEL);
   });
 
+  /**
+   * #1709 — the composer used to fail OPEN. Every archetype derived
+   * `task?.allowed_modes ?? ["solo", "collab", "duel"]`, so while the task was
+   * still loading (or its fetch had failed) the picker offered Collab to a
+   * viewer the backend gates out of it by level. The list is now derived once,
+   * inside ModePicker, from the state the picker already holds — and an unknown
+   * task yields no modes at all.
+   */
+  it.each(WIDTHS)("offers no modes on %s while the task is unknown", (width) => {
+    const markup = render(width, baseState({ task: null }));
+    expect(segmentCount(markup)).toBe(0);
+    expect(markup).not.toContain(SOLO);
+    expect(markup).not.toContain(COLLAB);
+  });
+
+  it.each(WIDTHS)("offers exactly the task's modes on %s once it arrives", (width) => {
+    const markup = render(width, baseState({ task: task(["solo"]) }));
+    expect(segmentCount(markup)).toBe(1);
+    expect(markup).toContain(SOLO);
+    expect(markup).not.toContain(COLLAB);
+  });
+
   it.each(WIDTHS)("collapses to the single active option on %s once locked", (width) => {
     const markup = render(
       width,

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -969,9 +969,6 @@ export interface ModeOptionRenderArgs {
 export interface ModePickerSkin<O extends { key: PraxisType }> {
   containerStyle?: CSSProperties;
   options: O[];
-  /** The task's allowed modes. Typed as `string[]` to match TaskOut.allowed_modes;
-   * each option whose `key` is present is rendered. */
-  allowedModes: readonly string[];
   renderOption: (option: O, args: ModeOptionRenderArgs) => ReactNode;
 }
 
@@ -983,6 +980,14 @@ export function ModePicker<O extends { key: PraxisType }>({
   skin: ModePickerSkin<O>;
 }) {
   const praxis = state.praxis!;
+  // The allowed modes are the TASK's, computed server-side against the viewer's
+  // level (`allowed_praxis_modes`). An unknown task means unknown permission, so
+  // this FAILS CLOSED (#1709): no options until the task lands. Each of the
+  // eight archetypes used to derive this line for itself and fall back to all
+  // three modes, which handed a level-0 viewer the Collab the API would refuse.
+  // Derived here, from the state the picker already holds, so there is one
+  // statement of the rule and nothing left to drift.
+  const allowedModes = state.task?.allowed_modes ?? [];
   return (
     <div style={skin.containerStyle}>
       {skin.options
@@ -991,7 +996,7 @@ export function ModePicker<O extends { key: PraxisType }>({
           // it's gated on the viewer's level instead (#311). Hide, don't disable.
           option.key === "duel"
             ? state.duelChipVisible
-            : skin.allowedModes.includes(option.key),
+            : allowedModes.includes(option.key),
         )
         .map((option, index) => {
           // A duel side stays type='solo' + duel_id, so the duel chip's active


### PR DESCRIPTION
Closes #1709

The issue's original body asked for an `EraConfig` field, a service check and a mirrored duel gate. **None of that is built here** — it all ships already under the full-word name `collaboration_level_required`, as the issue's own third comment records. This PR builds only what that correction describes, and touches no backend file.

## The defect

All eight edit-praxis archetypes derived the same line:

```ts
const allowedModes = task?.allowed_modes ?? ["solo", "collab", "duel"];
```

`ModePicker` is strict — it filters on `allowedModes.includes(option.key)` with no fallback of its own — but the archetypes handed it a permissive list. So whenever `task` was null, the picker offered Collab to everyone regardless of level. Null is not a rare state: `useEditPraxis` fires `getTask` *after* the praxis resolves and `.catch(() => {/* non-fatal */})`s a failure, while `loading` is already false. A slow task fetch, or a failed one, and the composer draws every mode.

## The fix

Fail closed, and hoist. `ModePicker` already receives `state`, already owns the picker's other hide guards ("filters to allowed modes, hides every non-active option once the mode is locked" — its own header comment), and derives the list itself now:

```ts
const allowedModes = state.task?.allowed_modes ?? [];
```

I took the hoist rather than eight `?? []` edits, because eight `?? []`s leave eight places for the next hand to write something else. Hoisting deletes the drift surface instead of documenting it: `allowedModes` comes off `ModePickerSkin`, and each archetype loses its `const` and its skin key — 16 lines deleted, one added. After this the archetypes cannot re-derive the list even by accident; the prop is not there to pass.

## Seam under test

`archetypes/__tests__/composerDispatch.test.tsx` → the existing "mode picker gates" block, which renders through `<EditPraxis />` so the dispatcher and a real archetype are in the path. The observable claim:

- `task: null` → the picker renders **no** mode segments (`aria-pressed` count 0, no Solo, no Collab).
- `task` arrives with `allowed_modes: ["solo"]` → exactly one segment, Solo, no Collab.

The first case was red on `cea934e4` at `expected 2 to be +0` — solo and collab, offered against an unknown task. That is the defect, not a proxy for it. This repo's frontend harness is `renderToStaticMarkup` (no DOM, effects never run), so the assertion is on markup, which is where this gate is observable anyway.

## The other-fallbacks sweep

Asked for in the issue: grep `pages/editPraxis/` for other permissive `?? [...]` of the same shape. There are none. Every other `??` in that tree is a display default, not a permission:

- `useEditPraxis.ts:256` — `loaded.applied_metatasks ?? []` (already empty, already closed)
- `task?.point_value ?? 0` in each archetype's points mark
- `PraxisWaitingSurface.tsx:351` — `dress.quietStyle ?? { color: … }`, a style default

No `?? true`, no `|| true`, no other permission-shaped fallback in the composer family.

## Verification

`tsc --noEmit` clean · `typecheck:design-sync` clean (no preview constructs `ModePickerSkin`) · `eslint` clean · full vitest **4254 passed / 236 files** · `npm run build` clean · byte budget ok (JS 129.0 KB, CSS 21.5 KB, both under warn). No route, `response_model` or Pydantic schema touched, so `api-schema` has nothing to regenerate. **Visual QA is outstanding** — I have no browser or dev stack here.

## What to eyeball

1. **The picker populates.** Open a composer on a slow connection: the mode row should start empty and fill in when the task lands, not stay empty. (Only the picker is affected — title, body, proof and Submit are unchanged.)
2. **The flash.** The task fetch is a second round trip after the praxis, so on desktop there may now be a brief moment with no mode row where all three used to sit. Confirm it reads as loading, not as a missing control.
3. **A task that genuinely 404s.** `getTask` failure is swallowed as non-fatal, so the composer still draws — now with no mode row at all. Confirm that reads as an error state rather than a broken composer. If it wants explicit copy, that is a design call and a separate issue, not this fix.
4. **Level 0, task loaded.** Collab should be absent — that is the backend's `allowed_modes` doing its job, and this PR should not have changed it.
5. **The duel chip is untouched.** It hides on `state.duelChipVisible` (ADR-0011, #311), never on `allowed_modes`, so it should behave exactly as before at every level — including with an unknown task.
6. **All eight skins.** Coven, Ephemerists, Everymen, Singularity, Snide, UA, WOW and the default kit each lost two lines; the mode row's faction arrangement should be pixel-identical once the task has loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
