### PR TITLE
The in-progress stat names people, not a state

### DIFF
--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -51,7 +51,7 @@
     "author": "author · lvl {{level}}",
     "stats": {
       "level": "Level",
-      "inProgress": "In progress"
+      "inProgress": "people working on this"
     },
     "points": {
       "base": "base",

--- a/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/albescentDetail.test.tsx
@@ -123,7 +123,7 @@ describe("Albescent task detail — Default plus the light", () => {
       "Discussion",
       "Sign up",
       "Level",
-      "In progress",
+      "people working on this",
       "base",
     ]) {
       expect(text, `inherited slot: ${shared}`).toContain(shared);
@@ -190,7 +190,7 @@ describe("Albescent task detail — Default plus the light", () => {
 
   it("renders the in-progress population as a header count", () => {
     const { text } = render(<AlbescentTaskDetail state={baseState()} />);
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
     expect(text).toContain("6");
   });
 });

--- a/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
@@ -163,7 +163,7 @@ describe("Coven task detail — the copy", () => {
     expect(text).toContain("author · lvl 4");
     expect(html).toContain('href="/characters/31"');
     expect(text).toContain("Level");
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
   });
 
   it("draws the brief in full — no clamp, no truncation", () => {
@@ -192,7 +192,7 @@ describe("Coven task detail — the contract", () => {
 
   it("renders the in-progress population as a header count", () => {
     const { text } = render(<CovenTaskDetail state={baseState()} />);
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
     expect(text).toContain("9");
   });
 

--- a/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
@@ -207,7 +207,7 @@ describe("na / Default task detail — the reference anatomy", () => {
 
   it("renders the in-progress population as a header count", () => {
     const { text } = render(<DefaultTaskDetail state={baseState()} />);
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
     expect(text).toContain("6");
   });
 

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -157,7 +157,7 @@ describe("Ephemerists task detail — the Valley plate", () => {
 
   it("renders the in-progress population as a header count", () => {
     const { text } = render(<EphemeristsTaskDetail state={baseState()} />);
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
     expect(text).toContain("9");
   });
 

--- a/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/everymenDetail.test.tsx
@@ -156,7 +156,7 @@ describe("Everymen task detail — the broadsheet", () => {
   it("renders the in-progress population as a header count", () => {
     const { text } = render(<EverymenTaskDetail state={baseState()} />);
     expect(text).not.toContain("on the job");
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
     expect(text).toContain("23");
   });
 

--- a/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/singularityDetail.test.tsx
@@ -177,7 +177,7 @@ describe("Singularity task detail — the shared anatomy", () => {
 
   it("renders the in-progress population as a header count", () => {
     const { text } = render(<SingularityTaskDetail state={baseState()} />);
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
     expect(text).toContain("17");
   });
 

--- a/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
@@ -160,7 +160,7 @@ describe("SNIDE task detail — the ransom dossier", () => {
 
   it("renders the in-progress population as a header count", () => {
     const { text } = render(<SnideTaskDetail state={baseState()} />);
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
     expect(text).toContain("9");
   });
 

--- a/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/uaTaskDetail.test.tsx
@@ -179,7 +179,7 @@ describe("UA task detail — the shared contract in UA's dress", () => {
 
   it("renders the in-progress population as a header count", () => {
     const { text } = render(<UaTaskDetail state={baseState()} />);
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
     expect(text).toContain("17");
   });
 

--- a/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/wowDetail.test.tsx
@@ -161,7 +161,7 @@ describe("wow task detail — the contract points it inherits", () => {
     // Owner ruling 2026-07-28, reversing epic #1028 decision 3. The design's own
     // header comment says the header count covers it.
     const { text } = render(<WowTaskDetail state={baseState()} />);
-    expect(text).toContain("In progress");
+    expect(text).toContain("people working on this");
     expect(text).toContain("4");
   });
 


### PR DESCRIPTION
The task-detail header's second stat is a count of characters. Its caption
said `In progress`, which names a *state* — a state the number itself is not
in. Now it names what the number counts.

Closes #1703

## The seam

The seam is **locale key -> rendered caption**, not a component. All nine
task-detail skins call `t("detail.stats.inProgress")`, so there is exactly one
place to change and nine places it shows up.

Red first: I flipped the nine existing render-level assertions in
`frontend/src/pages/taskDetail/__tests__/` to the new caption and watched
**11 tests across 9 files** fail on the real string. Then the one-key change
turned them green. No new test — a locale value does not earn one (YAGNI).

## The diff

One key in `frontend/src/locales/en/tasks.json`:

```
"detail.stats.inProgress":  "In progress"  ->  "people working on this"
```

Plus the nine assertion updates. **No `.tsx` component was touched**, and the
JSON was not reformatted — #1704 edits the adjacent `points` block and all nine
archetypes, so this PR deliberately stays off both.

## The wording is deliberate, and short

Four words, lower case, no article. The slot is the **caption of a stat block**
— a small label under a large numeral — not a sentence. The owner's original
`people are working on this task` was rejected during grilling because a
six-word sentence would have to break out of the stat block in all nine skins.
Several skins also apply their own casing (`textTransform: uppercase`), so the
string is authored in the neutral case and the skin decides.

## Layout: why the longer caption is safe

I read the caption's DOM context in every skin that renders it. All eight
archetypes (plus Albescent, which wraps Default) use the same shape: a
`flex-direction: column` stat whose label is an unconstrained `<span>`, sitting
in a `display: flex` row with `flexWrap: "wrap"`. There is **no** `nowrap`, no
`maxWidth`, no `textOverflow`, and no line clamp on any of the eight caption
spans — I grepped `nowrap|textOverflow|WebkitLineClamp` across all eight files
and every hit is elsewhere (breadcrumbs, CTAs, pills). So the caption widens its
own column, and a narrow viewport wraps the row rather than clipping the label.

Two skins are worth naming because they are the tightest:

- **S.N.I.D.E.** — `statBlock()` puts the caption at `--text-sm` (9px) with
  `letter-spacing: 0.18em` **and** `text-transform: uppercase`. This is the
  widest rendering of the string in the app: 22 uppercase characters plus
  tracking. It still sits in a wrapping flex row, so it pushes the row rather
  than overflowing it.
- **Coven** — `stat()` at `size.substatSize`, same wrapping row, divided from
  the Level stat by a 1px hairline with `alignSelf: stretch`. The hairline grows
  with the taller column, so a wrapped caption cannot desync the rule.

**Default / Albescent** is the one to look at for *tone* rather than fit: its
`.label-caption` sets `text-transform: none`, so it reads a lower-case
`people working on this` directly beneath a capitalised `Level`. That is the
skin's own casing rule and this PR does not override it.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`,
`npm test` (**236 files / 4250 tests, all passing**), `npm run build`, and
`npm run budget` (within budget) all pass locally. Backend and `api-schema` are
untouched — no Python, no route signature, no Pydantic schema.

**Visual QA is outstanding.** I have no browser and no dev stack; the layout
reasoning above is read from the source, not seen. Someone should eyeball it.

## What to eyeball

- **S.N.I.D.E. task detail** — the uppercase + 0.18em tracking rendering, at
  mobile width, is the widest the caption ever gets. Does the header stat row
  wrap cleanly, or does the Level slab and the count end up on awkward lines?
- **Coven task detail** — the hairline divider between Level and the count,
  once the right-hand column is much wider than the left.
- **Ephemerists task detail** — the caption sits *beside* an hourglass sign in
  a nested flex row; the extra width lands on that inner row first.
- **Default / Albescent** — lower-case `people working on this` under
  capitalised `Level`. Reads fine, or does it want the skin's casing changed?
  That is a style call, not a copy call.
- **Everymen** — caption is pinned to `--text-base` (10px), the smallest of the
  eight; check it is still legible at four words.
- Any skin at **mobile** form factor, where `gap` drops to `--space-lg`.
