### PR TITLE
The image editor stops forcing the photo's own shape on every crop

### DIFF
--- a/frontend/src/components/imageEdit/ImageEditModal.tsx
+++ b/frontend/src/components/imageEdit/ImageEditModal.tsx
@@ -10,8 +10,9 @@
  * reports through `onError` rather than uploading the unprocessed file behind
  * their back (#1527) — the decision table lives in `applyImageEdit`.
  *
- * One reusable component drives both call sites: praxis media (free-form frame
- * that follows the image's natural ratio) and character avatars (locked 1:1).
+ * One reusable component drives both call sites: praxis media (no locked
+ * aspect, so it gets the crop-shape picker — #1713) and character avatars
+ * (locked 1:1, no picker: every avatar frame on the site assumes square).
  *
  * Modal chrome mirrors LevelUpPopup / InvitationLetterPopup: fixed radial-dim
  * overlay, role="dialog", Escape closes, the primary action autofocuses, no
@@ -23,14 +24,17 @@ import Cropper from 'react-easy-crop'
 import type { Area, MediaSize, Point } from 'react-easy-crop'
 import { useTranslation } from 'react-i18next'
 import {
+  CROP_RATIO_CHOICES,
+  DEFAULT_CROP_RATIO,
   applyImageEdit,
   cropOutputSize,
   effectiveAspect,
   originalUpload,
   rotateSize,
+  showsRatioPicker,
   toRadians,
 } from './imageEditHelpers'
-import type { ApplyFailureReason } from './imageEditHelpers'
+import type { ApplyFailureReason, CropRatioChoice } from './imageEditHelpers'
 
 const PAPER = 'var(--color-bg-page)'
 const INK = 'var(--color-text-primary)'
@@ -44,6 +48,15 @@ const MIN_ZOOM = 1
 const MAX_ZOOM = 4
 const ZOOM_STEP = 0.01
 const ROTATE_STEP = 90
+const NO_PAN: Point = { x: 0, y: 0 }
+
+/** Ratio button copy — keys, not strings, so the catalog stays the only text (ADR-0032). */
+const RATIO_LABEL_KEY = {
+  original: 'imageEdit.ratioOriginal',
+  '1:1': 'imageEdit.ratio1x1',
+  '4:3': 'imageEdit.ratio4x3',
+  '16:9': 'imageEdit.ratio16x9',
+} as const satisfies Record<CropRatioChoice, string>
 
 export interface ImageEditModalProps {
   /** The picked source image. */
@@ -135,9 +148,10 @@ export default function ImageEditModal({
 }: ImageEditModalProps) {
   const { t } = useTranslation('common')
   const [objectUrl, setObjectUrl] = useState<string | null>(null)
-  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 })
+  const [crop, setCrop] = useState<Point>(NO_PAN)
   const [zoom, setZoom] = useState(MIN_ZOOM)
   const [rotation, setRotation] = useState(0)
+  const [ratioChoice, setRatioChoice] = useState<CropRatioChoice>(DEFAULT_CROP_RATIO)
   const [naturalAspect, setNaturalAspect] = useState<number | undefined>(undefined)
   const [applying, setApplying] = useState(false)
   const croppedAreaRef = useRef<Area | null>(null)
@@ -170,6 +184,20 @@ export default function ImageEditModal({
   const rotateBy = (delta: number) =>
     setRotation((previous) => (previous + delta + 360) % 360)
 
+  /**
+   * Picking a ratio re-locks the frame. "Original" is also the reset the owner
+   * asked for (#1713) — back to the photo's own shape, upright and unzoomed —
+   * so it clears zoom, rotation and pan even when it is already selected.
+   */
+  const pickRatio = (choice: CropRatioChoice) => {
+    setRatioChoice(choice)
+    if (choice === DEFAULT_CROP_RATIO) {
+      setZoom(MIN_ZOOM)
+      setRotation(0)
+      setCrop(NO_PAN)
+    }
+  }
+
   const failureMessage = (reason: ApplyFailureReason): string =>
     reason === 'not-ready' ? t('imageEdit.errorNotReady') : t('imageEdit.errorFailed')
 
@@ -199,7 +227,7 @@ export default function ImageEditModal({
     }
   }
 
-  const frameAspect = effectiveAspect(aspect, naturalAspect)
+  const frameAspect = effectiveAspect(aspect, naturalAspect, ratioChoice)
 
   const card = (
     <div
@@ -229,6 +257,32 @@ export default function ImageEditModal({
           />
         )}
       </div>
+
+      {/* Crop shape (#1713) — only where nothing is locked. Before this the frame
+          was the photo's own ratio and only ever that, so an iPhone's 4:3 could
+          never yield a square. Avatars lock 1:1 and show no picker: every avatar
+          frame on the site assumes square. */}
+      {showsRatioPicker(aspect) && (
+        <div style={controlRowStyle}>
+          <span style={controlLabelStyle}>{t('imageEdit.ratioLabel')}</span>
+          <div role="group" aria-label={t('imageEdit.ratioGroupAria')} style={ratioGroupStyle}>
+            {CROP_RATIO_CHOICES.map((choice) => (
+              <button
+                key={choice}
+                type="button"
+                aria-pressed={choice === ratioChoice}
+                aria-label={
+                  choice === DEFAULT_CROP_RATIO ? t('imageEdit.ratioOriginalAria') : undefined
+                }
+                onClick={() => pickRatio(choice)}
+                style={choice === ratioChoice ? selectedRatioButtonStyle : ratioButtonStyle}
+              >
+                {t(RATIO_LABEL_KEY[choice])}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Zoom */}
       <label style={controlRowStyle}>
@@ -353,6 +407,30 @@ const controlLabelStyle: CSSProperties = {
   color: FAINT,
   flex: 'none',
   width: 56,
+}
+const ratioGroupStyle: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 'var(--space-sm)',
+}
+// Same ghost button, tightened so four of them fit beside the label.
+const ratioButtonStyle: CSSProperties = {
+  fontFamily: FONT_BODY,
+  textTransform: 'uppercase',
+  letterSpacing: '0.1em',
+  fontSize: 'var(--text-base)',
+  padding: 'var(--space-xs) var(--space-md)',
+  border: `1px solid ${BORDER}`,
+  background: 'transparent',
+  color: INK,
+  cursor: 'pointer',
+}
+// Selection reads as the same ink/paper inversion the primary action uses.
+const selectedRatioButtonStyle: CSSProperties = {
+  ...ratioButtonStyle,
+  background: INK,
+  color: PAPER,
+  fontWeight: 700,
 }
 const actionRowStyle: CSSProperties = {
   display: 'flex',

--- a/frontend/src/components/imageEdit/__tests__/imageEditHelpers.test.ts
+++ b/frontend/src/components/imageEdit/__tests__/imageEditHelpers.test.ts
@@ -6,6 +6,8 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   AVATAR_ASPECT,
+  CROP_RATIO_CHOICES,
+  DEFAULT_CROP_RATIO,
   applyImageEdit,
   blobToFile,
   cropOutputSize,
@@ -15,6 +17,7 @@ import {
   originalUpload,
   partitionByEditability,
   rotateSize,
+  showsRatioPicker,
 } from '../imageEditHelpers'
 import type { Area } from 'react-easy-crop'
 
@@ -58,7 +61,7 @@ describe('cropOutputSize — final canvas rect', () => {
   })
 })
 
-describe('effectiveAspect — avatar locks 1:1, praxis is free-form', () => {
+describe('effectiveAspect — avatar locks 1:1, praxis picks its ratio', () => {
   it('locks to the avatar aspect even for a wide image', () => {
     expect(effectiveAspect(AVATAR_ASPECT, 1.78)).toBe(1)
   })
@@ -67,12 +70,50 @@ describe('effectiveAspect — avatar locks 1:1, praxis is free-form', () => {
     expect(AVATAR_ASPECT).toBe(1)
   })
 
-  it('follows the natural ratio when unlocked (free-form praxis)', () => {
+  it('follows the natural ratio on the default "original" choice', () => {
     expect(effectiveAspect(undefined, 1.5)).toBe(1.5)
+    expect(effectiveAspect(undefined, 1.5, DEFAULT_CROP_RATIO)).toBe(1.5)
   })
 
   it('falls back to square before the media reports its size', () => {
     expect(effectiveAspect(undefined, undefined)).toBe(1)
+  })
+
+  /**
+   * #1713: the crop frame used to be the photo's own shape and nothing else, so
+   * a 4:3 iPhone photo could never yield a square. A picked ratio must beat the
+   * natural one.
+   */
+  it('a picked ratio overrides the photo’s own shape (#1713)', () => {
+    const iphonePortrait = 3 / 4
+    expect(effectiveAspect(undefined, iphonePortrait, '1:1')).toBe(1)
+    expect(effectiveAspect(undefined, iphonePortrait, '4:3')).toBeCloseTo(4 / 3)
+    expect(effectiveAspect(undefined, iphonePortrait, '16:9')).toBeCloseTo(16 / 9)
+  })
+
+  it('a picked ratio still loses to a caller lock — avatars stay square', () => {
+    for (const choice of CROP_RATIO_CHOICES) {
+      expect(effectiveAspect(AVATAR_ASPECT, 1.78, choice)).toBe(1)
+    }
+  })
+
+  it('a picked ratio needs no natural aspect to be usable', () => {
+    expect(effectiveAspect(undefined, undefined, '16:9')).toBeCloseTo(16 / 9)
+  })
+
+  it('defaults to "original", so today’s behaviour is what you land on', () => {
+    expect(DEFAULT_CROP_RATIO).toBe('original')
+    expect(CROP_RATIO_CHOICES[0]).toBe('original')
+  })
+})
+
+describe('showsRatioPicker — only the unlocked (praxis) call site gets it', () => {
+  it('shows for praxis media, which supplies no aspect', () => {
+    expect(showsRatioPicker(undefined)).toBe(true)
+  })
+
+  it('hides for avatars, which lock 1:1 — every avatar frame assumes square', () => {
+    expect(showsRatioPicker(AVATAR_ASPECT)).toBe(false)
   })
 })
 

--- a/frontend/src/components/imageEdit/__tests__/ratioPicker.test.tsx
+++ b/frontend/src/components/imageEdit/__tests__/ratioPicker.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Who gets the crop-shape picker, and what it lands on (#1713).
+ *
+ * The aspect arithmetic is pinned in `imageEditHelpers.test.ts`; this file pins
+ * the two things only the mount decides — that praxis media (no `aspect`) is
+ * offered the ratios at all, and that avatars (locked 1:1) are not, because
+ * every avatar frame on the site assumes square.
+ *
+ * renderToStaticMarkup, no DOM, matching the rest of this suite: effects never
+ * run, so no object URL is minted and the Cropper itself never mounts. That is
+ * fine — the picker is rendered from props and state, not from the image.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import ImageEditModal from '../ImageEditModal'
+import { AVATAR_ASPECT } from '../imageEditHelpers'
+
+const PHOTO = new File(['bytes'], 'sunset.jpg', { type: 'image/jpeg' })
+
+function markup(aspect?: number): string {
+  return renderToStaticMarkup(
+    <ImageEditModal
+      file={PHOTO}
+      aspect={aspect}
+      onConfirm={() => {}}
+      onCancel={() => {}}
+    />,
+  )
+}
+
+const label = (key: string): string => i18n.t(`imageEdit.${key}`, { ns: 'common' })
+
+describe('crop-shape picker — praxis media only (#1713)', () => {
+  it('offers every ratio when nothing is locked', () => {
+    const html = markup(undefined)
+    for (const key of ['ratioOriginal', 'ratio1x1', 'ratio4x3', 'ratio16x9']) {
+      expect(html).toContain(label(key))
+    }
+  })
+
+  it('lands on Original, so the pre-#1713 shape is still the default', () => {
+    const html = markup(undefined)
+    // The only pressed button in the group is the one labelled Original.
+    const pressed = html.match(/aria-pressed="true"[^>]*>([^<]*)</)
+    expect(pressed?.[1]).toBe(label('ratioOriginal'))
+  })
+
+  it('shows no picker for an avatar — the 1:1 lock stays a lock', () => {
+    const html = markup(AVATAR_ASPECT)
+    expect(html).not.toContain(label('ratioGroupAria'))
+    for (const key of ['ratioOriginal', 'ratio1x1', 'ratio4x3', 'ratio16x9']) {
+      expect(html).not.toContain(label(key))
+    }
+  })
+
+  it('leaves rotation alone on both call sites — still two 90° buttons', () => {
+    for (const aspect of [undefined, AVATAR_ASPECT]) {
+      const html = markup(aspect)
+      expect(html).toContain(label('rotateLeft'))
+      expect(html).toContain(label('rotateRight'))
+    }
+  })
+})

--- a/frontend/src/components/imageEdit/__tests__/ratioPicker.test.tsx
+++ b/frontend/src/components/imageEdit/__tests__/ratioPicker.test.tsx
@@ -30,36 +30,45 @@ function markup(aspect?: number): string {
   )
 }
 
-const label = (key: string): string => i18n.t(`imageEdit.${key}`, { ns: 'common' })
+const RATIO_KEYS = [
+  'imageEdit.ratioOriginal',
+  'imageEdit.ratio1x1',
+  'imageEdit.ratio4x3',
+  'imageEdit.ratio16x9',
+] as const
+
+type CopyKey =
+  | (typeof RATIO_KEYS)[number]
+  | 'imageEdit.ratioGroupAria'
+  | 'imageEdit.rotateLeft'
+  | 'imageEdit.rotateRight'
+
+const label = (key: CopyKey): string => i18n.t(key, { ns: 'common' })
 
 describe('crop-shape picker — praxis media only (#1713)', () => {
   it('offers every ratio when nothing is locked', () => {
     const html = markup(undefined)
-    for (const key of ['ratioOriginal', 'ratio1x1', 'ratio4x3', 'ratio16x9']) {
-      expect(html).toContain(label(key))
-    }
+    for (const key of RATIO_KEYS) expect(html).toContain(label(key))
   })
 
   it('lands on Original, so the pre-#1713 shape is still the default', () => {
     const html = markup(undefined)
     // The only pressed button in the group is the one labelled Original.
     const pressed = html.match(/aria-pressed="true"[^>]*>([^<]*)</)
-    expect(pressed?.[1]).toBe(label('ratioOriginal'))
+    expect(pressed?.[1]).toBe(label('imageEdit.ratioOriginal'))
   })
 
   it('shows no picker for an avatar — the 1:1 lock stays a lock', () => {
     const html = markup(AVATAR_ASPECT)
-    expect(html).not.toContain(label('ratioGroupAria'))
-    for (const key of ['ratioOriginal', 'ratio1x1', 'ratio4x3', 'ratio16x9']) {
-      expect(html).not.toContain(label(key))
-    }
+    expect(html).not.toContain(label('imageEdit.ratioGroupAria'))
+    for (const key of RATIO_KEYS) expect(html).not.toContain(label(key))
   })
 
   it('leaves rotation alone on both call sites — still two 90° buttons', () => {
     for (const aspect of [undefined, AVATAR_ASPECT]) {
       const html = markup(aspect)
-      expect(html).toContain(label('rotateLeft'))
-      expect(html).toContain(label('rotateRight'))
+      expect(html).toContain(label('imageEdit.rotateLeft'))
+      expect(html).toContain(label('imageEdit.rotateRight'))
     }
   })
 })

--- a/frontend/src/components/imageEdit/imageEditHelpers.ts
+++ b/frontend/src/components/imageEdit/imageEditHelpers.ts
@@ -43,18 +43,63 @@ export function cropOutputSize(cropArea: Pick<Area, 'width' | 'height'>): Size {
 }
 
 /**
+ * The crop shapes the ratio picker offers when nothing is locked (#1713).
+ * `original` is the image's own ratio — the pre-#1713 behaviour, and still the
+ * default, so the picker unlocks rather than changes what you land on.
+ *
+ * ponytail: there is no `free` (drag-any-rectangle) choice. react-easy-crop
+ * 6.2.2 — the installed version — takes `aspect` as a plain number with a
+ * default and exposes no resize handles, so a user-draggable rect is not in its
+ * API at all; its one escape hatch, `cropSize`, is documented "you should
+ * probably not use this option" and is still not user-draggable. A free crop
+ * therefore needs a different cropper, which is a dependency decision, not this
+ * fix. Upgrade path: swap the cropper, then add 'free' here and let
+ * {@link effectiveAspect} return undefined for it.
+ */
+export const CROP_RATIO_CHOICES = ['original', '1:1', '4:3', '16:9'] as const
+
+export type CropRatioChoice = (typeof CROP_RATIO_CHOICES)[number]
+
+/** Land on the image's own shape — what every praxis crop did before #1713. */
+export const DEFAULT_CROP_RATIO: CropRatioChoice = 'original'
+
+/** The numeric aspect each named ratio locks to. `original` has none — it defers. */
+const RATIO_ASPECTS: Readonly<Record<CropRatioChoice, number | undefined>> = {
+  original: undefined,
+  '1:1': 1,
+  '4:3': 4 / 3,
+  '16:9': 16 / 9,
+}
+
+/**
  * The aspect the crop frame should lock to. A caller-supplied `lockAspect`
- * (e.g. 1 for a square avatar) always wins; otherwise the frame follows the
- * image's natural ratio so nothing is force-cropped (the "free-form" praxis
- * case). Falls back to square before the media reports its size.
+ * (e.g. 1 for a square avatar) always wins. Otherwise the player's picked ratio
+ * decides, and `original` — the default — follows the image's natural ratio so
+ * nothing is force-cropped. Falls back to square before the media reports its
+ * size.
+ *
+ * Before #1713 there was no picked ratio: the frame was the photo's own shape
+ * and only ever that, so a 4:3 phone photo could never yield a square.
  */
 export function effectiveAspect(
   lockAspect: number | undefined,
   naturalAspect: number | undefined,
+  ratioChoice: CropRatioChoice = DEFAULT_CROP_RATIO,
 ): number {
   if (lockAspect && lockAspect > 0) return lockAspect
+  const picked = RATIO_ASPECTS[ratioChoice]
+  if (picked && picked > 0) return picked
   if (naturalAspect && naturalAspect > 0) return naturalAspect
   return 1
+}
+
+/**
+ * Whether the modal offers the ratio picker. Only the call site that locks
+ * nothing gets it: avatars pass {@link AVATAR_ASPECT} and stay square, because a
+ * non-square avatar would need every avatar frame on the site to cope (#1713).
+ */
+export function showsRatioPicker(lockAspect: number | undefined): boolean {
+  return !(lockAspect && lockAspect > 0)
 }
 
 /** True when a picked file is an image — only images get the edit modal. */

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -359,6 +359,13 @@
   "imageEdit": {
     "heading": "Adjust your image",
     "dialogAria": "Edit image before uploading",
+    "ratioLabel": "Shape",
+    "ratioGroupAria": "Crop shape",
+    "ratioOriginal": "Original",
+    "ratioOriginalAria": "Original shape — resets zoom and rotation",
+    "ratio1x1": "1:1",
+    "ratio4x3": "4:3",
+    "ratio16x9": "16:9",
     "zoomLabel": "Zoom",
     "rotateLabel": "Rotate",
     "rotateLeft": "Rotate left",

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -148,10 +148,12 @@ export default function EditPraxis() {
           onDismiss={state.dismissConfirm}
         />
       )}
-      {/* Praxis images crop/rotate in place before upload (#514), free-form so
-          nothing is force-cropped. Sequential: keyed on identity so each queued
-          image gets a fresh modal. A failure reports on the tray's file-error
-          line rather than uploading the unprocessed image (#1545). */}
+      {/* Praxis images crop/rotate in place before upload (#514). No `aspect`,
+          which is what earns the crop-shape picker (#1713): the frame starts on
+          the photo's own ratio so nothing is force-cropped, and the player can
+          re-lock it to 1:1 / 4:3 / 16:9. Sequential: keyed on identity so each
+          queued image gets a fresh modal. A failure reports on the tray's
+          file-error line rather than uploading the unprocessed image (#1545). */}
       {state.pendingImage && (
         <ImageEditModal
           key={`${state.pendingImage.name}-${state.pendingImage.lastModified}`}


### PR DESCRIPTION
The crop frame was the photo's own shape and only ever that. `effectiveAspect`
fell back to the natural aspect whenever no lock was passed, and the praxis
mount passes none — so on an iPhone every crop was the phone's 4:3, and no
amount of panning or zooming could take a square out of a wide photo.

Closes #1713

## Seam

`effectiveAspect(lockAspect, naturalAspect)` in
`frontend/src/components/imageEdit/imageEditHelpers.ts` — the one pure function
that decides the frame's shape, and the only place the natural-aspect fallback
lives. The failing test went red there first
(`a picked ratio overrides the photo's own shape`), then green. A second seam,
the mount, pins who is offered the picker at all.

## What changed

- `effectiveAspect` takes a third argument, the player's picked ratio, and
  consults it between the caller's lock and the natural aspect. A caller lock
  still wins outright, so avatars are untouched by construction.
- `ImageEditModal` renders a crop-shape row when — and only when — no `aspect`
  prop was supplied: `[ Original ] [ 1:1 ] [ 4:3 ] [ 16:9 ]`.
- **Original** is the default, so today's behaviour is what you land on, and it
  is also the in-editor reset the owner asked for: clicking it restores the
  photo's own shape and clears zoom, rotation and pan, even when it is already
  selected.
- Copy is new keys in the existing `imageEdit` block of `common.json`.
- Rotation is untouched — still `ROTATE_STEP = 90` and two buttons.
- `applyImageEdit` is untouched, so the #1527 report-don't-swallow behaviour and
  the deliberate #569 GIF pass-through both stand.

## The one thing I did NOT build: `Free`

The issue asks for a fifth button, `Free` — drag any rectangle. **react-easy-crop
6.2.2, the installed version, cannot do it**, and per the brief I stopped rather
than working around it or swapping the library:

- `aspect` is a plain `number` on `CropperProps` with a `defaultProps` value of
  `4/3`. Omitting it does not mean "free"; it means 4:3.
- The component exposes no resize handles anywhere in its API — the crop rect is
  never user-draggable, only the media under it is.
- Its one override, `cropSize`, is documented in the package's own README as
  *"You should probably not use this option and should rely on aspect instead"*,
  and it still gives no handles — it just fixes the rect at a size you compute.

A genuinely free crop therefore needs a different cropper, which is a dependency
decision rather than part of this fix. The ceiling and the upgrade path are
recorded as a `ponytail:` comment on `CROP_RATIO_CHOICES`. Everything in the
issue's "Done when" list is met without it; if `Free` is wanted, it should be
its own issue about replacing the cropper.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally on this
branch: `lint`, `typecheck`, `typecheck:design-sync`, `test`
(237 files / 4260 tests), `build`, `budget` (JS 129.1 KB, within budget —
`ImageEditModal` is a lazy chunk, so nothing lands on initial load).

No API endpoints consumed, no backend or schema surface touched.

**Visual QA is outstanding** — I have no browser and no dev stack. The picker's
dress is deliberately minimal: existing tokens only, the same ink/paper
inversion the primary action already uses for the selected state. If it wants a
real treatment, that is a `frontend-style` job.

## What to eyeball

**Praxis composer** (Edit Praxis → attach an image), desktop and mobile:

1. A **portrait 4:3 phone photo** — the bug's own case. Pick `1:1` and confirm
   the frame actually becomes square, and that Apply uploads a square image, not
   a 3:4 one. This is the whole issue; if only one thing gets checked, this.
2. `16:9` on that same portrait photo — the widest jump from the natural ratio,
   and the most likely to expose a bad initial pan.
3. **Original as a reset**: zoom in, rotate 90°, pan off-centre, then press
   `Original`. Frame returns to the photo's shape, upright, unzoomed, centred.
   Press it again while already selected — it must still reset.
4. Rotate 90° *then* pick `4:3`, and Apply. The rendered blob comes from a
   rotated bounding box, so this is where the crop rect and the canvas are most
   likely to disagree.
5. A **PNG** and a **landscape** photo, to confirm the ratios are not
   portrait-only and PNG stays lossless.
6. A **GIF** — must still upload untouched and never open the modal (#569).
7. All four buttons at a narrow mobile width: they wrap rather than overflow the
   420px card, and the selected one is legible in **both light and dark mode**.

**Avatar surfaces** — `CreateCharacter`, `EditCharacter`, and both mobile
archetypes (`DefaultCreateCharacter`, `DefaultEditCharacter`):

8. **No shape row appears at all**, and the crop is still square. All four
   surfaces, because all four pass `AVATAR_ASPECT` independently.
