### PR TITLE
In-progress rows mark the task's faction, not the kit's accent

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../../auth/AuthContext'
 import { relativeTime } from '../../utils/dates'
-import { factionCssVar } from '../../utils/factions'
+import { factionCssVar, factionName } from '../../utils/factions'
 import { mediaUrl } from '../../utils/media'
 import type { ActivityFeedItem } from '../../api/activityFeed'
 import type { PraxisCardOut } from '../../api/praxis'
@@ -17,10 +17,15 @@ import { praxisModeLabel } from '../../utils/praxis'
 import { useGameConfig } from '../../hooks/useGameConfig'
 import { useLevelTrack } from '../../hooks/useLevelTrack'
 import CharacterSwitcherSheet from '../CharacterSwitcherSheet'
+import FactionSigil from '../sigil/FactionSigil'
 import { feedKicker, feedItemTitle } from '../feed/feedItemLabels'
 import { normalizeFeedItem } from '../feed/normalizeFeedItem'
 
 const DEFAULT_MAX_TASK_SLOTS = 20
+
+/** The task-faction mark on an in-progress row (#1711), set to the row's own
+ *  type size so it reads as part of the line rather than as an emblem. */
+const ROW_SIGIL = 14
 
 /**
  * Each reorderable panel's heading key.
@@ -354,21 +359,33 @@ function ActiveTasksBody({
               >
                 {praxis.task_title}
               </Link>
-              <span
-                className="shrink-0"
-                style={{
-                  fontFamily: 'var(--font-body)',
-                  fontSize: 'var(--text-sm)',
-                  letterSpacing: '0.16em',
-                  textTransform: 'uppercase',
-                  color: 'var(--faction-default-card-muted)',
-                  padding: 'var(--space-xs) var(--space-sm)',
-                  border: '1px solid var(--color-border-strong)',
-                  borderRadius: 999,
-                }}
-              >
-                {praxisModeLabel(praxis, t)}
-              </span>
+              <div className="shrink-0 flex items-center gap-2">
+                <span
+                  style={{
+                    fontFamily: 'var(--font-body)',
+                    fontSize: 'var(--text-sm)',
+                    letterSpacing: '0.16em',
+                    textTransform: 'uppercase',
+                    color: 'var(--faction-default-card-muted)',
+                    padding: 'var(--space-xs) var(--space-sm)',
+                    border: '1px solid var(--color-border-strong)',
+                    borderRadius: 999,
+                  }}
+                >
+                  {praxisModeLabel(praxis, t)}
+                </span>
+                {/* Whose faction the TASK belongs to, beside what kind of praxis
+                    it is (#1711) — two different facts, so the pill stays. This
+                    row spells the faction out nowhere else, so unlike the mobile
+                    FieldDesk rows the mark is NAMED rather than hidden. */}
+                <span
+                  className="flex"
+                  role="img"
+                  aria-label={factionName(praxis.task_faction_slug)}
+                >
+                  <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
+                </span>
+              </div>
             </div>
           ))}
         </div>

--- a/frontend/src/components/layout/__tests__/sidebarActiveTaskSigil.test.tsx
+++ b/frontend/src/components/layout/__tests__/sidebarActiveTaskSigil.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * #1711 — what the rail's in-progress row says about a task's faction.
+ *
+ * THE SEAM is the row itself: `ActiveTasksBody` renders a title link and a mode
+ * pill, and the faction the task belongs to was nowhere in it. The sigil is
+ * added BESIDE the pill rather than in place of it — the two facts are
+ * different (what kind of praxis, whose faction) and both survive.
+ *
+ * Probed by DIFFERENCE, like the mobile FieldDesk twin: the rail is drawn on
+ * the site's own default chrome, but a presence check on one faction's geometry
+ * would still pass on a row that had hardcoded that faction. Rendering the same
+ * rail twice with two different task factions and requiring the mark to move is
+ * the assertion that only holds if the row asks `task_faction_slug`.
+ *
+ * Unlike the mobile rows, this one carries NO faction word, so the mark is the
+ * only faction cue — hence the accessible name, asserted here rather than left
+ * to a reviewer's eye.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import type { CurrentUser } from '../../../api/auth'
+import type { PraxisCardOut } from '../../../api/praxis'
+import FactionSigil from '../../sigil/FactionSigil'
+import { factionName } from '../../../utils/factions'
+
+const panelsMock = vi.fn()
+vi.mock('../../../hooks/useSidebarPanels', () => ({
+  useSidebarPanels: () => panelsMock(),
+}))
+
+// Effects never run under `renderToStaticMarkup`; mock the two hooks that would
+// otherwise sit at their loading defaults and render a signed-out rail.
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: { character: null } as unknown as CurrentUser }),
+}))
+vi.mock('../../../hooks/useGameConfig', () => ({
+  useGameConfig: () => null,
+}))
+
+import Sidebar from '../Sidebar'
+
+function activeTask(taskFactionSlug: string): PraxisCardOut {
+  return {
+    id: 55,
+    task_id: 7,
+    task_title: 'Sunday Soup',
+    task_point_value: 30,
+    task_level_required: 1,
+    type: 'solo',
+    status: 'in_progress',
+    title: null,
+    moderation_status: 'visible',
+    created_by_id: 42,
+    created_by_display_name: 'Mollusk',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    submitted_at: null,
+    member_count: 1,
+    score: 0,
+    voter_count: 0,
+    metatask_points: 0,
+    display_multiplier: 1.0,
+    points_from_votes: 0,
+    habit_bonus_points: 0,
+    is_top_for_task: false,
+    task_faction_slug: taskFactionSlug,
+    applied_metatasks: [],
+    body_text: null,
+    created_by_avatar_url: '',
+    created_by_faction_slug: null,
+    duel_id: null,
+    media_items: [],
+    members: [],
+    opponent_display_name: null,
+    opponent_faction_slug: null,
+    opponent_praxis_id: null,
+    submit_proposed_at: null,
+    viewer_can_vote: true,
+    viewer_vote: null,
+    voted_by_name: null,
+  }
+}
+
+function renderRail(taskFactionSlug: string): string {
+  panelsMock.mockReturnValue({
+    pending_requests_count: 0,
+    global_activity: [],
+    active_praxes: [activeTask(taskFactionSlug)],
+    refetch: vi.fn(),
+    loading: false,
+  })
+  return renderToStaticMarkup(
+    <MemoryRouter initialEntries={['/']}>
+      <Sidebar />
+    </MemoryRouter>,
+  )
+}
+
+/** The mark's own geometry, taken from `FactionSigil` rather than transcribed. */
+function sigilPath(slug: string): string {
+  const html = renderToStaticMarkup(<FactionSigil slug={slug} />)
+  const match = html.match(/ d="([^"]+)"/)
+  if (!match) throw new Error(`the ${slug} sigil draws no path to probe`)
+  return match[1]
+}
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1
+}
+
+beforeEach(() => {
+  panelsMock.mockReset()
+})
+
+describe('the in-progress row in the rail', () => {
+  it("draws the TASK's faction sigil", () => {
+    const coven = renderRail('coven')
+    const snide = renderRail('snide')
+    expect(occurrences(coven, sigilPath('coven')), 'a coven task draws the coven mark').toBe(
+      occurrences(snide, sigilPath('coven')) + 1,
+    )
+    expect(occurrences(snide, sigilPath('snide')), 'a snide task draws the snide mark').toBe(
+      occurrences(coven, sigilPath('snide')) + 1,
+    )
+  })
+
+  /**
+   * The mark is the row's ONLY faction cue — nothing spells the faction out —
+   * so it is named rather than hidden. The name comes from the same catalog the
+   * rest of the site reads, so a renamed faction moves both together.
+   */
+  it('names the faction it is drawing', () => {
+    expect(renderRail('coven')).toContain(`aria-label="${factionName('coven')}"`)
+  })
+
+  /** Both facts survive: the mode pill is not what the sigil replaced. */
+  it('keeps the mode pill beside it', () => {
+    expect(renderRail('coven')).toContain(i18n.t('common:praxisType.solo'))
+  })
+})

--- a/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
@@ -28,6 +28,7 @@ import { describe, it, expect } from 'vitest'
 // Initialize the i18n catalog so shared copy keys resolve to English text.
 import '../../../i18n'
 import DefaultFieldDesk from '../mobileArchetypes/DefaultFieldDesk'
+import FactionSigil from '../../../components/sigil/FactionSigil'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import { CAST_VOTES_LINK, FIND_TASK_LINK, UPDATES_LINK } from '../homeDestinations'
 import { REQUESTS_QUEUE_LINK } from '../../updates/requestsQueueAnchor'
@@ -111,6 +112,35 @@ function baseState(overrides: Partial<FieldDeskHomeState> = {}): FieldDeskHomeSt
 
 const archetypes = { ...surfaceMap('mobileFieldDesk'), __default__: DefaultFieldDesk }
 
+/**
+ * The lead mark on an in-progress row is the TASK's faction sigil (#1711).
+ *
+ * Probed by DIFFERENCE rather than by presence: a skin draws its own faction's
+ * mark all over its own page (Coven's sparkle rule, WOW's crest), so
+ * "the coven sparkle is in the markup" would pass on CovenFieldDesk however the
+ * row is drawn. Rendering the same skin twice with two different TASK factions
+ * and requiring the count to move by exactly one is the assertion that only
+ * holds if the row dispatches on `task_faction_slug`.
+ *
+ * The mark is identified by its path geometry, taken from `FactionSigil` itself
+ * rather than transcribed — a re-drawn sigil moves both sides together, a row
+ * that stops asking for one does not.
+ */
+function sigilPath(slug: string): string {
+  const html = renderToStaticMarkup(<FactionSigil slug={slug} />)
+  const match = html.match(/ d="([^"]+)"/)
+  if (!match) throw new Error(`the ${slug} sigil draws no path to probe`)
+  return match[1]
+}
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1
+}
+
+function withTaskFaction(slug: string): FieldDeskHomeState {
+  return baseState({ activeTasks: [{ ...ACTIVE_TASK, task_faction_slug: slug }] })
+}
+
 describe('mobile FieldDesk-home content-slot invariant', () => {
   for (const [slug, Skin] of Object.entries(archetypes)) {
     it(`${slug} renders the identity block`, () => {
@@ -141,6 +171,30 @@ describe('mobile FieldDesk-home content-slot invariant', () => {
       const { html, text } = render(<Skin state={baseState()} />)
       expect(text, 'active task title slot').toContain('Sunday Soup')
       expect(html, 'continue-in-progress slot').toContain('href="/praxis/55/edit"')
+    })
+
+    /**
+     * #1711. Five skins marked the row with their OWN fixed accent (a red
+     * square, an acid square, an ochre square, a gilt sparkle) and three drew
+     * no faction mark at all; only Default's dot tracked the task. The mark now
+     * says the same true thing on all eight.
+     */
+    it(`${slug} marks the in-progress row with the TASK's faction`, () => {
+      // Probed inside the test, not at module scope: the faction manifests
+      // register as their modules evaluate, and a `sigilPath` call during this
+      // file's own import would resolve every slug to the fallback.
+      const COVEN_MARK = sigilPath('coven')
+      const SNIDE_MARK = sigilPath('snide')
+      const coven = render(<Skin state={withTaskFaction('coven')} />).html
+      const snide = render(<Skin state={withTaskFaction('snide')} />).html
+      expect(
+        occurrences(coven, COVEN_MARK),
+        'a coven task draws the coven mark',
+      ).toBe(occurrences(snide, COVEN_MARK) + 1)
+      expect(
+        occurrences(snide, SNIDE_MARK),
+        'a snide task draws the snide mark',
+      ).toBe(occurrences(coven, SNIDE_MARK) + 1)
     })
 
     it(`${slug} renders the empty state when no active tasks`, () => {

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import { CovenSigil } from '../../../components/sigil/CovenSigil'
+import FactionSigil from '../../../components/sigil/FactionSigil'
 import {
   Braid,
   CAPTION,
@@ -52,6 +53,10 @@ import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
  */
 
 const CHROME = 'var(--font-faction-rounded)' // Quicksand
+
+/** The task-faction mark on a quest row (#1711) — a shade larger than the gilt
+ *  sparkle it replaces, which was a filled shape where this is drawn line. */
+const ROW_SIGIL = 14
 
 /** The reading voice — every prose line on the page. */
 const PROSE: CSSProperties = {
@@ -381,7 +386,13 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
                     textDecoration: 'none',
                   }}
                 >
-                  <CovenSigil size={12} color={GOLD} />
+                  {/* The lead mark is the TASK's faction, not the coven's own
+                      sparkle in gold (#1711) — this row showed the same mark
+                      whoever owned the task. The caption below names the
+                      faction, so the mark is decorative. */}
+                  <span className="shrink-0 flex" aria-hidden>
+                    <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
+                  </span>
                   <div className="min-w-0 flex-1">
                     <div className="truncate" style={{ fontFamily: HAND, fontSize: 'var(--text-content)', lineHeight: 1, color: INK }}>
                       {praxis.task_title}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -1,10 +1,11 @@
 import { useState, type CSSProperties } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { factionCssVar, factionFill, factionName } from '../../../utils/factions'
+import { factionCssVar, factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
+import FactionSigil from '../../../components/sigil/FactionSigil'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
@@ -22,6 +23,10 @@ import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
  * Layout is flex/relative — no fixed-px grid drives the page structure
  * (SPEC-faction-ui-profile §1a).
  */
+
+/** The task-faction mark on an in-progress row (#1711), sized to the row's own
+ *  cap height — it stands where the lead dot stood, not where an emblem would. */
+const ROW_SIGIL = 14
 
 // Static style objects, hoisted to module scope (#586) — no closure deps.
 const pageTitleStyle: CSSProperties = {
@@ -314,10 +319,12 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                   textDecoration: 'none',
                 }}
               >
-                <span
-                  className="shrink-0"
-                  style={{ width: 10, height: 10, borderRadius: 3, ...factionFill(praxis.task_faction_slug, 'dot') }}
-                />
+                {/* The task's faction, drawn as its own mark rather than as a
+                    colour swatch (#1711). Decorative: the meta line below names
+                    the faction in words. */}
+                <span className="shrink-0 flex" aria-hidden>
+                  <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
+                </span>
                 <div className="min-w-0 flex-1">
                   <div className="font-display truncate content-text" style={{ lineHeight: 1.2, color: 'var(--color-text-primary)' }}>
                     {praxis.task_title}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
@@ -6,6 +6,7 @@ import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
 import { EphemeristsSigil } from '../../../components/sigil/EphemeristsSigil'
+import FactionSigil from '../../../components/sigil/FactionSigil'
 import {
   BRASS,
   CAPTION,
@@ -84,6 +85,11 @@ const trackMetaStyle: CSSProperties = {
 
 /** The valley's own spectrum: ochre through brass into the Nile (#1553). */
 const TRACK_FILL = `linear-gradient(90deg, ${OCHRE}, ${BRASS}, ${NILE})`
+
+/** The task-faction mark on a register row (#1711), at the row's cap height.
+ *  Below the kite's own 20px threshold, so an ephemerists task draws the mark's
+ *  reduced cut here — which is exactly what that cut is for. */
+const ROW_SIGIL = 14
 
 /** One leaf off the field journal — papyrus inside the plate's hairline. */
 function Leaf({ children }: { children: ReactNode }) {
@@ -284,9 +290,12 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${RULE}`, textDecoration: 'none' }}
               >
-                {/* ornament: the register's lead dot, drawn square to the row's
-                    cap height — illustration geometry, not layout spacing. */}
-                <span className="shrink-0" style={{ width: 9, height: 9, background: OCHRE }} />
+                {/* The register's lead mark is the TASK's faction now, not the
+                    valley's ochre (#1711). The small-caps line under the title
+                    names the faction, so the mark is decorative. */}
+                <span className="shrink-0 flex" aria-hidden>
+                  <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
+                </span>
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: DECO, fontSize: 'var(--text-content)', lineHeight: 1.15, color: INK }}>
                     {praxis.task_title}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
@@ -2,6 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
+import FactionSigil from '../../../components/sigil/FactionSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
@@ -32,6 +33,10 @@ const PAPER = 'var(--everymen-paper)'
 const PAPER_DEEP = 'var(--everymen-paper-deep)'
 const ACCENT_FONT = 'var(--font-accent)'
 const BODY_FONT = 'var(--font-body)'
+
+/** The task-faction mark on a dispatch row (#1711) — the square red slug it
+ *  replaces was 10px, and the mark carries more line, so it takes 14. */
+const ROW_SIGIL = 14
 
 const kicker: CSSProperties = {
   fontFamily: BODY_FONT,
@@ -324,7 +329,11 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid color-mix(in srgb, var(--everymen-ink) 20%, transparent)`, textDecoration: 'none' }}
               >
-                <span className="shrink-0" style={{ width: 10, height: 10, background: RED }} />
+                {/* The TASK's faction, not the shop's own red (#1711). The kicker
+                    line below says the faction in words, so the mark is decorative. */}
+                <span className="shrink-0 flex" aria-hidden>
+                  <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
+                </span>
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', lineHeight: 1.05, color: INK }}>
                     {praxis.task_title}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
@@ -2,6 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
+import FactionSigil from '../../../components/sigil/FactionSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
@@ -84,6 +85,10 @@ const trackMetaStyle: CSSProperties = {
 
 /** The node's own ramp: signal blue climbing into phosphor (#1553). */
 const TRACK_FILL = `linear-gradient(90deg, ${signal(85)}, ${PHOSPHOR})`
+
+/** The task-faction mark on a readout row (#1711) — the caret it replaces was
+ *  set at 13px, and the mark holds the same line. */
+const ROW_SIGIL = 13
 
 /** Blinking terminal cursor block. */
 function Cursor() {
@@ -294,8 +299,16 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${signal(14)}`, textDecoration: 'none' }}
               >
-                {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the prompt caret is a list bullet glyph, not text */}
-                <span className="shrink-0" style={{ fontFamily: FONT, fontSize: 13, color: PHOSPHOR }}>›</span>
+                {/* The row's lead slot carries the TASK's faction (#1711). It
+                    held a prompt caret in the terminal's own phosphor, the same
+                    glyph for every task alike; the slot takes one mark, so the
+                    faction's is the one that says something. The terminal reads
+                    on regardless — SingularitySigil IS a prompt caret with its
+                    cursor block, so a singularity task's row is unchanged. The
+                    line under the title names the faction: decorative. */}
+                <span className="shrink-0 flex" aria-hidden>
+                  <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
+                </span>
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1.2, color: PHOSPHOR }}>
                     {praxis.task_title}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
@@ -2,6 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
+import FactionSigil from '../../../components/sigil/FactionSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
@@ -35,6 +36,10 @@ const IMPACT = 'var(--faction-snide-font-impact)'
 const BLACK = 'var(--faction-snide-font-black)'
 const TYPE = 'var(--faction-snide-font-type)'
 const MARKER = 'var(--faction-snide-font-marker)'
+
+/** The task-faction mark on a cut-out row (#1711) — a touch under the other
+ *  skins' 14, because this row's rule is tight and the type is condensed. */
+const ROW_SIGIL = 13
 
 const HALFTONE = 'radial-gradient(rgba(182,255,46,0.09) 32%, transparent 34%)'
 const CARD_SHADOW = '5px 6px 0 rgba(0,0,0,.5)'
@@ -268,7 +273,11 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid ${LINE}`, textDecoration: 'none' }}
               >
-                <span className="shrink-0" style={{ width: 9, height: 9, background: ACID }} />
+                {/* The TASK's faction, not the zine's own acid (#1711). The kicker
+                    under the title names it in words, so the mark is decorative. */}
+                <span className="shrink-0 flex" aria-hidden>
+                  <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
+                </span>
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.02em', lineHeight: 1.15, color: TEXT }}>
                     {praxis.task_title}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import UaMandala from '../../../components/factionMarks/UaMandala'
 import { UaSigil } from '../../../components/sigil/UaSigil'
+import FactionSigil from '../../../components/sigil/FactionSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { praxisModeLabel } from '../../../utils/praxis'
@@ -81,6 +82,11 @@ const trackMetaStyle: CSSProperties = { ...smallCaps }
 
 /** The practice's own ramp: the sienna fill drawn out to its accent (#1553). */
 const TRACK_FILL = `linear-gradient(90deg, ${FILL}, ${ACCENT})`
+
+/** The task-faction mark on a practice row (#1711). The dot it replaces was
+ *  7px; a drawn mark needs more room, but this sheet is the quietest of the
+ *  eight, so it takes the smallest of the row sizes. */
+const ROW_SIGIL = 13
 
 /** A sheet: one surface, one hairline. What is left after the gilt frame. */
 function Sheet({ children }: { children: ReactNode }) {
@@ -297,7 +303,12 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
                 className="flex items-center gap-3"
                 style={{ padding: 'var(--space-md) 0', borderTop: index === 0 ? undefined : `1px solid var(--faction-ua-hair)`, textDecoration: 'none' }}
               >
-                <span className="shrink-0" style={{ width: 7, height: 7, borderRadius: '50%', background: FILL }} />
+                {/* The TASK's faction, not the sheet's own fill (#1711). The
+                    small-caps line under the title names it, so the mark is
+                    decorative. */}
+                <span className="shrink-0 flex" aria-hidden>
+                  <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
+                </span>
                 <div className="min-w-0 flex-1">
                   <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-content)', lineHeight: 1.15, color: INK }}>
                     {praxis.task_title}

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
@@ -54,6 +54,7 @@ import {
   wowMobilePage,
 } from "../../../components/factionMarks/wowMobile";
 import CharacterSwitcherSheet from "../../../components/CharacterSwitcherSheet";
+import FactionSigil from "../../../components/sigil/FactionSigil";
 import { factionName } from "../../../utils/factions";
 import type { FieldDeskHomeState } from "../useFieldDeskHome";
 import PendingRowPill from '../PendingRowPill'
@@ -61,6 +62,11 @@ import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /** Every tappable row clears the faction's 46px thumb target. */
 const TAP = 46;
+
+/** The task-faction mark on a quest chit (#1711). 15 rather than 14: the frame
+ *  is the roomiest of the eight, and WOW's own mark is a struck coin that needs
+ *  every pixel it can get before its motto band drops out. */
+const ROW_SIGIL = 15;
 
 /**
  * Characters / Edit as real controls (#1553) — a gilt-framed chit on the crest.
@@ -321,16 +327,33 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                       color: "inherit",
                     }}
                   >
+                    {/* The quest's own house, marked (#1711). This frame drew no
+                        faction mark at all; the sigil leads the title line, and
+                        the italic line below still names the faction in words,
+                        so the mark is decorative. `flex-start` rather than
+                        `center` because a quest title wraps. */}
                     <div
                       style={{
-                        fontFamily: WOW_DISPLAY,
-                        fontSize: "var(--text-content)",
-                        lineHeight: 1.15,
-                        color: WOW_INK,
-                        overflowWrap: "anywhere",
+                        display: "flex",
+                        alignItems: "flex-start",
+                        gap: "var(--space-sm)",
                       }}
                     >
-                      {praxis.task_title}
+                      <span aria-hidden style={{ display: "flex", flex: "none" }}>
+                        <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
+                      </span>
+                      <div
+                        style={{
+                          fontFamily: WOW_DISPLAY,
+                          fontSize: "var(--text-content)",
+                          lineHeight: 1.15,
+                          color: WOW_INK,
+                          overflowWrap: "anywhere",
+                          minWidth: 0,
+                        }}
+                      >
+                        {praxis.task_title}
+                      </div>
                     </div>
                     <div
                       style={{


### PR DESCRIPTION
Closes #1711

Every in-progress task list now marks a row with the **task's** faction sigil, through the shared `FactionSigil` dispatcher. Nine files: the eight mobile FieldDesk archetypes and the desktop rail.

## What was actually there

Only Default's mark carried information (`factionFill(praxis.task_faction_slug, 'dot')`). The others were the *viewing kit's* fixed accent — the same mark on every row whoever owned the task:

| skin | before | after |
|---|---|---|
| Default | 10px dot, task-faction fill | sigil, 14 |
| Everymen | 10px square, always `--everymen-red` | sigil, 14 |
| Snide | 9px square, always acid | sigil, 13 |
| Ephemerists | 9px square, always ochre | sigil, 14 |
| Ua | 7px disc, always `--faction-ua` | sigil, 13 |
| **Coven** | `CovenSigil size={12} color={GOLD}` — the issue lists Coven as having no marker; it has the coven sparkle in gold, i.e. the sharpest case of the bug | sigil, 14 |
| **Singularity** | the phosphor prompt caret `›` in the lead slot | sigil, 13 |
| WOW | no faction mark at all | sigil, 15, leading the title line |
| Sidebar | title + mode pill, no faction anywhere | pill **kept**, sigil added to its right, 14 |

Two corrections to the issue's survey, both found by grep: **Coven already had a marker** (its own sigil, gilt), and **Singularity's lead slot was occupied** by the prompt caret. Singularity's caret is replaced rather than doubled up — the slot takes one mark, and `SingularitySigil` *is* a prompt caret with its cursor block, so a singularity task's row is visually unchanged. The caret still leads the pending row elsewhere in that skin.

No `color` is passed anywhere: each sigil already defaults to its own faction token (`--faction-coven`, `--everymen-red`, `--faction-snide-acid`, …), so the ink comes from the faction rather than from the kit. `na` resolves through the same dispatch to the spectrum ring — not special-cased (ADR-0039/0040).

## The seam, and the test

**The seam is the row's faction mark: does it move when `praxis.task_faction_slug` moves?**

Presence checks are useless here — Coven's page is full of coven sparkles and WOW's is full of crests, so "the coven mark is in the markup" passes on CovenFieldDesk however the row is drawn. Both tests probe by **difference**: render the same skin twice, once with a coven task and once with a snide task, and require each mark's occurrence count to change by exactly one. That only holds if the row asks the task. The geometry is read out of `FactionSigil` itself rather than transcribed, so a re-drawn sigil moves both sides of the assertion together.

- `src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx` — one more per-skin slot in the existing invariant loop. Red on all 8 skins first, including `__default__`.
- `src/components/layout/__tests__/sidebarActiveTaskSigil.test.tsx` — new; also asserts the pill survives, and the accessible name.

**A11y.** On the FieldDesk rows the meta line names the faction in words, so the mark is decorative and the wrapper is `aria-hidden` (which also hides `DefaultSigil`'s own `role="img"` from doubling up). The rail row spells the faction out nowhere, so there the mark is the only cue and carries `role="img"` + `aria-label={factionName(slug)}` from the same catalog the rest of the site reads.

## Verification

`tsc --noEmit` after each file; the full CI list from `.github/workflows/test.yml` at the end — `lint`, `typecheck`, `typecheck:design-sync`, `npm test` (237 files / 4261 tests), `build`, `budget`: all green. No API surface touched, so no schema regen.

**One number worth a ruling:** the rail is on the eager path, so importing `FactionSigil` there moves the initial JS budget **129.1 KB → 130.0 KB gzipped** (warn at 130.9, fail at 175.8). Measured by building this branch with `Sidebar.tsx` reverted. The manifest sigils are already `lazyArchetype` loaders; the growth is `FactionSigil`'s four static imports (Default/Albescent/Ua/Singularity marks). The eight FieldDesk skins cost the entry chunk nothing — they are code-split archetypes. I did not put the rail's sigil behind `React.lazy`: a Suspense boundary in the rail to save 0.9 KB would make the mark pop in late, but say the word and it's four lines.

**Visual QA is outstanding** — no browser or dev stack here. Nothing about the palette or the type scale changed; the open question is purely how each mark sits in its row.

## What to eyeball

- **Coven** — the row that used to show a gilt sparkle for every task now shows eight different marks. Check the gold is not missed as the plate's accent.
- **Singularity** — a non-singularity task's row on the terminal: the caret is gone from the lead slot, and e.g. the WOW crest or Everymen cog now sits on the phosphor void. Contrast of a faction ink on that dark ground is the thing to judge.
- **Ephemerists** — an ephemerists task draws the kite's *reduced cut* at 14px (below its own 20px threshold). Confirm that is the mark you want in a list.
- **WOW** — the quest chit's title line is now a flex row with the sigil leading; check a long, wrapping title still reads (aligned `flex-start`, deliberately not `center`).
- **Ua / Snide** — the tightest rows: 13px marks replacing a 7px disc and a 9px square. Watch for the row reflowing or the rule crowding.
- **Default and Everymen** — the straight swaps; least likely to surprise.
- **Desktop rail** — pill then sigil, right-aligned; check the group does not push the title into truncation at the narrow rail width, and check a task with **no faction** (`na`) draws the spectrum ring rather than nothing.
- **Dark mode** on all of the above — the marks draw their own faction tokens, which carry their own cascade, but the grounds they now sit on are new pairings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
