### PR TITLE
An unmeasurable backdrop gets reported and ratcheted instead of failing 28 tests

### DIFF
--- a/frontend/e2e/contrast.spec.ts
+++ b/frontend/e2e/contrast.spec.ts
@@ -30,9 +30,11 @@ import { scanPageForContrast, type Finding } from './contrastScan'
  * red from the day the guard landed. See contrastBaseline.ts Part D.
  *
  * REGENERATING THE BASELINE. Set `CONTRAST_BASELINE_OUT=<path>` and run the
- * suite; every failure is appended there as a ready-to-paste entry. The list
- * is machine-produced on purpose — hand-typed ratios would be wrong within a
- * week, which is the whole thesis of this issue.
+ * suite; every MEASURED failure is appended there as a ready-to-paste entry.
+ * The list is machine-produced on purpose — hand-typed ratios would be wrong
+ * within a week, which is the whole thesis of this issue. Unmeasurable
+ * backdrops are not baseline entries any more, so nothing is emitted for them;
+ * their ceiling comes off the report this prints on every run.
  */
 
 const API = process.env.E2E_API_URL ?? 'http://localhost:8000'

--- a/frontend/e2e/contrast.spec.ts
+++ b/frontend/e2e/contrast.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from '@playwright/test'
 import { appendFileSync } from 'node:fs'
 
-import { RENDERED_BASELINE, baselineKey, unresolvedKey, type BaselineEntry } from './contrastBaseline'
+import { UNRESOLVED_SURFACE_CEILING, baselineKey, triageFindings } from './contrastBaseline'
 import { scanPageForContrast, type Finding } from './contrastScan'
 
 /**
@@ -21,6 +21,13 @@ import { scanPageForContrast, type Finding } from './contrastScan'
  *
  * Nightly, not per-PR: `.github/workflows/e2e.yml` already stands up Postgres
  * + backend + seed + Playwright. No new CI job.
+ *
+ * THREE OUTCOMES, NOT TWO (#1675). A measured pairing below AA fails. A
+ * backdrop the scanner REFUSES to measure — a gradient with an opaque stop, an
+ * image — is reported instead, and only its COUNT is asserted, against
+ * `UNRESOLVED_SURFACE_CEILING`. Failing on those made the spec unsatisfiable:
+ * the faction skins are built out of exactly those fills, so all 28 tests were
+ * red from the day the guard landed. See contrastBaseline.ts Part D.
  *
  * REGENERATING THE BASELINE. Set `CONTRAST_BASELINE_OUT=<path>` and run the
  * suite; every failure is appended there as a ready-to-paste entry. The list
@@ -85,26 +92,33 @@ async function useTheme(page: Page, theme: Theme): Promise<void> {
   }, theme)
 }
 
-function keyOf(theme: Theme, finding: Finding): string {
-  return finding.background === null
-    ? unresolvedKey(theme, finding.text, finding.backdropCss ?? 'unknown', finding.required)
-    : baselineKey(theme, finding.text, finding.background, finding.required)
-}
-
 function describeFinding(finding: Finding): string {
   const size = `${finding.fontSizePx}px/${finding.fontWeight}`
-  if (finding.background === null) {
-    return `  UNRESOLVED BACKDROP (${finding.unresolvedKind}) — ${finding.where} (${size})\n    "${finding.sample}"\n    ${finding.unresolved}`
-  }
   return `  ${finding.ratio.toFixed(2)}:1 (needs ${finding.required}:1) — ${finding.text} on ${finding.background}\n    ${finding.where} (${size}) "${finding.sample}"`
 }
 
+/**
+ * One line per surface the scanner refused to measure: how many text nodes sit
+ * on it, and one of them so a human can go look. The CSS is the identity, so
+ * it leads; it is trimmed only for the console.
+ */
+function describeSurface(css: string, over: Finding[]): string {
+  const example = over[0]
+  return (
+    `  ${over.length} node(s) over ${css.slice(0, 120)}${css.length > 120 ? '…' : ''}\n` +
+    `    e.g. ${example.where} (${example.fontSizePx}px/${example.fontWeight}) "${example.sample}"`
+  )
+}
+
 /** Emit a ready-to-paste BASELINE entry when regenerating (see header). */
-function emitBaseline(key: string, finding: Finding, faction: Faction, theme: Theme, viewport: ViewportName): void {
-  if (!BASELINE_OUT) return
-  const ratio = finding.background === null ? 'null' : finding.ratio.toFixed(2)
+function emitBaseline(finding: Finding, faction: Faction, theme: Theme, viewport: ViewportName): void {
+  if (!BASELINE_OUT || finding.background === null) return
+  const key = baselineKey(theme, finding.text, finding.background, finding.required)
   const where = `${faction}/${theme}/${viewport} ${finding.where}`.replace(/'/g, '')
-  appendFileSync(BASELINE_OUT, `  ${JSON.stringify(key)}: { ratio: ${ratio}, issue: 651, where: '${where}' },\n`)
+  appendFileSync(
+    BASELINE_OUT,
+    `  ${JSON.stringify(key)}: { ratio: ${finding.ratio.toFixed(2)}, issue: 651, where: '${where}' },\n`,
+  )
 }
 
 for (const faction of FACTIONS) {
@@ -116,9 +130,9 @@ for (const faction of FACTIONS) {
         await useTheme(page, theme)
         await loginAs(page, faction)
 
+        const combination = `${faction}/${theme}/${viewport}`
         const routes = [...SHARED_ROUTES, `/factions/${faction}`]
-        const failures: string[] = []
-        const passing: string[] = []
+        const findings: Finding[] = []
 
         for (const route of routes) {
           await page.goto(route)
@@ -126,39 +140,45 @@ for (const faction of FACTIONS) {
           // /auth/me — measuring before it lands would measure the default.
           await page.waitForLoadState('networkidle')
           await expect(page.locator('html')).toHaveAttribute('data-theme', theme)
-
-          const findings = (await page.evaluate(scanPageForContrast)) as Finding[]
-          for (const finding of findings) {
-            const ok = finding.background !== null && finding.ratio >= finding.required
-            const key = keyOf(theme, finding)
-            const allowed: BaselineEntry | undefined = RENDERED_BASELINE[key]
-
-            if (ok) {
-              // A pair that now passes but is still allowlisted is debt that
-              // got fixed without the list being updated. Catch it: an
-              // allowlist that outlives its bug stops being a ratchet.
-              if (allowed) passing.push(`${key} now measures ${finding.ratio.toFixed(2)}:1 (owned by #${allowed.issue})`)
-              continue
-            }
-            if (allowed) continue
-            emitBaseline(key, finding, faction, theme, viewport)
-            failures.push(describeFinding(finding))
-          }
+          findings.push(...((await page.evaluate(scanPageForContrast)) as Finding[]))
         }
 
+        const { failures, stale, unmeasurable } = triageFindings(theme, findings)
+        for (const finding of failures) emitBaseline(finding, faction, theme, viewport)
+
+        // The report is the whole point of #1675: an unmeasurable backdrop no
+        // longer fails, so it has to be VISIBLE, on every run, pass or fail. A
+        // silent skip is a green suite that checks less.
+        const ceiling: number | undefined = UNRESOLVED_SURFACE_CEILING[combination]
+        const unchecked = [...unmeasurable.values()].reduce((total, over) => total + over.length, 0)
+        console.log(
+          `\n[contrast] ${combination}: ${unmeasurable.size} unmeasurable surface(s) ` +
+            `(ceiling ${ceiling ?? 0}), ${unchecked} text node(s) unchecked.\n` +
+            [...unmeasurable].map(([css, over]) => describeSurface(css, over)).join('\n'),
+        )
+
+        const describedFailures = [...new Set(failures.map(describeFinding))]
         expect(
-          [...new Set(failures)],
-          `${faction}/${theme}/${viewport}: text below WCAG AA.\n` +
-            `An UNRESOLVED BACKDROP is a failure, not a skip — text over an opaque-stop gradient or an image ` +
-            `cannot be measured, so it must be given a solid backdrop (or the fill hoisted behind an opaque card).\n\n` +
-            [...new Set(failures)].join('\n\n'),
+          describedFailures,
+          `${combination}: text below WCAG AA.\n\n` + describedFailures.join('\n\n'),
         ).toHaveLength(0)
 
         expect(
-          [...new Set(passing)],
+          [...new Set(stale)],
           `These pairs are in RENDERED_BASELINE but now clear AA — delete their entries in contrastBaseline.ts. ` +
             `The list only ever shrinks.`,
         ).toHaveLength(0)
+
+        // Gaining a surface is a coverage regression, not a contrast defect:
+        // a region of the app just stopped being checked at all. Losing one is
+        // progress and only asks for the ceiling to come down.
+        expect(
+          unmeasurable.size,
+          `${combination}: ${unmeasurable.size} surfaces cannot be measured, up from ${ceiling ?? 0}. ` +
+            `Either give the new one a solid backdrop, or — if the fill is deliberate — raise its entry in ` +
+            `UNRESOLVED_SURFACE_CEILING to the number printed above and say which surface it is.\n\n` +
+            [...unmeasurable.keys()].join('\n'),
+        ).toBeLessThanOrEqual(ceiling ?? 0)
       })
     }
   }

--- a/frontend/e2e/contrastBaseline.ts
+++ b/frontend/e2e/contrastBaseline.ts
@@ -14,17 +14,26 @@
  * (text, backdrop) pairing; which component happens to produce it is
  * incidental, changes with every copy edit, and would make this list rot. So
  * `theme | rgb(text) on rgb(backdrop)` is the identity, and `where` is only a
- * breadcrumb for whoever picks up the fix. Unresolved findings are keyed the
- * same way — on the CSS that defeated resolution, not on a DOM path.
+ * breadcrumb for whoever picks up the fix.
  *
  * **This list only ever shrinks.** Fixing a pair means DELETING its entry, not
  * editing the ratio — an allowlisted pair that starts passing fails the spec
  * on purpose. Never add an entry for new work.
+ *
+ * UNMEASURABLE BACKDROPS ARE NOT ON THIS LIST (#1675). Text over a gradient
+ * with an opaque stop has no single backdrop colour, so the scanner refuses to
+ * measure it rather than guessing. It used to be enumerated here as a pair
+ * keyed on the gradient CSS, which rotted on contact: every colour edit minted
+ * a new key, and by 2026-08-14 not one of those 56 entries matched anything the
+ * sweep still saw. Those findings are now REPORTED, and ratcheted by count
+ * against `UNRESOLVED_SURFACE_CEILING` below.
  */
 
+import type { Finding } from './contrastScan';
+
 export type BaselineEntry = {
-  /** Measured ratio when this entry landed. `null` for an unresolved backdrop. */
-  ratio: number | null;
+  /** Measured ratio when this entry landed. Every entry here was MEASURED. */
+  ratio: number;
   /** The issue that owns the fix. 651 = found by the sweep, awaiting a child. */
   issue: number;
   /** Where it was seen — a breadcrumb, not part of the identity. */
@@ -44,85 +53,16 @@ export function baselineKey(theme: string, text: string, background: string, req
 }
 
 /**
- * Identity of an unresolved backdrop — keyed on the CSS that defeated
- * resolution (stable) rather than the DOM path (rots on the next copy edit).
- */
-export function unresolvedKey(theme: string, text: string, backdropCss: string, required: number): string {
-  return `${theme} | ${text} over UNRESOLVED ${backdropCss} @${required}`;
-}
-
-/**
- * THE LIST. 269 entries, machine-produced by the sweep itself
+ * THE LIST. Machine-produced by the sweep itself
  * (`CONTRAST_BASELINE_OUT=<path> bash frontend/e2e/run-e2e.sh contrast.spec.ts`),
- * never hand-typed — 269 hand-copied ratios would be wrong within a week,
+ * never hand-typed — 185 hand-copied ratios would be wrong within a week,
  * which is this issue's whole thesis.
  *
  *   - 7 entries owned by #649 (white `--color-text-on-accent` on a faction
  *     fill). That issue's acceptance, measured as rendered.
- *   - 56 UNRESOLVED entries: text over a gradient with an OPAQUE stop — the
- *     WOW `.exe` title bars, the Ephemerists' celestial radial fields, the gilt
- *     wordmark. The colour genuinely varies under the text, so these stay loud
- *     rather than being measured against a guess. (Before the texture/fill
- *     split there were 134 of these, almost all paper grain.)
  *   - the rest await triage into children off #651.
  */
 export const RENDERED_BASELINE: Record<string, BaselineEntry> = {
-  "dark | rgb(196, 100, 138) over UNRESOLVED linear-gradient(135deg, rgb(57, 21, 42), rgb(42, 13, 28)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > div' },
-  "dark | rgb(196, 100, 138) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 26px) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > p' },
-  "dark | rgb(230, 194, 103) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop a > div > div > div' },
-  "dark | rgb(230, 194, 103) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > div > span' },
-  "dark | rgb(230, 194, 103) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop header > div > div > div' },
-  "dark | rgb(239, 227, 198) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 70%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop a > div > div > div' },
-  "dark | rgb(239, 227, 198) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop header > div > div > h1' },
-  "dark | rgb(240, 230, 208) over UNRESOLVED linear-gradient(rgb(19, 18, 26), rgb(19, 18, 26)), linear-gradient(90deg, rgb(79, 70, 229), rgb(190, 24, 93), rgb(249, 115, 22), rgb(22, 163, 74)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop nav.sticky.top-0 > div.max-w-5xl.mx-auto > a.shrink-0.leading-none > span.font-display.italic' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED linear-gradient(135deg, rgb(57, 21, 42), rgb(42, 13, 28)) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > h1' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED linear-gradient(160deg, rgb(94, 42, 70), rgb(196, 100, 138) 60%, rgb(244, 114, 182)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/mobile div.py-4 > section > div > p' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 24px) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > div' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > a > span' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 26px) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > div' },
-  "dark | rgb(251, 207, 224) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > a > span' },
-  "dark | rgb(251, 214, 232) over UNRESOLVED linear-gradient(160deg, rgb(94, 42, 70), rgb(196, 100, 138) 60%, rgb(244, 114, 182)) @3": { ratio: null, issue: 651, where: 'wow/dark/mobile div.py-4 > section > div > h1' },
-  "dark | rgb(251, 214, 232) over UNRESOLVED linear-gradient(rgb(94, 42, 70), rgb(65, 32, 58)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
-  "dark | rgb(255, 255, 255) over UNRESOLVED linear-gradient(150deg, rgb(94, 42, 70), rgb(244, 114, 182)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/mobile section.mt-6 > div.flex.flex-col > a > span' },
-  "dark | rgb(255, 255, 255) over UNRESOLVED linear-gradient(rgb(244, 114, 182), rgb(196, 100, 138)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a' },
-  "dark | rgb(255, 255, 255) over UNRESOLVED radial-gradient(circle at 35% 28%, rgb(94, 42, 70), rgb(244, 114, 182)) @3": { ratio: null, issue: 651, where: 'wow/dark/mobile div > div.flex.items-center > div.shrink-0 > span.flex.w-full' },
-  "dark | rgb(57, 21, 42) over UNRESOLVED linear-gradient(150deg, rgb(94, 42, 70), rgb(244, 114, 182)) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop a > div > div > span' },
-  "dark | rgb(57, 21, 42) over UNRESOLVED linear-gradient(150deg, rgb(94, 42, 70), rgb(244, 114, 182)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > a > span' },
-  "dark | rgb(79, 143, 176) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > h1 > span' },
-  "dark | rgba(239, 227, 198, 0.62) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > p > span' },
-  "dark | rgba(239, 227, 198, 0.7) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop a > div > div > div' },
-  "dark | rgba(239, 227, 198, 0.75) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > div > span' },
-  "dark | rgba(239, 227, 198, 0.92) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop header > div > div > p' },
-  "dark | rgba(251, 214, 232, 0.7) over UNRESOLVED linear-gradient(rgb(94, 42, 70), rgb(65, 32, 58)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
-  "dark | rgba(251, 214, 232, 0.75) over UNRESOLVED linear-gradient(rgb(94, 42, 70), rgb(65, 32, 58)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
-  "light | rgb(131, 24, 67) over UNRESOLVED linear-gradient(135deg, rgb(255, 253, 250), rgb(253, 238, 243)) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > div' },
-  "light | rgb(131, 24, 67) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 26px) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > p' },
-  "light | rgb(142, 47, 92) over UNRESOLVED linear-gradient(160deg, rgb(251, 207, 226), rgb(131, 24, 67) 60%, rgb(236, 95, 153)) @3": { ratio: null, issue: 651, where: 'wow/light/mobile div.py-4 > section > div > h1' },
-  "light | rgb(142, 47, 92) over UNRESOLVED linear-gradient(rgb(251, 207, 226), rgb(243, 166, 203)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop div > div > div > span' },
-  "light | rgb(212, 171, 85) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop a > div > div > div' },
-  "light | rgb(212, 171, 85) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > div > span' },
-  "light | rgb(212, 171, 85) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop header > div > div > div' },
-  "light | rgb(236, 95, 153) over UNRESOLVED linear-gradient(135deg, rgb(255, 253, 250), rgb(253, 238, 243)) @3": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > h1' },
-  "light | rgb(236, 95, 153) over UNRESOLVED linear-gradient(160deg, rgb(251, 207, 226), rgb(131, 24, 67) 60%, rgb(236, 95, 153)) @4.5": { ratio: null, issue: 651, where: 'wow/light/mobile div.py-4 > section > div > p' },
-  "light | rgb(236, 95, 153) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 24px) @3": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > div' },
-  "light | rgb(236, 95, 153) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > a > span' },
-  "light | rgb(236, 95, 153) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 26px) @3": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > div' },
-  "light | rgb(241, 232, 207) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 70%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop a > div > div > div' },
-  "light | rgb(241, 232, 207) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop header > div > div > h1' },
-  "light | rgb(255, 253, 250) over UNRESOLVED linear-gradient(150deg, rgb(251, 207, 226), rgb(236, 95, 153)) @3": { ratio: null, issue: 651, where: 'wow/light/desktop a > div > div > span' },
-  "light | rgb(255, 253, 250) over UNRESOLVED linear-gradient(150deg, rgb(251, 207, 226), rgb(236, 95, 153)) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > a > span' },
-  "light | rgb(255, 255, 255) over UNRESOLVED linear-gradient(150deg, rgb(251, 207, 226), rgb(236, 95, 153)) @4.5": { ratio: null, issue: 651, where: 'wow/light/mobile section.mt-6 > div.flex.flex-col > a > span' },
-  "light | rgb(255, 255, 255) over UNRESOLVED linear-gradient(rgb(236, 95, 153), rgb(131, 24, 67)) @4.5": { ratio: null, issue: 651, where: 'wow/light/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a' },
-  "light | rgb(255, 255, 255) over UNRESOLVED radial-gradient(circle at 35% 28%, rgb(251, 207, 226), rgb(236, 95, 153)) @3": { ratio: null, issue: 651, where: 'wow/light/mobile div > div.flex.items-center > div.shrink-0 > span.flex.w-full' },
-  "light | rgb(26, 18, 9) over UNRESOLVED linear-gradient(rgb(247, 244, 238), rgb(247, 244, 238)), linear-gradient(90deg, rgb(79, 70, 229), rgb(190, 24, 93), rgb(249, 115, 22), rgb(22, 163, 74)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop nav.sticky.top-0 > div.max-w-5xl.mx-auto > a.shrink-0.leading-none > span.font-display.italic' },
-  "light | rgb(29, 79, 110) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > h1 > span' },
-  "light | rgb(88, 28, 57) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > a > span' },
-  "light | rgba(142, 47, 92, 0.7) over UNRESOLVED linear-gradient(rgb(251, 207, 226), rgb(243, 166, 203)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop div > div > div > span' },
-  "light | rgba(142, 47, 92, 0.75) over UNRESOLVED linear-gradient(rgb(251, 207, 226), rgb(243, 166, 203)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop div > div > div > span' },
-  "light | rgba(241, 232, 207, 0.62) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > p > span' },
-  "light | rgba(241, 232, 207, 0.7) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop a > div > div > div' },
-  "light | rgba(241, 232, 207, 0.75) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > div > span' },
-  "light | rgba(241, 232, 207, 0.92) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop header > div > div > p' },
   "dark | rgb(111, 174, 0) on rgb(244, 241, 232) @3": { ratio: 2.41, issue: 651, where: 'snide/dark/desktop div > div > div > div' },
   "dark | rgb(111, 174, 0) on rgb(244, 241, 232) @4.5": { ratio: 2.41, issue: 651, where: 'snide/dark/desktop div > div > div > div' },
   "dark | rgb(12, 10, 6) on rgb(19, 18, 26) @3": { ratio: 1.06, issue: 651, where: 'ephemerists/dark/desktop div.wz-faction-grid > div > div > h2' },
@@ -309,3 +249,123 @@ export const RENDERED_BASELINE: Record<string, BaselineEntry> = {
   "light | rgba(96, 165, 250, 0.6) on rgb(5, 15, 8) @4.5": { ratio: 3.41, issue: 651, where: 'ua/light/mobile div.flex.flex-col > a > div.flex.items-center > span' },
   "light | rgba(96, 165, 250, 0.7) on rgb(5, 15, 8) @4.5": { ratio: 4.24, issue: 651, where: 'singularity/light/desktop header > div > div > div' },
 };
+
+/**
+ * Part D (#1675) — the coverage ratchet for backdrops the scanner REFUSES to
+ * measure.
+ *
+ * `contrastScan` returns `background: null` when the thing behind the text is
+ * a gradient with an opaque stop or an image: the colour genuinely varies
+ * under the glyphs, so there is no ratio to compute. That refusal is correct —
+ * the alternative is measuring against a guess — but treating it as a contrast
+ * FAILURE made this spec unsatisfiable. World Zero's faction skins are built
+ * out of exactly those fills, so all 28 tests were red from the day the guard
+ * landed and stayed red (2026-08-14 nightly: 728 unmeasurable findings against
+ * 168 genuinely-measured ones).
+ *
+ * Molly's ruling on #1675: report them, don't fail on them — but LOUDLY. A
+ * silent skip turns a red suite into a green one that checks less. So the spec
+ * prints every surface it could not resolve, and the count is ratcheted here.
+ * Gaining a surface is a coverage regression even though it is not a contrast
+ * defect, and it fails the run.
+ *
+ * WHY A COUNT AND NOT A LIST OF SURFACES. The obvious shape — allowlist the
+ * gradient CSS, like `RENDERED_BASELINE` allowlists the colour pair — is what
+ * this file used to do, and it rotted: the CSS embeds its colour stops, so
+ * every palette edit minted a fresh key and the 56 grandfathered entries
+ * matched nothing at all by the time they were deleted. A count survives a
+ * restop; it still catches the thing that matters, which is a NEW region of the
+ * app going unchecked.
+ *
+ * A surface is one distinct `backdropCss`, counted per test. A combination
+ * with no entry here has a ceiling of 0 on purpose — add a faction or a
+ * viewport and you must record what it costs in coverage.
+ *
+ * ponytail: these numbers were read off the failing 2026-08-14 nightly (run
+ * 31779247838), not regenerated locally — a subagent worktree has no Playwright
+ * browsers and no seeded Postgres. They are exact for that run's output, which
+ * truncates each gradient to 80 characters; two surfaces agreeing to 80
+ * characters would count as one and leave the ceiling one low. If the first
+ * nightly after this lands reports a higher count, bump the offending entry to
+ * the number the run prints — do not raise them speculatively.
+ */
+export const UNRESOLVED_SURFACE_CEILING: Record<string, number> = {
+  'ua/light/mobile': 5,
+  'ua/light/desktop': 8,
+  'ua/dark/mobile': 5,
+  'ua/dark/desktop': 8,
+  'everymen/light/mobile': 5,
+  'everymen/light/desktop': 7,
+  'everymen/dark/mobile': 5,
+  'everymen/dark/desktop': 7,
+  'wow/light/mobile': 7,
+  'wow/light/desktop': 8,
+  'wow/dark/mobile': 7,
+  'wow/dark/desktop': 8,
+  'snide/light/mobile': 5,
+  'snide/light/desktop': 7,
+  'snide/dark/mobile': 5,
+  'snide/dark/desktop': 7,
+  'ephemerists/light/mobile': 5,
+  'ephemerists/light/desktop': 7,
+  'ephemerists/dark/mobile': 5,
+  'ephemerists/dark/desktop': 7,
+  'singularity/light/mobile': 5,
+  'singularity/light/desktop': 7,
+  'singularity/dark/mobile': 5,
+  'singularity/dark/desktop': 7,
+  'albescent/light/mobile': 5,
+  'albescent/light/desktop': 7,
+  'albescent/dark/mobile': 5,
+  'albescent/dark/desktop': 7,
+};
+
+/** What the sweep does with one page's worth of findings. */
+export type Triage = {
+  /** Measured below AA and not grandfathered — these FAIL the run. */
+  failures: Finding[];
+  /** Grandfathered pairs that now clear AA — the list only shrinks, so these FAIL too. */
+  stale: string[];
+  /**
+   * Text the scanner refused to measure, grouped by the CSS that defeated it.
+   * One key = one unmeasurable SURFACE. Reported, and counted against
+   * `UNRESOLVED_SURFACE_CEILING` — never a per-finding failure.
+   */
+  unmeasurable: Map<string, Finding[]>;
+};
+
+/**
+ * Sort findings into the three buckets above. Pure, so the policy this spec
+ * enforces can be exercised by `src/utils/__tests__/contrastTriage.test.ts`
+ * without standing up Playwright, a backend and a seeded database.
+ */
+export function triageFindings(theme: string, findings: readonly Finding[]): Triage {
+  const failures: Finding[] = [];
+  const stale: string[] = [];
+  const unmeasurable = new Map<string, Finding[]>();
+
+  for (const finding of findings) {
+    if (finding.background === null) {
+      const surface = finding.backdropCss ?? 'unknown';
+      const group = unmeasurable.get(surface);
+      if (group) group.push(finding);
+      else unmeasurable.set(surface, [finding]);
+      continue;
+    }
+
+    const key = baselineKey(theme, finding.text, finding.background, finding.required);
+    const allowed: BaselineEntry | undefined = RENDERED_BASELINE[key];
+
+    if (finding.ratio >= finding.required) {
+      // A pair that now passes but is still allowlisted is debt that got fixed
+      // without the list being updated. Catch it: an allowlist that outlives
+      // its bug stops being a ratchet.
+      if (allowed) stale.push(`${key} now measures ${finding.ratio.toFixed(2)}:1 (owned by #${allowed.issue})`);
+      continue;
+    }
+    if (allowed) continue;
+    failures.push(finding);
+  }
+
+  return { failures, stale, unmeasurable };
+}

--- a/frontend/src/utils/__tests__/contrastTriage.test.ts
+++ b/frontend/src/utils/__tests__/contrastTriage.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Part D of the contrast foundation (#1675) — the triage policy.
+ *
+ * `e2e/contrast.spec.ts` can only run against Playwright, a live backend and a
+ * seeded Postgres, so it runs nightly and nothing verifies it in a PR. The
+ * decision it makes about each finding, though, is pure: fail a measured
+ * pairing below AA, REPORT a backdrop the scanner refused to measure, and fail
+ * an allowlist entry that has outlived its bug. That decision lives in
+ * `triageFindings` precisely so it can be exercised here, in milliseconds,
+ * with no browser.
+ *
+ * The load-bearing case is the first one: `background === null` means the
+ * scanner could not resolve what is behind the text (a gradient with an opaque
+ * stop, an image), NOT that it measured 0:1. Treating those two states as one
+ * is what made the sweep unsatisfiable across all 28 of its tests.
+ */
+import { describe, expect, it } from "vitest";
+
+import { RENDERED_BASELINE, baselineKey, triageFindings } from "../../../e2e/contrastBaseline";
+import type { Finding } from "../../../e2e/contrastScan";
+
+function finding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    text: "rgb(0, 0, 0)",
+    background: "rgb(255, 255, 255)",
+    unresolved: null,
+    unresolvedKind: null,
+    backdropCss: null,
+    ratio: 21,
+    required: 4.5,
+    fontSizePx: 16,
+    fontWeight: 400,
+    where: "div > div > span",
+    sample: "some copy",
+    ...overrides,
+  };
+}
+
+/** A finding the scanner gave up on, over `css`. */
+function unresolved(css: string): Finding {
+  return finding({
+    background: null,
+    ratio: 0,
+    unresolved: `div paints ${css}`,
+    unresolvedKind: "opaque-gradient",
+    backdropCss: css,
+  });
+}
+
+/**
+ * Take a real entry out of the allowlist rather than hard-coding a pair: the
+ * list only ever shrinks, and a fixture naming one specific colour pairing
+ * would start testing nothing the day that pairing gets fixed.
+ */
+const [allowlistedKey, allowlistedEntry] = Object.entries(RENDERED_BASELINE)[0];
+const parsedKey = /^(\w+) \| (.+) on (rgba?\([^)]*\)) @([\d.]+)$/.exec(allowlistedKey);
+if (parsedKey === null) throw new Error(`RENDERED_BASELINE key is not in baselineKey() form: ${allowlistedKey}`);
+const [, allowedTheme, allowedText, allowedBackground, allowedRequired] = parsedKey;
+const allowlisted = finding({
+  text: allowedText,
+  background: allowedBackground,
+  required: Number(allowedRequired),
+  ratio: allowlistedEntry.ratio,
+});
+
+describe("triageFindings", () => {
+  it("parses a real allowlist key back into the fixture it describes", () => {
+    // Guards the three tests below: if this reverse-parse ever drifts from
+    // baselineKey(), they would silently stop exercising the allowlist.
+    expect(
+      baselineKey(allowedTheme, allowlisted.text, allowedBackground, allowlisted.required),
+    ).toBe(allowlistedKey);
+    expect(allowlisted.ratio).toBeLessThan(allowlisted.required);
+  });
+
+  it("reports an unresolvable backdrop instead of failing it", () => {
+    const { failures, unmeasurable } = triageFindings("light", [unresolved("linear-gradient(90deg, rgb(1, 2, 3), rgb(4, 5, 6))")]);
+
+    expect(failures).toHaveLength(0);
+    expect(unmeasurable.size).toBe(1);
+  });
+
+  it("counts one surface per distinct backdrop, however many nodes sit on it", () => {
+    const gilt = "linear-gradient(160deg, rgb(1, 2, 3), rgb(4, 5, 6))";
+    const rainbow = "linear-gradient(90deg, rgb(7, 8, 9), rgb(10, 11, 12))";
+    const { unmeasurable } = triageFindings("dark", [unresolved(gilt), unresolved(gilt), unresolved(rainbow)]);
+
+    expect([...unmeasurable.keys()]).toEqual([gilt, rainbow]);
+    expect(unmeasurable.get(gilt)).toHaveLength(2);
+  });
+
+  it("still fails a genuinely-measured pairing below AA", () => {
+    const { failures, unmeasurable } = triageFindings("light", [finding({ ratio: 3.2, required: 4.5 })]);
+
+    expect(failures).toHaveLength(1);
+    expect(unmeasurable.size).toBe(0);
+  });
+
+  it("passes a measured pairing that clears its requirement", () => {
+    const { failures, stale } = triageFindings("light", [finding({ ratio: 4.5, required: 4.5 })]);
+
+    expect(failures).toHaveLength(0);
+    expect(stale).toHaveLength(0);
+  });
+
+  it("holds its fire on a pairing that is still allowlisted", () => {
+    const { failures, stale } = triageFindings(allowedTheme, [allowlisted]);
+
+    expect(failures).toHaveLength(0);
+    expect(stale).toHaveLength(0);
+  });
+
+  it("fails an allowlisted pairing that now clears AA — the list only shrinks", () => {
+    const fixed = { ...allowlisted, ratio: allowlisted.required + 0.5 };
+    const { failures, stale } = triageFindings(allowedTheme, [fixed]);
+
+    expect(failures).toHaveLength(0);
+    expect(stale).toHaveLength(1);
+    expect(stale[0]).toContain(`#${allowlistedEntry.issue}`);
+  });
+
+  it("does not consult the allowlist for an unresolvable backdrop", () => {
+    // The old key shape put unresolved findings in RENDERED_BASELINE keyed on
+    // the gradient CSS. Nothing may grandfather them any more — they are
+    // ratcheted by count, so an allowlist hit here would double-count.
+    const { failures, stale, unmeasurable } = triageFindings(allowedTheme, [
+      { ...unresolved("linear-gradient(90deg, rgb(1, 2, 3), rgb(4, 5, 6))"), text: allowedText },
+    ]);
+
+    expect(failures).toHaveLength(0);
+    expect(stale).toHaveLength(0);
+    expect(unmeasurable.size).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #1675

Option (1) per the owner ruling of 2026-08-14: a backdrop the scanner cannot resolve stops failing the suite and gets **reported** instead, loudly, with a count ratchet so gaining one still fails.

## The seam

`triageFindings(theme, findings)` — the point where one scanner `Finding` becomes pass / report / fail. That decision used to be inline in the spec body, reachable only from a nightly run against Playwright + a live backend + a seeded Postgres. It is now a pure function in `contrastBaseline.ts`, and `src/utils/__tests__/contrastTriage.test.ts` drives it from a PR.

Red-first: making `background === null` fall through to the ratio comparison (i.e. the old behaviour) fails 3 of the 8 new tests, and only those 3.

## What changed

**Three outcomes, not two.**

- a **measured** pairing below AA still fails, unchanged, allowlist and all;
- `background === null` — the scanner *refusing* to measure, because what is behind the glyphs is a gradient with an opaque stop — is collected, printed, and asserted only by count;
- an allowlisted pair that now clears AA still fails. The list only ever shrinks.

**The report prints on every run, before any assertion, pass or fail:**

```
[contrast] wow/dark/desktop: 8 unmeasurable surface(s) (ceiling 8), 42 text node(s) unchecked.
  12 node(s) over linear-gradient(160deg, rgb(55, 46, 37), rgb(36, 30, 24) 60%)
    e.g. div > div > div > div (42px/600) "UA"
  ...
```

**The ratchet** is `UNRESOLVED_SURFACE_CEILING` in `contrastBaseline.ts` — distinct `backdropCss` values per faction/theme/viewport. A combination with no entry has a ceiling of 0, so adding a faction or a viewport forces you to record what it costs in coverage.

Why a count and not an allowlist of surfaces: that is what the file *used* to do, and it rotted. The gradient CSS embeds its colour stops, so every palette edit minted a fresh key — by 2026-08-14 **not one of the 56 grandfathered UNRESOLVED entries matched anything the sweep still saw.** They are deleted here. A count survives a restop and still catches the thing that matters, which is a new region of the app going unchecked.

## Where the ceiling numbers come from — and the thing this PR does NOT fix

I cannot run this suite: a subagent worktree has no Playwright browsers and no seeded Postgres. So instead of guessing, I read the numbers off the failing nightly itself, run `31779247838` (2026-08-14), and cross-checked every one against Playwright's own `Received length:` line. All 28 tests reconcile exactly, and both retry blocks agree.

That same parse turned up something the issue does not say, and it matters for the acceptance criteria:

| | findings | distinct |
|---|---|---|
| unmeasurable backdrops | 728 | 21 surfaces |
| **genuinely measured, below AA** | **168** | **23 colour pairs** |

**Every one of the 28 tests carries between 2 and 15 measured sub-AA pairs.** The issue reads the `UNRESOLVED BACKDROP is a failure, not a skip` wording as evidence that the failures are all unresolved-backdrop, but that sentence was a **constant in the assertion message**, printed for every failure including pure ratio ones.

So this PR removes ~81% of the noise (728 of 896 findings) but **will not turn contrast.spec.ts green.** The residual 23 pairs are genuine measured contrast debt, and the ruling is explicit that a measured low ratio must still fail. They are also not random: the top of the list is ghosted body text —

```
22x  light | rgba(26, 18, 9, 0.45)   on rgb(255, 253, 249) @4.5
22x  dark  | rgba(240, 230, 208, 0.4) on rgb(28, 27, 36)   @4.5
14x  light | rgba(107, 96, 80, 0.75) on rgb(255, 253, 249) @4.5
14x  dark  | rgba(155, 144, 128, 0.75) on rgb(28, 27, 36)  @4.5
```

— i.e. `--color-text-secondary` / `--color-text-tertiary`, which **#1715 is lifting in this same batch.** Worth re-reading the next nightly before filing anything: a chunk of the 23 may retire on their own. Separately, none of the 185 measured baseline entries matched anything in this run either, and zero "now measures" reports fired, so that list is stale too — out of scope here, and it does not affect this change.

## Verification

Everything `.github/workflows/test.yml` names for the `frontend` job, locally, all green: `lint`, `typecheck`, `typecheck:design-sync`, `test` (237 files / 4258 tests), `build`, `budget` (JS 129.0 KB, CSS 21.5 KB, both ok). `npm run typecheck` only includes `src`, so I also ran `tsc --noEmit` over the three `e2e/` modules directly — clean. No backend files touched, so `api-schema` and the backend job are unaffected.

**The only real verification is the next nightly.** I did not run the e2e suite and am not claiming it passes.

## What to eyeball

- **The ceiling numbers** in `contrastBaseline.ts`. They are exact for run `31779247838`, but that log truncates each gradient to 80 characters. Two surfaces agreeing for 80 characters would have counted as one and left a ceiling one low. If the first nightly reports a higher count for some combination, bump *that* entry to the number the run prints — please don't raise them speculatively.
- **Deleting the 56 UNRESOLVED entries.** The argument is that they were provably matching nothing; if you would rather keep them as a historical record, say so and I will restore them as a comment.
- **Count vs. set for the ratchet.** A count will not notice one gradient surface being swapped for a different one. That is the trade for surviving a palette edit — and #1727 (option 3, narrowing what is scanned) is the real answer either way.
- **`console.log` for the report.** It lands in the nightly job log. If you want it as an artifact instead, that is a different mechanism and I would rather do it deliberately.
- **The ceiling assertion is last**, after the measured-failure assertions, so while the 23 measured pairs are still red the ceiling never actually gets exercised. The report still prints on every run regardless — that was the non-negotiable part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
