### PR TITLE
The Players page wears the shared page header

### DIFF
--- a/frontend/src/__tests__/playersPageHeader.test.tsx
+++ b/frontend/src/__tests__/playersPageHeader.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * #1699 — the Players page wears the SHARED page header.
+ *
+ * Seam: the markup `DesktopLeaderboard` emits above the sky. It used to
+ * hand-roll an `<h1>` that copied `PageTitle`'s classes but dropped the
+ * per-letter rainbow underline (Style Guide §7, ADR-0066), then drew a second
+ * full-width rainbow rule of its own. Asserted here as what a reader sees:
+ * every letter of the title carries its own spectrum bar, the page draws that
+ * rainbow ONCE, and the controls that shared the old header row survive.
+ *
+ * Rendered through `DesktopLeaderboard`, not `<Leaderboard/>`: the page wrapper
+ * shows its Loading branch under `renderToStaticMarkup` (no effect resolves the
+ * fetch), so an assertion against it would pass with nothing on screen.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../i18n'
+import type { CharacterOut } from '../api/auth'
+import { DesktopLeaderboard } from '../pages/Leaderboard'
+
+function player(overrides: Partial<CharacterOut>): CharacterOut {
+  return {
+    id: 1,
+    username: 'wren',
+    display_name: 'Wren',
+    bio: '',
+    tagline: '',
+    avatar_url: '',
+    location: '',
+    level: 3,
+    score: 320,
+    all_time_score: 900,
+    faction_slug: 'everymen',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    badges: [],
+    invitations: [],
+    ...overrides,
+  }
+}
+
+const PLAYERS: CharacterOut[] = [
+  player({ id: 11, display_name: 'Perpetua', faction_slug: 'everymen', score: 2140 }),
+  player({ id: 22, display_name: 'Reza', faction_slug: 'ephemerists', score: 1880 }),
+  player({ id: 33, display_name: 'Molly', faction_slug: 'na', score: 340 }),
+]
+
+function board() {
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <DesktopLeaderboard characters={PLAYERS} loading={false} error={null} user={null} />
+    </MemoryRouter>,
+  )
+  return { html, text: html.replace(/<[^>]*>/g, '') }
+}
+
+/** The heading only — the sky below paints faction hues of its own. */
+function headingHtml(html: string): string {
+  const open = html.indexOf('<h1')
+  expect(open, 'the page has a heading').toBeGreaterThan(-1)
+  return html.slice(open, html.indexOf('</h1>', open))
+}
+
+describe('players page header (#1699)', () => {
+  it('underlines the title letter by letter, like every other page', () => {
+    const heading = headingHtml(board().html)
+    for (let stop = 1; stop <= 7; stop++) {
+      expect(heading, `letter ${stop} wears spectrum stop ${stop}`).toContain(
+        `var(--faction-default-stop-${stop})`,
+      )
+    }
+  })
+
+  it('draws that rainbow once — no separate full-width rule', () => {
+    const { html, text } = board()
+    expect(text, 'the title still reads as a word').toContain('Players')
+    expect(html, 'no second spectrum bar under the title').not.toContain(
+      'linear-gradient(90deg, var(--faction-everymen)',
+    )
+  })
+
+  it('keeps the score toggle and the counts line', () => {
+    const { text } = board()
+    expect(text, 'era toggle').toContain('Era')
+    expect(text, 'all-time toggle').toContain('All-Time')
+    expect(text, 'players count').toContain('3 adventurers')
+    expect(text, 'factions count').toContain('3 factions')
+  })
+})

--- a/frontend/src/pages/Leaderboard.tsx
+++ b/frontend/src/pages/Leaderboard.tsx
@@ -4,8 +4,8 @@ import { getLeaderboard } from '../api/leaderboard'
 import { useResource } from '../hooks/useResource'
 import { useAuth } from '../auth/AuthContext'
 import { extractError } from '../utils/errors'
-import { FACTION_RAINBOW_ORDER, factionCssVar } from '../utils/factions'
 import type { CharacterOut, CurrentUser } from '../api/auth'
+import PageTitle from '../components/ui/PageTitle'
 import { useFormFactor } from '../hooks/useFormFactor'
 import { type RankedPlayer } from './players/Constellation'
 import SkyCanvas, { DESKTOP_SKY_MAX_WIDTH } from './players/SkyCanvas'
@@ -127,36 +127,21 @@ export function DesktopLeaderboard({
     <div className="py-8">
       {/* ── The sky ── */}
       <section>
-        <div className="flex items-center justify-between gap-4 mb-1">
-          <p className="label-heading">{eyebrow}</p>
+        {/* The shared page header (#1699). This page hand-rolled an <h1> that
+            copied PageTitle's classes but dropped the per-letter rainbow, then
+            drew a full-width rainbow rule of its own — two spellings of one
+            ornament. PageTitle brings the rainbow, so the rule is gone and the
+            score toggle moves to the row below the title. */}
+        <PageTitle title={t('leaderboard.desktop.title')} eyebrow={eyebrow} />
+
+        <div className="flex items-center justify-between gap-4 mb-3">
+          <p className="label-caption">
+            {t('leaderboard.desktop.playersCount', { count: characters.length })}
+            {' · '}
+            {t('leaderboard.desktop.factionsCount', { count: factionCount })}
+          </p>
           <ScoreToggle mode={scoreMode} onChange={setScoreMode} />
         </div>
-
-        <h1
-          className="font-display italic font-medium leading-tight"
-          style={{ fontSize: 'var(--text-display)', color: 'var(--color-text-primary)' }}
-        >
-          {t('leaderboard.desktop.title')}
-        </h1>
-
-        <p className="label-caption mb-3">
-          {t('leaderboard.desktop.playersCount', { count: characters.length })}
-          {' · '}
-          {t('leaderboard.desktop.factionsCount', { count: factionCount })}
-        </p>
-
-        {/* Rainbow rule — the faction spectrum, in canonical order. */}
-        <div
-          aria-hidden
-          className="mb-3"
-          style={{
-            height: 3,
-            borderRadius: 2,
-            background: `linear-gradient(90deg, ${FACTION_RAINBOW_ORDER.map((slug) =>
-              factionCssVar(slug),
-            ).join(', ')})`,
-          }}
-        />
 
         <p
           className="mb-4"


### PR DESCRIPTION
The Players page was the one desktop page that did not use `PageTitle`. It
hand-rolled an `<h1>` with `PageTitle`'s exact classes and font size but no
per-letter rainbow underline, then drew a full-width rainbow rule and a script
subtitle beneath it. Closed epic #727 named the same habit on this page: it
bypasses the shared components.

**The seam tested:** the markup `DesktopLeaderboard` emits above the sky —
rendered through the exported board, not `<Leaderboard/>`, whose Loading branch
is all `renderToStaticMarkup` ever reaches. The new test
(`frontend/src/__tests__/playersPageHeader.test.tsx`) went red on the real
defect first: every letter of "Players" carrying its own spectrum stop, and the
page drawing that rainbow exactly once. Its third case is the preservation
guard — the score toggle and the counts line — and was green throughout.

**What changed** (`frontend/src/pages/Leaderboard.tsx`, current lines 126-144):

- `<PageTitle title eyebrow />` replaces the hand-rolled heading and the
  separate eyebrow row. No new prop on `PageTitle`.
- The score toggle moves to the row *under* the title, sharing it with the
  players/factions count — so the shared component does not grow a slot for one
  caller.
- The full-width rainbow rule is deleted: `PageTitle`'s per-letter bars are the
  same rainbow, and `FACTION_RAINBOW_ORDER` / `factionCssVar` were imported for
  nothing else here.
- The script-font tagline stays. It names the sky's encoding and follows the
  viz, which the rule did not.

Nothing touches `PageTitle.tsx`, `Constellation.tsx`, or `players/`. Based on
`origin/main` after #1763 (Meadow retirement) — no `useTheme` and no theme
branch are reintroduced, and #1763's "never calls `useTheme`" spy assertion
still passes.

**Verification:** `tsc --noEmit`, `typecheck:design-sync`, `lint`, `npm test`
(241 files / 4289 tests), `build` and `budget` all pass locally. No browser
here, so visual QA is outstanding.

Closes #1699

## What to eyeball

- **The underline.** "Players" should now carry the same seven-stop per-letter
  bars as Tasks, Praxes and Factions — and there should be no second rainbow
  bar between the counts line and the tagline.
- **The score toggle's new home.** It sits right-aligned on the counts row
  under the title instead of on the eyebrow row above it. Check the vertical
  rhythm there: `PageTitle` brings its own `mb-6`, which is a wider gap than
  the old header's `mb-1` eyebrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
