### PR TITLE
Filter-rail segments are as wide as their labels, and the thumb measures the one it sits on

### DIFF
--- a/frontend/src/components/ui/FilterBar/SegmentedRail.tsx
+++ b/frontend/src/components/ui/FilterBar/SegmentedRail.tsx
@@ -1,4 +1,19 @@
-import { thumbOffset, thumbWidth, type FilterRail } from './filterState'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+import {
+  sameBoxes,
+  thumbGeometry,
+  type FilterRail,
+  type SegmentBox,
+} from './filterState'
+
+/**
+ * The app is client-only, so this is `useLayoutEffect` everywhere it runs: the
+ * thumb must be placed before the browser paints or it flashes. The DOM-less
+ * test harness renders through `react-dom/server`, which warns about layout
+ * effects it cannot run — there it degrades to the effect it will not run
+ * either. Same idiom as the ubiquitous `useIsomorphicLayoutEffect`.
+ */
+const useMeasureEffect = typeof document === 'undefined' ? useEffect : useLayoutEffect
 
 /**
  * One segmented rail: a spectrum-ringed track with a sliding thumb (#1365).
@@ -14,9 +29,20 @@ import { thumbOffset, thumbWidth, type FilterRail } from './filterState'
  * and the Snide-lime accent is gone: selection reads as a neutral highlight
  * plus a full-strength ink, exactly as `FilterStamps` has always drawn it.
  *
- * All geometry beyond the thumb's `left`/`width` lives on `.filter-rail` in
- * index.css. Those two are inline because they are functions of the segment
- * count, which only the caller knows.
+ * **The thumb is measured, not calculated (#1726).** It used to be
+ * `calc(i * track / n)` — one nth of the rail — which forced every segment to
+ * be one nth wide too, and a 7-character label in a monospace face did not fit
+ * the share a four-segment status rail left it. Segments now size to their own
+ * labels and the thumb takes the active one's measured box whole, so nothing in
+ * this component or in index.css knows the segment count. That also survives
+ * translation: a longer word makes a wider segment instead of overflowing one.
+ *
+ * Re-measured on every render (the segment set is viewer-gated and changes at
+ * sign-in) and by a `ResizeObserver` on the rail and its segments (the rail
+ * resizes with the viewport; the segments resize when the webfont lands or the
+ * language changes). `useLayoutEffect` runs before the browser paints, so the
+ * thumb's first appearance is already in the right place — and until it has
+ * been measured there is NO thumb, which is why the DOM-less harness sees none.
  */
 export default function SegmentedRail({ rail }: { rail: FilterRail }) {
   const { label, value, segments, onChange } = rail
@@ -24,21 +50,58 @@ export default function SegmentedRail({ rail }: { rail: FilterRail }) {
     0,
     segments.findIndex((segment) => segment.value === value),
   )
+  const railRef = useRef<HTMLDivElement | null>(null)
+  const segmentRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const [boxes, setBoxes] = useState<SegmentBox[]>([])
+
+  // `offset*` rather than `getBoundingClientRect`: it is already relative to the
+  // rail's padding box — the same origin the absolutely positioned thumb
+  // resolves against — so the rail's 1.5px ring needs no correcting for.
+  const measure = useCallback(() => {
+    const measured = segmentRefs.current
+      .filter((element): element is HTMLButtonElement => element !== null)
+      .map((element) => ({
+        left: element.offsetLeft,
+        top: element.offsetTop,
+        width: element.offsetWidth,
+        height: element.offsetHeight,
+      }))
+    setBoxes((previous) => (sameBoxes(previous, measured) ? previous : measured))
+  }, [])
+
+  // No dependency array on purpose: a re-render is the one signal that covers
+  // every way the segment set can change (sign-in adds two status segments, a
+  // language switch relabels them). `sameBoxes` makes the repeat runs free.
+  useMeasureEffect(measure)
+
+  useEffect(() => {
+    const railElement = railRef.current
+    // Guarded as `SkyCanvas` guards its own observer: the constructor is a
+    // browser global, and this module is imported by a Node-side harness.
+    if (!railElement || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver(measure)
+    observer.observe(railElement)
+    for (const element of segmentRefs.current) {
+      if (element) observer.observe(element)
+    }
+    return () => observer.disconnect()
+  }, [measure, segments.length])
+
+  const geometry = thumbGeometry(boxes, activeIndex)
+
   return (
-    <div className="filter-rail" role="group" aria-label={label}>
-      <span
-        className="filter-rail__thumb"
-        aria-hidden="true"
-        style={{
-          left: thumbOffset(activeIndex, segments.length),
-          width: thumbWidth(segments.length),
-        }}
-      />
+    <div className="filter-rail" role="group" aria-label={label} ref={railRef}>
+      {geometry && (
+        <span className="filter-rail__thumb" aria-hidden="true" style={geometry} />
+      )}
       {segments.map((segment, index) => (
         <button
           key={segment.value}
           type="button"
           className="filter-rail__segment"
+          ref={(element) => {
+            segmentRefs.current[index] = element
+          }}
           // The selected ink is a data attribute rather than an inline colour
           // so the whole pairing lives in one place in index.css and flips with
           // the theme (STYLE §1.3).

--- a/frontend/src/components/ui/FilterBar/__tests__/filterBarOverflow.test.ts
+++ b/frontend/src/components/ui/FilterBar/__tests__/filterBarOverflow.test.ts
@@ -42,3 +42,62 @@ describe('.filter-bar does not clip its overflow (#1506)', () => {
     expect(bodies.some((body) => /border-(top-(left|right)-radius|radius)\s*:/.test(body))).toBe(true)
   })
 })
+
+/**
+ * #1726 — a segment must never be narrower than its own label.
+ *
+ * `.filter-rail__segment` used to be `flex: 1` with zero horizontal padding, so
+ * every label got the same box no matter how long it was. In Courier Prime a
+ * label's width is exactly its character count, and at the rail's own
+ * `min-width` a four-segment status rail gave each label 53.5px against a
+ * 58.8px "Retired" — it overflowed. Only a signed-in viewer allowed `retired`
+ * and `pending` ever saw four segments, which is why it survived.
+ *
+ * The measurement itself is not reachable from this harness (no DOM), so what
+ * is guarded here is the CSS half of the fix: content-sized segments with real
+ * horizontal padding, and a thumb whose WIDTH is animated now that it changes
+ * from segment to segment.
+ */
+describe('.filter-rail sizes segments to their labels (#1726)', () => {
+  const segmentBodies = ruleBodies(css, '.filter-rail__segment')
+
+  it('never gives a segment an equal 1/n share', () => {
+    expect(segmentBodies.length).toBeGreaterThan(0)
+    for (const body of segmentBodies) {
+      // `flex: 1` is shorthand for `1 1 0%` — a zero basis, i.e. an equal share
+      // that ignores the label. `flex: 1 1 auto` (grow into slack from a
+      // CONTENT basis) is the fix and must keep passing.
+      expect(body).not.toMatch(/flex\s*:\s*1\s*(?:1\s*(?:0|0%|0px)\s*)?;/)
+      expect(body).not.toMatch(/flex-basis\s*:\s*(0|0%|0px)\s*;/)
+    }
+  })
+
+  it('pads every segment horizontally, in both form factors', () => {
+    // One shorthand with a horizontal component, or an explicit inline pair.
+    // A single-value `padding: X` counts — it pads all four sides.
+    for (const body of segmentBodies) {
+      const shorthand = /padding\s*:\s*([^;]+);/.exec(body)
+      const inline = /padding-(inline|left|right)[^:]*:\s*([^;]+);/.test(body)
+      expect(
+        inline || (shorthand !== null && horizontalPadding(shorthand[1]) !== '0'),
+        `a .filter-rail__segment body pads no horizontal side: ${body.trim()}`,
+      ).toBe(true)
+    }
+  })
+
+  it('animates the thumb\'s width, not only its left edge', () => {
+    // The thumb is now as wide as the segment under it, so a transition that
+    // names only `left` slides the pill while snapping its width.
+    const bodies = ruleBodies(css, '.filter-rail__thumb')
+    expect(bodies.length).toBeGreaterThan(0)
+    const transitions = bodies.join('\n')
+    expect(transitions).toMatch(/transition[^;]*\bleft\b/)
+    expect(transitions).toMatch(/transition[^;]*\bwidth\b/)
+  })
+})
+
+/** The horizontal component of a `padding` shorthand: 1/2/3/4 values. */
+function horizontalPadding(shorthand: string): string {
+  const parts = shorthand.trim().split(/\s+/)
+  return parts.length === 1 ? parts[0] : parts[1]
+}

--- a/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
+++ b/frontend/src/components/ui/FilterBar/__tests__/filterState.test.tsx
@@ -7,7 +7,11 @@
  * effects — so the parts worth guarding are the ones that are functions of
  * state rather than of a pointer:
  *
- *   - thumbOffset / thumbWidth for each (index, segment count) pair, 2..6
+ *   - thumbGeometry / sameBoxes — the pure half of the measured thumb (#1726).
+ *     The MEASUREMENT is not reachable here and never will be: `offsetLeft` and
+ *     `ResizeObserver` need a real layout. What is reachable is the decision
+ *     taken from a set of measured boxes, and the fact that an unmeasured rail
+ *     draws no thumb at all.
  *   - deriveChips from a filter-state object, facet chips first, with and
  *     without an ornament
  *   - the applied-count badge, which is chips.length rendered
@@ -33,17 +37,16 @@ import FilterBar from '..'
 import { factionFacet, filterRoster } from '../factionFacet'
 import {
   deriveChips,
+  sameBoxes,
   selectEmptyState,
   selectedFirst,
-  thumbOffset,
-  thumbWidth,
+  thumbGeometry,
   toggleOption,
   type FilterFacet,
   type FilterRail,
+  type SegmentBox,
 } from '../filterState'
 import type { FactionOut } from '../../../../api/factions'
-
-const PAD = 'var(--filter-rail-pad)'
 
 const sortRail = (value: string, onChange = () => {}): FilterRail => ({
   key: 'sort',
@@ -86,50 +89,78 @@ const typeFacet = (
   onChange,
 })
 
-describe('thumbOffset / thumbWidth — the sliding thumb geometry', () => {
-  // The design's maths is `calc(i * (100% - 6px) / n + 3px)`; the 3px rail
-  // padding is a token here so the CSS and the JS cannot drift.
-  it('places a 2-segment thumb at either end', () => {
-    expect(thumbOffset(0, 2)).toBe(`calc(0 * (100% - 2 * ${PAD}) / 2 + ${PAD})`)
-    expect(thumbOffset(1, 2)).toBe(`calc(1 * (100% - 2 * ${PAD}) / 2 + ${PAD})`)
+describe('thumbGeometry — the thumb sits on the MEASURED active segment (#1726)', () => {
+  // The tasks status rail as a viewer who can see all four states measures it:
+  // "All" is 3 characters and "Pending" is 7, so the boxes are UNEQUAL. The old
+  // `calc(i * track / n)` arithmetic could only say "one nth", which is what
+  // forced `flex: 1` on the segment and made "Retired"/"Pending" overflow.
+  const statusBoxes: SegmentBox[] = [
+    { left: 3, top: 3, width: 49, height: 38 },
+    { left: 52, top: 3, width: 74, height: 38 },
+    { left: 126, top: 3, width: 83, height: 38 },
+    { left: 209, top: 3, width: 83, height: 38 },
+  ]
+
+  it('takes the active segment box whole, unequal widths and all', () => {
+    expect(thumbGeometry(statusBoxes, 0)).toEqual({
+      left: '3px',
+      top: '3px',
+      width: '49px',
+      height: '38px',
+    })
+    expect(thumbGeometry(statusBoxes, 3)).toEqual({
+      left: '209px',
+      top: '3px',
+      width: '83px',
+      height: '38px',
+    })
   })
 
-  it('places a 3-segment thumb (the tasks sort rail: level / newest / oldest)', () => {
-    expect(thumbOffset(0, 3)).toBe(`calc(0 * (100% - 2 * ${PAD}) / 3 + ${PAD})`)
-    expect(thumbOffset(1, 3)).toBe(`calc(1 * (100% - 2 * ${PAD}) / 3 + ${PAD})`)
-    expect(thumbOffset(2, 3)).toBe(`calc(2 * (100% - 2 * ${PAD}) / 3 + ${PAD})`)
+  // 2 segments logged out, 3 or 4 signed in: the same function, no segment
+  // count anywhere in it.
+  it('places the thumb at either end of a 2-segment rail', () => {
+    const twoUp: SegmentBox[] = [
+      { left: 3, top: 3, width: 90, height: 38 },
+      { left: 93, top: 3, width: 140, height: 38 },
+    ]
+    expect(thumbGeometry(twoUp, 1)?.left).toBe('93px')
+    expect(thumbGeometry(twoUp, 1)?.width).toBe('140px')
   })
 
-  it('places a 4-segment thumb (the praxis sort rail)', () => {
-    for (const index of [0, 1, 2, 3]) {
-      expect(thumbOffset(index, 4)).toBe(
-        `calc(${index} * (100% - 2 * ${PAD}) / 4 + ${PAD})`,
-      )
-    }
+  it('carries top and height too, so a wrapped rail still lands on its row', () => {
+    const wrapped: SegmentBox[] = [
+      { left: 3, top: 3, width: 90, height: 44 },
+      { left: 3, top: 47, width: 90, height: 44 },
+    ]
+    expect(thumbGeometry(wrapped, 1)?.top).toBe('47px')
   })
 
-  // #1446 widened RAIL_SEGMENTS_MAX to 6 for Updates' relationship rail
-  // (All / Your Stuff / Friends / Foes / Global).
-  it('places a 5-segment thumb (the relationship rail)', () => {
-    for (const index of [0, 1, 2, 3, 4]) {
-      expect(thumbOffset(index, 5)).toBe(
-        `calc(${index} * (100% - 2 * ${PAD}) / 5 + ${PAD})`,
-      )
-    }
+  it('is null before the rail has been measured — first paint draws no thumb', () => {
+    expect(thumbGeometry([], 0)).toBeNull()
   })
 
-  it('places a 6-segment thumb — the widened ceiling', () => {
-    for (const index of [0, 1, 2, 3, 4, 5]) {
-      expect(thumbOffset(index, 6)).toBe(
-        `calc(${index} * (100% - 2 * ${PAD}) / 6 + ${PAD})`,
-      )
-    }
+  it('is null for a zero-width measurement (a hidden or unlaid-out rail)', () => {
+    expect(thumbGeometry([{ left: 0, top: 0, width: 0, height: 0 }], 0)).toBeNull()
   })
 
-  it('sizes the thumb to one nth of the track for 2 through 6 segments', () => {
-    for (const count of [2, 3, 4, 5, 6]) {
-      expect(thumbWidth(count)).toBe(`calc((100% - 2 * ${PAD}) / ${count})`)
-    }
+  it('is null when the active index is past the measured set', () => {
+    // The rail is viewer-gated: signing out drops two segments, and the render
+    // that shrinks the set runs before the re-measure.
+    expect(thumbGeometry(statusBoxes.slice(0, 2), 3)).toBeNull()
+  })
+})
+
+describe('sameBoxes — the re-measure guard', () => {
+  const box = (left: number): SegmentBox => ({ left, top: 3, width: 49, height: 38 })
+
+  it('holds the old array when nothing moved, so a ResizeObserver cannot loop', () => {
+    expect(sameBoxes([box(3), box(52)], [box(3), box(52)])).toBe(true)
+  })
+
+  it('sees a move, a resize and a change of segment count', () => {
+    expect(sameBoxes([box(3)], [box(4)])).toBe(false)
+    expect(sameBoxes([box(3)], [{ ...box(3), width: 50 }])).toBe(false)
+    expect(sameBoxes([box(3)], [box(3), box(52)])).toBe(false)
   })
 })
 
@@ -223,6 +254,22 @@ describe('the applied-count badge', () => {
   it('counts facet chips and rail chips together', () => {
     const html = render(['ua', 'coven'], 'all')
     expect(html).toContain('>3<')
+  })
+})
+
+describe('the rail before it has been measured (#1726)', () => {
+  it('draws its segments but no thumb', () => {
+    // The thumb is a function of a measured rect since #1726, and this harness
+    // runs no effects, so the FIRST render carries no thumb at all. That is the
+    // shipped behaviour too: a thumb rendered before layout would flash at the
+    // wrong place or at zero width, and `useLayoutEffect` puts the real one in
+    // before the browser paints. If a thumb ever appears in this markup, some
+    // fallback geometry has been reintroduced — that fallback IS the flash.
+    const html = renderToStaticMarkup(
+      <FilterBar rails={[eraRail('current')]} facets={[]} onClearAll={() => {}} />,
+    )
+    expect(html).toContain('filter-rail__segment')
+    expect(html).not.toContain('filter-rail__thumb')
   })
 })
 

--- a/frontend/src/components/ui/FilterBar/filterState.ts
+++ b/frontend/src/components/ui/FilterBar/filterState.ts
@@ -93,36 +93,85 @@ export interface AppliedChip {
  * ponytail: no runtime guard, and 6 is a measurement rather than a limit the
  * code enforces. There is no ellipsis on `.filter-rail__segment` — it is
  * `white-space: nowrap` with no `overflow`/`text-overflow`, and a flex item's
- * `min-width` is `auto`, so a segment never shrinks below its label. The
- * failure mode past the ceiling is therefore clipping (`.filter-bar` is
- * `overflow: hidden`), not an ellipsis. Courier Prime advances 0.6em, segments
- * carry no horizontal padding, and the rail costs 9px of pad and border, so a
- * rail of C characters is `0.6 * fontSize * C + 9` wide at its narrowest.
- * The 5-segment relationship rail is 30 characters: 261px at the desktop
- * `--text-xl` (14px), 225px at the phone's `--text-lg` (12px) against a 240px
- * content box at a 320px viewport (`.page` is `px-4`, `.filter-bar__body` is
- * `--space-xl`). It fits, with ~15px to spare at 320px and ~70px at 375px.
- * Widening past 6 — or past ~32 characters on a five-up — means re-running that
- * arithmetic, not deleting this comment.
+ * `min-width` is `auto`, so a segment never shrinks below its label. Since
+ * #1726 a segment is sized to its own label plus horizontal padding, so a rail
+ * of C characters over S segments is `0.6 * fontSize * C + 2 * pad * S + 9`
+ * wide at its narrowest (Courier Prime advances 0.6em; the rail itself costs
+ * 9px of pad and border). At the phone's `--text-lg` (12px) and `--space-sm`
+ * (8px) of segment padding, the widest rail the site mounts — the praxis sort,
+ * 33 characters over 4 segments — is 311px against a 311px content box at a
+ * 375px viewport (`.page` is `px-4`, `.filter-bar__body` is `--space-lg` on the
+ * phone). Past that the rail WRAPS to a second row rather than overflowing the
+ * page: `.filter-rail` is `flex-wrap: wrap` with `max-width: 100%`, and the
+ * thumb is measured, so it lands on the active segment's row either way.
+ * Widening past 6 means re-running that arithmetic, not deleting this comment.
  */
 export const RAIL_SEGMENTS_MIN = 2
 export const RAIL_SEGMENTS_MAX = 6
 
-// The rail's inner padding, as the token `.filter-rail` is drawn with. The
-// design writes this maths as `calc(i * (100% - 6px) / n + 3px)`; the literal
-// 6/3 is that padding doubled and single, so it is read from index.css here
-// instead of restated — a number in two files is a number that drifts.
-const RAIL_PAD = 'var(--filter-rail-pad)'
-const TRACK = `(100% - 2 * ${RAIL_PAD})`
-
-/** Left edge of the sliding thumb over segment `index` of `segmentCount`. */
-export function thumbOffset(index: number, segmentCount: number): string {
-  return `calc(${index} * ${TRACK} / ${segmentCount} + ${RAIL_PAD})`
+/**
+ * One measured segment, in CSS px relative to the rail's padding box — that is,
+ * `offsetLeft`/`offsetTop`/`offsetWidth`/`offsetHeight` against the rail, which
+ * is the same origin an absolutely positioned thumb resolves `left`/`top`
+ * against. Deliberately plain numbers: the measuring is the component's job,
+ * and everything decided FROM a measurement lives here where a DOM-less harness
+ * can reach it.
+ */
+export interface SegmentBox {
+  left: number
+  top: number
+  width: number
+  height: number
 }
 
-/** Width of the sliding thumb — one nth of the track. */
-export function thumbWidth(segmentCount: number): string {
-  return `calc(${TRACK} / ${segmentCount})`
+/** Inline geometry for the sliding thumb. */
+export interface ThumbGeometry {
+  left: string
+  top: string
+  width: string
+  height: string
+}
+
+/**
+ * Where the thumb goes: exactly over the measured active segment (#1726).
+ *
+ * `null` means "not measurable yet" and the caller must draw no thumb at all —
+ * before layout there is no honest answer, and any fallback (zero width, an
+ * assumed 1/n share) IS the first-paint flash. The rail is viewer-gated, so the
+ * render that changes the segment count arrives before the re-measure does;
+ * that is the out-of-range case, not an error.
+ */
+export function thumbGeometry(
+  boxes: SegmentBox[],
+  activeIndex: number,
+): ThumbGeometry | null {
+  const box = boxes[activeIndex]
+  if (!box || box.width <= 0 || box.height <= 0) return null
+  return {
+    left: `${box.left}px`,
+    top: `${box.top}px`,
+    width: `${box.width}px`,
+    height: `${box.height}px`,
+  }
+}
+
+/**
+ * Did anything actually move? A `ResizeObserver` fires once per observed
+ * element the moment it is observed, so a re-measure that always stores a fresh
+ * array would re-render on every observation for no reason. Holding the old
+ * array when the numbers match keeps that to one render.
+ */
+export function sameBoxes(before: SegmentBox[], after: SegmentBox[]): boolean {
+  return (
+    before.length === after.length &&
+    before.every(
+      (box, index) =>
+        box.left === after[index].left &&
+        box.top === after[index].top &&
+        box.width === after[index].width &&
+        box.height === after[index].height,
+    )
+  )
 }
 
 /** Selected rows to the top, list order preserved inside each group. */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5517,10 +5517,10 @@
   --filter-thumb: color-mix(in srgb, var(--color-text-primary) 10%, transparent);
   --filter-thumb-edge: color-mix(in srgb, var(--color-text-primary) 18%, transparent);
 
-  /* The rail's inner padding. Read by SegmentedRail's thumb maths as well as by
-     .filter-rail, because the design writes that maths as
-     `calc(i * (100% - 6px) / n + 3px)` — the 6 and the 3 ARE this value, and a
-     number restated in a stylesheet and a module is a number that drifts. */
+  /* The rail's inner padding, and the height of the bar's spectrum strip.
+     SegmentedRail used to read this too, to write the design's
+     `calc(i * (100% - 6px) / n + 3px)` thumb maths in JS; #1726 measures the
+     active segment instead, so the number is back to living in one file. */
   --filter-rail-pad: 3px;
 
   --filter-popover-shadow: 0 24px 48px -18px rgba(0, 0, 0, 0.28);
@@ -5651,8 +5651,15 @@
   position: relative;
   display: flex;
   align-items: center;
-  flex: 1 1 248px;
-  min-width: 220px;
+  /* Sized by its labels, not by a number (#1726). The old `flex: 1 1 248px;
+     min-width: 220px` described four equal shares of a fixed box, and at 220px
+     a share was 53.5px against a 58.8px "Retired". A rail is now as wide as
+     what is written on it and never wider than the row it sits in; past that
+     it wraps to a second line rather than spilling out of the bar, and the
+     thumb is measured, so it lands on the active segment's row either way. */
+  flex: 0 1 auto;
+  max-width: 100%;
+  flex-wrap: wrap;
   padding: var(--filter-rail-pad);
   border-radius: 999px;
   border: 1.5px solid transparent;
@@ -5664,22 +5671,31 @@
     var(--faction-default-rainbow) border-box;
 }
 
+/* All four edges come from SegmentedRail's measurement of the active segment
+   (#1726) — there is no `top`/`bottom` here, because a rail that wraps has no
+   single row to pin them to. Width transitions alongside left now that the
+   thumb changes size from segment to segment; without it the pill would snap
+   its width while sliding. */
 .filter-rail__thumb {
   position: absolute;
-  top: var(--filter-rail-pad);
-  bottom: var(--filter-rail-pad);
   border-radius: 999px;
   background: var(--filter-thumb);
   box-shadow: inset 0 0 0 1px var(--filter-thumb-edge);
-  transition: left 220ms cubic-bezier(0.4, 1.4, 0.5, 1);
+  transition-property: left, top, width, height;
+  transition-duration: 220ms;
+  transition-timing-function: cubic-bezier(0.4, 1.4, 0.5, 1);
   pointer-events: none;
 }
 
 .filter-rail__segment {
   position: relative;
-  flex: 1;
+  /* Grow into whatever slack the rail has, from a CONTENT basis — never
+     `flex: 1`, whose 0 basis is the equal share that cut "Pending" off. The
+     horizontal padding is the breathing room between one label and the next;
+     nothing else separates them. */
+  flex: 1 1 auto;
   min-height: 38px;
-  padding: var(--space-sm) 0;
+  padding: var(--space-sm) var(--space-md);
   border: 0;
   background: none;
   cursor: pointer;
@@ -6186,14 +6202,16 @@
   }
 
   .filter-rail {
-    flex: 1 1 auto;
     width: 100%;
-    min-width: 0;
   }
 
+  /* Tighter horizontal padding than the desktop rail: the phone has a real
+     width budget (see the arithmetic on RAIL_SEGMENTS_MAX in filterState.ts),
+     and the segments grow into the full-width rail's slack anyway. */
   .filter-rail__segment {
     min-height: 44px;
     font-size: var(--text-lg);
+    padding: var(--space-sm);
   }
 
   .filter-factions__trigger {

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -255,6 +255,10 @@ describe('can-sign-up filter (#1130)', () => {
  * so it must sit on its default and raise no chip on a fresh load.
  */
 describe('the task rails', () => {
+  /** How many rail segments the page drew, across every rail it mounted. */
+  const segmentCount = (markup: string) =>
+    markup.split('filter-rail__segment').length - 1
+
   const SEES_EVERYTHING: CurrentUser = {
     ...VIEWER,
     can_see_retired_tasks: true,
@@ -271,9 +275,8 @@ describe('the task rails', () => {
     expect(out, 'no pending segment').not.toContain(
       `>${i18n.t('tasks:browse.status.pending')}<`,
     )
-    expect(out, 'no rail is four segments wide').not.toContain(
-      'width:calc((100% - 2 * var(--filter-rail-pad)) / 4)',
-    )
+    // type (2) + sort (3) + status (2). No eligibility rail logged out.
+    expect(segmentCount(out), 'seven segments across three rails').toBe(7)
   })
 
   it('widens the status rail to four for a viewer allowed the extra states', () => {
@@ -288,9 +291,11 @@ describe('the task rails', () => {
     // the API expects, which is what `statusFilters` above carries.
     expect(out).toContain(`>${i18n.t('tasks:browse.status.retired')}<`)
     expect(out).toContain(`>${i18n.t('tasks:browse.status.pending')}<`)
-    expect(out, 'a 4-segment thumb').toContain(
-      'width:calc((100% - 2 * var(--filter-rail-pad)) / 4)',
-    )
+    // type (2) + sort (3) + status (4) + eligibility (2).
+    expect(segmentCount(out), 'the status rail grew by two').toBe(11)
+    // The thumb is a measured rect since #1726 and this harness runs no
+    // effects, so its placement is not observable here — see
+    // components/ui/FilterBar/__tests__ for the half that is.
   })
 
   it('opens on `level`, raising no applied chip', () => {


### PR DESCRIPTION
`.filter-rail__segment` was `flex: 1` with **zero horizontal padding**, so every label got the same box no matter how long it was. In Courier Prime a label's width is exactly its character count, so at the rail's own `min-width: 220px` a four-segment status rail gave each label 53.5px against a 58.8px "Retired" — it overflowed on both sides. Only a signed-in viewer allowed `retired` and `pending` ever saw four segments, which is why nobody's screenshot showed it.

Segments now size to their own content plus real padding, and the thumb takes the **measured** box of the active segment instead of assuming one nth of the track — that assumption was what forced the equal shares in the first place. Nothing in the component or the stylesheet knows the segment count any more, so a longer translation makes a wider segment rather than an overflowing one.

## The seam, and which half is covered

The pure decision — *given a set of measured boxes and an active index, what `left`/`top`/`width`/`height` does the thumb get?* — is `thumbGeometry` in `filterState.ts`, with `sameBoxes` beside it as the re-measure guard. Both are unit-tested for 2, 4 and wrapped rails, for the unmeasured case, and for an active index past the measured set (the rail is viewer-gated, so the render that shrinks the set arrives before the re-measure).

**The measurement itself is not covered and cannot be here.** This repo's frontend harness is `renderToStaticMarkup` only — no DOM, effects never run — so `offsetLeft`, `ResizeObserver` and layout are out of reach. Adding jsdom would overturn the harness's founding assumption repo-wide, so I did not. What the harness *can* assert, and now does, is that an unmeasured rail renders its segments and **no thumb at all** — a thumb in that markup would mean some fallback geometry came back, and that fallback is exactly the first-paint flash.

The CSS half has its own ratchet in `filterBarOverflow.test.ts`: no segment may take an equal `1/n` share (`flex: 1` / a `0` basis), every `.filter-rail__segment` body must pad horizontally in both form factors, and the thumb must transition `width` and not only `left`. All three failed before the fix.

## What changed

- **`SegmentedRail.tsx`** — a ref per segment; `offsetLeft/Top/Width/Height` (already relative to the rail's padding box, so the 1.5px ring needs no correcting for); `useLayoutEffect` with no dependency array, so a re-render is the signal that covers a segment set changing at sign-in and a relabel at language switch; a `ResizeObserver` on the rail **and** its segments for viewport resize and webfont arrival. `sameBoxes` keeps the observer's initial callbacks from re-rendering. The layout effect degrades to `useEffect` under `react-dom/server` only, so the harness does not warn.
- **`filterState.ts`** — `thumbOffset`, `thumbWidth` and the `RAIL_PAD`/`TRACK` constants deleted with their tests; `SegmentBox`, `ThumbGeometry`, `thumbGeometry`, `sameBoxes` added. The `RAIL_SEGMENTS_MAX` ponytail comment's width arithmetic is re-derived for padded, content-sized segments.
- **`index.css`** — `.filter-rail` loses `flex: 1 1 248px; min-width: 220px` (four equal shares of a fixed box described nothing real any more) for `flex: 0 1 auto; max-width: 100%; flex-wrap: wrap`: a rail is as wide as what is written on it, never wider than its row, and wraps to a second line rather than spilling out of the bar. `.filter-rail__segment` gets `flex: 1 1 auto` (grow into slack from a **content** basis) and `var(--space-sm) var(--space-md)` padding, tightened to `var(--space-sm)` on the phone where the width budget is real. The thumb's `top`/`bottom` move out of CSS into the measurement, and the transition covers `left, top, width, height`.
- **`pages/tasks/__tests__/dispatch.test.tsx`** — the viewer-gating test proved a 4-segment rail by matching the thumb's old `calc(track / 4)` inline width. It counts segments now.

The spectrum ring and the `--filter-well` interior are untouched.

## Every caller of `SegmentedRail`

`SegmentedRail` is imported in exactly one place — `FilterBar/index.tsx` — which mounts one per entry in its `rails` prop. The full set of rails on the site:

| Page | Rails (segments) |
|---|---|
| Tasks (`TaskFilterBar`, desktop + `DefaultTasks` mobile) | type (2), sort (3), **status (2 logged out / 3 / 4)**, eligibility (2, signed in only) |
| Praxes (`PraxisFilterBar`, desktop + `MobilePraxisFeed`) | sort (4 — the widest rail on the site, 33 characters), era (2), voted (3, signed in only) |
| Updates (`UpdatesFilterBar`) | state (2), relationship (5, hidden on Archived) |

`admin/ModerationTab` has a local `QueueFilterBar` of its own and does not use this component.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (241 files, 4336 tests), `npm run build` and `npm run budget` all pass locally; CSS is 21.4 KB gzipped against a 22.5 KB warn line. No API endpoints consumed or changed.

**Visual QA is outstanding — I have no browser.** Everything below is unverified by me.

## What to eyeball

- **Signed in as a viewer who can see retired and pending tasks**, on `/tasks`: the four status segments — All / Active / Retired / Pending — each show their full label with visible space either side, and the thumb sits exactly on the selected one. This is the reported defect.
- **Signed out**, same page: the status rail is two segments and the thumb still covers the selected one exactly. Sign in *while the page is open* if you can — the segment set changes underneath the measurement.
- **A narrow viewport** (375px, then 320px if you have it), on `/praxes`: the sort rail is the widest one the site mounts (Newest / Oldest / Most voted / Least voted). It should fit; if it cannot, it should **wrap to a second row inside the pill** rather than spill out of the bar or scroll the page sideways. The wrapped state is the fallback I could not look at.
- **Click between segments**: the pill should slide *and* resize smoothly — "All" to "Pending" is a big width change. A width that snaps while the position slides is the failure.
- **First paint / hard refresh**: no thumb flash at the wrong place, at zero width, or at the left edge before it settles.
- **Updates** with the 5-segment relationship rail, and the rails on both mobile task and praxis feeds.

Closes #1726
