### PR TITLE
Unmeasurable backdrops get one mechanism, fully reported, and a test that runs in a PR

### DIFF
--- a/frontend/e2e/contrast.spec.ts
+++ b/frontend/e2e/contrast.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, type Page } from '@playwright/test'
 import { appendFileSync } from 'node:fs'
 
-import { RENDERED_BASELINE, baselineKey, unresolvedKey, type BaselineEntry } from './contrastBaseline'
+import { baselineKey, triageFindings } from './contrastBaseline'
 import { scanPageForContrast, type Finding } from './contrastScan'
 
 /**
@@ -23,9 +23,16 @@ import { scanPageForContrast, type Finding } from './contrastScan'
  * + backend + seed + Playwright. No new CI job.
  *
  * REGENERATING THE BASELINE. Set `CONTRAST_BASELINE_OUT=<path>` and run the
- * suite; every failure is appended there as a ready-to-paste entry. The list
- * is machine-produced on purpose — hand-typed ratios would be wrong within a
- * week, which is the whole thesis of this issue.
+ * suite; every MEASURED failure is appended there as a ready-to-paste entry.
+ * The list is machine-produced on purpose — hand-typed ratios would be wrong
+ * within a week, which is the whole thesis of this issue. Unmeasurable
+ * backdrops are NOT baseline entries (#1762), so nothing is emitted for them;
+ * their ceiling comes off the report this prints on every run.
+ *
+ * The policy itself — which finding fails, which is reported, which allowlist
+ * entry has gone stale — is `triageFindings` in contrastBaseline.ts, so that
+ * `src/utils/__tests__/contrastTriage.test.ts` can exercise it in a PR without
+ * a browser. This file drives the pages and prints; it decides nothing.
  */
 
 const API = process.env.E2E_API_URL ?? 'http://localhost:8000'
@@ -76,23 +83,47 @@ const SHARED_ROUTES = ['/', '/tasks', '/praxis', '/leaderboard', '/factions']
  *
  * The ceiling is what stops that from being a hole. A NEW unmeasurable surface
  * is a regression in coverage even though it is not a contrast defect, so the
- * count may only ever go down. These numbers are the deduped unresolved count
- * per test in nightly run 31779247838 — measured, not chosen. They are
- * independent of THEME (identical light and dark, all seven factions), which is
- * what you would expect of fills that are the same shape in both.
+ * count may only ever go down.
+ *
+ * A SURFACE, NOT A FINDING (#1762). The unit is one distinct `backdropCss`,
+ * however many text nodes sit on it. Counting findings made the ceiling churn
+ * on every copy edit — add a line of body text to a card on the gilt wordmark
+ * and the number moves — while the thing worth ratcheting, a NEW region of the
+ * app going unchecked, is exactly one new surface. The report prints both, so
+ * the node count is still visible; only the assertion is coarser.
+ *
+ * ponytail: these are the per-test surface counts read off nightly run
+ * 31779247838, which is the last run before #1749 landed. They are the best
+ * numbers available in a subagent worktree — no Playwright browsers, no seeded
+ * Postgres, so they were NOT regenerated here. That run measured with the 56
+ * `ratio: null` allowlist entries still in force, and #1762 deletes those, so
+ * any of the 22 distinct surfaces they named that both still renders AND was
+ * genuinely being filtered will now reach the report and push a count up. The
+ * breadcrumbs on those 56 entries put the exposure at up to +4 on wow
+ * desktop/mobile and up to +2 on ua and ephemerists desktop; the other four
+ * factions had no such entries at all, so their numbers cannot move for this
+ * reason. They are deliberately NOT pre-raised by that allowance — a ceiling
+ * set too high is silent, which is the disease #1762 is treating, and a ceiling
+ * set too low fails the nightly with the exact number to paste. Correct these
+ * from the first real run's output, not from arithmetic.
  *
  * Lower one whenever a fix retires a surface. Raising one is a decision, not a
  * chore: it means a new fill is now hiding text from the sweep.
  */
 const UNMEASURABLE_CEILING: Record<string, Record<ViewportName, number>> = {
   // WOW's title bars and UA's gilt wordmark are the two kits with extra fills.
-  wow: { desktop: 22, mobile: 25 },
-  ua: { desktop: 19, mobile: 14 },
-  default: { desktop: 16, mobile: 14 },
+  wow: { desktop: 8, mobile: 7 },
+  ua: { desktop: 8, mobile: 5 },
+  default: { desktop: 7, mobile: 5 },
+}
+
+/** Which row of the table governs this faction — named, so the failure message can quote it. */
+function ceilingKeyFor(faction: Faction): string {
+  return faction in UNMEASURABLE_CEILING ? faction : 'default'
 }
 
 function ceilingFor(faction: Faction, viewport: ViewportName): number {
-  return (UNMEASURABLE_CEILING[faction] ?? UNMEASURABLE_CEILING.default)[viewport]
+  return UNMEASURABLE_CEILING[ceilingKeyFor(faction)][viewport]
 }
 
 // This spec opts out of the shared bot's saved cookie: it re-logs per faction
@@ -116,26 +147,38 @@ async function useTheme(page: Page, theme: Theme): Promise<void> {
   }, theme)
 }
 
-function keyOf(theme: Theme, finding: Finding): string {
-  return finding.background === null
-    ? unresolvedKey(theme, finding.text, finding.backdropCss ?? 'unknown', finding.required)
-    : baselineKey(theme, finding.text, finding.background, finding.required)
-}
-
 function describeFinding(finding: Finding): string {
   const size = `${finding.fontSizePx}px/${finding.fontWeight}`
-  if (finding.background === null) {
-    return `  UNRESOLVED BACKDROP (${finding.unresolvedKind}) — ${finding.where} (${size})\n    "${finding.sample}"\n    ${finding.unresolved}`
-  }
   return `  ${finding.ratio.toFixed(2)}:1 (needs ${finding.required}:1) — ${finding.text} on ${finding.background}\n    ${finding.where} (${size}) "${finding.sample}"`
 }
 
+/**
+ * One line per surface the scanner refused to measure: how many text nodes sit
+ * on it, and one of them so a human can go and look. The CSS is the identity,
+ * so it leads. Printing every finding instead repeated the same gradient 14-25
+ * times per test, which is a report nobody reads.
+ */
+function describeSurface(css: string, over: Finding[]): string {
+  const example = over[0]
+  return (
+    `  ${over.length} node(s) over ${css.slice(0, 120)}${css.length > 120 ? '…' : ''}\n` +
+    `    e.g. ${example.where} (${example.fontSizePx}px/${example.fontWeight}) "${example.sample}"`
+  )
+}
+
 /** Emit a ready-to-paste BASELINE entry when regenerating (see header). */
-function emitBaseline(key: string, finding: Finding, faction: Faction, theme: Theme, viewport: ViewportName): void {
-  if (!BASELINE_OUT) return
-  const ratio = finding.background === null ? 'null' : finding.ratio.toFixed(2)
+function emitBaseline(finding: Finding, faction: Faction, theme: Theme, viewport: ViewportName): void {
+  // An unmeasurable backdrop has no ratio to record and is ratcheted by count,
+  // not allowlisted — emitting one would recreate the second mechanism #1762
+  // deleted. `triageFindings` only ever puts measured findings in `failures`;
+  // the guard is belt-and-braces for a hand-called regeneration.
+  if (!BASELINE_OUT || finding.background === null) return
+  const key = baselineKey(theme, finding.text, finding.background, finding.required)
   const where = `${faction}/${theme}/${viewport} ${finding.where}`.replace(/'/g, '')
-  appendFileSync(BASELINE_OUT, `  ${JSON.stringify(key)}: { ratio: ${ratio}, issue: 651, where: '${where}' },\n`)
+  appendFileSync(
+    BASELINE_OUT,
+    `  ${JSON.stringify(key)}: { ratio: ${finding.ratio.toFixed(2)}, issue: 651, where: '${where}' },\n`,
+  )
 }
 
 for (const faction of FACTIONS) {
@@ -147,10 +190,9 @@ for (const faction of FACTIONS) {
         await useTheme(page, theme)
         await loginAs(page, faction)
 
+        const combination = `${faction}/${theme}/${viewport}`
         const routes = [...SHARED_ROUTES, `/factions/${faction}`]
-        const failures: string[] = []
-        const passing: string[] = []
-        const unmeasurable: string[] = []
+        const findings: Finding[] = []
 
         for (const route of routes) {
           await page.goto(route)
@@ -159,59 +201,47 @@ for (const faction of FACTIONS) {
           await page.waitForLoadState('networkidle')
           await expect(page.locator('html')).toHaveAttribute('data-theme', theme)
 
-          const findings = (await page.evaluate(scanPageForContrast)) as Finding[]
-          for (const finding of findings) {
-            const ok = finding.background !== null && finding.ratio >= finding.required
-            const key = keyOf(theme, finding)
-            const allowed: BaselineEntry | undefined = RENDERED_BASELINE[key]
-
-            if (ok) {
-              // A pair that now passes but is still allowlisted is debt that
-              // got fixed without the list being updated. Catch it: an
-              // allowlist that outlives its bug stops being a ratchet.
-              if (allowed) passing.push(`${key} now measures ${finding.ratio.toFixed(2)}:1 (owned by #${allowed.issue})`)
-              continue
-            }
-            if (allowed) continue
-            emitBaseline(key, finding, faction, theme, viewport)
-            // The one branch #1675 added: a backdrop the scanner could not
-            // resolve is a hole in COVERAGE, not a contrast defect, so it is
-            // counted and printed rather than failed. See UNMEASURABLE_CEILING.
-            if (finding.background === null) {
-              unmeasurable.push(describeFinding(finding))
-              continue
-            }
-            failures.push(describeFinding(finding))
-          }
+          findings.push(...((await page.evaluate(scanPageForContrast)) as Finding[]))
         }
+
+        const { failures, stale, unmeasurable } = triageFindings(theme, findings)
+        for (const finding of failures) emitBaseline(finding, faction, theme, viewport)
 
         // LOUD, always — including on a green run. The whole risk of the #1675
         // ruling is a suite that looks greener because it checks less, and the
         // only defence against that is printing what went unchecked every time.
-        const unchecked = [...new Set(unmeasurable)]
         const ceiling = ceilingFor(faction, viewport)
+        const uncheckedNodes = [...unmeasurable.values()].reduce((total, over) => total + over.length, 0)
         console.log(
-          `\n${faction}/${theme}/${viewport}: ${unchecked.length} unmeasurable surface(s), ` +
-            `ceiling ${ceiling}.\n` +
-            (unchecked.length ? `${unchecked.join('\n\n')}\n` : '  (none)\n'),
+          `\n[contrast] ${combination}: ${unmeasurable.size} unmeasurable surface(s) ` +
+            `(ceiling ${ceiling}), ${uncheckedNodes} text node(s) unchecked.\n` +
+            (unmeasurable.size
+              ? `${[...unmeasurable].map(([css, over]) => describeSurface(css, over)).join('\n')}\n`
+              : '  (none)\n'),
         )
 
+        const describedFailures = [...new Set(failures.map(describeFinding))]
         expect(
-          [...new Set(failures)],
-          `${faction}/${theme}/${viewport}: text below WCAG AA.\n\n` +
-            [...new Set(failures)].join('\n\n'),
+          describedFailures,
+          `${combination}: text below WCAG AA.\n\n` + describedFailures.join('\n\n'),
         ).toHaveLength(0)
 
+        // Gaining a surface is a coverage regression, not a contrast defect: a
+        // region of the app just stopped being checked at all. Losing one is
+        // progress, and only asks for the ceiling to come down.
         expect(
-          unchecked.length,
-          `${faction}/${theme}/${viewport}: ${unchecked.length} unmeasurable surfaces, up from ${ceiling}. ` +
-            `A new opaque-stop fill is now hiding text from the sweep — that is lost coverage, not a style bug. ` +
-            `Give the text a solid backdrop, or raise this faction's entry in UNMEASURABLE_CEILING deliberately.\n\n` +
-            unchecked.join('\n\n'),
+          unmeasurable.size,
+          `${combination}: ${unmeasurable.size} unmeasurable surfaces, up from ${ceiling}. ` +
+            `A new opaque-stop fill is now hiding text from the sweep — that is lost coverage, not a style bug.\n\n` +
+            `TO CORRECT THIS CEILING from this run: the surfaces printed above are the whole population, so ` +
+            `set '${ceilingKeyFor(faction)}'.${viewport} in UNMEASURABLE_CEILING ` +
+            `to ${unmeasurable.size} — but only after checking the new surface against the list above. ` +
+            `If it is one you can give a solid backdrop, do that instead; the ceiling only ever comes down.\n\n` +
+            [...unmeasurable.keys()].join('\n'),
         ).toBeLessThanOrEqual(ceiling)
 
         expect(
-          [...new Set(passing)],
+          [...new Set(stale)],
           `These pairs are in RENDERED_BASELINE but now clear AA — delete their entries in contrastBaseline.ts. ` +
             `The list only ever shrinks.`,
         ).toHaveLength(0)

--- a/frontend/e2e/contrastBaseline.ts
+++ b/frontend/e2e/contrastBaseline.ts
@@ -14,17 +14,29 @@
  * (text, backdrop) pairing; which component happens to produce it is
  * incidental, changes with every copy edit, and would make this list rot. So
  * `theme | rgb(text) on rgb(backdrop)` is the identity, and `where` is only a
- * breadcrumb for whoever picks up the fix. Unresolved findings are keyed the
- * same way — on the CSS that defeated resolution, not on a DOM path.
+ * breadcrumb for whoever picks up the fix.
  *
  * **This list only ever shrinks.** Fixing a pair means DELETING its entry, not
  * editing the ratio — an allowlisted pair that starts passing fails the spec
  * on purpose. Never add an entry for new work.
+ *
+ * UNMEASURABLE BACKDROPS ARE NOT ON THIS LIST (#1675, #1762). Text over a
+ * gradient with an opaque stop has no single backdrop colour, so the scanner
+ * refuses to measure it rather than guessing. Those findings used to be
+ * enumerated here too, keyed on the gradient CSS — 56 of them — which gave
+ * unmeasurable surfaces TWO governing mechanisms at once. Worse, the older one
+ * was invisible: `contrast.spec.ts` consulted this list BEFORE the branch that
+ * collects the report, so an allowlisted unmeasurable surface was neither
+ * printed nor counted against the ceiling. A silent skip is exactly what the
+ * #1675 ruling forbade. They now go through one mechanism only — reported by
+ * `triageFindings` below, ratcheted by count in the spec.
  */
 
+import type { Finding } from './contrastScan';
+
 export type BaselineEntry = {
-  /** Measured ratio when this entry landed. `null` for an unresolved backdrop. */
-  ratio: number | null;
+  /** Measured ratio when this entry landed. Every entry here was MEASURED. */
+  ratio: number;
   /** The issue that owns the fix. 651 = found by the sweep, awaiting a child. */
   issue: number;
   /** Where it was seen — a breadcrumb, not part of the identity. */
@@ -44,85 +56,16 @@ export function baselineKey(theme: string, text: string, background: string, req
 }
 
 /**
- * Identity of an unresolved backdrop — keyed on the CSS that defeated
- * resolution (stable) rather than the DOM path (rots on the next copy edit).
- */
-export function unresolvedKey(theme: string, text: string, backdropCss: string, required: number): string {
-  return `${theme} | ${text} over UNRESOLVED ${backdropCss} @${required}`;
-}
-
-/**
- * THE LIST. 269 entries, machine-produced by the sweep itself
+ * THE LIST. 185 entries, machine-produced by the sweep itself
  * (`CONTRAST_BASELINE_OUT=<path> bash frontend/e2e/run-e2e.sh contrast.spec.ts`),
- * never hand-typed — 269 hand-copied ratios would be wrong within a week,
+ * never hand-typed — 185 hand-copied ratios would be wrong within a week,
  * which is this issue's whole thesis.
  *
  *   - 7 entries owned by #649 (white `--color-text-on-accent` on a faction
  *     fill). That issue's acceptance, measured as rendered.
- *   - 56 UNRESOLVED entries: text over a gradient with an OPAQUE stop — the
- *     WOW `.exe` title bars, the Ephemerists' celestial radial fields, the gilt
- *     wordmark. The colour genuinely varies under the text, so these stay loud
- *     rather than being measured against a guess. (Before the texture/fill
- *     split there were 134 of these, almost all paper grain.)
  *   - the rest await triage into children off #651.
  */
 export const RENDERED_BASELINE: Record<string, BaselineEntry> = {
-  "dark | rgb(196, 100, 138) over UNRESOLVED linear-gradient(135deg, rgb(57, 21, 42), rgb(42, 13, 28)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > div' },
-  "dark | rgb(196, 100, 138) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 26px) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > p' },
-  "dark | rgb(230, 194, 103) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop a > div > div > div' },
-  "dark | rgb(230, 194, 103) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > div > span' },
-  "dark | rgb(230, 194, 103) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop header > div > div > div' },
-  "dark | rgb(239, 227, 198) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 70%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop a > div > div > div' },
-  "dark | rgb(239, 227, 198) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop header > div > div > h1' },
-  "dark | rgb(240, 230, 208) over UNRESOLVED linear-gradient(rgb(19, 18, 26), rgb(19, 18, 26)), linear-gradient(90deg, rgb(79, 70, 229), rgb(190, 24, 93), rgb(249, 115, 22), rgb(22, 163, 74)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop nav.sticky.top-0 > div.max-w-5xl.mx-auto > a.shrink-0.leading-none > span.font-display.italic' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED linear-gradient(135deg, rgb(57, 21, 42), rgb(42, 13, 28)) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > h1' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED linear-gradient(160deg, rgb(94, 42, 70), rgb(196, 100, 138) 60%, rgb(244, 114, 182)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/mobile div.py-4 > section > div > p' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 24px) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > div' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > a > span' },
-  "dark | rgb(244, 114, 182) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 25px, color(srgb 0.478431 0.2 0.345098 / 0.55) 26px) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > div > div' },
-  "dark | rgb(251, 207, 224) over UNRESOLVED repeating-linear-gradient(rgb(57, 21, 42), rgb(57, 21, 42) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 23px, color(srgb 0.478431 0.2 0.345098 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > a > span' },
-  "dark | rgb(251, 214, 232) over UNRESOLVED linear-gradient(160deg, rgb(94, 42, 70), rgb(196, 100, 138) 60%, rgb(244, 114, 182)) @3": { ratio: null, issue: 651, where: 'wow/dark/mobile div.py-4 > section > div > h1' },
-  "dark | rgb(251, 214, 232) over UNRESOLVED linear-gradient(rgb(94, 42, 70), rgb(65, 32, 58)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
-  "dark | rgb(255, 255, 255) over UNRESOLVED linear-gradient(150deg, rgb(94, 42, 70), rgb(244, 114, 182)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/mobile section.mt-6 > div.flex.flex-col > a > span' },
-  "dark | rgb(255, 255, 255) over UNRESOLVED linear-gradient(rgb(244, 114, 182), rgb(196, 100, 138)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a' },
-  "dark | rgb(255, 255, 255) over UNRESOLVED radial-gradient(circle at 35% 28%, rgb(94, 42, 70), rgb(244, 114, 182)) @3": { ratio: null, issue: 651, where: 'wow/dark/mobile div > div.flex.items-center > div.shrink-0 > span.flex.w-full' },
-  "dark | rgb(57, 21, 42) over UNRESOLVED linear-gradient(150deg, rgb(94, 42, 70), rgb(244, 114, 182)) @3": { ratio: null, issue: 651, where: 'wow/dark/desktop a > div > div > span' },
-  "dark | rgb(57, 21, 42) over UNRESOLVED linear-gradient(150deg, rgb(94, 42, 70), rgb(244, 114, 182)) @4.5": { ratio: null, issue: 651, where: 'wow/dark/desktop div > div > a > span' },
-  "dark | rgb(79, 143, 176) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > h1 > span' },
-  "dark | rgba(239, 227, 198, 0.62) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > p > span' },
-  "dark | rgba(239, 227, 198, 0.7) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop a > div > div > div' },
-  "dark | rgba(239, 227, 198, 0.75) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop div > div > div > span' },
-  "dark | rgba(239, 227, 198, 0.92) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(79, 143, 176), rgb(10, 29, 42) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/dark/desktop header > div > div > p' },
-  "dark | rgba(251, 214, 232, 0.7) over UNRESOLVED linear-gradient(rgb(94, 42, 70), rgb(65, 32, 58)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
-  "dark | rgba(251, 214, 232, 0.75) over UNRESOLVED linear-gradient(rgb(94, 42, 70), rgb(65, 32, 58)) @4.5": { ratio: null, issue: 651, where: 'ua/dark/desktop div > div > div > span' },
-  "light | rgb(131, 24, 67) over UNRESOLVED linear-gradient(135deg, rgb(255, 253, 250), rgb(253, 238, 243)) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > div' },
-  "light | rgb(131, 24, 67) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 26px) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > p' },
-  "light | rgb(142, 47, 92) over UNRESOLVED linear-gradient(160deg, rgb(251, 207, 226), rgb(131, 24, 67) 60%, rgb(236, 95, 153)) @3": { ratio: null, issue: 651, where: 'wow/light/mobile div.py-4 > section > div > h1' },
-  "light | rgb(142, 47, 92) over UNRESOLVED linear-gradient(rgb(251, 207, 226), rgb(243, 166, 203)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop div > div > div > span' },
-  "light | rgb(212, 171, 85) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop a > div > div > div' },
-  "light | rgb(212, 171, 85) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > div > span' },
-  "light | rgb(212, 171, 85) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop header > div > div > div' },
-  "light | rgb(236, 95, 153) over UNRESOLVED linear-gradient(135deg, rgb(255, 253, 250), rgb(253, 238, 243)) @3": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > h1' },
-  "light | rgb(236, 95, 153) over UNRESOLVED linear-gradient(160deg, rgb(251, 207, 226), rgb(131, 24, 67) 60%, rgb(236, 95, 153)) @4.5": { ratio: null, issue: 651, where: 'wow/light/mobile div.py-4 > section > div > p' },
-  "light | rgb(236, 95, 153) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 24px) @3": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > div' },
-  "light | rgb(236, 95, 153) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > a > span' },
-  "light | rgb(236, 95, 153) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 25px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 26px) @3": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > div > div' },
-  "light | rgb(241, 232, 207) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 70%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop a > div > div > div' },
-  "light | rgb(241, 232, 207) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop header > div > div > h1' },
-  "light | rgb(255, 253, 250) over UNRESOLVED linear-gradient(150deg, rgb(251, 207, 226), rgb(236, 95, 153)) @3": { ratio: null, issue: 651, where: 'wow/light/desktop a > div > div > span' },
-  "light | rgb(255, 253, 250) over UNRESOLVED linear-gradient(150deg, rgb(251, 207, 226), rgb(236, 95, 153)) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > a > span' },
-  "light | rgb(255, 255, 255) over UNRESOLVED linear-gradient(150deg, rgb(251, 207, 226), rgb(236, 95, 153)) @4.5": { ratio: null, issue: 651, where: 'wow/light/mobile section.mt-6 > div.flex.flex-col > a > span' },
-  "light | rgb(255, 255, 255) over UNRESOLVED linear-gradient(rgb(236, 95, 153), rgb(131, 24, 67)) @4.5": { ratio: null, issue: 651, where: 'wow/light/mobile main.flex-1.relative > div.page > div.flex.gap-2.5 > a' },
-  "light | rgb(255, 255, 255) over UNRESOLVED radial-gradient(circle at 35% 28%, rgb(251, 207, 226), rgb(236, 95, 153)) @3": { ratio: null, issue: 651, where: 'wow/light/mobile div > div.flex.items-center > div.shrink-0 > span.flex.w-full' },
-  "light | rgb(26, 18, 9) over UNRESOLVED linear-gradient(rgb(247, 244, 238), rgb(247, 244, 238)), linear-gradient(90deg, rgb(79, 70, 229), rgb(190, 24, 93), rgb(249, 115, 22), rgb(22, 163, 74)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop nav.sticky.top-0 > div.max-w-5xl.mx-auto > a.shrink-0.leading-none > span.font-display.italic' },
-  "light | rgb(29, 79, 110) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @3": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > h1 > span' },
-  "light | rgb(88, 28, 57) over UNRESOLVED repeating-linear-gradient(rgb(255, 253, 250), rgb(255, 253, 250) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 23px, color(srgb 0.952941 0.713726 0.823529 / 0.55) 24px) @4.5": { ratio: null, issue: 651, where: 'wow/light/desktop div > div > a > span' },
-  "light | rgba(142, 47, 92, 0.7) over UNRESOLVED linear-gradient(rgb(251, 207, 226), rgb(243, 166, 203)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop div > div > div > span' },
-  "light | rgba(142, 47, 92, 0.75) over UNRESOLVED linear-gradient(rgb(251, 207, 226), rgb(243, 166, 203)) @4.5": { ratio: null, issue: 651, where: 'ua/light/desktop div > div > div > span' },
-  "light | rgba(241, 232, 207, 0.62) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > p > span' },
-  "light | rgba(241, 232, 207, 0.7) over UNRESOLVED radial-gradient(120% 130% at 50% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 70%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop a > div > div > div' },
-  "light | rgba(241, 232, 207, 0.75) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop div > div > div > span' },
-  "light | rgba(241, 232, 207, 0.92) over UNRESOLVED radial-gradient(120% 140% at 82% 0%, rgb(29, 79, 110), rgb(20, 59, 84) 60%, rgb(5, 19, 28) 100%) @4.5": { ratio: null, issue: 651, where: 'ephemerists/light/desktop header > div > div > p' },
   "dark | rgb(111, 174, 0) on rgb(244, 241, 232) @3": { ratio: 2.41, issue: 651, where: 'snide/dark/desktop div > div > div > div' },
   "dark | rgb(111, 174, 0) on rgb(244, 241, 232) @4.5": { ratio: 2.41, issue: 651, where: 'snide/dark/desktop div > div > div > div' },
   "dark | rgb(12, 10, 6) on rgb(19, 18, 26) @3": { ratio: 1.06, issue: 651, where: 'ephemerists/dark/desktop div.wz-faction-grid > div > div > h2' },
@@ -309,3 +252,63 @@ export const RENDERED_BASELINE: Record<string, BaselineEntry> = {
   "light | rgba(96, 165, 250, 0.6) on rgb(5, 15, 8) @4.5": { ratio: 3.41, issue: 651, where: 'ua/light/mobile div.flex.flex-col > a > div.flex.items-center > span' },
   "light | rgba(96, 165, 250, 0.7) on rgb(5, 15, 8) @4.5": { ratio: 4.24, issue: 651, where: 'singularity/light/desktop header > div > div > div' },
 };
+
+/** What the sweep does with one test's worth of findings. */
+export type Triage = {
+  /** Measured below AA and not grandfathered — these FAIL the run. */
+  failures: Finding[];
+  /** Grandfathered pairs that now clear AA — the list only shrinks, so these FAIL too. */
+  stale: string[];
+  /**
+   * Text the scanner refused to measure, grouped by the CSS that defeated it.
+   * One key = one unmeasurable SURFACE. Reported and ratcheted by count in
+   * `contrast.spec.ts` — never a per-finding failure, and never grandfathered.
+   */
+  unmeasurable: Map<string, Finding[]>;
+};
+
+/**
+ * Sort one test's findings into the three outcomes above.
+ *
+ * Pure on purpose (#1762). The spec that calls this needs Playwright, a live
+ * backend and a seeded Postgres, so it runs nightly and nothing exercises it in
+ * a PR — but the DECISION it makes about each finding needs none of that, and
+ * `src/utils/__tests__/contrastTriage.test.ts` covers it in vitest with no DOM.
+ * #1749 argued that was impossible because the harness has no DOM; that was a
+ * property of where the code sat, not of the harness.
+ *
+ * The load-bearing case is the first: `background === null` means the scanner
+ * could not resolve what is behind the text, NOT that it measured 0:1. The
+ * allowlist is deliberately not consulted for those — grandfathering an
+ * unmeasurable surface here is what hid 56 of them from the report.
+ */
+export function triageFindings(theme: string, findings: readonly Finding[]): Triage {
+  const failures: Finding[] = [];
+  const stale: string[] = [];
+  const unmeasurable = new Map<string, Finding[]>();
+
+  for (const finding of findings) {
+    if (finding.background === null) {
+      const surface = finding.backdropCss ?? 'unknown';
+      const over = unmeasurable.get(surface);
+      if (over) over.push(finding);
+      else unmeasurable.set(surface, [finding]);
+      continue;
+    }
+
+    const key = baselineKey(theme, finding.text, finding.background, finding.required);
+    const allowed: BaselineEntry | undefined = RENDERED_BASELINE[key];
+
+    if (finding.ratio >= finding.required) {
+      // A pair that now passes but is still allowlisted is debt that got fixed
+      // without the list being updated. Catch it: an allowlist that outlives
+      // its bug stops being a ratchet.
+      if (allowed) stale.push(`${key} now measures ${finding.ratio.toFixed(2)}:1 (owned by #${allowed.issue})`);
+      continue;
+    }
+    if (allowed) continue;
+    failures.push(finding);
+  }
+
+  return { failures, stale, unmeasurable };
+}

--- a/frontend/src/utils/__tests__/contrastTriage.test.ts
+++ b/frontend/src/utils/__tests__/contrastTriage.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Part D of the contrast foundation (#1675, #1762) — the triage policy.
+ *
+ * `e2e/contrast.spec.ts` can only run against Playwright, a live backend and a
+ * seeded Postgres, so it runs nightly and nothing verifies it in a PR. The
+ * decision it makes about each finding, though, is pure: fail a measured
+ * pairing below AA, REPORT a backdrop the scanner refused to measure, and fail
+ * an allowlist entry that has outlived its bug. That decision lives in
+ * `triageFindings` precisely so it can be exercised here, in milliseconds,
+ * with no browser.
+ *
+ * The load-bearing case is the first one: `background === null` means the
+ * scanner could not resolve what is behind the text (a gradient with an opaque
+ * stop, an image), NOT that it measured 0:1. Treating those two states as one
+ * is what made the sweep unsatisfiable across all 28 of its tests.
+ */
+import { describe, expect, it } from "vitest";
+
+import { RENDERED_BASELINE, baselineKey, triageFindings } from "../../../e2e/contrastBaseline";
+import type { Finding } from "../../../e2e/contrastScan";
+
+function finding(overrides: Partial<Finding> = {}): Finding {
+  return {
+    text: "rgb(0, 0, 0)",
+    background: "rgb(255, 255, 255)",
+    unresolved: null,
+    unresolvedKind: null,
+    backdropCss: null,
+    ratio: 21,
+    required: 4.5,
+    fontSizePx: 16,
+    fontWeight: 400,
+    where: "div > div > span",
+    sample: "some copy",
+    ...overrides,
+  };
+}
+
+/** A finding the scanner gave up on, over `css`. */
+function unresolved(css: string): Finding {
+  return finding({
+    background: null,
+    ratio: 0,
+    unresolved: `div paints ${css}`,
+    unresolvedKind: "opaque-gradient",
+    backdropCss: css,
+  });
+}
+
+/**
+ * Take a real entry out of the allowlist rather than hard-coding a pair: the
+ * list only ever shrinks, and a fixture naming one specific colour pairing
+ * would start testing nothing the day that pairing gets fixed.
+ */
+const [allowlistedKey, allowlistedEntry] = Object.entries(RENDERED_BASELINE)[0];
+const parsedKey = /^(\w+) \| (.+) on (rgba?\([^)]*\)) @([\d.]+)$/.exec(allowlistedKey);
+if (parsedKey === null) throw new Error(`RENDERED_BASELINE key is not in baselineKey() form: ${allowlistedKey}`);
+const [, allowedTheme, allowedText, allowedBackground, allowedRequired] = parsedKey;
+const allowlisted = finding({
+  text: allowedText,
+  background: allowedBackground,
+  required: Number(allowedRequired),
+  ratio: allowlistedEntry.ratio,
+});
+
+describe("triageFindings", () => {
+  it("parses a real allowlist key back into the fixture it describes", () => {
+    // Guards the three tests below: if this reverse-parse ever drifts from
+    // baselineKey(), they would silently stop exercising the allowlist.
+    expect(
+      baselineKey(allowedTheme, allowlisted.text, allowedBackground, allowlisted.required),
+    ).toBe(allowlistedKey);
+    expect(allowlisted.ratio).toBeLessThan(allowlisted.required);
+  });
+
+  it("reports an unresolvable backdrop instead of failing it", () => {
+    const { failures, unmeasurable } = triageFindings("light", [
+      unresolved("linear-gradient(90deg, rgb(1, 2, 3), rgb(4, 5, 6))"),
+    ]);
+
+    expect(failures).toHaveLength(0);
+    expect(unmeasurable.size).toBe(1);
+  });
+
+  it("counts one surface per distinct backdrop, however many nodes sit on it", () => {
+    const gilt = "linear-gradient(160deg, rgb(1, 2, 3), rgb(4, 5, 6))";
+    const rainbow = "linear-gradient(90deg, rgb(7, 8, 9), rgb(10, 11, 12))";
+    const { unmeasurable } = triageFindings("dark", [unresolved(gilt), unresolved(gilt), unresolved(rainbow)]);
+
+    expect([...unmeasurable.keys()]).toEqual([gilt, rainbow]);
+    expect(unmeasurable.get(gilt)).toHaveLength(2);
+  });
+
+  it("still fails a genuinely-measured pairing below AA", () => {
+    const { failures, unmeasurable } = triageFindings("light", [finding({ ratio: 3.2, required: 4.5 })]);
+
+    expect(failures).toHaveLength(1);
+    expect(unmeasurable.size).toBe(0);
+  });
+
+  it("passes a measured pairing that clears its requirement", () => {
+    const { failures, stale } = triageFindings("light", [finding({ ratio: 4.5, required: 4.5 })]);
+
+    expect(failures).toHaveLength(0);
+    expect(stale).toHaveLength(0);
+  });
+
+  it("holds its fire on a pairing that is still allowlisted", () => {
+    const { failures, stale } = triageFindings(allowedTheme, [allowlisted]);
+
+    expect(failures).toHaveLength(0);
+    expect(stale).toHaveLength(0);
+  });
+
+  it("fails an allowlisted pairing that now clears AA — the list only shrinks", () => {
+    const fixed = { ...allowlisted, ratio: allowlisted.required + 0.5 };
+    const { failures, stale } = triageFindings(allowedTheme, [fixed]);
+
+    expect(failures).toHaveLength(0);
+    expect(stale).toHaveLength(1);
+    expect(stale[0]).toContain(`#${allowlistedEntry.issue}`);
+  });
+
+  it("does not consult the allowlist for an unresolvable backdrop", () => {
+    // #1762's defect, as a test. The old key shape put unresolved findings in
+    // RENDERED_BASELINE keyed on the gradient CSS, and the spec's allowlist
+    // check ran BEFORE the branch that collects the report — so 56 surfaces
+    // were neither printed nor counted. Nothing may grandfather them now.
+    const { failures, stale, unmeasurable } = triageFindings(allowedTheme, [
+      { ...unresolved("linear-gradient(90deg, rgb(1, 2, 3), rgb(4, 5, 6))"), text: allowedText },
+    ]);
+
+    expect(failures).toHaveLength(0);
+    expect(stale).toHaveLength(0);
+    expect(unmeasurable.size).toBe(1);
+  });
+
+  it("holds no ratio:null entry — one mechanism, not two", () => {
+    // The structural half of #1762. An unmeasurable surface on this list is a
+    // surface the report cannot see, whatever the spec does downstream.
+    const unmeasurableEntries = Object.entries(RENDERED_BASELINE).filter(
+      ([, entry]) => (entry.ratio as number | null) === null,
+    );
+
+    expect(unmeasurableEntries).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #1762

Recovers the two things PR #1752 got right before it was closed unmerged. Ported
onto current `main` from `fix/1675-contrast-unmeasurable-report`, not rewritten —
the pure function and its test are that branch's, re-based over #1749's changes to
both files.

## The seam

**`triageFindings(theme, findings): { failures, stale, unmeasurable }`** in
`frontend/e2e/contrastBaseline.ts`. That is the decision the sweep makes about
each finding, and it is pure — no browser, no backend, no Postgres. The Playwright
spec now drives pages and prints; it decides nothing.

Tested at that seam by `frontend/src/utils/__tests__/contrastTriage.test.ts`, which
runs in the normal PR vitest job.

## 1. 56 unmeasurable surfaces were silently swallowed

Verified on `origin/main` before changing anything: `contrastBaseline.ts` held
exactly **56 `ratio: null` entries**, and `contrast.spec.ts` had

```ts
if (allowed) continue                    // <- those 56 exit here
emitBaseline(key, finding, faction, theme, viewport)
if (finding.background === null) {       // <- the report never sees them
```

So an unmeasurable surface that happened to be allowlisted was neither printed
nor counted against the ceiling — the exact silent skip #1675's ruling forbade.
Two mechanisms governed the same population and the older one was invisible.

Fixed by deleting the 56 entries and routing every unmeasurable surface through
the ceiling. `RENDERED_BASELINE` keeps all **185** measured entries untouched, and
`BaselineEntry.ratio` narrows from `number | null` to `number` so the second
mechanism cannot be reintroduced by accident. `unresolvedKey()` is deleted with
its last caller.

(The header comment claimed "269 entries". It was already stale — `main` had 241.
Now 185, counted.)

## 2. The ratchet had no unit test

#1749 argued the DOM-less vitest harness made this impossible. It was a property
of where the code sat. `triageFindings` moved out of the spec; nine cases now
cover it, including the two that are #1762's actual defects.

Both guards were driven red on the real defect before being made green:

- re-inserting one `ratio: null` entry → `holds no ratio:null entry — one
  mechanism, not two` fails
- making an unresolved backdrop fail rather than report → `reports an
  unresolvable backdrop instead of failing it` and `does not consult the
  allowlist for an unresolvable backdrop` both fail

The structural test is what makes the spec's branch ordering un-exploitable from
a PR: with no `ratio: null` entries on the list, `if (allowed) continue` has
nothing left to swallow, whatever order the branches sit in.

## 3. The report is grouped by surface

One line per distinct `backdropCss` with a node count and one example, instead of
N repetitions of the same gradient. At 14-25 findings per test that is the
difference between a report someone reads and one they scroll past. Both numbers
are still printed:

```
[contrast] wow/dark/desktop: 8 unmeasurable surface(s) (ceiling 8), 23 text node(s) unchecked.
  4 node(s) over repeating-linear-gradient(rgb(57, 21, 42), ...)
    e.g. div > div > a > span (14px/600) "Fielddesk"
```

The assertion moved to the same unit: **surfaces, not findings**. A finding count
churns on every copy edit (add a line of body text to a card on the gilt wordmark
and the number moves); the thing worth ratcheting — a new region of the app going
unchecked — is exactly one new surface.

## Ceiling numbers: what is measured and what is not

**I cannot run the suite.** No Playwright browsers, no Postgres in this worktree.
The new counts are not observable here, and I have not pretended otherwise.

The numbers shipped are the per-test **surface** counts read off nightly run
31779247838 (the last run before #1749), collapsed from #1752's 28-row table —
they are theme-independent, exactly as `main`'s comment already observed:

| row | desktop | mobile |
|---|---|---|
| `wow` | 8 | 7 |
| `ua` | 8 | 5 |
| `default` | 7 | 5 |

The arithmetic I *can* do statically, from the deleted entries themselves:

- 56 `ratio: null` entries → **22 distinct `backdropCss` values** (11 per theme).
- By breadcrumb: wow 4 desktop + 4 mobile per theme; ua 2 desktop per theme;
  ephemerists 2 desktop per theme.
- **snide, singularity, albescent and everymen had none at all.**

That last point corrects the issue's "removing the 56 allowlisted entries raises
every count" — it can only raise wow, ua and ephemerists. And it raises those only
for surfaces that both still render and were genuinely being filtered; #1752's own
note argued the gradient CSS had rotted far enough that few keys still matched.

**I have deliberately not pre-raised the ceilings by that allowance.** A ceiling
set too high is silent, which is the disease this issue is treating. A ceiling set
too low fails the nightly and prints the exact line to paste:

```
wow/dark/desktop: 11 unmeasurable surfaces, up from 8. ...
TO CORRECT THIS CEILING from this run: the surfaces printed above are the whole
population, so set 'wow'.desktop in UNMEASURABLE_CEILING to 11 — but only after
checking the new surface against the list above. ...
```

The `'wow'` in that message is derived from the table via `ceilingKeyFor()`, so it
cannot drift from the row that actually governs.

## Verification: which half is checked and which is not

| | status |
|---|---|
| `contrastTriage.test.ts` (9 cases) | **runs in PR CI**, passes; driven red on both defects first |
| `tsc --noEmit`, `typecheck:design-sync`, `lint`, `npm test` (4357), `build`, `budget` | all pass locally |
| `contrast.spec.ts` itself | **not verified.** `e2e` is nightly-only and not a required check, so CI will not exercise it either way |

Note `contrast.spec.ts` is reached by **no** CI step — `tsconfig.json` is
`include: ["src"]`, and `npm run lint` gives `e2e/**` only the axios import ban. I
typechecked it by hand with the app's compiler options plus `@playwright/test`
types; that is not a substitute for a run.

The first nightly is the real verification, and it is the thing that corrects a
wrong ceiling.

## Not touched

#1749's other half stands: the 19 measured contrast fixes (Constellation orb
opacity, `PraxisStats`' double-mute, the Ephemerists section titles, the vote
prompt) are untouched. `index.css`, `Constellation.tsx`, `praxisCard/shared.tsx`
and `EphemeristsFactionBody.tsx` are not in this diff — three files are. No colour
changes, no change to what is measured, only to how unmeasurable backdrops are
reported. The four remaining measured defects are #1766.

## What to eyeball

1. **The ceiling numbers are the judgement call.** I chose "fail loud and correct
   from the run" over "pre-raise by up to +4/+2 and hope". If you would rather the
   first nightly be green, the allowance to add is in the ponytail comment.
2. **Surfaces vs findings as the ratchet unit** — coarser than what `main` shipped
   yesterday. Three new nodes on an existing gradient no longer trip it. The node
   count is still printed on every run, but nothing asserts on it.
3. **The failure message's claim that "the surfaces printed above are the whole
   population"** is only true because nothing grandfathers an unmeasurable surface
   any more. That is the invariant the `holds no ratio:null entry` test defends.
4. **`emitBaseline` now refuses `background === null`.** Belt-and-braces —
   `triageFindings` never puts one in `failures` — but it is the thing that would
   quietly rebuild the deleted mechanism during a regeneration.
5. **The 185/241/269 entry counts** in the `contrastBaseline.ts` header: I counted
   them rather than trusting the previous number, which was wrong by 28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
