### PR TITLE
S.N.I.D.E. wears no tape

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -693,6 +693,16 @@ Owner ruling, and the first thing to know about it is that **it is deliberate**:
 
 **Opt IN, never opt out — the direction is the durable half.** "Turn by default, list the pages that must not" is an exclusion list, and it is wrong the first afternoon somebody adds a surface: a new page mounting a WOW card would silently start flipping, and nothing would fail. Unset being upright inverts that. The exempt pages are correct because they say nothing, not because anyone remembered them, and the cost of the whimsy reaching a new browsing page is one class. It is also the smaller edit today — four browsing mounts against twelve exempt ones — but the count is the lesser reason, and it would still be the right direction if the counts were reversed.
 
+### S.N.I.D.E. wears no tape, and it was SPECIFIED (#1708)
+
+Owner ruling, dated 2026-08-14, and the reason it is written down is that every piece of evidence a later editor will find says the opposite. `tape` is a first-class token in **both** SNIDE palettes in the design kit, `ground()` draws two strips in the composer design, and epic #1179's seam table names it outright ("ground() — SNIDE grain + tape"). **A fidelity pass that restores it is undoing deliberate work, not fixing a regression.** Eleven strips came off nine SNIDE files and two shared ones, and `--faction-snide-tape`, `--snide-tape` and `.snide-tape` went with them; `frontend/src/__tests__/snideWearsNoTape.test.ts` is what keeps them gone.
+
+**Deleting the class first is what makes the removal hold.** Leaving a declared token behind is an invitation: the next surface that wants a strip reaches for the name that already exists, and the metaphor is back on one file at a time with nothing failing. The two tokens here also held the *identical* rgba in two namespaces — latent drift that only ever got a chance to diverge because both were still declared.
+
+**A strip can be carrying more than ornament, so check each removal site rather than sweeping the draw calls.** Ten of the eleven were absolutely positioned decoration and left nothing behind. The eleventh was not: the faction hero's eyebrow printed in the press's near-black *because* it sat on a tape ground, and that near-black is the wall it would have been dropped onto — an invisible line, not a plainer one. It takes the faction's xerox paper as ink instead, an existing token repointed rather than a new value. The same shape appears in the composer, where `ComposerGround`'s default negative inset exists so a layer can overhang the sheet: the strips were the only thing allowed to run off, so the ground stays pinned at `inset={0}` and the raster stays inside the stock.
+
+**Not everything called tape is this tape.** SNIDE's task detail draws diagonal HAZARD stripes on its action plate, and its praxis detail hangs "taped-up clippings" along a rail. Both are different visual families, both stay, and neither reaches for the retired name — which is why the guard needs no exceptions list. The test for the ruling is "does it look like a strip of tape", never "does the identifier contain the string".
+
 ---
 
 ## 7. Components

--- a/frontend/src/__tests__/snideWearsNoTape.test.ts
+++ b/frontend/src/__tests__/snideWearsNoTape.test.ts
@@ -1,0 +1,67 @@
+/**
+ * #1708 — S.N.I.D.E. wears no tape.
+ *
+ * Tape was *specified*, not accidental: `tape` is a first-class token in both
+ * SNIDE palettes in the design kit and epic #1179's seam table names it
+ * ("ground() — SNIDE grain + tape"). The owner overrode that seam on
+ * 2026-08-14. This guard is the record, so a later fidelity pass against the
+ * design does not quietly put the strips back.
+ *
+ * A SOURCE SCAN rather than a render, for `covenSpeaksOneIdentity`'s reason:
+ * the strips sat on eleven surfaces, several of them behind a branch
+ * (`membership.state !== 'none'`, a spotlit member, the composer's waiting
+ * stage) that no fixture reaches. One assertion covers every surface, present
+ * and future, without instantiating any of them.
+ *
+ * One name covers all three retirements, because each contains it: the
+ * `--faction-snide-tape` token, its always-dark twin `--snide-tape`, and the
+ * `.snide-tape` class the strips wore.
+ *
+ * NOT covered, deliberately — these are a different visual family and stay:
+ *
+ *  • `SnideTaskDetail`'s HAZARD tape (diagonal stripes on the action plate);
+ *  • `SnidePraxisDetail`'s clippings "taped along the rail" — the clipping and
+ *    its look are the archetype.
+ *
+ * Neither reaches for the retired name, so neither has to be excused here.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect } from 'vitest'
+
+const SRC_DIR = fileURLToPath(new URL('..', import.meta.url))
+
+/** The retired strip, as the one substring every form of it contains. */
+const RETIRED = /snide-tape/
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap((entry: string) => {
+    const path = join(dir, entry)
+    if (statSync(path).isDirectory()) return entry === '__tests__' ? [] : sourceFiles(path)
+    return /\.(tsx?|css)$/.test(entry) ? [path] : []
+  })
+}
+
+/**
+ * A docstring may legitimately NAME the strip — several SNIDE headers explain
+ * what came off, and this file's own header does. Only a declaration or a draw
+ * call counts.
+ */
+const stripComments = (source: string) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '')
+
+const toRelative = (path: string) => relative(SRC_DIR, path).split('\\').join('/')
+
+describe('S.N.I.D.E. wears no tape (#1708)', () => {
+  it('nothing declares, draws or reaches for the tape strip', () => {
+    const offenders = sourceFiles(SRC_DIR)
+      .filter((path) => RETIRED.test(stripComments(readFileSync(path, 'utf8'))))
+      .map(toRelative)
+    expect(offenders).toEqual([])
+  })
+
+  it('scans a non-empty set, so the guard cannot pass by finding nothing', () => {
+    expect(sourceFiles(SRC_DIR).length).toBeGreaterThan(100)
+  })
+})

--- a/frontend/src/components/comments/__tests__/snideComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/snideComment.test.tsx
@@ -89,10 +89,13 @@ describe('SnideComment — the slip tells', () => {
     expect(html).toContain('--faction-snide-font-black')
   })
 
-  it('tapes the slip down and rasters the stock', () => {
+  it('rasters the stock, and no longer tapes the slip down (#1708)', () => {
     const html = row()
-    expect(html).toContain('snide-tape')
     expect(html).toContain('--faction-snide-slip-grain')
+    // The two strips at the head came off — an owner override of a seam the
+    // design kit specifies. The namespace-wide guard is
+    // `src/__tests__/snideWearsNoTape.test.ts`; this is the rendered half of it.
+    expect(html).not.toContain('snide-tape')
   })
 
   it('sits on the FLIPPING stock, not the theme-invariant photocopier card', () => {

--- a/frontend/src/components/comments/voices/SnideComment.tsx
+++ b/frontend/src/components/comments/voices/SnideComment.tsx
@@ -23,7 +23,10 @@ import { CommentFlagControl, canFlagComment } from '../FlagControl'
  * same object: a xerox photocopy taped to the wall, half a degree off true,
  * dusted with the halftone raster, the author's name cut letter-by-letter out of
  * five different scraps. Rows and the composer share one shape so a thread reads
- * as a run of flyposted slips rather than a list plus a form.
+ * as a run of flyposted slips rather than a list plus a form. Flyposted, but no
+ * longer with the tape DRAWN: the two strips at the head came off in #1708, an
+ * owner override of a seam the design kit specifies. The tilt, the hard printed
+ * shadow and the raster are what say "stuck to a wall" now.
  *
  * Six states, one responsive component (ADR-0056 / 0058 / 0063 — no mobile
  * twin): row · default | row · mention | row · edited | row · yours (hover) |
@@ -156,15 +159,6 @@ function slip(mobile: boolean): CSSProperties {
   }
 }
 
-function Tape() {
-  return (
-    <>
-      <div className="snide-tape" aria-hidden="true" style={{ top: -8, left: 28, transform: 'rotate(-8deg)' }} />
-      <div className="snide-tape" aria-hidden="true" style={{ top: -8, right: 22, transform: 'rotate(7deg)' }} />
-    </>
-  )
-}
-
 /** Typewriter label voice — the timestamp, the edited mark, the composer hint. */
 const TYPED: CSSProperties = {
   fontFamily: 'var(--faction-snide-font-type)',
@@ -193,7 +187,6 @@ export default function SnideComment(props: CommentProps) {
     const { character, value, onChange, onSubmit, submitting } = props
     return (
       <div style={slip(mobile)} aria-busy={submitting}>
-        <Tape />
         <div style={{ position: 'relative', display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
           <FactionAvatar character={character} size="sm" />
           <div style={{ flex: 1, minWidth: 0 }}>
@@ -251,7 +244,6 @@ export default function SnideComment(props: CommentProps) {
 
   return (
     <div style={slip(mobile)} {...reveal.containerProps}>
-      <Tape />
       <div style={{ position: 'relative', display: 'flex', gap: 'var(--space-md)', alignItems: 'flex-start' }}>
         <FactionAvatar character={authorToCharacter(comment.author)} size="sm" />
         <div style={{ flex: 1, minWidth: 0 }}>

--- a/frontend/src/components/factionCard/FactionCard.tsx
+++ b/frontend/src/components/factionCard/FactionCard.tsx
@@ -315,7 +315,6 @@ export function SnideCard({
           clipPath: SNIDE_TORN_CLIP,
         }}
       />
-      <div className="snide-tape" style={{ top: -10, left: 22, transform: "rotate(-8deg)" }} />
       <SnideMasthead subtitle={i18n.t("feed:factionCard.snide.subtitle")} />
       {invitationNote && (
         <InvitationNote slug={faction.slug} note={invitationNote} />

--- a/frontend/src/components/factionHero/SnideFactionHero.tsx
+++ b/frontend/src/components/factionHero/SnideFactionHero.tsx
@@ -108,21 +108,22 @@ export default function SnideFactionHero({
       >
         {/* identity — eyebrow + wordmark + motto + blurb */}
         <div style={{ flex: 1, minWidth: 300 }}>
-          {/* eyebrow on tape */}
+          {/* eyebrow, typed straight onto the wall (#1708 took the tape) */}
           <div
             style={{
               display: "inline-block",
               width: "fit-content",
               whiteSpace: "nowrap",
-              background: "var(--faction-snide-tape)",
-              color: "var(--faction-snide-ink)",
+              // The strip carried this line's ink as well as its ground: on the
+              // tape it printed in the press's near-black, which IS the wall.
+              // Xerox paper is the faction's own on-ink type colour and needs no
+              // new value; the padding and the paste-up shadow went with the
+              // strip, so the eyebrow sets flush with the wordmark below it.
+              color: "var(--faction-snide-paper)",
               fontFamily: "var(--faction-snide-font-type)",
               fontSize: "var(--text-base)",
               letterSpacing: "0.05em",
-              // eslint-disable-next-line local/no-raw-style-values -- ornament: inset of the eyebrow on its tape strip; rounding reflows the tape.
-              padding: "3px 12px",
               transform: "rotate(-1.5deg)",
-              boxShadow: "1px 1px 0 rgba(0,0,0,0.3)",
             }}
           >
             {i18n.t("feed:factionHero.snide.eyebrow")}
@@ -229,19 +230,6 @@ export default function SnideFactionHero({
               />
               <SnideSigil size={54} color="var(--faction-snide)" />
             </div>
-            <div
-              style={{
-                position: "absolute",
-                top: -9,
-                left: "50%",
-                // eslint-disable-next-line local/no-raw-style-values -- ornament: half the 52px tape strip, centring it on the sigil disc's crown. The offset IS the drawn strip's width; a rung slides the tape off-centre.
-                marginLeft: -26,
-                width: 52,
-                height: 18,
-                background: "var(--faction-snide-tape)",
-                transform: "rotate(-7deg)",
-              }}
-            />
           </div>
 
           {/* staggered acid stat chits — not a clean band */}

--- a/frontend/src/components/feed/SnideFeedFrame.tsx
+++ b/frontend/src/components/feed/SnideFeedFrame.tsx
@@ -8,9 +8,10 @@ import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
  *
  * Design: `Snide Comment + Update Cards.dc.html` (+ its `- Dark` companion),
  * epic #1192 / #1198. An INTERCEPTED SLIP: a xerox photocopy flyposted on the
- * wall, taped down at the head, half a degree off true, dusted with the halftone
- * raster, with an acid sprocket stripe ruled down its left edge and a near-black
- * intake bar typed across its top.
+ * wall half a degree off true, dusted with the halftone raster, with an acid
+ * sprocket stripe ruled down its left edge and a near-black intake bar typed
+ * across its top. It was taped down at the head too, until #1708 — an owner
+ * override of a seam the design kit specifies. Do not put the strip back.
  *
  * ── WHAT THIS LAYER OWNS ────────────────────────────────────────────────────
  * The outside of the card and the four chrome slots of {@link FeedFrameProps},
@@ -96,7 +97,9 @@ export default function SnideFeedFrame({
     // Printed, not floating — a hard offset with no blur.
     boxShadow: mobile ? undefined : 'var(--faction-snide-slip-shadow)',
     transform: mobile ? undefined : 'rotate(-0.6deg)',
-    // Clips the tape to a half-strip, as if it were applied from behind.
+    // The stock is guillotined: the sprocket stripe and the over-inked intake
+    // bar run to the cut edge and stop there, never past it. (It also clipped
+    // the tape to a half-strip; the tape came off in #1708, this did not.)
     overflow: 'hidden',
   }
 
@@ -118,13 +121,6 @@ export default function SnideFeedFrame({
       />
 
       <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
-        {/* A strip of tape pinning the slip to the wall. */}
-        <div
-          className="snide-tape"
-          aria-hidden="true"
-          style={{ top: -9, right: 40, width: 64, height: 20, transform: 'rotate(5deg)' }}
-        />
-
         {/* ── THE INTAKE BAR ── the kicker band, over-inked across the head of
             the slip. It carries three of the four chrome slots and tints the
             fourth: `archive` paints in `currentColor`, so setting `color` here

--- a/frontend/src/components/feed/__tests__/snideFeedFrame.test.tsx
+++ b/frontend/src/components/feed/__tests__/snideFeedFrame.test.tsx
@@ -86,8 +86,8 @@ describe('SnideFeedFrame — the stock flips, and acid stays a drawn thing', () 
   })
 
   it('prints no faction name (epic decision 5 — the skin is the identification)', () => {
-    // TEXT nodes only: token names and the `.snide-tape` class carry the slug by
-    // necessity, and neither is copy. What must not appear is a visible label.
+    // TEXT nodes only: token names carry the slug by necessity, and a token name
+    // is not copy. What must not appear is a visible label.
     const text = frame({ tag: 'Still waiting' })
       .replace(/<[^>]*>/g, ' ')
       .toLowerCase()

--- a/frontend/src/components/metataskSeal/skins/SnideSeal.tsx
+++ b/frontend/src/components/metataskSeal/skins/SnideSeal.tsx
@@ -4,7 +4,8 @@ import { factionName } from '../../../utils/factions'
 import type { SealSkinProps } from '../types'
 
 /**
- * S.N.I.D.E. seal — a photocopier-ink ransom note taped to the host praxis.
+ * S.N.I.D.E. seal — a photocopier-ink ransom note slapped on the host praxis.
+ * It was taped on until #1708 took the two strips off its head.
  * Same three-field contract as every seal (label / condition / bonus) but in
  * S.N.I.D.E.'s own voice: Archivo Black + Anton for the demand, Special Elite
  * for the eyebrow, acid-green on ink with a hot-pink tear.
@@ -79,9 +80,6 @@ export default function SnideSeal({ metatask, removable, onRemove }: SealSkinPro
       }}
     >
       <div className="ht-dots" style={{ position: 'absolute', inset: 0, color: 'rgba(182,255,46,0.08)', pointerEvents: 'none' }} />
-      <div className="snide-tape" style={{ top: -12, left: 18, transform: 'rotate(-7deg)' }} />
-      <div className="snide-tape" style={{ top: -10, right: 14, transform: 'rotate(6deg)' }} />
-
       {removable && (
         <button
           type="button"

--- a/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
@@ -14,7 +14,8 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  *  • the TORN-PAPER top/bottom edges (a 25-point clip-path). The design's slab
  *    is guillotined — square corners, unbroken acid rule. The tearing read as
  *    the Updates feed's aged-paper foe note;
- *  • the TAPE strip;
+ *  • the TAPE strip (and there is no strip to reconsider: #1708 retired tape
+ *    from every SNIDE surface);
  *  • the `Special Elite` MASTHEAD block. The design's running head is a single
  *    Courier eyebrow line in acid, inside the text column, where it stops at
  *    the score tag instead of running under it — so it is passed to

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -180,7 +180,6 @@ export function SnideSelectCard({ state = "locked", members, onVisit }: Omit<Fac
     }}>
       <div style={{ position: "absolute", top: -40, right: -40, width: 130, height: 130, borderRadius: "50%",
         background: "radial-gradient(circle, var(--snide-acid) 0%, transparent 62%)", opacity: 0.22, filter: "blur(2px)" }} />
-      <div style={{ position: "absolute", top: 14, left: 22, width: 74, height: 20, background: "var(--snide-tape)", transform: "rotate(-6deg)", boxShadow: "0 1px 2px rgba(0,0,0,0.4)" }} />
       <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-xl) 0" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)" }}>
           <SnideSigil size={40} color="var(--snide-acid)" />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -694,7 +694,11 @@
   --faction-snide-paper: #f4f1e8; /* warm xerox paper */
   --faction-snide-pink: #ff2d8b; /* hot zine pink */
   --faction-snide-pink-deep: #be185d;
-  --faction-snide-tape: rgba(228, 214, 120, 0.62);
+  /* `--faction-snide-tape` stood here. It and the always-dark `--snide-tape`
+     below held the SAME rgba, which is exactly the drift #1708 took with them.
+     Tape is SPECIFIED for this faction — a first-class token in both design
+     palettes, and epic #1179's seam table names it — and the owner retired it
+     anyway on 2026-08-14. Do not mint it back on a fidelity pass. */
   --faction-snide-wall: #efece3; /* flyposted xerox-paper wall (FLIP in dark) */
   --faction-snide-wall-deep: #e0ddd1;
   --faction-snide-wall-text: #14110b;
@@ -792,9 +796,10 @@
   --faction-snide-note-shadow: 0 12px 28px -14px rgba(20, 17, 11, 0.55);
 
   /* ══ S.N.I.D.E. — THE FLYPOSTED SHEET (edit-praxis composer, #1184) ══
-     The composer is a xerox sheet taped to the wall: grain raster, two tape
-     strips, a near-black masthead bar with the wordmark in acid, censor stripes
-     for section rules, and a full-bleed acid submit bar at the foot.
+     The composer is a xerox sheet flyposted to the wall: grain raster, a
+     near-black masthead bar with the wordmark in acid, censor stripes for
+     section rules, and a full-bleed acid submit bar at the foot. (Two tape
+     strips ran off its edge until #1708 retired tape from SNIDE entirely.)
 
      THIS FAMILY FLIPS, for the same reason `-note-*` above does and NOT for the
      reason `-card-*` doesn't: a sheet of paper is the whole conceit, so it goes
@@ -845,9 +850,10 @@
 
   /* ══ S.N.I.D.E. — THE INTERCEPTED SLIP (feed chassis + comment sheet, #1198) ══
      Design: `Snide Comment + Update Cards.dc.html` — a flyposted xerox slip
-     taped to the wall at half a degree off true, with a near-black intake bar
-     typed across its head, an acid sprocket stripe down its left edge, and the
-     halftone raster over the whole stock.
+     flyposted at half a degree off true, with a near-black intake bar typed
+     across its head, an acid sprocket stripe down its left edge, and the
+     halftone raster over the whole stock. (Taped down at the head as well,
+     until #1708 retired tape from SNIDE entirely.)
 
      THIS FAMILY FLIPS, and here that is a bug fix rather than only a dress
      choice. §3's "a block whose ink you do not control gets the stock that ink
@@ -3551,29 +3557,11 @@
     background-size: 3px 3px, 4px 4px;
     background-position: 0 0, 2px 1px;
   }
-  .snide-tape {
-    position: absolute;
-    height: 26px;
-    width: 64px;
-    background: var(--faction-snide-tape);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.25);
-    opacity: 0.9;
-  }
-  .snide-tape::before,
-  .snide-tape::after {
-    content: "";
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 4px;
-    background-image: repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.05) 0 1px, transparent 1px 3px);
-  }
-  .snide-tape::before {
-    left: 0;
-  }
-  .snide-tape::after {
-    right: 0;
-  }
+  /* `.snide-tape` — the strip, with its serrated ::before/::after edges — stood
+     here until #1708. Eleven surfaces wore it; the owner retired the whole
+     family, and both tokens behind it went with the class (see the two notes in
+     the token blocks above and below). `frontend/src/__tests__/snideWearsNoTape.test.ts`
+     is what keeps it retired. */
 }
 
 /* ══════════════════════════════════════════════════════════════
@@ -4745,7 +4733,8 @@
   --snide-ink: #14110b;
   --snide-paper: #f4f1e8;
   --snide-pink: #ff2d8b;
-  --snide-tape: rgba(228, 214, 120, 0.62);
+  /* `--snide-tape` stood here — the always-dark twin of `--faction-snide-tape`,
+     same rgba, retired with it in #1708. */
   /* ALBESCENT · vellum correspondence — THE REVEAL SURFACES ONLY (#783).
      Always-light, the same mechanism Singularity uses to stay always-dark.
 

--- a/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
@@ -1,7 +1,7 @@
 /**
  * SnideProfileBody — S.N.I.D.E. ransom-note / crime-board player-profile skin
  * (#460). Ported from docs/design/profile/templates/SNIDE Profile.dc.html: hard
- * offset shadows, skewed Impact headlines with a pink drop-shadow, tape strips,
+ * offset shadows, skewed Impact headlines with a pink drop-shadow,
  * halftone dot texture, and the tagline pasted up as a ransom slip (#1630, which
  * also dropped the torn acid strip along the header top). SNIDE is ALWAYS DARK — its
  * --faction-snide-* tokens are identical in both themes, so the container scopes

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -11,7 +11,8 @@
  *
  * **Geometry — radius 0, borderW 0.** SNIDE is the one skin that draws no card
  * border at all, so the sheet is a hard-cornered rectangle with nothing around
- * it: what separates it from the page is the stock, the grain and the tape. The
+ * it: what separates it from the page is the stock and the grain. (It was the
+ * stock, the grain and the tape until #1708 took the strips.) The
  * shared sheet's default 10px radius is overridden here rather than inherited.
  *
  * **Masthead** — a near-black bar carrying the wordmark in acid, a dashed acid
@@ -20,10 +21,13 @@
  * underneath it. The zine says DRAFT twice on purpose; a screen reader hears it
  * once.
  *
- * **Ground** — the photocopier raster plus two tape strips, both running off the
- * sheet's edge. They can only do that because `ComposerSheet` owns the
+ * **Ground** — the photocopier raster, flush with the sheet. It carried two tape
+ * strips running off the sheet's edge until #1708, an owner override of a seam
+ * the design kit specifies (`edit-praxis.jsx:349-350`); do not put them back on
+ * a fidelity pass. They could run off at all because `ComposerSheet` owns the
  * `overflow: hidden` clip: the ground is the COLUMN's, never the viewport's
- * (#1028, the trap six of eight task-detail skins fell into).
+ * (#1028, the trap six of eight task-detail skins fell into), and that clip is
+ * still what keeps the raster inside the stock.
  *
  * **Section rule** — the censor stripe, a solid redaction bar rather than a
  * hairline.
@@ -247,7 +251,7 @@ export default function SnideEditPraxis({ state }: Props) {
 
   /* The chrome, named once and mounted twice: the composer below, and the
      waiting surface once your part is in (#1189). The same ELEMENTS both
-     times, so the acid bar, the raster and the tape cannot drift between the
+     times, so the acid bar and the raster cannot drift between the
      two stages. The masthead's stage word travels with them — it reads
      SUBMITTED, not DRAFT, once your part is filed. */
   /* radius 0, borderW 0 — the sheet has no edge but its own stock. */
@@ -334,33 +338,12 @@ export default function SnideEditPraxis({ state }: Props) {
   const ground = (
           <ComposerGround
             background={`repeating-linear-gradient(0deg, ${GRAIN} 0 1px, transparent 1px 3px)`}
-            /* Flush, not overhanging: the raster is printed on the sheet, and
-               only the tape is allowed to run off it. */
+            /* Flush, not overhanging: the raster is printed ON the sheet, so it
+               stops where the stock does. It shared this layer with two tape
+               strips that ran off the edge, which is what the negative default
+               inset is for; #1708 took them and the raster keeps the flush 0. */
             inset={0}
-          >
-            <span
-              className="snide-tape"
-              style={{
-                width: 110,
-                height: 26,
-                right: -26,
-                top: 64,
-                transform: "rotate(-38deg)",
-                opacity: 0.75,
-              }}
-            />
-            <span
-              className="snide-tape"
-              style={{
-                width: 96,
-                height: 22,
-                left: -30,
-                bottom: 96,
-                transform: "rotate(34deg)",
-                opacity: 0.6,
-              }}
-            />
-          </ComposerGround>
+          />
   );
 
   const dress: ComposerDress = {

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -17,7 +17,7 @@ import type { FactionDetailState } from "../useFactionDetail";
  * Same shape as Everymen/UaFactionBody — Tasks/Praxis reuse the app-wide
  * per-faction cards (TaskCard/PraxisCard already dispatch to the SNIDE
  * archetypes); this file only owns the cut-and-paste chrome the design adds:
- * the two-column layout, taped photocopier frames, halftone dots, the fixed
+ * the two-column layout, tilted photocopier frames, halftone dots, the fixed
  * "Tasks"/"Praxis" titles with marker kickers, the join/gate "re: you"
  * dispatch, the "WANTED" spotlight + dashed "rap sheet", and the FDL laurel on
  * the single top-scoring praxis.
@@ -34,7 +34,6 @@ const INK = "var(--faction-snide-ink)";
 const PAPER = "var(--faction-snide-paper)";
 const PINK = "var(--faction-snide-pink)";
 const PINK_DEEP = "var(--faction-snide-pink-deep)";
-const TAPE = "var(--faction-snide-tape)";
 const MUTED = "var(--faction-snide-card-muted)";
 
 const IMPACT = "var(--faction-snide-font-impact)";
@@ -78,24 +77,6 @@ function Halftone({ on = "ink" }: { on?: "ink" | "paper" }) {
             ? "radial-gradient(color-mix(in srgb, var(--faction-snide-acid) 8%, transparent) 32%, transparent 34%)"
             : "radial-gradient(color-mix(in srgb, var(--faction-snide-ink) 5%, transparent) 32%, transparent 34%)",
         backgroundSize: "5px 5px",
-      }}
-    />
-  );
-}
-
-/** A strip of packing tape slapped across a corner. */
-function Tape({ style }: { style: CSSProperties }) {
-  return (
-    <div
-      aria-hidden="true"
-      style={{
-        position: "absolute",
-        height: 26,
-        width: 66,
-        background: TAPE,
-        boxShadow: "inset 0 0 0 1px rgba(255,255,255,.25)",
-        zIndex: 3,
-        ...style,
       }}
     />
   );
@@ -204,17 +185,15 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
     <div className="wz-faction-grid">
       {/* ── MAIN COLUMN ── */}
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
-        {/* ② ABOUT — taped xerox flyer */}
+        {/* ② ABOUT — tilted xerox flyer */}
         <div style={{ position: "relative", transform: "rotate(-0.6deg)" }}>
-          <Tape style={{ top: -11, left: 28, transform: "rotate(-7deg)" }} />
-          <Tape style={{ top: -9, right: 32, transform: "rotate(6deg)" }} />
           <div style={{ ...PAPER_PANEL, padding: "var(--space-xl)" }}>
             <Halftone on="paper" />
             <div
               style={{
                 position: "relative",
                 fontFamily: MARKER,
-                // eslint-disable-next-line local/no-raw-style-values -- ornament: marker scrawl heading on the taped xerox flyer.
+                // eslint-disable-next-line local/no-raw-style-values -- ornament: marker scrawl heading on the xerox flyer.
                 fontSize: 26,
                 color: GREEN,
                 transform: "rotate(-1deg)",
@@ -293,11 +272,9 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
 
       {/* ── RIGHT RAIL ── */}
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
-        {/* ③ RE: YOU — join / gate / standing (taped dispatch) */}
+        {/* ③ RE: YOU — join / gate / standing (tilted dispatch) */}
         {membership.state !== "none" && (
           <div style={{ position: "relative", transform: "rotate(-1deg)" }}>
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: half the 60px tape strip, centring it over the dispatch panel's head. The offset IS the drawn strip's width; a rung slides the tape off-centre. */}
-            <Tape style={{ top: -10, left: "50%", marginLeft: -30, width: 60, transform: "rotate(-5deg)" }} />
             <div style={{ ...INK_PANEL, padding: "var(--space-xl)" }}>
               <Halftone on="ink" />
               <div
@@ -503,7 +480,6 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
           {spot && (
             <Link to={`/characters/${spot.id}`} style={{ textDecoration: "none" }}>
               <div style={{ position: "relative", transform: "rotate(1.2deg)" }}>
-                <Tape style={{ top: -9, left: 26, width: 56, height: 22, transform: "rotate(-6deg)" }} />
                 <div style={{ ...INK_PANEL, border: `2px solid ${ACID}`, boxShadow: "5px 6px 0 rgba(0,0,0,.3)", padding: "var(--space-lg)", textAlign: "center" }}>
                   <Halftone on="ink" />
                   <div

--- a/frontend/src/pages/factionDetail/mobileArchetypes/SnideFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/SnideFactionPage.tsx
@@ -12,7 +12,7 @@ import type { FactionDetailState } from '../useFactionDetail'
  * same single-column slots as the Default mobile faction page (a hero with real
  * member/task counts, top members, recent praxis, and the invite-gated Join
  * model via `state.membership`, ADR-0019) — only the paste-up changes: a dark
- * ransom masthead over an acid rule, taped rows, hot-pink Join. Grounds on the
+ * ransom masthead over an acid rule, hot-pink Join. Grounds on the
  * `--faction-snide-*` tokens; native-dark. Reuses the shared `mobile.*` faction
  * copy so the slot contract holds. Presentation-only — all data + the join
  * handler arrive via {@link FactionDetailState}.
@@ -28,7 +28,6 @@ const MUTED = 'var(--faction-snide-card-muted)'
 const ACID = 'var(--faction-snide-card-accent)'
 const ACCENT_WALL = 'var(--faction-snide)'
 const PINK = 'var(--faction-snide-pink)'
-const TAPE = 'var(--faction-snide-tape)'
 const LINE = 'var(--faction-snide-border)'
 const PAPER = 'var(--faction-snide-paper)'
 const COND = 'var(--faction-snide-font-cond)'
@@ -127,7 +126,6 @@ export default function SnideFactionPage({ state }: { state: FactionDetailState 
       {/* Hero — dark ransom masthead */}
       <section style={{ position: 'relative', background: INK, color: TEXT, border: `1px solid ${LINE}`, boxShadow: CARD_SHADOW, padding: 'var(--space-xl) var(--space-lg)', transform: 'rotate(-0.6deg)', overflow: 'hidden' }}>
         <span aria-hidden style={{ position: 'absolute', inset: 0, pointerEvents: 'none', backgroundImage: 'radial-gradient(rgba(182,255,46,0.08) 32%, transparent 34%)', backgroundSize: '5px 5px' }} />
-        <span aria-hidden style={{ position: 'absolute', top: -11, left: 26, width: 64, height: 24, background: TAPE, transform: 'rotate(-5deg)', opacity: 0.92 }} />
         <div style={{ position: 'relative' }}>
           <div style={{ ...kicker, color: ACID }}>{t('snide.mobile.eyebrow')}</div>
           <h1

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
@@ -12,8 +12,8 @@ import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 /**
  * S.N.I.D.E. MOBILE FieldDesk home (#530) — the operative's file on a phone.
- * The carried life and its open jobs become dark ransom cards taped down on a
- * near-black desk: Bebas mastheads over an acid rule, halftone dot screens, hard
+ * The carried life and its open jobs become dark ransom cards slapped down on
+ * a near-black desk: Bebas mastheads over an acid rule, halftone dot screens, hard
  * offset shadows, a hot-pink primary. Same content slots as the Default mobile
  * home (the identity block — name, level, era points and the level track —
  * active-tasks list, primary actions) — only the paste-up changes. Grounds on the `--faction-snide-*`
@@ -29,7 +29,6 @@ const MUTED = 'var(--faction-snide-card-muted)'
 const ACID = 'var(--faction-snide-card-accent)'
 const ACCENT_WALL = 'var(--faction-snide)'
 const PINK = 'var(--faction-snide-pink)'
-const TAPE = 'var(--faction-snide-tape)'
 const LINE = 'var(--faction-snide-border)'
 const COND = 'var(--faction-snide-font-cond)'
 const IMPACT = 'var(--faction-snide-font-impact)'
@@ -53,7 +52,7 @@ const kicker: CSSProperties = {
 }
 
 /**
- * Characters / Edit as real controls (#1553) — a cut-out chip taped to the
+ * Characters / Edit as real controls (#1553) — a cut-out chip stuck to the
  * file. They were bare caps with no box: a sub-20px hit target on a phone. 44
  * is the WCAG 2.5.5 target floor and is GEOMETRY, not spacing.
  */
@@ -88,7 +87,7 @@ const trackMetaStyle: CSSProperties = {
 /** The operative's own ramp: hot pink burning up into acid (#1553). */
 const TRACK_FILL = `linear-gradient(90deg, ${PINK}, ${ACID})`
 
-/** Dark ransom card — taped, halftoned, hard-shadowed, slightly askew. */
+/** Dark ransom card — halftoned, hard-shadowed, slightly askew. */
 function RansomCard({ children, tilt = -1 }: { children: ReactNode; tilt?: number }) {
   return (
     <div
@@ -106,10 +105,6 @@ function RansomCard({ children, tilt = -1 }: { children: ReactNode; tilt?: numbe
       <span
         aria-hidden
         style={{ position: 'absolute', inset: 0, pointerEvents: 'none', backgroundImage: HALFTONE, backgroundSize: '5px 5px' }}
-      />
-      <span
-        aria-hidden
-        style={{ position: 'absolute', top: -10, left: 22, width: 60, height: 22, background: TAPE, transform: 'rotate(-4deg)', opacity: 0.92 }}
       />
       <div style={{ position: 'relative', zIndex: 1 }}>{children}</div>
     </div>


### PR DESCRIPTION
Closes #1708

Owner override of a shipped design seam. Tape is *specified* for S.N.I.D.E. — a first-class token in both design palettes, and epic #1179's seam table names it — and it goes anyway. Its presence was never evidence it should stay.

## The seam

**The token namespace, and every draw call that reaches for it.** `snide-tape` is the one substring that all three retirements contain (`--faction-snide-tape`, its always-dark twin `--snide-tape`, and the `.snide-tape` class), so one guard covers the lot.

`frontend/src/__tests__/snideWearsNoTape.test.ts` is a source-and-stylesheet scan, not a render, for `covenSpeaksOneIdentity`'s reason: several strips sat behind a branch (`membership.state !== 'none'`, a spotlit member, the composer's waiting stage) that no fixture reaches. It went red first on exactly eleven files — ten components plus `index.css` — which is my own count, re-grepped tonight after PR #1776 landed, and it matches the issue's list. `snideComment.test.tsx` carries the rendered half: its "tapes the slip down" assertion is now the negative.

## What came off

Eleven strips, nine SNIDE files and two shared ones:

| File | Strips |
|---|---|
| `components/comments/voices/SnideComment.tsx` | 2 (the whole `Tape()` component, mounted twice) |
| `components/factionHero/SnideFactionHero.tsx` | 2 |
| `components/metataskSeal/skins/SnideSeal.tsx` | 2 |
| `pages/editPraxis/archetypes/SnideEditPraxis.tsx` | 2 |
| `components/feed/SnideFeedFrame.tsx` | 1 |
| `pages/factionDetail/archetypes/SnideFactionBody.tsx` | 1 `Tape()` helper, 4 call sites |
| `pages/factionDetail/mobileArchetypes/SnideFactionPage.tsx` | 1 |
| `pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx` | 1 |
| `components/factionCard/FactionCard.tsx` | 1 — *not* a Snide-named file |
| `components/selectCard/FactionSelectCard.tsx` | 1 — *not* a Snide-named file |

Plus both tokens and the class, with their now-dead `TAPE` module consts. The two tokens held the **identical** `rgba(228, 214, 120, 0.62)` in two namespaces; that latent drift goes with them. Deleting the class *and* both tokens is what makes the removal hold — a token left declared is an invitation for the next surface to reach for a name that already exists.

## Two sites carried more than ornament

Nine of the eleven were absolutely positioned decoration and left nothing behind. Two were not:

- **`SnideFactionHero`'s eyebrow** was a label *on* a tape ground, printing in `--faction-snide-ink` — which is the near-black wall behind it. Cutting only the `background` would have left an invisible line, not a plainer one. It takes `--faction-snide-paper` as its ink (an existing token repointed, no new value), and the padding and paste-up shadow went with the strip, so it now sets flush with the wordmark below.
- **`SnideEditPraxis`'s `ComposerGround`** keeps `inset={0}`. The negative default inset exists so a layer can overhang the sheet, and the strips were the only thing allowed to run off it; the raster must not, so the flush 0 stays and the comment explaining why is rewritten rather than deleted.

Everywhere else the strips were `position: absolute` children of a `position: relative` box that also holds the panel, so nothing reflows.

## Untouched, on the owner's ruling

- `SnideTaskDetail.tsx` — **hazard tape**. Diagonal stripes, a different visual family. Stays.
- `SnidePraxisDetail.tsx` — the clippings "taped along the rail". No change.
- `SnidePraxisCard.tsx` — the stale header comment listing "the TAPE strip". Re-grepped: it draws none. Comment only.
- `UaMandala` / `UaVote` / `EphemeristsVote` — "tapered", a substring, not tape. Cozy Coven's three matches record a *removal*.

## Verification

Every step `.github/workflows/test.yml` names for the `frontend` job, run locally after rebasing onto `6b33233d`: `lint`, `typecheck`, `typecheck:design-sync`, `test` (243 files / 4350 tests), `build`, `budget` (CSS 21.3 KB, within). No backend, route or schema change, so `api-schema` has nothing to regenerate.

**Braces prove nothing about a CSS edit**, so the built stylesheet is what I checked: `grep -c snide-tape dist/assets/*.css` → **0**, while `--faction-snide-acid` and the neighbouring `.xerox` class still ship, which is what says the block survived the deletion rather than the deletion taking the block.

**Visual QA is outstanding** — I have no browser and did not run a dev server.

## What to eyeball

Both form factors, both themes, on each of these:

- **Comment voice** (`SnideComment`) — a praxis thread: rows *and* the composer, both had strips.
- **Feed chassis** (`SnideFeedFrame`) — the Updates feed; the slip's head is now bare above the intake bar.
- **Faction hero** (`SnideFactionHero`) — the changed one. Is the eyebrow readable in xerox paper on the black wall, and does it line up with the wordmark? And the sigil disc's crown, where a strip used to sit.
- **Faction detail body** (`SnideFactionBody`) — desktop: the ABOUT flyer, the "RE: YOU" dispatch (needs a membership state), and the WANTED spotlight.
- **Faction page, mobile** (`SnideFactionPage`) — the dark ransom masthead.
- **Field desk, mobile** (`SnideFieldDesk`) — every `RansomCard`.
- **Metatask seal** (`SnideSeal`) — on a praxis detail.
- **Edit-praxis composer** (`SnideEditPraxis`) — the sheet's edges, and the waiting stage after submitting, which mounts the same ground.
- **Faction card** (`FactionCard`) — the SNIDE tile on the factions list.
- **Faction select card** (`FactionSelectCard`) — the SNIDE tile in the join flow.
- **Not changed, confirm still tape-like:** SNIDE task detail's hazard stripes, SNIDE praxis detail's taped clippings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
