### PR TITLE
The label tier's local style objects leave the 8px and 9px steps

### DIFF
--- a/frontend/src/__tests__/labelTierSweep.test.ts
+++ b/frontend/src/__tests__/labelTierSweep.test.ts
@@ -117,3 +117,81 @@ describe('the label tier is two classes, and `.eyebrow` is not one of them (#130
     expect(css).toMatch(/^\s*\.label-caption\s*\{/m)
   })
 })
+
+/**
+ * #1608 — the half of the tier the census above CANNOT see.
+ *
+ * The guard at the top counts `className` values, and that is the right
+ * instrument for a class. It is the wrong one for the second population doing
+ * the same job: a local `const eyebrow: CSSProperties` declared inside an
+ * archetype and spread onto elements, which never names any class. 213 such
+ * declarations across 99 files carried the tier's two smallest steps while
+ * #1307 closed green, because a value laundered through a data structure is
+ * invisible to a sweep that greps a NAME.
+ *
+ * So this one greps the SIZE TOKEN instead, which is the one thing every member
+ * of that population has in common. It deliberately counts the raw string
+ * rather than parsing a `fontSize:` property, because the shapes vary — a
+ * ternary, a spread override, a plain declaration — and a parser tuned to the
+ * shapes we happened to find is the same mistake one layer down.
+ *
+ * The allow-list is the point of the file, not an exemption from it. Each entry
+ * is a site where the two steps survive for a reason that is NOT "we missed
+ * it", and the reason is written next to it. Adding a row here should feel like
+ * an argument you have to make.
+ */
+const SMALLEST_STEPS = /var\(--text-(?:sm|xs)\)/g
+
+/** file → how many hits are there on purpose, and why. */
+const ALLOWED: Record<string, { readonly hits: number; readonly why: string }> = {
+  'pages/praxisDetail/shared.tsx': {
+    hits: 16,
+    why:
+      'Moderation and flag controls carrying `.btn-primary`/`.btn-outline`, whose ' +
+      'own size IS this token — the inline value restates the class rather than ' +
+      'laundering one. Two more are the notice body under a --text-base title, ' +
+      'which raising alone would invert. Both belong to a button/content pass.',
+  },
+  'components/duel/shared.tsx': {
+    hits: 3,
+    why:
+      'Two `.btn-*` restatements on the seal actions, which #769 settled as ' +
+      'button chrome, plus one mention in the prose that records that decision.',
+  },
+  'components/collab/CollabSuccess.tsx': {
+    hits: 2,
+    why:
+      'One `.btn-primary` restatement, and one paragraph of body copy — content, ' +
+      'not a label, so the label tier is not where its size comes from.',
+  },
+  'pages/admin/AccountsTab.tsx': {
+    hits: 2,
+    why: 'Both `.btn-outline` restatements on the ban/unban control.',
+  },
+  'components/praxisCard/desktop/EphemeristsPraxisCard.tsx': {
+    hits: 1,
+    why:
+      'The glyph strip alternates two sizes as ornament. It is drawing, not ' +
+      'label text, and the sizes are a rhythm rather than a tier.',
+  },
+  'components/praxisCard/__tests__/cardChrome.test.tsx': {
+    hits: 1,
+    why: 'A NEGATIVE assertion — it exists to prove the token is absent.',
+  },
+}
+
+describe('the label tier left its two smallest steps, objects included (#1608)', () => {
+  it('names --text-sm/--text-xs only where a reason is written down', () => {
+    const here = fileURLToPath(import.meta.url)
+    const carrying = sources()
+      .filter(({ path }) => path !== here)
+      .map(({ path, source }) => ({
+        file: path.slice(SRC.length).replace(/\\/g, '/'),
+        hits: source.match(SMALLEST_STEPS)?.length ?? 0,
+      }))
+      .filter(({ hits }) => hits > 0)
+
+    const unexplained = carrying.filter(({ file, hits }) => ALLOWED[file]?.hits !== hits)
+    expect(unexplained).toEqual([])
+  })
+})

--- a/frontend/src/components/ActivityTicker.tsx
+++ b/frontend/src/components/ActivityTicker.tsx
@@ -86,7 +86,7 @@ function TickerCard({ entry }: { entry: TickerEntry }) {
       </div>
       <div
         className="font-body"
-        style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-tertiary)', lineHeight: 1 }}
+        style={{ fontSize: 'var(--text-lg)', color: 'var(--color-text-tertiary)', lineHeight: 1 }}
       >
         {t(entry.verbKey)}
       </div>

--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -194,7 +194,7 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
                     aria-pressed={selected}
                   >
                     <span style={{ ...serifItalic, fontSize: 'var(--text-content)', color: INK, lineHeight: 1.1 }}>{life.display_name}</span>
-                    <span style={{ ...monoCaps, fontSize: 'var(--text-xs)', letterSpacing: '0.08em', marginTop: 'var(--space-xs)' }}>
+                    <span style={{ ...monoCaps, fontSize: 'var(--text-md)', letterSpacing: '0.08em', marginTop: 'var(--space-xs)' }}>
                       {t('albescent.letter.lifeMeta', { username: life.username, faction: factionName(life.faction_slug) })}
                     </span>
                     {/* eslint-disable-next-line local/no-raw-style-values -- ornament: bullet/arrow dingbat marking the selected life */}

--- a/frontend/src/components/CharacterSwitcherSheet.tsx
+++ b/frontend/src/components/CharacterSwitcherSheet.tsx
@@ -237,11 +237,11 @@ const rowName: CSSProperties = {
   overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
 }
 const rowMeta: CSSProperties = {
-  display: 'block', fontSize: 'var(--text-sm)', letterSpacing: '0.14em', textTransform: 'uppercase',
+  display: 'block', fontSize: 'var(--text-md)', letterSpacing: '0.14em', textTransform: 'uppercase',
   color: 'var(--color-text-secondary)', marginTop: 'var(--space-xs)',
 }
 const rowTapHint: CSSProperties = {
-  fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase',
+  fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase',
   color: 'var(--color-text-tertiary)', flex: 'none',
 }
 const sheetAction: CSSProperties = {

--- a/frontend/src/components/CredentialCard.tsx
+++ b/frontend/src/components/CredentialCard.tsx
@@ -122,7 +122,7 @@ export default function CredentialCard({
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
-          fontSize: 'var(--text-xs)',
+          fontSize: 'var(--text-md)',
           letterSpacing: '0.12em',
           textTransform: 'uppercase',
           color: 'var(--fc-muted)',
@@ -268,7 +268,7 @@ export default function CredentialCard({
           <span
             style={{
               fontFamily: 'var(--font-body)',
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               marginLeft: 'var(--space-xs)',
               color: 'var(--fc-muted)',
               letterSpacing: '0.06em',

--- a/frontend/src/components/InvitationLetterPopup.tsx
+++ b/frontend/src/components/InvitationLetterPopup.tsx
@@ -177,7 +177,7 @@ export default function InvitationLetterPopup({
           style={{
             marginLeft: 'auto',
             fontFamily: FONT_MONO,
-            fontSize: 'var(--text-xs)',
+            fontSize: 'var(--text-md)',
             letterSpacing: '0.18em',
             textTransform: 'uppercase',
             color: FAINT,
@@ -191,7 +191,7 @@ export default function InvitationLetterPopup({
       <p
         style={{
           fontFamily: FONT_MONO,
-          fontSize: 'var(--text-sm)',
+          fontSize: 'var(--text-md)',
           letterSpacing: '0.18em',
           textTransform: 'uppercase',
           color: accent,
@@ -243,7 +243,7 @@ export default function InvitationLetterPopup({
           <div
             style={{
               fontFamily: FONT_MONO,
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               letterSpacing: '0.2em',
               textTransform: 'uppercase',
               color: FAINT,
@@ -266,7 +266,7 @@ export default function InvitationLetterPopup({
               <span
                 style={{
                   fontFamily: FONT_MONO,
-                  fontSize: 'var(--text-sm)',
+                  fontSize: 'var(--text-md)',
                   letterSpacing: '0.08em',
                   textTransform: 'uppercase',
                   color: FAINT,

--- a/frontend/src/components/LevelUpPopup.tsx
+++ b/frontend/src/components/LevelUpPopup.tsx
@@ -188,7 +188,7 @@ function AbilityRow({ ability, color }: { ability: LevelUnlock; color: string })
         {isSense ? '✦' : '■'}
       </span>
       <div>
-        <div style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-xs)', letterSpacing: '0.18em', textTransform: 'uppercase', color: FAINT, marginBottom: 'var(--space-xs)' }}>
+        <div style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-md)', letterSpacing: '0.18em', textTransform: 'uppercase', color: FAINT, marginBottom: 'var(--space-xs)' }}>
           {isSense ? t('popup.senseEyebrow') : t('popup.abilityEyebrow')}
         </div>
         <div style={{ fontFamily: FONT_DISPLAY, fontStyle: 'italic', fontSize: 'var(--text-content)', lineHeight: 1.2, color: INK }}>
@@ -308,14 +308,14 @@ function MobileLevelUpCard({
       >
         <SealStamp level={level} sealRing={sealRing} />
 
-        <p style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-sm)', textTransform: 'uppercase', letterSpacing: '0.15em', color: FAINT, margin: '0 0 var(--space-xs)' }}>
+        <p style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-md)', textTransform: 'uppercase', letterSpacing: '0.15em', color: FAINT, margin: '0 0 var(--space-xs)' }}>
           {t('popup.levelReached')}
         </p>
         <RainbowText text={rank} fontSize={28} />
 
         <RainbowRule style={{ margin: 'var(--space-lg) 0' }} />
 
-        <div style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-xs)', letterSpacing: '0.2em', textTransform: 'uppercase', color: FAINT, marginBottom: 'var(--space-lg)' }}>
+        <div style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-md)', letterSpacing: '0.2em', textTransform: 'uppercase', color: FAINT, marginBottom: 'var(--space-lg)' }}>
           {t('popup.nowUnlocked')}
         </div>
 
@@ -417,14 +417,14 @@ export default function LevelUpPopup({
     >
       <SealStamp level={level} sealRing={sealRing} />
 
-      <p style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-sm)', textTransform: 'uppercase', letterSpacing: '0.15em', color: FAINT, margin: '0 0 var(--space-xs)' }}>
+      <p style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-md)', textTransform: 'uppercase', letterSpacing: '0.15em', color: FAINT, margin: '0 0 var(--space-xs)' }}>
         {t('popup.levelReached')}
       </p>
       <RainbowText text={rank} />
 
       <RainbowRule style={{ margin: 'var(--space-lg) 0' }} />
 
-      <div style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-xs)', letterSpacing: '0.2em', textTransform: 'uppercase', color: FAINT, marginBottom: 'var(--space-lg)' }}>
+      <div style={{ fontFamily: FONT_BODY, fontSize: 'var(--text-md)', letterSpacing: '0.2em', textTransform: 'uppercase', color: FAINT, marginBottom: 'var(--space-lg)' }}>
         {t('popup.nowUnlocked')}
       </div>
 

--- a/frontend/src/components/collab/CollabSuccess.tsx
+++ b/frontend/src/components/collab/CollabSuccess.tsx
@@ -108,7 +108,7 @@ export function CollabSuccess({
               <span
                 className="font-body"
                 style={{
-                  fontSize: 'var(--text-xs)',
+                  fontSize: 'var(--text-lg)',
                   fontWeight: member.character_id === currentCharacterId ? 700 : 400,
                 }}
               >
@@ -118,7 +118,7 @@ export function CollabSuccess({
                 <span
                   className="font-body"
                   style={{
-                    fontSize: 'var(--text-xs)',
+                    fontSize: 'var(--text-lg)',
                     fontWeight: 700,
                     // Not --color-success: the global green is 2.07:1 on
                     // S.N.I.D.E.'s sheet and 2.14:1 on Singularity's (#694).

--- a/frontend/src/components/comments/voices/EphemeristsComment.tsx
+++ b/frontend/src/components/comments/voices/EphemeristsComment.tsx
@@ -93,7 +93,7 @@ const CTA_INK = 'var(--faction-ephemerists-plate-cta-ink)'
 /** Incised small caps at label tier — every mark on the sheet that is not prose. */
 const LABEL = {
   ...SMALL_CAPS,
-  fontSize: 'var(--text-sm)',
+  fontSize: 'var(--text-md)',
   color: CAPTION,
 } as const
 

--- a/frontend/src/components/comments/voices/EverymenComment.tsx
+++ b/frontend/src/components/comments/voices/EverymenComment.tsx
@@ -69,7 +69,7 @@ const BODY_INK = 'var(--everymen-paper-text)'
 /** Label voice for the marks on the band: the body face, tracked, uppercase. */
 const DATELINE = {
   fontFamily: 'var(--font-body)',
-  fontSize: 'var(--text-sm)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.15em',
   textTransform: 'uppercase',
   whiteSpace: 'nowrap',
@@ -208,7 +208,7 @@ export default function EverymenComment(props: CommentProps) {
               <span
                 style={{
                   fontFamily: 'var(--font-body)',
-                  fontSize: 'var(--text-sm)',
+                  fontSize: 'var(--text-md)',
                   letterSpacing: '0.15em',
                   textTransform: 'uppercase',
                   color: 'var(--everymen-muted)',

--- a/frontend/src/components/factionCard/FactionCard.tsx
+++ b/frontend/src/components/factionCard/FactionCard.tsx
@@ -414,7 +414,7 @@ export function EphemeristsCard({
           <div
             style={{
               ...eph.SMALL_CAPS,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               letterSpacing: "0.26em",
               color: eph.GOLD,
               marginBottom: "var(--space-xs)",
@@ -580,7 +580,7 @@ export function SingularityCard({
         )}
         <div
           style={{
-            fontSize: "var(--text-xs)",
+            fontSize: "var(--text-md)",
             color: "var(--faction-singularity-card-muted)",
             textTransform: "uppercase",
             letterSpacing: "0.15em",

--- a/frontend/src/components/factionCard/SnideMasthead.tsx
+++ b/frontend/src/components/factionCard/SnideMasthead.tsx
@@ -37,7 +37,7 @@ export default function SnideMasthead({
       </span>
       <span
         style={{
-          fontSize: "var(--text-xs)",
+          fontSize: "var(--text-md)",
           letterSpacing: "0.16em",
           textTransform: "uppercase",
           color: factionCssVar("snide", "card-muted"),

--- a/frontend/src/components/factionHero/CovenFactionHero.tsx
+++ b/frontend/src/components/factionHero/CovenFactionHero.tsx
@@ -138,7 +138,7 @@ export default function CovenFactionHero({
               <span style={{ fontFamily: READING, fontSize: 28, fontWeight: 600, lineHeight: 1, color: DEEP }}>
                 {stat.value}
               </span>
-              <span style={{ ...CAPTION, fontSize: "var(--text-xs)", width: 66 }}>{stat.label}</span>
+              <span style={{ ...CAPTION, fontSize: "var(--text-md)", width: 66 }}>{stat.label}</span>
             </div>
           ))}
         </div>

--- a/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
+++ b/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
@@ -186,7 +186,7 @@ export default function EphemeristsFactionHero({
                   borderTop: i > 0 ? `1px solid color-mix(in srgb, ${BRASS} 45%, transparent)` : undefined,
                 }}
               >
-                <span style={{ ...SMALL_CAPS, fontSize: "var(--text-sm)", letterSpacing: "0.14em", color: BAND_QUIET }}>
+                <span style={{ ...SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.14em", color: BAND_QUIET }}>
                   {s.label}
                 </span>
                 <span className="content-title" style={{ fontFamily: DECO, lineHeight: 0.85, color: GOLD }}>

--- a/frontend/src/components/factionHero/EverymenFactionHero.tsx
+++ b/frontend/src/components/factionHero/EverymenFactionHero.tsx
@@ -202,7 +202,7 @@ export default function EverymenFactionHero({
               <span
                 style={{
                   fontFamily: "var(--font-body)",
-                  fontSize: "var(--text-sm)",
+                  fontSize: "var(--text-md)",
                   letterSpacing: "0.14em",
                   textTransform: "uppercase",
                   color: CREAM,

--- a/frontend/src/components/factionHero/SingularityFactionHero.tsx
+++ b/frontend/src/components/factionHero/SingularityFactionHero.tsx
@@ -115,7 +115,7 @@ export default function SingularityFactionHero({
           {/* boot lines */}
           <div
             style={{
-              fontSize: "var(--text-sm)",
+              fontSize: "var(--text-md)",
               letterSpacing: "0.18em",
               color: signal(55),
               marginBottom: "var(--space-lg)",
@@ -226,7 +226,7 @@ export default function SingularityFactionHero({
           >
             <div
               style={{
-                fontSize: "var(--text-xs)",
+                fontSize: "var(--text-md)",
                 letterSpacing: "0.2em",
                 color: signal(55),
                 textTransform: "uppercase",
@@ -250,7 +250,7 @@ export default function SingularityFactionHero({
               >
                 <span
                   style={{
-                    fontSize: "var(--text-xs)",
+                    fontSize: "var(--text-md)",
                     letterSpacing: "0.14em",
                     color: signal(50),
                     textTransform: "uppercase",

--- a/frontend/src/components/factionHero/SnideFactionHero.tsx
+++ b/frontend/src/components/factionHero/SnideFactionHero.tsx
@@ -274,7 +274,7 @@ export default function SnideFactionHero({
               <div
                 style={{
                   fontFamily: "var(--font-body)",
-                  fontSize: "var(--text-xs)",
+                  fontSize: "var(--text-md)",
                   letterSpacing: "0.1em",
                   textTransform: "uppercase",
                   color: "#cfcdbf",

--- a/frontend/src/components/factionMarks/covenSlip.tsx
+++ b/frontend/src/components/factionMarks/covenSlip.tsx
@@ -83,7 +83,7 @@ export const SLIP_SHEET =
 export const CAPTION: CSSProperties = {
   fontFamily: CHROME,
   fontWeight: 700,
-  fontSize: "var(--text-sm)",
+  fontSize: "var(--text-md)",
   letterSpacing: "0.16em",
   textTransform: "uppercase",
   color: LABEL,

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -84,7 +84,7 @@ export const GRID = "var(--faction-ephemerists-grid)";
  *    tier, and uppercasing a kanji costs a `text-transform` and buys nothing.
  *  • `fontStyle` — the score stamp's tally line is set in italic Spectral, and a
  *    CJK fallback face has no italic, so the browser synthesises a slant.
- *  • `fontSize` — the label tier is `--text-xs` (8px). A Latin label is scanned
+ *  • `fontSize` — the label tier is `--text-md` (11px, #1608). A Latin label is scanned
  *    at that size; 基 is eleven strokes and simply fills in. `--text-xl` is the
  *    smallest token inside the 13–16px band #1637 names as legible, so it is the
  *    DEFAULT rather than the only value — a caller with its own ramp (the

--- a/frontend/src/components/factionMarks/uaAtoms.tsx
+++ b/frontend/src/components/factionMarks/uaAtoms.tsx
@@ -187,7 +187,7 @@ export function UaEnsoScore({
           <span
             style={{
               ...UA_EYEBROW,
-              fontSize: "var(--text-sm)",
+              fontSize: "var(--text-md)",
               lineHeight: 1,
               whiteSpace: "nowrap",
               ...(unitColor ? { color: unitColor } : {}),

--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -232,7 +232,7 @@ export default function EphemeristsFeedFrame({
             <span
               style={{
                 ...SMALL_CAPS,
-                fontSize: 'var(--text-sm)',
+                fontSize: 'var(--text-md)',
                 color: BAND_INK,
                 border: `1px solid ${BRASS}`,
                 padding: '0 var(--space-xs)',

--- a/frontend/src/components/feed/FeedBadge.tsx
+++ b/frontend/src/components/feed/FeedBadge.tsx
@@ -25,7 +25,7 @@ export default function FeedBadge({ type, label }: FeedBadgeProps) {
         background: style.bg,
         color: style.color,
         fontFamily: "'Courier Prime', monospace",
-        fontSize: 'var(--text-xs)',
+        fontSize: 'var(--text-md)',
         fontWeight: 700,
         textTransform: 'uppercase',
         letterSpacing: '0.1em',

--- a/frontend/src/components/feed/FeedBankFullModal.tsx
+++ b/frontend/src/components/feed/FeedBankFullModal.tsx
@@ -185,7 +185,7 @@ export default function FeedBankFullModal({
           style={{
             marginTop: 'var(--space-lg)',
             fontFamily: "'Courier Prime', monospace",
-            fontSize: 'var(--text-sm)',
+            fontSize: 'var(--text-md)',
             fontWeight: 700,
             textTransform: 'uppercase',
             background: 'transparent',

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -230,7 +230,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
               disabled={loading}
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-sm)",
+                fontSize: "var(--text-md)",
                 fontWeight: 700,
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
@@ -248,7 +248,7 @@ export default function FeedCardCollabInvite({ item }: Props) {
               disabled={loading}
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-sm)",
+                fontSize: "var(--text-md)",
                 fontWeight: 700,
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -260,7 +260,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
               disabled={loading || busy || withdrawing}
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-sm)",
+                fontSize: "var(--text-md)",
                 fontWeight: 700,
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
@@ -278,7 +278,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
               disabled={loading || busy || withdrawing}
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-sm)",
+                fontSize: "var(--text-md)",
                 fontWeight: 700,
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
@@ -298,7 +298,7 @@ export default function FeedCardDuelChallenge({ item }: Props) {
               disabled={loading || busy || withdrawing}
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-sm)",
+                fontSize: "var(--text-md)",
                 fontWeight: 700,
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -64,7 +64,7 @@ export function acceptMode(
 
 const CONTROL: CSSProperties = {
   fontFamily: "'Courier Prime', monospace",
-  fontSize: "var(--text-sm)",
+  fontSize: "var(--text-md)",
   fontWeight: 700,
   textTransform: "uppercase",
   letterSpacing: "0.1em",
@@ -155,7 +155,7 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
       to="/factions"
       style={{
         fontFamily: "'Courier Prime', monospace",
-        fontSize: "var(--text-sm)",
+        fontSize: "var(--text-md)",
         fontWeight: 700,
         textTransform: "uppercase",
         letterSpacing: "0.1em",

--- a/frontend/src/components/feed/FeedDateDivider.tsx
+++ b/frontend/src/components/feed/FeedDateDivider.tsx
@@ -26,7 +26,7 @@ export default function FeedDateDivider({ label }: FeedDateDividerProps) {
       <span
         style={{
           fontFamily: "'Courier Prime', monospace",
-          fontSize: 'var(--text-sm)',
+          fontSize: 'var(--text-md)',
           fontWeight: 700,
           textTransform: 'uppercase',
           letterSpacing: '0.15em',

--- a/frontend/src/components/imageEdit/ImageEditModal.tsx
+++ b/frontend/src/components/imageEdit/ImageEditModal.tsx
@@ -401,7 +401,7 @@ const controlRowStyle: CSSProperties = {
 }
 const controlLabelStyle: CSSProperties = {
   fontFamily: FONT_BODY,
-  fontSize: 'var(--text-sm)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.16em',
   textTransform: 'uppercase',
   color: FAINT,

--- a/frontend/src/components/layout/PendingBadge.tsx
+++ b/frontend/src/components/layout/PendingBadge.tsx
@@ -25,7 +25,7 @@ const BADGE_STYLE: CSSProperties = {
   height: 15,
   padding: '0 var(--space-xs)',
   borderRadius: 999,
-  fontSize: 'var(--text-sm)',
+  fontSize: 'var(--text-md)',
   fontWeight: 700,
   lineHeight: 1,
   color: 'var(--color-text-on-accent)',

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -363,7 +363,7 @@ function ActiveTasksBody({
                 <span
                   style={{
                     fontFamily: 'var(--font-body)',
-                    fontSize: 'var(--text-sm)',
+                    fontSize: 'var(--text-md)',
                     letterSpacing: '0.16em',
                     textTransform: 'uppercase',
                     color: 'var(--faction-default-card-muted)',
@@ -509,7 +509,7 @@ function RecentActivityBody({ recentActivity }: { readonly recentActivity: Activ
                     className="truncate"
                     style={{
                       fontFamily: 'var(--font-body)',
-                      fontSize: 'var(--text-sm)',
+                      fontSize: 'var(--text-md)',
                       letterSpacing: '0.18em',
                       textTransform: 'uppercase',
                       color: 'var(--color-text-secondary)',

--- a/frontend/src/components/metataskSeal/skins/EphemeristsSeal.tsx
+++ b/frontend/src/components/metataskSeal/skins/EphemeristsSeal.tsx
@@ -106,7 +106,7 @@ export default function EphemeristsSeal({ metatask, removable, onRemove }: SealS
           left: DISC_SIZE + DISC_INSET + 8,
           ...SMALL_CAPS,
           fontWeight: 600,
-          fontSize: 'var(--text-xs)',
+          fontSize: 'var(--text-md)',
           color: BAND_INK,
           background: BAND,
           padding: '0 var(--space-sm)',

--- a/frontend/src/components/metataskSeal/skins/SingularitySeal.tsx
+++ b/frontend/src/components/metataskSeal/skins/SingularitySeal.tsx
@@ -40,7 +40,7 @@ export default function SingularitySeal({ metatask, removable, onRemove }: SealS
             background: 'transparent',
             border: '1px solid var(--faction-singularity-card-accent)',
             color: 'var(--faction-singularity-card-accent)',
-            fontSize: 'var(--text-xs)',
+            fontSize: 'var(--text-md)',
             lineHeight: 1,
             padding: '0 var(--space-xs)',
             cursor: 'pointer',

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -64,7 +64,7 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
   const crowned = praxis.is_top_for_task && showCrown !== false;
 
   /** The cell's label voice: incised caps, at the plate's caption gold. */
-  const label = { ...SMALL_CAPS, fontSize: "var(--text-xs)", color: CAPTION };
+  const label = { ...SMALL_CAPS, fontSize: "var(--text-md)", color: CAPTION };
 
   return (
     <div
@@ -146,7 +146,7 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
             style={{
               ...SMALL_CAPS,
               fontWeight: 600,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               letterSpacing: "0.16em",
               color: DISC,
               background: OCHRE,

--- a/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
@@ -72,7 +72,7 @@ export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) 
           <span
             style={{
               fontFamily: "var(--font-body)",
-              fontSize: "var(--text-sm)",
+              fontSize: "var(--text-md)",
               letterSpacing: "0.1em",
               textTransform: "uppercase",
               color: "var(--faction-snide-vote-off)",
@@ -159,7 +159,7 @@ export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) 
         <span
           style={{
             fontFamily: "var(--font-body)",
-            fontSize: "var(--text-xs)",
+            fontSize: "var(--text-md)",
             letterSpacing: "0.14em",
             textTransform: "uppercase",
             color: "var(--faction-snide-card-muted)",

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -651,9 +651,9 @@ export function PraxisModeChip({
   // (`submit_proposed_at` is the collab submit window).
   const { notice, credit } = sheetInk(praxis.task_faction_slug);
   const chip: CSSProperties = {
-    // A chip is a LABEL, not running text: it keeps the label tier (#888 leaves
-    // `.eyebrow`/`--text-sm` alone by design), but at the 9px step rather than
-    // the 8px floor the meta line just left.
+    // A chip is a LABEL, not running text: it keeps the label tier, at the
+    // heading step the tier settled on in #1307 rather than the 8px floor the
+    // meta line just left. (#888 left this at 9px; #1608 swept the step.)
     fontSize: "var(--text-md)",
     fontFamily: fonts?.display,
     letterSpacing: "0.14em",
@@ -745,7 +745,7 @@ export function PraxisMediaGallery({
           border: `1px dashed color-mix(in srgb, ${accent} 45%, transparent)`,
           background: `color-mix(in srgb, ${accent} 4%, transparent)`,
           color: accent,
-          // Label tier, at the eyebrow step rather than the 8px floor (#888).
+          // Label tier, at its heading step rather than the 8px floor (#1608).
           fontSize: "var(--text-md)",
           fontFamily: fonts?.body,
           letterSpacing: "0.14em",
@@ -794,7 +794,7 @@ export function PraxisMediaGallery({
                 </span>
                 <span
                   style={{
-                    // Label tier, eyebrow step rather than the 8px floor (#888).
+                    // Label tier, heading step rather than the 8px floor (#1608).
                     fontSize: "var(--text-md)",
                     fontFamily: fonts?.body,
                     letterSpacing: "0.1em",

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -479,7 +479,7 @@ function RosterAvatar({
         background: paper,
         border: `1.5px solid ${accent}`,
         color: accent,
-        fontSize: "var(--text-xs)",
+        fontSize: "var(--text-md)",
         fontWeight: 700,
         lineHeight: 1,
       }}
@@ -594,7 +594,7 @@ export function PraxisDuelBanner({
         style={{
           // A LABEL, not running text — the same tier and tracking the duel mode
           // chip above it uses, so the two read as one mark.
-          fontSize: "var(--text-sm)",
+          fontSize: "var(--text-md)",
           fontFamily: fonts?.display,
           letterSpacing: "0.14em",
           textTransform: "uppercase",
@@ -654,7 +654,7 @@ export function PraxisModeChip({
     // A chip is a LABEL, not running text: it keeps the label tier (#888 leaves
     // `.eyebrow`/`--text-sm` alone by design), but at the 9px step rather than
     // the 8px floor the meta line just left.
-    fontSize: "var(--text-sm)",
+    fontSize: "var(--text-md)",
     fontFamily: fonts?.display,
     letterSpacing: "0.14em",
     textTransform: "uppercase",
@@ -746,7 +746,7 @@ export function PraxisMediaGallery({
           background: `color-mix(in srgb, ${accent} 4%, transparent)`,
           color: accent,
           // Label tier, at the eyebrow step rather than the 8px floor (#888).
-          fontSize: "var(--text-sm)",
+          fontSize: "var(--text-md)",
           fontFamily: fonts?.body,
           letterSpacing: "0.14em",
           textTransform: "uppercase",
@@ -795,7 +795,7 @@ export function PraxisMediaGallery({
                 <span
                   style={{
                     // Label tier, eyebrow step rather than the 8px floor (#888).
-                    fontSize: "var(--text-sm)",
+                    fontSize: "var(--text-md)",
                     fontFamily: fonts?.body,
                     letterSpacing: "0.1em",
                     textTransform: "uppercase",

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -230,14 +230,14 @@ export function EphemeristsSelectCard({ state = "locked", members, onVisit }: Om
       <svg width="100%" height={26} viewBox="0 0 360 26" preserveAspectRatio="xMinYMid slice" aria-hidden="true" style={{ position: "absolute", left: 0, bottom: 62, opacity: 0.55 }}>
         <eph.GlyphRegister width={360} y={13} strength={0.5} keyPrefix="sel" />
       </svg>
-      <div style={{ position: "absolute", top: 16, right: 18, fontSize: "var(--text-sm)", letterSpacing: "0.1em", color: eph.BAND_QUIET, textAlign: "right", lineHeight: 1.5 }}>{i18n.t("feed:factionSelect.ephemerists.coords")}<br />{i18n.t("feed:factionSelect.ephemerists.coordsPolar")}</div>
+      <div style={{ position: "absolute", top: 16, right: 18, fontSize: "var(--text-md)", letterSpacing: "0.1em", color: eph.BAND_QUIET, textAlign: "right", lineHeight: 1.5 }}>{i18n.t("feed:factionSelect.ephemerists.coords")}<br />{i18n.t("feed:factionSelect.ephemerists.coordsPolar")}</div>
       <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-xl) 0" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)" }}>
           <span style={{ width: 46, height: 46, borderRadius: "50%", border: `1.5px solid ${eph.BRASS}`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
             <EphemeristsSigil size={26} color={eph.GOLD} />
           </span>
           <div>
-            <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-sm)", letterSpacing: "0.24em", color: eph.GOLD }}>{i18n.t("feed:factionSelect.ephemerists.eyebrow")}</div>
+            <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.24em", color: eph.GOLD }}>{i18n.t("feed:factionSelect.ephemerists.eyebrow")}</div>
             {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the plate’s masthead wordmark — Poiret One letterspaced until the width is the mark */}
             <div style={{ fontFamily: eph.DECO, fontSize: 24, lineHeight: 1.1, letterSpacing: "0.22em", textTransform: "uppercase", color: eph.BAND_INK, marginTop: "var(--space-xs)" }}>{i18n.t("feed:identity.ephemerists.wordmark")}</div>
           </div>
@@ -476,7 +476,7 @@ export function AlbescentSelectCard({ state = "locked", members, onVisit }: Omit
       <div style={{ position: "absolute", inset: 12, border: "1px solid var(--albescent-reveal-border-faint)", pointerEvents: "none" }} />
       <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-2xl) 0", display: "flex", flexDirection: "column" }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-          <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-sm)", letterSpacing: "0.34em", color: "var(--albescent-reveal-text-muted)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.albescent.eyebrow")}</div>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.34em", color: "var(--albescent-reveal-text-muted)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.albescent.eyebrow")}</div>
           <AlbescentSigil size={26} color="var(--albescent-reveal-ink)" />
         </div>
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: vellum-letter name — the archetype's calligraphic display type */}
@@ -487,7 +487,7 @@ export function AlbescentSelectCard({ state = "locked", members, onVisit }: Omit
         </p>
       </div>
       <div style={{ position: "relative", padding: "var(--space-lg) var(--space-2xl) var(--space-xl)" }}>
-        <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-sm)", letterSpacing: "0.06em", color: "var(--albescent-reveal-text-muted)", marginBottom: "var(--space-md)", textTransform: "uppercase" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.albescent.members", { count: members })}`}</div>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.06em", color: "var(--albescent-reveal-text-muted)", marginBottom: "var(--space-md)", textTransform: "uppercase" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.albescent.members", { count: members })}`}</div>
         <button onClick={onVisit} style={{
           width: "100%", cursor: "pointer", border: "1px solid var(--albescent-reveal-text)", background: "transparent", color: "var(--albescent-reveal-text)",
           fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.22em", padding: "var(--space-md)", textTransform: "uppercase", transition: "background 140ms, color 140ms",

--- a/frontend/src/components/taskCard/DefaultTaskCard.tsx
+++ b/frontend/src/components/taskCard/DefaultTaskCard.tsx
@@ -135,7 +135,7 @@ export default function DefaultTaskCard({
               }}
             >
               <span
-                style={{ ...CAPTION, fontSize: "var(--text-sm)", marginBottom: "var(--space-xs)" }}
+                style={{ ...CAPTION, fontSize: "var(--text-md)", marginBottom: "var(--space-xs)" }}
               >
                 {i18n.t("feed:taskCard.na.levelCaption")}
               </span>
@@ -181,7 +181,7 @@ export default function DefaultTaskCard({
                   {basePoints}
                 </span>
                 <span
-                  style={{ ...CAPTION, fontSize: "var(--text-xs)", marginTop: "var(--space-xs)" }}
+                  style={{ ...CAPTION, fontSize: "var(--text-md)", marginTop: "var(--space-xs)" }}
                 >
                   {i18n.t("feed:taskCard.na.pointsUnit")}
                 </span>
@@ -215,7 +215,7 @@ export default function DefaultTaskCard({
                 >
                   {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
                 </span>
-                <span style={{ ...CAPTION, fontSize: "var(--text-xs)" }}>
+                <span style={{ ...CAPTION, fontSize: "var(--text-md)" }}>
                   {i18n.t("feed:taskCard.modifierCaption")}
                 </span>
               </div>

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -282,7 +282,7 @@ export default function EphemeristsTaskCard({
                 and the cartouche held nothing else, so both are gone. */}
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", padding: "var(--space-md) 0 var(--space-lg)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", gap: "var(--space-xs)", lineHeight: 1 }}>
-                <span style={{ ...SMALL_CAPS, fontSize: "var(--text-sm)", color: "var(--faction-ephemerists-plate-caption)" }}>
+                <span style={{ ...SMALL_CAPS, fontSize: "var(--text-md)", color: "var(--faction-ephemerists-plate-caption)" }}>
                   {i18n.t("feed:taskCard.ephemerists.levelCaption")}
                 </span>
                 <span style={{ fontFamily: DECO, fontSize: size.levelSize, lineHeight: 0.8 }}>
@@ -332,7 +332,7 @@ export default function EphemeristsTaskCard({
                   >
                     {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
                   </span>
-                  <span style={{ ...SMALL_CAPS, fontSize: "var(--text-xs)", color: "var(--faction-ephemerists-plate-caption)" }}>
+                  <span style={{ ...SMALL_CAPS, fontSize: "var(--text-md)", color: "var(--faction-ephemerists-plate-caption)" }}>
                     {i18n.t("feed:taskCard.modifierCaption")}
                   </span>
                 </div>

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -242,7 +242,7 @@ export default function EverymenTaskCard({
                     >
                       {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
                     </span>
-                    <span style={{ ...LABEL, fontSize: "var(--text-xs)", color: "var(--everymen-muted)" }}>
+                    <span style={{ ...LABEL, fontSize: "var(--text-md)", color: "var(--everymen-muted)" }}>
                       {i18n.t("feed:taskCard.modifierCaption")}
                     </span>
                   </div>

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -188,7 +188,7 @@ export default function SingularityTaskCard({
           <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
             <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-md)", marginBottom: "var(--space-lg)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1 }}>
-                <span style={{ ...LABEL, fontSize: "var(--text-sm)", marginBottom: "var(--space-xs)" }}>
+                <span style={{ ...LABEL, fontSize: "var(--text-md)", marginBottom: "var(--space-xs)" }}>
                   {i18n.t("feed:taskCard.singularity.levelCaption")}
                 </span>
                 <span style={{ fontFamily: MONO, fontSize: size.levelSize, lineHeight: 0.85, color: BRIGHT }}>
@@ -217,7 +217,7 @@ export default function SingularityTaskCard({
                   >
                     {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
                   </span>
-                  <span style={{ ...LABEL, fontSize: "var(--text-xs)" }}>
+                  <span style={{ ...LABEL, fontSize: "var(--text-md)" }}>
                     {i18n.t("feed:taskCard.modifierCaption")}
                   </span>
                 </div>

--- a/frontend/src/components/taskCard/SnideTaskCard.tsx
+++ b/frontend/src/components/taskCard/SnideTaskCard.tsx
@@ -255,7 +255,7 @@ export default function SnideTaskCard({
                 <span
                   style={{
                     fontFamily: TYPE,
-                    fontSize: "var(--text-sm)",
+                    fontSize: "var(--text-md)",
                     letterSpacing: "0.2em",
                     textTransform: "uppercase",
                     color: MUTED,
@@ -293,7 +293,7 @@ export default function SnideTaskCard({
                   <span
                     style={{
                       fontFamily: TYPE,
-                      fontSize: "var(--text-xs)",
+                      fontSize: "var(--text-md)",
                       letterSpacing: "0.16em",
                       textTransform: "uppercase",
                       color: MUTED,

--- a/frontend/src/components/taskCard/TaskCard.tsx
+++ b/frontend/src/components/taskCard/TaskCard.tsx
@@ -128,7 +128,7 @@ export default function TaskCard({
           <span
             style={{
               fontFamily: "'Courier Prime', monospace",
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               fontWeight: 700,
               textTransform: 'uppercase',
               letterSpacing: '0.15em',
@@ -147,7 +147,7 @@ export default function TaskCard({
               background: factionCssVar(shown.metatask_faction_slug, 'light'),
               color: factionCssVar(shown.metatask_faction_slug),
               fontFamily: "'Courier Prime', monospace",
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               fontWeight: 700,
               textTransform: 'uppercase',
               letterSpacing: '0.1em',

--- a/frontend/src/components/taskCard/UaTaskCard.tsx
+++ b/frontend/src/components/taskCard/UaTaskCard.tsx
@@ -133,7 +133,7 @@ export default function UaTaskCard({
 
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginBottom: "var(--space-md)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1 }}>
-                <span style={{ ...UA_EYEBROW, fontSize: "var(--text-sm)", marginBottom: "var(--space-xs)" }}>
+                <span style={{ ...UA_EYEBROW, fontSize: "var(--text-md)", marginBottom: "var(--space-xs)" }}>
                   {i18n.t("feed:taskCard.ua.levelCaption")}
                 </span>
                 <span style={{ fontFamily: UA_DISPLAY, fontWeight: 700, fontSize: size.levelSize, lineHeight: 0.9 }}>
@@ -163,7 +163,7 @@ export default function UaTaskCard({
                   >
                     {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
                   </span>
-                  <span style={{ ...UA_EYEBROW, fontSize: "var(--text-xs)" }}>
+                  <span style={{ ...UA_EYEBROW, fontSize: "var(--text-md)" }}>
                     {i18n.t("feed:taskCard.modifierCaption")}
                   </span>
                 </div>

--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -199,7 +199,7 @@ export default function WowTaskCard({
                   >
                     {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
                   </span>
-                  <span style={{ fontFamily: LORA, fontStyle: "italic", fontSize: "var(--text-xs)", color: MUTED }}>
+                  <span style={{ fontFamily: LORA, fontStyle: "italic", fontSize: "var(--text-lg)", color: MUTED }}>
                     {i18n.t("feed:taskCard.modifierCaption")}
                   </span>
                 </div>

--- a/frontend/src/components/vote/AlbescentVote.tsx
+++ b/frontend/src/components/vote/AlbescentVote.tsx
@@ -226,7 +226,7 @@ export default function AlbescentVote({
         {selected > 0 && (
           <span
             style={{
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               letterSpacing: '0.14em',
               textTransform: 'uppercase',
               color: 'var(--faction-default-vote-off)',

--- a/frontend/src/components/vote/CovenVote.tsx
+++ b/frontend/src/components/vote/CovenVote.tsx
@@ -228,7 +228,7 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
         {selected > 0 && (
           <span
             style={{
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               letterSpacing: '0.14em',
               textTransform: 'uppercase',
               color: 'var(--faction-coven-vote-off)',

--- a/frontend/src/components/vote/DefaultVote.tsx
+++ b/frontend/src/components/vote/DefaultVote.tsx
@@ -151,7 +151,7 @@ export default function DefaultVote({
         {selected > 0 && (
           <span
             style={{
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               letterSpacing: '0.14em',
               textTransform: 'uppercase',
               color: 'var(--faction-default-vote-off)',

--- a/frontend/src/components/vote/EverymenVote.tsx
+++ b/frontend/src/components/vote/EverymenVote.tsx
@@ -224,7 +224,7 @@ export default function EverymenVote({ praxisId, currentValue, points, totalVote
         {selected > 0 && (
           <span
             style={{
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               letterSpacing: '0.14em',
               textTransform: 'uppercase',
               color: 'var(--everymen-muted)',

--- a/frontend/src/components/vote/SingularityVote.tsx
+++ b/frontend/src/components/vote/SingularityVote.tsx
@@ -165,7 +165,7 @@ export default function SingularityVote({ praxisId, currentValue, points, totalV
         {selected > 0 && (
           <span
             style={{
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               letterSpacing: '0.14em',
               textTransform: 'uppercase',
               color: 'var(--faction-singularity-vote-off)',

--- a/frontend/src/components/vote/SnideVote.tsx
+++ b/frontend/src/components/vote/SnideVote.tsx
@@ -137,7 +137,7 @@ export default function SnideVote({ praxisId, currentValue, points, totalVotes }
         {selected > 0 && (
           <span
             style={{
-              fontSize: 'var(--text-xs)',
+              fontSize: 'var(--text-md)',
               letterSpacing: '0.14em',
               textTransform: 'uppercase',
               color: 'var(--faction-snide-vote-off)',

--- a/frontend/src/pages/AlbescentSecretPlaceholder.tsx
+++ b/frontend/src/pages/AlbescentSecretPlaceholder.tsx
@@ -60,7 +60,7 @@ export default function AlbescentSecretPlaceholder() {
         <div
           style={{
             fontFamily: MONO,
-            fontSize: 'var(--text-xs)',
+            fontSize: 'var(--text-md)',
             letterSpacing: '0.28em',
             textTransform: 'uppercase',
             color: ink(30),

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -248,7 +248,7 @@ export default function CharacterProfile() {
                       : "var(--color-danger)",
                 color: "var(--color-text-on-accent)",
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-xs)",
+                fontSize: "var(--text-md)",
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
                 padding: "var(--space-xs) 0",
@@ -312,7 +312,7 @@ export default function CharacterProfile() {
               disabled={relationshipLoading}
               style={{
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-xs)",
+                fontSize: "var(--text-md)",
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
                 padding: "var(--space-xs) 0",
@@ -333,7 +333,7 @@ export default function CharacterProfile() {
                 background: "none",
                 color: "var(--color-danger)",
                 fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-xs)",
+                fontSize: "var(--text-md)",
                 textTransform: "uppercase",
                 letterSpacing: "0.1em",
                 padding: "var(--space-xs) 0",

--- a/frontend/src/pages/CreateCharacter.tsx
+++ b/frontend/src/pages/CreateCharacter.tsx
@@ -215,7 +215,7 @@ function DesktopCreateCharacter({ state }: { state: CreateCharacterState }) {
 
 const backLink: CSSProperties = {
   background: 'none', border: 'none', cursor: 'pointer',
-  fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)', padding: 0, marginBottom: 'var(--space-lg)',
+  fontSize: 'var(--text-lg)', color: 'var(--color-text-secondary)', padding: 0, marginBottom: 'var(--space-lg)',
 }
 const twoCol: CSSProperties = { display: 'flex', flexWrap: 'wrap', gap: 'var(--space-4xl)', alignItems: 'flex-start' }
 const titleStyle: CSSProperties = {
@@ -223,7 +223,7 @@ const titleStyle: CSSProperties = {
   fontSize: 'var(--text-heading)', lineHeight: 1.02, color: 'var(--color-text-primary)', margin: '0 0 var(--space-xl)',
 }
 const eyebrow: CSSProperties = {
-  display: 'block', fontSize: 'var(--text-sm)', letterSpacing: '0.16em', textTransform: 'uppercase',
+  display: 'block', fontSize: 'var(--text-md)', letterSpacing: '0.16em', textTransform: 'uppercase',
   color: 'var(--color-text-secondary)',
 }
 const nameInput: CSSProperties = {
@@ -240,7 +240,7 @@ const bioInput: CSSProperties = {
 }
 const metaRow: CSSProperties = {
   display: 'flex', justifyContent: 'space-between', marginTop: 'var(--space-sm)',
-  fontFamily: 'var(--font-body)', fontSize: 'var(--text-sm)',
+  fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)',
 }
 const pickerGrid: CSSProperties = {
   display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 'var(--space-md)', marginTop: 'var(--space-md)',
@@ -262,5 +262,5 @@ const primaryBtn: CSSProperties = {
 }
 const cancelBtn: CSSProperties = {
   cursor: 'pointer', background: 'none', border: 'none', fontFamily: 'var(--font-body)',
-  fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--color-text-secondary)',
+  fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: 'var(--color-text-secondary)',
 }

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -168,7 +168,7 @@ export default function FieldDesk() {
                 ) : (
                   <span style={{ ...pillAvatar, display: 'inline-block' }} />
                 )}
-                <span style={{ fontSize: 'var(--text-sm)', color: 'var(--color-text-secondary)' }}>
+                <span style={{ fontSize: 'var(--text-lg)', color: 'var(--color-text-secondary)' }}>
                   @{active.username} ·{' '}
                   <b style={{ color: 'var(--color-text-primary)' }}>
                     {t('fieldDesk.livesInPlay', { count: lives.length })}
@@ -475,7 +475,7 @@ function ContinueRow({
         className="shrink-0"
         style={{
           fontFamily: 'var(--font-body)',
-          fontSize: 'var(--text-sm)',
+          fontSize: 'var(--text-md)',
           letterSpacing: '0.16em',
           textTransform: 'uppercase',
           color: 'var(--faction-default-card-muted)',
@@ -739,7 +739,7 @@ const medallion: CSSProperties = {
   marginBottom: 'var(--space-lg)',
 }
 const slotOpen: CSSProperties = {
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.14em',
   textTransform: 'uppercase',
   color: 'var(--color-success)',

--- a/frontend/src/pages/Praxes.tsx
+++ b/frontend/src/pages/Praxes.tsx
@@ -84,7 +84,7 @@ function DesktopPraxes({ state }: { state: PraxesFeedState }) {
                 onClick={loadMore}
                 className="font-body uppercase"
                 style={{
-                  fontSize: 'var(--text-sm)',
+                  fontSize: 'var(--text-md)',
                   letterSpacing: '0.1em',
                   padding: 'var(--space-sm) var(--space-lg)',
                   border: '1px solid var(--color-border-strong)',

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -112,7 +112,7 @@ function DesktopTasks({ state }: { state: TasksState }) {
                 onClick={loadMore}
                 className="font-body uppercase"
                 style={{
-                  fontSize: 'var(--text-sm)',
+                  fontSize: 'var(--text-md)',
                   letterSpacing: '0.1em',
                   padding: 'var(--space-sm) var(--space-lg)',
                   border: '1px solid var(--color-border-strong)',

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultCreateCharacter.tsx
@@ -195,7 +195,7 @@ const ringInner: CSSProperties = {
   background: 'var(--color-bg-surface-alt)',
 }
 const label: CSSProperties = {
-  display: 'block', fontSize: 'var(--text-sm)', letterSpacing: '0.16em', textTransform: 'uppercase',
+  display: 'block', fontSize: 'var(--text-md)', letterSpacing: '0.16em', textTransform: 'uppercase',
   color: 'var(--color-text-secondary)',
 }
 const field: CSSProperties = {

--- a/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
+++ b/frontend/src/pages/characterPaths/mobileArchetypes/DefaultEditCharacter.tsx
@@ -239,7 +239,7 @@ const ringInner: CSSProperties = {
   background: 'var(--faction-default-card-bg)',
 }
 const label: CSSProperties = {
-  display: 'block', fontSize: 'var(--text-sm)', letterSpacing: '0.16em', textTransform: 'uppercase',
+  display: 'block', fontSize: 'var(--text-md)', letterSpacing: '0.16em', textTransform: 'uppercase',
   color: 'var(--color-text-secondary)', marginBottom: 'var(--space-sm)',
 }
 const field: CSSProperties = {
@@ -255,7 +255,7 @@ const factionRow: CSSProperties = {
   fontFamily: 'var(--font-body)', color: 'var(--color-text-secondary)',
 }
 const counterRow: CSSProperties = {
-  textAlign: 'right', fontFamily: 'var(--font-body)', fontSize: 'var(--text-sm)',
+  textAlign: 'right', fontFamily: 'var(--font-body)', fontSize: 'var(--text-lg)',
   color: 'var(--color-text-tertiary)', marginTop: 'var(--space-sm)',
 }
 const help: CSSProperties = {

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -470,7 +470,7 @@ function DesktopProfile({
                       lineHeight: 1,
                     }}
                   >
-                    <span style={{ ...EYEBROW, fontSize: 'var(--text-xs)', letterSpacing: '0.1em' }}>{t('profile.lvl')}</span>
+                    <span style={{ ...EYEBROW, fontSize: 'var(--text-md)', letterSpacing: '0.1em' }}>{t('profile.lvl')}</span>
                     <span
                       className="font-display italic"
                       style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)' }}
@@ -496,7 +496,7 @@ function DesktopProfile({
                     >
                       {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
                     </span>
-                    <span style={{ ...EYEBROW, fontSize: 'var(--text-sm)', letterSpacing: '0.08em' }}>
+                    <span style={{ ...EYEBROW, fontSize: 'var(--text-md)', letterSpacing: '0.08em' }}>
                       {t('profile.nextLevel', { level: progression.nextLevel })}
                     </span>
                   </div>
@@ -564,7 +564,7 @@ function DesktopProfile({
               <span
                 style={{
                   ...EYEBROW,
-                  fontSize: 'var(--text-sm)',
+                  fontSize: 'var(--text-md)',
                   letterSpacing: '0.1em',
                   marginLeft: 'auto',
                   border: '1px solid var(--color-border-strong)',
@@ -741,7 +741,7 @@ function MobileProfile({
                       lineHeight: 1,
                     }}
                   >
-                    <span style={{ ...EYEBROW, fontSize: 'var(--text-xs)', letterSpacing: '0.1em' }}>{t('profile.lvl')}</span>
+                    <span style={{ ...EYEBROW, fontSize: 'var(--text-md)', letterSpacing: '0.1em' }}>{t('profile.lvl')}</span>
                     <span
                       className="font-display italic"
                       style={{ fontSize: 'var(--text-title)', color: 'var(--color-text-primary)' }}
@@ -762,7 +762,7 @@ function MobileProfile({
                     <span className="font-body" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}>
                       {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
                     </span>
-                    <span style={{ ...EYEBROW, fontSize: 'var(--text-sm)', letterSpacing: '0.08em' }}>
+                    <span style={{ ...EYEBROW, fontSize: 'var(--text-md)', letterSpacing: '0.08em' }}>
                       {t('profile.nextLevel', { level: progression.nextLevel })}
                     </span>
                   </div>

--- a/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EphemeristsProfileBody.tsx
@@ -152,7 +152,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     ...SMALL_CAPS,
-    fontSize: 'var(--text-sm)',
+    fontSize: 'var(--text-md)',
     letterSpacing: '0.14em',
     color: QUIET,
     marginLeft: 'auto',

--- a/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/EverymenProfileBody.tsx
@@ -134,7 +134,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: MONO,
-    fontSize: 'var(--text-sm)',
+    fontSize: 'var(--text-md)',
     letterSpacing: '0.1em',
     textTransform: 'uppercase',
     color: MUTED,

--- a/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
@@ -52,7 +52,7 @@ function heading(title: string, eyebrow: string): ReactNode {
       <div
         style={{
           fontFamily: FONT,
-          fontSize: 'var(--text-sm)',
+          fontSize: 'var(--text-md)',
           letterSpacing: '0.14em',
           textTransform: 'uppercase',
           color: signal(65),
@@ -146,7 +146,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: FONT,
-    fontSize: 'var(--text-sm)',
+    fontSize: 'var(--text-md)',
     letterSpacing: '0.12em',
     textTransform: 'uppercase',
     color: signal(70),

--- a/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SnideProfileBody.tsx
@@ -153,7 +153,7 @@ const kit: ProfileKit = {
   },
   badgeChipStyle: {
     fontFamily: TYPE,
-    fontSize: 'var(--text-sm)',
+    fontSize: 'var(--text-md)',
     letterSpacing: '0.1em',
     textTransform: 'uppercase',
     color: PINK,

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -605,7 +605,7 @@ export function ProfileSkin({
                       <span
                         style={{
                           fontFamily: kit.eyebrowFont,
-                          fontSize: 'var(--text-xs)',
+                          fontSize: 'var(--text-md)',
                           letterSpacing: '0.12em',
                           textTransform: 'uppercase',
                           // `kit.muted`, not `headerMuted`: this label sits
@@ -655,7 +655,7 @@ export function ProfileSkin({
                       <span
                         style={{
                           fontFamily: kit.eyebrowFont,
-                          fontSize: 'var(--text-sm)',
+                          fontSize: 'var(--text-md)',
                           letterSpacing: '0.1em',
                           textTransform: 'uppercase',
                           color: headerMuted,

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -252,7 +252,7 @@ function PointsMark({ points, unit }: { points: number; unit: string }) {
           right: 0,
           bottom: "7%",
           textAlign: "center",
-          fontSize: "var(--text-xs)",
+          fontSize: "var(--text-md)",
           letterSpacing: "0.2em",
           color: CAPTION,
         }}

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -442,7 +442,7 @@ export function InviteSearch({
                 <span style={{ fontWeight: 700 }}>
                   {character.display_name}
                 </span>
-                <span style={{ marginLeft: "auto", fontSize: "var(--text-sm)", opacity: 0.7 }}>
+                <span style={{ marginLeft: "auto", fontSize: "var(--text-lg)", opacity: 0.7 }}>
                   {factionName(character.faction_slug)}
                 </span>
               </button>

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -43,7 +43,7 @@ export function Breadcrumb({
     <nav
       className="font-body"
       style={{
-        fontSize: "var(--text-sm)",
+        fontSize: "var(--text-md)",
         letterSpacing: "0.1em",
         color: tone,
         marginBottom: "var(--space-md)",

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -436,7 +436,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
                   >
                     {spot.display_name}
                   </div>
-                  <div style={{ ...SMALL_CAPS, fontSize: "var(--text-sm)", letterSpacing: "0.14em", color: BAND_QUIET, marginTop: "var(--space-sm)" }}>
+                  <div style={{ ...SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.14em", color: BAND_QUIET, marginTop: "var(--space-sm)" }}>
                     {t("ephemerists.spotlight.stat", {
                       level: romanLevel(spot.level),
                       score: spot.all_time_score.toLocaleString(),

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -102,7 +102,7 @@ function SectionHeading({ children, right }: { children: ReactNode; right?: Reac
 
 const KICKER: CSSProperties = {
   fontFamily: MONO,
-  fontSize: "var(--text-sm)",
+  fontSize: "var(--text-md)",
   letterSpacing: "0.2em",
   textTransform: "uppercase",
   color: MUTED,
@@ -168,7 +168,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
         <div style={{ ...PAPER_FRAME, padding: "var(--space-xl) var(--space-2xl)" }}>
           <Halftone />
           <div style={{ position: "relative", display: "flex", alignItems: "center", gap: "var(--space-md)", marginBottom: "var(--space-lg)" }}>
-            <span style={{ fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED }}>
+            <span style={{ fontFamily: MONO, fontSize: "var(--text-md)", letterSpacing: "0.24em", textTransform: "uppercase", color: MUTED }}>
               {t("everymen.charter.heading")}
             </span>
             <span style={{ flex: 1, height: 2, background: `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)` }} />
@@ -286,7 +286,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
 
                 {membership.state === "eligible" && !confirming && (
                   <div>
-                    <div style={{ fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: "var(--space-xs)" }}>
+                    <div style={{ fontFamily: MONO, fontSize: "var(--text-md)", letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: "var(--space-xs)" }}>
                       {t("everymen.roll.eligibleKicker")}
                     </div>
                     <div
@@ -363,7 +363,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                       <button
                         onClick={() => setConfirming(false)}
                         disabled={membership.joining}
-                        style={{ fontFamily: MONO, fontSize: "var(--text-sm)", fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, background: "transparent", border: `1.5px solid color-mix(in srgb, ${INK} 30%, transparent)`, padding: "var(--space-md) var(--space-lg)", cursor: membership.joining ? "not-allowed" : "pointer" }}
+                        style={{ fontFamily: MONO, fontSize: "var(--text-md)", fontWeight: 700, letterSpacing: "0.12em", textTransform: "uppercase", color: MUTED, background: "transparent", border: `1.5px solid color-mix(in srgb, ${INK} 30%, transparent)`, padding: "var(--space-md) var(--space-lg)", cursor: membership.joining ? "not-allowed" : "pointer" }}
                       >
                         {t("detail.join.cancel")}
                       </button>
@@ -373,7 +373,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
 
                 {(membership.state === "gate" || burned) && (
                   <div>
-                    <div style={{ fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: "var(--space-xs)" }}>
+                    <div style={{ fontFamily: MONO, fontSize: "var(--text-md)", letterSpacing: "0.18em", textTransform: "uppercase", color: GOLD, marginBottom: "var(--space-xs)" }}>
                       {burned
                         ? t("detail.burned.kicker")
                         : t("everymen.roll.gateKicker")}
@@ -414,7 +414,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                   style={{ position: "absolute", inset: 0, pointerEvents: "none", opacity: 0.5, background: `repeating-conic-gradient(from 0deg at 50% 30%, color-mix(in srgb, var(--everymen-red-deep) 60%, transparent) 0deg 8deg, transparent 8deg 16deg)` }}
                 />
                 <div style={{ position: "relative", zIndex: 2, padding: "var(--space-xl) var(--space-lg) var(--space-lg)" }}>
-                  <div style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.3em", textTransform: "uppercase", color: GOLD, marginBottom: "var(--space-md)" }}>
+                  <div style={{ fontFamily: MONO, fontSize: "var(--text-md)", letterSpacing: "0.3em", textTransform: "uppercase", color: GOLD, marginBottom: "var(--space-md)" }}>
                     {t("everymen.spotlight.label")}
                   </div>
                   <div style={{ display: "flex", justifyContent: "center", marginBottom: "var(--space-md)" }}>
@@ -432,7 +432,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
                   >
                     {spot.display_name}
                   </div>
-                  <div style={{ fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.08em", textTransform: "uppercase", color: GOLD, marginTop: "var(--space-sm)" }}>
+                  <div style={{ fontFamily: MONO, fontSize: "var(--text-md)", letterSpacing: "0.08em", textTransform: "uppercase", color: GOLD, marginTop: "var(--space-sm)" }}>
                     {t("everymen.spotlight.stat", {
                       level: spot.level,
                       score: spot.all_time_score.toLocaleString(),
@@ -445,7 +445,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
 
           <div style={{ ...PAPER_FRAME, padding: "var(--space-lg) var(--space-lg) var(--space-md)" }}>
             <Halftone />
-            <div style={{ position: "relative", fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.22em", textTransform: "uppercase", color: MUTED, marginBottom: "var(--space-md)" }}>
+            <div style={{ position: "relative", fontFamily: MONO, fontSize: "var(--text-md)", letterSpacing: "0.22em", textTransform: "uppercase", color: MUTED, marginBottom: "var(--space-md)" }}>
               {t("everymen.roster.heading")}
             </div>
             {roster.length === 0 ? (

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -107,7 +107,7 @@ function SectionHeading({ children }: { children: ReactNode }) {
 
 const KICKER: CSSProperties = {
   fontFamily: FONT,
-  fontSize: "var(--text-xs)",
+  fontSize: "var(--text-md)",
   letterSpacing: "0.24em",
   textTransform: "uppercase",
   color: phosphor(40),
@@ -180,7 +180,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
             style={{
               position: "relative",
               fontFamily: FONT,
-              fontSize: "var(--text-sm)",
+              fontSize: "var(--text-md)",
               letterSpacing: "0.14em",
               color: signal(55),
               marginBottom: "var(--space-lg)",
@@ -294,7 +294,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
               >
                 {t("singularity.access.heading")}
               </span>
-              <span style={{ fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.1em", color: phosphor(60) }}>
+              <span style={{ fontFamily: FONT, fontSize: "var(--text-md)", letterSpacing: "0.1em", color: phosphor(60) }}>
                 {t("singularity.access.reLabel")}
               </span>
             </div>
@@ -325,7 +325,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
 
                 {membership.state === "eligible" && !confirming && (
                   <div>
-                    <div style={{ fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.2em", color: signal(50), marginBottom: "var(--space-sm)" }}>
+                    <div style={{ fontFamily: FONT, fontSize: "var(--text-md)", letterSpacing: "0.2em", color: signal(50), marginBottom: "var(--space-sm)" }}>
                       {t("singularity.access.eligibleKicker")}
                     </div>
                     <div
@@ -407,7 +407,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                         disabled={membership.joining}
                         style={{
                           fontFamily: FONT,
-                          fontSize: "var(--text-xs)",
+                          fontSize: "var(--text-md)",
                           letterSpacing: "0.16em",
                           textTransform: "uppercase",
                           color: signal(60),
@@ -425,7 +425,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
 
                 {(membership.state === "gate" || burned) && (
                   <div>
-                    <div style={{ fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.2em", color: signal(50), marginBottom: "var(--space-sm)" }}>
+                    <div style={{ fontFamily: FONT, fontSize: "var(--text-md)", letterSpacing: "0.2em", color: signal(50), marginBottom: "var(--space-sm)" }}>
                       {burned
                         ? t("detail.burned.kicker")
                         : t("singularity.access.gateKicker")}
@@ -471,7 +471,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                 }}
               >
                 <Scanlines opacity={0.014} />
-                <div style={{ position: "relative", fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.28em", color: phosphor(45), marginBottom: "var(--space-md)" }}>
+                <div style={{ position: "relative", fontFamily: FONT, fontSize: "var(--text-md)", letterSpacing: "0.28em", color: phosphor(45), marginBottom: "var(--space-md)" }}>
                   {t("singularity.spotlight.label")}
                 </div>
                 <div style={{ position: "relative", display: "flex", justifyContent: "center", marginBottom: "var(--space-md)" }}>
@@ -480,7 +480,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
                 <div className="content-title" style={{ position: "relative", fontFamily: FONT, lineHeight: 1, color: PHOSPHOR, letterSpacing: "0.03em" }}>
                   {spot.display_name}
                 </div>
-                <div style={{ position: "relative", fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.1em", color: signal(55), marginTop: "var(--space-sm)", textTransform: "uppercase" }}>
+                <div style={{ position: "relative", fontFamily: FONT, fontSize: "var(--text-md)", letterSpacing: "0.1em", color: signal(55), marginTop: "var(--space-sm)", textTransform: "uppercase" }}>
                   {t("singularity.spotlight.stat", {
                     level: spot.level,
                     score: spot.all_time_score.toLocaleString(),
@@ -492,7 +492,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
 
           <div style={{ ...PANEL, padding: "var(--space-lg) var(--space-lg) var(--space-md)" }}>
             <Scanlines />
-            <div style={{ position: "relative", fontFamily: FONT, fontSize: "var(--text-xs)", letterSpacing: "0.24em", textTransform: "uppercase", color: phosphor(40), marginBottom: "var(--space-md)" }}>
+            <div style={{ position: "relative", fontFamily: FONT, fontSize: "var(--text-md)", letterSpacing: "0.24em", textTransform: "uppercase", color: phosphor(40), marginBottom: "var(--space-md)" }}>
               {t("singularity.roster.heading")}
             </div>
             {array.length === 0 ? (

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -322,7 +322,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                 >
                   {t("snide.dispatch.letterhead")}
                 </span>
-                <span style={{ fontFamily: MONO, fontSize: "var(--text-xs)", letterSpacing: "0.16em", textTransform: "uppercase", color: MUTED }}>
+                <span style={{ fontFamily: MONO, fontSize: "var(--text-md)", letterSpacing: "0.16em", textTransform: "uppercase", color: MUTED }}>
                   {t("snide.dispatch.reLabel")}
                 </span>
               </div>
@@ -547,7 +547,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
                   >
                     {spot.display_name}
                   </div>
-                  <div style={{ position: "relative", fontFamily: MONO, fontSize: "var(--text-sm)", letterSpacing: "0.08em", textTransform: "uppercase", color: "#cfcdbf", marginTop: "var(--space-xs)" }}>
+                  <div style={{ position: "relative", fontFamily: MONO, fontSize: "var(--text-md)", letterSpacing: "0.08em", textTransform: "uppercase", color: "#cfcdbf", marginTop: "var(--space-xs)" }}>
                     {t("snide.spotlight.stat", {
                       level: spot.level,
                       score: spot.all_time_score.toLocaleString(),

--- a/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/CovenFactionPage.tsx
@@ -286,7 +286,7 @@ function HeroStat({ value, label }: { value: number; label: string }) {
   return (
     <div style={{ ...PANEL, flex: '1 1 0', textAlign: 'center', padding: 'var(--space-md) var(--space-sm)' }}>
       <b className="content-title" style={{ fontFamily: READING, fontWeight: 600, display: 'block', lineHeight: 1, color: DEEP }}>{value}</b>
-      <span style={{ ...CAPTION, fontSize: 'var(--text-xs)', marginTop: 'var(--space-xs)', display: 'block' }}>
+      <span style={{ ...CAPTION, fontSize: 'var(--text-md)', marginTop: 'var(--space-xs)', display: 'block' }}>
         {label}
       </span>
     </div>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/DefaultFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/DefaultFactionPage.tsx
@@ -191,7 +191,7 @@ function HeroStat({ value, label }: { value: number; label: string }) {
       </b>
       <span
         style={{
-          fontSize: 'var(--text-xs)',
+          fontSize: 'var(--text-md)',
           letterSpacing: '0.16em',
           textTransform: 'uppercase',
           opacity: 0.85,

--- a/frontend/src/pages/factionDetail/mobileArchetypes/EphemeristsFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/EphemeristsFactionPage.tsx
@@ -47,7 +47,7 @@ const NA_SLUG = 'na'
 
 const kicker: CSSProperties = {
   ...SMALL_CAPS,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.2em',
   color: QUIET,
 }
@@ -265,7 +265,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
         {member.display_name}
       </span>
       <Tally level={member.level} />
-      <span style={{ ...SMALL_CAPS, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', color: NILE, flex: 'none' }}>
+      <span style={{ ...SMALL_CAPS, fontSize: 'var(--text-md)', letterSpacing: '0.12em', color: NILE, flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/EverymenFactionPage.tsx
@@ -33,7 +33,7 @@ const BODY_FONT = 'var(--font-body)'
 
 const kicker: CSSProperties = {
   fontFamily: BODY_FONT,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: MUTED,

--- a/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/SingularityFactionPage.tsx
@@ -41,7 +41,7 @@ const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, t
 
 const kicker: CSSProperties = {
   fontFamily: FONT,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: signal(60),
@@ -284,7 +284,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
       >
         {member.display_name}
       </span>
-      <span style={{ fontFamily: FONT, fontSize: 'var(--text-sm)', letterSpacing: '0.04em', color: AMBER, flex: 'none' }}>
+      <span style={{ fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.04em', color: AMBER, flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/factionDetail/mobileArchetypes/SnideFactionPage.tsx
+++ b/frontend/src/pages/factionDetail/mobileArchetypes/SnideFactionPage.tsx
@@ -41,7 +41,7 @@ const CARD_SHADOW = '5px 6px 0 rgba(0,0,0,.5)'
 
 const kicker: CSSProperties = {
   fontFamily: TYPE,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -281,7 +281,7 @@ function MemberRow({ rank, member }: { rank: number; member: CharacterOut }) {
       >
         {member.display_name}
       </span>
-      <span style={{ fontFamily: TYPE, fontSize: 'var(--text-sm)', letterSpacing: '0.06em', color: MUTED, flex: 'none' }}>
+      <span style={{ fontFamily: TYPE, fontSize: 'var(--text-md)', letterSpacing: '0.06em', color: MUTED, flex: 'none' }}>
         {t('mobile.memberStat', { level: member.level, score: member.all_time_score.toLocaleString() })}
       </span>
     </Link>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -334,7 +334,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                     style={{
                       marginTop: 'var(--space-xs)',
                       fontFamily: 'var(--font-body)',
-                      fontSize: 'var(--text-sm)',
+                      fontSize: 'var(--text-md)',
                       letterSpacing: '0.1em',
                       textTransform: 'uppercase',
                       color: 'var(--color-text-secondary)',

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
@@ -46,7 +46,7 @@ import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
 
 const kicker: CSSProperties = {
   ...SMALL_CAPS,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.22em',
   color: QUIET,
 }
@@ -78,7 +78,7 @@ const actionPillStyle: CSSProperties = {
 /** The baseline row under the track — the leaf's marginalia voice. */
 const trackMetaStyle: CSSProperties = {
   ...SMALL_CAPS,
-  fontSize: 'var(--text-sm)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.12em',
   color: QUIET,
 }
@@ -300,7 +300,7 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
                   <div className="truncate" style={{ fontFamily: DECO, fontSize: 'var(--text-content)', lineHeight: 1.15, color: INK }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', ...SMALL_CAPS, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', color: QUIET }}>
+                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', ...SMALL_CAPS, fontSize: 'var(--text-md)', letterSpacing: '0.1em', color: QUIET }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -309,7 +309,7 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ ...SMALL_CAPS, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', color: NILE, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${LINE}` }}
+                  style={{ ...SMALL_CAPS, fontSize: 'var(--text-md)', letterSpacing: '0.1em', color: NILE, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${LINE}` }}
                 >
                   {praxisModeLabel(praxis, t)}
                 </span>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
@@ -40,7 +40,7 @@ const ROW_SIGIL = 14
 
 const kicker: CSSProperties = {
   fontFamily: BODY_FONT,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -73,7 +73,7 @@ const actionPillStyle: CSSProperties = {
 /** The baseline row under the track — the broadsheet's kicker voice. */
 const trackMetaStyle: CSSProperties = {
   fontFamily: BODY_FONT,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.2em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -347,7 +347,7 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: BODY_FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: CREAM, background: INK, padding: 'var(--space-xs) var(--space-sm)' }}
+                  style={{ fontFamily: BODY_FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: CREAM, background: INK, padding: 'var(--space-xs) var(--space-sm)' }}
                 >
                   {praxisModeLabel(praxis, t)}
                 </span>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
@@ -44,7 +44,7 @@ const signal = (pct: number): string => `color-mix(in srgb, ${SIGNAL} ${pct}%, t
 
 const kicker: CSSProperties = {
   fontFamily: FONT,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: signal(60),
@@ -77,7 +77,7 @@ const actionPillStyle: CSSProperties = {
 /** The baseline row under the track — the terminal's signal voice. */
 const trackMetaStyle: CSSProperties = {
   fontFamily: FONT,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.22em',
   textTransform: 'uppercase',
   color: signal(60),
@@ -199,7 +199,7 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: FONT, fontSize: 'var(--text-sm)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(60) }}>
+            <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(60) }}>
               {t('sidebar.characterCard.level', { level: character.level })}
             </div>
           </div>
@@ -313,7 +313,7 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
                   <div className="truncate" style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1.2, color: PHOSPHOR }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>
+                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -322,7 +322,7 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: FONT, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: AMBER, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${signal(30)}` }}
+                  style={{ fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: AMBER, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${signal(30)}` }}
                 >
                   {praxisModeLabel(praxis, t)}
                 </span>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
@@ -46,7 +46,7 @@ const CARD_SHADOW = '5px 6px 0 rgba(0,0,0,.5)'
 
 const kicker: CSSProperties = {
   fontFamily: TYPE,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -79,7 +79,7 @@ const actionPillStyle: CSSProperties = {
 /** The baseline row under the track — the file's typewriter voice. */
 const trackMetaStyle: CSSProperties = {
   fontFamily: TYPE,
-  fontSize: 'var(--text-xs)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.24em',
   textTransform: 'uppercase',
   color: MUTED,
@@ -173,7 +173,7 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
             >
               {character.display_name}
             </Link>
-            <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: TYPE, fontSize: 'var(--text-sm)', letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
+            <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: TYPE, fontSize: 'var(--text-md)', letterSpacing: '0.12em', textTransform: 'uppercase', color: MUTED }}>
               {t('sidebar.characterCard.level', { level: character.level })}
             </div>
           </div>
@@ -282,7 +282,7 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
                   <div className="truncate" style={{ fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.02em', lineHeight: 1.15, color: TEXT }}>
                     {praxis.task_title}
                   </div>
-                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: TYPE, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
+                  <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: TYPE, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
                       points: praxis.task_point_value,
@@ -291,7 +291,7 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
                 </div>
                 <span
                   className="shrink-0"
-                  style={{ fontFamily: TYPE, fontSize: 'var(--text-xs)', letterSpacing: '0.1em', textTransform: 'uppercase', color: ACID, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${LINE}` }}
+                  style={{ fontFamily: TYPE, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: ACID, padding: 'var(--space-xs) var(--space-sm)', border: `1px solid ${LINE}` }}
                 >
                   {praxisModeLabel(praxis, t)}
                 </span>

--- a/frontend/src/pages/players/Constellation.tsx
+++ b/frontend/src/pages/players/Constellation.tsx
@@ -343,7 +343,7 @@ function SkyNode({
             background: 'var(--sky-bg)',
             border: '1px solid var(--sky-ring)',
             color: 'var(--sky-name)',
-            fontSize: 'var(--text-sm)',
+            fontSize: 'var(--text-md)',
             lineHeight: 1,
           }}
         >

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -142,7 +142,7 @@ const SIZES: Record<'desktop' | 'mobile', SizeSet> = {
 const CAPTION: CSSProperties = {
   fontFamily: CHROME,
   fontWeight: 700,
-  fontSize: 'var(--text-sm)',
+  fontSize: 'var(--text-md)',
   letterSpacing: '0.16em',
   textTransform: 'uppercase',
   color: LABEL,

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -277,7 +277,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
    *  PLATE and does not clear on the darker page this surface introduces. */
   const eyebrow: CSSProperties = {
     ...SMALL_CAPS,
-    fontSize: "var(--text-sm)",
+    fontSize: "var(--text-md)",
     color: QUIET,
   };
   /** The same label voice on a panel cell, where the caption gold clears. */

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -177,7 +177,7 @@ const CREW_INK = {
 /** Terminal caption voice — every label on the chassis speaks in it. */
 const LABEL: CSSProperties = {
   fontFamily: MONO,
-  fontSize: "var(--text-sm)",
+  fontSize: "var(--text-md)",
   letterSpacing: "0.14em",
   textTransform: "uppercase",
   color: DIM,

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -266,7 +266,7 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
   /** Special Elite, uppercase, wide — every micro-label on the wall. */
   const eyebrow: CSSProperties = {
     fontFamily: TYPE,
-    fontSize: "var(--text-sm)",
+    fontSize: "var(--text-md)",
     letterSpacing: "0.2em",
     textTransform: "uppercase",
     color: MUTED,

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -19,7 +19,7 @@ import {
 const LEVEL_OPTIONS = [0, 1, 2, 3, 4, 5, 6, 7, 8];
 
 const breadcrumbStyle: CSSProperties = {
-  fontSize: "var(--text-sm)",
+  fontSize: "var(--text-md)",
   letterSpacing: "0.1em",
   color: "var(--color-text-tertiary)",
 };
@@ -94,7 +94,7 @@ const submitDashStyle: CSSProperties = {
 const basePennantStyle: CSSProperties = {
   display: "block",
   fontFamily: "'Courier Prime', monospace",
-  fontSize: "var(--text-xs)",
+  fontSize: "var(--text-md)",
   fontWeight: 700,
   textTransform: "uppercase",
   letterSpacing: "0.07em",

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -309,7 +309,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
   const hasAction =
     canSignUp || !!mySubmission || (isInProgress && inProgressPraxisId !== null);
 
-  const eyebrow: CSSProperties = { ...CAPTION, fontSize: "var(--text-sm)" };
+  const eyebrow: CSSProperties = { ...CAPTION, fontSize: "var(--text-md)" };
   const innerBox: CSSProperties = {
     background: PAGE,
     border: `1.5px solid ${BORDER}`,
@@ -633,7 +633,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             style={{
               fontFamily: CHROME,
               fontWeight: 700,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               textTransform: "uppercase",
               letterSpacing: "0.15em",
               padding: "var(--space-xs) var(--space-sm)",
@@ -845,7 +845,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
                   onClick={() => setSubmissionSort(sort)}
                   style={{
                     ...CAPTION,
-                    fontSize: "var(--text-sm)",
+                    fontSize: "var(--text-md)",
                     letterSpacing: "0.14em",
                     cursor: "pointer",
                     border: "none",

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -493,7 +493,7 @@ export default function DefaultTaskDetail({
           <span
             className="font-body"
             style={{
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               textTransform: "uppercase",
               letterSpacing: "0.15em",
               padding: "var(--space-xs) var(--space-sm)",

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -306,7 +306,7 @@ export default function EphemeristsTaskDetail({
    */
   const eyebrow: CSSProperties = {
     ...SMALL_CAPS,
-    fontSize: "var(--text-sm)",
+    fontSize: "var(--text-md)",
     color: QUIET,
   };
   /** The same label voice on a panel cell, where the caption gold clears. */
@@ -461,7 +461,7 @@ export default function EphemeristsTaskDetail({
           <span
             style={{
               ...SMALL_CAPS,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               fontWeight: 600,
               letterSpacing: "0.16em",
               padding: "var(--space-xs) var(--space-sm)",
@@ -685,7 +685,7 @@ export default function EphemeristsTaskDetail({
           <span
             style={{
               ...SMALL_CAPS,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               letterSpacing: "0.2em",
               marginTop: "var(--space-xs)",
               color: CAPTION,
@@ -862,7 +862,7 @@ export default function EphemeristsTaskDetail({
         cursor: "pointer",
         border: "none",
         padding: "var(--space-xs) var(--space-md)",
-        fontSize: "var(--text-sm)",
+        fontSize: "var(--text-md)",
         background: submissionSort === sort ? CTA_BG : "transparent",
         color: submissionSort === sort ? CTA_INK : QUIET,
       }}

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -332,7 +332,7 @@ export default function EverymenTaskDetail({
             className="font-body"
             style={{
               display: "inline-block",
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               textTransform: "uppercase",
               letterSpacing: "0.15em",
               padding: "var(--space-xs) var(--space-sm)",
@@ -619,7 +619,7 @@ export default function EverymenTaskDetail({
           <span
             style={{
               ...label,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               letterSpacing: "0.22em",
               color: ACCENT,
               marginTop: "var(--space-xs)",

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -91,7 +91,7 @@ const GALLERY_PREVIEW = 3;
 /** Terminal caption voice — every label on the chassis speaks in it. */
 const LABEL: CSSProperties = {
   fontFamily: MONO,
-  fontSize: "var(--text-sm)",
+  fontSize: "var(--text-md)",
   letterSpacing: "0.14em",
   textTransform: "uppercase",
   color: DIM,
@@ -343,7 +343,7 @@ export default function SingularityTaskDetail({
           <span
             style={{
               fontFamily: MONO,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               textTransform: "uppercase",
               letterSpacing: "0.15em",
               padding: "var(--space-xs) var(--space-sm)",
@@ -519,7 +519,7 @@ export default function SingularityTaskDetail({
       {showBreakdown && (
         <>
           <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
-            <span style={{ ...LABEL, fontSize: "var(--text-xs)" }}>
+            <span style={{ ...LABEL, fontSize: "var(--text-md)" }}>
               {t("detail.points.base")}
             </span>
             <span

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -208,7 +208,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
   /** Special Elite, uppercase, wide — every micro-label on the sheet. */
   const eyebrow: CSSProperties = {
     fontFamily: TYPE,
-    fontSize: "var(--text-sm)",
+    fontSize: "var(--text-md)",
     letterSpacing: "0.2em",
     textTransform: "uppercase",
     color: MUTED,
@@ -333,7 +333,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
           <span
             style={{
               fontFamily: BLACK,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               letterSpacing: "0.16em",
               textTransform: "uppercase",
               color: "var(--faction-snide-acid)",
@@ -669,7 +669,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
           <span
             style={{
               fontFamily: BLACK,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               textTransform: "uppercase",
               letterSpacing: "0.15em",
               padding: "var(--space-xs) var(--space-sm)",
@@ -896,7 +896,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
                   cursor: "pointer",
                   border: "none",
                   fontFamily: TYPE,
-                  fontSize: "var(--text-xs)",
+                  fontSize: "var(--text-md)",
                   letterSpacing: "0.14em",
                   textTransform: "uppercase",
                   whiteSpace: "nowrap",

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -587,7 +587,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
           <span
             style={{
               ...EYEBROW,
-              fontSize: "var(--text-xs)",
+              fontSize: "var(--text-md)",
               letterSpacing: "0.15em",
               padding: "var(--space-xs) var(--space-sm)",
               borderRadius: 4,
@@ -791,7 +791,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
                 onClick={() => setSubmissionSort(sort)}
                 style={{
                   ...EYEBROW,
-                  fontSize: "var(--text-sm)",
+                  fontSize: "var(--text-md)",
                   cursor: "pointer",
                   border: "none",
                   borderRadius: 6,

--- a/frontend/src/pages/taskDetail/archetypes/shared.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/shared.tsx
@@ -57,7 +57,7 @@ export function LevelJumpBanner({ state }: { state: TaskDetailState }) {
       </span>
       <span
         style={{
-          fontSize: "var(--text-sm)",
+          fontSize: "var(--text-lg)",
           color: "var(--color-text-secondary)",
         }}
       >


### PR DESCRIPTION
Closes #1608

Per the owner ruling of 2026-08-14: **the objects stay, the sizes move.** Nothing is
converted to `.label-heading` / `.label-caption`, no `fontFamily`, `color`,
`letterSpacing` or `textTransform` is touched, and every faction keeps its own label
face and ink. Only `fontSize` changed.

## The seam

**The source tree**, same as the guard already in `src/__tests__/labelTierSweep.test.ts`.
That has to be the seam, because a 9px label renders perfectly — nothing throws, nothing
warns, and no render test can tell a deliberate 9px from a missed one. The existing guard
counts `className` values, which is the right instrument for a class and the wrong one for
this population: these sites do the same job through a local `const eyebrow: CSSProperties`
that never names any class. So the new guard greps **the size token**, which is the one
thing every member of the population has in common.

Red first: reintroducing a single `var(--text-sm)` into `SnidePraxisDetail.tsx` fails it and
names the file. Restored, green.

## Census, from my own tooling (not the issue's figures)

Instrument: every `var(--text-sm)` / `var(--text-xs)` occurrence in `frontend/src/**/*.{ts,tsx}`,
found by token rather than by name. Script logic is reproduced in the new test.

| | before | after |
|---|---|---|
| declarations | **213** | **25** |
| files | **99** | **6** |
| `--text-sm` (9px) | 117 | 22 |
| `--text-xs` (8px) | 96 | 3 |

(The ruling's 2026-08-14 figures were 213 / 99, sm 118 / xs 95. Mine differ by one either
way — files moved tonight. 213 total is unchanged, which is a coincidence, not a copy.)

**188 swaps across 94 files** — 178 to `--text-md` (11px), 10 to `--text-lg` (12px).

### How each target was picked

By what the object **is**, not by which token it named — as instructed, and it matters,
because a token-to-token mapping would have been wrong for most of the 8px half:

- **`--text-md` (11px), 178 sites.** The object is uppercase and/or letter-spaced, directly
  or through the spread base it derives from (`SMALL_CAPS`, `CAPTION`, `EYEBROW`, `LABEL`,
  `UA_EYEBROW`, `monoCaps`). That is `.label-heading`'s job and `.label-heading`'s size.
  **93 of these came from `--text-xs`** — i.e. the 8px half is overwhelmingly *heading*-like,
  not caption-like, so mapping `xs -> lg` mechanically would have mis-set most of it.
- **`--text-lg` (12px), 10 sites.** Sentence-case facts: the activity ticker's verb line,
  collab member names and credits, the create-character back link and meta row, the Field
  Desk byline, the edit-character counter, the character-picker's faction name, the task
  detail level-jump note, WOW's italic modifier caption.
- **Four fixed-geometry marks** went to `--text-md` rather than `--text-lg` and are worth
  naming: `PendingBadge`'s count (a 15px dot), the praxis-card roster monogram (a 24px disc),
  the Constellation rank pip (an 18px+ disc) and Singularity's `[x]` seal button. These are
  numerals and glyphs sized to a shape — scanned marks, not read facts — and 12px would not
  sit in the disc.

### Derived objects

`{ ...CAPTION, fontSize: "var(--text-sm)" }` overrides were swept at the spread site as well
as at the declaration, so no derived copy kept 9px. One base — `UA_EYEBROW` in `uaAtoms.tsx` —
was **already** `--text-md` and was being downgraded by its own spread sites; those now
restate the base rather than undercut it.

## Deliberately left: 25 occurrences in 6 files

Each is allow-listed **with its reason** in the new guard, so the residue stays visible
instead of being laundered to zero — which is exactly the failure this issue exists to name.

- **`pages/praxisDetail/shared.tsx` (16)** — 14 are moderation/flag controls carrying
  `.btn-primary` / `.btn-outline`, whose *own* declared size is `--text-sm`. The inline value
  restates the class; bumping it alone would desynchronise those buttons from every other
  button in the app. Two more (`:667`, `:683`) are notice body copy sitting under a
  `--text-base` (10px) title — raising the body above its own heading would invert the pair,
  and `--text-base` is outside this sweep's two tokens.
- **`components/duel/shared.tsx` (3)** — two `.btn-*` restatements on the seal actions, which
  **#769 explicitly settled** as button chrome, plus one mention inside the comment recording
  that decision (not a declaration — the raw grep counts it, which is why the number is 3
  and not 2).
- **`components/collab/CollabSuccess.tsx` (2)** — one `.btn-primary` restatement, and one
  paragraph of body copy. That paragraph is **content, not a label**, so per the ruling I did
  not guess a label-tier step for it; it wants a content-tier decision.
- **`pages/admin/AccountsTab.tsx` (2)** — both `.btn-outline` restatements on ban/unban.
- **`components/praxisCard/desktop/EphemeristsPraxisCard.tsx` (1)** — the `epg-glyph` strip
  alternates two sizes as ornament. Drawing, not label text.
- **`components/praxisCard/__tests__/cardChrome.test.tsx` (1)** — a *negative* assertion that
  exists to prove the token is absent.

### The follow-up this leaves open

`index.css` still declares four label-tier **classes** at the two smallest steps:
`.btn-primary` and `.btn-outline` (`--text-sm`, uppercase, 0.12em), `.card-meta`
(`--text-xs`, uppercase, 0.1em) and `.level-gem-caption` (`--text-sm`). Those are the class
population — #1307's half — and every "restatement" left above is downstream of them.
Changing them moves every button and every card meta line in the app at once, which is a
size call with a blast radius this issue's ruling explicitly scoped out ("needs no design
call"). **Worth its own issue.** It is also why one hand-rolled confirm button
(`praxisDetail/shared.tsx:611`) was left: it stands next to a `.btn-outline` cancel, and
raising one of a pair is worse than raising neither.

## Also in here

Four comments that justified the old sizes in prose ("the 9px step rather than the 8px
floor", "the label tier is `--text-xs` (8px)") now name the step the tier actually uses. A
comment left asserting 9px above a `var(--text-md)` is the next reader's false premise.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(**243 files / 4350 tests green**), `npm run build`, `npm run budget` (JS 129.8 KB, CSS
21.4 KB — both ok, CSS unchanged: no rule was added). Rebased on `origin/main`
(`10b42dba`) and the census re-run after the rebase found **0** new sites.

**Visual QA is outstanding.** I have no browser and no dev stack; every check above is
static or render-to-string. This changes text size on most surfaces in the app and needs eyes.

## What to eyeball

Densest first — these are where 11px vs 9px will show as a reflow, not just a size:

1. **Task detail, every faction** — Coven, Ephemerists, S.N.I.D.E. and Singularity each drive
   7-10 label sites off one object, including the metatask pennant and the submission-sort
   buttons. Check the sort row does not wrap.
2. **Praxis detail, every faction** — same shape; Singularity's `LABEL` and S.N.I.D.E.'s
   `eyebrow` are the highest-count objects in the tree.
3. **Task cards in a grid** (`/tasks`) — Default, Ephemerists, Everymen, Singularity, UA,
   S.N.I.D.E., WOW all moved their card meta lines. Watch for a two-line meta where there
   was one.
4. **The feed** — action buttons on the collab invite, duel challenge and bank-full modal all
   went 9px -> 11px. These are hand-rolled, so they now read larger than a `.btn-primary`
   elsewhere on the page; that gap is the follow-up above, but confirm it does not look broken.
5. **Faction pages, desktop and mobile** — Singularity's body has 9 sites and Everymen's 8;
   the mobile `kicker` objects moved on five factions.
6. **Field Desk mobile** (all skins) and the **sidebar** — truncated single-line labels with
   `whiteSpace: nowrap` are the likeliest place for an ellipsis to appear that was not there.
7. **Small fixed geometry** — the pending-count badge, the praxis roster monogram, the
   Constellation rank pip, Ephemerists' seal issuer tab (absolutely positioned at `top: -9`)
   and Singularity's `[x]`. These are the four-plus sites where a bigger glyph could overflow
   its shape.
8. **Vote widgets** on all six skins — the "x N" off-count moved on each.

Draft until those have been looked at.

Generated with [Claude Code](https://claude.com/claude-code)
