### PR TITLE
A verified email is one Account, whatever provider vouches for it

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -489,12 +489,12 @@ foes — the feed item type `foe_taunt` names the one kind there is).
 ### Account & Character
 
 **Account**:
-The login identity — one Google OAuth2 → JWT principal, one email. Owns one or more
-**Characters** and never appears on public game surfaces (`account_id` and `email` are
-private). The Account is the unit of all *cross-character* rules: the multi-character cap,
-the account-pooled invite gate (see **Faction invite**), the account-collective
-Albescent unlock, and account-scoped anti-self-voting (a character cannot vote on a praxis
-authored by any character sharing its account).
+The login identity — one verified email, reachable through one or more identity providers
+(ADR-0075). Owns one or more **Characters** and never appears on public game surfaces
+(`account_id` and `email` are private). The Account is the unit of all *cross-character*
+rules: the multi-character cap, the account-pooled invite gate (see **Faction invite**),
+the account-collective Albescent unlock, and account-scoped anti-self-voting (a character
+cannot vote on a praxis authored by any character sharing its account).
 _Avoid_: user, player (the *player* is the human; the *account* is their credential record).
 
 **Character**:

--- a/docs/adr/0075-a-verified-email-is-one-account-whatever-provider-vouches-for-it.md
+++ b/docs/adr/0075-a-verified-email-is-one-account-whatever-provider-vouches-for-it.md
@@ -1,0 +1,114 @@
+# ADR-0075 — A verified email is one Account, whatever provider vouches for it
+
+**Status:** Accepted
+**Date:** 2026-08-14
+**Relates to:** ADR-0041 (the *shape* of identity: Account vs Character), CONTEXT.md
+("Account"), #1769 (this ADR), #1771 (the verified-email check moves to the linking
+seam), #1772 (a second provider)
+
+## Context
+
+ADR-0041 settled the **shape** of identity: a private Account owning public
+Characters, with the provider identity held in a row rather than a column, so
+that adding a provider is a handler plus a row and not a schema change. What it
+did not settle is **trust between providers** — what happens when two of them
+hand us the same email. Does the second sign-in find the existing Account, or
+mint a new one beside it?
+
+The system has answered that since v1, but only in code. A player arriving from a
+second provider whose email an Account already holds is signed into that Account.
+Nothing announces it, and no surface exists to arrange, inspect or undo it.
+
+That answer deserves a record on all three of the usual grounds. It is **hard to
+reverse** — once two provider identities point at one Account and Characters,
+praxis, votes and score have accrued underneath, there is no clean unlink. It is
+**surprising** read as raw mechanics: "a stranger's provider account can sign
+into mine when the emails match" sounds like a defect. And it is a **real
+trade-off** with a real alternative, which was considered and turned down. The
+check that makes it safe currently reads as an unexplained precaution, and the
+next person to add a provider has nothing to consult.
+
+## Decision
+
+**A verified email from any configured provider resolves to the existing Account
+holding that email.** Silently — no confirmation step, no notification, no
+"connect your accounts" interstitial. The email is the identity; providers are
+routes to it.
+
+### Why this is safe
+
+Taking over an Account this way requires holding an account, at some provider we
+accept, whose email is the victim's *and* which that provider has verified.
+Provider verification asserts exactly one thing: the holder receives mail at that
+address.
+
+Anyone who receives mail at the victim's address can already run a password reset
+at the victim's original provider and take the Account by that route. So the
+security of auto-linking **equals inbox control** — which is already the floor
+for every provider in the system, not a new floor this decision sets. It adds no
+attack surface. Refusing to link would not protect an Account whose inbox is
+compromised; it would cost the attacker one extra step and cost every honest
+player a wall.
+
+### The invariant
+
+**Never link on an unverified or absent email.**
+
+This is the load-bearing half of the decision, and it is stated separately from
+the mechanism on purpose. The safety argument above is *entirely* a claim about
+what provider verification buys. A provider that hands over an email it has not
+verified — or hands over none — drops the requirement from inbox control to
+typing a string, and the argument collapses with it.
+
+So accepting a provider with weaker email guarantees is a decision that must come
+back to **this ADR**, not a config change that passes as adding a row.
+
+The invariant guards the **email-matching branch** specifically. A provider
+identity the system has seen before is recognised by that identity, and needs no
+email claim to be recognised again; gating recognition on a claim that may be
+absent buys no security and locks out returning players. The check belongs where
+an email is about to be treated as proof of who someone is — nowhere earlier.
+
+## Consequences
+
+**Good — sign-in behaves the way a player expects.** The same email is the same
+Account, whichever button they pressed. No settings page to find first, no
+dead-end error, no support path for "I clicked the wrong button and now I have
+two accounts and half my history".
+
+**Good — adding a provider stays the cheap thing ADR-0041 promised**, with
+exactly one question attached to it: does this provider verify email? That
+question is now on the record, with the reason the answer matters.
+
+**Bad — the link is invisible.** A player cannot see which providers reach their
+Account, and cannot detach one. Accepted while every accepted provider carries
+the same guarantee: there is nothing to inspect and nothing surprising to
+explain. It stops being acceptable the day that guarantee stops being uniform.
+
+**Neutral — the Character layer is untouched.** Linking happens wholly at the
+Account layer. Which provider walked in has no bearing on Characters, their
+score, faction or history, and no public surface can observe it either way
+(ADR-0041).
+
+## Considered and rejected
+
+**Explicit linking** — a "connect a provider" surface in settings, with sign-in
+refused when a new provider's email collides with an existing Account. Rejected:
+it buys no real security, because the threat it defends against already holds
+inbox control and can take the Account by other means. Its costs are concrete — a
+settings page to build and maintain, plus a dead-end error shown to a player
+whose only intention was to sign in, on a path where they cannot serve themselves
+out of it.
+
+**A visible connected-accounts list** — read-only, showing which providers reach
+this Account. Rejected as speculative *now*, not as wrong. While every provider
+shares one guarantee it displays a fact with no decision attached. It becomes
+worth building the day a provider with a weaker guarantee is accepted — arriving
+alongside whatever else that acceptance requires, and this ADR is what should
+send that reader here.
+
+**Match on provider identity alone; never match on email** — mint a fresh Account
+per provider. Rejected: it turns a second provider into a way to *lose* your
+history rather than a way to reach it, and it hands the merge problem to the
+player, and eventually to us, at the point where two Accounts already own
+Characters.


### PR DESCRIPTION
Closes #1769

Docs only. Two files, no code, no tests.

## The seam

There is no code seam to test here — the deliverable is prose. The *rule* being
documented lives at the account-linking seam (`create_or_get_account`), and it is
already covered by the backend suite; this PR adds no behaviour and asserts none.
Per the brief, no test was invented for prose.

What the ADR is written against is the **rule and its invariant**, not the current
implementation, because the implementation is moving underneath it this week
(#1771 relocates the verified-email check; #1772 adds a second provider). The ADR
therefore cites no line numbers, no function names, and no vendor names — verified
by grep before commit.

## 1. `CONTEXT.md` — the `Account` entry

Only the first sentence changed, exactly as the issue specified. Was:

> The login identity — one Google OAuth2 → JWT principal, one email.

Now:

> The login identity — one verified email, reachable through one or more identity
> providers (ADR-0075).

The rest of the paragraph (ownership of Characters, never appearing on public
surfaces, being the unit of cross-character rules) is untouched in content — the
diff shows 6 changed lines because the paragraph rewraps. Inline ADR citation
follows existing house style in this file (`(ADR-0009)`, `(ADR-0031)`,
`*(ADR-0025; "life" in the UI)*`).

### The sweep — my numbers, not the issue's

`git grep -i google -- '*.md'` on tracked markdown: **14 hits across 7 files.**

- **1 auth-related and wrong** — `CONTEXT.md:492`. Fixed here.
- **2 auth-related and correct as written** — `docs/adr/0041:36` and `:46`. These
  are an ADR's record of a decision at its date ("Google OAuth2 is the only v1
  provider"); an ADR is a historical record, so they stay. ADR-0075 supplements
  0041 rather than amending it.
- **11 unrelated** — Google *Fonts* (`WORLD_ZERO_STYLE.md` ×3, `load-time.md` ×1,
  `SPEC-faction-ui-profile.md` ×1, `.design-sync/NOTES.md` ×4) and Google *Docs*
  as a UX analogy (`docs/adr/0073` ×2).

The issue claimed "every other hit is Google *Fonts*" — that is very slightly off
(two are Google *Docs*), but its conclusion holds: **no third document needed
changing.** I also swept `CONTEXT.md` for provider/oauth/jwt/identity/credential
/verified terms independently of the word "Google"; the only auth-bearing entry in
the glossary is `Account`, and no other entry assumes a single provider.

## 2. `docs/adr/0075-a-verified-email-is-one-account-whatever-provider-vouches-for-it.md`

New ADR. Numbering corrected from the issue's proposed `0073`: **0073 and 0074
both exist on main**, so this is **0075** (`ls docs/adr/` re-checked at branch
time, off `faa8f888`).

Payload as specified in the issue: the decision (silent resolve, no confirmation,
no notification); why it is safe (auto-linking's security *equals inbox control*,
already the floor for every provider, so no new attack surface); the invariant
(*never link on an unverified or absent email*, stated separately because it is
what forces a weaker-guarantee provider back to this ADR instead of through as a
config change); and both rejected alternatives (explicit linking; a
connected-accounts list). It cross-references ADR-0041 for the *shape* of identity
rather than restating it, and scopes itself to *trust between providers*.

Structure follows the corpus (0041, 0074): title / Status / Date / Relates to /
Context / Decision / Consequences / Considered and rejected.

## Sub-task dropped: `CLAUDE.md:18`

The issue also asked to make the Stack line provider-neutral. **Already resolved
by #1759**, which deleted that line entirely as derivable from
`backend/requirements.txt`. `## Stack` on main now contains only the "Deeper
notes:" pointer — confirmed on `faa8f888` before starting. `CLAUDE.md` is
untouched by this PR.

## Verification

`.github/workflows/test.yml` names three jobs: `test`, `api-schema`, `frontend`.
No step in any of them reads `CONTEXT.md` or `docs/adr/` — the only in-code
references to either are prose in comments and docstrings (checked with
`git grep -n "docs/adr\|CONTEXT\.md" -- backend frontend scripts`; 5 hits, all
comments, zero file reads). The diff is two `.md` files, so no job's inputs
changed.

Backend suite run anyway, against a dedicated `wz1769_test` DB (dropped after):

```
pytest --cov=. --cov-report=term-missing --cov-fail-under=80
1214 passed, 1 warning in 134.13s — total coverage 93.29%
```

`api-schema` and `frontend` not run locally: no Python route/schema and no
TS/CSS/asset bytes changed, so their inputs are provably untouched by this diff.
No visual surface is affected; no visual QA applies.

## What to eyeball

1. **The one sentence.** Does "one verified email, reachable through one or more
   identity providers" read as glossary, not implementation? The issue proposed
   this wording verbatim; I added only the `(ADR-0075)` pointer.
2. **The two ADR-0041 hits I deliberately left.** I treated 0041 as a historical
   record that should not be retro-edited when reality moves past it. If the house
   rule is instead that ADRs get amended in place, say so and I will add a
   superseding note to 0041 rather than leaving it reading "Google OAuth2 is the
   only v1 provider".
3. **The invariant's scope paragraph.** ADR-0075 says the check guards the
   *email-matching branch* specifically, and that a previously-seen provider
   identity needs no email claim to be re-recognised. That is #1771's shape,
   asserted as doctrine here. If #1771 lands differently, this paragraph is the
   one that goes stale.
4. **Whether the ADR survives #1772.** I wrote it with no vendor name anywhere so
   that adding Discord requires no edit to it. Worth a skim with #1772's diff in
   the other window.
5. **`docs/adr/ADR-FORMAT` does not exist.** The brief and the issue both cite it.
   There is no such file, and no format spec in `docs/agents/domain.md` either — I
   followed the corpus (0041 and 0074) instead. Flagging in case the file was
   meant to exist and got lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
