### PR TITLE
The verified-email gate guards the branch that needs it, and one identity is one row

### DIFF
--- a/backend/alembic/versions/0007_oauth_provider_unique.py
+++ b/backend/alembic/versions/0007_oauth_provider_unique.py
@@ -1,0 +1,52 @@
+"""Make ``(provider, provider_user_id)`` unique on ``oauth_provider``.
+
+Every sign-in resolves an OAuth identity by looking that pair up with
+``scalar_one_or_none()`` (``services/auth.py``). Nothing stopped two rows from
+carrying the same pair — two concurrent first logins for one identity being the
+obvious route — and the second one does not break the login that created it: it
+breaks **every subsequent login for that account, permanently**, with
+``MultipleResultsFound``, and the player has no way to fix it themselves.
+Unlikely race, unrecoverable outcome, so the database refuses it. The index the
+constraint brings also turns that per-sign-in lookup into a seek.
+
+``0002_squashed`` builds a fresh database straight from the ORM models
+(``models/account.py``), so CI, local resets and the test harness already land
+on this shape without this file — which is exactly why it has to exist
+explicitly. A deployed database is stamped at a later revision and never re-runs
+the root, so only this revision puts the constraint there. Written idempotent
+(``DROP CONSTRAINT IF EXISTS`` first, the shape ``0006`` uses) so it is a no-op
+on the databases that already have it.
+
+If a deployed database somehow *does* hold a duplicate pair, the ``ADD
+CONSTRAINT`` fails and names the offending key rather than deduplicating
+silently: that data is a broken account whose correct resolution is a decision,
+not a migration's guess.
+
+Revision ID: 0007_oauth_provider_unique
+Revises: 0006_praxis_child_fk_cascade
+Create Date: 2026-08-14
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0007_oauth_provider_unique"
+down_revision: Union[str, None] = "0006_praxis_child_fk_cascade"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+#: Spelled out rather than derived: ``models/base.py``'s ``uq_`` convention
+#: produces this from the table and both columns, and a migration has to name
+#: the object it edits.
+_CONSTRAINT = "uq_oauth_provider_provider_provider_user_id"
+
+
+def upgrade() -> None:
+    op.execute(f"ALTER TABLE oauth_provider DROP CONSTRAINT IF EXISTS {_CONSTRAINT}")
+    op.create_unique_constraint(
+        _CONSTRAINT, "oauth_provider", ["provider", "provider_user_id"]
+    )
+
+
+def downgrade() -> None:
+    op.execute(f"ALTER TABLE oauth_provider DROP CONSTRAINT IF EXISTS {_CONSTRAINT}")

--- a/backend/models/account.py
+++ b/backend/models/account.py
@@ -1,7 +1,15 @@
 import enum
 from typing import TYPE_CHECKING, List
 
-from sqlalchemy import BigInteger, Boolean, Enum, ForeignKey, Identity, String
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    Enum,
+    ForeignKey,
+    Identity,
+    String,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from models.base import Base
@@ -24,6 +32,30 @@ class AccountStatus(enum.Enum):
 
     active = "active"
     suspended = "suspended"
+
+
+class AuthProvider(enum.StrEnum):
+    """The identity providers World Zero accepts, as written to ``OAuthProvider.provider``.
+
+    A ``StrEnum`` and **not** a Postgres enum on purpose. ADR-0041 promises that
+    adding a provider is "a new handler + a row — no schema change"; a DB-level
+    enum would make every future provider an ``ALTER TYPE`` migration and a
+    deploy-ordering problem. The column stays ``String`` and this is the
+    application-level constraint, which is where the rest of the domain values
+    in this codebase live too.
+
+    ``DISCORD`` has no handler yet (#1772). It is listed here because the enum
+    is the complete vocabulary of the column, not an inventory of what is wired
+    up — which is also why ``DEMO`` is here: ``scripts/seed_demo_praxes.py``
+    writes it for the demo roster, and those rows exist only so the seeded
+    characters have the Account every character needs. Nothing signs in through
+    it (the dev bypass mints ``DEV`` rows).
+    """
+
+    GOOGLE = "google"
+    DISCORD = "discord"
+    DEV = "dev"
+    DEMO = "demo"
 
 
 class Account(TimestampMixin, Base):
@@ -66,10 +98,22 @@ class Account(TimestampMixin, Base):
 class OAuthProvider(TimestampMixin, Base):
     __tablename__ = "oauth_provider"
 
+    # ``(provider, provider_user_id)`` is the pair every sign-in looks up, with
+    # ``scalar_one_or_none()`` (``services/auth.py``). Two rows for one pair —
+    # two concurrent first logins being the obvious route — would make that call
+    # raise ``MultipleResultsFound`` on every *subsequent* login for that
+    # account, permanently, with no self-service recovery. The constraint makes
+    # the race lose loudly at insert time instead, and turns the lookup into an
+    # index seek. Unique on the pair, not on ``provider_user_id`` alone: two
+    # providers may hand out the same opaque id.
+    __table_args__ = (UniqueConstraint("provider", "provider_user_id"),)
+
     id: Mapped[int] = mapped_column(BigInteger, Identity(), primary_key=True)
     account_id: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("account.id"), nullable=False
     )
+    # Values come from :class:`AuthProvider`; the column is a plain ``String``
+    # so a new provider stays "a handler + a row" (ADR-0041).
     provider: Mapped[str] = mapped_column(String, nullable=False)
     provider_user_id: Mapped[str] = mapped_column(String, nullable=False)
     # No `access_token` (#1374). The Google token was written once at sign-in

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -7,10 +7,9 @@ from fastapi.responses import RedirectResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
-from errors import ErrorCode, raise_coded
 from db import get_db
 from game_config import CURRENT_ERA
-from models.account import Account
+from models.account import Account, AuthProvider
 from schemas.auth import CurrentUser, DevLoginOut, LogoutOut
 from schemas.character import CharacterCreate
 from services.auth import create_jwt, create_or_get_account, get_current_account
@@ -79,29 +78,21 @@ async def auth_google_callback(
     token = await _OAUTH.google.authorize_access_token(request)
     user_info = token.get("userinfo") or await _OAUTH.google.userinfo(token=token)
 
-    # An unseen OAuth identity is attached to any EXISTING account holding the
-    # same email (`create_or_get_account`), which makes the email claim an
-    # authentication decision — so it has to be one the provider vouches for.
-    # Nothing checked `email_verified`, so any condition under which Google
-    # emits an address the bearer does not control (an unverified Workspace
-    # identity; a Workspace domain changing hands, letting a new admin mint
-    # `victim@thatdomain` with a fresh `sub`) linked a new provider row to the
-    # victim's account and minted a full session for it — their characters,
-    # their score — with no re-authentication and no notification.
-    if user_info.get("email_verified") is not True:
-        raise_coded(
-            403,
-            ErrorCode.oauth_email_unverified,
-            "Your Google account's email address is not verified.",
-        )
-
     # Google's access token is used here and then discarded (#1374): it proves
     # this sign-in, and nothing afterwards calls a Google API as the player. The
     # session that follows is World Zero's own JWT.
+    #
+    # `email_verified` is forwarded, not enforced here (#1771): it only matters
+    # on the branch that resolves an account *by email*, and the service owns
+    # that branch. Gating here would also have rejected a returning player whose
+    # provider says "unverified" while an address change is in flight — someone
+    # their `sub` already identifies. The claim is normalised to a real bool at
+    # the edge because a provider may answer with anything at all.
     account = await create_or_get_account(
-        provider="google",
+        provider=AuthProvider.GOOGLE,
         provider_user_id=user_info["sub"],
         email=user_info["email"],
+        email_verified=user_info.get("email_verified") is True,
         session=session,
     )
 
@@ -185,9 +176,12 @@ async def dev_login(
     email = "dev@localhost" if key == "1" else f"dev-{key}@localhost"
 
     account = await create_or_get_account(
-        provider="dev",
+        provider=AuthProvider.DEV,
         provider_user_id=provider_user_id,
         email=email,
+        # This seam mints its own `@localhost` addresses and is 404 outside
+        # development, so there is no provider to ask — the fact is asserted.
+        email_verified=True,
         session=session,
     )
 

--- a/backend/scripts/seed_demo_praxes.py
+++ b/backend/scripts/seed_demo_praxes.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from game_config import CURRENT_ERA, EraConfig
 from script_utils import get_settings
-from models.account import Account, OAuthProvider
+from models.account import Account, AuthProvider, OAuthProvider
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.duel import Duel, DuelStatus
@@ -190,7 +190,7 @@ async def get_or_create_metatask_owner(
         # `?key=meta` logs straight into this character.
         session.add(OAuthProvider(
             account_id=account.id,
-            provider="dev",
+            provider=AuthProvider.DEV,
             provider_user_id=f"dev-{METATASK_PLAYER_KEY}",
         ))
         existing = Character(
@@ -516,7 +516,7 @@ async def get_or_create_players(session) -> dict[str, Character]:
         await session.flush()
         session.add(OAuthProvider(
             account_id=account.id,
-            provider="demo",
+            provider=AuthProvider.DEMO,
             provider_user_id=username,
         ))
         character = Character(

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -29,7 +29,7 @@ from sqlalchemy import func, select
 from faction_slugs import CROSS_FACTION_SLUG, UNAFFILIATED_FACTION_SLUG
 from game_config import CURRENT_ERA
 from script_utils import add_env_argument, get_settings
-from models.account import Account, OAuthProvider
+from models.account import Account, AuthProvider, OAuthProvider
 from models.character import Character
 from models.character_stats import CharacterStats
 from models.era import Era
@@ -97,7 +97,7 @@ async def bootstrap_admin(session, era, pixie_acc) -> Character:
 
     session.add(OAuthProvider(
         account_id=pixie_acc.id,
-        provider="google",
+        provider=AuthProvider.GOOGLE,
         provider_user_id="google_pixie",
     ))
 
@@ -277,7 +277,7 @@ async def seed_dev_demo(session) -> None:
     """
     dev_oauth = (await session.execute(
         select(OAuthProvider).where(
-            OAuthProvider.provider == "dev",
+            OAuthProvider.provider == AuthProvider.DEV,
             OAuthProvider.provider_user_id == "dev-user-1",
         )
     )).scalar_one_or_none()
@@ -289,7 +289,7 @@ async def seed_dev_demo(session) -> None:
         await session.flush()
         session.add(OAuthProvider(
             account_id=dev_acc.id,
-            provider="dev",
+            provider=AuthProvider.DEV,
             provider_user_id="dev-user-1",
         ))
         molly = Character(

--- a/backend/services/auth.py
+++ b/backend/services/auth.py
@@ -9,7 +9,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import settings
 from db import get_db
-from models.account import Account, AccountStatus, OAuthProvider
+from errors import ErrorCode, raise_coded
+from models.account import Account, AccountStatus, AuthProvider, OAuthProvider
 
 _ALGORITHM = "HS256"
 _TOKEN_EXPIRE_DAYS = 7
@@ -73,12 +74,18 @@ async def get_current_account(
 
 
 async def create_or_get_account(
-    provider: str,
+    provider: AuthProvider,
     provider_user_id: str,
     email: str,
+    email_verified: bool,
     session: AsyncSession,
 ) -> Account:
     """Resolve an OAuth identity to an Account, minting one on first sight.
+
+    ``email_verified`` is the provider's claim that the bearer controls the
+    address, and it has **no default on purpose** (#1771): a boolean a caller
+    must supply is harder to forget than a check a new provider handler must
+    remember to write. It is enforced on the email branch only — see below.
 
     Deliberately takes no ``access_token`` (#1374): World Zero authenticates
     every request with its own JWT and never calls a provider API on the
@@ -95,10 +102,37 @@ async def create_or_get_account(
     oauth_row = result.scalar_one_or_none()
 
     if oauth_row:
+        # A returning player is identified by ``provider_user_id``; their email
+        # decides nothing here, so ``email_verified`` is deliberately not
+        # consulted. Any provider whose verified flag can go transiently false
+        # — changing a Discord email re-sends a verification mail — would
+        # otherwise 403 a player who has signed in fifty times (ADR-0075).
         result = await session.execute(
             select(Account).where(Account.id == oauth_row.account_id)
         )
         return result.scalar_one()
+
+    # Everything past here keys off the email claim, so the claim has to be one
+    # the provider vouches for. An unseen OAuth identity is attached to any
+    # EXISTING account holding the same email (below), which makes that claim an
+    # authentication decision: any condition under which a provider emits an
+    # address the bearer does not control (an unverified Google Workspace
+    # identity; a Workspace domain changing hands, letting a new admin mint
+    # `victim@thatdomain` with a fresh `sub`) would link a new provider row to
+    # the victim's account and mint a full session for it — their characters,
+    # their score — with no re-authentication and no notification. Minting is
+    # gated too, not just linking: an Account created under an unverified
+    # address is the same takeover one sign-in later, with the roles reversed.
+    #
+    # `is not True` rather than a falsy test: Google has emitted this claim as
+    # the *string* "true", and every other non-bool is equally a provider whose
+    # answer we did not understand.
+    if email_verified is not True:
+        raise_coded(
+            403,
+            ErrorCode.oauth_email_unverified,
+            "Your account's email address is not verified.",
+        )
 
     # No existing OAuth link — find or create the Account by email
     result = await session.execute(select(Account).where(Account.email == email))

--- a/backend/tests/integration/test_account_linking.py
+++ b/backend/tests/integration/test_account_linking.py
@@ -27,6 +27,7 @@ import pytest
 from fastapi import HTTPException
 from httpx import AsyncClient
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from errors import ErrorCode, detail_code
@@ -365,3 +366,40 @@ async def test_callback_admits_a_returning_identity_with_an_unverified_email(
     assert resp.cookies.get("access_token")
     assert await _account_count(db_session) == accounts_before
     assert len(await _provider_rows(db_session, _GOOGLE, "google-sub-returning")) == 1
+
+
+# ---------------------------------------------------------------------------
+# Case 8 - the pair every sign-in looks up cannot be duplicated (#1771)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_provider_pair_is_unique_in_the_database(
+    db_session: AsyncSession, account: Account, account2: Account
+):
+    """A second row for one pair is refused at insert, not discovered at login.
+
+    Without the constraint this insert succeeds and every case-1 lookup for that
+    identity raises ``MultipleResultsFound`` from then on - a permanently
+    unloggable account. Asserted against the database rather than the service
+    because the service is not what enforces it.
+    """
+    db_session.add(
+        OAuthProvider(
+            account_id=account.id,
+            provider=_GOOGLE,
+            provider_user_id="google-sub-dup",
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(
+        OAuthProvider(
+            account_id=account2.id,
+            provider=_GOOGLE,
+            provider_user_id="google-sub-dup",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()

--- a/backend/tests/integration/test_account_linking.py
+++ b/backend/tests/integration/test_account_linking.py
@@ -247,3 +247,54 @@ async def test_callback_rejects_an_unverified_email(
     assert detail_code(resp.json()["detail"]) == ErrorCode.oauth_email_unverified.value
     assert await _account_count(db_session) == accounts_before
     assert await _provider_rows(db_session, _GOOGLE, "google-sub-unverified") == []
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — the gate does not apply to a returning identity (#1771)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_callback_admits_a_returning_identity_with_an_unverified_email(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    account: Account,
+):
+    """A known provider pair signs in even while the provider says unverified.
+
+    The case-5 gate defends the *email-matching* branch; this player never
+    reaches it. Their ``provider_user_id`` already names their Account, so a
+    transient ``verified: false`` window at the provider (changing a Discord
+    email re-sends a verification mail) must not lock them out.
+    """
+    db_session.add(
+        OAuthProvider(
+            account_id=account.id,
+            provider=_GOOGLE,
+            provider_user_id="google-sub-returning",
+        )
+    )
+    await db_session.commit()
+    accounts_before = await _account_count(db_session)
+
+    from routers import auth as auth_router
+
+    monkeypatch.setattr(
+        auth_router._OAUTH,
+        "google",
+        _StubGoogleClient(
+            {
+                "sub": "google-sub-returning",
+                "email": account.email,
+                "email_verified": False,
+            }
+        ),
+    )
+
+    resp = await client.get("/auth/google/callback")
+
+    assert resp.status_code == 302
+    assert resp.cookies.get("access_token")
+    assert await _account_count(db_session) == accounts_before
+    assert len(await _provider_rows(db_session, _GOOGLE, "google-sub-returning")) == 1

--- a/backend/tests/integration/test_account_linking.py
+++ b/backend/tests/integration/test_account_linking.py
@@ -9,33 +9,34 @@ three rules that nothing else enforces:
    **without consulting email at all**;
 2. an unknown pair whose email matches an existing Account *links* to that
    Account rather than minting a second one;
-3. an unknown pair with an unknown email mints both rows.
+3. an unknown pair with an unknown email mints both rows;
+4. neither of those last two happens on an unverified email claim (#1771).
 
 Rule 1 is the load-bearing one: the email a provider asserts is only an
-authentication decision on the *linking* path, and any future gate on that claim
-(#1771) must not start rejecting returning players. These tests pin that down.
+authentication decision on the *linking* path, so rule 4's gate sits behind
+rule 1's early return and a returning player never meets it (ADR-0075).
 
 Tested at the service, not through authlib: the rules live in the service, and
 mocked OAuth transport would only put ceremony between the test and the
-assertions. The single route-level test at the bottom covers the one rule that
-does live in the router today — the ``email_verified`` gate.
-
-No behaviour change accompanies this file; it describes what the code already
-does, so that two queued changes to it have a baseline.
+assertions. The two route-level cases at the bottom stub the Google client to
+prove the callback forwards the claim rather than deciding on it — one that the
+gate still rejects an unverified newcomer end to end, one that it admits a
+returning identity the provider currently calls unverified.
 """
 import pytest
+from fastapi import HTTPException
 from httpx import AsyncClient
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from errors import ErrorCode, detail_code
-from models.account import Account, OAuthProvider
+from models.account import Account, AuthProvider, OAuthProvider
 from services.auth import create_or_get_account
 
-#: The two provider names in service today (``routers/auth.py``). Free-form
-#: strings on the model for now; #1771 replaces them with an enum.
-_GOOGLE = "google"
-_DEV = "dev"
+#: The two provider names the OAuth legs write (``routers/auth.py``). Values of
+#: the :class:`AuthProvider` enum since #1771; the column stays a plain string.
+_GOOGLE = AuthProvider.GOOGLE
+_DEV = AuthProvider.DEV
 
 
 async def _account_count(session: AsyncSession) -> int:
@@ -83,6 +84,7 @@ async def test_returning_identity_ignores_the_email_claim(
         provider=_GOOGLE,
         provider_user_id="google-sub-1",
         email=account2.email,
+        email_verified=True,
         session=db_session,
     )
 
@@ -108,6 +110,7 @@ async def test_new_identity_with_known_email_links_to_that_account(
         provider=_GOOGLE,
         provider_user_id="google-sub-new",
         email=account.email,
+        email_verified=True,
         session=db_session,
     )
 
@@ -134,6 +137,7 @@ async def test_unknown_identity_and_email_creates_account_and_link(
         provider=_GOOGLE,
         provider_user_id="google-sub-fresh",
         email="newcomer@example.com",
+        email_verified=True,
         session=db_session,
     )
 
@@ -167,12 +171,14 @@ async def test_two_providers_sharing_an_email_resolve_to_one_account(
         provider=_GOOGLE,
         provider_user_id="google-sub-2",
         email=account.email,
+        email_verified=True,
         session=db_session,
     )
     second = await create_or_get_account(
         provider=_DEV,
         provider_user_id="dev-sub-2",
         email=account.email,
+        email_verified=True,
         session=db_session,
     )
 
@@ -191,13 +197,74 @@ async def test_two_providers_sharing_an_email_resolve_to_one_account(
             provider=provider,
             provider_user_id=provider_user_id,
             email=account.email,
+            email_verified=True,
             session=db_session,
         )
         assert again.id == account.id
 
 
 # ---------------------------------------------------------------------------
-# Case 5 — the router's email_verified gate
+# Case 5 — the email branch refuses an unverified claim, both halves of it
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "email_verified",
+    [
+        pytest.param(False, id="explicitly-false"),
+        # A provider may answer with anything; only the boolean True is a yes.
+        pytest.param("true", id="stringy-true"),
+    ],
+)
+async def test_unverified_email_cannot_link_to_an_existing_account(
+    db_session: AsyncSession, account: Account, email_verified
+):
+    """The takeover the gate exists to stop: linking into someone else's Account."""
+    accounts_before = await _account_count(db_session)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await create_or_get_account(
+            provider=_GOOGLE,
+            provider_user_id="google-sub-attacker",
+            email=account.email,
+            email_verified=email_verified,
+            session=db_session,
+        )
+
+    assert excinfo.value.status_code == 403
+    assert detail_code(excinfo.value.detail) == ErrorCode.oauth_email_unverified.value
+    assert await _account_count(db_session) == accounts_before
+    assert await _provider_rows(db_session, _GOOGLE, "google-sub-attacker") == []
+
+
+@pytest.mark.asyncio
+async def test_unverified_email_cannot_mint_an_account_either(
+    db_session: AsyncSession,
+):
+    """Minting is gated too — it is the same takeover, one sign-in later.
+
+    An Account created under an address its holder never proved control of is
+    exactly what case 2 then links the real owner into.
+    """
+    accounts_before = await _account_count(db_session)
+
+    with pytest.raises(HTTPException) as excinfo:
+        await create_or_get_account(
+            provider=_GOOGLE,
+            provider_user_id="google-sub-squatter",
+            email="not-mine@example.com",
+            email_verified=False,
+            session=db_session,
+        )
+
+    assert excinfo.value.status_code == 403
+    assert await _account_count(db_session) == accounts_before
+    assert await _provider_rows(db_session, _GOOGLE, "google-sub-squatter") == []
+
+
+# ---------------------------------------------------------------------------
+# Case 6 — the callback forwards the claim, and the gate still bites end to end
 # ---------------------------------------------------------------------------
 
 
@@ -250,7 +317,7 @@ async def test_callback_rejects_an_unverified_email(
 
 
 # ---------------------------------------------------------------------------
-# Case 6 — the gate does not apply to a returning identity (#1771)
+# Case 7 — the gate does not apply to a returning identity (#1771)
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #1771
Closes #1758

Three changes to one file footprint: the verified-email gate moves onto the
branch it actually defends, `provider` stops being a bare string, and the pair
every sign-in looks up becomes unique.

Does **not** close #1757 — the JWT cookie's `httponly`/`samesite`/`secure` flags
and both router legs end to end are still uncovered. This PR stubs the Google
client for two callback cases but does not exercise the authlib transport.

## Migration

**New revision `0007_oauth_provider_unique`, `down_revision = "0006_praxis_child_fk_cascade"`.**

That was the single head on `main` at branch time. #1740 is authoring a
migration in parallel against the same head; whoever lands second has to
re-point. `alembic heads` on this branch prints exactly one head:

```
0007_oauth_provider_unique (head)
```

Applied against a scratch DB in both directions — `upgrade head` on a fresh
build (where `0002_squashed`'s `create_all` has already made the constraint, so
the revision is a no-op) and `downgrade -1` then `upgrade head` again (the
deployed-DB path, where the constraint genuinely gets added). `\d oauth_provider`
confirmed after each.

## The seam

`services.auth.create_or_get_account` — where an OAuth identity becomes an
Account, and the only place that knows whether this sign-in is a *recognition*
or a *link*. The characterization tests from #1768 already sat on it.

The failing test first, at the route level because that is where the defect is
observable: a returning identity whose provider currently says
`email_verified: false` gets a **403** today.
`test_callback_admits_a_returning_identity_with_an_unverified_email` went red on
exactly that (`403 != 302`) before any production code moved, then green after.

## 1. The gate

The check is now in the service, immediately after the returning-user early
return and immediately before the email lookup. The router forwards the claim
and decides nothing.

Placement is the whole point, so to be explicit about the two boundaries:

- **Above it** — the `(provider, provider_user_id)` hit. Never consults the
  claim. This is the fix.
- **Below it** — *both* halves of the email branch, the link **and** the mint.
  Gating only the link would let someone mint an Account under an address they
  never proved control of, which is the same takeover one sign-in later with the
  roles reversed — and it would have broken #1768's case 5, which asserts
  nothing is minted when the gate rejects. That test is unmodified and green.

Status and code unchanged (403 / `ErrorCode.oauth_email_unverified`), so the
existing frontend string still applies. The message lost the word "Google" —
the service serves every provider now.

The comment explaining *why* the gate exists moved with the check rather than
being deleted, and picked up the extra sentence about minting.

`email_verified` has **no default**. Every caller states the fact.

This agrees with ADR-0075 (#1786, merged into `main` while this was in flight —
I rebased onto it): *"The check belongs where an email is about to be treated as
proof of who someone is — nowhere earlier."*

## 2. `AuthProvider(StrEnum)`

In `models/account.py`, next to the column it constrains. Column stays `String`
— a Postgres enum would make every future provider a migration and break
ADR-0041's "a handler + a row".

**My own count of the literals, not the issue's: 6 sites, not the 3 the issue
listed.** `routers/auth.py` ×2 (the two `create_or_get_account` calls), `seed.py`
×3 (one write for the Google row, one write and one *read predicate* for the dev
row), `scripts/seed_demo_praxes.py` ×2. All swapped.

**The issue also missed a third provider value.** `scripts/seed_demo_praxes.py`
writes `provider="demo"` for the seeded demo roster — no login path reaches it
(the dev bypass writes `dev`), it exists only so seeded characters have the
Account every character needs. I added `DEMO` to the enum and documented why
rather than leaving one bare literal behind; say the word if you would rather it
were a seed-local constant.

`GOOGLE`, `DISCORD`, `DEV`, `DEMO`. `DISCORD` has no handler yet — #1772 adds it.

**One literal deliberately left:** `_OAUTH.register(name="google", ...)` in
`routers/auth.py`. That is authlib's client-registry key, read back as the
attribute `_OAUTH.google`, not a value that ever reaches the column. #1772's call
if they want it unified.

## 3. Uniqueness

`__table_args__ = (UniqueConstraint("provider", "provider_user_id"),)` →
`uq_oauth_provider_provider_provider_user_id` (from `models/base.py`'s naming
convention; name read out of the live metadata, not guessed).

The migration does **not** deduplicate if a deployed DB already holds a duplicate
pair — the `ADD CONSTRAINT` fails and names the offending key. Such a row is a
permanently-unloggable account, and which of the two links to keep is a decision,
not something a migration should guess.

## Tests

`backend/tests/integration/test_account_linking.py` — #1768's file, extended.
Cases 1–4 are untouched apart from the new required `email_verified=True`
argument, which is what makes them assert the verified path still behaves
identically. Case 5's route-level rejection (all three parametrisations,
including stringy-`"true"`) is unmodified and still green.

Added:

- **Case 5, service-level:** an unverified claim cannot link into an existing
  Account, and cannot mint a new one. Both assert *nothing was written*.
- **Case 6/7, route-level:** the callback still rejects an unverified newcomer
  end to end; and it admits a returning identity the provider currently calls
  unverified (the red test above).
- **Case 8:** a second row for one pair raises `IntegrityError` at flush.
  Asserted against the database, since the database is what enforces it.

```
pytest --cov=. --cov-report=term-missing --cov-fail-under=80
1226 passed, 1 warning in 126.24s — total coverage 93.43%
```

Run from `backend/` against a dedicated `wz1771_test` (another agent is on this
Postgres).

`api-schema`: no route signature, `response_model` or Pydantic schema changed. I
ran `backend/scripts/dump_openapi.py` anyway — `git status` clean, so
`backend/openapi.json` and the generated TS types are unaffected. The `frontend`
job's inputs are untouched: this diff is backend-only.

## Visual QA is outstanding

I have no browser and no dev stack. Nothing here renders — no component, no copy
key, no CSS — but the Google sign-in leg is a live path and the only real
end-to-end proof is a browser sign-in against a deployed build.

## What to eyeball

1. **The gate's lower boundary.** I put it in front of the mint as well as the
   link. ADR-0075's invariant says "never link on an unverified or absent
   email"; minting is not literally linking, but it creates the address a later
   link would trust. This also preserves #1768's case 5. If you read the ADR as
   permitting an unverified mint, this is the line to move.
2. **`DEMO` in the enum.** Extra scope over the issue's three values, taken so
   no bare literal survives. The docstring carries the justification.
3. **`down_revision = "0006_praxis_child_fk_cascade"`** — the coordination point
   with #1740. One head on this branch; whoever lands second re-points.
4. **The dev-login `email_verified=True`.** Asserted rather than obtained: that
   seam mints its own `@localhost` addresses and 404s outside development.
5. **The dropped word "Google"** in the 403 message. The code is unchanged so
   the frontend string is unaffected, but the fallback prose is now
   provider-neutral.
6. **The comment that moved.** It grew a sentence about minting; the original
   Workspace-takeover paragraph is otherwise intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
