### PR TITLE
Bind the composer to the room: CodeMirror 6 replaces the one textarea

### DIFF
--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -259,11 +259,14 @@ test.describe('collaboration UI (clicked buttons)', () => {
       //    Alice reloads so her roster reflects Bob's membership (her cast label
       //    depends on the live member count) before she casts.
       await aPage.goto(`/praxis/${praxisId}/edit`)
-      await aPage.locator('textarea').first().fill('Alice weaves her part')
+      // The body is a CodeMirror editor bound to the praxis room since #1742,
+      // not a textarea. Playwright fills a contenteditable, and auto-waits for
+      // it to become editable -- which is the room finishing its first sync.
+      await aPage.locator('.cm-content').first().fill('Alice weaves her part')
       await aPage.getByRole('button', { name: SNIDE_CAST }).click()
 
       await bPage.goto(`/praxis/${praxisId}/edit`)
-      await bPage.locator('textarea').first().fill('Bob weaves his part')
+      await bPage.locator('.cm-content').first().fill('Bob weaves his part')
       await bPage.getByRole('button', { name: SNIDE_CAST }).click()
 
       // The last cast seals consensus → the closing beat renders for Bob.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,9 @@
       "name": "worldzero-frontend",
       "version": "0.0.1",
       "dependencies": {
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.8",
         "i18next": "^26.3.6",
         "openapi-fetch": "^0.17.0",
         "react": "^18.3.1",
@@ -16,7 +19,10 @@
         "react-i18next": "^17.0.9",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.24.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "y-codemirror.next": "^0.3.5",
+        "y-websocket": "^3.1.0",
+        "yjs": "^13.6.32"
       },
       "devDependencies": {
         "@playwright/test": "^1.49.0",
@@ -339,6 +345,53 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
+      "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -954,6 +1007,36 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2370,6 +2453,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3290,6 +3379,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -3418,6 +3517,27 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lilconfig": {
@@ -5461,6 +5581,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -6118,6 +6244,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6161,6 +6293,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/y-codemirror.next": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/y-codemirror.next/-/y-codemirror.next-0.3.5.tgz",
+      "integrity": "sha512-VluNu3e5HfEXybnypnsGwKAj+fKLd4iAnR7JuX1Sfyydmn1jCBS5wwEL/uS04Ch2ib0DnMAOF6ZRR/8kK3wyGw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "yjs": "^13.5.6"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/y-websocket": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/y-websocket/-/y-websocket-3.1.0.tgz",
+      "integrity": "sha512-ZNzwH84Ysxv7zjpFNZHjTJvrBZgcAqMljTe+6zrWciAML9LQ18aVylyPNH9faxCXqEOV8I0JY4TGtrIHFX+Xwg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.102",
+        "y-protocols": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.5.6"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -6199,6 +6390,23 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.32",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.32.tgz",
+      "integrity": "sha512-lfiJIIC4Xayt5ItynE407ehlE03pCjeOc4hkR4yxxvvNJ4kuiN25B0g+Qp8XagYz361LLL7DCzR5bvFJ81QKtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,9 @@
     "e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.8",
     "i18next": "^26.3.6",
     "openapi-fetch": "^0.17.0",
     "react": "^18.3.1",
@@ -25,7 +28,10 @@
     "react-i18next": "^17.0.9",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.24.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "y-codemirror.next": "^0.3.5",
+    "y-websocket": "^3.1.0",
+    "yjs": "^13.6.32"
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -294,6 +294,7 @@
       "tabPreview": "Preview",
       "tabsAria": "Switch between write and preview",
       "bodyPlaceholder": "Say what you did and how it went.",
+    "bodyConnecting": "Opening the shared write-up…",
       "wordCount": "{{words}} words · markdown ok",
       "proofLabel": "Proof",
       "proofButton": "Drop a photo of the work\nor browse files",

--- a/frontend/src/pages/Attributions.tsx
+++ b/frontend/src/pages/Attributions.tsx
@@ -42,6 +42,27 @@ const attributions = [
     url: 'https://authlib.org',
     description: 'OAuth library used for Google authentication.',
   },
+  // The praxis room (ADR-0073). Versions and licences read off the installed
+  // packages, not off the issue that proposed them: yjs 13.6.32,
+  // y-websocket 3.1.0, y-codemirror.next 0.3.5, @codemirror/{state,view,
+  // commands} 6.x — all MIT, as are the transitive lib0, y-protocols and
+  // style-mod they bring. `pycrdt` is the server half.
+  {
+    name: 'Yjs',
+    url: 'https://yjs.dev',
+    description:
+      'CRDT library behind live co-editing of a praxis, with y-websocket and y-codemirror.next.',
+  },
+  {
+    name: 'CodeMirror',
+    url: 'https://codemirror.net',
+    description: 'Plain-text editor the praxis write-up is composed in.',
+  },
+  {
+    name: 'pycrdt',
+    url: 'https://github.com/y-crdt/pycrdt',
+    description: 'Python CRDT bindings holding the server side of a praxis room.',
+  },
 ]
 
 export default function Attributions() {

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -18,6 +18,8 @@ import { preloadArchetype } from "../factions/lazyArchetype";
 import {
   useEditPraxis,
 } from "./editPraxis/useEditPraxis";
+import { PraxisRoomProvider } from "./editPraxis/praxisRoom";
+import { isWaitingStage } from "./editPraxis/editPraxisPhase";
 import DefaultEditPraxis from "./editPraxis/archetypes/DefaultEditPraxis";
 import MetataskPicker from "../components/metataskSeal/MetataskPicker";
 import MetataskRemoveConfirm from "../components/metataskSeal/MetataskRemoveConfirm";
@@ -98,7 +100,25 @@ export default function EditPraxis() {
   return (
     <>
       <PageTitle title="Edit Praxis" />
-      <Archetype state={state} />
+      {/* Every praxis is written in a room (ADR-0073) — solo, collab and duel
+          part alike, so the composer has one authoring path and not two. Opened
+          here rather than inside an archetype because the title and the body
+          are two controls in one document, and both are the archetype's
+          children.
+
+          Only where there is authoring to do: the archetype draws the waiting
+          surface instead of its own regions once your part is filed (ADR-0059),
+          and a moderated praxis renders the composer locked. Neither mounts an
+          editor, and a socket per reader is a socket for nothing. */}
+      <PraxisRoomProvider
+        praxisId={
+          state.controlsLocked || isWaitingStage(state.phase)
+            ? null
+            : state.praxis.id
+        }
+      >
+        <Archetype state={state} />
+      </PraxisRoomProvider>
       {/* The cast that closes a collab's consensus gate earns a standalone beat
           rather than a silent redirect (#591). Rendered here, over whichever
           archetype is mounted, so it's one shared screen for every faction and

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -106,16 +106,14 @@ export default function EditPraxis() {
           are two controls in one document, and both are the archetype's
           children.
 
-          Only where there is authoring to do: the archetype draws the waiting
-          surface instead of its own regions once your part is filed (ADR-0059),
-          and a moderated praxis renders the composer locked. Neither mounts an
-          editor, and a socket per reader is a socket for nothing. */}
+          Wherever the composer's own regions are drawn, and only there: once
+          your part is filed the archetype draws the waiting surface instead
+          (ADR-0059), which has no title box and no write-up box, and a socket
+          opened for a surface with no editor on it is a socket for nothing.
+          A moderated praxis is NOT that case — it renders the composer locked,
+          write-up and all, and that box still has to have the text in it. */}
       <PraxisRoomProvider
-        praxisId={
-          state.controlsLocked || isWaitingStage(state.phase)
-            ? null
-            : state.praxis.id
-        }
+        praxisId={isWaitingStage(state.phase) ? null : state.praxis.id}
       >
         <Archetype state={state} />
       </PraxisRoomProvider>

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -843,7 +843,6 @@ export default function CovenEditPraxis({ state }: Props) {
               state={state}
               skin={{
                 id: "composer-body",
-                rows: 8,
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 textareaStyle: {
                   ...fieldBox,

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -478,7 +478,6 @@ export default function DefaultEditPraxis({ state }: Props) {
               state={state}
               skin={{
                 id: "composer-body",
-                rows: 8,
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 textareaStyle: {
                   ...fieldBox,

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -677,7 +677,6 @@ export default function EphemeristsEditPraxis({ state }: Props) {
               state={state}
               skin={{
                 id: "composer-body",
-                rows: 8,
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 textareaStyle: {
                   ...fieldBox,

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -660,7 +660,6 @@ export default function EverymenEditPraxis({ state }: Props) {
               state={state}
               skin={{
                 id: "composer-body",
-                rows: 9,
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 toolbarButtonStyle: {
                   background: PANEL,

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -639,7 +639,6 @@ export default function SingularityEditPraxis({ state }: Props) {
               state={state}
               skin={{
                 id: "composer-body",
-                rows: 10,
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 textareaStyle: {
                   ...fieldBox,

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -599,7 +599,6 @@ export default function SnideEditPraxis({ state }: Props) {
               state={state}
               skin={{
                 id: "composer-body",
-                rows: 8,
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 toolbarButtonStyle: {
                   background: FIELD,

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -503,7 +503,6 @@ export default function UaEditPraxis({ state }: Props) {
               state={state}
               skin={{
                 id: "composer-body",
-                rows: 8,
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 toolbarButtonStyle: {
                   fontFamily: UA_TEXT,

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -572,7 +572,6 @@ export default function WowEditPraxis({ state }: Props) {
               state={state}
               skin={{
                 id: "composer-body",
-                rows: 10,
                 placeholder: t("editPraxis.composer.bodyPlaceholder"),
                 toolbarButtonStyle: {
                   background: FIELD,

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodyToolbarTabOrder.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodyToolbarTabOrder.test.tsx
@@ -53,9 +53,24 @@ describe("body markdown toolbar", () => {
     expect(markup).toMatch(/role="toolbar"[^>]*aria-label="[^"]+"/);
   });
 
-  it("leaves the textarea itself tabbable", () => {
-    const textarea = html().match(/<textarea[^>]*>/)?.[0] ?? "";
-    expect(textarea, "textarea renders").not.toEqual("");
-    expect(textarea, "body must remain the next tab stop").not.toContain("tabindex");
+  /**
+   * #1742 replaced the `<textarea>` with a CodeMirror editor, which builds its
+   * own DOM into this host on mount. The tab stop is therefore CodeMirror's
+   * contenteditable — focusable by default and NOT observable here, because
+   * this harness runs the `node` environment with no DOM and no effects.
+   *
+   * What is still testable is the half of #693 that lives in this file's own
+   * markup: the toolbar draws before the body, and the body's host is really
+   * there for the editor to mount into. Asserting the tab stop itself needs a
+   * browser, and it belongs to the nightly Playwright suite.
+   */
+  it("draws the body's host after the toolbar, for the editor to mount into", () => {
+    const markup = html();
+    const host = markup.indexOf("data-composer-body");
+    expect(host, "the body's host renders").toBeGreaterThan(-1);
+    expect(
+      markup.indexOf('role="toolbar"'),
+      "the toolbar is drawn before the body",
+    ).toBeLessThan(host);
   });
 });

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodyToolbarTabOrder.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodyToolbarTabOrder.test.tsx
@@ -28,7 +28,7 @@ const state = {
 
 function html(): string {
   return renderToStaticMarkup(
-    <BodyTextarea state={state} skin={{ textareaStyle: {}, rows: 8 }} />,
+    <BodyTextarea state={state} skin={{ textareaStyle: {} }} />,
   );
 }
 

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
@@ -212,10 +212,16 @@ describe("the last two archetype seams of #1706", () => {
     const words = i18n.t("forms:editPraxis.composer.wordCount", { words: 4 });
     // The header row is the one holding the Write/Preview tablist. Both live
     // inside the section's `meta` span, so the count sits before the tablist
-    // and — the part that used to be false — before the textarea.
+    // and — the part that used to be false — before the body box.
+    //
+    // `data-composer-body` is that box since #1742: the body is a CodeMirror
+    // editor built into this host on mount, so there is no `<textarea>` left to
+    // name and nothing inside the host to see in a DOM-less render.
     expect(count(markup, words)).toBe(1);
     expect(markup.indexOf(words)).toBeLessThan(markup.indexOf('role="tablist"'));
-    expect(markup.indexOf(words)).toBeLessThan(markup.indexOf("<textarea"));
+    expect(markup.indexOf(words)).toBeLessThan(
+      markup.indexOf("data-composer-body"),
+    );
   });
 
   it("the drop target's label carries the design's second line", () => {

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/sharedComposerLayout.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/sharedComposerLayout.test.tsx
@@ -51,7 +51,7 @@ const TOOLBAR_ROSTER = [
 describe("markdown toolbar roster", () => {
   it("draws the design's seven commands, in order", () => {
     const markup = renderToStaticMarkup(
-      <BodyTextarea state={bodyState} skin={{ textareaStyle: {}, rows: 8 }} />,
+      <BodyTextarea state={bodyState} skin={{ textareaStyle: {} }} />,
     );
     // Buttons only — the toolbar element carries an aria-label of its own.
     const labels = [...markup.matchAll(/<button[^>]*aria-label="([^"]+)"/g)].map(

--- a/frontend/src/pages/editPraxis/archetypes/bodyEditorTheme.ts
+++ b/frontend/src/pages/editPraxis/archetypes/bodyEditorTheme.ts
@@ -1,0 +1,77 @@
+/**
+ * The eight `textareaStyle` skins, as a CodeMirror theme (#1742).
+ *
+ * ADR-0065 makes the composer one shared layout every faction dresses, so the
+ * body had exactly one element and eight style objects. Swapping the
+ * `<textarea>` for CodeMirror 6 keeps that count — and keeps the eight objects
+ * *themselves*, untouched, in the archetypes that already own them.
+ *
+ * The skin dresses the editor's host element exactly as it dressed the textarea
+ * — same ground, rule, radius, padding, min-height, ink and face — and the two
+ * rules below are the whole translation: CodeMirror's own chrome goes
+ * transparent and every inheritable property comes from the skin above it.
+ *
+ * Deliberately not eight transcribed theme literals. That would be eight copies
+ * of eight objects free to drift from the skins they were copied from, and
+ * eight fresh chances to inline a colour that today comes from a CSS variable
+ * through `factionCssVar()`. Dark mode arrives the way it always did: through
+ * the `[data-theme="dark"]` cascade on those variables, with nothing in this
+ * file to know about it.
+ */
+import { EditorView } from "@codemirror/view";
+import type { Extension } from "@codemirror/state";
+import type { CSSProperties } from "react";
+
+/**
+ * What the host must add to a skin's `textareaStyle` for the editor inside it
+ * to behave like the textarea it replaced.
+ *
+ * Spread BEFORE the skin, so a skin that ever wants its own value wins.
+ *
+ * - `display: flex` + the base theme's `flex: 1` make the editor fill a box the
+ *   skin gave a `min-height` to, so the empty half of a tall field is still
+ *   click-to-focus rather than dead space.
+ * - `overflow: hidden` is what makes `resize: vertical` — which all eight skins
+ *   set — do anything at all: CSS ignores `resize` on a `visible` box. The
+ *   editor's own scroller takes over inside it.
+ */
+export const BODY_EDITOR_HOST_STYLE: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  overflow: "hidden",
+};
+
+/**
+ * CodeMirror's code-editor defaults, undone.
+ *
+ * Every value here is structural or `inherit`; the one colour is
+ * `currentColor`, which resolves to the skin's own ink.
+ */
+export const BODY_EDITOR_BASE_THEME: Extension = EditorView.theme({
+  "&": {
+    // Fill the host, including the part of it the skin's min-height created.
+    flex: "1 1 auto",
+    minHeight: 0,
+    // The skin's box is drawn by the host; the editor is a pane inside it.
+    backgroundColor: "transparent",
+  },
+  // Every skin's `fieldBox` sets `outline: none`, and the base theme's dotted
+  // default sits on the editor rather than on the host, out of that reach.
+  "&.cm-focused": { outline: "none" },
+  ".cm-scroller": {
+    fontFamily: "inherit",
+    lineHeight: "inherit",
+    overflow: "auto",
+  },
+  ".cm-content": {
+    fontFamily: "inherit",
+    // The base theme pads the content and every line to clear a code editor's
+    // gutter. There is no gutter here, and the skin owns the padding.
+    padding: 0,
+    // `&light .cm-content` hardcodes a black caret, which is invisible on the
+    // dark fields half these skins draw. `currentColor` is the skin's ink.
+    caretColor: "currentColor",
+  },
+  ".cm-line": { padding: 0 },
+  ".cm-placeholder": { color: "var(--color-text-tertiary)" },
+});

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -881,10 +881,12 @@ export function BodyTextarea({
       view.destroy();
       viewRef.current = null;
     };
-    // Only the bound text may rebuild the editor. Everything else below
-    // reconfigures it in place — a rebuild would drop the caret and the undo
-    // history mid-sentence.
-  }, [ytext]);
+    // Only the bound text and the placeholder rebuild the editor. Everything
+    // else below reconfigures it in place — a rebuild would drop the caret and
+    // the undo history mid-sentence. The placeholder is a translated string, so
+    // it changes exactly once, on a language switch, where a rebuild costs
+    // nothing: the text itself lives in the room, not in the editor.
+  }, [ytext, skin.placeholder]);
 
   useEffect(() => {
     viewRef.current?.dispatch({

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -938,9 +938,16 @@ export function BodyTextarea({
     ...skin.toolbarButtonStyle,
   };
 
+  // The room exists but has not told us what the praxis says yet. The editor is
+  // read-only until it does (#1742), so the toolbar is a set of controls the
+  // player cannot use — hidden, not drawn disabled. It would not merely look
+  // wrong: `dispatch` writes past `editable`, so a press here would put markdown
+  // into a document still waiting for its seed.
+  const awaitingRoom = ytext !== null && !synced;
+
   return (
     <div>
-      {skin.hideToolbar ? null : (
+      {skin.hideToolbar || awaitingRoom ? null : (
       <div
         role="toolbar"
         aria-label={t("editPraxis.toolbar.label")}
@@ -982,8 +989,11 @@ export function BodyTextarea({
         className="content-text"
         style={{ ...BODY_EDITOR_HOST_STYLE, ...skin.textareaStyle }}
       />
-      {ytext !== null && !synced && (
-        <p className="label-caption" style={{ color: "var(--color-text-tertiary)" }}>
+      {awaitingRoom && (
+        <p
+          className="label-caption"
+          style={{ color: "var(--color-text-tertiary)" }}
+        >
           {t("editPraxis.composer.bodyConnecting")}
         </p>
       )}

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -4,15 +4,24 @@
  * (paperclips, customs stamps, sticky notes); these are the inner essentials
  * that must always render: file picker, member chips, search dropdown.
  */
-import { useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { Compartment } from "@codemirror/state";
+import { EditorView, keymap, placeholder as cmPlaceholder } from "@codemirror/view";
+import { defaultKeymap } from "@codemirror/commands";
+import { yCollab, yUndoManagerKeymap } from "y-codemirror.next";
 import { factionCssVar, factionName } from "../../../utils/factions";
 import type { PraxisType } from "../../../api/praxis";
 import type { DuelSideOut } from "../../../api/duel";
 import MarkdownPreview from "../blocks/MarkdownPreview";
-import { applyMarkdown } from "../blocks/markdownToolbar";
+import { applyMarkdown, minimalReplacement } from "../blocks/markdownToolbar";
 import type { MarkdownCommand } from "../blocks/markdownToolbar";
+import { usePraxisRoom, ROOM_TITLE_KEY } from "../praxisRoom";
+import {
+  BODY_EDITOR_BASE_THEME,
+  BODY_EDITOR_HOST_STYLE,
+} from "./bodyEditorTheme";
 import type { EditPraxisState } from "../useEditPraxis";
 import { duelSides } from "../../../components/duel/shared";
 import { CollabRoster, deriveCollabGate } from "../../../components/collab/CollabRoster";
@@ -655,6 +664,17 @@ export interface TitleFieldSkin {
   ariaLabel?: string;
 }
 
+/**
+ * How long a title sits still before it is published to the room (#1742).
+ *
+ * The title is one **last-write-wins** map key, not co-edited text: 200
+ * characters interleaved character-by-character between two people produces
+ * garbage more often than it helps (ADR-0073). Publishing on a debounce and on
+ * blur, rather than on every keystroke, is what keeps a co-author's typing from
+ * arriving inside yours.
+ */
+const TITLE_PUBLISH_DEBOUNCE_MS = 600;
+
 export function TitleField({
   state,
   skin,
@@ -662,18 +682,75 @@ export function TitleField({
   state: EditPraxisState;
   skin: TitleFieldSkin;
 }) {
+  const room = usePraxisRoom();
+  const meta = room?.meta ?? null;
+  const inputRef = useRef<HTMLInputElement>(null);
+  const publishTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Read through refs so the observer below can be installed once per room
+  // rather than re-subscribed on every keystroke.
+  const setTitleRef = useRef(state.setTitle);
+  setTitleRef.current = state.setTitle;
+  const titleRef = useRef(state.title);
+  titleRef.current = state.title;
+
+  const publish = (value: string) => {
+    if (publishTimerRef.current) clearTimeout(publishTimerRef.current);
+    publishTimerRef.current = null;
+    // The key may not exist yet — nothing seeds it server-side — so this is
+    // also what creates it. Writing the same value again would still broadcast.
+    if (meta && meta.get(ROOM_TITLE_KEY) !== value) meta.set(ROOM_TITLE_KEY, value);
+  };
+
+  // Remote title → the box.
+  useEffect(() => {
+    if (!meta) return;
+    const apply = () => {
+      const remote = meta.get(ROOM_TITLE_KEY);
+      // ABSENT is "no remote value yet", never "remote cleared the title":
+      // #1740 seeds only `body`, so the key arrives with the first co-author to
+      // edit a title and not before.
+      if (remote === undefined || remote === titleRef.current) return;
+      // Never while the player is in the field. Last-write-wins is fine between
+      // edits and unbearable during one.
+      if (inputRef.current !== null && document.activeElement === inputRef.current) {
+        return;
+      }
+      setTitleRef.current(remote);
+    };
+    meta.observe(apply);
+    apply();
+    return () => meta.unobserve(apply);
+  }, [meta]);
+
+  useEffect(
+    () => () => {
+      if (publishTimerRef.current) clearTimeout(publishTimerRef.current);
+    },
+    [],
+  );
+
   return (
     // The role class owns the type size; the skin keeps font/colour/ornament
     // only (§4a). Inline style wins over class, so the size lands as soon as the
     // skin stops setting fontSize.
     <input
+      ref={inputRef}
       type="text"
       maxLength={200}
       id={skin.id}
       aria-label={skin.ariaLabel}
       className="content-text"
       value={state.title}
-      onChange={(event) => state.setTitle(event.target.value)}
+      onChange={(event) => {
+        const next = event.target.value;
+        state.setTitle(next);
+        if (publishTimerRef.current) clearTimeout(publishTimerRef.current);
+        publishTimerRef.current = setTimeout(
+          () => publish(next),
+          TITLE_PUBLISH_DEBOUNCE_MS,
+        );
+      }}
+      onBlur={(event) => publish(event.target.value)}
       placeholder={skin.placeholder}
       style={skin.inputStyle}
     />
@@ -687,8 +764,13 @@ export function TitleField({
 /* binding.                                                                    */
 /* -------------------------------------------------------------------------- */
 export interface BodyTextareaSkin {
+  /**
+   * The body's box. Dresses the editor's host (#1742) exactly as it dressed the
+   * `<textarea>` before it — ground, rule, radius, padding, min-height, ink,
+   * face — and everything inheritable reaches CodeMirror's own DOM from there.
+   * See `bodyEditorTheme.ts` for the two rules that make that true.
+   */
   textareaStyle: CSSProperties;
-  rows?: number;
   placeholder?: string;
   /** Optional override for the toolbar wrapper (e.g. archetype spacing). */
   toolbarStyle?: CSSProperties;
@@ -751,22 +833,96 @@ export function BodyTextarea({
   skin: BodyTextareaSkin;
 }) {
   const { t } = useTranslation("forms");
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const room = usePraxisRoom();
+  const ytext = room?.body ?? null;
+  const synced = room?.synced ?? false;
+  const hostRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  // Stable across the editor's life; reconfigured rather than remounted.
+  const editableSlot = useRef(new Compartment()).current;
+  const setBodyRef = useRef(state.setBody);
+  setBodyRef.current = state.setBody;
+
+  const contentAttributes = useMemo(() => {
+    const attributes: Record<string, string> = {};
+    // `<label for>` does nothing for a contenteditable div, so the section's
+    // label reaches the editor as `aria-labelledby` instead (ComposerSection
+    // gives that label its id).
+    if (skin.id) attributes["aria-labelledby"] = `${skin.id}-label`;
+    if (skin.ariaLabel) attributes["aria-label"] = skin.ariaLabel;
+    return attributes;
+  }, [skin.id, skin.ariaLabel]);
+
+  // ---- The editor, bound to the ROOM's text (never seeded from here) ----
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host || !ytext) return;
+    const view = new EditorView({
+      // The room's current text, which is empty until the server's seed lands.
+      // Deliberately not `state.body`: a client that writes the praxis body
+      // into the document ends up merging a second copy of it (ADR-0073).
+      doc: ytext.toString(),
+      parent: host,
+      extensions: [
+        // Prose, not code: wrap long lines the way the textarea did.
+        EditorView.lineWrapping,
+        keymap.of([...yUndoManagerKeymap, ...defaultKeymap]),
+        cmPlaceholder(skin.placeholder ?? ""),
+        BODY_EDITOR_BASE_THEME,
+        editableSlot.of(EditorView.editable.of(synced)),
+        EditorView.contentAttributes.of(contentAttributes),
+        // `null` awareness: carets and collaborator colours are #1744, and
+        // passing it here is what would draw them.
+        yCollab(ytext, null),
+      ],
+    });
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // Only the bound text may rebuild the editor. Everything else below
+    // reconfigures it in place — a rebuild would drop the caret and the undo
+    // history mid-sentence.
+  }, [ytext]);
+
+  useEffect(() => {
+    viewRef.current?.dispatch({
+      effects: editableSlot.reconfigure(EditorView.editable.of(synced)),
+    });
+  }, [synced, editableSlot]);
+
+  // ---- The room's text → `state.body` ----
+  //
+  // One direction only. `state.body` still feeds `BodyPreview`, the word count
+  // and the debounced `PUT` (#1743 retires that last one), so it has to follow
+  // the document — but nothing may push it back the other way, or the praxis
+  // would seed the room it is supposed to be seeded BY.
+  useEffect(() => {
+    if (!ytext) return;
+    const mirror = () => setBodyRef.current(ytext.toString());
+    ytext.observe(mirror);
+    return () => ytext.unobserve(mirror);
+  }, [ytext]);
 
   const runCommand = (command: MarkdownCommand) => {
-    const el = textareaRef.current;
-    if (!el) return;
+    const view = viewRef.current;
+    if (!view) return;
+    const text = view.state.doc.toString();
+    const selection = view.state.selection.main;
     const result = applyMarkdown(command, {
-      text: state.body,
-      selectionStart: el.selectionStart,
-      selectionEnd: el.selectionEnd,
+      text,
+      selectionStart: selection.from,
+      selectionEnd: selection.to,
     });
-    state.setBody(result.text);
-    // Restore the caret/selection after React commits the new value.
-    requestAnimationFrame(() => {
-      el.focus();
-      el.setSelectionRange(result.selectionStart, result.selectionEnd);
+    // The narrowest edit that gets there, not a whole-document replacement: in
+    // a CRDT the latter deletes every character a co-author is standing on and
+    // leaves the deletions behind as tombstones.
+    view.dispatch({
+      changes: minimalReplacement(text, result.text),
+      selection: { anchor: result.selectionStart, head: result.selectionEnd },
     });
+    view.focus();
   };
 
   const buttonStyle: CSSProperties = {
@@ -815,18 +971,22 @@ export function BodyTextarea({
         ))}
       </div>
       )}
-      {/* Role class owns the size; the skin gives up only fontSize (§4a). */}
-      <textarea
-        ref={textareaRef}
+      {/* The editor's host. CodeMirror builds its own DOM inside this on mount,
+          which is why the box is empty in a server render — and why the binding
+          itself is not observable in this DOM-less harness (#1742).
+          Role class owns the size; the skin gives up only fontSize (§4a). */}
+      <div
+        ref={hostRef}
         id={skin.id}
-        aria-label={skin.ariaLabel}
+        data-composer-body
         className="content-text"
-        value={state.body}
-        onChange={(event) => state.setBody(event.target.value)}
-        rows={skin.rows}
-        placeholder={skin.placeholder}
-        style={skin.textareaStyle}
+        style={{ ...BODY_EDITOR_HOST_STYLE, ...skin.textareaStyle }}
       />
+      {ytext !== null && !synced && (
+        <p className="label-caption" style={{ color: "var(--color-text-tertiary)" }}>
+          {t("editPraxis.composer.bodyConnecting")}
+        </p>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/editPraxis/archetypes/shared.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/shared.tsx
@@ -592,7 +592,11 @@ export function ComposerSection({
           }}
         >
           {htmlFor ? (
-            <label htmlFor={htmlFor} style={heading}>
+            // The id is what a control that is NOT a labelable element reaches
+            // for: since #1742 the body is a CodeMirror editor, and `for` does
+            // nothing for a contenteditable div — it names itself with
+            // `aria-labelledby="<htmlFor>-label"` instead.
+            <label id={`${htmlFor}-label`} htmlFor={htmlFor} style={heading}>
               {label}
             </label>
           ) : (

--- a/frontend/src/pages/editPraxis/blocks/__tests__/minimalReplacement.test.ts
+++ b/frontend/src/pages/editPraxis/blocks/__tests__/minimalReplacement.test.ts
@@ -1,0 +1,103 @@
+/**
+ * THE SEAM: what a toolbar press sends to a shared document (#1742).
+ *
+ * The composer's body is a CRDT now, so the toolbar can no longer hand it a
+ * whole new string the way it handed one to a `<textarea>`. It has to send the
+ * change itself, and how narrow that change is IS the correctness: a
+ * whole-document replacement deletes every character a co-author is standing on
+ * and leaves the deletions behind as tombstones forever.
+ *
+ * The binding that carries these edits cannot be tested here — the harness runs
+ * the `node` environment with no DOM, so `EditorView` never mounts and effects
+ * never run. This is the part of the change that is pure, and it is the part
+ * that decides what reaches the other end of the socket.
+ */
+import { describe, it, expect } from "vitest";
+import { applyMarkdown, minimalReplacement } from "../markdownToolbar";
+
+/** Apply the edit the way CodeMirror's `dispatch` would, to prove it lands. */
+function applyReplacement(
+  before: string,
+  edit: { from: number; to: number; insert: string },
+): string {
+  return before.slice(0, edit.from) + edit.insert + before.slice(edit.to);
+}
+
+describe("minimalReplacement", () => {
+  it("sends nothing when nothing changed", () => {
+    expect(minimalReplacement("same text", "same text")).toEqual({
+      from: 9,
+      to: 9,
+      insert: "",
+    });
+  });
+
+  it("touches only the wrapped word for a bold press mid-document", () => {
+    const before = "the quick fox jumped over the lazy dog";
+    const after = applyMarkdown("bold", {
+      text: before,
+      selectionStart: 4,
+      selectionEnd: 9,
+    }).text;
+
+    const edit = minimalReplacement(before, after);
+
+    expect(applyReplacement(before, edit)).toBe(after);
+    // The whole-document replacement this replaces would be `from: 0`,
+    // `to: 38` — every character in the praxis, deleted and retyped. This
+    // reaches only the wrapped word and its new markers.
+    expect(edit.from).toBe(4);
+    expect(edit.to).toBe(9);
+    expect(edit.insert).toBe("**quick**");
+    expect(edit.to - edit.from).toBeLessThan(before.length);
+  });
+
+  it("reaches the same text as a whole-document replacement, every command", () => {
+    const before = "## What I did\n\nCaught the papers.\nTwice.";
+    const commands = [
+      "bold",
+      "italic",
+      "heading",
+      "blockquote",
+      "unorderedList",
+      "orderedList",
+      "link",
+    ] as const;
+    for (const command of commands) {
+      const after = applyMarkdown(command, {
+        text: before,
+        selectionStart: 15,
+        selectionEnd: 21,
+      }).text;
+      expect(
+        applyReplacement(before, minimalReplacement(before, after)),
+        `${command} must land the same text`,
+      ).toBe(after);
+    }
+  });
+
+  it("handles an insertion at the very start and at the very end", () => {
+    expect(applyReplacement("body", minimalReplacement("body", "> body"))).toBe(
+      "> body",
+    );
+    expect(applyReplacement("body", minimalReplacement("body", "body!"))).toBe(
+      "body!",
+    );
+  });
+
+  it("handles a deletion, including emptying the document", () => {
+    expect(
+      applyReplacement("- item", minimalReplacement("- item", "item")),
+    ).toBe("item");
+    const emptied = minimalReplacement("gone", "");
+    expect(emptied).toEqual({ from: 0, to: 4, insert: "" });
+  });
+
+  it("never overlaps prefix and suffix on a repeating string", () => {
+    // "aaaa" → "aaaaa" shares its whole length with itself at both ends; a
+    // naive prefix+suffix scan would return a negative-length range.
+    const edit = minimalReplacement("aaaa", "aaaaa");
+    expect(edit.to).toBeGreaterThanOrEqual(edit.from);
+    expect(applyReplacement("aaaa", edit)).toBe("aaaaa");
+  });
+});

--- a/frontend/src/pages/editPraxis/blocks/markdownToolbar.ts
+++ b/frontend/src/pages/editPraxis/blocks/markdownToolbar.ts
@@ -184,3 +184,48 @@ export function applyMarkdown(
     }
   }
 }
+
+/** A single-range document edit, in the shape CodeMirror's `dispatch` takes. */
+export interface TextReplacement {
+  from: number;
+  to: number;
+  insert: string;
+}
+
+/**
+ * The narrowest edit that turns `before` into `after` (#1742).
+ *
+ * `applyMarkdown` returns a whole new document, which was the only thing a
+ * `<textarea>` could be handed. A CodeMirror document bound to a CRDT is not:
+ * replacing all of it deletes every character a co-author is standing on —
+ * their caret jumps, their concurrent insert lands beside a corpse, and the
+ * deletions stay in the document forever as tombstones. A toolbar press changes
+ * a few characters, so this sends a few characters.
+ *
+ * ponytail: common prefix and common suffix, so ONE range. A wrap (`**word**`)
+ * therefore re-sends the wrapped word between the two markers it really added.
+ * That is a few characters instead of the whole praxis, and it is what a single
+ * `changes` spec can say. The ceiling is a co-author standing inside the wrapped
+ * word itself; the upgrade path is a real diff emitting the two insertions as
+ * separate ranges, which CodeMirror's `changes` already accepts as an array.
+ */
+export function minimalReplacement(
+  before: string,
+  after: string,
+): TextReplacement {
+  const shorter = Math.min(before.length, after.length);
+  let start = 0;
+  while (start < shorter && before[start] === after[start]) start += 1;
+  let end = 0;
+  while (
+    end < shorter - start &&
+    before[before.length - 1 - end] === after[after.length - 1 - end]
+  ) {
+    end += 1;
+  }
+  return {
+    from: start,
+    to: before.length - end,
+    insert: after.slice(start, after.length - end),
+  };
+}

--- a/frontend/src/pages/editPraxis/praxisRoom.tsx
+++ b/frontend/src/pages/editPraxis/praxisRoom.tsx
@@ -1,0 +1,175 @@
+/**
+ * The praxis room, client side (ADR-0073, #1742).
+ *
+ * A **room** is the live editing space for one praxis. The server holds the
+ * CRDT document (`backend/services/praxis_room.py`, #1740); this opens one
+ * WebSocket onto it and hands the two shared types to the composer's controls.
+ *
+ * ## The one rule
+ *
+ * **The server seeds the document. This file never does.** `getText` below
+ * *reads* a root type into existence locally; it never inserts. Two clients
+ * that each build a document out of the same `body_text` and then merge end up
+ * with **two copies of that text** — the standard Yjs duplication footgun, and
+ * the reason `_load_or_seed` is server-side and holds a lock. So an empty
+ * `body` here means either "the praxis really is empty" or "the seed has not
+ * arrived yet", and in neither case may we write `state.body` into it.
+ *
+ * The composer's read-only-until-synced gate (`controls.tsx`) is the visible
+ * half of that rule: nobody can type into a document that has not told us what
+ * it contains, so nothing can be typed *in front of* the seed and nothing can
+ * be flushed over the praxis on the strength of an empty editor.
+ *
+ * ## What is deliberately not here
+ *
+ * Carets, collaborator colours and the presence roster (#1744) — the provider's
+ * own awareness channel exists (it is y-websocket's keep-alive) but nothing
+ * reads it yet. Freeze-on-pending (#1745). Offline persistence and the retiring
+ * of the debounced `PUT` (#1743): until then the room is a *live view*, and
+ * `useComposerDraft`'s `PUT` is still the only thing that writes the record.
+ */
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import * as Y from "yjs";
+import { WebsocketProvider } from "y-websocket";
+
+/**
+ * The body's root key — `ROOM_BODY_KEY` in `praxis_room.py`. The server seeds a
+ * `Text` under exactly this name, so a mismatch is not an error, it is a second
+ * empty document sitting silently beside the real one.
+ */
+const ROOM_BODY_KEY = "body";
+
+/**
+ * The title's last-write-wins map, and its one key.
+ *
+ * Nothing seeds these server-side (#1740 seeds `body` alone), so the key does
+ * not exist until a co-author edits the title. **Absent means "no remote value
+ * yet", never "remote cleared the title"** — see `TitleField`.
+ */
+const ROOM_META_KEY = "meta";
+export const ROOM_TITLE_KEY = "title";
+
+/**
+ * RFC 6455 "policy violation" — what the room sends when door one refuses a
+ * handshake or door two revokes a kicked member (`_WS_POLICY_VIOLATION`).
+ * y-websocket reconnects with backoff for every code outside 4400-4499, which
+ * for a refusal is an infinite retry of a request that will never be granted.
+ */
+const WS_POLICY_VIOLATION = 1008;
+
+/** The room mount in `main.py`: `app.mount("/rooms", PRAXIS_ROOM_APP)`. */
+const ROOM_PATH = "/rooms/praxis";
+
+/**
+ * The socket origin, derived from the one base URL `api/client.ts` uses.
+ *
+ * No ticket and no token in the URL: the handshake carries the existing
+ * httpOnly `access_token` cookie, which the browser attaches because the API is
+ * same-site with the app (ADR-0073). Nothing here can read that cookie, and
+ * nothing here should try.
+ */
+function roomServerUrl(): string {
+  const apiBase = import.meta.env.VITE_API_URL ?? "http://localhost:8000";
+  return `${apiBase.replace(/^http/, "ws")}${ROOM_PATH}`;
+}
+
+export interface PraxisRoom {
+  /** The co-edited markdown body. Bound to CodeMirror by `BodyTextarea`. */
+  body: Y.Text;
+  /** The last-write-wins map holding {@link ROOM_TITLE_KEY}. */
+  meta: Y.Map<string>;
+  /**
+   * The server's document has arrived at least once.
+   *
+   * Until it has, the editor shows an empty document that means nothing, so the
+   * composer holds the body read-only. It goes back to `false` on disconnect.
+   */
+  synced: boolean;
+}
+
+const PraxisRoomContext = createContext<PraxisRoom | null>(null);
+
+/**
+ * The room this composer is writing in, or `null` where there is none — an
+ * archetype rendered outside the page (the design-sync preview kit, a static
+ * test) gets `null` and draws an editor bound to nothing rather than throwing.
+ */
+export function usePraxisRoom(): PraxisRoom | null {
+  return useContext(PraxisRoomContext);
+}
+
+/**
+ * Open a room for `praxisId` for as long as this subtree is mounted.
+ *
+ * `praxisId` of `null` opens nothing, which is how the page keeps its hooks
+ * unconditional while the praxis is still loading.
+ */
+export function PraxisRoomProvider({
+  praxisId,
+  children,
+}: {
+  praxisId: number | null;
+  children: ReactNode;
+}) {
+  // The shared types, kept apart from `synced` so their identity survives a
+  // sync flip — `BodyTextarea` keys its editor on `body`, and a new identity
+  // there would tear the editor down and rebuild it the moment the seed lands.
+  const [types, setTypes] = useState<{ body: Y.Text; meta: Y.Map<string> } | null>(
+    null,
+  );
+  const [synced, setSynced] = useState(false);
+
+  useEffect(() => {
+    if (praxisId == null) {
+      setTypes(null);
+      setSynced(false);
+      return;
+    }
+    const doc = new Y.Doc();
+    // Read the root types into existence. NEVER insert into them: the server
+    // seeded `body` already, and a second seed merges as a second copy.
+    const body = doc.getText(ROOM_BODY_KEY);
+    const meta = doc.getMap<string>(ROOM_META_KEY);
+    const provider = new WebsocketProvider(
+      roomServerUrl(),
+      String(praxisId),
+      doc,
+      {
+        // A refusal is not a hiccup. Door one turns away a non-member and door
+        // two closes on a kicked one; both are permanent for this praxis, and
+        // retrying either forever is a socket storm that changes no answer.
+        shouldReconnect: (event) => event.code !== WS_POLICY_VIOLATION,
+      },
+    );
+    setTypes({ body, meta });
+    setSynced(provider.synced);
+    const onSync = (isSynced: boolean) => setSynced(isSynced);
+    provider.on("sync", onSync);
+
+    return () => {
+      provider.off("sync", onSync);
+      provider.destroy();
+      doc.destroy();
+      setTypes(null);
+      setSynced(false);
+    };
+  }, [praxisId]);
+
+  const room = useMemo<PraxisRoom | null>(
+    () => (types === null ? null : { ...types, synced }),
+    [types, synced],
+  );
+
+  return (
+    <PraxisRoomContext.Provider value={room}>
+      {children}
+    </PraxisRoomContext.Provider>
+  );
+}


### PR DESCRIPTION
Closes #1742

The composer's `<textarea>` becomes a CodeMirror 6 editor bound to the praxis room #1740 stood up, and the title becomes one last-write-wins map key. `body_text` stays markdown, so `BodyPreview`, the #1181 toolbar, `react-markdown` and every read surface are untouched.

The debounced `PUT` is still the only thing that writes the record; it is retired in #1743. Presence and carets (#1744) and freeze-on-pending (#1745) are not here.

## The seam, and where the test is

**The seam under test is what a toolbar press sends to a shared document.** `applyMarkdown` returns a whole new string — the only thing a textarea could be handed, and the worst thing a CRDT can be handed: replacing the document deletes every character a co-author is standing on and leaves the deletions behind as tombstones forever. `minimalReplacement` (`blocks/markdownToolbar.ts`) narrows it to one range, and `blocks/__tests__/minimalReplacement.test.ts` pins that: it went red on the real defect (a bold press mid-praxis reaching `from: 0, to: 38`) before it went green at `from: 4, to: 9`.

**The binding itself has no seam in this harness and I did not invent one.** `vite.config.ts` runs the `node` environment with no DOM, so `EditorView` never mounts and effects never run. Per the issue I did *not* add jsdom. The eight archetypes' static-render suites all still pass unchanged; the two tests that named the `<textarea>` by hand now name the host the editor mounts into.

## The one rule

**The server seeds the document. This client never does.** `praxisRoom.tsx` calls `getText`, which reads the root type into existence, and nothing anywhere inserts into it. Two clients each building a document out of the same `body_text` merge into two copies of it — the standard Yjs footgun, and the reason `_load_or_seed` is server-side under a lock. The backend test asserting a joining client does not duplicate the seed is not defeated from this side.

The visible half of that rule: **the editor is read-only until the room has synced**, and the toolbar is hidden with it. That closes a data-loss path that would otherwise be real today — an unsynced editor is empty, and typing one character into it would mirror `state.body` down to that character and let the still-live `PUT` flush it over the praxis.

## Compatibility, checked first

`pycrdt-websocket` 0.16.4 and `y-websocket` 3.1.0 speak the same wire protocol. Verified by reading both, not by assuming: `pycrdt/_sync.py` defines `SYNC = 0` / `AWARENESS = 1` and `SYNC_STEP1/2/UPDATE = 0/1/2`, byte-identical framing to `y-websocket`'s `messageSync`/`messageAwareness` and `y-protocols`' sync steps. `y-websocket` also sends `messageQueryAwareness = 3`, which `yroom.py` falls through without raising, so it is ignored rather than fatal.

A refusal is not a hiccup: the provider passes `shouldReconnect` so a `1008` close — door one turning away a non-member, door two closing on a kicked one — stops the retry loop instead of storming the socket forever.

## Eight skins, one theme

ADR-0065 already made the composer one shared layout, so this is one component and one theme, not eight rewrites. **The eight `textareaStyle` objects are untouched in the archetypes that own them** — each dresses the editor's host exactly as it dressed the textarea, and `bodyEditorTheme.ts` is two rules making CodeMirror's own chrome transparent and inherit from it.

Deliberately *not* eight transcribed theme literals: that would be eight copies free to drift from the skins they were copied from, and eight fresh chances to inline a colour that today comes from a CSS variable through `factionCssVar()`. **No hex is added by this PR.** Dark mode arrives the way it always did, through the `[data-theme="dark"]` cascade on those variables, with nothing in the new files knowing about it. The one colour written anywhere is `currentColor`, replacing CodeMirror's hardcoded black caret, which is invisible on the dark fields half these skins draw.

`rows` is deleted from the skin rather than left inert: all eight set `min-height` explicitly and CodeMirror sizes from that.

## Title as last-write-wins

Published on blur and on a 600ms debounce, and a remote value is never applied while the field has focus — so a co-author's keystroke cannot arrive inside yours. **No title key is seeded server-side**, so an absent key reads as "no remote value yet" and never as "remote cleared the title"; the key comes into existence the first time somebody edits a title.

## Two things that grew out of the change

- `<label for>` does nothing for a contenteditable div, so `ComposerSection`'s label gained an id and the editor names itself with `aria-labelledby`. Without this the body would have lost its accessible name outright.
- The room opens for a **locked** (moderated) composer too. That archetype renders the write-up box read-only, and gating the room on `controlsLocked` would have emptied it. The waiting surface, which draws no editor at all, still opens nothing.

## Payload

`EditPraxis` is a lazy route, so CodeMirror and Yjs land in the composer's chunk. Both numbers from builds produced in this branch (`bundle-budget.mjs` reads an existing `dist/`, so a stale one measures the wrong artifact):

| | before (`9ec7a39a`) | after |
|---|---|---|
| **entry JS, gzipped** | **129.8 KB** | **129.9 KB** |
| entry CSS, gzipped | 21.3 KB | 21.3 KB |

`warn > 130.9 KB`, `fail > 175.8 KB` — within budget, and `dist/index.html` emits no `modulepreload` at all, so nothing new is on the critical path. The composer chunk carries the weight: 39.7 KB → 403 KB raw (127.8 KB gzipped), downloaded only by someone who opens the composer, which is what ADR-0073 signed up for.

## Attributions

Versions and licences read off the installed packages, not copied from the issue: `yjs` 13.6.32, `y-websocket` 3.1.0, `y-codemirror.next` 0.3.5, `@codemirror/{state,view,commands}` 6.x — all MIT, as are the transitive `lib0`, `y-protocols` and `style-mod`. `pycrdt` credited alongside as the server half. (`y-indexeddb` belongs to #1743.)

## Verified locally

Every step in `.github/workflows/test.yml`'s `frontend` job:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **248 files, 4434 tests, all passing**
- `npm run build` — clean
- `npm run budget` — within budget (table above)

`api-schema` is not exercised: no route, `response_model` or Pydantic schema is touched. This PR is frontend-only.

## ⚠️ What is NOT verified

**I have no browser and no dev stack. Visual QA and live convergence are both outstanding, and I am not claiming either.** Specifically:

- **Convergence is unverified by me.** No test in this repo exercises the binding — the harness has no DOM, by design. What covers it is #1740's backend two-client tests plus the nightly Playwright spec.
- Every visual claim about the eight skins is an argument from the code (the same style object, on the host instead of the textarea), not an observation.

## What to eyeball

1. **Two browser profiles, same collab praxis, type in both.** Confirm the text converges — and, the thing that matters most, **confirm no text duplicates on join**. A doubled write-up is what a client-side seed looks like.
2. **Open a solo praxis with an existing write-up.** The text should appear as the room syncs. Watch the moment before it: the box is read-only with "Opening the shared write-up…" under it, and the toolbar is absent. It should be brief.
3. **All eight faction composers**, light and dark. The write-up box should look exactly as it did — ground, rule, radius, padding, min-height, face, ink. The caret is the one thing that is newly ours: it should be the skin's ink on every field, not black.
4. **The resize grip** at the bottom-right of the write-up box still drags, and the box still scrolls once dragged shorter than its content.
5. **The markdown toolbar**, mid-paragraph. Selection should survive the press and the caret land on the wrapped text.
6. **Ctrl+Z** in the write-up (Yjs's undo manager, not the browser's).
7. **A moderated (hidden/failed) praxis** still shows its write-up in the composer.

## Deferred to `frontend-style`

Three judgement calls I made mechanically rather than designed, all flagged rather than hidden:

- The unsynced note is `label-caption` at `--color-text-tertiary` — placement and copy ("Opening the shared write-up…") want a real look.
- The placeholder is `--color-text-tertiary`, replacing the browser default the textarea used.
- CodeMirror's focus outline is suppressed to match the `outline: none` every skin's `fieldBox` already sets. That is parity with today, not an improvement — the composer's focus affordance is a live a11y question either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
