### PR TITLE
Retire the debounced PUT: the room is the only way a praxis body is written

### DIFF
--- a/.design-sync/previews/_state.tsx
+++ b/.design-sync/previews/_state.tsx
@@ -282,7 +282,7 @@ export function editPraxisState(slug: string): EditPraxisState {
     acceptConfirm: noop,
     dismissConfirm: noop,
     autosaveAt: null,
-    saveStatus: 'idle',
+    setAutosaveAt: () => {},
     autoSubmitDays: null,
     isPublished: false,
     controlsLocked: false,

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -5107,34 +5107,6 @@
         "title": "PraxisTypeChange",
         "type": "object"
       },
-      "PraxisUpdate": {
-        "properties": {
-          "body_text": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Body Text"
-          },
-          "title": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Title"
-          }
-        },
-        "title": "PraxisUpdate",
-        "type": "object"
-      },
       "PraxisVoteIn": {
         "properties": {
           "value": {
@@ -9837,77 +9809,6 @@
           }
         ],
         "summary": "Get Praxis Route",
-        "tags": [
-          "praxes"
-        ]
-      },
-      "put": {
-        "operationId": "update_praxis_route_praxes__praxis_id__put",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "praxis_id",
-            "required": true,
-            "schema": {
-              "title": "Praxis Id",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "cookie",
-            "name": "access_token",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Access Token"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PraxisUpdate"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PraxisOut"
-                }
-              }
-            },
-            "description": "Successful Response"
-          },
-          "422": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            },
-            "description": "Validation Error"
-          }
-        },
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "summary": "Update Praxis Route",
         "tags": [
           "praxes"
         ]

--- a/backend/routers/praxes.py
+++ b/backend/routers/praxes.py
@@ -39,7 +39,6 @@ from schemas.praxis import (
     PraxisInviteOut,
     PraxisOut,
     PraxisTypeChange,
-    PraxisUpdate,
     PraxisVoteIn,
 )
 
@@ -91,7 +90,6 @@ from services.praxis import (
     VotedFilter,
     respond_to_invite,
     submit_praxis,
-    update_praxis,
     unsubmit_praxis,
 )
 from services.praxis_metatask import apply_metatask, remove_metatask
@@ -256,21 +254,11 @@ async def create_praxis_route(
     return await build_praxis_out(praxis, session, viewer=character)
 
 
-@router.put("/{praxis_id}", response_model=PraxisOut)
-async def update_praxis_route(
-    praxis_id: int,
-    data: PraxisUpdate,
-    character: Character = Depends(get_current_character),
-    session: AsyncSession = Depends(get_db),
-):
-    praxis = await update_praxis(
-        praxis_id=praxis_id,
-        data=data,
-        character_id=character.id,
-        session=session,
-        era=CURRENT_ERA,
-    )
-    return await build_praxis_out(praxis, session, viewer=character)
+# `PUT /praxes/{praxis_id}` was the composer's debounced autosave and is gone
+# (#1743, ADR-0073). Title and body are now written in the praxis's room and
+# flushed to the record by the room server, so there is one write path for a
+# praxis body and not two — see `tests/test_deleted_routes_stay_deleted.py`
+# for why re-adding it is the argument to answer, not the fix.
 
 
 @router.post("/{praxis_id}/change-type", response_model=PraxisOut)

--- a/backend/schemas/praxis.py
+++ b/backend/schemas/praxis.py
@@ -226,11 +226,6 @@ class PraxisCreate(WireModel):
     body_text: Optional[str] = None
 
 
-class PraxisUpdate(WireModel):
-    title: Optional[str] = None
-    body_text: Optional[str] = None
-
-
 class PraxisTypeChange(WireModel):
     """Body for the in-place solo↔collab mode switch (#321)."""
 

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -40,7 +40,6 @@ from models.vote import Vote
 from schemas.praxis import (
     MediaItemOut,
     MediaUploadResultOut,
-    PraxisUpdate,
 )
 from services import collab_consensus
 from services.character_stats import (
@@ -943,29 +942,19 @@ async def create_praxis(
     return await get_praxis(praxis.id, session)
 
 
-async def update_praxis(
-    praxis_id: int,
-    data: PraxisUpdate,
-    character_id: int,
-    session: AsyncSession,
-    era: EraConfig = CURRENT_ERA,
-) -> Praxis:
-    """Update title/body_text. Any member may edit (ADR-0013).
-
-    On a collab, an edit cancels any pending-publish window and un-submits everyone
-    (ADR-0012 hard reset).
-    """
-    praxis = await get_praxis(praxis_id, session)
-    _require_member(praxis, character_id, "edit")
-    if data.title is not None:
-        praxis.title = data.title
-    if data.body_text is not None:
-        praxis.body_text = data.body_text
-    await session.flush()
-    await collab_consensus.on_member_edit(praxis, session, era)
-    # Re-fetch rather than session.refresh(praxis): refresh expires the
-    # lazy='raise' relationships and breaks the subsequent build_praxis_out.
-    return await get_praxis(praxis_id, session)
+# ``update_praxis`` — the debounced autosave's write — is gone (#1743,
+# ADR-0073). ``praxis.title`` and ``praxis.body_text`` are derived columns now,
+# written only by the praxis's room (``services/praxis_room.py``).
+#
+# ``_require_member(praxis, character_id, "edit")`` is unchanged and still the
+# one implementation of ADR-0013's "any member may edit" — the room's door one
+# calls it at connect, which is where it moved to, not where it was duplicated.
+#
+# The text edit no longer triggers ADR-0012's hard reset. That is deliberate and
+# is the ADR's "freeze, not reset": a CRDT has no discrete edit event to key on,
+# so submitting freezes the document instead and ``pullBack`` is the one door
+# back in (#1745). Media edits still call ``on_member_edit`` — the reset
+# mechanism is intact, it simply has one fewer trigger until the freeze lands.
 
 
 async def unsubmit_praxis(
@@ -2025,6 +2014,5 @@ __all__ = [
     "SignupEligibility",
     "SignupFacts",
     "submit_praxis",
-    "update_praxis",
     "unsubmit_praxis",
 ]

--- a/backend/services/praxis_room.py
+++ b/backend/services/praxis_room.py
@@ -5,7 +5,7 @@ plus the members currently connected. It mounts as an ASGI WebSocket route
 inside this same FastAPI app (``main.py``) — one process, one deploy, no second
 service.
 
-Four rules live here, and all four are here rather than in a client because a
+Five rules live here, and all five are here rather than in a client because a
 rule that runs on the client is not a rule:
 
 1. **The server seeds the document exactly once**, from ``praxis.body_text``,
@@ -17,19 +17,24 @@ rule that runs on the client is not a rule:
 2. **The document persists to Postgres.** ``pycrdt-websocket``'s bundled stores
    are SQLite/file only, so :class:`PostgresYStore` is ours, with a squash
    policy — a Y store appends every update forever otherwise.
-3. **Authorization has two doors.** At connect, ``Origin`` is validated by hand
+3. **The room is the only way a praxis body is written** (#1743). The debounced
+   ``PUT`` is gone, not kept as a fallback, so ``praxis.title`` and
+   ``praxis.body_text`` are **derived columns**: :class:`_RoomFlusher` copies
+   the document into them once the typing stops. That direction is one-way and
+   the seed above is the only path back — a room that read the record it writes
+   would seed itself.
+4. **Authorization has two doors.** At connect, ``Origin`` is validated by hand
    (``CORSMiddleware`` does not apply to WebSockets, so the allowlist that
    protects every REST route would silently not protect this one) and the
    praxis's existing member check runs against the cookie's account. At revoke,
    kick and leave *close the socket*: a gate checked only on the way in lets a
    removed member keep writing until they close the tab.
-4. **Exactly one backend instance may run**, because rooms live in-process.
+5. **Exactly one backend instance may run**, because rooms live in-process.
    Enforced by :func:`acquire_single_instance_lock`. ADR-0073 states the
    constraint once; ADR-0012's lazy-on-access timeout depends on the same fact.
 
-What is deliberately *not* here: ``praxis.body_text`` is still written by the
-existing debounced ``PUT`` (retired in #1743), and nothing freezes a room on
-submit yet (#1745).
+What is deliberately *not* here: nothing freezes a room on submit yet, and the
+document is not discarded on publish (#1745).
 """
 
 import logging
@@ -42,11 +47,12 @@ from typing import Any
 import anyio
 from anyio import Event, Lock
 from fastapi import HTTPException
-from pycrdt import Doc, Text
+from pycrdt import Doc, Map, Text
 from pycrdt.store import BaseYStore, YDocNotFound
 from pycrdt.websocket import ASGIServer, WebsocketServer, YRoom
 from pycrdt.websocket.asgi_server import ASGIWebsocket
 from sqlalchemy import delete, func, select
+from sqlalchemy import update as sql_update
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
 
 from config import settings
@@ -59,11 +65,27 @@ from services.character import resolve_active_character
 
 logger = logging.getLogger(__name__)
 
-# The co-edited body inside a room's document — the one root type this issue
-# seeds. #1742 binds CodeMirror to it; #1743 flushes it back to
-# ``praxis.body_text``. The title is a last-write-wins map key (ADR-0073) and
-# arrives with the editor that needs it.
+# The co-edited body inside a room's document — the one root type the server
+# seeds, and the one CodeMirror binds to (#1742).
 ROOM_BODY_KEY = "body"
+
+# The title, as **one last-write-wins map key** rather than co-edited text
+# (ADR-0073): a praxis title is 200 characters, and interleaving two people
+# typing one character-by-character produces garbage more often than it helps.
+#
+# Nothing seeds it. ``_load_or_seed`` writes ``body`` alone, so the key does not
+# exist until a co-author edits a title — which is why :meth:`_RoomFlusher.write`
+# reads its absence as "no room value yet" and never as "the title is empty".
+ROOM_META_KEY = "meta"
+ROOM_TITLE_KEY = "title"
+
+# How long a room sits still before its document is copied into the praxis.
+#
+# The record is derived, so this is not "how long until your work is safe" —
+# every update is already durable in ``praxis_room_update`` before this timer
+# starts. It is how long until the *read* surfaces catch up, and the answer only
+# has to beat a player finishing their write-up and going to look at it.
+_FLUSH_DEBOUNCE_SECONDS = 2.0
 
 # The socket's path, relative to the mount in ``main.py`` — ``/rooms/praxis/12``.
 _ROOM_PATH = re.compile(r"^/praxis/(?P<praxis_id>\d+)/?$")
@@ -196,6 +218,107 @@ class PostgresYStore(BaseYStore):
 
 
 # ---------------------------------------------------------------------------
+# The flush — the document becomes the record
+# ---------------------------------------------------------------------------
+
+
+class _RoomFlusher:
+    """Copies one room's document into ``praxis.title`` / ``praxis.body_text``.
+
+    Since #1743 this is the **only** writer of those two columns. There is no
+    ``PUT`` behind it and no reconciliation rule to state, which is the point:
+    two ways to persist a body means every future rule about saving has to be
+    written twice and kept in step (ADR-0073, #1692).
+
+    The copy is one-way. Nothing here re-reads the columns it writes — the
+    server's single seed in :meth:`PraxisRoomServer._load_or_seed` is the only
+    path from the record back into a document, and a flush that read as well as
+    wrote would be that second seed.
+    """
+
+    def __init__(
+        self,
+        room: YRoom,
+        praxis_id: int,
+        session_factory: SessionFactory,
+        debounce_seconds: float,
+        log: logging.Logger,
+    ) -> None:
+        self._room = room
+        self._praxis_id = praxis_id
+        self._session_factory = session_factory
+        self._debounce_seconds = debounce_seconds
+        self._log = log
+        self._changed = Event()
+        self._pending = False
+        self._cancel_scope: anyio.CancelScope | None = None
+
+    def mark_changed(self) -> None:
+        """The document moved. Safe from the observer: it only sets a flag."""
+        self._pending = True
+        self._changed.set()
+
+    async def run(self) -> None:
+        """Flush once the room has been quiet for the whole debounce window.
+
+        Trailing edge, deliberately. A leading-edge flush would write the first
+        character of every sentence and then nothing until the writer paused
+        anyway, which is more statements for a column nobody is reading yet.
+        """
+        with anyio.CancelScope() as cancel_scope:
+            self._cancel_scope = cancel_scope
+            while True:
+                await self._changed.wait()
+                # Re-armed *before* the wait, so a keystroke arriving during it
+                # restarts the quiet window instead of being swallowed by it.
+                self._changed = Event()
+                await anyio.sleep(self._debounce_seconds)
+                if self._changed.is_set():
+                    continue
+                await self.write()
+
+    async def close(self) -> None:
+        """Stop, after one last flush if the room stopped mid-window.
+
+        A tab closed two seconds after the last sentence would otherwise leave
+        that sentence in the room's store and out of ``body_text``, where every
+        read surface would look for it.
+        """
+        if self._cancel_scope is not None:
+            self._cancel_scope.cancel()
+        if self._pending:
+            await self.write()
+
+    async def write(self) -> None:
+        """One UPDATE, from whatever the document says right now.
+
+        A Core statement rather than an ORM load: the entity's relationships are
+        ``lazy='raise'``, and a room task has no business waking the identity map
+        of a session that a request may also be holding.
+        """
+        document = self._room.ydoc
+        values: dict[str, str] = {
+            "body_text": str(document.get(ROOM_BODY_KEY, type=Text))
+        }
+        title = document.get(ROOM_META_KEY, type=Map).get(ROOM_TITLE_KEY)
+        # ABSENT is "the room has no title yet", never "the title was cleared" —
+        # nothing seeds this key, so it arrives with the first co-author to type
+        # in the title box and not before. Reading it the other way would blank
+        # the title of every praxis whose body someone edited.
+        if isinstance(title, str):
+            values["title"] = title
+
+        async with self._session_factory() as session:
+            await session.execute(
+                sql_update(Praxis).where(Praxis.id == self._praxis_id).values(**values)
+            )
+            await session.commit()
+        # Only once the write is committed: cancelled halfway, the room still
+        # owes the praxis this text and :meth:`close` has to know it.
+        self._pending = False
+
+
+# ---------------------------------------------------------------------------
 # Authorization — door one, at connect
 # ---------------------------------------------------------------------------
 
@@ -314,6 +437,7 @@ class PraxisRoomServer(WebsocketServer):
         session_factory: SessionFactory = AsyncSessionLocal,
         log: logging.Logger | None = None,
         squash_updates_above: int = _SQUASH_UPDATES_ABOVE,
+        flush_debounce_seconds: float = _FLUSH_DEBOUNCE_SECONDS,
     ) -> None:
         super().__init__(
             rooms_ready=False,
@@ -325,7 +449,9 @@ class PraxisRoomServer(WebsocketServer):
         )
         self._session_factory = session_factory
         self._squash_updates_above = squash_updates_above
+        self._flush_debounce_seconds = flush_debounce_seconds
         self._connections: set[_RoomConnection] = set()
+        self._flushers: dict[str, _RoomFlusher] = {}
         self.__open_lock: Lock | None = None
 
     @property
@@ -365,9 +491,29 @@ class PraxisRoomServer(WebsocketServer):
             self.rooms[name] = room
             await self.start_room(room)
             await self._load_or_seed(room, name)
+            self._start_flusher(room, name)
             # Only now may clients synchronize against it.
             room.ready = True
             return room
+
+    def _start_flusher(self, room: YRoom, name: str) -> None:
+        """Watch this room's document and copy it into the praxis (#1743).
+
+        Subscribed *after* the seed on purpose. The seed is the record's own
+        text arriving in the document; flushing it straight back would be a
+        write nobody asked for, on every room that opens.
+        """
+        assert self._task_group is not None  # start_room above proves it
+        flusher = _RoomFlusher(
+            room,
+            _praxis_id_of(name),
+            self._session_factory,
+            self._flush_debounce_seconds,
+            self.log,
+        )
+        self._flushers[name] = flusher
+        room.ydoc.observe(lambda _event: flusher.mark_changed())
+        self._task_group.start_soon(flusher.run)
 
     async def _load_or_seed(self, room: YRoom, name: str) -> None:
         store = room.ystore
@@ -403,6 +549,9 @@ class PraxisRoomServer(WebsocketServer):
             async with self._open_lock:
                 room = self.rooms.get(connection.room_name)
                 if room is not None and not room.clients:
+                    flusher = self._flushers.pop(connection.room_name, None)
+                    if flusher is not None:
+                        await flusher.close()
                     await self.delete_room(room=room)
 
     def revoke(self, praxis_id: int, character_id: int) -> None:

--- a/backend/tests/integration/test_praxes.py
+++ b/backend/tests/integration/test_praxes.py
@@ -1453,61 +1453,14 @@ async def test_collab_all_submit_transitions_to_submitted(
 
 
 # ---------------------------------------------------------------------------
-# Edit praxis
+# Edit praxis — moved wholesale to the room (#1743)
+#
+# There is no edit *endpoint* left to test here. Title and body are written in
+# the praxis's room and flushed to the record by the room server, so both the
+# capability and its member check live at that seam now and are tested there
+# (``test_praxis_room.py``): the flush itself, ADR-0013's "any member may edit",
+# and the non-member refusal that used to be this file's 403.
 # ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_edit_praxis(
-    client: AsyncClient,
-    character: Character,
-    active_task: Task,
-    auth_headers: dict,
-):
-    """PUT /praxes/{id} updates title and body_text."""
-    create_resp = await client.post(
-        "/praxes",
-        json={"task_id": active_task.id, "type": "solo", "title": "Original"},
-        headers=auth_headers,
-    )
-    assert create_resp.status_code == 201
-    praxis_id = create_resp.json()["id"]
-
-    edit_resp = await client.put(
-        f"/praxes/{praxis_id}",
-        json={"title": "Updated Title", "body_text": "New body"},
-        headers=auth_headers,
-    )
-    assert edit_resp.status_code == 200
-    data = edit_resp.json()
-    assert data["title"] == "Updated Title"
-    assert data["body_text"] == "New body"
-
-
-@pytest.mark.asyncio
-async def test_edit_praxis_wrong_owner_returns_403(
-    client: AsyncClient,
-    character: Character,
-    active_task: Task,
-    auth_headers: dict,
-    auth_headers2: dict,
-    character2: Character,
-):
-    """Editing another character's praxis returns 403."""
-    create_resp = await client.post(
-        "/praxes",
-        json={"task_id": active_task.id, "type": "solo", "title": "Mine"},
-        headers=auth_headers,
-    )
-    assert create_resp.status_code == 201
-    praxis_id = create_resp.json()["id"]
-
-    resp = await client.put(
-        f"/praxes/{praxis_id}",
-        json={"title": "Hacked"},
-        headers=auth_headers2,
-    )
-    assert resp.status_code == 403
 
 
 # ---------------------------------------------------------------------------
@@ -1544,27 +1497,8 @@ async def _two_member_collab(
     return praxis_id
 
 
-@pytest.mark.asyncio
-async def test_collab_non_creator_can_edit(
-    client: AsyncClient,
-    character: Character,
-    character2: Character,
-    active_task: Task,
-    auth_headers: dict,
-    auth_headers2: dict,
-):
-    """A non-creator member can edit a collab's title/body (ADR-0013)."""
-    # character2 creates, character (non-creator) edits.
-    praxis_id = await _two_member_collab(
-        client, active_task, auth_headers2, character.id, auth_headers
-    )
-    resp = await client.put(
-        f"/praxes/{praxis_id}",
-        json={"title": "Edited by member", "body_text": "ours"},
-        headers=auth_headers,
-    )
-    assert resp.status_code == 200
-    assert resp.json()["title"] == "Edited by member"
+# "A non-creator member can edit" (ADR-0013) is now a room rule, asserted where
+# it is enforced: ``test_a_non_creator_members_edit_reaches_the_record``.
 
 
 @pytest.mark.asyncio
@@ -1722,31 +1656,11 @@ async def test_collab_all_submit_clears_window(
     assert data["submit_proposed_at"] is None
 
 
-@pytest.mark.asyncio
-async def test_collab_edit_cancels_pending_publish(
-    client: AsyncClient,
-    character: Character,
-    character2: Character,
-    active_task: Task,
-    auth_headers: dict,
-    auth_headers2: dict,
-):
-    """An edit while pending hard-resets: window cancelled, everyone un-submitted."""
-    praxis_id = await _two_member_collab(
-        client, active_task, auth_headers2, character.id, auth_headers
-    )
-    await client.post(f"/praxes/{praxis_id}/submit", headers=auth_headers2)
-
-    resp = await client.put(
-        f"/praxes/{praxis_id}",
-        json={"body_text": "second thoughts"},
-        headers=auth_headers,
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["status"] == "in_progress"
-    assert data["submit_proposed_at"] is None
-    assert all(not m["has_submitted"] for m in data["members"])
+# A *text* edit no longer cancels a pending publish. ADR-0012's hard reset needs
+# a discrete edit event and a CRDT has none, so ADR-0073 answers it with freeze:
+# submitting freezes the room read-only and ``pullBack`` is the one door back in
+# (#1745). The reset MECHANISM is unchanged and still triggered by media edits —
+# ``test_praxis_media_batch.py`` holds those assertions.
 
 
 @pytest.mark.asyncio
@@ -1780,13 +1694,17 @@ async def test_roster_row_carries_when_each_member_filed(
     # The member who has not filed is still NULL — one row moved, not the pair.
     assert rows[character.id]["submitted_at"] is None
 
-    # An edit while pending hard-resets everyone (ADR-0012); the timestamp has
-    # to go with the flag.
-    reset = await client.put(
-        f"/praxes/{praxis_id}",
-        json={"body_text": "second thoughts"},
-        headers=auth_headers,
+    # ...and NULL again when that part is pulled back. The trigger used to be a
+    # praxis PUT and its ADR-0012 hard reset; since #1743 there is no PUT, so it
+    # is the door ADR-0059 leaves open — ``pullBack``, which on a pending collab
+    # retracts only the caller's own part (#590). The claim is unchanged: a
+    # "when they filed" that outlived the filing would be worse than never
+    # shipping the field.
+    reset = await client.post(
+        f"/praxes/{praxis_id}/unsubmit", headers=auth_headers2
     )
+    assert reset.status_code == 200, reset.text
+    assert all(not m["has_submitted"] for m in reset.json()["members"])
     assert all(m["submitted_at"] is None for m in reset.json()["members"])
 
 
@@ -2344,33 +2262,8 @@ async def test_create_praxis_minimal_body_starts_as_draft(
     assert data["media_items"] == []
 
 
-@pytest.mark.asyncio
-async def test_edit_minimal_draft_adds_content(
-    client: AsyncClient,
-    character: Character,
-    active_task: Task,
-    auth_headers: dict,
-):
-    """A praxis created with a minimal body can be filled in later via PUT."""
-    create_resp = await client.post(
-        "/praxes",
-        json={"task_id": active_task.id},
-        headers=auth_headers,
-    )
-    assert create_resp.status_code == 201
-    praxis_id = create_resp.json()["id"]
-
-    edit_resp = await client.put(
-        f"/praxes/{praxis_id}",
-        json={"title": "Finally a title", "body_text": "Here is what I did."},
-        headers=auth_headers,
-    )
-    assert edit_resp.status_code == 200
-    data = edit_resp.json()
-    assert data["title"] == "Finally a title"
-    assert data["body_text"] == "Here is what I did."
-    # Status stays in_progress — editing does not submit
-    assert data["status"] == "in_progress"
+# Filling in a minimal draft later is the room's job now, and lands in
+# ``body_text`` through the flush: ``test_an_edit_in_a_room_lands_in_body_text``.
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_praxis_room.py
+++ b/backend/tests/integration/test_praxis_room.py
@@ -658,6 +658,31 @@ async def test_an_edit_in_a_room_lands_in_body_text(
             )
 
 
+async def test_a_non_creator_members_edit_reaches_the_record(
+    db_session, collab, account2, monkeypatch
+) -> None:
+    """Any member may edit, creator or not (ADR-0013) — inherited from the ``PUT``.
+
+    The membership rule has one implementation, ``_require_member(.., "edit")``,
+    and door one calls it: the rule moved to the room's handshake rather than
+    being copied there. ``account2`` is a member of ``collab`` and did not
+    create it, which is the case ``test_collab_non_creator_can_edit`` used to
+    make against the retired endpoint.
+    """
+    async with running_rooms(db_session, monkeypatch, flush_debounce_seconds=0.05) as rooms:
+        socket = await rooms.open(collab.id, account2.id)
+        assert socket.accepted.is_set()
+        async with client_doc(socket) as doc:
+            await _wait_for_body(doc, SEED_BODY, "the non-creator member")
+            doc.get(ROOM_BODY_KEY, type=Text).insert(0, "theirs too ")
+            await _wait_for_record(
+                rooms,
+                collab.id,
+                "the non-creator's flush",
+                body_text=f"theirs too {SEED_BODY}",
+            )
+
+
 async def test_flushed_body_text_is_the_markdown_the_document_holds(
     db_session, collab, account, monkeypatch
 ) -> None:

--- a/backend/tests/integration/test_praxis_room.py
+++ b/backend/tests/integration/test_praxis_room.py
@@ -19,7 +19,7 @@ from typing import Any, AsyncIterator, Callable
 
 import pytest
 import pytest_asyncio
-from pycrdt import Doc, Provider, Text
+from pycrdt import Doc, Map, Provider, Text
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -33,6 +33,8 @@ from services.auth import create_jwt
 from services.praxis import kick_member, leave_praxis
 from services.praxis_room import (
     ROOM_BODY_KEY,
+    ROOM_META_KEY,
+    ROOM_TITLE_KEY,
     PraxisRoomASGIServer,
     PraxisRoomServer,
     acquire_single_instance_lock,
@@ -148,9 +150,18 @@ class _SharedSessionFactory:
 class _Rooms:
     """A running room server plus the ASGI app in front of it."""
 
-    def __init__(self, server: PraxisRoomServer) -> None:
+    def __init__(
+        self, server: PraxisRoomServer, sessions: _SharedSessionFactory
+    ) -> None:
         self.server = server
         self.app = PraxisRoomASGIServer(server)
+        #: The room's own session factory. A test that reads the database while
+        #: rooms are running MUST go through this rather than touching
+        #: ``db_session`` directly: one savepoint-backed session serves both
+        #: sides here, and using it from two tasks at once raises
+        #: "concurrent operations are not permitted" out of a room task, where
+        #: it reads as a room bug rather than as the harness bug it is.
+        self.sessions = sessions
         self._tasks: list[asyncio.Task] = []
 
     async def open(
@@ -201,6 +212,7 @@ async def running_rooms(
     db_session: AsyncSession,
     monkeypatch: pytest.MonkeyPatch,
     squash_updates_above: int = 200,
+    flush_debounce_seconds: float = 2.0,
 ) -> AsyncIterator[_Rooms]:
     """A room server for one test, standing in for the module singleton.
 
@@ -208,12 +220,14 @@ async def running_rooms(
     every call, so patching it here is what puts the kick/leave revoke door
     under test rather than a copy of it.
     """
+    sessions = _SharedSessionFactory(db_session)
     server = PraxisRoomServer(
-        session_factory=_SharedSessionFactory(db_session),
+        session_factory=sessions,
         squash_updates_above=squash_updates_above,
+        flush_debounce_seconds=flush_debounce_seconds,
     )
     monkeypatch.setattr(praxis_room, "PRAXIS_ROOM_SERVER", server)
-    rooms = _Rooms(server)
+    rooms = _Rooms(server, sessions)
     async with server:
         try:
             yield rooms
@@ -584,3 +598,241 @@ async def _update_count(session: AsyncSession, praxis_id: int) -> int:
         .select_from(PraxisRoomUpdate)
         .where(PraxisRoomUpdate.praxis_id == praxis_id)
     )
+
+
+# ---------------------------------------------------------------------------
+# The flush — the room is the only way a body is written (#1743)
+# ---------------------------------------------------------------------------
+
+
+async def _record(rooms: _Rooms, praxis_id: int) -> tuple[str | None, str | None]:
+    """``(title, body_text)`` straight from the row, past any identity map."""
+    async with rooms.sessions() as session:
+        row = (
+            await session.execute(
+                select(Praxis.title, Praxis.body_text).where(Praxis.id == praxis_id)
+            )
+        ).one()
+    return row[0], row[1]
+
+
+async def _wait_for_record(
+    rooms: _Rooms,
+    praxis_id: int,
+    description: str,
+    *,
+    title: str | None = None,
+    body_text: str | None = None,
+) -> None:
+    """Poll the row until the named columns match. Only what is passed is checked."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _TIMEOUT_SECONDS
+    while True:
+        stored_title, stored_body = await _record(rooms, praxis_id)
+        if (title is None or stored_title == title) and (
+            body_text is None or stored_body == body_text
+        ):
+            return
+        if loop.time() >= deadline:
+            raise AssertionError(
+                f"timed out waiting for {description}: the row holds "
+                f"title={stored_title!r} body_text={stored_body!r}"
+            )
+        await asyncio.sleep(0.02)
+
+
+async def test_an_edit_in_a_room_lands_in_body_text(
+    db_session, collab, account, monkeypatch
+) -> None:
+    """The whole point of #1743: no ``PUT``, and the praxis is still written."""
+    async with running_rooms(db_session, monkeypatch, flush_debounce_seconds=0.05) as rooms:
+        socket = await rooms.open(collab.id, account.id)
+        async with client_doc(socket) as doc:
+            await _wait_for_body(doc, SEED_BODY, "the first client")
+            doc.get(ROOM_BODY_KEY, type=Text).insert(0, "typed ")
+            await _wait_for_record(
+                rooms,
+                collab.id,
+                "the debounced flush",
+                body_text=f"typed {SEED_BODY}",
+            )
+
+
+async def test_flushed_body_text_is_the_markdown_the_document_holds(
+    db_session, collab, account, monkeypatch
+) -> None:
+    """``body_text`` stays markdown, byte for byte (ADR-0073).
+
+    Praxis detail, the feed, search and every ``react-markdown`` reader read
+    this column, and this epic deliberately changes none of them. A flush that
+    normalized whitespace, trimmed, or re-wrapped would change all of them at
+    once, and no assertion about the socket would notice.
+    """
+    markdown = "# A heading\n\n- one\n- two\n\n> quoted  \n\n**bold** and `code`\n"
+    async with running_rooms(db_session, monkeypatch, flush_debounce_seconds=0.05) as rooms:
+        socket = await rooms.open(collab.id, account.id)
+        async with client_doc(socket) as doc:
+            body = doc.get(ROOM_BODY_KEY, type=Text)
+            await _wait_for_body(doc, SEED_BODY, "the first client")
+            del body[0 : len(SEED_BODY)]
+            body.insert(0, markdown)
+            await _wait_for_record(
+                rooms, collab.id, "the flush", body_text=markdown
+            )
+            _, stored = await _record(rooms, collab.id)
+            assert stored == str(body)
+
+
+async def test_two_clients_editing_converge_into_one_body_text(
+    db_session, collab, account, account2, monkeypatch
+) -> None:
+    """Concurrent edits converge; they do not clobber.
+
+    This is the defect the ADR exists for. Under the retired ``PUT`` the second
+    writer's text simply replaced the first's with no signal to either of them,
+    so what matters is that BOTH insertions survive in the column — not merely
+    that the column changed.
+    """
+    async with running_rooms(db_session, monkeypatch, flush_debounce_seconds=0.05) as rooms:
+        first = await rooms.open(collab.id, account.id)
+        second = await rooms.open(collab.id, account2.id)
+        async with client_doc(first) as first_doc, client_doc(second) as second_doc:
+            await _wait_for_body(first_doc, SEED_BODY, "the first client")
+            await _wait_for_body(second_doc, SEED_BODY, "the second client")
+
+            first_doc.get(ROOM_BODY_KEY, type=Text).insert(0, "one ")
+            second_doc.get(ROOM_BODY_KEY, type=Text).insert(len(SEED_BODY), " two")
+
+            await _wait_for(
+                lambda: _body(first_doc) == _body(second_doc)
+                and "one " in _body(first_doc)
+                and " two" in _body(first_doc),
+                "both clients to converge",
+            )
+            converged = _body(first_doc)
+            assert SEED_BODY in converged
+            await _wait_for_record(
+                rooms, collab.id, "the converged flush", body_text=converged
+            )
+
+
+async def test_opening_a_room_alone_leaves_the_record_untouched(
+    db_session, collab, account, monkeypatch
+) -> None:
+    """Open, sync, close. Nothing was typed, so nothing may be rewritten."""
+    async with running_rooms(db_session, monkeypatch, flush_debounce_seconds=0.05) as rooms:
+        socket = await rooms.open(collab.id, account.id)
+        async with client_doc(socket) as doc:
+            await _wait_for_body(doc, SEED_BODY, "the first client")
+        await socket.disconnect()
+        await _wait_for(
+            lambda: rooms.room_doc(collab.id) is None, "the empty room to be dropped"
+        )
+    assert await _record(rooms, collab.id) == ("Collab Praxis", SEED_BODY)
+
+
+async def test_a_praxis_whose_room_never_opened_keeps_its_body_text(
+    db_session, collab, account, active_task, character, monkeypatch
+) -> None:
+    """The neighbouring praxis is not collateral: only the edited room flushes."""
+    untouched = Praxis(
+        task_id=active_task.id,
+        created_by_id=character.id,
+        type=PraxisType.solo,
+        status=PraxisStatus.in_progress,
+        title="Untouched",
+        body_text="Never opened in a room.",
+    )
+    db_session.add(untouched)
+    await db_session.flush()
+    db_session.add(PraxisMember(praxis_id=untouched.id, character_id=character.id))
+    await db_session.commit()
+
+    async with running_rooms(db_session, monkeypatch, flush_debounce_seconds=0.05) as rooms:
+        socket = await rooms.open(collab.id, account.id)
+        async with client_doc(socket) as doc:
+            await _wait_for_body(doc, SEED_BODY, "the first client")
+            doc.get(ROOM_BODY_KEY, type=Text).insert(0, "edited ")
+            await _wait_for_record(
+                rooms,
+                collab.id,
+                "the edited praxis",
+                body_text=f"edited {SEED_BODY}",
+            )
+
+    assert await _record(rooms, untouched.id) == (
+        "Untouched",
+        "Never opened in a room.",
+    )
+
+
+async def test_the_title_key_flushes_to_praxis_title(
+    db_session, collab, account, monkeypatch
+) -> None:
+    """The title is one last-write-wins map key, and it reaches the record too.
+
+    Without this the retired ``PUT`` would still be the only way to rename a
+    praxis — the second write path the ADR refuses to keep.
+    """
+    async with running_rooms(db_session, monkeypatch, flush_debounce_seconds=0.05) as rooms:
+        socket = await rooms.open(collab.id, account.id)
+        async with client_doc(socket) as doc:
+            await _wait_for_body(doc, SEED_BODY, "the first client")
+            doc.get(ROOM_META_KEY, type=Map)[ROOM_TITLE_KEY] = "A renamed praxis"
+            await _wait_for_record(
+                rooms,
+                collab.id,
+                "the title flush",
+                title="A renamed praxis",
+                body_text=SEED_BODY,
+            )
+
+
+async def test_an_absent_title_key_never_blanks_the_praxis_title(
+    db_session, collab, account, monkeypatch
+) -> None:
+    """Nothing seeds the title key, so absent means "no remote value yet".
+
+    Reading absence as "the title is empty" would blank every praxis the
+    instant anybody typed one character of body text.
+    """
+    async with running_rooms(db_session, monkeypatch, flush_debounce_seconds=0.05) as rooms:
+        socket = await rooms.open(collab.id, account.id)
+        async with client_doc(socket) as doc:
+            await _wait_for_body(doc, SEED_BODY, "the first client")
+            doc.get(ROOM_BODY_KEY, type=Text).insert(0, "body only ")
+            await _wait_for_record(
+                rooms,
+                collab.id,
+                "the flush",
+                title="Collab Praxis",
+                body_text=f"body only {SEED_BODY}",
+            )
+
+
+async def test_the_last_edit_before_a_room_closes_still_lands(
+    db_session, collab, account, monkeypatch
+) -> None:
+    """A tab closed inside the debounce window must not strand the keystrokes.
+
+    The room's own store keeps them either way, and reopening would show them —
+    but ``body_text`` is what every *read* surface reads, and a praxis detail
+    page missing the sentence its author typed a minute ago is the visible half
+    of "the record is derived". The debounce here is long enough that only the
+    closing flush can satisfy this.
+    """
+    async with running_rooms(db_session, monkeypatch, flush_debounce_seconds=30.0) as rooms:
+        socket = await rooms.open(collab.id, account.id)
+        async with client_doc(socket) as doc:
+            await _wait_for_body(doc, SEED_BODY, "the first client")
+            doc.get(ROOM_BODY_KEY, type=Text).insert(0, "last words ")
+            await _wait_for_body(
+                rooms.room_doc(collab.id), f"last words {SEED_BODY}", "the room"
+            )
+        await socket.disconnect()
+        await _wait_for_record(
+            rooms,
+            collab.id,
+            "the closing flush",
+            body_text=f"last words {SEED_BODY}",
+        )

--- a/backend/tests/test_deleted_routes_stay_deleted.py
+++ b/backend/tests/test_deleted_routes_stay_deleted.py
@@ -1,4 +1,8 @@
-"""The thirteen unreachable endpoints deleted by #1667 stay deleted.
+"""Endpoints deleted on purpose stay deleted.
+
+Thirteen unreachable ones went in #1667; ``PUT /praxes/{praxis_id}`` went in
+#1743 for a different reason — it was very much reachable, and that was the
+problem.
 
 THE SEAM
 --------
@@ -33,6 +37,16 @@ WHAT EACH GROUP WAS
   creates that ``seed.py`` or another route already does, and a task update the
   admin ``PATCH`` supersedes.
 
+* **One write path, deleted so there is only one** (#1743). ``PUT /praxes/{id}``
+  took a title and a body and was the composer's debounced autosave. Every
+  praxis is now written in a *room* (ADR-0073) — a server-held CRDT the composer
+  binds to — and the room server flushes that document into ``praxis.title`` and
+  ``praxis.body_text``. Keeping the ``PUT`` as a fallback was considered and
+  refused: it is the second write path wearing a different hat, and it would
+  need a reconciliation rule for a ``PUT`` landing behind the room's document.
+  A rule stated twice and never reconciled is what shipped three production bugs
+  in #1692.
+
 If you are here because you want one of these back, the honest move is a new
 route with a new name and a caller in the same PR — not a revert of this list.
 """
@@ -43,10 +57,12 @@ from pathlib import Path
 BACKEND_ROOT = Path(__file__).resolve().parent.parent
 COMMITTED_SCHEMA = BACKEND_ROOT / "openapi.json"
 
-#: ``(method, path)`` for every operation #1667 removed. Methods are lowercase
-#: because that is how an OpenAPI path item keys them.
+#: ``(method, path)`` for every operation deliberately removed. Methods are
+#: lowercase because that is how an OpenAPI path item keys them.
 DELETED_OPERATIONS: frozenset[tuple[str, str]] = frozenset(
     {
+        # #1743: the composer's debounced autosave. The room is the write path.
+        ("put", "/praxes/{praxis_id}"),
         # The four-way task-status duplicate, minus the one that survived.
         ("put", "/admin/tasks/{task_id}/approve"),
         ("put", "/admin/tasks/{task_id}/retire"),
@@ -123,8 +139,7 @@ def test_deleted_routes_are_absent_from_the_contract() -> None:
     resurrected = sorted(DELETED_OPERATIONS & _published_operations())
 
     assert not resurrected, (
-        "These operations were deleted as unreachable in #1667 and are published "
-        "again:\n  "
+        "These operations were deleted on purpose and are published again:\n  "
         + "\n  ".join(f"{method.upper()} {path}" for method, path in resurrected)
         + "\n\nEach one had a live replacement at the time it was removed — read "
         "this module's docstring for which. If the replacement genuinely no "

--- a/docs/adr/0073-a-praxis-is-written-in-a-room-and-the-room-is-not-the-record.md
+++ b/docs/adr/0073-a-praxis-is-written-in-a-room-and-the-room-is-not-the-record.md
@@ -1,7 +1,10 @@
 # ADR-0073 — A praxis is written in a room, and the room is not the record
 
-**Status:** Accepted — **designed, not built.** The vocabulary and the decisions
-below are the design; no room server, no CRDT and no editor swap exist yet.
+**Status:** Accepted — **built, except freeze.** The room server and its two
+auth doors (#1740), the CodeMirror binding (#1742) and the one write path —
+`body_text` as a derived column, the `PUT` deleted, offline in `y-indexeddb`
+(#1743) — are live. Still design only: freeze-on-pending and discarding the
+document on publish (#1745), and presence (#1744).
 **Date:** 2026-08-14
 **Relates to:** ADR-0011 (a duel is two solo praxes), ADR-0012 (lazy consensus;
 "an edit means we're not done"), ADR-0013 (any member may edit), ADR-0059

--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -84,11 +84,17 @@ async function seedCollabDraft(browser: Browser, suffix: string) {
   return { alice, bob, task, praxisId: praxis.id as number }
 }
 
-/** Both members edit then submit; consensus seals to `submitted` on the last submit. */
-async function bothEditAndSubmit(seed: Awaited<ReturnType<typeof seedCollabDraft>>) {
+/**
+ * Both members submit; consensus seals to `submitted` on the last submit.
+ *
+ * It used to write a contribution each with `PUT /praxes/{id}` first. That
+ * endpoint is gone (#1743) — a praxis body is written in its room, over a
+ * WebSocket CRDT this suite has no way to drive — and no assertion downstream
+ * ever read the text it wrote. `seedCollabDraft` gives the praxis a body at
+ * create time, which is the part these tests actually depend on.
+ */
+async function bothSubmit(seed: Awaited<ReturnType<typeof seedCollabDraft>>) {
   const { alice, bob, praxisId } = seed
-  await alice.ctx.request.put(`${API}/praxes/${praxisId}`, { data: { body_text: 'Alice contribution' } })
-  await bob.ctx.request.put(`${API}/praxes/${praxisId}`, { data: { body_text: 'Alice + Bob contribution' } })
   await alice.ctx.request.post(`${API}/praxes/${praxisId}/submit`)
   const last = await bob.ctx.request.post(`${API}/praxes/${praxisId}/submit`)
   return (await last.json()).status as string
@@ -103,7 +109,7 @@ test.describe('collaboration lifecycle', () => {
   test('full lifecycle publishes the praxis with both players as members', async ({ browser }) => {
     const seed = await seedCollabDraft(browser, 'life')
     try {
-      const status = await bothEditAndSubmit(seed)
+      const status = await bothSubmit(seed)
       expect(status).toBe('submitted')
 
       // Data: the published praxis records BOTH collaborators as members.
@@ -163,7 +169,7 @@ test.describe('collaboration lifecycle', () => {
     test.fail()
     const seed = await seedCollabDraft(browser, 'credit')
     try {
-      await bothEditAndSubmit(seed)
+      await bothSubmit(seed)
       const page = await seed.bob.ctx.newPage()
       await page.goto(`/praxis/${seed.praxisId}`)
       // Scope to main: the collaborator's name must appear in the praxis CONTENT,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-router-dom": "^6.24.0",
         "remark-gfm": "^4.0.1",
         "y-codemirror.next": "^0.3.5",
+        "y-indexeddb": "^9.0.12",
         "y-websocket": "^3.1.0",
         "yjs": "^13.6.32"
       },
@@ -6309,6 +6310,26 @@
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
         "yjs": "^13.5.6"
+      }
+    },
+    "node_modules/y-indexeddb": {
+      "version": "9.0.12",
+      "resolved": "https://registry.npmjs.org/y-indexeddb/-/y-indexeddb-9.0.12.tgz",
+      "integrity": "sha512-9oCFRSPPzBK7/w5vOkJBaVCQZKHXB/v6SIT+WYhnJxlEC61juqG0hBrAf+y3gmSMLFLwICNH9nQ53uscuse6Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
       }
     },
     "node_modules/y-protocols": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "react-router-dom": "^6.24.0",
     "remark-gfm": "^4.0.1",
     "y-codemirror.next": "^0.3.5",
+    "y-indexeddb": "^9.0.12",
     "y-websocket": "^3.1.0",
     "yjs": "^13.6.32"
   },

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -1030,8 +1030,7 @@ export interface paths {
         };
         /** Get Praxis Route */
         get: operations["get_praxis_route_praxes__praxis_id__get"];
-        /** Update Praxis Route */
-        put: operations["update_praxis_route_praxes__praxis_id__put"];
+        put?: never;
         post?: never;
         /** Delete Praxis Route */
         delete: operations["delete_praxis_route_praxes__praxis_id__delete"];
@@ -3891,13 +3890,6 @@ export interface components {
         PraxisTypeChange: {
             type: components["schemas"]["PraxisType"];
         };
-        /** PraxisUpdate */
-        PraxisUpdate: {
-            /** Body Text */
-            body_text?: string | null;
-            /** Title */
-            title?: string | null;
-        };
         /** PraxisVoteIn */
         PraxisVoteIn: {
             /** Value */
@@ -6180,43 +6172,6 @@ export interface operations {
             };
         };
         requestBody?: never;
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PraxisOut"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    update_praxis_route_praxes__praxis_id__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                praxis_id: number;
-            };
-            cookie?: {
-                access_token?: string | null;
-            };
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["PraxisUpdate"];
-            };
-        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -1,4 +1,4 @@
-import { apiDelete, apiGet, apiPost, apiPut } from './client'
+import { apiDelete, apiGet, apiPost } from './client'
 import { clearCastTallies } from '../components/vote/castTallies'
 import { notifyRequestsChanged } from '../utils/requestsBus'
 import type { components } from './generated/schema'
@@ -166,7 +166,8 @@ export type PraxisCardOut = components['schemas']['PraxisCardOut']
  */
 export type PraxisCreate = components['schemas']['PraxisCreate']
 
-export type PraxisUpdate = components['schemas']['PraxisUpdate']
+// There is no `PraxisUpdate`. A praxis body is written in its room and flushed
+// to the record server-side (ADR-0073, #1743) — see `pages/editPraxis/praxisRoom`.
 
 // ---------------------------------------------------------------------------
 // List / detail
@@ -273,14 +274,6 @@ export async function createPraxis(data: PraxisCreate): Promise<PraxisOut> {
   const { data: created } = await apiPost('/praxes', { body: data })
   justCreatedPraxis = created
   return created
-}
-
-export async function updatePraxis(id: number, data: PraxisUpdate): Promise<PraxisOut> {
-  const { data: result } = await apiPut('/praxes/{praxis_id}', {
-    params: { path: { praxis_id: id } },
-    body: data,
-  })
-  return result
 }
 
 export async function deletePraxis(id: number): Promise<void> {

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -114,6 +114,7 @@ export default function EditPraxis() {
           write-up and all, and that box still has to have the text in it. */}
       <PraxisRoomProvider
         praxisId={isWaitingStage(state.phase) ? null : state.praxis.id}
+        onUpdate={state.setAutosaveAt}
       >
         <Archetype state={state} />
       </PraxisRoomProvider>

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -156,7 +156,7 @@ function baseState(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
     dismissConfirm: () => {},
     cancel: async () => {},
     autosaveAt: null,
-    saveStatus: "idle",
+    setAutosaveAt: () => {},
     autoSubmitDays: 10,
     isPublished: false,
     controlsLocked: false,

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerRule.test.tsx
@@ -121,7 +121,7 @@ function state(): EditPraxisState {
     leaveCollab: async () => {},
     cancel: async () => {},
     autosaveAt: null,
-    saveStatus: "idle",
+    setAutosaveAt: () => {},
     autoSubmitDays: 10,
     isPublished: false,
     controlsLocked: false,

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/singularityComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/singularityComposer.test.tsx
@@ -76,7 +76,7 @@ function state(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
     duel: null,
     submitting: false,
     autosaveAt: null,
-    saveStatus: "idle",
+    setAutosaveAt: () => {},
     isPublished: false,
     controlsLocked: false,
     modeIsLocked: false,

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/taskSlipLink.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/taskSlipLink.test.tsx
@@ -146,7 +146,7 @@ function state(slug: string | null, phase: "composing" | "waiting"): EditPraxisS
     dismissConfirm: () => {},
     cancel: async () => {},
     autosaveAt: null,
-    saveStatus: "idle",
+    setAutosaveAt: () => {},
     autoSubmitDays: 10,
     isPublished: false,
     controlsLocked: false,

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/wowEditPraxis.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/wowEditPraxis.test.tsx
@@ -109,7 +109,7 @@ function state(overrides: Partial<EditPraxisState> = {}): EditPraxisState {
     leaveCollab: async () => {},
     cancel: async () => {},
     autosaveAt: null,
-    saveStatus: "idle",
+    setAutosaveAt: () => {},
     autoSubmitDays: 10,
     isPublished: false,
     controlsLocked: false,

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -835,7 +835,7 @@ export function BodyTextarea({
   const { t } = useTranslation("forms");
   const room = usePraxisRoom();
   const ytext = room?.body ?? null;
-  const synced = room?.synced ?? false;
+  const seeded = room?.seeded ?? false;
   const hostRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   // Stable across the editor's life; reconfigured rather than remounted.
@@ -869,7 +869,7 @@ export function BodyTextarea({
         keymap.of([...yUndoManagerKeymap, ...defaultKeymap]),
         cmPlaceholder(skin.placeholder ?? ""),
         BODY_EDITOR_BASE_THEME,
-        editableSlot.of(EditorView.editable.of(synced)),
+        editableSlot.of(EditorView.editable.of(seeded)),
         EditorView.contentAttributes.of(contentAttributes),
         // `null` awareness: carets and collaborator colours are #1744, and
         // passing it here is what would draw them.
@@ -890,16 +890,17 @@ export function BodyTextarea({
 
   useEffect(() => {
     viewRef.current?.dispatch({
-      effects: editableSlot.reconfigure(EditorView.editable.of(synced)),
+      effects: editableSlot.reconfigure(EditorView.editable.of(seeded)),
     });
-  }, [synced, editableSlot]);
+  }, [seeded, editableSlot]);
 
   // ---- The room's text → `state.body` ----
   //
-  // One direction only. `state.body` still feeds `BodyPreview`, the word count
-  // and the debounced `PUT` (#1743 retires that last one), so it has to follow
-  // the document — but nothing may push it back the other way, or the praxis
-  // would seed the room it is supposed to be seeded BY.
+  // One direction only, and now the ONLY direction: `state.body` feeds
+  // `BodyPreview` and the word count, and nothing else. Since #1743 no client
+  // write exists to feed, so there is not even a reason to be tempted — and
+  // nothing may push `state.body` back into the document, or the praxis would
+  // seed the room it is supposed to be seeded BY.
   useEffect(() => {
     if (!ytext) return;
     const mirror = () => setBodyRef.current(ytext.toString());
@@ -941,11 +942,12 @@ export function BodyTextarea({
   };
 
   // The room exists but has not told us what the praxis says yet. The editor is
-  // read-only until it does (#1742), so the toolbar is a set of controls the
-  // player cannot use — hidden, not drawn disabled. It would not merely look
-  // wrong: `dispatch` writes past `editable`, so a press here would put markdown
-  // into a document still waiting for its seed.
-  const awaitingRoom = ytext !== null && !synced;
+  // read-only until it does (#1742, re-derived in #1743 — see `PraxisRoom.seeded`
+  // for the reason that outlived the retired `PUT`), so the toolbar is a set of
+  // controls the player cannot use: hidden, not drawn disabled. It would not
+  // merely look wrong — `dispatch` writes past `editable`, so a press here would
+  // put markdown into a document still waiting for its seed.
+  const awaitingRoom = ytext !== null && !seeded;
 
   return (
     <div>

--- a/frontend/src/pages/editPraxis/editPraxisState.ts
+++ b/frontend/src/pages/editPraxis/editPraxisState.ts
@@ -24,8 +24,6 @@ import type { CharacterOut } from "../../api/characters";
 import type { EditPraxisPhase } from "./editPraxisPhase";
 import type { CrewNudgeResult } from "./useComposerRoster";
 
-export type SaveStatus = "idle" | "saving" | "saved" | "error";
-
 export interface EditPraxisState {
   // Routing / loading
   loading: boolean;
@@ -214,9 +212,20 @@ export interface EditPraxisState {
   /** Escape, backdrop, or "Never mind" — the handler returns without acting. */
   dismissConfirm: () => void;
 
-  // Autosave
+  /**
+   * When the room last took an update — local or a co-author's (#1743).
+   *
+   * The composer's "Saved …" line, and the only honest thing it can say now
+   * that no client-side request writes the praxis: an update the room has
+   * acknowledged is already in `praxis_room_update`, and `praxis.body_text`
+   * follows it on the server's own debounce.
+   */
   autosaveAt: Date | null;
-  saveStatus: SaveStatus;
+  /**
+   * Stamped by `PraxisRoomProvider` on every document update. `EditPraxis.tsx`
+   * hands it over as the provider's `onUpdate`; nothing else calls it.
+   */
+  setAutosaveAt: (value: Date | null) => void;
 
   /**
    * The ADR-0012 pending-publish window length, in days, from `/game-config`

--- a/frontend/src/pages/editPraxis/praxisRoom.tsx
+++ b/frontend/src/pages/editPraxis/praxisRoom.tsx
@@ -20,24 +20,36 @@
  * it contains, so nothing can be typed *in front of* the seed and nothing can
  * be flushed over the praxis on the strength of an empty editor.
  *
+ * ## The room is the record's only writer
+ *
+ * There is no debounced `PUT` behind this any more (#1743). The document goes
+ * to the server, which flushes it into `praxis.title` and `praxis.body_text`;
+ * nothing on this side writes the praxis, which is why nothing on this side has
+ * a dirty check, a flush order or an "unsaved" state to get wrong.
+ *
+ * Updates are held locally in IndexedDB as well, so a composer that loses the
+ * network keeps taking text and merges it on reconnect — where the `PUT` simply
+ * failed and lost the paragraph.
+ *
  * ## What is deliberately not here
  *
  * Carets, collaborator colours and the presence roster (#1744) — the provider's
  * own awareness channel exists (it is y-websocket's keep-alive) but nothing
- * reads it yet. Freeze-on-pending (#1745). Offline persistence and the retiring
- * of the debounced `PUT` (#1743): until then the room is a *live view*, and
- * `useComposerDraft`'s `PUT` is still the only thing that writes the record.
+ * reads it yet. Freeze-on-pending and discarding the document on publish
+ * (#1745).
  */
 import {
   createContext,
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
 import * as Y from "yjs";
 import { WebsocketProvider } from "y-websocket";
+import { IndexeddbPersistence } from "y-indexeddb";
 
 /**
  * The body's root key — `ROOM_BODY_KEY` in `praxis_room.py`. The server seeds a
@@ -80,18 +92,34 @@ function roomServerUrl(): string {
   return `${apiBase.replace(/^http/, "ws")}${ROOM_PATH}`;
 }
 
+/** The IndexedDB database holding one praxis's offline copy of its document. */
+function roomStoreName(praxisId: number): string {
+  return `praxis-room-${praxisId}`;
+}
+
 export interface PraxisRoom {
   /** The co-edited markdown body. Bound to CodeMirror by `BodyTextarea`. */
   body: Y.Text;
   /** The last-write-wins map holding {@link ROOM_TITLE_KEY}. */
   meta: Y.Map<string>;
   /**
-   * The server's document has arrived at least once.
+   * The document has arrived — from the socket, or from the offline store.
    *
-   * Until it has, the editor shows an empty document that means nothing, so the
-   * composer holds the body read-only. It goes back to `false` on disconnect.
+   * Until it has, the editor holds an empty document that means nothing, and
+   * the composer keeps the body read-only (`BodyTextarea`). #1742 kept that
+   * gate because a keystroke landing in front of the seed could be flushed over
+   * the praxis by the still-live `PUT`. That `PUT` is gone, and the gate is
+   * kept for a reason that survives it: the server seeds the document exactly
+   * once, so text typed *before* the seed is merged into text the player has
+   * never seen, at whatever positions the CRDT picks. Nothing is lost, but the
+   * result is a document nobody wrote.
+   *
+   * **It latches.** Seeding is a once-per-document event, so a dropped socket
+   * does not un-seed anything — and if this went back to `false` on
+   * disconnect, a wifi blip would freeze the editor mid-sentence and offline
+   * authoring, the whole point of the local store, could never happen.
    */
-  synced: boolean;
+  seeded: boolean;
 }
 
 const PraxisRoomContext = createContext<PraxisRoom | null>(null);
@@ -113,23 +141,39 @@ export function usePraxisRoom(): PraxisRoom | null {
  */
 export function PraxisRoomProvider({
   praxisId,
+  onUpdate,
   children,
 }: {
   praxisId: number | null;
+  /**
+   * The room took an update — the composer's one honest "Saved …" signal
+   * (#1743).
+   *
+   * Fires for a co-author's typing as well as your own, which is the point: an
+   * update the room has is already in `praxis_room_update`, and
+   * `praxis.body_text` follows it on the server's own debounce. Passed in
+   * rather than exposed on the context because the archetypes read it off
+   * `EditPraxisState`, and `useEditPraxis` runs outside this provider.
+   */
+  onUpdate?: (at: Date) => void;
   children: ReactNode;
 }) {
-  // The shared types, kept apart from `synced` so their identity survives a
-  // sync flip — `BodyTextarea` keys its editor on `body`, and a new identity
-  // there would tear the editor down and rebuild it the moment the seed lands.
+  // The shared types, kept apart from `seeded` so their identity survives the
+  // seed landing — `BodyTextarea` keys its editor on `body`, and a new identity
+  // there would tear the editor down and rebuild it at that moment.
   const [types, setTypes] = useState<{ body: Y.Text; meta: Y.Map<string> } | null>(
     null,
   );
-  const [synced, setSynced] = useState(false);
+  const [seeded, setSeeded] = useState(false);
+  // Read through a ref so a caller passing an inline callback does not tear the
+  // socket down and rebuild it on every render.
+  const onUpdateRef = useRef(onUpdate);
+  onUpdateRef.current = onUpdate;
 
   useEffect(() => {
     if (praxisId == null) {
       setTypes(null);
-      setSynced(false);
+      setSeeded(false);
       return;
     }
     const doc = new Y.Doc();
@@ -137,6 +181,18 @@ export function PraxisRoomProvider({
     // seeded `body` already, and a second seed merges as a second copy.
     const body = doc.getText(ROOM_BODY_KEY);
     const meta = doc.getMap<string>(ROOM_META_KEY);
+    // Offline authoring (#1743). Not a cache and not a second seed: it is the
+    // SAME document, replayed from the browser and merged by the CRDT on
+    // reconnect. What it replaces — a `PUT` that simply failed when the network
+    // was down, losing the paragraph outright — is why this is strictly better
+    // rather than a nicety. The room is still the only thing that writes the
+    // record; this only decides where the updates wait.
+    //
+    // #1745 discards the server's document on publish and re-seeds a fresh one
+    // through `pullBack`. When it does, it has to `clearData()` this store in
+    // the same beat: a stale local copy merging back into a re-seeded document
+    // is the duplication footgun by another route.
+    const offline = new IndexeddbPersistence(roomStoreName(praxisId), doc);
     const provider = new WebsocketProvider(
       roomServerUrl(),
       String(praxisId),
@@ -149,22 +205,48 @@ export function PraxisRoomProvider({
       },
     );
     setTypes({ body, meta });
-    setSynced(provider.synced);
-    const onSync = (isSynced: boolean) => setSynced(isSynced);
+
+    // Latch, never unlatch — see `PraxisRoom.seeded`.
+    const markSeeded = () => setSeeded(true);
+    if (provider.synced) markSeeded();
+    const onSync = (isSynced: boolean) => {
+      if (isSynced) markSeeded();
+    };
     provider.on("sync", onSync);
 
+    // The offline store counts as the seed arriving, but ONLY when it restored
+    // something. An empty store is a praxis whose room this browser has never
+    // opened, and unlocking the editor for it would let a first-ever offline
+    // visit type in front of a seed that has not happened yet. An empty
+    // document's state vector is one byte; a seeded one names the server's
+    // client id, so this asks "did anything come back?" without reaching into
+    // y-indexeddb's internals.
+    const onOfflineLoaded = () => {
+      if (Y.encodeStateVector(doc).byteLength > 1) markSeeded();
+    };
+    offline.on("synced", onOfflineLoaded);
+
+    const onDocUpdate = () => onUpdateRef.current?.(new Date());
+    doc.on("update", onDocUpdate);
+
     return () => {
+      doc.off("update", onDocUpdate);
       provider.off("sync", onSync);
+      offline.off("synced", onOfflineLoaded);
       provider.destroy();
+      // `destroy()` closes the store; `clearData()` is what would delete it,
+      // and must not be called here — the point of the store is that it
+      // outlives the tab.
+      void offline.destroy();
       doc.destroy();
       setTypes(null);
-      setSynced(false);
+      setSeeded(false);
     };
   }, [praxisId]);
 
   const room = useMemo<PraxisRoom | null>(
-    () => (types === null ? null : { ...types, synced }),
-    [types, synced],
+    () => (types === null ? null : { ...types, seeded }),
+    [types, seeded],
   );
 
   return (

--- a/frontend/src/pages/editPraxis/useComposerDraft.ts
+++ b/frontend/src/pages/editPraxis/useComposerDraft.ts
@@ -1,104 +1,25 @@
 /**
- * The composer's draft text: title, body, the 2s debounced autosave, and the
- * cancel-then-write flush every manual save runs.
+ * The composer's draft text: title, body, and the word count over it.
  *
- * This is the concern that owns *what has and has not reached the server*. The
- * last-persisted title and body live here in refs and are never read from
- * outside — callers ask `isDirty()` / `needsTitle()` instead, so no other file
- * can drift on what "unsaved" means.
+ * **Nothing here writes to the server.** A praxis is written in its room and
+ * flushed to the record by the room server (ADR-0073, #1743), so this hook is
+ * a *view* of the document, not a copy of it waiting to be sent.
  *
- * Split out of `useEditPraxis.ts` (#1392); behaviour is unchanged from #360 /
- * #1081 / #1164.
+ * What used to live here — the 2s debounced `PUT`, `flushEdits`' cancel-then-write
+ * ordering, the last-persisted refs, `isDirty()` / `needsTitle()` — existed to
+ * make single-writer autosave safe (#360 / #1081 / #1164). Every one of them
+ * answered "what has and has not reached the server", and the room answers that
+ * by construction: an update is in `praxis_room_update` before the socket
+ * acknowledges it. `hasUnsavedEdits` in particular was a workaround for a praxis
+ * `PUT` hard-resetting every member's `has_submitted` (ADR-0012) and went with
+ * the `PUT` that caused it.
+ *
+ * The values still flow one way, and only one way. `body` follows the room's
+ * `Y.Text` (`BodyTextarea`) and `title` follows the room's map key
+ * (`TitleField`); nothing pushes either back into the document, or the praxis
+ * would seed the room it is supposed to be seeded BY.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
-import { updatePraxis, type PraxisOut } from "../../api/praxis";
-import type { SaveStatus } from "./editPraxisState";
-
-const AUTOSAVE_DEBOUNCE_MS = 2000;
-
-/**
- * Dirty-check gate for the pre-submit save (#360).
- *
- * On a collab, ANY praxis PUT hard-resets every member's has_submitted
- * (ADR-0012 — "an edit means we're not done"). If Submit always fired a PUT,
- * the last member's submit would reset everyone else's, so
- * all(has_submitted) could never be reached through the UI. Only persist
- * when the form actually differs from the last-persisted values; a genuine
- * edit still resets consensus, which is correct per ADR-0012.
- */
-export function hasUnsavedEdits(
-  title: string,
-  body: string,
-  lastSavedTitle: string | null,
-  lastSavedBody: string | null,
-): boolean {
-  return title !== lastSavedTitle || body !== lastSavedBody;
-}
-
-/**
- * The composer's one manual write: **cancel the queued autosave first, then
- * persist the text in hand** — in that order, and never one without the other.
- *
- * The ordering is the whole correctness of a manual save (#1081). A queued
- * debounce holds a *stale* closure over title/body; leaving it armed lets it
- * land after the manual PUT and re-write older text, while cancelling without
- * writing drops every keystroke typed inside the 2s window. Publish has always
- * done both (#360); Save draft needs exactly the same two steps, so they live
- * here once rather than being re-typed at each call site.
- *
- * Exported (and dependency-injected on `cancelQueuedAutosave`) so the ordering
- * is provable in a test that calls it directly — the frontend harness runs no
- * effects, so the debounce timer can't be exercised through the component.
- *
- * Returns whether a PUT actually went out: nothing changed since the last save
- * → no request at all (#360; on a collab a PUT would reset every member's
- * `has_submitted`, ADR-0012).
- */
-export async function flushEdits(options: {
-  praxisId: number;
-  title: string;
-  body: string;
-  lastSavedTitle: string | null;
-  lastSavedBody: string | null;
-  cancelQueuedAutosave: () => void;
-}): Promise<boolean> {
-  const {
-    praxisId,
-    title,
-    body,
-    lastSavedTitle,
-    lastSavedBody,
-    cancelQueuedAutosave,
-  } = options;
-  // First, always — even on the clean path, where the queued write would be a
-  // no-op PUT the collab consensus rules can't afford.
-  cancelQueuedAutosave();
-  if (!hasUnsavedEdits(title, body, lastSavedTitle, lastSavedBody)) return false;
-  await updatePraxis(praxisId, { title, body_text: body || undefined });
-  return true;
-}
-
-/**
- * Save draft can't leave when the flush it's about to run would be rejected.
- *
- * The backend requires a title, which is why the autosave effect sits out a
- * blank one. That's harmless while the player stays on the page — but Save
- * draft *navigates away*, so a blank title with unsaved body text would strand
- * the writing with nowhere to land. Refuse the exit and say why instead (#1081).
- *
- * A blank title with nothing unsaved is not this case: there is no pending
- * write to reject, so leaving is free.
- */
-export function draftNeedsTitle(
-  title: string,
-  body: string,
-  lastSavedTitle: string | null,
-  lastSavedBody: string | null,
-): boolean {
-  return (
-    hasUnsavedEdits(title, body, lastSavedTitle, lastSavedBody) && !title.trim()
-  );
-}
+import { useCallback, useState } from "react";
 
 export interface ComposerDraft {
   title: string;
@@ -108,148 +29,29 @@ export interface ComposerDraft {
   wordCount: number;
   autosaveAt: Date | null;
   setAutosaveAt: (value: Date | null) => void;
-  saveStatus: SaveStatus;
-  setSaveStatus: (value: SaveStatus) => void;
   /**
-   * Seed the boxes AND the last-persisted marks from a freshly loaded praxis.
-   * Both halves matter: without the marks the autosave effect would read the
-   * hydration itself as a user edit and PUT it straight back.
+   * Seed the boxes from a freshly loaded praxis.
+   *
+   * Still needed with the room in place, and not a second seed: this fills the
+   * title box and the preview pane from the record while the socket is still
+   * opening, and both controls hand over to the document the moment it arrives.
+   * The room's own seed is server-side and reads the same column.
    */
   hydrate: (title: string, body: string) => void;
-  cancelQueuedAutosave: () => void;
-  /** Cancel-then-write, then remember what was written. */
-  persistEdits: (praxisId: number) => Promise<boolean>;
-  /** Does the text on screen differ from what the server last accepted? */
-  isDirty: () => boolean;
-  /** Would the pending flush be rejected for want of a title? (#1081) */
-  needsTitle: () => boolean;
 }
 
-export function useComposerDraft(
-  praxis: PraxisOut | null,
-  setPraxis: (praxis: PraxisOut) => void,
-): ComposerDraft {
+export function useComposerDraft(): ComposerDraft {
   const [title, setTitle] = useState("");
   const [body, setBody] = useState("");
+  // "The room has this" — stamped by the provider on every document update, so
+  // the composer's "Saved …" line marks something that actually happened rather
+  // than a request this hook fired.
   const [autosaveAt, setAutosaveAt] = useState<Date | null>(null);
-  const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle");
-
-  // Track last-persisted title/body so the autosave effect can detect
-  // genuine user edits and skip the initial hydration round-trip.
-  const lastSavedTitleRef = useRef<string | null>(null);
-  const lastSavedBodyRef = useRef<string | null>(null);
-  const autosaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const hydrate = useCallback((initialTitle: string, initialBody: string) => {
     setTitle(initialTitle);
     setBody(initialBody);
-    lastSavedTitleRef.current = initialTitle;
-    lastSavedBodyRef.current = initialBody;
   }, []);
-
-  // ---- Debounced autosave for title + body ----
-  useEffect(() => {
-    if (!praxis) return;
-    if (lastSavedTitleRef.current === null) return; // not yet hydrated
-    const titleChanged = title !== lastSavedTitleRef.current;
-    const bodyChanged = body !== lastSavedBodyRef.current;
-    if (!titleChanged && !bodyChanged) return;
-    if (!title.trim()) return; // backend rejects empty titles; wait for input
-
-    if (
-      praxis.status === "submitted" ||
-      praxis.moderation_status === "hidden" ||
-      praxis.moderation_status === "failed"
-    ) {
-      return;
-    }
-
-    if (autosaveTimerRef.current) clearTimeout(autosaveTimerRef.current);
-    autosaveTimerRef.current = setTimeout(() => {
-      void (async () => {
-        setSaveStatus("saving");
-        try {
-          const updated = await updatePraxis(praxis.id, {
-            title,
-            body_text: body || undefined,
-          });
-          lastSavedTitleRef.current = title;
-          lastSavedBodyRef.current = body;
-          // Take the payload, don't discard it (#1164). A PUT is exactly what
-          // `cancel_pending_publish_on_edit` reacts to: the pending-publish
-          // window is cancelled and every member's submission cleared
-          // (ADR-0012), so the `submit_proposed_at` this hook is holding is
-          // stale the instant a save lands. The holdout's countdown reads that
-          // field, and a countdown still ticking against a window that no
-          // longer exists is worse than no countdown at all. Costs nothing:
-          // `updatePraxis` already returns the fresh praxis.
-          //
-          // Safe against a loop — the effect's first act is to compare title
-          // and body against the refs just written, so the re-render it causes
-          // returns immediately.
-          setPraxis(updated);
-          setAutosaveAt(new Date());
-          setSaveStatus("saved");
-        } catch {
-          setSaveStatus("error");
-        }
-      })();
-    }, AUTOSAVE_DEBOUNCE_MS);
-
-    return () => {
-      if (autosaveTimerRef.current) clearTimeout(autosaveTimerRef.current);
-    };
-  }, [title, body, praxis]);
-
-  const cancelQueuedAutosave = useCallback(() => {
-    if (autosaveTimerRef.current) {
-      clearTimeout(autosaveTimerRef.current);
-      autosaveTimerRef.current = null;
-    }
-  }, []);
-
-  /** Cancel-then-write, then remember what was written. Resolves to whether a
-   * PUT went out — see `flushEdits` for why the order matters. */
-  const persistEdits = useCallback(
-    async (praxisId: number) => {
-      const wrote = await flushEdits({
-        praxisId,
-        title,
-        body,
-        lastSavedTitle: lastSavedTitleRef.current,
-        lastSavedBody: lastSavedBodyRef.current,
-        cancelQueuedAutosave,
-      });
-      if (wrote) {
-        lastSavedTitleRef.current = title;
-        lastSavedBodyRef.current = body;
-      }
-      return wrote;
-    },
-    [title, body, cancelQueuedAutosave],
-  );
-
-  const isDirty = useCallback(
-    () =>
-      hasUnsavedEdits(
-        title,
-        body,
-        lastSavedTitleRef.current,
-        lastSavedBodyRef.current,
-      ),
-    [title, body],
-  );
-
-  const needsTitle = useCallback(
-    () =>
-      draftNeedsTitle(
-        title,
-        body,
-        lastSavedTitleRef.current,
-        lastSavedBodyRef.current,
-      ),
-    [title, body],
-  );
 
   const wordCount = body.trim() ? body.trim().split(/\s+/).length : 0;
 
@@ -261,12 +63,6 @@ export function useComposerDraft(
     wordCount,
     autosaveAt,
     setAutosaveAt,
-    saveStatus,
-    setSaveStatus,
     hydrate,
-    cancelQueuedAutosave,
-    persistEdits,
-    isDirty,
-    needsTitle,
   };
 }

--- a/frontend/src/pages/editPraxis/useEditPraxis.test.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.test.ts
@@ -1,145 +1,22 @@
 /**
- * Mode-switch confirm logic. Switches are now in-place (#321 solo↔collab, #311
+ * Mode-switch confirm logic. Switches are in-place (#321 solo↔collab, #311
  * duel), so the draft is always preserved — only genuinely destructive
  * transitions warn: leaving a live duel, or collab→solo dropping co-authors.
+ *
+ * This file used to open with three describes over the composer's save
+ * machinery: `hasUnsavedEdits`, `flushEdits`' cancel-then-write ordering, and
+ * `draftNeedsTitle`. All three are gone with the debounced `PUT` they existed
+ * to make safe (#1743). They were not deleted because they were awkward to
+ * keep — they were deleted because there is no client-side write left to order,
+ * no "last persisted" for anything to be dirty against, and no write that can
+ * be rejected for want of a title. The praxis is written in its room, and the
+ * rules that replace these are asserted server-side in
+ * `backend/tests/integration/test_praxis_room.py`.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { updatePraxis } from "../../api/praxis";
-import { draftNeedsTitle, flushEdits, hasUnsavedEdits } from "./useEditPraxis";
+import { describe, it, expect } from "vitest";
 // The mode-switch confirm moved out of the hook with the rest of them (#1082)
 // and now returns a whole ConfirmRequest instead of a `window.confirm` string.
 import { modeSwitchConfirm } from "../../components/confirm/composerConfirms";
-
-vi.mock("../../api/praxis", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../../api/praxis")>()),
-  updatePraxis: vi.fn(async () => ({})),
-}));
-
-/**
- * Dirty-check gating the pre-submit PUT (#360). persistEdits only fires
- * updatePraxis when this returns true — on a collab an unconditional PUT
- * reset every member's has_submitted (ADR-0012), so consensus was never
- * reachable through the UI.
- */
-describe("hasUnsavedEdits", () => {
-  it("is false when title and body match the last-persisted values → no PUT on submit", () => {
-    expect(hasUnsavedEdits("Title", "Body", "Title", "Body")).toBe(false);
-  });
-
-  it("is true when the title changed → PUT fires (and resets collab consensus, per ADR-0012)", () => {
-    expect(hasUnsavedEdits("New title", "Body", "Title", "Body")).toBe(true);
-  });
-
-  it("is true when the body changed", () => {
-    expect(hasUnsavedEdits("Title", "New body", "Title", "Body")).toBe(true);
-  });
-
-  it("is true before hydration (refs still null), preserving the old always-save behavior", () => {
-    expect(hasUnsavedEdits("Title", "", null, null)).toBe(true);
-  });
-});
-
-/**
- * The manual flush behind Publish and Save draft (#1081). The harness runs no
- * effects, so the 2s debounce can't be exercised through the component — but
- * `flushEdits` takes its cancel as an argument precisely so the ordering that
- * makes a manual save safe is provable by calling it directly.
- */
-describe("flushEdits", () => {
-  const put = vi.mocked(updatePraxis);
-  let log: string[];
-  const cancelQueuedAutosave = () => {
-    log.push("cancel");
-  };
-
-  beforeEach(() => {
-    log = [];
-    put.mockClear();
-    put.mockImplementation(async () => {
-      log.push("put");
-      return {} as Awaited<ReturnType<typeof updatePraxis>>;
-    });
-  });
-
-  it("cancels the queued autosave BEFORE writing, never after", async () => {
-    await flushEdits({
-      praxisId: 7,
-      title: "Title",
-      body: "typed one keystroke ago",
-      lastSavedTitle: "Title",
-      lastSavedBody: "",
-      cancelQueuedAutosave,
-    });
-    // Cancel-then-write. The other order lets a debounce holding stale text land
-    // after the manual save and overwrite it.
-    expect(log).toEqual(["cancel", "put"]);
-  });
-
-  it("writes the text it was handed, so the last keystrokes go out too", async () => {
-    const wrote = await flushEdits({
-      praxisId: 7,
-      title: "Title",
-      body: "typed one keystroke ago",
-      lastSavedTitle: "Title",
-      lastSavedBody: "",
-      cancelQueuedAutosave,
-    });
-    expect(wrote).toBe(true);
-    expect(put).toHaveBeenCalledWith(7, {
-      title: "Title",
-      body_text: "typed one keystroke ago",
-    });
-  });
-
-  it("still cancels the debounce when nothing changed, but issues no PUT (#360)", async () => {
-    const wrote = await flushEdits({
-      praxisId: 7,
-      title: "Title",
-      body: "Body",
-      lastSavedTitle: "Title",
-      lastSavedBody: "Body",
-      cancelQueuedAutosave,
-    });
-    // On a collab that skipped PUT is load-bearing: it would reset every
-    // member's has_submitted (ADR-0012).
-    expect(wrote).toBe(false);
-    expect(log).toEqual(["cancel"]);
-    expect(put).not.toHaveBeenCalled();
-  });
-
-  it("sends an empty body as undefined rather than an empty string", async () => {
-    await flushEdits({
-      praxisId: 7,
-      title: "Title",
-      body: "",
-      lastSavedTitle: "",
-      lastSavedBody: "",
-      cancelQueuedAutosave,
-    });
-    expect(put).toHaveBeenCalledWith(7, { title: "Title", body_text: undefined });
-  });
-});
-
-/**
- * Save draft navigates away, so the one write it depends on has to be one the
- * backend will accept — otherwise the body text leaves with the page (#1081).
- */
-describe("draftNeedsTitle", () => {
-  it("refuses to leave when unsaved writing has no title to be saved under", () => {
-    expect(draftNeedsTitle("", "a body I just typed", "", "")).toBe(true);
-    expect(draftNeedsTitle("   ", "a body I just typed", "", "")).toBe(true);
-  });
-
-  it("lets a titled draft go", () => {
-    expect(draftNeedsTitle("Title", "a body I just typed", "Title", "")).toBe(
-      false,
-    );
-  });
-
-  it("lets an untitled but fully-persisted draft go — there is nothing to lose", () => {
-    expect(draftNeedsTitle("", "", "", "")).toBe(false);
-  });
-});
 
 describe("modeSwitchConfirm", () => {
   it("warns that co-authors will be dropped on collab → solo with a crew (#155)", () => {

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -8,7 +8,7 @@
  * `EditPraxisState` all nine archetypes, the waiting surface and the dispatcher
  * read:
  *
- *   `useComposerDraft`   — title, body, the 2s autosave, the flush
+ *   `useComposerDraft`   — title and body, as a view of the room's document
  *   `useComposerMedia`   — the tray: pick, edit, upload, remove
  *   `useMetataskApply`   — the applied seal stack, picker and peel-off
  *   `useComposerRoster`  — the search box, invites, challenge, kick, nudge
@@ -79,7 +79,7 @@ export { MAX_FILE_SIZE } from "./useComposerMedia";
  * because every importer — nine archetypes, the waiting surface, the seal
  * components, the dispatcher — reaches for both names by this path.
  */
-export type { EditPraxisState, SaveStatus } from "./editPraxisState";
+export type { EditPraxisState } from "./editPraxisState";
 import type { EditPraxisState } from "./editPraxisState";
 
 /**
@@ -99,18 +99,11 @@ export {
  * one string for `window.confirm`, and it belongs beside the other six confirms
  * the composer asks for. */
 
-/**
- * The draft's own machinery — the 2s debounced autosave, the cancel-then-write
- * flush, and the three predicates that decide whether a write is owed — moved
- * to `useComposerDraft.ts` (#1392). Re-exported here because
- * `useEditPraxis.test.ts` calls all three directly: the harness runs no
- * effects, so calling them is the only way the ordering is provable.
- */
-export {
-  draftNeedsTitle,
-  flushEdits,
-  hasUnsavedEdits,
-} from "./useComposerDraft";
+/* The draft's save machinery — the 2s debounced autosave, the cancel-then-write
+ * flush, and the three predicates that decided whether a write was owed — was
+ * re-exported here so a test could call it directly. It is gone (#1743): the
+ * praxis is written in its room, so there is no client-side write to order and
+ * no "unsaved" for anything to be dirty against. */
 
 /**
  * The invite/opponent search box, the two sends that clear it, and the roster
@@ -193,7 +186,9 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
   const duelLevelRequired = gameConfig?.duel_level_required ?? null;
   const autoSubmitDays = gameConfig?.collab_auto_submit_days ?? null;
 
-  // ---- Draft text + autosave (#360, #1081, #1164) ----
+  // ---- Draft text ----
+  // A view of the room's document, not a copy waiting to be sent: the room is
+  // the one write path since #1743, so nothing here persists anything.
   const {
     title,
     setTitle,
@@ -202,14 +197,8 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     wordCount,
     autosaveAt,
     setAutosaveAt,
-    saveStatus,
-    setSaveStatus,
     hydrate: hydrateDraft,
-    cancelQueuedAutosave,
-    persistEdits,
-    isDirty,
-    needsTitle,
-  } = useComposerDraft(praxis, setPraxis);
+  } = useComposerDraft();
 
   // ---- Initial load ----
   useEffect(() => {
@@ -335,7 +324,9 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     setError("");
     try {
       const praxisId = parseInt(idParam, 10);
-      await persistEdits(praxisId);
+      // No flush first. The text is already in the room and already durable
+      // there (#1743); the record catches up on the room's own debounce, and
+      // #1745 makes the freeze flatten it at exactly this moment instead.
       await submitPraxis(praxisId);
       let refreshed: PraxisOut | null = null;
       let refreshedDuel: DuelDetailOut | null = duel;
@@ -389,56 +380,27 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     } finally {
       setSubmitting(false);
     }
-  }, [idParam, title, persistEdits, navigate, refetch, user?.character?.id, duel]);
+  }, [idParam, title, navigate, refetch, user?.character?.id, duel]);
 
   // The third exit (#1081). Publish files the praxis and Drop destroys it; this
   // is the one that keeps the draft and simply leaves.
   //
-  // Almost every byte is already persisted by the time it's pressed — title and
-  // body on the 2s debounce, media the moment it's picked — so the work here is
-  // the flush, not a save: the queued autosave is cancelled and the text in hand
-  // written in its place, exactly as publish does. Without that, the keystrokes
-  // typed inside the debounce window would be discarded by the unmount.
+  // It leaves, and that is all it does. It used to carry the flush — cancel the
+  // queued autosave, write the text in hand — because keystrokes typed inside
+  // the 2s debounce window would otherwise be discarded by the unmount. There
+  // is no window to lose them in now: every keystroke is in the room's store
+  // before the socket acknowledges it (#1743), so there is nothing to save, no
+  // request that can fail, and no reason to refuse a blank title on the way out.
   //
   // Destination is the player's own profile, whose praxis grid shows them their
   // own `in_progress` work (`praxis_visibility_condition` ORs in the viewer's
-  // member praxes) — i.e. the draft they just saved, waiting where they left it.
+  // member praxes) — i.e. the draft they just left, waiting where they left it.
   const saveDraft = useCallback(async () => {
     if (!idParam) return;
-    if (needsTitle()) {
-      // Stay put: the body is still in the box, and leaving would strand it.
-      setError(i18n.t("forms:editPraxis.errors.titleRequired"));
-      return;
-    }
-    const dirty = isDirty();
     setError("");
-    if (dirty) setSaveStatus("saving");
-    try {
-      await persistEdits(parseInt(idParam, 10));
-    } catch (err) {
-      // The write failed, so the only copy of this text is the one on screen.
-      // Report and hold — navigating now would be the data loss the flush exists
-      // to prevent.
-      if (dirty) setSaveStatus("error");
-      setError(extractError(err, i18n.t("forms:editPraxis.errors.saveDraft")));
-      return;
-    }
-    if (dirty) {
-      setAutosaveAt(new Date());
-      setSaveStatus("saved");
-    }
     const characterId = user?.character?.id;
     navigate(characterId != null ? `/characters/${characterId}` : "/tasks");
-  }, [
-    idParam,
-    needsTitle,
-    isDirty,
-    persistEdits,
-    setAutosaveAt,
-    setSaveStatus,
-    navigate,
-    user?.character?.id,
-  ]);
+  }, [idParam, navigate, user?.character?.id]);
 
   // Pull my own part back out of a pending collab (#591) — clears my cast so the
   // composer unlocks for editing. Backend re-opens only my membership (#590).
@@ -536,7 +498,6 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
         : dropTaskConfirm(),
     );
     if (!confirmed) return;
-    cancelQueuedAutosave();
     try {
       await deletePraxis(praxis.id);
     } catch (err) {
@@ -544,7 +505,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       return;
     }
     navigate("/tasks");
-  }, [praxis, navigate, askConfirm, cancelQueuedAutosave]);
+  }, [praxis, navigate, askConfirm]);
 
   // ---- Mode switching ----
   const changeMode = useCallback(
@@ -763,7 +724,7 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     dismissConfirm,
 
     autosaveAt,
-    saveStatus,
+    setAutosaveAt,
 
     autoSubmitDays,
     isPublished: !!isPublished,


### PR DESCRIPTION
Closes #1743

Part of the ADR-0073 epic. #1740 built the room server, #1742 bound CodeMirror to
it, and this makes the room the **only** way a praxis body is written: the
debounced `PUT` is deleted, not kept as a fallback.

## The seam I tested at

**The room's ASGI app plus the `praxis` row.** "An edit reaches the record" is a
server rule now — it has to be, or it is not a rule — so it is driven with real
`pycrdt` clients over an in-memory socket in the existing pytest-against-Postgres
suite, in a dedicated `wz1743_test` database. The frontend harness runs the
`node` environment with no DOM, so an effect-driven binding is untestable there
by construction; no jsdom was added.

The loop went red first on the real defect: the four verification cases in the
issue all failed against the unchanged server, and the first failure was not the
one I expected — the harness's own `db_session` is one savepoint-backed session
shared with the room tasks, so polling the row from the test body raised
"concurrent operations are not permitted" *out of a room task*, where it reads
as a room bug. Test reads now go through the room's own session factory, and
`_Rooms.sessions` says why.

## What happened to `PUT /praxes/{praxis_id}`

**It is gone entirely**, along with `update_praxis`, the `PraxisUpdate` schema
and `updatePraxis` in the frontend client. It carried exactly two fields, title
and body, and both are written in the room now — so there was nothing left for
it to carry.

What the grep found, before deleting:

| caller | verdict |
|---|---|
| `frontend/src/pages/editPraxis/useComposerDraft.ts` (×2 — the debounce and the flush) | the composer's autosave; the thing being retired |
| `frontend/src/pages/editPraxis/useEditPraxis.test.ts` | tested the flush ordering; deleted with it |
| `frontend/e2e/collaboration.spec.ts:90-91` | **the one this repo warned me about.** Two `request.put` calls in `bothEditAndSubmit`. Nightly, not PR-blocking, so CI would never have said. No assertion downstream read the text they wrote, and `seedCollabDraft` already gives the praxis a body at create time, so the helper is now `bothSubmit` |
| `backend/tests/integration/test_praxes.py` (×6) | see below |
| everything else | prose only |

There were **no** other consumers: no admin surface, no script, no other page.

`backend/tests/test_deleted_routes_stay_deleted.py` takes the route. The ratchet
#1667 built for "deleted because unreachable" also holds "deleted because there
may be only one of these", and the argument for re-adding it is written down
there to be answered rather than quietly reverted.

## The title had to come too

The issue says the `PUT` "loses title/body". `PraxisUpdate` held only those two,
so losing both means the route goes — which only works if the title has a home.
It does, and it was already there: #1742 shipped `ROOM_TITLE_KEY` on a
last-write-wins `meta` map and `TitleField` already publishes to it (ADR-0073,
"the title is one last-write-wins key in the room's map"). Nothing had ever
flushed it. The flusher now does.

Its **absence** is read as "the room has no title yet", never "the title was
cleared" — nothing seeds that key, so the other reading would blank the title of
every praxis whose body someone edited. There is a test for exactly that.

## `has_submitted` is not left with nothing that resets it

I checked, because `hasUnsavedEdits` existed only because a `PUT` hard-reset it
(ADR-0012) and that whole workaround goes with the `PUT`.

`on_member_edit` has three other callers — media upload, media batch, media
delete — plus `unsubmit_praxis` / `pullBack` and the submit paths, all of which
still clear the flag. The **mechanism** is untouched; it has one fewer trigger.

That a *text* edit no longer resets consensus is deliberate, not an oversight:
ADR-0073 rejects "any CRDT update resets consensus" outright (a CRDT has no
discrete edit event to key on) and answers it with freeze, which is #1745.

## The read-only-until-synced guard: KEPT, and re-derived

#1742's stated reason was that a keystroke before sync would mirror `state.body`
down and let the still-live `PUT` flush it over the praxis. **That reason is
gone.** I kept the guard for a different one that outlives it:

> The server seeds the document exactly once. Text typed *in front of* the seed
> is merged into text the player has never seen, at whatever positions the CRDT
> picks. Nothing is lost, and the result is a document nobody wrote.

But re-deriving it turned up something the original framing hid, and it is the
change here I would most like a second pair of eyes on. `provider.synced` goes
back to `false` on disconnect. With `y-indexeddb` added, that flag would have:

- frozen the editor mid-sentence on a wifi blip, and
- made offline authoring — the entire point of adding the dependency —
  impossible, since the flag can never become true without a socket.

So the flag is renamed `seeded` and **latches**. Seeding is a once-per-document
event; a dropped socket does not un-seed anything. The offline store satisfies it
too, but only when it actually restored state — an empty store means this browser
has never opened this room, and unlocking there is the pre-seed case again. (An
empty `Y.Doc`'s state vector is one byte; a seeded one names the server's client
id.)

## What to eyeball

1. **The latch, and the rename `synced` → `seeded`** (`praxisRoom.tsx`,
   `controls.tsx`). This is the one judgement call I made that the issue did not
   ask for. If you would rather ship the guard exactly as #1742 wrote it and take
   the wifi-blip freeze, say so and I will revert to the non-latching flag — but
   then `y-indexeddb` is inert and should probably come out with it.
2. **`saveStatus` deleted outright.** It had zero readers — not one archetype,
   not the design kit. `autosaveAt` keeps its eight archetypes and is now stamped
   by the room provider on every document update, which is the only "Saved …"
   the composer can claim honestly. `EditPraxis.tsx` passes `setAutosaveAt` as
   the provider's `onUpdate`; nothing else calls it. **This is what the "Saved
   just now" line means now, and it is worth deciding you like it** — it also
   ticks for a *co-author's* typing, which I think is right (the room has it,
   so it is saved) but is a behaviour change.
3. **Save draft only leaves now.** No flush, no request that can fail, and no
   blank-title refusal on the way out — there is no longer a window in which
   keystrokes can be stranded. The button still keeps the draft and navigates to
   your profile.
4. **A ~2s staleness window after Publish**, which #1745 closes properly.
   Flushing *on freeze* is explicitly #1745's half and out of scope here, so
   between this PR and that one, a player who types and submits inside the
   debounce publishes a praxis whose `body_text` catches up a moment later. It
   is staleness, not loss: the flusher also fires when the room closes, and
   nothing in the submit path reads `body_text`.
5. **The five backend tests I deleted and the one I re-pointed.**
   `test_edit_praxis`, `test_edit_praxis_wrong_owner_returns_403`,
   `test_collab_non_creator_can_edit`, `test_collab_edit_cancels_pending_publish`
   and `test_edit_minimal_draft_adds_content` all tested the endpoint rather than
   the rule. Each deletion leaves a comment naming where the rule went, and
   ADR-0013's "any member may edit" gained a replacement at the new seam
   (`test_a_non_creator_members_edit_reaches_the_record`). The sixth,
   `test_roster_row_carries_when_each_member_filed`, keeps its subject and
   changes its trigger to `pullBack`.
6. **`y-indexeddb` 9.0.12, MIT** — verified from the installed package, not from
   the issue: `license: MIT`, one dependency (`lib0`, which `yjs` already pulls),
   peer `yjs@^13`. The issue's suggested version was right. It lands in the lazy
   `EditPraxis` chunk; the initial-load budget is unmoved (129.9 KB JS, ok).
7. **`clearData()` is #1745's obligation**, noted in the code where the store is
   created: when #1745 discards the server's document on publish, a stale local
   copy merging back into a re-seeded one is the duplication footgun by another
   route.

## Verification

All four cases from the issue, plus the ones the change turned up:

- an edit in a room lands in `body_text` after the debounce ✅
- `body_text` is markdown, byte-identical to the document (asserted against a
  heading / list / blockquote / trailing-newline sample, because a flush that
  normalised whitespace would change every read surface at once and no assertion
  about the socket would notice) ✅
- two clients editing concurrently converge into one `body_text` — asserted on
  **both** insertions surviving, since the retired `PUT` would have kept exactly
  one ✅
- a praxis whose room never opened reads its `body_text` unchanged ✅
- opening and closing a room without typing rewrites nothing ✅
- the last edit before a room closes still lands (debounce set to 30s so only the
  closing flush can satisfy it) ✅
- the title key flushes; an absent title key never blanks the praxis title ✅
- a non-creator member's edit reaches the record (ADR-0013) ✅

Ran locally, from `.github/workflows/test.yml`, all three jobs:

- `test` — 1232 passed, coverage 92.73% (gate 80)
- `api-schema` — `python scripts/regen_api_client.py` re-run after the last
  commit produces no diff; `backend/openapi.json` and
  `frontend/src/api/generated/schema.d.ts` are both committed from that script,
  never hand-edited
- `frontend` — lint, `typecheck`, `typecheck:design-sync`, 4423 tests in 248
  files, build, byte budget: all pass

## Outstanding

- **Visual QA is outstanding.** I have no browser and no dev stack; nothing here
  was seen rendered. The composer's status row, the toolbar's hide-while-unseeded
  behaviour and the editor's read-only state all need a human look.
- **Live convergence is outstanding.** Two real browsers in one room, with a
  network between them, is not something this PR proves. The convergence
  assertions here are two `pycrdt` clients over an in-memory socket, and the
  offline path — drop the network, type, reconnect, watch it merge — has been
  reasoned about and never observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
