### PR TITLE
The FieldDesk's <h1> is the page's, not the roster's (#1794)

### DIFF
--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -60,10 +60,15 @@ import DefaultFieldDesk from './fieldDesk/mobileArchetypes/DefaultFieldDesk'
  * #1560 was written when `/` was ONLY the roster, so it asked for the route to
  * be gated. Since #1557 landed, `/` also carries "continue where you left off"
  * and the browse — a pre-gate player still needs those. So the seam is the
- * ROSTER SECTION (chip, heading, rule, cards, dossier, closing line), which is
- * hidden as one piece unless it has a choice to offer. `rosterOffersAChoice`
- * below is that rule, and the create-your-first-life path is inside it: an
- * account with zero lives ALWAYS sees the roster, or signup dead-ends.
+ * ROSTER SECTION (chip, cards, dossier, closing line), which is hidden as one
+ * piece unless it has a choice to offer. `rosterOffersAChoice` below is that
+ * rule, and the create-your-first-life path is inside it: an account with zero
+ * lives ALWAYS sees the roster, or signup dead-ends.
+ *
+ * The page TITLE is deliberately not in that piece (#1794): `/` is the
+ * authenticated home and must have a level-1 heading in every gate state, so
+ * the `<h1>` and its rule sit outside and the heading changes what it says
+ * instead of disappearing.
  *
  * The Albescent letter (#395) is deliberately OUTSIDE the gate. It converts an
  * existing life rather than adding one, so it is a real control for a
@@ -145,6 +150,19 @@ export default function FieldDesk() {
   // does, the carried life is the best proof there is: an account playing
   // someone has at least one. Keeps the heading from swapping under the viewer.
   const drawerEmpty = lives === null ? !carriesALife : lives.length === 0
+  // The page's <h1>, which is the PAGE's and not the roster's (#1794): it used
+  // to be drawn inside the gated block, so the commonest state of all — one
+  // life, gate shut — served `/` with an outline starting at level 2.
+  //
+  // With the roster hidden the page is no longer asking whose shoes; its subject
+  // is the life being carried, so the heading names it (owner ruling
+  // 2026-08-15). No new string — the name is data already on the page. A shut
+  // gate implies `carriesALife`, so `active` is always there to name; the `&&`
+  // is what the type-checker needs to see it, and a blank display name falls to
+  // the handle rather than to an empty heading.
+  const heading = !showRoster && active
+    ? active.display_name || `@${active.username}`
+    : drawerEmpty ? t('fieldDesk.headingFirstLife') : t('fieldDesk.heading')
 
   // Phone + a carried life → the mobile-native home skin for that faction.
   if (formFactor === 'mobile' && homeState) {
@@ -155,70 +173,69 @@ export default function FieldDesk() {
   return (
     <div className="page" style={pageStyle}>
       {/* ── The roster (#1560: only when it has a choice to offer) ─────────── */}
+      {/* Top-bar pill: the ACTIVE life's @handle + avatar + lives-in-play. No
+          account handle. Inside the gate — a count is an invitation to make
+          it bigger, which is the thing being kept back. */}
       {showRoster && (
-        <>
-          {/* Top-bar pill: the ACTIVE life's @handle + avatar + lives-in-play. No
-              account handle. Inside the gate — a count is an invitation to make
-              it bigger, which is the thing being kept back. */}
-          <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 'var(--space-sm)' }}>
-            {active && lives !== null && (
-              <div style={pillStyle}>
-                {active.avatar_url ? (
-                  <img src={mediaUrl(active.avatar_url)} alt={active.display_name} style={pillAvatar} />
-                ) : (
-                  <span style={{ ...pillAvatar, display: 'inline-block' }} />
-                )}
-                <span style={{ fontSize: 'var(--text-lg)', color: 'var(--color-text-secondary)' }}>
-                  @{active.username} ·{' '}
-                  <b style={{ color: 'var(--color-text-primary)' }}>
-                    {t('fieldDesk.livesInPlay', { count: lives.length })}
-                  </b>
-                </span>
-              </div>
-            )}
-          </div>
-
-          <h1 style={headingStyle}>
-            {/* "Whose shoes today?" presumes shoes. An account with none is being
-                asked to cut its first pair, not to choose between pairs. */}
-            {drawerEmpty ? t('fieldDesk.headingFirstLife') : t('fieldDesk.heading')}
-          </h1>
-          <div style={rainbowUnderline} />
-
-          {lives === null ? (
-            <p className="font-body text-muted" style={{ marginTop: 'var(--space-xl)' }}>{t('fieldDesk.loading')}</p>
-          ) : (
-            <div style={rosterRow}>
-              {lives.map((life, index) => (
-                <button
-                  key={life.id}
-                  type="button"
-                  onClick={() => enterLife(life.id)}
-                  disabled={switching != null}
-                  className="fielddesk-life"
-                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
-                  title={t('fieldDesk.stepInto', { name: life.display_name })}
-                >
-                  <CredentialCard
-                    displayName={life.display_name}
-                    handle={life.username}
-                    factionSlug={life.faction_slug}
-                    level={life.level}
-                    score={life.score}
-                    avatarUrl={mediaUrl(life.avatar_url)}
-                    rotation={TILTS[index % TILTS.length]}
-                  />
-                </button>
-              ))}
-
-              {/* "Begin a new self" — the dossier has no locked face any more
-                  (#1560). Either the slot is open and the card is here, or the
-                  offer is not made at all. */}
-              {canBeginNewSelf && <NewSelfDossier onBegin={() => navigate('/characters/create')} />}
+        <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 'var(--space-sm)' }}>
+          {active && lives !== null && (
+            <div style={pillStyle}>
+              {active.avatar_url ? (
+                <img src={mediaUrl(active.avatar_url)} alt={active.display_name} style={pillAvatar} />
+              ) : (
+                <span style={{ ...pillAvatar, display: 'inline-block' }} />
+              )}
+              <span style={{ fontSize: 'var(--text-lg)', color: 'var(--color-text-secondary)' }}>
+                @{active.username} ·{' '}
+                <b style={{ color: 'var(--color-text-primary)' }}>
+                  {t('fieldDesk.livesInPlay', { count: lives.length })}
+                </b>
+              </span>
             </div>
           )}
-        </>
+        </div>
       )}
+
+      {/* Outside the gate (#1794). The title and its rule travel together — the
+          rule is the title's, not the roster's — so the gate-open drawing is
+          unchanged: pill, title, rule, roster. See `heading` above for what it
+          says once the roster is gone. */}
+      <h1 style={headingStyle}>{heading}</h1>
+      <div style={rainbowUnderline} />
+
+      {showRoster &&
+        (lives === null ? (
+          <p className="font-body text-muted" style={{ marginTop: 'var(--space-xl)' }}>{t('fieldDesk.loading')}</p>
+        ) : (
+          <div style={rosterRow}>
+            {lives.map((life, index) => (
+              <button
+                key={life.id}
+                type="button"
+                onClick={() => enterLife(life.id)}
+                disabled={switching != null}
+                className="fielddesk-life"
+                style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+                title={t('fieldDesk.stepInto', { name: life.display_name })}
+              >
+                <CredentialCard
+                  displayName={life.display_name}
+                  handle={life.username}
+                  factionSlug={life.faction_slug}
+                  level={life.level}
+                  score={life.score}
+                  avatarUrl={mediaUrl(life.avatar_url)}
+                  rotation={TILTS[index % TILTS.length]}
+                />
+              </button>
+            ))}
+
+            {/* "Begin a new self" — the dossier has no locked face any more
+                (#1560). Either the slot is open and the card is here, or the
+                offer is not made at all. */}
+            {canBeginNewSelf && <NewSelfDossier onBegin={() => navigate('/characters/create')} />}
+          </div>
+        ))}
 
       {/* The order's correspondence (#395) — account-collective invitation
           (ADR-0021), shown only while the server flag holds. Deliberately no

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskRosterGate.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskRosterGate.test.tsx
@@ -96,13 +96,22 @@ function currentUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
   }
 }
 
-function render(user: CurrentUser | null): string {
+function renderRaw(user: CurrentUser | null): string {
   mocks.user = user
   return renderToStaticMarkup(
     <MemoryRouter>
       <FieldDesk />
     </MemoryRouter>,
-  ).replace(/<[^>]*>/g, '')
+  )
+}
+
+function render(user: CurrentUser | null): string {
+  return renderRaw(user).replace(/<[^>]*>/g, '')
+}
+
+/** The text of every `<h1>` the page drew, in document order. */
+function h1s(html: string): string[] {
+  return [...html.matchAll(/<h1\b[^>]*>(.*?)<\/h1>/gs)].map((m) => m[1].replace(/<[^>]*>/g, '').trim())
 }
 
 describe('a life before the gate is told nothing about a second one (#1560)', () => {
@@ -138,6 +147,30 @@ describe('the roster is shown whenever it has a choice to offer (#1560)', () => 
     const body = render(currentUser({ character: null }))
     expect(body).toContain('Nothing in the drawer yet.')
     expect(body).not.toContain('Whose shoes today?')
+  })
+})
+
+describe('the page keeps its level-1 heading whatever the gate does (#1794)', () => {
+  // The <h1> used to live INSIDE the roster block, so the commonest state of
+  // all — one life, gate shut — served `/` with an outline starting at level 2.
+  it('names the carried life when the roster is gated away', () => {
+    const heads = h1s(renderRaw(currentUser()))
+    expect(heads).toEqual(['Mollusk'])
+  })
+
+  it('falls back to the handle rather than an empty heading', () => {
+    const heads = h1s(renderRaw(currentUser({ character: life({ display_name: '' }) })))
+    expect(heads).toEqual(['@molly'])
+  })
+
+  it('still asks whose shoes once the gate opens', () => {
+    const heads = h1s(renderRaw(currentUser({ can_create_additional_character: true })))
+    expect(heads).toEqual(['Whose shoes today?'])
+  })
+
+  it('still has exactly one for an account playing nobody', () => {
+    const heads = h1s(renderRaw(currentUser({ character: null })))
+    expect(heads).toEqual(['Nothing in the drawer yet.'])
   })
 })
 


### PR DESCRIPTION
`/` is the authenticated home, and for the commonest account there is — one life, below the era's `second_character_level_required` — it rendered **no `<h1>` at all**. The heading was drawn inside the block #1560 gates, so hiding the roster took the page's only level-1 heading with it.

## The change

`frontend/src/pages/FieldDesk.tsx` only. The `<h1>` and its rainbow rule move **out** of `{showRoster && …}`; the top-bar pill above it and the roster row below it stay **in**, so the gate-open drawing is the same nodes in the same order it ships today: pill, title, rule, roster row. The gate itself (`rosterOffersAChoice`) is untouched — #1560 is correct, only the heading's placement inside it was wrong.

What the heading says:

| state | heading |
|---|---|
| gate open, lives in the drawer | `fieldDesk.heading` — "Whose shoes today?" (unchanged) |
| gate open, drawer empty | `fieldDesk.headingFirstLife` (unchanged) |
| gate shut | **the carried life's display name** |

No new string. Per the owner ruling of 2026-08-15, the gated page's subject is the current life, so the heading names it — data already on the page rather than a new catalogue entry, so ADR-0031 has nothing to route.

The "no character resolvable" row is not a guess: **a shut gate implies a carried life.** `rosterOffersAChoice` returns `true` whenever `!carriesALife`, and `carriesALife` and `active` are the same `user?.character`. So there is always a life to name; the `&& active` in the expression is what lets the type-checker see that, and a blank `display_name` falls to `@username` rather than to an empty heading — an empty `<h1>` would pass a naive "is there an h1" check and fail the actual requirement.

The rule (`rainbowUnderline`) travels with the title because it is the *title's* rule, not the roster's — that keeps the gate-open render identical and stops the gated heading floating ruleless.

## Seam tested at

The **desktop `FieldDesk` render** under `renderToStaticMarkup` — the same seam `fieldDeskRosterGate.test.tsx` already drives, with state pushed through the mocked `useAuth` rather than through an effect (the harness is `node`, no DOM, effects never run, so `lives` stays `null` in every rendered case).

Four new cases in `fieldDeskRosterGate.test.tsx` assert the **text of every `<h1>` in document order**, so "exactly one" is asserted, not just "at least one": gated → `['Mollusk']`, gated with a blank display name → `['@molly']`, gate open → `['Whose shoes today?']`, no life at all → `['Nothing in the drawer yet.']`. The first two go red on `main` (`expected [] to deeply equal [ 'Mollusk' ]`) — verified by stashing the component and re-running.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (248 files / 4,436 passed), `npm run build`, `npm run budget` (JS 130.0 KB, CSS 21.3 KB — unchanged, within budget) all pass locally. No API contract touched, so `api-schema` has nothing to regenerate.

**Visual QA is outstanding** — no browser or dev stack here.

## Mobile: already compliant, with one exception that is NOT this issue

The issue flagged the mobile skins as unchecked. Seven of the eight archetypes under `frontend/src/pages/fieldDesk/mobileArchetypes/` render their own `<h1>` unconditionally and never mention the roster gate: `Default`, `Coven`, `Ephemerists`, `Everymen`, `Singularity`, `Snide`, `Ua`. **They need no change** — the gate is a desktop-only concern and the mobile branch returns before it.

`WowFieldDesk.tsx` is the exception: it has **no `<h1>`**. Its identity block is `WowPavilionHeader` (`frontend/src/components/factionMarks/wowMobile.tsx`), which draws the name in a plain `<div>`. That is a separate defect from this one — it has nothing to do with the roster gate, it is in a shared component whose second consumer (`frontend/src/pages/factionDetail/mobileArchetypes/WowFactionPage.tsx`) also has no `<h1>`, and promoting that `div` would change the outline of both pages at once. Left alone here; worth its own issue.

`frontend/e2e/smoke.spec.ts` is untouched — its `/whose shoes today/i` assertion belongs to #1676, which is deliberately re-anchoring to `Tasks you can sign up for`. This change neither fixes nor worsens it.

## What to eyeball

- `/` on **desktop**, one life, below `second_character_level_required` (gate shut): the character's display name as the page title, with the rainbow rule under it, then "Continue where you left off" / the browse below. Check the space between the rule and the sections below reads as deliberate — the gated page is now title-then-content with no roster in between, which is a layout `frontend-style` may want an opinion on.
- `/` on **desktop** with the gate open (or two lives): should be pixel-identical to today — pill, "Whose shoes today?", rule, credential cards.
- `/` on **desktop** for a brand-new account with no character: "Nothing in the drawer yet." plus the "Begin a new self" dossier, unchanged.
- A **phone** at `/`: the mobile skins are unchanged; the WOW one still has no `<h1>` (see above).

Closes #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)
