### PR TITLE
A night-plate ink is not for the app's page, and the second Ephemerists root owed the label seam

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1567,7 +1567,19 @@
      gold, which is likewise never painted as text. */
   --faction-ephemerists-plate-bg: #171a26;
   --faction-ephemerists-plate-ink: #f0e6c8;
-  --faction-ephemerists-plate-muted: #a2977a; /* brief + in-progress */
+  /* Brief + in-progress, on the task card. THE SAME HEX AS `-plate-quiet` below,
+     which is a fact worth stating rather than leaving to be rediscovered: #1793
+     re-derived this twin when it caught that one's comment lying, and this one
+     is sound. It is painted as text in exactly one file
+     (`EphemeristsTaskCard.tsx`) on exactly two grounds — the plate 5.98:1 and
+     the medallion disc 6.28:1 — both of which are the register's own night
+     stocks, so it is never off-register the way `-plate-quiet` was.
+
+     Two names for one value is normally what this file warns about; they are
+     kept apart because they are two roles that happen to have converged, and
+     collapsing them would decide for the card what the page decided. If a
+     repaint ever walks one, walk it knowing the other does not follow. */
+  --faction-ephemerists-plate-muted: #a2977a;
   --faction-ephemerists-plate-caption: #c9a24b; /* small-caps labels */
   --faction-ephemerists-plate-brass: #c9a24b; /* rules, borders — never an ink */
   --faction-ephemerists-plate-brass-light: #e6c877;
@@ -1585,7 +1597,17 @@
   --faction-ephemerists-plate-disc: #12151f; /* the medallion's field */
   --faction-ephemerists-plate-ochre: #d9744c; /* the fifth tally stroke */
   /* The CTA bar swaps ends against the light plate it replaced: a BRASS bar
-     carrying dark ink, where the papyrus had a dark bar and gold ink. */
+     carrying dark ink, where the papyrus had a dark bar and gold ink.
+
+     NO LABEL TIER CAN SIT ON THIS BAR (noted while measuring #1800; nothing is
+     broken, this is a record so nobody tries). It is a mid-luminance brass, and
+     the label seam is a QUIET ink by definition — the app's tertiary reads
+     3.58:1 on it in light and 1.15:1 in dark, and `-plate-quiet`, the ink both
+     Ephemerists roots point `--label-ink` at, is 1.21:1. There is no quiet
+     neutral this bar can carry, in either cascade. What works is the dark
+     partner the bar was drawn with: `-plate-cta-ink`, 7.59:1. Every CTA site
+     sets that explicitly today, which is why the seam's value never lands here
+     — keep it that way rather than repointing the seam for one bar. */
   --faction-ephemerists-plate-cta-bg: #c9a24b;
   --faction-ephemerists-plate-cta-ink: #12151f;
   /* The gold wash behind the cartouche and the ratio chip is GONE, not dimmed —
@@ -1606,7 +1628,26 @@
      collapsed onto it rather than onto its twin. */
   --faction-ephemerists-plate-page: #101320; /* the page ground under the plate */
   --faction-ephemerists-plate-inner: #1d2130; /* the action panel's two cells */
-  --faction-ephemerists-plate-quiet: #a2977a; /* quiet ink — AA on all 3 grounds */
+  /* Quiet ink for the register's THREE NIGHT GROUNDS, and only those: the page
+     6.38:1, the plate 5.98, the panel cell 5.52 — one reading each, since the
+     register declares nothing under dark (#1627). It also clears the two grounds
+     the family added later, the medallion disc 6.28 and the cornice band 6.73,
+     though the band has its own second tier in `-plate-band-quiet`.
+
+     WHAT IT IS NOT AA ON (#1793). The APP's page ground: 2.64:1 on #f7f4ee in
+     light. This line used to read "AA on all 3 grounds" full stop, and a bare
+     `.wz-faction-grid` is not one of those three — `EphemeristsFactionBody`'s
+     two empty states were painted in it on the app's own near-white page and the
+     nightly sweep measured them there. They now take `--color-text-secondary`,
+     because NO value of this token could have served both: clearing the panel
+     cell (#1d2130) needs relative luminance >= 0.1937 and clearing the light
+     page needs <= 0.1611, and the intervals do not meet. Same shape of finding
+     as the `-plate-bg` block above, one axis over — there it was two themes,
+     here it is two page grounds.
+
+     The rule for the next reader: this ink belongs to a surface this register
+     paints. Off the register, the ground is the app's and so is the ink. */
+  --faction-ephemerists-plate-quiet: #a2977a;
   --faction-ephemerists-plate-nile: #5fb3a6; /* links, affirmations, the eye */
   --faction-ephemerists-plate-rule: rgba(201, 162, 75, 0.12); /* journal ruling */
   --faction-ephemerists-plate-line: rgba(201, 162, 75, 0.28); /* hairline borders */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1640,8 +1640,8 @@
      two empty states were painted in it on the app's own near-white page and the
      nightly sweep measured them there. They now take `--color-text-secondary`,
      because NO value of this token could have served both: clearing the panel
-     cell (#1d2130) needs relative luminance >= 0.1937 and clearing the light
-     page needs <= 0.1611, and the intervals do not meet. Same shape of finding
+     cell (#1d2130) needs relative luminance >= 0.2453 and clearing the light
+     page needs <= 0.1626, and the intervals do not meet. Same shape of finding
      as the `-plate-bg` block above, one axis over — there it was two themes,
      here it is two page grounds.
 

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -447,12 +447,33 @@ export default function EphemeristsEditPraxis({ state }: Props) {
        renders into (hover 1.16:1). The detail column declares the identical
        pair through `.eph-plate-sheet`; this is the same seam reached from the
        one Ephemerists root that is not inside that column. NILE is the plate's
-       declared link hue and is measured on all three of its grounds. */
+       declared link hue and is measured on all three of its grounds.
+
+       AND THE LABEL SEAM, for the identical reason, one issue later (#1754 fixed
+       the sheet, #1800 this root — the #1754 agent found this one and was scoped
+       out of `editPraxis/**` at the time). Unset, `.label-caption` and
+       `.label-heading` inherit the global tertiary: on the sheet's `PLATE` that
+       is 2.01:1 in light and in a panel cell's `INNER` 1.86:1. QUIET is
+       `-plate-quiet`, the same ink `.eph-plate-sheet` names, so both Ephemerists
+       roots land on one value — 5.98 on the sheet, 5.52 in a cell, in both
+       cascades.
+
+       THE COMPOSER'S PAGE GROUND IS NOT THE PLATE'S, which is worth saying
+       because the plate's numbers do not transfer wholesale. `ComposerPage`
+       renders a bare `<div style={style}>` with no background, so what is under
+       the sheet here is the APP's `--color-bg-page` — near-white in light, where
+       QUIET reads 2.64:1 (the #1793 defect, on the faction page). Every label
+       this seam reaches renders inside `ComposerSheet` or a panel, and the one
+       thing on the bare page, the breadcrumb, takes `breadcrumbInk` explicitly.
+       A `.label-caption` mounted directly on this page would need the app's own
+       tier instead; there is none today, and the guard in
+       `factionContrast.test.ts` records why. */
     pageStyle: {
       fontFamily: DECO,
       color: INK,
       ["--link-ink" as string]: NILE,
       ["--link-ink-hover" as string]: INK,
+      ["--label-ink" as string]: QUIET,
     } as CSSProperties,
     breadcrumbInk: QUIET,
     sheetStyle,

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -54,11 +54,33 @@ import type { FactionDetailState } from "../useFactionDetail";
  * private drawing: the roster's circular vellum medallions are `AuthorOctagon`,
  * the level beside a keeper's name gains the `Tally`, and every section rule is
  * `RuneRule`. Two grounds carry ink here — the plate (`ink` 11.3:1, `quiet`
- * 5.6, `caption` 4.8, `nile` 5.0) and the night band under the spotlight
- * (`band-ink` 12.4, `gold` 9.4, `band-quiet` 8.6). The page beneath both is
- * `.eph-backdrop`, repainted onto `-plate-page` in the same issue; only `ink`,
- * `quiet` and `nile` clear on it, which is why no caption sits directly on it.
+ * 5.98, `caption` 4.8, `nile` 5.0) and the night band under the spotlight
+ * (`band-ink` 14.00, `gold` 9.4, `band-quiet` 8.97).
+ *
+ * THE THIRD GROUND IS THE APP'S OWN PAGE, and no plate ink may be spent on it
+ * (#1675, #1793). This header used to say "the page beneath both is
+ * `.eph-backdrop`, repainted onto `-plate-page`; only `ink`, `quiet` and `nile`
+ * clear on it" — and every clause of that was false here. Nothing in this file
+ * applies `.eph-backdrop` or any other ground: the root is a bare
+ * `.wz-faction-grid`, so what is behind anything outside a `CARD` is
+ * `--color-bg-page`, which is near-WHITE in light. #1675 caught the section
+ * headings and kickers that way (cream on cream, 1.13:1); #1793 caught the two
+ * empty states, at 2.64:1. So everything on this page that is not inside a card
+ * takes the app's own tiers, and `PAGE_QUIET` below is the third of them.
  */
+
+/**
+ * The page's quiet ink — the app's second tier, NOT `-plate-quiet` (#1793).
+ *
+ * `QUIET` is #a2977a, minted for the Valley plate's three NIGHT grounds (page
+ * 6.38, plate 5.98, panel cell 5.52). On the app's light page it is 2.64:1, and
+ * no value of that token could be both: clearing the panel cell needs relative
+ * luminance >= 0.1937, clearing the light page needs <= 0.1611, and the
+ * intervals do not meet. So the ink changes rather than the token — 7.78:1 in
+ * light, 8.33:1 in dark, and the same tier `KICKER` beside it already reads.
+ * Both readings are gated in `factionContrast.test.ts`.
+ */
+const PAGE_QUIET = "var(--color-text-secondary)";
 
 /** One plate off the field journal, at the weight the design draws it. */
 const CARD: CSSProperties = {
@@ -183,7 +205,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
           <SectionHeading>{t("ephemerists.tasks.heading")}</SectionHeading>
           <Kicker>{t("ephemerists.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
-            <p className="content-text" style={{ fontFamily: MARGINALIA, fontStyle: "italic", color: QUIET }}>
+            <p className="content-text" style={{ fontFamily: MARGINALIA, fontStyle: "italic", color: PAGE_QUIET }}>
               {t("ephemerists.tasks.empty")}
             </p>
           ) : (
@@ -209,7 +231,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
           <SectionHeading>{t("ephemerists.praxis.heading")}</SectionHeading>
           <Kicker>{t("ephemerists.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
-            <p className="content-text" style={{ fontFamily: MARGINALIA, fontStyle: "italic", color: QUIET }}>
+            <p className="content-text" style={{ fontFamily: MARGINALIA, fontStyle: "italic", color: PAGE_QUIET }}>
               {t("ephemerists.praxis.empty")}
             </p>
           ) : (

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -53,9 +53,12 @@ import type { FactionDetailState } from "../useFactionDetail";
  * SWEPT OFF THE CODEX (#1208). Every mark is the plate kit's rather than a
  * private drawing: the roster's circular vellum medallions are `AuthorOctagon`,
  * the level beside a keeper's name gains the `Tally`, and every section rule is
- * `RuneRule`. Two grounds carry ink here — the plate (`ink` 11.3:1, `quiet`
- * 5.98, `caption` 4.8, `nile` 5.0) and the night band under the spotlight
- * (`band-ink` 14.00, `gold` 9.4, `band-quiet` 8.97).
+ * `RuneRule`. Two faction grounds carry ink here — the plate (`ink` 13.91:1,
+ * `quiet` 5.98, `caption` 7.22, `nile` 7.00) and the night band under the
+ * spotlight (`band-ink` 14.00, `gold` 14.00, `band-quiet` 8.97). Every one of
+ * those eight numbers was stale when #1793 re-derived them: they were measured
+ * on the PAPYRUS plate, and #1627 turned the whole register night without
+ * anything asking this comment to keep up.
  *
  * THE THIRD GROUND IS THE APP'S OWN PAGE, and no plate ink may be spent on it
  * (#1675, #1793). This header used to say "the page beneath both is
@@ -75,7 +78,7 @@ import type { FactionDetailState } from "../useFactionDetail";
  * `QUIET` is #a2977a, minted for the Valley plate's three NIGHT grounds (page
  * 6.38, plate 5.98, panel cell 5.52). On the app's light page it is 2.64:1, and
  * no value of that token could be both: clearing the panel cell needs relative
- * luminance >= 0.1937, clearing the light page needs <= 0.1611, and the
+ * luminance >= 0.2453, clearing the light page needs <= 0.1626, and the
  * intervals do not meet. So the ink changes rather than the token — 7.78:1 in
  * light, 8.33:1 in dark, and the same tier `KICKER` beside it already reads.
  * Both readings are gated in `factionContrast.test.ts`.

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -39,6 +39,7 @@ import {
   deltaE76,
   formatRatio,
   parseColor,
+  relativeLuminance,
 } from "../contrast";
 import { readThemes, resolveVar, stripComments, type Theme } from "./cssVars";
 
@@ -1514,6 +1515,22 @@ function ruleBody(selector: string): string {
   return CSS_TEXT.slice(at, CSS_TEXT.indexOf("}", at));
 }
 
+/** A component's source, for the same reason `ruleBody` exists. */
+function sourceOf(relative: string): string {
+  return readFileSync(fileURLToPath(new URL(`../../${relative}`, import.meta.url)), "utf8");
+}
+
+/**
+ * `dress.pageStyle` out of `EphemeristsEditPraxis` — THE SECOND EPHEMERISTS
+ * ROOT, and the one two separate seams (#1636's links, #1800's labels) have now
+ * had to be declared on. One reader, so the third seam does not re-derive the
+ * slice.
+ */
+function ephemeristsComposerPageStyle(): string {
+  const source = sourceOf("pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx");
+  return source.slice(source.indexOf("pageStyle: {"), source.indexOf("breadcrumbInk:"));
+}
+
 describe("faction token contrast (WCAG AA)", () => {
   for (const theme of BOTH_THEMES) {
     describe(theme, () => {
@@ -1942,6 +1959,39 @@ describe("the label tier stays two tiers on one seam (#1307)", () => {
       "`.eph-plate-sheet` is the column both Ephemerists detail pages wear, and it is the one sheet in the kit where a bare `.label-caption` lands on the global neutral over a night ground — the comment leaves' owner controls and the thread heading at 2.01:1 in light. Without this the plate has no way to fix its own sheet.",
     ).toContain("--label-ink: var(--faction-ephemerists-plate-quiet)");
   });
+
+  /**
+   * #1800 — AND THE OTHER ROOT, which is the same finding #1636 made one
+   * property over and the reason that block's assertion is not one assertion.
+   * `.eph-plate-sheet` is worn by the two DETAIL columns and nothing else;
+   * `EphemeristsEditPraxis`'s `dress.pageStyle` is the one Ephemerists root
+   * outside that column, mounted by both `ComposerPage` and
+   * `PraxisWaitingSurface`. Unset there, every `.label-caption` inside the
+   * composer sheet reads the global tertiary on `-plate-bg` (2.01:1 light) and
+   * inside a panel cell on `-plate-inner` (1.86:1) — the same numbers #1754
+   * measured, on the column it was scoped out of.
+   *
+   * The composer's PAGE ground is not the plate's, and that is worth stating
+   * because it is the trap: `ComposerPage` renders a bare `<div style={style}>`
+   * with no background, so the ground under the sheet is the APP's
+   * `--color-bg-page`, where `-plate-quiet` reads 2.64:1 in light. Nothing is
+   * broken by that today — every `.label-caption` this root cascades to renders
+   * inside `ComposerSheet` (`-plate-bg`) or a panel (`-plate-inner`), and the
+   * breadcrumb, the one thing on the bare page, takes `breadcrumbInk`
+   * explicitly. A label mounted directly on the composer page would be the
+   * exception, and it would be the same defect #1793 fixed on the faction page.
+   */
+  it("the composer and waiting surface set the same label seam on their own root (#1800)", () => {
+    const pageStyle = ephemeristsComposerPageStyle();
+    expect(
+      pageStyle,
+      "`dress.pageStyle` is the second Ephemerists root. Without the seam, every `.label-caption` in the composer and the waiting surface reads the global tertiary on a night sheet — 2.01:1 on the plate, 1.86:1 in a panel cell.",
+    ).toContain('["--label-ink" as string]: QUIET');
+    expect(
+      ruleBody(".eph-plate-sheet"),
+      "both Ephemerists roots must land on ONE ink, or the label tier reads two different quiets depending on which page you are on.",
+    ).toContain("--label-ink: var(--faction-ephemerists-plate-quiet)");
+  });
 });
 
 /**
@@ -2018,11 +2068,7 @@ describe("a prose link's ink is a seam (#1636)", () => {
   // pairing it would name (`nile` on `-plate-inner`) is already green above,
   // measured on a surface that was not reading it.
   it("the composer and waiting surface set the same seam on their own root", () => {
-    const source = readFileSync(
-      fileURLToPath(new URL("../../pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx", import.meta.url)),
-      "utf8",
-    );
-    const pageStyle = source.slice(source.indexOf("pageStyle: {"), source.indexOf("breadcrumbInk:"));
+    const pageStyle = ephemeristsComposerPageStyle();
     expect(
       pageStyle,
       "`dress.pageStyle` is mounted by both `ComposerPage` and `PraxisWaitingSurface`; without the seam their prose links fall back to the app neutral on a night ground.",
@@ -2088,4 +2134,88 @@ describe("a themed ground is a longhand (#1636)", () => {
     }
   });
 
+});
+
+/**
+ * #1793 — A NIGHT-PLATE INK ON THE APP'S OWN PAGE.
+ *
+ * `EphemeristsFactionBody`'s root is a bare `.wz-faction-grid`, so the ground
+ * under everything it does NOT put inside a `CARD` is `--color-bg-page`. #1675
+ * already found this once, for the section headings and their kickers, and
+ * repainted those onto the app's own tiers with the ruling that names the shape:
+ * "the root is a bare `.wz-faction-grid`, so the ground is the app's, and the
+ * ink has to be the app's too." Three quiet paragraphs on the same page were
+ * left behind — the tasks and praxis empty states, which the nightly rendered
+ * sweep then caught at 2.64:1.
+ *
+ * WHY THE TOKEN DOES NOT MOVE, which is the answer this block exists to record
+ * so the next reader does not re-run the search. `-plate-quiet` has to clear
+ * 4.5:1 on the plate register's loosest ground, `-plate-inner` (#1d2130), which
+ * puts a floor under its relative luminance of 0.1937; clearing 4.5:1 on the
+ * light page ground (#f7f4ee) puts a CEILING on it of 0.1611. The intervals do
+ * not overlap, so no sRGB value satisfies both and the search is not "pick a
+ * better hex" — it is "this ink is not for this ground". Same conclusion the
+ * Ephemerists register itself reached one cascade over, in the `-plate-bg`
+ * comment in index.css.
+ *
+ * ASSERTED ON THE SOURCE, not on a ratio, for the reason #1413 and #1307 give:
+ * the pairing "a faction ink on the app's page" is one a token-value manifest is
+ * structurally unable to name, and every row above stays green through it.
+ */
+describe("the Ephemerists faction page paints the page's ink outside its cards (#1793)", () => {
+  const SOURCE = sourceOf("pages/factionDetail/archetypes/EphemeristsFactionBody.tsx");
+
+  // The two strings the nightly sweep measured, plus the roster's — the third
+  // is INSIDE a `CARD` and is here to prove the guard can tell them apart.
+  for (const key of ["ephemerists.tasks.empty", "ephemerists.praxis.empty"]) {
+    it(`\`${key}\` reads the page's quiet ink, not the plate's`, () => {
+      const at = SOURCE.indexOf(`t("${key}")`);
+      expect(at, `no \`t("${key}")\` call in EphemeristsFactionBody`).toBeGreaterThan(-1);
+      const element = SOURCE.slice(at - 400, at);
+      expect(
+        element,
+        "an empty state outside a `CARD` sits on `--color-bg-page`, where the plate's quiet ink is 2.64:1 in light. `PAGE_QUIET` is the app's own second tier — 7.78:1 light, 8.33:1 dark — and it is what the kicker beside it already reads (#1675).",
+      ).toContain("color: PAGE_QUIET");
+      expect(
+        element,
+        "`QUIET` is `-plate-quiet`, minted for the three NIGHT grounds of the Valley plate. On the app's light page it is the defect this issue reports.",
+      ).not.toContain("color: QUIET");
+    });
+  }
+
+  it("prose that IS inside a card keeps the plate's ink", () => {
+    const at = SOURCE.indexOf('t("ephemerists.roster.emptyWithSpotlight")');
+    expect(at, "no roster empty state in EphemeristsFactionBody").toBeGreaterThan(-1);
+    expect(
+      SOURCE.slice(at - 400, at),
+      "the roster empty state renders inside `CARD`, whose ground is `-plate-bg`. Repainting it too would swap a 5.98:1 faction ink for a neutral on a night sheet — the mistake in the other direction.",
+    ).toContain("color: QUIET");
+  });
+
+  for (const theme of BOTH_THEMES) {
+    it(`the ink it takes instead clears AA on the app's page (${theme})`, () => {
+      const ink = resolveColor("--color-text-secondary", theme);
+      const page = resolveColor("--color-bg-page", theme);
+      expect(ink.color, `--color-text-secondary (${theme}) resolved to "${ink.raw}"`).not.toBeNull();
+      expect(page.color, `--color-bg-page (${theme}) resolved to "${page.raw}"`).not.toBeNull();
+      const ratio = contrastRatio(ink.color!, page.color!);
+      expect(ratio, `18px content prose owes 4.5:1; measured ${formatRatio(ratio)}`).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+  }
+
+  it("no value of `-plate-quiet` could have cleared both registers", () => {
+    // The search #1793 asks for, run rather than asserted in prose. The plate's
+    // loosest ground and the app's light page bound the ink's luminance from
+    // opposite sides, and a ratio is monotonic in luminance — so if the floor
+    // the one imposes is above the ceiling the other imposes, the set is empty
+    // whatever the hue.
+    const plate = resolveColor("--faction-ephemerists-plate-inner", "light").color!;
+    const page = resolveColor("--color-bg-page", "light").color!;
+    const floorOnPlate = AA_NORMAL * (relativeLuminance(plate) + 0.05) - 0.05;
+    const ceilingOnPage = (relativeLuminance(page) + 0.05) / AA_NORMAL - 0.05;
+    expect(
+      floorOnPlate,
+      "if this ever stops holding, `-plate-quiet` CAN serve both grounds and the split above is no longer necessary — delete it rather than working around it.",
+    ).toBeGreaterThan(ceilingOnPage);
+  });
 });

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -2151,8 +2151,8 @@ describe("a themed ground is a longhand (#1636)", () => {
  * WHY THE TOKEN DOES NOT MOVE, which is the answer this block exists to record
  * so the next reader does not re-run the search. `-plate-quiet` has to clear
  * 4.5:1 on the plate register's loosest ground, `-plate-inner` (#1d2130), which
- * puts a floor under its relative luminance of 0.1937; clearing 4.5:1 on the
- * light page ground (#f7f4ee) puts a CEILING on it of 0.1611. The intervals do
+ * puts a floor under its relative luminance of 0.2453; clearing 4.5:1 on the
+ * light page ground (#f7f4ee) puts a CEILING on it of 0.1626. The intervals do
  * not overlap, so no sRGB value satisfies both and the search is not "pick a
  * better hex" — it is "this ink is not for this ground". Same conclusion the
  * Ephemerists register itself reached one cascade over, in the `-plate-bg`


### PR DESCRIPTION
Closes #1793
Closes #1800

One token, `--faction-ephemerists-plate-quiet`, so one PR.

## The seam I tested at

`frontend/src/utils/__tests__/factionContrast.test.ts` — the token-value manifest and its
source-assertion blocks. Both defects are the shape that file already names as the one a
ratio row cannot see: *an ink measured against a ground it is not actually mounted on*
(#1413/#694). So the guards assert on the source and on the luminance bounds, not on a
pairing the manifest could have listed. The loop went red on three tests before any fix:
the two faction-page empty states and the composer's missing `--label-ink`.

## Re-derived measurements

Every number below was measured in this branch with `frontend/src/utils/contrast.ts`
(`parseColor` → `compositeOver` → `contrastRatio`) against tokens resolved out of
`index.css` through the test's own `cssVars` resolver — not copied from either issue.
No ground here turned out to be translucent, so no compositing stack was needed; the
resolver was still run over each one rather than assumed.

### #1793 — `-plate-quiet` (`#a2977a`), on every ground it is painted on

| colour | ground | ratio | where I measured it |
|---|---|---|---|
| `#a2977a` | `#f7f4ee` app page, light | **2.64:1 FAIL** | `EphemeristsFactionBody` tasks + praxis empty states — outside any `CARD`, root is a bare `.wz-faction-grid` |
| `#a2977a` | `#13121a` app page, dark | 6.42:1 | same two nodes, other cascade — which is why this only ever reported in light |
| `#a2977a` | `#101320` `-plate-page` | 6.38:1 | task/praxis detail column ground |
| `#a2977a` | `#171a26` `-plate-bg` | 5.98:1 | the card sheet and `.eph-plate-sheet` |
| `#a2977a` | `#1d2130` `-plate-inner` | 5.52:1 | the action panel's cells |
| `#a2977a` | `#12151f` `-plate-disc` | 6.28:1 | the medallion field |
| `#a2977a` | `#0a0c15` `-plate-band` | 6.73:1 | the cornice masthead |
| `#554b3c` | `#f7f4ee` app page, light | **7.78:1** | the ink the two empty states now take |
| `#b9ac97` | `#13121a` app page, dark | **8.33:1** | same, dark |

**The token does not move, and that is the finding.** Clearing 4.5:1 on the register's
loosest ground, `-plate-inner`, puts a *floor* under the ink's relative luminance of
**0.2453**. Clearing 4.5:1 on the light page ground puts a *ceiling* on it of **0.1626**.
A contrast ratio is monotonic in luminance, so the intervals not meeting means the set of
satisfying sRGB values is empty — whatever the hue. Same shape of answer the Ephemerists
register itself reached one axis over (`-plate-bg`'s comment, on two *themes* rather than
two *page grounds*). The two empty states take the app's own second tier instead, which is
what the `Kicker` beside them has read since #1675 and for the same stated reason.

That inequality is asserted, not described — `no value of \`-plate-quiet\` could have
cleared both registers` recomputes both bounds from the live tokens, so if a repaint ever
makes the split unnecessary the test says so rather than fossilising it.

### The `-plate-muted` twin — audited, sound, left alone

Same hex, second name. Painted as text in exactly one file (`EphemeristsTaskCard.tsx`,
three sites) on exactly two grounds: `-plate-bg` **5.98:1** and `-plate-disc` **6.28:1**.
Both are the register's own night stocks, so unlike `-plate-quiet` it is never off-register.
Its comment now records that, and records that the two names are two roles that converged —
so a future repaint of one does not assume the other follows.

### #1800 — the label seam on the second Ephemerists root

| colour | ground | before | after |
|---|---|---|---|
| `--label-ink` unset → `#4d4868` | `#171a26` `-plate-bg`, light | **2.01:1** | **5.98:1** |
| `--label-ink` unset → `#4d4868` | `#1d2130` `-plate-inner`, light | **1.86:1** | **5.52:1** |
| `--label-ink` unset → `#b3b0d6` | `#171a26` `-plate-bg`, dark | 8.33:1 | 5.98:1 |
| `--label-ink` unset → `#b3b0d6` | `#1d2130` `-plate-inner`, dark | 7.69:1 | 5.52:1 |

Dark spends ~2.3 points to hold one ink across a register that declares nothing under
`[data-theme="dark"]`, and stays well over the floor — the same trade #1754 made on the
sheet, deliberately matched so both roots read one quiet.

**The composer's page ground is NOT the plate's, and I checked rather than assumed.**
`ComposerPage` renders a bare `<div style={style}>` with no background, so what is under
the sheet here is the app's `--color-bg-page` — where `-plate-quiet` is the 2.64:1 of
#1793, not the 6.38:1 of `-plate-page` that `.eph-plate-sheet` paints for itself. It is
safe anyway: every `.label-caption` / `.label-heading` this seam cascades to renders inside
`ComposerSheet` (`-plate-bg`) or a `panelStyle` cell (`-plate-inner`), and the one element
on the bare page — the breadcrumb — takes `breadcrumbInk` explicitly. Recorded in the code
so the first label mounted directly on that page is caught. **Both roots now agree**, which
the test asserts as one `it`, reading `.eph-plate-sheet` and `dress.pageStyle` together.

### The brass CTA bar — a comment, not a change (as instructed)

I agree with #1800's reading, and re-derived it:

| colour | ground | ratio |
|---|---|---|
| `#4d4868` app tertiary, light | `#c9a24b` `-plate-cta-bg` | 3.58:1 |
| `#b3b0d6` app tertiary, dark | `#c9a24b` | 1.15:1 |
| `#a2977a` `-plate-quiet` | `#c9a24b` | 1.21:1 |
| `#12151f` `-plate-cta-ink` | `#c9a24b` | **7.59:1** |

No quiet ink can sit on a mid-luminance brass in either cascade — the bar's own dark partner
is the only thing that works, and every CTA site already sets `CTA_INK` explicitly. Left as
a comment at the token recording that, so the next person does not repoint the seam for one bar.

## Also corrected, same disease

`EphemeristsFactionBody`'s file header was quoting **eight** ratios measured on the papyrus
plate; #1627 turned the register night and nothing asked the comment to keep up
(`ink` 11.3 → 13.91, `quiet` 5.6 → 5.98, `caption` 4.8 → 7.22, `nile` 5.0 → 7.00,
`band-ink` 12.4 → 14.00, `gold` 9.4 → 14.00, `band-quiet` 8.6 → 8.97). It also asserted the
page beneath was `.eph-backdrop` — #1675 already found that nothing applies it here, which
is precisely the assumption both of these bugs grew out of.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(248 files / 4,439 passing), `npm run build` and `npm run budget` (JS 130.0 KB, CSS 21.3 KB,
both inside warn) all green locally. The built stylesheet was grepped, not just the source —
`--faction-ephemerists-plate-quiet`, `-plate-muted`, `-plate-cta-bg` and the whole
`.eph-plate-sheet` body all resolve in `dist/assets/index-*.css`, so no comment edit ate a
brace. Nothing here touches a route, a `response_model` or a Pydantic schema, so `api-schema`
has nothing to regenerate. No `contrastBaseline.ts` entry existed for this pair (it was a new
nightly finding, not allowlisted), so there is none to delete.

**Visual QA is outstanding** — I have no browser and did not run a dev server.

## What to eyeball

1. **Ephemerists faction page, LIGHT, desktop** — the ④ Tasks and ⑤ Praxis empty states
   ("No surveys open.", "Nothing sealed to the codex yet."). This is the fix: they should
   now read as legible warm-grey prose, matching the italic kicker directly above each of
   them, rather than washing out. Needs a faction with zero open tasks and zero recent praxis.
2. **Ephemerists faction page, DARK, desktop** — same two strings. They were passing before
   at 6.42:1 and are now 8.33:1, so this is a check that the tone shift is acceptable, not
   that it is legible.
3. **Ephemerists faction page, LIGHT, mobile** — the same two strings once the grid stacks;
   the ground does not change but the column width does.
4. **Ephemerists faction page, both themes** — the ③ Road block, the keeper spotlight and
   the roster empty state. These deliberately did NOT change: they are inside a `CARD` on the
   night plate and keep the faction's quiet ink. If any of them shifted tone, the split is wrong.
5. **Ephemerists praxis composer, LIGHT, desktop** — every small label on the sheet: the
   title counter, the section captions, the collab/duel chips. They were near-invisible at
   2.01:1 and should now be the plate's warm quiet.
6. **Ephemerists praxis composer, LIGHT, desktop, in a panel cell** — the labels inside the
   action panels specifically (1.86:1 before), which is the tightest of the pair.
7. **Ephemerists praxis composer, DARK, desktop** — the same labels. This is the direction
   that *loses* ~2.3 ratio points by design; the check is that they still read as a quiet
   tier and not as body copy.
8. **Ephemerists praxis WAITING surface (post-cast), LIGHT and DARK** — same root, different
   stage, and the half that is easy to forget. The nudge receipt and the pull-back description
   under the primary button.
9. **Ephemerists praxis composer + waiting surface, mobile, both themes** — the sheet narrows
   and more labels wrap; nothing should change colour between form factors.
10. **A NON-Ephemerists composer and the praxis-detail steward bar, either theme** — the
    control. `.card-on-page` pins `--label-ink` back to the global neutral, and none of this
    should have leaked off the Ephemerists column.

## Two things I noticed and did not fix

- `frontend/src/pages/editPraxis/archetypes/controls.tsx:1004` and `:1023` hardcode
  `color: "var(--color-text-tertiary)"` on `.label-caption` (the `bodyConnecting` and
  `bodyFrozen` notices). That defeats the seam this PR just set: on the Ephemerists sheet
  they read **2.01:1** in light, and they will do the same on S.N.I.D.E. and Singularity.
  It is the exact pattern `factionContrast.test.ts` warns about at its `.label-caption`
  assertion, one layer out where the CSS guard cannot see it. Cross-faction and not this
  issue — worth its own ticket.
- `--faction-ephemerists-plate-muted` and `-plate-quiet` are the same hex under two names.
  Both are sound and each is measured, so collapsing them is a judgement call about roles
  rather than a fix; I recorded the duplication at both declarations instead of deciding it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
