### PR TITLE
Presence: faction-coloured carets in the composer and a live dot on the roster

### DIFF
--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -378,3 +378,89 @@ test.describe('collaboration UI (clicked buttons)', () => {
     }
   })
 })
+
+/**
+ * Presence (#1744) — the only assertions in this repo that can see a caret.
+ *
+ * Everything else about presence is unit-testable: the derivation, the paint
+ * and the sanitizing proxy in `roomPresence.test.ts`, the roster dot in
+ * `CollabRoster.test.tsx`. What no unit test can reach is the actual claim —
+ * that two real browsers in one room draw each other, and that closing one
+ * takes its caret away. That needs two contexts, a live WebSocket and the
+ * CodeMirror plugin, so it lives here (nightly, `.github/workflows/e2e.yml`).
+ *
+ * Locators are the library's own class names: `.cm-ySelectionCaret` is the
+ * widget span, `.cm-ySelectionInfo` the hover label carrying the name. Each
+ * page sees only the OTHER player's caret — `y-codemirror.next` skips the local
+ * client id, which is also why a solo author alone in their room draws nothing.
+ *
+ * A block rather than a new file: `login` / `seedCollabDraft` are module-local
+ * helpers, and exporting them to reuse them elsewhere would be a wider change
+ * than the tests are worth.
+ */
+test.describe('presence: carets and the roster dot', () => {
+  test('P1: each member sees the other caret, and it goes when they leave', async ({
+    browser,
+  }) => {
+    const seed = await seedCollabDraft(browser, 'presence')
+    try {
+      const aPage = await seed.alice.ctx.newPage()
+      const bPage = await seed.bob.ctx.newPage()
+      await aPage.goto(`/praxis/${seed.praxisId}/edit`)
+      await bPage.goto(`/praxis/${seed.praxisId}/edit`)
+
+      // A caret exists only once its owner's cursor is IN the document, so both
+      // have to put a selection there. `fill` auto-waits on the editor becoming
+      // editable, which is the room finishing its first sync.
+      await aPage.locator('.cm-content').first().fill('Alice is typing')
+      await bPage.locator('.cm-content').first().fill('Bob is typing')
+
+      // Alice sees exactly one remote caret: Bob's, labelled with his name.
+      await expect(aPage.locator('.cm-ySelectionCaret')).toHaveCount(1)
+      await expect(aPage.locator('.cm-ySelectionInfo')).toHaveText(seed.bob.name)
+      await expect(bPage.locator('.cm-ySelectionInfo')).toHaveText(seed.alice.name)
+
+      // The roster's live dot names the same fact in words, on Bob's row.
+      await expect(
+        aPage.getByRole('img', { name: `${seed.bob.name} is here now` }),
+      ).toBeVisible()
+
+      // Presence is ephemeral: closing the tab closes the socket, and the caret
+      // must go with it. This is the half that distinguishes "he's not here"
+      // from the persistent workflow state beside it.
+      await bPage.close()
+      await expect(aPage.locator('.cm-ySelectionCaret')).toHaveCount(0)
+      await expect(
+        aPage.getByRole('img', { name: `${seed.bob.name} is here now` }),
+      ).toHaveCount(0)
+    } finally {
+      await seed.alice.ctx.close()
+      await seed.bob.ctx.close()
+    }
+  })
+
+  // Presence chrome must not appear for an audience of one (ADR-0073). Nothing
+  // gates on the praxis type: the plugin skips the local client, so a solo
+  // author is alone in a room that draws nobody.
+  test('P2: a solo author alone in their room draws no caret', async ({ browser }) => {
+    const s = pairSeq++
+    const solo = await login(browser, `p-${RUN}-${s}`, `P${s}-${RUN}`, 0)
+    const task = await pickOpenTask(solo)
+    try {
+      const created = await solo.ctx.request.post(`${API}/praxes`, {
+        data: { task_id: task.id, type: 'solo', title: `Solo ${s}`, body_text: 'draft' },
+      })
+      expect(created.ok(), `solo create failed: ${await created.text()}`).toBeTruthy()
+      const praxis = await created.json()
+
+      const page = await solo.ctx.newPage()
+      await page.goto(`/praxis/${praxis.id}/edit`)
+      await page.locator('.cm-content').first().fill('Just me in here')
+      await expect(page.locator('.cm-ySelectionCaret')).toHaveCount(0)
+      // And no roster at all, which `CollabRoster` already gates on positively.
+      await expect(page.getByRole('img', { name: /is here now/ })).toHaveCount(0)
+    } finally {
+      await solo.ctx.close()
+    }
+  })
+})

--- a/frontend/src/components/collab/CollabRoster.tsx
+++ b/frontend/src/components/collab/CollabRoster.tsx
@@ -60,6 +60,13 @@ export type { CollabGate, CollabState } from './collabGate'
 const AVATAR_SIZE = 34
 /** The design's 6px status dot. */
 const DOT_SIZE = 6
+/**
+ * The "here now" badge on the avatar's corner (#1744), and the ring that lifts
+ * it off the monogram's edge. Bigger than DOT_SIZE because it stands alone on a
+ * 34px circle rather than inside a pill that is already a word wide.
+ */
+const PRESENCE_DOT_SIZE = 10
+const PRESENCE_DOT_RING = 2
 
 /**
  * The ink for text sitting ON the faction's card-accent, declared once on the
@@ -91,6 +98,7 @@ export function CollabRoster({
   currentCharacterId,
   factionSlug,
   taskPointValue,
+  presentCharacterIds,
   onKick,
   onNudge,
   onRescindInvite,
@@ -123,6 +131,26 @@ export function CollabRoster({
   currentCharacterId: number | null | undefined
   factionSlug: string | null | undefined
   taskPointValue?: number | null
+  /**
+   * Who has this praxis's room open right now (#1744, ADR-0073) — a live dot on
+   * their row, answering "is he even here?".
+   *
+   * A PROP, never derived here. Only the composer mount sits inside
+   * `PraxisRoomProvider`; the eight praxis-detail mounts, the duel/collab
+   * waiting surface and the composer's own waiting stage have no room, and
+   * **absent must mean "nothing known", not "everyone away"** — an empty dot
+   * column on a public page would read as a crew that had left.
+   *
+   * Different SOURCE and different lifetime from `StatusPill`, and deliberately
+   * a different shape: this is ephemeral awareness that vanishes with a tab,
+   * while the pill is workflow state that must still be true tomorrow. Only the
+   * pill can tell you the publish is waiting on somebody.
+   *
+   * **Decoration, never authorization.** Awareness is self-reported by each
+   * client and relayed, so an id here is a claim, not a fact. Nothing may gate
+   * on it. Membership is the edit key and is checked server-side (#1740).
+   */
+  presentCharacterIds?: readonly number[]
   /**
    * Remove another member (#959). Receives the target's CHARACTER id. When
    * provided, a kick × renders on every OTHER member's row — but only if the
@@ -291,13 +319,48 @@ export function CollabRoster({
                 borderTop: index === 0 ? undefined : '1px solid var(--color-border)',
               }}
             >
-              <RosterAvatar
-                name={row.name}
-                size={AVATAR_SIZE}
-                borderColor={done ? accent : quiet}
-                dashed={row.state === 'invited'}
-                color={done ? accent : undefined}
-              />
+              {/* Identity, and whether they are here. The dot rides the
+                  AVATAR's corner — the universal online affordance, sitting
+                  with the face rather than beside the pill it must not be
+                  confused with. `RosterAvatar` stays a pure, aria-hidden leaf,
+                  so the badge is layered by this wrapper instead. Only a MEMBER
+                  can be in the room: an invited or declined row has no
+                  `row.member`, so it can never light up. */}
+              <span style={{ position: 'relative', display: 'inline-flex', flexShrink: 0 }}>
+                <RosterAvatar
+                  name={row.name}
+                  size={AVATAR_SIZE}
+                  borderColor={done ? accent : quiet}
+                  dashed={row.state === 'invited'}
+                  color={done ? accent : undefined}
+                />
+                {row.member != null &&
+                  presentCharacterIds?.includes(row.member.character_id) && (
+                    <span
+                      role="img"
+                      aria-label={t('editPraxis.composer.presentAria', { name: row.name })}
+                      title={t('editPraxis.composer.presentAria', { name: row.name })}
+                      style={{
+                        position: 'absolute',
+                        right: -1,
+                        bottom: -1,
+                        width: PRESENCE_DOT_SIZE,
+                        height: PRESENCE_DOT_SIZE,
+                        borderRadius: '50%',
+                        // `card-credit`, not `card-accent`: the row already
+                        // spends the accent on DONE, and a dot in that same ink
+                        // would read as a second, quieter claim about the same
+                        // thing (#694 measures both against this sheet).
+                        background: credit,
+                        // Cut out of the sheet the roster is mounted on, so the
+                        // badge reads as a separate mark rather than a bump on
+                        // the monogram's rule.
+                        border: `${PRESENCE_DOT_RING}px solid ${factionCssVar(factionSlug, 'card-bg')}`,
+                        boxSizing: 'content-box',
+                      }}
+                    />
+                  )}
+              </span>
 
               <span
                 className="font-body text-[13px]"

--- a/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
+++ b/frontend/src/components/collab/__tests__/CollabRoster.test.tsx
@@ -357,6 +357,61 @@ describe('CollabRoster rescind × visibility (#1416)', () => {
   })
 })
 
+/**
+ * The live "here now" dot (#1744).
+ *
+ * Presence is a PROP, never derived here: only the composer mount sits inside
+ * `PraxisRoomProvider`, so the ten other mounts (praxis detail ×8, the waiting
+ * surface, and the composer's own waiting stage) get "nothing known" for free —
+ * and the dot becomes testable in a harness where no effect ever runs.
+ *
+ * The dot is ephemeral (a tab closing takes it away) while `StatusPill` is
+ * persistent workflow state, so they must not look alike: "he's not here" and
+ * "he hasn't approved" are different facts and only one blocks the publish.
+ * That is why the dot is a bare filled badge on the avatar's corner rather than
+ * a second bordered chip, and why it takes `card-credit` rather than the
+ * `card-accent` the row already spends on *done*.
+ */
+describe('CollabRoster — the live presence dot (#1744)', () => {
+  const rosterHtml = (present?: readonly number[]) =>
+    renderToStaticMarkup(
+      <CollabRoster
+        praxisType="collab"
+        members={[member(1, false), member(2, false)]}
+        invites={[invite(7, 'Asked', 'pending')]}
+        currentCharacterId={1}
+        factionSlug="coven"
+        presentCharacterIds={present}
+      />,
+    )
+
+  it('lights the dot on the connected member only', () => {
+    const html = rosterHtml([1])
+    expect(html).toContain('M1 is here now')
+    expect(html).not.toContain('M2 is here now')
+  })
+
+  // A public praxis-detail page knows nobody's connection state. An empty dot
+  // column there would read as a crew that had left, which is a claim the page
+  // is in no position to make — so absent means NO MARKUP, not "everyone away".
+  it('draws no dot markup at all where the prop is absent', () => {
+    const html = rosterHtml()
+    expect(html).not.toContain('is here now')
+    expect(html).not.toContain('role="img"')
+  })
+
+  // `invite()` derives `invitee_id` as `id + 100`, so 107 is the invitee behind
+  // invite 7. Nobody who has not accepted can be in the room at all — the
+  // membership check at connect (#1740) is what makes that true — so a claimed
+  // id colliding with an invitee must never light their row.
+  it('never lights an invited row, even for its own invitee id', () => {
+    const html = rosterHtml([1, 2, 107])
+    expect(html).toContain('M1 is here now')
+    expect(html).toContain('M2 is here now')
+    expect(html).not.toContain('Asked is here now')
+  })
+})
+
 // Mirrors the backend `kick_member` guard — see the comment above `canKick`.
 describe('CollabRoster kick × visibility (#959, #1076)', () => {
   const kick = () => {}

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -286,6 +286,7 @@
       "modeCollab": "Collab",
       "modeDuel": "Duel",
       "collaboratorsLabel": "Collaborators · {{count}}",
+      "presentAria": "{{name}} is here now",
       "opponentLabel": "Opponent",
       "invitePlaceholder": "Search by name",
       "sealsLabel": "Seals",

--- a/frontend/src/pages/editPraxis/__tests__/roomPresence.test.ts
+++ b/frontend/src/pages/editPraxis/__tests__/roomPresence.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Presence in a praxis room (#1744) — the pure seam.
+ *
+ * Everything visible about presence is drawn by `y-codemirror.next` out of one
+ * awareness field, and awareness is **self-reported by each client and
+ * relayed** (ADR-0073). So this file tests two different things:
+ *
+ * 1. The derivation the roster's dot reads — who is connected, deduped and
+ *    stable enough that a cursor twitch is not a re-render.
+ * 2. The **sanitizing seam**, which is the security half. The caret widget
+ *    writes `style="background-color: ${color}"` into the DOM from the remote's
+ *    own state object, so a co-member could otherwise post arbitrary CSS onto
+ *    your page. The wire carries a faction SLUG and the receiver derives the
+ *    colour, which means a remote can only ever pick one of nine known hues.
+ *
+ * The wire path is simulated with the real `y-protocols` encoder rather than by
+ * poking `awareness.states`, because JSON-through-the-socket is exactly the
+ * step that turns a claimed object into whatever the sender wanted.
+ */
+import { describe, it, expect } from 'vitest'
+import * as Y from 'yjs'
+import {
+  Awareness,
+  applyAwarenessUpdate,
+  encodeAwarenessUpdate,
+} from 'y-protocols/awareness'
+import {
+  paintedAwareness,
+  presentCharacterIds,
+  publishPresence,
+  samePresence,
+} from '../roomPresence'
+
+interface Peer {
+  doc: Y.Doc
+  awareness: Awareness
+}
+
+function peer(): Peer {
+  const doc = new Y.Doc()
+  return { doc, awareness: new Awareness(doc) }
+}
+
+function destroy(...peers: Peer[]): void {
+  for (const p of peers) {
+    p.awareness.destroy()
+    p.doc.destroy()
+  }
+}
+
+/** Ship `from`'s local state to `into`, over the real awareness encoding. */
+function relay(from: Peer, into: Peer): void {
+  applyAwarenessUpdate(
+    into.awareness,
+    encodeAwarenessUpdate(from.awareness, [from.awareness.clientID]),
+    'test',
+  )
+}
+
+const CHARACTER = { id: 7, display_name: 'Wren', faction_slug: 'coven' }
+
+describe('presentCharacterIds — who the roster dot lights up', () => {
+  it('carries a published character across the wire', () => {
+    const me = peer()
+    const them = peer()
+    publishPresence(them.awareness, CHARACTER)
+    relay(them, me)
+
+    expect(presentCharacterIds(me.awareness.getStates())).toEqual([7])
+    destroy(me, them)
+  })
+
+  it('is empty before anyone publishes — a socket alone is not a person', () => {
+    const me = peer()
+    expect(presentCharacterIds(me.awareness.getStates())).toEqual([])
+    destroy(me)
+  })
+
+  // Two tabs are two clientIDs and one player. A roster row is per CHARACTER,
+  // so the derivation has to collapse them or the dot means "sockets", not
+  // "here".
+  it('dedupes one character open in two tabs, and sorts', () => {
+    const me = peer()
+    const tabA = peer()
+    const tabB = peer()
+    const other = peer()
+    publishPresence(tabA.awareness, CHARACTER)
+    publishPresence(tabB.awareness, CHARACTER)
+    publishPresence(other.awareness, { ...CHARACTER, id: 2 })
+    relay(tabA, me)
+    relay(tabB, me)
+    relay(other, me)
+
+    expect(presentCharacterIds(me.awareness.getStates())).toEqual([2, 7])
+    destroy(me, tabA, tabB, other)
+  })
+
+  // The awareness `change` event fires on every cursor move. Without a value
+  // equality guard the roster re-renders on each keystroke of every co-author.
+  it('samePresence compares by value, not identity', () => {
+    expect(samePresence([2, 7], [2, 7])).toBe(true)
+    expect(samePresence([2, 7], [7, 2])).toBe(false)
+    expect(samePresence([2, 7], [2])).toBe(false)
+    expect(samePresence([], [])).toBe(true)
+  })
+})
+
+describe('paintedAwareness — the sanitizing seam (CSS injection)', () => {
+  function remoteUserAsSeen(state: Record<string, unknown>): Record<string, unknown> {
+    const me = peer()
+    const them = peer()
+    them.awareness.setLocalState(state)
+    relay(them, me)
+    const seen = paintedAwareness(me.awareness).getStates().get(them.awareness.clientID)
+    destroy(me, them)
+    return (seen?.user ?? {}) as Record<string, unknown>
+  }
+
+  it('derives the caret colour from the slug, as a CSS variable', () => {
+    const user = remoteUserAsSeen({
+      user: { characterId: 7, name: 'Wren', factionSlug: 'coven' },
+    })
+    expect(user.color).toBe('var(--faction-coven)')
+  })
+
+  // THE ONE THIS SEAM EXISTS FOR. `y-codemirror.next` interpolates `color`
+  // straight into a style attribute, so a co-member sending a declaration
+  // instead of a colour gets `position: fixed` real estate on your composer.
+  it('ignores a colour the remote supplied and paints its slug instead', () => {
+    const user = remoteUserAsSeen({
+      user: {
+        characterId: 7,
+        name: 'Wren',
+        factionSlug: 'coven',
+        color: 'red; position: fixed; inset: 0; background-image: url(https://evil/x',
+        colorLight: 'url(https://evil/beacon)',
+      },
+    })
+    expect(user.color).toBe('var(--faction-coven)')
+    expect(JSON.stringify(user)).not.toContain('evil')
+    expect(JSON.stringify(user)).not.toContain('fixed')
+  })
+
+  // An unregistered slug resolves to `default` rather than borrowing a hue, so
+  // the set of reachable colours is closed (ADR-0039, `factionCssVar`).
+  it('resolves an unknown slug to the default hue, never a raw value', () => {
+    const user = remoteUserAsSeen({
+      user: { characterId: 7, name: 'Wren', factionSlug: '); content: url(x' },
+    })
+    expect(user.color).toBe('var(--faction-default)')
+  })
+
+  it('survives a `user` field that is not an object at all', () => {
+    expect(remoteUserAsSeen({ user: 'nope' }).color).toBe('var(--faction-default)')
+    expect(remoteUserAsSeen({ cursor: null }).color).toBe('var(--faction-default)')
+  })
+
+  // The library's fallback is `color + '33'`, which on a `var()` produces the
+  // invalid `var(--faction-coven)33` and paints no selection at all. Supplying
+  // it is not a nicety — it is what makes the selection band render.
+  it('always supplies colorLight, so the library never appends 33 to a var()', () => {
+    const user = remoteUserAsSeen({
+      user: { characterId: 7, name: 'Wren', factionSlug: 'coven' },
+    })
+    expect(user.colorLight).toBe(
+      'color-mix(in srgb, var(--faction-coven) 22%, transparent)',
+    )
+  })
+
+  // The name lands in an absolutely-positioned `white-space: nowrap` label, so
+  // an unbounded one is a layout weapon even though it cannot inject markup.
+  it('clips an unbounded remote name', () => {
+    const user = remoteUserAsSeen({
+      user: { characterId: 7, name: 'x'.repeat(5000), factionSlug: 'coven' },
+    })
+    expect((user.name as string).length).toBeLessThanOrEqual(64)
+  })
+
+  it('keeps the remote cursor untouched — it is what positions the caret', () => {
+    const me = peer()
+    const them = peer()
+    them.awareness.setLocalState({
+      user: { characterId: 7, name: 'Wren', factionSlug: 'coven' },
+      cursor: { anchor: { type: null, tname: 'body', item: null, assoc: 0 }, head: null },
+    })
+    relay(them, me)
+    const seen = paintedAwareness(me.awareness)
+      .getStates()
+      .get(them.awareness.clientID)
+    expect((seen?.cursor as { anchor: { tname: string } }).anchor.tname).toBe('body')
+    destroy(me, them)
+  })
+})
+
+describe('paintedAwareness — everything else passes through', () => {
+  it('forwards the fields y-codemirror.next reads off the awareness object', () => {
+    const me = peer()
+    const painted = paintedAwareness(me.awareness)
+
+    // The caret plugin skips the local client by comparing against this.
+    expect(painted.doc.clientID).toBe(me.doc.clientID)
+
+    // It writes the local cursor through `setLocalStateField` and reads it back
+    // through `getLocalState` — both must reach the REAL awareness or the
+    // provider broadcasts nothing.
+    painted.setLocalStateField('cursor', { anchor: 1, head: 1 })
+    expect(me.awareness.getLocalState()?.cursor).toEqual({ anchor: 1, head: 1 })
+    expect(painted.getLocalState()?.cursor).toEqual({ anchor: 1, head: 1 })
+
+    // `on`/`off` must subscribe to the real emitter, or a remote's arrival never
+    // redraws — and must UNsubscribe, or a destroyed editor keeps dispatching.
+    let changes = 0
+    const listener = () => {
+      changes += 1
+    }
+    painted.on('change', listener)
+    const them = peer()
+    publishPresence(them.awareness, CHARACTER)
+    relay(them, me)
+    expect(changes).toBe(1)
+
+    painted.off('change', listener)
+    publishPresence(them.awareness, { ...CHARACTER, display_name: 'Wren the second' })
+    relay(them, me)
+    expect(changes).toBe(1)
+
+    destroy(me, them)
+  })
+})

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -18,6 +18,7 @@ import MarkdownPreview from "../blocks/MarkdownPreview";
 import { applyMarkdown, minimalReplacement } from "../blocks/markdownToolbar";
 import type { MarkdownCommand } from "../blocks/markdownToolbar";
 import { usePraxisRoom, ROOM_TITLE_KEY } from "../praxisRoom";
+import { paintedAwareness } from "../roomPresence";
 import {
   BODY_EDITOR_BASE_THEME,
   BODY_EDITOR_HOST_STYLE,
@@ -260,6 +261,10 @@ export function InviteSearch({
 }) {
   const { t } = useTranslation("forms");
   const praxis = state.praxis!;
+  // The one roster mount that sits inside a room, and so the only one that can
+  // say who is here (#1744). Every other mount — the eight detail pages, the
+  // waiting surface — passes nothing and draws no dot at all.
+  const room = usePraxisRoom();
   // The invite search is behind the `+ invite` chip (#1417) rather than sitting
   // permanently open across a whole row of the composer. Local state, because it
   // is a disclosure and nothing outside this control has an opinion about it.
@@ -313,6 +318,7 @@ export function InviteSearch({
                   currentCharacterId={state.currentCharacterId}
                   factionSlug={praxis.task_faction_slug}
                   taskPointValue={praxis.task_point_value}
+                  presentCharacterIds={room?.present}
                   onKick={state.kickMember}
                   onRescindInvite={state.cancelInvite}
                 />
@@ -836,6 +842,9 @@ export function BodyTextarea({
   const room = usePraxisRoom();
   const ytext = room?.body ?? null;
   const seeded = room?.seeded ?? false;
+  // Stable for the room's whole life (it lives beside `body` in one state
+  // object), so listing it as an editor dependency cannot cause a rebuild.
+  const awareness = room?.awareness ?? null;
   const hostRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   // Stable across the editor's life; reconfigured rather than remounted.
@@ -877,9 +886,17 @@ export function BodyTextarea({
         BODY_EDITOR_BASE_THEME,
         editableSlot.of(EditorView.editable.of(writable)),
         EditorView.contentAttributes.of(contentAttributes),
-        // `null` awareness: carets and collaborator colours are #1744, and
-        // passing it here is what would draw them.
-        yCollab(ytext, null),
+        // Co-authors' carets and selections, each in their own faction's hue
+        // (#1744). PAINTED, never raw: `y-codemirror.next` interpolates the
+        // remote's `user.color` straight into a style attribute, so the wire
+        // carries a faction slug and `paintedAwareness` derives the colour —
+        // see `roomPresence.ts`.
+        //
+        // No `praxisType` gate. The plugin skips `clientid ===
+        // awareness.doc.clientID`, so a solo author alone in their own room
+        // draws nothing by construction — which is also the honest rule for a
+        // collab that happens to have one member online.
+        yCollab(ytext, awareness == null ? null : paintedAwareness(awareness)),
       ],
     });
     viewRef.current = view;
@@ -887,12 +904,14 @@ export function BodyTextarea({
       view.destroy();
       viewRef.current = null;
     };
-    // Only the bound text and the placeholder rebuild the editor. Everything
-    // else below reconfigures it in place — a rebuild would drop the caret and
-    // the undo history mid-sentence. The placeholder is a translated string, so
-    // it changes exactly once, on a language switch, where a rebuild costs
-    // nothing: the text itself lives in the room, not in the editor.
-  }, [ytext, skin.placeholder]);
+    // Only the bound text, its awareness channel and the placeholder rebuild
+    // the editor. Everything else below reconfigures it in place — a rebuild
+    // would drop the caret and the undo history mid-sentence. `awareness`
+    // arrives and departs with `ytext`, so it never rebuilds anything on its
+    // own. The placeholder is a translated string, so it changes exactly once,
+    // on a language switch, where a rebuild costs nothing: the text itself
+    // lives in the room, not in the editor.
+  }, [ytext, awareness, skin.placeholder]);
 
   useEffect(() => {
     viewRef.current?.dispatch({

--- a/frontend/src/pages/editPraxis/praxisRoom.tsx
+++ b/frontend/src/pages/editPraxis/praxisRoom.tsx
@@ -31,12 +31,17 @@
  * network keeps taking text and merges it on reconnect — where the `PUT` simply
  * failed and lost the paragraph.
  *
- * ## What is deliberately not here
+ * ## Presence rides the same socket (#1744)
  *
- * Carets, collaborator colours and the presence roster (#1744) — the provider's
- * own awareness channel exists (it is y-websocket's keep-alive) but nothing
- * reads it yet. Freeze-on-pending and discarding the document on publish
- * (#1745).
+ * The provider's awareness channel — y-websocket's keep-alive — now also
+ * carries who is in the room. This file publishes the viewer's identity into it
+ * and derives {@link PraxisRoom.present} out of it; the caret paint and the
+ * sanitizing seam that makes a remote's claimed state safe to render live next
+ * door in `roomPresence.ts`.
+ *
+ * Awareness is **self-reported by each client and relayed**, so nothing derived
+ * from it may reach an authorization branch. Membership is the edit key and the
+ * server checks it at connect and at revoke (#1740).
  */
 import {
   createContext,
@@ -50,6 +55,13 @@ import {
 import * as Y from "yjs";
 import { WebsocketProvider } from "y-websocket";
 import { IndexeddbPersistence } from "y-indexeddb";
+import type { Awareness } from "y-protocols/awareness";
+import { useAuth } from "../../auth/AuthContext";
+import {
+  presentCharacterIds,
+  publishPresence,
+  samePresence,
+} from "./roomPresence";
 
 /**
  * The body's root key — `ROOM_BODY_KEY` in `praxis_room.py`. The server seeds a
@@ -127,6 +139,21 @@ export interface PraxisRoom {
   /** The last-write-wins map holding {@link ROOM_TITLE_KEY}. */
   meta: Y.Map<string>;
   /**
+   * The room's presence channel, already carrying this client's identity.
+   *
+   * Handed to `yCollab` — through `paintedAwareness()`, never raw — so
+   * co-authors' carets draw in their own faction's hue (#1744). Anything else
+   * reading it should read {@link present} instead.
+   */
+  awareness: Awareness;
+  /**
+   * The character ids with this room open, including the viewer's own. Sorted,
+   * deduped across tabs, and stable while only cursors move.
+   *
+   * **Decoration, never authorization** — see the file docblock.
+   */
+  present: readonly number[];
+  /**
    * The document has arrived — from the socket, or from the offline store.
    *
    * Until it has, the editor holds an empty document that means nothing, and
@@ -182,13 +209,25 @@ export function PraxisRoomProvider({
   onUpdate?: (at: Date) => void;
   children: ReactNode;
 }) {
-  // The shared types, kept apart from `seeded` so their identity survives the
-  // seed landing — `BodyTextarea` keys its editor on `body`, and a new identity
-  // there would tear the editor down and rebuild it at that moment.
-  const [types, setTypes] = useState<{ body: Y.Text; meta: Y.Map<string> } | null>(
-    null,
-  );
+  // The room's long-lived handles, kept apart from `seeded` and `present` so
+  // their identity survives both landing — `BodyTextarea` keys its editor on
+  // `body` AND on `awareness`, and a new identity on either would tear the
+  // editor down and rebuild it mid-sentence.
+  const [types, setTypes] = useState<{
+    body: Y.Text;
+    meta: Y.Map<string>;
+    awareness: Awareness;
+  } | null>(null);
   const [seeded, setSeeded] = useState(false);
+  const [present, setPresent] = useState<readonly number[]>([]);
+  // The viewer, for the identity this client publishes. Narrowed to the three
+  // fields rather than held as `user`, because `/auth/me` mints a fresh object
+  // on every refetch and an effect keyed on the whole thing re-runs for each
+  // one (#1390).
+  const character = useAuth().user?.character ?? null;
+  const characterId = character?.id ?? null;
+  const characterName = character?.display_name ?? null;
+  const characterFaction = character?.faction_slug ?? null;
   // Read through a ref so a caller passing an inline callback does not tear the
   // socket down and rebuild it on every render.
   const onUpdateRef = useRef(onUpdate);
@@ -198,6 +237,7 @@ export function PraxisRoomProvider({
     if (praxisId == null) {
       setTypes(null);
       setSeeded(false);
+      setPresent([]);
       return;
     }
     const doc = new Y.Doc();
@@ -227,7 +267,19 @@ export function PraxisRoomProvider({
         shouldReconnect: (event) => event.code !== WS_POLICY_VIOLATION,
       },
     );
-    setTypes({ body, meta });
+    const awareness = provider.awareness;
+    setTypes({ body, meta, awareness });
+
+    // Who is in the room (#1744). `change` fires on every remote cursor move,
+    // so the derivation is sorted and compared BY VALUE — otherwise a co-author
+    // holding a key re-renders the roster, and every composer archetype under
+    // it, once per keystroke.
+    const syncPresence = () => {
+      const next = presentCharacterIds(awareness.getStates());
+      setPresent((current) => (samePresence(current, next) ? current : next));
+    };
+    awareness.on("change", syncPresence);
+    syncPresence();
 
     // Latch, never unlatch — see `PraxisRoom.seeded`.
     const markSeeded = () => setSeeded(true);
@@ -255,7 +307,10 @@ export function PraxisRoomProvider({
     return () => {
       doc.off("update", onDocUpdate);
       provider.off("sync", onSync);
+      awareness.off("change", syncPresence);
       offline.off("synced", onOfflineLoaded);
+      // Also drops this client's awareness state — the socket closing is what
+      // takes the dot off everyone else's roster.
       provider.destroy();
       // `destroy()` closes the store; `clearData()` is what would delete it,
       // and must not be called here — the point of the store is that it
@@ -264,12 +319,30 @@ export function PraxisRoomProvider({
       doc.destroy();
       setTypes(null);
       setSeeded(false);
+      setPresent([]);
     };
   }, [praxisId]);
 
+  // Say who is typing. A SECOND effect, keyed on the viewer rather than on the
+  // praxis, so switching character re-publishes an identity without tearing the
+  // socket — and its document — down and rebuilding it. `user` is a
+  // last-write-wins awareness field, so a re-publish costs one small broadcast.
+  //
+  // Nothing is published without a character: there is no identity to claim,
+  // and a room only opens on a page that already required one.
+  useEffect(() => {
+    const awareness = types?.awareness;
+    if (!awareness || characterId == null) return;
+    publishPresence(awareness, {
+      id: characterId,
+      display_name: characterName ?? "",
+      faction_slug: characterFaction ?? "",
+    });
+  }, [types, characterId, characterName, characterFaction]);
+
   const room = useMemo<PraxisRoom | null>(
-    () => (types === null ? null : { ...types, seeded }),
-    [types, seeded],
+    () => (types === null ? null : { ...types, seeded, present }),
+    [types, seeded, present],
   );
 
   return (

--- a/frontend/src/pages/editPraxis/roomPresence.ts
+++ b/frontend/src/pages/editPraxis/roomPresence.ts
@@ -1,0 +1,215 @@
+/**
+ * Presence in a praxis room (#1744, ADR-0073) — the pure half.
+ *
+ * A room's **awareness** channel is the ephemeral sidecar to its CRDT document:
+ * who has the composer open, and where their cursor is. `y-codemirror.next`
+ * draws the carets straight out of it, and `CollabRoster` lights a dot from
+ * {@link presentCharacterIds}. Nothing here touches the record; presence
+ * vanishes with the tab.
+ *
+ * ## Decoration, never authorization
+ *
+ * Awareness is **self-reported by each client and relayed** — the server does
+ * not vouch for a word of it, so a co-member can claim to be any character.
+ * That is acceptable *because presence never reaches an authorization branch*:
+ * membership is the edit key and is checked server-side at connect and at
+ * revoke (#1740). A dot beside the wrong name is a cosmetic lie by somebody you
+ * invited. Do not grow a permission, a gate or a count that anybody acts on out
+ * of this data.
+ *
+ * ## Why the wire carries a SLUG and never a colour
+ *
+ * The caret widget in `y-codemirror.next` builds its DOM as
+ * `style="background-color: ${color}; border-color: ${color}"` — the remote's
+ * own `user.color` string, interpolated into a style attribute on your page. A
+ * remote that sends `red; position: fixed; inset: 0; background-image: url(…)`
+ * gets full-viewport real estate and a load beacon on your composer.
+ *
+ * So the sender publishes `factionSlug` ({@link publishPresence}) and the
+ * RECEIVER derives the paint ({@link paintedAwareness}) through
+ * `factionCssVar()`, which resolves anything it does not recognise to
+ * `default`. The reachable set of colours is then closed at nine, whatever a
+ * remote sends. `name` is clipped in the same pass: it is not an injection —
+ * the library writes it with `textContent` — but it is unbounded text in an
+ * absolutely-positioned, `nowrap` label.
+ */
+import { factionCssVar } from "../../utils/factions";
+
+/**
+ * The awareness field `y-codemirror.next` reads its caret out of. Not a choice:
+ * `y-remote-selections.js` destructures `state.user`, so this name is the
+ * library's, and a mismatch is a silent no-caret rather than an error.
+ */
+const PRESENCE_FIELD = "user";
+
+/**
+ * How much of a remote name reaches the DOM. The hover label is one line of
+ * `nowrap` text over the editor, so this is a layout ceiling, not a security
+ * one — the library sets it with `textContent`.
+ */
+const MAX_PRESENCE_NAME = 64;
+
+/**
+ * How much of the faction hue the selection band takes. `color-mix` rather than
+ * an alpha hex because the colour is a `var()`, which cannot be suffixed — see
+ * {@link paintUser}.
+ */
+const SELECTION_TINT = "22%";
+
+/** What this client publishes about itself. JSON — it crosses a socket. */
+export interface PresenceUser {
+  characterId: number;
+  name: string;
+  factionSlug: string;
+}
+
+/** What a receiver hands `y-codemirror.next`, derived and never relayed. */
+interface PaintedPresenceUser {
+  name: string;
+  color: string;
+  colorLight: string;
+}
+
+/** The shape of the awareness map both halves read. */
+type PresenceStates = Map<number, Record<string, unknown>>;
+
+/**
+ * The slice of `y-protocols`' `Awareness` this module needs. Structural so the
+ * pure functions can be exercised against a bare `Awareness` in the
+ * effect-less node harness, and so nothing here depends on y-websocket.
+ */
+export interface AwarenessLike {
+  getStates(): PresenceStates;
+  setLocalStateField(field: string, value: unknown): void;
+}
+
+/** The identity fields presence publishes. A `CharacterOut` satisfies it. */
+export interface PresenceCharacter {
+  id: number;
+  display_name: string;
+  faction_slug: string;
+}
+
+/**
+ * Announce who is typing here. Call it whenever the viewer changes — it is a
+ * last-write-wins field, so re-publishing costs one small broadcast and never
+ * disturbs the document or the socket.
+ */
+export function publishPresence(
+  awareness: AwarenessLike,
+  character: PresenceCharacter,
+): void {
+  const user: PresenceUser = {
+    characterId: character.id,
+    name: character.display_name,
+    factionSlug: character.faction_slug,
+  };
+  awareness.setLocalStateField(PRESENCE_FIELD, user);
+}
+
+/**
+ * The character ids currently connected, deduped and sorted.
+ *
+ * Deduped because two tabs are two client ids and one player, and a roster row
+ * is per character. Sorted so {@link samePresence} can compare by value.
+ *
+ * The local client is included: the viewer IS connected, and a lit dot on your
+ * own row is what teaches you what the dot means.
+ */
+export function presentCharacterIds(states: PresenceStates): number[] {
+  const ids = new Set<number>();
+  states.forEach((state) => {
+    const user = readUser(state);
+    const id = user.characterId;
+    if (typeof id === "number" && Number.isInteger(id) && id > 0) ids.add(id);
+  });
+  return [...ids].sort((a, b) => a - b);
+}
+
+/**
+ * Value equality for a presence list.
+ *
+ * The awareness `change` event fires on **every cursor move**, so without this
+ * guard a co-author holding a key re-renders the roster — and every composer
+ * archetype under it — per keystroke.
+ */
+export function samePresence(
+  a: readonly number[],
+  b: readonly number[],
+): boolean {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
+}
+
+/**
+ * The awareness object to hand `yCollab`, with every remote's paint derived
+ * from its slug instead of taken from the wire.
+ *
+ * A `Proxy` over `getStates()` alone: `setLocalStateField`, `getLocalState`,
+ * `doc.clientID` and the `on`/`off` the caret plugin subscribes with all reach
+ * the real object untouched, so the provider still broadcasts this client's
+ * cursor and a remote's arrival still redraws. Only the READ the DOM is built
+ * from is filtered — which is the only place a remote string was ever going to
+ * land in a style attribute.
+ *
+ * Hand this to `yCollab` and nothing else. The `WebsocketProvider` keeps the
+ * real `Awareness`: the protocol encoder reads `awareness.states` directly, and
+ * broadcasting the painted view would put our derived `var()` strings on the
+ * wire as if they were somebody's identity.
+ */
+export function paintedAwareness<A extends AwarenessLike>(awareness: A): A {
+  return new Proxy(awareness, {
+    get(target, property) {
+      if (property === "getStates") {
+        return () => paintStates(target.getStates());
+      }
+      const value = Reflect.get(target, property, target) as unknown;
+      // Bound, so an inherited method called through the proxy still resolves
+      // `this.states` / `this._observers` on the real awareness.
+      return typeof value === "function"
+        ? (value as (...args: unknown[]) => unknown).bind(target)
+        : value;
+    },
+  });
+}
+
+function paintStates(states: PresenceStates): PresenceStates {
+  const painted: PresenceStates = new Map();
+  states.forEach((state, clientId) => {
+    // Spread first, then overwrite: `cursor` is what positions the caret and
+    // must survive verbatim, while `user` is replaced WHOLESALE so a
+    // remote-supplied `color` / `colorLight` cannot ride along beside ours.
+    painted.set(clientId, { ...state, [PRESENCE_FIELD]: paintUser(state) });
+  });
+  return painted;
+}
+
+function paintUser(state: Record<string, unknown>): PaintedPresenceUser {
+  const user = readUser(state);
+  const slug = typeof user.factionSlug === "string" ? user.factionSlug : null;
+  // No suffix: a caret is scalar ink on the VIEWER's editor ground, not on the
+  // remote's card sheet, so the `card-*` family (measured against that sheet)
+  // is the wrong tier. `na` and `albescent` landing on `--faction-default` is
+  // ADR-0039 §2's decision, not a fallback.
+  const color = factionCssVar(slug);
+  return {
+    name: typeof user.name === "string" ? user.name.slice(0, MAX_PRESENCE_NAME) : "",
+    color,
+    // The library's own fallback is `color + '33'`, which on a `var()` yields
+    // the invalid `var(--faction-coven)33` and paints no selection at all.
+    colorLight: `color-mix(in srgb, ${color} ${SELECTION_TINT}, transparent)`,
+    // ponytail: the hover label (`.cm-ySelectionInfo`) keeps the library's
+    // hardcoded white ink on this faction's hue. It is measured against the
+    // REMOTE's colour, so no single ink is right for all nine, and the
+    // `-on-accent` tier does not cover them all (#1232 deleted Ephemerists').
+    // Upgrade path is minting that tier in index.css (frontend-style's file)
+    // and overriding the label's `color` in `BODY_EDITOR_BASE_THEME`.
+  };
+}
+
+/** A remote's `user` field, defensively — it is whatever the sender sent. */
+function readUser(state: Record<string, unknown>): Partial<PresenceUser> {
+  const raw = state[PRESENCE_FIELD];
+  return typeof raw === "object" && raw !== null
+    ? (raw as Partial<PresenceUser>)
+    : {};
+}


### PR DESCRIPTION
Presence in a praxis room: co-authors' carets and selections in their own faction's hue, and a live "here now" dot on the roster. Last issue in the ADR-0073 epic.

`Closes #1744`

## The seam I tested at

**`frontend/src/pages/editPraxis/roomPresence.ts`** — a new pure module holding the awareness→`characterId[]` derivation, the slug→paint, and the sanitizing proxy. It is exercised against a real `y-protocols` `Awareness`, with remote state relayed through the real `encodeAwarenessUpdate`/`applyAwarenessUpdate` encoder rather than by poking `awareness.states`, because JSON-through-the-socket is exactly the step that turns a *claimed* object into whatever the sender wanted. The roster dot is tested at the existing `renderToStaticMarkup` seam in `CollabRoster.test.tsx`.

Both loops went red on the real defect first (module missing; then "M1 is here now" absent from the markup).

## Security: the wire carries a slug, the receiver derives the colour

`y-codemirror.next` builds its caret as `style="background-color: ${color}; border-color: ${color}"` — **the remote's own `user.color` string, interpolated into a style attribute on your page.** Awareness is self-reported and relayed, so a co-member could send `red; position: fixed; inset: 0; background-image: url(…)` and take the viewport plus a load beacon. Membership is server-checked at connect (#1740), so the blast radius is people you invited — but that is not a reason to render an attacker-controlled declaration.

So the sender publishes `factionSlug` and the **receiver** derives `color`/`colorLight` through `factionCssVar()`, whose unknown-slug fallback resolves to `default`. The reachable set of colours is closed at nine whatever a remote sends. `paintedAwareness()` is a `Proxy` over `getStates()` **only** — `setLocalStateField`, `getLocalState`, `doc.clientID` and the `on`/`off` the caret plugin subscribes with all reach the real `Awareness` bound and untouched, and the `WebsocketProvider` keeps the raw object so our derived `var()` strings never go on the wire. The remote `name` is clipped in the same pass (not an injection — the library uses `textContent` — but unbounded text in an absolutely-positioned `nowrap` label). `presence` reaches no authorization branch anywhere.

Two related library facts the tests pin: `colorLight` **must** be supplied, because the library's `color + '33'` fallback produces the invalid `var(--faction-coven)33` and paints no selection at all; and `yCollab` skips `clientid === awareness.doc.clientID`, so **a solo author alone in their room draws nothing by construction** — no `praxisType` gate needed on the caret side.

## The roster dot

`presentCharacterIds?: readonly number[]` is a **prop, not a derivation**. `CollabRoster` is mounted in 11 places and only the composer mount sits inside `PraxisRoomProvider`; the other ten get "nothing known" for free, and **absent means no dot markup at all** — an empty dot column on a public detail page would read as a crew that had left.

It is a bare filled badge on the **avatar's corner**, not a chip: connected is ephemeral awareness that vanishes with a tab, while `StatusPill` is persistent workflow state, and only one of them means the publish is waiting on somebody. Ink is `card-credit`, not `card-accent` — the row already spends the accent on *done*. The badge carries no word, so it has `role="img"` + `aria-label`/`title`. The one new string lives in `editPraxis.composer` (the shared, voiceless block beside `collaboratorsLabel`), not `editPraxis.collab`, per the owner's shared-copy ruling.

Only a `row.member` can ever light up, so an invited or declined row cannot — pinned with `presentCharacterIds={[1, 2, 107]}` against the invite whose `invitee_id` is 107.

## Files

- **new** `frontend/src/pages/editPraxis/roomPresence.ts`, `frontend/src/pages/editPraxis/__tests__/roomPresence.test.ts` (12 tests)
- `frontend/src/pages/editPraxis/praxisRoom.tsx` — `awareness` lives beside `body`/`meta` so its identity is stable; `present` is derived behind a **value** guard (awareness `change` fires on every cursor move, so without it a co-author holding a key re-renders the roster per keystroke); the local identity is published from a **second** effect keyed on the viewer, so a character switch re-publishes without tearing the socket down. Deps are narrowed to `id`/`display_name`/`faction_slug` per #1390.
- `frontend/src/components/collab/CollabRoster.tsx` + its test — the prop and the badge
- `frontend/src/pages/editPraxis/archetypes/controls.tsx` — `yCollab(ytext, paintedAwareness(awareness))`, `presentCharacterIds={room?.present}`
- `frontend/src/locales/en/forms.json` — one key
- `frontend/e2e/collaboration.spec.ts` — a `presence` describe block

No backend change and no new API endpoint consumed. `PraxisMemberOut` carries no faction slug, which is why the slug rides awareness — so nothing regenerates `openapi.json` / `schema.d.ts`.

## Verification

Every step in the CI `frontend` job, run locally: `npm run lint` ✅ · `npm run typecheck` ✅ · `npm run typecheck:design-sync` ✅ · `npm test` ✅ (249 files, 4447 passed) · `npm run build` ✅ · `npm run budget` ✅ (JS 130.0 KB, CSS 21.3 KB, both within budget).

**The Playwright spec has never executed.** `npx playwright test --list` collects both new tests (`collaboration.spec.ts:402` and `:445`); nothing here ran them, and they are nightly-only by design (`e2e.yml`), outside PR CI.

**A manual contrast pass across the faction grounds in both themes is owed to a human.** A caret is a 1–2px mark and is the easiest thing in this epic to lose against a dark surface; I have no browser and cannot measure it.

## For `frontend-style`

`.cm-ySelectionInfo` — the hover label — keeps the library's hardcoded **white** ink on the remote's faction hue. It is measured against the *remote's* colour, so no single ink is right for all nine, and the `-on-accent` tier does not cover them (#1232 deleted Ephemerists'). Per the owner's ruling this PR accepts white rather than minting a tier as a byproduct; it is marked with a `ponytail:` comment in `roomPresence.ts` naming the upgrade path (mint the tier in `index.css`, override the label's `color` in `BODY_EDITOR_BASE_THEME`). It is a hover-only tooltip.

## What to eyeball

1. **Two browsers, one collab.** Open the same collab composer as two members. Each should see the other's caret in the *other's* faction colour, a tinted selection band when they select text, and their name on hover. Close one tab: the caret and the dot should both go.
2. **Caret contrast on every faction ground, light and dark** — eight composer skins, and a 1–2px mark. This is the pass that most needs a human.
3. **The selection band.** `color-mix(… 22%, transparent)` over each skin's field — legible text through it, visible band.
4. **Dot vs pill.** On a row where somebody is connected *and* has cast, the corner badge and the status pill must not read as two versions of the same statement.
5. **A solo praxis draws nothing** — no caret, no roster.
6. **No jitter.** Type a paragraph while a co-author types: the caret must not reflow the line, and the roster must not flicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
