### PR TITLE
Save draft stopped writing in #1743; four comments still say it flushes

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/__tests__/SaveDraftButton.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/SaveDraftButton.test.tsx
@@ -1,10 +1,11 @@
 /**
  * SaveDraftButton (#1081) — the composer's third exit: keep the draft and go.
  *
- * The button itself is thin on purpose (the flush lives in the hook, proved in
- * `useEditPraxis.test.ts`), so what's worth pinning here is where it does and
- * does not appear: a cast or moderated praxis has no draft to save, and per the
- * house rule that state hides the control rather than greying it out.
+ * The button itself is thin on purpose — thinner since #1743, which left the
+ * hook's `saveDraft` with nothing to do but navigate — so what's worth pinning
+ * here is where it does and does not appear: a cast or moderated praxis has no
+ * draft to keep, and per the house rule that state hides the control rather
+ * than greying it out.
  */
 import type { ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -588,8 +588,9 @@ export function DropButton({
 /* SaveDraftButton — the composer's third exit (#1081): keep the draft, leave.  */
 /*                                                                              */
 /* Publish files the praxis and Drop destroys it; until now there was no way to */
-/* simply stop for the night. The click flushes the queued autosave and lands   */
-/* on the player's own profile, where their in_progress praxes are listed.      */
+/* simply stop for the night. The click writes nothing — the text is already in */
+/* the room (#1743) — it just lands on the player's own profile, where their    */
+/* in_progress praxes are listed.                                               */
 /*                                                                              */
 /* Deliberately unskinned by default, like the collab Leave link above: this is */
 /* a mechanics affordance, not a faction gesture, and the shared neutral        */
@@ -614,8 +615,8 @@ export function SaveDraftButton({
   skin?: SaveDraftButtonSkin;
 }) {
   const { t } = useTranslation("forms");
-  // A cast or moderated praxis has no draft to save — the autosave effect sits
-  // the same states out, and the archetype is read-only in them. Hide rather
+  // A cast or moderated praxis has no draft to keep — the room refuses a change
+  // in the same states, and the archetype is read-only in them. Hide rather
   // than disable, as everywhere else.
   if (state.controlsLocked) return null;
   return (

--- a/frontend/src/pages/editPraxis/editPraxisState.ts
+++ b/frontend/src/pages/editPraxis/editPraxisState.ts
@@ -150,10 +150,12 @@ export interface EditPraxisState {
   /**
    * The composer's third exit (#1081): keep the draft and leave.
    *
-   * Flushes the queued autosave — cancel, then write the text in hand, the same
-   * two steps publish runs — and navigates to the player's own profile, where
-   * their `in_progress` praxes are listed. Refuses to leave (and says so) if the
-   * flush can't be written, so no keystroke is lost on the way out.
+   * Navigation, and nothing else: it clears the error line and sends the player
+   * to their own profile, where their `in_progress` praxes are listed (`/tasks`
+   * if they somehow have no character). It carried a flush until #1743 — title
+   * and body now live in the room and reach the record on the room server's own
+   * debounce (ADR-0073), so there is no client-side write left to order, none
+   * that can fail, and nothing to refuse leaving over.
    */
   saveDraft: () => Promise<void>;
   /** Pull my own cast back on a pending collab (#591). */

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -16,9 +16,9 @@
  *   `useComposerConfirm` — the one in-page confirm slot
  *
  * What stays here is what nothing else can own: the initial load and the
- * viewer's seal catalogue, the lifecycle writes (publish, save draft, pull
- * back, leave, drop, mode switch), and the derived flags that read across two
- * or more of the concerns above.
+ * viewer's seal catalogue, the lifecycle transitions (publish, pull back,
+ * leave, drop, mode switch — plus `saveDraft`, which since #1743 only leaves),
+ * and the derived flags that read across two or more of the concerns above.
  *
  * The split is pure restructuring — the interface, the request count and the
  * mount-time request ORDER are all unchanged, and the existing suite that


### PR DESCRIPTION
`saveDraft` clears the error line and navigates to the player's own profile (`/tasks` fallback). It has done only that since praxis title and body moved into the CRDT room (ADR-0073, #1743) — the room server flushes them into the record on its own debounce, so there is no client-side write left to order, none that can fail, and nothing to refuse leaving over.

Four comments still described the old cancel-then-write flush:

- `editPraxisState.ts` — the `saveDraft` docstring ("Flushes the queued autosave … Refuses to leave (and says so) if the flush can't be written")
- `useEditPraxis.ts` — the assembler header listing "save draft" among "the lifecycle **writes**"
- `archetypes/controls.tsx` — `SaveDraftButton`'s banner ("The click flushes the queued autosave") and its "the autosave effect sits the same states out"
- `archetypes/__tests__/SaveDraftButton.test.tsx` — a header pointing at flush cases `useEditPraxis.test.ts` no longer has

The implementation comment above `saveDraft` in `useEditPraxis.ts` was already accurate and is untouched. `useComposerMedia.ts`'s "autosave covers title/body only" is left alone deliberately — a different claim, about media uploading on pick, and still true in substance.

Documentation only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)