### PR TITLE
A mobile field desk's quest row is metered by the praxis's score, and WOW prints it once (#1834)

### DIFF
--- a/frontend/src/components/duel/shared.tsx
+++ b/frontend/src/components/duel/shared.tsx
@@ -53,6 +53,7 @@ import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { DuelDetailOut, DuelSideOut, DuelStatus } from '../../api/duel'
 import { useGameConfig } from '../../hooks/useGameConfig'
+import { formatPoints } from '../../utils/points'
 
 /**
  * The per-faction voice each slot dresses itself in. Every value is a CSS var.
@@ -189,10 +190,6 @@ export function useDuelStakes(
   }
 }
 
-/** Points render as integers where they are whole, one decimal otherwise. */
-export function formatPoints(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(1)
-}
 
 /* -------------------------------------------------------------------------- */
 /* StakesTiles — what winning and losing are worth                            */

--- a/frontend/src/pages/FieldDesk.tsx
+++ b/frontend/src/pages/FieldDesk.tsx
@@ -12,7 +12,7 @@ import PraxisCard from '../components/praxisCard/PraxisCard'
 import TaskCard from '../components/taskCard/TaskCard'
 import { mediaUrl } from '../utils/media'
 import { pickVariant } from '../utils/factionDispatch'
-import { computeFactionMultiplier } from '../utils/points'
+import { computeFactionMultiplier, formatPoints } from '../utils/points'
 import { praxisModeLabel } from '../utils/praxis'
 import { extractError } from '../utils/errors'
 import { surfaceMap } from '../factions'
@@ -397,15 +397,6 @@ const metaLine: CSSProperties = {
   letterSpacing: '0.16em',
   textTransform: 'uppercase',
   color: 'var(--color-text-secondary)',
-}
-
-/**
- * A praxis score for a one-line meta stamp. Same rule the duel surfaces use:
- * whole numbers stay whole, anything else takes one decimal — never a raw float
- * with fifteen digits of arithmetic noise on it.
- */
-function formatPoints(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(1)
 }
 
 /**

--- a/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
@@ -171,6 +171,25 @@ describe('mobile FieldDesk-home content-slot invariant', () => {
       ).toBe(occurrences(coven, SNIDE_MARK) + 1)
     })
 
+    /**
+     * #1834. The row is a PRAXIS, so its figure is the praxis's `score` — what
+     * the player has actually earned — not `task_point_value`, the task's base
+     * worth. The two agree until the first vote lands, which is why eight skins
+     * read the wrong field for so long: equal fixtures hide it.
+     *
+     * A score is a weighted sum and carries float noise, so the assertion is on
+     * the FORMATTED figure, and on its COUNT: WOW printed the same number twice
+     * in one row (once in the meta line, once as the gilt ✦ figure), and
+     * "the row contains the score" passes for that too.
+     */
+    it(`${slug} meters the in-progress row by the praxis's score, not the task's worth`, () => {
+      const voted = { ...ACTIVE_TASK, task_point_value: 88, score: 47.300000000000004 }
+      const { text } = render(<Skin state={baseState({ activeTasks: [voted] })} />)
+      expect(occurrences(text, '47.3'), 'the earned score, printed once').toBe(1)
+      expect(text, 'no raw float arithmetic noise').not.toContain('0000')
+      expect(text, "the task's base worth is not this row's figure").not.toContain('88')
+    })
+
     it(`${slug} renders the empty state when no active tasks`, () => {
       const { text } = render(<Skin state={baseState({ activeTasks: [] })} />)
       expect(text.toLowerCase(), 'empty-tasks slot').toContain('nothing in progress')

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../../components/factionMarks/covenSlip'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { formatPoints } from '../../../utils/points'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
@@ -400,7 +401,7 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
                     <div className="truncate" style={{ ...CAPTION, marginTop: 'var(--space-xs)' }}>
                       {t('fieldDesk.home.taskMeta', {
                         faction: factionName(praxis.task_faction_slug),
-                        points: praxis.task_point_value,
+                        points: formatPoints(praxis.score),
                       })}
                     </div>
                   </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { factionCssVar, factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { formatPoints } from '../../../utils/points'
 import { praxisModeLabel } from '../../../utils/praxis'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import FactionSigil from '../../../components/sigil/FactionSigil'
@@ -342,7 +343,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                   >
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
-                      points: praxis.task_point_value,
+                      points: formatPoints(praxis.score),
                     })}
                   </div>
                 </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { formatPoints } from '../../../utils/points'
 import { praxisModeLabel } from '../../../utils/praxis'
 import { EphemeristsSigil } from '../../../components/sigil/EphemeristsSigil'
 import FactionSigil from '../../../components/sigil/FactionSigil'
@@ -303,7 +304,7 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
                   <div className="truncate" style={{ marginTop: 'var(--space-xs)', ...SMALL_CAPS, fontSize: 'var(--text-md)', letterSpacing: '0.1em', color: QUIET }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
-                      points: praxis.task_point_value,
+                      points: formatPoints(praxis.score),
                     })}
                   </div>
                 </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
@@ -5,6 +5,7 @@ import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { formatPoints } from '../../../utils/points'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
@@ -358,7 +359,7 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
                   <div className="truncate" style={{ ...kicker, marginTop: 'var(--space-xs)' }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
-                      points: praxis.task_point_value,
+                      points: formatPoints(praxis.score),
                     })}
                   </div>
                 </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
@@ -5,6 +5,7 @@ import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { formatPoints } from '../../../utils/points'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
@@ -317,7 +318,7 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
                   <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
-                      points: praxis.task_point_value,
+                      points: formatPoints(praxis.score),
                     })}
                   </div>
                 </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
@@ -5,6 +5,7 @@ import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { formatPoints } from '../../../utils/points'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
@@ -280,7 +281,7 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
                   <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: TYPE, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
-                      points: praxis.task_point_value,
+                      points: formatPoints(praxis.score),
                     })}
                   </div>
                 </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
@@ -7,6 +7,7 @@ import { UaSigil } from '../../../components/sigil/UaSigil'
 import FactionSigil from '../../../components/sigil/FactionSigil'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
+import { formatPoints } from '../../../utils/points'
 import { praxisModeLabel } from '../../../utils/praxis'
 import type { FieldDeskHomeState } from '../useFieldDeskHome'
 import PendingRowPill from '../PendingRowPill'
@@ -316,7 +317,7 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
                   <div className="truncate" style={{ ...smallCaps, marginTop: 'var(--space-xs)' }}>
                     {t('fieldDesk.home.taskMeta', {
                       faction: factionName(praxis.task_faction_slug),
-                      points: praxis.task_point_value,
+                      points: formatPoints(praxis.score),
                     })}
                   </div>
                 </div>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/WowFieldDesk.tsx
@@ -29,6 +29,14 @@
  *    that line collides, so points move to their own footer row beside the level
  *    — geometry yields to type (§4), and it is also what makes the whole row a
  *    46px-tall target rather than a 14px title.
+ *
+ * ONE FIGURE PER ROW, AND IT IS THE PRAXIS'S SCORE (#1834). The footer row used
+ * the shared `fieldDesk.home.taskMeta` line ("faction · +N pts") NEXT TO the
+ * kit's gilt ✦ figure, so the same number was printed twice — and both read the
+ * TASK's base worth rather than what the quest has actually earned. The gilt
+ * figure is the kit's, so it stays and carries the score; the muted line beside
+ * it keeps naming the task's faction, which is what makes the row's sigil
+ * decorative.
  */
 import { useState, type CSSProperties } from "react";
 import { Link } from "react-router-dom";
@@ -56,6 +64,7 @@ import {
 import CharacterSwitcherSheet from "../../../components/CharacterSwitcherSheet";
 import FactionSigil from "../../../components/sigil/FactionSigil";
 import { factionName } from "../../../utils/factions";
+import { formatPoints } from "../../../utils/points";
 import type { FieldDeskHomeState } from "../useFieldDeskHome";
 import PendingRowPill from '../PendingRowPill'
 import { CAST_VOTES_LINK, FIND_TASK_LINK } from '../homeDestinations'
@@ -376,10 +385,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                           whiteSpace: "nowrap",
                         }}
                       >
-                        {t("fieldDesk.home.taskMeta", {
-                          faction: factionName(praxis.task_faction_slug),
-                          points: praxis.task_point_value,
-                        })}
+                        {factionName(praxis.task_faction_slug)}
                       </span>
                       <span
                         style={{
@@ -389,7 +395,7 @@ export default function WowFieldDesk({ state }: { state: FieldDeskHomeState }) {
                           whiteSpace: "nowrap",
                         }}
                       >
-                        ✦{praxis.task_point_value}
+                        ✦{formatPoints(praxis.score)}
                       </span>
                     </div>
                   </Link>

--- a/frontend/src/utils/points.ts
+++ b/frontend/src/utils/points.ts
@@ -58,6 +58,20 @@ export function isNeutralMultiplier(multiplier: number): boolean {
 }
 
 /**
+ * A points figure for a one-line stamp: whole numbers stay whole, anything else
+ * takes one decimal — never a raw float with fifteen digits of arithmetic noise
+ * on it. A praxis score is a weighted sum, so that noise is the normal case.
+ *
+ * Lives here rather than beside any one surface because the duel stakes tiles,
+ * the desktop FieldDesk's "continue" rows and all eight mobile field desks print
+ * the same kind of figure, and three private copies of one `toFixed` is how the
+ * rounding rule drifts (#1834).
+ */
+export function formatPoints(value: number): string {
+  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+}
+
+/**
  * Compute the display point value for a task given the viewing player's
  * faction — base points with {@link computeFactionMultiplier} already applied,
  * rounded to an integer.


### PR DESCRIPTION
The in-progress row on a mobile field desk is a **praxis**, so its figure is `praxis.score` — what the quest has actually earned once votes land — not `task_point_value`, the task's base worth. Eight skins read the wrong field; WOW read it twice.

Closes #1834

## The seam

`renderToStaticMarkup` over every `mobileFieldDesk` skin (`surfaceMap('mobileFieldDesk')` + `DefaultFieldDesk`), driven by a hand-built `FieldDeskHomeState` — the existing slot-invariant suite, `pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx`. One new per-skin case feeds a praxis whose `task_point_value` (88) and `score` (47.300000000000004) disagree and asserts the formatted score appears **exactly once** and the base worth does not appear at all. It went red on 8 of 8 skins first, for the real defect (7 × "no score", WOW × "printed twice"); green after.

The float noise in the fixture is deliberate: a score is a weighted sum, so the count assertion also pins the rounding rule.

## The call-site census the issue asked for

`fieldDesk.home.taskMeta` had **8 call sites, all of them praxis rows, 0 task rows** — one per archetype file, each inside the `activeTasks.map(...)` over `PraxisCardOut[]`. There is no other consumer of the key anywhere in `src`, so no task row was at risk; every site changed. (Eight files serve nine identities: `albescent` declares no `mobileFieldDesk` and falls through to `DefaultFieldDesk` alongside `na`.)

Line numbers re-derived in this worktree at `325d39b4` (the issue's were a day old and PR #1822 had moved two files):

| file | was | now |
|---|---|---|
| `DefaultFieldDesk.tsx` | 345 | 346 |
| `CovenFieldDesk.tsx` | 403 | 404 |
| `EphemeristsFieldDesk.tsx` | 306 | 307 |
| `EverymenFieldDesk.tsx` | 344 → **361** | 362 |
| `SingularityFieldDesk.tsx` | 319 → **320** | 321 |
| `SnideFieldDesk.tsx` | 283 | 284 |
| `UaFieldDesk.tsx` | 319 | 320 |
| `WowFieldDesk.tsx` | 381 + 392 | 388 + 398 |

## What changed

- Seven skins: `points: praxis.task_point_value` → `points: formatPoints(praxis.score)`. Same key, same copy ("faction · +N pts"), same line — only the figure moves, which keeps the faction word that makes each row's sigil decorative.
- **WOW** printed the number twice: the shared meta line *and* the kit's gilt `✦` figure. The gilt figure is the kit's own element (`10-mobile-skins.html`), so it stays and now carries `formatPoints(praxis.score)`; the muted line beside it keeps naming the task's faction and drops its duplicate points clause. One row, one number. If `frontend-style` would rather keep "· +N pts" on the left and drop the gilt figure, that flip is two lines — the archetype note in the file header explains the choice.
- `formatPoints` now lives once, in `utils/points.ts`. It existed as two identical private copies (`pages/FieldDesk.tsx`, `components/duel/shared.tsx` — the latter with no external consumer), and adding eight more callers would have made a third. Both copies now import it; no behaviour change.

No i18n catalog needed editing: `common.json`'s `fieldDesk.home.taskMeta` string is unchanged, and `home.json`'s `signedIn.continue.meta.*` (the desktop's wording) was not adopted — the mobile row already carries the draft/submitted distinction in its mode pill.

## Verification

`tsc --noEmit` after each file; every step named by `.github/workflows/test.yml`'s `frontend` job run locally: `lint` ✓, `typecheck` ✓, `typecheck:design-sync` ✓, `test` ✓ (249 files, 4476 passed), `build` ✓, `budget` ✓ (JS 130.1 KB, CSS 21.4 KB — unmoved). No backend or schema surface touched, so `api-schema` has nothing to regenerate.

**Visual QA is outstanding** — no browser here.

## What to eyeball

Mobile field-desk home (narrow viewport / device mode), signed in as a character with **at least one submitted praxis that has votes**, so `score` ≠ `task_point_value` and the corrected figure is visibly different:

1. **na / Unaffiliated** — `DefaultFieldDesk`, the "In progress" list.
2. **Albescent** — same skin as na; confirm it still falls through and reads the same.
3. **Cozy Coven**
4. **Ephemerists**
5. **Everymen**
6. **Singularity**
7. **Snide**
8. **UA**
9. **WOW** — the one to look hardest at: the quest card footer should read the faction name on the left and a single gilt `✦<score>` on the right. No second copy of the number, and nothing collides at 375px.
10. A **draft** praxis with no votes yet (score 0) on any skin — the row should read `+0 pts` / `✦0`, not blank.
11. The **desktop** FieldDesk's "Continue where you left off" rows — they now call the moved `formatPoints` and should be byte-identical to today.
