### PR TITLE
Wire "Notes to admin" from the propose form to the review queue (#1823)

### DIFF
--- a/backend/alembic/versions/0009_task_notes.py
+++ b/backend/alembic/versions/0009_task_notes.py
@@ -1,0 +1,41 @@
+"""Give a proposed task the proposer's note to the admin: `task.notes` (#1823).
+
+The propose-task form has asked "Why do you want this task to exist? What
+inspired it?" since it shipped, and threw the answer away — there was nowhere to
+put it. This is that column.
+
+NOT NULL with an empty-string default, matching ``task.description``: an absent
+note is "" rather than NULL, so no reader needs a None branch and the admin
+queue can render it with a plain truthiness check. Every existing row gets "".
+
+Plain ``TEXT`` — the 2,000-character trust-boundary cap is enforced on the wire
+in ``schemas.task.MAX_TASK_NOTES``, so it can be raised without a migration.
+
+``0002_squashed`` builds a *fresh* DB straight from the ORM models, so CI and
+local resets already land on this shape and would hit ``DuplicateColumn`` on a
+bare ``ADD COLUMN``. Hence ``IF NOT EXISTS`` — this revision exists to carry a
+deployed DB, stamped at an earlier revision, forward to the shape the models
+already describe. Idempotent either way.
+
+Revision ID: 0009_task_notes
+Revises: 0008_praxis_room_update
+Create Date: 2026-08-15
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0009_task_notes"
+down_revision: Union[str, None] = "0008_praxis_room_update"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE task ADD COLUMN IF NOT EXISTS notes TEXT NOT NULL DEFAULT ''"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE task DROP COLUMN IF EXISTS notes")

--- a/backend/models/task.py
+++ b/backend/models/task.py
@@ -46,6 +46,17 @@ class Task(TimestampMixin, Base):
         default=TaskType.standard,
         server_default="standard",
     )
+    # Free text the proposer writes for the reviewing admin ("Why do you want
+    # this task to exist? What inspired it?") — context for a judgement call,
+    # not part of the task itself. Deliberately NOT on the public ``TaskOut``
+    # (#1823): it is addressed to an admin, and only the admin review queue
+    # (``PendingTaskOut``) serialises it. Empty string, never NULL, so readers
+    # need no None branch — the same shape ``description`` uses. The length cap
+    # lives on the wire in ``schemas.task``; the column is plain TEXT so the cap
+    # can move without a migration.
+    notes: Mapped[str] = mapped_column(
+        Text, nullable=False, default="", server_default=""
+    )
     created_by: Mapped[int] = mapped_column(
         BigInteger, ForeignKey("character.id"), nullable=False
     )

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -4275,6 +4275,11 @@
             ],
             "title": "Metatask Faction Slug"
           },
+          "notes": {
+            "default": "",
+            "title": "Notes",
+            "type": "string"
+          },
           "point_value": {
             "title": "Point Value",
             "type": "integer"
@@ -4326,7 +4331,8 @@
           "allowed_modes",
           "eligible_for_current_user",
           "signup_reason",
-          "created_by_name"
+          "created_by_name",
+          "notes"
         ],
         "title": "PendingTaskOut",
         "type": "object"
@@ -5377,6 +5383,18 @@
               }
             ],
             "title": "Metatask Faction Slug"
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
           },
           "point_value": {
             "exclusiveMinimum": 0.0,

--- a/backend/routers/admin.py
+++ b/backend/routers/admin.py
@@ -319,6 +319,12 @@ async def admin_update_task_status(
 
 class PendingTaskOut(TaskOut):
     created_by_name: str = ""
+    # The proposer's note to the reviewing admin (#1823). It lives here and not
+    # on ``TaskOut`` on purpose: the field is labelled "Notes to admin" and is
+    # written in the expectation that a reviewer reads it, not the whole player
+    # base. ``TaskOut`` is the public browse/detail payload, so putting it there
+    # would publish it. This route is the one behind ``require_admin``.
+    notes: str = ""
 
 
 @router.get("/tasks/pending", response_model=list[PendingTaskOut])
@@ -349,6 +355,7 @@ async def list_pending_tasks(
             created_at=task.created_at,
             in_progress_count=in_progress_counts.get(task.id, 0),
             created_by_name=display_name or "",
+            notes=task.notes,
         )
         for task, display_name in rows
     ]

--- a/backend/schemas/task.py
+++ b/backend/schemas/task.py
@@ -71,8 +71,8 @@ class TaskOut(WireModel):
     signup_reason: Optional[str] = None
 
 
-#: Trust-boundary caps on the two free-text fields a player writes, matching the
-#: convention `CommentIn` already follows (ADR-0006). Both were unbounded, and
+#: Trust-boundary caps on the three free-text fields a player writes, matching
+#: the convention `CommentIn` already follows (ADR-0006). All were unbounded, and
 #: the DB columns behind them are `String`/`Text` with no length either — so a
 #: task proposal could carry an arbitrarily long body. That body is read back by
 #: the admin moderation queue and by `mcp/worldzero-admin`'s `wz_list_pending_-
@@ -81,6 +81,11 @@ class TaskOut(WireModel):
 #: field is a comfortable place to hide one.
 MAX_TASK_TITLE = 200
 MAX_TASK_DESCRIPTION = 5000
+#: The proposer's note to the reviewing admin (#1823). It lands in exactly the
+#: same admin queue and the same agent context as the description above, so it
+#: is capped for exactly the same reason. Smaller because it answers one narrow
+#: question ("why should this exist?") instead of specifying the task.
+MAX_TASK_NOTES = 2000
 
 
 class TaskCreate(WireModel):
@@ -89,6 +94,12 @@ class TaskCreate(WireModel):
     point_value: int = Field(..., gt=0)
     level_required: int = Field(0, ge=0)
     primary_faction_slug: Optional[str] = None
+    # Context for the reviewing admin; not part of the task. One field serves
+    # both proposal kinds — a metatask proposal is this same body with
+    # ``task_type="metatask"`` (the client's `MetataskProposal` is a frontend
+    # convenience type, not a second endpoint). The form only collects notes for
+    # standard tasks today; the schema needs no opinion about that.
+    notes: Optional[str] = Field(None, max_length=MAX_TASK_NOTES)
     # Metatask fields — optional; defaults to a standard task.
     task_type: Optional[str] = None
     metatask_faction_slug: Optional[str] = None

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -89,6 +89,7 @@ async def propose_task(
     task = Task(
         title=data.title,
         description=data.description or "",
+        notes=data.notes or "",
         point_value=data.point_value,
         level_required=data.level_required,
         primary_faction_slug=data.primary_faction_slug or CROSS_FACTION_SLUG,

--- a/backend/tests/integration/test_admin.py
+++ b/backend/tests/integration/test_admin.py
@@ -15,6 +15,7 @@ from models.faction import Faction
 from models.praxis import Praxis
 from models.roles import AccountRole, Role
 from models.task import Task, TaskStatus
+from schemas.task import MAX_TASK_NOTES
 from tests.integration.factories import make_admin
 
 
@@ -1034,3 +1035,97 @@ async def test_admin_era_reset_preserves_votes_spent_without_flag(
     new_stats = new_result.scalar_one()
     await db_session.refresh(new_stats)
     assert new_stats.votes_spent_this_era == 9
+
+
+# ---------------------------------------------------------------------------
+# Notes to admin (#1823)
+# ---------------------------------------------------------------------------
+#
+# The seam these cover is the whole point of the field: a player writes a note
+# on the propose form and an admin reads it in the review queue. Before #1823
+# the value was dropped client-side, so a test that only asserted the schema
+# accepted `notes` would have passed against the broken build. These assert the
+# round trip, and that the note does *not* travel any further than the queue.
+
+
+@pytest.mark.asyncio
+async def test_proposal_notes_reach_the_admin_review_queue(
+    client: AsyncClient,
+    account: Account,
+    character2: Character,
+    auth_headers: dict,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+):
+    """A player's note to the admin survives POST /tasks and is readable in the queue."""
+    note = "My run group already does this every Sunday.\n\nSeemed worth sharing."
+
+    resp = await client.post(
+        "/tasks",
+        json={
+            "title": "Sunday long run",
+            "description": "Run for an hour",
+            "point_value": 15,
+            "notes": note,
+        },
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 201
+    task_id = resp.json()["id"]
+
+    await make_admin(db_session, account)
+    queue = await client.get("/admin/tasks/pending", headers=auth_headers)
+    assert queue.status_code == 200
+
+    row = next(t for t in queue.json() if t["id"] == task_id)
+    assert row["notes"] == note
+
+
+@pytest.mark.asyncio
+async def test_proposal_notes_are_absent_from_the_public_task_payload(
+    client: AsyncClient,
+    character2: Character,
+    auth_headers2: dict,
+):
+    """`notes` is addressed to an admin, so TaskOut must not carry it anywhere.
+
+    Guards the placement decision in #1823: the field lives on the admin-only
+    ``PendingTaskOut``. If someone later moves it up onto ``TaskOut`` for
+    convenience, every player would be able to read every proposer's note off
+    the browse list and the task detail page.
+    """
+    resp = await client.post(
+        "/tasks",
+        json={
+            "title": "Sunday long run",
+            "point_value": 15,
+            "notes": "private context for the reviewer",
+        },
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 201
+    assert "notes" not in resp.json()
+
+    task_id = resp.json()["id"]
+    detail = await client.get(f"/tasks/{task_id}", headers=auth_headers2)
+    assert detail.status_code == 200
+    assert "notes" not in detail.json()
+
+
+@pytest.mark.asyncio
+async def test_proposal_notes_over_the_cap_are_rejected(
+    client: AsyncClient,
+    character2: Character,
+    auth_headers2: dict,
+):
+    """The trust-boundary cap is enforced by the schema, not just the textarea."""
+    resp = await client.post(
+        "/tasks",
+        json={
+            "title": "Sunday long run",
+            "point_value": 15,
+            "notes": "x" * (MAX_TASK_NOTES + 1),
+        },
+        headers=auth_headers2,
+    )
+    assert resp.status_code == 422

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -3625,6 +3625,11 @@ export interface components {
             level_required: number;
             /** Metatask Faction Slug */
             metatask_faction_slug: string | null;
+            /**
+             * Notes
+             * @default
+             */
+            notes: string;
             /** Point Value */
             point_value: number;
             /** Primary Faction Slug */
@@ -4040,6 +4045,8 @@ export interface components {
             level_required: number;
             /** Metatask Faction Slug */
             metatask_faction_slug?: string | null;
+            /** Notes */
+            notes?: string | null;
             /** Point Value */
             point_value: number;
             /** Primary Faction Slug */

--- a/frontend/src/locales/en/admin.json
+++ b/frontend/src/locales/en/admin.json
@@ -64,6 +64,7 @@
     "meta": "{{points}} pts · lvl {{level}} · {{faction}}",
     "crossFaction": "cross-faction",
     "proposedBy": "Proposed by {{name}}",
+    "notesLabel": "Notes to admin",
     "status": {
       "active": "active",
       "pending": "pending",

--- a/frontend/src/pages/admin/TasksTab.tsx
+++ b/frontend/src/pages/admin/TasksTab.tsx
@@ -317,6 +317,36 @@ export default function TasksTab() {
                         })}
                       </p>
                     )}
+                    {/* The proposer's answer to "why should this task exist?" —
+                        the context this review is meant to weigh (#1823).
+                        Pending-only for the same reason as the byline above:
+                        /tasks does not carry it. Rendered as text and never
+                        through dangerouslySetInnerHTML — this is unfiltered
+                        free text from any signed-in player. `pre-wrap` keeps
+                        the paragraph breaks they typed without letting
+                        anything else through. */}
+                    {task.status === "pending" && task.notes && (
+                      <div
+                        style={{
+                          marginTop: "var(--space-sm)",
+                          paddingLeft: "var(--space-sm)",
+                          borderLeft: "2px solid var(--color-border)",
+                        }}
+                      >
+                        <span
+                          className="label-caption"
+                          style={{ display: "block" }}
+                        >
+                          {t("tasks.notesLabel")}
+                        </span>
+                        <p
+                          className="font-body text-xs"
+                          style={{ whiteSpace: "pre-wrap" }}
+                        >
+                          {task.notes}
+                        </p>
+                      </div>
+                    )}
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
                     {(task.status === "pending" ||

--- a/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
+++ b/frontend/src/pages/admin/__tests__/adminTaskRows.test.ts
@@ -49,6 +49,7 @@ const PENDING_METATASK: PendingTaskOut = {
     title: "Chart the coven's tasks",
   }),
   created_by_name: "mollusk",
+  notes: "",
 };
 
 describe("mergeAdminTaskRows", () => {

--- a/frontend/src/pages/admin/adminTaskRows.ts
+++ b/frontend/src/pages/admin/adminTaskRows.ts
@@ -2,10 +2,16 @@ import type { TaskOut } from "../../api/tasks";
 import type { PendingTaskOut } from "../../api/admin";
 
 /**
- * One row in the admin Tasks tab. A plain task, optionally carrying the
- * proposer's display name — only `/admin/tasks/pending` supplies that.
+ * One row in the admin Tasks tab. A plain task, optionally carrying the two
+ * review-only fields — the proposer's display name and their note to the admin.
+ * Only `/admin/tasks/pending` supplies either; neither is on the public
+ * `TaskOut`, so both are optional here and absent on rows that came from
+ * `/tasks`.
  */
-export type AdminTaskRow = TaskOut & { created_by_name?: string };
+export type AdminTaskRow = TaskOut & {
+  created_by_name?: string;
+  notes?: string;
+};
 
 /**
  * Merge the two sources the admin Tasks tab reads (#909).

--- a/frontend/src/pages/proposeTask/__tests__/metataskProposal.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/metataskProposal.test.tsx
@@ -85,6 +85,7 @@ describe('planProposalSubmission — checkbox routes to proposeMetatask', () => 
     pointValue: '10',
     metaBonusValue: '25',
     levelRequired: 3 as number | '',
+    notes: '',
   }
 
   it('routes a checked proposal through the metatask endpoint with the picked faction', () => {

--- a/frontend/src/pages/proposeTask/__tests__/proposalNotes.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/proposalNotes.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * #1823 — "Notes to admin (optional)" reaches the server.
+ *
+ * The seam is `planProposalSubmission`, the pure core that turns raw form
+ * fields into the request body. `notes` was held in `ProposeTaskState` and
+ * bound to a textarea, but the planner never read it, so the answer to "Why do
+ * you want this task to exist?" was dropped between the keystroke and the wire.
+ *
+ * The planner is the right seam because it is the single place both proposal
+ * kinds build their body — a test here fails on the real defect rather than on
+ * a mocked axios call.
+ */
+import { describe, it, expect } from 'vitest'
+import { planProposalSubmission, UNAFFILIATED_FACTION_SLUG } from '../useProposeTask'
+
+const base = {
+  title: 'Meditate daily',
+  description: 'Sit for ten minutes',
+  pointValue: '10',
+  metaBonusValue: '25',
+  levelRequired: 0 as number | '',
+  factionSlug: 'coven',
+  notes: '',
+}
+
+describe('planProposalSubmission — notes to admin', () => {
+  it('sends what the proposer typed', () => {
+    const plan = planProposalSubmission({
+      ...base,
+      isMetatask: false,
+      notes: 'My whole run group already does this every Sunday.',
+    })
+    if (plan.kind !== 'standard') throw new Error('expected standard plan')
+    expect(plan.body.notes).toBe(
+      'My whole run group already does this every Sunday.',
+    )
+  })
+
+  it('omits the field entirely when the proposer left it blank', () => {
+    const plan = planProposalSubmission({ ...base, isMetatask: false })
+    if (plan.kind !== 'standard') throw new Error('expected standard plan')
+    // Not "" — an untouched optional textarea should not write an empty
+    // string onto the row, matching how `description` is already handled.
+    expect(plan.body.notes).toBeUndefined()
+  })
+
+  it('does not attach notes to a metatask — the form hides the field there', () => {
+    const plan = planProposalSubmission({
+      ...base,
+      isMetatask: true,
+      factionSlug: UNAFFILIATED_FACTION_SLUG,
+      notes: 'typed before ticking the metatask box',
+    })
+    if (plan.kind !== 'metatask') throw new Error('expected metatask plan')
+    expect('notes' in plan.body).toBe(false)
+  })
+})

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -576,11 +576,16 @@ export default function DefaultProposeTask({
                 >
                   {t("proposeTask.fields.notes.label")}
                 </span>
+                {/* maxLength mirrors schemas.task.MAX_TASK_NOTES, which stays
+                    the authority and still rejects an over-long body. Stated
+                    as a literal for the same reason the title and description
+                    fields above state 200 / 5000. */}
                 <textarea
                   rows={3}
                   value={notes}
                   onChange={(e) => setNotes(e.target.value)}
                   disabled={submitting}
+                  maxLength={2000}
                   placeholder={t("proposeTask.fields.notes.placeholder")}
                   className="content-text"
                   style={notesTextareaStyle}

--- a/frontend/src/pages/proposeTask/useProposeTask.ts
+++ b/frontend/src/pages/proposeTask/useProposeTask.ts
@@ -43,6 +43,9 @@ export interface ProposalFields {
   metaBonusValue: string;
   levelRequired: number | "";
   factionSlug: string;
+  /** Free-text note to the reviewing admin. Only the standard-task branch
+   *  reads it — the form hides the textarea for metatasks (#1823). */
+  notes: string;
 }
 
 /** Which endpoint {@link handleSubmit} will hit, plus its ready-built body. */
@@ -60,6 +63,10 @@ export type ProposalPlan =
  * `primary_faction_slug` and a metatask's issuing `metatask_faction_slug`. Any
  * slug routes through unchanged, including `na` (Unaffiliated = anyone); the
  * backend only requires a truthy slug and metatasks are faction-open (#894).
+ *
+ * `notes` rides the standard branch only, because that is the only branch whose
+ * form renders the textarea (#1823). Both branches POST /tasks and both are
+ * validated as `TaskCreate`, so the omission is a UI fact, not a wire limit.
  */
 export function planProposalSubmission(fields: ProposalFields): ProposalPlan {
   const level = fields.levelRequired === "" ? 0 : fields.levelRequired;
@@ -83,6 +90,7 @@ export function planProposalSubmission(fields: ProposalFields): ProposalPlan {
       point_value: parseInt(fields.pointValue) || 10,
       level_required: level,
       primary_faction_slug: fields.factionSlug || undefined,
+      notes: fields.notes || undefined,
     },
   };
 }
@@ -169,6 +177,7 @@ export function useProposeTask(): ProposeTaskState {
         metaBonusValue,
         levelRequired,
         factionSlug,
+        notes,
       });
       if (plan.kind === "metatask") {
         await proposeMetatask(plan.body);


### PR DESCRIPTION
The propose-task form has always asked "Why do you want this task to exist? What inspired it?" and thrown the answer away. `notes` was held in `ProposeTaskState` and bound to a textarea, but `planProposalSubmission()` never read it, `TaskCreate` had no such field, and there was no column to put it in. This wires it end to end.

Closes #1823

## The fork: wire it, don't delete it

The issue offers "delete the field" as an equally acceptable outcome. Rejected — the propose-task redesign (#1824, `ready-for-agent`, not yet built) explicitly keeps `fields.notes.placeholder` rendering and gives the notes textarea an `aria-label`. Deleting the field would contradict a design that is already approved and queued to build.

## The seam I tested at

**`planProposalSubmission()`** — the pure core that turns raw form fields into a request body. It is the single place both proposal kinds build their body, so a test there fails on the real defect rather than on a mocked axios call. The new test went red exactly as expected (`expected undefined to be 'My run group already does this…'`) before any fix, then green.

The second seam is the round trip itself: a player POSTs a note, an admin reads it out of the review queue. Covered by integration tests in `backend/tests/integration/test_admin.py`.

## What changed

**Backend**
- `Task.notes` — `TEXT NOT NULL DEFAULT ''`, the same shape `task.description` already uses, so no reader needs a `None` branch.
- `TaskCreate.notes: Optional[str]` capped at `MAX_TASK_NOTES = 2000`.
- `services/task.py::propose_task` persists it.
- `PendingTaskOut.notes` — the admin-only response model behind `require_admin`.
- Migration `0009_task_notes`, revising `0008_praxis_room_update`.

**Frontend**
- `planProposalSubmission()` reads `notes` and sends it; `notes` is now a required member of `ProposalFields` (two existing fixtures updated to match).
- The admin Tasks tab renders the note under a pending row's byline.
- The textarea gets `maxLength={2000}`, matching how title and description already state 200 / 5000.
- New copy in `admin.json`. **`forms.json` is untouched** — the propose-form strings already exist there, and another agent owns that file this batch.

**Generated** — `backend/openapi.json` and `frontend/src/api/generated/schema.d.ts`, produced by `python scripts/regen_api_client.py`, never hand-edited. The diff is 26 lines and contains only these two fields.

## Two decisions worth reviewing

**`notes` is on `PendingTaskOut`, not `TaskOut`.** The field is labelled "Notes to admin" and is written in the expectation that a *reviewer* reads it. `TaskOut` is the public browse/detail payload, so putting it there would publish every proposer's private note to every player. There is a regression test asserting `notes` is absent from both the POST response and `GET /tasks/{id}`.

This placement also means `typecheck:design-sync` never fires: `.design-sync/previews/_fixtures.tsx` constructs `TaskOut`, which is unchanged. I ran the step rather than assuming it — it passes.

**One backend field covers both proposal kinds.** A metatask proposal is the *same* `POST /tasks` with `task_type: "metatask"` — the client's `MetataskProposal` is a frontend convenience type, not a second endpoint. So `TaskCreate.notes` covers both. The planner only attaches notes on the standard branch, because the form renders the textarea under `{!isMetatask && …}`. That is a UI fact, not a wire limit, and it is commented as such.

## Trust boundary

`notes` is unfiltered free text from any signed-in player, stored and later rendered to an admin.

- Length is capped at the schema boundary (2,000 chars), not only by the textarea — there is a test posting `MAX_TASK_NOTES + 1` and asserting 422. The existing cap comment in `schemas/task.py` notes this body also reaches `mcp/worldzero-admin`'s `wz_list_pending_tasks`, i.e. an agent context that also holds `wz_manage_role`; `notes` lands in exactly the same place, so it is capped for exactly the same reason.
- The admin surface renders it as **text**, never `dangerouslySetInnerHTML` (there is none anywhere under `pages/admin/`). `white-space: pre-wrap` preserves the proposer's paragraph breaks without letting markup through.

## Verification

Every job in `.github/workflows/test.yml`, run locally:

- `lint`, `typecheck`, `typecheck:design-sync` — clean
- `npm test` — 250 files, 4,461 passed
- `npm run build`, `npm run budget` — within budget (JS 130.0 KB, CSS 21.3 KB)
- backend `pytest --cov` on a dedicated `wz1823_test` DB

The migration is the one irreversible part, so I exercised it for real against Postgres rather than trusting `create_all`: full chain on a fresh empty DB (what CI's "Run migrations" step does), `alembic check` reports no drift, the column lands as `text NOT NULL DEFAULT ''` identical to `description`, and `downgrade -1` → `upgrade head` round-trips cleanly.

**Visual QA is outstanding** — I have no browser or dev stack here, so nothing below was seen rendered.

## What to eyeball

1. **The propose-task form** (`/propose`) — type into "Notes to admin (optional)", submit, and confirm the proposal still succeeds. The field is unchanged visually; the only new attribute is a 2,000-char `maxLength`.
2. **The admin pending-review surface** (Admin → Tasks, `pending` filter) — the submitted note should appear under the "Proposed by …" byline, in a left-bordered block labelled "Notes to admin". Worth submitting a note **with blank lines in it** to confirm `pre-wrap` holds the paragraph breaks, and one with something like `<b>hi</b>` to confirm it renders as literal text.
3. **A proposal with no note** should render no block at all — not an empty label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
