### PR TITLE
Propose a Task: faction chips replace the pennant picker, and one accent runs the form (#1824)

### DIFF
--- a/.design-sync/previews/FilterLevelNodes.tsx
+++ b/.design-sync/previews/FilterLevelNodes.tsx
@@ -1,7 +1,8 @@
-// FilterLevelNodes preview cells — the level filter as connected nodes (Style
-// Guide §5.3): a row of circles wired by short bars, each meaning "level ≥ N".
-// The active node fills dark and scales up. Cells show a mid selection and the
-// none-selected rest state.
+// FilterLevelNodes preview cells — a wrapping row of circles, each meaning
+// "level ≥ N". Redrawn in #1824 to the propose form's geometry: 40px nodes with
+// a 2px border in every state, tinted by the SELECTED faction (the spectrum
+// stands in for unaffiliated). The component carries no label of its own, so
+// each cell renders the one its caller would.
 import { FilterLevelNodes } from 'worldzero-frontend'
 import { noop } from './_fixtures'
 
@@ -9,19 +10,25 @@ const wrap: React.CSSProperties = { padding: '28px 24px', maxWidth: 520 }
 
 const LEVELS = [1, 2, 3, 4, 5, 6, 7, 8]
 
-/** Level 4 active — the filled, scaled node against its dimmer neighbours. */
+/** Level 4 active, on a faction: the tint wash and its 2px ring. */
 export function ActiveLevel() {
   return (
     <div style={wrap}>
-      <FilterLevelNodes levels={LEVELS} value={4} onChange={noop} />
+      <span className="label-heading" style={{ display: 'block', marginBottom: 'var(--space-sm)' }}>
+        Minimum Level
+      </span>
+      <FilterLevelNodes levels={LEVELS} value={4} onChange={noop} factionSlug="coven" />
     </div>
   )
 }
 
-/** No floor set — every node in its hollow rest state. */
+/** No floor set — every node in its hollow rest state, unaffiliated. */
 export function NoneSelected() {
   return (
     <div style={wrap}>
+      <span className="label-heading" style={{ display: 'block', marginBottom: 'var(--space-sm)' }}>
+        Minimum Level
+      </span>
       <FilterLevelNodes levels={LEVELS} value="" onChange={noop} />
     </div>
   )

--- a/frontend/src/components/ui/ChipRow.tsx
+++ b/frontend/src/components/ui/ChipRow.tsx
@@ -40,6 +40,17 @@ export function ChipRow({ label, children }: { label: string; children: ReactNod
  * single-colour box-shadow cannot carry the spectrum, so the frame alone
  * carries selection. The caller passes `!isKnownFaction(slug)` (a VALUE test,
  * not key presence, #749) — so every non-na chip stays pixel-identical.
+ *
+ * `sigilText` (#1824) is the third variant: a sigil AND its faction's name, at
+ * the propose-task form's own geometry (40px tall, 2px border in EVERY state so
+ * selection cannot reflow the row, a 14% tint wash and a soft glow instead of a
+ * ring). It keeps `iconOnly`'s selection semantics — the dark-inverted fill
+ * would fight the sigil the same way — including the na frame, so it reads
+ * `unaffiliated` too. It suppresses the swatch (the sigil is the mark) and
+ * announces as `role="radio"`, because its chips are a radiogroup rather than
+ * eight independent toggles. Every value it introduces is gated on the flag:
+ * the mobile leaderboard and the praxis feed mount the other two variants and
+ * must stay pixel-identical (`__tests__/chipVariants.test.tsx` is that guard).
  */
 export function Chip({
   on,
@@ -48,6 +59,7 @@ export function Chip({
   ariaLabel,
   iconOnly,
   unaffiliated,
+  sigilText,
   children,
 }: {
   on: boolean
@@ -56,14 +68,16 @@ export function Chip({
   ariaLabel?: string
   iconOnly?: boolean
   unaffiliated?: boolean
+  sigilText?: boolean
   children: ReactNode
 }) {
   // ponytail: one style object with a handful of ternaries rather than two chip
   // components — the two variants share every box property but the fill.
   const ring = tint ?? 'var(--color-text-primary)'
-  // Selected na glyph chip: the spectrum arrives as a border ring, replacing
-  // the grey ring/glow. `frameStyle` overrides background/border/boxSizing.
-  const useFrame = Boolean(iconOnly && on && unaffiliated)
+  // Selected na chip (glyph or sigil+text): the spectrum arrives as a border
+  // ring, replacing the grey ring/glow. `frameStyle` overrides
+  // background/border/boxSizing.
+  const useFrame = Boolean((iconOnly || sigilText) && on && unaffiliated)
   const frameStyle = useFrame ? factionFill(null, 'frame') : undefined
 
   return (
@@ -71,6 +85,8 @@ export function Chip({
       type="button"
       onClick={onClick}
       aria-label={ariaLabel}
+      role={sigilText ? 'radio' : undefined}
+      aria-checked={sigilText ? on : undefined}
       aria-pressed={iconOnly ? on : undefined}
       className="font-body uppercase"
       style={{
@@ -82,28 +98,60 @@ export function Chip({
         fontSize: 'var(--text-md)',
         fontWeight: on ? 700 : 400,
         letterSpacing: '0.05em',
-        color: on && !iconOnly ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
-        background: on && !iconOnly ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
-        border: `1px solid ${
-          iconOnly ? (on ? ring : 'var(--color-border-strong)') : on ? 'transparent' : 'var(--color-border-strong)'
-        }`,
+        lineHeight: sigilText ? 1 : undefined,
+        color: sigilText
+          ? on
+            ? 'var(--color-text-primary)'
+            : 'var(--color-text-secondary)'
+          : on && !iconOnly
+            ? 'var(--color-text-on-accent)'
+            : 'var(--color-text-secondary)',
+        background: sigilText
+          ? on && !useFrame
+            ? `color-mix(in srgb, ${ring} 14%, var(--color-bg-surface))`
+            : 'var(--color-bg-surface)'
+          : on && !iconOnly
+            ? 'var(--color-text-primary)'
+            : 'var(--color-bg-surface)',
+        // 2px in both states for the sigil+text variant: selection changes the
+        // border's COLOUR, never its width, so eight wrapped chips cannot
+        // reflow under the pointer.
+        border: sigilText
+          ? `2px solid ${on ? ring : 'var(--color-border-strong)'}`
+          : `1px solid ${
+              iconOnly ? (on ? ring : 'var(--color-border-strong)') : on ? 'transparent' : 'var(--color-border-strong)'
+            }`,
         // Ring is a box-shadow, not a thicker border, so selecting a chip does
         // not reflow the row by a pixel. na's frame carries its own selection,
         // so the coloured glow is dropped there (a solid glow can't be spectral).
-        boxShadow: iconOnly && on && !useFrame ? `0 0 0 2px ${ring}, 0 0 8px ${ring}` : undefined,
-        opacity: iconOnly && !on ? 0.85 : undefined,
+        boxShadow: sigilText
+          ? on && !useFrame
+            ? `0 0 8px color-mix(in srgb, ${ring} 45%, transparent)`
+            : undefined
+          : iconOnly && on && !useFrame
+            ? `0 0 0 2px ${ring}, 0 0 8px ${ring}`
+            : undefined,
+        opacity: sigilText ? (on ? undefined : 0.88) : iconOnly && !on ? 0.85 : undefined,
         borderRadius: 999,
-        padding: iconOnly ? 'var(--space-xs)' : 'var(--space-sm) var(--space-md)',
-        minHeight: 36,
+        padding: sigilText
+          ? '0 var(--space-md)'
+          : iconOnly
+            ? 'var(--space-xs)'
+            : 'var(--space-sm) var(--space-md)',
+        minHeight: sigilText ? 40 : 36,
         minWidth: iconOnly ? 36 : undefined,
+        boxSizing: sigilText ? 'border-box' : undefined,
         whiteSpace: 'nowrap',
         cursor: 'pointer',
+        transition: sigilText
+          ? 'box-shadow 120ms, color 120ms, border-color 120ms, background 120ms'
+          : undefined,
         // Spread last so the rainbow frame's background/border/boxSizing win
         // over the scalar ring above. Empty for every non-na chip.
         ...frameStyle,
       }}
     >
-      {tint && !iconOnly && (
+      {tint && !iconOnly && !sigilText && (
         <i style={{ width: 8, height: 8, borderRadius: 2, flex: 'none', background: tint }} />
       )}
       {children}

--- a/frontend/src/components/ui/FilterLevelNodes.tsx
+++ b/frontend/src/components/ui/FilterLevelNodes.tsx
@@ -1,54 +1,78 @@
 import { useTranslation } from 'react-i18next'
+import { factionCssVar, factionFill, isKnownFaction } from '../../utils/factions'
 
 /**
- * Level filter — Connected Nodes (Style Guide §5.3).
- * Row of circles connected by horizontal bars. Active: dark fill, scale(1.15).
- * Colors use CSS variables so dark mode is handled by the cascade.
+ * Level nodes — a wrapping row of circles, each meaning "level ≥ N".
+ *
+ * Redrawn in #1824 to the propose form's one geometry: 40px circles with a 2px
+ * border in EVERY state, matching the faction chips above them, so a selection
+ * changes colour and nothing else moves. The connector bars and the
+ * `scale(1.15)` on the active node went with that — a scaling node in a
+ * wrapping row is the one thing that CAN reflow it.
+ *
+ * `factionSlug` is the selected faction, and it is what makes the row part of
+ * the same sentence as the chips: the active node takes that faction's tint,
+ * and an unaffiliated selection takes the spectrum as a frame rather than
+ * degrading to grey (ADR-0039 — `factionCssVar('na')` is neutral by design).
+ * Undefined behaves as na.
+ *
+ * It carries NO label. The propose form renders its own "Minimum Level" above
+ * the row, so the internal `label-heading` this used to draw announced the
+ * field twice. Callers own the label; the preview cells supply their own.
+ *
+ * Colours are CSS variables, so dark mode arrives through the cascade.
  */
 
 interface Props {
   levels: number[]
   value: number | ''
   onChange: (level: number | '') => void
+  /** Selected faction, for the active node's accent. Undefined = unaffiliated. */
+  factionSlug?: string
 }
 
-export default function FilterLevelNodes({ levels, value, onChange }: Props) {
+export default function FilterLevelNodes({ levels, value, onChange, factionSlug }: Props) {
   const { t } = useTranslation('common')
+  const known = isKnownFaction(factionSlug)
+  const tint = factionCssVar(factionSlug)
   return (
-    <div className="flex items-center">
-      <span className="label-heading mr-2">{t('filters.level')}</span>
-      {levels.map((level, index) => {
+    <div className="flex flex-wrap items-center" style={{ gap: 'var(--space-xs)' }}>
+      {levels.map((level) => {
         const active = value === level
+        // The spectrum can't be a border-colour, so na's selection arrives as a
+        // frame spread last — same treatment the selected chip takes.
+        const frameStyle = active && !known ? factionFill(null, 'frame') : undefined
         return (
-          <div key={level} className="flex items-center">
-            {index > 0 && (
-              <div style={{ width: 12, height: 2, background: 'var(--color-border-strong)' }} />
-            )}
-            <button
-              type="button"
-              onClick={() => onChange(value === level ? '' : level)}
-              style={{
-                width: 30,
-                height: 30,
-                borderRadius: '50%',
-                border: `2px solid ${active ? 'var(--color-text-primary)' : 'var(--color-border-strong)'}`,
-                background: active ? 'var(--color-text-primary)' : 'var(--color-bg-surface)',
-                color: active ? 'var(--color-bg-page)' : 'var(--color-text-tertiary)',
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: 'var(--text-base)',
-                fontWeight: 700,
-                cursor: 'pointer',
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                transform: active ? 'scale(1.15)' : 'scale(1)',
-                transition: 'all 120ms',
-                padding: 0,
-              }}
-            >
-              {t('filters.levelAtLeast', { level })}
-            </button>
-          </div>
+          <button
+            key={level}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange(value === level ? '' : level)}
+            style={{
+              width: 40,
+              height: 40,
+              borderRadius: '50%',
+              boxSizing: 'border-box',
+              border: `2px solid ${active && known ? tint : 'var(--color-border-strong)'}`,
+              background:
+                active && known
+                  ? `color-mix(in srgb, ${tint} 18%, var(--color-bg-surface))`
+                  : 'var(--color-bg-surface)',
+              color: active ? 'var(--color-text-primary)' : 'var(--color-text-secondary)',
+              fontFamily: 'var(--font-body)',
+              fontSize: 'var(--text-md)',
+              fontWeight: active ? 700 : 400,
+              cursor: 'pointer',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              transition: 'all 120ms',
+              padding: 0,
+              ...frameStyle,
+            }}
+          >
+            {t('filters.levelAtLeast', { level })}
+          </button>
         )
       })}
     </div>

--- a/frontend/src/components/ui/__tests__/chipVariants.test.tsx
+++ b/frontend/src/components/ui/__tests__/chipVariants.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * #1824 — `Chip` grows a third variant (`sigilText`) for the propose-task
+ * faction row, and the two that already shipped may not move by a pixel.
+ *
+ * THE SEAM IS THE STYLE OBJECT `Chip` emits, not any page that mounts it. The
+ * variants share one object with a handful of ternaries (that is the whole
+ * point of #644's consolidation), so a value added for the new variant leaks
+ * into the mobile leaderboard and the praxis feed by DEFAULT unless every one
+ * of them is gated. No jsdom in this repo, so we read the inline style off
+ * `renderToStaticMarkup` — which is exactly what a leak would show up in.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import { Chip } from '../ChipRow'
+
+const noop = () => {}
+
+const text = (on: boolean) =>
+  renderToStaticMarkup(
+    <Chip on={on} onClick={noop} tint="var(--faction-ua)">
+      UA
+    </Chip>,
+  )
+
+const iconOnly = (on: boolean) =>
+  renderToStaticMarkup(
+    <Chip on={on} onClick={noop} tint="var(--faction-ua)" iconOnly ariaLabel="UA">
+      <i />
+    </Chip>,
+  )
+
+const sigilText = (on: boolean, slug: 'ua' | 'na') =>
+  renderToStaticMarkup(
+    <Chip
+      on={on}
+      onClick={noop}
+      tint={slug === 'ua' ? 'var(--faction-ua)' : 'var(--faction-default)'}
+      unaffiliated={slug === 'na'}
+      sigilText
+    >
+      <span>Name</span>
+    </Chip>,
+  )
+
+describe('the two shipped chip variants are untouched', () => {
+  it('keeps the text chip at 36px with a 1px border', () => {
+    for (const markup of [text(false), text(true)]) {
+      expect(markup).toContain('min-height:36px')
+      expect(markup).toContain('border:1px solid')
+      expect(markup).not.toContain('min-height:40px')
+    }
+  })
+
+  it('keeps the glyph chip at 36px with a 1px border', () => {
+    for (const markup of [iconOnly(false), iconOnly(true)]) {
+      expect(markup).toContain('min-height:36px')
+      expect(markup).toContain('border:1px solid')
+    }
+  })
+
+  it('still draws the 8x8 swatch for the text chip', () => {
+    expect(text(false)).toContain('width:8px')
+  })
+})
+
+describe('sigilText — the propose-task faction chip', () => {
+  it('is 40px tall with a 2px border in BOTH states, so selecting never reflows the row', () => {
+    for (const markup of [sigilText(false, 'ua'), sigilText(true, 'ua')]) {
+      expect(markup).toContain('min-height:40px')
+      expect(markup).toContain('border:2px solid')
+    }
+  })
+
+  it('drops the swatch — the sigil is the mark', () => {
+    expect(sigilText(false, 'ua')).not.toContain('width:8px')
+  })
+
+  it('is a radio, not a toggle: the chips live in a radiogroup', () => {
+    expect(sigilText(true, 'ua')).toContain('role="radio"')
+    expect(sigilText(true, 'ua')).toContain('aria-checked="true"')
+    expect(sigilText(true, 'ua')).not.toContain('aria-pressed')
+  })
+
+  it('paints selection in the faction tint', () => {
+    const on = sigilText(true, 'ua')
+    expect(on).toContain('border:2px solid var(--faction-ua)')
+    expect(on).toContain('color-mix(in srgb, var(--faction-ua) 14%, var(--color-bg-surface))')
+  })
+
+  it('gives a selected na chip the spectrum frame and no solid glow', () => {
+    const on = sigilText(true, 'na')
+    expect(on).toContain('--faction-default-rainbow')
+    // A single-colour box-shadow cannot carry seven stops (#794). Match the
+    // declaration, not the word — the variant's `transition` list names the
+    // property too.
+    expect(on).not.toContain('box-shadow:')
+    expect(sigilText(true, 'ua')).toContain('box-shadow:')
+  })
+})

--- a/frontend/src/components/ui/__tests__/filterLevelNodes.test.tsx
+++ b/frontend/src/components/ui/__tests__/filterLevelNodes.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * #1824 — the minimum-level nodes join the propose form's one visual language:
+ * chip geometry (40px, 2px border) and the SELECTED faction's accent, with the
+ * spectrum standing in for na exactly as it does on the chips.
+ *
+ * THE SEAM IS THE COMPONENT, not the page. `FilterLevelNodes` owned two things
+ * the page could not reach: the accent (it had none — the active node was
+ * always the neutral primary ink) and its own `label-heading`, which duplicated
+ * the caller's "Minimum Level" so the field announced twice.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import FilterLevelNodes from '../FilterLevelNodes'
+
+const noop = () => {}
+const LEVELS = [0, 1, 2, 3]
+
+const render = (value: number | '', factionSlug?: string) =>
+  renderToStaticMarkup(
+    <FilterLevelNodes levels={LEVELS} value={value} onChange={noop} factionSlug={factionSlug} />,
+  )
+
+describe('FilterLevelNodes', () => {
+  it('is chip-sized: 40px nodes with a 2px border in every state', () => {
+    const markup = render(2, 'ua')
+    expect(markup).toContain('width:40px')
+    expect(markup).toContain('height:40px')
+    // Every node carries the 2px border; only its colour changes, so selecting
+    // one cannot reflow the row.
+    expect(markup.match(/border:2px solid/g)).toHaveLength(LEVELS.length)
+  })
+
+  it('carries no label of its own — the caller already names the field', () => {
+    expect(render('', 'ua')).not.toContain('label-heading')
+  })
+
+  it('tints the selected node with the faction', () => {
+    const markup = render(2, 'ua')
+    expect(markup).toContain('border:2px solid var(--faction-ua)')
+    expect(markup).toContain('color-mix(in srgb, var(--faction-ua) 18%, var(--color-bg-surface))')
+  })
+
+  it('gives an unaffiliated selection the spectrum, never a grey tint', () => {
+    for (const markup of [render(2), render(2, 'na')]) {
+      expect(markup).toContain('--faction-default-rainbow')
+      expect(markup).not.toContain('var(--faction-default)')
+    }
+  })
+
+  it('leaves an unselected row entirely neutral', () => {
+    const markup = render('', 'ua')
+    expect(markup).not.toContain('var(--faction-ua)')
+    expect(markup).not.toContain('--faction-default-rainbow')
+  })
+})

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -313,35 +313,24 @@
       "body": "An admin will review it soon. Only admins can see it for its first {{hours}} hours; other players see it after that."
     },
     "successMeta": {
-      "heading": "Meta task proposed!",
+      "heading": "Metatask proposed!",
       "body": "An admin will review it, and only admins can see it for its first {{hours}} hours; other players see it after that. Once activated, {{faction}} players can apply it to their praxis for a points bonus."
     },
-    "factionSelectorLabel": "Choose a faction for this task, or leave it open to everyone",
-    "factionDescriptor": {
-      "na": "Anyone",
-      "ua": "Practise with us — one true piece a day.",
-      "coven": "Circle",
-      "wow": "Knights who take the ridiculous with total seriousness.",
-      "everymen": "Mobilize",
-      "snide": "Mischief",
-      "ephemerists": "Record",
-      "singularity": "Discover"
-    },
+    "factionLabel": "Faction",
     "fields": {
       "name": {
         "label": "Task name",
-        "placeholder": "What do you want people to do?",
+        "placeholder": "Task Name",
         "tooLong": "Task name must be 200 characters or fewer."
       },
       "description": {
         "label": "Description",
-        "placeholder": "Write the task description here. What exactly should the player do? What counts as completing it?",
+        "placeholder": "Task Description",
         "tooLong": "Description must be 5000 characters or fewer."
       },
       "basePoints": {
         "label": "Base points",
-        "placeholder": "pts",
-        "hint": "Admin may adjust"
+        "placeholder": "pts"
       },
       "bonusPoints": {
         "label": "Bonus points",
@@ -349,21 +338,18 @@
         "hint": "Flat bonus added to score"
       },
       "minimumLevel": {
-        "label": "Minimum level",
-        "hint": "Level 0 = anyone can attempt"
+        "label": "Minimum level"
       },
       "notes": {
         "label": "Notes to admin (optional)",
-        "placeholder": "Why do you want this task to exist? What inspired it?"
+        "placeholder": "Notes to Admin (optional)"
       }
     },
     "metaToggle": {
-      "label": "Create as meta task",
-      "hint": "applies as a bonus to all {{faction}} submissions",
-      "hintNoFaction": "pick a faction above (Unaffiliated = anyone)"
+      "label": "Create as Metatask"
     },
     "preview": {
-      "metaHeading": "Meta task preview — {{faction}}",
+      "metaHeading": "Metatask preview — {{faction}}",
       "taskHeading": "Task preview — {{faction}} · Pending",
       "bonusPoints": "+{{points}} bonus pts",
       "points": "{{points}} pts",
@@ -371,27 +357,15 @@
       "pending": "Pending review"
     },
     "errors": {
-      "createMeta": "Could not create meta task.",
+      "createMeta": "Could not create metatask.",
       "propose": "Could not propose task."
     },
     "submit": {
       "busy": "Submitting...",
-      "meta": "Propose meta task",
+      "meta": "Propose Metatask",
       "task": "Submit proposal",
       "cancel": "Cancel",
       "note": "Your proposal goes to admin for review. Only admins can see it for its first {{hours}} hours; other players see it after that."
-    },
-    "tips": {
-      "goodTaskHeading": "What makes a good task",
-      "goodTaskItems": [
-        "It should be doable by someone with no money and no special skills.",
-        "The proof post should be interesting to read even if you didn't do the task.",
-        "It should have a clear pass/fail.",
-        "It should feel like it belongs to its faction.",
-        "If anyone could do it anywhere, it's probably right."
-      ],
-      "nextHeading": "What happens next",
-      "nextBody": "Your proposal goes to admin review. If approved, it enters the pending task list. Admins typically review proposals within 1-2 weeks."
     }
   }
 }

--- a/frontend/src/pages/proposeTask/__tests__/metataskProposal.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/metataskProposal.test.tsx
@@ -1,5 +1,5 @@
 /**
- * #894 — wiring the "Create as meta task" checkbox.
+ * #894 — wiring the "Create as Metatask" checkbox.
  *
  * Two guarantees:
  *  1. The checkbox is gated off the capability seam (`canProposeMetatask`,
@@ -64,16 +64,16 @@ function renderText(overrides: Partial<ProposeTaskState> = {}): string {
   ).replace(/<[^>]*>/g, '')
 }
 
-describe('meta task checkbox — capability gate', () => {
+describe('metatask checkbox — capability gate', () => {
   it('is hidden below the propose-metatask gate', () => {
     expect(renderText({ canProposeMetatask: false })).not.toContain(
-      'Create as meta task',
+      'Create as Metatask',
     )
   })
 
   it('appears once the proposer is eligible', () => {
     expect(renderText({ canProposeMetatask: true })).toContain(
-      'Create as meta task',
+      'Create as Metatask',
     )
   })
 })

--- a/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
+++ b/frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx
@@ -57,16 +57,24 @@ function render(overrides: Partial<ProposeTaskState> = {}): string {
   )
 }
 
-describe('propose task — unaffiliated option', () => {
+describe('propose task — the faction chips', () => {
   it('offers an unaffiliated choice alongside the real factions', () => {
     const text = render().replace(/<[^>]*>/g, '')
     expect(text).toContain('Unaffiliated')
-    expect(text).toContain('Anyone')
     // The registry factions are still listed.
     expect(text).toContain('Everymen')
   })
 
-  it('gives the unaffiliated pennant the rainbow, never a borrowed faction hue', () => {
+  it('is one radiogroup of eight radios — na plus the seven factions (#1824)', () => {
+    const markup = render()
+    expect(markup).toContain('role="radiogroup"')
+    expect(markup.match(/role="radio"/g)).toHaveLength(8)
+    // Unaffiliated leads, then the rainbow: everymen is the first faction.
+    expect(markup.indexOf('Unaffiliated')).toBeLessThan(markup.indexOf('Everymen'))
+    expect(markup.indexOf('Everymen')).toBeLessThan(markup.indexOf('Cozy Coven'))
+  })
+
+  it('gives the unaffiliated chip the rainbow, never a borrowed faction hue', () => {
     // ADR-0039: `na` has no hue, so it takes the spectrum as a frame rather
     // than resolving to `default` grey or impersonating UA orange (#749).
     expect(render()).toContain('--faction-default-rainbow')
@@ -76,19 +84,32 @@ describe('propose task — unaffiliated option', () => {
     expect(render({ factionSlug: 'ua' })).toContain('var(--faction-ua)')
   })
 
-  it('reads Unaffiliated as a legitimate metatask issuer, not an error', () => {
-    // #894: `na` metatasks are allowed ("anyone"), so the helper next to the
-    // checkbox invites the choice rather than rejecting it.
-    const unaffiliated = render({ canProposeMetatask: true }).replace(
-      /<[^>]*>/g,
-      '',
+  it('runs the selected faction through the whole form, not just the chip', () => {
+    // The card frame, the task-name face, the level nodes and the submit pill
+    // all read the same slug (factionSurfaces.ts) — that is the point of the
+    // change, and a per-surface accent is exactly what silently drops out.
+    const markup = render({ factionSlug: 'coven', title: 'Bake something' })
+    expect(markup).toContain('var(--faction-coven-card-font)')
+    expect(markup).toContain('border:2px solid var(--faction-coven)')
+    expect(markup).toContain(
+      'color-mix(in srgb, var(--faction-coven) 18%, var(--color-bg-surface))',
     )
-    expect(unaffiliated).toContain('Unaffiliated = anyone')
+    // The card's own frame is the bevelled ramp, over an OPAQUE paper layer.
+    expect(markup).toContain('var(--faction-default-card-bg)')
+    expect(markup).toContain('background-clip:padding-box, border-box')
+  })
 
-    const affiliated = render({
-      canProposeMetatask: true,
-      factionSlug: 'coven',
-    }).replace(/<[^>]*>/g, '')
-    expect(affiliated).toContain('applies as a bonus to all')
+  it('leaves the metatask control announceable without a native checkbox', () => {
+    // `accent-color` takes one colour and na's identity is seven (#1824).
+    const markup = render({ canProposeMetatask: true })
+    expect(markup).toContain('role="checkbox"')
+    expect(markup).not.toContain('type="checkbox"')
+  })
+
+  it('names the three placeholder-only fields for a screen reader', () => {
+    const markup = render()
+    expect(markup).toContain('aria-label="Task name"')
+    expect(markup).toContain('aria-label="Description"')
+    expect(markup).toContain('aria-label="Notes to admin (optional)"')
   })
 })

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -242,9 +242,10 @@ export default function DefaultProposeTask({
       <PageTitle title={t("proposeTask.pageTitle")} />
       <div aria-hidden="true" style={titleRuleStyle} />
 
-      {/* One column (§20.1). The tips rail is gone; the form is the page. */}
+      {/* One column (§20.1). The tips rail is gone; the form is the page — and
+          a single column is also what the mobile path needs, which the old
+          `1fr 280px` inline grid was a standing violation of. */}
       <div style={{ maxWidth: 760 }}>
-        <div>
           {/* Faction chips (§20.2) — the site's chip idiom, one wrapping
               radiogroup. Not `ChipRow`: its shell scrolls horizontally with a
               hidden scrollbar and prints a visible inline label, which would
@@ -619,7 +620,6 @@ export default function DefaultProposeTask({
               )}
             </div>
           </form>
-        </div>
       </div>
     </div>
   );

--- a/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
+++ b/frontend/src/pages/proposeTask/archetypes/DefaultProposeTask.tsx
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PageTitle from "../../../components/ui/PageTitle";
 import FilterLevelNodes from "../../../components/ui/FilterLevelNodes";
+import { Chip } from "../../../components/ui/ChipRow";
+import FactionSigil from "../../../components/sigil/FactionSigil";
 import { useGameConfig } from "../../../hooks/useGameConfig";
 import {
   factionCssVar,
@@ -10,7 +12,14 @@ import {
   factionName,
   getAllFactions,
   isKnownFaction,
+  sortFactionsByRainbowOrder,
 } from "../../../utils/factions";
+import {
+  metaBoxStyle,
+  proposeCardStyle,
+  submitButtonStyle,
+  taskNameInputStyle,
+} from "../factionSurfaces";
 import {
   UNAFFILIATED_FACTION_SLUG,
   type ProposeTaskState,
@@ -66,59 +75,31 @@ const basePointsInputStyle: CSSProperties = {
   textAlign: "center",
 };
 
-const tipsListStyle: CSSProperties = {
-  color: "var(--color-text-primary)",
-  lineHeight: 1.6,
-  paddingLeft: "var(--space-lg)",
-  listStyleType: "disc",
-};
-
-const tipsBodyStyle: CSSProperties = {
-  color: "var(--color-text-secondary)",
-  lineHeight: 1.6,
-};
-
 const submitNoteStyle: CSSProperties = {
   color: "var(--color-text-tertiary)",
   marginLeft: "auto",
 };
 
-const submitDashStyle: CSSProperties = {
-  position: "absolute",
-  inset: 3,
-  border: "1px dashed rgba(255,255,255,0.25)",
-  pointerEvents: "none",
+/** The one page rule under the title — the site's spectrum, not a faction's. */
+const titleRuleStyle: CSSProperties = {
+  height: 3,
+  width: 240,
+  background: "var(--faction-default-rainbow)",
+  marginBottom: "var(--space-xl)",
 };
 
-/** Shape/type of the selector pennant; the FILL is picked per-slug below. */
-const basePennantStyle: CSSProperties = {
-  display: "block",
-  fontFamily: "'Courier Prime', monospace",
-  fontSize: "var(--text-md)",
-  fontWeight: 700,
-  textTransform: "uppercase",
-  letterSpacing: "0.07em",
-  padding: "var(--space-xs) var(--space-md)",
-  marginBottom: "var(--space-xs)",
+/** The metatask control: a real checkbox can't carry seven colours (#1824). */
+const metaToggleStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "var(--space-sm)",
+  background: "transparent",
+  border: "none",
+  padding: 0,
+  margin: 0,
+  cursor: "pointer",
+  textAlign: "left",
 };
-
-/** Solid-hue pennant fill — only for slugs that pass isKnownFaction. */
-const knownPennantFillStyle = (slug: string): CSSProperties => ({
-  background: factionCssVar(slug),
-  color: "var(--color-text-on-accent)",
-  textShadow: "0 1px 2px rgba(0,0,0,0.3)",
-});
-
-const FACTION_DESCRIPTOR_KEY = {
-  na: "proposeTask.factionDescriptor.na",
-  ua: "proposeTask.factionDescriptor.ua",
-  coven: "proposeTask.factionDescriptor.coven",
-  wow: "proposeTask.factionDescriptor.wow",
-  everymen: "proposeTask.factionDescriptor.everymen",
-  snide: "proposeTask.factionDescriptor.snide",
-  ephemerists: "proposeTask.factionDescriptor.ephemerists",
-  singularity: "proposeTask.factionDescriptor.singularity",
-} as const;
 
 /**
  * Default propose-task archetype — the original universal form, now consuming
@@ -133,10 +114,6 @@ export default function DefaultProposeTask({
   state: ProposeTaskState;
 }) {
   const { t } = useTranslation("forms");
-  const factionDescriptor = (slug: string): string => {
-    const key = FACTION_DESCRIPTOR_KEY[slug as keyof typeof FACTION_DESCRIPTOR_KEY];
-    return key ? t(key) : "";
-  };
   const {
     canProposeMetatask,
     success,
@@ -184,10 +161,15 @@ export default function DefaultProposeTask({
   // Unaffiliated leads the picker: it is the default, and it is a state rather
   // than a faction, so it is an extra option here rather than a registry entry
   // (ADR-0039). Everything after it comes from the API, falling back to the
-  // static registry before the fetch lands.
+  // static registry before the fetch lands, in the site's one rainbow order
+  // (#352) — the chips are a spectrum now, so their sequence is the spectrum's.
   const factionOptions: string[] = [
     UNAFFILIATED_FACTION_SLUG,
-    ...(factions.length > 0 ? factions : getAllFactions()).map((f) => f.slug),
+    ...sortFactionsByRainbowOrder(
+      (factions.length > 0 ? factions : getAllFactions()).map((f) => ({
+        slug: f.slug,
+      })),
+    ).map((f) => f.slug),
   ];
 
   if (success) {
@@ -258,73 +240,39 @@ export default function DefaultProposeTask({
       </nav>
 
       <PageTitle title={t("proposeTask.pageTitle")} />
+      <div aria-hidden="true" style={titleRuleStyle} />
 
-      {/* Two-column: form left, tips right (§20.1) */}
-      <div
-        style={{
-          display: "grid",
-          gridTemplateColumns: "1fr 280px",
-          gap: "var(--space-xl)",
-          alignItems: "start",
-        }}
-      >
-        {/* ── Left: Form ── */}
+      {/* One column (§20.1). The tips rail is gone; the form is the page. */}
+      <div style={{ maxWidth: 760 }}>
         <div>
-          {/* Faction Selector (§20.2) */}
+          {/* Faction chips (§20.2) — the site's chip idiom, one wrapping
+              radiogroup. Not `ChipRow`: its shell scrolls horizontally with a
+              hidden scrollbar and prints a visible inline label, which would
+              bury three of the eight options. */}
           <div style={{ marginBottom: "var(--space-lg)" }}>
-            {/* A full sentence, not a region name — caption tier (#1307). */}
-            <span
-              className="label-caption"
-              style={{ display: "block", marginBottom: "var(--space-sm)" }}
+            <div
+              role="radiogroup"
+              aria-label={t("proposeTask.factionLabel")}
+              style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-sm)" }}
             >
-              {t("proposeTask.factionSelectorLabel")}
-            </span>
-            <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-sm)" }}>
-              {factionOptions.map((slug) => {
-                const active = factionSlug === slug;
-                const known = isKnownFaction(slug);
-                return (
-                  <button
-                    key={slug}
-                    type="button"
-                    onClick={() => setFactionSlug(slug)}
-                    style={{
-                      border: `2px solid ${active ? factionCssVar(slug, "border") : "var(--color-border)"}`,
-                      background: active
-                        ? factionCssVar(slug, "light")
-                        : "var(--color-bg-surface)",
-                      borderRadius: 6,
-                      padding: "var(--space-sm) var(--space-lg)",
-                      cursor: "pointer",
-                      textAlign: "center",
-                      transition: "all 120ms",
-                      transform: active ? "translateY(-2px)" : "none",
-                    }}
-                  >
-                    <span
-                      className="pennant-shape"
-                      style={{
-                        ...basePennantStyle,
-                        // A real faction flies its solid hue with on-accent ink.
-                        // `na` has no hue — it gets the spectrum as a FRAME
-                        // around paper with ink text, because no single ink is
-                        // legible across the rainbow (ADR-0039, factionFill).
-                        ...(known
-                          ? knownPennantFillStyle(slug)
-                          : factionFill(slug, "pill")),
-                      }}
-                    >
-                      {factionName(slug)}
-                    </span>
-                    {/* Sentence-case: the descriptors are no longer uniformly
-                        one word (#850 gave UA a full sentence), and 0.15em
-                        all-caps is a wall at that length. */}
-                    <span className="label-caption">
-                      {factionDescriptor(slug)}
-                    </span>
-                  </button>
-                );
-              })}
+              {factionOptions.map((slug) => (
+                <Chip
+                  key={slug}
+                  on={factionSlug === slug}
+                  onClick={() => setFactionSlug(slug)}
+                  tint={factionCssVar(slug)}
+                  // `na` (and Albescent) have no single hue for the selected
+                  // ring, so they take the spectrum frame instead (#749).
+                  unaffiliated={!isKnownFaction(slug)}
+                  sigilText
+                >
+                  {/* The slug, not a null for `na`: FactionSigil already falls
+                      through to the spectrum ring for it, and passing the slug
+                      is what keeps Albescent's own mark on Albescent's chip. */}
+                  <FactionSigil slug={slug} size={18} />
+                  <span>{factionName(slug)}</span>
+                </Chip>
+              ))}
             </div>
           </div>
 
@@ -333,23 +281,19 @@ export default function DefaultProposeTask({
             <div
               className="sidebar-card"
               style={{
-                // A real faction accents its left edge; `na` is framed in the
-                // spectrum (a gradient can't be a scalar border-colour).
-                ...(selectedKnown
-                  ? { borderLeft: `4px solid ${color}` }
-                  : factionFill(factionSlug, "frame")),
-                padding: "var(--space-lg) var(--space-xl)",
+                // One frame for every selection — an even 2px gradient edge,
+                // the spectrum for `na` and a bevelled ramp of its own hue for
+                // a real faction (factionSurfaces.ts).
+                ...proposeCardStyle(factionSlug),
                 marginBottom: "var(--space-lg)",
               }}
             >
-              {/* Task Name (§20.4) */}
+              {/* Task Name (§20.4). The visible label is gone — the field is
+                  set in the faction's own display face and identified by its
+                  placeholder — so the label key it used to render is now what
+                  it ANNOUNCES: a placeholder disappears on the first keystroke
+                  (§7). Same for the description and notes below. */}
               <div style={{ marginBottom: "var(--space-lg)" }}>
-                <span
-                  className="label-heading"
-                  style={{ display: "block", marginBottom: "var(--space-sm)" }}
-                >
-                  {t("proposeTask.fields.name.label")}
-                </span>
                 <input
                   type="text"
                   required
@@ -357,28 +301,9 @@ export default function DefaultProposeTask({
                   value={title}
                   onChange={(e) => setTitle(e.target.value)}
                   disabled={submitting}
+                  aria-label={t("proposeTask.fields.name.label")}
                   placeholder={t("proposeTask.fields.name.placeholder")}
-                  style={{
-                    width: "100%",
-                    fontFamily: "'Courier Prime', monospace",
-                    fontSize: "var(--text-title)",
-                    fontWeight: 700,
-                    color: "var(--color-text-primary)",
-                    background: "transparent",
-                    border: "none",
-                    borderBottom: `2px solid ${title ? color : "var(--color-border-strong)"}`,
-                    outline: "none",
-                    paddingBottom: "var(--space-sm)",
-                    transition: "border-color 150ms",
-                  }}
-                  onFocus={(e) => {
-                    e.currentTarget.style.borderBottomColor = color;
-                  }}
-                  onBlur={(e) => {
-                    if (!title)
-                      e.currentTarget.style.borderBottomColor =
-                        "var(--color-border-strong)";
-                  }}
+                  style={taskNameInputStyle(factionSlug, Boolean(title))}
                 />
                 <span
                   className={`label-caption self-end ${title.length >= 180 ? "text-red-600" : ""}`}
@@ -398,18 +323,13 @@ export default function DefaultProposeTask({
 
               {/* Description (§20.4) */}
               <div style={{ marginBottom: "var(--space-lg)" }}>
-                <span
-                  className="label-heading"
-                  style={{ display: "block", marginBottom: "var(--space-sm)" }}
-                >
-                  {t("proposeTask.fields.description.label")}
-                </span>
                 <textarea
                   rows={6}
                   maxLength={5000}
                   value={description}
                   onChange={(e) => setDescription(e.target.value)}
                   disabled={submitting}
+                  aria-label={t("proposeTask.fields.description.label")}
                   placeholder={t("proposeTask.fields.description.placeholder")}
                   className="content-text"
                   style={descriptionTextareaStyle}
@@ -459,12 +379,6 @@ export default function DefaultProposeTask({
                       className="content-title"
                       style={basePointsInputStyle}
                     />
-                    <span
-                      className="label-caption"
-                      style={{ display: "block", marginTop: "var(--space-xs)" }}
-                    >
-                      {t("proposeTask.fields.basePoints.hint")}
-                    </span>
                   </div>
                 )}
                 {isMetatask && (
@@ -509,73 +423,44 @@ export default function DefaultProposeTask({
                     levels={LEVEL_OPTIONS}
                     value={levelRequired}
                     onChange={setLevelRequired}
+                    factionSlug={factionSlug}
                   />
-                  <span
-                    className="label-caption"
-                    style={{ display: "block", marginTop: "var(--space-xs)" }}
-                  >
-                    {t("proposeTask.fields.minimumLevel.hint")}
-                  </span>
                 </div>
               </div>
 
               {canProposeMetatask && (
                 <div
                   style={{
-                    borderTop: "1px dashed var(--color-border)",
-                    paddingTop: "var(--space-md)",
-                    marginTop: "var(--space-xs)",
+                    borderTop: "1px solid var(--color-border)",
+                    paddingTop: "var(--space-lg)",
                   }}
                 >
-                  <label
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "var(--space-sm)",
-                      cursor: "pointer",
-                    }}
+                  {/* A `role="checkbox"` button, not an `<input>`: a native box
+                      is tinted with `accent-color`, which takes ONE colour, and
+                      unaffiliated's identity is seven of them (ADR-0039). */}
+                  <button
+                    type="button"
+                    role="checkbox"
+                    aria-checked={isMetatask}
+                    onClick={() => setIsMetatask(!isMetatask)}
+                    disabled={submitting}
+                    style={metaToggleStyle}
                   >
-                    <input
-                      type="checkbox"
-                      checked={isMetatask}
-                      onChange={(e) => setIsMetatask(e.target.checked)}
-                      style={{
-                        accentColor: color,
-                        width: 14,
-                        height: 14,
-                        cursor: "pointer",
-                      }}
-                    />
                     <span
-                      className="content-text font-body"
-                      style={{
-                        color: "var(--color-text-primary)",
-                        fontWeight: isMetatask ? 700 : 400,
-                      }}
-                    >
+                      aria-hidden="true"
+                      style={metaBoxStyle(factionSlug, isMetatask)}
+                    />
+                    <span className="label-heading">
                       {t("proposeTask.metaToggle.label")}
                     </span>
-                    <span className="label-caption">
-                      {isKnownFaction(factionSlug)
-                        ? t("proposeTask.metaToggle.hint", {
-                            faction: factionName(factionSlug),
-                          })
-                        : t("proposeTask.metaToggle.hintNoFaction")}
-                    </span>
-                  </label>
+                  </button>
                 </div>
               )}
             </div>
 
-            {/* Notes to Admin (§20.5) — hidden for meta tasks */}
+            {/* Notes to Admin (§20.5) — hidden for metatasks */}
             {!isMetatask && (
               <div style={{ marginBottom: "var(--space-lg)" }}>
-                <span
-                  className="label-heading"
-                  style={{ display: "block", marginBottom: "var(--space-sm)" }}
-                >
-                  {t("proposeTask.fields.notes.label")}
-                </span>
                 {/* maxLength mirrors schemas.task.MAX_TASK_NOTES, which stays
                     the authority and still rejects an over-long body. Stated
                     as a literal for the same reason the title and description
@@ -586,6 +471,7 @@ export default function DefaultProposeTask({
                   onChange={(e) => setNotes(e.target.value)}
                   disabled={submitting}
                   maxLength={2000}
+                  aria-label={t("proposeTask.fields.notes.label")}
                   placeholder={t("proposeTask.fields.notes.placeholder")}
                   className="content-text"
                   style={notesTextareaStyle}
@@ -697,32 +583,18 @@ export default function DefaultProposeTask({
             )}
 
             {/* Submit Row (§20.7) */}
-            <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)" }}>
+            <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", flexWrap: "wrap" }}>
               <button
                 type="submit"
                 disabled={submitting}
                 style={{
-                  // A real faction fills the CTA with its solid hue + on-accent
-                  // ink. `na` has no legible single ink across the spectrum, so
-                  // it takes the `pill` — rainbow frame, neutral paper, dark ink
-                  // — instead of a grey block (ADR-0039, #649).
-                  ...(selectedKnown
-                    ? { background: color, color: "var(--color-text-on-accent)", border: "none" }
-                    : factionFill(factionSlug, "pill")),
-                  fontFamily: "'Courier Prime', monospace",
-                  fontSize: "var(--text-lg)",
-                  fontWeight: 700,
-                  textTransform: "uppercase",
-                  letterSpacing: "0.15em",
-                  padding: "var(--space-md) var(--space-xl)",
+                  // The selected chip's treatment at CTA size: the faction's
+                  // tint, or the spectrum frame for `na` (factionSurfaces.ts).
+                  ...submitButtonStyle(factionSlug),
                   cursor: submitting ? "wait" : "pointer",
-                  position: "relative",
                   opacity: submitting ? 0.6 : 1,
                 }}
               >
-                <span
-                  style={submitDashStyle}
-                />
                 {submitting
                   ? t("proposeTask.submit.busy")
                   : isMetatask
@@ -747,41 +619,6 @@ export default function DefaultProposeTask({
               )}
             </div>
           </form>
-        </div>
-
-        {/* ── Right: Tips Column (§20.8) ── */}
-        <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-md)" }}>
-          <div className="sidebar-card" style={{ padding: "var(--space-md) var(--space-lg)" }}>
-            {/* Both tips-card titles are prose phrases rather than region
-                names ("What makes a good task"), so they take the caption tier
-                — and they take the SAME one, or two sibling cards disagree
-                about what a card title is. */}
-            <p className="label-caption mb-2">
-              {t("proposeTask.tips.goodTaskHeading")}
-            </p>
-            <ul
-              className="content-text font-body"
-              style={tipsListStyle}
-            >
-              {(
-                t("proposeTask.tips.goodTaskItems", {
-                  returnObjects: true,
-                }) as string[]
-              ).map((item, index) => (
-                <li key={index}>{item}</li>
-              ))}
-            </ul>
-          </div>
-
-          <div className="sidebar-card" style={{ padding: "var(--space-md) var(--space-lg)" }}>
-            <p className="label-caption mb-2">{t("proposeTask.tips.nextHeading")}</p>
-            <p
-              className="content-text font-body"
-              style={tipsBodyStyle}
-            >
-              {t("proposeTask.tips.nextBody")}
-            </p>
-          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/proposeTask/factionSurfaces.ts
+++ b/frontend/src/pages/proposeTask/factionSurfaces.ts
@@ -1,0 +1,158 @@
+/**
+ * The propose-task form's faction surfaces (#1824).
+ *
+ * One selected faction, one visual language: the card's frame, the task-name
+ * field, the metatask box and the submit pill all read the SAME slug, and they
+ * are here rather than inline so they answer it the same way. Before this, the
+ * card wore a 4px left rule for a known faction and a full spectrum frame for
+ * `na` — two different-looking components depending on selection.
+ *
+ * No colour lives here. Every value resolves through `factionCssVar` /
+ * `factionFill` into `index.css`, so each faction and each `[data-theme]`
+ * arrives through the cascade (ADR-0039 for why `na` branches at all: its
+ * identity is a gradient, and `factionCssVar('na')` is deliberately neutral
+ * grey). The branch is `isKnownFaction`, a VALUE test — which is also what
+ * keeps Albescent unthemed here (#749, #783).
+ */
+import type { CSSProperties } from "react";
+import { factionCssVar, factionFill, isKnownFaction } from "../../utils/factions";
+
+/**
+ * A gradient border around an OPAQUE interior.
+ *
+ * Two background layers: the neutral card paper clipped to the padding box, the
+ * gradient clipped to the border box, with a transparent border for it to show
+ * through. The paper layer must be `--faction-default-card-bg` and not
+ * `--color-bg-surface` — surface is translucent in BOTH themes
+ * (rgba(255,255,255,0.04) dark, rgba(255,255,255,0.72) light), so the gradient
+ * reads straight through it and the whole card fills rainbow.
+ *
+ * Longhand rather than the `background` shorthand `factionFill(_, "frame")`
+ * uses: this one lands on a `.sidebar-card`, whose own background rules the
+ * shorthand interacts badly with. `backgroundColor: transparent` is part of
+ * that — the longhand image list does not reset the class's colour on its own.
+ */
+function gradientFrame(edge: string): CSSProperties {
+  return {
+    backgroundColor: "transparent",
+    backgroundImage: `linear-gradient(var(--faction-default-card-bg), var(--faction-default-card-bg)), ${edge}`,
+    backgroundOrigin: "border-box",
+    backgroundClip: "padding-box, border-box",
+    backgroundRepeat: "no-repeat",
+    border: "2px solid transparent",
+    boxSizing: "border-box",
+  };
+}
+
+/**
+ * The form card: an even 2px frame on all four sides.
+ *
+ * `na` flies the spectrum; a real faction gets a 135° ramp of its own hue,
+ * shaded at one end and lifted at the other so the edge reads as a bevel rather
+ * than a flat outline. `#000` / `#fff` there are `color-mix` ENDPOINTS — the
+ * arithmetic that darkens and lightens the faction's own token — not theme
+ * colours, and there is deliberately no per-faction hex anywhere near them.
+ */
+export function proposeCardStyle(slug: string | null | undefined): CSSProperties {
+  const tint = factionCssVar(slug);
+  const edge = isKnownFaction(slug)
+    ? `linear-gradient(135deg, color-mix(in srgb, ${tint} 30%, #000) 0%, ${tint} 55%, color-mix(in srgb, ${tint} 45%, #fff) 100%)`
+    : "var(--faction-default-rainbow)";
+  return {
+    ...gradientFrame(edge),
+    borderRadius: 8,
+    padding: "var(--space-lg) var(--space-xl)",
+  };
+}
+
+/**
+ * The task-name field, set in the faction's own display face.
+ *
+ * DEVIATION FROM THE ISSUE PROSE, FOLLOWING THE DESIGN FILE: unaffiliated keeps
+ * the body face. `factionCssVar("na", "card-font")` resolves to
+ * `--faction-default-card-font`, which is Bebas Neue — a condensed display face
+ * the form's DEFAULT state never asked for. The design's `titleInputStyle`
+ * hands `na` `var(--font-body)`, and this is the state the page opens in.
+ *
+ * The bottom rule takes the tint once the field has a value; unaffiliated has
+ * no single hue to take, so it reads as the primary ink instead.
+ */
+export function taskNameInputStyle(
+  slug: string | null | undefined,
+  hasValue: boolean,
+): CSSProperties {
+  const known = isKnownFaction(slug);
+  const rule = hasValue
+    ? known
+      ? factionCssVar(slug)
+      : "var(--color-text-primary)"
+    : "var(--color-border-strong)";
+  return {
+    width: "100%",
+    fontFamily: known
+      ? `${factionCssVar(slug, "card-font")}, var(--font-body)`
+      : "var(--font-body)",
+    fontSize: "var(--text-title)",
+    fontWeight: 700,
+    color: "var(--color-text-primary)",
+    background: "transparent",
+    border: "none",
+    borderBottom: `2px solid ${rule}`,
+    outline: "none",
+    paddingBottom: "var(--space-sm)",
+    transition: "border-color 150ms",
+  };
+}
+
+/**
+ * The metatask tick box.
+ *
+ * A native `<input type="checkbox">` cannot carry this: `accent-color` takes a
+ * single colour, and unaffiliated's identity is seven of them. So the control
+ * is a `role="checkbox"` button and this is the box it draws.
+ */
+export function metaBoxStyle(
+  slug: string | null | undefined,
+  checked: boolean,
+): CSSProperties {
+  const box: CSSProperties = {
+    width: 18,
+    height: 18,
+    flex: "none",
+    borderRadius: 4,
+    boxSizing: "border-box",
+  };
+  if (!checked) {
+    return { ...box, border: "2px solid var(--color-border-strong)", background: "transparent" };
+  }
+  if (!isKnownFaction(slug)) {
+    // The spectrum fills the whole box, so the border is only there to keep the
+    // checked and unchecked states the same size.
+    return { ...box, border: "2px solid transparent", ...factionFill(slug, "bar") };
+  }
+  const tint = factionCssVar(slug);
+  return { ...box, border: `2px solid ${tint}`, background: tint };
+}
+
+/** The submit pill — the chips' selected treatment at CTA size. */
+export function submitButtonStyle(slug: string | null | undefined): CSSProperties {
+  const tint = factionCssVar(slug);
+  return {
+    fontFamily: "var(--font-body)",
+    fontSize: "var(--text-md)",
+    fontWeight: 700,
+    textTransform: "uppercase",
+    letterSpacing: "0.08em",
+    borderRadius: 999,
+    padding: "var(--space-sm) var(--space-xl)",
+    minHeight: 40,
+    boxSizing: "border-box",
+    color: "var(--color-text-primary)",
+    ...(isKnownFaction(slug)
+      ? {
+          border: `2px solid ${tint}`,
+          background: `color-mix(in srgb, ${tint} 18%, var(--color-bg-surface))`,
+        }
+      : factionFill(slug, "frame")),
+  };
+}


### PR DESCRIPTION
The propose-task faction picker becomes the site's chip idiom, and the selected faction drives one accent through the rest of the form: the card frame, the task-name face, the level nodes, the metatask box and the submit pill all read the same slug.

Closes #1824

Built against the vendored `Propose a Task.dc.html` (its `chipStyle` / `cardStyle` / `titleInputStyle` / `submitStyle` / `metaBoxStyle` / `levels[].style` / `RAINBOW_FRAME` are the geometry). The design was vendored outside git, so there is no `.design-sync/propose-task/` to delete. The design's legacy `pennants` branch is not ported — the pennant code is deleted here.

## Seams tested

| Seam | Why there | File |
|---|---|---|
| The style object `Chip` emits | The three variants share ONE object with ternaries, so a new value leaks into the mobile leaderboard and the praxis feed by default. A test on the emitted inline style is the only thing that sees a leak. | `frontend/src/components/ui/__tests__/chipVariants.test.tsx` |
| `FilterLevelNodes` itself | It owned the two things the page could not reach: it had no accent at all, and it drew its own `label-heading`, so the field announced twice. | `frontend/src/components/ui/__tests__/filterLevelNodes.test.tsx` |
| `DefaultProposeTask`'s markup | A per-surface accent silently dropping out is exactly the failure this change risks, so one test asserts the card frame, the name face, the nodes and the submit pill all resolve the SAME slug. | `frontend/src/pages/proposeTask/__tests__/unaffiliatedOption.test.tsx` |

Each went red on the real defect first (5/8, 4/5 and the pennant assertions respectively) before the code moved.

## What changed

- **`components/ui/ChipRow.tsx`** — `Chip` gains `sigilText`: 40px, a 2px border in *every* state (selection changes colour, never width, so eight wrapping chips cannot reflow), a 14% tint wash plus a soft glow, `role="radio"` + `aria-checked`, and no 8×8 swatch. Every new value is gated on the flag; `iconOnly`'s `unaffiliated` frame is reused so `na` gets the spectrum instead of grey. No fourth chip component (#644).
- **`pages/proposeTask/factionSurfaces.ts`** (new) — `proposeCardStyle`, `taskNameInputStyle`, `metaBoxStyle`, `submitButtonStyle`. All colour resolves through `factionCssVar` / `factionFill`; the card's frame is the longhand two-layer gradient border over an OPAQUE `--faction-default-card-bg` paper layer (`--color-bg-surface` is translucent in both themes and the rainbow reads straight through it).
- **`pages/proposeTask/archetypes/DefaultProposeTask.tsx`** — pennant grid → one wrapping `role="radiogroup"` of eight chips (`na` first, then `sortFactionsByRainbowOrder`), each an 18px `FactionSigil` + its name. Card takes an even 2px frame; task name takes the faction's display face; metatask checkbox becomes a `role="checkbox"` button (`accent-color` takes one colour, `na` is seven); submit becomes the selected chip at CTA size. Both sidebar tip cards deleted, grid collapsed to a single 760px column (which also clears the `1fr 280px` fixed-px inline grid `frontend/CLAUDE.md` forbids on the mobile path), rainbow rule added under the title. Name / description / notes lose their visible `label-heading` and gain `aria-label` from the label keys that already existed.
- **`components/ui/FilterLevelNodes.tsx`** — 40×40, 2px border, `--text-md`, connector bars and `scale(1.15)` gone, new `factionSlug` prop, internal label removed, `aria-pressed` added. `.design-sync/previews/FilterLevelNodes.tsx` updated to supply its own label and show the faction accent.
- **`locales/en/forms.json`** — added `proposeTask.factionLabel`; three placeholders re-set to the design's; "meta task" → "metatask" everywhere in this flow; deleted `factionDescriptor.*`, `factionSelectorLabel`, `tips.*`, `basePoints.hint`, `minimumLevel.hint`, `metaToggle.hint`/`hintNoFaction` (each verified unreferenced, all in `forms.json`).

## Deviations, and the one contradiction I did not guess at

- **Unaffiliated keeps the body face in the task-name field.** The issue's §3 says `na`/`albescent` "resolve to `--faction-default-card-font`"; the design file's `titleInputStyle` hands `na` `var(--font-body)`. `--faction-default-card-font` is `--font-accent` (Bebas Neue), a condensed display face — and `na` is the state the page OPENS in. I followed the design file and named it in a comment in `factionSurfaces.ts`. Say the word and it flips to one line.
- **A selected `na` level node gets the spectrum frame.** The design's `levels[].style` spreads `RAINBOW_FRAME` and then sets `background: var(--color-bg-surface)` after it, which clobbers the frame's image/clip — so in the design an `na` selection reads as a plain node. The issue's §4 and its acceptance criterion ("`na` selected shows the spectrum frame everywhere a known faction shows its tint") both say frame, and every other `na` surface in the same design puts the frame last. I read that as an ordering slip and built the frame.
- **The Cancel button keeps `.btn-outline`.** The design draws it as a 40px outline pill, but the issue's scope list names only the submit button and `.btn-outline` is a shared class — forking it inline is style work, not feature work.
- **The submit button's dashed inner ornament is deleted** along with the old solid-hue CTA; the design's pill has no such layer.
- **`#000` / `#fff` appear inside two `color-mix()` calls** in the card's bevel ramp. They are mixing endpoints for the faction's own token, not theme colours; the `no-raw-style-values` ratchet inspects `fontSize`/`padding`/`margin`/`gap` only, and lint is green. There is no per-faction hex anywhere.
- **`errors.createMeta` also renamed** ("Could not create meta task." → "…metatask."). The issue lists four strings and misses this one, but it renders in this flow, and the acceptance criterion is "no screen shows both spellings".
- **`factions.json`'s Albescent description still says "meta tasks".** Outside this flow, so per the issue it is left for a separate copy issue.

## Verification

`npm run lint`, `tsc --noEmit`, `typecheck:design-sync`, `npm test` (253 files, 4520 passing), `npm run build`, `npm run budget` (JS 128.6 KB, CSS 21.3 KB — both within budget) all green locally. No backend, API or schema surface touched.

**Visual QA is outstanding** — I have no browser and no dev stack, and none of the above can see a wrong accent.

## What to eyeball

Load `/propose-task` and step the chip row, in **light and dark** for each:

1. **`na` (default, the page's opening state)** — card frame is the spectrum on all four sides, evenly 2px; the interior is opaque (no rainbow bleeding through the fill); selected chip is the rainbow frame with **no** glow; level node and submit pill are the same frame, never grey.
2. **everymen / ua / wow / snide / ephemerists / singularity / coven** — chip border, card bevel, level node, meta box and submit pill are all the SAME hue; the task-name field is in that faction's display face (Bebas Neue / Cormorant / MedievalSharp / Permanent Marker / Cinzel / Share Tech Mono / Caveant — a font that fails to load falls back to Courier silently). WOW and Coven are the pair that has worn each other's identity before (ADR-0050).
3. **Dark mode on `singularity` and `snide`** specifically — the card's paper layer is `--faction-default-card-bg` (near-black in dark), and the ink on it is the global set.
4. **Click through every chip in one sitting** and watch the row: nothing may shift by a pixel, and the eight chips must all be visible (wrapping, not scrolling).
5. **The rainbow rule under the title** sits below `PageTitle`, which already draws per-letter spectrum underline bars — worth a look at whether two spectra that close read as one idea or two.
6. **Mobile leaderboard and praxis feed chips** — the guard test says the style object is unchanged; a glance confirms nothing else moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
