### PR TITLE
Fix the four functional e2e failures: roster gate, dev-login premise, sidebar scope, missing duel task (#1676)

### DIFF
--- a/backend/seed.py
+++ b/backend/seed.py
@@ -255,6 +255,74 @@ async def ensure_onboarding_task(session, created_by_id: int) -> bool:
     return True
 
 
+# ---------------------------------------------------------------------------
+# Dev-only e2e fixture task
+# ---------------------------------------------------------------------------
+# The duel e2e suite (frontend/e2e/duel.helpers.ts) needs a task that is BOTH
+# faction-skinned and reachable at `era.duel_level_required`, so the duel flow
+# drives a real archetype (UaEditPraxis / UaDuelSealConfirm / UaPraxisDetail)
+# instead of only the Default skins. Era 1 seeds no such task — ERA_1_TASKS is
+# empty by design and the onboarding task above is cross-faction — so the duel
+# specs have failed on every nightly they ever ran (#1676).
+#
+# Dev-only, and deliberately NOT in the era config: #1398's ruling is that the
+# board is admin-authored, and anything named in the era config comes back the
+# deploy after an admin deletes it. This is created from `seed_dev_demo`, which
+# never runs against production, so that ruling is untouched.
+DUEL_FIXTURE_TASK_TITLE = "Hold Your Breath and Count"
+DUEL_FIXTURE_TASK_DESCRIPTION = (
+    "Take one slow breath in, hold it, and count until you have to let go. "
+    "Tell us the number — and what you were thinking about while you waited."
+)
+DUEL_FIXTURE_TASK_FACTION_SLUG = "ua"
+DUEL_FIXTURE_TASK_POINT_VALUE = 10
+
+
+async def ensure_duel_fixture_task(session, created_by_id: int) -> bool:
+    """Dev-only: upsert the faction-skinned task the duel e2e fixture picks.
+
+    Title-guarded like ``ensure_onboarding_task``, so it is safe to re-run.
+    Returns True if the task was created this run.
+
+    `level_required` reads ``era.duel_level_required`` rather than repeating the
+    number: the fixture's whole point is a task a duelling character can sign up
+    for, so the two must move together.
+
+    The faction slug is a literal because it names a *fixture*, not a rule — the
+    e2e suite asks for UA's archetype by name. A future era need not carry that
+    faction, so this no-ops when the row is absent rather than writing a Task
+    whose ``primary_faction_slug`` points at nothing.
+    """
+    existing = (
+        await session.execute(
+            select(Task).where(Task.title == DUEL_FIXTURE_TASK_TITLE)
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return False
+
+    faction = (
+        await session.execute(
+            select(Faction).where(Faction.slug == DUEL_FIXTURE_TASK_FACTION_SLUG)
+        )
+    ).scalar_one_or_none()
+    if faction is None:
+        return False
+
+    session.add(Task(
+        title=DUEL_FIXTURE_TASK_TITLE,
+        description=DUEL_FIXTURE_TASK_DESCRIPTION,
+        point_value=DUEL_FIXTURE_TASK_POINT_VALUE,
+        level_required=CURRENT_ERA.duel_level_required,
+        status=TaskStatus.active,
+        task_type=TaskType.standard,
+        created_by=created_by_id,
+        primary_faction_slug=DUEL_FIXTURE_TASK_FACTION_SLUG,
+    ))
+    await session.flush()
+    return True
+
+
 # There is deliberately no metatask phase (#1398). A "placeholder" metatask
 # ("Upside Down") used to be seeded here so the metatask surface had something
 # to render; it was invented content that appeared on production every deploy
@@ -267,7 +335,7 @@ async def ensure_onboarding_task(session, created_by_id: int) -> bool:
 # Dev-only demo content
 # ---------------------------------------------------------------------------
 
-async def seed_dev_demo(session) -> None:
+async def seed_dev_demo(session, created_by_id: int) -> None:
     """Dev-only: guarantee the app is never empty on a fresh DB.
 
     Creates the `dev login (no OAuth)` character ("Molly", unaffiliated) with a
@@ -338,6 +406,16 @@ async def seed_dev_demo(session) -> None:
         print("  >Dev-login character (@dev 'Molly', unaffiliated) + 1 in-progress task")
     else:
         print("  >Dev-login character already exists — skipping")
+
+    # The duel e2e fixture's task. Outside the branch above so it is topped up on
+    # an already-seeded dev database, not only on a fresh one.
+    #
+    # Committed here rather than left to `seed_demo_praxes` below: that function
+    # has several early returns that skip its own commit on an already-seeded
+    # database, which is exactly the case where this top-up matters.
+    if await ensure_duel_fixture_task(session, created_by_id):
+        print("  >Duel e2e fixture task (1 UA task at the duel level)")
+    await session.commit()
 
     # Cross-faction demo players + community-voted praxes (reused, idempotent).
     from scripts.seed_demo_praxes import seed as seed_demo_praxes
@@ -433,7 +511,7 @@ async def seed(env: str, yes: bool) -> None:
 
         # Phase 5: Dev-only demo content (characters + praxes). Never in prod.
         if env == "dev":
-            await seed_dev_demo(session)
+            await seed_dev_demo(session, pixie_char.id)
 
         print("\nSeed complete!\n")
         print(f"  era            : {era.name} ({era.config_key})")

--- a/backend/tests/integration/test_seed_task_sync.py
+++ b/backend/tests/integration/test_seed_task_sync.py
@@ -23,13 +23,16 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from faction_slugs import CROSS_FACTION_SLUG
-from game_config import TaskDef
+from game_config import CURRENT_ERA, TaskDef
 from models.character import Character
 from models.era import Era
 from models.faction import Faction
-from models.task import Task, TaskType
+from models.task import Task, TaskStatus, TaskType
 from seed import (
+    DUEL_FIXTURE_TASK_FACTION_SLUG,
+    DUEL_FIXTURE_TASK_TITLE,
     ONBOARDING_TASK_TITLE,
+    ensure_duel_fixture_task,
     ensure_onboarding_task,
     sync_era_tasks,
 )
@@ -173,3 +176,76 @@ async def test_seed_creates_no_metatask(
         )
     ).scalars().all()
     assert metatasks == []
+
+
+# ---------------------------------------------------------------------------
+# The duel e2e fixture task (#1676)
+# ---------------------------------------------------------------------------
+# `frontend/e2e/duel.helpers.ts::pickUaDuelTask` asks the API for a UA task at
+# level <= era.duel_level_required and fails the whole duel suite when there is
+# none — which was the case on every nightly, because Era 1 declares no tasks
+# (#1398) and the onboarding task above is cross-faction. These pin the two
+# properties that helper selects on, so the fixture and the duel gate cannot
+# drift apart silently.
+
+
+@pytest.mark.asyncio
+async def test_duel_fixture_task_is_reachable_at_the_duel_level(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+    faction_ua: Faction,
+):
+    """It lands as a UA task the duel gate's level can sign up for, and repeats safely."""
+    created = await ensure_duel_fixture_task(db_session, character.id)
+    assert created is True
+
+    rows = (
+        await db_session.execute(
+            select(Task).where(Task.title == DUEL_FIXTURE_TASK_TITLE)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+    task = rows[0]
+    # The two properties pickUaDuelTask filters on.
+    assert task.primary_faction_slug == DUEL_FIXTURE_TASK_FACTION_SLUG
+    assert task.level_required <= CURRENT_ERA.duel_level_required
+    # ...and the two that make it pickable at all.
+    assert task.status == TaskStatus.active
+    assert task.task_type == TaskType.standard
+
+    # Idempotent: seed.py runs this on every dev seed.
+    assert await ensure_duel_fixture_task(db_session, character.id) is False
+    rows = (
+        await db_session.execute(
+            select(Task).where(Task.title == DUEL_FIXTURE_TASK_TITLE)
+        )
+    ).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_duel_fixture_task_skipped_when_the_era_lacks_the_faction(
+    db_session: AsyncSession,
+    era: Era,
+    character: Character,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """No matching faction row → no task, rather than a Task with a dangling FK.
+
+    A future era need not carry UA, and the seeder must degrade to a no-op. The
+    slug is repointed rather than the `ua` row deleted, because `character`
+    itself holds an FK to that row — so "the faction is absent" is only
+    expressible from the seeder's side.
+    """
+    monkeypatch.setattr("seed.DUEL_FIXTURE_TASK_FACTION_SLUG", "no_such_faction")
+
+    created = await ensure_duel_fixture_task(db_session, character.id)
+    assert created is False
+
+    rows = (
+        await db_session.execute(
+            select(Task).where(Task.title == DUEL_FIXTURE_TASK_TITLE)
+        )
+    ).scalars().all()
+    assert rows == []

--- a/frontend/e2e/collaboration.spec.ts
+++ b/frontend/e2e/collaboration.spec.ts
@@ -136,9 +136,18 @@ test.describe('collaboration lifecycle', () => {
     try {
       const page = await seed.alice.ctx.newPage()
       await page.goto('/')
-      const sidebar = page.locator('aside')
-      await expect(sidebar.locator(`a[href="/praxis/${seed.praxisId}/edit"]`)).toBeVisible()
-      await expect(sidebar.getByText(seed.task.title)).toBeVisible()
+      // Scoped to the panel, not the whole <aside> (#1676). The sidebar names
+      // one task in two places — the draft under "In progress tasks"
+      // (→ /praxis/{id}/edit) and the task under "Recent activity"
+      // (→ /tasks/{id}) — so an aside-wide getByText is a strict-mode
+      // violation. That is not the duplication bug it looks like: different
+      // sections, different destinations, both correct. `.first()` would pass
+      // by accident and stop asserting WHICH section the draft appears in,
+      // which is the whole claim of this test. `exact` keeps the panel's own
+      // collapse control ("Collapse In progress tasks") out of the match.
+      const inProgress = page.getByLabel('In progress tasks', { exact: true })
+      await expect(inProgress.locator(`a[href="/praxis/${seed.praxisId}/edit"]`)).toBeVisible()
+      await expect(inProgress.getByText(seed.task.title)).toBeVisible()
     } finally {
       await seed.alice.ctx.close()
       await seed.bob.ctx.close()

--- a/frontend/e2e/duel.helpers.ts
+++ b/frontend/e2e/duel.helpers.ts
@@ -12,11 +12,24 @@ import { expect, type Browser, type BrowserContext, type Page } from '@playwrigh
  * unreachable control fails the test instead of passing silently.
  *
  * Why a UA task specifically (pickUaDuelTask): the composer archetype, the seal
- * dialog, and the read-page rail are each dispatched by the TASK's faction, not
- * the player's. A UA task yields the Ua *composer* but the *Default* seal dialog
- * ("Seal the duel?" / "Seal it") and the *Default* rail ("⚔ Duel" / live tally) —
- * the stable base English strings this suite asserts against. A level-2 player
- * (duels need era.duel_level_required = 2) can sign up for UA tasks at level ≤ 2.
+ * dialog and the praxis-detail page (which mounts the duel rail) are each
+ * dispatched by the TASK's faction, not the player's — so a UA task drives three
+ * real archetypes (UaEditPraxis / UaDuelSealConfirm / UaPraxisDetail) instead of
+ * the Default fall-through an `na` task would give. A level-2 player (duels need
+ * era.duel_level_required = 2) can sign up for UA tasks at level ≤ 2.
+ *
+ * CORRECTED (#1676) — the old note here claimed a UA task yields the *Default*
+ * seal dialog and rail. It does not: `factions/ua.ts` registers both `duelSeal`
+ * and `praxisDetail`. What is actually true, and what makes UA safe to assert
+ * against, is that the COPY is faction-invariant — every skin takes the heading
+ * and confirm label from the shared `useDuelSealCopy`, and all eight
+ * praxis-detail archetypes render the same `duelCrossLink` strings. The one
+ * faction that does override them is `wow` ("Take the Field", praxis.json
+ * `duelSeal.wow`), so this helper must not drift onto a wow task.
+ *
+ * The task itself is dev-seeded — `seed.py::ensure_duel_fixture_task`. Era 1
+ * declares no tasks (#1398), so before that this filter matched nothing and the
+ * whole duel suite failed here on every nightly it ever ran.
  */
 
 export const API = process.env.E2E_API_URL ?? 'http://localhost:8000'
@@ -87,10 +100,13 @@ export async function createSoloDraft(
  * opponent chip so the challenge is confirmed before returning.
  */
 export async function challengeViaUi(page: Page, opponentName: string): Promise<void> {
-  // The UA duel mode chip: the visible label+desc differ per archetype, but UA's
-  // "a mark made against another" (forms.json editPraxis.ua.mode.duel.desc) is a
-  // stable, unique accessible-name fragment. The chip only renders at level ≥ 2.
-  const duelChip = page.getByRole('button', { name: /a mark made against another/i })
+  // The duel mode chip. It is NOT per-archetype copy (#1676): every composer
+  // builds its mode options from the shared `editPraxis.composer.modeDuel`
+  // ("Duel", forms.json), and the `editPraxis.ua.*` block the old locator quoted
+  // does not exist anywhere in the catalog — so that name matched nothing and
+  // this helper could never get past here. `exact` keeps it off the longer
+  // duel-related labels elsewhere on the page. The chip only renders at level ≥ 2.
+  const duelChip = page.getByRole('button', { name: 'Duel', exact: true })
   await expect(duelChip).toBeVisible()
   await duelChip.click()
   await expect(duelChip).toHaveAttribute('aria-pressed', 'true')
@@ -136,13 +152,19 @@ export async function waitForDuelAttached(page: Page, opponentName: string): Pro
 /**
  * Seal a duel side through the composer UI: the primary submit opens the seal
  * confirm when a duel is attached (controls.tsx sealsADuel → requestDuelSeal),
- * then confirm inside the dialog. UA's composer submit label is "Seal it"
- * (publishIdle) and the Default confirm button is ALSO "Seal it" — the dialog is
- * scoped so the confirm is unambiguous.
+ * then confirm inside the dialog.
+ *
+ * CORRECTED (#1676): the composer submit is NOT "Seal it". `PublishButton` only
+ * replaces its idle label for the collab consensus gate and the duel PULL-BACK;
+ * an unsealed duel side falls through to the archetype's own `idleLabel`, which
+ * is the shared `editPraxis.composer.submit` ("Submit") in all eight composers.
+ * "Seal it" exists only as the DIALOG's confirm (praxis.json duelSeal.confirm),
+ * so the old pre-dialog locator matched nothing.
  */
 export async function sealViaUi(page: Page): Promise<void> {
-  // Pre-dialog there is exactly one "Seal it" — the composer submit.
-  await page.getByRole('button', { name: /seal it/i }).click()
+  // The composer submit — it opens the seal dialog rather than publishing,
+  // because a duel is attached (controls.tsx sealsADuel).
+  await page.getByRole('button', { name: 'Submit', exact: true }).click()
   const dialog = page.getByRole('dialog', { name: 'Seal the duel?' })
   await expect(dialog).toBeVisible()
   await dialog.getByRole('button', { name: /seal it/i }).click()

--- a/frontend/e2e/guest.spec.ts
+++ b/frontend/e2e/guest.spec.ts
@@ -11,8 +11,15 @@ test('marketing home renders for a guest', async ({ page }) => {
 test('the dev-login button logs a bot in', async ({ page }) => {
   await page.goto('/')
   await page.getByRole('button', { name: /dev login/i }).click()
-  // This bot has no character (clicked the real button, not the seeded fixture),
-  // so it correctly redirects to character creation rather than the FieldDesk.
+  // The button logs into the ONE dev account — `dev_login`'s `key` defaults to
+  // "1", i.e. provider_user_id "dev-user-1" — and `seed.py`'s `seed_dev_demo`
+  // gives that account a character ("Molly"). That was #464's fix for an earlier
+  // red nightly, so the old comment here ("this bot has no character") has been
+  // false since. It lands on the FieldDesk, not character creation (#1676).
+  //
+  // Assert being logged in, which is what this test's name actually claims. A
+  // destination heading re-breaks every time the FieldDesk's copy moves, which
+  // is how its sibling in smoke.spec.ts broke.
   await expect(page.getByRole('button', { name: /sign up here/i })).toHaveCount(0)
-  await expect(page.getByRole('heading', { name: /who are you becoming/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: /logout/i })).toBeVisible()
 })

--- a/frontend/e2e/smoke.spec.ts
+++ b/frontend/e2e/smoke.spec.ts
@@ -4,7 +4,15 @@ import { test, expect } from '@playwright/test'
 
 test('authed root shows the FieldDesk, not the marketing Home', async ({ page }) => {
   await page.goto('/')
-  await expect(page.getByRole('heading', { name: /whose shoes today/i })).toBeVisible()
+  // NOT the <h1>, and NOT "Whose shoes today?" (#1676). #1560 gates the roster
+  // behind `rosterOffersAChoice`, and the seeded bot carries one life below the
+  // second-character level, so the gate is shut and that string never renders.
+  // #1794/#1815 then moved the <h1> outside the gate but made its text
+  // data-dependent — it reads the character's own name — so it is not an anchor
+  // either. This <h2> (home.json `signedIn.browse.headings.tasks`) is what
+  // #1560's own unit test anchors on for "the gate hides the roster, not the
+  // page", and it is proof the FieldDesk rendered rather than the marketing Home.
+  await expect(page.getByRole('heading', { name: /tasks you can sign up for/i })).toBeVisible()
   await expect(page.getByRole('button', { name: /sign up here/i })).toHaveCount(0)
 })
 


### PR DESCRIPTION
Closes #1676

Four functional e2e failures, four unrelated causes. Built from the owner's 2026-08-15 run (`3f2573c1`) and its accessibility snapshots, **re-verified against current `origin/main`** — which has moved several commits since. Two of the written diagnoses did not survive that re-check; both are called out below.

## The seam

Each fix is at the **assertion-to-source seam**: an e2e locator on one side, the string or row it selects on the other. Every anchor below was checked against the thing that produces it — the i18n catalog entry, the element that renders it, or the seeded row — rather than against the prose describing it. No app behaviour changes; the only production-shaped change is a dev-only seed row.

## 1. `smoke.spec.ts:5` — the roster gate

`"Whose shoes today?"` lives inside the `showRoster && (...)` block. `rosterOffersAChoice([life()], true, false)` is `false`, so for the seeded one-life bot that block never renders. Re-anchored to `Tasks you can sign up for` (`home.json` `signedIn.browse.headings.tasks`, an `<h2>` at `FieldDesk.tsx:556`) — the same anchor #1560's own gate test uses.

Deliberately **not** the `<h1>`: #1794/#1815 moved it outside the gate but made its text data-dependent (it reads the character's display name), so it is not an anchor.

## 2. `guest.spec.ts:11` — ⚠️ the handed-down diagnosis was wrong

The diagnosis said storage state from `auth.setup.ts` was leaking into this spec and to check whether it opts out. **It already does** — `guest.spec.ts:4` is `test.use({ storageState: { cookies: [], origins: [] } })`, and the config's comment documents exactly that.

The pass/fail pattern proves it independently: the *first* test in the same file asserts the guest sign-up button **is** visible, and it passed. Leaked auth state would have failed it too.

The real cause is the one recorded in the 21:13 comment. The dev-login button logs into the **one** dev account (`dev_login`'s `key` defaults to `"1"` → `dev-user-1`), and `seed_dev_demo` gives that account a character — #464's fix for an earlier red nightly. So it lands on the FieldDesk, and the snapshot matching smoke's is a *consequence*, not evidence of leakage.

Now asserts *being logged in* (the `logout` button, `common.json:249`), which is what the test's name claims and does not re-break when FieldDesk copy moves.

**No separate issue needed** — there is no test-isolation bug to split out.

## 3. `collaboration.spec.ts` — scoped, not `.first()`

The duplication is legitimate: `In progress tasks` → `/praxis/{id}/edit` and `Recent activity` → `/tasks/{id}`, different sections and destinations. `.first()` would pass by accident and stop asserting *which* section the draft is in. Scoped to `getByLabel('In progress tasks', { exact: true })` — the panel is a `<section aria-labelledby>` (`Sidebar.tsx:251`), and `exact` keeps the panel's own `Collapse In progress tasks` control out of the match.

The sibling invitee test was left alone: it asserts only the `a[href=...]`, which is unique, so it has no strict-mode violation.

## 4. `duel.spec.ts:60` — seed data, plus two more stale locators behind it

`pickUaDuelTask` wants a UA task at level ≤ `era.duel_level_required`. `ERA_1_TASKS` is `()` and the onboarding task is cross-faction, so there has never been one.

Fixed by seeding it in `seed_dev_demo` — **not** the era config, because #1398's ruling is that a config-owned task returns the deploy after an admin deletes it. `seed_dev_demo` never runs against prod, so that ruling is untouched. `level_required` reads `era.duel_level_required` rather than repeating the `2`, and the helper no-ops when the era carries no such faction instead of writing a dangling FK.

The faction filter was **not** relaxed, as instructed.

### ⚠️ But the rationale for keeping it was wrong, and two more locators are dead

The helper's header claimed a UA task yields the **Default** seal dialog and rail. It does not — `factions/ua.ts` registers both `duelSeal` and `praxisDetail`. What is actually true is that the *copy* is faction-invariant (every skin takes heading/confirm from the shared `useDuelSealCopy`; all eight detail archetypes render the same `duelCrossLink` strings). The one faction that **does** override it is `wow` (`praxis.json` `duelSeal.wow` → "Take the Field"), so UA remains a good choice and `wow` is now named as the one to avoid. Header corrected.

While verifying that, two locators past the task-pick turned out to match nothing on current main — so the seed fix alone would only have moved the failure one step later:

| Locator | Claimed source | Reality |
|---|---|---|
| duel mode chip `/a mark made against another/i` | `forms.json editPraxis.ua.mode.duel.desc` | **no `editPraxis.ua` block exists**; chips use the shared `editPraxis.composer.modeDuel` = `"Duel"` |
| pre-dialog `/seal it/i` | UA composer `publishIdle` | `PublishButton` swaps its idle label only for the collab gate and the duel **pull-back**; an unsealed duel side reads `editPraxis.composer.submit` = `"Submit"`. `"Seal it"` is the dialog's confirm only |

Both repointed. The in-dialog assertions (`role="dialog"` named `Seal the duel?`, confirm `Seal it`) were already correct and are unchanged.

## Verification

**The e2e suite itself is UNVERIFIED and needs an owner-machine run** (`bash frontend/e2e/run-e2e.sh`, Discord env vars exported first). This agent has no Playwright browsers. Everything below is what *was* checkable:

- **`test` job** — 1269 passed, coverage 93.76% (≥80). Dedicated DB `wz1676_test`.
- **`frontend` job** — `lint` (which *does* cover `e2e/`), `typecheck`, `typecheck:design-sync`, `test` (4504 passed), `build`, `budget` (JS 129.0 KB / CSS 21.4 KB, within budget). All green.
- **`api-schema`** — `regen_api_client.py` then `git diff --exit-code`: clean.
- **`frontend/e2e/` typecheck** — not covered by CI (#1780), so run ad-hoc against all six touched specs: clean.
- **New runnable check**: two tests in `backend/tests/integration/test_seed_task_sync.py` pin the two properties `pickUaDuelTask` selects on (UA slug, level ≤ `era.duel_level_required`), plus idempotency and the missing-faction no-op — so the fixture and the duel gate cannot drift apart silently.

### What remains unknown

Both lifecycle specs are `mode: 'serial'`, so **9 tests have never executed** — the duel flow past `pickUaDuelTask` has never run at all. The two extra locator fixes above were derived by reading the catalogs and `controls.tsx`, not by observing a run. Expect the first green run to be the one that discovers anything further downstream.

No visual QA (no browser tools). No UI code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
