### PR TITLE
Per-faction composer dress: WOW, Everymen, Ephemerists, SNIDE and Singularity against the updated skin rows (#1830)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/ephemeristsGravity.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsGravity.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * The gravity field (#1830) — the Ephemerists composer's ground.
+ *
+ * The design replaced the plate's ruled lines with a field: brass rows at a
+ * fixed 52px pitch bowed toward a well off the sheet's right edge, each row
+ * sagging by its distance from the mass, and three ochre rings marking where
+ * the mass is. Its own comment is *"the plate's field, not lined paper"*.
+ *
+ * Geometry is the whole of this mark, and geometry is the one thing a `tsc`
+ * pass cannot see, so what is asserted here is the SHAPE: that the sag peaks at
+ * the well's latitude and falls away either side, that the rows are drawn in the
+ * rule colour and never in an ink, and that the well sits past the right edge
+ * where the sheet's clip will crop it. `renderToStaticMarkup`, no DOM, matching
+ * the rest of this suite.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import { GravityField } from "../ephemeristsPlate";
+
+const WIDTH = 720;
+const HEIGHT = 2400;
+
+function field(): string {
+  return renderToStaticMarkup(<GravityField width={WIDTH} height={HEIGHT} />);
+}
+
+/** Every row's `M-6 <y> C … <yEnd>` as a [start, end] pair. */
+function rows(markup: string): Array<[number, number]> {
+  return [...markup.matchAll(/d="M-6 (-?[\d.]+) C [\d.]+ -?[\d.]+ [\d.]+ (-?[\d.]+)/g)].map(
+    (m) => [Number(m[1]), Number(m[2])],
+  );
+}
+
+describe("the Ephemerists gravity field", () => {
+  it("rules the whole canvas at the design's 52px pitch", () => {
+    const starts = rows(field()).map(([y]) => y);
+    expect(starts[0]).toBe(-52);
+    expect(starts[1] - starts[0]).toBe(52);
+    // One row past the top edge, then the canvas: the field cannot stop short
+    // of the sheet, which is why the canvas overruns the design's own 1500.
+    expect(starts).toHaveLength(Math.ceil((HEIGHT + 52) / 52));
+    expect(starts.at(-1)).toBeGreaterThan(HEIGHT - 52);
+  });
+
+  it("draws every row toward the well, and the well's own row flat", () => {
+    const drawn = rows(field());
+    const sag = new Map(drawn.map(([y, end]) => [y, end - y]));
+    // A row THROUGH the well has nowhere to fall to.
+    expect(sag.get(520)).toBe(0);
+    // Rows above it sag DOWN toward it, rows below rise UP to it. That sign
+    // flip is what makes the field read as a mass rather than as a fan.
+    expect(sag.get(468)).toBeGreaterThan(0);
+    expect(sag.get(572)).toBeLessThan(0);
+    // And every row ends nearer the well's latitude than it started — the pull
+    // is always toward the mass, never past it.
+    for (const [y, end] of drawn) {
+      expect(Math.abs(end - 520), `row ${y}`).toBeLessThanOrEqual(Math.abs(y - 520));
+    }
+  });
+
+  it("fades the rows out with distance from the mass", () => {
+    // Opacity tracks the pull itself (0.1 + pull × 0.34), so the field is
+    // strongest at the well's latitude and thins toward the sheet's ends —
+    // which is what stops a ruled ground from reading as ruled paper.
+    const opacities = new Map(
+      [...field().matchAll(/M-6 (-?[\d.]+)[^/]*opacity="([\d.]+)"/g)].map((m) => [
+        Number(m[1]),
+        Number(m[2]),
+      ]),
+    );
+    expect(opacities.get(520)!).toBeGreaterThan(opacities.get(-52)!);
+    expect(opacities.get(520)!).toBeGreaterThan(opacities.get(2340)!);
+    expect(opacities.get(520)!).toBeCloseTo(0.1 + 0.42 * 0.34, 5);
+  });
+
+  it("draws in the plate's rule brass, never an ink", () => {
+    const markup = field();
+    expect(markup).toContain('stroke="var(--faction-ephemerists-plate-brass)"');
+    expect(markup).not.toContain("plate-ink");
+    expect(markup).not.toContain("plate-quiet");
+  });
+
+  it("marks the well past the sheet's right edge, in ochre", () => {
+    const markup = field();
+    // Three rings, all centred 12px beyond `width` — the sheet's own
+    // `overflow: hidden` is what crops them into arcs.
+    const rings = [...markup.matchAll(/<circle cx="(\d+)"/g)].map((m) => Number(m[1]));
+    expect(rings).toEqual([WIDTH + 12, WIDTH + 12, WIDTH + 12]);
+    expect(markup).toContain('fill="var(--faction-ephemerists-plate-ochre)"');
+  });
+
+  it("anchors its canvas to the right edge so the well cannot drift", () => {
+    // A phone wider than the nominal 360 scales the rows up rather than
+    // stranding the well mid-sheet.
+    const markup = field();
+    expect(markup).toContain('preserveAspectRatio="xMaxYMin slice"');
+    expect(markup).toContain(`viewBox="0 0 ${WIDTH + 40} ${HEIGHT}"`);
+    expect(markup).toContain("right:-40px");
+  });
+
+  it("is inert: decorative, unreachable and unable to eat a click", () => {
+    const markup = field();
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup).toContain("pointer-events:none");
+  });
+});

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -340,6 +340,100 @@ export function GlyphRegister({ width, y, strength, keyPrefix, color }: {
   );
 }
 
+/* ── The gravity field (#1830) ──
+ *
+ * Every number below is the design's own `ephGravity()`. They are ornament
+ * geometry on an SVG canvas, not layout spacing (§4a).
+ */
+/** The leading of the unbent rows, at the top and bottom of the sheet. */
+const GRAVITY_PITCH = 52;
+/** Where the mass sits: `WELL_X` past the sheet's right edge, `WELL_Y` down. */
+const WELL_X = 12;
+const WELL_Y = 520;
+/** How far the canvas overruns the sheet, so the well itself is drawn. */
+const WELL_MARGIN = 40;
+/** Strongest sag, at the well's own latitude, and the falloff either side. */
+const PULL_MAX = 0.42;
+const PULL_FALLOFF = 620;
+
+/**
+ * THE GRAVITY FIELD — the plate's ground, and NOT lined paper (#1830).
+ *
+ * The composer used to rule this sheet with a `repeating-linear-gradient` at
+ * 25px, which is a notebook. The design replaced it with a field: fixed-pitch
+ * brass rows bowed toward a well sitting just off the sheet's right edge, each
+ * row sagging by its distance from the mass, plus three ochre rings marking
+ * where the mass is. Its own comment is *"the plate's field, not lined paper"* —
+ * the Ephemerists read the world, they do not take minutes on it. The curvature
+ * is also doing a job: it is strongest in the open right-hand margin and
+ * flattest where a field or a panel covers the ground, so what you see of the
+ * field is exactly what the layout does not use.
+ *
+ * `width` is the sheet's nominal width — the well's position is measured from
+ * its right edge. The canvas is anchored to that edge (`xMaxYMin slice`), so a
+ * viewport wider than the nominal keeps the well where it belongs and scales
+ * the rows up rather than stranding them mid-sheet.
+ *
+ * DEVIATION, named: the design's canvas stops at 1500px because its own preview
+ * sheet does. A composer's sheet grows with what you write, and a field that
+ * stops two thirds of the way down is worse than no field, so `height` runs to
+ * the caller's number with the same formula on every row. Nothing else moves.
+ */
+export function GravityField({ width, height }: { width: number; height: number }) {
+  const span = width + WELL_MARGIN;
+  const rows = [];
+  for (let y = -GRAVITY_PITCH; y < height; y += GRAVITY_PITCH) {
+    const pull = PULL_MAX / (1 + Math.pow((y - WELL_Y) / PULL_FALLOFF, 2));
+    const end = y + (WELL_Y - y) * pull;
+    rows.push(
+      <path
+        key={y}
+        d={`M-6 ${y} C ${width * 0.42} ${y} ${width * 0.66} ${end} ${span + 6} ${end}`}
+        fill="none"
+        stroke={BRASS}
+        strokeWidth={0.8}
+        opacity={0.1 + pull * 0.34}
+      />,
+    );
+  }
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox={`0 0 ${span} ${height}`}
+      preserveAspectRatio="xMaxYMin slice"
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: -WELL_MARGIN,
+        height,
+        pointerEvents: "none",
+      }}
+    >
+      {rows}
+      <circle cx={width + WELL_X} cy={WELL_Y} r={4} fill={OCHRE} opacity={0.55} />
+      <circle
+        cx={width + WELL_X}
+        cy={WELL_Y}
+        r={26}
+        fill="none"
+        stroke={OCHRE}
+        strokeWidth={0.7}
+        opacity={0.28}
+      />
+      <circle
+        cx={width + WELL_X}
+        cy={WELL_Y}
+        r={52}
+        fill="none"
+        stroke={OCHRE}
+        strokeWidth={0.6}
+        opacity={0.16}
+      />
+    </svg>
+  );
+}
+
 /* `Wing` and `WingedDisc` stood here — the winged sun disc, the mark that headed
    every Ephemerists band and crowned the task detail's action panel.
 

--- a/frontend/src/components/factionMarks/wowOrnament.tsx
+++ b/frontend/src/components/factionMarks/wowOrnament.tsx
@@ -38,10 +38,19 @@ import type { CSSProperties, ReactNode } from "react";
 
 /** Frame + rule gold. Theme-invariant, and never an ink: 2.24:1 on the cream. */
 const GOLD = "var(--faction-wow-chronicle-gold)";
-/** Plum as INK/ornament — this one DOES flip with the theme. */
+/** Plum as INK — this one DOES flip with the theme. */
 const PLUM = "var(--faction-wow-card-accent)";
-/** The burnt gold that finishes the balloon strings. */
-const GILT = "var(--faction-wow-stamp-total)";
+/**
+ * Plum as ORNAMENT (#1830).
+ *
+ * The design's skin row splits the two in dark and only in dark: the ink lifts
+ * to `#C79BE0` so it can be read, while the plum that is only ever a *shape* —
+ * the zigzag's far stop, the odd balloon — stays at `#8A5AAE`, one step off the
+ * light value it is theme-invariantly meant to look like. `-stamp-chip-bg`
+ * dereferences `-card-accent` in light, so the two are the same swatch by day
+ * and it is the night that tells them apart.
+ */
+const PLUM_ORNAMENT = "var(--faction-wow-stamp-chip-bg)";
 
 /**
  * The wavy rule's path, stretched to whatever its container gives it.
@@ -78,7 +87,7 @@ export function Zig({ id, style }: { id: string; style?: CSSProperties }) {
         <defs>
           <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
             <stop offset="0" stopColor={GOLD} />
-            <stop offset="1" stopColor={PLUM} />
+            <stop offset="1" stopColor={PLUM_ORNAMENT} />
           </linearGradient>
         </defs>
         <path
@@ -188,8 +197,16 @@ export function BalloonBunch({
         </g>
         <Balloon cx={12} cy={15} fill="var(--faction-wow-balloon-5)" delay={0} />
         <Balloon cx={31} cy={12} fill="var(--faction-wow-balloon-5)" delay={0.2} />
-        <Balloon cx={22} cy={27} fill="var(--faction-wow-balloon-1)" delay={0.4} />
-        <circle cx={22} cy={51} r={1.6} fill={GILT} />
+        {/* The odd balloon takes the ORNAMENT plum, not the vote plate's first
+            ramp rung (`--faction-wow-balloon-1`), which is frozen at the LIGHT
+            plum in both themes because the ramp it belongs to is theme-
+            invariant. Same swatch by day, the design's lifted `#8A5AAE` by
+            night (#1830). */}
+        <Balloon cx={22} cy={27} fill={PLUM_ORNAMENT} delay={0.4} />
+        {/* The tie-off knot is struck metal, so it takes the theme-invariant
+            frame gold rather than the burnt `-stamp-total`, which is an INK
+            and moves with the theme (#1830). */}
+        <circle cx={22} cy={51} r={1.6} fill={GOLD} />
       </svg>
     </span>
   );

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -6,10 +6,10 @@
  * Dress over the shared layout, not a layout of its own. `DefaultEditPraxis` is
  * the reference implementation and the contract (ADR-0065 §1); read it there
  * rather than re-deriving it here. What this file adds is the Deco × Egypt plate
- * at composer size: a night-sky masthead under a cavetto cornice, a papyrus
- * ground ruled like a field journal with an ochre margin rule struck down its
- * gutter, a brass octagon for the points, an ankh in an octagon for the stage,
- * and an open eye following the cast.
+ * at composer size: a night-sky masthead under a cavetto cornice, a ground bowed
+ * toward a gravity well off the sheet's right edge with an ochre margin rule
+ * struck down its gutter, a brass octagon for the points, an ankh in an octagon
+ * for the stage, and an open eye following the cast.
  *
  * ## The layout, in order — unchanged from Default
  *
@@ -44,10 +44,12 @@
  *
  * ## Marks: reused, not redrawn (WORLD_ZERO_STYLE §6, "one primitive")
  *
- * The engraved masthead, the cornice, the rune band, the incised signs and the
- * stepped octagon are all `components/factionMarks` — the module #1120 extracted
- * so the plate's ornament is shared rather than copied. This file draws no new
- * SVG apart from the two marks' arrangement. The winged sun disc that headed the
+ * The engraved masthead, the cornice, the rune band, the incised signs, the
+ * stepped octagon and the gravity field are all `components/factionMarks` — the
+ * module #1120 extracted so the plate's ornament is shared rather than copied.
+ * This file draws no new SVG apart from the two marks' arrangement; the field
+ * went into the module for the same reason (#1830), and the waiting surface
+ * mounts it through this file's `dress.ground`. The winged sun disc that headed the
  * sky band was retired kit-wide by #1634: the sigil is the only mark, and it
  * arrives inside the masthead.
  *
@@ -78,12 +80,14 @@
  * carry the same value, so it does not move either.
  *
  * `-brass` is a rule colour and never an ink; quiet type takes `-quiet`, which
- * clears AA on the page, the plate AND the inner cells (#1028). The design's two
- * theme-tuned opacities for the ruling (.3 light / .22 dark) collapse to one
- * here for the same reason: `-rule` carries the tuning in the colour, and there
- * is only one `-rule`, so the ground layer needs no opacity ternary. This is the
+ * clears AA on the page, the plate AND the inner cells (#1028). This is the
  * plate (`--faction-ephemerists-plate-*`), never the illuminated codex
  * (`--eph-*`); the two grounds must not be mixed on one surface (ADR-0055).
+ *
+ * ONE DEVIATION IS KEPT AND IS NOT A DRIFT (re-affirmed by #1830). The design's
+ * `danger` is the plate ochre `#D9744C`; this file ships
+ * `--faction-ephemerists-card-alarm`, which is #1449's alarm rung, because the
+ * ochre misses AA for the error banner's ink on this ground. See {@link ALARM}.
  *
  * ## Not drawn as designed
  *
@@ -141,7 +145,8 @@ import {
   CAPTION,
   Cornice,
   DECO,
-  RuneRule,
+  DISC,
+  GravityField,
   INK,
   INNER,
   LINE,
@@ -151,7 +156,7 @@ import {
   PLATE,
   QUIET,
   READING,
-  RULE,
+  RuneRule,
   SHADOW,
   Sign,
 } from "../../../components/factionMarks/ephemeristsPlate";
@@ -180,8 +185,21 @@ const CTA_INK = "var(--faction-ephemerists-plate-cta-ink)";
  * praxis-detail masthead's: one plate, one masthead, at the same two sizes on
  * both surfaces. `WORDMARK_DISC` went with the winged disc it measured. */
 const EPH_BAND = { desktop: 84, mobile: 68 };
-/** The journal ruling's leading, and where the ochre margin rule is struck. */
-const RULING = 25;
+/**
+ * The gravity field's nominal sheet width — the design's own `s.w`, and the
+ * same pair `useComposerSizes` sets the column to. The well is measured from
+ * the sheet's RIGHT edge, so this is what the field's canvas is drawn against;
+ * a viewport wider than the nominal scales the rows rather than moving the well
+ * (see `GravityField`).
+ */
+const GRAVITY_WIDTH = { desktop: 720, mobile: 360 };
+/**
+ * How far down the field is drawn. The design's canvas is 1500; a composer's
+ * sheet is taller than that as soon as you write anything, and the ground is
+ * clipped to the sheet, so the canvas overruns and the clip decides.
+ */
+const GRAVITY_HEIGHT = 2400;
+/** Where the ochre margin rule is struck. */
 const MARGIN_RULE = { desktop: 22, mobile: 13 };
 /** The stage mark: a stepped octagon, drawn on a 100-unit viewBox. */
 const STATUS_MARK = 44;
@@ -217,7 +235,7 @@ function StatusMark() {
         aria-hidden="true"
         style={{ position: "absolute", inset: 0 }}
       >
-        <Octagon inset={0} stroke={BRASS} width={3.4} fill={INNER} />
+        <Octagon inset={0} stroke={BRASS} width={3.4} fill={DISC} />
       </svg>
       <span
         style={{
@@ -228,7 +246,7 @@ function StatusMark() {
           justifyContent: "center",
         }}
       >
-        <Sign name="ankh" size={STATUS_SIGN} color={NILE} weight={1.6} />
+        <Sign name="ankh" size={STATUS_SIGN} color={BRASS} weight={1.6} />
       </span>
     </span>
   );
@@ -317,8 +335,10 @@ export default function EphemeristsEditPraxis({ state }: Props) {
           <>
             {/* The sky band. A wash rather than a flat fill: the night blue
                 lifts toward the nile at the horizon and settles back into the
-                band at its foot. Both stops are tokens, so the sky flips with
-                the theme. */}
+                band at its foot. Both stops are plate tokens, so — like the
+                rest of this register — the sky is the SAME in both themes and
+                does not flip; the design's byte-identical light/dark objects
+                say so too (#1830 corrected this note). */}
             <ComposerMasthead
               height={EPH_BAND[factor]}
               background={`linear-gradient(180deg, color-mix(in srgb, var(--faction-ephemerists-plate-band) 82%, ${NILE}) 0%, var(--faction-ephemerists-plate-band) 100%)`}
@@ -344,10 +364,13 @@ export default function EphemeristsEditPraxis({ state }: Props) {
           </>
   );
   const ground = (
-          <ComposerGround
-            inset={0}
-            background={`repeating-linear-gradient(0deg, transparent 0 ${RULING}px, ${RULE} ${RULING}px ${RULING + 1}px)`}
-          >
+          <ComposerGround inset={0} style={{ overflow: "hidden" }}>
+            {/* The plate's own field, bowed toward the well off the sheet's
+                right edge (#1830). NOT lined paper — see `GravityField`. */}
+            <GravityField
+              width={GRAVITY_WIDTH[factor]}
+              height={GRAVITY_HEIGHT}
+            />
             {/* The margin rule, struck in ochre down the gutter — outside the
                 content column's inset, so no line of type ever runs into it. */}
             <span

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -64,10 +64,12 @@
  * ## Motion
  *
  * Two cogs on the masthead, `ep-spin` against `ep-spin-rev` — the counter-turn
- * is the whole gag, and it is the only motion here. Both are CLASSES: the
- * keyframes live in `index.css` behind the shared `prefers-reduced-motion`
- * guard, and an inline `animation:` would bypass it (#1003). `index.css` needed
- * no motion edit for this skin.
+ * is the whole gag — and a third on the waiting surface's hero mark, forward,
+ * which the design turns too (#1830). All three are CLASSES: the keyframes live
+ * in `index.css` behind the shared `prefers-reduced-motion` guard, and an
+ * inline `animation:` would bypass it (#1003). `index.css` needed no motion
+ * edit for this skin; the period comes through `--ep-spin-dur` ({@link
+ * COG_PERIOD}).
  *
  * ## Not drawn as designed
  *
@@ -200,6 +202,9 @@ function buildGearPath(): string {
 
 const GEAR_PATH = buildGearPath();
 
+/** The cogs' period, the design's own 22s. It had drifted to 26 (#1830). */
+const COG_PERIOD = "22s";
+
 /**
  * The union cog. Ornament only — aria-hidden at every call site.
  *
@@ -264,12 +269,19 @@ export default function EverymenEditPraxis({ state }: Props) {
    * takes the louder rung, because being a size larger than the rest of the site
    * IS the distinction here (§4a — a token names a tier, so the number lands
    * where it lands).
+   *
+   * The tracking is the design's `label.spacing` of 0.2em (#1830). It used to
+   * default to 0.16em with the loud slots — the labels, the status word, the
+   * slip — overriding back up, which left the quiet ones (mode chips, write-up
+   * tabs, picker, exits, slip pill) stencilled a step tighter than the row they
+   * sat in. The masthead wordmark still says 0.16em, out of its own line in the
+   * design; it is chrome on the plate, not a label on the paper.
    */
   const stencil = (overrides: CSSProperties = {}): CSSProperties =>
     composerLabelStyle({
       fontFamily: BEBAS,
       fontSize: "var(--text-xl)",
-      letterSpacing: "0.16em",
+      letterSpacing: "0.2em",
       ...overrides,
     });
 
@@ -306,7 +318,22 @@ export default function EverymenEditPraxis({ state }: Props) {
     borderRadius: 0,
     boxShadow: SHADOW,
   };
-  const statusMark = <Gear size={40} fill={RED} hole={PANEL} />;
+  /* The waiting surface's hero mark: `gear(40, accent, field, 1)` in the design
+     row — the SHEET accent rather than the rule red, on the panel stock, and
+     turning forward like the pair on the nameplate. It was drawn in `--everymen-
+     red` and stilled; a cog that has stopped is the one thing this metaphor
+     cannot say on a page whose whole message is that the work is in hand
+     (#1830). It is a mark on a plate, not type, so the accent's 4.49:1 on the
+     paper is not the measurement that governs it. */
+  const statusMark = (
+    <Gear
+      size={40}
+      fill={ACCENT}
+      hole={PANEL}
+      spin="forward"
+      duration={COG_PERIOD}
+    />
+  );
   const slip = {
     style: {
       background: PANEL,
@@ -317,7 +344,7 @@ export default function EverymenEditPraxis({ state }: Props) {
       borderRadius: 0,
       padding: "var(--space-lg)",
     },
-    labelStyle: stencil({ color: ACCENT, letterSpacing: "0.2em" }),
+    labelStyle: stencil({ color: ACCENT }),
     titleStyle: {
       fontFamily: BEBAS,
       textTransform: "uppercase" as const,
@@ -358,7 +385,7 @@ export default function EverymenEditPraxis({ state }: Props) {
               boxShadow: `inset 0 -6px 0 -4px ${PAPER_DEEP}`,
             }}
           >
-            <Gear size={16} fill={MAST_INK} hole={MAST} spin="forward" duration="26s" />
+            <Gear size={16} fill={MAST_INK} hole={MAST} spin="forward" duration={COG_PERIOD} />
             <span
               style={{
                 fontFamily: BEBAS,
@@ -371,7 +398,7 @@ export default function EverymenEditPraxis({ state }: Props) {
             >
               {factionName(slug)}
             </span>
-            <Gear size={16} fill={MAST_INK} hole={MAST} spin="reverse" duration="26s" />
+            <Gear size={16} fill={MAST_INK} hole={MAST} spin="reverse" duration={COG_PERIOD} />
           </ComposerMasthead>
   );
   const ground = (
@@ -408,9 +435,9 @@ export default function EverymenEditPraxis({ state }: Props) {
     ground,
     rule: () => dashRule,
     mark: statusMark,
-    statusStyle: stencil({ color: INK, letterSpacing: "0.2em" }),
+    statusStyle: stencil({ color: INK }),
     metaStyle: { color: MUTED },
-    labelStyle: stencil({ color: INK, letterSpacing: "0.2em" }),
+    labelStyle: stencil({ color: INK }),
     slip,
     panelStyle: {
       background: PANEL,
@@ -470,7 +497,7 @@ export default function EverymenEditPraxis({ state }: Props) {
           label={t("editPraxis.composer.titleLabel")}
           htmlFor="composer-title"
           rule={false}
-          labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+          labelStyle={stencil({ color: INK })}
         >
           <TitleField
             state={state}
@@ -492,7 +519,7 @@ export default function EverymenEditPraxis({ state }: Props) {
           <ComposerSection
             label={t("editPraxis.composer.modeLabel")}
             rule={false}
-            labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+            labelStyle={stencil({ color: INK })}
           >
             <ModePicker
               state={state}
@@ -510,14 +537,20 @@ export default function EverymenEditPraxis({ state }: Props) {
                     aria-pressed={active}
                     onClick={onSelect}
                     disabled={disabled && !active}
+                    /* The chosen mode takes the kit's CTA fill, which for the
+                       Everymen is the report bar's near-black — the design's
+                       control dress says a faction's active state is "its CTA
+                       fill … never a generic accent block", and a red block
+                       under an offset shadow was the union's one irreversible
+                       act restated on a control that only chooses how you file
+                       (#1830). */
                     style={stencil({
                       cursor: disabled ? "not-allowed" : "pointer",
                       padding: "var(--space-sm) var(--space-lg)",
                       borderRadius: 0,
-                      background: active ? RED : PANEL,
-                      color: active ? ON_ACCENT : INK,
-                      border: `2px solid ${FRAME}`,
-                      boxShadow: active ? `4px 4px 0 ${FRAME}` : "none",
+                      background: active ? BAR : PANEL,
+                      color: active ? BAR_INK : INK,
+                      border: `2px solid ${active ? BAR : FRAME}`,
                     })}
                   >
                     {option.label}
@@ -543,7 +576,7 @@ export default function EverymenEditPraxis({ state }: Props) {
                 : undefined
             }
             rule={false}
-            labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+            labelStyle={stencil({ color: INK })}
           >
             <InviteSearch
               state={state}
@@ -568,7 +601,7 @@ export default function EverymenEditPraxis({ state }: Props) {
           <ComposerSection
             label={t("editPraxis.composer.sealsLabel")}
             rule={false}
-            labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+            labelStyle={stencil({ color: INK })}
           >
             <MetataskSealStack state={state} />
           </ComposerSection>
@@ -580,7 +613,7 @@ export default function EverymenEditPraxis({ state }: Props) {
           label={t("editPraxis.composer.writeUpLabel")}
           htmlFor="composer-body"
           rule={false}
-          labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+          labelStyle={stencil({ color: INK })}
           meta={
             <span style={composerMetaCluster}>
               <span
@@ -678,7 +711,7 @@ export default function EverymenEditPraxis({ state }: Props) {
         <ComposerSection
           label={t("editPraxis.composer.proofLabel")}
           rule={false}
-          labelStyle={stencil({ color: INK, letterSpacing: "0.2em" })}
+          labelStyle={stencil({ color: INK })}
         >
           <div
             style={{

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -253,6 +253,10 @@ export default function SingularityEditPraxis({ state }: Props) {
         fontFamily: FACE,
         // 19 in the design → the 18px content rung (§4a).
         fontSize: "var(--text-content)",
+        // The design's own 0.04em. A monospace readout is set loose, and this
+        // is the one slot on the page that had been left at the face's natural
+        // fit (#1830).
+        letterSpacing: "0.04em",
         lineHeight: 1,
         color: ACCENT,
       }}

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -143,7 +143,6 @@ const ALARM = "var(--faction-snide-composer-alarm)";
 const ACID = "var(--faction-snide-acid)";
 const PRESS_INK = "var(--faction-snide-ink)";
 const PRESS_PAPER = "var(--faction-snide-paper)";
-const HOT_PINK = "var(--faction-snide-pink)";
 
 const TITLE_FACE = "var(--faction-snide-font-impact)"; /* Anton */
 const BODY_FACE = "var(--faction-snide-font-type)"; /* Special Elite */
@@ -190,26 +189,19 @@ function SnideBlob({ width, height, struck = false, children }: BlobProps) {
         style={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
       >
         <path d={BLOB_PATH} fill={ACID} />
+        {/* Acid fill, press-ink tick, and nothing else. The hot-pink bar that
+            used to cross the blob is not in the design's mark — a strike-through
+            reads as "cancelled" on the one mark that says your part is IN
+            (#1830). */}
         {struck && (
-          <>
-            <polyline
-              points="28,36 41,50 66,22"
-              fill="none"
-              stroke={PRESS_INK}
-              strokeWidth={8}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <line
-              x1="10"
-              y1="58"
-              x2="84"
-              y2="15"
-              stroke={HOT_PINK}
-              strokeWidth={6}
-              strokeLinecap="round"
-            />
-          </>
+          <polyline
+            points="28,36 41,50 66,22"
+            fill="none"
+            stroke={PRESS_INK}
+            strokeWidth={8}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
         )}
       </svg>
       {children}

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -45,13 +45,16 @@
  *   passes `fontFamily`: `composerLabelStyle` defaults to Courier Prime.
  * - **Geometry.** radius 6, borders 1.5px, and the border takes gold — the
  *   sheet, the fields, the slip and the plaque are all framed in the same gilt.
+ *   TWO gilts, strictly: see {@link RULE} for the quiet half and where it goes.
  * - **Masthead.** The 7px gold/plum barber ribbon, straight off
  *   `--faction-wow-quest-ribbon` (the composed token the quest decree already
  *   ships: `0 11px` gold, `11px 22px` plum, which is the design's band exactly).
  *   Decorative, so `aria-hidden` — the shared masthead's default.
- * - **Ground.** A dashed gold ring turning at the top-right on `.ep-spin`
- *   (90s, the keyframe's own default duration), and a bunch of googly balloons
- *   tucked into the bottom-right corner. Both live on `ComposerGround`, which
+ * - **Ground.** A bunch of googly balloons floating at the bottom-right, and
+ *   nothing else: the dashed gold ring that used to turn at the top-right is
+ *   dropped with #1830, because #1828 gave the bottom edge to the full-bleed
+ *   cast band and the design answers it by lifting the balloons clear and
+ *   leaving them alone on the layer. The bunch lives on `ComposerGround`, which
  *   the sheet CLIPS — the site background still shows around the column and no
  *   ornament here can reach the viewport (#1028).
  * - **Rule.** The zigzag: `Zig`, from the faction's one ornament module. Drawn
@@ -88,10 +91,11 @@
  *
  * ## Motion
  *
- * `.ep-spin` on the ring, `.wow-balloon-bunch` / `.wow-balloon-eye` inside the
- * bunch. All three are CLASSES whose keyframes live in `index.css` behind the
- * shared `prefers-reduced-motion` guard; an inline `animation:` would bypass it
- * (#1003). Nothing here carries state, so the page reads correctly stilled.
+ * `.wow-balloon-bunch` and `.wow-balloon-eye`, both inside the bunch — the
+ * page's only two since the turning ring went (#1830). Both are CLASSES whose
+ * keyframes live in `index.css` behind the shared `prefers-reduced-motion`
+ * guard; an inline `animation:` would bypass it (#1003). Nothing here carries
+ * state, so the page reads correctly stilled.
  *
  * ## Not drawn as designed
  *
@@ -192,6 +196,16 @@ const PLUM_FILL = "var(--faction-wow-plum-surface)";
 const ON_PLUM = "var(--faction-wow-on-plum)";
 /** Frame + rule gold. Theme-invariant, and never an ink. */
 const GOLD = "var(--faction-wow-chronicle-gold)";
+/**
+ * The QUIET gold — the same gilt at 40% (#1830).
+ *
+ * The design's skin row carries two: `frame` (solid {@link GOLD}) for the edges
+ * that make a plate — the sheet, the fields, the slip, the active chip — and
+ * `border` for the edges that only suggest one, the inactive mode chip and the
+ * proof drop zone. Drawing both at full gilt gave a chip you had not chosen and
+ * a zone you had not filled the same weight of frame as the writ itself.
+ */
+const RULE = "var(--faction-wow-rule)";
 /** Burnt gold that is legible AS TEXT — the plaque's figure. */
 const GOLD_INK = "var(--faction-wow-stamp-total)";
 /** The AA ink for anything printed ON the gold. */
@@ -203,13 +217,20 @@ const RIBBON = "var(--faction-wow-quest-ribbon)";
 const SHEET_SHADOW = "var(--faction-wow-detail-shadow)";
 
 /**
- * The two corner ornaments' geometry. Illustration, not layout, so raw pixels
+ * The corner ornament's geometry. Illustration, not layout, so raw pixels
  * (§4a) — and the only thing `sizes.isMobile` decides on this page, because the
  * layout itself stacks with flow at every width.
+ *
+ * The bunch sits INSIDE the sheet now, not tucked under its corner: #1828 gave
+ * the cast a full-bleed band along the bottom edge, and the design's ground row
+ * lifts the balloons clear of it (`bottom: 76` desktop / `66` mobile, `right:
+ * 10`) rather than letting the band crop them. The dashed gold ring that used
+ * to turn in the opposite corner went at the same time — *"Balloons only,
+ * lifted clear of the submit band; the dashed ring is dropped"* (#1830).
  */
 const ORNAMENT = {
-  desktop: { ring: 190, ringRight: -40, ringTop: -30, bunch: 96 },
-  mobile: { ring: 132, ringRight: -34, ringTop: -22, bunch: 66 },
+  desktop: { bunch: 96, bottom: 76 },
+  mobile: { bunch: 66, bottom: 66 },
 } as const;
 
 /** Lora label ink on the cream. Every label row on the sheet takes this. */
@@ -314,29 +335,14 @@ export default function WowEditPraxis({ state }: Props) {
   });
   const ground = (
           <ComposerGround inset={0}>
-            {/* The turning ring. `.ep-spin` reads --ep-spin-dur, whose default
-                is the design's own 90s, so no re-time is needed. */}
-            <span
-              style={{
-                position: "absolute",
-                top: ornament.ringTop,
-                right: ornament.ringRight,
-                width: ornament.ring,
-                height: ornament.ring,
-                borderRadius: "50%",
-                border: `2px dashed ${GOLD}`,
-                opacity: 0.25,
-              }}
-              className="ep-spin"
-            />
-            {/* The crowd, tucked into the corner and clipped by the sheet. Held
-                below full strength so the footer's words stay first. */}
+            {/* The crowd, standing clear of the cast's band. Held below full
+                strength so the footer's words stay first. */}
             <BalloonBunch
               size={ornament.bunch}
               style={{
                 position: "absolute",
-                right: -10,
-                bottom: -14,
+                right: 10,
+                bottom: ornament.bottom,
                 opacity: 0.55,
               }}
             />
@@ -455,7 +461,9 @@ export default function WowEditPraxis({ state }: Props) {
                       borderRadius: 6,
                       background: active ? PLUM_FILL : FIELD,
                       color: active ? ON_PLUM : LABEL,
-                      border: `1.5px solid ${GOLD}`,
+                      /* Solid gilt only on the mode you are IN; the rest take
+                         the quiet gold (#1830). */
+                      border: `1.5px solid ${active ? GOLD : RULE}`,
                     })}
                   >
                     {option.label}
@@ -662,10 +670,11 @@ export default function WowEditPraxis({ state }: Props) {
                   buttonStyle: composerLabelStyle({
                     fontFamily: MED,
                     cursor: "pointer",
-                    /* Translucent, so the turning ring and the balloons read
-                       through the drop zone (#1828). */
+                    /* Translucent, so the balloons read through the drop zone
+                       (#1828), and dashed in the QUIET gold: an empty zone is
+                       an invitation, not a plate (#1830). */
                     background: composerDropGround(FIELD),
-                    border: `1.5px dashed ${GOLD}`,
+                    border: `1.5px dashed ${RULE}`,
                     borderRadius: 6,
                     padding: "var(--space-2xl) var(--space-lg)",
                     textAlign: "center",

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -324,6 +324,24 @@ describe("every skin swaps in the waiting surface (#1189)", () => {
     },
   );
 
+  it("the Ephemerists ground is the gravity field, not lined paper (#1830)", () => {
+    // The ground is `dress.ground`, so the composer and the waiting surface
+    // mount the SAME element and this harness reaches both. The design replaced
+    // the 25px journal ruling with a field bowed toward a well off the sheet's
+    // right edge; `ephemeristsGravity.test.tsx` owns the field's geometry, and
+    // what is pinned here is that the ruling did not survive beside it.
+    const Archetype = resolvedArchetype(
+      pickVariant(surfaceMap("editPraxis"), "ephemerists", DefaultEditPraxis),
+    )!;
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <Archetype state={waitingState("ephemerists")} />
+      </MemoryRouter>,
+    );
+    expect(markup).toContain('preserveAspectRatio="xMaxYMin slice"');
+    expect(markup).not.toContain("repeating-linear-gradient");
+  });
+
   it("na falls through to the spectrum kit's own band (ADR-0065 §4)", () => {
     const markup = renderToStaticMarkup(
       <MemoryRouter>

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/everymenComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/everymenComposer.test.tsx
@@ -153,6 +153,29 @@ describe("Everymen composer dress", () => {
     expect(markup).not.toContain("animation:");
   });
 
+  it("fills the chosen mode with the CTA, not a generic accent block (#1830)", () => {
+    // The design's shared control dress says so in as many words: a control's
+    // active state takes "its CTA fill … never a generic accent block". The red
+    // block with a 4px offset shadow was the union's ONE irreversible act —
+    // filing — restated on a control that only picks how you file.
+    const markup = render("desktop");
+    expect(markup).toContain("background:var(--faction-everymen-bill-cta-bg)");
+    expect(markup).not.toContain("4px 4px 0 var(--everymen-frame)");
+  });
+
+  it("stencils every label at the design's 0.2em (#1830)", () => {
+    // `stencil()` is the whole label tier, and its 0.16em reached the mode
+    // chips, the write-up tabs, the picker and the exits — the slots that did
+    // NOT pass their own tracking. The masthead wordmark keeps 0.16em, which is
+    // the design's own value there.
+    const markup = render("desktop");
+    const tight = markup.match(/letter-spacing:0\.16em;[^"]*/g) ?? [];
+    expect(tight).toHaveLength(1);
+    expect(tight[0]).toContain("--faction-everymen-bill-mast-ink");
+    const chip = markup.slice(markup.indexOf('aria-pressed="true"'));
+    expect(chip.slice(0, 400)).toContain("letter-spacing:0.2em");
+  });
+
   it.each(WIDTHS)("keeps its ground inside its own column on %s (#1028)", (width) => {
     const markup = render(width);
     expect(markup).not.toContain("100vh");

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/wowEditPraxis.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/wowEditPraxis.test.tsx
@@ -235,14 +235,39 @@ describe("WOW composer — the dress", () => {
     expect(markup).toContain("border-radius:6px");
   });
 
-  it.each(WIDTHS)("runs both corner ornaments on %s", (width) => {
+  it.each(WIDTHS)("floats the balloons alone over the ground on %s", (width) => {
     const markup = render(width);
-    // The turning dashed ring: a CLASS, so the reduced-motion guard in
-    // index.css still governs it. An inline `animation:` would bypass it.
-    expect(markup).toContain('class="ep-spin"');
-    expect(markup).not.toMatch(/animation:/);
-    // ...and the bunch, from the faction's one ornament module (§6/#849).
+    // The bunch, from the faction's one ornament module (§6/#849) — and it is
+    // now the WHOLE ground. The dashed gold ring went with #1830: the submit
+    // band owns the sheet's bottom edge, and the design's ground row reads
+    // "Balloons only, lifted clear of the submit band; the dashed ring is
+    // dropped."
     expect(markup).toContain("wow-balloon-bunch");
+    expect(markup).not.toContain('class="ep-spin"');
+    expect(markup).not.toContain("2px dashed var(--faction-wow-chronicle-gold)");
+    // Motion stays CLASS-gated either way: an inline `animation:` would bypass
+    // the reduced-motion guard in index.css (#1003).
+    expect(markup).not.toMatch(/animation:/);
+  });
+
+  it.each(WIDTHS)("lifts the bunch clear of the band on %s", (width) => {
+    // Design ground row: `right: 10, bottom: 76` desktop / 66 mobile. The old
+    // negative offsets tucked the bunch into the corner the full-bleed band
+    // now occupies, so it read as clipped rather than as an ornament (#1830).
+    const markup = render(width);
+    expect(markup).toContain("right:10px");
+    expect(markup).toContain(width === "mobile" ? "bottom:66px" : "bottom:76px");
+  });
+
+  it("spends the quiet gold on its quiet edges (#1830)", () => {
+    // Two golds, not one: the solid `--faction-wow-chronicle-gold` frames the
+    // sheet, the fields and the ACTIVE chip; `--faction-wow-rule` (the same
+    // gold at 40%) draws the edges that are only suggesting a boundary — the
+    // inactive mode chip and the proof drop zone.
+    const markup = render();
+    expect(markup).toContain("1.5px solid var(--faction-wow-rule)");
+    expect(markup).toContain("1.5px dashed var(--faction-wow-rule)");
+    expect(markup).not.toContain("1.5px dashed var(--faction-wow-chronicle-gold)");
   });
 
   it("closes the sheet with the zigzag, not a hairline", () => {


### PR DESCRIPTION
Five faction composers against the rewritten skin rows in `edit-praxis.jsx` (project `c491945e`, updated 2026-08-15).

Closes #1830

## Seam

Per-faction DRESS on `pages/editPraxis/archetypes/*EditPraxis.tsx` plus the two ornament modules those files consume (`factionMarks/wowOrnament.tsx`, `factionMarks/ephemeristsPlate.tsx`). No layout, no control, no copy, no shared seam — #1828 owns those and merged first. Tests go at the seam that renders: `renderToStaticMarkup` of the archetype, or of the mark alone where the mark is geometry.

**#1830's line numbers were all stale** — #1828 (PR #1847) rewrote every file it names minutes before this branch started. Every claim was re-located by grepping for the code it described, and where the two disagreed the code won. See "Already done by #1828" and "Premises the code overturned" below.

## Warriors of Whimsy

- **The ground is the balloons, alone.** The dashed gold ring is dropped — #1828 gave the sheet's bottom edge to the full-bleed cast band, and the design answers by lifting the bunch clear of it (`right: 10`, `bottom: 76` desktop / `66` mobile) instead of tucking it under the corner the band now crops. `ORNAMENT` loses its four ring numbers.
- **Two golds again.** The skin row carries `frame` (solid `--faction-wow-chronicle-gold`) for the edges that make a plate and `border` (`--faction-wow-rule`, the same gilt at 40%) for the edges that only suggest one. `--faction-wow-rule` was read by nothing; it now draws the INACTIVE mode chip and the proof drop zone. The active chip keeps solid gilt.
- **`wowOrnament.tsx`: plum as INK vs plum as SHAPE.** The zigzag's far stop and the odd balloon take `--faction-wow-stamp-chip-bg`; the balloon knot takes the theme-invariant `--faction-wow-chronicle-gold` instead of the burnt `-stamp-total`, which is an ink.
- Test: `wowEditPraxis.test.tsx`'s "runs both corner ornaments" becomes "floats the balloons alone", keeping the no-inline-`animation:` half intact, plus the offsets and the quiet-gold edges.

## The Everymen

- **`stencil()` tracks 0.2em**, the design's `label.spacing`. It defaulted to 0.16em with the loud slots overriding back up, which left the quiet ones (mode chips, write-up tabs, picker, drop button, slip pill) a step tighter than the row they sat in; nine now-redundant overrides are deleted. The masthead wordmark keeps its own 0.16em, which is the design's value there.
- **The chosen mode takes the CTA fill** (`--faction-everymen-bill-cta-bg` on `-cta-ink`), not a red block under a `4px 4px 0` offset shadow. The design's control dress says it in as many words: *"its CTA fill for the active state … never a generic accent block."*
- **The waiting surface's hero cog** is `gear(40, accent, field, 1)`: `--faction-everymen-sheet-accent`, not the rule red, and turning forward. It is a mark on a plate, not type, so the accent's 4.49:1 on the paper is not the measurement that governs it.
- **Cog period 22s**, the design's, via one `COG_PERIOD`. It had drifted to 26s.

## The Ephemerists — the big one

The design replaced the plate's ruled lines with `ephGravity()`, and prose cannot carry it, so it was ported from the source: brass rows at a fixed 52px pitch bowed toward a well 12px off the sheet's right edge, each row's sag `0.42 / (1 + ((y − 520)/620)²)` of its distance to the mass, opacity tracking the same pull, and three ochre rings marking the well. Its own comment: *"the plate's field, **not lined paper**."*

It lands in `ephemeristsPlate.tsx` as `GravityField`, not in the archetype — §6, and the archetype's own header promises it draws no new SVG. The composer and the waiting surface mount one element through `dress.ground`.

- **The stage mark** reads its own two values: the octagon field is the medallion `DISC` (was the `INNER` cell) and the ankh is inked in `BRASS` (was `NILE`). The `clipPath` → `Octagon` swap stays, argued in-file.
- **Prose.** Both file headers already stated the theme-invariance correctly; the one line left over was the sky band's *"both stops are tokens, so the sky flips with the theme"*. It does not, and the design's byte-identical light/dark objects agree.

## S.N.I.D.E. / The Singularity

- The blob loses the hot-pink strike (`--faction-snide-pink`). The design's mark is an acid fill plus a press-ink tick — a strike-through on the one mark that says your part is IN reads as cancelled. The const goes with it.
- The `[ok]` readout takes the design's `letterSpacing: 0.04em`, the one value the cleanest of the five had dropped.

## Deviations kept, each argued

1. **Ephemerists `danger`** — design `#D9744C` (plate ochre), shipped `--faction-ephemerists-card-alarm` `#fca5a5`. A reasoned AA deviation from #1231/#1449: the ochre misses AA for the error banner's ink on this ground. **Left alone on the issue's instruction**, and the file header now says so under its own heading citing #1830, so the next audit does not re-raise it.
2. **`GravityField`'s canvas runs past the design's fixed 1500px** (2400 at the call site). The design's canvas is the height of its own preview sheet; a composer's sheet grows with what you write, and a field that stops two thirds of the way down is worse than no field. The formula is unchanged on every row and the sheet's `overflow: hidden` decides where the field ends. Named in the component's doc block.
3. **WOW's active mode chip stays plum**, not the design's gold CTA fill. Not raised by #1830, and the in-file argument is a measured pairing (5.16:1 both themes) — not re-litigated here.
4. **SNIDE / Everymen / WOW band sizes stay `--text-content`.** #1828 took the size half of that finding and argued it per skin at the call site; this PR only owned the tracking.

## Already done by #1828 — verified, not re-done

- **SNIDE band tracking** is already the design's 0.2em (the size is `--text-content` 18 with a named argument, which was #1828's half).
- **The Everymen band's top rule** already passes `SHEET_FRAME` = `--faction-everymen-composer-frame`, not the panel ink.
- **SNIDE's stale tape prose** is already corrected — the header now says shipped and kit agree.
- **The Ephemerists `[data-theme="dark"]` claims** in both file headers are already correct; only the sky-band line was left.

## Premises the code overturned

- **"The third balloon paints at the ink value."** It painted at `--faction-wow-balloon-1`, the vote plate's first ramp rung — frozen at the LIGHT plum in both themes because that ramp is documented theme-invariant and shared with `WowVote`. Fixed by pointing the balloon at `--faction-wow-stamp-chip-bg` (identical by day, the design's `#8A5AAE` by night) rather than by touching the ramp, which would have repainted the vote widget.
- **#1800 is not merged in.** `--label-ink` is already set to `plate-quiet` on the composer root; the design's new `labelInk` is `plate-caption`, a different ink and a different seam. Untouched.

## Blast radius outside the composer

`wowOrnament.tsx` is consumed by five surfaces (task card, task detail, praxis detail, faction body, this composer). The two colour changes are dark-only and one hue step each; `Bunting` is untouched. `GravityField` is new and has one caller.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (254 files / 4571 tests), `npm run build`, `npm run budget` (JS 128.6 KB, CSS 21.3 KB — both ok) all pass locally. No backend or schema file is touched.

**Visual QA is outstanding.** There is no browser in this loop: a green build proves the tokens resolve and the geometry computes, not that the gravity field looks like a gravity field or that the balloons clear the band. Every item below wants an eyeball.

## What to eyeball

- **Ephemerists · composer · desktop 720 and a phone wider than 360** — the well should sit just off the right edge with its rings cropped into arcs, the rows should fan hardest in the open right margin and lie flat under the fields, and the field must reach the BOTTOM of a long draft.
- **Ephemerists · waiting surface** — same ground, plus the stage octagon: dark medallion field, brass ankh.
- **Ephemerists · light and dark** — must be identical. Any difference is a regression.
- **WOW · composer · desktop and mobile** — balloons standing clear above the gold band, no ring anywhere; then the mode chips (one solid gilt, the rest 40%) and the drop zone's dashed 40% edge.
- **WOW · dark** — the zigzag's plum end and the third balloon should read one step deeper than the plum body text beside them.
- **Everymen · composer · both widths** — every label at one tracking; the chosen mode chip near-black with cream type and NO offset shadow; the masthead cogs a touch quicker.
- **Everymen · waiting surface, both themes** — the hero cog red-accent and turning, and stilled under `prefers-reduced-motion`.
- **SNIDE · waiting surface** — acid blob, black tick, no pink bar.
- **Singularity · waiting surface, dark** — `[ok]` at its new tracking, still carrying the green halo.
