### PR TITLE
Button and card-meta chrome joins the label-tier floor; 19 inline restatements deleted (#1783)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -468,6 +468,22 @@ Size and tracking overrides are the same tell. **11 size pins** (`text-[9px]`, `
 
 One site refused the rule and is worth knowing about: the **logged-out vote gate** takes `.label-heading`, not the caption. Its nine faction treatments override size, face, ink and — for two of them — casing, so the only thing the class still contributes is the uppercase the other seven rely on, and `.label-caption` sets `text-transform: none`. **When a class is doing nothing but supply a default its callers depend on, the tier question is which default, not which intent.**
 
+### Button and card-meta chrome is on the same floor, and a RESTATEMENT is why it could not move one site at a time (#1783)
+
+`.btn-primary`, `.btn-outline` and `.card-meta` sat below the tier the two role classes had already been walked up to — buttons at `--text-sm` (9px), card meta at `--text-xs` (8px), the ramp's bottom two rungs. All three are uppercase and letter-spaced, which is the **heading** register, so `--text-md` is the step they join. Not `--text-lg`: the caption is nominally the larger of the two only because it drops the casing, and pulling caps up to match the number un-matches the voices.
+
+**Owner ruling: a button label is text a player must read TO ACT, which is a stronger case than a caption's, not a weaker one.** #769 had ruled the duel seal's buttons stay at 9px "as button chrome"; that settled a decorative seal, not the primary action chrome of the whole site, and it did not carry.
+
+**The reason this had to move at the class and could not be swept is a shape worth recognising anywhere.** Twenty-five sites named the two smallest steps in an inline `style`, and **19 of them were RESTATEMENTS rather than overrides** — a component typing the button's own font size next to `className="btn-primary"`, the same number by intent. A restatement reads as redundant and is the opposite of redundant: an inline style wins, so every one of the 19 would have pinned its own button at 9px on the day the class moved, and *nothing warns you* — no test fails, no lint fires, the class is correct and the page is wrong. Raising one of them individually is the mirror failure: it desynchronises that button from every other button on the site. **So the only two coherent moves are "move the class and delete every restatement" and "do nothing", and raising the inline sites while leaving the class is worse than either.** They are deleted, not edited; a swap leaves the fork in place for the next move to find.
+
+Three things the census turned up that a `className` grep would not have.
+
+**Count with a tool, and count the twins.** The issue said 20 and the tool said 19; #1608's own headline of "461 sites" was really 241 classes plus ~121 inline twins. The instrument is `__tests__/labelTierSweep.test.ts`, which greps the **size token** rather than a class name, because the population that hides is a `CSSProperties` object laundered through a data structure. Its allow-list is the point of the file rather than an exemption from it: each surviving hit carries a written reason, and it went from 25 to 6.
+
+**A Tailwind utility is a third twin, and it beats the class.** Eighteen `.btn-*` sites across admin carry `text-xs` (12px), which wins over the component layer — those are *overrides*, an admin density decision, and they stay. But one of them **also** carried the inline 9px, so a dormant 12px override sat under a live 9px one and the button rendered 3px below its own siblings. Deleting the inline value there activates the utility rather than landing on the class, which is the opposite of a no-op. **Before deleting a restatement, read every layer under it.**
+
+**A hand-rolled twin resolves itself once the pair moves together.** The praxis detail's withdraw-confirm was left behind by the earlier sweep for a sharper reason than the rest: it stands *beside* a `.btn-outline` cancel, and raising one of a visible pair is worse than raising neither. The fix is not to give it a number — it is to make it wear the class it was imitating, keeping only its fill, rule, ink, pad and square corner inline. The same reasoning retired eight hand-rolled copies of the feed's action label into `.feed-action`, which is deliberately **not** `.btn-*` (weight 700, 0.1em tracking, a denser pad and a `--badge-*` fill are dress a design owns) but now reads the same `--text-md`. **Two families stepping off one token is the goal; flattening them into one class would have been a restyle nobody asked for.**
+
 ---
 
 ## 4a. Spacing

--- a/frontend/src/__tests__/labelTierSweep.test.ts
+++ b/frontend/src/__tests__/labelTierSweep.test.ts
@@ -119,6 +119,49 @@ describe('the label tier is two classes, and `.eyebrow` is not one of them (#130
 })
 
 /**
+ * #1783 — button and card-meta chrome joins the label-tier floor.
+ *
+ * THE SEAM IS `index.css`, because that is where the size actually lives. Every
+ * `.btn-primary` / `.btn-outline` / `.card-meta` on the site takes its size from
+ * one of three declarations, so a per-site test would assert 22 files' worth of
+ * the same fact and still not catch the one edit that matters. This reads the
+ * declaration.
+ *
+ * The three sat at the tier's two SMALLEST steps — buttons at `--text-sm` (9px),
+ * card meta at `--text-xs` (8px) — while #1307 had already moved the tier's two
+ * role classes up: `.label-heading` to `--text-md` (11px), `.label-caption` to
+ * `--text-lg` (12px). All three of these rules are uppercase and letter-spaced,
+ * which is the HEADING register, so `--text-md` is the step they join. Not
+ * `--text-lg`: the caption is nominally larger only because it drops the casing,
+ * and the reasoning is written out at `.label-caption`'s declaration.
+ *
+ * The guard below (#1608) is the other half and it is what makes this stick. It
+ * counts the two smallest steps in the SOURCE TREE, and 19 of the sites it was
+ * allow-listing were components restating one of these three class values
+ * inline. Moving the class without deleting those restatements would have moved
+ * nothing on screen — an inline style wins — so the two assertions are one
+ * change: the declaration goes up here, the restatements come out of the
+ * allow-list there.
+ */
+const LABEL_TIER_FLOOR = 'var(--text-md)'
+const CHROME_RULES = ['.btn-primary', '.btn-outline', '.card-meta'] as const
+
+/** The `font-size` a single-level rule declares, or undefined if it declares none. */
+function declaredFontSize(css: string, selector: string): string | undefined {
+  const rule = new RegExp(`^\\s*${selector.replace('.', '\\.')}\\s*\\{([^}]*)\\}`, 'm').exec(css)
+  return /font-size:\s*([^;]+);/.exec(rule?.[1] ?? '')?.[1]
+}
+
+describe('button and card-meta chrome sits on the label-tier floor (#1783)', () => {
+  it('declares all three at the floor, in one place, so none of them can fork', () => {
+    const css = readFileSync(CSS, 'utf8')
+    expect(CHROME_RULES.map((selector) => [selector, declaredFontSize(css, selector)])).toEqual(
+      CHROME_RULES.map((selector) => [selector, LABEL_TIER_FLOOR]),
+    )
+  })
+})
+
+/**
  * #1608 — the half of the tier the census above CANNOT see.
  *
  * The guard at the top counts `className` values, and that is the right

--- a/frontend/src/__tests__/labelTierSweep.test.ts
+++ b/frontend/src/__tests__/labelTierSweep.test.ts
@@ -188,28 +188,24 @@ const SMALLEST_STEPS = /var\(--text-(?:sm|xs)\)/g
 /** file → how many hits are there on purpose, and why. */
 const ALLOWED: Record<string, { readonly hits: number; readonly why: string }> = {
   'pages/praxisDetail/shared.tsx': {
-    hits: 16,
+    hits: 2,
     why:
-      'Moderation and flag controls carrying `.btn-primary`/`.btn-outline`, whose ' +
-      'own size IS this token — the inline value restates the class rather than ' +
-      'laundering one. Two more are the notice body under a --text-base title, ' +
-      'which raising alone would invert. Both belong to a button/content pass.',
+      'The report card\'s notice body, twice, under a --text-base title — raising ' +
+      'it alone would invert the pair. Content tier, not the label tier, so it is ' +
+      'not what #1783 moved. The fourteen button restatements above it are gone.',
   },
   'components/duel/shared.tsx': {
-    hits: 3,
+    hits: 1,
     why:
-      'Two `.btn-*` restatements on the seal actions, which #769 settled as ' +
-      'button chrome, plus one mention in the prose that records that decision.',
+      'Prose only. It records what #769 FIXED — rail wrappers that used to force ' +
+      'this size onto the slots inheriting from them. The two seal-button ' +
+      'restatements it also used to describe went with #1783.',
   },
   'components/collab/CollabSuccess.tsx': {
-    hits: 2,
+    hits: 1,
     why:
-      'One `.btn-primary` restatement, and one paragraph of body copy — content, ' +
-      'not a label, so the label tier is not where its size comes from.',
-  },
-  'pages/admin/AccountsTab.tsx': {
-    hits: 2,
-    why: 'Both `.btn-outline` restatements on the ban/unban control.',
+      'One paragraph of body copy — content, not a label, so the label tier is ' +
+      'not where its size comes from. Its `.btn-primary` restatement is gone.',
   },
   'components/praxisCard/desktop/EphemeristsPraxisCard.tsx': {
     hits: 1,

--- a/frontend/src/components/collab/CollabSuccess.tsx
+++ b/frontend/src/components/collab/CollabSuccess.tsx
@@ -137,7 +137,6 @@ export function CollabSuccess({
           autoFocus
           onClick={onContinue}
           className="btn-primary px-4 py-2"
-          style={{ fontSize: 'var(--text-sm)' }}
         >
           {collabCopy(factionSlug, 'successContinue')}
         </button>

--- a/frontend/src/components/duel/shared.tsx
+++ b/frontend/src/components/duel/shared.tsx
@@ -47,7 +47,17 @@
  * the 18px content floor. `DuelSlotTheme` deliberately carries no size field: a
  * skin owns font, colour and ornament, never type size (WORLD_ZERO_STYLE §4a).
  * Genuine Label-tier bits keep their own token explicitly — the tile captions
- * stay on the caption tier, the seal buttons on `--text-sm` as button chrome.
+ * stay on the caption tier.
+ *
+ * THE SEAL BUTTONS NO LONGER NAME A SIZE AT ALL (#1783). #769 ruled they stay
+ * at the tier's second-smallest step "as button chrome", and they carried that
+ * as an inline value beside `.btn-primary` / `.btn-outline` — the same number
+ * the class already declared. #1783 moved button chrome site-wide onto the
+ * label-tier floor and weighed that precedent: it settled a decorative seal, not
+ * the primary action chrome of the whole site, so it did not carry. Both buttons
+ * take the class's size now, which is the only way they stay level with every
+ * other confirm on the site. Do not reintroduce the inline value; an inline
+ * style wins, so it would pin these two and nothing would warn you.
  */
 import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -500,7 +510,7 @@ export function SealActions({
         type="button"
         onClick={onCancel}
         className="btn-outline px-4 py-2"
-        style={{ fontSize: 'var(--text-sm)', fontFamily: theme.bodyFont ?? DEFAULT_THEME.bodyFont }}
+        style={{ fontFamily: theme.bodyFont ?? DEFAULT_THEME.bodyFont }}
       >
         {cancelLabel ?? t('duelSeal.cancel')}
       </button>
@@ -511,7 +521,6 @@ export function SealActions({
         onClick={onConfirm}
         className="btn-primary px-4 py-2"
         style={{
-          fontSize: 'var(--text-sm)',
           fontFamily: theme.bodyFont ?? DEFAULT_THEME.bodyFont,
           opacity: busy ? 0.5 : 1,
           ...(danger

--- a/frontend/src/components/feed/FeedBankFullModal.tsx
+++ b/frontend/src/components/feed/FeedBankFullModal.tsx
@@ -180,14 +180,15 @@ export default function FeedBankFullModal({
             {error}
           </p>
         )}
+        {/* Face is `.feed-action` (#1783). This copy was the odd one of the
+            eight — it had dropped the 0.1em tracking the other seven carry —
+            so it picks that up here, which is the drift a de-duplication is
+            for. */}
         <button
           onClick={onDismiss}
+          className="feed-action"
           style={{
             marginTop: 'var(--space-lg)',
-            fontFamily: "'Courier Prime', monospace",
-            fontSize: 'var(--text-md)',
-            fontWeight: 700,
-            textTransform: 'uppercase',
             background: 'transparent',
             border: '1px solid var(--color-border)',
             padding: 'var(--space-xs) var(--space-lg)',

--- a/frontend/src/components/feed/FeedCardCollabInvite.tsx
+++ b/frontend/src/components/feed/FeedCardCollabInvite.tsx
@@ -225,15 +225,15 @@ export default function FeedCardCollabInvite({ item }: Props) {
               flexWrap: "wrap",
             }}
           >
+            {/* Face is `.feed-action` (#1783) — the same five declarations
+                stood here, in FeedCardDuelChallenge, in FeedBankFullModal and
+                in FeedCardInvitationLetter, eight copies of one label. Only the
+                fill, the rule and the cursor are this button's own. */}
             <button
               onClick={handleAccept}
               disabled={loading}
+              className="feed-action"
               style={{
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-md)",
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.1em",
                 background: "var(--badge-collab)",
                 color: "var(--color-text-on-accent)",
                 border: "none",
@@ -246,12 +246,8 @@ export default function FeedCardCollabInvite({ item }: Props) {
             <button
               onClick={handleDecline}
               disabled={loading}
+              className="feed-action"
               style={{
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-md)",
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.1em",
                 background: "transparent",
                 color: "var(--color-text-secondary)",
                 border: "1px solid var(--color-border)",

--- a/frontend/src/components/feed/FeedCardDuelChallenge.tsx
+++ b/frontend/src/components/feed/FeedCardDuelChallenge.tsx
@@ -255,15 +255,12 @@ export default function FeedCardDuelChallenge({ item }: Props) {
               flexWrap: "wrap",
             }}
           >
+            {/* Face is `.feed-action` (#1783); see FeedCardCollabInvite. */}
             <button
               onClick={handleAccept}
               disabled={loading || busy || withdrawing}
+              className="feed-action"
               style={{
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-md)",
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.1em",
                 background: "var(--badge-duel)",
                 color: "var(--color-text-on-accent)",
                 border: "none",
@@ -276,12 +273,8 @@ export default function FeedCardDuelChallenge({ item }: Props) {
             <button
               onClick={handleDecline}
               disabled={loading || busy || withdrawing}
+              className="feed-action"
               style={{
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-md)",
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.1em",
                 background: "transparent",
                 color: "var(--color-text-secondary)",
                 border: "1px solid var(--color-border)",
@@ -296,12 +289,8 @@ export default function FeedCardDuelChallenge({ item }: Props) {
             <button
               onClick={handleWithdraw}
               disabled={loading || busy || withdrawing}
+              className="feed-action"
               style={{
-                fontFamily: "'Courier Prime', monospace",
-                fontSize: "var(--text-md)",
-                fontWeight: 700,
-                textTransform: "uppercase",
-                letterSpacing: "0.1em",
                 background: "transparent",
                 color: "var(--color-text-tertiary)",
                 border: "1px solid var(--color-border)",

--- a/frontend/src/components/feed/FeedCardInvitationLetter.tsx
+++ b/frontend/src/components/feed/FeedCardInvitationLetter.tsx
@@ -62,12 +62,16 @@ export function acceptMode(
   return "confirm-first";
 }
 
+/**
+ * The BOX a feed control wears. Its FACE — font, size, weight, casing,
+ * tracking — is `.feed-action`, so every element styled from here also carries
+ * that class (#1783). Those five declarations used to sit at the top of this
+ * object and again on the "view factions" link below, and again twice over in
+ * FeedCardCollabInvite, three times in FeedCardDuelChallenge and once in
+ * FeedBankFullModal: eight copies of one label, which is how the feed's
+ * controls and `.btn-*` came to sit on two different rungs of the same ramp.
+ */
 const CONTROL: CSSProperties = {
-  fontFamily: "'Courier Prime', monospace",
-  fontSize: "var(--text-md)",
-  fontWeight: 700,
-  textTransform: "uppercase",
-  letterSpacing: "0.1em",
   padding: "var(--space-xs) var(--space-lg)",
   border: "none",
   cursor: "pointer",
@@ -153,12 +157,8 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
   const viewFactions = (
     <Link
       to="/factions"
+      className="feed-action"
       style={{
-        fontFamily: "'Courier Prime', monospace",
-        fontSize: "var(--text-md)",
-        fontWeight: 700,
-        textTransform: "uppercase",
-        letterSpacing: "0.1em",
         color,
         textDecoration: "none",
       }}
@@ -245,11 +245,12 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
               flexWrap: "wrap",
             }}
           >
-            <button type="button" onClick={() => void join()} disabled={joining} style={acceptStyle}>
+            <button type="button" className="feed-action" onClick={() => void join()} disabled={joining} style={acceptStyle}>
               {i18n.t("feed:invitationLetter.confirm.confirm")}
             </button>
             <button
               type="button"
+              className="feed-action"
               onClick={() => setConfirming(false)}
               disabled={joining}
               style={QUIET}
@@ -280,6 +281,7 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
               {mode !== "suppressed" && (
                 <button
                   type="button"
+                  className="feed-action"
                   data-invitation-accept={mode}
                   onClick={() => {
                     if (mode === "confirm-first") setConfirming(true);
@@ -292,7 +294,7 @@ export default function FeedCardInvitationLetter({ item, onNotNow }: Props) {
                 </button>
               )}
               {onNotNow && (
-                <button type="button" data-invitation-not-now onClick={onNotNow} style={QUIET}>
+                <button type="button" className="feed-action" data-invitation-not-now onClick={onNotNow} style={QUIET}>
                   {i18n.t("feed:invitationLetter.notNow")}
                 </button>
               )}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3236,8 +3236,11 @@
 
   /* ── Task card shared patterns ── */
 
+  /* --text-md, not --text-xs (#1783). See the note above .btn-primary: this is
+     the same uppercase, letter-spaced heading register at the same step, and it
+     was the one rule still sitting on the ramp's very bottom rung. */
   .card-meta {
-    font-size: var(--text-xs);
+    font-size: var(--text-md);
     text-transform: uppercase;
     letter-spacing: 0.1em;
     margin-bottom: 6px;
@@ -3254,13 +3257,41 @@
     -webkit-box-orient: vertical;
   }
 
-  /* ── Buttons ── */
+  /* ── Buttons ──
+     BUTTON CHROME IS ON THE LABEL-TIER FLOOR, --text-md (#1783). It used to be
+     --text-sm (9px), with .card-meta a rung below it at --text-xs (8px), while
+     #1307 had already walked the tier's two role classes up — .label-heading to
+     --text-md, .label-caption to --text-lg. All three of these rules are
+     uppercase and letter-spaced, i.e. the HEADING register, so --text-md is the
+     step they join. NOT --text-lg: the caption is nominally the larger of the
+     two only because it drops the casing, and pulling caps up to 12px to match
+     the number un-matches the voices (the argument is written out in full at
+     .label-caption).
+
+     WHY THE WHOLE SITE'S BUTTONS MOVED AT ONCE, AND WHY THEY HAD TO. A button
+     label carries the four stacked legibility costs the tier split exists to
+     remove, and unlike a caption it is text a player must read TO ACT. #769
+     ruled the duel seal's buttons stay --text-sm "as button chrome"; that was a
+     decorative seal rather than the primary action chrome of the site, and
+     #1783 weighed it and did not carry it. The seal buttons ride this rule now
+     like everything else.
+
+     THE HAZARD THIS RULE HAS ALREADY SURVIVED ONCE, so do not re-open it: 19
+     components had this number typed into an inline `style` beside the class —
+     a RESTATEMENT, not an override, identical by intent and load-bearing by
+     accident. An inline style wins, so every one of them would have pinned its
+     button at 9px while the rest of the site moved, and nothing would have
+     warned you. They were deleted, not edited. `__tests__/labelTierSweep.test.ts`
+     reads this declaration and counts the two smallest steps in the source tree
+     so the pair can never drift apart again. If you are about to write
+     `fontSize: 'var(--text-*)'` next to `className="btn-…"`, the answer is that
+     the class already says it. */
 
   .btn-primary {
     @apply font-body;
     background: var(--color-text-primary);
     color: var(--color-bg-page);
-    font-size: var(--text-sm);
+    font-size: var(--text-md);
     text-transform: uppercase;
     letter-spacing: 0.12em;
     padding: 0.5rem 1rem;
@@ -3276,7 +3307,7 @@
     background: var(--color-bg-surface);
     color: var(--color-text-primary);
     border: 1px solid var(--color-border-strong);
-    font-size: var(--text-sm);
+    font-size: var(--text-md);
     text-transform: uppercase;
     letter-spacing: 0.12em;
     padding: 0.5rem 1rem;
@@ -3285,6 +3316,28 @@
   }
   .btn-outline:hover {
     opacity: 0.85;
+  }
+
+  /* ── Feed action controls ──
+     The feed's accept / decline / withdraw / dismiss controls, and the one
+     plain link that sits among them. NOT .btn-* on purpose: they carry
+     font-weight 700, 0.1em tracking and a denser pad, and they take their fill
+     from a --badge-* rather than the neutral. That is dress a design owns, so
+     #1783 did not flatten them into the button classes — it deleted the eight
+     hand-rolled copies of this face across FeedCardCollabInvite,
+     FeedCardDuelChallenge, FeedBankFullModal and FeedCardInvitationLetter and
+     left the copies' per-instance colour, padding and cursor inline, where they
+     belong. Reading --text-md here is the point: the two families now step
+     together off one token instead of two ramps drifting apart.
+
+     Size, face and casing only. It sets no colour and no box, so a caller keeps
+     dressing itself and an inline style still wins for everything it does set. */
+  .feed-action {
+    @apply font-body;
+    font-size: var(--text-md);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
   }
 
   /* ── Filter chips ── */

--- a/frontend/src/pages/admin/AccountsTab.tsx
+++ b/frontend/src/pages/admin/AccountsTab.tsx
@@ -232,22 +232,28 @@ export default function AccountsTab() {
                                 character.status !== "banned",
                               )
                             }
+                            // The inline `--text-sm` is gone (#1783): it
+                            // restated `.btn-outline`'s own value, and this
+                            // control was the ONE admin button carrying it, so
+                            // it rendered 3px under the seventeen `text-xs`
+                            // siblings around it — including its own account-
+                            // level twin, the suspend button above. `text-xs`
+                            // stays: that is admin's live density decision and
+                            // it beats the component layer, which is why this
+                            // one had to be deleted rather than edited.
                             className="btn-outline text-xs"
-                            style={
-                              character.status === "banned"
+                            style={{
+                              padding: "var(--space-xs) var(--space-sm)",
+                              ...(character.status === "banned"
                                 ? {
                                     borderColor: "var(--color-success)",
                                     color: "var(--color-success)",
-                                    fontSize: "var(--text-sm)",
-                                    padding: "var(--space-xs) var(--space-sm)",
                                   }
                                 : {
                                     borderColor: "var(--color-danger-ring)",
                                     color: "var(--color-danger)",
-                                    fontSize: "var(--text-sm)",
-                                    padding: "var(--space-xs) var(--space-sm)",
-                                  }
-                            }
+                                  }),
+                            }}
                           >
                             {character.status === "banned"
                               ? t("accounts.unban")

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -236,6 +236,34 @@ export function MemberByline({
   )
 }
 
+// ── Compact `.btn-*` overrides (#1783) ───────────────────────────────────────
+/**
+ * What the moderation and flag controls are still allowed to say inline.
+ *
+ * These sat as sixteen near-identical `style` objects, and thirteen of them
+ * opened by restating the button's own `fontSize` — the number the class
+ * already declares, typed out again beside it. That restatement is what #1783
+ * removed: it looks redundant and is the opposite, because an inline style wins,
+ * so each of the thirteen would have pinned its button at 9px on the day the
+ * class moved to the label-tier floor. The class owns size, face, casing and
+ * tracking; nothing here may name any of the four again.
+ *
+ * The pad IS a real override — a denser row than `.btn-*`'s default 8px/16px —
+ * and the two ring/ink pairs are the danger and warning outline variants. Three
+ * objects, declared once, rather than twelve copies that can drift one at a time.
+ */
+const BTN_COMPACT: CSSProperties = { padding: 'var(--space-xs) var(--space-md)' }
+const BTN_COMPACT_DANGER: CSSProperties = {
+  ...BTN_COMPACT,
+  borderColor: 'var(--color-danger-ring)',
+  color: 'var(--color-danger)',
+}
+const BTN_COMPACT_WARNING: CSSProperties = {
+  ...BTN_COMPACT,
+  borderColor: 'var(--color-warning-ring)',
+  color: 'var(--color-warning)',
+}
+
 // ── Admin moderation bar ─────────────────────────────────────────────────────
 
 export function PraxisAdminBar({ state }: { state: PraxisDetailState }) {
@@ -265,21 +293,21 @@ export function PraxisAdminBar({ state }: { state: PraxisDetailState }) {
         <div className="flex items-center gap-2 ml-auto">
           {praxis.moderation_status === 'flagged' && (
             <>
-              <button onClick={() => void handleModerate('visible')} disabled={moderating} className="btn-primary" style={{ padding: 'var(--space-xs) var(--space-md)', fontSize: 'var(--text-sm)' }}>{t('detail.admin.approve')}</button>
-              <button onClick={() => void handleModerate('hidden')} disabled={moderating} className="btn-outline" style={{ padding: 'var(--space-xs) var(--space-md)', fontSize: 'var(--text-sm)', borderColor: 'var(--color-danger-ring)', color: 'var(--color-danger)' }}>{t('detail.admin.hide')}</button>
-              <button onClick={() => setShowFailInput(!showFailInput)} disabled={moderating} className="btn-outline" style={{ padding: 'var(--space-xs) var(--space-md)', fontSize: 'var(--text-sm)', borderColor: 'var(--color-warning-ring)', color: 'var(--color-warning)' }}>{t('detail.admin.fail')}</button>
+              <button onClick={() => void handleModerate('visible')} disabled={moderating} className="btn-primary" style={BTN_COMPACT}>{t('detail.admin.approve')}</button>
+              <button onClick={() => void handleModerate('hidden')} disabled={moderating} className="btn-outline" style={BTN_COMPACT_DANGER}>{t('detail.admin.hide')}</button>
+              <button onClick={() => setShowFailInput(!showFailInput)} disabled={moderating} className="btn-outline" style={BTN_COMPACT_WARNING}>{t('detail.admin.fail')}</button>
             </>
           )}
           {praxis.moderation_status === 'visible' && (
             <>
-              <button onClick={() => void handleModerate('hidden')} disabled={moderating} className="btn-outline" style={{ padding: 'var(--space-xs) var(--space-md)', fontSize: 'var(--text-sm)', borderColor: 'var(--color-danger-ring)', color: 'var(--color-danger)' }}>{t('detail.admin.hide')}</button>
-              <button onClick={() => setShowFailInput(!showFailInput)} disabled={moderating} className="btn-outline" style={{ padding: 'var(--space-xs) var(--space-md)', fontSize: 'var(--text-sm)', borderColor: 'var(--color-warning-ring)', color: 'var(--color-warning)' }}>{t('detail.admin.fail')}</button>
+              <button onClick={() => void handleModerate('hidden')} disabled={moderating} className="btn-outline" style={BTN_COMPACT_DANGER}>{t('detail.admin.hide')}</button>
+              <button onClick={() => setShowFailInput(!showFailInput)} disabled={moderating} className="btn-outline" style={BTN_COMPACT_WARNING}>{t('detail.admin.fail')}</button>
             </>
           )}
           {(praxis.moderation_status === 'hidden' || praxis.moderation_status === 'failed') && (
             <>
-              <button onClick={() => void handleModerate('visible')} disabled={moderating} className="btn-primary" style={{ padding: 'var(--space-xs) var(--space-md)', fontSize: 'var(--text-sm)' }}>{t('detail.admin.restore')}</button>
-              <button onClick={() => setShowFailInput(!showFailInput)} disabled={moderating} className="btn-outline" style={{ padding: 'var(--space-xs) var(--space-md)', fontSize: 'var(--text-sm)', borderColor: 'var(--color-warning-ring)', color: 'var(--color-warning)' }}>{t('detail.admin.fail')}</button>
+              <button onClick={() => void handleModerate('visible')} disabled={moderating} className="btn-primary" style={BTN_COMPACT}>{t('detail.admin.restore')}</button>
+              <button onClick={() => setShowFailInput(!showFailInput)} disabled={moderating} className="btn-outline" style={BTN_COMPACT_WARNING}>{t('detail.admin.fail')}</button>
             </>
           )}
         </div>
@@ -297,7 +325,7 @@ export function PraxisAdminBar({ state }: { state: PraxisDetailState }) {
             onClick={() => void handleModerate('failed', adminFailNote)}
             disabled={moderating}
             className="btn-primary"
-            style={{ background: 'var(--color-warning)', borderColor: 'var(--color-warning)', fontSize: 'var(--text-sm)' }}
+            style={{ background: 'var(--color-warning)', borderColor: 'var(--color-warning)' }}
           >
             {t('detail.admin.confirm')}
           </button>
@@ -635,11 +663,20 @@ export function PraxisSubmitControls({ state }: { state: PraxisDetailState }) {
         // The LABEL takes the wall's alarm ink (#1451); the fill and the rule
         // stay the neutral rungs. `--color-danger` as a 1.5px rule owes 3:1
         // (WCAG 1.4.11) and clears it on all nine walls — 3.31:1 worst.
-        style={{ background: 'var(--color-danger-veil)', border: '1.5px solid var(--color-danger)', color: wallInk(praxis, 'alarm'), fontFamily: "'Courier Prime', monospace", fontSize: 'var(--text-sm)', textTransform: 'uppercase', padding: 'var(--space-xs) var(--space-md)', cursor: 'pointer', borderRadius: 0 }}
+        //
+        // `.btn-outline` DRESSED BY HAND, not hand-rolled from nothing (#1783).
+        // This was a free-standing style object repeating the class's face —
+        // font, size, casing, cursor — beside a cancel that wears the class, and
+        // #1608 left it exactly because raising one of a visible pair is worse
+        // than raising neither. Wearing the class is what makes the pair move
+        // together and keep moving together; the fill, the rule, the ink, the
+        // denser pad and the square corner are the dress, and they stay here.
+        className="btn-outline"
+        style={{ background: 'var(--color-danger-veil)', border: '1.5px solid var(--color-danger)', color: wallInk(praxis, 'alarm'), ...BTN_COMPACT, borderRadius: 0 }}
       >
         {withdrawing ? t('detail.owner.submitting') : t(unsubmitCopy.confirm)}
       </button>
-      <button onClick={() => setShowWithdrawConfirm(false)} className="btn-outline" style={{ fontSize: 'var(--text-sm)', padding: 'var(--space-xs) var(--space-md)' }}>{t('detail.owner.cancel')}</button>
+      <button onClick={() => setShowWithdrawConfirm(false)} className="btn-outline" style={BTN_COMPACT}>{t('detail.owner.cancel')}</button>
     </div>
   )
 }
@@ -710,7 +747,7 @@ export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
           <p className="font-body" style={{ fontSize: 'var(--text-xs)', color: 'var(--color-text-tertiary)' }}>{t('detail.flag.body')}</p>
         </div>
         {!showFlagForm && (
-          <button onClick={() => { setShowFlagForm(true); setFlagError(null) }} className="btn-outline" style={{ fontSize: 'var(--text-sm)', padding: 'var(--space-xs) var(--space-md)', borderColor: 'var(--color-danger-ring)', color: 'var(--color-danger)' }}>
+          <button onClick={() => { setShowFlagForm(true); setFlagError(null) }} className="btn-outline" style={BTN_COMPACT_DANGER}>
             {t('detail.flag.flag')}
           </button>
         )}
@@ -728,8 +765,7 @@ export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
                 disabled={flagging}
                 className="btn-outline"
                 style={{
-                  fontSize: 'var(--text-sm)',
-                  padding: 'var(--space-xs) var(--space-md)',
+                  ...BTN_COMPACT,
                   ...(flagReason === value
                     ? { background: 'var(--color-danger)', borderColor: 'var(--color-danger)', color: 'var(--color-on-danger)' }
                     : {}),
@@ -758,11 +794,11 @@ export function PraxisFlagBlock({ state }: { state: PraxisDetailState }) {
           )}
           <div className="flex items-center gap-2" style={{ marginTop: 'var(--space-sm)' }}>
             {flagReason !== null && (
-              <button onClick={() => void handleFlag()} disabled={flagging} className="btn-primary" style={{ fontSize: 'var(--text-sm)', padding: 'var(--space-xs) var(--space-md)', background: 'var(--color-danger)', borderColor: 'var(--color-danger)', color: 'var(--color-on-danger)' }}>
+              <button onClick={() => void handleFlag()} disabled={flagging} className="btn-primary" style={{ ...BTN_COMPACT, background: 'var(--color-danger)', borderColor: 'var(--color-danger)', color: 'var(--color-on-danger)' }}>
                 {flagging ? t('detail.flag.submitting') : t('detail.flag.submit')}
               </button>
             )}
-            <button onClick={() => { setShowFlagForm(false); setFlagReason(null); setFlagDetail(''); setFlagError(null) }} disabled={flagging} className="btn-outline" style={{ fontSize: 'var(--text-sm)', padding: 'var(--space-xs) var(--space-md)' }}>
+            <button onClick={() => { setShowFlagForm(false); setFlagReason(null); setFlagDetail(''); setFlagError(null) }} disabled={flagging} className="btn-outline" style={BTN_COMPACT}>
               {t('detail.flag.cancel')}
             </button>
           </div>


### PR DESCRIPTION
**Owner ruling built** (comment 1 on the issue): button and card-meta chrome joins the label-tier floor, and the de-duplication underneath is in scope.

Closes #1783

## The seam I tested at

`frontend/src/index.css` — the **declaration**, not any rendered markup. Every `.btn-primary` / `.btn-outline` / `.card-meta` on the site takes its size from one of three rules, so a per-surface render test would assert 22 files' worth of the same fact and still miss the one edit that matters. The new block in `frontend/src/__tests__/labelTierSweep.test.ts` parses the three rules out of `index.css` and asserts all three read `var(--text-md)`. It went red on exactly the real defect first (`--text-sm` / `--text-sm` / `--text-xs`), then green.

The existing #1608 guard in the same file is the other half, and the two are one change: the declaration goes up, the inline restatements come out of the allow-list. Moving the class alone would have moved **nothing on screen**, because an inline style wins.

## Confirmed against `index.css` myself (the ramp does not mean what the names suggest)

| Token | Value |
| --- | --- |
| `--text-xs` | **8px** |
| `--text-sm` | **9px** |
| `--text-md` | **11px** (`.label-heading`, #1307) |
| `--text-lg` | **12px** (`.label-caption`, #1307) |

`.btn-primary` / `.btn-outline` were `--text-sm` (9px); `.card-meta` was `--text-xs` (8px). All three now read `--text-md` (11px).

**Why 11 and not 12.** All three are uppercase and letter-spaced — the *heading* register. The caption is nominally the larger of the pair only because it drops the casing, and `index.css` states outright that matching the numbers un-matches the voices.

## RE-CENSUS — the tool's number, and where it disagrees with the issue

Counted with `grep -ro 'var(--text-sm)\|var(--text-xs)' src` (occurrences, not lines), excluding the guard file itself.

| | Issue said | Tool said |
| --- | --- | --- |
| Total allow-listed hits | 25 | **25** OK |
| Inline restatements to delete | 20 | **19** |
| Inline button objects in `praxisDetail/shared.tsx` | 16 | **16** OK (13 class restatements + 1 hand-rolled twin + 2 notice bodies) |
| Hand-rolled button-label copies across the 4 feed files | 6 | **8** |

- **19, not 20.** The 6 that stay all have written reasons and are not restatements: 1 prose comment (`duel/shared.tsx`), 1 ornament rhythm (`EphemeristsPraxisCard`), 1 negative assertion (`cardChrome.test.tsx`), 1 paragraph of body copy (`CollabSuccess`), and **2** notice bodies in `praxisDetail/shared.tsx` (the issue's arithmetic appears to have counted those two as one). Those two are content tier under a `--text-base` title — raising them alone would invert the pair — so they stay allow-listed for a content pass.
- **8, not 6.** `FeedCardCollabInvite` x2, `FeedCardDuelChallenge` x3, `FeedBankFullModal` x1, `FeedCardInvitationLetter` x2 (its `CONTROL` object *and* the "view factions" link, which a census by `className` would never see).

**Allow-list: 25 hits → 6.** No entry was laundered to zero; `pages/admin/AccountsTab.tsx` is the only file that leaves the list, because it had nothing but restatements.

## A twin the issue did not name, and it is not a no-op

A `className` census misses inline twins — and inline twins miss **Tailwind** twins. **18 `.btn-*` sites carry `text-xs` (12px)**, which sits in the utilities layer and *beats* the component layer: `pages/admin/{ModerationTab,TasksTab,TaskImportPanel,AccountsTab}.tsx` and `pages/Donate.tsx` (`text-base`). Those are **overrides**, not restatements — a deliberate admin density decision — and I left every one of them. Out of scope, flagged for a follow-up ruling: after this PR every admin button sits 1px above the class rather than 3px above it.

But **one** of them also carried the inline 9px (`AccountsTab.tsx`, the ban/unban control), so a dormant 12px override sat underneath a live 9px one and that button rendered 3px below its own account-level twin. Deleting the restatement there *activates* the utility rather than landing on the class. I kept `text-xs` deliberately so it joins its 17 siblings instead of becoming a new outlier, and said so in a comment at the site.

## De-duplication (ruling item 3) — one shared style, not 22 copies

- **`pages/praxisDetail/shared.tsx`: 16 objects → 3 consts.** `BTN_COMPACT` (the genuine pad override, 4/12 against the class's 8/16) plus `BTN_COMPACT_DANGER` / `BTN_COMPACT_WARNING` for the two ring/ink pairs.
- **The hand-rolled withdraw-confirm resolves itself, as the ruling predicted.** It now wears `className="btn-outline"` and keeps only its fill, 1.5px danger rule, wall alarm ink, compact pad and square corner inline — so the pair it stands beside moves together and *keeps* moving together, which is why #1608 deferred it.
- **New `.feed-action` in `index.css`** absorbs the 8 hand-rolled feed label copies. Deliberately **not** `.btn-*`: weight 700, 0.1em tracking, a denser pad and a `--badge-*` fill are dress a design owns, and flattening them into the button classes would be a restyle nobody asked for. It reads the same `--text-md`, so the two families now step off one token.

## Concurrency

Rebased onto `origin/main` at `a151886d` immediately before pushing; nothing had landed since branching, and `.design-sync/` + `.ds-kit/` reference none of these classes. **The census found no restatement in `pages/editPraxis/archetypes/controls.tsx`**, so this PR does not touch the file the concurrent `InviteSearch` shadow-token work is in — no shared-registry collision.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally: `lint` OK - `typecheck` OK - `typecheck:design-sync` OK - `test` OK (254 files, 4572 passed) - `build` OK - `budget` OK (CSS 21.3 KB against a 22.5 KB warn line). No backend or schema surface touched, so `api-schema` is not implicated. I also grepped the **built** stylesheet — all four rules survive the Tailwind purge with `font-size:var(--text-md)`; the source braces prove nothing on their own.

## VISUAL QA IS ENTIRELY OUTSTANDING

**This change is 100% visual and I have no browser.** Tests, tsc and the byte budget prove the tokens resolve and the tree compiles; they prove *nothing at all* about how any of this looks. This moves **every button and every card-meta line on the site at once**.

### What to eyeball

**Highest traffic first:**

1. **NavBar** — the site-wide `.btn-*`, on every page, both themes.
2. **The feed / `/updates`** — the busiest place two differently-dressed controls now sit near each other: `.feed-action` (11px, weight 700, 0.1em) beside any `.btn-*` (11px, normal weight, 0.12em). Same size now, different weight — check that reads as intentional and not as a mismatch.
3. **Faction cards** — the only 3 consumers of `.card-meta`, and the biggest single jump (8px → 11px, +37%). Check nothing wraps or overflows in `FactionCard.tsx`'s three meta slots at narrow widths.
4. **Praxis detail** — the moderation bar and the report card, where the compact pad (4/12) now holds an 11px label in a dense row. The most likely place for a button to grow taller than its row.

**Pairs where two differently-tiered controls now sit side by side:**

5. **Praxis detail → withdraw confirm + cancel** — the whole reason #1608 deferred this. The confirm now inherits `.btn-outline`'s **0.12em tracking** (it had none) and its **hover opacity fade** (it had none). Both move it toward the cancel beside it, but both are new.
6. **Admin `AccountsTab`** — the suspend button (account row, `text-xs` 12px) directly above the ban button (character row, now the class's 11px). 1px apart; previously 3px apart.
7. **Every admin tab** — `ModerationTab` / `TasksTab` buttons stay at 12px via `text-xs` while any un-utilitied `.btn-*` on the same page is 11px.
8. **Duel seal confirm across the 6 faction skins** — these were pinned at 9px by #769 and jump to 11px inside faction-dressed seals with their own frames. Six bespoke frames, one shared button.
9. **`FeedBankFullModal`'s dismiss button** — the one of the 8 feed copies that had *dropped* the 0.1em tracking. It picks it up here, which is the drift a de-duplication is for, but it is a real (small) change.
10. **`CollabSuccess`** and the **collab / duel invite rows** — the accept/decline pairs, in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
