### PR TITLE
Sign-up rings the requests bus, and the active-tasks hook listens (#1867)

### DIFF
--- a/frontend/src/api/praxis.ts
+++ b/frontend/src/api/praxis.ts
@@ -273,6 +273,11 @@ export function takeJustCreatedPraxis(praxisId: number): PraxisOut | null {
 export async function createPraxis(data: PraxisCreate): Promise<PraxisOut> {
   const { data: created } = await apiPost('/praxes', { body: data })
   justCreatedPraxis = created
+  // A signup is a new in-progress praxis in the viewer's own bank — the rail's
+  // "In progress" panel and the `{n} of {max}` slot counter both read that list
+  // (#1867). All four signup entry points funnel through here, so this is the
+  // one place any of them needs it.
+  notifyRequestsChanged()
   return created
 }
 
@@ -468,6 +473,11 @@ export async function kickMember(
   const { data } = await apiPost('/praxes/{praxis_id}/kick/{member_id}', {
     params: { path: { praxis_id: praxisId, member_id: memberId } },
   })
+  // The reset lands on the KICKER too: a group that had been submitted is back
+  // to editing, so this praxis re-enters the viewer's own in-progress list and
+  // their "awaiting your submission" bucket — the same move `unsubmitPraxis`
+  // announces (#1867).
+  notifyRequestsChanged()
   return data
 }
 

--- a/frontend/src/hooks/useMyActiveTasks.ts
+++ b/frontend/src/hooks/useMyActiveTasks.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { listPraxes, type PraxisCardOut } from '../api/praxis'
 import { useAuth } from '../auth/AuthContext'
+import { onRequestsChanged } from '../utils/requestsBus'
 
 /**
  * Hook to fetch the current character's in-progress praxes.
@@ -13,6 +14,12 @@ import { useAuth } from '../auth/AuthContext'
  * a character switch, a sign-out, a praxis submit — so no memo upstream can make
  * that object stable. The character id is the only thing this request is
  * actually keyed on, and it survives all of them.
+ *
+ * ...and again on `requestsBus`, a SECOND trigger rather than a replacement
+ * (#1867). Signing up for a task, dropping one, or accepting a collab invite
+ * all change this list without moving the character id, so the keying above
+ * could never see them. Same subscription shape as `useSidebarPanels`, which
+ * reads the same list off `/me/sidebar`.
  */
 export function useMyActiveTasks() {
   const { user } = useAuth()
@@ -35,6 +42,7 @@ export function useMyActiveTasks() {
 
   useEffect(() => {
     refetch()
+    return onRequestsChanged(refetch)
   }, [refetch])
 
   return { activeTasks, loading, refetch } as const

--- a/frontend/src/utils/__tests__/requestsBusWiring.test.ts
+++ b/frontend/src/utils/__tests__/requestsBusWiring.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #1867 — both ends of `utils/requestsBus`.
+ *
+ * THE SEAM is the bus itself, not a rendered panel. A write fires
+ * `notifyRequestsChanged()`; the surfaces that show the viewer's own in-flight
+ * work subscribe with `onRequestsChanged(refetch)`. A gap at either end is
+ * invisible: a notify nobody hears, or a listener nobody notifies.
+ *
+ * Signing up for a task went through `createPraxis`, which was the one write in
+ * `api/praxis.ts` that never rang the bell, so the sidebar's "In progress"
+ * panel — and the `{n} of {max}` slot counter derived from the same array —
+ * kept the pre-signup list until a hard refresh.
+ *
+ * WHY HALF OF THIS IS A SOURCE TEST
+ * ---------------------------------
+ * Vitest runs in the `node` environment with no jsdom, so the harness is
+ * `renderToStaticMarkup` and effects never run (`docs/spec/SPEC-testing.md`).
+ * The notify half is real behaviour and asserted as such — a stubbed wire, the
+ * real `createPraxis`, a real subscriber. The subscribe half cannot be observed
+ * that way by anything in this repo, so it is pinned at the source, the same
+ * posture as `hooks/__tests__/authDepNarrowing.test.ts`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+/**
+ * The stub goes in via `vi.hoisted`, not `beforeEach`: `openapi-fetch` binds
+ * `globalThis.fetch` when the client is CREATED, at `api/client`'s top level,
+ * which happens during this file's imports. A later stub is never consulted and
+ * the suite silently posts to whatever is listening on localhost:8000 (see
+ * `api/client.test.ts`).
+ */
+vi.hoisted(() => {
+  globalThis.fetch = (async () =>
+    new Response('{"id":7}', {
+      status: 201,
+      headers: { 'content-type': 'application/json' },
+    })) as unknown as typeof globalThis.fetch
+})
+
+import { createPraxis, kickMember, submitPraxis } from '../../api/praxis'
+import { onRequestsChanged } from '../requestsBus'
+
+describe('praxis writes that move the viewer’s own in-flight work ring the bus', () => {
+  let heard = 0
+  let unsubscribe: () => void
+
+  beforeEach(() => {
+    heard = 0
+    unsubscribe = onRequestsChanged(() => {
+      heard += 1
+    })
+  })
+
+  afterEach(() => unsubscribe())
+
+  it('createPraxis — a signup adds an in-progress praxis to the rail (#1867)', async () => {
+    await createPraxis({ task_id: 1, type: 'solo' })
+    expect(heard).toBe(1)
+  })
+
+  it('kickMember — a kick reopens the whole group, the kicker included (ADR-0013)', async () => {
+    await kickMember(7, 9)
+    expect(heard).toBe(1)
+  })
+
+  it('submitPraxis — the sibling that was always wired, as the control', async () => {
+    await submitPraxis(7)
+    expect(heard).toBe(1)
+  })
+
+  it('stops delivering once unsubscribed', async () => {
+    unsubscribe()
+    await createPraxis({ task_id: 1, type: 'solo' })
+    expect(heard).toBe(0)
+    // afterEach unsubscribes again; the Set makes that a no-op.
+  })
+})
+
+describe('useMyActiveTasks listens as well as keys on the character', () => {
+  const source = readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), '../../hooks/useMyActiveTasks.ts'),
+    'utf8',
+  )
+
+  it('subscribes to the bus, in the shape useSidebarPanels already uses', () => {
+    expect(source).toMatch(/return onRequestsChanged\(refetch\)/)
+  })
+
+  it('keeps the #1390 character keying — the bus is a SECOND trigger, not a swap', () => {
+    // `/auth/me` mints a fresh `CurrentUser` on every refetch, so keying the
+    // effect on the auth object would re-request on every unrelated refresh.
+    expect(source).toMatch(/\}, \[characterId\]\)/)
+    expect(source).toMatch(/user\?\.character\?\.id/)
+  })
+})

--- a/frontend/src/utils/requestsBus.ts
+++ b/frontend/src/utils/requestsBus.ts
@@ -14,7 +14,12 @@ const listeners = new Set<Listener>()
 /**
  * Fire after any action that changes the current character's pending requests
  * (accept/decline an invite or challenge, submit/unsubmit, leave/delete a
- * collab or duel praxis). Every subscribed feed surface refetches.
+ * collab or duel praxis) or their bank of in-progress work (sign up for a task,
+ * kick a member and reopen the group). Every subscribed feed surface refetches.
+ *
+ * NOT for a write whose effect lands on someone ELSE — sending or rescinding an
+ * invite, for one. The bus is a module-local Set, so it can only ever reach the
+ * tab that made the call, and the inviter's own panels do not move.
  */
 export function notifyRequestsChanged(): void {
   for (const fn of listeners) fn()


### PR DESCRIPTION
Closes #1867

Signing up for a task left the rail's **In progress** panel — and the `{n} of {max}` slot counter derived from the same array — showing the pre-signup list until a hard refresh.

## The seam I tested at

`frontend/src/utils/requestsBus.ts` — **both ends of the bus**, not a rendered panel. A write fires `notifyRequestsChanged()`; the surfaces showing the viewer's own in-flight work subscribe with `onRequestsChanged(refetch)`. A gap at either end is invisible: a notify nobody hears, or a listener nobody notifies.

New file `frontend/src/utils/__tests__/requestsBusWiring.test.ts`. It went **red on main** on 3 of 6 cases before the fix.

- **Notify half — real behaviour.** A stubbed wire (hoisted, per `api/client.test.ts`), the real `createPraxis`/`kickMember`/`submitPraxis`, a real subscriber counting calls.
- **Subscribe half — source ratchet.** The harness is `renderToStaticMarkup` with no DOM and no effects (`docs/spec/SPEC-testing.md`), so nothing in this repo can observe a refetch. Pinned at the source instead, the same posture as `hooks/__tests__/authDepNarrowing.test.ts` — including a case asserting the `#1390` `characterId` keying **survives**, so nobody "fixes" this later by swapping the trigger instead of adding one.

## What changed

- `frontend/src/api/praxis.ts` — `createPraxis` now fires `notifyRequestsChanged()`. All four signup entry points funnel through it, so this is one line for all four.
- `frontend/src/hooks/useMyActiveTasks.ts` — `return onRequestsChanged(refetch)`, in the shape `useSidebarPanels.tsx:87` already uses. The `characterId` keying stays as the first trigger; the bus is a second one.
- `frontend/src/utils/requestsBus.ts` — docblock now names the in-progress bank alongside the requests bucket, and says what the bus is *not* for.

## One premise in the issue is wrong — the sidebar needed only half

The issue says the rail goes stale because `useMyActiveTasks` does not subscribe. It does not: **`Sidebar.tsx:645` reads `active_praxes` off `useSidebarPanels`**, which has subscribed since #346. `backend/routers/me.py:97` builds that field from exactly the query `useMyActiveTasks` makes, which is why the two look interchangeable.

So the rail's staleness is caused by gap 1 **alone**, and gap 1 alone fixes it. Gap 2 is a real second bug on different surfaces — `pages/tasks/CanSignUpEmpty.tsx` (the bank-full empty state) and the drop-modal option lists in `FeedCardCollabInvite` / `FeedCardDuelChallenge` — and is fixed here too.

## Every caller of `createPraxis`, checked

`useTasks.ts:405`, `useTaskDetail.ts:251`, `Home.tsx:89`, `FieldDesk.tsx:136`. All four are single signups that navigate to the composer; none is a bulk or loop path, so none is harmed by a notify. The two test doubles (`fieldDeskDesktopHome`, `fieldDeskRosterGate`) mock the whole module, so they never reach it.

## Sibling writes in `api/praxis.ts`, checked one by one

One other had drifted, and it is fixed here:

- **`kickMember` — fixed.** A kick resets the whole group back to editing (ADR-0013), and that lands on the *kicker* too: their submitted praxis re-enters their own in-progress list and their "awaiting your submission" bucket. Exactly the move `unsubmitPraxis` already announces. Flagging it explicitly since it is adjacent to the reported bug — easy to drop if you would rather it went on its own issue.

Deliberately left alone, with reasons:

- `inviteToPraxis`, `cancelInvite` — the effect lands on the **invitee**. The bus is a module-local `Set`, so it can only reach the tab that made the call, and the inviter's own panels do not move.
- `changePraxisType` — flips the mode pill on a rail row that is already there. No bucket or slot-count change; a row's content, not the list. Left as-is rather than buying a `/me/sidebar` fan-out (the widest read on the page) for a pill.
- `applyMetatask`, `removeMetatask`, `uploadPraxisMedia`, `uploadPraxisMediaBatch`, `deletePraxisMedia`, `flagPraxis` — praxis content, no panel reads them.

## The issue's "also check": the manual `refetchActiveTasks()` calls stay

`FeedCardCollabInvite.tsx:87` and `FeedCardDuelChallenge.tsx:97` both fire on the **failed** bank-full accept, where `respondToInvite` threw or returned an error and therefore never reached its own `notifyRequestsChanged()`. They are not redundant and cause no double fetch. (Their drop modal's `deletePraxis`/`leavePraxis` now do refresh the hook via the bus, which is the behaviour you want.)

## Verification

`tsc --noEmit` clean; `lint`, `typecheck:design-sync`, `build` and `budget` (JS 128.8 KB / CSS 21.2 KB, within budget) all pass; full suite **258 files, 4610 passing, 1 skipped**. No route, `response_model` or Pydantic schema touched, so `api-schema` is untouched.

**Visual QA is outstanding** — I have no browser or dev stack here.

## What to eyeball

Sign in, keep a page with the rail visible, note the In-progress list **and** the `{n} of {max}` counter, then for each entry point sign up, come back from `/praxis/{id}/edit`, and check both moved **without a refresh**:

1. Task list — `/tasks`, sign up from a task card.
2. Task detail — `/tasks/{id}`, sign up from the detail page.
3. Home — `/`, sign up from the home task list.
4. Field desk — the desktop field-desk sign-up.

Then the two second-surface cases:

5. `/tasks` with the "can sign up" filter on and a full bank — the "you already hold N of M" empty-state sentence should track a drop without a refresh.
6. Accept a collab invite with a full bank, drop one praxis in the modal — the rail should lose the dropped row immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
