### PR TITLE
Score stamps drop the decimal unless the score is fractional

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/uaEnsoScore.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/uaEnsoScore.test.tsx
@@ -86,7 +86,8 @@ describe('the praxis stamp draws the same ring as every other UA surface', () =>
     const atom = renderToStaticMarkup(
       <UaEnsoScore
         size={STAMP_RING}
-        value="15.0"
+        // A whole score prints whole (#1866); the stamp hands the atom `15`.
+        value="15"
         unit="points"
         ringColor="var(--faction-ua-card-enso)"
         valueColor="var(--faction-ua-card-total)"
@@ -98,8 +99,14 @@ describe('the praxis stamp draws the same ring as every other UA surface', () =>
   })
 
   it('fits a four-digit total inside the ring it is struck in', () => {
-    const stamp = renderToStaticMarkup(<UaScoreStamp praxis={praxis(1500)} />)
-    expect(fittedPx(stamp)).toBeLessThan(30)
-    expect(stamp.replace(/<[^>]*>/g, '')).toContain('points')
+    const wide = renderToStaticMarkup(<UaScoreStamp praxis={praxis(1500)} />)
+    const narrow = renderToStaticMarkup(<UaScoreStamp praxis={praxis(15)} />)
+    // The ring takes over: four glyphs are pulled below the 38px the design
+    // struck for a two-glyph total. The threshold is stated as a comparison
+    // rather than a px so it survives the notation — a whole score dropped its
+    // trailing `.0` in #1866, which is one glyph fewer to fit.
+    expect(fittedPx(wide)).toBeLessThan(36)
+    expect(fittedPx(wide)).toBeLessThan(fittedPx(narrow))
+    expect(wide.replace(/<[^>]*>/g, '')).toContain('points')
   })
 })

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -196,7 +196,10 @@ describe('the meta line does not restate the stamp (#1833)', () => {
   it('drops the base figure when the stamp already prints it as the total', () => {
     // base 12, nothing else in play → the stamp's total IS 12.
     const html = body({ score: 12, points_from_votes: 0 })
-    expect(html, 'the stamp still carries the figure').toContain('12.0')
+    // `12points` — the stamp's figure with its own unit welded on once the tags
+    // are stripped, which is what tells it apart from the band's `12 pts` now
+    // that a whole score prints without a decimal (#1866).
+    expect(html, 'the stamp still carries the figure').toContain('12points')
     expect(html, 'and the meta line does not repeat it').not.toContain('12 pts')
     // The line keeps its other three segments and their separators.
     expect(html).toContain('L2')
@@ -207,14 +210,14 @@ describe('the meta line does not restate the stamp (#1833)', () => {
     // base 12 + 4 from votes = 16: two figures answering two questions.
     const html = body({ score: 16, points_from_votes: 4 })
     expect(html, 'what the task is worth').toContain('12 pts')
-    expect(html, 'what this praxis scored').toContain('16.0')
+    expect(html, 'what this praxis scored').toContain('16points')
   })
 
   it('keeps the base figure on a praxis with no stamp at all', () => {
     // #1444 gates the stamp off a `failed` praxis, so the meta line is the only
     // points readout left and suppressing it would leave the card silent.
     const html = body({ score: 12, points_from_votes: 0, moderation_status: 'failed' })
-    expect(html, 'no total was banked').not.toContain('12.0')
+    expect(html, 'no total was banked').not.toContain('12points')
     expect(html, 'so what the task is worth stays').toContain('12 pts')
   })
 })

--- a/frontend/src/components/praxisCard/scoreStamp/CovenScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/CovenScoreStamp.tsx
@@ -14,6 +14,7 @@ import {
   SHADOW,
 } from "../../factionMarks/covenSlip";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
@@ -181,7 +182,7 @@ export default function CovenScoreStamp({ praxis, showCrown }: ScoreStampProps) 
             color: DEEP,
           }}
         >
-          {total.toFixed(1)}
+          {formatPoints(total)}
         </span>
         {/* Coven's total mark. Decorative — the figure beside it is the value. */}
         <span

--- a/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
@@ -177,7 +178,7 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
               color: "transparent",
             }}
           >
-            {total.toFixed(1)}
+            {formatPoints(total)}
           </span>
           <span
             style={{

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -19,6 +19,7 @@ import {
   stepClip,
 } from "../../factionMarks/ephemeristsPlate";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
@@ -245,7 +246,7 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
             }}
           >
             <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", color: OCHRE }}>
-              {total.toFixed(1)}
+              {formatPoints(total)}
             </span>
             <GlossedGlyph
               glyph={t("card.stamp.ephemerists.points")}

--- a/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import { PointsRoundel } from "../../factionMarks";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
@@ -173,7 +174,7 @@ export default function EverymenScoreStamp({ praxis, showCrown }: ScoreStampProp
       {/* The total mark — a second, separate strike. */}
       <PointsRoundel
         className="everymen-stamp-print"
-        total={total.toFixed(1)}
+        total={formatPoints(total)}
         unitLabel={t("card.stamp.points")}
         arcLabel={t("card.stamp.onTheRecord")}
         color="var(--everymen-red)"

--- a/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
@@ -11,11 +12,15 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * Its TOTAL MARK is typographic: `TOT` against the figure in cyan with a soft
  * halo and a blinking block cursor, the machine still holding the line open.
  *
- * TWO DELIBERATE FORMATTING CHOICES, both the design's and both faction voice
- * rather than data:
- *  - the total prints to TWO decimals (`13.60`). A row rule fixes the row
- *    selection, not the notation, and a terminal pads its output;
- *  - the votes row zero-pads to two digits (`+04`), for the same reason.
+ * ONE DELIBERATE FORMATTING CHOICE, the design's and faction voice rather than
+ * data: the votes row zero-pads to two digits (`+04`), because a terminal pads
+ * its output.
+ *
+ * The TOTAL used to be the second such choice — two decimals, `13.60` — and the
+ * owner ruled it drift, not voice (#1866): it made a whole 10 read `10.00` here
+ * and `10.0` on the other seven, which is one figure printed three ways. It goes
+ * through the shared `formatPoints` with every other stamp now.
+ *
  * Row SELECTION stays in `scoreBreakdown` — a hidden row leaves the register
  * shorter, never gappy, so all five conditional states read as one read-out.
  * That includes `BASE`, which the resolver drops when the figure would only
@@ -159,7 +164,7 @@ export default function SingularityScoreStamp({ praxis, showCrown }: ScoreStampP
             textShadow: "0 0 8px var(--faction-singularity-total-glow)",
           }}
         >
-          {total.toFixed(2)}
+          {formatPoints(total)}
           <span aria-hidden className="sg-cursor">
             _
           </span>

--- a/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
@@ -162,7 +163,7 @@ export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) 
             textShadow: "2px 2px 0 var(--faction-snide-pink)",
           }}
         >
-          {total.toFixed(1)}
+          {formatPoints(total)}
         </span>
         <span
           style={{

--- a/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import { UaEnsoScore } from "../../factionMarks/uaAtoms";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
@@ -274,7 +275,7 @@ export default function UaScoreStamp({ praxis, showCrown }: ScoreStampProps) {
       >
         <UaEnsoScore
           size={ENSO_SIZE}
-          value={total.toFixed(1)}
+          value={formatPoints(total)}
           unit={t("card.stamp.points")}
           ringColor="var(--faction-ua-card-enso)"
           valueColor="var(--faction-ua-card-total)"

--- a/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
+import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
@@ -186,7 +187,7 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
             transform: "rotate(var(--wow-points-flip, 0deg))",
           }}
         >
-          {total.toFixed(1)}
+          {formatPoints(total)}
         </span>
         {/* The total MARK. Decorative to a screen reader — the figure beside it
             is the value; the star is the faction's device on it. */}

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -19,6 +19,7 @@ import { pickVariant } from '../../../../utils/factionDispatch'
 import { resolvedArchetype } from '../../../../factions/lazyArchetype'
 import { surfaceMap } from '../../../../factions'
 import { scoreBreakdown, formatMult } from '../scoreBreakdown'
+import { formatPoints } from '../../../../utils/points'
 import { applyCastTally } from '../../../vote/useVotedPraxis'
 import { recordCastTally, castTally, __resetCastTallies } from '../../../vote/castTallies'
 import ScoreStamp from '../ScoreStamp'
@@ -397,7 +398,7 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
       else expect(html).not.toContain('TALLY')
       expect(html).toContain('ON THE RECORD')
       // The roundel carries the total whichever rows are present.
-      expect(html).toContain(fields.score.toFixed(1))
+      expect(html).toContain(formatPoints(fields.score))
       expectVotesRow(html, showsVotes, 'votes')
       expectBaseRow(html, showsBase)
       expect(html).not.toMatch(HEX)
@@ -409,7 +410,7 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
       )
       expectBaseRow(html, showsBase, EPHEMERISTS_LABEL.base)
       expectVotesRow(html, showsVotes, EPHEMERISTS_LABEL.fromVotes)
-      expect(html).toContain(fields.score.toFixed(1))
+      expect(html).toContain(formatPoints(fields.score))
       expect(html).not.toMatch(HEX)
     })
 
@@ -422,7 +423,7 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
       // bordered box under the ensō (ADR-0076).
       if (showsBase) expect(markup).toContain('--faction-ua-card-box-bg')
       else expect(markup).not.toContain('--faction-ua-card-box-bg')
-      expect(html).toContain(fields.score.toFixed(1))
+      expect(html).toContain(formatPoints(fields.score))
       expect(html).toContain('points')
       // The total mark is the ensō, masked from the asset and tinted by a token.
       expect(markup).toContain('/factionMarks/enso.webp')
@@ -442,7 +443,7 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
       // gold token — the ✦ below wears that too.
       if (showsBase) expect(markup).toContain('linear-gradient(90deg')
       else expect(markup).not.toContain('linear-gradient(90deg')
-      expect(html).toContain(fields.score.toFixed(1))
+      expect(html).toContain(formatPoints(fields.score))
       // The retired ✦ survives here and only here — see ADR-0050 / the design
       // README's carve-out. Losing it is half of what #840 exists to fix.
       expect(html).toContain('✦')
@@ -458,7 +459,7 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
       // is nothing to rule (ADR-0076).
       if (showsBase) expect(markup).toContain('cvn-braid')
       else expect(markup).not.toContain('cvn-braid')
-      expect(html).toContain(fields.score.toFixed(1))
+      expect(html).toContain(formatPoints(fields.score))
       expect(html).toContain('✨')
       expect(html).not.toMatch(HEX)
     })
@@ -560,7 +561,7 @@ describe('#842 stamps across the conditional states (ADR-0047)', () => {
       // the total, so it tears nothing off an empty tag (ADR-0076).
       if (showsBase) expect(markup).toContain('2px dashed')
       else expect(markup).not.toContain('2px dashed')
-      expect(html).toContain(fields.score.toFixed(1))
+      expect(html).toContain(formatPoints(fields.score))
       expect(html).toContain('pts')
       expect(html).not.toMatch(HEX)
     })
@@ -574,7 +575,7 @@ describe('#842 stamps across the conditional states (ADR-0047)', () => {
       expect(html).toContain('tot')
       // The terminal pads its output: two decimals, and a zero-padded votes row —
       // which is exactly the `+00` ADR-0076 stops it printing.
-      expect(html).toContain(fields.score.toFixed(2))
+      expect(html).toContain(formatPoints(fields.score))
       expectVotesRow(html, showsVotes, `+${String(fields.points_from_votes).padStart(2, '0')}`)
       // The read-out's rule sits between the register and `TOT`; an empty
       // register has no register to rule off.
@@ -593,7 +594,7 @@ describe('#842 stamps across the conditional states (ADR-0047)', () => {
       // the disc is alone and neither survives (ADR-0076).
       if (showsBase) expect(markup).toContain('--faction-default-card-muted')
       else expect(markup).not.toContain('--faction-default-card-muted')
-      expect(html).toContain(fields.score.toFixed(1))
+      expect(html).toContain(formatPoints(fields.score))
       expect(html).toContain('points')
       expect(html).not.toMatch(HEX)
     })
@@ -652,14 +653,18 @@ describe('a base-only score reads as a bare total on every stamp (ADR-0076)', ()
       const html = text(markup)
       expect(html).not.toContain(baseLabel)
       // The total mark stays — under ADR-0049 it is the faction's signature
-      // device, so it is the one number that never drops out. Singularity's
-      // two-decimal `10.00` contains this too.
-      expect(html).toContain('10.0')
+      // device, so it is the one number that never drops out. #1866: a whole
+      // score prints WHOLE, so the figure that survives is `10`, not `10.0`
+      // (nor Singularity's old `10.00`).
+      expect(html).not.toContain('10.0')
       // The tally goes with it: no votes, no votes row (ADR-0076).
       expect(html).not.toMatch(votesLabel)
       if (rule) expect(markup).not.toContain(rule)
-      // The label is gone, not blanked: no orphaned figure left behind.
-      expect(html).not.toMatch(/\b10\b(?!\.)/)
+      // The label is gone, not blanked, and the total mark is the one survivor:
+      // the figure is stated exactly once (#1131). Counted as a substring rather
+      // than with `\b`, because several stamps butt the unit straight onto the
+      // numeral ('10points', '10pts') and there is no word boundary there.
+      expect(html.split('10')).toHaveLength(2)
     })
   }
 })
@@ -870,7 +875,9 @@ describe('the Ephemerists label their score in kanji (#1637)', () => {
     expect(html).toContain('40')
     expect(html).toContain('×1.20')
     expect(html).toContain('+ 4 ')
-    expect(html).toContain('52.0')
+    // Whole, so no decimal — the kanji labels do not change the notation (#1866).
+    expect(html).toContain('52')
+    expect(html).not.toContain('52.0')
     // The one thing that would break the bound: a number written as a glyph.
     expect(html).not.toMatch(/[〇一二三四五六七八九十百千万]/)
   })

--- a/frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts
+++ b/frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts
@@ -80,7 +80,8 @@ export interface ScoreBreakdown {
  *    declared exception until 2026-08-15 — ADR-0047 kept `+0` on the grounds
  *    that an absent row cannot say "nobody has voted yet" — and the owner ruled
  *    the other way: a score with no votes reads as the total alone.
- *  - total to 1 decimal at the render sites
+ *  - total through `formatPoints` at the render sites — one decimal only when
+ *    the score has one (#1866)
  *
  * A duel side's multiplier is live and provisional (ADR-0052) — a side that is
  * currently behind legitimately shows a loss modifier, ×0.0 for Snide.
@@ -118,7 +119,14 @@ export function scoreBreakdown(praxis: ScoredPraxis): ScoreBreakdown {
   };
 }
 
-/** `×0.80` — two decimals, matching the ADR-0047 sample. */
+/**
+ * `×0.80` — two decimals, matching the ADR-0047 sample. A multiplier is the one
+ * figure that keeps its trailing zeros: `×0.8` reads as a typo, `×0.80` as a
+ * rate. The TOTAL is the opposite and does NOT belong here — it goes through
+ * `formatPoints` in `utils/points`, shared with the duel tiles and field desks,
+ * because eight private `toFixed` calls are how Singularity drifted to two
+ * decimals on a figure that should have had none (#1866).
+ */
 export function formatMult(mult: number): string {
   return `×${mult.toFixed(2)}`;
 }

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerDispatch.test.tsx
@@ -384,7 +384,7 @@ describe("the composer's shared seams (#1828)", () => {
   const BAND_SLUGS = ["coven", "ephemerists", "everymen", "singularity", "snide", "ua", "wow"];
   const INLINE_SLUGS = [null, "albescent"];
 
-  const composingState = (slug: string | null) =>
+  const composingState = (slug: string | null, over: Record<string, unknown> = {}) =>
     baseState({
       task: task(["solo", "collab", "duel"], slug),
       praxis: {
@@ -397,20 +397,25 @@ describe("the composer's shared seams (#1828)", () => {
         points_from_votes: 0,
         habit_bonus_points: 0,
         is_top_for_task: false,
+        ...over,
       } as unknown as PraxisOut,
       // `formatAutosave` is relative to now, so the fixture has to be too —
       // a fixed instant renders "42 minutes ago" and grows every day.
       autosaveAt: new Date(),
     });
 
-  const composer = (slug: string | null, width: "mobile" | "desktop" = "desktop") => {
+  const composer = (
+    slug: string | null,
+    width: "mobile" | "desktop" = "desktop",
+    over: Record<string, unknown> = {},
+  ) => {
     mocks.formFactor = width;
     const Archetype = resolvedArchetype(
       pickVariant(surfaceMap("editPraxis"), slug, DefaultEditPraxis),
     )!;
     return renderToStaticMarkup(
       <MemoryRouter>
-        <Archetype state={composingState(slug)} />
+        <Archetype state={composingState(slug, over)} />
       </MemoryRouter>,
     );
   };
@@ -467,11 +472,16 @@ describe("the composer's shared seams (#1828)", () => {
   it.each([...INLINE_SLUGS, ...BAND_SLUGS])(
     "%s marks the task slip with the shared score stamp",
     (slug) => {
-      // The stamp prints the praxis's TOTAL to a decimal; every composer-only
-      // mark printed the task's bare `point_value`. So the decimal is the claim
-      // — it cannot be satisfied by the device this replaces, and it holds for
-      // all eight skins without naming eight ornaments.
-      expect(composer(slug).replace(/<[^>]*>/g, "")).toContain("20.0");
+      // The stamp prints the praxis's TOTAL; every composer-only mark printed
+      // the task's bare `point_value`. The claim used to ride on the stamp's
+      // trailing decimal, which #1866 removed, so it rides on the FIGURE now:
+      // votes move the total off the base, and only the stamp can say 24. That
+      // holds for all eight skins without naming eight ornaments.
+      const text = composer(slug, "desktop", { points_from_votes: 4, score: 24 }).replace(
+        /<[^>]*>/g,
+        "",
+      );
+      expect(text).toContain("24");
     },
   );
 });

--- a/frontend/src/pages/praxisDetail/DuelCard.tsx
+++ b/frontend/src/pages/praxisDetail/DuelCard.tsx
@@ -75,6 +75,7 @@ import type { CSSProperties, ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { mediaUrl } from '../../utils/media'
+import { formatPoints } from '../../utils/points'
 import type { DuelDetailOut, DuelSideOut } from '../../api/duel'
 import type { PraxisDetailState } from './usePraxisDetail'
 
@@ -144,15 +145,6 @@ function resolveInk(ink?: DuelCardInk): Required<DuelCardInk> {
     line: ink?.line ?? DEFAULT_INK.line,
     plate: ink?.plate ?? DEFAULT_INK.plate,
   }
-}
-
-/**
- * Scores render to one decimal, matching `ScoreStamp`'s total on the same page
- * ("16.0") and the design's "18.0". A duel margin is the difference of two such
- * figures, so it takes the same shape.
- */
-function formatScore(value: number): string {
-  return value.toFixed(1)
 }
 
 /** The dash a side with no total wears. Ornament, not copy. */
@@ -313,11 +305,15 @@ export function DuelCard({ state, style, heading, ink }: DuelCardProps) {
    * A side's total, or the em-dash where it has none. A forfeiter's total is
    * absent by rule (see the header), which is checked before the frozen pair
    * because a forfeit survives era close.
+   *
+   * `formatPoints` rather than a local `toFixed`: this figure sits on the same
+   * page as `ScoreStamp`'s total and has to read the same way (#1866). A duel
+   * margin is the difference of two such figures, so it takes the same shape.
    */
   const scoreFor = (side: DuelSideOut, frozen: number | null): string => {
     if (forfeitedBy != null && side.character_id === forfeitedBy) return NO_SCORE
-    if (resolved) return frozen != null ? formatScore(frozen) : NO_SCORE
-    return formatScore(side.points_from_votes)
+    if (resolved) return frozen != null ? formatPoints(frozen) : NO_SCORE
+    return formatPoints(side.points_from_votes)
   }
 
   // ── The one footer verdict line ───────────────────────────────────────────
@@ -350,7 +346,7 @@ export function DuelCard({ state, style, heading, ink }: DuelCardProps) {
           ? t('duelCrossLink.standing.tied')
           : t('duelCrossLink.standing.leads', {
               name: margin > 0 ? mine.display_name : rival.display_name,
-              margin: formatScore(Math.abs(margin)),
+              margin: formatPoints(Math.abs(margin)),
             }),
     })
   }

--- a/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/archetypeSlots.test.tsx
@@ -312,7 +312,10 @@ describe("task-reference points (#1833)", () => {
     it(`${slug} drops the figure the stamp already prints`, () => {
       const { text } = render(<Archetype state={baseOnly()} />);
       expect(text, "the level still reads").toContain("Level 3");
-      expect(text, "the stamp still carries the total").toContain("30.0");
+      // Stated ONCE. A whole score prints without a decimal now (#1866), so the
+      // stamp's total and the band's figure are the same string and only the
+      // count tells them apart — which is the rule this case is about.
+      expect(text.split("30"), "the stamp still carries the total").toHaveLength(2);
       expect(text, "and the band does not repeat it").not.toContain("30 pts");
     });
 
@@ -320,14 +323,15 @@ describe("task-reference points (#1833)", () => {
       // base 30 + 16 from votes = 46: two figures, two questions.
       const { text } = render(<Archetype state={state()} />);
       expect(text, "what the task is worth").toContain("30 pts");
-      expect(text, "what this praxis scored").toContain("46.0");
+      expect(text, "what this praxis scored").toContain("46");
     });
 
     it(`${slug} keeps the figure on a praxis with no stamp at all`, () => {
       // #1444 gates the stamp off a failed praxis and `scoreWasBanked` takes the
       // whole panel with it, so the band is the only points readout left.
       const { text } = render(<Archetype state={baseOnly({ moderation_status: "failed" })} />);
-      expect(text, "no total was banked").not.toContain("30.0");
+      // Stated once again, and this time the one statement is the band's.
+      expect(text.split("30"), "no total was banked").toHaveLength(2);
       expect(text, "so what the task is worth stays").toContain("30 pts");
     });
   }

--- a/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelCard.test.tsx
@@ -152,7 +152,10 @@ describe('duel card — the three readings', () => {
   it('settled: both totals, the margin, and never a decided verdict', () => {
     const { text, html } = render(state())
     expect(text, 'the card label').toContain('The duel')
-    expect(text, "this side's total").toContain('18.0')
+    // `Ada18`, not `18`: a whole total prints without a decimal now (#1866), so
+    // a bare `18` is also satisfied by the score stamp's `+ 18 from votes`
+    // higher up the same page. The figure is anchored to the row it belongs to.
+    expect(text, "this side's total").toContain('Ada18')
     expect(text, "the rival's total").toContain('15.4')
     expect(text, 'the leader and the margin').toContain('Ada leads by 2.6')
     expect(text, 'live, not decided').toContain('live')
@@ -179,7 +182,7 @@ describe('duel card — the three readings', () => {
       state({ duel: duel({ forfeited_by_character_id: RIVAL.character_id }) }),
     )
     expect(text, 'the verdict').toContain('Won by default')
-    expect(text, 'this side still stands').toContain('18.0')
+    expect(text, 'this side still stands').toContain('Ada18')
     // Absent, not losing: the tally stopped deciding this duel the moment they
     // threw it, so their real figure is gone rather than shown as a loss.
     expect(text, "the forfeiter's total is gone").not.toContain('15.4')
@@ -194,7 +197,7 @@ describe('duel card — the three readings', () => {
     )
     expect(text).toContain('Won by default')
     expect(text, 'the rival keeps their total').toContain('15.4')
-    expect(text, 'this side has none').not.toContain('18.0')
+    expect(text, 'this side has none').not.toContain('Ada18')
   })
 
   it('resolved: the frozen pair and the named winner', () => {
@@ -208,7 +211,7 @@ describe('duel card — the three readings', () => {
         }),
       }),
     )
-    expect(text, 'the frozen figures, not the live ones').toContain('21.0')
+    expect(text, 'the frozen figures, not the live ones').toContain('Ada21')
     expect(text).toContain('24.5')
     expect(text).toContain('Rax won')
     expect(text).toContain('frozen at era close')
@@ -228,7 +231,7 @@ describe('duel card — the three readings', () => {
     )
     expect(text).toContain('No contest')
     expect(text).toContain('never became votable')
-    expect(text, 'no frozen figures exist to print').not.toContain('18.0')
+    expect(text, 'no frozen figures exist to print').not.toContain('Ada18')
   })
 })
 
@@ -341,7 +344,7 @@ describe('duel card — the ink seam', () => {
     const html = dressed()
     const text = html.replace(/<[^>]*>/g, '')
     expect(text, 'the live reading, whole').toContain('Ada leads by 2.6')
-    expect(text).toContain('18.0')
+    expect(text).toContain('Ada18')
     expect(text).toContain('15.4')
     const declined = renderToStaticMarkup(
       <MemoryRouter>

--- a/frontend/src/pages/praxisDetail/__tests__/duelCardOpponentInk.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelCardOpponentInk.test.tsx
@@ -190,7 +190,7 @@ describe('praxis detail: the opponent colour is never an ink and never a ground'
     // that passes on an empty string: the card is genuinely on the page, with
     // the rival named and both totals printed.
     expect(text, `the ${_slug} page drew no duel card at all`).toContain('Rax')
-    expect(text, "this side's total").toContain('18.0')
+    expect(text, "this side's total").toContain('Ada18')
     expect(text, "the rival's total").toContain('15.4')
 
     // `color:` may never name the opponent's hue — not on a name, not on a

--- a/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
@@ -286,7 +286,7 @@ describe("Ephemerists praxis detail — the state axes", () => {
     const { text } = render(state());
     expect(text, "base").toContain("12");
     expect(text, "points from votes").toContain("4");
-    expect(text, "total").toContain("16.0");
+    expect(text, "total").toContain("16");
   });
 
   /**

--- a/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/everymenDetailV2.test.tsx
@@ -285,7 +285,7 @@ describe("Everymen praxis detail — the state axes", () => {
     const { text } = render(state());
     expect(text, "base").toContain("12");
     expect(text, "points from votes").toContain("4");
-    expect(text, "total").toContain("16.0");
+    expect(text, "total").toContain("16");
     expect(text, "neutral era hides the multiplier row").not.toContain("mult");
   });
 

--- a/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
@@ -379,7 +379,7 @@ describe("Singularity praxis detail — the state axes", () => {
     const { text } = render(state());
     expect(text, "base").toContain("12");
     expect(text, "points from votes").toContain("4");
-    expect(text, "total, in this faction's own two-decimal register").toContain("16.00");
+    expect(text, "total — through the shared formatter now, not a private two-decimal register (#1866)").toContain("16");
   });
 
   it("shows the multiplier row only when the factor is not 1.0", () => {

--- a/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/snidePraxisDetail.test.tsx
@@ -376,7 +376,7 @@ describe("S.N.I.D.E. praxis detail — the dress traps", () => {
   it("mounts ONE score readout and invents no arithmetic", () => {
     const { text } = render(state());
     expect(text, "base").toContain("12");
-    expect(text, "total from the shared resolver").toContain("16.0");
+    expect(text, "total from the shared resolver").toContain("16");
     expect(
       text.match(/from votes/g)?.length,
       "the stamp carries the tally; the page does not restate it",

--- a/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unaffiliatedDetailV2.test.tsx
@@ -259,7 +259,7 @@ describe("Unaffiliated praxis detail — the state axes", () => {
     const { text } = render(state());
     expect(text, "base").toContain("12");
     expect(text, "points from votes").toContain("4");
-    expect(text, "total").toContain("16.0");
+    expect(text, "total").toContain("16");
   });
 
   // #1091: the rows come from the mounted `ScoreStamp` now, so they speak the
@@ -293,7 +293,7 @@ describe("Unaffiliated praxis detail — the state axes", () => {
     });
     const { text } = render(unvoted);
     expect(text).not.toContain("from votes");
-    expect(text, "the total still stands alone").toContain("12.0");
+    expect(text, "the total still stands alone").toContain("12");
   });
 
   /**
@@ -311,11 +311,11 @@ describe("Unaffiliated praxis detail — the state axes", () => {
     });
     const { text } = render(failed);
     expect(text, "no headed empty panel").not.toContain("Score");
-    expect(text, "no total nobody banked").not.toContain("16.0");
+    expect(text, "no total nobody banked").not.toContain("16");
     // The banner is the honest signal and it stays (the #1373 ruling).
     expect(text).toContain("Not the task.");
 
-    expect(render(state()).text, "a visible praxis still stamps").toContain("16.0");
+    expect(render(state()).text, "a visible praxis still stamps").toContain("16");
   });
 
   it("banners flagged, failed-with-note, and the crown", () => {

--- a/frontend/src/utils/__tests__/points.test.ts
+++ b/frontend/src/utils/__tests__/points.test.ts
@@ -11,6 +11,7 @@ import type { FactionConfigOut } from '../../api/gameConfig'
 import {
   computeDisplayPoints,
   computeFactionMultiplier,
+  formatPoints,
   isNeutralMultiplier,
 } from '../points'
 
@@ -78,6 +79,38 @@ describe('isNeutralMultiplier', () => {
   it('is false for a tuned modifier', () => {
     expect(isNeutralMultiplier(1.5)).toBe(false)
     expect(isNeutralMultiplier(0.5)).toBe(false)
+  })
+})
+
+/**
+ * The one formatter every points figure on the site goes through (#1866).
+ *
+ * The rule is "no decimal unless it is relevant", and the values below are the
+ * ones `era_1` actually produces — a `.5` from any faction's duel modifiers and
+ * Coven's `collab_own_modifier=1.1`. `compute_praxis_score` does no rounding, so
+ * the raw IEEE product reaches the wire and the last two cases are live.
+ */
+describe('formatPoints', () => {
+  it('drops the decimal on a whole figure', () => {
+    expect(formatPoints(10)).toBe('10')
+    expect(formatPoints(0)).toBe('0')
+  })
+
+  it('keeps a fractional figure — era_1 duels halve a base', () => {
+    // duel_loss_modifier=0.5 on a 15-point task.
+    expect(formatPoints(7.5)).toBe('7.5')
+  })
+
+  it('keeps a Coven collab tenth without its arithmetic noise', () => {
+    // collab_own_modifier=1.1 on a 13-point task: 14.300000000000001 in JS.
+    expect(formatPoints(13 * 1.1)).toBe('14.3')
+  })
+
+  it('drops the decimal when the noise is all that makes it fractional', () => {
+    // The same modifier on 50 points: 55.00000000000001, which `Number.isInteger`
+    // rejects. Rounding must come BEFORE the trailing zero is stripped, or the
+    // stamp reads `55.0` on a whole score.
+    expect(formatPoints(50 * 1.1)).toBe('55')
   })
 })
 

--- a/frontend/src/utils/points.ts
+++ b/frontend/src/utils/points.ts
@@ -63,12 +63,18 @@ export function isNeutralMultiplier(multiplier: number): boolean {
  * on it. A praxis score is a weighted sum, so that noise is the normal case.
  *
  * Lives here rather than beside any one surface because the duel stakes tiles,
- * the desktop FieldDesk's "continue" rows and all eight mobile field desks print
- * the same kind of figure, and three private copies of one `toFixed` is how the
- * rounding rule drifts (#1834).
+ * the desktop FieldDesk's "continue" rows, all eight mobile field desks, the
+ * duel card on praxis detail and all eight praxis-card score stamps print the
+ * same kind of figure, and private copies of one `toFixed` are how the rounding
+ * rule drifts (#1834, #1866 — one stamp had already drifted to two decimals).
+ *
+ * Round FIRST, then strip: `Number.isInteger` is not the test, because
+ * `compute_praxis_score` does no rounding and puts the raw product on the wire.
+ * Coven's `collab_own_modifier=1.1` on 50 points is `55.00000000000001`, which
+ * is not an integer and would print as `55.0` on a score that is whole (#1866).
  */
 export function formatPoints(value: number): string {
-  return Number.isInteger(value) ? String(value) : value.toFixed(1)
+  return Number(value.toFixed(1)).toString()
 }
 
 /**


### PR DESCRIPTION
Closes #1866

A whole score of 10 rendered as `10.0` on seven praxis score stamps and as `10.00` on Singularity, which had drifted to two decimals.

## The seam I tested at

`formatPoints` in `frontend/src/utils/points.ts` — the shared formatter — plus the eight stamps' rendered markup.

The stamp seam already had a test that **pinned the defect**: `scoreStamp.test.tsx`'s "a base-only score reads as a bare total on every stamp" asserted `expect(html).toContain('10.0')` on all eight. Inverting it went red on all eight, on the real thing. The unit seam went red on the float case (`50 * 1.1` -> `55.0`).

## What I found that the issue did not say

**The formatter already existed.** `formatPoints` was built by #1834 for the duel stakes tiles and the field desks, with a docstring naming this exact drift risk. The issue asked for a new one beside `formatMult` in `scoreBreakdown.ts`; writing a second copy there would have been the very duplication the issue is about, so the eight stamps route through the existing one instead, and `formatMult` carries a comment pointing at it.

**It was not sufficient as written.** Its test was `Number.isInteger(value)`. `compute_praxis_score` (`backend/services/scoring.py:157`) does no rounding, so the raw IEEE product reaches the wire: Coven's `collab_own_modifier=1.1` on a 50-point collab is `55.00000000000001`, not an integer, and printed `55.0`. It rounds to one decimal first and strips after, per the issue's suggested shape.

**A ninth site was formatting a score.** `DuelCard.tsx` had a private `formatScore` whose docstring pinned it to *"matching `ScoreStamp`'s total on the same page ('16.0')"*. Leaving it would have printed one class of figure two ways in a single frame. It is gone; the totals and the margin go through `formatPoints`.

Confirmed against `backend/eras/era_1.py` that fractional totals are live and must survive: `duel_win_modifier=1.5` / `duel_loss_modifier=0.5` for every faction (Snide `2.0`/`0.0`), and Coven's `collab_own_modifier=1.1` — the only non-1.0 collab modifier in the era. Nothing truncates to an integer.

## The test churn is not cosmetic

Eleven sibling test files pinned the trailing `.0`, and several used it as the **discriminator**, not as notation. Those are re-anchored to something the notation is not carrying:

- `duelCard`: `Ada18` rather than `18` — a bare `18` is also satisfied by the score stamp's `+ 18 from votes` higher up the same page.
- `composerDispatch`: the fixture's votes move the total to 24, off the task's own 20, so only the stamp can print it. That is a stronger claim than the decimal was.
- `cardChrome` / `archetypeSlots`: the figure stated **exactly once**, which is what #1131 and #1833 were about to begin with.
- `uaEnsoScore`: a comparison instead of a px threshold calibrated to the glyph count of `1500.0`.

Singularity's docstring called its two decimals a deliberate faction voice alongside its `+04` vote padding. The owner ruled it drift; the padding stays, the docstring says so.

## Verification

`tsc --noEmit` clean; `typecheck:design-sync` clean; `lint` clean; `npm test` 4608 passed / 1 skipped, 257 files; `npm run build` clean; `npm run budget` within budget (JS 128.9 KB, CSS 21.2 KB). No backend or schema surface touched, so `api-schema` is a no-op.

**Visual QA is outstanding** — I have no browser and no dev stack.

## What to eyeball

1. **A whole score** — any freshly submitted, unvoted praxis under Era 1's neutral x1.0. The stamp should read `10`, not `10.0`, and on Singularity `10`, not `10.00`. This is the commonest card on the site.
2. **A `.5` duel score** — a 15-point task lost in a duel (`duel_loss_modifier=0.5`) still reads `7.5`. Check the praxis-detail duel card in the same frame: both sides' totals and the "leads by" margin should read the same way as the stamp above them.
3. **A Coven `.1` collab score** — a 13-point collab (`collab_own_modifier=1.1`) still reads `14.3` and never `14.300000000000001`. A 50-point one reads `55`, not `55.0`.

Worth a glance at each faction stamp for fit, since every total is now up to two glyphs narrower: the UA ensō sizes its numeral to the ring and will draw it larger, Everymen's roundel and WOW's flipped mark are the other two where the figure is set into an ornament.

🤖 Generated with [Claude Code](https://claude.com/claude-code)