### PR TITLE
The OAuth state cookie gets Secure, a ten-minute life and a lax it means, and an expired sign-in says so

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,5 +1,18 @@
 from pydantic_settings import BaseSettings
 
+#: The ONE value that unlocks a development seam. ``ENVIRONMENT`` is a free-form
+#: ``str`` defaulting to "development", and the guards that read it used to be
+#: deny-lists against the literal "production" — so every value that was not
+#: exactly that ("prod", "Production", a trailing space, an env var dropped when
+#: a Render service is re-created, unset) simultaneously enabled an
+#: unauthenticated JWT mint AND stripped ``Secure`` from a cookie. Everything
+#: now fails closed: anything unrecognised is treated as production.
+#:
+#: Safe to invert — ``.github/workflows/e2e.yml:42`` sets ``ENVIRONMENT:
+#: development`` explicitly ("dev-login must be enabled"), the field default is
+#: "development", and ``render.yaml:34`` is "production".
+_ENV_DEVELOPMENT = "development"
+
 
 class Settings(BaseSettings):
     DATABASE_URL: str
@@ -39,6 +52,20 @@ class Settings(BaseSettings):
     def cors_origins(self) -> list[str]:
         """``CORS_ORIGINS`` as a list, blanks dropped."""
         return [origin.strip() for origin in self.CORS_ORIGINS.split(",") if origin.strip()]
+
+    @property
+    def is_development(self) -> bool:
+        """Is this the local development environment, exactly and knowably?
+
+        The single answer to that question (#1755). It was a private
+        ``_is_development()`` inside ``routers/auth.py`` while ``db.py`` had
+        already open-coded the same comparison a third time — and the next
+        caller was ``main.py``'s session-cookie ``https_only``, which would have
+        made a fourth. Every security guard that fails closed on this now reads
+        one property: the OAuth and dev-login seams in ``routers/auth.py``, the
+        SQLAlchemy ``echo`` in ``db.py``, and the session cookie in ``main.py``.
+        """
+        return self.ENVIRONMENT == _ENV_DEVELOPMENT
 
 
 settings = Settings()

--- a/backend/db.py
+++ b/backend/db.py
@@ -5,7 +5,7 @@ from config import settings
 
 engine = create_async_engine(
     settings.DATABASE_URL,
-    echo=settings.ENVIRONMENT == "development",
+    echo=settings.is_development,
 )
 
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)

--- a/backend/errors.py
+++ b/backend/errors.py
@@ -190,14 +190,21 @@ class ErrorCode(str, enum.Enum):
     #: an unseen OAuth identity is linked to an existing account BY EMAIL, which
     #: makes the claim an authentication decision rather than a profile detail.
     oauth_email_unverified = "OAUTH_EMAIL_UNVERIFIED"
-    #: #1773. Every other way a callback ends without a session: the player
-    #: declined the consent screen, or came back with a state authlib no longer
-    #: recognises. One code rather than a taxonomy, because the player's next
-    #: move is the same for all of them and the provider's own error strings are
-    #: not copy we would show. Unlike every other member this one is never
-    #: raised — it is the fallback ``routers.auth._sign_in_failed_redirect``
-    #: carries when the exception it caught has no coded detail of its own.
+    #: #1773. Every other way a callback ends without a session — in practice,
+    #: the player declined the consent screen. One code rather than a taxonomy,
+    #: because the player's next move is the same for all of them and the
+    #: provider's own error strings are not copy we would show. Unlike every
+    #: other member this one is never raised — it is the fallback
+    #: ``routers.auth._sign_in_failed_redirect`` carries when the exception it
+    #: caught has no coded detail of its own.
     oauth_failed = "OAUTH_FAILED"
+    #: #1756. The sign-in went stale rather than being refused: the player
+    #: started it, got distracted, and came back after the session cookie
+    #: carrying the OAuth ``state`` had expired (ten minutes, #1755). Split out
+    #: of :attr:`oauth_failed` because it is the one member of that family the
+    #: player did not choose, and the only one where "try again" is genuine
+    #: advice rather than a shrug. Never raised, for the same reason.
+    oauth_state_expired = "OAUTH_STATE_EXPIRED"
 
 
 #: The keys of a coded ``detail`` body. Named so the frontend contract is

--- a/backend/main.py
+++ b/backend/main.py
@@ -88,8 +88,41 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
     )
 
 
-# Session middleware is required by Authlib for OAuth state management
-app.add_middleware(SessionMiddleware, secret_key=settings.SECRET_KEY)
+# Session middleware is required by Authlib for OAuth state management. This
+# cookie holds nothing but the OAuth `state` for one round trip — and that makes
+# it a live CSRF control, not a convenience (#1755). Every kwarg below is load-
+# bearing; `tests/integration/test_session_cookie.py` pins all three.
+app.add_middleware(
+    SessionMiddleware,
+    secret_key=settings.SECRET_KEY,
+    # Fail closed, exactly as the JWT cookie does (`routers/auth.py`). Without
+    # `Secure` a network attacker can PLANT a session cookie over plain HTTP
+    # that the browser then sends to the HTTPS site (RFC 6265bis §5.7 step 16,
+    # §8.6) — the login-CSRF that binding `state` to the user agent exists to
+    # prevent, and there is no HSTS here to make it theoretical. Gated rather
+    # than unconditional because Safari refuses `Secure` on `http://localhost`
+    # (WebKit bug 232088, still open): it drops the `Set-Cookie` at storage
+    # time, so the callback carries no session and authlib raises "CSRF
+    # Warning! State not equal in request and response" — an error that reads
+    # as a bug in `state` handling rather than a cookie flag.
+    https_only=not settings.is_development,
+    # The only expiry OAuth state actually has. authlib stamps `exp = now +
+    # 3600` into the stored value and never reads it back, so its hour is
+    # decorative; the default this replaces is FOURTEEN DAYS of replayability
+    # for an abandoned sign-in. Starlette feeds this to `TimestampSigner.
+    # unsign()`, so it is server-enforced rather than a browser hint. Safe to
+    # cut this short because nothing in `backend/` reads `request.session`
+    # except authlib.
+    max_age=600,
+    # LOAD-BEARING — never "strict". The callback arrives via a cross-site 302
+    # from the provider, so `Lax`'s carve-out for top-level safe-method
+    # navigations is the only reason `state` comes back at all. OWASP's Session
+    # Management Cheat Sheet recommends `Strict` for session cookies; following
+    # it here breaks sign-in SILENTLY. Stated explicitly rather than left to
+    # Starlette's default so the next hardening pass has to read this comment
+    # before "correcting" it.
+    same_site="lax",
+)
 
 # CORS — allow frontend origin; configured via env in production.
 # The same list also guards the praxis room's WebSocket handshake, which this

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -1,5 +1,8 @@
 from typing import Optional
 
+# `MismatchingStateError` is not re-exported by `starlette_client`, which
+# publishes only `OAuthError` — hence the one level down for it.
+from authlib.integrations.base_client import MismatchingStateError
 from authlib.integrations.starlette_client import OAuth, OAuthError
 from fastapi import APIRouter, Depends, HTTPException, Response
 from fastapi import Request
@@ -110,6 +113,16 @@ _PROVIDER_ENDED_IT = coded_error(
     403, ErrorCode.oauth_failed, "That sign-in did not complete."
 )
 
+#: What a callback carries home when the sign-in went STALE rather than being
+#: refused (#1756) — the player started it, wandered off, and came back after
+#: the session cookie holding the OAuth `state` had expired. Ten minutes since
+#: #1755, which is what turns this from a fourteen-day theoretical into the
+#: ordinary outcome of getting distracted. Built, never raised, exactly as
+#: `_PROVIDER_ENDED_IT` above is.
+_STATE_WENT_STALE = coded_error(
+    403, ErrorCode.oauth_state_expired, "That sign-in expired before it finished."
+)
+
 
 def _sign_in_failed_redirect(exc: Exception) -> Response:
     """The failure counterpart to :func:`_signed_in_redirect` (#1773).
@@ -121,20 +134,38 @@ def _sign_in_failed_redirect(exc: Exception) -> Response:
     back. So both legs answer a terminal failure the way they answer success:
     a 302 to the frontend. No cookie — the sign-in did not happen.
 
-    Two exception families reach here, and neither is a bug:
+    Three cases reach here, and none is a bug:
 
     * :class:`HTTPException` — our own gates. The Discord leg's missing-email
       refusal below, and, on **both** legs, ``create_or_get_account``'s
       unverified-email gate (ADR-0075, #1771). Its code rides along in the
       coded detail, so the catalog can say something specific.
-    * :class:`OAuthError` — the provider ended it. A declined consent screen or
-      a stale ``state`` both land here carrying no detail of ours, so they
-      borrow :data:`_PROVIDER_ENDED_IT`'s.
+    * :class:`MismatchingStateError` — the sign-in went stale: the ``state``
+      came back after the session cookie carrying it had expired. Split from
+      the case below in #1756 because it is the only one the player did not
+      CHOOSE, and the only one where "try again" is real advice.
+    * :class:`OAuthError` — the provider ended it, in practice a declined
+      consent screen. Carries no detail of ours, so it borrows
+      :data:`_PROVIDER_ENDED_IT`'s.
 
     Anything else still 500s, which is right: an unhandled error is a defect,
     not a rejection, and dressing it as "try another provider" would hide it.
+
+    The dispatch below is ORDERED, and the order is the whole point:
+    ``MismatchingStateError`` SUBCLASSES ``OAuthError`` (its MRO is
+    ``MismatchingStateError -> OAuthError -> AuthlibBaseError``), so testing the
+    general case first would swallow the specific one and every expired sign-in
+    would read "something went wrong". Stated once here rather than as a pair of
+    ``except`` arms in each callback, so there is one place to get it right
+    instead of one per provider — the same argument :func:`_signed_in_redirect`
+    makes about its cookie flags.
     """
-    detail = exc.detail if isinstance(exc, HTTPException) else _PROVIDER_ENDED_IT.detail
+    if isinstance(exc, HTTPException):
+        detail = exc.detail
+    elif isinstance(exc, MismatchingStateError):
+        detail = _STATE_WENT_STALE.detail
+    else:
+        detail = _PROVIDER_ENDED_IT.detail
     # The `or` is belt-and-braces: every HTTPException that reaches here today
     # went through `raise_coded`, but an uncoded one must not redirect to
     # `?login=None`.

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -20,24 +20,6 @@ from services.era import get_current_era_row, get_or_create_stats
 
 router = APIRouter()
 
-#: The ONE value that unlocks the dev seams below. `ENVIRONMENT` is a free-form
-#: `str` defaulting to "development" (`config.py`), and the guards here used to
-#: be deny-lists against the literal "production" — so every value that was not
-#: exactly that ("prod", "Production", a trailing space, an env var dropped when
-#: a Render service is re-created, unset) simultaneously enabled an
-#: unauthenticated JWT mint AND stripped `Secure` from the session cookie. Both
-#: now fail closed: anything unrecognised is treated as production.
-#:
-#: Safe to invert — `.github/workflows/e2e.yml:42` sets `ENVIRONMENT: development`
-#: explicitly ("dev-login must be enabled"), the config default is "development",
-#: and `render.yaml:34` is "production".
-_ENV_DEVELOPMENT = "development"
-
-
-def _is_development() -> bool:
-    return settings.ENVIRONMENT == _ENV_DEVELOPMENT
-
-
 _OAUTH = OAuth()
 _OAUTH.register(
     name="google",
@@ -99,7 +81,7 @@ def _signed_in_redirect(account_id: int) -> Response:
         httponly=True,
         samesite="lax",
         # Fail closed: Secure unless we KNOW this is local development.
-        secure=not _is_development(),
+        secure=not settings.is_development,
         max_age=_COOKIE_MAX_AGE,
         # `or None`: an unset COOKIE_DOMAIN arrives as "" from a .env line with
         # no value, and "" is not None — Starlette would emit a bare `Domain=`.
@@ -330,7 +312,7 @@ async def auth_logout(response: Response) -> LogoutOut:
         httponly=True,
         samesite="lax",
         # Fail closed, and must match the flags the cookie was set with.
-        secure=not _is_development(),
+        secure=not settings.is_development,
         # `or None`: an unset COOKIE_DOMAIN arrives as "" from a .env line with
         # no value, and "" is not None — Starlette would emit a bare `Domain=`.
         domain=settings.COOKIE_DOMAIN or None,
@@ -364,7 +346,7 @@ async def dev_login(
 
     Returns account_id + character_id so tests can invite/credit by id.
     """
-    if not _is_development():
+    if not settings.is_development:
         raise HTTPException(status_code=404, detail="Not found.")
 
     provider_user_id = "dev-user-1" if key == "1" else f"dev-{key}"

--- a/backend/tests/integration/test_account_linking.py
+++ b/backend/tests/integration/test_account_linking.py
@@ -26,6 +26,10 @@ returning identity the provider currently calls unverified.
 from urllib.parse import parse_qs, urlparse
 
 import pytest
+# `MismatchingStateError` is NOT re-exported from `starlette_client`, which only
+# publishes `OAuthError` — the same reason `routers/auth.py` reaches one level
+# down for it.
+from authlib.integrations.base_client import MismatchingStateError
 from authlib.integrations.starlette_client import OAuthError
 from fastapi import HTTPException
 from httpx import AsyncClient
@@ -653,11 +657,12 @@ async def test_discord_callback_rejects_an_unverified_email(
 class _DecliningClient:
     """A provider that answers the code exchange with an OAuth error.
 
-    The shape of every failure that never reaches our own gates: the player
-    pressed Cancel on the consent screen, or came back with a state authlib no
-    longer recognises. Both surface as ``OAuthError`` out of
-    ``authorize_access_token``, and an uncaught one is a 500 whose body the
-    player reads — because a callback is a navigation, not an XHR.
+    The player pressed Cancel on the consent screen. It surfaces as a bare
+    ``OAuthError`` out of ``authorize_access_token``, and an uncaught one is a
+    500 whose body the player reads — because a callback is a navigation, not
+    an XHR.
+
+    An expired ``state`` is deliberately NOT this case; see case 13.
     """
 
     async def authorize_access_token(self, request):
@@ -682,5 +687,62 @@ async def test_a_declined_consent_screen_lands_the_player_back_home(
 
     assert resp.status_code == 302
     assert _login_error_code(resp) == ErrorCode.oauth_failed.value
+    assert resp.cookies.get("access_token") is None
+    assert await _account_count(db_session) == accounts_before
+
+
+# ---------------------------------------------------------------------------
+# Case 13 — the sign-in went stale rather than being refused (#1756)
+# ---------------------------------------------------------------------------
+
+
+class _StaleStateClient:
+    """A provider callback arriving with a ``state`` authlib no longer holds.
+
+    Exactly what authlib does when the session cookie carrying the state is
+    gone: ``StarletteOAuth2App.authorize_access_token`` looks the state up,
+    gets ``None`` back, and ``_format_state_params`` raises. Reproduced by
+    raising the real exception rather than by expiring a cookie, because the
+    cookie's ten-minute lifetime (#1755) is enforced by
+    ``TimestampSigner.unsign()`` against the wall clock — a test that waited it
+    out would take ten minutes.
+    """
+
+    async def authorize_access_token(self, request):
+        raise MismatchingStateError()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["google", "discord"])
+async def test_an_expired_state_says_so_rather_than_something_went_wrong(
+    client: AsyncClient,
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+):
+    """A stale sign-in is retryable, and the copy has to be able to say that.
+
+    This is the one requirement of #1756 that #1862 did not deliver: it caught
+    the whole ``OAuthError`` family under one generic code, on the reasoning
+    that the player's next move is the same for all of them. That holds for a
+    declined consent screen — declining is a choice — but not for a state that
+    went stale while the player was distracted, which is not a choice they made
+    and which succeeds on a second attempt.
+
+    The assertion that matters is the INEQUALITY as much as the equality:
+    ``MismatchingStateError`` subclasses ``OAuthError``, so a dispatch that
+    tested the general case first would swallow this one and every stale
+    sign-in would read "something went wrong".
+    """
+    from routers import auth as auth_router
+
+    monkeypatch.setattr(auth_router._OAUTH, provider, _StaleStateClient())
+    accounts_before = await _account_count(db_session)
+
+    resp = await client.get(f"/auth/{provider}/callback")
+
+    assert resp.status_code == 302
+    assert _login_error_code(resp) == ErrorCode.oauth_state_expired.value
+    assert _login_error_code(resp) != ErrorCode.oauth_failed.value
     assert resp.cookies.get("access_token") is None
     assert await _account_count(db_session) == accounts_before

--- a/backend/tests/integration/test_session_cookie.py
+++ b/backend/tests/integration/test_session_cookie.py
@@ -1,0 +1,100 @@
+"""The Starlette session cookie that carries OAuth ``state`` (#1755).
+
+Lives here rather than in ``tests/unit`` because it reads the *assembled*
+application object, and ``tests/unit/conftest.py`` exists precisely so unit
+tests import neither the app nor anything needing env vars. Nothing here
+touches the database.
+
+**Why the kwargs and not a response.** ``https_only`` is consumed by
+``SessionMiddleware.__init__``, which runs once at import when ``main`` builds
+the app. By the time a test could monkeypatch ``settings.ENVIRONMENT`` the flag
+is already baked into a string. So the seam is the installed middleware's own
+kwargs — the arguments the app was actually constructed with — plus a direct
+test of the property those kwargs are derived from. Between them they pin both
+halves: that the flag tracks the environment, and which way it fails.
+"""
+
+import pytest
+from starlette.middleware.sessions import SessionMiddleware
+
+from config import settings
+from main import app
+
+#: How long an OAuth ``state`` stays replayable. This is the only expiry it
+#: actually has: authlib stamps an ``exp`` into the stored value and never reads
+#: it back (``StarletteIntegration.get_state_data`` returns ``value["data"]``
+#: with no clock comparison), so its hour is decorative. Starlette hands this to
+#: ``TimestampSigner.unsign()``, making it server-enforced rather than a browser
+#: hint — and the default it replaces is fourteen days.
+_EXPECTED_MAX_AGE = 600
+
+
+def _session_middleware_kwargs() -> dict:
+    """The kwargs ``main`` actually installed ``SessionMiddleware`` with."""
+    for middleware in app.user_middleware:
+        if middleware.cls is SessionMiddleware:
+            return middleware.kwargs
+    raise AssertionError(
+        "SessionMiddleware is not installed — authlib stores OAuth state in "
+        "request.session, so both sign-in legs are broken without it."
+    )
+
+
+def test_the_oauth_state_cookie_expires_in_ten_minutes() -> None:
+    """Not Starlette's fourteen-day default (#1755).
+
+    Safe to shorten this far because the cookie has no other job: nothing in
+    ``backend/`` reads ``request.session`` except authlib, so it only has to
+    survive one round trip to the provider.
+    """
+    assert _session_middleware_kwargs()["max_age"] == _EXPECTED_MAX_AGE
+
+
+def test_the_oauth_state_cookie_stays_lax_not_strict() -> None:
+    """LOAD-BEARING, and the reason it is asserted rather than left to default.
+
+    The callback arrives via a cross-site 302 from the provider. ``Lax``'s
+    carve-out for top-level safe-method navigations is the only reason the
+    session comes back at all, so ``Strict`` — which OWASP's Session Management
+    Cheat Sheet recommends for session cookies generally — breaks sign-in
+    silently. This test is what a future hardening pass trips over.
+    """
+    assert _session_middleware_kwargs()["same_site"] == "lax"
+
+
+def test_the_oauth_state_cookie_is_secure_unless_this_is_development() -> None:
+    """The flag is derived from the environment, not hardcoded either way.
+
+    Deliberately not asserted as a literal: CI sets no ``ENVIRONMENT`` and the
+    field defaults to "development", so a literal ``False`` here would pass in
+    CI while saying nothing about production, and a literal ``True`` would fail
+    for every developer. What matters is the coupling; which way it falls is
+    pinned by the fail-closed test below.
+    """
+    assert _session_middleware_kwargs()["https_only"] == (not settings.is_development)
+
+
+@pytest.mark.parametrize(
+    "environment,is_development",
+    [
+        pytest.param("development", True, id="the-one-value-that-counts"),
+        pytest.param("production", False, id="production"),
+        pytest.param("prod", False, id="abbreviated"),
+        pytest.param("Development", False, id="capitalised"),
+        pytest.param("development ", False, id="trailing-space"),
+        pytest.param("", False, id="env-var-dropped"),
+    ],
+)
+def test_only_the_exact_string_development_is_development(
+    monkeypatch: pytest.MonkeyPatch, environment: str, is_development: bool
+) -> None:
+    """Fail closed: anything unrecognised is production (#1755).
+
+    This is the half the middleware kwargs cannot show. The property is what
+    decides whether the session cookie ships ``Secure``, and it is an allow-list
+    of exactly one string rather than a deny-list against "production" — so an
+    ``ENVIRONMENT`` dropped when a Render service is re-created hardens the
+    cookie instead of stripping it.
+    """
+    monkeypatch.setattr(settings, "ENVIRONMENT", environment)
+    assert settings.is_development is is_development

--- a/frontend/src/locales/en/errors.json
+++ b/frontend/src/locales/en/errors.json
@@ -87,6 +87,7 @@
     "AVATAR_MUST_BE_IMAGE": "Avatar must be an image file.",
     "AVATAR_TOO_LARGE": "Avatar too large (max {{max_megabytes}} MB).",
     "OAUTH_EMAIL_UNVERIFIED": "We can't sign you in: that account has no verified email address. Verify your email where you signed in, then try again.",
-    "OAUTH_FAILED": "That sign-in didn't go through. Pick a way in and try again."
+    "OAUTH_FAILED": "That sign-in didn't go through. Pick a way in and try again.",
+    "OAUTH_STATE_EXPIRED": "That sign-in took too long, so we let it lapse. Pick a way in and you'll go straight through."
   }
 }


### PR DESCRIPTION
Closes #1755
Closes #1756

The session cookie that carries OAuth `state` was installed with `secret_key` alone. This hardens it, and adds the one thing #1756 still wanted: an expired sign-in that says so. They ship together because #1755's `max_age` is what makes #1756's expired-state path reachable rather than theoretical.

## Seams tested

Two, and both were chosen because the obvious seam does not work:

- **#1755 — the installed middleware's own kwargs** (`app.user_middleware`). `https_only` is consumed by `SessionMiddleware.__init__`, which runs once at import when `main` builds the app; by the time a test could `monkeypatch.setattr(settings, "ENVIRONMENT", ...)` the flag is already baked into a string. So the test reads the arguments the app was actually constructed with. That pins the coupling but not the *direction*, so it is paired with a direct parametrized test of `Settings.is_development` — which is where the fail-closed decision actually lives.
- **#1756 — the callback route**, driven through `AsyncClient` with the OAuth client stubbed to raise the real `MismatchingStateError`. Asserts the `?login=` code on the 302, on **both** legs. Reproduced by raising the exception rather than by expiring a cookie, because the ten-minute lifetime is enforced by `TimestampSigner.unsign()` against the wall clock and a test that waited it out would take ten minutes.

Both went red on the real defect first: the #1755 test with `KeyError: 'https_only'` (all three kwargs absent), and the #1756 test with `AssertionError: assert 'OAUTH_FAILED' == 'OAUTH_STATE_EXPIRED'` on google and discord.

## What was already on `main` vs. what this adds

**#1756 was mostly delivered by #1862 (`de8762a2`), and none of it is rebuilt here.** Already on `main` and untouched: `_sign_in_failed_redirect` with both legs answering 302 + an `ErrorCode` in the `login` query param; both callbacks wrapped in `except (HTTPException, OAuthError)`; `Home.tsx` reading the param; `OAUTH_EMAIL_UNVERIFIED` and `OAUTH_FAILED` in `errors.json`; tests pinning the redirect rather than the exception.

I re-verified the MRO claim against the installed authlib 1.7.2 rather than taking it on trust — `MismatchingStateError -> OAuthError -> AuthlibBaseError -> Exception`, `issubclass` True — so the uncaught-500 half of #1756 is indeed already fixed.

**What this PR adds to #1756** is the single remaining requirement: distinguishing an expired `state` from a refusal. #1862 lumped the whole `OAuthError` family under one generic `OAUTH_FAILED`. That reasoning holds for a declined consent screen — declining is a choice — but not for a `state` that went stale while the player was distracted, which is not a choice they made and which succeeds on a second attempt.

**Everything under #1755 is new.**

## The three defaults #1755 fixes

`https_only` defaulted to `False`, so the cookie shipped without `Secure` in production. The exposure is integrity, not confidentiality — everything stored was already in the player's address bar — but without `Secure` a network attacker can *plant* a session cookie over plain HTTP that the browser then sends to the HTTPS site, which is the login-CSRF that binding `state` to the user agent exists to prevent. There is no HSTS to make that theoretical.

`max_age` defaulted to fourteen days, and I confirmed in the installed source that this really is the only expiry OAuth state has: `StarletteIntegration.get_state_data` returns `value.get("data")` with no clock comparison, so authlib's `exp = now + 3600` is decorative. Starlette feeds `max_age` to `TimestampSigner.unsign()`, so ten minutes is server-enforced rather than a browser hint.

`same_site` is now stated explicitly as `"lax"` — not a change in value, a change in whether it is an accident.

## The two traps, and that I did not fall into them

- **`same_site` is `"lax"`, never `"strict"`**, with the reasoning in a comment at the call site *and* a dedicated test whose name says so. The callback arrives via a cross-site 302 from the provider, so `Lax`'s top-level-safe-method carve-out is the only reason `state` comes back at all. OWASP recommends `Strict` for session cookies generally; following that here breaks sign-in silently, so the comment exists to stop the next hardening pass "correcting" it.
- **`https_only` is gated, not unconditional** — `not settings.is_development`. Safari refuses `Secure` on `http://localhost` (WebKit bug 232088), dropping the `Set-Cookie` at storage time so the callback carries no session and authlib raises a CSRF warning that reads as a `state` bug rather than a cookie flag.

## Prerequisite refactor

`Settings.is_development` on `config.py`, replacing the private `_is_development()` in `routers/auth.py`. I grepped for every caller: the issue named two, there were **four** — three in `routers/auth.py` (two cookie `secure` flags and the dev-login gate) plus the open-coded `ENVIRONMENT == "development"` in `db.py:8`. The new `https_only` would have been a fifth. There is now exactly one comparison in the codebase, and the fail-closed rationale lives on it.

## One deliberate deviation from the issue text, flagged for review

#1756 asks for an `except MismatchingStateError` arm placed before the `OAuthError` arm. I kept the ordering requirement but put it as an ordered `isinstance` dispatch **inside the shared `_sign_in_failed_redirect`** instead of as a second `except` arm in each callback.

Both legs already route through that helper, so this states the ordering once rather than once per provider — the same argument `_signed_in_redirect`'s docstring already makes about its cookie flags ("a third provider handler that copies the block is a third place for one of them to be quietly dropped"). The subclass hazard is identical in nature and called out in a comment, and the regression test asserts the **inequality** as well as the equality on both legs, so a future reordering fails loudly. Happy to convert it to `except` arms if you would rather match the issue literally.

## Verification

Every job and step in `.github/workflows/test.yml`, run locally against a dedicated `wz1755_test` database:

- `test` — 1286 passed, coverage 93.87% (gate is 80%)
- `api-schema` — `regen_api_client.py` then `git diff --exit-code`: **no diff**. Expected: no route signature, `response_model` or Pydantic schema changed, and the edited docstring is a helper's, not a route's.
- `frontend` — lint, `tsc --noEmit`, `typecheck:design-sync`, tests (257 files / 4604 passed), build, byte budget (JS 128.9 KB, CSS 21.2 KB, both within budget)

**Visual QA is outstanding** — I have no browser or dev stack here, so the new copy has not been seen rendered on `Home.tsx`.

## What to eyeball

1. **Sign-in still works locally, on both Google and Discord.** This is the one that matters: it is exactly what the two traps above would break, and both failure modes are silent or misdirecting rather than obvious.
2. **Sign-in still works in production after deploy**, where `https_only` is now `True` for the first time.
3. **Safari specifically, on localhost**, if it is available — that is the browser the `https_only` gate exists for.
4. **The expired-state copy, rendered.** Start a sign-in, wait past ten minutes, come back: the page should say the sign-in lapsed and is retryable, not "something went wrong". Reads on `Home.tsx` via the `?login=OAUTH_STATE_EXPIRED` param.
5. **The copy itself** — "That sign-in took too long, so we let it lapse. Pick a way in and you'll go straight through." Tone and length against the neighbouring `OAUTH_FAILED` string.
6. **Ten minutes is a product decision, not just a security one.** It is long enough for a consent screen plus a password manager, but a player who wanders off mid-sign-in now has to start over.
7. **The `is_development` refactor touched `db.py`'s SQLAlchemy `echo`** — same value as before, but worth a glance that local dev still logs SQL as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
