### PR TITLE
The onboarding spec records the resume that shipped, not the return-to that was cancelled

### DIFF
--- a/docs/research/oauth-return-to.md
+++ b/docs/research/oauth-return-to.md
@@ -3,6 +3,11 @@
 Research for [#1734](https://github.com/pixieofhugs/WorldZeroPlayground/issues/1734), part of the
 onboarding map [#1732](https://github.com/pixieofhugs/WorldZeroPlayground/issues/1732).
 
+> **Status: none of this was built.** #1734 was superseded — the onboarding arc carries nothing
+> through the round trip and remembers its place client-side instead. §7's recommendation is
+> live only as an answer to a *future* destination that must survive OAuth. Why the arc went the
+> other way: `docs/spec/SPEC-onboarding.md` § Authentication.
+
 **The question.** The intended arc is *scan → read what this is → accept terms → auth → create a
 character → do the one task → level 1*. It breaks at the arrow after auth, because the OAuth
 callback redirects to one fixed place. How should a destination survive the round trip to Google

--- a/docs/spec/SPEC-onboarding.md
+++ b/docs/spec/SPEC-onboarding.md
@@ -102,15 +102,30 @@ here. The rules that matter:
 (`/auth/google`, `/auth/discord`). The frontend has no Discord control anywhere yet, so the
 auth card is the first surface in the app to offer one.
 
-**Carrying a destination through the round trip.**
-([#1734](https://github.com/pixieofhugs/WorldZeroPlayground/issues/1734)) If a destination
-must survive OAuth, it rides as an **opaque key from a closed server-side set** inside
-authlib's `state`, mapped to a constant path in the callback — never a path or URL on the
-wire. `Admin.tsx` already implements that validate-against-a-closed-set pattern.
+**Nothing rides on the wire.**
+([#1899](https://github.com/pixieofhugs/WorldZeroPlayground/pull/1899)) The OAuth callback
+redirects to a constant, and that is deliberate rather than a gap. The flow remembers its own
+place client-side: a session-scoped boolean written the moment before the auth card hands the
+browser to a provider, acted on by the root landing route only once a session exists, and
+cleared by the flow on its next mount so it can fire at most once. No query parameter, no
+return-to path, no `state` payload, no backend change. The mechanism and its failure modes
+live in `frontend/src/utils/onboardingResume.ts`. This is the same visit interrupted, not a
+new scan — see *Coming back*.
 
-But prefer to **carry nothing**: `create_or_get_account` runs before the callback builds its
-redirect, so the server can distinguish a new account from a returning one without being
-told. Findings and sources: `research/oauth-return-to`.
+**The server is not asked to decide.**
+([#1734](https://github.com/pixieofhugs/WorldZeroPlayground/issues/1734) — superseded) The
+rejected design would have had the server derive the destination: `create_or_get_account` runs
+before the callback builds its redirect, so it can distinguish a new account from a returning
+one without being told. **That is the wrong predicate.** The rule this flow runs on is
+character-level — *has this character completed the onboarding task* — and a player who signed
+up, never made a character, and re-scans the sticker months later reads as **returning**. A
+server-side new-vs-returning branch drops exactly that player at `/`, and they never reach the
+terms card. Answer that before proposing a return-to again.
+
+Carrying a destination instead — an opaque key from a closed server-side set inside authlib's
+`state`, mapped to a constant path in the callback, never a path or URL on the wire — is
+worked out in full in `docs/research/oauth-return-to.md`. **Not built, and not needed by this
+arc**, which has exactly one destination.
 
 ## Terms
 
@@ -162,7 +177,9 @@ needed; and admin is an account-level role while the mark is a character-level d
 ([#1856](https://github.com/pixieofhugs/WorldZeroPlayground/issues/1856))
 
 **A scan always re-runs the cards from the top.** No resume, no bookmark. Terms simply shows
-again and writes another row; the append-only log absorbs the duplicate.
+again and writes another row; the append-only log absorbs the duplicate. The one exception is
+the OAuth round trip, which is the same visit interrupted rather than a new scan
+(*Authentication*, above).
 
 Consequently **`CurrentUser` gains nothing** — no terms flag, no new field, and no way for
 the flow and the server to disagree about where someone stands. The intro is not waste on a

--- a/docs/spec/SPEC-onboarding.md
+++ b/docs/spec/SPEC-onboarding.md
@@ -109,9 +109,8 @@ its own place client-side: a session-scoped boolean written the moment before th
 hands the browser to a provider, acted on by the root landing route only once a session exists,
 and cleared by the flow on its next mount so it can fire at most once. No destination on the
 wire — no query parameter, no return-to path, no `state` payload, no backend change. The
-mechanism and its failure modes
-live in `frontend/src/utils/onboardingResume.ts`. This is the same visit interrupted, not a
-new scan — see *Coming back*.
+mechanism and its failure modes live in `frontend/src/utils/onboardingResume.ts`. This is the
+same visit interrupted, not a new scan — see *Coming back*.
 
 **The server is not asked to decide.**
 ([#1734](https://github.com/pixieofhugs/WorldZeroPlayground/issues/1734) — superseded) The

--- a/docs/spec/SPEC-onboarding.md
+++ b/docs/spec/SPEC-onboarding.md
@@ -103,12 +103,13 @@ here. The rules that matter:
 auth card is the first surface in the app to offer one.
 
 **Nothing rides on the wire.**
-([#1899](https://github.com/pixieofhugs/WorldZeroPlayground/pull/1899)) The OAuth callback
-redirects to a constant, and that is deliberate rather than a gap. The flow remembers its own
-place client-side: a session-scoped boolean written the moment before the auth card hands the
-browser to a provider, acted on by the root landing route only once a session exists, and
-cleared by the flow on its next mount so it can fire at most once. No query parameter, no
-return-to path, no `state` payload, no backend change. The mechanism and its failure modes
+([#1899](https://github.com/pixieofhugs/WorldZeroPlayground/pull/1899)) A successful OAuth
+callback redirects to a constant, and that is deliberate rather than a gap. The flow remembers
+its own place client-side: a session-scoped boolean written the moment before the auth card
+hands the browser to a provider, acted on by the root landing route only once a session exists,
+and cleared by the flow on its next mount so it can fire at most once. No destination on the
+wire — no query parameter, no return-to path, no `state` payload, no backend change. The
+mechanism and its failure modes
 live in `frontend/src/utils/onboardingResume.ts`. This is the same visit interrupted, not a
 new scan — see *Coming back*.
 


### PR DESCRIPTION
Closes #1913

`docs/spec/SPEC-onboarding.md` § Authentication specified an opaque key inside authlib's `state`, with a "prefer to carry nothing" fallback underneath it. Neither is what shipped, and the fallback is the heuristic the owner ruled against. The section now records the mechanism from #1899 and the argument that killed the alternative.

## The seam I verified at

**Grep on disk, post-edit.** There is no test for prose; the check is that no surviving line describes the `state`-key mechanism as the live decision.

```
$ grep -rn "opaque key\|closed server-side set\|authlib's \`state\`" docs/
docs/research/oauth-return-to.md:255:**Carry an opaque key from a closed server-side set, inside the OAuth `state` value (carrier A), and
docs/spec/SPEC-onboarding.md:125:Carrying a destination instead — an opaque key from a closed server-side set inside authlib's
```

Two survivors, both deliberate. The spec's is the paragraph #1913 said to keep if marked plainly — it now reads **"Not built, and not needed by this arc"**. The research doc's is §7's recommendation, now sitting under a status block (below).

```
$ grep -rn "carry nothing\|carrying nothing\|create_or_get_account" docs/
docs/research/oauth-return-to.md:162:| **H** | **Carry nothing; derive it** | ... |
docs/research/oauth-return-to.md:291:**carrier H — derive it, carry nothing — needs no mechanism at all.** ...
docs/spec/SPEC-onboarding.md:117:rejected design would have had the server derive the destination: `create_or_get_account` runs

$ grep -rn "issues/1734" docs/
docs/research/oauth-return-to.md:3:Research for [#1734](.../issues/1734), part of the
docs/spec/SPEC-onboarding.md:116:([#1734](.../issues/1734) — superseded) The
```

The spec's only remaining mention of `create_or_get_account` is inside the paragraph explaining why that predicate is **wrong**. `#1734` is cited once, marked superseded.

## What I read before describing it

I did not take the issue's summary. From the merged code:

- **The key is `wz_onboarding_handoff`**, a boolean, in `frontend/src/utils/onboardingResume.ts` — every access wrapped, because `sessionStorage` throws in some privacy modes and is absent under the DOM-less harness.
- **Written** by `AuthCard.tsx` via `SignInOptions`' optional `onChoose`, immediately before `loginWith` navigates away.
- **The guard is `App.tsx:100`** — `if (user && onboardingHandoffPending())`. The `user &&` is the "only when a session exists" half: a guest with a stale mark still gets Home.
- **Cleared** in `Onboarding.tsx`'s mount `useEffect`, having been read during that render into `useState(onboardingHandoffPending)`.
- `backend/routers/auth.py::_signed_in_redirect` is untouched: `headers={"location": settings.FRONTEND_URL}`.

## The § Coming back question — they now agree, but only after one added clause

§ Coming back said *"A scan always re-runs the cards from the top. No resume, no bookmark."* Read flat, the shipped resume **does** contradict it: the mark seeds `pastIntro`, so a returning browser skips the intro card.

They are reconcilable, and `Onboarding.tsx` already states the reconciliation in its own docstring — an interrupted OAuth round trip is *the same visit*, not a new scan. But the spec did not say so, and "say so rather than paper over it" means writing the exception down rather than relying on a reader inferring it. § Coming back gains one sentence naming it and pointing at § Authentication. **That is the only change outside § Authentication in that file.**

## One edit outside the stated scope — drop it if you disagree

#1913 scoped this to the spec. `docs/research/oauth-return-to.md` is the other doc in `docs/` describing the cancelled mechanism, and its §7 **recommends** it. The document self-disclaims (its §7 closes "this recommendation should be read as conditional"), so it is not wrong — but a reader arriving there directly gets no signal that the condition resolved the other way.

I added a four-line status block under its header: none of it was built, §7 is live only for a *future* destination, and the reasoning is in the spec. It is a pointer, not a state mirror. Revert that hunk if you want the research doc left as a pure artefact.

## Precision fix worth flagging

My first draft said "No query parameter". That is true of the *destination* but not of the wire: #1873 gave the OAuth **failure** branch `?login=<code>` (`auth.py:175`). It now reads "A successful OAuth callback redirects to a constant … **no destination on the wire** — no query parameter, …". Left unqualified, that sentence would have been the next contradiction this file grew.

## CI

`.github/workflows/test.yml` is `on: [push, pull_request]` with **no path filters**, so all three jobs (backend pytest, schema/generated-types staleness, frontend lint+tsc+vitest+build+budget) run on this PR regardless. The diff is two `.md` files under `docs/` — no Python, no TS, no schema source, no asset — so it touches no job's inputs. Nothing here is expected to move any job's result.

## Not changed

No code. #1899 is the implementation and it is correct. `CLAUDE.md`'s routing table cites neither #1734 nor the return-to mechanism — its onboarding row points at this spec, which is now right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
