### PR TITLE
The Singularity card's punch holes take a token, and rgba() with three arguments turns out to be valid CSS

### DIFF
--- a/frontend/src/__tests__/rawColourRule.test.ts
+++ b/frontend/src/__tests__/rawColourRule.test.ts
@@ -56,6 +56,28 @@ describe('local/no-raw-colour-values reports raw colour', () => {
     )
   })
 
+  /**
+   * #1912. `background: 'rgba(10,26,14)'` sat in `FactionCard.tsx` and was read
+   * as a no-op — "rgba() takes four arguments, so the browser drops the
+   * declaration". It does not. The legacy COMMA grammar makes the alpha
+   * optional in both spellings:
+   *
+   *   rgba() = rgba( <number>#{3} , <alpha-value>? ) | …
+   *
+   * (mdn-data `css/syntaxes.json`, mirroring CSS Color 4, where `rgba()` is a
+   * full alias of `rgb()`.) So the declaration was PAINTING all along, and
+   * tokenizing it repainted nothing.
+   *
+   * What the episode is really about is ARITY: the `[\d.]` lookahead matches on
+   * the first argument and never counts them, which is the only reason this arm
+   * caught the line at all. Pinned here so that "hardening" the regex into a
+   * four-argument shape cannot silently un-ratchet the three-argument one.
+   */
+  it('flags a comma-form rgba() whether or not it carries the optional alpha', async () => {
+    expect(await reports("export const s = { background: 'rgba(10,26,14)' }")).toBe(true)
+    expect(await reports("export const s = { background: 'rgba(10,26,14,1)' }")).toBe(true)
+  })
+
   it('flags a colour laundered through a ternary, as the px arm does', async () => {
     expect(
       await reports("export const s = (w: boolean) => ({ background: w ? 'rgba(234,179,8,0.08)' : 'transparent' })"),

--- a/frontend/src/components/factionCard/FactionCard.tsx
+++ b/frontend/src/components/factionCard/FactionCard.tsx
@@ -483,7 +483,7 @@ function SingularityHoles() {
           style={{
             width: 6,
             height: 4,
-            background: "rgba(10,26,14)",
+            background: "var(--faction-singularity-punch-hole)",
             border:
               "1px solid var(--faction-singularity-card-accent, var(--faction-singularity-border-hard))",
             borderRadius: 1,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -972,6 +972,27 @@
   /* ── Singularity terminal border (blue brand) ── */
   --faction-singularity-border-hard: #2563eb;
 
+  /* The punched sprocket hole — the row of five wells the faction card wears
+     above and below its body, tape running through a reader. It is ORNAMENT,
+     not a rung of the `--faction-singularity-card-*` contract: nothing else
+     paints it, and the drawing (a 6×4 well, blue-bordered) is the whole of its
+     meaning. Named here rather than beside `-card-bg` for exactly that reason —
+     `-card-*` is a two-theme contract whose halves are both near-black, and a
+     later editor re-cutting it must not have to wonder whether the hole is one
+     of its tiers.
+
+     A LIFT, not a shade of the ground: #050f08 is the chassis and this is two
+     stops above it, so the well reads as a recess catching phosphor rather than
+     as a hole cut clean through. §6: Singularity's older ornament families
+     (`-stamp-*`, `-vote-*`, `-phosphor-dim`) are theme-INVARIANT, and this joins
+     them — one value serves both cascades, and there is deliberately no
+     [data-theme="dark"] half to "complete".
+
+     Value carried across unchanged from the inline `rgba(10,26,14)` this
+     replaces (#1912). Nothing repaints; see that issue for why the literal was
+     painting all along. */
+  --faction-singularity-punch-hole: #0a1a0e;
+
   /* Dim sage phosphor (#723) — the SECOND green. `card-text` and `card-accent`
      are the same bright #4ade80, so a Singularity surface had one weight of
      green and reached for `color-mix(… accent N%, transparent)` whenever it


### PR DESCRIPTION
Closes #1912

## The issue's premise is wrong, and I have the receipt

#1912 says `background: "rgba(10,26,14)"` is invalid CSS that "the browser discards today", so the panel paints nothing and fixing it is a **visible** change. **It is not invalid, it has been painting `#0a1a0e` all along, and this PR repaints nothing.**

The refutation is not the space-separated syntax (the issue pre-empts that argument, correctly). It is the *legacy comma* grammar's own definition, in which the alpha argument is **optional in both spellings**:

```
rgba() = rgba( <percentage>#{3} , <alpha-value>? )
       | rgba( <number>#{3} , <alpha-value>? )
       | rgba( [ <number> | <percentage> | none ]{3} [ / [ <alpha-value> | none ] ]? )
```

That is `mdn-data`'s `css/syntaxes.json` verbatim, which mirrors CSS Color 4 — where `rgba()` is a *full* alias of `rgb()`, grammar included. The issue concedes the alias and then asserts the comma form is somehow excluded from it; the `, <alpha-value>?` above is exactly the comma form, with the alpha optional.

Checked empirically rather than from memory, by matching the value against the spec grammar with `css-tree`'s lexer:

| value | matches `background-color`? |
| --- | --- |
| `rgba(10,26,14)` | **valid** |
| `rgb(10,26,14)` | valid |
| `rgba(10,26,14,1)` | valid |
| `rgb(10 26 14)` | valid |
| `rgba(10,26)` | invalid |
| `rgba(10,26,14,1,1)` | invalid |

So the arity error is real for 2 and 5 arguments and **not** for 3. Browsers have accepted the 3-argument comma form since the Color 4 alias shipped (~Chrome 65 / Firefox 52 / Safari 12.1).

**This is good news for the change, not bad.** The fix the issue asks for — swap the literal for a token — is correct under either reading, and because the literal was painting, the token carries the identical value and **nothing on screen moves**. The visual risk the issue warns about does not exist.

## The seam I tested at

The rule **as wired through the real `eslint.config.js`** — the seam `src/__tests__/rawColourRule.test.ts` already names in its header (same plugin registration, same legacy list, same exemptions CI runs).

I did **not** write the test #1912 proposes ("assert a three-argument `rgba()` is malformed"), because it would pin a false claim about CSS into the ratchet and go red on valid colour across the tree. The true thing the episode exposes is **arity blindness**, and it runs the *other* way: `RAW_COLOUR_LITERAL`'s `[\d.]` lookahead matches on the first argument and never counts them, which is the only reason the colour arm caught this line at all. The fixture pins that — so a later "hardening" of the regex into a four-argument shape cannot silently un-ratchet the three-argument one.

## What changed

- **`frontend/src/index.css`** — mints `--faction-singularity-punch-hole: #0a1a0e`, the value carried across unchanged.
  - Placed in the Singularity **ornament** neighbourhood (beside `-border-hard` / `-phosphor-dim`), *not* in the `--faction-singularity-card-*` contract. The card family is a two-theme contract whose halves are both near-black; the sprocket hole is one drawing nothing else paints, and putting it in the contract would make a later editor re-cutting the card wonder whether the hole is one of its tiers.
  - Declared **theme-INVARIANT** — one value, both cascades, no `[data-theme="dark"]` half — which is the shape Singularity's older ornament families (`-stamp-*`, `-vote-*`, `-phosphor-dim`) already use. WORLD_ZERO_STYLE §6 asks a new block to say which of the two shapes it is; the comment says it, and says not to "complete" it with a dark half.
  - It is a **lift**, not a shade of the ground: `#050f08` is the chassis and this sits two stops above it, so the well reads as a recess catching phosphor.
- **`frontend/src/components/factionCard/FactionCard.tsx`** — `SingularityHoles` reads the token. One line; no logic, state or API touched.
- **`frontend/src/__tests__/rawColourRule.test.ts`** — the arity fixture above, with the grammar written into the comment so nobody re-derives it.

## What did NOT change, deliberately

`frontend/.eslint-legacy-raw-colours.txt` keeps its `FactionCard.tsx` line. I checked, as the issue asks, whether the swap clears the file — **it does not.** With the line removed the rule reports two more:

- `139:11` `border: "2px solid rgba(0,0,0,0.25)"` — the UA card's ring, GROUP 2's hand-rolled-lift shape.
- `522:11` the Singularity scanline, `rgba(74,222,128,0.015)` — which is the card accent at 1.5%, i.e. §6's `color-mix(in srgb, <token> 1.5%, transparent)` shape.

Both are GROUP 3 per-site judgement calls that the list's own header reserves for #1609. The list only ever shrinks, so its line stays until the file is actually clean.

Also unchanged: `frontend/src/utils/factions.ts`. The sync rule covers `CSS_KEY` (slug → css key); this token is not reached through `factionCssVar` — every Singularity var in this component is written literally — so there is nothing to keep in sync.

## Verification

Every job in `.github/workflows/test.yml`'s frontend lane, run locally:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **271 files, 4844 passed**, 1 skipped
- `npm run build` — ok
- `npm run budget` — within budget (JS 129.5 KB, CSS 21.2 KB)

Braces prove nothing, so I grepped the **built** stylesheet: `punch-hole: #0a1a0e` is in `dist/assets/index-*.css`, and the consumer is in the built `FactionCard-*.js` chunk.

Backend lanes are untouched — no Python or schema file in this diff.

## What to eyeball

**Visual QA is outstanding — I have no browser and no dev stack, and did not run `npm run dev`.**

1. **The Singularity faction card's punch-hole rows, light and dark** (`/factions`) — the five 6×4 wells above and below the card body. Contrary to #1912, these should look **exactly as they do on `main`**: a near-black green well, two stops up from the terminal chassis, blue-bordered. **Any visible change here is a regression, not the fix** — that is the inversion worth knowing before you look.
2. Same card in dark mode, confirming the hole did not flip — the token is deliberately theme-invariant, so it must render identically in both.
3. Nothing else. The other two faction-card surfaces the file draws (UA ring, Singularity scanline) are untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
