### PR TITLE
A room that hangs up because the praxis froze stops the editor and says what was lost

### DIFF
--- a/.design-sync/previews/_state.tsx
+++ b/.design-sync/previews/_state.tsx
@@ -287,6 +287,9 @@ export function editPraxisState(slug: string): EditPraxisState {
     autoSubmitDays: null,
     // Drafting, so the shared document is open (#1745).
     documentFrozen: false,
+    // Nothing has sealed under this preview: no room, so no 4001 (#1931).
+    sealedMidEdit: false,
+    noteRoomSealed: noop,
     isPublished: false,
     controlsLocked: false,
     modeIsLocked: false,

--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -301,6 +301,7 @@
     "bodyConnecting": "Opening the shared write-up…",
     "bodyUnreachable": "The shared write-up would not open, so this editor cannot take text. Reload the page to try again.",
     "bodyFrozen": "Frozen while the crew's publish window is open. Submitting locks the write-up for everyone — including whoever submitted — so nothing changes under a submission already made.",
+    "bodyFrozenMidEdit": "Someone submitted while you were writing, so the write-up froze mid-sentence. Anything you typed after that never reached the crew and cannot be recovered — you will have to write it again.",
     "bodyFrozenAction": "Reopen the write-up for the crew",
       "wordCount": "{{words}} words · markdown ok",
       "proofLabel": "Proof",

--- a/frontend/src/pages/EditPraxis.tsx
+++ b/frontend/src/pages/EditPraxis.tsx
@@ -115,6 +115,7 @@ export default function EditPraxis() {
       <PraxisRoomProvider
         praxisId={isWaitingStage(state.phase) ? null : state.praxis.id}
         onUpdate={state.setAutosaveAt}
+        onSealed={state.noteRoomSealed}
       >
         <Archetype state={state} />
       </PraxisRoomProvider>

--- a/frontend/src/pages/editPraxis/__tests__/roomReconnect.test.ts
+++ b/frontend/src/pages/editPraxis/__tests__/roomReconnect.test.ts
@@ -19,6 +19,8 @@ import { describe, it, expect } from 'vitest'
 import {
   PRE_OPEN_RETRY_LIMIT,
   WS_POLICY_VIOLATION,
+  WS_ROOM_FROZEN,
+  isRoomSealedClose,
   shouldReconnectRoom,
 } from '../roomReconnect'
 
@@ -60,5 +62,35 @@ describe('shouldReconnectRoom', () => {
     // Door two: a member kicked mid-session. Permanent, and re-asking cannot
     // change the answer.
     expect(shouldReconnectRoom(WS_POLICY_VIOLATION, 1, true)).toBe(false)
+  })
+
+  it('reconnects after the room is sealed, so the sealed text can be read back', () => {
+    // 4001 is NOT 1008 on purpose (#1808/#1923): the member is still a member
+    // and the server still answers their `SYNC_STEP1`, so the room must come
+    // back or the write-up they just sealed is off their screen for good.
+    // Unbounded like any other post-open close — the seal is told to them by
+    // `isRoomSealedClose` below, not by refusing to reconnect.
+    expect(shouldReconnectRoom(WS_ROOM_FROZEN, 1, true)).toBe(true)
+    expect(
+      shouldReconnectRoom(WS_ROOM_FROZEN, PRE_OPEN_RETRY_LIMIT * 100, true),
+    ).toBe(true)
+  })
+})
+
+describe('isRoomSealedClose', () => {
+  it('recognises the code the room hangs up with when a praxis freezes', () => {
+    // The wire contract: `_WS_ROOM_FROZEN` in `backend/services/praxis_room.py`,
+    // where a backend test pins the literal as well as the constant.
+    expect(WS_ROOM_FROZEN).toBe(4001)
+    expect(isRoomSealedClose(WS_ROOM_FROZEN)).toBe(true)
+  })
+
+  it('reads nothing into the codes that mean something else', () => {
+    // A drop and a kick are not a seal. Only 4001 says "the praxis froze under
+    // you"; anything else that reached this would freeze an editor that is
+    // still perfectly writable.
+    expect(isRoomSealedClose(WS_ABNORMAL_CLOSURE)).toBe(false)
+    expect(isRoomSealedClose(WS_POLICY_VIOLATION)).toBe(false)
+    expect(isRoomSealedClose(1000)).toBe(false)
   })
 })

--- a/frontend/src/pages/editPraxis/__tests__/roomSeal.test.ts
+++ b/frontend/src/pages/editPraxis/__tests__/roomSeal.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The client's half of the freeze (#1931) — the pure seam.
+ *
+ * #1808's server half (PR #1923) hangs up every socket on a praxis the moment
+ * it freezes, with close code 4001. The client reconnected and carried on as
+ * if nothing had happened: `documentFrozen` is derived from the *fetched*
+ * praxis and nothing refetched it, so the holdout kept typing into a room the
+ * server was dropping every update from. The text was on screen, so they
+ * believed it was saved. **It was not, and it cannot be recovered** — Yjs
+ * merges additively, the server never accepted the update, and it exists only
+ * in that tab's memory.
+ *
+ * These three functions are that gap closed, extracted the way #1804 extracted
+ * `shouldReconnectRoom`: the composer's harness is `renderToStaticMarkup`, no
+ * DOM and no effects, so the rule has to be callable to be provable.
+ *
+ * The chain each test walks is the production one:
+ *   a 4001 close → `documentIsFrozen` → `composerWritable` → the editor.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { WS_ROOM_FROZEN, isRoomSealedClose } from '../roomReconnect'
+import { applyRoomSeal, composerWritable, documentIsFrozen } from '../roomSeal'
+import type { PraxisOut } from '../../../api/praxis'
+
+const drafting = { id: 7, status: 'in_progress' } as unknown as PraxisOut
+const sealed = { id: 7, status: 'submitted' } as unknown as PraxisOut
+
+describe('documentIsFrozen', () => {
+  it('freezes on a seal close before any refetch can land', () => {
+    // The whole point. The praxis in hand still says `in_progress` — it is the
+    // row that was fetched at mount, and the freeze happened after it. The
+    // close code is the newer fact, so it wins, and it wins IMMEDIATELY: every
+    // keystroke between the hang-up and the response would be lost silently.
+    expect(isRoomSealedClose(WS_ROOM_FROZEN), 'the trigger').toBe(true)
+    expect(documentIsFrozen(drafting, true)).toBe(true)
+  })
+
+  it('keeps the freeze when the refetch never arrives', () => {
+    // Failure-safe on purpose. A refetch that 500s or times out leaves the
+    // stale `in_progress` row in hand, and deriving the freeze from that alone
+    // would hand the editor back to a member whose typing goes nowhere — the
+    // exact loss this issue exists to end.
+    expect(documentIsFrozen(null, true)).toBe(true)
+  })
+
+  it('freezes on the fetched status, seal close or not', () => {
+    // The pre-existing rule (#1745), unchanged: the server's own predicate,
+    // reached by a member who loads an already-frozen praxis and never saw a
+    // close at all.
+    expect(documentIsFrozen(sealed, false)).toBe(true)
+  })
+
+  it('leaves a live draft writable', () => {
+    expect(documentIsFrozen(drafting, false)).toBe(false)
+    // Nothing loaded yet is not frozen — it is not anything. The composer is
+    // held shut by `seeded` until the document arrives.
+    expect(documentIsFrozen(null, false)).toBe(false)
+  })
+})
+
+describe('composerWritable', () => {
+  it('refuses the keystroke once the document is frozen', () => {
+    expect(composerWritable(true, documentIsFrozen(drafting, true))).toBe(false)
+  })
+
+  it('takes text from a seeded, unfrozen room', () => {
+    expect(composerWritable(true, documentIsFrozen(drafting, false))).toBe(true)
+  })
+
+  it('refuses until the document has arrived, frozen or not', () => {
+    // "Not yet" and "not now" are different refusals (see `controls.tsx`), and
+    // neither may be mistaken for permission.
+    expect(composerWritable(false, false)).toBe(false)
+    expect(composerWritable(false, true)).toBe(false)
+  })
+})
+
+describe('applyRoomSeal', () => {
+  it('reads the praxis back so the rest of the composer catches up', async () => {
+    // The freeze is already on by the time this runs. What the refetch buys is
+    // everything else the sealed row carries — the status the footer reads, and
+    // the way back in.
+    const fetchPraxis = vi.fn().mockResolvedValue(sealed)
+    const setPraxis = vi.fn()
+    await applyRoomSeal(7, fetchPraxis, setPraxis)
+    expect(fetchPraxis).toHaveBeenCalledWith(7)
+    expect(setPraxis).toHaveBeenCalledWith(sealed)
+  })
+
+  it('swallows a failed read rather than letting it surface as an error', async () => {
+    // Nothing the member did failed, so there is nothing to report to them —
+    // and the freeze does not depend on this call succeeding.
+    const setPraxis = vi.fn()
+    await expect(
+      applyRoomSeal(7, vi.fn().mockRejectedValue(new Error('offline')), setPraxis),
+    ).resolves.toBeUndefined()
+    expect(setPraxis).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodyFrozen.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodyFrozen.test.tsx
@@ -20,25 +20,33 @@ import i18n from "../../../../i18n";
 import type { EditPraxisState } from "../../useEditPraxis";
 import { BodyTextarea } from "../controls";
 
-function state(documentFrozen: boolean): EditPraxisState {
+function state(
+  documentFrozen: boolean,
+  sealedMidEdit = false,
+): EditPraxisState {
   return {
     body: "## What I did\n\nCaught the papers.",
     setBody: () => {},
     documentFrozen,
+    sealedMidEdit,
     submitting: false,
     reopenForEdit: async () => {},
   } as unknown as EditPraxisState;
 }
 
-function html(documentFrozen: boolean): string {
+function html(documentFrozen: boolean, sealedMidEdit = false): string {
   // The copy has an apostrophe, which the static renderer emits as `&#x27;` —
   // the same decode the confirm-copy and praxis-detail suites carry.
   return renderToStaticMarkup(
-    <BodyTextarea state={state(documentFrozen)} skin={{ textareaStyle: {} }} />,
+    <BodyTextarea
+      state={state(documentFrozen, sealedMidEdit)}
+      skin={{ textareaStyle: {} }}
+    />,
   ).replace(/&#x27;|&#39;/g, "'");
 }
 
 const frozenLine = i18n.t("forms:editPraxis.composer.bodyFrozen");
+const sealedLine = i18n.t("forms:editPraxis.composer.bodyFrozenMidEdit");
 const reopenLine = i18n.t("forms:editPraxis.composer.bodyFrozenAction");
 
 describe("a frozen write-up", () => {
@@ -59,6 +67,33 @@ describe("a frozen write-up", () => {
     // `reopenForEdit`, not a raw write: ADR-0059, and since #1745 the only way
     // a sealed document reopens at all.
     expect(markup).toMatch(/<button[^>]*>[^<]*Reopen/);
+  });
+
+  it("tells the member sealed mid-sentence that their text is gone (#1931)", () => {
+    // The whole reason the two cases are told apart. This member watched their
+    // own typing appear on screen after the room hung up, and none of it
+    // reached the server; the generic notice would leave them believing the
+    // text in front of them is saved.
+    const markup = html(true, true);
+    expect(sealedLine, "the copy exists in the catalog").not.toBe("");
+    expect(markup).toContain(sealedLine);
+    expect(markup).not.toContain(frozenLine);
+    // Honest, not euphemistic: no recovery exists, and this is the one place
+    // that can say so before they close the tab.
+    expect(sealedLine).toMatch(/cannot be recovered/i);
+  });
+
+  it("does not claim a loss to a member who loaded an already-frozen praxis", () => {
+    // They typed nothing and lost nothing — the pre-existing #1745 case.
+    const markup = html(true);
+    expect(markup).toContain(frozenLine);
+    expect(markup).not.toContain(sealedLine);
+  });
+
+  it("still offers the way back in after a mid-sentence seal", () => {
+    // Losing the paragraph is not losing the door — `pullBack` is what lets
+    // them write it again, and it is the only door.
+    expect(html(true, true)).toContain(reopenLine);
   });
 
   it("hides the markdown toolbar, which writes past the read-only flag", () => {

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -18,6 +18,7 @@ import MarkdownPreview from "../blocks/MarkdownPreview";
 import { applyMarkdown, minimalReplacement } from "../blocks/markdownToolbar";
 import type { MarkdownCommand } from "../blocks/markdownToolbar";
 import { usePraxisRoom, ROOM_TITLE_KEY } from "../praxisRoom";
+import { composerWritable } from "../roomSeal";
 import { paintedAwareness } from "../roomPresence";
 import {
   BODY_EDITOR_BASE_THEME,
@@ -861,8 +862,9 @@ export function BodyTextarea({
   // same thing. `seeded` is "not yet" — the document has not arrived. Frozen is
   // "not now" — it has arrived and is sealed for the whole group until somebody
   // reopens it (#1745). The server drops the update messages either way; this
-  // only stops the member typing into a void.
-  const writable = seeded && !state.documentFrozen;
+  // only stops the member typing into a void. The rule itself is one line in
+  // `roomSeal.ts`, where the harness can call it (#1931).
+  const writable = composerWritable(seeded, state.documentFrozen);
   const setBodyRef = useRef(state.setBody);
   setBodyRef.current = state.setBody;
 
@@ -1052,7 +1054,20 @@ export function BodyTextarea({
           className="flex flex-col items-start gap-1"
           style={{ marginTop: "var(--space-xs)" }}
         >
-          <p className="label-caption">{t("editPraxis.composer.bodyFrozen")}</p>
+          {/* Two sentences for two different members (#1931). Whoever loaded a
+              praxis that was already sealed has lost nothing and is told the
+              rule. Whoever was still typing when the room hung up under them
+              has lost whatever they typed after that — it never reached the
+              server and cannot be recovered — and being told the rule instead
+              of the loss would leave them believing text they can still see on
+              screen is safe. */}
+          <p className="label-caption">
+            {t(
+              state.sealedMidEdit
+                ? "editPraxis.composer.bodyFrozenMidEdit"
+                : "editPraxis.composer.bodyFrozen",
+            )}
+          </p>
           <button
             type="button"
             className="label-caption"

--- a/frontend/src/pages/editPraxis/editPraxisState.ts
+++ b/frontend/src/pages/editPraxis/editPraxisState.ts
@@ -257,6 +257,24 @@ export interface EditPraxisState {
    * everything else about it still working.
    */
   documentFrozen: boolean;
+  /**
+   * This member's room was sealed **under them**, mid-session (#1931) — the
+   * server hung their socket up with `WS_ROOM_FROZEN` rather than their having
+   * loaded a praxis that was already frozen.
+   *
+   * The one thing that distinguishes the two cases client-side, and the only
+   * reason to distinguish them: whatever they typed after that close never
+   * reached the server and **cannot be recovered**, so the frozen notice owes
+   * them a different sentence. See `roomSeal.ts` for why nothing tries to save
+   * it.
+   */
+  sealedMidEdit: boolean;
+  /**
+   * Called by `EditPraxis.tsx` as the room provider's `onSealed`; nothing else
+   * calls it. Freezes the document off the close code and refetches the praxis.
+   * Idempotent — the provider may fire it more than once.
+   */
+  noteRoomSealed: () => void;
   isPublished: boolean;
   /**
    * The composer is read-only. Since #1164 this means **"hand off"** rather than

--- a/frontend/src/pages/editPraxis/praxisRoom.tsx
+++ b/frontend/src/pages/editPraxis/praxisRoom.tsx
@@ -62,7 +62,7 @@ import {
   publishPresence,
   samePresence,
 } from "./roomPresence";
-import { shouldReconnectRoom } from "./roomReconnect";
+import { isRoomSealedClose, shouldReconnectRoom } from "./roomReconnect";
 
 /**
  * The body's root key — `ROOM_BODY_KEY` in `praxis_room.py`. The server seeds a
@@ -199,6 +199,7 @@ export function usePraxisRoom(): PraxisRoom | null {
 export function PraxisRoomProvider({
   praxisId,
   onUpdate,
+  onSealed,
   children,
 }: {
   praxisId: number | null;
@@ -213,6 +214,22 @@ export function PraxisRoomProvider({
    * `EditPraxisState`, and `useEditPraxis` runs outside this provider.
    */
   onUpdate?: (at: Date) => void;
+  /**
+   * The room hung up because the praxis **froze** (#1931).
+   *
+   * The server closes every socket on the open→frozen transition with
+   * `WS_ROOM_FROZEN`, and this is the only moment a client can learn of it: the
+   * socket reconnects immediately (a sealed room still serves reads), so
+   * nothing else about the room ever looks different afterwards. Without this,
+   * the member goes on typing into a document the server is dropping every
+   * update from.
+   *
+   * Passed in beside `onUpdate` for the same reason: `useEditPraxis` holds the
+   * praxis and runs OUTSIDE this provider, so the signal has to travel down the
+   * props rather than up the context. May fire more than once — a re-close
+   * before the page re-renders — so the handler must be idempotent.
+   */
+  onSealed?: () => void;
   children: ReactNode;
 }) {
   // The room's long-lived handles, kept apart from `seeded` and `present` so
@@ -239,6 +256,8 @@ export function PraxisRoomProvider({
   // socket down and rebuild it on every render.
   const onUpdateRef = useRef(onUpdate);
   onUpdateRef.current = onUpdate;
+  const onSealedRef = useRef(onSealed);
+  onSealedRef.current = onSealed;
 
   useEffect(() => {
     if (praxisId == null) {
@@ -295,6 +314,20 @@ export function PraxisRoomProvider({
     // already stopped. Nothing else will happen in this room now, so say so.
     const onClosed = () => setUnreachable(true);
     provider.on("closed", onClosed);
+    // The praxis froze under us (#1931). `connection-close` carries the close
+    // event for EVERY close, terminal or not — `closed` fires only for the
+    // terminal ones, and a seal is deliberately not terminal (the socket comes
+    // straight back so the sealed write-up can still be read). `event` is null
+    // when WE closed the socket, which is a teardown and not a signal.
+    //
+    // This is the one and only moment the client can learn the document is
+    // sealed. Nothing else about the reconnected room looks any different, and
+    // `unreachable` cannot stand in — `controls.tsx` draws that only while
+    // `!seeded`, and a room that reconnects is seeded.
+    const onConnectionClose = (event: CloseEvent | null) => {
+      if (event && isRoomSealedClose(event.code)) onSealedRef.current?.();
+    };
+    provider.on("connection-close", onConnectionClose);
     const awareness = provider.awareness;
     setTypes({ body, meta, awareness });
 
@@ -337,6 +370,7 @@ export function PraxisRoomProvider({
       provider.off("sync", onSync);
       provider.off("status", onStatus);
       provider.off("closed", onClosed);
+      provider.off("connection-close", onConnectionClose);
       awareness.off("change", syncPresence);
       offline.off("synced", onOfflineLoaded);
       // Also drops this client's awareness state — the socket closing is what

--- a/frontend/src/pages/editPraxis/roomReconnect.ts
+++ b/frontend/src/pages/editPraxis/roomReconnect.ts
@@ -19,6 +19,34 @@
 export const WS_POLICY_VIOLATION = 1008;
 
 /**
+ * What the room hangs up with when the praxis it holds **freezes** —
+ * `_WS_ROOM_FROZEN` in `backend/services/praxis_room.py` (#1808 / PR #1923).
+ *
+ * A private-use code (RFC 6455 reserves 4000-4999) and deliberately **not**
+ * 1008: a frozen praxis still answers its members' `SYNC_STEP1`, so the member
+ * must be able to come back and read the write-up that was just sealed. Sent
+ * on the open→frozen *transition* only, so it never reaches someone opening an
+ * already-frozen praxis.
+ *
+ * **This is the wire contract.** A backend test pins the literal as well as
+ * the constant, so renumbering either side fails in CI rather than in a
+ * browser. Do not renumber it here.
+ */
+export const WS_ROOM_FROZEN = 4001;
+
+/**
+ * Did this close mean "the praxis froze under you"?
+ *
+ * The only thing on the client that can know. `documentFrozen` is derived from
+ * the fetched praxis, and nothing refetches it on its own — so without this
+ * the holdout's editor stays writable, they keep typing, and the server keeps
+ * dropping it (#1931). What follows a `true` here lives in `roomSeal.ts`.
+ */
+export function isRoomSealedClose(code: number): boolean {
+  return code === WS_ROOM_FROZEN;
+}
+
+/**
  * How many consecutive failures a room that has never opened will tolerate.
  *
  * A handful, because it exists for exactly one case the "did it ever open?"
@@ -46,6 +74,12 @@ export function shouldReconnectRoom(
 ): boolean {
   // Door two, post-accept: the member was kicked. Re-asking changes nothing.
   if (code === WS_POLICY_VIOLATION) return false;
+  // {@link WS_ROOM_FROZEN} is NOT listed here, and that is the point of its
+  // being a private code rather than a second 1008: a sealed room still serves
+  // reads, so the member reconnects and gets the sealed text back. What stops
+  // them typing into it is the freeze — see `roomSeal.ts` — not a refusal to
+  // reconnect. It falls through to `hasOpened`, which a sealed room always has.
+
   // Everything else asks one question instead of reading a status the browser
   // never received. A refusal always fails BEFORE the first open — the viewer
   // was never admitted, so the offline store holds nothing that could merge and

--- a/frontend/src/pages/editPraxis/roomSeal.ts
+++ b/frontend/src/pages/editPraxis/roomSeal.ts
@@ -1,0 +1,99 @@
+/**
+ * What a sealed room means to the composer (#1931) — the client half of #1808.
+ *
+ * The server freezes a praxis and hangs up every socket on it with
+ * {@link import('./roomReconnect').WS_ROOM_FROZEN} (PR #1923). Before this
+ * file, that code reached the browser and nothing acted on it: the client
+ * reconnected — correctly, so the sealed write-up can still be read — and the
+ * editor **stayed writable**, because `documentFrozen` is derived from the
+ * praxis that was fetched at mount and nothing refetches it. The holdout kept
+ * typing and the server kept dropping every update. The text was on screen, so
+ * they believed it was saved.
+ *
+ * **The text typed after the seal cannot be recovered, and nothing here tries.**
+ * Yjs merges additively and never reverts, the server never accepted the
+ * update, so it exists only in that tab's memory. What these three functions do
+ * is make the gap short — one close event wide instead of unbounded — and make
+ * the failure honest, which is the copy the composer draws over them.
+ *
+ * The rules live here rather than inline in `useEditPraxis.ts` and
+ * `controls.tsx` because the frontend harness is `renderToStaticMarkup`: no
+ * DOM, and effects never run. A rule that cannot be called cannot be proved —
+ * the same reason #1804 pulled `shouldReconnectRoom` out of `praxisRoom.tsx`.
+ *
+ * **The server is and stays the enforcer.** It drops the room messages a frozen
+ * praxis would otherwise take, and `backend/tests/integration/test_praxis_room.py`
+ * is where that is proved. Nothing here is a permission check; it is how the
+ * member is *told*.
+ */
+import type { PraxisOut } from "../../api/praxis";
+
+/**
+ * The document is sealed and may not take another keystroke.
+ *
+ * Two facts, OR'd, and the order matters:
+ *
+ * - `sawSealClose` — this client's socket was hung up with 4001. The **newer**
+ *   fact, and the only one available in the round trip that follows it. It is
+ *   also the failure-safe one: a refetch that never answers leaves the stale
+ *   `in_progress` row in hand, and deriving the freeze from that alone would
+ *   hand the editor back to a member whose typing goes nowhere.
+ * - the fetched status — the pre-existing rule (#1745), stated exactly as the
+ *   server states it. Reached without any close at all by a member who loads a
+ *   praxis that was already frozen.
+ *
+ * `sawSealClose` is cleared when the praxis is reopened (`pullBack` in
+ * `useEditPraxis.ts`), which is the one transition that makes a sealed room
+ * writable again from this tab.
+ */
+export function documentIsFrozen(
+  praxis: Pick<PraxisOut, "status"> | null,
+  sawSealClose: boolean,
+): boolean {
+  if (sawSealClose) return true;
+  return !!praxis && praxis.status !== "in_progress";
+}
+
+/**
+ * May the body editor take text? The composer's one gate, in one place.
+ *
+ * Two different refusals, and neither may be mistaken for permission.
+ * `seeded` is **not yet** — the document has not arrived, and typing in front
+ * of the server's seed merges into text the player has never seen. Frozen is
+ * **not now** — it arrived and is sealed for the whole group until somebody
+ * reopens it.
+ */
+export function composerWritable(
+  seeded: boolean,
+  documentFrozen: boolean,
+): boolean {
+  return seeded && !documentFrozen;
+}
+
+/**
+ * Catch the praxis up after its room sealed under this client.
+ *
+ * The freeze is already on by the time this runs — {@link documentIsFrozen}
+ * takes the close code, not this row. What the read buys is everything else
+ * the sealed praxis carries: the status the footer draws, and the way back in.
+ *
+ * A failure is swallowed. Nothing the member did failed, so there is nothing to
+ * report to them, and the freeze does not depend on this answering.
+ *
+ * ponytail: one read, no retry. The ceiling is a member who is sealed, offline,
+ * and stays on the page — they see the frozen notice (correct) against a stale
+ * row until something else refetches. The upgrade is to retry this alongside
+ * the socket's own reconnect, which is where a fresh praxis is next wanted
+ * anyway.
+ */
+export async function applyRoomSeal(
+  praxisId: number,
+  fetchPraxis: (id: number) => Promise<PraxisOut>,
+  setPraxis: (praxis: PraxisOut) => void,
+): Promise<void> {
+  try {
+    setPraxis(await fetchPraxis(praxisId));
+  } catch {
+    /* the seal close already froze the editor; this only enriches it */
+  }
+}

--- a/frontend/src/pages/editPraxis/useEditPraxis.ts
+++ b/frontend/src/pages/editPraxis/useEditPraxis.ts
@@ -45,6 +45,7 @@ import {
 import { deriveCollabGate } from "../../components/collab/CollabRoster";
 import { deriveEditPraxisPhase } from "./editPraxisPhase";
 import { discardRoomStore } from "./praxisRoom";
+import { applyRoomSeal, documentIsFrozen } from "./roomSeal";
 import {
   deleteCollabConfirm,
   dropDuelSideConfirm,
@@ -118,6 +119,12 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
 
   // ---- Core state ----
   const [praxis, setPraxis] = useState<PraxisOut | null>(null);
+  // This client's room was hung up because the praxis froze (#1931). Held here
+  // rather than read off the praxis because it is the NEWER fact — the row in
+  // hand still says `in_progress`, and every keystroke taken between the
+  // hang-up and the refetch below would be dropped by the server in silence.
+  // See `roomSeal.ts` for both halves of the rule.
+  const [sawSealClose, setSawSealClose] = useState(false);
   const [task, setTask] = useState<TaskOut | null>(null);
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
@@ -421,6 +428,11 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
       // `refetch` only refreshes auth — without reloading the praxis the roster
       // would keep showing my part as cast right after I pulled it back.
       setPraxis(await getPraxis(praxisId));
+      // The one transition that makes a sealed room writable again from this
+      // tab, so it is the one place the seal latch is released (#1931).
+      // Ordered after the read on purpose: clearing it first would unfreeze the
+      // editor for the length of a round trip, against a praxis still sealed.
+      setSawSealClose(false);
     } catch (err) {
       setError(extractError(err, i18n.t("forms:editPraxis.errors.publish")));
     } finally {
@@ -628,11 +640,26 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
     [praxis, duel, askConfirm],
   );
 
+  // The room hung up with `WS_ROOM_FROZEN` (#1931). `EditPraxis.tsx` hands this
+  // to the provider as `onSealed`; nothing else calls it, and it is idempotent
+  // because the provider may fire it more than once.
+  //
+  // The freeze goes on HERE, off the close code, not off the answer below —
+  // the round trip is exactly the window in which the member's typing is being
+  // dropped, and a read that fails or never returns must not hand the editor
+  // back. The refetch catches the rest of the composer up.
+  const noteRoomSealed = useCallback(() => {
+    setSawSealClose(true);
+    if (!idParam) return;
+    void applyRoomSeal(parseInt(idParam, 10), getPraxis, setPraxis);
+  }, [idParam]);
+
   // ---- Derived ----
-  // The freeze (#1745), stated as the server states it. Drafting is the only
-  // status in which the room accepts a change, so it is the only status in
-  // which the editor may accept a keystroke.
-  const documentFrozen = !!praxis && praxis.status !== "in_progress";
+  // The freeze (#1745), stated as the server states it, plus the close code
+  // that says so before the status can (#1931) — see `roomSeal.ts`. Drafting is
+  // the only status in which the room accepts a change, so it is the only
+  // status in which the editor may accept a keystroke.
+  const documentFrozen = documentIsFrozen(praxis, sawSealClose);
   const isPublished = praxis?.status === "submitted";
 
   // A published praxis has no room document any more — the server destroyed it
@@ -775,6 +802,8 @@ export function useEditPraxis(idParam: string | undefined): EditPraxisState {
 
     autoSubmitDays,
     documentFrozen,
+    sealedMidEdit: sawSealClose,
+    noteRoomSealed,
     isPublished: !!isPublished,
     controlsLocked,
     modeIsLocked,


### PR DESCRIPTION
#1808's server half (PR #1923) hangs up every socket on a praxis the moment it freezes, with close code `4001`. That code reached the browser and **nothing acted on it**: the client reconnected — correctly, a sealed room still serves reads — and the editor stayed writable, because `documentFrozen` is derived from the praxis fetched at mount and nothing refetched it. The holdout kept typing and the server kept dropping every update. The text was on screen, so they believed it was saved.

Closes #1931

## The seam I tested at

Two pure functions, extracted the way #1804 extracted `shouldReconnectRoom` — the harness is `renderToStaticMarkup`, no DOM and no effects, so a rule that cannot be called cannot be proved:

- `roomReconnect.ts` — `WS_ROOM_FROZEN = 4001` and `isRoomSealedClose(code)`. The close-code file already owned `WS_POLICY_VIOLATION`; `shouldReconnectRoom` is **unchanged** and now says in a comment why 4001 is deliberately not listed beside 1008.
- `roomSeal.ts` (new) — `documentIsFrozen(praxis, sawSealClose)`, `composerWritable(seeded, documentFrozen)`, `applyRoomSeal(id, fetchPraxis, setPraxis)`. The chain each test walks is the production one: a 4001 close -> `documentIsFrozen` -> `composerWritable` -> the editor.

The failing tests went in first (commit 1), the wiring after (commit 2).

## The wiring

1. `praxisRoom.tsx` gains an `onSealed?` prop beside `onUpdate`, fired from y-websocket's **`connection-close`** event. That event carries the `CloseEvent` for *every* close; `closed` fires only for terminal ones, and a seal is deliberately not terminal. Not surfaced on the context, because `useEditPraxis` runs outside the provider — the same reason `onUpdate` is a prop.
2. `useEditPraxis.ts` sets a `sawSealClose` latch and refetches the praxis. `EditPraxis.tsx` hands `state.noteRoomSealed` over as `onSealed`.
3. `controls.tsx` picks a second copy variant when the seal happened under this member.

**One deliberate departure from the issue's wording**, flagged for review: the issue says the refetch alone flips `documentFrozen`. I OR the close code in as well (`documentIsFrozen` above), because the round trip is *exactly* the window in which the member's keystrokes are being dropped, and a refetch that 500s or never returns would leave the editor writable against a stale `in_progress` row — the loss this issue exists to end, just narrower. The refetch still runs and still catches the rest of the composer up. The latch is released in `pullBack`, the one transition that makes a sealed room writable again from this tab.

Not enforcement — the server is and stays the enforcer (`_refuse_writes_when_frozen`). This is only about telling the member.

## What it does not do

**The lost text is not recovered, and nothing here tries.** Yjs merges additively and never reverts, the server never accepted the update, so it exists only in that tab's memory. This makes the gap one close event wide and the failure honest.

Untouched, per the issue: the server's `4001`, its transition-only revoke, the `SYNC_STEP1` exemption, the offline store, `discardRoomStore`, and PR #1923's earlier `body_text` write on a partial collab submit.

## Copy

One new key, `forms:editPraxis.composer.bodyFrozenMidEdit`, shown only to a client that saw a 4001:

> Someone submitted while you were writing, so the write-up froze mid-sentence. Anything you typed after that never reached the crew and cannot be recovered — you will have to write it again.

The existing `bodyFrozen` still serves the member who loaded an already-frozen praxis and has lost nothing. The reopen link is unchanged and still offered in both cases. No new styling — the notice reuses `.label-caption` in place. Wording is open to a copy pass.

## Checks

Every step in `.github/workflows/test.yml`'s frontend job, run locally on this branch:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean (the two new required `EditPraxisState` fields hit `TS2739` in `.design-sync/previews/_state.tsx`; the preview builder now supplies them)
- `npm test` — 272 files, 4858 passed, 1 skipped. #1804's four `roomReconnect` cases are untouched and green.
- `npm run build` — clean
- `npm run budget` — within budget, JS 129.6 KB / CSS 21.2 KB, unmoved

Backend untouched.

**Visual QA is outstanding** — I have no browser and no dev stack here, so the new notice has never been rendered on screen.

## What to eyeball

Two browsers, two members, one collab praxis, both in the composer:

1. B is typing a paragraph. A submits. **B's editor must stop taking text within a beat** — the caret goes read-only, the markdown toolbar disappears, and the notice underneath says their text is gone, not the generic "publish window is open" line.
2. Whatever B typed in the second or two before that is still on screen and is **not** saved. Check it is genuinely absent after a reload — that is the honest failure this PR describes, not a bug in it.
3. B clicks "Reopen the write-up for the crew". The editor takes text again, the notice disappears, and it does **not** come back on the next keystroke (the latch is released).
4. A, who submitted, gets the same freeze from the same close — their socket is revoked too. Their notice should be the mid-edit one as well, and it should not read as an error.
5. A third member C, who was not in the room and opens the praxis after the freeze, gets the **original** `bodyFrozen` sentence — no claim of a loss they did not have.
6. B, sealed, reloads the page: the room reconnects and the sealed write-up is readable (the reason 4001 is not 1008). The notice reverts to the original wording, since this session saw no close.
7. Solo praxis: submit, and confirm nothing about the frozen notice regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
