### PR TITLE
97 faction key slots the copy audit ruled generic are deleted, and a guard reads their absence

### DIFF
--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -47,11 +47,16 @@ const HAIRLINE_FAINT = 'rgba(0,0,0,0.055)'
 const RULE = 'rgba(0,0,0,0.07)'
 
 // i18n key stems under factions:albescent.letter — resolved at render.
+//
+// The fourth row was "standing / unranked, by design"
+// (`terms.standingLabel` + `terms.standingValue`). #1909 CUT both: they are the
+// Albescent twin of the `{F}.invitation.terms[3]` standing row the audit cut
+// across all seven other letters, which meant three different things by faction
+// and was static flavour presented as live standing.
 const TERM_KEYS: ReadonlyArray<{ label: string; value: string }> = [
   { label: 'terms.tollLabel', value: 'terms.tollValue' },
   { label: 'terms.skillsLabel', value: 'terms.skillsValue' },
   { label: 'terms.outputLabel', value: 'terms.outputValue' },
-  { label: 'terms.standingLabel', value: 'terms.standingValue' },
 ]
 
 const PERK_KEYS: ReadonlyArray<string> = [

--- a/frontend/src/components/__tests__/wowFeedChassis.test.tsx
+++ b/frontend/src/components/__tests__/wowFeedChassis.test.tsx
@@ -120,8 +120,12 @@ describe('the skin is the identification (epic decision 5)', () => {
     // v1 headed every card "HERALD'S DISPATCH" as well as its kicker. #1194 made
     // `kicker` a card's ONLY kind label; two labels naming one kind is exactly
     // what that rule exists to stop.
+    //
+    // Spelled out because #1909 DELETED `feed:identity.wow.dispatch`: a key
+    // kept alive only by a negative assertion is one the next dead-key sweep
+    // cannot tell from a live one.
     const html = frame()
-    expect(html).not.toContain(i18n.t('feed:identity.wow.dispatch'))
+    expect(html).not.toContain("Herald's Dispatch")
     expect(html.split('Task completed').length - 1, 'the kind is named once').toBe(1)
   })
 })

--- a/frontend/src/components/comments/__tests__/wowComment.test.tsx
+++ b/frontend/src/components/comments/__tests__/wowComment.test.tsx
@@ -157,7 +157,13 @@ describe('row states', () => {
   it('draws no reaction pill — nothing in the product can answer one', () => {
     // The kit draws "✦ Huzzah · 12" and #898 shipped the word, but there is no
     // reaction endpoint, column or count. A control that no-ops is forbidden.
-    expect(row()).not.toContain(i18n.t('praxis:comments.wow.react'))
+    //
+    // The word is spelled out because #1909 DELETED `praxis:comments.wow.react`
+    // as dead copy: a key kept alive only by a negative assertion is one the
+    // next dead-key sweep cannot tell from a live one. The ✦ is carried too, so
+    // this cannot pass or fail on `comments.wow.empty`, which says "Huzzah" in
+    // a sentence about having no counsel yet.
+    expect(row()).not.toContain('✦ Huzzah')
   })
 })
 

--- a/frontend/src/components/comments/voices/SingularityComment.tsx
+++ b/frontend/src/components/comments/voices/SingularityComment.tsx
@@ -197,7 +197,11 @@ export default function SingularityComment(props: CommentProps) {
         <div aria-busy={submitting}>
           <div style={{ ...LABEL, color: BLUE, marginBottom: 'var(--space-sm)' }}>
             <span aria-hidden="true">{'> '}</span>
-            {t('comments.singularity.protocol')}
+            {/* The prompt read "singularity function"
+                (`comments.singularity.protocol`). #1909 cut it: Singularity was
+                the only faction with the slot, and the audit ruled the comment
+                masthead generic. The `> ` and the caret are the prompt's
+                punctuation and stay. */}
             {/* `.sg-cursor` owns the blink AND its reduced-motion guard (#1003:
                 keyframes never live in a component). The caret is punctuation on
                 the prompt, so it stays drawn when the blink is stilled. */}

--- a/frontend/src/components/comments/voices/WowComment.tsx
+++ b/frontend/src/components/comments/voices/WowComment.tsx
@@ -52,12 +52,13 @@ import { CommentFlagControl, canFlagComment } from '../FlagControl'
  * comment voices should also be neutralised is a call for the owner, not for a
  * dress issue holding a shared locale file eight agents are queued on.
  *
- * THE HUZZAH IS STILL NOT BUILT. The kit draws a "✦ Huzzah · 12" reaction pill
- * and #898 shipped the word (`comments.wow.react`), but there is no reaction
- * anywhere in the product — no endpoint, no column, no count on `CommentOut` —
- * so the pill would be a control that no-ops, which UX principle 5 forbids. The
- * key waits for the feature. "Reply" is absent for the same reason: comments are
- * flat (ADR-0006).
+ * THE HUZZAH IS STILL NOT BUILT, AND ITS WORD IS GONE. The kit draws a "✦ Huzzah
+ * · 12" reaction pill and #898 shipped the word (`comments.wow.react`), but
+ * there is no reaction anywhere in the product — no endpoint, no column, no
+ * count on `CommentOut` — so the pill would be a control that no-ops, which UX
+ * principle 5 forbids. The key waited for a feature that never came, so #1909
+ * deleted it as dead copy: no button is removed here, because none was ever
+ * built. "Reply" is absent for the same reason: comments are flat (ADR-0006).
  *
  * Every colour is a shipped `--faction-wow-*` token and both themes come from
  * the `[data-theme="dark"]` cascade. The one AA trap on this palette is avoided
@@ -195,7 +196,10 @@ export default function WowComment(props: CommentProps) {
             // one WOW ink measured against the parchment plate.
             bg="var(--faction-wow-chronicle-panel)"
             text={INK}
-            submitLabel={t('comments.wow.post')}
+            // The submit label was `comments.wow.post` ("Proclaim"). #1909
+            // deleted it: the generic `praxis:comments.post` ("Post comment")
+            // already covers the slot, and `ComposerControls` reads it as its
+            // own default — so dropping the override IS the repoint.
             // The shared string in the decree's own quiet register — an OVERRIDE
             // of ComposerControls' neutral default, not a new hint.
             hint={<span style={QUIET}>{t('comments.mentionHint')}</span>}

--- a/frontend/src/components/duel/WowDuelSealConfirm.tsx
+++ b/frontend/src/components/duel/WowDuelSealConfirm.tsx
@@ -81,20 +81,15 @@ import {
   INK,
   LISTS_BG,
   ListsBand,
-  ListsRibbonMark,
   ListsSpark,
   listsEyebrow,
-  MUTED,
   NOTICE,
-  ON_RIBBON,
   PANEL,
   PANEL_BORDER,
   PANEL_QUIET,
-  RIBBON,
   Rosette,
   SCRIM,
   SHADOW,
-  useWowSealVoice,
 } from './wowLists'
 
 export default function WowDuelSealConfirm({
@@ -108,7 +103,10 @@ export default function WowDuelSealConfirm({
 }: DuelSealConfirmProps) {
   const { me, foe } = duelSides(duel, viewerCharacterId)
   const copy = useDuelSealCopy(mode, duel, viewerCharacterId, taskPointValue)
-  const voice = useWowSealVoice(mode)
+  // `useWowSealVoice` supplied nine strings on top of `copy` — the kicker, the
+  // two section headings, the ribbon line and the two button labels per mode.
+  // #1909 CUT all nine; see the note where the hook used to live in
+  // `wowLists.tsx`. This skin now renders `copy` alone, like the other eight.
 
   // The opponent's tokens (#310) — spent on the rosette ring only. See the note
   // in `wowLists.tsx`: a foreign hue is never a ground and never an ink here.
@@ -152,21 +150,10 @@ export default function WowDuelSealConfirm({
         >
           <WowSigil size={46} />
           <div style={{ minWidth: 0 }}>
-            {/* The kicker is WOW's; the HEADING below is the shared, neutral
-                one (#718 — and `duelSkinSlots.test.tsx` enforces it). A span,
-                not a <p>: this line is a byline, Label tier by role, and the
-                seal guard rightly treats a Label-sized <p> as sunk body copy. */}
-            <span
-              style={{
-                display: 'block',
-                fontFamily: BODY_FONT,
-                fontStyle: 'italic',
-                fontSize: 'var(--text-lg)',
-                color: MUTED,
-              }}
-            >
-              {voice.sub}
-            </span>
+            {/* The kicker above the heading was WOW's ("Enter the lists ·
+                submitting proof" / "Leave the lists · yielding the joust");
+                #1909 cut both. The HEADING below is the shared, neutral one
+                (#718 — and `duelSkinSlots.test.tsx` enforces it), unchanged. */}
             <h2
               className="content-title"
               style={{ fontFamily: DISPLAY_FONT, color: INK, lineHeight: 1.15 }}
@@ -221,7 +208,8 @@ export default function WowDuelSealConfirm({
               marginBottom: 'var(--space-sm)',
             }}
           >
-            {voice.rosterLabel}
+            {/* "The Roster" (`duelSeal.wow.rosterLabel`) stood here; #1909 cut
+                it. The rosette stays — it is drawn, not written. */}
             <Rosette accent={accent} soft={soft} size={18} />
           </span>
           <div
@@ -236,11 +224,9 @@ export default function WowDuelSealConfirm({
           </div>
         </div>
 
-        {/* ── the stakes, struck in gold ── */}
+        {/* ── the stakes, struck in gold. Its "The Stakes" eyebrow
+            (`duelSeal.wow.stakesLabel`) was cut by #1909. ── */}
         <div style={{ marginTop: 'var(--space-lg)' }}>
-          <span style={{ ...listsEyebrow, marginBottom: 'var(--space-sm)' }}>
-            {voice.stakesLabel}
-          </span>
           <div
             style={{
               background: PANEL,
@@ -259,30 +245,11 @@ export default function WowDuelSealConfirm({
             />
           </div>
 
-          {/* The ribbon promise — suppressed on the forfeit face, where it
-              would be a lie: a rider who quits has not entered the lists to
-              the end. */}
-          {!copy.danger && (
-            <p
-              className="content-text"
-              style={{
-                display: 'flex',
-                alignItems: 'baseline',
-                gap: 'var(--space-sm)',
-                marginTop: 'var(--space-sm)',
-                padding: 'var(--space-sm) var(--space-md)',
-                borderRadius: 11,
-                background: RIBBON,
-                color: ON_RIBBON,
-                fontFamily: BODY_FONT,
-                fontStyle: 'italic',
-              }}
-            >
-              <ListsRibbonMark color={ON_RIBBON} />
-              <span>{voice.ribbonLine}</span>
-            </p>
-
-          )}
+          {/* The ribbon promise ("A ribbon for the courage to enter — in our
+              lists both riders are honoured.", `duelSeal.wow.ribbonLine`) sat
+              here, suppressed on the forfeit face where it would be a lie.
+              #1909 cut the string, and the plum band existed only to carry it —
+              a coloured plate holding nothing is not a survivor. */}
         </div>
 
         <div style={{ marginTop: 'var(--space-lg)' }}>
@@ -290,8 +257,11 @@ export default function WowDuelSealConfirm({
             onConfirm={onConfirm}
             onCancel={onCancel}
             busy={busy}
-            confirmLabel={voice.confirm}
-            cancelLabel={voice.cancel}
+            /* WOW's own verbs ("Take the Field" / "Yield the Field",
+               "Withdraw" / "Hold thy Ground") were cut by #1909. `copy` already
+               carries the right confirm label in both modes, and `SealActions`
+               falls back to `duelSeal.cancel` for the other. */
+            confirmLabel={copy.confirmLabel}
             danger={copy.danger}
             theme={theme}
           />

--- a/frontend/src/components/duel/wowLists.tsx
+++ b/frontend/src/components/duel/wowLists.tsx
@@ -5,7 +5,7 @@
  * a checkered barrier rail, a rosette for the rider who comes from elsewhere,
  * and a ribbon that goes home with the loser. This module holds the pieces that
  * would otherwise be drawn twice — the token names, the barrier band, the
- * rosette, and the seal's voice resolver. It shipped serving FOUR surfaces; the
+ * rosette, and (until #1909) the seal's voice resolver. It shipped serving FOUR surfaces; the
  * two `*DuelRail` skins went with the rail in #1090 and the phone seal went with
  * the `mobileDuelSeal` SURFACE in #1313, so the consumer is now
  * `WowDuelSealConfirm` — one responsive component, both form factors.
@@ -27,9 +27,6 @@
  * keyframes the crest already declares.
  */
 import type { CSSProperties } from 'react'
-import { useTranslation } from 'react-i18next'
-
-import type { DuelSealMode } from './shared'
 
 /* -------------------------------------------------------------------------- */
 /* Tokens                                                                     */
@@ -184,55 +181,24 @@ export function ListsRibbonMark({ color = PLUM }: { color?: string }) {
 }
 
 /* -------------------------------------------------------------------------- */
-/* Voice                                                                      */
+/* Voice — RETIRED (#1909)                                                    */
 /* -------------------------------------------------------------------------- */
 
-/** The strings WOW's seal supplies on top of the shared, faction-neutral copy. */
-export interface WowSealVoice {
-  sub: string
-  confirm: string
-  cancel: string
-  rosterLabel: string
-  stakesLabel: string
-  ribbonLine: string
-}
-
-/**
- * WOW's chrome voice for the seal.
+/*
+ * `useWowSealVoice` and its `WowSealVoice` shape lived here. It supplied nine
+ * strings on top of the shared, faction-neutral seal copy: a KICKER above the
+ * heading ("Enter the lists · submitting proof" / "Leave the lists · yielding
+ * the joust"), the two section headings ("The Roster", "The Stakes"), the ribbon
+ * line, and the two button labels per mode.
  *
- * It deliberately does NOT replace `useDuelSealCopy`. That helper owns
- * `heading`, `body`, `note` and `danger`, and the seal skins render all four
- * unchanged. Two reasons, and the second one is enforced:
+ * ALL NINE ARE ON THE COPY AUDIT'S CUT LIST. WOW was the only faction with a
+ * voiced duel seal — the other eight skins already rendered `useDuelSealCopy`'s
+ * neutral strings alone — and the audit ruled the surface generic. The buttons
+ * are the interesting case: dropping the override is the whole fix, because
+ * `SealActions` already falls back to `duelSeal.confirm` / `duelSeal.cancel`,
+ * and `useDuelSealCopy` already carries the forfeit-mode label.
  *
- *  1. `body` and `note` carry live figures and the pending/active/forfeit
- *     branch. Re-authoring them here would be a skin re-implementing a slot,
- *     which `duel/shared.tsx` forbids outright.
- *  2. `heading` is a CONTRACT, not a flourish. `duelSkinSlots.test.tsx` asserts
- *     that every registered seal skin renders "Lock the duel?" in submit mode
- *     and "Forfeit" in forfeit mode — that is #718's faction-neutral-copy
- *     decision with a guard behind it. A WOW-voiced title was drafted here and
- *     removed when the guard (correctly) caught it.
- *
- * What is left, and what WOW takes: the KICKER above the heading, the two
- * section headings the kit draws, the ribbon line, and the two button labels.
- * That is the same faction-scoped-key pattern `praxis.json`'s `card.wow` block
- * already uses, so the shared resolver stays neutral and only this skin reads
- * the WOW keys. (Praxis DETAIL is the counter-example, not a sibling: ADR-0061
- * keeps that page on one neutral block, and its per-faction WOW block was
- * deleted when the voiced amendment was withdrawn.)
- *
- * The single branch here is on `mode`, which arrives as a prop — no duel fact is
- * re-derived.
+ * What the hook DELIBERATELY did not own — `heading`, `body`, `note`, `danger` —
+ * was never WOW's, and `duelSkinSlots.test.tsx` still enforces that. Nothing
+ * about that contract changes here; there is simply nothing left on top of it.
  */
-export function useWowSealVoice(mode: DuelSealMode): WowSealVoice {
-  const { t } = useTranslation('praxis')
-  const scope = mode === 'forfeit' ? 'forfeit' : 'submit'
-  return {
-    sub: t(`duelSeal.wow.${scope}.sub`),
-    confirm: t(`duelSeal.wow.${scope}.confirm`),
-    cancel: t(`duelSeal.wow.${scope}.cancel`),
-    rosterLabel: t('duelSeal.wow.rosterLabel'),
-    stakesLabel: t('duelSeal.wow.stakesLabel'),
-    ribbonLine: t('duelSeal.wow.ribbonLine'),
-  }
-}

--- a/frontend/src/components/factionCard/EverymenFactionCard.tsx
+++ b/frontend/src/components/factionCard/EverymenFactionCard.tsx
@@ -7,7 +7,7 @@ import { EverymenSigil } from "../sigil/EverymenSigil";
  * EverymenFactionCard — the Everymen faction PREVIEW card.
  *
  * A union recruitment poster: a masthead with the faction name in a big Bebas
- * headline and the motto/blurb from factionDescription(slug). Pure preview —
+ * headline and the blurb from factionDescription(slug). Pure preview —
  * the whole card is a link to the faction detail page, where the enlist / leave
  * membership block lives (issue #347). No interactive controls here.
  *
@@ -75,11 +75,9 @@ export default function EverymenCard({
 }: FactionCardProps) {
   const blurb = factionDescription(faction.slug);
 
-  const perks = [
-    i18n.t("feed:factionCard.everymen.perks.honestPoints"),
-    i18n.t("feed:factionCard.everymen.perks.finishesWork"),
-    i18n.t("feed:factionCard.everymen.perks.stampedWork"),
-  ];
+  // The three-perk checklist under the blurb was Everymen's alone — no other
+  // faction card had one — and #1909 cut all three strings with the surface.
+  // The card ends on the description, which is where the other eight end.
 
   return (
     <div
@@ -98,29 +96,38 @@ export default function EverymenCard({
       <Sunburst color="var(--everymen-field-deep)" from="50% 32%" opacity={0.55} step={7.5} />
       <Halftone color="var(--everymen-cream)" opacity={0.09} />
 
-      {/* gold top rule + kicker */}
-      <div
-        style={{
-          position: "relative",
-          zIndex: 2,
-          background: "var(--everymen-ink)",
-          color: "var(--everymen-gold)",
-          textAlign: "center",
-          fontFamily: "var(--faction-everymen-card-font)",
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: struck banner ribbon across the card head — illustration, not chrome
-          fontSize: 15,
-          letterSpacing: "0.34em",
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: lead of the struck banner ribbon; rounding reflows it.
-          padding: "7px 0",
-        }}
-      >
-        {invitationNote
-          ? i18n.t("feed:factionCard.everymen.summons", {
-              note: invitationNote.toUpperCase(),
-            })
-          : i18n.t("feed:factionCard.everymen.kicker")}
-      </div>
-      <div style={{ height: 4, background: "var(--everymen-gold)", position: "relative", zIndex: 2 }} />
+      {/* The struck banner ribbon, now ONLY for an invitation.
+          #1909 cut both of its strings. `factionCard.everymen.summons` ("NEW
+          SUMMONS · {{note}}") is covered by the generic
+          `factionCard.newInvitation` the shared card already prints, so the
+          ribbon reads that instead — the note is appended here rather than
+          interpolated, because the generic key takes no variable.
+          `factionCard.everymen.kicker` ("THE EVERYMEN WANT YOU") had no generic
+          twin, so with no invitation there is nothing for the ribbon to say and
+          it is not drawn. */}
+      {invitationNote && (
+        <>
+          <div
+            style={{
+              position: "relative",
+              zIndex: 2,
+              background: "var(--everymen-ink)",
+              color: "var(--everymen-gold)",
+              textAlign: "center",
+              fontFamily: "var(--faction-everymen-card-font)",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: struck banner ribbon across the card head — illustration, not chrome
+              fontSize: 15,
+              letterSpacing: "0.34em",
+              // eslint-disable-next-line local/no-raw-style-values -- ornament: lead of the struck banner ribbon; rounding reflows it.
+              padding: "7px 0",
+            }}
+          >
+            <span>{i18n.t("feed:factionCard.newInvitation")}</span>
+            <span> · {invitationNote.toUpperCase()}</span>
+          </div>
+          <div style={{ height: 4, background: "var(--everymen-gold)", position: "relative", zIndex: 2 }} />
+        </>
+      )}
 
       <div style={{ position: "relative", zIndex: 2, padding: "var(--space-2xl)", textAlign: "center" }}>
         {/* sigil seal */}
@@ -141,19 +148,9 @@ export default function EverymenCard({
           </div>
         </div>
 
-        {/* World Zero · Faction eyebrow */}
-        <div
-          style={{
-            fontFamily: "var(--font-body)",
-            fontSize: "var(--text-base)",
-            letterSpacing: "0.3em",
-            textTransform: "uppercase",
-            color: "var(--everymen-gold)",
-            marginBottom: "var(--space-sm)",
-          }}
-        >
-          {i18n.t("feed:factionCard.everymen.eyebrow")}
-        </div>
+        {/* A "WORLD ZERO · FACTION" eyebrow sat here
+            (`factionCard.everymen.eyebrow`). #1909 cut it — two factions wrote
+            one, seven never had the slot, and the audit ruled the card generic. */}
 
         {/* big Bebas headline = faction name */}
         <h1
@@ -171,24 +168,9 @@ export default function EverymenCard({
           {factionName(faction.slug)}
         </h1>
 
-        {/* motto plaque */}
-        <div
-          style={{
-            display: "inline-block",
-            marginTop: "var(--space-lg)",
-            background: "var(--everymen-ink)",
-            color: "var(--everymen-gold)",
-            fontFamily: "var(--faction-everymen-card-font)",
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: struck motto plaque — poster type set to the ink block
-            fontSize: 16,
-            letterSpacing: "0.2em",
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: inset of the motto on its struck ink plaque; rounding reflows the plaque.
-            padding: "4px 16px",
-            whiteSpace: "nowrap",
-          }}
-        >
-          {i18n.t("feed:factionCard.everymen.motto")}
-        </div>
+        {/* The struck motto plaque ("UNITED · WE · STAND") sat here.
+            #1909 cut `factionCard.everymen.motto`: Everymen was the only faction
+            with a motto on this card, on a surface the audit ruled generic. */}
 
         {/* blurb from description */}
         <p
@@ -204,51 +186,8 @@ export default function EverymenCard({
           {blurb}
         </p>
 
-        {/* what you get */}
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 0,
-            maxWidth: 380,
-            margin: "var(--space-xl) auto 0",
-            textAlign: "left",
-          }}
-        >
-          {perks.map((perk) => (
-            <div
-              key={perk}
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-md)",
-                padding: "var(--space-md) 0",
-                borderTop: "1px dashed color-mix(in srgb, var(--everymen-cream) 35%, transparent)",
-              }}
-            >
-              <span
-                style={{
-                  flexShrink: 0,
-                  width: 22,
-                  height: 22,
-                  background: "var(--everymen-gold)",
-                  color: "var(--everymen-ink)",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  fontFamily: "var(--faction-everymen-card-font)",
-                  // eslint-disable-next-line local/no-raw-style-values -- ornament: the checkmark is a dingbat glyph used as an icon in a 22px chip
-                  fontSize: 14,
-                }}
-              >
-                ✓
-              </span>
-              <span className="content-text" style={{ fontFamily: "var(--font-body)", color: "var(--everymen-cream)" }}>
-                {perk}
-              </span>
-            </div>
-          ))}
-        </div>
+        {/* The "what you get" checklist stood here — see the note beside the
+            blurb above. #1909 cut all three of its strings. */}
       </div>
     </div>
   );

--- a/frontend/src/components/factionCard/FactionCard.tsx
+++ b/frontend/src/components/factionCard/FactionCard.tsx
@@ -315,7 +315,9 @@ export function SnideCard({
           clipPath: SNIDE_TORN_CLIP,
         }}
       />
-      <SnideMasthead subtitle={i18n.t("feed:factionCard.snide.subtitle")} />
+      {/* The masthead used to close on "field dispatch"
+          (`feed:factionCard.snide.subtitle`); #1909 cut the slot. */}
+      <SnideMasthead />
       {invitationNote && (
         <InvitationNote slug={faction.slug} note={invitationNote} />
       )}
@@ -410,17 +412,10 @@ export function EphemeristsCard({
       >
         <eph.EmblemOctagon size={64} />
         <div style={{ minWidth: 0 }}>
-          <div
-            style={{
-              ...eph.SMALL_CAPS,
-              fontSize: "var(--text-md)",
-              letterSpacing: "0.26em",
-              color: eph.GOLD,
-              marginBottom: "var(--space-xs)",
-            }}
-          >
-            {i18n.t("feed:factionCard.ephemerists.eyebrow")}
-          </div>
+          {/* "World Zero · Faction №5" sat here
+              (`feed:factionCard.ephemerists.eyebrow`). #1909 cut it: two
+              factions wrote an eyebrow, seven never had the slot, and the audit
+              ruled the card generic. */}
           <div
             style={{
               fontFamily: eph.DECO,
@@ -577,29 +572,11 @@ export function SingularityCard({
         {invitationNote && (
           <InvitationNote slug={faction.slug} note={invitationNote} />
         )}
-        <div
-          style={{
-            fontSize: "var(--text-md)",
-            color: "var(--faction-singularity-card-muted)",
-            textTransform: "uppercase",
-            letterSpacing: "0.15em",
-            marginBottom: "var(--space-sm)",
-          }}
-        >
-          {i18n.t("feed:identity.singularity.protocol")}
-          <span
-            aria-hidden
-            className="sg-cursor"
-            style={{
-              display: "inline-block",
-              width: 5,
-              height: 9,
-              background: "var(--faction-singularity-card-text)",
-              marginLeft: "var(--space-xs)",
-              verticalAlign: "middle",
-            }}
-          />
-        </div>
+        {/* The card opened on "singularity protocol" with the blinking cursor
+            after it (`feed:identity.singularity.protocol`). #1909 cut the
+            string: Singularity was the only faction with the slot, on a surface
+            the audit ruled generic. The cursor was that line's punctuation and
+            goes with it — the terminal chrome below still carries the `> `. */}
         <div
           style={{
             display: "flex",

--- a/frontend/src/components/factionCard/SnideMasthead.tsx
+++ b/frontend/src/components/factionCard/SnideMasthead.tsx
@@ -7,10 +7,16 @@ import { factionCssVar } from "../../utils/factions";
  * card, faction byline, praxis card) so the dispatch header lives in one place.
  */
 export default function SnideMasthead({
+  /**
+   * The right-aligned line beside the wordmark. Optional since #1909: the one
+   * mount that passed it read `feed:factionCard.snide.subtitle` ("field
+   * dispatch"), which the copy audit CUT — Snide was the only faction with a
+   * subtitle on the card, and the surface is ruled generic.
+   */
   subtitle,
   size = 12,
 }: {
-  subtitle: string;
+  subtitle?: string;
   size?: number;
 }) {
   return (
@@ -35,16 +41,18 @@ export default function SnideMasthead({
       >
         {i18n.t("feed:identity.snide.wordmark")}
       </span>
-      <span
-        style={{
-          fontSize: "var(--text-md)",
-          letterSpacing: "0.16em",
-          textTransform: "uppercase",
-          color: factionCssVar("snide", "card-muted"),
-        }}
-      >
-        {subtitle}
-      </span>
+      {subtitle !== undefined && (
+        <span
+          style={{
+            fontSize: "var(--text-md)",
+            letterSpacing: "0.16em",
+            textTransform: "uppercase",
+            color: factionCssVar("snide", "card-muted"),
+          }}
+        >
+          {subtitle}
+        </span>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from "react-i18next";
 import { EphemeristsSigil } from "../sigil/EphemeristsSigil";
 import {
   BAND_INK,
@@ -6,7 +5,6 @@ import {
   BRASS,
   CAPS,
   GOLD,
-  GlossedGlyph,
   READING,
 } from "./ephemeristsPlate";
 import { factionName } from "../../utils/factions";
@@ -16,10 +14,11 @@ import { formatDate } from "../../utils/dates";
  * THE ENGRAVED MASTHEAD (#1634) — the head of every Ephemerists surface, and the
  * end of the deco wordmark it replaces.
  *
- * A row: the kite sigil on the left, and a column holding three stacked bands —
- * the wordmark in incised small caps, a four-kanji register ruled off above and
- * below, and a datum row of date, right ascension and declination closed by the
- * sigil again at inline scale.
+ * A row: the kite sigil on the left, and a column holding two stacked bands —
+ * the wordmark in incised small caps, and a datum row of date, right ascension
+ * and declination, ruled off above and below and closed by the sigil again at
+ * inline scale. A four-kanji register sat between them until #1909 cut all eight
+ * of its strings; the note below the coordinates records what went.
  *
  * WHAT IT REPLACED, AND WHY IT IS ONE COMPONENT. Four surfaces each drew the
  * same centred stack — a 150–176px winged sun disc over the faction's name in
@@ -42,9 +41,10 @@ import { formatDate } from "../../utils/dates";
  * spacing scale — see {@link SIZES} for the three places the scale had no step.
  */
 
-/** The design's grid, shared by the glyph row and the datum row so their cells
- *  line up. The fourth column is narrower and right-aligned: it is the row's
- *  closing mark rather than a fourth reading. */
+/** The design's grid. It was shared by the glyph row and the datum row so their
+ *  cells lined up; the glyph row is gone (#1909) and the datum row keeps it. The
+ *  fourth column is narrower and right-aligned: it is the row's closing mark
+ *  rather than a fourth reading. */
 const COLUMNS = "1.1fr 1fr 1fr 0.9fr";
 
 /**
@@ -71,27 +71,22 @@ const COLUMNS = "1.1fr 1fr 1fr 0.9fr";
 const RIGHT_ASCENSION = "8ʰ 13ᵐ";
 const DECLINATION = "+44° 03′";
 
-/**
- * The four-kanji register — 星 暦 観 録, "star · almanac · observation · record".
+/*
+ * THE FOUR-KANJI REGISTER IS GONE (#1909) — 星 暦 観 録, "star · almanac ·
+ * observation · record", and the ruled band it sat in.
  *
- * The design set this row in cuneiform; the owner replaced cuneiform with kanji
- * across the kit, and the four chosen here read top-to-bottom as what an
- * ephemeris IS: the thing watched, the table it is kept in, the act of watching,
- * and what survives the watcher. 暦 is the load-bearing one — an ephemeris is
- * literally an almanac of positions, so the faction's name is in its own
- * masthead a second time in a script most readers cannot spend.
+ * All EIGHT of its strings are on the copy audit's CUT list: the four marks and
+ * the four English glosses that `title`'d them. No other faction had a register
+ * row, and the audit ruled the masthead a generic surface, so the slot goes
+ * rather than settling to a shared wording — there is nothing shared to settle
+ * onto. The wordmark now sits straight above the datum row.
  *
- * Each is a {@link GlossedGlyph}: the English is on `title`, so hover and focus
- * reveal it and assistive tech reads it out. Written as literal pairs — never a
- * template literal — so every key survives both a grep and the catalog's own
- * key types, which a computed key silently widens out of.
+ * ponytail: this leaves a masthead of two bands where the design drew three, and
+ * the datum row inherits none of the register's rules. Ceiling: I have no
+ * browser, so the two-band proportion is unverified at either scale. Upgrade
+ * path: `frontend-style` re-rules the wordmark/datum seam, or the audit's own
+ * "put it back in intentionally" restores a register under keys of its own.
  */
-const REGISTER = [
-  ["ephemerists.masthead.starMark", "ephemerists.masthead.star"],
-  ["ephemerists.masthead.almanacMark", "ephemerists.masthead.almanac"],
-  ["ephemerists.masthead.observationMark", "ephemerists.masthead.observation"],
-  ["ephemerists.masthead.recordMark", "ephemerists.masthead.record"],
-] as const;
 
 export type MastheadScale = "page" | "card";
 
@@ -99,7 +94,6 @@ interface MastheadSize {
   /** The sigil's HEIGHT; the mark owns its 486:560 ratio (#1635). Ornament. */
   sigil: number;
   wordmark: string;
-  glyph: string;
   datum: string;
   padding: string;
   gap: string;
@@ -113,18 +107,15 @@ interface MastheadSize {
  * The design's two size tables, mapped onto the type and spacing scales.
  *
  * The sigil sizes stay raw: a drawn mark's dimensions are ornament geometry and
- * never spacing (§4a). Everything else takes a rung, and three of them needed a
+ * never spacing (§4a). Everything else takes a rung, and one of them needed a
  * decision because the scale has no step at the design's number:
  *
- *  • the page glyph row is drawn at 16px, which sits exactly between `--text-xl`
- *    (14) and `--text-content` (18). It rounds UP, for #1637's reason rather
- *    than §4a's: a kanji at 14px is at the bottom of the legible band and these
- *    four are the row, not a caption beside one.
- *  • the card glyph row is drawn at 13 and takes `--text-xl` (14), the same
- *    rung #1637 already chose for a glossed kanji.
  *  • the wordmarks are drawn at 26 and 19 and take `--text-title` (24) and
  *    `--text-content` (18) — the rungs the composer's own wordmark comment
  *    already picked for 19.
+ *
+ * The two glyph rungs that used to be decided here left with the kanji register
+ * (#1909); the `glyph` field went with them.
  *
  * The four spacing values are all ties (20, 14, 14, 10) and all round UP, per
  * §4a. The paddings are asymmetric, so they are checked against §4a's carve-out
@@ -135,7 +126,6 @@ const SIZES: Record<MastheadScale, MastheadSize> = {
   page: {
     sigil: 62,
     wordmark: "var(--text-title)",
-    glyph: "var(--text-content)",
     datum: "var(--text-md)",
     padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
     gap: "var(--space-xl)",
@@ -145,7 +135,6 @@ const SIZES: Record<MastheadScale, MastheadSize> = {
   card: {
     sigil: 44,
     wordmark: "var(--text-content)",
-    glyph: "var(--text-xl)",
     datum: "var(--text-base)",
     padding: "var(--space-md) var(--space-lg) var(--space-sm)",
     gap: "var(--space-lg)",
@@ -181,7 +170,6 @@ export function EphemeristsMasthead({ slug, scale, date }: {
    */
   date?: string | null;
 }) {
-  const { t } = useTranslation("factions");
   const size = SIZES[scale];
   const grid = { display: "grid", gridTemplateColumns: COLUMNS, gap: `0 ${size.columnGap}` } as const;
 
@@ -212,9 +200,14 @@ export function EphemeristsMasthead({ slug, scale, date }: {
           {factionName(slug)}
         </div>
 
-        {/* The register, ruled 1px above and 3px double below. The double rule
-            is the design's, and it is what makes the row read as an engraved
-            band rather than a line of type with a border. */}
+        {/* The datum row. It used to sit under the four-kanji register, which
+            carried the design's 1px + 3px-double rules; #1909 cut all eight of
+            the register's strings, so the rules move here to keep the wordmark
+            reading as an engraved band rather than free type.
+
+            `tabular-nums` is the design's, and it is doing real
+            work: three of the four cells are figures that must not shimmy as the
+            date changes underneath them. */}
         <div
           style={{
             ...grid,
@@ -222,23 +215,6 @@ export function EphemeristsMasthead({ slug, scale, date }: {
             padding: "var(--space-sm) 0",
             borderTop: `1px solid ${BRASS}`,
             borderBottom: `3px double ${BRASS}`,
-            color: GOLD,
-          }}
-        >
-          {REGISTER.map(([mark, gloss], index) => (
-            <span key={mark} style={{ textAlign: index === REGISTER.length - 1 ? "right" : "left" }}>
-              <GlossedGlyph glyph={t(mark)} gloss={t(gloss)} size={size.glyph} />
-            </span>
-          ))}
-        </div>
-
-        {/* The datum row. `tabular-nums` is the design's, and it is doing real
-            work: three of the four cells are figures that must not shimmy as the
-            date changes underneath them. */}
-        <div
-          style={{
-            ...grid,
-            marginTop: "var(--space-xs)",
             fontFamily: READING,
             fontSize: size.datum,
             fontVariantNumeric: "tabular-nums",

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsMasthead.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsMasthead.test.tsx
@@ -78,24 +78,35 @@ describe("EphemeristsMasthead — the datum row", () => {
   });
 });
 
-describe("EphemeristsMasthead — the register", () => {
+/**
+ * THE REGISTER IS GONE (#1909), and this block is what says so.
+ *
+ * It used to assert the four kanji and their glossed `title=`. All EIGHT of its
+ * strings are on the copy audit's CUT list — the marks AND the English — because
+ * no other faction had a register row and the audit ruled the masthead a shared
+ * surface. Kept as an ABSENCE rather than deleted: the way a faction-only band
+ * comes back onto a settled surface is a later voice pass, and only a negative
+ * assertion can fail on that.
+ */
+describe("EphemeristsMasthead — the register, deleted", () => {
   const html = render("page");
 
-  it("sets four kanji, each with its English one gesture away", () => {
-    for (const [mark, gloss] of [
-      ["星", "Star"],
-      ["暦", "Almanac"],
-      ["観", "Observation"],
-      ["録", "Record"],
-    ]) {
-      expect(html).toContain(`title="${gloss}"`);
-      expect(html).toContain(`>${mark}</abbr>`);
+  it("sets no kanji, at either scale", () => {
+    for (const mark of ["星", "暦", "観", "録"]) {
+      expect(html).not.toContain(mark);
+      expect(render("card")).not.toContain(mark);
     }
   });
 
-  it("reaches the focus gloss the tooltip cannot give a keyboard user", () => {
-    expect((html.match(/class="eph-gloss"/g) ?? []).length).toBe(4);
-    expect((html.match(/tabindex="0"/g) ?? []).length).toBe(4);
+  it("carries no glossed abbreviation at all", () => {
+    expect(html).not.toContain('class="eph-gloss"');
+    expect(html).not.toContain("</abbr>");
+  });
+
+  it("still rules the datum row off, top and bottom", () => {
+    // The register carried the design's 1px + 3px-double band; those rules moved
+    // to the datum row rather than leaving with the copy.
+    expect(html).toContain("3px double");
   });
 });
 

--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -127,24 +127,29 @@ describe('the Ephemerists praxis card wears the Valley plate (#1207)', () => {
     // deleted with the pill, and a key kept alive by a negative assertion is a
     // key the next dead-key sweep cannot tell from a live one.
     expect(rendered).not.toContain('Ephemeris · sealed entry')
-    // The masthead's own register, at the card scale's rung.
-    expect(rendered).toContain('星')
+    // The four-kanji register (星 暦 観 録) is GONE, and so is the English it
+    // was glossed with: #1909 CUT all eight `ephemerists.masthead.*` strings —
+    // no other faction had a register row, and the audit ruled the masthead
+    // generic. Asserted as an absence so a voice pass cannot quietly put a
+    // faction-only band back on a surface ruled shared.
+    expect(rendered).not.toContain('星')
     expect(html()).toContain('var(--faction-ephemerists-plate-band-quiet)')
   })
 
-  it('reads the task through the plate gloss rather than as a bare reference', () => {
-    expect(text(html())).toContain(i18n.t('praxis:card.ephemerists.for'))
-  })
+  /* The plate gloss ("for:", `praxis:card.ephemerists.for`) and the card's own
+     vote prompt ("Cast your metal", `votes:chrome.ephemerists.prompt`) each had
+     a test here. #1909 CUT both keys — the gloss was a two-faction flourish on a
+     surface ruled generic, and the whole `chrome.{F}.prompt` slot went because
+     only three of nine factions rendered one. What remains of the second test —
+     the drift strip breathing on the shared gate rather than inline — is the
+     assertion below, which is the part that was never about copy. */
 
-  it('drifts a glyph strip above the vote block, and heads the cast', () => {
+  it('drifts a glyph strip above the vote block', () => {
     const markup = html()
     // The strip breathes on the shared `.epg-glyph` gate rather than an inline
     // animation, so a reduced-motion reader still gets the marks.
     expect(text(markup)).toContain('∮')
     expect(markup).not.toContain('animation:')
-    // The CARD states the vote prompt — the widget carries none, so the detail
-    // page's own section heading is not doubled up.
-    expect(text(markup)).toContain(i18n.t('votes:chrome.ephemerists.prompt'))
   })
 
   it('keeps no hex in the frame it draws', () => {

--- a/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
@@ -1,9 +1,7 @@
-import { useTranslation } from "react-i18next";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 import {
   Braid,
-  CAPTION,
   CARD,
   BORDER,
   DEEP,
@@ -40,7 +38,6 @@ import {
  * and a name, not a card's whole content.
  */
 export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
-  const { t } = useTranslation("praxis");
   return (
     <div
       style={{
@@ -73,13 +70,13 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
           display: DISPLAY,
           body: READING,
         }}
-        eyebrow={
-          <div style={{ marginBottom: "var(--space-sm)" }}>
-            <div style={CAPTION}>{t("card.masthead.coven", { id: praxis.id })}</div>
-            <Braid style={{ marginTop: "var(--space-xs)" }} />
-          </div>
-        }
-        mediaEmptyLabel={t("card.coven.mediaEmpty")}
+        /* The eyebrow's dispatch line ("dispatch no. {{id}} · all done!",
+           `card.masthead.coven`) and the empty gallery's "Drop a happy little
+           photo" (`card.coven.mediaEmpty`) were both CUT by #1909 — the masthead
+           because a generic one just says "Praxis" on a praxis card, the media
+           label because Coven was one of two factions with the slot. The braid
+           stays: it is drawn, not written. */
+        eyebrow={<Braid style={{ marginBottom: "var(--space-sm)" }} />}
         mediaEmptyStyle={{
           height: 158,
           borderRadius: 12,

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties } from "react";
-import { useTranslation } from "react-i18next";
 import {
   BAND,
   BAND_INK,
@@ -16,7 +15,6 @@ import {
   QUIET,
   READING,
   SHADOW,
-  SMALL_CAPS,
 } from "../../factionMarks/ephemeristsPlate";
 import { EphemeristsMasthead } from "../../factionMarks/EphemeristsMasthead";
 import { AdminOverlay } from "../shared";
@@ -57,10 +55,11 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  *  • the byline keeps the shared portrait (`FactionAvatar`) rather than the
  *    design's octagon monogram: the byline slot is shared card chrome (#888) and
  *    the avatar is one convention across every faction;
- *  • the "for:" gloss is upright, not italic — `PraxisBody` owns that line's
- *    style, and a faction may not reach into a shared slot to italicise it;
  *  • the design's `border-radius` is 0 here (the design draws none), against the
  *    8 the codex folio used.
+ *
+ * The fourth deviation — "the 'for:' gloss is upright, not italic" — retired with
+ * its string: #1909 CUT `card.ephemerists.for`, so there is no gloss to set.
  */
 
 /** Masthead band, and the field its register is drawn across. Geometry (§4a).
@@ -81,9 +80,6 @@ const DRIFT = [
 ];
 
 export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
-  const { t } = useTranslation("praxis");
-  const { t: tVotes } = useTranslation("votes");
-
   return (
     <div
       style={{
@@ -161,8 +157,11 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
           titleStyle={{ fontFamily: DECO, fontWeight: 400, letterSpacing: "0.02em", color: INK }}
           // Poiret One for the display line, Spectral for the reading matter.
           fonts={{ display: DECO, body: READING }}
-          taskLead={t("card.ephemerists.for")}
-          mediaEmptyLabel={t("card.ephemerists.mediaEmpty")}
+          // #1909 CUT the two strings that used to fill the shared slots here:
+          // `card.ephemerists.for` ("for:") and `card.ephemerists.mediaEmpty`
+          // ("Affix the observation"). Both were single- or two-faction
+          // flourishes on a surface the audit ruled generic; the slots survive
+          // unfilled and the shared card draws its own.
           mediaEmptyStyle={{
             borderRadius: 0,
             border: `1px solid ${BRASS}`,
@@ -216,16 +215,11 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
                   marginBottom: "var(--space-md)",
                 }}
               >
-                <span
-                  style={{
-                    ...SMALL_CAPS,
-                    fontSize: "var(--text-base)",
-                    letterSpacing: "0.26em",
-                    color: CAPTION,
-                  }}
-                >
-                  {tVotes("chrome.ephemerists.prompt")}
-                </span>
+                {/* "Cast your metal" (`votes:chrome.ephemerists.prompt`) headed
+                    this rule. #1909 cut the whole `chrome.{F}.prompt` slot:
+                    only three of nine factions ever rendered one, two more held
+                    dead strings, and six ship none at all. The rule and the
+                    lotus stay — they are the vote panel's frame, not its copy. */}
                 <span aria-hidden style={{ flex: 1, height: 1, background: BRASS, opacity: 0.5 }} />
                 <LotusSign width={16} color={BRASS} />
               </div>

--- a/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties } from "react";
-import { useTranslation } from "react-i18next";
 import { factionCssVar } from "../../../utils/factions";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
@@ -37,7 +36,6 @@ const everymenMarginRule: CSSProperties = {
 };
 
 export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
-  const { t } = useTranslation("praxis");
   return (
     <div
       style={{
@@ -73,12 +71,14 @@ export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeP
           boxShadow: "0 2px 0 rgba(34, 26, 18, 0.22)",
         }}
       >
-        {/* Cogs flank the name — a drawn glyph, not an icon (§7). */}
+        {/* Cogs flank the name — a drawn glyph, not an icon (§7). The name
+            itself ("The Everymen", `card.masthead.everymen`) was CUT by #1909:
+            once the masthead is generic it reads "Praxis" on a praxis card, and
+            Everymen's was only ever the faction's own name. The cogs stay. */}
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: flanking cog glyph, sized under the lettering (§4a) */}
         <span aria-hidden style={{ fontSize: 12, opacity: 0.85 }}>
           ⚙
         </span>
-        <span>{t("card.masthead.everymen")}</span>
         {/* eslint-disable-next-line local/no-raw-style-values -- ornament: flanking cog glyph, sized under the lettering (§4a) */}
         <span aria-hidden style={{ fontSize: 12, opacity: 0.85 }}>
           ⚙

--- a/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties } from "react";
-import { useTranslation } from "react-i18next";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -83,7 +82,6 @@ const scanSweepStyle: CSSProperties = {
 const ledStyle: CSSProperties = { width: 7, height: 7, borderRadius: "50%", flexShrink: 0 };
 
 export function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
-  const { t } = useTranslation("praxis");
   return (
     <div
       style={{
@@ -124,16 +122,10 @@ export function SingularityPraxisCard({ praxis, adminProps, showCrown }: Archety
           <span aria-hidden style={{ ...ledStyle, background: "var(--faction-singularity-led-red)" }} />
           <span aria-hidden style={{ ...ledStyle, background: "var(--faction-singularity-led-amber)" }} />
           <span aria-hidden style={{ ...ledStyle, background: "var(--faction-singularity-led-green)" }} />
-          <span
-            className="label-heading"
-            style={{
-              marginLeft: "auto",
-              letterSpacing: "0.14em",
-              color: "var(--faction-singularity-vote-off)",
-            }}
-          >
-            {t("card.masthead.singularity")}
-          </span>
+          {/* "singularity protocol" closed this LED bar
+              (`card.masthead.singularity`). #1909 cut the slot: once the praxis
+              masthead is generic it reads "Praxis" on a praxis card, and this
+              one was the faction naming itself. The lamps stay. */}
         </div>
 
         <AdminOverlay {...adminProps} />

--- a/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from "react-i18next";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -16,16 +15,16 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  *    the Updates feed's aged-paper foe note;
  *  • the TAPE strip (and there is no strip to reconsider: #1708 retired tape
  *    from every SNIDE surface);
- *  • the `Special Elite` MASTHEAD block. The design's running head is a single
- *    Courier eyebrow line in acid, inside the text column, where it stops at
- *    the score tag instead of running under it — so it is passed to
- *    {@link PraxisBody} as `eyebrow`, the seam #841 opened for the codex.
+ *  • the `Special Elite` MASTHEAD block. The design's running head was a single
+ *    Courier eyebrow line in acid, inside the text column, where it stopped at
+ *    the score tag instead of running under it — passed to {@link PraxisBody} as
+ *    `eyebrow`, the seam #841 opened for the codex. #1909 CUT its string
+ *    (`card.masthead.snide`, "evidence locker"), so the slot ships empty.
  *
  * The dashed acid rule above the vote widget is the design's, and is the one
  * divider the slab carries.
  */
 export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
-  const { t } = useTranslation("praxis");
   return (
     <div
       style={{
@@ -67,18 +66,9 @@ export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
           transform: "skewX(-3deg)",
           color: "var(--faction-snide-card-text)",
         }}
-        eyebrow={
-          <div
-            className="label-heading"
-            style={{
-              letterSpacing: "0.16em",
-              color: "var(--faction-snide-acid)",
-              marginBottom: "var(--space-xs)",
-            }}
-          >
-            {t("card.masthead.snide")}
-          </div>
-        }
+        /* The eyebrow read "evidence locker" (`card.masthead.snide`). #1909 cut
+           the slot — once generic it says "Praxis" on a praxis card — so the
+           shared eyebrow is left unfilled here. */
         voteRule={
           <div
             aria-hidden

--- a/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
@@ -1,4 +1,3 @@
-import { useTranslation } from "react-i18next";
 import { Lotus } from "../../factionMarks";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
@@ -28,7 +27,6 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  * tooth. Do not reintroduce either.
  */
 export function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
-  const { t } = useTranslation("praxis");
   return (
     <div
       style={{
@@ -84,25 +82,14 @@ export function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
             display: "var(--faction-ua-card-font)",
             body: "var(--faction-ua-body-font)",
           }}
-          eyebrow={
-            /*
-             * The running head sits INSIDE the text column, above the title, so
-             * it stops at the score box rather than running under the ensō —
-             * the `eyebrow` slot #841 added for exactly this shape.
-             */
-            <div
-              style={{
-                fontFamily: "var(--faction-ua-body-font)",
-                fontSize: "var(--text-base)",
-                letterSpacing: "0.22em",
-                textTransform: "uppercase",
-                color: "var(--faction-ua-card-muted)",
-                marginBottom: "var(--space-sm)",
-              }}
-            >
-              {t("card.masthead.ua")}
-            </div>
-          }
+          /*
+           * The running head ("Acquisition · filed", `card.masthead.ua`) sat
+           * INSIDE the text column, above the title, so it stopped at the score
+           * box rather than running under the ensō — the `eyebrow` slot #841
+           * added for exactly that shape. #1909 CUT the string: once the praxis
+           * masthead is generic it reads "Praxis" on a praxis card. The slot
+           * stays for whatever fills it next.
+           */
         />
       </div>
     </div>

--- a/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties } from "react";
-import { useTranslation } from "react-i18next";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -24,13 +23,16 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  *    wearing WOW's frame; with Coven on its own sticker, one indirection for one
  *    caller was just a place for the two palettes to meet again.
  *
- * The archaic register is not decoration either — "for the quest —", "Sealed by
- * the Court", "❦ here, an illumination ❦" are the card's voice, and they are fed
- * to the shared slots rather than replacing them.
+ * THE ARCHAIC REGISTER IS GONE (#1909). Four strings fed the shared slots —
+ * `card.masthead.wow` ("Chronicle of proof · № {{id}}"), `card.wow.forQuest`
+ * ("for the quest —"), `card.wow.illumination` ("❦ here, an illumination ❦") and
+ * `card.wow.sealed` ("Sealed by the Court") — and the copy audit CUT all four:
+ * every one was a single-faction flourish on a surface it ruled generic. The
+ * SLOTS survive; they are simply not filled here any more, and the shared card
+ * draws its own. The footnote keeps the submission date, which is data.
  */
 export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
-  const { t } = useTranslation("praxis");
-  const sealed = praxis.submitted_at
+  const submitted = praxis.submitted_at
     ? new Date(praxis.submitted_at).toLocaleDateString(undefined, {
         month: "short",
         day: "numeric",
@@ -79,21 +81,6 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
             display: "var(--faction-wow-card-font)",
             body: "var(--faction-wow-body-font)",
           }}
-          eyebrow={
-            <div
-              className="label-heading"
-              style={{
-                fontFamily: "var(--faction-wow-card-font)",
-                letterSpacing: "0.14em",
-                color: "var(--faction-wow-card-accent)",
-                marginBottom: "var(--space-xs)",
-              }}
-            >
-              {t("card.masthead.wow", { id: praxis.id })}
-            </div>
-          }
-          taskLead={t("card.wow.forQuest")}
-          mediaEmptyLabel={t("card.wow.illumination")}
           mediaEmptyStyle={{
             height: 150,
             borderRadius: 6,
@@ -106,17 +93,19 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
             opacity: 1,
           }}
           footnote={
-            <div
-              style={{
-                fontFamily: "var(--faction-wow-body-font)",
-                fontStyle: "italic",
-                fontSize: "var(--text-content)",
-                color: "var(--faction-wow-card-muted)",
-                marginTop: "var(--space-sm)",
-              }}
-            >
-              {sealed ? `${t("card.wow.sealed")} · ${sealed}` : t("card.wow.sealed")}
-            </div>
+            submitted && (
+              <div
+                style={{
+                  fontFamily: "var(--faction-wow-body-font)",
+                  fontStyle: "italic",
+                  fontSize: "var(--text-content)",
+                  color: "var(--faction-wow-card-muted)",
+                  marginTop: "var(--space-sm)",
+                }}
+              >
+                {submitted}
+              </div>
+            )
           }
         />
       </div>

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -6,7 +6,6 @@ import {
   CAPTION,
   DECO,
   DISC,
-  GlossedGlyph,
   INK,
   INNER,
   LotusSign,
@@ -53,6 +52,13 @@ import type { ScoreStampProps } from "./ScoreStamp";
  *    in the box pattern's own place, because the stamp must stay legible in all
  *    five states — its chip is ochre, the plate's one accent, since brass is
  *    never an ink and a gold chip would pay under 3:1 behind a label.
+ *
+ * THE FIVE KANJI ARE GONE (#1909). Four rows were labelled 基 / 票 / 習 / 点 as
+ * {@link GlossedGlyph}s with the shared English on `title`. The copy audit ruled
+ * all five strings CUT — they were the only faction-specific score-stamp labels
+ * in the app, on a surface it ruled generic — so every row now prints the SHARED
+ * label it was already glossed with, in the same incised small caps. The tally's
+ * `+ N` still sets its figure outside the label, so #1637's bound holds.
  */
 
 /** The octagon medallion, and its inner rule. Ornament geometry (§4a). */
@@ -102,11 +108,11 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
             gap: "var(--space-sm)",
           }}
         >
-          <GlossedGlyph
-            glyph={t("card.stamp.ephemerists.base")}
-            gloss={t("card.stamp.base")}
-            style={label}
-          />
+          {/* 基 stood here, glossed "base". #1909 cut all five of this cell's
+              kanji: they were the only faction-specific score-stamp labels in
+              the app, on a surface the audit ruled generic. The shared gloss
+              each one carried is now the visible label. */}
+          <span style={label}>{t("card.stamp.base")}</span>
           <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", lineHeight: 0.8, color: INK }}>
             {base}
           </span>
@@ -178,17 +184,14 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
             marginTop: "var(--space-sm)",
           }}
         >
-          + {votes}{" "}
-          <GlossedGlyph
-            glyph={t("card.stamp.ephemerists.fromVotes")}
-            gloss={t("card.stamp.ephemerists.fromVotesGloss")}
-          />
+          + {votes} <span style={label}>{t("card.stamp.votes")}</span>
         </div>
       )}
 
       {/* The habit bonus (#1617), cut after the tally: flat, outside the ratio.
-          Labelled 習 like every other row of this cell — the #1637 bound holds,
-          so the LABEL is encoded and the figure stays a Western numeral. */}
+          Labelled from the shared key like every other row of this cell — the
+          #1637 bound holds, so the LABEL is encoded and the figure stays a
+          Western numeral. */}
       {habit !== null && (
         <div
           style={{
@@ -199,7 +202,7 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
             marginTop: "var(--space-xs)",
           }}
         >
-          + {habit} <GlossedGlyph glyph={t("card.stamp.ephemerists.habit")} gloss={t("card.stamp.habit")} />
+          + {habit} <span style={label}>{t("card.stamp.habit")}</span>
         </div>
       )}
 
@@ -248,11 +251,16 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
             <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", color: OCHRE }}>
               {formatPoints(total)}
             </span>
-            <GlossedGlyph
-              glyph={t("card.stamp.ephemerists.points")}
-              gloss={t("card.stamp.points")}
-              style={{ ...SMALL_CAPS, color: CAPTION, marginTop: "var(--space-xs)" }}
-            />
+            <span
+              style={{
+                ...SMALL_CAPS,
+                fontSize: "var(--text-md)",
+                color: CAPTION,
+                marginTop: "var(--space-xs)",
+              }}
+            >
+              {t("card.stamp.points")}
+            </span>
           </div>
         </div>
         {/* The lotus itself, closing the cell. */}

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -372,13 +372,16 @@ function expectVotesRow(html: string, showsVotes: boolean, votesLabel = 'from vo
 }
 
 /**
- * The Ephemerists' rows are the same rows under different NAMES (#1637): the
- * labels are kanji and the English rides on `title`, which `text()` strips with
- * the tag it lives on. So every shared row assertion below hands in the glyph
- * the reader actually sees — passing the English would go quietly green on the
- * NEGATIVE half ("no base row") while proving nothing about the positive one.
+ * The Ephemerists' rows used to be the same rows under different NAMES (#1637):
+ * the labels were kanji and the English rode on `title`. #1909 CUT all five of
+ * those strings — they were the only faction-specific score-stamp labels in the
+ * app, on a surface the audit ruled generic — so each row now prints the SHARED
+ * label it was glossed with. The one that is not simply the shared default is
+ * the tally: the gloss said "from votes", the shared sentence key
+ * `card.stamp.fromVotes` interpolates a figure, and the row sets its own `+ N`
+ * outside the label (#1637's bound), so it takes `card.stamp.votes`.
  */
-const EPHEMERISTS_LABEL = { base: '基', points: '点', fromVotes: '票' } as const
+const EPHEMERISTS_LABEL = { base: 'base', points: 'points', fromVotes: 'votes' } as const
 
 /**
  * The five conditional states of design v2, on both #841 stamps. The failure
@@ -895,20 +898,21 @@ describe('PraxisOut satisfies the stamp contract without a cast (#1079)', () => 
 })
 
 /**
- * #1637 — the Ephemerists label their score in kanji, and ONLY the labels.
+ * #1637 IS RETIRED, and #1909 is what retired it.
  *
- * The seam under test is the rendered label markup of the Ephemerists stamp:
- * which string reaches the glyph slot, and what the reader can get back out of
- * it. It is an i18n change, not a DOM one — the design walks every text node
- * with a `TreeWalker` because a canvas cannot reach the components, and a sweep
- * built from that would rewrite the word "base" anywhere on the page.
+ * The Ephemerists used to label their score in kanji — 基 / 点 / 票 / 習 — with
+ * the English on `title`. The copy audit CUT all five strings: they were the
+ * only faction-specific score-stamp labels in the app, on a surface it ruled
+ * generic, and the shared gloss each glyph carried is now the visible label.
  *
- * The bound that makes the puzzle acceptable is asserted here as its own case:
- * the cost of not decoding is losing a LABEL, never a number. So the numerals
- * assertion is not a nicety — it is the rule. A future skin that renders 四 for
- * a vote count would render fine, read beautifully, and be the defect.
+ * #1637's own BOUND survives the change and is still the thing worth guarding:
+ * the cost of not decoding a label may never be a NUMBER. A skin that renders
+ * 四 for a vote count would render fine, read beautifully, and be the defect.
+ * So the numerals case stays exactly as written, and the label cases invert to
+ * absences — because the way a faction-only label comes back onto a settled
+ * surface is a voice pass, which only a negative assertion can catch.
  */
-describe('the Ephemerists label their score in kanji (#1637)', () => {
+describe('the Ephemerists score stamp reads in the shared words (#1909)', () => {
   /** A praxis with every row live, so all three substituted labels are drawn. */
   const full = () =>
     renderToStaticMarkup(
@@ -924,14 +928,14 @@ describe('the Ephemerists label their score in kanji (#1637)', () => {
       />,
     )
 
-  it('prints the glyphs, and none of the English, in the visible text', () => {
+  it('prints the shared English, and none of the glyphs, in the visible text', () => {
     const html = text(full())
-    expect(html).toContain('基')
-    expect(html).toContain('点')
-    expect(html).toContain('票')
-    expect(html).not.toContain('base')
-    expect(html).not.toContain('points')
-    expect(html).not.toContain('from votes')
+    expect(html).toContain('base')
+    expect(html).toContain('points')
+    expect(html).toContain('votes')
+    for (const glyph of ['基', '点', '票', '習']) {
+      expect(html).not.toContain(glyph)
+    }
   })
 
   it('leaves every numeral Western — undecoded, the arithmetic still checks out', () => {
@@ -946,25 +950,16 @@ describe('the Ephemerists label their score in kanji (#1637)', () => {
     expect(html).not.toMatch(/[〇一二三四五六七八九十百千万]/)
   })
 
-  it('carries the English on one attribute, for hover, focus and assistive tech', () => {
+  it('needs no glossed abbreviation, because nothing is abbreviated', () => {
     const markup = full()
-    // `title` is the whole reveal: a pointer opens it as a tooltip and AT reads
-    // it out, so there is no second accessibility path that could drift.
-    for (const gloss of ['base', 'points', 'from votes']) {
-      expect(markup).toContain(`title="${gloss}"`)
-    }
-    // …and every substituted label is reachable, so FOCUS is a real gesture and
-    // not just a word in the ruling.
-    expect(markup.match(/tabindex="0"/g)).toHaveLength(3)
-    // `<abbr>` is the element that says "short form, expansion available" — it
-    // is what draws the native dotted underline hinting there is a lookup here.
-    expect(markup.match(/<abbr /g)).toHaveLength(3)
-  })
-
-  it('never uppercases a kanji, whatever voice the surrounding label wears', () => {
-    // SMALL_CAPS sets `text-transform: uppercase` for the plate's whole label
-    // voice; uppercasing does nothing to a kanji but cost it the override.
-    expect(full().match(/text-transform:none/g)).toHaveLength(3)
+    // The whole `<abbr title=…>` reveal existed to expand a glyph. With the
+    // label itself in English there is nothing to expand — and an `<abbr>` with
+    // no expansion is a dotted underline promising a lookup that is not there.
+    expect(markup).not.toContain('<abbr ')
+    expect(markup).not.toContain('tabindex="0"')
+    // The plate's `text-transform: none` overrides existed for the same reason:
+    // uppercasing does nothing to a kanji but cost it the override.
+    expect(markup).not.toContain('text-transform:none')
   })
 
   it('leaves every other faction reading in English', () => {
@@ -993,15 +988,14 @@ describe('every stamp shows the habit bonus when one is banked (#1617)', () => {
    * The line is spelled out per faction rather than pattern-matched, because
    * `5 × 0.80 = 4` is the bug this guards and 4 is already on every one of these
    * sheets as the votes figure — a bare numeral assertion would go green on it.
-   * Seven label the row in English; the Ephemerists label it in kanji like every
-   * other row of theirs (#1637), and handing in 'habit' there would assert
-   * nothing. Singularity zero-pads (`+05`) — its declared terminal notation,
-   * the same one its votes row already uses.
+   * All eight label the row in English since #1909 cut the Ephemerists' four
+   * kanji; only the surrounding notation differs. Singularity zero-pads (`+05`)
+   * — its declared terminal notation, the same one its votes row already uses.
    */
   const STAMPS = [
     ['the unaffiliated sheet', DefaultScoreStamp, 'habit', '+ 5 habit bonus'],
     ['Everymen', EverymenScoreStamp, 'habit', 'habit+5'],
-    ['the Ephemerists', EphemeristsScoreStamp, '習', '+ 5 習'],
+    ['the Ephemerists', EphemeristsScoreStamp, 'habit', '+ 5 habit'],
     ['S.N.I.D.E.', SnideScoreStamp, 'habit', 'habit +5'],
     ['Singularity', SingularityScoreStamp, 'habit', 'habit+05'],
     ['WOW', WowScoreStamp, 'habit', 'habit +5'],
@@ -1034,8 +1028,10 @@ describe('every stamp shows the habit bonus when one is banked (#1617)', () => {
     expect(html).not.toMatch(/[〇一二三四五六七八九十百千万]/)
   })
 
-  it('carries the English gloss on the kanji, for hover, focus and assistive tech', () => {
+  it('labels the habit row in the shared word, not a kanji (#1909)', () => {
     const markup = renderToStaticMarkup(<EphemeristsScoreStamp praxis={banked} />)
-    expect(markup).toContain('title="habit"')
+    expect(text(markup)).toContain('habit')
+    expect(markup).not.toContain('習')
+    expect(markup).not.toContain('title="habit"')
   })
 })

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -276,9 +276,12 @@ export function SingularitySelectCard({ state = "locked", members, onVisit }: Om
         {Array.from({ length: 9 }).map((_, i) => <i key={i} style={{ width: 6, height: 6, borderRadius: 1, background: "rgba(96,165,250,0.5)" }} />)}
       </div>
       <div style={{ position: "relative", flex: 1, padding: "var(--space-lg) var(--space-lg) 0" }}>
-        <div style={{ fontSize: "var(--text-md)", letterSpacing: "0.14em", color: "#60a5fa", textTransform: "uppercase" }}>
-          {i18n.t("feed:identity.singularity.protocol")}<span aria-hidden className="sg-cursor" style={{ display: "inline-block", width: 6, height: 11, background: green, marginLeft: "var(--space-xs)", verticalAlign: "middle" }} />
-        </div>
+        {/* The card opened on "singularity protocol" with the blinking cursor
+            after it (`feed:identity.singularity.protocol`). That key is on
+            #1864's CUT list, so #1909 removed it here too — the surface KEPT by
+            the audit is `feed:factionSelect.*`, every one of which this card
+            still reads; the `identity.*` overline was a different, single-faction
+            slot on top of it. */}
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginTop: "var(--space-md)" }}>
           <SingularitySigil size={30} color={green} />
           {/* eslint-disable-next-line local/no-raw-style-values -- ornament: terminal-printout faction name — display-size mono, the archetype's banner */}

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -194,11 +194,12 @@ export default function EverymenTaskCard({
               boxShadow: "inset 0 -6px 0 -4px var(--everymen-paper-deep)",
             }}
           >
+            {/* The masthead read "Help Wanted!" between the two gears
+                (`feed:taskCard.everymen.billMasthead`). #1909 cut it: Everymen
+                was the only faction with a masthead on a task card, and the
+                audit ruled the surface generic. The gears and the double rule
+                are the band, and they stay. */}
             <Gear size={15} fill="currentColor" hub="var(--faction-everymen-bill-mast)" opacity={0.95} />
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: poster lettering; Bebas at label-ramp sizes stops reading as a masthead. */}
-            <span style={{ ...LABEL, fontSize: 17, letterSpacing: "0.18em" }}>
-              {i18n.t("feed:taskCard.everymen.billMasthead")}
-            </span>
             <Gear size={15} fill="currentColor" hub="var(--faction-everymen-bill-mast)" opacity={0.95} />
           </div>
 
@@ -276,10 +277,17 @@ export default function EverymenTaskCard({
                   <span style={{ fontFamily: POSTER, fontSize: size.pointsSize, lineHeight: 0.8 }}>
                     {basePoints}
                   </span>
-                  {/* eslint-disable-next-line local/no-raw-style-values -- ornament: stamp text, sized to the struck seal rather than the label ramp (§4a). */}
-                  <span style={{ ...LABEL, fontSize: 8, letterSpacing: "0.22em", marginTop: "var(--space-xs)" }}>
-                    {i18n.t("feed:taskCard.everymen.sealUnit")}
-                  </span>
+                  {/* The seal's unit word ("POINTS",
+                      `feed:taskCard.everymen.sealUnit`) stood here. #1909 cut
+                      it: Everymen was the only faction with the slot.
+
+                      ponytail: this leaves the struck seal a bare figure, and
+                      `taskCard.everymen` has no `pointsUnit` to fall back on —
+                      it is the one faction card that never had one. Ceiling: no
+                      unit word on this card until the shared key exists.
+                      Upgrade path: #1910 collapses `taskCard.{F}.pointsUnit` to
+                      ONE shared key; read it here when it lands. Inventing a
+                      cross-faction read now would collide with that PR. */}
                 </div>
               </div>
 

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -176,10 +176,11 @@ export default function SingularityTaskCard({
             <Lamp fill="var(--faction-singularity-led-amber)" />
             <Lamp fill="var(--faction-singularity-led-green)" />
           </span>
-          {/* eslint-disable-next-line local/no-raw-style-values -- ornament: window-bar lettering, sized to the 8px lamps beside it rather than the label ramp (§4a). */}
-          <span style={{ ...LABEL, fontSize: 10.5 }}>
-            {i18n.t("feed:taskCard.singularity.windowTitle")}
-          </span>
+          {/* The window bar read "task.proc — singularity"
+              (`feed:taskCard.singularity.windowTitle`). #1909 cut it:
+              Singularity was the only faction with a window title on a task
+              card, on a surface the audit ruled generic. The lamps and the
+              chrome band stay — they are the window, not its caption. */}
         </div>
 
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>

--- a/frontend/src/components/vote/CovenVote.tsx
+++ b/frontend/src/components/vote/CovenVote.tsx
@@ -68,18 +68,10 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
 
   return (
     <div>
-      <div
-        style={{
-          fontFamily: 'var(--faction-coven-card-font)',
-          fontWeight: 700,
-          fontSize: 'var(--text-content)',
-          color: 'var(--faction-coven-vote-off)',
-          marginBottom: 'var(--space-xs)',
-        }}
-      >
-        {t('chrome.coven.prompt')}
-      </div>
-
+      {/* "how'd this land?" (`chrome.coven.prompt`) headed the row. #1909 cut
+          the whole `chrome.{F}.prompt` slot: three of nine factions rendered
+          one, two more held dead strings, and six ship none at all — so the
+          prompt was never a widget feature, it was three exceptions. */}
       <div
         onMouseLeave={() => setHovered(0)}
         style={{

--- a/frontend/src/components/vote/WowVote.tsx
+++ b/frontend/src/components/vote/WowVote.tsx
@@ -111,25 +111,20 @@ export default function WowVote({ praxisId, currentValue, points, totalVotes }: 
   const cheering = active >= 5
   // The design's own caption logic: hovering previews the bare word, a cast vote
   // is spoken as a sentence, and an untouched row waits.
+  // A cast vote used to be spoken in WOW's own voice — `chrome.wow.picked`,
+  // "thou dubbed it {{label}}". #1909 cut it: the audit found the generic
+  // `chrome.voted` already covers the slot. It takes `stars`, not `label`, so
+  // the call site moves with the key.
   const caption = hovered
     ? TIERS[hovered - 1].label
     : selected
-      ? t('chrome.wow.picked', { label: TIERS[selected - 1].label })
+      ? t('chrome.voted', { stars: selected })
       : t('chrome.wow.idle')
 
   return (
     <div>
-      <div
-        style={{
-          fontFamily: 'var(--faction-wow-card-font)',
-          fontSize: 'var(--text-content)',
-          color: 'var(--faction-wow-vote-on)',
-          marginBottom: 'var(--space-xs)',
-        }}
-      >
-        {t('chrome.wow.prompt')}
-      </div>
-
+      {/* "Cast thy Verdict" (`chrome.wow.prompt`) headed the row. #1909 cut the
+          whole `chrome.{F}.prompt` slot — see the note in `CovenVote`. */}
       <div
         onMouseLeave={() => setHovered(0)}
         className={cheering ? 'wow-balloon-cheer' : undefined}

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -594,3 +594,176 @@ describe('i18next runtime', () => {
     expect(() => i18n.t('nonexistent:some.key')).toThrow('missing copy key')
   })
 })
+
+/* ========================================================================== *
+ * #1909 (child of #1864) — the 97 key slots the copy audit ruled CUT.
+ *
+ * THE SEAM IS THE CATALOG'S LEAF SET. Each of these was one faction writing a
+ * bespoke string on a surface the audit ruled generic while the other eight
+ * never had the slot at all, so the ruling is not "these words are wrong", it is
+ * "this slot should not exist". A key-presence test cannot see that: it asserts
+ * what IS in the catalog, and a later voice pass adding `wow.charter.title`
+ * back would pass every one of them. So this guard reads the same
+ * `catalogLeaves()` walk and asserts ABSENCE, which is the only shape that can
+ * fail on a re-addition.
+ *
+ * The list is the 133 strings, by KEY rather than by value — #1863 rewrote
+ * values across these same catalogs while this was being built, and matching on
+ * the string would have deleted whatever the rewrite left behind.
+ *
+ * Adding a slot back is not forbidden forever. The audit's own principle is
+ * "we can put it back in intentionally" — putting it back means deleting its
+ * line here, in a diff that says so.
+ * ========================================================================== */
+describe('the slots the copy audit ruled generic stay deleted (#1909)', () => {
+  const DELETED_SLOTS = [
+    'common.json:fieldDesk.home.coven.charWindow',
+    'common.json:fieldDesk.home.coven.questsWindow',
+    'common.json:profile.singularity.scoreFootnote',
+    'common.json:profile.wow.eyebrow',
+    'common.json:profile.wow.honours',
+    'common.json:profile.wow.praxisEmpty',
+    'common.json:profile.wow.stats.points',
+    'common.json:profile.wow.stats.praxis',
+    'common.json:profile.wow.stats.tasks',
+    'common.json:profile.wow.tabPraxis',
+    'common.json:profile.wow.tabTasks',
+    'common.json:profile.wow.tasksEmpty',
+    'factions.json:albescent.letter.terms.standingLabel',
+    'factions.json:albescent.letter.terms.standingValue',
+    'factions.json:coven.invitation.terms.3.label',
+    'factions.json:coven.invitation.terms.3.value',
+    'factions.json:coven.praxis.kicker',
+    'factions.json:coven.tasks.kicker',
+    'factions.json:ephemerists.invitation.terms.3.label',
+    'factions.json:ephemerists.invitation.terms.3.value',
+    'factions.json:ephemerists.masthead.almanac',
+    'factions.json:ephemerists.masthead.almanacMark',
+    'factions.json:ephemerists.masthead.observation',
+    'factions.json:ephemerists.masthead.observationMark',
+    'factions.json:ephemerists.masthead.record',
+    'factions.json:ephemerists.masthead.recordMark',
+    'factions.json:ephemerists.masthead.star',
+    'factions.json:ephemerists.masthead.starMark',
+    'factions.json:ephemerists.praxis.kicker',
+    'factions.json:ephemerists.tasks.kicker',
+    'factions.json:everymen.invitation.terms.3.label',
+    'factions.json:everymen.invitation.terms.3.value',
+    'factions.json:everymen.praxis.kicker',
+    'factions.json:everymen.tasks.kicker',
+    'factions.json:singularity.invitation.terms.3.label',
+    'factions.json:singularity.invitation.terms.3.value',
+    'factions.json:singularity.manifest.command',
+    'factions.json:singularity.praxis.kicker',
+    'factions.json:singularity.tasks.kicker',
+    'factions.json:snide.invitation.terms.3.label',
+    'factions.json:snide.invitation.terms.3.value',
+    'factions.json:snide.praxis.kicker',
+    'factions.json:snide.spotlight.wanted',
+    'factions.json:snide.tasks.kicker',
+    'factions.json:ua.invitation.terms.3.label',
+    'factions.json:ua.invitation.terms.3.value',
+    'factions.json:ua.praxis.kicker',
+    'factions.json:ua.tasks.kicker',
+    'factions.json:wow.charter.paragraphs.0',
+    'factions.json:wow.charter.paragraphs.1',
+    'factions.json:wow.charter.paragraphs.2',
+    'factions.json:wow.charter.title',
+    'factions.json:wow.invitation.terms.3.label',
+    'factions.json:wow.invitation.terms.3.value',
+    'factions.json:wow.mobile.subtitle',
+    'factions.json:wow.praxis.kicker',
+    'factions.json:wow.tasks.kicker',
+    'feed.json:factionCard.ephemerists.eyebrow',
+    'feed.json:factionCard.everymen.eyebrow',
+    'feed.json:factionCard.everymen.kicker',
+    'feed.json:factionCard.everymen.motto',
+    'feed.json:factionCard.everymen.perks.finishesWork',
+    'feed.json:factionCard.everymen.perks.honestPoints',
+    'feed.json:factionCard.everymen.perks.stampedWork',
+    'feed.json:factionCard.everymen.summons',
+    'feed.json:factionCard.snide.subtitle',
+    'feed.json:identity.coven.windowTitle',
+    'feed.json:identity.singularity.protocol',
+    'feed.json:identity.wow.dispatch',
+    'feed.json:row.wow.levelUp',
+    'feed.json:row.wow.praxisSealed',
+    'feed.json:row.wow.questTaken',
+    'feed.json:taskCard.albescent.eyebrow',
+    'feed.json:taskCard.ephemerists.coordPolar',
+    'feed.json:taskCard.ephemerists.coordXPrefix',
+    'feed.json:taskCard.ephemerists.footnote',
+    'feed.json:taskCard.ephemerists.marginalia',
+    'feed.json:taskCard.ephemerists.motto',
+    'feed.json:taskCard.ephemerists.vanishingLabel',
+    'feed.json:taskCard.everymen.billMasthead',
+    'feed.json:taskCard.everymen.sealUnit',
+    'feed.json:taskCard.singularity.levelLabel',
+    'feed.json:taskCard.singularity.levelPill',
+    'feed.json:taskCard.singularity.pointsLabel',
+    'feed.json:taskCard.singularity.windowTitle',
+    'feed.json:taskCard.snide.dispatchNumber',
+    'feed.json:taskCard.snide.scrawl',
+    'feed.json:taskCard.ua.estLine',
+    'feed.json:taskCard.ua.pointsLine',
+    'feed.json:taskCard.wow.byOrder',
+    'feed.json:taskCard.wow.decree',
+    'praxis.json:card.coven.mediaEmpty',
+    'praxis.json:card.ephemerists.for',
+    'praxis.json:card.ephemerists.mediaEmpty',
+    'praxis.json:card.masthead.albescent',
+    'praxis.json:card.masthead.coven',
+    'praxis.json:card.masthead.everymen',
+    'praxis.json:card.masthead.singularity',
+    'praxis.json:card.masthead.snide',
+    'praxis.json:card.masthead.ua',
+    'praxis.json:card.masthead.wow',
+    'praxis.json:card.stamp.ephemerists.base',
+    'praxis.json:card.stamp.ephemerists.fromVotes',
+    'praxis.json:card.stamp.ephemerists.fromVotesGloss',
+    'praxis.json:card.stamp.ephemerists.habit',
+    'praxis.json:card.stamp.ephemerists.points',
+    'praxis.json:card.wow.forQuest',
+    'praxis.json:card.wow.illumination',
+    'praxis.json:card.wow.sealed',
+    'praxis.json:comments.albescent.letterhead',
+    'praxis.json:comments.everymen.masthead',
+    'praxis.json:comments.singularity.protocol',
+    'praxis.json:comments.ua.house',
+    'praxis.json:comments.wow.post',
+    'praxis.json:comments.wow.react',
+    'praxis.json:duelSeal.wow.forfeit.cancel',
+    'praxis.json:duelSeal.wow.forfeit.confirm',
+    'praxis.json:duelSeal.wow.forfeit.sub',
+    'praxis.json:duelSeal.wow.ribbonLine',
+    'praxis.json:duelSeal.wow.rosterLabel',
+    'praxis.json:duelSeal.wow.stakesLabel',
+    'praxis.json:duelSeal.wow.submit.cancel',
+    'praxis.json:duelSeal.wow.submit.confirm',
+    'praxis.json:duelSeal.wow.submit.sub',
+    'votes.json:chrome.coven.prompt',
+    'votes.json:chrome.ephemerists.prompt',
+    'votes.json:chrome.singularity.prompt',
+    'votes.json:chrome.singularity.promptHint',
+    'votes.json:chrome.ua.plateNumber',
+    'votes.json:chrome.ua.plateTopMark',
+    'votes.json:chrome.ua.prompt',
+    'votes.json:chrome.wow.picked',
+    'votes.json:chrome.wow.prompt',
+  ] as const
+
+  it('has the whole ruling in the list', () => {
+    // 97 keys, 133 strings — #1864's count. A line lost to a bad merge would
+    // otherwise silently shrink the guard.
+    expect(new Set(DELETED_SLOTS).size).toBe(133)
+  })
+
+  it('finds catalog leaves to check against, so absence cannot be vacuous', () => {
+    expect(catalogLeaves().length).toBeGreaterThan(1000)
+  })
+
+  it('holds none of them', () => {
+    const present = new Set(catalogLeaves().map(([id]) => id))
+    expect(DELETED_SLOTS.filter((id) => present.has(id))).toEqual([])
+  })
+})

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -155,19 +155,22 @@ describe('UA taunts', () => {
 // as soon as its key is listed, and a kit that drops one fails immediately.
 describe('faction profile kits keep their copy in the catalog', () => {
   // Per slug, the `profile.<slug>.*` keys ProfileSkin reads. Not a uniform
-  // shape on purpose: `levelUnit` and `scoreFootnote` are optional knobs only
-  // some kits set (the rest take ProfileSkin's shared `profile.levelUnit` and
-  // draw no footnote), and WOW's badge heading is `profile.wow.honours` —
-  // already in the catalog for its phone stack, the same words for the same
-  // section, so the desktop kit reads that key rather than a second copy of it.
+  // shape on purpose: `levelUnit` is an optional knob only some kits set (the
+  // rest take ProfileSkin's shared `profile.levelUnit`).
+  //
+  // Two rows lost an entry to #1909's CUT list rather than to a code change:
+  // WOW's badge heading was `profile.wow.honours` and Singularity was the one
+  // kit setting `scoreFootnote`. WOW's kit now reads the SHARED
+  // `profile.badgesHeading` and Singularity draws no footnote, which is what
+  // the other six already did — so neither key belongs in a per-slug list.
   const PROFILE_KIT_KEYS: Record<string, readonly string[]> = {
     ua: ['ringLabel', 'levelUnit', 'nextLevel', 'praxisEyebrow', 'praxisEmptyTitle', 'praxisEmptyBody', 'badgeTitle'],
     snide: ['ringLabel', 'nextLevel', 'praxisEyebrow', 'praxisEmptyTitle', 'praxisEmptyBody', 'badgeTitle'],
-    wow: ['ringLabel', 'levelUnit', 'nextLevel', 'praxisEyebrow', 'praxisEmptyTitle', 'praxisEmptyBody', 'honours'],
+    wow: ['ringLabel', 'levelUnit', 'nextLevel', 'praxisEyebrow', 'praxisEmptyTitle', 'praxisEmptyBody'],
     coven: ['ringLabel', 'nextLevel', 'praxisEyebrow', 'praxisEmptyTitle', 'praxisEmptyBody', 'badgeTitle'],
     ephemerists: ['ringLabel', 'levelUnit', 'nextLevel', 'praxisEyebrow', 'praxisEmptyTitle', 'praxisEmptyBody', 'badgeTitle'],
     everymen: ['ringLabel', 'nextLevel', 'praxisEyebrow', 'praxisEmptyTitle', 'praxisEmptyBody', 'badgeTitle'],
-    singularity: ['ringLabel', 'nextLevel', 'scoreFootnote', 'praxisEyebrow', 'praxisEmptyTitle', 'praxisEmptyBody', 'badgeTitle'],
+    singularity: ['ringLabel', 'nextLevel', 'praxisEyebrow', 'praxisEmptyTitle', 'praxisEmptyBody', 'badgeTitle'],
   }
 
   for (const [slug, keys] of Object.entries(PROFILE_KIT_KEYS)) {
@@ -207,9 +210,9 @@ describe('faction profile kits keep their copy in the catalog', () => {
       'The first bit of mischief is always the hardest ✦',
     )
     expect(i18n.t('common:profile.singularity.praxisEmptyTitle')).toBe('> NO OUTPUT SEALED')
-    expect(i18n.t('common:profile.singularity.scoreFootnote', { score: 1880 })).toBe(
-      '> 1880 PTS LOGGED',
-    )
+    // `profile.singularity.scoreFootnote` ("> 1880 PTS LOGGED") was pinned here
+    // for its `> ` prefix. #1909 CUT the key; `praxisEmptyTitle` above still
+    // carries the prefix, so the character check is not lost with it.
     expect(i18n.t('common:profile.snide.praxisEmptyBody')).toBe(
       "Clean record's a bad look around here. Go pull a job.",
     )
@@ -344,8 +347,9 @@ describe('the five domain words are one word each on the voiced surfaces (#1863)
     'factions.json:ephemerists.invitation.perks.1',
     'factions.json:singularity.invitation.perks.1',
     'factions.json:snide.invitation.perks.1',
-    // #1864 CUT: the whole terms[3] "standing" row goes, all seven factions.
-    'factions.json:coven.invitation.terms.3.label',
+    // The whole terms[3] "standing" row was listed here, waiting for #1864's
+    // deletion child. #1909 took it — all seven factions — so it is a survivor
+    // no longer, and the guard is that much tighter.
   ].sort()
 
   it('finds enough voiced strings that the sweep cannot pass by scanning nothing', () => {
@@ -388,16 +392,14 @@ describe('"seal" survives nowhere it means submitted (#1863)', () => {
     // submitted yet."), so the retired word leaves with the key.
     'factions.json:ephemerists.praxis.empty',
     'factions.json:ua.praxis.heading',
-    'factions.json:ua.praxis.kicker',
     'factions.json:ua.praxis.empty',
     'factions.json:ua.registry.gateBody',
     'feed.json:factionHero.ephemerists.stats.praxes',
     'feed.json:factionHero.singularity.stats.praxes',
     'feed.json:factionHero.ua.stats.praxes',
     'feed.json:factionHero.wow.stats.praxes',
-    // #1864 CUT — single-faction flourishes on surfaces ruled generic.
-    'feed.json:row.wow.praxisSealed',
-    'praxis.json:card.wow.sealed',
+    // `feed.json:row.wow.praxisSealed` and `praxis.json:card.wow.sealed` were
+    // listed here as #1864 CUTs waiting on their child. #1909 deleted both.
     // #1864 GENERIC, blocked on the profile-kit collapse. The decision record's
     // own agreed wording for these rows still reads "No praxis sealed yet",
     // which contradicts this ruling — flagged on #1863 rather than picked here.
@@ -419,14 +421,12 @@ describe('"seal" survives nowhere it means submitted (#1863)', () => {
     'praxis.json:listPage.emptyFiltered',
     // Pure metaphor — a mind filing contingencies submits no praxis.
     'progression.json:unlocks.three_plans.desc',
-    // #1864 GENERIC / CUT, as above.
-    'factions.json:ephemerists.praxis.kicker',
+    // #1864 GENERIC, as above. The three CUTs that sat here —
+    // `ephemerists.praxis.kicker` and both `card.masthead.*` — left with #1909.
     'factions.json:everymen.praxis.empty',
     'feed.json:factionHero.coven.stats.praxes',
     'feed.json:factionHero.everymen.stats.praxes',
     'feed.json:factionHero.snide.stats.praxes',
-    'praxis.json:card.masthead.ua',
-    'praxis.json:card.masthead.albescent',
     'common.json:profile.ephemerists.praxisEyebrow',
   ].sort()
 

--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -73,7 +73,6 @@
     "singularity": {
       "ringLabel": "lvl",
       "nextLevel": "next // lvl {{level}}",
-      "scoreFootnote": "> {{score}} PTS LOGGED",
       "praxisEyebrow": "Sealed outputs // by {{name}}",
       "praxisEmptyTitle": "> NO OUTPUT SEALED",
       "praxisEmptyBody": "Run a protocol. Cast the first signal.",
@@ -97,23 +96,12 @@
       "badgeTitle": "Seals of the practice"
     },
     "wow": {
-      "eyebrow": "Of the Court of Whimsy",
       "ringLabel": "rank",
       "levelUnit": "huzzahs toward the next rank",
       "nextLevel": "next · rank {{level}}",
       "praxisEyebrow": "Chronicles sealed by {{name}}",
       "praxisEmptyTitle": "No chronicle yet",
-      "praxisEmptyBody": "The Court waits. Go and do something gloriously daft, then write it down.",
-      "honours": "Honours & Credentials",
-      "tabPraxis": "Chronicles",
-      "tabTasks": "Quests Decreed",
-      "stats": {
-        "points": "Huzzahs",
-        "praxis": "Chronicles",
-        "tasks": "Quests"
-      },
-      "praxisEmpty": "No chronicle yet. The Court waits.",
-      "tasksEmpty": "No quest decreed by this knight, as yet."
+      "praxisEmptyBody": "The Court waits. Go and do something gloriously daft, then write it down."
     }
   },
   "leaderboard": {
@@ -207,8 +195,6 @@
       "findTask": "Find a Task",
       "castVotes": "Cast Your Votes",
       "coven": {
-        "charWindow": "you",
-        "questsWindow": "quests",
         "questsHeading": "quests"
       },
       "ua": {

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -77,9 +77,7 @@
         "skillsLabel": "required skills",
         "skillsValue": "none — only care",
         "outputLabel": "expected output",
-        "outputValue": "accounts, entered plainly",
-        "standingLabel": "standing",
-        "standingValue": "unranked, by design"
+        "outputValue": "accounts, entered plainly"
       },
       "perks": {
         "record": "A record that survives the keeper",
@@ -96,28 +94,16 @@
     }
   },
   "ephemerists": {
-    "masthead": {
-      "starMark": "星",
-      "star": "Star",
-      "almanacMark": "暦",
-      "almanac": "Almanac",
-      "observationMark": "観",
-      "observation": "Observation",
-      "recordMark": "録",
-      "record": "Record"
-    },
     "apparatus": {
       "heading": "The Apparatus",
       "empty": "No apparatus recorded yet."
     },
     "tasks": {
       "heading": "Surveys",
-      "kicker": "Surveys awaiting a hand to triangulate them",
       "empty": "No surveys open."
     },
     "praxis": {
       "heading": "Transcriptions",
-      "kicker": "Truths filed to the codex & weighed for concordance",
       "empty": "Nothing sealed to the codex yet."
     },
     "road": {
@@ -163,10 +149,7 @@
           "label": "expected output",
           "value": "truths, submitted to the codex"
         },
-        {
-          "label": "your standing",
-          "value": "keeper of the road"
-        }
+        {}
       ],
       "perks": [
         "A codex that weighs your findings for concordance",
@@ -186,12 +169,10 @@
     },
     "tasks": {
       "heading": "Jobs",
-      "kicker": "Now mobilizing",
       "empty": "No work orders posted."
     },
     "praxis": {
       "heading": "Accomplishments",
-      "kicker": "Work that held up",
       "empty": "No reports filed yet."
     },
     "roll": {
@@ -237,10 +218,7 @@
           "label": "expected output",
           "value": "honest work, finished"
         },
-        {
-          "label": "your standing",
-          "value": "card-carrying"
-        }
+        {}
       ],
       "perks": [
         "A roll that has your back on every shift",
@@ -255,17 +233,14 @@
   },
   "singularity": {
     "manifest": {
-      "command": "> cat /faction/manifest.txt",
       "empty": "> manifest.txt: empty"
     },
     "tasks": {
       "heading": "Functions",
-      "kicker": "Open functions needing cycles // awaiting nodes",
       "empty": "> no open functions"
     },
     "praxis": {
       "heading": "Signals Generated",
-      "kicker": "function outputs // verified by the array",
       "empty": "> no answers yet"
     },
     "access": {
@@ -313,10 +288,7 @@
           "label": "expected output",
           "value": "signal, into consensus"
         },
-        {
-          "label": "node status",
-          "value": "awaiting connect"
-        }
+        {}
       ],
       "perks": [
         "A consensus that verifies, coalesces, amplifies",
@@ -336,12 +308,10 @@
     },
     "tasks": {
       "heading": "Heists",
-      "kicker": "We've come up with a new caper to pull off",
       "empty": "No mischief here"
     },
     "praxis": {
       "heading": "Good Stories",
-      "kicker": "Successful heists",
       "empty": "No heists pulled off yet."
     },
     "dispatch": {
@@ -360,7 +330,6 @@
       "gateBody": "Keep pulling off jobs and {{faction}} will come looking for you. Cause enough trouble and the invitation writes itself."
     },
     "spotlight": {
-      "wanted": "★ WANTED ★",
       "label": "Champion",
       "stat": "lvl {{level}} · {{score}} pts"
     },
@@ -386,10 +355,7 @@
           "label": "expected output",
           "value": "trouble, well-made"
         },
-        {
-          "label": "your standing",
-          "value": "accomplice, pending"
-        }
+        {}
       ],
       "perks": [
         "A crew that covers for you, not on you",
@@ -412,12 +378,10 @@
     },
     "tasks": {
       "heading": "Today's points",
-      "kicker": "Open to any hand",
       "empty": "Nothing set down today."
     },
     "praxis": {
       "heading": "Sealed work",
-      "kicker": "Recently sealed",
       "empty": "Nothing sealed yet."
     },
     "registry": {
@@ -465,10 +429,7 @@
           "label": "expected output",
           "value": "work, submitted & signed"
         },
-        {
-          "label": "season seat",
-          "value": "#2 in the roster"
-        }
+        {}
       ],
       "perks": [
         "A circle that reads your work closely, and kindly",
@@ -488,12 +449,10 @@
     },
     "tasks": {
       "heading": "Open Quests",
-      "kicker": "Fresh quests on the board",
       "empty": "No quests pinned up."
     },
     "praxis": {
       "heading": "Spells cast",
-      "kicker": "Spells that stuck the landing",
       "empty": "Nothing cast yet."
     },
     "join": {
@@ -537,10 +496,7 @@
           "label": "expected output",
           "value": "small, brave, strange things"
         },
-        {
-          "label": "season rank",
-          "value": "#3 and rising"
-        }
+        {}
       ],
       "perks": [
         "A coven that cheers every tiny victory",
@@ -555,22 +511,14 @@
   },
   "wow": {
     "charter": {
-      "heading": "The Charter",
-      "title": "The Charter of Whimsy",
-      "paragraphs": [
-        "Hear ye. We are the Warriors of Whimsy, and we have taken a vow so grave it loops entirely back around to silly: to bring whimsy into a world that keeps insisting on being sensible.",
-        "We march in real armour after imaginary dragons. We hold ceremonies for the frankly ceremonious. We knight houseplants. Our motto, borne on the crest in the honest tongue of Pig Latin, is Imsy-whay or-fay every-oneway — whimsy, for everyone — and we mean it with our whole gleaming breastplates.",
-        "The noodle sword is not a joke to us. It is THE joke, and we carry it with both hands and a straight face. That is the crusade. Enlist, and take the ridiculous seriously alongside us."
-      ]
+      "heading": "The Charter"
     },
     "tasks": {
       "heading": "Quests Awaiting a Champion",
-      "kicker": "The herald's call",
       "empty": "No quests afoot. The realm is, briefly and tragically, sensible."
     },
     "praxis": {
       "heading": "Chronicles of Proof",
-      "kicker": "Deeds set down",
       "empty": "The chronicle stands open, its pages still blank."
     },
     "join": {
@@ -596,8 +544,7 @@
       "level": "lvl {{level}}"
     },
     "mobile": {
-      "eyebrow": "The Field Pavilion",
-      "subtitle": "thy crusade, in the palm of thy gauntlet"
+      "eyebrow": "The Field Pavilion"
     },
     "invitation": {
       "kicker": "the Court is mustering —",
@@ -616,10 +563,7 @@
           "label": "expected output",
           "value": "the ridiculous, taken gravely seriously"
         },
-        {
-          "label": "thy standing",
-          "value": "knight, freshly sworn"
-        }
+        {}
       ],
       "perks": [
         "The Leap of Whimsy — once each level, a knight may storm a single task one rung above their station and take it anyway"

--- a/frontend/src/locales/en/feed.json
+++ b/frontend/src/locales/en/feed.json
@@ -115,12 +115,7 @@
     "points": "{{points}} pts",
     "pointsEarned": "+{{points}} pts",
     "level": "lvl {{level}}",
-    "quotedHeadline": "“{{headline}}”",
-    "wow": {
-      "questTaken": "{{name}} took up a quest, breastplate agleam.",
-      "praxisSealed": "{{name}} sealed a chronicle of proof.",
-      "levelUp": "{{name}} was elevated a rank by the Court."
-    }
+    "quotedHeadline": "“{{headline}}”"
   },
   "dateDivider": {
     "today": "Today",
@@ -199,17 +194,8 @@
     "ephemerists": {
       "wordmark": "THE EPHEMERISTS"
     },
-    "coven": {
-      "windowTitle": "coven.exe"
-    },
-    "singularity": {
-      "protocol": "singularity protocol"
-    },
     "na": {
       "sigilLabel": "Unaffiliated — all paths open"
-    },
-    "wow": {
-      "dispatch": "Herald's Dispatch"
     }
   },
   "taskCrown": {
@@ -225,20 +211,13 @@
       "signup": "Sign up"
     },
     "albescent": {
-      "eyebrow": "Albescent",
       "signup": "acknowledge",
       "level": "Lvl {{level}}",
       "pointsUnit": "pts"
     },
     "ephemerists": {
-      "motto": "exhibit C · no single here",
-      "coordXPrefix": "x 14 · y ",
-      "coordPolar": "r 47 · θ 31°",
-      "vanishingLabel": "∞ · vanishing",
-      "marginalia": "¼″ wider within than without †",
       "level": "level {{level}}",
       "points": "{{points}} pvncta",
-      "footnote": "† the road does not return you to where you began — <1>see †</1>",
       "signup": "Sign up",
       "masthead": "Ephemerists",
       "levelCaption": "Level",
@@ -246,31 +225,21 @@
     },
     "everymen": {
       "masthead": "THE EVERYMEN",
-      "sealUnit": "POINTS",
       "points": "{{points}} PTS",
       "signup": "Sign up",
-      "billMasthead": "Help Wanted!",
       "levelCaption": "Level"
     },
     "snide": {
-      "dispatchNumber": "dispatch №{{number}}",
-      "scrawl": "your assignment, should you ignore it —",
       "signup": "Sign up",
       "pointsUnit": "PTS",
       "levelCaption": "level"
     },
     "singularity": {
-      "pointsLabel": "PTS:",
-      "levelLabel": "LVL: {{level}}",
       "signup": "Sign up",
-      "levelPill": "lvl {{level}}",
-      "windowTitle": "task.proc — singularity",
       "levelCaption": "lvl",
       "pointsUnit": "pts"
     },
     "ua": {
-      "estLine": "A daily practice",
-      "pointsLine": "{{points}} points",
       "signup": "Sign up",
       "levelCaption": "Level",
       "pointsUnit": "points"
@@ -283,8 +252,6 @@
     },
     "wow": {
       "signup": "Sign up",
-      "decree": "By Royal Decree",
-      "byOrder": "by order of the Whimsy Court",
       "pointsUnit": "points",
       "levelCaption": "level"
     }
@@ -297,23 +264,8 @@
       "welcomeBack": "WELCOME BACK"
     },
     "newInvitation": "NEW INVITATION",
-    "ephemerists": {
-      "eyebrow": "World Zero · Faction №5"
-    },
-    "snide": {
-      "subtitle": "field dispatch"
-    },
     "everymen": {
-      "kicker": "THE EVERYMEN WANT YOU",
-      "summons": "NEW SUMMONS · {{note}}",
-      "eyebrow": "World Zero · Faction",
-      "motto": "UNITED · WE · STAND",
-      "blurbFallback": "No tricks, no inner circle, no waiting to be chosen. The Everymen do the work in front of them and finish what they start.",
-      "perks": {
-        "honestPoints": "Honest tasks with honest points",
-        "finishesWork": "A faction that finishes what it starts",
-        "stampedWork": "Your work stamped by the people beside you"
-      }
+      "blurbFallback": "No tricks, no inner circle, no waiting to be chosen. The Everymen do the work in front of them and finish what they start."
     }
   },
   "factionHero": {

--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -55,14 +55,7 @@
       "pointsShort": "pts",
       "tally": "TALLY",
       "group": "group",
-      "onTheRecord": "★ VERIFIED ★ ON THE RECORD ",
-      "ephemerists": {
-        "base": "基",
-        "points": "点",
-        "fromVotes": "票",
-        "fromVotesGloss": "from votes",
-        "habit": "習"
-      }
+      "onTheRecord": "★ VERIFIED ★ ON THE RECORD "
     },
     "mediaEmpty": "no proof attached",
     "adminStatus": {
@@ -77,27 +70,6 @@
     "errors": {
       "hide": "Failed to hide.",
       "fail": "Failed to fail."
-    },
-    "masthead": {
-      "ua": "Acquisition · filed",
-      "everymen": "The Everymen",
-      "snide": "evidence locker",
-      "albescent": "Account · filed",
-      "singularity": "singularity protocol",
-      "coven": "dispatch no. {{id}} · all done! ✿",
-      "wow": "Chronicle of proof · № {{id}}"
-    },
-    "wow": {
-      "forQuest": "for the quest —",
-      "sealed": "Sealed by the Court",
-      "illumination": "❦ here, an illumination ❦"
-    },
-    "coven": {
-      "mediaEmpty": "Drop a happy little photo ✿"
-    },
-    "ephemerists": {
-      "for": "for:",
-      "mediaEmpty": "Affix the observation"
     }
   },
   "detail": {
@@ -216,12 +188,10 @@
     "editError": "Could not save the edit.",
     "withdrawError": "Could not withdraw the comment.",
     "ua": {
-      "house": "University of Asthmatics",
       "edited": "edited",
       "prompt": "Leave a note in the margin…"
     },
     "everymen": {
-      "masthead": "EVERYMEN · DISPATCH FROM THE FLOOR",
       "edited": "edited"
     },
     "coven": {
@@ -236,17 +206,13 @@
       "edited": "edited"
     },
     "singularity": {
-      "protocol": "singularity function",
       "edited": "edited"
     },
     "albescent": {
-      "letterhead": "Albescent — correspondence",
       "edited": "edited"
     },
     "wow": {
       "prompt": "Add thy counsel to the chronicle…",
-      "post": "Proclaim",
-      "react": "Huzzah",
       "empty": "No counsel yet. Be the first to cry Huzzah.",
       "edited": "edited"
     }
@@ -290,22 +256,7 @@
     "cancel": "Not yet",
     "bodyActive": "{{name}} has accepted. Casting now locks the duel — once you have both cast, pulling back is a permanent forfeit.",
     "bodyPending": "{{name}} hasn't accepted yet. You can cast now; if they decline, this scores as an ordinary praxis.",
-    "reopenNote": "Until {{name}} casts, you can still pull this back for free — no forfeit.",
-    "wow": {
-      "submit": {
-        "sub": "Enter the lists · submitting proof",
-        "confirm": "Take the Field",
-        "cancel": "Withdraw"
-      },
-      "forfeit": {
-        "sub": "Leave the lists · yielding the joust",
-        "confirm": "Yield the Field",
-        "cancel": "Hold thy Ground"
-      },
-      "rosterLabel": "The Roster",
-      "stakesLabel": "The Stakes",
-      "ribbonLine": "A ribbon for the courage to enter — in our lists both riders are honoured."
-    }
+    "reopenNote": "Until {{name}} casts, you can still pull this back for free — no forfeit."
   },
   "duelForfeit": {
     "confirmPrompt": "Pulling back now FORFEITS the duel.",

--- a/frontend/src/locales/en/votes.json
+++ b/frontend/src/locales/en/votes.json
@@ -67,8 +67,7 @@
       "rateAria": "Rate {{value}} of 5"
     },
     "ephemerists": {
-      "rateAria": "Rate {{value}} — {{label}}",
-      "prompt": "Cast your metal"
+      "rateAria": "Rate {{value}} — {{label}}"
     },
     "everymen": {
       "rateAria": "Rate {{value}} — {{label}}",
@@ -77,15 +76,12 @@
     },
     "coven": {
       "rateAria": "Rate {{value}} — {{label}}",
-      "prompt": "how'd this land?",
       "idle": "tap to cheer",
       "tag": "yay!"
     },
     "wow": {
       "rateAria": "Rate {{value}} — {{label}}",
-      "prompt": "Cast thy Verdict",
-      "idle": "— awaiting thy judgment —",
-      "picked": "thou dubbed it {{label}}"
+      "idle": "— awaiting thy judgment —"
     },
     "snide": {
       "rateAria": "Rate {{value}} — {{label}}",
@@ -94,16 +90,11 @@
     },
     "singularity": {
       "rateAria": "Rate {{value}} — {{label}}",
-      "prompt": "Cast Signal",
-      "promptHint": "how confidently does this output hold?",
       "idle": "no signal",
       "tag": "locked"
     },
     "ua": {
-      "rateAria": "Rate {{value}} — {{label}}",
-      "prompt": "How true did it land",
-      "plateNumber": "№{{value}}",
-      "plateTopMark": "✦"
+      "rateAria": "Rate {{value}} — {{label}}"
     },
     "albescent": {
       "rateAria": "Rate {{value}} of 5"

--- a/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileFormFactor.test.tsx
@@ -207,7 +207,12 @@ describe('wow profile serves both form factors from WowProfileBody', () => {
   it('still renders the crested desktop page on a wide viewport', () => {
     const html = renderBody({ faction_slug: 'wow' })
     expect(html).not.toContain('data-testid="mobile-profile"')
-    expect(html, 'the desktop kit heading').toContain('Honours &amp; Credentials')
+    // The kit heading was 'Honours &amp; Credentials' until #1909 CUT
+    // `profile.wow.honours`; both form factors now read the shared 'Badges',
+    // which every kit says. So WOW is identified by a mark instead: the gilt
+    // rope ring the desktop kit mounts its credential in.
+    expect(html, 'the crested desktop page').toContain('--faction-wow-avatar-ring')
+    expect(html, 'the desktop kit heading').toContain('Badges')
   })
 })
 

--- a/frontend/src/pages/characterProfile/__tests__/profileKitCopy.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileKitCopy.test.tsx
@@ -98,7 +98,11 @@ const KIT_COPY: Record<string, readonly string[]> = {
     'Chronicles sealed by Reza',
     'No chronicle yet',
     'The Court waits. Go and do something gloriously daft, then write it down.',
-    'Honours & Credentials',
+    // WOW's badge heading was 'Honours & Credentials' (`profile.wow.honours`),
+    // shared with its phone stack. #1909 CUT the key with the rest of the
+    // `profile.wow.*` block, so the kit reads the SHARED 'Badges' — which is
+    // where #1910's `profileKit.{F}.badgeTitle` collapse settles every kit.
+    'Badges',
   ],
   coven: [
     'lvl',
@@ -133,9 +137,9 @@ const KIT_COPY: Record<string, readonly string[]> = {
     'lvl',
     '380 / 500 pts this level',
     'next // lvl 8',
-    // The only kit with a score footnote — it names the absolute score, not the
-    // threshold, which is why it could not share na's `ptsToNext`.
-    '> 1880 PTS LOGGED',
+    // It was the only kit with a score footnote — it named the absolute score,
+    // not the threshold, which is why it could not share na's `ptsToNext`.
+    // #1909 CUT `profile.singularity.scoreFootnote`, so no footnote is drawn.
     'Sealed outputs // by Reza',
     '> NO OUTPUT SEALED',
     'Run a protocol. Cast the first signal.',

--- a/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/SingularityProfileBody.tsx
@@ -188,9 +188,13 @@ export default function SingularityProfileBody(props: ProfileBodyProps) {
         ...dress,
         ringLabel: t('profile.singularity.ringLabel'),
         nextLevelLabel: (next) => t('profile.singularity.nextLevel', { level: next }),
-        // The one kit with a footnote: it logs the absolute score and ignores
-        // the threshold, which is why it takes a key of its own.
-        scoreFootnote: (score) => t('profile.singularity.scoreFootnote', { score }),
+        /* It was the one kit with a footnote — it logged the absolute score and
+           ignored the threshold, which is why it took a key of its own.
+           `scoreFootnote` read `profile.singularity.scoreFootnote`
+           ("> {{score}} PTS LOGGED"). #1909 CUT it: Singularity was the only
+           kit that set the optional footnote, on a surface the audit ruled
+           generic. `ProfileSkin` draws no footnote when the knob is unset,
+           which is what the other six kits already do. */
         praxisEyebrow: (name) => t('profile.singularity.praxisEyebrow', { name }),
         praxisEmpty: {
           title: t('profile.singularity.praxisEmptyTitle'),

--- a/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
@@ -268,11 +268,13 @@ export default function WowProfileBody(props: ProfileBodyProps) {
           title: t('profile.wow.praxisEmptyTitle'),
           body: t('profile.wow.praxisEmptyBody'),
         },
-        // `honours`, not a `badgeTitle` of its own: the phone stack's badge
-        // heading below already reads this key and says the same words about
-        // the same section. Two keys holding one string is how a copy pass
-        // reworders half a page.
-        badgeTitle: t('profile.wow.honours'),
+        // This read `profile.wow.honours` ("Honours & Credentials"), shared
+        // with the phone stack's badge heading below so one string covered one
+        // section. #1909 CUT that key with the rest of WOW's profile block, and
+        // `badgeTitle` is required, so both now read the SHARED
+        // `profile.badgesHeading` ("Badges") — which is the wording #1910's
+        // `profileKit.{F}.badgeTitle` collapse settles every kit onto anyway.
+        badgeTitle: t('profile.badgesHeading'),
       }}
     />
   )
@@ -295,10 +297,21 @@ function MobileProfile({
   const [segment, setSegment] = useState<Segment>('praxis')
   const badges = character.badges ?? []
 
+  // The tally's three labels were WOW's own — "Huzzahs", "Chronicles",
+  // "Quests" — and #1909 CUT all three with the rest of `profile.wow.*`. No
+  // other profile body draws a stat row, so there is no per-faction twin to
+  // settle onto; these are the SHARED words for the same three entities.
+  //
+  // ponytail: `sidebar.characterCard.points` is a sidebar key doing duty on a
+  // profile. Ceiling: it is the only shared string in this namespace that says
+  // "points", and a deletion PR may not mint a new one. Upgrade path: #1910
+  // owns the profile-kit collapse and can give the row a proper
+  // `profile.stats.*` block. The row itself is kept because its figures are
+  // real data — deleting it would take the score and both counts off the page.
   const stats = [
-    { label: t('profile.wow.stats.points'), value: character.score },
-    { label: t('profile.wow.stats.praxis'), value: submissions.length },
-    { label: t('profile.wow.stats.tasks'), value: proposedTasks.length },
+    { label: t('sidebar.characterCard.points'), value: character.score },
+    { label: t('profile.mobile.tabPraxis'), value: submissions.length },
+    { label: t('profile.mobile.tabTasks'), value: proposedTasks.length },
   ]
 
   return (
@@ -430,9 +443,10 @@ function MobileProfile({
               level: character.level,
             })}
           </div>
-          <div className="label-heading" style={{ fontFamily: WOW_DISPLAY, color: WOW_DEEP }}>
-            {t('profile.wow.eyebrow')}
-          </div>
+          {/* "Of the Court of Whimsy" (`profile.wow.eyebrow`) sat under the
+              faction/level line. #1909 cut it: WOW was the only faction with a
+              profile eyebrow, on a surface the audit ruled generic, and there
+              is no shared twin to fall back to. */}
 
           {identityActions && (
             <div style={{ marginTop: 'var(--space-lg)', width: '100%', maxWidth: 220 }}>
@@ -495,7 +509,7 @@ function MobileProfile({
         {/* ── honours & credentials — hidden entirely when empty ── */}
         {badges.length > 0 && (
           <section>
-            <WowSectionHead>{t('profile.wow.honours')}</WowSectionHead>
+            <WowSectionHead>{t('profile.badgesHeading')}</WowSectionHead>
             <div
               style={{
                 background: WOW_PLATE,
@@ -516,10 +530,10 @@ function MobileProfile({
         <div>
           <div style={{ display: 'flex', gap: 'var(--space-sm)' }}>
             <SegTab on={segment === 'praxis'} onClick={() => setSegment('praxis')}>
-              {t('profile.wow.tabPraxis')}
+              {t('profile.mobile.tabPraxis')}
             </SegTab>
             <SegTab on={segment === 'tasks'} onClick={() => setSegment('tasks')}>
-              {t('profile.wow.tabTasks')}
+              {t('profile.mobile.tabTasks')}
             </SegTab>
           </div>
           <WowCheckerBand height={3} />
@@ -527,7 +541,7 @@ function MobileProfile({
 
         {segment === 'praxis' ? (
           submissions.length === 0 ? (
-            <Empty>{t('profile.wow.praxisEmpty')}</Empty>
+            <Empty>{t('profile.praxisEmptyTitle')}</Empty>
           ) : (
             <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
               {submissions.map((praxis) => (
@@ -536,7 +550,7 @@ function MobileProfile({
             </div>
           )
         ) : proposedTasks.length === 0 ? (
-          <Empty>{t('profile.wow.tasksEmpty')}</Empty>
+          <Empty>{t('profile.proposedTasksEmpty')}</Empty>
         ) : (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
             {proposedTasks.map((task) => (

--- a/frontend/src/pages/factionDetail/__tests__/factionDetailResponsive.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/factionDetailResponsive.test.tsx
@@ -74,8 +74,11 @@ const OWN_VOICE: Record<string, readonly string[]> = {
     'ephemerists.tasks.heading',
   ],
   everymen: ['everymen.charter.heading', 'everymen.roster.heading', 'everymen.tasks.heading'],
+  // Singularity's long-form panel had no heading of its own — it opened on a
+  // shell prompt, `singularity.manifest.command`, which #1909 CUT. Its praxis
+  // heading stands in: still a string only this body draws, still unconditional.
   singularity: [
-    'singularity.manifest.command',
+    'singularity.praxis.heading',
     'singularity.roster.heading',
     'singularity.tasks.heading',
   ],

--- a/frontend/src/pages/factionDetail/__tests__/wowFactionBody.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/wowFactionBody.test.tsx
@@ -82,16 +82,31 @@ describe('the enlist rail answers every membership state', () => {
 describe('the page speaks in WOW voice, not the phone catalog', () => {
   it('wires the charter, the roll and both galleries', () => {
     const markup = render('none')
-    expect(markup).toContain('The Charter of Whimsy')
+    expect(markup).toContain('The Charter')
     expect(markup).toContain('The Muster Roll')
     expect(markup).toContain('Quests Awaiting a Champion')
     expect(markup).toContain('Chronicles of Proof')
   })
 
-  it('renders the charter body, which is the one thing the hero cannot show', () => {
-    // The array-valued key needs `returnObjects`; a plain `t()` yields the key
-    // back and the section renders its frame with nothing in it.
-    expect(render('none')).toContain('We knight houseplants')
+  /**
+   * THE CHARTER OF WHIMSY IS GONE (#1909), and the panel prints the DESCRIPTION.
+   *
+   * `wow.charter.title` and the three `wow.charter.paragraphs` were all on the
+   * copy audit's CUT list: no other faction had body copy on its about panel —
+   * the other seven print `factionDescription(slug)` — so once the audit ruled
+   * the surface generic, WOW prints it too. That is several hundred words of
+   * real writing, deleted deliberately, under the audit's own terms ("we can
+   * put it back in intentionally").
+   *
+   * Guarded as an absence AND a presence: the panel must not be empty (the bug
+   * the old `returnObjects` test caught), and the bespoke charter must not creep
+   * back onto a settled surface under a new key.
+   */
+  it('fills the charter panel with the faction description, not a bespoke charter', () => {
+    const markup = render('none')
+    expect(markup).toContain('We wield the noodle sword')
+    expect(markup).not.toContain('The Charter of Whimsy')
+    expect(markup).not.toContain('We knight houseplants')
   })
 
   it('does not fall back to the phone page copy', () => {

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -59,8 +59,14 @@ import type { FactionDetailState } from "../useFactionDetail";
 
 const CHROME = "var(--font-faction-rounded)"; // Quicksand
 
-/** Section heading — the display face, a braid, then the kicker. */
-function SectionHead({ children, kicker }: { children: ReactNode; kicker?: ReactNode }) {
+/**
+ * Section heading — the display face, then a braid.
+ *
+ * It used to close on a kicker (`coven.tasks.kicker` / `coven.praxis.kicker`).
+ * #1909 cut the slot: the audit found the kicker restated its own heading, and
+ * only the seven bespoke bodies had one at all.
+ */
+function SectionHead({ children }: { children: ReactNode }) {
   return (
     <div
       style={{
@@ -84,7 +90,6 @@ function SectionHead({ children, kicker }: { children: ReactNode; kicker?: React
         {children}
       </span>
       <Braid style={{ flex: 1 }} />
-      {kicker !== undefined && <span style={{ ...CAPTION, flex: "0 0 auto" }}>{kicker}</span>}
     </div>
   );
 }
@@ -165,7 +170,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
 
         {/* ④ TASKS */}
         <div>
-          <SectionHead kicker={t("coven.tasks.kicker")}>{t("coven.tasks.heading")}</SectionHead>
+          <SectionHead>{t("coven.tasks.heading")}</SectionHead>
           {tasks.length === 0 ? (
             <p className="content-text" style={{ ...PROSE, marginTop: "var(--space-md)" }}>{t("coven.tasks.empty")}</p>
           ) : (
@@ -188,7 +193,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
 
         {/* ⑤ PRAXIS */}
         <div>
-          <SectionHead kicker={t("coven.praxis.kicker")}>{t("coven.praxis.heading")}</SectionHead>
+          <SectionHead>{t("coven.praxis.heading")}</SectionHead>
           {recentPraxis.length === 0 ? (
             <p className="content-text" style={{ ...PROSE, marginTop: "var(--space-md)" }}>{t("coven.praxis.empty")}</p>
           ) : (

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -94,19 +94,10 @@ const CARD: CSSProperties = {
   boxShadow: SHADOW,
 };
 
-const KICKER: CSSProperties = {
-  fontFamily: MARGINALIA,
-  fontStyle: "italic",
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: marginal gloss under the section title, not copy.
-  fontSize: 13,
-  // The PAGE's ink, not the plate's (#1675). See SECTION_HEADING below.
-  color: "var(--color-text-secondary)",
-  margin: "var(--space-xs) 0 var(--space-lg)",
-};
-
-function Kicker({ children }: { children: ReactNode }) {
-  return <div style={KICKER}>{children}</div>;
-}
+/* The marginalia `Kicker` under each section title lived here. #1909 cut its two
+   strings (`ephemerists.tasks.kicker` / `.praxis.kicker`): the audit ruled the
+   line restated its own heading, and no faction outside the seven bespoke bodies
+   ever had one. The style went with the only component that used it. */
 
 const SECTION_HEADING: CSSProperties = {
   fontFamily: DECO,
@@ -206,7 +197,6 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
         {/* ④ TASKS */}
         <div>
           <SectionHeading>{t("ephemerists.tasks.heading")}</SectionHeading>
-          <Kicker>{t("ephemerists.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
             <p className="content-text" style={{ fontFamily: MARGINALIA, fontStyle: "italic", color: PAGE_QUIET }}>
               {t("ephemerists.tasks.empty")}
@@ -232,7 +222,6 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
         {/* ⑤ PRAXIS */}
         <div>
           <SectionHeading>{t("ephemerists.praxis.heading")}</SectionHeading>
-          <Kicker>{t("ephemerists.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
             <p className="content-text" style={{ fontFamily: MARGINALIA, fontStyle: "italic", color: PAGE_QUIET }}>
               {t("ephemerists.praxis.empty")}

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -100,18 +100,10 @@ function SectionHeading({ children, right }: { children: ReactNode; right?: Reac
   );
 }
 
-const KICKER: CSSProperties = {
-  fontFamily: MONO,
-  fontSize: "var(--text-md)",
-  letterSpacing: "0.2em",
-  textTransform: "uppercase",
-  color: MUTED,
-  marginBottom: "var(--space-lg)",
-};
-
-function Kicker({ children }: { children: ReactNode }) {
-  return <div style={KICKER}>{children}</div>;
-}
+/* The union `Kicker` under each section title lived here. #1909 cut its two
+   strings (`everymen.tasks.kicker` / `.praxis.kicker`): the audit ruled the line
+   restated its own heading, and no faction outside the seven bespoke bodies ever
+   had one. The style went with the only component that used it. */
 
 const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
 
@@ -191,7 +183,6 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
         {/* ④ TASKS */}
         <div>
           <SectionHeading>{t("everymen.tasks.heading")}</SectionHeading>
-          <Kicker>{t("everymen.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
             <p className="content-text" style={{ fontFamily: MONO, color: MUTED }}>{t("everymen.tasks.empty")}</p>
           ) : (
@@ -215,7 +206,6 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
         {/* ⑤ PRAXIS */}
         <div>
           <SectionHeading>{t("everymen.praxis.heading")}</SectionHeading>
-          <Kicker>{t("everymen.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
             <p className="content-text" style={{ fontFamily: MONO, color: MUTED }}>{t("everymen.praxis.empty")}</p>
           ) : (

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -106,18 +106,10 @@ function SectionHeading({ children }: { children: ReactNode }) {
   );
 }
 
-const KICKER: CSSProperties = {
-  fontFamily: FONT,
-  fontSize: "var(--text-md)",
-  letterSpacing: "0.24em",
-  textTransform: "uppercase",
-  color: phosphor(40),
-  marginBottom: "var(--space-lg)",
-};
-
-function Kicker({ children }: { children: ReactNode }) {
-  return <div style={KICKER}>{children}</div>;
-}
+/* The system `Kicker` under each section title lived here. #1909 cut its two
+   strings (`singularity.tasks.kicker` / `.praxis.kicker`): the audit ruled the
+   line restated its own heading, and no faction outside the seven bespoke bodies
+   ever had one. The style went with the only component that used it. */
 
 const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
 
@@ -177,18 +169,13 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
         {/* ② MANIFEST */}
         <div style={{ ...PANEL, padding: "var(--space-xl)" }}>
           <Scanlines />
-          <div
-            style={{
-              position: "relative",
-              fontFamily: FONT,
-              fontSize: "var(--text-md)",
-              letterSpacing: "0.14em",
-              color: signal(55),
-              marginBottom: "var(--space-lg)",
-            }}
-          >
-            {t("singularity.manifest.command")}
-          </div>
+          {/* The panel opened on a shell prompt (`singularity.manifest.command`,
+              "> cat /faction/manifest.txt"). #1909 cut it: no other faction had
+              a command line over its about panel, and the audit ruled the
+              surface generic. Singularity is the one faction with no
+              about-panel HEADING to fall back on — #1910 gives all seven the
+              shared "About", and until it lands this block opens on the
+              description itself. */}
           <div style={{ position: "relative", display: "flex", flexDirection: "column", gap: "var(--space-md)" }}>
             {paragraphs.length ? (
               paragraphs.map((para, i) => (
@@ -216,7 +203,6 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
         {/* ④ TASKS */}
         <div>
           <SectionHeading>{t("singularity.tasks.heading")}</SectionHeading>
-          <Kicker>{t("singularity.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
             <p className="content-text" style={{ fontFamily: FONT, color: phosphor(45) }}>
               {t("singularity.tasks.empty")}
@@ -242,7 +228,6 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
         {/* ⑤ PRAXIS */}
         <div>
           <SectionHeading>{t("singularity.praxis.heading")}</SectionHeading>
-          <Kicker>{t("singularity.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
             <p className="content-text" style={{ fontFamily: FONT, color: phosphor(45) }}>
               {t("singularity.praxis.empty")}

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -118,19 +118,10 @@ function SectionHeading({ children }: { children: ReactNode }) {
   );
 }
 
-const KICKER: CSSProperties = {
-  fontFamily: MARKER,
-  // eslint-disable-next-line local/no-raw-style-values -- ornament: hand-scrawled marker aside slapped over the flyer — illustration, not copy.
-  fontSize: 16,
-  color: PINK,
-  transform: "rotate(-1deg)",
-  marginBottom: "var(--space-lg)",
-};
-
-/** Scrawled marker kicker. */
-function Kicker({ children }: { children: ReactNode }) {
-  return <div style={KICKER}>{children}</div>;
-}
+/* The scrawled marker `Kicker` under each section title lived here. #1909 cut
+   its two strings (`snide.tasks.kicker` / `.praxis.kicker`): the audit ruled the
+   line restated its own heading, and no faction outside the seven bespoke bodies
+   ever had one. The style went with the only component that used it. */
 
 const initial = (name: string) => name.trim().charAt(0).toUpperCase() || "?";
 
@@ -221,7 +212,6 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
         {/* ④ TASKS */}
         <div>
           <SectionHeading>{t("snide.tasks.heading")}</SectionHeading>
-          <Kicker>{t("snide.tasks.kicker")}</Kicker>
           {tasks.length === 0 ? (
             <p className="content-text" style={{ fontFamily: TYPE, color: MUTED }}>{t("snide.tasks.empty")}</p>
           ) : (
@@ -245,7 +235,6 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
         {/* ⑤ PRAXIS */}
         <div>
           <SectionHeading>{t("snide.praxis.heading")}</SectionHeading>
-          <Kicker>{t("snide.praxis.kicker")}</Kicker>
           {recentPraxis.length === 0 ? (
             <p className="content-text" style={{ fontFamily: TYPE, color: MUTED }}>{t("snide.praxis.empty")}</p>
           ) : (
@@ -482,18 +471,10 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
               <div style={{ position: "relative", transform: "rotate(1.2deg)" }}>
                 <div style={{ ...INK_PANEL, border: `2px solid ${ACID}`, boxShadow: "5px 6px 0 rgba(0,0,0,.3)", padding: "var(--space-lg)", textAlign: "center" }}>
                   <Halftone on="ink" />
-                  <div
-                    style={{
-                      position: "relative",
-                      fontFamily: COND,
-                      // eslint-disable-next-line local/no-raw-style-values -- ornament: WANTED-poster furniture — wide-tracked condensed caps.
-                      fontSize: 13,
-                      letterSpacing: "0.35em",
-                      color: PINK,
-                    }}
-                  >
-                    {t("snide.spotlight.wanted")}
-                  </div>
+                  {/* The poster's "★ WANTED ★" rule stood here. #1909 cut
+                      `snide.spotlight.wanted`: Snide was the only faction with
+                      the slot, on a surface the audit ruled generic. The
+                      spotlight LABEL below it stays — that one keeps its voice. */}
                   <div
                     style={{
                       position: "relative",

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -74,16 +74,14 @@ function RuledLabel({ children }: { children: ReactNode }) {
   );
 }
 
-function SectionHeading({
-  kicker,
-  children,
-}: {
-  kicker: string;
-  children: ReactNode;
-}) {
+/**
+ * A section title. It used to open on an eyebrow kicker (`ua.tasks.kicker` /
+ * `ua.praxis.kicker`); #1909 cut the slot, because the audit ruled the line
+ * restated its own heading and only the seven bespoke bodies ever had one.
+ */
+function SectionHeading({ children }: { children: ReactNode }) {
   return (
     <div style={{ marginBottom: "var(--space-xl)" }}>
-      <div style={UA_EYEBROW}>{kicker}</div>
       <h2
         style={{
           fontFamily: UA_DISPLAY,
@@ -209,7 +207,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
 
         {/* ④ TASKS */}
         <div>
-          <SectionHeading kicker={t("ua.tasks.kicker")}>
+          <SectionHeading>
             {t("ua.tasks.heading")}
           </SectionHeading>
           {tasks.length === 0 ? (
@@ -246,7 +244,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
 
         {/* ⑤ PRAXIS */}
         <div>
-          <SectionHeading kicker={t("ua.praxis.kicker")}>
+          <SectionHeading>
             {t("ua.praxis.heading")}
           </SectionHeading>
           {recentPraxis.length === 0 ? (

--- a/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/WowFactionBody.tsx
@@ -6,7 +6,7 @@ import TaskCard from "../../../components/taskCard/TaskCard";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
 import { BalloonBunch, Bunting, Zig } from "../../../components/factionMarks/wowOrnament";
 import { WowSigil } from "../../../components/sigil/WowSigil";
-import { factionName } from "../../../utils/factions";
+import { factionName, factionDescription } from "../../../utils/factions";
 import { computeFactionMultiplier } from "../../../utils/points";
 import type { CharacterOut } from "../../../api/auth";
 import type { FactionDetailState } from "../useFactionDetail";
@@ -133,7 +133,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
     >
       {/* ── MAIN COLUMN ── */}
       <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-2xl)" }}>
-        <Charter />
+        <Charter slug={faction.slug} />
 
         {/* ── the muster roll ── */}
         <section>
@@ -159,7 +159,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
 
         {/* ── quests awaiting a champion ── */}
         <section>
-          <SectionHead kicker={t("wow.tasks.kicker")}>{t("wow.tasks.heading")}</SectionHead>
+          <SectionHead>{t("wow.tasks.heading")}</SectionHead>
           {tasks.length === 0 ? (
             <Quiet>{t("wow.tasks.empty")}</Quiet>
           ) : (
@@ -182,7 +182,7 @@ export default function WowFactionBody({ state }: { state: FactionDetailState })
 
         {/* ── chronicles of proof ── the one bunch of balloons on the page ── */}
         <section>
-          <SectionHead kicker={t("wow.praxis.kicker")} balloons>
+          <SectionHead balloons>
             {t("wow.praxis.heading")}
           </SectionHead>
           {recentPraxis.length === 0 ? (
@@ -214,14 +214,21 @@ const CARD_GRID: CSSProperties = {
 /**
  * The charter — the faction's own voice at length, bunting strung across it.
  * The only section the hero above cannot show.
+ *
+ * #1909 CUT the four strings that used to fill it: `wow.charter.title` ("The
+ * Charter of Whimsy") and the three `wow.charter.paragraphs`. No other faction
+ * had body copy on this panel — the other seven bodies all print the faction
+ * DESCRIPTION here, split on blank lines — so once the audit ruled the surface
+ * generic, WOW prints the description too. This is the one deletion in #1909
+ * that removes several hundred words of real writing; the ruling's own terms
+ * are "we can put it back in intentionally".
  */
-function Charter() {
+function Charter({ slug }: { slug: string }) {
   const { t } = useTranslation("factions");
-  // The catalog holds the charter as an array of paragraphs; `t` is typed to a
-  // string, so the array form needs the same cast every other reader uses.
-  const resolve = t as unknown as (k: string, o: { returnObjects: true }) => unknown;
-  const raw = resolve("wow.charter.paragraphs", { returnObjects: true });
-  const paragraphs = Array.isArray(raw) ? (raw as string[]) : [];
+  const paragraphs = factionDescription(slug)
+    .split(/\n\s*\n/)
+    .map((p) => p.trim())
+    .filter(Boolean);
 
   return (
     <section style={{ ...PLATE_FRAME, padding: 0, overflow: "hidden" }}>
@@ -230,18 +237,7 @@ function Charter() {
         <div className="label-heading" style={{ fontFamily: MED }}>
           {t("wow.charter.heading")}
         </div>
-        <h2
-          style={{
-            fontFamily: MED,
-            fontSize: "var(--text-title)",
-            lineHeight: 1.15,
-            color: INK,
-            margin: "var(--space-xs) 0 var(--space-md)",
-          }}
-        >
-          {t("wow.charter.title")}
-        </h2>
-        <Zig id="charter" style={{ marginBottom: "var(--space-md)" }} />
+        <Zig id="charter" style={{ margin: "var(--space-md) 0" }} />
         {paragraphs.map((paragraph) => (
           <p
             key={paragraph}
@@ -261,23 +257,22 @@ function Charter() {
   );
 }
 
-/** A section head in the display face, over the wavy gold→plum rule. */
+/**
+ * A section head in the display face, over the wavy gold→plum rule.
+ *
+ * It used to open on a herald's kicker (`wow.tasks.kicker` /
+ * `wow.praxis.kicker`); #1909 cut the slot, because the audit ruled the line
+ * restated its own heading and only the seven bespoke bodies ever had one.
+ */
 function SectionHead({
   children,
-  kicker,
   balloons,
 }: {
   children: ReactNode;
-  kicker?: string;
   balloons?: boolean;
 }) {
   return (
     <div style={{ marginBottom: "var(--space-lg)" }}>
-      {kicker && (
-        <div className="label-heading" style={{ fontFamily: MED }}>
-          {kicker}
-        </div>
-      )}
       <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-md)" }}>
         <h2
           style={{

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -67,8 +67,15 @@ const PROSE: CSSProperties = {
   color: SOFT,
 }
 
-/** A slip band over a candle-lit panel. */
-function Plate({ title, children }: { title: string; children: ReactNode }) {
+/**
+ * A slip band over a candle-lit panel.
+ *
+ * The band used to close on a window title (`fieldDesk.home.coven.charWindow`
+ * / `.questsWindow` — "you" and "quests"). #1909 CUT both: Coven was the only
+ * faction with the slot, and the audit ruled the field desk generic. The sigil
+ * and the slip stay — they are the band.
+ */
+function Plate({ children }: { children: ReactNode }) {
   return (
     <section
       style={{
@@ -89,7 +96,6 @@ function Plate({ title, children }: { title: string; children: ReactNode }) {
         }}
       >
         <SigilMark size={22} />
-        <span style={{ ...CAPTION, marginLeft: 'auto' }}>{title}</span>
       </div>
       <div style={{ background: CARD, padding: 'var(--space-lg)' }}>{children}</div>
     </section>
@@ -202,7 +208,7 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
         </header>
 
         {/* ── Character plate ── */}
-        <Plate title={t('fieldDesk.home.coven.charWindow')}>
+        <Plate>
           <div className="flex justify-end gap-2" style={{ marginBottom: 'var(--space-md)' }}>
             <button
               type="button"
@@ -350,7 +356,7 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
         )}
 
         {/* ── Quests plate ── */}
-        <Plate title={t('fieldDesk.home.coven.questsWindow')}>
+        <Plate>
           <div className="flex items-center" style={{ gap: 'var(--space-md)', marginBottom: 'var(--space-sm)' }}>
             <span
               style={{

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -131,7 +131,12 @@ describe("Ephemerists task detail — the Valley plate", () => {
     expect(html, "the stepped octagon medallion").toContain("M30 4 L70 4 L96 30");
     expect(text, "the masthead wordmark").toContain("The Ephemerists");
     expect(html, "the masthead's kite sigil").toContain("M243 120 L55 272 L243 490 L425 272 Z");
-    expect(text, "the masthead's four-kanji register").toContain("星暦観録");
+    // The masthead's four-kanji register (星 暦 観 録) was asserted here.
+    // #1909 CUT all EIGHT of its strings — the marks and their English glosses
+    // — because no other faction had a register row and the audit ruled the
+    // masthead generic. Held as an absence so a voice pass cannot put a
+    // faction-only band back on a settled surface.
+    expect(text, "the retired four-kanji register").not.toContain("星");
     // The codex ground belongs to the OTHER Ephemerists surfaces now.
     expect(html, "retired illuminated-codex ground").not.toContain("--eph-vellum");
   });


### PR DESCRIPTION
Closes #1909

Child of #1864. **97 keys, 133 strings** — the exact count the audit ruled, verified against `docs/copy/faction-copy-decisions.csv` rather than retyped from the issue.

## The seam I tested at

**The en catalogs' leaf set.** The ruling here is not "these words are wrong", it is "**this slot should not exist**": one faction wrote a bespoke string on a surface the audit ruled generic, and the other eight never had the slot. A key-presence test asserts what IS in a catalog and is structurally blind to that — a later voice pass re-adding `wow.charter.title` would pass every one of them. So the guard walks the same `catalogLeaves()` the #1863 sweep walks and asserts **absence**, which is the only shape that can fail on a re-addition.

`src/locales/__tests__/catalog.test.ts` gained `the slots the copy audit ruled generic stay deleted (#1909)` and was **committed red** (`eea59c2b`): all 133 present, `toEqual([])` failing with the full list. Green from `3b328009`.

The list carries a `expect(new Set(DELETED_SLOTS).size).toBe(133)` so a line lost to a bad merge cannot silently shrink the guard, and a leaf-count floor so absence cannot pass vacuously.

## Deleted by KEY, not by value — and that mattered

#1863 (PR #1928) rewrote values across these same catalogs while this was being built. I resolved every row from the CSV's `concept` column to a concrete dotted path and deleted by path. **Seven of the CSV's concepts are audit ALIASES, not real key paths**, and each was confirmed by matching the CSV's own recorded value against the string on disk before deleting:

| CSV concept | real key |
|---|---|
| `{F}.aboutpanel.command` | `singularity.manifest.command` |
| `{F}.aboutpanel.title` | `wow.charter.title` |
| `{F}.aboutpanel.paragraphs.[0..2]` | `wow.charter.paragraphs[0..2]` |
| `identity.{F}.joinpanel` | `feed:identity.wow.dispatch` |
| `profileKit.{F}.scoreFootnote` | `common:profile.singularity.scoreFootnote` (moved there by #1858) |

Every one of the 133 was found at its real path. **No drift**: none of the CUT set was among #1863's rewrites.

## The three deletions that remove real writing — all three had NO live reader for the thing being cut

Each was traced end to end before deleting, and each is called out because the sweep was *not* mechanical.

**1. WOW's Charter of Whimsy** — `wow.charter.title` + three `paragraphs`. Live reader: `WowFactionBody`'s `Charter`. **Not stopped**, because the audit's own reasoning holds: no other faction has body copy on that panel — the other seven all print `factionDescription(slug)` split on blank lines — so the Charter now prints the description too, exactly like its siblings. Several hundred words of real writing gone, deliberately, under the ruling's own terms ("we can put it back in intentionally"). `wowFactionBody.test.tsx` now asserts both halves: the panel is **not empty** (the bug the old `returnObjects` test caught) and the bespoke charter is **absent**.

**2. WOW's nine-string profile block** — `profile.wow.eyebrow`, `.honours`, `.tabPraxis`, `.tabTasks`, `.stats.{points,praxis,tasks}`, `.praxisEmpty`, `.tasksEmpty`. All live, all in `WowProfileBody`. **One needed care and I want it looked at**: `profile.wow.honours` was dual-use — the phone stack's badge heading AND the DESKTOP kit's `badgeTitle`, which is a **required** field on `ProfileSkin`'s kit. Deleting it without a replacement is a `t()` throw, not a missing word. Both now read the shared `common:profile.badgesHeading` ("Badges") — which is the wording #1910's `profileKit.{F}.badgeTitle` collapse settles every kit onto anyway. The rest take existing shared keys (`profile.mobile.tabPraxis/tabTasks`, `profile.praxisEmptyTitle`, `profile.proposedTasksEmpty`); the eyebrow has no shared twin and is simply gone.

**3. `comments.wow.react` ("Huzzah")** — confirmed **dead**. `WowComment.tsx` names it only in a comment recording that #898 shipped the word and no reaction feature was ever built; the only other reference was a *negative* assertion. Deleting it removes dead copy, not a button.

## The three keys the audit says are already covered

| deleted | now reads |
|---|---|
| `praxis:comments.wow.post` ("Proclaim") | `praxis:comments.post` — by **dropping the `submitLabel` override**, which is `ComposerControls`' own default. The repoint *is* the deletion. |
| `feed:factionCard.everymen.summons` ("NEW SUMMONS · {{note}}") | `feed:factionCard.newInvitation` ("NEW INVITATION") |
| `votes:chrome.wow.picked` ("thou dubbed it {{label}}") | `votes:chrome.voted` ("Voted {{stars}} pts") |

**Two of the three changed the call site's interpolation, as the issue warned:**
- `newInvitation` takes **no** variable where `summons` interpolated `{{note}}`, so `EverymenFactionCard` appends the note in a second span — the shape `FactionCard`'s own invitation chip already uses. Its other branch was `factionCard.everymen.kicker`, also CUT with no generic twin, so **the ribbon is now drawn only when there is an invitation**.
- `chrome.voted` takes `{{stars}}`, not `{{label}}` — `WowVote`'s caption passes `selected` instead of the tier word.

## The one multi-site cut

`chrome.{F}.prompt` — whole slot (5 strings) + `chrome.singularity.promptHint` + **3 render sites**: `CovenVote`, `WowVote`, `EphemeristsPraxisCard`. `chrome.ua.prompt` and `chrome.singularity.prompt` were already dead, as the issue records.

## Where a deletion took drawn furniture with it, and where it did not

The rule I applied: **a mark that is drawn stays; a plate that existed only to carry a deleted string goes.**

- **Kept**: Coven's braid, WOW's rosette, the Everymen task card's gears and double rule, Singularity's LED bar and `> ` prompt, the Ephemerists' lotus and drift strip, Snide's WANTED plate.
- **Went with the string**: the WOW duel seal's plum ribbon band (a coloured plate holding nothing), Singularity's blinking `.sg-cursor` on the faction card and select card (it was that line's punctuation), Everymen's motto plaque and perk checklist.
- **Moved**: the Ephemerists masthead's 1px + 3px-double rules moved from the deleted kanji register onto the datum row, so the wordmark still reads as an engraved band.

## Three `ponytail:` markers, each with a ceiling and an upgrade path

1. **`EverymenTaskCard`** — `taskCard.everymen.sealUnit` ("POINTS") was the struck seal's only unit word, and `taskCard.everymen` is the one faction card with **no `pointsUnit`** to fall back on. Ceiling: a bare figure in the seal. Upgrade path: #1910 collapses `taskCard.{F}.pointsUnit` to one shared key — read it then. Inventing a cross-faction read now would collide with that PR.
2. **`WowProfileBody`'s stat row** — its three labels were WOW's own and no other profile body draws a stat row, so there is no per-faction twin. I kept the row (its figures are the score and both counts — real data) and labelled it from shared strings, but `sidebar.characterCard.points` is a sidebar key doing duty on a profile. Upgrade path: #1910 owns the profile-kit collapse and can mint `profile.stats.*`.
3. **`EphemeristsMasthead`** — the register's eight strings had no shared twin at all, so the whole band goes and the masthead is two bands where the design drew three. I have no browser; the proportion is unverified. Upgrade path: `frontend-style` re-rules the wordmark/datum seam.

## Two transient gaps #1910 closes

- **Singularity's about panel now has no heading.** It never had one — its panel opened on `manifest.command` (`> cat /faction/manifest.txt`), which is on the CUT list, and the CSV confirms Singularity is the one faction with no `aboutpanel.heading`. #1910's collapse gives all seven the shared "About".
- **Snide's faction card masthead has no subtitle**, and `SnideMasthead.subtitle` is now optional rather than required.

## #1314 (PR #1929)'s 16 orphaned keys — **1 of the 16 is in my 97**

- **In scope, deleted**: `wow.mobile.subtitle`. That is the whole overlap.
- **Not mine — #1910's**: the seven `{F}.mobile.eyebrow`. They are on #1864's **GENERIC** table (collapse to "Faction"), not the CUT table.
- **Not mine and not ruled on at all**: the eight shared `factions:mobile.*` — `topMembers`, `recentPraxis`, `membersStat`, `tasksStat`, `membersEmpty`, `praxisEmpty`, `memberStat`, `burnedHint`. These are not faction-scoped, so the audit never saw them. They are **orphans with no reader and no ruling** — a different finding from "ruled generic", and I have deliberately not folded them in. They are still in `factions.json`, unread, and want their own issue.

Also **not** done here: #1929 asked for `mobile.join` / `mobile.joining` / `mobile.confirm` / `mobile.memberBadge` / `mobile.gateHint` to be **renamed** (their names misdescribe a now-responsive body). That is a rename, not one of the 97 deletions, so it stays out.

## Tests: rows tightened, never weakened

- **Four negative assertions that were keeping a doomed key alive now spell the words out.** `expect(x).not.toContain(i18n.t('praxis:comments.wow.react'))` is a *reader*: it is why the typed `t()` flagged four test files, and a key held up only by a `not.toContain` is one the next dead-key sweep cannot tell from a live one. (That reasoning is not mine — `ephemeristsPlateSurfaces.test.tsx` already had it written in for `card.masthead.ephemerists`.)
- **Six rows left `catalog.test.ts`'s own #1863 `SURVIVORS` / `SEAL_SURVIVORS` / `FILED_SURVIVORS` lists.** Those are exact `toEqual` lists whose comments said "#1864 CUT, waiting for the child" — the child landed, and each removal makes the #1863 guard *stricter*, not looser.
- **The kanji tests invert rather than disappear.** `#1637`'s bound — *the cost of not decoding a label may never be a NUMBER* — survives the change and is still the thing worth guarding, so the numerals case is untouched and only the label cases become absences. Same in `ephemeristsMasthead.test.tsx` and `ephemeristsDetail.test.tsx`.
- **`factionDetailResponsive.test.tsx`** swapped Singularity's "own voice" entry from `manifest.command` to `praxis.heading` — still a string only that body draws, still unconditional.
- **`profileFormFactor.test.tsx`** identified the desktop WOW page by `'Honours &amp; Credentials'`, which every kit now says; it identifies it by the gilt rope ring token instead.

## Local gate — every step in `.github/workflows/test.yml`'s `frontend` job

`npm run lint` ✅ · `npm run typecheck` ✅ · `npm run typecheck:design-sync` ✅ · `npm test` ✅ **273 files / 4,868 passed / 1 skipped** · `npm run build` ✅ · `npm run budget` ✅.

`tsc --version` → **5.9.3**, run from the worktree's own binary, so the green typecheck is real and not a missing-binary false pass. No backend change (ADR-0031/0038 keep wording in the frontend), so no `wz1909_test` run.

### The typed `t()` did the hard part

`i18n.t` is typed off the catalog JSON and `missingKeyHandler` **throws** outside production, so a deleted key with a live reader is a compile error or a thrown test, not a raw key on screen. After the catalog deletion `tsc` named exactly five dangling readers, all in tests, and the suite named 20 more assertions. Nothing reached a browser to be discovered by eye.

## Payload — measured on this machine, both sides

| | `origin/main` | branch | Δ |
|---|---|---|---|
| initial JS (gzip) | 129.6 KB | **127.7 KB** | **−1.9 KB** |
| initial CSS (gzip) | 21.3 KB | **21.3 KB** | 0 |

Both within budget and below the 130.9 KB warn line. `main` was measured by checking `origin/main` out in this same worktree and building it, not quoted from another PR.

## ⚠️ Visual QA is outstanding, and it is the substance of this PR

**I have no browser and no dev stack.** Everything above is `tsc`, `eslint`, 4,868 vitest assertions, `vite build` and `npm run budget`. Every item below changes what a surface *says or draws*, and none of it has been looked at.

## What to eyeball

**The two that lose real writing — look at these first:**

1. **WOW's faction page, the charter panel.** It now prints the faction DESCRIPTION where four paragraphs of the Charter of Whimsy used to be. The panel is shorter and the `h2` title line is gone entirely — check the bunting, the "The Charter" label and the zig rule still frame something that looks deliberate rather than truncated.
2. **WOW's character profile, BOTH widths.** Desktop: the badge column heading is now "Badges". Phone: the "Of the Court of Whimsy" eyebrow is gone from under the faction/level line; the segmented tabs read "Praxis" / "Tasks" instead of "Chronicles" / "Quests Decreed"; the three-up tally reads "points" / "Praxis" / "Tasks" instead of "Huzzahs" / "Chronicles" / "Quests"; both empty states are the shared sentences. **This is the single biggest voice loss in the PR** and the one most likely to read as a bug rather than a decision.

**Then the ones where furniture moved:**

3. **Any Ephemerists surface with a masthead** (praxis card, task detail, faction page, composer) — the four-kanji register band is **gone**, and its 1px + 3px-double rules moved onto the datum row. Two bands where the design drew three, at both `page` and `card` scale, and I could not see it.
4. **The Ephemerists praxis score stamp** — every row now reads its English label ("base", "mult", "meta", "votes", "habit", "points") in the same incised small caps the kanji wore. Check the cell still balances with wider labels, especially the total's octagon.
5. **WOW's duel seal**, submit and forfeit. The kicker above the heading, both section eyebrows ("The Roster", "The Stakes") and the plum ribbon band are gone; the buttons say "Lock it" / "Not yet" (and the forfeit face keeps "Forfeit"). It is a noticeably barer sheet.
6. **The Everymen faction card** — no eyebrow, no motto plaque, no perk checklist, and **the gold banner ribbon is drawn only when there is an invitation**. Card ends on the description.
7. **The Everymen task card** — the "Help Wanted!" masthead between the gears is gone, and the struck points seal is a **bare figure with no unit word** (`ponytail:` #1). Judge whether that reads.
8. **The Singularity faction card and the faction SELECT card** — both lose the "singularity protocol" overline and its blinking cursor. The select card is on a surface the audit *keeps* (`factionSelect.*`, all still read); the `identity.*` overline was a separate single-faction slot sitting on top of it. **If that reads as taking voice off a kept surface, this is the line to send back.**
9. **Coven's field desk (phone)** — both plate bands lose their right-aligned window title; only the sigil is left in the band.
10. **The vote widgets** — Coven, WOW and the Ephemerists praxis card lose their prompt line above the stars. WOW's cast-vote caption now reads "Voted 4 pts" where it said "thou dubbed it splendid".
11. **Snide's faction page spotlight** ("★ WANTED ★" rule gone, the label below it stays) and **Snide's faction card masthead** (no "field dispatch").
12. **Every faction page's Tasks and Praxis sections, all seven** — the kicker line under each heading is gone. Check the heading-to-content spacing on each; four of them had the kicker carrying a `margin-bottom` that left with it.
13. **The Singularity faction page** — its about panel now opens straight on the description with **no heading at all** until #1910 lands.
14. **Six praxis cards** (UA, Snide, WOW, Coven, Everymen, Singularity) lose their masthead/eyebrow line, and WOW's also loses "for the quest —", "❦ here, an illumination ❦" and "Sealed by the Court" (its footnote keeps the date).
15. **The invitation letter, all eight factions** — the fourth "standing" term row is gone from the terms slip, including Albescent's twin. Check the slip's grid and its dashed dividers with three rows instead of four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
