### PR TITLE
The Field Stamp's scrim scrolls, so a short viewport can still reach Continue

### DIFF
--- a/frontend/src/components/LevelUpPopup.tsx
+++ b/frontend/src/components/LevelUpPopup.tsx
@@ -17,6 +17,14 @@ function tKey(t: TFunction<'progression'>, key: string): string {
 /**
  * LevelUpPopup — World Zero "Field Stamp" level-up popup (design: docs/design/level-up/).
  * Self-contained inline-styled modal, matching EverymenVote / the feed modals.
+ *
+ * Both skins make their fixed scrim the scroller so the CTA stays reachable on
+ * a short viewport (#1947 — reported at 361x233, where the card is roughly
+ * twice the viewport's height). ponytail: the CTA keeps a plain `autoFocus`,
+ * so on a viewport too short for the card the popup opens scrolled to the
+ * button — the celebration is a scroll up, and the primary control is never
+ * off-screen. Suppressing that with `focus({ preventScroll: true })` would
+ * need a ref and buys a first paint nobody can act on.
  */
 
 /**
@@ -278,10 +286,21 @@ function MobileLevelUpCard({
         inset: 0,
         zIndex: 1000,
         display: 'flex',
-        alignItems: 'center',
+        // Short viewports (#1947): the scrim is the scroller. `flex-start` +
+        // `margin: auto` on the card, NOT `align-items: center` — a centred
+        // flex item that outgrows its scroll container overflows off BOTH
+        // ends and the top end is unreachable, because a scroll container
+        // cannot scroll to negative offsets. Auto margins centre while there
+        // is free space and collapse to 0 when there isn't, so the seal stays
+        // reachable above and the CTA below.
+        alignItems: 'flex-start',
         justifyContent: 'center',
         padding: 'var(--space-xl)',
-        overflow: 'hidden',
+        // Was `overflow: hidden` — that clipped the confetti AND pinned the
+        // card. The confetti layer clips itself, so only the y-axis changes.
+        overflowX: 'hidden',
+        overflowY: 'auto',
+        overscrollBehavior: 'contain',
         background: 'radial-gradient(ellipse at 50% 42%, rgba(26,18,9,0.44), rgba(26,18,9,0.74))',
       }}
     >
@@ -296,6 +315,9 @@ function MobileLevelUpCard({
           zIndex: 2,
           width: '100%',
           maxWidth: 340,
+          // Centres inside the scrolling scrim; collapses to 0 when the card
+          // is taller than the viewport (#1947). See the scrim's note.
+          margin: 'auto',
           boxSizing: 'border-box',
           background: PAPER,
           border: `1px solid ${BORDER}`,
@@ -467,14 +489,21 @@ export default function LevelUpPopup({
         position: 'fixed',
         inset: 0,
         display: 'flex',
-        alignItems: 'center',
+        // Same short-viewport contract as the mobile skin (#1947): the scrim
+        // scrolls, the card centres with auto margins rather than
+        // `align-items: center`, which would put the top of an over-tall card
+        // out of scroll range. A laptop window dragged short — or any zoomed
+        // desktop — hits this too.
+        alignItems: 'flex-start',
         justifyContent: 'center',
         padding: 'var(--space-xl)',
+        overflowY: 'auto',
+        overscrollBehavior: 'contain',
         zIndex: 1000,
         background: 'radial-gradient(ellipse at 50% 42%, rgba(26,18,9,0.30), rgba(26,18,9,0.66))',
       }}
     >
-      <div onClick={(e) => e.stopPropagation()}>{card}</div>
+      <div style={{ margin: 'auto' }} onClick={(e) => e.stopPropagation()}>{card}</div>
     </div>
   )
 }

--- a/frontend/src/components/__tests__/levelUpPopupScroll.test.tsx
+++ b/frontend/src/components/__tests__/levelUpPopupScroll.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Field Stamp reachability on a short viewport (#1947).
+ *
+ * Seam: the RENDERED MARKUP's inline style strings. This repo's harness is
+ * renderToStaticMarkup with no jsdom, so there is no layout and an overflow
+ * cannot be measured — what can be pinned is the rule that makes the overflow
+ * scrollable, which the popup carries inline (the whole file is inline-styled;
+ * nothing here lives in index.css).
+ *
+ * Two properties per skin, and they only work as a pair:
+ *   - the fixed scrim scrolls on the y-axis, so an over-tall card is reachable;
+ *   - the card centres with `margin: auto`, NOT `align-items: center`. A
+ *     centred flex item that outgrows its scroll container overflows off both
+ *     ends and the start end cannot be scrolled to, so `align-items: center`
+ *     on a scrolling scrim would leave the top of the stamp unreachable.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+import '../../i18n'
+import type { LevelUnlock } from '../../api/gameConfig'
+
+const mocks = vi.hoisted(() => ({
+  formFactor: 'desktop' as 'mobile' | 'desktop',
+}))
+
+vi.mock('../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+// Imported after the mock is registered.
+import LevelUpPopup from '../LevelUpPopup'
+
+// Level 1 / trailhead is the reported state: the onboarding arc's first win.
+const abilities: LevelUnlock[] = [
+  { key: 'duels', kind: 'ability' },
+  { key: 'shortcut_sense', kind: 'sense' },
+]
+
+function render(): string {
+  return renderToStaticMarkup(
+    <LevelUpPopup level={1} rankKey="trailhead" abilities={abilities} onContinue={() => {}} />,
+  )
+}
+
+/** Inline `style="..."` bodies, in document order. */
+function styleAttrs(html: string): string[] {
+  return [...html.matchAll(/style="([^"]*)"/g)].map((m) => m[1].replace(/&quot;/g, '"'))
+}
+
+describe.each(['mobile', 'desktop'] as const)('Field Stamp on a short viewport (%s)', (factor) => {
+  it('gives the scrim a y-axis scroller so the CTA is reachable', () => {
+    mocks.formFactor = factor
+    const scrim = styleAttrs(render()).find((s) => s.includes('position:fixed'))
+    expect(scrim).toBeDefined()
+    expect(scrim).toContain('overflow-y:auto')
+    // The bug was the scrim pinning its content: no scroller at all on
+    // desktop, and a hard `overflow:hidden` on mobile.
+    expect(scrim).not.toMatch(/(^|;)overflow:hidden/)
+  })
+
+  it('centres the card with auto margins, not align-items:center', () => {
+    mocks.formFactor = factor
+    const styles = styleAttrs(render())
+    const scrim = styles.find((s) => s.includes('position:fixed'))
+    expect(scrim).toContain('align-items:flex-start')
+    expect(scrim).not.toContain('align-items:center')
+    // Some element between the scrim and the stamp takes the auto margins.
+    expect(styles.some((s) => /(^|;)margin:auto/.test(s))).toBe(true)
+  })
+
+  it('keeps the continue button focusable at open so keyboard users reach it', () => {
+    mocks.formFactor = factor
+    const html = render()
+    // autoFocus lands on the CTA; in a scroll container the browser scrolls a
+    // focused element into view, which is what makes it reachable at 233px.
+    expect(html).toMatch(/<button[^>]*autofocus/i)
+  })
+})


### PR DESCRIPTION
The Field Stamp fires on reaching level 1, and on a short viewport its Continue
button sits below the fold with no way to scroll to it. Reported at 361x233.

Closes #1947

## Diagnosis — it is not a `max-height`, it is no scroller at all

`LevelUpPopup` is neither a `<dialog>` nor a portal: it is an inline
`position: fixed; inset: 0` overlay rendered by `LevelUpWatcher` inside
`Layout`. Nothing anywhere sets `overflow: hidden` on `body` or
`documentElement` — there is no scroll lock, so that half of the guess is out.

Two separate things were wrong, and the second is the one that bites:

1. **The scrim was not a scroll container.** Desktop set no `overflow` at all
   (default `visible`, so an over-tall card just spills past the fixed
   overlay's edges and is clipped by the viewport); the mobile skin set an
   explicit `overflow: hidden` to clip its confetti, which hard-pins the card.
   Because the overlay is `position: fixed`, scrolling the page behind it moves
   nothing — exactly the reporter's "even if I scroll down, it doesn't scroll
   this popup window".
2. **`align-items: center` on a scrolling flex container is its own bug.** A
   centred flex item taller than its container overflows off *both* ends, and a
   scroll container cannot scroll to a negative offset — so adding
   `overflow-y: auto` alone would have reached the CTA at the bottom and made
   the seal at the top permanently unreachable instead. The fix is
   `align-items: flex-start` plus `margin: auto` on the card, which centres
   while there is free space and collapses to 0 when there isn't.

Not faction-dispatched — the popup is *form-factor* dispatched (mobile /
desktop skins in one file), so there are exactly two scrims and both got the
same treatment. Nine skins were never in play. The reported 361px width lands
on the mobile skin (breakpoint is 767px), but the desktop skin has the same
defect and is fixed alongside it.

The card is roughly twice the height of the reported viewport, so this is a
container-scroll fix, not a squash: no type sizes, no paddings, no colours
change. `src/index.css` is **untouched** (verified `git diff --stat` = 0), which
matters given #1919/#1944/#1945/#1946 are queued on that file.

## a11y

The CTA keeps `autoFocus`. Once the scrim is a real scroll container the
browser scrolls a focused element into view, so on a viewport too short for the
card the popup now *opens* with Continue on screen and the celebration a scroll
up — and `Tab` reaching the button scrolls it into view for the same reason.
Marked `ponytail:` in the component doc: suppressing that opening scroll with
`focus({ preventScroll: true })` would need a ref and would buy a first paint
nobody can act on.

`overscroll-behavior: contain` stops the scroll chaining out to the page behind
once the popup hits its end.

**Pre-existing and left alone (worth a follow-up issue, not this diff):** the
overlay has `role="dialog" aria-modal="true"` but no focus trap and no
`inert`/`aria-hidden` on the background, so `Tab` can walk out of it into the
page underneath. That is true of the sibling modals too and is a behaviour
change, not a layout one.

## Seam tested

`frontend/src/components/__tests__/levelUpPopupScroll.test.tsx` — the seam is
the **rendered markup's inline style strings**, via `renderToStaticMarkup`. The
harness has no jsdom and therefore no layout, so an overflow cannot be measured;
what can be pinned is the rule that makes the overflow scrollable. This popup is
inline-styled end to end (nothing of it lives in `index.css`), so the stylesheet
`ruleBodies` seam has nothing to say here — the markup is where the contract is.
Both skins are asserted, `describe.each`, at level 1 / `trailhead`: scrim has
`overflow-y:auto` and no `overflow:hidden`, scrim has `align-items:flex-start`
and not `align-items:center`, some element carries `margin:auto`, and the CTA
still renders `autofocus`.

Then grepped the **built** bundle after `npm run build`, since a source edit
proves nothing about what ships:

```
dist/assets/index-*.js: ...justifyContent:"center",padding:"var(--space-xl)",overflowX:"hidden",overflowY:"auto",overscrollBehavior:"contain",...
dist/assets/index-*.js: ...alignItems:"flex-start",justifyContent:"center",padding:"var(--space-xl)",overflowY:"auto",overscrollBehavior:"contain",zIndex:1e3,...
```

Both scrims present; `maxWidth:340,margin:"auto"` present; zero surviving
`position:"fixed",inset:0,...overflow:"hidden"` matches.

## Verification run locally

Every step in `.github/workflows/test.yml`'s frontend job: `npm run lint`,
`npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(278 files, 4905 passed / 1 skipped), `npm run build`, `npm run budget`
(JS 127.7 KB ok, CSS 21.4 KB ok — unchanged, no CSS was touched).

## What to eyeball

> **Nothing here has been seen rendered.** I have no browser and no dev stack;
> this is a layout bug at a specific viewport and every claim above is read off
> source and the built bundle, not off a screen. It needs a human at a window.

1. **Reach level 1 at a ~360x230 viewport** (the reported size — DevTools
   responsive mode, 361x233) and confirm the Continue button is on screen at
   open and that the popup scrolls up to reveal the seal and the rank.
2. Same thing shorter still — 320x200 — and in landscape on a real phone, where
   the URL bar eats the height that caused this.
3. A normal phone (390x844) and a desktop window: nothing should scroll at all,
   and the card should sit dead-centre exactly as before.
4. A desktop window dragged short, or browser zoom at 200% — the desktop skin
   takes the same fix and should scroll rather than clip.
5. Keyboard only: `Tab` to Continue and `Enter`; `Esc` still dismisses; the
   scrim click-to-dismiss and the card's click-through guard still behave.
6. Mobile confetti still falls and is still clipped to the viewport (the
   confetti layer already clipped itself, so dropping the scrim's
   `overflow:hidden` should change nothing), and `prefers-reduced-motion`
   still stills it.
7. Dark mode, both skins — no colour changed, so this is a no-op check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
