### PR TITLE
Coven's join panel stops titling a window that was deleted

### DIFF
--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -507,6 +507,101 @@ describe('the four functional controls say one thing across every faction (#1863
   })
 })
 
+/* ========================================================================== *
+ * #1948 — THE TERMINAL REGISTER BELONGS TO EXACTLY ONE FACTION.
+ *
+ * THE SEAM IS THE CATALOG LEAF VALUE, per faction block. Cozy Coven's join panel
+ * read `JOIN.EXE` over witch-house body copy. It was not a shared panel and not
+ * a wrong slug: `coven.join.windowTitle` was the title bar of the pushpinned
+ * `join.exe` window that #1209 deleted, and CovenFactionBody's replacement
+ * changed no copy, so the title outlived its window and got re-hung on the new
+ * bar. `coven.mobile.eyebrow` ("coven.exe") is the same residue of the retired
+ * lo-fi `coven.exe` / `whimsy.exe` desktop metaphor (#784 / #1023 / #1209).
+ *
+ * Every other faction names that same panel in its own voice — "The Road",
+ * "THE ROLL", "ACCESS", "Those practising", "THE MUSTER", the S.N.I.D.E.
+ * letterhead — so the fix is Coven's two strings, not seven factions'.
+ *
+ * A key-presence test cannot see this: the key existed, resolved, and rendered.
+ * The way it comes back is a voice pass writing `.exe` into a skin that is not
+ * Singularity's, so the guard reads VALUES and pins the whole offender set with
+ * an exact toEqual. Singularity's 13 strings are listed one by one: the register
+ * IS its voice, and enumerating them is what makes an eighth entry fail.
+ * ========================================================================== */
+describe('only Singularity speaks in the terminal register (#1948)', () => {
+  // `.exe`-style extensions, and a leading `> ` shell prompt.
+  const TERMINAL = /\.(exe|bat|cmd|sh|dll|proc)\b|^\s*>\s/i
+
+  /**
+   * Singularity's whole terminal voice, string by string. Nothing else in any en
+   * catalog may match — a `.exe` on a witch-house, cork-board or broadsheet skin
+   * is the bug #1948 reports.
+   *
+   * `manifest.txt` inside `singularity.manifest.empty` is Singularity's too; it
+   * is caught by the `> ` prompt rather than by the extension, which is why the
+   * pattern does not need a `.txt` arm.
+   */
+  const TERMINAL_VOICE = [
+    'common.json:profile.singularity.praxisEmptyTitle',
+    'factions.json:singularity.access.eligibleKicker',
+    'factions.json:singularity.access.gateKicker',
+    'factions.json:singularity.access.joinButton',
+    'factions.json:singularity.access.joining',
+    'factions.json:singularity.invitation.kicker',
+    'factions.json:singularity.manifest.empty',
+    'factions.json:singularity.mobile.eyebrow',
+    'factions.json:singularity.praxis.empty',
+    'factions.json:singularity.roster.empty',
+    'factions.json:singularity.roster.emptyWithSpotlight',
+    'factions.json:singularity.roster.heading',
+    'factions.json:singularity.tasks.empty',
+  ].sort()
+
+  it('finds catalog leaves to scan, so the sweep cannot pass by scanning nothing', () => {
+    expect(catalogLeaves().length).toBeGreaterThan(1000)
+  })
+
+  it('finds no executable flavour text outside Singularity', () => {
+    const offenders = catalogLeaves()
+      .filter(([, value]) => TERMINAL.test(value))
+      .map(([id]) => id)
+      .sort()
+    expect(offenders).toEqual(TERMINAL_VOICE)
+  })
+
+  it('renames the key the retired window titled, and keeps the panel labelled', () => {
+    // ponytail: "the circle" and "The Circle" are PROVISIONAL — assembled from
+    // the four strings already in this panel ("You're in the circle", "The
+    // circle is open", "Not in the circle — yet", "the circle is recruiting"),
+    // not written. The owner writes strings in this repo; pinning them here
+    // means a later voice pass reads as a deliberate edit, not a drift.
+    expect(factions.coven.join).not.toHaveProperty('windowTitle')
+    expect(factions.coven.join.heading).toBe('the circle')
+    expect(factions.coven.mobile.eyebrow).toBe('The Circle')
+  })
+
+  it('names the join panel in every faction voice, so none falls back to chrome', () => {
+    // The bar Coven's `.exe` sat on. Albescent has no join panel (ADR-0048: the
+    // letter IS its join surface), so it is absent by design, not by omission.
+    const labels: Record<string, string> = {
+      coven: factions.coven.join.heading,
+      wow: factions.wow.join.heading,
+      ephemerists: factions.ephemerists.road.heading,
+      everymen: factions.everymen.roll.heading,
+      singularity: factions.singularity.access.heading,
+      snide: factions.snide.dispatch.letterhead,
+      ua: factions.ua.registry.heading,
+    }
+    for (const [slug, label] of Object.entries(labels)) {
+      expect(label, slug).toBeTypeOf('string')
+      expect(label.length, slug).toBeGreaterThan(0)
+    }
+    // Seven distinct voices — a copy pass that settled them onto one shared
+    // string would be a different ruling, and should fail here first.
+    expect(new Set(Object.values(labels)).size).toBe(7)
+  })
+})
+
 describe('no duplicate keys in any locale catalog', () => {
   // JSON is last-wins: a key repeated inside the same object silently drops the
   // earlier block at parse time, so the copy vanishes with no error (this is

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -456,7 +456,7 @@
       "empty": "Nothing cast yet."
     },
     "join": {
-      "windowTitle": "join.exe",
+      "heading": "the circle",
       "memberTitle": "You're in the circle",
       "memberStanding": "Standing · <1>coven witch</1>",
       "eligibleTitle": "The circle is open",
@@ -477,7 +477,7 @@
       "level": "lvl {{level}}"
     },
     "mobile": {
-      "eyebrow": "coven.exe"
+      "eyebrow": "The Circle"
     },
     "invitation": {
       "kicker": "the circle is recruiting",

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -54,7 +54,10 @@ import type { FactionDetailState } from "../useFactionDetail";
  * — so the member list and the spotlight are built from the two list shapes the
  * design DOES draw: the submission card and the comment row.
  *
- * NO COPY CHANGED. Every string is the `factions` catalog key it was.
+ * NO COPY CHANGED when this file replaced the memo board — every string was the
+ * `factions` catalog key it was. That is exactly how `join.exe` survived the
+ * window it titled: #1948 is the one string since changed (`join.windowTitle` →
+ * `join.heading`, "the circle").
  */
 
 const CHROME = "var(--font-faction-rounded)"; // Quicksand
@@ -240,7 +243,14 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
               }}
             >
               <SigilMark size={26} />
-              <span style={{ ...CAPTION, marginLeft: "auto" }}>{t("coven.join.windowTitle")}</span>
+              {/*
+                #1948: this bar used to read `join.exe` — the title of the
+                pushpinned window #1209 deleted, re-hung on the panel that
+                replaced it. Every sibling names its join panel in its own voice
+                (`road.heading` "The Road", `roll.heading` "THE ROLL",
+                `access.heading` "ACCESS"), so Coven's is `join.heading` too.
+              */}
+              <span style={{ ...CAPTION, marginLeft: "auto" }}>{t("coven.join.heading")}</span>
             </div>
 
             <div style={{ background: CARD, padding: "var(--space-lg)" }}>


### PR DESCRIPTION
`JOIN.EXE` over witch-house body copy on the Cozy Coven faction page.

## The cause: a title bar that outlived its window

Not a shared panel, and not a wrong slug. It is Coven's own key holding Coven's own retired chrome.

`coven.join.windowTitle` was the title bar of the **pushpinned `join.exe` window** on the cork-memo-board Coven faction page. #1209 deleted that window — `CovenFactionBody`'s own file header says so — and the replacement panel was built under an explicit "NO COPY CHANGED. Every string is the `factions` catalog key it was." So the window went and its title stayed, re-hung on the slip band that replaced it. Same residue as the lo-fi `coven.exe` / `whimsy.exe` desktop metaphor that #784 / #1023 / #1209 stripped off thirteen other Coven surfaces.

It is not Singularity leaking, either: the bar's face is `--font-faction-rounded` (Quicksand) at `letter-spacing: 0.16em` + `text-transform: uppercase` — Coven's own `CAPTION`. The terminal look is entirely the word. Nothing is restyled here.

## Extent: the other seven factions are fine

Every faction names that same join panel in its own voice, so this is two strings, not seven factions':

| faction | key | renders |
|---|---|---|
| coven | `coven.join.windowTitle` | **`join.exe`** &larr; the bug |
| wow | `wow.join.heading` | `THE MUSTER` |
| ephemerists | `ephemerists.road.heading` | `The Road` |
| everymen | `everymen.roll.heading` | `THE ROLL` |
| singularity | `singularity.access.heading` | `ACCESS` |
| snide | `snide.dispatch.letterhead` | `S.N.I.D.E.` |
| ua | `ua.registry.heading` | `Those practising` |
| albescent | — | no join panel (ADR-0048: the letter is its join surface) |

A sweep of every leaf in every `locales/en/*.json` for the terminal register (`.exe`-class extensions, a leading `> ` prompt) returns **15 strings: 13 Singularity, and Coven's two**. The second is `coven.mobile.eyebrow` ("coven.exe") — the faction page's mobile eyebrow, where the siblings read "The Codex" / "The Union Hall" / "The Dossier" / "The Field Pavilion". It has **no reader on `main`** (there is no `pages/factionDetail/mobileArchetypes/`), so it is not what was screenshotted; it is the same residue waiting on the mobile kit, and fixing it costs one word versus writing "this `.exe` is fine" into an allowlist.

## The change

- `coven.join.windowTitle` &rarr; `coven.join.heading`. The key is renamed, not just revalued, per #1910's rule that a key may not be named for something it no longer holds — there is no window. The new name matches the six siblings above.
- Values are **PROVISIONAL** and marked as such at the assertion that pins them: `"the circle"` and `"The Circle"`. They are assembled from the four strings already in this panel ("You're in the circle", "The circle is open", "Not in the circle — yet", "the circle is recruiting") rather than written — **the owner writes strings in this repo, and these are the line to redraw.** They follow Coven's lowercase heading habit (`"the manifesto ✦"`, `"the coven roster"`).
- `CovenFactionBody`'s header said "NO COPY CHANGED". This PR falsifies that for exactly one string, so the comment now says which and why.

## The seam I'm testing at

**The catalog leaf VALUE, per faction block** — not the key set. The key existed, resolved, and rendered; a key-presence test passes on the bug and would pass again on its return. The way it comes back is a voice pass writing `.exe` into a skin that is not Singularity's. So `catalog.test.ts` walks the same `catalogLeaves()` the #1863 / #1909 / #1910 guards use and asserts the terminal-register offender set `toEqual` an exact 13-line list of Singularity strings — enumerated one by one, so an eighth faction's entry fails rather than quietly widening a regex. Mutation-checked: putting `coven.exe` back fails two assertions (`expected [ …(14) ] to deeply equal [ …(13) ]`).

## Verification

`npm run lint`, `npm run typecheck` (tsc 5.9.3 — confirmed the binary actually runs), `npm run typecheck:design-sync`, `npm test` (277 files / 4903 passed), `npm run build`, `npm run budget` (within budget) — all green locally, off `origin/main` @ b7edacd. Backend untouched.

**Visual QA is outstanding** — no browser and no dev stack in this environment, so nobody has seen the new bar rendered.

## What to eyeball

Only Cozy Coven's copy changed, so only its surfaces need a look; the rest of the list is there to confirm nothing moved.

- **Cozy Coven faction page &rarr; join gate, all three states.** The bar now reads `THE CIRCLE` (uppercased by `CAPTION`) beside the pentacle. Check it against the *gate* state in the issue screenshot, and also the **member** state ("You're in the circle") and the **eligible** state ("The circle is open") — the bar is shared by all three, and "THE CIRCLE" sitting directly above "You're in the circle" is the repetition most likely to read badly. Also check the longer word does not crowd the sigil at narrow widths (it is `marginLeft: auto` in a flex row).
- **Cozy Coven faction page &rarr; mobile.** Nothing to see today (no mobile archetype on `main`); the eyebrow value is staged for whenever that kit lands.
- The seven other faction pages' join gates, to confirm they are untouched: **Warriors of Whimsy** (`THE MUSTER`), **The Ephemerists** (`The Road`), **Everymen** (`THE ROLL`), **Singularity** (`ACCESS` — and its `> ` prompts are deliberately preserved), **S.N.I.D.E.** (letterhead), **UA** (`Those practising`), **/Albescent** (no join panel at all).

Closes #1948

🤖 Generated with [Claude Code](https://claude.com/claude-code)
