### PR TITLE
The faction names on the Players page open their faction pages, and Albescent's still does not exist

### DIFF
--- a/frontend/src/pages/players/DesktopPlayers.tsx
+++ b/frontend/src/pages/players/DesktopPlayers.tsx
@@ -14,6 +14,7 @@ import {
   PLAYERS_FILTERS_DEFAULT,
   PODIUM_SIZE,
   ROSTER_PAGE_STEP,
+  factionHref,
   factionStandings,
   rosterView,
   selectRoster,
@@ -50,8 +51,11 @@ const ELLIPSIS_GLYPH = '⋮'
  *   - **Seven lanes in the race, not eight.** The design's "Albescent" row is
  *     unaffiliated players, and `na` is a state rather than a faction — see
  *     `factionStandings`.
- *   - **Roster rows are `<Link>`s.** The design draws none; the roster has
- *     linked to the public profile since #517 and losing that is a regression.
+ *   - **The whole roster row navigates to the player.** The design draws no
+ *     link; the roster has linked to the public profile since #517 and losing
+ *     that is a regression. Since #1953 the row is a `<div>` with a stretched
+ *     overlay rather than one big `<Link>`, so the faction line inside it can
+ *     be its own link without nesting anchors — see `RosterRow`.
  *   - **The podium's latest-praxis title takes `--text-content`**, not the
  *     design's 14px: a task title is prose that can run to any length, and the
  *     content-text floor governs those (WORLD_ZERO_STYLE §4, #627).
@@ -364,9 +368,12 @@ function RaceRow({
     >
       <span style={{ fontSize: 'var(--text-md)', color: 'var(--color-text-tertiary)' }}>{rank}</span>
       <FactionSigil slug={lane.slug} size={22} />
-      <span className="font-display" style={{ fontSize: 'var(--text-content)' }}>
-        {factionName(lane.slug)}
-      </span>
+      {/* The lane's name opens its faction page (#1953). A race row is a plain
+          div — it links to nothing else — so this is one anchor, not the
+          nested-anchor case `RosterRow` below has to work around. `factionHref`
+          still gates it: see its docblock for why a lane can never be `na` or a
+          masked Albescent and why it is asked anyway. */}
+      <FactionLaneName slug={lane.slug} />
       <span
         aria-hidden
         style={{
@@ -407,14 +414,57 @@ function RaceRow({
   )
 }
 
-/** One roster row. A link, always — the design draws none and that is a bug. */
+/**
+ * A race lane's name, linked to its faction page (#1953).
+ *
+ * `<a>` is blockified as a grid item and Tailwind's preflight gives it `color:
+ * inherit; text-decoration: inherit`, so it renders identically to the `<span>`
+ * it replaces. Whether a linked faction name should grow a hover affordance of
+ * its own is a style question, deliberately not answered here.
+ */
+function FactionLaneName({ slug }: { slug: string }) {
+  const href = factionHref(slug)
+  const style = { fontSize: 'var(--text-content)' }
+  if (href === null) {
+    return (
+      <span className="font-display" style={style}>
+        {factionName(slug)}
+      </span>
+    )
+  }
+  return (
+    <Link to={href} className="font-display" style={style}>
+      {factionName(slug)}
+    </Link>
+  )
+}
+
+/**
+ * One roster row. The whole row still navigates to the player — the design
+ * draws no link at all and that is a bug — but the faction line under the name
+ * now opens that faction's page (#1953), and those two facts cannot both be
+ * anchors nested one inside the other.
+ *
+ * So the row takes the shape #1893 settled for feed cards: the row's ROOT is a
+ * plain positioned `<div>`, ONE anchor inside it (the player's name) carries a
+ * stretched overlay that covers the row, and every other link is lifted above
+ * that overlay with `position: relative; z-index: 1`. The overlay declares no
+ * z-index of its own, so any positioned sibling that declares one paints — and
+ * hit-tests — above it. The name anchor itself must NOT be positioned, or the
+ * overlay collapses to the name's own box.
+ *
+ * The faction name is the lifted link, and it is only a link at all when
+ * `factionHref` says so: unaffiliated has no page, and an unrevealed viewer must
+ * not be handed `/factions/albescent` behind a word `factionName` has already
+ * masked to "Unaffiliated" (#1926).
+ */
 function RosterRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
   const { t } = useTranslation('common')
   const { character, rank, points } = row
+  const href = factionHref(character.faction_slug)
 
   return (
-    <Link
-      to={`/characters/${character.id}`}
+    <div
       className={isMe ? 'grid items-center' : 'leaderboard-row grid items-center'}
       style={{
         position: 'relative',
@@ -425,7 +475,6 @@ function RosterRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
         borderBottom: '1px solid var(--color-border)',
         background: isMe ? 'var(--color-bg-surface)' : undefined,
         color: 'var(--color-text-primary)',
-        textDecoration: 'none',
       }}
     >
       {/* Your row's edge is the spectrum, bled into the gutter — one mark for
@@ -453,7 +502,13 @@ function RosterRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
           <FactionAvatar character={character} size={34} />
         </span>
         <span className="flex flex-col min-w-0" style={{ gap: 'var(--space-xs)' }}>
-          <span className="font-display truncate" style={{ fontSize: 'var(--text-content)' }}>
+          {/* The row's one anchor. NOT positioned — the overlay it carries has
+              to cover the row's root, not this name. */}
+          <Link
+            to={`/characters/${character.id}`}
+            className="font-display truncate"
+            style={{ fontSize: 'var(--text-content)', color: 'inherit', textDecoration: 'none' }}
+          >
             {character.display_name}
             {isMe && (
               <>
@@ -461,15 +516,34 @@ function RosterRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
                 <span className="label-heading">{t('leaderboard.roster.you')}</span>
               </>
             )}
-          </span>
+            <span aria-hidden style={{ position: 'absolute', inset: 0 }} />
+          </Link>
           {/* The faction's NAME, in the label tier's own ink (#1932). It used
               to be printed in the faction hue, which is 2.09:1 for WOW on the
               frost this row wears when it is yours. Nothing is lost: the word
               is the identity, and the avatar's ring and the gem's outline
-              beside it are still hue-coded. */}
-          <span className="label-heading truncate">
-            {factionName(character.faction_slug)}
-          </span>
+              beside it are still hue-coded.
+
+              It links to that faction's page (#1953) — lifted above the row's
+              overlay so the click reaches it — unless `factionHref` withholds
+              one, in which case the word stays exactly what it was. */}
+          {href === null ? (
+            <span className="label-heading truncate">
+              {factionName(character.faction_slug)}
+            </span>
+          ) : (
+            <Link
+              to={href}
+              className="label-heading truncate"
+              // No inline `color`: `.label-heading` owns `--label-ink` and an
+              // inline declaration outranks the class, which is the #1932
+              // regression. Tailwind's preflight `a { color: inherit }` is an
+              // element selector and loses to the class, so the ink is right.
+              style={{ position: 'relative', zIndex: 1 }}
+            >
+              {factionName(character.faction_slug)}
+            </Link>
+          )}
         </span>
       </div>
 
@@ -483,6 +557,6 @@ function RosterRow({ row, isMe }: { row: RankedPlayer; isMe: boolean }) {
       >
         {points}
       </span>
-    </Link>
+    </div>
   )
 }

--- a/frontend/src/pages/players/MobilePlayers.tsx
+++ b/frontend/src/pages/players/MobilePlayers.tsx
@@ -12,6 +12,7 @@ import {
   PLAYERS_FILTERS_DEFAULT,
   PODIUM_SIZE,
   ROSTER_PAGE_STEP,
+  factionHref,
   factionStandings,
   rosterView,
   selectRoster,
@@ -128,9 +129,13 @@ export default function MobilePlayers({
                 }}
               >
                 <FactionSigil slug={lane.slug} size={18} />
-                <span className="font-display truncate" style={{ fontSize: 'var(--text-content)' }}>
-                  {factionName(lane.slug)}
-                </span>
+                {/* The lane's name opens its faction page (#1953). A race row is
+                    a plain div — it links to nothing else — so this is one
+                    anchor, not the nested-anchor case the roster has on
+                    desktop. `factionHref` still gates it: see its docblock for
+                    why a lane can never be `na` or a masked Albescent and why
+                    it is asked anyway. */}
+                <FactionLaneName slug={lane.slug} />
                 <span className="font-display rainbow-ink" style={{ fontSize: 'var(--text-content)' }}>
                   {Math.round(lane.points)}
                 </span>
@@ -239,6 +244,32 @@ export default function MobilePlayers({
         )}
       </section>
     </div>
+  )
+}
+
+/**
+ * A race lane's name, linked to its faction page (#1953).
+ *
+ * `<a>` is blockified as a grid item, so `truncate` still clips exactly as the
+ * `<span>` it replaces did, and Tailwind's preflight (`color: inherit;
+ * text-decoration: inherit`) leaves it looking identical. Whether a linked
+ * faction name should grow a hover affordance of its own is a style question,
+ * deliberately not answered here.
+ */
+function FactionLaneName({ slug }: { slug: string }) {
+  const href = factionHref(slug)
+  const style = { fontSize: 'var(--text-content)' }
+  if (href === null) {
+    return (
+      <span className="font-display truncate" style={style}>
+        {factionName(slug)}
+      </span>
+    )
+  }
+  return (
+    <Link to={href} className="font-display truncate" style={style}>
+      {factionName(slug)}
+    </Link>
   )
 }
 

--- a/frontend/src/pages/players/__tests__/playersFactionLinks.test.tsx
+++ b/frontend/src/pages/players/__tests__/playersFactionLinks.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Faction names on the Players page open their faction page (#1953).
+ *
+ * SEAM: the ANCHORS each surface emits given props — which faction name is an
+ * `<a href>`, what that href is, and which faction names deliberately are not
+ * links at all. Not the click, not the route: `renderToStaticMarkup` has no DOM
+ * and runs no effects, so what a test can hold is the markup, and the markup is
+ * where both bugs this file guards actually live.
+ *
+ * WHY IT IS ITS OWN FILE next to `playersDirectory.test.tsx`, which already
+ * renders both surfaces. That file asserts what the page SAYS; this one asserts
+ * where it GOES, and one of the two cases here needs a module-level flag set
+ * (`setAlbescentRevealed`) that would leak into every unrelated assertion in a
+ * shared file. The mask outlives the case that set it — a leaked `true` makes a
+ * later assertion pass for the wrong reason — so it is reset in `beforeEach`
+ * here and never touched next door.
+ *
+ * THE ONE THAT MATTERS is the last describe. `factionName()` masks Albescent to
+ * "Unaffiliated" for a viewer who has never been revealed to it (#1926), and an
+ * `href="/factions/albescent"` under that masked word defeats the mask twice
+ * over: the slug is in the page source in plain text, and following it lands on
+ * `AlbescentSecretPlaceholder`, which tells the reader that the row they just
+ * clicked is a sealed door. Neither is something the word "Unaffiliated" was
+ * supposed to be able to say.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import '../../../i18n'
+import type { CharacterOut } from '../../../api/auth'
+import {
+  ALBESCENT_FACTION_SLUG,
+  FACTION_RAINBOW_ORDER,
+  factionName,
+  setAlbescentRevealed,
+} from '../../../utils/factions'
+
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light' as const, toggle: () => {} }),
+}))
+
+import DesktopPlayers from '../DesktopPlayers'
+import MobilePlayers from '../MobilePlayers'
+import { NO_RELATIONSHIPS, factionHref, rankPlayers, type PlayersViewProps } from '../playersData'
+
+function render(element: ReactElement): string {
+  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+}
+
+function player(overrides: Partial<CharacterOut>): CharacterOut {
+  return {
+    id: 1,
+    username: 'wren',
+    display_name: 'Wren',
+    bio: '',
+    tagline: '',
+    avatar_url: '',
+    location: '',
+    level: 3,
+    score: 100,
+    all_time_score: 100,
+    faction_slug: 'everymen',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    badges: [],
+    invitations: [],
+    ...overrides,
+  }
+}
+
+/**
+ * Three podium-fillers so the interesting rows land in the ROSTER — the roster
+ * is the only section that prints a player's own faction, and `selectRoster`
+ * drops the top three at rest.
+ */
+const FILLER: CharacterOut[] = [
+  player({ id: 1, display_name: 'Filler A', faction_slug: 'coven', score: 900 }),
+  player({ id: 2, display_name: 'Filler B', faction_slug: 'ua', score: 800 }),
+  player({ id: 3, display_name: 'Filler C', faction_slug: 'singularity', score: 700 }),
+]
+
+function props(field: CharacterOut[]): PlayersViewProps {
+  return {
+    ranked: rankPlayers([...FILLER, ...field], 'era'),
+    scoreMode: 'era',
+    onScoreMode: () => {},
+    eyebrow: 'Renaissance · The Standings',
+    myCharId: null,
+    related: NO_RELATIONSHIPS,
+    latest: {},
+  }
+}
+
+/** Every `href` in the markup, in document order. */
+function hrefs(html: string): string[] {
+  return [...html.matchAll(/href="([^"]*)"/g)].map((match) => match[1])
+}
+
+// The flag is module-level and mutable by design (#1891), so it outlives any
+// case that sets it. Reset on both edges: `beforeEach` protects this file's own
+// cases from each other, `afterEach` protects whatever runs next in the worker.
+beforeEach(() => setAlbescentRevealed(false))
+afterEach(() => setAlbescentRevealed(false))
+
+describe('the faction race', () => {
+  for (const [surface, view] of [
+    ['desktop', DesktopPlayers],
+    ['mobile', MobilePlayers],
+  ] as const) {
+    it(`${surface}: every lane's name opens that faction's page`, () => {
+      const Surface = view
+      // Mobile shows four lanes at rest; the one asserted is the leader, whose
+      // lane is drawn on both surfaces without any state change.
+      const html = render(<Surface {...props([player({ id: 9, faction_slug: 'wow', score: 5000 })])} />)
+      const linked = hrefs(html)
+      expect(linked).toContain('/factions/wow')
+      // The href is on the NAME, not on a sigil or a bar wrapped around it.
+      expect(html).toContain(`/factions/wow"`)
+      expect(html).toContain(factionName('wow'))
+    })
+  }
+
+  it('desktop draws one lane link per faction and no more', () => {
+    const html = render(<DesktopPlayers {...props([])} />)
+    for (const slug of FACTION_RAINBOW_ORDER) {
+      expect(hrefs(html).filter((href) => href === `/factions/${slug}`), slug).toHaveLength(1)
+    }
+    // `factionStandings` keys off FACTION_RAINBOW_ORDER, so neither of the two
+    // slugs that must never be linked can reach a lane in the first place.
+    expect(hrefs(html)).not.toContain('/factions/na')
+    expect(hrefs(html)).not.toContain(`/factions/${ALBESCENT_FACTION_SLUG}`)
+  })
+})
+
+describe('a roster row', () => {
+  it("links the faction line under a player's name to that faction", () => {
+    const html = render(<DesktopPlayers {...props([player({ id: 77, faction_slug: 'snide', score: 10 })])} />)
+    expect(hrefs(html)).toContain('/factions/snide')
+    // And the row still goes to the player: the two live in one row without
+    // nesting, which is what the stretched overlay buys (#1893).
+    expect(hrefs(html)).toContain('/characters/77')
+  })
+
+  it('nests no anchor inside another', () => {
+    const html = render(<DesktopPlayers {...props([player({ id: 77, faction_slug: 'snide', score: 10 })])} />)
+    // Walk the tags: depth must never exceed one open <a>. A nested anchor is
+    // invalid HTML the browser silently re-parents, so it cannot be caught by
+    // looking at the rendered result — only at the string.
+    let depth = 0
+    let deepest = 0
+    for (const tag of html.matchAll(/<(\/?)a[\s>]/g)) {
+      depth += tag[1] === '/' ? -1 : 1
+      deepest = Math.max(deepest, depth)
+    }
+    expect(deepest).toBe(1)
+  })
+
+  it('does not link an unaffiliated player — there is no page for a non-faction', () => {
+    const html = render(<DesktopPlayers {...props([player({ id: 78, faction_slug: 'na', score: 10 })])} />)
+    expect(hrefs(html)).not.toContain('/factions/na')
+    // The word is still printed; only the link is withheld.
+    expect(html).toContain(factionName('na'))
+    expect(hrefs(html)).toContain('/characters/78')
+  })
+})
+
+describe('Albescent is not linked to a viewer who has not been revealed to it', () => {
+  const field = [player({ id: 79, display_name: 'Ash', faction_slug: ALBESCENT_FACTION_SLUG, score: 10 })]
+
+  it('emits no albescent href — the slug never reaches the page source', () => {
+    setAlbescentRevealed(false)
+    const html = render(<DesktopPlayers {...props(field)} />)
+    expect(hrefs(html), 'an href is the leak the mask exists to prevent').not.toContain(
+      `/factions/${ALBESCENT_FACTION_SLUG}`,
+    )
+    // Belt and braces: the word must not appear anywhere in the markup either,
+    // href or not. This is #1926's guarantee, restated where a link could undo it.
+    expect(html).not.toContain(ALBESCENT_FACTION_SLUG)
+    // The row still renders, still names the player, still reads "Unaffiliated".
+    expect(html).toContain('Ash')
+    expect(html).toContain(factionName('na'))
+  })
+
+  it('links it for a viewer who HAS been revealed', () => {
+    setAlbescentRevealed(true)
+    const html = render(<DesktopPlayers {...props(field)} />)
+    expect(hrefs(html)).toContain(`/factions/${ALBESCENT_FACTION_SLUG}`)
+  })
+})
+
+describe('factionHref, the one rule all three sections ask', () => {
+  it('answers a page for a real faction', () => {
+    expect(factionHref('coven')).toBe('/factions/coven')
+  })
+
+  it('answers null for unaffiliated, however it is spelled', () => {
+    expect(factionHref('na')).toBeNull()
+    expect(factionHref(null)).toBeNull()
+    expect(factionHref(undefined)).toBeNull()
+  })
+
+  it('answers null for albescent until the viewer is revealed, then a page', () => {
+    setAlbescentRevealed(false)
+    expect(factionHref(ALBESCENT_FACTION_SLUG)).toBeNull()
+    setAlbescentRevealed(true)
+    expect(factionHref(ALBESCENT_FACTION_SLUG)).toBe(`/factions/${ALBESCENT_FACTION_SLUG}`)
+  })
+})

--- a/frontend/src/pages/players/playersData.ts
+++ b/frontend/src/pages/players/playersData.ts
@@ -24,7 +24,11 @@
  *   a deliberate deviation, ruled in #1855.
  */
 import type { CharacterOut } from '../../api/auth'
-import { FACTION_RAINBOW_ORDER, UNAFFILIATED_FACTION_SLUG } from '../../utils/factions'
+import {
+  FACTION_RAINBOW_ORDER,
+  UNAFFILIATED_FACTION_SLUG,
+  isFactionHiddenFromChoosers,
+} from '../../utils/factions'
 
 /** How many players stand on the podium. The roster starts below them. */
 export const PODIUM_SIZE = 3
@@ -46,6 +50,49 @@ export interface RankedPlayer {
 /** Unaffiliated characters carry a null-ish slug; normalise to the sentinel. */
 export function slugKey(slug: string | null | undefined): string {
   return slug ?? UNAFFILIATED_FACTION_SLUG
+}
+
+/**
+ * Where a faction NAME printed on this page links to — or `null` when that name
+ * must not be a link at all (#1953).
+ *
+ * ONE rule for all three sections, because two would eventually disagree and
+ * only one of the disagreements is cosmetic.
+ *
+ * Two slugs answer `null`, for two unrelated reasons:
+ *
+ *   - **`na` / a null slug.** Unaffiliated is a state, not a faction (ADR-0030 /
+ *     ADR-0039), so there is nothing to open. `/factions/na` is not merely
+ *     pointless, it is broken: `na` is seeded hidden, `GET /factions` returns
+ *     visible rows only and `FactionDetail` derives from that list, so it
+ *     renders "Faction not found" for exactly the population the link would
+ *     serve. `DefaultEditCharacter` sends `na` to the `/factions` DIRECTORY
+ *     instead; that is a page about the viewer's own character offering them a
+ *     next step. A roster row is a LABEL on someone else, and a label whose
+ *     only honest destination is "here are all the factions" is not a link.
+ *
+ *   - **`albescent`, for a viewer who has not been revealed to it (#1926).**
+ *     `factionName()` already masks the word to "Unaffiliated" for them — but an
+ *     href is the leak the mask exists to prevent, wearing a different label.
+ *     `/factions/albescent` in the markup names the secret society in plain
+ *     text, and following it lands on `AlbescentSecretPlaceholder`, which tells
+ *     an unrevealed player that the "Unaffiliated" row they just clicked is a
+ *     sealed door. `isFactionHiddenFromChoosers` is the exported read of that
+ *     reveal flag; its name is about choosers, and a link is the stronger case
+ *     of the same question — do not show this viewer a way to pick this out.
+ *     A REVEALED viewer gets the ordinary `/factions/albescent`, which
+ *     `AlbescentGate` hands the real faction page.
+ *
+ * The race lanes can be neither by construction (`factionStandings` keys off
+ * `FACTION_RAINBOW_ORDER`, which holds neither slug), and they still route
+ * through here on purpose: the mask must not depend on the lane list staying
+ * that way.
+ */
+export function factionHref(slug: string | null | undefined): string | null {
+  const key = slugKey(slug)
+  if (key === UNAFFILIATED_FACTION_SLUG) return null
+  if (isFactionHiddenFromChoosers(key)) return null
+  return `/factions/${key}`
 }
 
 /**


### PR DESCRIPTION
The Players page prints faction names in three places. Two of them now link to
`/factions/<slug>`; the third has no faction name to link.

Closes #1953

## Seam under test

**The anchors each Players surface emits given props** — which faction name is
an `<a href>`, what that href is, and which faction names deliberately render
none. The harness is `renderToStaticMarkup`: no DOM, no effects, so the markup
string is what a test can hold, and the markup string is exactly where both
bugs guarded here live (a nested anchor, and a leaked slug).

## Which names link, and why

| Where | Links? | Why |
|---|---|---|
| **Faction race** lanes (desktop + mobile) | **yes** | This is the block in the issue's screenshot. The lane row is a plain `<div>` that links to nothing else, so the name is the row's only anchor. |
| **Roster** rows' faction line (desktop) | **yes** | It is a faction name on the Players page, and it is the only place `na` or `albescent` can appear — see below. Needed the row restructured. |
| **Podium** (both surfaces) | **n/a** | The podium draws no faction name at all. `DesktopPlayers` says so explicitly ("the tint, the avatar ring and the sigil already say which one"); mobile's row is name / level / latest task. There is nothing to link. |
| **Roster** rows on mobile | **n/a** | Mobile's roster deliberately drops the faction line. |

## The nested-anchor problem, solved the way #1893 solved it

The desktop roster row *was* one big `<Link>` to the player. Putting a faction
`<Link>` inside it nests anchors — invalid HTML the browser silently
re-parents, so it would not have shown up in a rendered result, only in the
string.

So the row takes the shape `feedBodyTarget.tsx` settled for feed cards:

- the row's root is a plain positioned `<div>`;
- **one** anchor inside it — the player's name — carries a stretched
  `position: absolute; inset: 0` overlay covering the row, so the whole row
  still navigates to the player;
- the faction link is lifted with `position: relative; z-index: 1`. The overlay
  declares no z-index at all, so any positioned sibling that declares one paints
  — and hit-tests — above it.
- The name anchor itself is **not** positioned; give it `position: relative` and
  the overlay collapses to the name's own box.

A test walks the tag stream and asserts open-`<a>` depth never exceeds 1.

## Albescent

`factionHref()` in `playersData.ts` is the one rule all three sections ask, and
it answers `null` twice:

- **`na` / a null slug.** Unaffiliated is a state, not a faction. `/factions/na`
  is not merely pointless — `na` is seeded hidden, `GET /factions` returns
  visible rows only and `FactionDetail` derives from that list, so it renders
  "Faction not found" for exactly the population the link would serve.
  (`DefaultEditCharacter` sends `na` to the `/factions` **directory** instead;
  that is a page about the viewer's own character offering a next step. A roster
  row is a label on someone else.)
- **`albescent`, for a viewer not revealed to it (#1926).** `factionName()`
  already masks the word to "Unaffiliated" — but an href is the same leak wearing
  a different label. `href="/factions/albescent"` puts the secret society's slug
  in the page source in plain text, and following it lands on
  `AlbescentSecretPlaceholder`, which tells the reader the "Unaffiliated" row
  they just clicked is a sealed door. `isFactionHiddenFromChoosers` is the
  exported read of that reveal flag and is what gates it. A **revealed** viewer
  gets the ordinary `/factions/albescent`, which `AlbescentGate` hands the real
  faction page.

The race lanes can be neither slug by construction (`factionStandings` keys off
`FACTION_RAINBOW_ORDER`, which holds neither) — they route through `factionHref`
anyway, so the mask does not depend on the lane list staying that way.

`playersFactionLinks.test.tsx` resets `setAlbescentRevealed(false)` on both
`beforeEach` and `afterEach`: the flag is module-level and outlives the case that
set it, and a leaked `true` makes a later assertion pass for the wrong reason.

## No visual decisions taken

Tailwind's preflight gives `a { color: inherit; text-decoration: inherit }`, and
`<a>` is blockified as a grid/flex item, so every linked name renders as the
`<span>` it replaced (`truncate` still clips). The roster's faction link takes
**no** inline `color` on purpose — `.label-heading` owns `--label-ink` and an
inline declaration outranks the class, which would re-break #1932; the preflight
rule is an element selector and loses to the class.

**Deferred to `frontend-style`:** whether a linked faction name should grow a
hover/underline affordance of its own. Today its only tell is the pointer cursor,
same as the roster row already was.

## Checks

`.github/workflows/test.yml`, frontend job, every step run locally:

- `npm run lint` — clean
- `npm run typecheck` — clean (`tsc --version` → 5.9.3, confirmed the binary
  actually runs before believing the pass)
- `npm run typecheck:design-sync` — clean
- `npm test` — 278 files, 4910 passed, 1 skipped
- `npm run build` — ok
- `npm run budget` — JS 127.7 KB, CSS 21.4 KB, within budget

No backend change, no new API endpoint, no CSS change.

**Visual QA is outstanding** — I have no browser and no dev stack.

## What to eyeball

Desktop and mobile, in both themes, as a **revealed** and an **unrevealed**
viewer:

1. **Podium** — unchanged. No faction name, no new link, the leader's wash and
   rank rings as before.
2. **Faction race** — each of the seven lane names is clickable and goes to that
   faction page. The name should look identical to before (no underline, no
   colour shift); the sigil, bar and points are not part of the link.
3. **Roster (desktop)** — clicking anywhere in a row still goes to the player,
   *including* the empty space right of the points. Clicking the small faction
   word under a name goes to that faction instead. Hover still tints the whole
   row (`.leaderboard-row`). Your own row keeps its frost background and the
   rainbow rule bled into the left gutter, and the "YOU" tag still sits inline
   after your name.
4. **An unaffiliated player's row** — the word "Unaffiliated" is present and is
   *not* clickable.
5. **As an unrevealed viewer, an Albescent member's row** — reads "Unaffiliated",
   is not clickable, and view-source contains no `albescent`.
6. **As a revealed viewer, the same row** — reads "Albescent" and opens the real
   faction page.
7. **Roster (mobile)** — unchanged; it draws no faction line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
