### PR TITLE
On the first line a co-author's name label flips under the caret, where there is room

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodyEditorRemoteLabel.test.ts
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodyEditorRemoteLabel.test.ts
@@ -1,0 +1,117 @@
+/**
+ * #1951 — a co-author's name label, clipped on the composer's first line.
+ *
+ * **The visual half is not verified and cannot be.** This harness has no DOM and
+ * no layout, and the bug needs two live clients in one room with the remote
+ * caret parked on line 1. Nothing below proves a label is on screen.
+ *
+ * What it does prove is the argument, which is entirely made of values:
+ *
+ *   1. `y-codemirror.next` really does place the label ABOVE the caret, by
+ *      `top: -1.05em`. That is the premise; if the library ever flips it, the
+ *      override here becomes wrong and this file says so.
+ *   2. Our rule flips it below, and only on the first line, so every other
+ *      line keeps the conventional above placement.
+ *   3. Our rule OUT-SPECIFIES the library's. Both are class-only selectors, so
+ *      equal weight would leave the winner to mount order — and the two themes
+ *      mount from different extensions in a list built in `controls.tsx`. The
+ *      weight is counted here rather than asserted as a sentence.
+ *
+ * The seam is the same one #1852 established: the theme *as a value*.
+ * `EditorState.create` needs no DOM, and `EditorView.styleModule` holds the
+ * exact CSS that will mount — including selector text, which is the only place
+ * a specificity claim is checkable at all.
+ */
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { yCollab } from "y-codemirror.next";
+import * as Y from "yjs";
+import { BODY_EDITOR_BASE_THEME } from "../bodyEditorTheme";
+
+function mountedRules(extensions: Parameters<typeof EditorState.create>[0]) {
+  return EditorState.create(extensions)
+    .facet(EditorView.styleModule)
+    .flatMap((module) => module.getRules().split("\n"));
+}
+
+/**
+ * The one mounted rule that POSITIONS `selector`, split in two.
+ *
+ * `:hover` rules are skipped: the library ships a second `.cm-ySelectionInfo`
+ * rule that only fades the label in, and it is not what places it.
+ */
+function ruleFor(rules: string[], selector: string) {
+  const matches = rules.filter((rule) => {
+    const head = rule.slice(0, rule.indexOf("{")).trim();
+    return head.endsWith(selector) && !head.includes(":hover");
+  });
+  expect(matches).toHaveLength(1);
+  const brace = matches[0].indexOf("{");
+  return {
+    selector: matches[0].slice(0, brace).trim(),
+    body: matches[0].slice(brace),
+  };
+}
+
+/**
+ * A selector's class-column weight — the `b` of (a,b,c) — counting classes and
+ * pseudo-classes, which is every token either of these selectors is made of.
+ * Neither has an id or an attribute selector, so the whole comparison lives in
+ * this column and a plain `>` on the count is the real cascade answer.
+ */
+function classWeight(selector: string): number {
+  const classes = selector.match(/\.[^\s.>+~:[\](),]+/g) ?? [];
+  const pseudoClasses = selector.match(/(?<![:\w])[:][a-z-]+/g) ?? [];
+  return classes.length + pseudoClasses.length;
+}
+
+// `yCollab` only mounts the remote-selection theme when it is given an
+// awareness object (see its source), and the plugin that would read this one is
+// a `ViewPlugin` that never instantiates without a view. So an empty object is
+// enough to make the library's CSS appear, and nothing here touches a socket.
+const libraryRules = mountedRules({
+  extensions: [yCollab(new Y.Doc().getText("body"), {})],
+});
+const ourRules = mountedRules({ extensions: [BODY_EDITOR_BASE_THEME] });
+
+const LABEL = ".cm-ySelectionInfo";
+
+describe("the co-author name label on the composer's first line (#1951)", () => {
+  it("is placed above the caret by the library — the premise being overridden", () => {
+    // Absolute, and lifted clear of the caret. On line 1 there is nothing above
+    // to lift into: `.cm-scroller` is `overflow: auto`, and overflow past a
+    // scroll container's START edge is unreachable by scrolling, not merely
+    // hidden. Half the label is cut off, which is #1951's screenshot.
+    const { body } = ruleFor(libraryRules, LABEL);
+    expect(body).toContain("position: absolute");
+    expect(body).toContain("top: -1.05em");
+  });
+
+  it("is flipped below the caret, on the first line only", () => {
+    const { selector, body } = ruleFor(ourRules, LABEL);
+    // `100%` of the caret's own box: the mirror of the library's rise, in the
+    // units the containing block already has. No font metric, and no
+    // line-height — the skins' 1.6–1.85 is the reading measure (#1852).
+    expect(body).toContain("top: 100%");
+    expect(body).not.toContain("line-height");
+    // Scoped, so lines 2..n keep the conventional above placement.
+    expect(selector).toContain(".cm-line:first-child");
+  });
+
+  it("out-specifies the library's rule, so mount order cannot decide it", () => {
+    const ours = classWeight(ruleFor(ourRules, LABEL).selector);
+    const theirs = classWeight(ruleFor(libraryRules, LABEL).selector);
+    expect(theirs).toBe(2); // `.ͼ1 .cm-ySelectionInfo`
+    expect(ours).toBeGreaterThan(theirs);
+  });
+
+  it("leaves the caret and its dot to the library", () => {
+    // The dot overhangs the caret by only .2em, which fits inside the
+    // half-leading of a 1.6+ line-height. Moving it would be a second guess at
+    // a thing nobody reported.
+    const touched = ourRules.filter((rule) => rule.includes(".cm-ySelection"));
+    expect(touched).toHaveLength(1);
+    expect(touched[0]).toContain(LABEL);
+  });
+});

--- a/frontend/src/pages/editPraxis/archetypes/bodyEditorTheme.ts
+++ b/frontend/src/pages/editPraxis/archetypes/bodyEditorTheme.ts
@@ -55,6 +55,11 @@ export const BODY_EDITOR_HOST_STYLE: CSSProperties = {
  * - the placeholder colour
  * - **the caret's height** — see `BODY_EDITOR_SELECTION` below
  * - **the caret's colour and the selection's** — same
+ *
+ * Plus one rule that is not a CodeMirror default at all: where a co-author's
+ * name label sits on the first line (`.cm-ySelectionInfo`, #1951). It lives
+ * here because it is `y-codemirror.next` colliding with the box THIS file
+ * builds, and because one rule beats eight per-skin copies of it.
  */
 const BODY_EDITOR_SKIN_THEME = EditorView.theme({
   "&": {
@@ -121,6 +126,48 @@ const BODY_EDITOR_SKIN_THEME = EditorView.theme({
   // that this rule reads and a skin may repoint — not eight literals here.
   "&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionLayer .cm-selectionBackground":
     { background: "color-mix(in srgb, currentColor 22%, transparent)" },
+
+  // ---- A co-author's name label, flipped under the caret on line 1 (#1951) ----
+  //
+  // `y-codemirror.next` hangs the label off the caret widget as
+  // `.cm-ySelectionInfo { position: absolute; top: -1.05em }` — an ABOVE
+  // placement, in the label's own `em` (its `font-size` is `.75em`, so the rise
+  // is ~0.79 of the body's em) on a box ~0.9 body-em tall. Every line but the
+  // first has a whole line box overhead to rise into. The first has the
+  // scroller's edge: `.cm-scroller` is `overflow: auto` here, `.cm-content` has
+  // the base theme's `4px 0` padding stripped above, and overflow past a scroll
+  // container's START edge is not merely hidden but unreachable — no scroll
+  // position brings it back. So roughly half the label is cut off, which is the
+  // screenshot on #1951.
+  //
+  // Nothing else in the chain can give way. The scroller's `overflow` is what
+  // makes the field scroll; the host's `overflow: hidden` above it is what makes
+  // `resize: vertical` work at all (see BODY_EDITOR_HOST_STYLE); a `padding-top`
+  // on `.cm-content` would buy the room by pushing the body text down inside
+  // every one of the eight skins' boxes, away from the inset the skin chose. The
+  // one thing that can move is the label, and only where it has to.
+  //
+  // `top: 100%` is the caret box's own bottom edge — the mirror of the library's
+  // rise, in the units the containing block already has, so it needs no font
+  // metric and no line-height (which is the reading measure and stays untouched,
+  // #1852). The label lands over the top of line 2 exactly as it used to land
+  // over line 0.
+  //
+  // Specificity: the library's rule is a `baseTheme` at (0,2,0). Written as a
+  // descendant of `.cm-content` this is (0,5,0), so it wins on weight and does
+  // not depend on which theme mounts last — unlike `.cm-cursor` above, where
+  // matched weight made mount order load-bearing.
+  //
+  // ponytail: `:first-child` is "the first line CodeMirror rendered", not "the
+  // first line on screen". Scrolled down, an out-of-viewport prefix becomes a
+  // `.cm-gap` block widget and this stops matching — correct for the flipped
+  // line, but it means a caret parked on whichever line sits at the scrolled top
+  // edge is still clipped there. That case needs geometry, which CSS does not
+  // have; the fix would be a ViewPlugin measuring `coordsAtPos` against the
+  // scroller rect. Not worth it for the reported bug, which is a short composer
+  // at scroll top. The 0.4em `.cm-ySelectionCaretDot` overhangs by 0.2em and is
+  // left alone: it fits inside the half-leading of a 1.6+ line-height.
+  ".cm-content > .cm-line:first-child .cm-ySelectionInfo": { top: "100%" },
 });
 
 /**


### PR DESCRIPTION
Closes #1951

## Nothing here has been observed

**I have not seen this bug and I have not seen the fix.** It takes two live clients in one collab room with the remote caret parked on line 1, and an agent worktree has no browser and no dev stack. The diagnosis below is read out of `node_modules` and out of the CSS the extensions actually generate; the pixels are unverified.

## The mechanism, from the library's source

`y-codemirror.next`'s `yRemoteSelections` hangs the name label off the caret widget. Its `baseTheme` (`src/y-remote-selections.js`) emits, verbatim:

```
.ͼ1 .cm-ySelectionInfo {position: absolute; top: -1.05em; left: -1px; font-size: .75em; … opacity: 0; …}
.ͼ1 .cm-ySelectionCaret:hover > .cm-ySelectionInfo {opacity: 1; …}
```

So the label is **above** the caret — `-1.05em` in its own `em` (its `font-size` is `.75em`, so ~0.79 of the body's em) on a box ~0.9 body-em tall — and it only shows on hover, which is why the screenshot is a hover.

Every line but the first has a whole line box overhead to rise into. The first has the scroller's edge:

- `.cm-scroller` is `overflow: auto` (set in `bodyEditorTheme.ts`, which is what makes the field scroll at all).
- `.cm-content` has the base theme's `padding: 4px 0` stripped to `0`, because the skin owns the padding — so there is not even 4px.
- Overflow past a scroll container's **start** edge is not merely hidden, it is **unreachable**: no scroll position brings it back.

Roughly half the label is therefore cut. That is the screenshot.

Nothing else in the chain can give way. The scroller's `overflow` is the scrolling; the host's `overflow: hidden` above it (`BODY_EDITOR_HOST_STYLE`) is what makes the `resize: vertical` all eight skins set do anything; a `padding-top` on `.cm-content` would buy the room by pushing body text down away from the inset each skin chose. The one thing that can move is the label, and only where it has to.

## The fix

One rule in `BODY_EDITOR_BASE_THEME`, not eight per-skin copies:

```ts
".cm-content > .cm-line:first-child .cm-ySelectionInfo": { top: "100%" },
```

`100%` is the caret box's own bottom edge — the mirror of the library's rise, in the units the containing block already has, so it needs no font metric. The label lands over the top of line 2 exactly as it used to land over line 0.

**Line-height is untouched.** The skins' 1.6–1.85 is the reading measure (#1852 was explicit), and nothing here reads it. **#1852's rules are untouched too** — `drawSelection()`, `.cm-cursor { borderLeftColor }` and the two-selector `.cm-selectionBackground` argument all still assert green.

**No colour added**, so neither `no-raw-colour-values` nor `no-global-ink-on-faction-surface` is in play. The label's ink is still the library's hardcoded white on the remote's faction hue — that is the pre-existing `ponytail:` note in `roomPresence.ts` with its own named upgrade path (mint an `-on-accent` tier, override `color` here), and it is a different question from clipping.

## The seam I tested at

`BODY_EDITOR_BASE_THEME` **as a value** — the seam #1852 established. `EditorState.create` needs no DOM, and `EditorView.styleModule` holds the exact CSS that will mount, including selector text. That is the only place a specificity claim is checkable.

`frontend/src/pages/editPraxis/archetypes/__tests__/bodyEditorRemoteLabel.test.ts` mounts **both** themes as values — ours, and the library's via `yCollab(ytext, {})` (its remote-selection theme only registers when awareness is truthy; the plugin that would read it is a `ViewPlugin` and never instantiates without a view, so no socket is touched) — and asserts:

1. the library really places the label at `position: absolute; top: -1.05em`, so the premise being overridden is pinned and a library flip fails the test;
2. ours sets `top: 100%`, sets no `line-height`, and is scoped to `.cm-line:first-child`;
3. ours **out-specifies** theirs, counted from the generated selector strings rather than asserted in prose: theirs is `.ͼ1 .cm-ySelectionInfo` at weight 2, ours `.ͼ5 .cm-content > .cm-line:first-child .cm-ySelectionInfo` at 5. Equal weight would have left the winner to mount order, and the two themes come from different entries in a list built in `controls.tsx`;
4. ours touches exactly one `.cm-ySelection*` rule — the caret and its `.4em` dot are left to the library.

## Known residue

`:first-child` is "the first line CodeMirror **rendered**", not "the first line on screen". Scrolled down, the out-of-viewport prefix becomes a `.cm-gap` block widget and this stops matching — correct for the flipped line, but a caret parked on whichever line sits at the scrolled **top edge** is still clipped there, for the same reason. That case needs geometry, which CSS does not have; the fix would be a ViewPlugin measuring `coordsAtPos` against the scroller rect. Marked `ponytail:` in the source. The reported bug is a short composer at scroll top.

The `.4em` `.cm-ySelectionCaretDot` overhangs the caret by `.2em` and is left alone: that fits inside the half-leading of a 1.6+ line-height. Font-metric dependent, so unmeasured.

## What to eyeball

1. **Two browsers in one collab, remote caret on the FIRST line, across all eight composer skins.** Hover the remote caret; the name label should sit fully visible *below* it, not clipped at the top. Eight skins because the line-height differs (1.6–1.85) and the label's placement is now derived from the caret box rather than from a fixed offset.
2. The same, remote caret on **line 2 and lower** — the label should still be *above* the caret, unchanged.
3. The label's legibility on each faction's hue, since it is now over a different piece of text (line 2's, not line 0's). Still the library's white ink; if a hue reads badly that is the `roomPresence.ts` ponytail, not this.
4. **Selection and caret still #1852's**: drag a selection while focused (should be the skin's ink at 22%, not CodeMirror's indigo), and check the local caret is text-height, on a dark skin and a light one.
5. Scrolled long body, remote caret at the top visible edge — expected to still clip. Confirming the residue, not a regression.
6. Multi-line remote selection: the label rides the head, so check both drag directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
