### PR TITLE
A card's title stops assuming a section heading it cannot see

### DIFF
--- a/frontend/src/components/__tests__/cardHeadingOutline.test.tsx
+++ b/frontend/src/components/__tests__/cardHeadingOutline.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * #1950 — A CARD'S TITLE MAY NOT SKIP A HEADING LEVEL.
+ *
+ * THE SEAM: the join between a page's chrome and a card mounted on it. A card
+ * is rendered by a component that cannot see the page, and the page is written
+ * by someone who cannot see inside the card, so the outline they produce
+ * TOGETHER is nobody's file — which is exactly how it broke. Lighthouse read a
+ * Coven task card's `<h3>` on a surface whose only other heading was the page
+ * `<h1>` and flagged the jump.
+ *
+ * THE RULE PINNED HERE: mounted under a page that carries exactly one `<h1>`
+ * and nothing else, a card must add no skipped level. A card carries one
+ * heading, so under a lone `<h1>` that rule has exactly one solution — the
+ * card's title is an `<h2>` — and stating it as "no skip" rather than "is h2"
+ * is deliberate: the property a screen reader cares about is the outline, and a
+ * skin that later grows a SECOND heading inside itself is caught by the same
+ * assertion without anyone editing it.
+ *
+ * WHY THE FIX IS THE CARD AND NOT THE PAGE. The alternative reading — cards stay
+ * `<h3>` and every list surface grows an `<h2>` section heading above them — was
+ * measured and rejected. Fourteen surfaces mount a card with no `<h2>` in front
+ * of it (`/tasks` in both form factors, `/praxis` in both, `/updates`, the eight
+ * task-detail archetypes' praxis galleries, and the Coven + Snide faction
+ * bodies, whose section heads are `<div>`s), against ten that do. That fix is
+ * fourteen files plus fourteen invented section strings and stays broken the
+ * day a fifteenth surface mounts a card. This one is a tag swap per card family
+ * and holds for every surface that will ever exist.
+ *
+ * The slug list is derived from `FACTION_MANIFESTS`, not typed out, so a TENTH
+ * faction is covered on the day it registers rather than the day someone
+ * remembers this file.
+ *
+ * `renderToStaticMarkup`; this repo has no jsdom. These are markup assertions.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import '../../i18n'
+
+// Task cards read the form factor; SSR runs no effects, so it has to be stubbed
+// rather than measured. Registered before the card modules are imported.
+vi.mock('../../hooks/useFormFactor', () => ({ useFormFactor: () => 'desktop' }))
+
+import { FACTION_MANIFESTS, surfaceMap } from '../../factions'
+import { pickVariant } from '../../utils/factionDispatch'
+import { DEFAULT_CARD } from '../taskCard/TaskCard'
+import DefaultPraxisCard from '../praxisCard/desktop/DefaultPraxisCard'
+import type { AdminProps } from '../praxisCard/shared'
+import FeedCardEraAnnouncement from '../feed/FeedCardEraAnnouncement'
+import type { ActivityFeedItem } from '../../api/activityFeed'
+import { aTask, aPraxisCard } from '../../test/fixtures'
+
+/** `na` plus every faction that ships a manifest — the nine card skins. */
+const SLUGS = ['na', ...FACTION_MANIFESTS.map((manifest) => manifest.slug)]
+
+/** Every heading level the markup draws, in document order. */
+function headingLevels(html: string): number[] {
+  return [...html.matchAll(/<h([1-6])\b/g)].map((match) => Number(match[1]))
+}
+
+/**
+ * Each place the outline jumps more than one level, as `"h1 → h3"`. Empty is
+ * the pass; the strings are there so a failure names the jump it found.
+ */
+function skippedLevels(levels: number[]): string[] {
+  return levels.flatMap((level, index) =>
+    index > 0 && level - levels[index - 1] > 1
+      ? [`h${levels[index - 1]} → h${level}`]
+      : [],
+  )
+}
+
+/**
+ * The card on the least generous surface that still counts as well-formed: a
+ * page heading and nothing between it and the card. Every real surface either
+ * looks like this (`/tasks`, `/praxis`, `/updates`) or puts an `<h2>` section
+ * head in the gap, which can only make the outline flatter — so a card that
+ * passes here passes everywhere.
+ */
+function pageOutline(card: ReactElement): number[] {
+  return headingLevels(
+    renderToStaticMarkup(
+      <MemoryRouter>
+        <>
+          <h1>Page</h1>
+          {card}
+        </>
+      </MemoryRouter>,
+    ),
+  )
+}
+
+const NO_ADMIN: AdminProps = {
+  praxis: aPraxisCard(),
+  showAdminControls: false,
+  onHide: () => {},
+  onFail: () => {},
+  moderateError: null,
+}
+
+describe.each(SLUGS)('%s task card', (slug) => {
+  it('titles itself one level under the page heading', () => {
+    const Card = pickVariant(surfaceMap('taskCard'), slug, DEFAULT_CARD)
+    const levels = pageOutline(
+      <Card
+        task={aTask({ primary_faction_slug: slug })}
+        basePoints={18}
+        multiplier={1}
+        inProgressCount={0}
+      />,
+    )
+    expect(levels.length, 'the card drew a heading at all').toBeGreaterThan(1)
+    expect(skippedLevels(levels), 'no skipped level').toEqual([])
+  })
+})
+
+describe.each(SLUGS)('%s praxis card', (slug) => {
+  it('titles itself one level under the page heading', () => {
+    const praxis = aPraxisCard({ task_faction_slug: slug })
+    const Card = pickVariant(surfaceMap('praxisCard'), slug, DefaultPraxisCard)
+    const levels = pageOutline(
+      <Card praxis={praxis} adminProps={{ ...NO_ADMIN, praxis }} />,
+    )
+    expect(levels.length, 'the card drew a heading at all').toBeGreaterThan(1)
+    expect(skippedLevels(levels), 'no skipped level').toEqual([])
+  })
+})
+
+describe('era-announcement feed card', () => {
+  it('titles itself one level under the page heading', () => {
+    // The one factionless feed card, and the only feed type with a heading of
+    // its own (#1192 decision 6). It rides `/updates`, whose chrome is
+    // `PageTitle` — an `<h1>` and nothing else.
+    const item = {
+      id: 'era-1',
+      type: 'era_announcement',
+      created_at: '2026-01-01T00:00:00Z',
+      payload: { era_name: 'Era One', era_notes: 'The bell.' },
+    } as unknown as ActivityFeedItem
+    const levels = pageOutline(<FeedCardEraAnnouncement item={item} />)
+    expect(levels.length, 'the card drew a heading at all').toBeGreaterThan(1)
+    expect(skippedLevels(levels), 'no skipped level').toEqual([])
+  })
+})

--- a/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
+++ b/frontend/src/components/feed/FeedCardEraAnnouncement.tsx
@@ -45,12 +45,12 @@ export default function FeedCardEraAnnouncement({ item, archive }: Props) {
         {archive}
       </div>
 
-      <h3
+      <h2
         className="font-display italic"
         style={{ fontSize: 'var(--text-content)', color: 'var(--badge-admin-text)', marginBottom: 'var(--space-sm)', lineHeight: 1.3 }}
       >
         {i18n.t('feed:eraAnnouncement.headline', { name: era_name })}
-      </h3>
+      </h2>
 
       {era_notes && (
         <p className="font-body" style={{ fontSize: 'var(--text-content)', color: 'rgba(247,244,238,0.75)', marginBottom: 'var(--space-lg)', lineHeight: 1.5 }}>

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -142,7 +142,16 @@ export function rosterNames(
   return { names, overflow }
 }
 
-/** Slot: the praxis title, linked to the praxis detail page. */
+/**
+ * Slot: the praxis title, linked to the praxis detail page.
+ *
+ * An `<h2>`, and the one place that is decided for all nine archetypes — every
+ * skin composes this through `desktop/shared`'s `PraxisBody`. A card is a
+ * top-level item of whatever page mounts it and cannot see whether a section
+ * heading sits between it and the page `<h1>`, so it takes level 2 and never
+ * assumes one does (#1950). As an `<h3>` it skipped a level on `/praxis` in
+ * both form factors and in all eight task-detail praxis galleries.
+ */
 export function PraxisTitle({
   praxis,
   style,
@@ -154,7 +163,7 @@ export function PraxisTitle({
 }) {
   return (
     <Link to={`/praxis/${praxis.id}`}>
-      <h3
+      <h2
         className="content-title font-display font-semibold leading-tight hover:underline"
         style={{
           marginBottom: "var(--space-sm)",
@@ -163,7 +172,7 @@ export function PraxisTitle({
         }}
       >
         {praxis.title}
-      </h3>
+      </h2>
     </Link>
   );
 }

--- a/frontend/src/components/taskCard/CovenTaskCard.tsx
+++ b/frontend/src/components/taskCard/CovenTaskCard.tsx
@@ -331,7 +331,7 @@ export default function CovenTaskCard({
               <Sigil size={size.sigil} points={basePoints} />
             </div>
 
-            <h3
+            <h2
               style={{
                 fontFamily: DISPLAY,
                 fontWeight: 600,
@@ -343,7 +343,7 @@ export default function CovenTaskCard({
               }}
             >
               {task.title}
-            </h3>
+            </h2>
 
             {task.description && (
               <p

--- a/frontend/src/components/taskCard/DefaultTaskCard.tsx
+++ b/frontend/src/components/taskCard/DefaultTaskCard.tsx
@@ -222,7 +222,7 @@ export default function DefaultTaskCard({
             )}
           </div>
 
-          <h3
+          <h2
             style={{
               fontFamily: LORA,
               fontWeight: 600,
@@ -234,7 +234,7 @@ export default function DefaultTaskCard({
             }}
           >
             {task.title}
-          </h3>
+          </h2>
 
           {task.description && (
             <p

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -373,7 +373,7 @@ export default function EphemeristsTaskCard({
               </div>
             </div>
 
-            <h3
+            <h2
               style={{
                 fontFamily: DECO,
                 fontWeight: 400,
@@ -385,7 +385,7 @@ export default function EphemeristsTaskCard({
               }}
             >
               {task.title}
-            </h3>
+            </h2>
 
             {task.description && (
               <p

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -291,7 +291,7 @@ export default function EverymenTaskCard({
                 </div>
               </div>
 
-              <h3
+              <h2
                 style={{
                   fontFamily: POSTER,
                   fontSize: size.titleSize,
@@ -303,7 +303,7 @@ export default function EverymenTaskCard({
                 }}
               >
                 {task.title}
-              </h3>
+              </h2>
 
               {task.description && (
                 <p

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -253,7 +253,7 @@ export default function SingularityTaskCard({
               </div>
             </div>
 
-            <h3
+            <h2
               style={{
                 fontFamily: MONO,
                 fontWeight: 400,
@@ -265,7 +265,7 @@ export default function SingularityTaskCard({
               }}
             >
               {task.title}
-            </h3>
+            </h2>
 
             {task.description && (
               <p

--- a/frontend/src/components/taskCard/SnideTaskCard.tsx
+++ b/frontend/src/components/taskCard/SnideTaskCard.tsx
@@ -317,7 +317,7 @@ export default function SnideTaskCard({
                 inline flow instead — the cuts are `inline-block`, separated by
                 REAL space characters, and they still wrap, still sit on a shared
                 baseline and still carry their own grounds. */}
-            <h3
+            <h2
               style={{
                 fontSize: size.titleSize,
                 fontWeight: 400,
@@ -340,7 +340,7 @@ export default function SnideTaskCard({
                   </span>
                 </span>
               ))}
-            </h3>
+            </h2>
 
             {task.description && (
               <p

--- a/frontend/src/components/taskCard/TaskCard.tsx
+++ b/frontend/src/components/taskCard/TaskCard.tsx
@@ -14,6 +14,17 @@ import { surfaceMap } from '../../factions'
 /**
  * The contract every faction task-card skin is built against (ADR-0055).
  *
+ * THE TITLE IS AN `<h2>` (#1950). Every skin draws its own title element — the
+ * layouts are too different to share a slot — so the level is a convention this
+ * doc holds rather than a component that enforces it, and
+ * `components/__tests__/cardHeadingOutline.test.tsx` is what makes the
+ * convention bite. A card is a top-level item of whatever page mounts it, one
+ * level under that page's `<h1>`; it cannot see the page, so it may not assume
+ * a section heading sits in between. It was an `<h3>`, which skipped a level on
+ * every surface that lists cards straight under its title, and Lighthouse said
+ * so. Do not add a `headingLevel` prop: no consumer wants a different one
+ * (#1817 refused the same prop for the same reason).
+ *
  * Points arrive UNMULTIPLIED, with the viewer's faction modifier alongside,
  * rather than as the pre-multiplied product the pre-v2 `displayPoints` prop
  * carried. A card renders `basePoints`, and renders a `×multiplier` badge only

--- a/frontend/src/components/taskCard/UaTaskCard.tsx
+++ b/frontend/src/components/taskCard/UaTaskCard.tsx
@@ -183,7 +183,7 @@ export default function UaTaskCard({
               />
             </div>
 
-            <h3
+            <h2
               className="content-title"
               style={{
                 fontFamily: UA_DISPLAY,
@@ -195,7 +195,7 @@ export default function UaTaskCard({
               }}
             >
               {task.title}
-            </h3>
+            </h2>
 
             {task.description && (
               <p

--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -245,7 +245,7 @@ export default function WowTaskCard({
               </div>
             </div>
 
-            <h3
+            <h2
               style={{
                 fontFamily: MED,
                 fontWeight: 400,
@@ -256,7 +256,7 @@ export default function WowTaskCard({
               }}
             >
               {task.title}
-            </h3>
+            </h2>
 
             {task.description && (
               <p


### PR DESCRIPTION
## The seam

**The join between a page's chrome and a card mounted on it.** A card component
cannot see the page; the page cannot see inside the card. The heading outline
they produce *together* is nobody's file — which is exactly how it broke, and
why the test renders a card *under a page `<h1>`* rather than testing a card in
isolation.

Lighthouse (Navigation) flagged a Coven task card titled "High Fives",
`<h3 style="font-family: var(--font-faction-witch); font-weight: 600;">`, with
"Heading elements are not in a sequentially-descending order". I fetched the
screenshot and confirmed it.

## Diagnosis — the card was consistent, the pages were not

Lighthouse flags a **skip**, not an absolute level, so I read every card and
every surface that mounts one before touching a tag.

**Cards agree with each other.** All nine task-card skins render `<h3>` —
`Albescent` has no title of its own (it forwards to `DefaultTaskCard`), so the
element lives in eight files. Praxis cards route through **one** shared slot,
`PraxisTitle` in `components/praxisCard/shared.tsx`, reached by all nine skins
via `PraxisBody`; also `<h3>`. `FeedCardEraAnnouncement` (the one factionless
feed card, and the only feed type with a heading) is `<h3>`. No per-skin drift.

**The pages do not agree.** `<h3>` is correct only where an `<h2>` section head
sits between the card and the page `<h1>`. Counting host surfaces:

| No `<h2>` above the card — **skips** | Has an `<h2>` — fine |
|---|---|
| `Tasks.tsx` (desktop `/tasks`) — `PageTitle` `<h1>`, then cards | `FieldDesk.tsx` (`<h1>` + `<h2>` section heads) |
| `tasks/mobileArchetypes/DefaultTasks.tsx` | `factionDetail` Default / Everymen / Singularity / Ephemerists / UA / WOW |
| `Praxes.tsx` (desktop `/praxis`) | `characterProfile` bodies (sr-only `<h1>` + `<h2>` sections) |
| `praxes/MobilePraxisFeed.tsx` | |
| `Updates.tsx` (`PageTitle`, then feed cards) | |
| the **eight** `taskDetail` archetypes' praxis galleries | |
| `factionDetail` **Coven** + **Snide** — their `SectionHead` / `SectionHeading` render a `<div>`+`<span>`, not an `<h2>` | |

Fourteen skipping against ten fine. `Home.tsx` is a further case: its
`SectionHeader` is a `<div>` and it renders **no `<h1>` at all** — see follow-ups.

## The fix

**Card titles take level 2.** A card is a top-level item of whatever page mounts
it, one level under that page's `<h1>`, and it may not assume a section heading
sits in between.

Where an `<h2>` section head *does* exist the outline flattens (`h1 → h2 → h2`)
rather than skipping — valid, and what a screen reader needs. Where none exists,
the skip is gone.

Following **#1794/PR #1815** and **#1817/PR #1879**: fixed once per card family
where the callers route through — one line in `PraxisTitle` covers all nine
praxis skins. Task cards have no shared title slot (the layouts differ too much),
so the level is a convention recorded in the `CardProps` docblock — the contract
every skin is built against — and enforced by the test, not by a component.

**No `headingLevel` / `as` prop**, per #1817's ruling: every consumer wants the
same level, so a prop would only be a way to get it wrong.

### The alternative I rejected

Keep cards at `<h3>` and give the fourteen bare surfaces an `<h2>`. Strictly
nicer nesting, but it is fourteen files plus fourteen invented section strings
(`/tasks` already says "Tasks" in its `<h1>`, so the section head would be
redundant copy), and it breaks again the day a fifteenth surface mounts a card.
**If you prefer that reading, say so — it is a copy decision, not a code one,
and I did not want to invent fourteen strings unasked.**

## Nothing visual changes

`index.css` sets `h1, h2, h3, h4 { @apply font-display }` — identical for both
tags — and Tailwind preflight resets `font-size`/`font-weight`/margin for every
heading. Each card title already declares its own `fontSize`/`fontFamily`
inline. The swap is inert; no CSS was touched (that file is not mine to edit).

## The check

`frontend/src/components/__tests__/cardHeadingOutline.test.tsx` — new.

It renders each card under `<h1>Page</h1>` and asserts the outline **skips no
level**, rather than asserting "is an h2". A card carries one heading, so under a
lone `<h1>` that has exactly one solution — but stating the *property* means a
skin that later grows a second heading inside itself is caught by the same
assertion with no edit. Failures name the jump they found (`"h1 → h3"`).

Shaped after `pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx` and the
faction-detail twin: a `describe.each` over the skin loop. The slug list is
derived from `FACTION_MANIFESTS`, not typed out, **so a tenth faction is covered
the day it registers**, not the day someone remembers this file.

**Red before the fix: 19/19, every one `h1 → h3`.** Green after.

## Verification

All five steps of the `frontend` job in `.github/workflows/test.yml`, run locally:

- `npm run lint` — clean
- `npm run typecheck` — clean (`tsc --version` → 5.9.3 confirmed before trusting it)
- `npm run typecheck:design-sync` — clean
- `npm test` — **278 files, 4918 passed, 1 skipped**. No existing test asserted `h3` on a card.
- `npm run build` — ok; `npm run budget` — within budget (JS 127.7 KB, CSS 21.4 KB)

No backend change, no new API endpoint consumed.

## What I could not check

**I have no browser and no dev stack, so I could not re-run Lighthouse.** Worth
re-auditing, in rough priority order:

1. `/tasks` desktop and mobile — the reported surface (Coven card).
2. `/praxis` desktop and mobile — same shape, praxis cards.
3. A task-detail page with praxis (e.g. `/tasks/:id`) — eight archetypes share the gallery.
4. `/updates` — era-announcement card.
5. `/factions/coven` and `/factions/snide` — their section heads are still `<div>`s; the cards now pass, but see below.
6. `/` (Home) — see below; **expect this one to still report something.**

## Follow-ups I did not take (out of scope, worth issues)

- **`Home.tsx` renders no `<h1>`.** Its `SectionHeader` (line 16) is a `<div>`.
  After this PR its first heading is an `<h2>` — no *skip*, so `heading-order`
  passes, but the `page-has-heading-one` best-practice audit will still fail.
  Promoting `SectionHeader` to `<h2>` is free and correct; the `<h1>` is a copy
  decision for a landing page.
- **Coven and Snide faction bodies** render section heads as `<div>`+`<span>`
  while the other six use `<h2>`. Not a skip any more, but it is real drift and
  the same #1817 shape (promote the element, keep the type).
- **`CommentThread`'s `{n} comments` `<h3>`** — on detail pages that now carry an
  `<h2>` praxis card above it the outline reads `h1 → h2 → h3` and is fine; on a
  detail page with *no* praxis it is `h1 → h3`. Detail pages suppress that
  heading in several archetypes already, so I did not chase it here.

Closes #1950

🤖 Generated with [Claude Code](https://claude.com/claude-code)
