### PR TITLE
Four index.css issues: a dead class, the filter bar's corner, and WOW's white balloons

### DIFF
--- a/frontend/src/components/ui/FilterBar/__tests__/filterBarOverflow.test.ts
+++ b/frontend/src/components/ui/FilterBar/__tests__/filterBarOverflow.test.ts
@@ -93,6 +93,51 @@ describe('.filter-bar is a surface card with a rainbow top edge (#1854)', () => 
 })
 
 /**
+ * #1944 — the rainbow edge has to be able to HOLD the corner it declares.
+ *
+ * `border-radius` is a request, not a guarantee: where the radii along one edge
+ * sum to more than that edge, CSS scales every radius on the box down by the
+ * same factor until they fit. The strip asked for the bar's 12px top corners at
+ * `height: 3px`, got 0.25 of it, and drew a 3px corner alongside a padding box
+ * that turns at 11px — so its left end overhung the bar's rounded corner and
+ * sat out over the border.
+ *
+ * The sibling `describe` above already asserted a radius WAS declared, and that
+ * assertion passed throughout. What it could not see is the box: this harness
+ * has no layout, so the clamp is unobservable at runtime and the only thing a
+ * DOM-less test can check is that the strip's box is at least as tall as the
+ * corner it is drawing. That is the whole contract here — the band's thickness
+ * moves to `padding-top`, and a mask is what keeps the rest of the taller box
+ * from painting as a 12px rainbow slab.
+ */
+describe('.filter-bar__spectrum can hold the bar\'s corner (#1944)', () => {
+  const strip = ruleBodies(css, '.filter-bar__spectrum').join('\n')
+
+  it('sizes its BOX to the radius and its BAND to the rail pad', () => {
+    expect(strip).toMatch(/height\s*:\s*var\(--space-md\)/)
+    // The tell for the regression: the band thickness back in `height`.
+    expect(strip).not.toMatch(/height\s*:\s*var\(--filter-rail-pad\)/)
+    expect(strip).toMatch(/padding-top\s*:\s*var\(--filter-rail-pad\)/)
+  })
+
+  it('builds its radius from the same token the bar rounds with', () => {
+    // `calc(var(--space-md) - 1px)`: the bar's PADDING-box radius, one border
+    // in from the 12px it rounds its own border box with.
+    const radius = /border-radius\s*:\s*([^;]+);/.exec(strip)
+    expect(radius, 'the strip must declare a radius').not.toBeNull()
+    expect(radius![1]).toContain('var(--space-md)')
+  })
+
+  it('gives back the flow the taller box would add, and masks the rest', () => {
+    expect(strip).toMatch(
+      /margin-bottom\s*:\s*calc\(\s*var\(--filter-rail-pad\)\s*-\s*var\(--space-md\)\s*\)/,
+    )
+    // Without the exclude, the extra 9px paints as rainbow instead of nothing.
+    expect(strip).toMatch(/mask[^;]*content-box[^;]*exclude/)
+  })
+})
+
+/**
  * #1726 — a segment must never be narrower than its own label.
  *
  * `.filter-rail__segment` used to be `flex: 1` with zero horizontal padding, so

--- a/frontend/src/components/vote/__tests__/wowBalloonPlate.test.ts
+++ b/frontend/src/components/vote/__tests__/wowBalloonPlate.test.ts
@@ -1,0 +1,70 @@
+/**
+ * #1946 — a WOW balloon drawn against the PLATE must flip when the plate does.
+ *
+ * The googly-balloon widget draws three things straight onto its parchment
+ * plate: the idle fill of an unreached balloon, the outline every balloon
+ * carries, and the string that hangs off it. The plate itself flips
+ * (`-plate-from` / `-plate-to` are both restated in the dark cascade). Only the
+ * string had been given a dark half, so on a dark plate the idle fill stayed a
+ * literal cream and an untouched row rendered five near-white blobs — the
+ * UNREACHED state louder than anything the plum→gold ramp climbs to.
+ *
+ * What is guarded is the split, not the hexes. The RAMP is deliberately
+ * theme-invariant (it sits on the balloon, not on the plate) and must stay
+ * that way; the three plate-facing marks must each carry both cascades. A
+ * value assertion cannot see this class of bug — every one of these tokens had
+ * a perfectly good value the whole time — so this reads the CASCADE, in the
+ * shape `frozenThemeAliases.test.ts` set.
+ *
+ * No DOM and no layout here, and none is needed: the defect is entirely in
+ * which selector declares what.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { declarationsIn, ruleBodies, stripComments } from '../../../utils/__tests__/cssVars'
+
+const css = stripComments(
+  readFileSync(fileURLToPath(new URL('../../../index.css', import.meta.url)), 'utf8'),
+)
+const dark = declarationsIn(ruleBodies(css, '[data-theme="dark"]'))
+const light = declarationsIn(ruleBodies(css, ':root'))
+
+/** Drawn ON the plate — so each one owes the plate's own flip. */
+const PLATE_FACING = [
+  '--faction-wow-balloon-idle',
+  '--faction-wow-balloon-outline',
+  '--faction-wow-balloon-string',
+]
+
+/** Drawn ON a balloon — theme-invariant on purpose, and must stay so. */
+const RAMP = [1, 2, 3, 4, 5].map((tier) => `--faction-wow-balloon-${tier}`)
+
+describe('the WOW balloon plate (#1946)', () => {
+  it('flips the plate itself, which is the premise everything else rests on', () => {
+    for (const token of ['--faction-wow-balloon-plate-from', '--faction-wow-balloon-plate-to']) {
+      expect(dark.has(token), `${token} must be restated in dark`).toBe(true)
+    }
+  })
+
+  it('gives every mark drawn against the plate a dark half', () => {
+    for (const token of PLATE_FACING) {
+      expect(light.has(token), `${token} must be declared in the light cascade`).toBe(true)
+      expect(
+        dark.has(token),
+        `${token} is drawn on a plate that flips, so it must flip too (#1946)`,
+      ).toBe(true)
+      expect(dark.get(token)).not.toBe(light.get(token))
+    }
+  })
+
+  it('leaves the plum→gold ramp theme-invariant', () => {
+    for (const token of RAMP) {
+      expect(light.has(token)).toBe(true)
+      expect(
+        dark.has(token),
+        `${token} sits on a balloon, not on the plate — one ramp for both themes`,
+      ).toBe(false)
+    }
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3779,12 +3779,6 @@
   .praxis-gallery > * {
     max-width: var(--praxis-card-basis);
   }
-  /* ── Pennant shape (faction filter tabs) ── */
-
-  .pennant-shape {
-    clip-path: polygon(0 0, 100% 0, 95% 100%, 5% 100%);
-  }
-
   /* ── Leaderboard row hover ── */
 
   .leaderboard-row:hover {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1550,9 +1550,13 @@
   );
   --faction-wow-quest-shadow: 0 8px 24px -12px rgba(74, 56, 10, 0.5), inset 0 0 0 1px rgba(138, 109, 31, 0.28);
 
-  /* WOW — googly-balloon vote plate. The balloon ramp climbs plum → gold and is
-     THEME-INVARIANT (the prototype ships one ramp for both themes); only the
-     plate and the caption inks flip. */
+  /* WOW — googly-balloon vote plate. The RAMP climbs plum → gold and is
+     THEME-INVARIANT (the prototype ships one ramp for both themes). What flips
+     is the plate, the caption inks, and — since #1946 — the two things drawn
+     directly ON the plate rather than on a balloon: the idle fill and the
+     outline, which join the string in the dark cascade. The rule the family
+     now follows is that a mark measured against the plate flips when the plate
+     does, and only a mark measured against a ramp colour may stay put. */
   --faction-wow-balloon-plate-from: var(--faction-wow-card-bg);
   --faction-wow-balloon-plate-to: var(--faction-wow-chronicle-panel);
   --faction-wow-balloon-plate-border: var(--faction-wow-chronicle-gold);
@@ -1564,10 +1568,12 @@
   /* An UNREACHED balloon is drawn, not outlined-and-hollow: the design fills it
      with a dead parchment #EDE4C8 so the whole bunch is present and only the
      colour climbs (#860 ask 3). #821 made it transparent, which read as four
-     missing balloons. */
+     missing balloons. It is the PLATE's own parchment a shade down — see the
+     dark half, where that is the whole argument. */
   --faction-wow-balloon-idle: #ede4c8;
-  /* Every balloon carries the same dark ink outline — the googly-cartoon line,
-     not a state signal (#860 ask 3). */
+  /* Every balloon carries the same outline — the googly-cartoon line, not a
+     state signal (#860 ask 3). Dark ink here, parchment in the dark cascade,
+     for the same reason the string flips: it is drawn against the plate. */
   --faction-wow-balloon-outline: rgba(60, 44, 6, 0.42);
   --faction-wow-balloon-string: rgba(60, 44, 6, 0.42);
   --faction-wow-balloon-eye: #241c0b;
@@ -2692,11 +2698,39 @@
   --faction-wow-balloon-plate-from: var(--faction-wow-chronicle-panel);
   --faction-wow-balloon-plate-to: var(--faction-wow-card-bg);
   /* plate-border inherits the theme-invariant --faction-wow-chronicle-gold */
-  /* The prototype's dark card reuses the light balloon SVG verbatim, ink outline
-     and all. That works for the OUTLINE — every balloon is filled now, so the
-     dark line lands on parchment or on a ramp colour either way, and it stays
-     put. It does not work for the STRING, whose tail hangs off the balloon onto
-     the dark plate; that one hairline inverts to parchment. */
+
+  /* THE IDLE BALLOON IS THE PLATE, AND ONLY ONE OF THE TWO FLIPPED (#1946).
+     The block in `:root` calls #EDE4C8 a "dead parchment", and the arithmetic
+     says it is the plate itself: the light plate runs #FBF4E0 → #F3E7C4 and
+     the idle fill is #EDE4C8, a hair under its darker stop. So an untouched
+     bunch reads as five OUTLINE drawings on parchment, and the ramp is the
+     only thing that carries rank. That is the design, and it is right.
+
+     It could not survive the plate going dark. `-plate-from` / `-plate-to`
+     flip to #2A2210 → #1B1508 and the fill stayed a literal cream, which
+     inverts the whole widget: at rest, the UNREACHED state is now the loudest
+     thing on the plate — five near-white blobs at ~15:1, louder than any
+     colour the ramp climbs to. "They look like sperms" is that inversion
+     reported from the far side. The defect sorts perfectly by cascade
+     (WORLD_ZERO_STYLE §3, #1792 / #1932), so it is one bug about a flip and
+     not a quarrel with the drawing.
+
+     Dark therefore restates what light already does — a fill a shade off its
+     own plate, lifting rather than sinking because a dark sheet lifts. The
+     ramp stays theme-invariant and untouched; nothing about the light render
+     moves by a byte.
+
+     WHICH FORCES THE OUTLINE, and the note this replaces says so in its own
+     words: the dark ink line was kept "because every balloon is filled now, so
+     the dark line lands on parchment or on a ramp colour either way". With the
+     idle fill no longer parchment, an ink outline on a #3A2F16 body is an
+     invisible line around an invisible balloon — #821's four missing balloons
+     by another route (#860 ask 3). It inverts to parchment, at the same alpha
+     it carried in light, which is the treatment the STRING beside it already
+     shipped. The two hairlines are the same drawing; only one of them had been
+     asked the question. */
+  --faction-wow-balloon-idle: #3a2f16;
+  --faction-wow-balloon-outline: rgba(243, 231, 196, 0.42);
   --faction-wow-balloon-string: rgba(243, 231, 196, 0.45);
   /* The crest family is theme-invariant (struck metal — see :root). Only the
      disc the coin is MOUNTED on flips, to the kit's dark avatar field. */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5949,7 +5949,9 @@
 }
 
 :root {
-  /* The rail's inner padding, and the height of the bar's spectrum strip.
+  /* The rail's inner padding, and the THICKNESS of the bar's spectrum edge —
+     which since #1944 is the strip's `padding-top` rather than its `height`,
+     because a 3px box cannot hold the bar's corner. Same number, same job.
      SegmentedRail used to read this too, to write the design's
      `calc(i * (100% - 6px) / n + 3px)` thumb maths in JS; #1726 measures the
      active segment instead, so the number is back to living in one file. */
@@ -5975,11 +5977,47 @@
 
 /* The spectrum edge along the top of the bar — ruling 1's ring, laid flat.
    Rounded on its own top corners so it still follows the bar's radius now
-   that the bar no longer clips its children with overflow: hidden. */
+   that the bar no longer clips its children with overflow: hidden.
+
+   A BOX CANNOT HOLD A CORNER LARGER THAN ITSELF, AND THE CLAMP IS SILENT
+   (#1944). When the radii along one edge sum to more than that edge, CSS
+   scales EVERY radius on the box down by the same factor until they fit (CSS
+   Backgrounds §5.3.1). At `height: 3px` against a 12px top-left that factor is
+   0.25, so the strip drew a 3px corner where the bar's padding box turns at
+   11px — its nearly-square left end overhung the bar's rounded corner and
+   floated out over the border. Nothing about the declaration looks wrong; the
+   number that renders is not the number that is written, and only the zoomed
+   screenshot on the report says so. **A radius asserted in a test is not a
+   radius the box can hold — assert the box too**, which is what the sibling
+   `describe` in `filterBarOverflow.test.ts` now does.
+
+   So the box is as tall as its own corner and the 3px band is carved out of
+   it: `padding-top` marks the band, the two-layer `content-box` mask drops
+   everything below it (the exclude idiom `.alb-profile-edge` and
+   `.level-gem-shape` already use), and the negative bottom margin hands back
+   the 9px of flow the taller box would otherwise add above
+   `.filter-bar__body`. The rainbow tapers into each top corner now, because
+   the curve doing the tapering is the bar's own.
+
+   `calc(var(--space-md) - 1px)` is the bar's PADDING-box radius rather than
+   its border-box one: the strip is the first child inside a 1px border, and a
+   border shrinks the curve it wraps by its own width. */
 .filter-bar__spectrum {
-  height: var(--filter-rail-pad);
+  box-sizing: border-box;
+  height: var(--space-md);
+  margin-bottom: calc(var(--filter-rail-pad) - var(--space-md));
+  padding-top: var(--filter-rail-pad);
+  border-radius: calc(var(--space-md) - 1px) calc(var(--space-md) - 1px) 0 0;
   background: var(--faction-default-rainbow);
-  border-radius: var(--space-md) var(--space-md) 0 0;
+  /* Decoration, and now nine pixels taller than it paints. */
+  pointer-events: none;
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box exclude,
+    linear-gradient(#000 0 0);
 }
 
 .filter-bar__body {


### PR DESCRIPTION
Four small `index.css` issues in one PR, because they all contend for the same file and a parallel batch here goes green individually and red on the trunk. One commit each.

Closes #1919
Closes #1944
Part of #1945 — **not built**; see below. It reverses a written design ruling, and that is the owner's call, not mine.
Closes #1946

---

## 1. #1919 — `.pennant-shape` deleted

Both checks the issue asked for come back clean, and the second one is the interesting half.

**Wider grep.** `pennant-shape` appears outside `frontend/src` in exactly one place: ten `where:` annotations in `frontend/e2e/contrastBaseline.ts`. That field's own docstring says it "is only a" note — `contrast.spec.ts` keys on the `theme | rgb(text) on rgb(backdrop)` identity and never reads `where` as a selector. `.design-sync/ua-faction-kit.html` §7 and `docs/spec/SPEC-faction-ui-profile.md` row 7 both describe a *filter pennant* in prose; neither names this class.

**No ruling preserved it.** `git log -S` gives one adding commit (`077cae33`) with no keep-note. The two commits that removed the wearers both did it on purpose: **#1368** deleted `FilterFactionTabs`, and **#1824 / #1845** replaced the propose-task pennant picker with `ChipRow`. That is the opposite of "unbuilt, not dead" — this class was built, worn, and had every wearer removed by a ruling. `dist/assets/index-*.css` contains zero occurrences of `pennant` before and after, so no shipped byte moves.

**The guard is NOT built, and the census is the argument.** A pass over `index.css` finds **176 declared class names; 175 appear literally in a tracked source file** — so a naive substring check has no dynamic-construction false positives today, and the mechanism is genuinely cheap. It has exactly one other hit, and that hit is a second finding rather than a clean red:

> **`.divider-curved` also has no wearer.** `WORLD_ZERO_STYLE.md` line 873 still states it as shipped behaviour — "Desktop rows are separated by `.divider-curved`" on the Players roster — which **#1855 rebuilt**. So it is either a regression the rebuild dropped or a class the rebuild retired, and the doc is stale either way. Landing the guard would mean deciding that on my own authority or exempting the one thing the guard exists to catch. **Worth its own issue.**

## 2. #1944 — the rainbow edge misaligned with the bar's rounded corner

`border-radius` is a request, not a guarantee. Where the radii along one edge sum to more than that edge, CSS scales **every** radius on the box down by one shared factor until they fit (CSS Backgrounds §5.3.1). `.filter-bar__spectrum` asked for the bar's `var(--space-md)` (12px) top corners at `height: var(--filter-rail-pad)` (**3px**), so the factor was 0.25 and the strip drew a **3px** corner — against a bar whose padding box turns at **11px**, being a 12px border-box radius one 1px border in. A nearly-square left end beside an 11px curve is exactly the overhang the zoomed screenshot shows: the rainbow pokes past the corner and floats over the border.

The clamp cannot be argued with, so the box is now as tall as its own corner and the 3px band is carved out of it — `padding-top` marks the band, a `content-box` + `exclude` mask drops the rest (the same two-layer idiom `.alb-profile-edge` and `.level-gem-shape` already use), and a negative bottom margin hands back the 9px of flow the taller box would otherwise insert above `.filter-bar__body`.

**Why not the `DefaultTaskCard` border-box trick.** It was the first thing tried, per the hand-off. It needs an **opaque** paint on the padding box to hide the gradient behind the sheet, and `--color-bg-surface` is `rgba(255,255,255,0.72)` — painting it over a bar already painted in it would band the top 9px in a second wash of the same translucent white. The mask carries no colour at all, which is why it is the one that works here.

Nothing about `.filter-bar` moves — no `overflow`, no `position`, its three declarations untouched — so #1506 and #1854 are unaffected, and `FilterBar/index.tsx` is not touched at all. This is one stylesheet change on all five surfaces that mount the bar.

The #1506 test already asserted a radius *was declared* and passed through the whole regression. The harness has no layout, so the clamp is unobservable; the new `describe` asserts the only thing a DOM-less test can — that **the box is at least as tall as the corner it draws**.

## 3. #1945 — cards on the same row should be the same height — **NOT BUILT**

Reporting instead of guessing, on rule 8. This is not a false premise; it is a **request to reverse a documented decision**, and it needs an owner ruling.

- `WORLD_ZERO_STYLE.md` §6: *"Cards are arranged in a `flex-wrap` container with varied heights and slight rotations. This is intentional — they are NOT on a strict grid."*
- `pages/Tasks.tsx:88`, the container's own comment: *"Flex-wrap container — NOT a grid. Varied card sizes and rotations are intentional (Style Guide §6)."*

**The container is opting out, not the card**: `pages/Tasks.tsx:89` sets `alignItems: 'flex-start'` inline. **This is not `.praxis-gallery`** — I checked, per the hand-off's warning. That class is mounted only by the eight task-detail archetypes and `WowFactionBody`; #1897's `max-width` cap is not in the frame at all.

**And flipping it to `stretch` would not equalise anything.** All nine archetypes render the identical wrapper — `<div style={{ width: size.cardWidth, maxWidth: "100%", boxSizing: "border-box" }}>` around an auto-height `<article>`. A stretched wrapper leaves the card its content height with dead space under it. Equal heights means nine archetypes learning to grow, each with frames, plates, tape and rules drawn to content. That is a design epic, not a one-line style fix — and `Tasks.tsx` and the archetypes are `frontend-feature`'s files, not mine.

Note in passing that half the §6 sentence is already stale: every archetype is `384` desktop / `340` mobile, so the *widths* stopped varying at task-cards-v2. Only the heights still do.

## 4. #1946 — the WOW vote balloons should not be white

**The idle fill IS the plate, written as a literal.** Its declaration calls `#EDE4C8` "a dead parchment"; the arithmetic says it is the plate itself — the light plate runs `#FBF4E0 → #F3E7C4` and the fill is a hair under its darker stop. So in light an untouched bunch reads as five **outline drawings** on parchment and the ramp is the only thing carrying rank. That is the design (#860 ask 3, against #821's transparent balloons) and it is right.

It could not survive the plate going dark. `-plate-from` / `-plate-to` are both restated in the dark cascade (`#2A2210 → #1B1508`); the fill had **no dark half**, so at rest the **unreached** state became the loudest mark on the plate — five near-white blobs brighter than anything the plum→gold ramp climbs to. "They look like sperms" is that inversion reported from the far side. The defect sorts perfectly by cascade, which §3 (#1792 / #1932) names as the tell that this is one bug about a flip, not a quarrel with the drawing.

Dark now restates what light already does: a fill a shade off its own plate, lifting rather than sinking because a dark sheet lifts. **The ramp is untouched and stays theme-invariant** — it sits on a *balloon*, not on the plate, so it owes no flip. **The light render does not move by a byte.**

That forces the outline, and the note it replaces says so in its own words: the dark ink line was kept *"because every balloon is filled now, so the dark line lands on parchment or on a ramp colour either way."* With the idle fill no longer parchment, an ink outline on a `#3A2F16` body is an invisible line round an invisible balloon — #821's missing balloons by another route. It inverts to parchment at the alpha it already carried, which is the treatment the **string** beside it already shipped. The two hairlines are the same drawing; only one had ever been asked the question.

No token minted, no component touched, no hex outside `index.css`. `--faction-wow`'s `-on-fill` line is not in play: nothing inside a balloon is text.

> ### ⚠️ The exact treatment is the owner's to redraw.
> There is no ruling on this issue and the reporter asked for one thing — that the balloons not be white. This is the reading that costs the light render nothing: it restores parity with the approved light drawing rather than recolouring the widget. **The louder alternative is real and deliberately not taken** — filling an idle balloon with one of WOW's own hues would make the bunch colourful at rest, but plum is `--faction-wow-balloon-1` and gold is `-4`/`-5`, so it would spend the ramp's own signal to do it. If coloured idle balloons are wanted, that is one token repoint on top of this.

---

## 🚨 Nothing here has been seen rendered

I have **no browser and no dev stack**. Three of these four are pure visual bugs, and every claim about how they look is arithmetic on the stylesheet plus the reporter's screenshots. `npm run dev` is a blocking foreground server that verifies nothing without eyes on it, so it was not run. **Visual QA is outstanding on all of it.**

What *was* verified: `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (282 files / 4949 tests), `npm run build`, `npm run budget` (CSS 21.4 KB, JS 127.8 KB — both ok) — the full `frontend` job from `.github/workflows/test.yml`. Nothing touches the backend or the API schema. Both stylesheet changes were confirmed in **`dist/assets/index-*.css` after a build**, not by counting braces: the spectrum rule survives the Tailwind merge intact, and the two balloon tokens land under `:root` and `[data-theme=dark]` respectively.

## What to eyeball

**#1944 — Tasks / Praxes / Updates / Players / `admin/ModerationTab`** (all five mount `FilterBar`)
- The rainbow now **tapers into** each top corner instead of ending in a stub. Both corners, both themes.
- Nothing shifted vertically: the bar's total height and the gap above the search field must be unchanged. The negative margin is what buys that, so this is the thing to look at hardest.
- Open a faction filter — the popover must still escape the bar (#1506). Nothing here touches `overflow`, but check it.
- Phone width, where `.filter-bar__body` tightens.

**#1946 — a WOW praxis with an uncast vote, DARK theme**
- Five balloons at rest: dim brown bodies on the dark plate, drawn by a **parchment** outline, googly eyes still white. Not white blobs.
- Hover and cast: the plum→gold ramp must be **unchanged**, and a reached balloon now carries a parchment outline rather than an ink one — check that a plum `#7A4A9E` balloon still reads as drawn.
- Rank-5 confetti, unchanged.
- **LIGHT theme must be pixel-identical to before.** If anything moved in light, I got the split wrong.

**#1919** — nothing to eyeball. The class was purged from every build before this PR.

## Inline-style usage spotted, for `frontend-feature` later

Not fixed here — outside a style agent's scope, and none of it blocks these four.

- `components/vote/WowVote.tsx:85` — the balloon's specular highlight is a raw `rgba(255,255,255,0.5)` inline in the SVG, the one colour in that component not reading a token. On a **dark** idle balloon it is now a visible white dot rather than the invisible-on-cream it used to be. Small, and arguably correct as a balloon highlight, but it is the last untokenised colour in the widget and it wants a name.
- `pages/Tasks.tsx:89` — the whole card row is an inline `display/flexWrap/gap/alignItems` object. `alignItems: 'flex-start'` is #1945's mechanism, and it is unreachable from a stylesheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
