### PR TITLE
The praxis composer body asks the browser for its dictionary back

### DIFF
--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodySpellcheck.test.ts
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodySpellcheck.test.ts
@@ -1,0 +1,58 @@
+/**
+ * #1978 — the composer body gets the browser's dictionary back.
+ *
+ * The visible half cannot be automated here: this harness is
+ * `renderToStaticMarkup`, there is no DOM, effects never run and CodeMirror
+ * never mounts. Nothing below proves a red underline appears on a real screen.
+ *
+ * The seam is the one #1852 established for this file: a *value* the editor is
+ * built from. `EditorState.create` needs no DOM, and `EditorView.contentAttributes`
+ * is a facet holding exactly the attributes that will land on `.cm-content`, so
+ * the attribute can be asserted through the same facet the view reads it from.
+ */
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { bodyContentAttributes } from "../controls";
+
+function facetValue(skin: { id?: string; ariaLabel?: string }) {
+  return EditorState.create({
+    extensions: [EditorView.contentAttributes.of(bodyContentAttributes(skin))],
+  }).facet(EditorView.contentAttributes);
+}
+
+describe("the composer body editor's spell check (#1978)", () => {
+  it("asks for spell check through contentAttributes", () => {
+    // `@codemirror/view` hard-codes `spellcheck: "false"` on `.cm-content` and
+    // then merges this facet over it, so a truthy value here is the whole fix.
+    // The string, not a boolean: it is a DOM attribute.
+    expect(facetValue({}).some((attrs) => attrs.spellcheck === "true")).toBe(
+      true,
+    );
+  });
+
+  it("keeps the accessibility attributes it already carried", () => {
+    // Spell check is an authoring aid. These two are the accessibility half and
+    // predate it — a regression fix must not cost the editor its name.
+    const attrs = bodyContentAttributes({ id: "wow-body", ariaLabel: "Body" });
+    expect(attrs["aria-labelledby"]).toBe("wow-body-label");
+    expect(attrs["aria-label"]).toBe("Body");
+    expect(attrs.spellcheck).toBe("true");
+  });
+
+  it("is what the composer body actually mounts", () => {
+    // The assertions above are about a value; this one is why that value
+    // matters. `BodyTextarea` builds its extension list inside an effect no
+    // DOM-less test can reach, so the binding gets checked in the source.
+    const controls = readFileSync(
+      fileURLToPath(new URL("../controls.tsx", import.meta.url)),
+      "utf8",
+    );
+    expect(controls).toMatch(
+      /EditorView\.contentAttributes\.of\(contentAttributes\)/,
+    );
+    expect(controls).toContain("bodyContentAttributes(skin)");
+  });
+});

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/bodySpellcheck.test.ts
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/bodySpellcheck.test.ts
@@ -17,10 +17,15 @@ import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { bodyContentAttributes } from "../controls";
 
+// The facet accepts an attribute object OR a `(view) => Attrs` function. The
+// composer registers the plain object, which is the branch a DOM-less test can
+// read; anything else would need a view to resolve.
 function facetValue(skin: { id?: string; ariaLabel?: string }) {
   return EditorState.create({
     extensions: [EditorView.contentAttributes.of(bodyContentAttributes(skin))],
-  }).facet(EditorView.contentAttributes);
+  })
+    .facet(EditorView.contentAttributes)
+    .filter((source) => typeof source !== "function");
 }
 
 describe("the composer body editor's spell check (#1978)", () => {

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -806,6 +806,36 @@ export interface BodyTextareaSkin {
   hideToolbar?: boolean;
 }
 
+/**
+ * The attributes the body editor puts on its own content element (#1978).
+ *
+ * Exported, and pure, because it is the seam a DOM-less harness can reach: the
+ * editor is built inside an effect that never runs here, but this value can be
+ * handed to `EditorView.contentAttributes` and read back off an
+ * `EditorState`. Same move `bodyEditorTheme.ts` makes for the theme.
+ *
+ * `spellcheck` is the reason this is a function at all. `@codemirror/view`
+ * hard-codes `spellcheck: "false"` on `.cm-content` (it is a code editor by
+ * birth), and `contentAttributes` is merged over those defaults, so this facet
+ * is the only place that decision can be reversed. A `<textarea>` had it for
+ * free; when #1742 moved the write-up into the room it silently lost it. This
+ * is the long-form prose a player is judged on — it gets the browser's
+ * dictionary back. Note that is an authoring aid, not an accessibility
+ * affordance; the `aria-*` entries below are the accessibility half and are
+ * unrelated.
+ */
+export function bodyContentAttributes(
+  skin: Pick<BodyTextareaSkin, "id" | "ariaLabel">,
+): Record<string, string> {
+  const attributes: Record<string, string> = { spellcheck: "true" };
+  // `<label for>` does nothing for a contenteditable div, so the section's
+  // label reaches the editor as `aria-labelledby` instead (ComposerSection
+  // gives that label its id).
+  if (skin.id) attributes["aria-labelledby"] = `${skin.id}-label`;
+  if (skin.ariaLabel) attributes["aria-label"] = skin.ariaLabel;
+  return attributes;
+}
+
 // Toolbar buttons in render order. Each glyph is referenced through
 // `button.glyph` (an identifier expression, not JSX text) so it never trips
 // i18next/no-literal-string; the accessible name comes from the t() labelKey.
@@ -868,15 +898,10 @@ export function BodyTextarea({
   const setBodyRef = useRef(state.setBody);
   setBodyRef.current = state.setBody;
 
-  const contentAttributes = useMemo(() => {
-    const attributes: Record<string, string> = {};
-    // `<label for>` does nothing for a contenteditable div, so the section's
-    // label reaches the editor as `aria-labelledby` instead (ComposerSection
-    // gives that label its id).
-    if (skin.id) attributes["aria-labelledby"] = `${skin.id}-label`;
-    if (skin.ariaLabel) attributes["aria-label"] = skin.ariaLabel;
-    return attributes;
-  }, [skin.id, skin.ariaLabel]);
+  const contentAttributes = useMemo(
+    () => bodyContentAttributes(skin),
+    [skin.id, skin.ariaLabel],
+  );
 
   // ---- The editor, bound to the ROOM's text (never seeded from here) ----
   useEffect(() => {


### PR DESCRIPTION
A `<textarea>` gets the browser's dictionary for free. `@codemirror/view` does
not: it hard-codes `spellcheck: "false"` on `.cm-content` because it is a code
editor by birth. When #1742 moved the praxis write-up into the room, the
long-form prose a player is judged on silently lost spell check. This puts it
back, through the `EditorView.contentAttributes` facet that was already there.

**Verified in the installed package**, not taken from the issue —
`@codemirror/view@6.43.8`, `dist/index.js:8268`, in `updateAttrs()`:

```js
let contentAttrs = { spellcheck: "false", autocorrect: "off", ... };
...
attrsFromFacet(this, contentAttributes, contentAttrs);
```

`attrsFromFacet` -> `combineAttrs` assigns facet entries over the defaults for
every name except `class`/`style`, so `contentAttributes` is the only place
that default can be reversed, and it wins. (`autocorrect`, `autocapitalize` and
`writingsuggestions` are also forced off there. Out of scope — this issue is
about spell check, and `data-gramm` is explicitly out too.)

`new EditorView` appears exactly **once** in `frontend/src`. Every other box a
player types into is a native `<textarea>` / `<input>`, so the whole defect
surface is one attribute in one place.

## The seam I tested at

The same one #1852 established for this file: **a value the editor is built
from**, not the mounted editor. The harness is `renderToStaticMarkup`, there is
no DOM and effects never run, so CodeMirror never mounts here. But
`EditorState.create` needs no DOM, and `EditorView.contentAttributes` is a
facet holding exactly the attributes destined for `.cm-content` — so the
attribute is asserted through the same facet the view reads it from.

To reach that seam the inline `useMemo` body became an exported pure
`bodyContentAttributes(skin)`. That is the entire structural change; the
`aria-labelledby` / `aria-label` entries are carried through untouched and are
asserted, because a regression fix must not cost the editor its name.

`bodySpellcheck.test.ts` goes **red** with `spellcheck: "true"` removed
(2 of 3 fail), green with it.

Nothing from #1852 / #1951 / #1931 is touched: `BODY_EDITOR_BASE_THEME`, the
remote-label first-line rule and `composerWritable` are all as they were on
`main`.

## Turned ON (1)

| Field | Where |
|---|---|
| Praxis composer **body** | `editPraxis/archetypes/controls.tsx` — the CodeMirror editor, the regression |

## Already on, and deliberately NOT edited (native, browser default)

A no-op `spellcheck="true"` on a `<textarea>` implies a fix where there was no
defect, so none of these were touched. Audited, not assumed:

- Comment composer body — `components/comments/shared.tsx`
- Flag note (comment + praxis detail) — `comments/FlagControl.tsx`, `praxisDetail/shared.tsx`
- Propose-a-task **title**, **description**, **notes to admin** — `proposeTask/archetypes/DefaultProposeTask.tsx`
- Praxis composer **title** — `controls.tsx` (a headline, still a native input)
- Character **bio/story** and **tagline**, desktop and mobile — `CreateCharacter.tsx`, `EditCharacter.tsx`, `mobileArchetypes/Default{Create,Edit}Character.tsx`
- Character **location** — `EditCharacter.tsx`
- Contact form **message** — `Contact.tsx`
- Admin fail-reason note, admin task description — `praxisDetail/shared.tsx`, `admin/TasksTab.tsx`

## Deliberately left OFF (no `spellcheck="true"` added)

These are not prose. A red underline here is noise, not help:

- **Search boxes** — FilterBar's `type="search"`, the invite search in the
  composer, the metatask picker's search. You are typing somebody's name or a
  fragment; every query would underline.
- **Names and identifiers** — character display name, contact-form name. The
  issue's own example: a red underline under a username is noise. A character
  name is invented on purpose.
- **Numeric fields** — base points / bonus points. They are
  `inputMode="numeric"` with a digits-only filter, so there is never a word to
  underline; spell check there is a genuine no-op.
- **Email** — `type="email"`; browsers already exempt it.

Note these still carry the *browser's* default (on for a native input). Adding
an explicit `spellcheck="false"` to them would be a real behaviour change with
no reported defect behind it, and a wider diff than this regression warrants —
flagging it rather than smuggling it in. Say the word and it is a two-line
follow-up for the search boxes and the name fields.

## What this PR does not prove

Spell check is an **authoring aid, not an accessibility affordance** — no a11y
claim is made for it.

I have no browser and no dev stack, so I **cannot see a red underline**. The
build is green (`lint`, `typecheck`, `typecheck:design-sync`, `npm test`
283 files / 4952 tests, `build`, `budget` — every job in
`.github/workflows/test.yml`), but the acceptance test is a human typing.

The issue's second risk is genuinely untestable here and needs **two sessions
in one room**: spell check operates on the browser's own DOM and the room
reconciles that DOM. A right-click -> replace correction is a browser-initiated
mutation of a contenteditable that a CRDT also owns.

## What to eyeball

1. Open the praxis composer. Type **"teh recieved acomplishment"** into the
   **body**. Red underlines appear — this is the fix.
2. Right-click one of them, pick the browser's suggestion. The word is replaced
   once, not duplicated or reverted.
3. **With a co-author in the same room**, repeat step 2. The correction reaches
   the other session intact, and their caret does not jump.
4. Confirm the body's label still reads to a screen reader (the `aria-*`
   attributes are unchanged).
5. Same misspelling in the **comment composer**, **propose-a-task**
   description/notes, and a character **bio** — all should underline, as they
   did before this PR (nothing changed there; this is the audit's control).
6. Confirm the ones left off stay as they are: typing a name into the
   **FilterBar search** or a **character display name** behaves exactly as it
   did on `main`.

Closes #1978
