### PR TITLE
Selecting Unaffiliated finds Albescent too, in the one place a faction filter becomes a predicate

### DIFF
--- a/backend/faction_slugs.py
+++ b/backend/faction_slugs.py
@@ -1,6 +1,7 @@
 """Canonical faction-slug sentinels.
 
-A **leaf** module: it imports nothing, so the pure-math layer
+A **leaf** module: it imports nothing of this project's (the single import
+below is stdlib and costs no edge), so the pure-math layer
 (``services/scoring.py``), the config layer (``game_config.py``), the async
 services, the routers and ``seed.py`` can all name the same string without any
 of them importing each other. Before #1559 the string ``"na"`` was re-declared
@@ -20,6 +21,8 @@ the era doc wins. Services read ``era.starting_faction_slug``; they must not
 read the constant below to answer "what faction does a new character get?".
 """
 
+from collections.abc import Iterable
+
 #: A **character** has joined no faction — the unaffiliated state every
 #: character is born into by default (ADR-0019 / ADR-0030). This is a real,
 #: seeded ``Faction`` row (hidden, so it never appears in the faction registry)
@@ -33,3 +36,74 @@ UNAFFILIATED_FACTION_SLUG: str = "na"
 #: :data:`UNAFFILIATED_FACTION_SLUG`: a cross-faction task is not "a task that
 #: failed to join a faction", it is a task deliberately open to all of them.
 CROSS_FACTION_SLUG: str = "na"
+
+#: The secret society (ADR-0027). Unlike ``na`` this is a ``visible`` ``Faction``
+#: row — its tasks and its members appear in ordinary listings, and the slug is
+#: on the wire there — but the *word* is never shown to an account that has not
+#: been revealed to it (#1891 / #1926 mask ``factionName()`` client-side), and it
+#: is never a filter option of its own.
+#:
+#: Declared here rather than in ``services.character`` (which now re-exports it,
+#: so every existing importer is unchanged) because
+#: :func:`faction_filter_slugs` below needs it and this module is the leaf that
+#: every layer may import. Membership *rules* still live on the era —
+#: ``EraConfig.albescent_level_required``, ``ERA_1.factions["albescent"]``.
+ALBESCENT_FACTION_SLUG: str = "albescent"
+
+#: The one filter bucket ``na`` and ``albescent`` share. Order is the answer's
+#: order; the group is a tuple rather than a set so a predicate built from it is
+#: deterministic (and so the SQL is stable to read in a log).
+_UNAFFILIATED_FILTER_GROUP: tuple[str, ...] = (
+    UNAFFILIATED_FACTION_SLUG,
+    ALBESCENT_FACTION_SLUG,
+)
+
+
+def faction_filter_slugs(
+    selected: Iterable[str | None] | None,
+) -> list[str]:
+    """The slugs a caller's faction *filter* must match — #1975's one seam.
+
+    Every faceted list service turns a caller-supplied faction selection into a
+    ``... IN (:slugs)`` predicate. This is the only place that translation
+    happens, because the four surfaces sharing the facet
+    (``GET /tasks``, ``GET /praxes``, ``GET /characters``, ``GET /leaderboard``)
+    would otherwise drift and one of them would leak.
+
+    **Selecting Unaffiliated matches ``na`` OR ``albescent``.** ``default ≡ na ≡
+    Unaffiliated`` is one identity (ADR-0039 / ADR-0046 / ADR-0048) and an
+    Albescent member is *shown* as Unaffiliated everywhere. Matching on slug
+    equality made that identity a lie in one direction only: the facet correctly
+    keeps Albescent out of its options, so before this an Albescent row matched
+    **no** filter at all — unreachable rather than hidden behind another option.
+    Folding it under Unaffiliated is also what preserves the secret, because it
+    produces exactly the result an observer would expect if Albescent did not
+    exist.
+
+    An explicit ``?faction=albescent`` — a slug a client was never told — is
+    **normalised into that same group**, not refused: it answers exactly what
+    ``?faction=na`` answers, so the Albescent slice is never separable by any
+    query. Rejecting it would be the louder tell: a 422 for this one string
+    while every other unrecognised slug returns 200-with-nothing is an oracle
+    for the slug's existence.
+
+    Not applied to the admin roster (``services.admin_service``): moderation
+    reads the truth, and that surface has no facet of this kind.
+
+    An empty selection — or one holding only blanks, which is what a cleared
+    client-side filter sends — returns ``[]``, which every call site reads as
+    "no faction filter", never as "match nothing" (#1364).
+    """
+    out: list[str] = []
+    for slug in selected or ():
+        if not slug:
+            continue
+        group = (
+            _UNAFFILIATED_FILTER_GROUP
+            if slug in _UNAFFILIATED_FILTER_GROUP
+            else (slug,)
+        )
+        for member in group:
+            if member not in out:
+                out.append(member)
+    return out

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -101,6 +101,10 @@ async def list_characters(
         .order_by(Character.created_at.desc())
     )
     if faction:
+        # Deliberately NOT `faction_slugs.faction_filter_slugs`: that helper
+        # folds Albescent under Unaffiliated for the player-facing facet
+        # (#1975), and moderation reads the roster as it is. `?faction=albescent`
+        # here means Albescent, and `?faction=na` means only `na`.
         query = query.where(Character.faction_slug == faction)
     if status:
         query = query.where(Character.status == status)

--- a/backend/services/character.py
+++ b/backend/services/character.py
@@ -9,7 +9,11 @@ from sqlalchemy.sql import Select, false as sa_false
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from errors import ErrorCode, raise_coded
-from faction_slugs import UNAFFILIATED_FACTION_SLUG
+from faction_slugs import (
+    ALBESCENT_FACTION_SLUG,
+    UNAFFILIATED_FACTION_SLUG,
+    faction_filter_slugs,
+)
 from game_config import CURRENT_ERA, EraConfig
 from models.account import Account
 from models.character import Character, CharacterStatus
@@ -81,7 +85,11 @@ async def get_character_by_id(character_id: int, session: AsyncSession) -> Chara
     return result.scalar_one_or_none()
 
 
-ALBESCENT_FACTION_SLUG = "albescent"
+# ALBESCENT_FACTION_SLUG now lives in `faction_slugs` alongside the other
+# sentinels — the leaf module `faction_filter_slugs` needed it from, and the one
+# place a slug string may be declared (#1559). Re-exported from here so the
+# existing importers (`character_stats`, `faction_service`, `routers/factions`)
+# are unchanged; `__all__`-less module, so the name above is the export.
 
 _ALBESCENT_SENTINEL_SLUGS: frozenset[str] = frozenset(
     {UNAFFILIATED_FACTION_SLUG, ALBESCENT_FACTION_SLUG}
@@ -643,8 +651,13 @@ async def list_characters_for_viewer(
             ),
             else_=2,
         )
-    if faction_slug:
-        query = query.where(Character.faction_slug == faction_slug)
+    # One slug in, possibly several out: selecting Unaffiliated also matches
+    # Albescent members (#1975), who are shown as Unaffiliated everywhere and
+    # otherwise matched no filter at all. `.in_()` rather than `==` because the
+    # fold is the shared helper's answer, not this route's.
+    roster_faction_slugs = faction_filter_slugs([faction_slug])
+    if roster_faction_slugs:
+        query = query.where(Character.faction_slug.in_(roster_faction_slugs))
     if exclude_account_id is not None:
         query = query.where(Character.account_id != exclude_account_id)
     if exclude_active_task_id is not None:

--- a/backend/services/praxis.py
+++ b/backend/services/praxis.py
@@ -21,6 +21,7 @@ from errors import (
     detail_message,
     raise_coded,
 )
+from faction_slugs import faction_filter_slugs
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.flag import Flag, FlagReason, stored_flag_reason
@@ -340,11 +341,14 @@ async def list_praxes(
     # need it, and joining once keeps ``?faction=x&q=y`` from double-joining.
     query = query.join(Task, Praxis.task_id == Task.id)
 
-    if faction:
-        # Praxis has no faction of its own; it inherits the linked task's
-        # faction. Multi-select (#1362): an EMPTY list means "no faction filter",
-        # never "match nothing" — clearing every checkbox shows everything.
-        query = query.where(Task.primary_faction_slug.in_(faction))
+    # Praxis has no faction of its own; it inherits the linked task's faction.
+    # Multi-select (#1362): an EMPTY list means "no faction filter", never
+    # "match nothing" — clearing every checkbox shows everything. Routed through
+    # the same helper as the task browse so Unaffiliated means the same set of
+    # slugs on both, Albescent included (#1975).
+    faction_slugs = faction_filter_slugs(faction)
+    if faction_slugs:
+        query = query.where(Task.primary_faction_slug.in_(faction_slugs))
 
     if search:
         term = search.strip()

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -8,7 +8,7 @@ from sqlalchemy import and_, exists, false, func, or_, select, true
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from errors import ErrorCode, raise_coded
-from faction_slugs import CROSS_FACTION_SLUG
+from faction_slugs import CROSS_FACTION_SLUG, faction_filter_slugs
 from game_config import CURRENT_ERA, EraConfig
 from models.character import Character
 from models.character_stats import CharacterStats
@@ -820,8 +820,10 @@ async def list_tasks(
 
     # Multi-select faction (#1364): an empty list — or one holding only blanks,
     # which is what a cleared client-side filter sends — means "no faction
-    # filter", never "match nothing".
-    faction_slugs = [slug for slug in (faction or []) if slug]
+    # filter", never "match nothing". faction_filter_slugs also folds Albescent
+    # under Unaffiliated (#1975); it is the ONE place that fold happens, shared
+    # with the praxis feed and the character roster.
+    faction_slugs = faction_filter_slugs(faction)
     if faction_slugs:
         query = query.where(Task.primary_faction_slug.in_(faction_slugs))
     if min_points is not None:

--- a/backend/tests/integration/test_faction_filter_folds_albescent.py
+++ b/backend/tests/integration/test_faction_filter_folds_albescent.py
@@ -1,0 +1,169 @@
+"""#1975 — every faceted surface folds Albescent under Unaffiliated.
+
+The seam under test is the one place a caller-supplied faction *selection*
+becomes a query predicate: ``faction_slugs.faction_filter_slugs``. These drive
+it through the four routes that share the faction facet, so a surface that
+bypasses the helper and matches on slug equality again fails here rather than
+in production:
+
+* ``GET /tasks?faction=``   → ``services.task.list_tasks``
+* ``GET /praxes?faction=``  → ``services.praxis.list_praxes``
+* ``GET /characters?faction=`` and ``GET /leaderboard?faction=``
+  → ``services.character.list_characters_for_viewer`` (one function, two routes)
+
+The rule: selecting **Unaffiliated** matches ``na`` **or** ``albescent``;
+Albescent is never separable and never an option of its own. Before this an
+Albescent row matched *no* filter at all — unreachable rather than hidden.
+
+Slugs come from ``faction_slugs``, never from literals, so a change of sentinel
+does not need finding here.
+"""
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from faction_slugs import ALBESCENT_FACTION_SLUG, UNAFFILIATED_FACTION_SLUG
+from models.era import Era
+from models.faction import Faction, FactionStatus
+from tests.integration.factories import make_character, make_solo_praxis, make_task
+
+#: A faction that is neither half of the unaffiliated bucket. ``faction_ua``
+#: already seeds its row.
+OTHER_FACTION_SLUG = "ua"
+
+
+@pytest_asyncio.fixture
+async def faction_albescent(db_session: AsyncSession, faction_ua: Faction) -> Faction:
+    """The Albescent ``Faction`` row — ``visible``, exactly as ``seed.py`` makes it.
+
+    ``seed.HIDDEN_FACTION_SLUGS`` is ``{aged_out, na}``: Albescent is a *visible*
+    row whose secrecy is enforced per-viewer by ``GET /factions`` and by the
+    client-side name mask (#1891 / #1926), not by the faction's status. Seeding
+    it hidden here would quietly excuse the bug — ``list_tasks`` drops hidden
+    factions' tasks outright, so nothing would reach the filter to be folded.
+    """
+    result = await db_session.execute(
+        select(Faction).where(Faction.slug == ALBESCENT_FACTION_SLUG)
+    )
+    existing = result.scalar_one_or_none()
+    if existing is not None:
+        return existing
+    row = Faction(slug=ALBESCENT_FACTION_SLUG, status=FactionStatus.visible)
+    db_session.add(row)
+    await db_session.commit()
+    result = await db_session.execute(
+        select(Faction).where(Faction.slug == ALBESCENT_FACTION_SLUG)
+    )
+    return result.scalar_one()
+
+
+@pytest_asyncio.fixture
+async def world(db_session: AsyncSession, era: Era, faction_albescent: Faction) -> dict:
+    """One row of each faction on every axis the facet filters.
+
+    Tasks carry a faction of their own (``primary_faction_slug``) and praxes
+    inherit their task's; characters carry the member faction. Three slugs times
+    three axes, so each surface has something to include and something to
+    exclude.
+    """
+    rows: dict[str, dict[str, int]] = {"tasks": {}, "praxes": {}, "characters": {}}
+    for slug in (UNAFFILIATED_FACTION_SLUG, ALBESCENT_FACTION_SLUG, OTHER_FACTION_SLUG):
+        character = await make_character(
+            db_session, era, username=f"filter_{slug}", faction_slug=slug
+        )
+        task = await make_task(
+            db_session, character, title=f"{slug} task", faction_slug=slug
+        )
+        praxis = await make_solo_praxis(db_session, task, character, title=f"{slug} praxis")
+        rows["characters"][slug] = character.id
+        rows["tasks"][slug] = task.id
+        rows["praxes"][slug] = praxis.id
+    await db_session.commit()
+    return rows
+
+
+async def _ids(client: AsyncClient, url: str) -> set[int]:
+    resp = await client.get(url)
+    assert resp.status_code == 200, resp.text
+    return {row["id"] for row in resp.json()}
+
+
+#: ``(surface key, URL template)`` for every route the faction facet feeds.
+#: ``{slug}`` is the selected faction. Adding a faceted route means adding a row
+#: here, which is the point: the parametrisation is the census.
+SURFACES = [
+    ("tasks", "/tasks?faction={slug}"),
+    ("praxes", "/praxes?faction={slug}"),
+    ("characters", "/characters?faction={slug}"),
+    ("characters", "/leaderboard?faction={slug}"),
+]
+
+
+@pytest.mark.parametrize("key,url", SURFACES)
+@pytest.mark.asyncio
+async def test_unaffiliated_returns_albescent_too(
+    client: AsyncClient, world: dict, key: str, url: str
+):
+    """Selecting Unaffiliated returns both ``na`` and ``albescent`` rows."""
+    found = await _ids(client, url.format(slug=UNAFFILIATED_FACTION_SLUG))
+    assert world[key][UNAFFILIATED_FACTION_SLUG] in found
+    assert world[key][ALBESCENT_FACTION_SLUG] in found
+    assert world[key][OTHER_FACTION_SLUG] not in found
+
+
+@pytest.mark.parametrize("key,url", SURFACES)
+@pytest.mark.asyncio
+async def test_another_faction_returns_neither(
+    client: AsyncClient, world: dict, key: str, url: str
+):
+    """Selecting any other faction returns neither half of the bucket."""
+    found = await _ids(client, url.format(slug=OTHER_FACTION_SLUG))
+    assert world[key][OTHER_FACTION_SLUG] in found
+    assert world[key][UNAFFILIATED_FACTION_SLUG] not in found
+    assert world[key][ALBESCENT_FACTION_SLUG] not in found
+
+
+@pytest.mark.parametrize("key,url", SURFACES)
+@pytest.mark.asyncio
+async def test_albescent_is_not_separable(
+    client: AsyncClient, world: dict, key: str, url: str
+):
+    """A guessed ``?faction=albescent`` answers what Unaffiliated answers.
+
+    No query may isolate the Albescent slice. The alternative — refusing the
+    slug — is the louder tell, since every *other* unrecognised slug returns 200
+    with nothing.
+    """
+    guessed = await _ids(client, url.format(slug=ALBESCENT_FACTION_SLUG))
+    assert guessed == await _ids(client, url.format(slug=UNAFFILIATED_FACTION_SLUG))
+
+
+@pytest.mark.asyncio
+async def test_union_of_two_factions_still_folds(client: AsyncClient, world: dict):
+    """Repeated ``?faction=`` is a union (#1364), and the fold rides along."""
+    found = await _ids(
+        client,
+        f"/tasks?faction={OTHER_FACTION_SLUG}&faction={UNAFFILIATED_FACTION_SLUG}",
+    )
+    assert found >= set(world["tasks"].values())
+
+
+@pytest.mark.parametrize("key,url", SURFACES)
+@pytest.mark.asyncio
+async def test_no_row_is_labelled_albescent(
+    client: AsyncClient, world: dict, key: str, url: str
+):
+    """The fold names the society to nobody.
+
+    The backend emits *slugs* and the catalog owns the wording (ADR-0031 /
+    ADR-0038), so what must never appear is the display name — the string the
+    client-side mask exists to withhold (#1891 / #1926). The raw
+    ``albescent`` slug does ride these payloads, as it already does on the
+    unfiltered listing every one of these rows is in: the fold makes existing
+    rows *reachable*, it does not put anything new on the wire.
+    """
+    resp = await client.get(url.format(slug=UNAFFILIATED_FACTION_SLUG))
+    assert resp.status_code == 200
+    assert "Albescent" not in resp.text

--- a/backend/tests/unit/test_faction_filter_slugs.py
+++ b/backend/tests/unit/test_faction_filter_slugs.py
@@ -1,0 +1,63 @@
+"""#1975 — the one translation from a faction *selection* to a predicate.
+
+Unit half. The integration half
+(``tests/integration/test_faction_filter_folds_albescent.py``) proves each
+faceted route actually routes through this; these pin the rule itself, with no
+DB in the way.
+"""
+from faction_slugs import (
+    ALBESCENT_FACTION_SLUG,
+    UNAFFILIATED_FACTION_SLUG,
+    faction_filter_slugs,
+)
+
+
+def test_empty_selection_is_no_filter():
+    """``[]`` means "no faction filter", never "match nothing" (#1364)."""
+    assert faction_filter_slugs(None) == []
+    assert faction_filter_slugs([]) == []
+    assert faction_filter_slugs(["", None]) == []
+
+
+def test_unaffiliated_expands_to_albescent():
+    assert faction_filter_slugs([UNAFFILIATED_FACTION_SLUG]) == [
+        UNAFFILIATED_FACTION_SLUG,
+        ALBESCENT_FACTION_SLUG,
+    ]
+
+
+def test_albescent_is_not_separable():
+    """A guessed ``?faction=albescent`` answers exactly what Unaffiliated does.
+
+    Not refused: a 422 for this one string while every other unrecognised slug
+    returns 200-with-nothing would itself be the oracle.
+    """
+    assert faction_filter_slugs([ALBESCENT_FACTION_SLUG]) == faction_filter_slugs(
+        [UNAFFILIATED_FACTION_SLUG]
+    )
+
+
+def test_other_factions_are_untouched():
+    assert faction_filter_slugs(["ua"]) == ["ua"]
+    assert faction_filter_slugs(["ua", "coven"]) == ["ua", "coven"]
+
+
+def test_union_keeps_order_and_deduplicates():
+    """Repeated ``?faction=`` is a union (#1364); the group joins it once."""
+    assert faction_filter_slugs(["ua", UNAFFILIATED_FACTION_SLUG]) == [
+        "ua",
+        UNAFFILIATED_FACTION_SLUG,
+        ALBESCENT_FACTION_SLUG,
+    ]
+    assert faction_filter_slugs(
+        [UNAFFILIATED_FACTION_SLUG, ALBESCENT_FACTION_SLUG]
+    ) == [UNAFFILIATED_FACTION_SLUG, ALBESCENT_FACTION_SLUG]
+
+
+def test_unknown_slug_still_matches_nothing():
+    """An unrecognised slug arms the filter rather than clearing it.
+
+    ``["zzz"]`` must not collapse to ``[]`` — that would turn a nonsense filter
+    into "show everything", which is the shape a mis-typed deep link takes.
+    """
+    assert faction_filter_slugs(["zzz"]) == ["zzz"]


### PR DESCRIPTION
Selecting **Unaffiliated** now returns rows whose faction is `na` **or** `albescent`, on every surface the faction facet feeds. Albescent gains no option of its own.

Before this, the filters matched on slug equality, so the facet's correct decision to keep Albescent out of its *options* left an Albescent row matching **no** filter at all — unreachable, rather than hidden behind a different option.

## The seam I tested at

**The one place a caller-supplied faction *selection* becomes a query predicate.** That is now `faction_slugs.faction_filter_slugs()`, and the failing test was written there first: `tests/integration/test_faction_filter_folds_albescent.py` drives all four routes and was 9-red before a line of service code changed.

## Which side expands `na`, and why the server

**The server.** Three reasons, in order of weight:

1. **The client cannot cover every predicate.** The Players page does not send a faction param at all — it filters `GET /leaderboard` in memory (`playersData.selectRoster`). "Expand on the client" would mean expanding in two unrelated client shapes, which is the four-way drift the issue exists to prevent.
2. **It keeps the slug out of a request a bystander reads.** The facet serialises as repeated bare `?faction=` on the XHR; a client-side expansion would put `faction=albescent` in the network tab of a viewer who was never told the slug. (The slug is *already* on the wire in listing **responses** — see "Pre-existing, unchanged" below — but a request the client volunteers is the shape #1891 closed.)
3. The fold is a query semantic, not a widget's business.

## Functions touched (relevant to #1972)

Exactly the faction predicate, nothing else in the filter path:

- `services/task.py` — `list_tasks`, the 3 lines at the `Multi-select faction (#1364)` comment. **#1972 changes this function; this is the only hunk in it.**
- `services/praxis.py` — `list_praxes`, the `if faction:` block.
- `services/character.py` — `list_characters_for_viewer`, the `if faction_slug:` block (`==` becomes `.in_()`).
- `faction_slugs.py` — the new helper, plus `ALBESCENT_FACTION_SLUG` moved here from `services/character.py` and **re-exported** from there (every existing importer unchanged). The leaf module is where the helper could reach it, and #1559 already made this the one place a slug string may be declared.
- `services/admin_service.py` — a comment only. The admin roster is deliberately **not** folded: moderation reads the truth.

## The census — four routes, three predicate sites, one fold

The issue says four surfaces. Verified, with a correction to the shape:

| Route | Predicate site | Folded |
|---|---|---|
| `GET /tasks?faction=` | `services/task.py` | yes |
| `GET /praxes?faction=` | `services/praxis.py` | yes |
| `GET /characters?faction=` | `services/character.py` | yes |
| `GET /leaderboard?faction=` | *same function* | yes |
| `GET /admin/characters?faction=` | `services/admin_service.py` | no, by decision |

`POST /auth/dev-login?faction=` is a setter, not a filter. No other router takes a faction filter.

## What an explicit `?faction=albescent` does — decided, not accidental

**Silently treated as Unaffiliated.** A guessed slug answers exactly what `?faction=na` answers, so **no query isolates the Albescent slice** — which is the issue's "included, without being separable". Refusing it was the alternative and is the louder tell: a 422 for this one string while every *other* unrecognised slug returns 200-with-nothing is an oracle for the slug's existence. Pinned by `test_albescent_is_not_separable` on all four routes and in the unit test.

An Albescent member filtering their own view gets the same answer as anyone else selecting Unaffiliated — the fold is viewer-independent, so there is nothing on their screen to read over their shoulder.

## Pre-existing, unchanged (please read this bit)

`primary_faction_slug` / `faction_slug` already ship the raw `albescent` string in listing **responses** — that is what the client-side mask in #1891/#1926 exists to cover, and it is how a revealed viewer gets their real faction page. Every row this fold newly makes reachable was already in the unfiltered listing carrying that slug. **The fold puts nothing new on the wire**; it makes existing rows reachable through the filter that already claims to describe them. I did not touch the mask.

## Outstanding — one surface a server fix cannot reach (frontend, out of this PR's scope)

`frontend/src/pages/players/playersData.ts` → `selectRoster` filters the roster **client-side** over one `GET /leaderboard` page and never sends `?faction=`. So the Players page's Unaffiliated facet still misses Albescent members. The twin fix is one line at `filters.factions.includes(slugKey(character.faction_slug))` — normalise the **row's** slug (albescent reads as `na` for matching), which mirrors what `factionName()` already does and keeps the slug off any wire. `utils/factions.ts` already exports `ALBESCENT_FACTION_SLUG` and `isFactionHiddenFromChoosers`. Not done here: this branch is backend-only.

## Tests

```
pytest --cov=. --cov-report=term-missing --cov-fail-under=80
```
from `backend/`, against a dedicated `wz1975_test`: **1410 passed**, coverage 94.03%.

- `tests/integration/test_faction_filter_folds_albescent.py` — parametrised over the four routes: Unaffiliated returns both halves; any other faction returns neither; `?faction=albescent` is not separable; a union still folds; no row is labelled Albescent.
- `tests/unit/test_faction_filter_slugs.py` — the rule itself, including that an unknown slug still arms the filter rather than collapsing it to "show everything".

Slugs come from `faction_slugs`, never literals. `backend/openapi.json` regenerates byte-identical (no route or schema touched), so `api-schema` is clean; no frontend file changed.

## What to eyeball

Visual QA is **outstanding** — I have no browser and no dev stack on this branch.

- The faction facet on **Tasks**, **Praxes**, **Players** and the **Updates** bar, as an **unrevealed** viewer: Albescent appears in no option, no chip, no count label, and no URL.
- The same four as a **revealed** viewer: still no Albescent option; selecting Unaffiliated shows their own rows.
- **Tasks** and **Praxes**, Unaffiliated selected: Albescent-faction rows appear, drawn as Unaffiliated/default (no white sigil, no leaked name).
- **Players**, Unaffiliated selected: this is the known gap above — expect Albescent members still missing until the frontend twin lands.
- A hand-typed `/tasks?factions=albescent` deep link: no extra row in the facet, and the same list as Unaffiliated.

Closes #1975
