### PR TITLE
Task cards say why sign-up is shut, in the detail page's own words

### DIFF
--- a/frontend/src/components/taskCard/CovenTaskCard.tsx
+++ b/frontend/src/components/taskCard/CovenTaskCard.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
+import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
@@ -210,6 +211,7 @@ export default function CovenTaskCard({
 }: CardProps) {
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
+  const cta = taskCardSignupCta(task, onSignup, i18n.t("feed:taskCard.coven.signup"));
   const showMultiplier = !isNeutralMultiplier(multiplier);
 
   return (
@@ -385,13 +387,15 @@ export default function CovenTaskCard({
           </Link>
         </div>
 
-        {onSignup && (
+        {cta && (
           <button
-            onClick={() => onSignup(task.id)}
+            type="button"
+            onClick={cta.onPress}
+            aria-disabled={cta.denied || undefined}
             style={{
               position: "relative",
               zIndex: 2,
-              cursor: "pointer",
+              cursor: cta.denied ? "not-allowed" : "pointer",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
@@ -416,7 +420,7 @@ export default function CovenTaskCard({
                 fill="currentColor"
               />
             </svg>
-            {i18n.t("feed:taskCard.coven.signup")}
+            {cta.label}
           </button>
         )}
       </article>

--- a/frontend/src/components/taskCard/DefaultTaskCard.tsx
+++ b/frontend/src/components/taskCard/DefaultTaskCard.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
+import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
@@ -81,6 +82,7 @@ export default function DefaultTaskCard({
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
   const showMultiplier = !isNeutralMultiplier(multiplier);
+  const cta = taskCardSignupCta(task, onSignup, i18n.t("feed:taskCard.na.signup"));
 
   return (
     <div
@@ -284,12 +286,14 @@ export default function DefaultTaskCard({
           )}
         </Link>
 
-        {onSignup && (
+        {cta && (
           <div style={{ display: "flex", justifyContent: "center" }}>
             <button
-              onClick={() => onSignup(task.id)}
+              type="button"
+              onClick={cta.onPress}
+              aria-disabled={cta.denied || undefined}
               style={{
-                cursor: "pointer",
+                cursor: cta.denied ? "not-allowed" : "pointer",
                 display: "inline-flex",
                 alignItems: "center",
                 justifyContent: "center",
@@ -307,7 +311,7 @@ export default function DefaultTaskCard({
                   "1px solid color-mix(in srgb, var(--faction-default-card-accent) 35%, transparent)",
               }}
             >
-              {i18n.t("feed:taskCard.na.signup")}
+              {cta.label}
             </button>
           </div>
         )}

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
+import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
@@ -189,6 +190,7 @@ export default function EphemeristsTaskCard({
 }: CardProps) {
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
+  const cta = taskCardSignupCta(task, onSignup, i18n.t("feed:taskCard.ephemerists.signup"));
   const showMultiplier = !isNeutralMultiplier(multiplier);
 
   return (
@@ -429,13 +431,15 @@ export default function EphemeristsTaskCard({
           </Link>
         </div>
 
-        {onSignup && (
+        {cta && (
           <button
-            onClick={() => onSignup(task.id)}
+            type="button"
+            onClick={cta.onPress}
+            aria-disabled={cta.denied || undefined}
             style={{
               position: "relative",
               zIndex: 2,
-              cursor: "pointer",
+              cursor: cta.denied ? "not-allowed" : "pointer",
               display: "flex",
               alignItems: "center",
               justifyContent: "center",
@@ -456,7 +460,7 @@ export default function EphemeristsTaskCard({
             <svg width={17} height={17} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
               <path d={GLYPHS.platinum} fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
             </svg>
-            <span>{i18n.t("feed:taskCard.ephemerists.signup")}</span>
+            <span>{cta.label}</span>
             <svg width={16} height={16} viewBox="0 0 24 24" aria-hidden="true" style={{ display: "block", flex: "0 0 auto" }}>
               <path d={GLYPHS.planet} fill="none" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
             </svg>

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
+import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
@@ -139,6 +140,7 @@ export default function EverymenTaskCard({
 }: CardProps) {
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
+  const cta = taskCardSignupCta(task, onSignup, i18n.t("feed:taskCard.everymen.signup"));
   const showMultiplier = !isNeutralMultiplier(multiplier);
 
   return (
@@ -332,13 +334,15 @@ export default function EverymenTaskCard({
             </Link>
           </div>
 
-          {onSignup && (
+          {cta && (
             <button
-              onClick={() => onSignup(task.id)}
+              type="button"
+              onClick={cta.onPress}
+              aria-disabled={cta.denied || undefined}
               style={{
                 position: "relative",
                 zIndex: 2,
-                cursor: "pointer",
+                cursor: cta.denied ? "not-allowed" : "pointer",
                 width: "100%",
                 background: "var(--faction-everymen-bill-cta-bg)",
                 color: "var(--faction-everymen-bill-cta-ink)",
@@ -352,7 +356,7 @@ export default function EverymenTaskCard({
                 borderTop: `2px solid ${INK}`,
               }}
             >
-              {i18n.t("feed:taskCard.everymen.signup")}
+              {cta.label}
             </button>
           )}
         </div>

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
+import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
@@ -108,6 +109,7 @@ export default function SingularityTaskCard({
 }: CardProps) {
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
+  const cta = taskCardSignupCta(task, onSignup, i18n.t("feed:taskCard.singularity.signup"));
   const showMultiplier = !isNeutralMultiplier(multiplier);
 
   return (
@@ -299,12 +301,14 @@ export default function SingularityTaskCard({
             )}
           </Link>
 
-          {onSignup && (
+          {cta && (
             <div style={{ display: "flex", justifyContent: "center", marginTop: "var(--space-lg)" }}>
               <button
-                onClick={() => onSignup(task.id)}
+                type="button"
+                onClick={cta.onPress}
+                aria-disabled={cta.denied || undefined}
                 style={{
-                  cursor: "pointer",
+                  cursor: cta.denied ? "not-allowed" : "pointer",
                   display: "inline-flex",
                   alignItems: "center",
                   justifyContent: "center",
@@ -319,7 +323,7 @@ export default function SingularityTaskCard({
                   border: `1.5px solid ${BRIGHT}`,
                 }}
               >
-                {i18n.t("feed:taskCard.singularity.signup")}
+                {cta.label}
                 {/* The block cursor trailing the prompt. `.sg-cursor` carries the
                     reduced-motion-guarded blink; stilled it stays drawn, because
                     it is punctuation on the prompt, not an indicator. */}

--- a/frontend/src/components/taskCard/SnideTaskCard.tsx
+++ b/frontend/src/components/taskCard/SnideTaskCard.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
+import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
@@ -197,6 +198,7 @@ export default function SnideTaskCard({
 }: CardProps) {
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
+  const cta = taskCardSignupCta(task, onSignup, i18n.t("feed:taskCard.snide.signup"));
   const showMultiplier = !isNeutralMultiplier(multiplier);
 
   return (
@@ -375,13 +377,15 @@ export default function SnideTaskCard({
           </Link>
         </div>
 
-        {onSignup && (
+        {cta && (
           <button
-            onClick={() => onSignup(task.id)}
+            type="button"
+            onClick={cta.onPress}
+            aria-disabled={cta.denied || undefined}
             style={{
               position: "relative",
               zIndex: 2,
-              cursor: "pointer",
+              cursor: cta.denied ? "not-allowed" : "pointer",
               width: "100%",
               background: "var(--faction-snide-note-cta-bg)",
               color: "var(--faction-snide-note-cta-ink)",
@@ -394,7 +398,7 @@ export default function SnideTaskCard({
               border: "none",
             }}
           >
-            {i18n.t("feed:taskCard.snide.signup")}
+            {cta.label}
           </button>
         )}
       </article>

--- a/frontend/src/components/taskCard/UaTaskCard.tsx
+++ b/frontend/src/components/taskCard/UaTaskCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
+import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
@@ -82,6 +83,7 @@ export default function UaTaskCard({
 }: CardProps) {
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
+  const cta = taskCardSignupCta(task, onSignup, i18n.t("feed:taskCard.ua.signup"));
   const showMultiplier = !isNeutralMultiplier(multiplier);
 
   return (
@@ -231,12 +233,14 @@ export default function UaTaskCard({
             )}
           </Link>
 
-          {onSignup && (
+          {cta && (
             <div style={{ display: "flex", justifyContent: "center", marginTop: "var(--space-lg)" }}>
               <button
-                onClick={() => onSignup(task.id)}
+                type="button"
+                onClick={cta.onPress}
+                aria-disabled={cta.denied || undefined}
                 style={{
-                  cursor: "pointer",
+                  cursor: cta.denied ? "not-allowed" : "pointer",
                   fontFamily: UA_DISPLAY,
                   fontWeight: 600,
                   fontSize: "var(--text-content)",
@@ -249,7 +253,7 @@ export default function UaTaskCard({
                   border: "1.5px solid var(--faction-ua-card-frame)",
                 }}
               >
-                {i18n.t("feed:taskCard.ua.signup")}
+                {cta.label}
               </button>
             </div>
           )}

--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
+import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
@@ -130,6 +131,7 @@ export default function WowTaskCard({
 }: CardProps) {
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
+  const cta = taskCardSignupCta(task, onSignup, i18n.t("feed:taskCard.wow.signup"));
   const showMultiplier = !isNeutralMultiplier(multiplier);
 
   return (
@@ -285,12 +287,14 @@ export default function WowTaskCard({
             )}
           </Link>
 
-          {onSignup && (
+          {cta && (
             <div style={{ display: "flex", justifyContent: "center", marginTop: "var(--space-lg)" }}>
               <button
-                onClick={() => onSignup(task.id)}
+                type="button"
+                onClick={cta.onPress}
+                aria-disabled={cta.denied || undefined}
                 style={{
-                  cursor: "pointer",
+                  cursor: cta.denied ? "not-allowed" : "pointer",
                   fontFamily: MED,
                   fontSize: "var(--text-content)",
                   letterSpacing: "0.04em",
@@ -302,7 +306,7 @@ export default function WowTaskCard({
                   border: `2px solid ${PLUM_SURFACE}`,
                 }}
               >
-                {i18n.t("feed:taskCard.wow.signup")}
+                {cta.label}
               </button>
             </div>
           )}

--- a/frontend/src/components/taskCard/__tests__/defaultTaskCard.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/defaultTaskCard.test.tsx
@@ -45,14 +45,16 @@ function markup(element: ReactElement): { html: string; text: string } {
 }
 
 function card(props: Partial<{
+  task: TaskOut
   multiplier: number
   inProgressCount: number
   onSignup: (id: number) => void
 }> = {}) {
+  const task = props.task ?? TASK
   return markup(
     <DefaultTaskCard
-      task={TASK}
-      basePoints={TASK.point_value}
+      task={task}
+      basePoints={task.point_value}
       multiplier={props.multiplier ?? 1}
       inProgressCount={props.inProgressCount ?? 0}
       onSignup={props.onSignup}
@@ -91,9 +93,24 @@ describe('na task card — content slots', () => {
     )
   })
 
-  it('hides the sign-up CTA rather than disabling it when the viewer cannot sign up', () => {
+  it('draws no action slot at all on a surface that did not ask for one', () => {
     expect(card({ onSignup: () => {} }).text).toContain(SIGNUP)
     expect(card().text, 'no onSignup → no control').not.toContain(SIGNUP)
+    expect(card().html, 'and nothing to refuse either').not.toContain('aria-disabled')
+  })
+
+  // #1976 — the ninth skin. The other eight ride the manifest loop in
+  // `factionTaskCardsV2.test.tsx`; na is the fallback skin and is only reached
+  // there through Albescent, which is na + drift (ADR-0048). It gets its own
+  // row here so the fallback is pinned in its own right.
+  it('states why sign-up is shut instead of offering a claim the server refuses', () => {
+    const { html, text } = card({
+      task: aTask({ ...TASK, level_required: 4, can_sign_up: false, signup_reason: 'below_level' }),
+      onSignup: () => {},
+    })
+    expect(text).toContain(i18n.t('tasks:detail.signup.denied.belowLevel', { level: 4 }))
+    expect(text, 'and stops calling it a sign-up').not.toContain(SIGNUP)
+    expect(html, 'not actionable, and it says so').toContain('aria-disabled="true"')
   })
 })
 

--- a/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
@@ -87,6 +87,23 @@ const SKINS: Skin[] = [
 ]
 
 /**
+ * Every value of `services/praxis.py`'s `SignupDenialReason`, with the copy the
+ * card must show for it (#1976).
+ *
+ * Written out rather than derived from the mapper: a table that reads the thing
+ * it is testing would pass just as happily if the mapper started returning one
+ * generic key for all five. The `below_level` row leaves `{{level}}` uninterpolated
+ * on purpose — `TASK.level_required` is 2 and its own test pins the number.
+ */
+const DENIALS: [reason: string, copy: string][] = [
+  ['below_level', i18n.t('tasks:detail.signup.denied.belowLevel', { level: 2 })],
+  ['task_status_closed', i18n.t('tasks:detail.signup.denied.taskStatusClosed')],
+  ['already_active_member', i18n.t('tasks:detail.signup.denied.alreadyActiveMember')],
+  ['bank_full', i18n.t('tasks:detail.signup.denied.bankFull')],
+  ['is_metatask', i18n.t('tasks:detail.signup.denied.isMetatask')],
+]
+
+/**
  * The five entities React escapes on the way out. They have to come back before
  * the text is compared to a catalog string, or a perfectly correct card fails
  * for having an apostrophe in its CTA — which is exactly what S.N.I.D.E.'s
@@ -112,12 +129,13 @@ function markup(element: ReactElement): { html: string; text: string } {
 
 function render(
   { Card }: Skin,
-  props: Partial<Pick<CardProps, 'multiplier' | 'inProgressCount' | 'onSignup'>> = {},
+  props: Partial<Pick<CardProps, 'task' | 'multiplier' | 'inProgressCount' | 'onSignup'>> = {},
 ) {
+  const task = props.task ?? TASK
   return markup(
     <Card
-      task={TASK}
-      basePoints={TASK.point_value}
+      task={task}
+      basePoints={task.point_value}
       multiplier={props.multiplier ?? 1}
       inProgressCount={props.inProgressCount ?? 0}
       onSignup={props.onSignup}
@@ -155,9 +173,56 @@ describe.each(SKINS)('$slug task card v2 — content slots', (skin) => {
     )
   })
 
-  it('hides the sign-up CTA rather than disabling it when the viewer cannot sign up', () => {
+  it('draws no action slot at all on a surface that did not ask for one', () => {
+    // A character profile's task list and a faction page's roster are readouts.
+    // They withhold `onSignup`, and they get neither a claim nor a refusal.
     expect(render(skin, { onSignup: () => {} }).text).toContain(skin.signup)
     expect(render(skin).text, 'no onSignup → no control').not.toContain(skin.signup)
+    expect(render(skin).html, 'and nothing to refuse either').not.toContain('aria-disabled')
+  })
+
+  // #1976. The card used to say "Sign up" on a task the server would refuse, or
+  // (where the list gated on `can_sign_up`) say nothing at all — either way it
+  // disagreed with the detail page for the same task, which has read
+  // `signup_reason` since #1497.
+  it('states the reason instead of offering a claim the server will refuse', () => {
+    for (const [reason, expected] of DENIALS) {
+      const { html, text } = render(skin, {
+        task: aTask({ ...TASK, can_sign_up: false, signup_reason: reason }),
+        onSignup: () => {},
+      })
+      expect(text, `${reason} states why`).toContain(expected)
+      expect(text, `${reason} does not still say ${skin.signup}`).not.toContain(skin.signup)
+      // The control communicates its state rather than merely not working:
+      // `aria-disabled` keeps it in the tab order and announces it, where the
+      // `disabled` attribute would take it out of the tree unheard.
+      expect(html, `${reason} is not actionable`).toContain('aria-disabled="true"')
+    }
+  })
+
+  it('interpolates the level the viewer is short of, rather than a generic no', () => {
+    const { text } = render(skin, {
+      task: aTask({ ...TASK, level_required: 4, can_sign_up: false, signup_reason: 'below_level' }),
+      onSignup: () => {},
+    })
+    expect(text).toContain(i18n.t('tasks:detail.signup.denied.belowLevel', { level: 4 }))
+    expect(text, 'the placeholder must not survive to the screen').not.toContain('{{level}}')
+  })
+
+  it('keeps the claim pressable, and says the detail page words, when sign-up is open', () => {
+    // `multi_membership` is a PERMIT: Double Dipper lets its members go again,
+    // and the detail page has said "Begin again" for it since #1497 while the
+    // card said "Sign up". One mapper, one answer.
+    const again = render(skin, {
+      task: aTask({ ...TASK, signup_reason: 'multi_membership' }),
+      onSignup: () => {},
+    })
+    expect(again.text).toContain(i18n.t('tasks:detail.signup.ctaAgain'))
+    expect(again.html, 'still a live control').not.toContain('aria-disabled')
+
+    const open = render(skin, { onSignup: () => {} })
+    expect(open.text, "the faction's own verb, unchanged").toContain(skin.signup)
+    expect(open.html, 'still a live control').not.toContain('aria-disabled')
   })
 })
 

--- a/frontend/src/components/taskCard/__tests__/signupAffordance.test.ts
+++ b/frontend/src/components/taskCard/__tests__/signupAffordance.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The task card's action slot, decided (#1976).
+ *
+ * This suite exists because the render suites cannot ask the one question that
+ * matters most: `renderToStaticMarkup` never serialises an event handler, so no
+ * markup assertion can tell a button that does nothing from a button that posts
+ * a sign-up. The nine skins spread `cta.onPress` onto their button, so the
+ * absence of that field IS the un-pressability — and it is checkable right here,
+ * value-out.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+import { aTask } from '../../../test/fixtures'
+import { taskCardSignupCta } from '../signupAffordance'
+
+const FACTION_VERB = 'FALL IN'
+
+/** Every value of `services/praxis.py`'s `SignupDenialReason`. */
+const DENIALS = [
+  'below_level',
+  'task_status_closed',
+  'already_active_member',
+  'bank_full',
+  'is_metatask',
+] as const
+
+describe('the card asks for a slot at all', () => {
+  it('gives none to a surface that withheld onSignup, however shut sign-up is', () => {
+    const shut = aTask({ can_sign_up: false, signup_reason: 'below_level' })
+    expect(taskCardSignupCta(shut, undefined, FACTION_VERB)).toBeNull()
+  })
+})
+
+describe.each(DENIALS)('a %s denial', (reason) => {
+  const task = aTask({ can_sign_up: false, signup_reason: reason, level_required: 4 })
+
+  it('carries no press handler — the dead end cannot be reattached by a skin', () => {
+    const cta = taskCardSignupCta(task, vi.fn(), FACTION_VERB)!
+    expect(cta.denied).toBe(true)
+    expect(cta.onPress, 'a denied slot has nothing to press').toBeUndefined()
+  })
+
+  it('says why, in the words the shared mapper holds, not the faction verb', () => {
+    const cta = taskCardSignupCta(task, vi.fn(), FACTION_VERB)!
+    expect(cta.label).not.toBe(FACTION_VERB)
+    expect(cta.label, 'no unfilled placeholder').not.toContain('{{')
+    expect(cta.label.length, 'a reason, not an empty string').toBeGreaterThan(0)
+  })
+})
+
+describe('a permitted sign-up', () => {
+  it('keeps the faction verb and calls the surface back with the task id', () => {
+    const onSignup = vi.fn()
+    const cta = taskCardSignupCta(aTask({ id: 42 }), onSignup, FACTION_VERB)!
+    expect(cta.denied).toBe(false)
+    expect(cta.label).toBe(FACTION_VERB)
+    cta.onPress!()
+    expect(onSignup).toHaveBeenCalledWith(42)
+  })
+
+  it('says "begin again" for multi_membership, as the detail page already does', () => {
+    // Double Dipper: the server ALLOWS the claim and explains why it is unusual.
+    // A denial check that read `signup_reason` as "any reason means no" would
+    // turn this permit into a dead button, which is the regression this pins.
+    const cta = taskCardSignupCta(
+      aTask({ signup_reason: 'multi_membership' }),
+      vi.fn(),
+      FACTION_VERB,
+    )!
+    expect(cta.denied).toBe(false)
+    expect(cta.onPress).toBeTypeOf('function')
+    expect(cta.label).toBe(i18n.t('tasks:detail.signup.ctaAgain'))
+  })
+
+  it('falls back to the faction verb for a reason this build has never heard of', () => {
+    // A backend that ships a sixth ALLOWING reason must not blank the button.
+    const cta = taskCardSignupCta(
+      aTask({ signup_reason: 'a_gate_from_the_future' }),
+      vi.fn(),
+      FACTION_VERB,
+    )!
+    expect(cta.denied).toBe(false)
+    expect(cta.label).toBe(FACTION_VERB)
+  })
+
+  it('hides rather than lying when sign-up is shut and no reason came with it', () => {
+    // A sixth DENYING gate, or any payload where the two fields disagree. The
+    // pre-#1976 behaviour was to hide — a card cannot state a reason it has no
+    // copy for, and offering the claim anyway is the doomed button the whole
+    // issue is about. `pages/tasks/__tests__/dispatch.test.tsx` pins the same
+    // invariant end to end.
+    expect(
+      taskCardSignupCta(
+        aTask({ can_sign_up: false, signup_reason: 'a_gate_from_the_future' }),
+        vi.fn(),
+        FACTION_VERB,
+      ),
+    ).toBeNull()
+    expect(
+      taskCardSignupCta(aTask({ can_sign_up: false }), vi.fn(), FACTION_VERB),
+    ).toBeNull()
+  })
+
+  it('interpolates the level the viewer is short of', () => {
+    const cta = taskCardSignupCta(
+      aTask({ can_sign_up: false, signup_reason: 'below_level', level_required: 7 }),
+      vi.fn(),
+      FACTION_VERB,
+    )!
+    expect(cta.label).toBe(i18n.t('tasks:detail.signup.denied.belowLevel', { level: 7 }))
+    expect(cta.label).toContain('7')
+  })
+})

--- a/frontend/src/components/taskCard/signupAffordance.ts
+++ b/frontend/src/components/taskCard/signupAffordance.ts
@@ -72,15 +72,23 @@ export function taskCardSignupCta(
 ): TaskCardSignupCta | null {
   if (!onSignup) return null;
 
-  const key = signupCtaKey(task.signup_reason);
-  if (key === SIGNUP_CTA_KEY) {
-    return { label: signupLabel, denied: false, onPress: () => onSignup(task.id) };
+  if (isSignupDenial(task.signup_reason)) {
+    // `level` is only read by `denied.belowLevel`; passing it to the others is
+    // free and keeps this a single call rather than a branch per reason.
+    const key = signupCtaKey(task.signup_reason);
+    return { label: i18n.t(`tasks:${key}`, { level: task.level_required }), denied: true };
   }
 
-  // `level` is only read by `denied.belowLevel`; passing it to the others is
-  // free and keeps this a single call rather than a branch per reason.
-  const label = i18n.t(`tasks:${key}`, { level: task.level_required });
-  return isSignupDenial(task.signup_reason)
-    ? { label, denied: true }
-    : { label, denied: false, onPress: () => onSignup(task.id) };
+  // Shut, with nothing to say about it — hide rather than lie. Reachable two
+  // ways: a backend that grows a sixth gate this build has no copy for, and any
+  // payload where the two fields disagree. The old behaviour for BOTH was to
+  // hide, because the list gated on `can_sign_up` and never asked why; keeping
+  // that as the fallback is what makes a new backend reason a missing
+  // explanation rather than a live button the server will refuse.
+  if (!task.can_sign_up) return null;
+
+  const key = signupCtaKey(task.signup_reason);
+  const label =
+    key === SIGNUP_CTA_KEY ? signupLabel : i18n.t(`tasks:${key}`, { level: task.level_required });
+  return { label, denied: false, onPress: () => onSignup(task.id) };
 }

--- a/frontend/src/components/taskCard/signupAffordance.ts
+++ b/frontend/src/components/taskCard/signupAffordance.ts
@@ -1,0 +1,86 @@
+import i18n from "../../i18n";
+import type { TaskOut } from "../../api/tasks";
+import {
+  SIGNUP_CTA_KEY,
+  isSignupDenial,
+  signupCtaKey,
+} from "../../pages/taskDetail/signupCta";
+
+/**
+ * What the nine task-card skins draw in their one action slot (#1976).
+ *
+ * The card used to say "Sign up" and mean it unconditionally: the label was the
+ * skin's own flat `feed:taskCard.{F}.signup`, and whether the button existed at
+ * all was the LIST's decision, made by withholding `onSignup`. So a card and the
+ * detail page for the same task disagreed — the detail page reads
+ * `TaskOut.signup_reason` and says "Begin again"; the card said "Sign up". And
+ * on the surfaces that pass `onSignup` unconditionally (the field desk) the card
+ * offered a button the server was always going to refuse.
+ *
+ * This is the adapter, not a second mapper: the reason-to-copy question is
+ * answered by {@link signupCtaKey}, the same function the eight task-detail
+ * archetypes call. What lives here is the card's own two extras — the faction
+ * verb, and the fact that a shut sign-up still draws something.
+ */
+export interface TaskCardSignupCta {
+  /** Already resolved copy. The skin renders it; it never picks a key. */
+  label: string;
+  /**
+   * True when the server has shut sign-up. The skin renders the same slot, in
+   * the same place, saying WHY instead of offering a claim.
+   */
+  denied: boolean;
+  /**
+   * The press handler — **absent iff {@link denied}**, and that is the whole
+   * enforcement. A skin spreads this onto its button, so there is no skin in
+   * which the dead-ended control can come back: the handler simply is not there
+   * to attach. `pages/fieldDesk/PendingRowPill.tsx` states the doctrine — a
+   * dead-ended pill that still looks pressable is worse than no pill — and this
+   * is the one place a card can honour it for all nine skins at once.
+   */
+  onPress?: () => void;
+}
+
+/**
+ * The action slot for one card, or `null` for no slot at all.
+ *
+ * `null` when the surface did not ask for one (`onSignup` undefined) — a
+ * character profile's task list and a faction page's roster are readouts, not
+ * claim points, and neither should sprout a refusal. The surfaces that DO ask
+ * pass `onSignup` for any signed-in viewer and let this decide; an anonymous
+ * viewer has no reason on the wire (the server sends `signup_reason: null` when
+ * there is no viewer to explain anything to) and so would only ever be offered
+ * a button, which is why those surfaces still gate on the user.
+ *
+ * `signupLabel` is the faction's own verb, resolved by the skin because `t()`
+ * takes a typed literal and a `string` parameter here would need a cast that
+ * defeats the catalog's key checking.
+ *
+ * ponytail: `signupLabel` is a parameter only because the nine
+ * `feed:taskCard.{F}.signup` keys are still nine — eight of them literally
+ * "Sign up", and `locales/__tests__/catalog.test.ts` pins that. #1864 owns
+ * collapsing them; when it lands this parameter loses its reason to exist and
+ * the plain branch below becomes `i18n.t("tasks:" + SIGNUP_CTA_KEY)` like the
+ * other three. Deliberately NOT collapsed here: ADR-0048 keeps
+ * `taskCard.albescent.signup` deliberately unsettled, and that is a copy ruling,
+ * not a refactor this issue gets to make in passing.
+ */
+export function taskCardSignupCta(
+  task: TaskOut,
+  onSignup: ((id: number) => void) | undefined,
+  signupLabel: string,
+): TaskCardSignupCta | null {
+  if (!onSignup) return null;
+
+  const key = signupCtaKey(task.signup_reason);
+  if (key === SIGNUP_CTA_KEY) {
+    return { label: signupLabel, denied: false, onPress: () => onSignup(task.id) };
+  }
+
+  // `level` is only read by `denied.belowLevel`; passing it to the others is
+  // free and keeps this a single call rather than a branch per reason.
+  const label = i18n.t(`tasks:${key}`, { level: task.level_required });
+  return isSignupDenial(task.signup_reason)
+    ? { label, denied: true }
+    : { label, denied: false, onPress: () => onSignup(task.id) };
+}

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -62,7 +62,14 @@
       "cta": "Sign up",
       "ctaAgain": "Begin again",
       "slots": "You have {{open}} of {{max}} task slots open",
-      "levelMet": "Level {{level}} met"
+      "levelMet": "Level {{level}} met",
+      "denied": {
+        "belowLevel": "Must be level {{level}}",
+        "taskStatusClosed": "No longer open",
+        "alreadyActiveMember": "You're on this task",
+        "bankFull": "No task slots open",
+        "isMetatask": "Applied to praxis, not claimed"
+      }
     },
     "inProgress": {
       "text": "You're on this task",

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -232,7 +232,9 @@ export default function Home() {
               newestTask.primary_faction_slug,
               factionConfigs,
             )}
-            onSignup={user && newestTask.can_sign_up ? handleSignup : undefined}
+            // The card decides claim-vs-reason off `newestTask.signup_reason`
+            // (#1976); this only decides whether there is a viewer at all.
+            onSignup={user ? handleSignup : undefined}
           />
         ) : (
           <p className="font-body text-muted">{t('sections.newestTask.empty')}</p>

--- a/frontend/src/pages/Tasks.tsx
+++ b/frontend/src/pages/Tasks.tsx
@@ -87,13 +87,20 @@ function DesktopTasks({ state }: { state: TasksState }) {
           ) : (
             /* Flex-wrap container — NOT a grid. Varied card sizes and rotations are intentional (Style Guide §6). */
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-lg)', alignItems: 'flex-start' }}>
+              {/* `onSignup` is offered to any signed-in viewer. Whether the slot
+                  it produces is a claim or a statement of why not is the CARD's
+                  call, off `task.signup_reason` (#1976) — gating it on
+                  `can_sign_up` here is what made this list go silent about a
+                  task it was still showing, and with the eligibility filter
+                  switched off, silent about most of them. An anonymous viewer
+                  still gets nothing: the server sends no reason to explain. */}
               {tasks.map((task) => (
                 <TaskCard
                   key={task.id}
                   task={task}
                   basePoints={task.point_value}
                   multiplier={displayMultiplierFor(task)}
-                  onSignup={user && task.can_sign_up ? handleSignup : undefined}
+                  onSignup={user ? handleSignup : undefined}
                 />
               ))}
             </div>

--- a/frontend/src/pages/taskDetail/signupCta.ts
+++ b/frontend/src/pages/taskDetail/signupCta.ts
@@ -37,10 +37,55 @@ export function canSignUpForTask(params: {
   return params.signedIn && !!params.canSignUp;
 }
 
-const CTA_KEY = "detail.signup.cta" as const;
+export const SIGNUP_CTA_KEY = "detail.signup.cta" as const;
 const CTA_AGAIN_KEY = "detail.signup.ctaAgain" as const;
 
-export type SignupCtaKey = typeof CTA_KEY | typeof CTA_AGAIN_KEY;
+/**
+ * Every reason sign-up is SHUT, mapped to the copy that says so (#1976).
+ *
+ * The left column is `services/praxis.py`'s `SignupDenialReason`, value for
+ * value — the wire's own spelling, so a new gate on the backend shows up here
+ * as a missing row rather than as a silently generic button. Anything not in
+ * this table is not a denial, which is what {@link isSignupDenial} means; the
+ * fallthrough in {@link signupCtaKey} then treats it as the plain CTA, because
+ * a reason this build has never heard of must not blank the button.
+ *
+ * These live in the SAME map as the permitting keys on purpose. The task detail
+ * hides its CTA outright when sign-up is shut, so only the card renders these
+ * today — but a card that said "Must be level 4" out of its own private table
+ * while the detail page said something else is the exact drift #1497 built this
+ * file to end. If the card ever needs shorter words than the detail page, that
+ * is a copy edit inside this table, not a second table.
+ */
+const DENIAL_KEYS = {
+  below_level: "detail.signup.denied.belowLevel",
+  task_status_closed: "detail.signup.denied.taskStatusClosed",
+  already_active_member: "detail.signup.denied.alreadyActiveMember",
+  bank_full: "detail.signup.denied.bankFull",
+  is_metatask: "detail.signup.denied.isMetatask",
+} as const;
+
+export type SignupDenialKey = (typeof DENIAL_KEYS)[keyof typeof DENIAL_KEYS];
+
+export type SignupCtaKey =
+  | typeof SIGNUP_CTA_KEY
+  | typeof CTA_AGAIN_KEY
+  | SignupDenialKey;
+
+/**
+ * Whether the server's reason is a DENIAL — i.e. whether the affordance may be
+ * pressed at all.
+ *
+ * A caller asks this rather than comparing `can_sign_up`, because the reason is
+ * the thing it also needs for the label, and two reads of two fields can
+ * disagree. Nothing is re-derived: the answer is a lookup in the table above,
+ * which is the backend's own enum.
+ */
+export function isSignupDenial(
+  signupReason: string | null | undefined,
+): boolean {
+  return !!signupReason && signupReason in DENIAL_KEYS;
+}
 
 /**
  * The i18n key for the sign-up button, given the server's `signup_reason`.
@@ -49,13 +94,20 @@ export type SignupCtaKey = typeof CTA_KEY | typeof CTA_AGAIN_KEY;
  * against the catalog — a key typo stays a compile error, which is the whole
  * point of the typed catalog.
  *
+ * `detail.signup.denied.belowLevel` is the one key with an interpolation: it
+ * wants `{ level }`, and `TaskOut.level_required` is on the card payload as
+ * well as the detail one, so no caller has to go and fetch it.
+ *
  * Undefined and null get the same answer as any unrecognised reason: the plain
- * CTA. A reason this build has never heard of must not blank the button.
+ * CTA.
  */
 export function signupCtaKey(
   signupReason: string | null | undefined,
 ): SignupCtaKey {
+  if (signupReason && signupReason in DENIAL_KEYS) {
+    return DENIAL_KEYS[signupReason as keyof typeof DENIAL_KEYS];
+  }
   return signupReason === SIGNUP_REASON_MULTI_MEMBERSHIP
     ? CTA_AGAIN_KEY
-    : CTA_KEY;
+    : SIGNUP_CTA_KEY;
 }

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -159,12 +159,38 @@ describe('task-browse card + CTA parity (ADR-0056)', () => {
     }
   })
 
-  it('hides the CTA on both when the task refuses the viewer a praxis', () => {
+  it('hides the CTA on both when the task refuses the viewer without saying why', () => {
+    // `can_sign_up: false` with no `signup_reason` is a shape the server does
+    // not send to a signed-in viewer, but it is the shape a sixth backend gate
+    // would arrive in before this build has copy for it — and the answer then
+    // is silence, never a button the server will refuse (#1976).
     const barred: TaskOut = { ...TASK, can_sign_up: false }
     for (const formFactor of ['mobile', 'desktop'] as const) {
       dispatch.formFactor = formFactor
       state.current = { ...CANNED, user: VIEWER, tasks: [barred] }
       expect(text(), formFactor).not.toContain(SIGNUP)
+    }
+  })
+
+  // #1976 — the owner-reported surface. This list used to withhold `onSignup`
+  // whenever `can_sign_up` was false, so a task the browse was still SHOWING
+  // said nothing at all about why it could not be taken, while the detail page
+  // for that same task had read `signup_reason` since #1497.
+  it('states the reason on both when the task names why it refuses', () => {
+    const barred: TaskOut = {
+      ...TASK,
+      can_sign_up: false,
+      signup_reason: 'below_level',
+      level_required: 4,
+    }
+    for (const formFactor of ['mobile', 'desktop'] as const) {
+      dispatch.formFactor = formFactor
+      state.current = { ...CANNED, user: VIEWER, tasks: [barred] }
+      expect(text(), formFactor).toContain(
+        i18n.t('tasks:detail.signup.denied.belowLevel', { level: 4 }),
+      )
+      expect(text(), `${formFactor}: no longer calls it a sign-up`).not.toContain(SIGNUP)
+      expect(html(), `${formFactor}: and it is not pressable`).toContain('aria-disabled="true"')
     }
   })
 

--- a/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
+++ b/frontend/src/pages/tasks/mobileArchetypes/DefaultTasks.tsx
@@ -86,13 +86,16 @@ export default function DefaultTasks({ state }: { state: TasksState }) {
             {isMetatask ? (
               <MetataskSeal metatasks={tasks} />
             ) : (
+              // Same rule as the desktop list: the card decides claim-vs-reason
+              // off `task.signup_reason` (#1976), so this only decides whether
+              // there is a viewer to say anything to.
               tasks.map((task) => (
                 <TaskCard
                   key={task.id}
                   task={task}
                   basePoints={task.point_value}
                   multiplier={displayMultiplierFor(task)}
-                  onSignup={user && task.can_sign_up ? handleSignup : undefined}
+                  onSignup={user ? handleSignup : undefined}
                 />
               ))
             )}


### PR DESCRIPTION
A task card's bottom button said **"Sign up"** on a task the server was always
going to refuse — or, where the list gated on `can_sign_up`, said nothing at all
about a task it was still showing. Either way the card and the detail page for
the same task disagreed, and the detail page has read `TaskOut.signup_reason`
since #1497.

Now the card states the reason: *"Must be level 4"*, and it is not pressable.

## The seam I'm testing at

`TaskOut.signup_reason` → `signupCtaKey` (the one mapper, shared with the eight
task-detail archetypes) → the nine card skins' single action slot: both what it
says and whether a control exists there at all.

Not the network, not the eligibility rule. Nothing here re-derives who may claim
what; the server's ruling arrives on the wire and this decides what to draw.

## What changed

**`pages/taskDetail/signupCta.ts` — one mapper, widened.** `signupCtaKey` gains
a table of the five `SignupDenialReason` values from `services/praxis.py`, keyed
by the wire's own spelling so a sixth backend gate shows up as a missing row
rather than as a silently generic button. New sibling `isSignupDenial` answers
"may this be pressed", from the same table. No second mapper — if the card ever
wants shorter words than the detail page, that is a copy edit inside this table.

**`components/taskCard/signupAffordance.ts` (new) — the card's adapter.** Returns
`null` (no slot), a live claim with an `onPress`, or a denial with **no
`onPress`**. The absence of that field is the enforcement: the nine skins spread
it onto their button, so no skin can reattach the dead end.
`pages/fieldDesk/PendingRowPill.tsx` states the doctrine this honours.

**The nine skins** render `{cta.label}` with `onClick={cta.onPress}` and
`aria-disabled={cta.denied || undefined}`. Albescent is untouched — it forwards
whole to `DefaultTaskCard` (ADR-0048), so it inherits this the way it inherits
everything else.

**Three browse call sites** (`Tasks.tsx`, `tasks/mobileArchetypes/DefaultTasks.tsx`,
`Home.tsx`) stop withholding `onSignup` when `can_sign_up` is false. That gate is
what made the list go silent; the card decides claim-vs-reason now. Anonymous
viewers still get nothing — the server sends them no reason to explain.
`FieldDesk.tsx` already passed `onSignup` unconditionally, so its cards used to
offer a button the server would 403; that is fixed by the same change.

## Copy

`tasks.json`, under `detail.signup.denied`. `below_level` interpolates
`task.level_required`, which is confirmed on the card payload (`TaskOut` in
`schema.d.ts`) — no extra fetch, no generic "you cannot".

## A finding, and a behaviour I did NOT change

`can_sign_up: false` with `signup_reason: null` **hides the slot** rather than
labelling it. That shape is not one the server sends a signed-in viewer, but it
is how a sixth backend gate would arrive before this build has copy for it, and
a card cannot state a reason it does not have. `dispatch.test.tsx` already pinned
this end to end and went red when my first cut got it wrong; it now pins it on
purpose. Hiding is also exactly the pre-#1976 behaviour, so the fallback is a
no-op rather than a new rule.

## What I deliberately did NOT do

The nine `feed:taskCard.{F}.signup` keys stay nine. **#1864 owns collapsing
them** (`locales/__tests__/catalog.test.ts` says so in as many words), and
`taskCard.albescent.signup` is deliberately unsettled under ADR-0048 — a
per-faction verb is as identifying as a per-faction hue, so the Albescent card
speaks na's word and its own stays orphaned. Flattening that in passing is a
copy ruling, not a refactor this issue gets to make. The adapter takes the
faction verb as a parameter with a `ponytail:` comment naming #1864 as the
upgrade path; when it lands, the parameter loses its reason to exist.

`multi_membership` (Double Dipper) is routed through the mapper too, so the card
now says "Begin again" where the detail page always has. That was the same
card/detail disagreement, one key over.

## Checks

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`,
`npm test` (283 files, 4991 passing), `npm run build`, `npm run budget` — all
green locally, on a branch rebased onto `origin/main`. Backend untouched, so the
`test` and `api-schema` jobs have nothing to say about this.

The card suites went red first: 24 failures across the eight manifest rows before
the skins changed. The harness is `renderToStaticMarkup`, which never serialises
an event handler — so "not pressable" is asserted value-out in
`signupAffordance.test.ts` (no `onPress` on a denial) and the a11y state is
asserted in markup (`aria-disabled="true"`) across all nine skins.

**Visual QA is outstanding.** I have no browser and no dev stack, so nothing here
has been looked at. One styling question is deferred to `frontend-style`: a
denied slot currently differs from a live one only by its words and its
`cursor: not-allowed` — several skins (Everymen, S.N.I.D.E.) fill their button
with a solid faction ground, and a refusal wearing a call-to-action's fill may
want a dimmed treatment. I did not invent one.

## What to eyeball

Signed in, on `/tasks` with the eligibility filter switched **off** (and on
the field desk, whose browse never filtered), across the nine skins and both
themes:

- **A task above your level** — reads "Must be level N" with your actual shortfall,
  not a generic refusal. The longest string on the densest layout; if anything
  breaks a card's width it is this one.
- **A closed task** (retired/pending) — "No longer open".
- **A full bank** — "No task slots open", on every card at once, which is the
  case where the whole list turns into refusals.
- **A task you can take** — unchanged: the faction's own verb, live, pressable.
- **A task you are already on, as a Coven member** (Double Dipper) — "Begin
  again", live. This one is a permit; if it renders greyed the denial check has
  swallowed an allowing reason.
- **Logged out** — no slot at all, on any card.

Closes #1976
