### PR TITLE
The word count stops explaining the toolbar above it (#1967)

### DIFF
--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -302,7 +302,7 @@
     "bodyFrozen": "Frozen while the crew's publish window is open. Submitting locks the write-up for everyone — including whoever submitted — so nothing changes under a submission already made.",
     "bodyFrozenMidEdit": "Someone submitted while you were writing, so the write-up froze mid-sentence. Anything you typed after that never reached the crew and cannot be recovered — you will have to write it again.",
     "bodyFrozenAction": "Reopen the write-up for the crew",
-      "wordCount": "{{words}} words · markdown ok",
+      "wordCount": "{{words}} words",
       "proofLabel": "Proof",
       "proofButton": "Drop a photo of the work\nor browse files",
       "proofHelper": "Photos, clips or receipts — max 50 MB each.",


### PR DESCRIPTION
Closes #1967

## What changed

One catalog string, one file.

```diff
-      "wordCount": "{{words}} words · markdown ok",
+      "wordCount": "{{words}} words",
```

`frontend/src/locales/en/forms.json:305`. The `·` separator goes with the phrase, per the ruling.

## The seam

**The catalog string, read back through `i18n.t()`.** That seam already has a test: `composerRule.test.tsx` asserts each of the eight archetypes renders `i18n.t("forms:editPraxis.composer.wordCount", { words: 4 })` exactly once, before the tablist and before the body box. It resolves the catalog at runtime rather than hardcoding the literal, so it is the check that would have caught a broken interpolation — and it stays green on the new string. A catalog swap with an unchanged interpolation shape is the trivial case, so no new test was added.

## Why remove rather than clarify

The affordance announces itself. Every edit-praxis archetype draws the seven-button markdown toolbar (bold / italic / heading / quote / bullets / numbers / link) directly above the body, with a Write / Preview tab pair beside it. `hideToolbar` exists as a skin option in `controls.tsx` but no archetype passes it, so the buttons are present on all eight.

## Verification of the ruling's scope notes

Each confirmed against `origin/main` (`5ade5fdc`) rather than assumed:

- **Line 305 is still the line.** `git show origin/main:frontend/src/locales/en/forms.json | grep -n wordCount` → 305. The ruling's citation had not rotted.
- **Eight call sites, none edited.** `git grep wordCount` finds `Coven` / `Default` / `Ephemerists` / `Everymen` / `Singularity` / `Snide` / `Ua` / `Wow`, all rendering `t("editPraxis.composer.wordCount", { words: state.wordCount })`. The interpolation shape is unchanged, so no component moves.
- **No test hardcodes the literal.** The only reference is `composerRule.test.tsx:212`, through `i18n.t()`.
- **`en` is the only catalogue.** No sibling string to chase.
- **This was the only place the product says "markdown" to a player.** A case-insensitive grep across `frontend/src` returns this string and nothing else user-facing — the rest are CSS class names (`.markdown-preview`), identifiers (`MarkdownPreview`, `applyMarkdown`, `markdownStyle`), test names, and code comments. Nothing to widen into.

## Checks run (every step `.github/workflows/test.yml` names for the `frontend` job)

- `npm run lint` — clean
- `npm run typecheck` (`tsc --noEmit`) — 0 errors (`tsc --version` → 5.9.3 confirmed before believing it)
- `npm run typecheck:design-sync` — clean
- `npm test` — **294 files, 5110 passed, 1 skipped**, 0 failed
- `npm run build` — built
- `npm run budget` — within budget (JS 128.1 KB, CSS 23.0 KB; unchanged, a catalog string is not a blocking asset)

Backend untouched, so the `test` and `api-schema` jobs have nothing to react to.

## What to eyeball

- **The composer's Write-up header row, on any archetype.** The word count now reads `12 words` with no trailing separator — confirm the line does not look truncated or orphaned now that it is a single token, and that nothing was relying on the `·` for visual weight in that row.
- **The zero state.** `0 words` on an empty body, before the separator had anything to separate.
- **The markdown toolbar is genuinely visible** on all eight archetypes — that visibility is the whole argument for deleting the prose. If any kit hides it, the removal is wrong there.
- **Right-aligned or narrow layouts** (Coven, Ephemerists, UA run tighter type) — the string got ~12 characters shorter, so any row that was balancing against its old width will shift.

Visual QA is outstanding: I have no browser tooling or dev stack, so everything above is verified through tsc, eslint, vitest, the build and the byte budget only. No CSS and no component changed, so there is no styling question deferred to `frontend-style`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)