### PR TITLE
Vendor the Coven point-card and vote-plate designs for the build pair

### DIFF
--- a/.design-sync/coven-stamps/BRIEF-coven-stamps.md
+++ b/.design-sync/coven-stamps/BRIEF-coven-stamps.md
@@ -1,0 +1,123 @@
+# Brief — Cozy Coven point card + light-mode vote plate
+
+Vendored 2026-08-17 from Claude design project `8766d74b-5280-45c5-ae36-e980dfe1f3a9`
+(files `TallyStamp.dc.html`, `VoteStamp.dc.html`). Owner-grilled the same day.
+
+Per `docs/agents/design-fidelity.md`: **port from the source files in this
+directory**, not from the issue's description of them. Every deviation goes in
+the PR body. The last PR of this pair deletes `.design-sync/coven-stamps/`.
+
+> **The scope rule for both files: this is 100% visual and 0% new mechanics.**
+> Owner ruling, verbatim. No payload field, no service, no resolver, no copy
+> string changes. If a change you are about to make alters what a number *is*
+> rather than how it *looks*, you have left scope.
+
+---
+
+## Corrections to the vendored copy — read before porting
+
+The design files are annotated below rather than edited, so they stay a faithful
+record of what was drawn.
+
+### TallyStamp.dc.html
+
+1. **Its `breakdown()` is a stale mirror of `scoreBreakdown.ts`.** The comment at
+   the top of the script claims to mirror
+   `frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts`. It does
+   not: it has **no `habit` term** (added by #1617) and it keeps `votes` as
+   `0`-or-number where the real resolver nulls it at `<= 0` (ADR-0076).
+   **Call the repo's `scoreBreakdown()`. Do not port the design's copy of it.**
+2. **The `vessel` prop is not a live choice.** It offers `cauldron | crystal
+   ball`. **Owner ruling: cauldron.** Ignore the `isCrystal` branch entirely; do
+   not build a toggle.
+3. **The 8-case grid is a spec sheet, not a layout.** The page title, the
+   per-case titles/notes, and the `width:210px` columns are the presentation of
+   the *specimen sheet*. Only one case is a component.
+4. **No case exercises `crowned`.** `is_top_for_task` is never set in any spec,
+   so the `♛` branch is undrawn in every rendered case.
+
+### VoteStamp.dc.html
+
+1. **It is a comparison sheet.** Both plates render stacked so the sun can be
+   seen beside the moon. **The shipping component renders exactly one plate.**
+2. **Its `moonNode` is a simplified redraw of what already ships**, missing three
+   ornament families that are live in `CovenVote.tsx` — see ruling 6 below.
+3. **Its theme detection is not the repo's.** The `MutationObserver` +
+   `readTheme()` + `state.theme` machinery reinvents `useTheme()`
+   (`frontend/src/hooks/useTheme.tsx`). No component in this repo reads
+   `data-theme` off the DOM.
+4. **Its labels are not the shipped copy** and its eyebrow reinstates a slot
+   #1909 deleted — see ruling 3 below.
+
+---
+
+## The ten rulings
+
+| # | Question | Ruling |
+|---|---|---|
+| 1 | The `Group` row (`base + meta`) — shared or local? | **Local.** Computed in the Coven skin from two values `scoreBreakdown` already returns. No change to `ScoreBreakdown`, no ADR-0049 amendment. |
+| 2 | Pirata One, or an existing face? | **Existing.** `var(--font-faction-witch)` (Grenze Gotisch) in all three places. Do not add a 19th font family. |
+| 3 | Does the vote copy change? | **No.** `VOTE_REFRAMES['coven']` and `votes.json` are untouched, and **the "how true did it land" eyebrow is not built** — #1909 deleted that slot on purpose. |
+| 4 | How does the sun/moon swap happen? | **`useTheme()` picks the motif; tokens carry every colour.** The ternary chooses a component, never a hex. |
+| 5 | Does the full plate + cauldron land on both stamp surfaces? | **Yes, both** — the praxis card *and* the composer task slip. |
+| 6 | Does the moon keep its ornaments? | **Yes — the moon is untouched.** This work adds a sun; it does not open the existing dark path. |
+| 7 | Design hexes, or the tokens they nearly are? | **Tokens.** Map each design colour to the nearest existing `--faction-coven-slip-*`. |
+| 8 | Is the three-way row colour-code deliberate? | **Yes, ship it** — base pink, mult dark gold, votes blue — as new measured tokens with light **and** dark values. |
+| 9 | The cast burst? | **Not built.** The sun gets *the flourish the moon already has* — dust motes and rank-5 sparkles — not the design's ring-and-11-sparks. |
+| 10 | Does the stamp keep its `rotate(-3deg)` tilt? | **No.** The new composition renders upright as drawn. |
+
+---
+
+## Facts established during the grill — verified, reuse rather than re-derive
+
+**Six of TallyStamp's palette entries are already repo tokens, exactly:**
+
+| design var | hex | token |
+|---|---|---|
+| `--pk` | `#ec4f92` | `--faction-coven-slip-pk` |
+| `--pk-deep` / `--seal` | `#c9327a` | `--faction-coven-slip-deep` |
+| `--pk-dk` | `#8f2557` | `--faction-coven-slip-ink` |
+| `--pk-lt` | `#fbc4dd` | `--faction-coven-slip-mid` |
+| `--border` | `#f4a9cc` | `--faction-coven-slip-border` |
+| `--yl` | `#f4c430` | `--faction-coven-slip-gold` |
+
+All six have dark-mode values at `index.css:2647-2659`. **Porting the literals
+would ship a light-only card** — the current stamp responds to dark mode today,
+so that is a regression, not fidelity.
+
+The design's near-misses run **lighter than the token they resemble**, and both
+are painted on text: `--pk-soft` `#b8517f` vs `--faction-coven-slip-soft`
+`#973660`; `--label` `#b06a92` vs `--faction-coven-slip-label` `#83466a`.
+`covenSlip.tsx:22-45` carries the measurements — `INK`/`SOFT`/`LABEL` are the
+three tiers that clear AA, `DEEP` is already 4.44:1, and `PINK` is **ornament
+only** at 3.07:1. Take the tokens.
+
+**`.coven-moon-dust` and `.coven-moon-sparkle` are motion-only** — both live
+inside `@media (prefers-reduced-motion: no-preference)` (`index.css:4108-4109`)
+and take their stagger from `--tw-delay`. Colour comes from the SVG `fill`, so
+the sun reuses both classes verbatim with sun-token fills. No new keyframes.
+`--tw-delay` is a **real app variable**, not a Tailwind internal (#1318).
+
+**`ScoreStamp` dispatches on `praxis.task_faction_slug`** — the *task's* faction
+(`ScoreStamp.tsx:87`). A UA character's praxis on a Coven task therefore renders
+`CovenScoreStamp` **with a live habit row**, a case the design never draws.
+
+**`ScoreStamp` has two consumer families**, and Coven passes no `mark` override,
+so both get this change:
+- `components/praxisCard/desktop/shared.tsx:190` — the praxis card's right column
+- `pages/editPraxis/archetypes/shared.tsx:1009` — the composer task slip (#1828)
+
+**No existing test renders `CovenVote`.** `voteUI.test.tsx` dispatches with
+`factionSlug={null}` to `DefaultVote`. Note `useTheme()` **throws** outside a
+`ThemeProvider`, so any new Coven vote test must wrap it.
+
+---
+
+## The trap that will not show up in a green build
+
+**`Group` is `base + meta` and must never include `habit`.** The habit bonus is
+flat and sits *outside* the multiplier (`scoreBreakdown.ts:50-57`) — multiplying
+it would make the same faction ability worth more under a non-neutral era than
+under Era 1. Because the stamp dispatches on the task's faction, this skin does
+see live habit rows, and a `Group` that swallowed one would print arithmetic
+that does not reach the printed total. The design never shows that case.

--- a/.design-sync/coven-stamps/TallyStamp.dc.html
+++ b/.design-sync/coven-stamps/TallyStamp.dc.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="stylesheet" href="_ds/world-zero-frontend-kit-11486504-5815-4db4-b388-26d1cb494917/_ds_bundle.css">
+<link rel="stylesheet" href="_ds/world-zero-frontend-kit-11486504-5815-4db4-b388-26d1cb494917/styles.css">
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,600;1,500;1,600&family=Pirata+One&family=Quicksand:wght@500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root{ --pk:#ec4f92; --pk-deep:#c9327a; --pk-dk:#8f2557; --pk-soft:#b8517f; --pk-lt:#fbc4dd; --card:#fff6fb; --label:#b06a92; --border:#f4a9cc; --yl:#f4c430; --yl-dk:#c9932a; --acc-vio:#9b6ad0; --seal:#c9327a; }
+  @keyframes sigilGlow{ 0%,100%{ filter:drop-shadow(0 0 2px var(--seal)) } 50%{ filter:drop-shadow(0 0 8px var(--seal)) } }
+  @keyframes bub{ 0%{ opacity:0; transform:translateY(7px) scale(.7) } 30%{ opacity:.9 } 100%{ opacity:0; transform:translateY(-22px) scale(1.05) } }
+  .sigil{ transform-box:fill-box; transform-origin:center; animation:sigilGlow 3.4s ease-in-out infinite }
+  .bub{ transform-box:fill-box; transform-origin:center; animation:bub 3.2s ease-in-out infinite }
+  .bub.b2{ animation-delay:1.1s } .bub.b3{ animation-delay:2.1s }
+</style>
+</helmet>
+<div style="font-family:'Quicksand',sans-serif; padding:28px 26px 40px;">
+  <div style="text-align:center; margin-bottom:6px;">
+    <div style="font-family:'Pirata One',cursive; font-size:34px; letter-spacing:.05em; color:var(--seal); line-height:1;">Points</div>
+    <div style="font-size:9px; font-weight:700; letter-spacing:.18em; text-transform:uppercase; color:var(--label); margin-top:8px;">every state scoreBreakdown() can produce</div>
+  </div>
+
+  <div style="display:flex; flex-wrap:wrap; gap:28px; justify-content:center; align-items:flex-start; margin-top:30px;">
+    <sc-for list="{{ cases }}" as="c" hint-placeholder-count="8">
+      <div style="display:flex; flex-direction:column; align-items:center; gap:12px; width:210px;">
+        <div style="text-align:center;">
+          <div style="font-family:'Cormorant Garamond',serif; font-style:italic; font-weight:600; font-size:17px; color:var(--pk-dk);">{{ c.title }}</div>
+          <div style="font-size:9.5px; font-weight:600; letter-spacing:.06em; color:var(--label); margin-top:3px; text-wrap:pretty;">{{ c.note }}</div>
+        </div>
+
+        <sc-if value="{{ c.showPlate }}" hint-placeholder-val="{{ true }}">
+        <div style="position:relative; padding:30px 22px 22px; min-width:150px; background:linear-gradient(180deg,var(--card),color-mix(in srgb,var(--pk-lt) 34%,var(--card))); border:2.5px solid var(--seal); border-radius:92px 92px 20px 20px / 108px 108px 20px 20px; box-shadow:0 7px 18px rgba(201,50,122,.22), inset 0 0 22px color-mix(in srgb,var(--seal) 12%,transparent);">
+          <span style="position:absolute; inset:4px; border:1px dashed color-mix(in srgb,var(--seal) 55%,transparent); border-radius:88px 88px 16px 16px / 104px 104px 16px 16px; pointer-events:none;"></span>
+          <sc-if value="{{ c.crowned }}">
+            <span style="position:absolute; top:-14px; right:-10px; z-index:3; font-size:26px; line-height:1; transform:rotate(8deg); color:var(--yl); text-shadow:0 1px 3px rgba(201,50,122,.35);">♛</span>
+          </sc-if>
+          <div style="display:flex; align-items:center; justify-content:center; gap:9px; margin-bottom:10px;">
+            <span style="color:var(--yl-dk); font-size:15px;">☾</span>
+            <span style="font-family:'Pirata One',cursive; font-size:23px; letter-spacing:.06em; color:var(--seal); line-height:1;">Points</span>
+            <span style="color:var(--yl-dk); font-size:15px;">☽</span>
+          </div>
+          <sc-for list="{{ c.rows }}" as="r" hint-placeholder-count="2">
+            <div style="{{ r.rowStyle }}">
+              <span style="display:flex; align-items:baseline; gap:6px; font-family:'Cormorant Garamond',serif; font-style:italic; font-weight:600; font-size:16.5px; letter-spacing:.02em; color:var(--pk-soft);"><span style="font-size:10px; color:var(--seal); opacity:.7;">✦</span>{{ r.label }}</span>
+              <span style="{{ r.valStyle }}">{{ r.val }}</span>
+            </div>
+          </sc-for>
+          <sc-if value="{{ c.bare }}">
+            <div style="text-align:center; font-family:'Cormorant Garamond',serif; font-style:italic; font-size:15px; color:var(--pk-soft); padding:4px 0 2px;">no working shown</div>
+          </sc-if>
+        </div>
+        </sc-if>
+
+        <sc-if value="{{ c.isCauldron }}">
+        <div style="position:relative; width:158px; height:158px; margin-top:2px; display:flex; align-items:center; justify-content:center; color:var(--seal);">
+          <svg width="158" height="158" viewBox="0 0 132 132" style="position:absolute; inset:0;" aria-hidden="true">
+            <g class="bub" fill="none" stroke="var(--seal)" stroke-width="1.6" opacity=".8"><circle cx="50" cy="38" r="4.5"></circle></g>
+            <g class="bub b2" fill="none" stroke="var(--seal)" stroke-width="1.4" opacity=".8"><circle cx="68" cy="28" r="3"></circle></g>
+            <g class="bub b3" fill="none" stroke="var(--seal)" stroke-width="1.6" opacity=".8"><circle cx="82" cy="36" r="5.5"></circle></g>
+            <g class="sigil">
+              <path d="M46 108 l-5 13" stroke="var(--seal)" stroke-width="2.4" stroke-linecap="round"></path>
+              <path d="M86 108 l5 13" stroke="var(--seal)" stroke-width="2.4" stroke-linecap="round"></path>
+              <path d="M25 54 C25 92 42 112 66 112 C90 112 107 92 107 54 Z" fill="var(--card)" fill-opacity=".94" stroke="var(--seal)" stroke-width="1.8"></path>
+              <ellipse cx="66" cy="54" rx="41" ry="8.5" fill="var(--card)" fill-opacity=".94" stroke="var(--seal)" stroke-width="1.8"></ellipse>
+              <ellipse cx="66" cy="54" rx="32" ry="5" fill="none" stroke="var(--seal)" stroke-width="1" opacity=".4"></ellipse>
+            </g>
+          </svg>
+          <div style="text-align:center; position:relative; z-index:2; margin-top:30px;">
+            <div style="font-family:'Cormorant Garamond',serif; font-weight:600; font-size:33px; line-height:.78; color:var(--pk-deep); margin-top:5px;">{{ c.total }}</div>
+            <div style="font-family:'Pirata One',cursive; font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--pk-soft); margin-top:3px;">points</div>
+          </div>
+        </div>
+        </sc-if>
+
+        <sc-if value="{{ c.isCrystal }}">
+        <div style="position:relative; width:158px; height:158px; margin-top:2px; display:flex; align-items:center; justify-content:center; color:var(--seal);">
+          <svg width="158" height="158" viewBox="0 0 132 132" style="position:absolute; inset:0;" aria-hidden="true">
+            <g class="sigil">
+              <path d="M40 108 q26 10 52 0 q-6 12 -26 12 q-20 0 -26 -12 Z" fill="var(--card)" fill-opacity=".94" stroke="var(--seal)" stroke-width="1.8" stroke-linejoin="round"></path>
+              <path d="M44 104 q22 -12 44 0" fill="none" stroke="var(--seal)" stroke-width="1.8" stroke-linecap="round"></path>
+              <circle cx="66" cy="64" r="39" fill="var(--card)" fill-opacity=".9" stroke="var(--seal)" stroke-width="1.8"></circle>
+              <circle cx="66" cy="64" r="31" fill="none" stroke="var(--seal)" stroke-width="1" opacity=".35"></circle>
+              <path d="M44 44 q9 -9 20 -10" fill="none" stroke="var(--seal)" stroke-width="2.4" stroke-linecap="round" opacity=".45"></path>
+            </g>
+            <g class="bub" fill="var(--seal)" opacity=".75"><path d="M96 26l1.5 4.4 4.4 1.5-4.4 1.5-1.5 4.4-1.5-4.4-4.4-1.5 4.4-1.5z"></path></g>
+            <g class="bub b2" fill="var(--seal)" opacity=".75"><path d="M32 22l1.1 3.3 3.3 1.1-3.3 1.1-1.1 3.3-1.1-3.3-3.3-1.1 3.3-1.1z"></path></g>
+            <g class="bub b3" fill="var(--seal)" opacity=".75"><path d="M110 62l1.1 3.3 3.3 1.1-3.3 1.1-1.1 3.3-1.1-3.3-3.3-1.1 3.3-1.1z"></path></g>
+          </svg>
+          <div style="text-align:center; position:relative; z-index:2;">
+            <div style="font-family:'Cormorant Garamond',serif; font-weight:600; font-size:33px; line-height:.78; color:var(--pk-deep);">{{ c.total }}</div>
+            <div style="font-family:'Pirata One',cursive; font-size:12px; letter-spacing:.18em; text-transform:uppercase; color:var(--pk-soft); margin-top:3px;">points</div>
+          </div>
+        </div>
+        </sc-if>
+
+        <sc-if value="{{ c.unscored }}">
+        <div style="width:158px; height:120px; display:flex; align-items:center; justify-content:center; text-align:center; border:1.5px dashed color-mix(in srgb,var(--seal) 40%,transparent); border-radius:16px; font-family:'Cormorant Garamond',serif; font-style:italic; font-size:16px; color:var(--pk-soft); padding:10px;">the stamp renders nothing</div>
+        </sc-if>
+      </div>
+    </sc-for>
+  </div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1080,&quot;height&quot;:1500},&quot;vessel&quot;:{&quot;editor&quot;:&quot;enum&quot;,&quot;options&quot;:[&quot;cauldron&quot;,&quot;crystal ball&quot;],&quot;default&quot;:&quot;cauldron&quot;,&quot;tsType&quot;:&quot;string&quot;}}">
+class Component extends DCLogic {
+  // mirrors frontend/src/components/praxisCard/scoreStamp/scoreBreakdown.ts
+  breakdown(p){
+    const rawBase = p.task_point_value ?? 0;
+    const rawMult = p.display_multiplier ?? 1;
+    const rawMeta = p.metatask_points ?? 0;
+    const mult = rawMult !== 1 ? rawMult : null;
+    const meta = rawMeta > 0 ? rawMeta : null;
+    const votes = p.points_from_votes ?? 0;
+    const total = p.score ?? 0;
+    const baseRestatesTotal = mult === null && meta === null && votes === 0 && total === rawBase;
+    return { base: baseRestatesTotal ? null : rawBase, mult, meta, votes, total };
+  }
+
+  renderVals(){
+    const vessel = this.props.vessel ?? 'cauldron';
+    const crystal = vessel === 'crystal ball';
+    const rowBase = { display:'flex', justifyContent:'space-between', gap:'14px', alignItems:'baseline', padding:'3px 0' };
+    const ruleRow = { ...rowBase, borderTop:'1.5px dashed color-mix(in srgb,var(--seal) 45%,transparent)', marginTop:'2px', paddingTop:'5px' };
+    const val = (strong, color) => ({ fontFamily:'Cormorant Garamond,serif', fontWeight:600, fontSize: strong?'21px':'19px', color: color||'var(--pk-dk)' });
+
+    const specs = [
+      { title:'Bare score', note:'base restates the total — no working printed', p:{ task_point_value:12, score:12 } },
+      { title:'Votes only', note:'points_from_votes lands on top of the base', p:{ task_point_value:12, points_from_votes:4, score:16 } },
+      { title:'Metatask', note:'metatask_points > 0 adds the +meta row', p:{ task_point_value:12, metatask_points:5, score:17 } },
+      { title:'Multiplier', note:'display_multiplier ≠ 1 draws ×mult', p:{ task_point_value:12, display_multiplier:1.5, score:18 } },
+      { title:'Meta × mult', note:'the group is multiplied, not the base', p:{ task_point_value:12, metatask_points:5, display_multiplier:1.5, score:25.5 } },
+      { title:'Everything', note:'all four fields at once', p:{ task_point_value:12, metatask_points:5, display_multiplier:1.5, points_from_votes:4, score:29.5 } },
+      { title:'Zero', note:'a scored praxis worth nothing still stamps', p:{ task_point_value:0, score:0 }, plateless:true },
+      { title:'Unscored', note:'score is null — the stamp returns null', p:{ task_point_value:12, score:null }, none:true },
+    ];
+
+    const cases = specs.map((s, i) => {
+      if(s.none){
+        return { key:i, title:s.title, note:s.note, rows:[], bare:false, crowned:false, showPlate:true,
+          isCauldron:false, isCrystal:false, unscored:true, total:'' };
+      }
+      const b = this.breakdown(s.p);
+      const rows = [];
+      if(b.base !== null) rows.push({ label:'Base', val:b.base, rowStyle:rowBase, valStyle:val(false,'#d1568a') });
+      if(b.meta !== null){
+        rows.push({ label:'Meta', val:'+'+b.meta, rowStyle:rowBase, valStyle:val(false) });
+        rows.push({ label:'Group', val:(s.p.task_point_value + b.meta), rowStyle:ruleRow, valStyle:val(true) });
+      }
+      if(b.mult !== null) rows.push({ label:'Mult', val:'×'+b.mult.toFixed(2), rowStyle:rowBase, valStyle:val(false,'#d9a521') });
+      if(b.votes !== 0) rows.push({ label:'Votes', val:(b.votes>0?'+':'')+b.votes, rowStyle:rowBase, valStyle:val(false,'#4f86c6') });
+      return {
+        key:i, title:s.title, note:s.note, rows,
+        bare: rows.length === 0,
+        showPlate: !s.plateless,
+        crowned: !!s.p.is_top_for_task,
+        isCauldron: !crystal, isCrystal: crystal, unscored:false,
+        total: Number.isInteger(b.total) ? b.total : Number(b.total.toFixed(1)),
+      };
+    });
+    return { cases };
+  }
+}
+</script>
+</body>
+</html>

--- a/.design-sync/coven-stamps/VoteStamp.dc.html
+++ b/.design-sync/coven-stamps/VoteStamp.dc.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="stylesheet" href="_ds/world-zero-frontend-kit-11486504-5815-4db4-b388-26d1cb494917/_ds_bundle.css">
+<link rel="stylesheet" href="_ds/world-zero-frontend-kit-11486504-5815-4db4-b388-26d1cb494917/styles.css">
+<link href="https://fonts.googleapis.com/css2?family=Caveat:wght@600;700&family=Quicksand:wght@500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root{ --pk:#ec4f92; --pk-deep:#c9327a; --pk-dk:#8f2557; --label:#b06a92; }
+  @keyframes vsSpark{ from{transform:translate(0,0) scale(1);opacity:1} to{transform:translate(var(--dx),var(--dy)) scale(0);opacity:0} }
+  @keyframes vsRing{ from{transform:translate(-50%,-50%) scale(.3);opacity:.85} to{transform:translate(-50%,-50%) scale(1.9);opacity:0} }
+  @keyframes vsPop{ 0%{transform:scale(1)} 45%{transform:scale(1.3)} 100%{transform:scale(1)} }
+  @keyframes arcaneIn{ from{opacity:0; transform:rotate(-40deg) scale(.5)} to{opacity:1; transform:rotate(0) scale(1)} }
+</style>
+</helmet>
+<div style="font-family:'Quicksand',sans-serif;">
+  <div style="font-size:8px; font-weight:700; letter-spacing:.18em; text-transform:uppercase; color:var(--label); margin-bottom:11px;">how true did it land</div>
+  <div ref="{{ rootRef }}" onMouseLeave="{{ clearHover }}" style="display:flex; flex-direction:column; gap:10px;">
+    <div style="{{ sunPlateStyle }}">
+      {{ sunBurstEl }}
+      <button ref="{{ s0.ref }}" onMouseEnter="{{ s0.onEnter }}" onClick="{{ s0.onClick }}" title="1" style="{{ s0.style }}">{{ s0.node }}</button>
+      <button ref="{{ s1.ref }}" onMouseEnter="{{ s1.onEnter }}" onClick="{{ s1.onClick }}" title="2" style="{{ s1.style }}">{{ s1.node }}</button>
+      <button ref="{{ s2.ref }}" onMouseEnter="{{ s2.onEnter }}" onClick="{{ s2.onClick }}" title="3" style="{{ s2.style }}">{{ s2.node }}</button>
+      <button ref="{{ s3.ref }}" onMouseEnter="{{ s3.onEnter }}" onClick="{{ s3.onClick }}" title="4" style="{{ s3.style }}">{{ s3.node }}</button>
+      <button ref="{{ s4.ref }}" onMouseEnter="{{ s4.onEnter }}" onClick="{{ s4.onClick }}" title="5" style="{{ s4.style }}">{{ s4.node }}</button>
+    </div>
+    <div style="{{ moonPlateStyle }}">
+      {{ moonBurstEl }}
+      <button ref="{{ g0.ref }}" onMouseEnter="{{ g0.onEnter }}" onClick="{{ g0.onClick }}" title="1" style="{{ g0.style }}">{{ g0.node }}</button>
+      <button ref="{{ g1.ref }}" onMouseEnter="{{ g1.onEnter }}" onClick="{{ g1.onClick }}" title="2" style="{{ g1.style }}">{{ g1.node }}</button>
+      <button ref="{{ g2.ref }}" onMouseEnter="{{ g2.onEnter }}" onClick="{{ g2.onClick }}" title="3" style="{{ g2.style }}">{{ g2.node }}</button>
+      <button ref="{{ g3.ref }}" onMouseEnter="{{ g3.onEnter }}" onClick="{{ g3.onClick }}" title="4" style="{{ g3.style }}">{{ g3.node }}</button>
+      <button ref="{{ g4.ref }}" onMouseEnter="{{ g4.onEnter }}" onClick="{{ g4.onClick }}" title="5" style="{{ g4.style }}">{{ g4.node }}</button>
+    </div>
+  </div>
+  <div style="{{ labelStyle }}">{{ label }}</div>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:320,&quot;height&quot;:230},&quot;value&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:5,&quot;min&quot;:1,&quot;max&quot;:5,&quot;tsType&quot;:&quot;number&quot;},&quot;accent&quot;:{&quot;editor&quot;:&quot;color&quot;,&quot;default&quot;:[&quot;#ec4f92&quot;,&quot;#a888dd&quot;,&quot;#7fb795&quot;],&quot;tsType&quot;:&quot;string&quot;},&quot;onCast&quot;:{&quot;editor&quot;:null,&quot;tsType&quot;:&quot;(v:number)=&gt;void&quot;}}">
+class Component extends DCLogic {
+  state = { hover:0, val:null, cast:0, tick:0, theme:'light' };
+
+  componentDidMount(){
+    this._obs = new MutationObserver(() => this.readTheme());
+    this._obs.observe(document.documentElement, { subtree:true, attributes:true, attributeFilter:['data-theme'] });
+    this.readTheme();
+  }
+
+  readTheme(){
+    const host = this._el && this._el.closest('[data-theme]');
+    const t = (host && host.getAttribute('data-theme')) || document.documentElement.getAttribute('data-theme') || 'light';
+    if(t !== this.state.theme) this.setState({ theme:t });
+  }
+
+  componentWillUnmount(){ clearInterval(this._tick); if(this._obs) this._obs.disconnect(); }
+
+  cast(v, motif){
+    clearInterval(this._tick);
+    this._btns = this._btns || { sun:{}, moon:{} };
+    const el = this._btns[motif] && this._btns[motif][v];
+    if(el) this._castPos = { x: el.offsetLeft + el.offsetWidth / 2, y: el.offsetTop + el.offsetHeight / 2 };
+    this.setState(s => ({ val:v, cast:s.cast+1, tick:s.tick+1, castMotif:motif }));
+    if(v===5){ this._tick = setInterval(() => this.setState(s => ({ tick:s.tick+1 })), 1500); }
+    if(this.props.onCast) this.props.onCast(v);
+  }
+
+  // light mode gets the sun — the same 1–5 climb, told in rays
+  sunNode(level){
+    const R = React.createElement;
+    const eff = this.state.hover || (this.state.val != null ? this.state.val : (this.props.value != null ? Number(this.props.value) : 5));
+    const reached = level <= eff;
+    const top = level === 5;
+    const size = top ? 40 : 30;
+    const disc = 7 + level * 0.9;
+    const gold = reached ? '#f4c430' : '#e3d6f6';
+    const edge = reached ? '#d99a1f' : '#c3a9e8';
+    const kids = [];
+    const rays = level * 2 + 2;
+    for(let i=0;i<rays;i++){
+      const a = (i/rays) * Math.PI * 2;
+      kids.push(R('line', { key:'r'+i,
+        x1: 15 + Math.cos(a)*(disc+2.4), y1: 15 + Math.sin(a)*(disc+2.4),
+        x2: 15 + Math.cos(a)*(disc+5.6), y2: 15 + Math.sin(a)*(disc+5.6),
+        stroke: gold, strokeWidth:1.6, strokeLinecap:'round', opacity: reached ? 1 : 0.7 }));
+    }
+    kids.push(R('circle', { key:'disc', cx:15, cy:15, r:disc, fill: reached ? '#fbe6a8' : '#efe6fa', stroke:edge, strokeWidth:1.2 }));
+    if(reached && top){
+      const line = (k,d,w) => R('path', { key:k, d, fill:'none', stroke:'#b06a1a', strokeWidth:w, strokeLinecap:'round' });
+      kids.push(R('g', { key:'face' }, [
+        line('e1','M11.2 13.8 Q12.4 12.4 13.6 13.8',1.2),
+        line('e2','M16.4 13.8 Q17.6 12.4 18.8 13.8',1.2),
+        line('m','M12.2 17.2 Q15 19.6 17.8 17.2',1.3),
+        R('circle', { key:'c1', cx:11, cy:16.4, r:1.5, fill:'rgba(236,95,153,.4)' }),
+        R('circle', { key:'c2', cx:19, cy:16.4, r:1.5, fill:'rgba(236,95,153,.4)' }),
+      ]));
+    }
+    return R('svg', { key:'s'+level+'-'+(reached?1:0), width:size, height:size, viewBox:'0 0 30 30',
+      'aria-hidden':true, style:{ overflow:'visible',
+        filter: reached ? 'drop-shadow(0 0 6px rgba(244, 196, 48, 0.55))' : 'none' } }, kids);
+  }
+
+  // the site's moon — CovenVote's phase disc (R=12 in a 30×30 field)
+  moonNode(level){
+    const R = React.createElement;
+    const RAD = 12;
+    const f = level / 5;
+    const rx = RAD * (1 - 2 * f);
+    const sweep = rx > 0 ? 0 : 1;
+    const phase = 'M15 ' + (15 - RAD) + ' A' + RAD + ' ' + RAD + ' 0 0 1 15 ' + (15 + RAD) +
+      ' A' + Math.abs(rx).toFixed(2) + ' ' + RAD + ' 0 0 ' + sweep + ' 15 ' + (15 - RAD) + 'Z';
+    const eff = this.state.hover || (this.state.val != null ? this.state.val : (this.props.value != null ? Number(this.props.value) : 5));
+    const reached = level <= eff;
+    const top = level === 5;
+    const size = top ? 40 : 30;
+    const kids = [
+      R('circle', { key:'disc', cx:15, cy:15, r:RAD, fill: reached ? 'var(--faction-coven-moon-disc-on)' : 'var(--faction-coven-moon-disc-off)' }),
+      R('path', { key:'phase', d:phase, fill: reached ? 'var(--faction-coven-moon-gold)' : 'var(--faction-coven-moon-lit-off)' }),
+      R('circle', { key:'ring', cx:15, cy:15, r:RAD, fill:'none', strokeWidth:1.2,
+        stroke: reached ? 'var(--faction-coven-moon-ring-on)' : 'var(--faction-coven-moon-ring-off)' }),
+    ];
+    if(reached && top){
+      const line = (k,d,w) => R('path', { key:k, d, fill:'none', stroke:'var(--faction-coven-moon-face)', strokeWidth:w, strokeLinecap:'round' });
+      kids.push(R('g', { key:'face' }, [
+        line('e1','M10.6 13.6 Q11.9 12.1 13.2 13.6',1.2),
+        line('e2','M16.8 13.6 Q18.1 12.1 19.4 13.6',1.2),
+        line('m','M12 17.4 Q15 20 18 17.4',1.3),
+        R('circle', { key:'c1', cx:10.4, cy:16.6, r:1.6, fill:'var(--faction-coven-moon-cheek)' }),
+        R('circle', { key:'c2', cx:19.6, cy:16.6, r:1.6, fill:'var(--faction-coven-moon-cheek)' }),
+      ]));
+    }
+    return R('svg', { key:'m'+level+'-'+(reached?1:0), width:size, height:size, viewBox:'0 0 30 30',
+      'aria-hidden':true, style:{ overflow:'visible',
+        filter: reached ? 'drop-shadow(0 0 6px rgba(190, 120, 225, 0.6))' : 'none' } }, kids);
+  }
+
+  burst(cid, accent){
+    if(!cid) return null;
+    const R = React.createElement;
+    const kids = [ R('span', { key:'ring', style:{
+      position:'absolute', left:'50%', top:'50%', width:'44px', height:'44px',
+      borderRadius:'50%', border:'2px solid '+accent, animation:'vsRing .7s ease-out forwards' } }) ];
+    for(let i=0;i<11;i++){
+      const a = (i/11)*Math.PI*2;
+      kids.push(R('span', { key:i, style:{
+        position:'absolute', left:'50%', top:'50%', width:'5px', height:'5px',
+        marginLeft:'-2.5px', marginTop:'-2.5px', borderRadius:'50%',
+        background:accent, boxShadow:'0 0 6px 1px '+accent,
+        animation:'vsSpark .68s ease-out forwards', animationDelay:(i*0.01)+'s',
+        '--dx':(Math.cos(a)*32)+'px', '--dy':(Math.sin(a)*32)+'px' } }));
+    }
+    const p = this._castPos || { x:36, y:22 };
+    return R('div', { key:cid, style:{ position:'absolute', left:p.x+'px', top:p.y+'px', width:0, height:0, zIndex:6, pointerEvents:'none' } }, kids);
+  }
+
+  renderVals(){
+    const accent = this.props.accent || 'var(--pk)';
+    const dark = this.state.theme === 'dark';
+    const base = this.props.value != null ? Number(this.props.value) : 5;
+    const eff = this.state.hover || (this.state.val != null ? this.state.val : base);
+    const labels = ['barely there','a faint flicker','it landed warm','it landed bright','alive'];
+    const out = {
+      label: labels[eff-1] || labels[0],
+      labelStyle: { fontFamily:"'Caveat',cursive", fontSize:'32px', lineHeight:'1', color:accent, marginTop:'9px', animation:'vsPop .4s ease' },
+      clearHover: () => this.setState({ hover:0 }),
+      rootRef: (el) => { this._el = el; if(el) this.readTheme(); },
+      sunPlateStyle: {
+        display:'flex', gap:'8px', alignItems:'center', justifyContent:'center',
+        position:'relative', padding:'8px 14px', borderRadius:'12px',
+        background:'radial-gradient(120% 150% at 50% -20%, #fdf1d6, #f6dfae)',
+        border:'1px solid #e6c78a',
+        boxShadow:'inset 0 1px 8px rgba(170,120,30,.16)',
+      },
+      moonPlateStyle: {
+        display:'flex', gap:'8px', alignItems:'center', justifyContent:'center',
+        position:'relative', padding:'8px 14px', borderRadius:'12px',
+        background: dark
+          ? 'radial-gradient(120% 150% at 50% -20%, var(--faction-coven-moon-plate-from), var(--faction-coven-moon-plate-to))'
+          : 'radial-gradient(120% 150% at 50% -20%, #efe6fb, #ddcbf4)',
+        border: '1px solid ' + (dark ? 'var(--faction-coven-moon-plate-border)' : '#c9b2ec'),
+        boxShadow: dark ? 'inset 0 1px 8px rgba(0,0,0,.5)' : 'inset 0 1px 8px rgba(120,80,170,.18)',
+      },
+      sunBurstEl: this.state.castMotif === 'sun' ? this.burst(this.state.cast, '#f4c430') : null,
+      moonBurstEl: this.state.castMotif === 'moon' ? this.burst(this.state.cast, '#c79bf0') : null,
+    };
+    const btnStyle = (picked) => ({
+      position:'relative', border:'none', background:'transparent', padding:0,
+      minWidth:'44px', minHeight:'44px',
+      display:'flex', alignItems:'center', justifyContent:'center', cursor:'pointer',
+      transform: picked ? 'scale(1.12)' : 'none',
+      transition: 'transform 150ms',
+    });
+    for(let i=1;i<=5;i++){
+      const picked = this.state.val === i;
+      out['s'+(i-1)] = {
+        node: this.sunNode(i),
+        ref: (el) => { this._btns = this._btns || { sun:{}, moon:{} }; this._btns.sun[i] = el; },
+        onEnter: () => this.setState({ hover:i }),
+        onClick: () => this.cast(i, 'sun'),
+        style: btnStyle(picked),
+      };
+      out['g'+(i-1)] = {
+        node: this.moonNode(i),
+        ref: (el) => { this._btns = this._btns || { sun:{}, moon:{} }; this._btns.moon[i] = el; },
+        onEnter: () => this.setState({ hover:i }),
+        onClick: () => this.cast(i, 'moon'),
+        style: btnStyle(picked),
+      };
+    }
+    return out;
+  }
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
Prerequisite for the two Cozy Coven build issues. Nothing ships to users — this adds `.design-sync/coven-stamps/` only.

`docs/agents/design-fidelity.md` requires designs be vendored into the repo for the life of the epic: **subagents cannot reach `claude.ai` design URLs from a worktree**, and a design summarised into an issue is prose. Both of these are almost entirely geometry — the plate's split `border-radius`, the cauldron's beziers, the sun's `level*2+2` ray maths — so prose would lose them.

## Contents

| file | what |
|---|---|
| `TallyStamp.dc.html` | the Coven point card — arched plate + cauldron, 8 breakdown states |
| `VoteStamp.dc.html` | the light-mode sun plate beside the existing dark moon plate |
| `BRIEF-coven-stamps.md` | the owner's ten rulings, plus corrections to the vendored copy |

## Why the brief exists

Policy step 2 is *"correct the labels in the vendored copy before dispatch — annotate, don't assume."* Both files carry claims that are stale against the code:

- `TallyStamp`'s `breakdown()` says it mirrors `scoreBreakdown.ts` and does not — **no `habit` term** (#1617), and `votes` kept as `0`-or-number where the resolver nulls it (ADR-0076). Agents must call the repo's resolver, not port the design's copy.
- `TallyStamp`'s `vessel` enum (`cauldron | crystal ball`) is not a live choice — owner ruled cauldron.
- `VoteStamp` reinvents `useTheme()` with a `MutationObserver`; no component in this repo reads `data-theme` off the DOM.
- `VoteStamp` reinstates the `chrome.{F}.prompt` eyebrow that **#1909 deleted on purpose**, and its five tier labels are not the shipped copy.

The brief also records the finding that mattered most: **six of the design's palette entries are already `--faction-coven-slip-*` tokens exactly**, and all six have dark-mode values. Porting the literals would ship a light-only card — a regression, since the current stamp responds to dark mode today.

The last PR of the build pair removes this directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)