### PR TITLE
Vendor the task-cards v3 design for the epic

### DIFF
--- a/.design-sync/task-cards/BRIEF-task-cards.md
+++ b/.design-sync/task-cards/BRIEF-task-cards.md
@@ -1,0 +1,145 @@
+# Brief — Task cards v3
+
+Vendored 2026-08-17 from Claude design project `41610660-5bc9-4ccf-8659-92cc43a44942`
+(`Task Cards.dc.html`). Owner-grilled the same day.
+
+Per `docs/agents/design-fidelity.md`: port from the vendored file, list deviations
+in every PR body, and let the epic's last PR delete `.design-sync/task-cards/`.
+
+---
+
+## Read this first: the design is a picture, not an implementation
+
+**Nothing in this design is portable code.** It is a *specimen sheet* that mounts
+the **existing** kit cards —
+
+```html
+<x-import component-from-global-scope="WZ.CovenTaskCard" …>
+```
+
+— and then runs ~1,090 lines of `DCLogic` that **mutate them in the DOM**: it finds
+the CTA with `button[data-boxed]`, identifies the faction by reading the *spec
+sheet's own heading text* (`/TaskCard$/i`), and re-dresses what it finds.
+
+Its sibling `eph-dress.css` is the same thing in CSS — selectors like
+`div[style*="repeating-linear-gradient(0deg, transparent 0 25px"]`,
+`svg:has(> ellipse[transform="rotate(-24 12 12)"])`, and
+`:nth-child(22n+7)::before { content: "Ψ" }`, all reaching into the *rendered
+inline styles* of shipped components to override them.
+
+`eph-dress.css`, `eph-dress.js` and `sigils.js` are **deliberately not vendored**.
+Policy step 3 says port production-intent code where the bundle ships it; this
+bundle ships none, and 40 KB of unportable override selectors would mislead
+rather than help. They remain in the design project if anyone wants to look.
+
+**So: read the design for WHAT CHANGES. Write the change in the real component.**
+A PR that introduces a `[style*=…]` selector or a DOM-mutating effect has
+misread this brief.
+
+### Two more stale claims in the file
+
+- `normalizeSignups()` matches `/take up the quest|i'm in|triangulate the truth|report for duty|enlist|answer the call/i`. **None of those are task-card CTAs on `main`** — they are invitation-letter copy. The #1863 / #1909 / #1939 sweep already retired them. Its only real effect is Albescent.
+- `rotateEphWordmark()`'s body reads *"Wordmark stays in English — the rotation is retired."* The wordmark does **not** rotate. Only the points label and the CTA do.
+
+---
+
+## The rulings
+
+| # | Question | Ruling |
+|---|---|---|
+| 1 | Does the copy normalise, or is this visual-only? | **Copy normalises.** One word for level, one for points, one for the CTA. |
+| 2 | The three non-Latin scripts | **Self-host subsets** — ten codepoints across three faces. Do **not** rely on the system fallback chain. |
+| 3 | How is the work cut up? | **Shared-first.** Copy, header anatomy and CTA shape land before any faction ornament issue starts. |
+| — | Screen readers | **The accessible name is the i18n string** — English, or Spanish on a Spanish site. Rotating glyphs are `aria-hidden`. |
+| — | Task Details | **Out of scope** for now (the sibling `Task Details.dc.html` is not part of this). |
+
+## What the design changes
+
+### Cross-faction (land these first)
+
+1. **Copy normalisation** — `feed.json` `taskCard.*`:
+   - level → `Level` (today: `Level` ×4, `level` ×3, `lvl`, `Lvl {{level}}`)
+   - points → `Points` (today: `points` ×4, `pts` ×2, `PTS` ×2, `pvncta`)
+   - CTA → `Sign up` (today 8 of 9 already say it; **only `albescent`'s "acknowledge" changes**)
+2. **Header anatomy** — one masthead shape: **sigil hard left, faction title centred**.
+   Seven of nine cards carry one. **UA and WOW gain a masthead they do not ship today.**
+   `na` and `albescent` stay bare.
+3. **CTA shape** — the skins that ship the sign-up as a full-bleed footer bar shrink to a
+   discrete inset button, with real air beneath it. Some factions also gain a drawn rule
+   above the CTA region (`default`, `albescent`, `ua`, `ephemerists` — `wow`, `snide`,
+   `singularity`, `coven`, `everymen` keep their own bottom treatment).
+
+### Per-faction ornament (parallel, after the above)
+
+| faction | what the design adds |
+|---|---|
+| `ua` | masthead in UA's hand; ensō score ring grown so "Points" clears the stroke; mandalas lose their outer ring and flank the CTA |
+| `wow` | plum masthead banner; gold wordmark; sigil off the card edge; bunting under the band; balloon knights beside the CTA |
+| `coven` | floating wordmark becomes a banded header; **the score sits in a bubbling cauldron**; CTA reads as a rounded box |
+| `everymen` | masthead names the faction; stamped points seal; fists-and-lightning flanking the CTA |
+| `snide` | bigger mark; sprayed CTA lettering; pen circle grown |
+| `singularity` | ASCII face drifting beside the CTA |
+| `ephemerists` | compass-rose points plate replaces the plain octagon; sigil moves onto the wordmark's row |
+| `albescent` / `na` | no masthead; rainbow rule above the CTA |
+
+### Separate, because each carries something no other card does
+
+- **The Ephemerists script rotation** — fonts + a11y. See below.
+- **The Coven watermark: pentagram → cat.** `.cvn-wheel` is mounted in **two** places
+  (`CovenTaskCard.tsx:242` and `CovenProfileBody.tsx:104`, whose docblock says the sharing
+  is deliberate), and the class carries `animation: cvn-wheel 120s linear infinite` — so as
+  drawn **the cat still slowly rotates**, and the profile either follows or diverges. Decide
+  both, explicitly.
+- **Faction backdrops** should follow the new cards (owner). Eight exist
+  (`components/backdrop/`, no Albescent, no `na`). **This is not drawn in the design** — the
+  look needs deciding before anyone builds it.
+
+---
+
+## The Ephemerists rotation, in full
+
+Two elements rotate; the wordmark does not.
+
+| element | cycle | frames |
+|---|---|---|
+| points label | 6.5s | `Points` → `PVNCTA` → `نقاط` → `点数` → `𒌦𒋫` |
+| CTA | 7.0s | `Sign up` → `ADSCRIBE` → `اشترك` → `参加` → `𒃻𒈬` |
+
+Each pins its box to the **widest** variant before starting, so the label can change
+script without the button resizing under it, then picks a random non-repeating frame
+each cycle. `pvncta` is therefore not deleted by the copy normalisation — it moves from
+being the static unit to being one turn of the wheel.
+
+**Fonts.** The repo carries **no Noto family**. Subset each to only the codepoints used:
+
+| frames | face | design's fallback (do not rely on it) |
+|---|---|---|
+| `نقاط` `اشترك` | Noto Naskh Arabic | `Geeza Pro` — macOS only |
+| `点数` `参加` | Noto Serif JP | `Hiragino Mincho ProN` — macOS only |
+| `𒌦𒋫` `𒃻𒈬` | Noto Sans Cuneiform | `Segoe UI Historic` — Windows only |
+
+Unsubset these would blow the budget; ten codepoints will not. The fallback chain fails
+**asymmetrically by platform** — cuneiform renders as tofu on Linux and Android while a Mac
+reviewer sees nothing wrong. `--font-faction-engraved` is **Cinzel** and is already loaded.
+
+**Accessibility.**
+- The accessible name is the **i18n string** — `Points` / `Sign up`, or their Spanish
+  equivalents on a Spanish site. The rotating glyphs are `aria-hidden`.
+- **Frame 1 is the live i18n string** (so it reads "Puntos" on a Spanish site); frames 2–5
+  are fixed ornament.
+- **`prefers-reduced-motion` pins the label to frame 1, static.** WCAG 2.2.2 covers
+  auto-updating content and 6.5s is inside it.
+- **The four non-Latin frames are NOT catalog entries.** They are decorative constants in
+  the component. In `feed.json` they would become four strings no translator can act on,
+  which is exactly the mess #440 does not need.
+
+---
+
+## Sequencing, and why
+
+Owner ruling: **shared passes land before any faction ornament issue starts.**
+
+The header anatomy and the CTA shape are shared by nine cards. Nine agents each inventing
+them produces nine slightly different versions — every branch green, `main` red. That has
+happened in this repo before. Land the shared work first and each faction issue becomes
+genuinely independent ornament.

--- a/.design-sync/task-cards/TaskCards.dc.html
+++ b/.design-sync/task-cards/TaskCards.dc.html
@@ -1,0 +1,1225 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="stylesheet" href="_ds/world-zero-frontend-kit-11486504-5815-4db4-b388-26d1cb494917/_ds_bundle.css">
+<link rel="stylesheet" href="_ds/world-zero-frontend-kit-11486504-5815-4db4-b388-26d1cb494917/styles.css">
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+Cuneiform&family=Permanent+Marker&display=swap">
+<link rel="stylesheet" href="eph-dress.css">
+<script>window.__dsPreview = window.__dsPreview || {};</script>
+<script src="_ds/world-zero-frontend-kit-11486504-5815-4db4-b388-26d1cb494917/_ds_bundle.js"></script>
+<style>
+body{margin:0;background:var(--color-bg-page,#faf8f4)}
+@keyframes uaHueOuter{0%,100%{color:#f0894a}25%{color:#f5c542}50%{color:#c1653f}75%{color:#e8a15e}}
+@keyframes uaHueMid{0%,100%{color:#f4d472}30%{color:#e07a3a}65%{color:#b45a22}}
+@keyframes uaHueInner{0%,100%{color:#ffd9a0}40%{color:#e86a2c}70%{color:#f5c542}}
+@keyframes uaPetalPop{0%{opacity:0;transform:scale(.55)}12%{opacity:1;transform:scale(1)}62%{opacity:1;transform:scale(1)}80%,100%{opacity:0;transform:scale(.55)}}
+.ua-mand g{transform-origin:50% 50%;animation:uaHueInner 11s ease-in-out infinite,uaPetalPop 8s ease-in-out infinite}
+.ua-mand g:nth-child(1){animation:uaHueOuter 11s ease-in-out -0.4s infinite,uaPetalPop 8s ease-in-out 0s infinite}
+.ua-mand g:nth-child(2){animation:uaHueMid 11s ease-in-out -1.8s infinite,uaPetalPop 8s ease-in-out .8s infinite}
+.ua-mand g:nth-child(3){animation:uaHueInner 11s ease-in-out -3.2s infinite,uaPetalPop 8s ease-in-out 1.6s infinite}
+.ua-mand g:nth-child(4){animation:uaHueMid 11s ease-in-out -4.6s infinite,uaPetalPop 8s ease-in-out 2.4s infinite}
+.ua-mand g:nth-child(5){animation:uaHueOuter 11s ease-in-out -6s infinite,uaPetalPop 8s ease-in-out 3.2s infinite}
+.ua-mand g:nth-child(6){animation:uaHueInner 11s ease-in-out -7.4s infinite,uaPetalPop 8s ease-in-out 4s infinite}
+@keyframes cvnBubble{0%{transform:translateY(0) scale(.55);opacity:0}18%{opacity:.95}100%{transform:translateY(-30px) scale(1.1);opacity:0}}
+.cvn-bub{animation:cvnBubble 4.6s ease-in-out infinite;transform-box:fill-box;transform-origin:50% 50%}
+.cvn-bub:nth-of-type(2){animation-duration:5.4s;animation-delay:-1.6s}
+.cvn-bub:nth-of-type(3){animation-duration:6.2s;animation-delay:-3.1s}
+@keyframes sgFloat{0%,100%{transform:translateY(0);opacity:.45}50%{transform:translateY(-6px);opacity:.8}}
+.sg-ascii{animation:sgFloat 6s ease-in-out infinite}
+@keyframes evmCrackle{0%,100%{opacity:0}4%{opacity:1}9%{opacity:.15}13%{opacity:.9}18%{opacity:0}52%{opacity:0}56%{opacity:.8}60%{opacity:0}}
+.evm-arc{animation:evmCrackle 1.15s steps(1,end) infinite}
+@keyframes evmShake{0%,100%{transform:translate(0,0) rotate(0deg)}20%{transform:translate(1.4px,-1px) rotate(.5deg)}40%{transform:translate(-1.2px,.8px) rotate(-.45deg)}60%{transform:translate(1px,1.2px) rotate(.35deg)}80%{transform:translate(-.9px,-1.1px) rotate(-.3deg)}}
+.evm-shake{transform-box:fill-box;transform-origin:50% 50%;animation:evmShake .32s steps(1,end) infinite}
+@keyframes evmShakeBolt{0%,100%{transform:translate(0,0) rotate(0deg)}20%{transform:translate(14px,-10px) rotate(.6deg)}40%{transform:translate(-12px,8px) rotate(-.5deg)}60%{transform:translate(10px,12px) rotate(.4deg)}80%{transform:translate(-9px,-11px) rotate(-.35deg)}}
+.evm-shake-b{transform-box:fill-box;transform-origin:50% 50%;animation:evmShakeBolt .32s steps(1,end) infinite}
+@keyframes evmFlicker{0%,100%{opacity:1}38%{opacity:.72}44%{opacity:1}61%{opacity:.85}67%{opacity:1}}
+.evm-bolt{animation:evmFlicker 2.4s ease-in-out infinite}
+</style>
+</helmet>
+<div style="min-height:100vh;padding:48px 40px 96px;font-family:var(--font-body,system-ui)">
+  <div style="display:flex;flex-direction:column;gap:8px;max-width:1400px;margin:0 auto 40px">
+    <div style="font:600 11px/1 system-ui;letter-spacing:.14em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">World Zero · taskcard surface</div>
+    <h1 style="margin:0;font:600 30px/1.15 var(--font-heading,Georgia,serif);color:var(--color-text-primary,#221f1a)">Every task card, side by side</h1>
+    <p style="margin:0;max-width:62ch;font:400 15px/1.6 system-ui;color:var(--color-text-secondary,#57514a);text-wrap:pretty">Nine faction skins on the same task shape, so the differences are the only thing moving. Same point value, same level gate, same description length.</p>
+  </div>
+
+  <x-import component-from-global-scope="WZ.DSProvider" hint-size="100%,800px">
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(380px,1fr));gap:32px;max-width:1400px;margin:0 auto;align-items:start">
+
+      <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
+        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid var(--color-border,#e2ddd3)">
+          <span style="font:600 13px/1 system-ui;letter-spacing:.02em;color:var(--color-text-primary,#221f1a)">Unaffiliated · na</span>
+          <span style="font:400 11px/1 system-ui;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">DefaultTaskCard</span>
+        </div>
+        <x-import component-from-global-scope="WZ.DefaultTaskCard" task="{{ naTask }}" base-points="{{ points }}" multiplier="{{ multiplier }}" in-progress-count="{{ inProgress }}" on-signup="{{ onSignup }}" hint-size="100%,260px"></x-import>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
+        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid var(--color-border,#e2ddd3)">
+          <span style="font:600 13px/1 system-ui;letter-spacing:.02em;color:var(--color-text-primary,#221f1a)">University of Asthmatics · ua</span>
+          <span style="font:400 11px/1 system-ui;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">UaTaskCard</span>
+        </div>
+        <x-import component-from-global-scope="WZ.UaTaskCard" task="{{ uaTask }}" base-points="{{ points }}" multiplier="{{ multiplier }}" in-progress-count="{{ inProgress }}" on-signup="{{ onSignup }}" hint-size="100%,260px"></x-import>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
+        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid var(--color-border,#e2ddd3)">
+          <span style="font:600 13px/1 system-ui;letter-spacing:.02em;color:var(--color-text-primary,#221f1a)">Warriors of Whimsy · wow</span>
+          <span style="font:400 11px/1 system-ui;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">WowTaskCard</span>
+        </div>
+        <x-import component-from-global-scope="WZ.WowTaskCard" task="{{ wowTask }}" base-points="{{ points }}" multiplier="{{ multiplier }}" in-progress-count="{{ inProgress }}" on-signup="{{ onSignup }}" hint-size="100%,260px"></x-import>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
+        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid var(--color-border,#e2ddd3)">
+          <span style="font:600 13px/1 system-ui;letter-spacing:.02em;color:var(--color-text-primary,#221f1a)">S.N.I.D.E. · snide</span>
+          <span style="font:400 11px/1 system-ui;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">SnideTaskCard</span>
+        </div>
+        <x-import component-from-global-scope="WZ.SnideTaskCard" task="{{ snideTask }}" base-points="{{ points }}" multiplier="{{ multiplier }}" in-progress-count="{{ inProgress }}" on-signup="{{ onSignup }}" hint-size="100%,260px"></x-import>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
+        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid var(--color-border,#e2ddd3)">
+          <span style="font:600 13px/1 system-ui;letter-spacing:.02em;color:var(--color-text-primary,#221f1a)">Ephemerists · ephemerists</span>
+          <span style="font:400 11px/1 system-ui;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">EphemeristsTaskCard</span>
+        </div>
+        <div id="eph-scope" style="display:flex;flex-direction:column;min-width:0">
+          <div data-masthead="1" style="background:#f7f1e2;border:1px solid var(--faction-ephemerists-plate-brass);border-bottom:none;padding:9px 16px 10px;display:flex;flex-direction:column;gap:0">
+            <div style="font-family:var(--font-faction-engraved), Georgia, serif;font-size:18px;font-variant:small-caps;letter-spacing:0.13em;color:#2f2a22;line-height:1.2;text-align:center">The Ephemerists</div>
+          </div>
+          <x-import component-from-global-scope="WZ.EphemeristsTaskCard" task="{{ ephTask }}" base-points="{{ points }}" multiplier="{{ multiplier }}" in-progress-count="{{ inProgress }}" on-signup="{{ onSignup }}" hint-size="100%,260px"></x-import>
+        </div>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
+        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid var(--color-border,#e2ddd3)">
+          <span style="font:600 13px/1 system-ui;letter-spacing:.02em;color:var(--color-text-primary,#221f1a)">Singularity · singularity</span>
+          <span style="font:400 11px/1 system-ui;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">SingularityTaskCard</span>
+        </div>
+        <x-import component-from-global-scope="WZ.SingularityTaskCard" task="{{ singTask }}" base-points="{{ points }}" multiplier="{{ multiplier }}" in-progress-count="{{ inProgress }}" on-signup="{{ onSignup }}" hint-size="100%,260px"></x-import>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
+        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid var(--color-border,#e2ddd3)">
+          <span style="font:600 13px/1 system-ui;letter-spacing:.02em;color:var(--color-text-primary,#221f1a)">Everymen · everymen</span>
+          <span style="font:400 11px/1 system-ui;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">EverymenTaskCard</span>
+        </div>
+        <x-import component-from-global-scope="WZ.EverymenTaskCard" task="{{ everyTask }}" base-points="{{ points }}" multiplier="{{ multiplier }}" in-progress-count="{{ inProgress }}" on-signup="{{ onSignup }}" hint-size="100%,260px"></x-import>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
+        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid var(--color-border,#e2ddd3)">
+          <span style="font:600 13px/1 system-ui;letter-spacing:.02em;color:var(--color-text-primary,#221f1a)">Cozy Coven · coven</span>
+          <span style="font:400 11px/1 system-ui;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">CovenTaskCard</span>
+        </div>
+        <x-import component-from-global-scope="WZ.CovenTaskCard" task="{{ covenTask }}" base-points="{{ points }}" multiplier="{{ multiplier }}" in-progress-count="{{ inProgress }}" on-signup="{{ onSignup }}" hint-size="100%,260px"></x-import>
+      </div>
+
+      <div style="display:flex;flex-direction:column;gap:10px;min-width:0">
+        <div style="display:flex;align-items:baseline;justify-content:space-between;gap:12px;padding-bottom:8px;border-bottom:1px solid var(--color-border,#e2ddd3)">
+          <span style="font:600 13px/1 system-ui;letter-spacing:.02em;color:var(--color-text-primary,#221f1a)">Albescent · albescent</span>
+          <span style="font:400 11px/1 system-ui;letter-spacing:.08em;text-transform:uppercase;color:var(--color-text-tertiary,#8a8378)">AlbescentTaskCard</span>
+        </div>
+        <x-import component-from-global-scope="WZ.AlbescentTaskCard" task="{{ albTask }}" base-points="{{ points }}" multiplier="{{ multiplier }}" in-progress-count="{{ inProgress }}" on-signup="{{ onSignup }}" hint-size="100%,260px"></x-import>
+      </div>
+
+    </div>
+  </x-import>
+</div>
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;showSignup&quot;:{&quot;editor&quot;:&quot;boolean&quot;,&quot;default&quot;:true,&quot;tsType&quot;:&quot;boolean&quot;,&quot;section&quot;:&quot;Card state&quot;},&quot;inProgressCount&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:0,&quot;min&quot;:0,&quot;max&quot;:6,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Card state&quot;},&quot;multiplier&quot;:{&quot;editor&quot;:&quot;float&quot;,&quot;default&quot;:1,&quot;min&quot;:1,&quot;max&quot;:2,&quot;step&quot;:0.25,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Card state&quot;},&quot;pointValue&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:30,&quot;min&quot;:5,&quot;max&quot;:120,&quot;step&quot;:5,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Task&quot;},&quot;levelRequired&quot;:{&quot;editor&quot;:&quot;int&quot;,&quot;default&quot;:2,&quot;min&quot;:1,&quot;max&quot;:10,&quot;tsType&quot;:&quot;number&quot;,&quot;section&quot;:&quot;Task&quot;}}">
+const TITLES = {
+  na: "Choose a faction, or stay open to all of them",
+  ua: "Render the old library facade in charcoal",
+  wow: "Host a sidewalk chalk festival for the block",
+  snide: "Wheatpaste an original poem on a condemned wall",
+  ephemerists: "Catalogue every bench along the river walk",
+  singularity: "Log one week of your resting heart rate",
+  everymen: "Organize a neighborhood tool library",
+  coven: "Brew a tea from three plants you foraged yourself",
+  albescent: "Sit with a stranger's grief for one hour"
+};
+
+class Component extends DCLogic {
+  task(slug, id) {
+    const pts = this.props.pointValue ?? 30;
+    return {
+      id, title: TITLES[slug],
+      description: "Choose a species native to your region, plant it in soil that will hold it for decades, and photograph the sapling beside something for scale.",
+      point_value: pts,
+      level_required: this.props.levelRequired ?? 2,
+      status: "active", task_type: "standard", created_by: 7,
+      primary_faction_slug: slug, metatask_faction_slug: null,
+      created_at: "2026-07-01T15:04:00Z",
+      in_progress_count: this.props.inProgressCount ?? 0,
+      created_by_display_name: "", created_by_avatar_url: "",
+      created_by_faction_slug: null, created_by_level: 0,
+      signup_reason: null, can_sign_up: true,
+      allowed_modes: ["solo", "collab"], eligible_for_current_user: true
+    };
+  }
+  // Every faction's sign-up affordance reads as a button labelled "Sign up":
+  // the four skins that ship it as a full-bleed footer bar get shrunk to a
+  // discrete inset button, and faction-specific CTA wording is normalised.
+  normalizeSignups() {
+    const CTA = /sign\s*up|take up the quest|i'?m in|triangulate the truth|report for duty|enlist|answer the call/i;
+    document.querySelectorAll('#dc-root button').forEach((b) => {
+      if (b.dataset.rotating) return;
+      const label = (b.textContent || '').trim();
+      if (!CTA.test(label)) return;
+      if (label !== 'Sign up' || b.querySelector('svg')) {
+        b.textContent = '';
+        const sp = document.createElement('span');
+        sp.textContent = 'Sign up';
+        b.append(sp);
+      }
+      const faction = (() => {
+        let el = b;
+        for (let i = 0; i < 8 && el.parentElement; i++) {
+          el = el.parentElement;
+          const s = [...el.querySelectorAll(':scope > div > span')].find((x) => /TaskCard$/i.test(x.textContent.trim()));
+          if (s) return s.textContent.trim().replace(/TaskCard$/i, '').toLowerCase();
+        }
+        return '';
+      })();
+      if (faction === 'everymen' && !b.dataset.accented) {
+        b.dataset.accented = '1';
+        b.style.setProperty('background', 'var(--faction-everymen-bill-mast)', 'important');
+        b.style.setProperty('color', 'var(--faction-everymen-bill-mast-ink)', 'important');
+        b.style.setProperty('border-color', 'var(--faction-everymen-bill-mast)', 'important');
+      }
+      if (faction === 'albescent' && !b.dataset.accented) {
+        b.dataset.accented = '1';
+        let ground = '', el = b.parentElement;
+        while (el && (!ground || /rgba\(0, 0, 0, 0\)|transparent/.test(ground))) {
+          ground = getComputedStyle(el).backgroundColor;
+          el = el.parentElement;
+        }
+        b.style.setProperty('border', '1.5px solid transparent', 'important');
+        b.style.setProperty('background',
+          'linear-gradient(' + ground + ',' + ground + ') padding-box, var(--faction-default-rainbow-conic) border-box', 'important');
+      }
+      if (b.dataset.boxed) return;
+      const cs = getComputedStyle(b);
+      const parentW = b.parentElement ? b.parentElement.getBoundingClientRect().width : 0;
+      const isBar = b.getBoundingClientRect().width > parentW - 8 && parseFloat(cs.paddingLeft) < 8;
+      b.dataset.boxed = '1';
+      if (!isBar) return;
+      b.style.setProperty('width', 'fit-content', 'important');
+      b.style.setProperty('display', 'flex', 'important');
+      b.style.setProperty('align-items', 'center', 'important');
+      b.style.setProperty('justify-content', 'center', 'important');
+      b.style.setProperty('margin', '14px auto 16px', 'important');
+      b.style.setProperty('padding', '9px 26px', 'important');
+      b.style.setProperty('text-align', 'center', 'important');
+    });
+    // A CTA that used to be the card's bottom bar can sit flush on the card edge
+    // once it shrinks — give every boxed button real air under it.
+    document.querySelectorAll('#dc-root button[data-boxed]').forEach((b) => {
+      const card = b.closest('article, [style*="praxis-card-basis"]');
+      if (!card || b.dataset.gapFixed) return;
+      const gap = card.getBoundingClientRect().bottom - b.getBoundingClientRect().bottom;
+      if (gap >= 14) return;
+      b.dataset.gapFixed = '1';
+      const pb = parseFloat(getComputedStyle(card).paddingBottom) || 0;
+      card.style.setProperty('padding-bottom', Math.round(pb + (16 - gap)) + 'px', 'important');
+    });
+  }
+  // One word for the level gate across every skin: "Level".
+  normalizeLevelLabels() {
+    const WORDS = /^(level|lvl|grade|rank|tier|deg|degree)$/i;
+    document.querySelectorAll('#dc-root article, #dc-root [style*="praxis-card-basis"]').forEach((card) => {
+      card.querySelectorAll('span,div,p,small,abbr').forEach((el) => {
+        if (el.children.length || el.dataset.levelLabel || el.dataset.rotating) return;
+        const t = (el.textContent || '').trim();
+        if (!WORDS.test(t)) return;
+        el.dataset.levelLabel = '1';
+        el.textContent = 'Level';
+      });
+    });
+  }
+  // One word for the score across every skin: "Points".
+  normalizePointsLabels() {
+    const WORDS = /^(points?|pts?|mark|marks|pvncta|puncta|nqat|点数|نقاط)$/i;
+    const CUNEI = /^[\u{12000}-\u{123FF}\s]+$/u;
+    document.querySelectorAll('#dc-root article, #dc-root [style*="praxis-card-basis"]').forEach((card) => {
+      card.querySelectorAll('span,div,p,small,abbr').forEach((el) => {
+        if (el.children.length || el.dataset.pointsLabel || el.dataset.rotating) return;
+        const t = (el.textContent || '').trim();
+        if (!t || t.length > 8) return;
+        const numeric = /\d/.test((el.parentElement && el.parentElement.textContent) || '');
+        if (!(WORDS.test(t) || (CUNEI.test(t) && numeric))) return;
+        el.dataset.pointsLabel = '1';
+        el.setAttribute('data-plain-english', '1');
+        el.classList.remove('eph-cun');
+        el.style.removeProperty('animation-duration');
+        el.style.removeProperty('animation-delay');
+        el.style.removeProperty('font-family');
+        el.textContent = 'Points';
+      });
+    });
+  }
+  // A faction-drawn rule closing the text block off from the sign-up region.
+  addCtaDividers() {
+    const RULES = {
+      default: { line: 'var(--faction-default-rainbow)', h: '1px', op: '0.6' },
+      albescent: { line: 'var(--faction-default-rainbow)', h: '1px', op: '0.45' },
+      ua: { line: 'var(--faction-ua-hair)', h: '1px' },
+      ephemerists: { double: 'var(--faction-ephemerists-plate-brass)' },
+      everymen: { dashes: 'var(--faction-everymen-card-accent)', h: '2px' },
+      coven: { dots: 'var(--faction-coven-card-accent, var(--faction-coven-slip-cta-ink))', h: '3px', gem: '✦', gemColor: 'var(--faction-coven-slip-cta-ink)' }
+    };
+    document.querySelectorAll('#dc-root button[data-boxed]').forEach((b) => {
+      const card = b.closest('article, [style*="praxis-card-basis"]');
+      if (!card) return;
+      let anchor = b;
+      while (anchor.parentElement && anchor.parentElement !== card
+        && anchor.parentElement.children.length === 1) anchor = anchor.parentElement;
+      const host = anchor.parentElement;
+      if (!host || host.querySelector(':scope > [data-cta-divider]')) return;
+      // Skins that already draw their own rule above the CTA keep it.
+      const prev = anchor.previousElementSibling;
+      if (prev && prev.getBoundingClientRect().height <= 6 && prev.getBoundingClientRect().width > 40) return;
+      const faction = (() => {
+        let el = b;
+        for (let i = 0; i < 8 && el.parentElement; i++) {
+          el = el.parentElement;
+          const s = [...el.querySelectorAll(':scope > div > span')].find((x) => /TaskCard$/i.test(x.textContent.trim()));
+          if (s) return s.textContent.trim().replace(/TaskCard$/i, '').toLowerCase();
+        }
+        return 'default';
+      })();
+      // Wow, S.N.I.D.E. and Singularity keep their own bottom treatment — no added rule.
+      if (['wow', 'snide', 'singularity', 'coven', 'everymen'].includes(faction)) return;
+      const R = RULES[faction] || RULES.default;
+      const wrap = document.createElement('div');
+      wrap.setAttribute('data-cta-divider', faction);
+      Object.assign(wrap.style, {
+        display: 'flex', alignItems: 'center', gap: '10px',
+        margin: '18px 0 14px', flex: '0 0 auto', alignSelf: 'stretch'
+      });
+      const bar = () => {
+        const d = document.createElement('div');
+        Object.assign(d.style, { flex: '1 1 0', minWidth: '0' });
+        if (R.double) {
+          Object.assign(d.style, {
+            height: '3px',
+            borderTop: '1px solid ' + R.double,
+            borderBottom: '1px solid ' + R.double
+          });
+        } else if (R.dashes) {
+          Object.assign(d.style, {
+            height: R.h,
+            background: 'repeating-linear-gradient(90deg, ' + R.dashes + ' 0 7px, transparent 7px 14px)'
+          });
+        } else if (R.dots) {
+          Object.assign(d.style, {
+            height: R.h,
+            background: 'repeating-linear-gradient(90deg, ' + R.dots + ' 0 3px, transparent 3px 9px)',
+            opacity: '0.8'
+          });
+        } else {
+          Object.assign(d.style, { height: R.h, background: R.line, opacity: R.op || '1' });
+        }
+        return d;
+      };
+      wrap.appendChild(bar());
+      if (R.gem) {
+        const g = document.createElement('span');
+        g.textContent = R.gem;
+        Object.assign(g.style, { flex: '0 0 auto', fontSize: '9px', lineHeight: '1', color: R.gemColor });
+        wrap.appendChild(g);
+        wrap.appendChild(bar());
+      }
+      host.insertBefore(wrap, anchor);
+    });
+  }
+  // The Everymen bill's masthead names the faction, not the notice.
+  // Stale dividers from an earlier pass on skins that keep their own rule.
+  pruneDividers() {
+    document.querySelectorAll('[data-cta-divider="wow"], [data-cta-divider="snide"], [data-cta-divider="singularity"], [data-cta-divider="coven"], [data-cta-divider="everymen"]').forEach((d) => d.remove());
+    document.querySelectorAll('#dc-root a span').forEach((sp) => {
+      if (sp.children.length || sp.dataset.sparkleDropped) return;
+      if (!/^[✦✧★]$/.test((sp.textContent || '').trim())) return;
+      sp.dataset.sparkleDropped = '1';
+      sp.style.display = 'none';
+    });
+  }
+  // UA ships no masthead — give it one at the S.N.I.D.E. band's scale, in UA's own hand.
+  addUaMasthead() {
+    // The band's left mark is the faction sigil (standardizeHeaders); the card's
+    // own ensō and the mandala slot stand down so only one 20px mark sits left.
+    document.querySelectorAll('#dc-root [data-ua-band]').forEach((band) => {
+      band.querySelectorAll(':scope > div, :scope > span').forEach((child) => {
+        if (child.dataset.sigilSlot !== undefined || child.dataset.headerSpacer !== undefined) return;
+        if (child.textContent.trim()) return;
+        child.style.removeProperty('transform');
+        child.style.setProperty('display', 'none', 'important');
+      });
+      band.querySelectorAll('div > div[style*="width: 24px"]').forEach((slot) => {
+        slot.style.setProperty('display', 'none', 'important');
+      });
+    });
+    document.querySelectorAll('#dc-root article').forEach((card) => {
+      if (card.dataset.uaMast) return;
+      const btn = card.querySelector('button');
+      if (!btn || !/faction-ua-card-chip-bg/.test(btn.getAttribute('style') || '')) return;
+      card.dataset.uaMast = '1';
+      const cs = getComputedStyle(card);
+      const band = document.createElement('div');
+      band.setAttribute('data-ua-band', '1');
+      Object.assign(band.style, {
+        position: 'relative', zIndex: '2', display: 'flex', alignItems: 'center', gap: '14px',
+        padding: '8px ' + cs.paddingLeft, margin: '-' + cs.paddingTop + ' -' + cs.paddingRight + ' 16px -' + cs.paddingLeft,
+        background: 'var(--faction-ua-hair)', borderBottom: '1px solid var(--faction-ua-card-accent)'
+      });
+      const word = document.createElement('span');
+      word.textContent = 'University of Asthmatics';
+      Object.assign(word.style, {
+        flex: '0 0 auto', fontFamily: 'var(--faction-ua-card-font)', fontSize: '20px',
+        lineHeight: '22px', letterSpacing: '0.08em', color: 'var(--faction-ua-card-accent)', whiteSpace: 'nowrap'
+      });
+      const mandala = () => {
+        const slot = document.createElement('div');
+        Object.assign(slot.style, { flex: '0 0 auto', width: '24px', height: '24px', lineHeight: '0' });
+        try {
+          const R = window.React, RD = window.ReactDOM, M = window.WZ && window.WZ.UaMandala;
+          if (R && RD && M) {
+            RD.createRoot(slot).render(R.createElement(M, { size: 24, strength: 'full', rings: 2, petalsPerRing: 8, spin: true }));
+          }
+        } catch (e) { /* mark is decorative */ }
+        return slot;
+      };
+      const center = document.createElement('div');
+      Object.assign(center.style, { flex: '1 1 0', minWidth: '0', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '12px' });
+      center.append(mandala(), word);
+      const spacer = document.createElement('span');
+      Object.assign(spacer.style, { flex: '0 0 auto', width: '22px' });
+      band.append(center, spacer);
+      card.insertBefore(band, card.firstChild);
+    });
+  }
+  // The UA ensō score ring: grow it so "Points" clears the brush stroke.
+  growUaScoreRing() {
+    document.querySelectorAll('#dc-root [data-ua-mast] a span[style*="width: 96px"]').forEach((host) => {
+      if (host.dataset.ringGrown) return;
+      host.dataset.ringGrown = '1';
+      host.style.setProperty('width', '124px', 'important');
+      host.style.setProperty('height', '124px', 'important');
+      const ring = host.firstElementChild;
+      if (ring) {
+        ring.style.setProperty('width', '124px', 'important');
+        ring.style.setProperty('height', '124px', 'important');
+      }
+    });
+  }
+  // The Ephemerists wordmark speaks in turns, fading between scripts.
+  rotateEphWordmark() {
+    // Wordmark stays in English — the rotation is retired.
+    const el = document.querySelector('#eph-scope [data-masthead] > div');
+    if (!el || el.dataset.rotating) return;
+    el.dataset.rotating = 'off';
+    el.classList.remove('eph-cun');
+    el.style.removeProperty('animation-duration');
+    el.textContent = 'The Ephemerists';
+    if (true) return;
+    const CUN = "'Noto Sans Cuneiform','Segoe UI Historic','Akkadian',Georgia,serif";
+    const ENG = 'var(--font-faction-engraved), Georgia, serif';
+    const SET = [
+      { t: 'The Ephemerists', f: ENG, s: '1em', ls: '0.13em', v: 'small-caps' },
+      { t: 'EPHEMERISTAE', f: ENG, s: '0.86em', ls: '0.2em', v: 'normal' },
+      { t: 'Οἱ Ἐφήμεροι', f: ENG, s: '0.94em', ls: '0.06em', v: 'normal' },
+      { t: 'العابرون', f: "'Noto Naskh Arabic','Geeza Pro',Georgia,serif", s: '0.92em', ls: '0', v: 'normal' },
+      { t: '蜉蝣派', f: "'Noto Serif JP','Hiragino Mincho ProN','Yu Mincho',Georgia,serif", s: '0.86em', ls: '0.06em', v: 'normal' },
+      { t: 'Эфемеристы', f: ENG, s: '0.86em', ls: '0.08em', v: 'normal' },
+      { t: '𒌓𒈦𒀭𒁍𒌓', f: CUN, s: '0.9em', ls: '0.04em', v: 'normal' }
+    ];
+    el.classList.add('eph-cun');
+    el.style.animationDuration = '7.5s';
+    let i = 0;
+    el.addEventListener('animationiteration', () => {
+      let n = i;
+      while (n === i) n = Math.floor(Math.random() * SET.length);
+      i = n;
+      const c = SET[n];
+      el.textContent = c.t;
+      el.style.fontFamily = c.f;
+      el.style.fontSize = c.s;
+      el.style.letterSpacing = c.ls;
+      el.style.fontVariant = c.v;
+    });
+  }
+  // The Ephemerists score label turns through scripts like the wordmark.
+  rotateEphPoints() {
+    const el = document.querySelector('#eph-scope [data-points-label]');
+    if (!el || el.dataset.rotating) return;
+    el.dataset.rotating = '1';
+    el.removeAttribute('data-plain-english');
+    const SET = [
+      { t: 'Points', f: 'var(--font-faction-engraved), Georgia, serif', ls: '0.16em' },
+      { t: 'PVNCTA', f: 'var(--font-faction-engraved), Georgia, serif', ls: '0.2em' },
+      { t: 'نقاط', f: "'Noto Naskh Arabic','Geeza Pro',Georgia,serif", ls: '0' },
+      { t: '点数', f: "'Noto Serif JP','Hiragino Mincho ProN',Georgia,serif", ls: '0.04em' },
+      { t: '𒌦𒋫', f: "'Noto Sans Cuneiform','Segoe UI Historic',Georgia,serif", ls: '0.04em' }
+    ];
+    el.classList.add('eph-cun');
+    el.style.animationDuration = '6.5s';
+    el.style.whiteSpace = 'nowrap';
+    // Pin the label's box to the widest script so the score above it never shifts.
+    const cs = getComputedStyle(el);
+    const probe = document.createElement('span');
+    Object.assign(probe.style, {
+      position: 'absolute', visibility: 'hidden', left: '-9999px', whiteSpace: 'nowrap',
+      fontSize: cs.fontSize, fontWeight: cs.fontWeight, textTransform: cs.textTransform
+    });
+    document.body.appendChild(probe);
+    let w = 0, h = 0;
+    SET.forEach((s) => {
+      probe.style.fontFamily = s.f;
+      probe.style.letterSpacing = s.ls;
+      probe.textContent = s.t;
+      const r = probe.getBoundingClientRect();
+      w = Math.max(w, r.width);
+      h = Math.max(h, r.height);
+    });
+    probe.remove();
+    if (w && h) {
+      el.style.setProperty('display', 'block', 'important');
+      el.style.setProperty('width', Math.ceil(w) + 10 + 'px', 'important');
+      el.style.setProperty('height', Math.ceil(h) + 2 + 'px', 'important');
+      el.style.setProperty('line-height', Math.ceil(h) + 'px', 'important');
+      el.style.setProperty('text-align', 'center', 'important');
+      el.style.setProperty('overflow', 'hidden', 'important');
+    }
+    let i = 0;
+    el.addEventListener('animationiteration', () => {
+      let n = i;
+      while (n === i) n = Math.floor(Math.random() * SET.length);
+      i = n;
+      el.textContent = SET[n].t;
+      el.style.fontFamily = SET[n].f;
+      el.style.letterSpacing = SET[n].ls;
+    });
+  }
+  // Wow ships no masthead either — a plum banner at the S.N.I.D.E. band's scale.
+  addWowMasthead() {
+    document.querySelectorAll('#dc-root article').forEach((card) => {
+      if (card.dataset.wowMast) return;
+      const btn = card.querySelector('button');
+      if (!btn || !/faction-wow-plum-surface/.test(btn.getAttribute('style') || '')) return;
+      card.dataset.wowMast = '1';
+      const cs = getComputedStyle(card);
+      const band = document.createElement('div');
+      band.setAttribute('data-wow-band', '1');
+      Object.assign(band.style, {
+        position: 'relative', zIndex: '2', display: 'flex', alignItems: 'center', gap: '14px',
+        padding: '8px ' + cs.paddingLeft,
+        margin: '-' + cs.paddingTop + ' -' + cs.paddingRight + ' 16px -' + cs.paddingLeft,
+        background: 'var(--faction-wow-plum-surface)',
+        borderBottom: '2px solid var(--faction-wow-card-accent)'
+      });
+      const word = document.createElement('span');
+      word.textContent = 'Warriors of Whimsy';
+      Object.assign(word.style, {
+        flex: '0 0 auto', fontFamily: 'var(--faction-wow-card-font)', fontSize: '21px',
+        lineHeight: '22px', letterSpacing: '0.04em', color: 'var(--faction-wow-on-plum)', whiteSpace: 'nowrap'
+      });
+      band.style.justifyContent = 'center';
+      band.append(word);
+      card.insertBefore(band, card.firstChild);
+    });
+  }
+  // The Ephemerists points badge is the kit's compass-rose plate, not a plain octagon.
+  ephCompassBadge() {
+    const brass = 'var(--faction-ephemerists-plate-brass)';
+    const light = 'var(--faction-ephemerists-plate-brass-light)';
+    const disc = 'var(--faction-ephemerists-plate-disc)';
+    const nile = 'var(--faction-ephemerists-plate-nile, #1e3a6e)';
+    const ROSE = '<circle cx="50" cy="50" r="47" fill="' + disc + '" stroke="' + brass + '" stroke-width="1.6"></circle>'
+      + '<circle cx="50" cy="50" r="41" fill="none" stroke="' + light + '" stroke-width="0.7"></circle>'
+      + '<g stroke="' + light + '" stroke-width="0.7" opacity="0.7"><path d="M16.8 16.8 L21 21"></path><path d="M83.2 16.8 L79 21"></path><path d="M16.8 83.2 L21 79"></path><path d="M83.2 83.2 L79 79"></path></g>'
+      + '<path d="M50 8 L55.5 26 L44.5 26 Z" fill="' + nile + '"></path>'
+      + '<path d="M50 92 L55.5 74 L44.5 74 Z" fill="none" stroke="' + brass + '" stroke-width="0.9"></path>'
+      + '<path d="M8 50 L26 44.5 L26 55.5 Z" fill="none" stroke="' + light + '" stroke-width="0.7"></path>'
+      + '<path d="M92 50 L74 44.5 L74 55.5 Z" fill="none" stroke="' + light + '" stroke-width="0.7"></path>'
+      + '<circle cx="50" cy="50" r="29" fill="' + disc + '" stroke="' + light + '" stroke-width="0.7"></circle>';
+    document.querySelectorAll('#eph-scope svg').forEach((svg) => {
+      if (svg.dataset.ephRose) return;
+      if (!svg.querySelector('path[fill="var(--faction-ephemerists-plate-disc)"]')) return;
+      svg.dataset.ephRose = '1';
+      svg.setAttribute('viewBox', '0 0 100 100');
+      svg.innerHTML = ROSE;
+      // grow the plate so the score and its label clear the compass points
+      const host = svg.parentElement;
+      if (host) {
+        host.style.setProperty('width', '128px', 'important');
+        host.style.setProperty('height', '128px', 'important');
+      }
+      svg.setAttribute('width', '128');
+      svg.setAttribute('height', '128');
+    });
+  }
+  // Coven's floating wordmark becomes a banded header at the shared scale.
+  bandCovenMast() {
+    document.querySelectorAll('#dc-root article').forEach((card) => {
+      const el = [...card.children].find((c) => /^the cozy coven$/i.test(c.textContent.trim()));
+      if (!el || el.dataset.covenBand === 'v3') return;
+      Object.assign(el.style, {
+        position: 'relative', zIndex: '2', display: 'flex', alignItems: 'center',
+        justifyContent: 'flex-start', gap: '10px', padding: '8px 16px', margin: '0 0 12px',
+        background: 'var(--faction-coven-slip-sigil-ground)',
+        borderBottom: '1px solid var(--faction-coven-slip-pk)', textAlign: 'left'
+      });
+      const word = [...el.querySelectorAll('div,span')].find((x) => /^the cozy coven$/i.test(x.textContent.trim()));
+      if (word) {
+        Object.assign(word.style, { fontSize: '24px', lineHeight: '24px', margin: '0', flex: '0 0 auto', textAlign: 'left' });
+      }
+      // the trailing ornament run repeats what the band already says
+      [...el.children].forEach((c) => {
+        if (c === word || c.contains(word) || /^svg$/i.test(c.tagName)) return;
+        if (!c.textContent.trim() || /^[\s♥♡✦✧·•]+$/.test(c.textContent.trim())) c.style.display = 'none';
+      });
+      const mark = el.querySelector('svg');
+      if (mark) {
+        mark.style.setProperty('position', 'static', 'important');
+        mark.style.setProperty('width', '22px', 'important');
+        mark.style.setProperty('height', '22px', 'important');
+        mark.style.setProperty('opacity', '1', 'important');
+        mark.style.setProperty('flex', '0 0 auto', 'important');
+        mark.style.setProperty('margin', '0', 'important');
+        if (mark.parentElement !== el) el.insertBefore(mark, el.firstChild);
+      }
+      el.dataset.covenBand = 'v3';
+      if (card.firstElementChild !== el) card.insertBefore(el, card.firstChild);
+    });
+  }
+  // UA mandalas lose their outer boundary ring; the S.N.I.D.E. pen circle grows a little.
+  trimMarks() {
+    document.querySelectorAll('#dc-root [data-ua-mast] svg circle[r="47"]').forEach((c) => c.remove());
+    document.querySelectorAll('#dc-root svg').forEach((svg) => {
+      if (svg.dataset.penGrown) return;
+      const p = svg.querySelector('path[d^="M14 40 C13 19 38 7 56 9"]');
+      if (!p) return;
+      svg.dataset.penGrown = '1';
+      svg.style.setProperty('transform', 'scale(1.18)', 'important');
+      svg.style.setProperty('transform-origin', 'center', 'important');
+    });
+  }
+  // The Ephemerists CTA turns through scripts like its score label.
+  rotateEphSignup() {
+    const btn = document.querySelector('#eph-scope button');
+    if (!btn || btn.dataset.rotating) return;
+    const el = btn.querySelector('span') || btn;
+    btn.dataset.rotating = '1';
+    const SET = [
+      { t: 'Sign up', f: 'var(--font-faction-engraved), Georgia, serif', ls: '0.24em' },
+      { t: 'ADSCRIBE', f: 'var(--font-faction-engraved), Georgia, serif', ls: '0.26em' },
+      { t: 'اشترك', f: "'Noto Naskh Arabic','Geeza Pro',Georgia,serif", ls: '0' },
+      { t: '参加', f: "'Noto Serif JP','Hiragino Mincho ProN',Georgia,serif", ls: '0.08em' },
+      { t: '𒃻𒈬', f: "'Noto Sans Cuneiform','Segoe UI Historic',Georgia,serif", ls: '0.06em' }
+    ];
+    el.classList.add('eph-cun');
+    el.style.animationDuration = '7s';
+    el.style.whiteSpace = 'nowrap';
+    // Measure every variant once and pin the button to the widest, so the
+    // label can change script without the button resizing under it.
+    const probe = document.createElement('span');
+    const cs = getComputedStyle(el);
+    Object.assign(probe.style, {
+      position: 'absolute', visibility: 'hidden', whiteSpace: 'nowrap', left: '-9999px',
+      fontSize: cs.fontSize, fontWeight: cs.fontWeight, textTransform: cs.textTransform
+    });
+    document.body.appendChild(probe);
+    let widest = 0;
+    SET.forEach((s) => {
+      probe.style.fontFamily = s.f;
+      probe.style.letterSpacing = s.ls;
+      probe.textContent = s.t;
+      widest = Math.max(widest, probe.getBoundingClientRect().width);
+    });
+    probe.remove();
+    if (widest) {
+      el.style.setProperty('display', 'inline-block', 'important');
+      el.style.setProperty('width', Math.ceil(widest) + 'px', 'important');
+      el.style.setProperty('text-align', 'center', 'important');
+    }
+    let i = 0;
+    el.addEventListener('animationiteration', () => {
+      let n = i;
+      while (n === i) n = Math.floor(Math.random() * SET.length);
+      i = n;
+      el.textContent = SET[n].t;
+      el.style.fontFamily = SET[n].f;
+      el.style.letterSpacing = SET[n].ls;
+    });
+  }
+  // One header anatomy across factions: sigil hard left, faction title centred.
+  standardizeHeaders() {
+    const S = this._sigils;
+    if (!S) return;
+    const bandFor = {
+      ua: (c) => c.querySelector('[data-ua-band]'),
+      wow: (c) => c.querySelector('[data-wow-band]'),
+      coven: (c) => c.querySelector('[data-coven-band]'),
+      snide: (c) => [...c.children].find((x) => /^s\.n\.i\.d\.e\./i.test(x.textContent.trim())),
+      everymen: (c) => [...c.querySelectorAll('div')].find((x) => /^everymen$/i.test(x.textContent.trim())),
+      singularity: (c) => [...c.querySelectorAll('div')].find((x) => /task\.proc/i.test(x.textContent.trim()))
+    };
+    const mountSigil = (slug) => {
+      const slot = document.createElement('span');
+      slot.setAttribute('data-sigil-slot', slug);
+      Object.assign(slot.style, {
+        flex: '0 0 auto', width: '20px', height: '20px', lineHeight: '0',
+        display: 'inline-flex', alignItems: 'center', justifyContent: 'center'
+      });
+      if (S[slug]) { slot.innerHTML = S[slug]; return slot; }
+      try {
+        const R = window.React, RD = window.ReactDOM, F = window.WZ && window.WZ.FactionSigil;
+        if (R && RD && F) RD.createRoot(slot).render(R.createElement(F, { slug, size: 20 }));
+      } catch (e) { /* decorative */ }
+      return slot;
+    };
+    const dress = (band, slug) => {
+      if (!band || band.dataset.headerStd === slug) return;
+      band.dataset.headerStd = slug;
+      // one inset for every faction's sigil: 14px in, 10px to the title row
+      Object.assign(band.style, {
+        display: 'flex', flexDirection: 'row', alignItems: 'center',
+        justifyContent: 'flex-start', gap: '10px', textAlign: 'center'
+      });
+      band.style.setProperty('padding-left', '14px', 'important');
+      band.style.setProperty('padding-right', '14px', 'important');
+      // the sigil stands in for the UA mandala
+      band.querySelectorAll(':scope > div > div[style*="24px"]').forEach((slot) => {
+        if (slot.querySelector('svg') && !slot.dataset.sigilSlot) slot.style.setProperty('display', 'none', 'important');
+      });
+      const leaves = [...band.querySelectorAll('*')].filter((e) => !e.children.length && e.textContent.trim().length > 2);
+      const title = leaves.sort((a, b) => b.textContent.trim().length - a.textContent.trim().length)[0];
+      if (!title) return;
+      // ornaments the sigil now stands in for
+      [...band.children].forEach((c) => {
+        if (c === title || c.contains(title) || c.dataset.sigilSlot !== undefined) return;
+        const t = c.textContent.trim();
+        if (!t || /^[\s♥♡✦✧·•◆★]+$/.test(t)) c.style.setProperty('display', 'none', 'important');
+      });
+      band.querySelectorAll(':scope > svg, :scope > span > svg').forEach((s) => {
+        if (!s.closest('[data-sigil-slot]')) s.style.setProperty('display', 'none', 'important');
+      });
+      // The title is centred on the BAND, not on the space left over beside the sigil.
+      const holder = [...band.children].find((c) => c === title || c.contains(title)) || title;
+      band.style.position = 'relative';
+      const th = Math.round(holder.getBoundingClientRect().height);
+      if (th) band.style.minHeight = Math.max(th, 22) + 'px';
+      Object.assign(holder.style, {
+        position: 'absolute', left: '0', right: '0', textAlign: 'center', pointerEvents: 'none'
+      });
+      title.style.textAlign = 'center';
+      if (!band.querySelector(':scope > [data-sigil-slot]')) band.insertBefore(mountSigil(slug), band.firstChild);
+      // pin every sigil to the same 14px inset from its card's left edge
+      requestAnimationFrame(() => {
+        const slot = band.querySelector(':scope > [data-sigil-slot]');
+        const box = band.closest('article') || band.parentElement;
+        if (!slot || !box) return;
+        const delta = 14 - Math.round(slot.getBoundingClientRect().left - box.getBoundingClientRect().left);
+        if (Math.abs(delta) > 0.5) {
+          const cur = parseFloat(getComputedStyle(slot).marginLeft) || 0;
+          slot.style.setProperty('margin-left', Math.round(cur + delta) + 'px', 'important');
+        }
+      });
+      const stale = band.querySelector(':scope > [data-header-spacer]');
+      if (stale) stale.remove();
+    };
+    document.querySelectorAll('#dc-root article').forEach((card) => {
+      Object.keys(bandFor).forEach((slug) => {
+        const band = bandFor[slug](card);
+        if (band) dress(band, slug);
+      });
+    });
+    dress(document.querySelector('#eph-scope [data-masthead]'), 'ephemerists');
+  }
+  // Per-faction flourishes around the CTA and header.
+  factionFlourishes() {
+    const cardOf = (sel) => [...document.querySelectorAll('#dc-root article')]
+      .find((c) => c.querySelector(sel));
+
+    // S.N.I.D.E. — bigger mark, sprayed CTA lettering
+    const snide = cardOf('[data-header-std="snide"]');
+    if (snide) {
+      if (snide.dataset.punkGround !== 'v1') {
+        snide.dataset.punkGround = 'v1';
+        // pitch-black flyposted wall: photocopier grain, tape strips, acid bleed
+        snide.style.setProperty('background', [
+          'repeating-linear-gradient(115deg, rgba(255,255,255,0.035) 0 2px, transparent 2px 7px)',
+          'repeating-linear-gradient(0deg, rgba(0,0,0,0.5) 0 1px, transparent 1px 4px)',
+          'radial-gradient(120% 80% at 8% -10%, rgba(182,255,46,0.13), transparent 60%)',
+          'radial-gradient(90% 70% at 100% 110%, rgba(236,64,122,0.14), transparent 62%)',
+          'linear-gradient(180deg, #0a0a0b 0%, #050506 100%)'
+        ].join(','), 'important');
+        snide.style.setProperty('border-color', 'rgba(182,255,46,0.35)', 'important');
+        snide.style.setProperty('box-shadow', '0 0 0 1px rgba(0,0,0,0.9), 0 18px 40px -22px rgba(0,0,0,1)', 'important');
+      }
+      const sig = snide.querySelector('[data-sigil-slot] svg');
+      if (sig && !sig.dataset.grown) {
+        sig.dataset.grown = '1';
+        sig.setAttribute('width', '24');
+        sig.setAttribute('height', '24');
+        sig.parentElement.style.width = '24px';
+        sig.parentElement.style.height = '24px';
+      }
+      const btn = snide.querySelector('button');
+      if (btn && btn.dataset.sprayed !== 'v2') {
+        btn.dataset.sprayed = 'v2';
+        btn.style.setProperty('font-family', "'Permanent Marker', var(--faction-snide-font-impact), Impact, sans-serif", 'important');
+        btn.style.setProperty('font-size', '19px', 'important');
+        btn.style.setProperty('letter-spacing', '0.06em', 'important');
+        btn.style.setProperty('padding', '11px 30px', 'important');
+        btn.style.setProperty('transform', 'rotate(-1.6deg)', 'important');
+        btn.style.setProperty('background', '#000', 'important');
+        btn.style.setProperty('background-image', 'none', 'important');
+        btn.style.setProperty('color', 'var(--faction-snide-note-cta-bg, #b6ff2e)', 'important');
+        btn.style.setProperty('text-shadow', [
+          '0 0 1px rgba(182,255,46,0.95)',
+          '0 0 6px rgba(182,255,46,0.7)',
+          '0 0 16px rgba(182,255,46,0.45)',
+          '1px 2px 0 rgba(8,7,6,0.65)',
+          '-2px 1px 5px rgba(182,255,46,0.35)'
+        ].join(', '), 'important');
+        btn.style.setProperty('box-shadow', '0 0 0 2px rgba(182,255,46,0.28), inset 0 0 18px rgba(182,255,46,0.15)', 'important');
+        btn.style.setProperty('border', 'none', 'important');
+      }
+    }
+
+    // UA — the card's own ensō and the stray mandala slot stand down; mandalas flank the CTA
+    const ua = cardOf('[data-header-std="ua"]');
+    if (ua) {
+      const stray = ua.querySelector('a > div > span[style*="faction-ua-glow"]');
+      if (stray && stray.parentElement) stray.parentElement.remove();
+      ua.querySelectorAll('[data-ua-band] svg[width="24"]').forEach((s) => {
+        const slot = s.parentElement;
+        if (slot && slot.dataset.sigilSlot === undefined) slot.remove();
+      });
+      const btn = ua.querySelector('button');
+      const row = btn && btn.parentElement;
+      if (row && row.dataset.mandalaFlank !== 'v2') {
+        row.querySelectorAll(':scope > .ua-mand').forEach((n) => n.remove());
+        row.dataset.mandalaFlank = 'v2';
+        Object.assign(row.style, {
+          position: 'relative', display: 'flex', alignItems: 'center',
+          justifyContent: 'center', gap: '0'
+        });
+        const spec = [{ size: 46, rings: 3, petalsPerRing: 8, rotation: 0 }];
+        const make = (s) => {
+          const slot = document.createElement('span');
+          slot.className = 'ua-mand';
+          Object.assign(slot.style, { flex: '0 0 auto', width: s.size + 'px', height: s.size + 'px', lineHeight: '0' });
+          try {
+            const R = window.React, RD = window.ReactDOM, M = window.WZ && window.WZ.UaMandala;
+            if (R && RD && M) RD.createRoot(slot).render(R.createElement(M, Object.assign({ strength: 'full', color: 'currentColor' }, s)));
+          } catch (e) { /* decorative */ }
+          return slot;
+        };
+        const mand = make(spec[0]);
+        Object.assign(mand.style, { position: 'absolute', right: '6px', top: '50%', transform: 'translateY(-50%)' });
+        row.appendChild(mand);
+      }
+    }
+
+    // Singularity — ASCII art drifting beside the CTA
+    const sing = cardOf('[data-header-std="singularity"]');
+    if (sing) {
+      const btn = sing.querySelector('button');
+      const row = btn && btn.parentElement;
+      if (row && row.dataset.ascii !== 'v2') {
+        row.querySelectorAll(':scope > .sg-ascii').forEach((n) => n.remove());
+        row.dataset.ascii = 'v2';
+        Object.assign(row.style, {
+          position: 'relative', display: 'flex', alignItems: 'center',
+          justifyContent: 'center', gap: '0'
+        });
+        // one little robot, parked where Wow keeps its balloons
+        const bot = document.createElement('pre');
+        bot.className = 'sg-ascii';
+        bot.textContent = '[^-^]\n /|_|\\\n  d b';
+        Object.assign(bot.style, {
+          margin: '0', position: 'absolute', right: '18px', bottom: '-6px',
+          font: '400 13px/1.2 var(--faction-singularity-card-font, monospace)',
+          color: 'var(--faction-singularity-card-accent, #4ade80)'
+        });
+        row.appendChild(bot);
+      }
+    }
+
+    // Wow — gold wordmark, sigil off the card edge, bunting under the band
+    const wowBand = document.querySelector('[data-wow-band]');
+    if (wowBand && !wowBand.dataset.wowFlourish) {
+      wowBand.dataset.wowFlourish = '1';
+
+      const GOLD = 'var(--faction-wow-gilt-mid, #e7b94e)';
+      [...wowBand.querySelectorAll('*')].forEach((n) => {
+        if (/warriors of whimsy/i.test(n.textContent || '')) {
+          n.style.setProperty('color', GOLD, 'important');
+        }
+      });
+      wowBand.style.setProperty('border-bottom', '2px solid ' + GOLD, 'important');
+      const sigil = wowBand.querySelector('[data-sigil-slot]');
+      if (sigil) sigil.style.setProperty('margin-left', '2px', 'important');
+      const card = wowBand.closest('article');
+      // the confetti strip the flags replace
+      [...(card ? card.children : [])].forEach((c) => {
+        if (c === wowBand || c.dataset.wowFlags) return;
+        const r = c.getBoundingClientRect();
+        if (r.height > 0 && r.height <= 8 && /gradient/.test(getComputedStyle(c).backgroundImage)) {
+          c.style.setProperty('display', 'none', 'important');
+        }
+      });
+      if (card && !card.querySelector('[data-wow-flags]')) {
+        const flags = document.createElement('div');
+        flags.setAttribute('data-wow-flags', '1');
+        Object.assign(flags.style, {
+          position: 'relative', zIndex: '2', display: 'flex', gap: '0',
+          margin: '-1px 0 12px', padding: '0', overflow: 'visible'
+        });
+        const inks = ['var(--faction-wow-plum-surface)', 'var(--faction-wow-gilt-mid, #e7b94e)', 'var(--faction-wow-card-text)'];
+        for (let i = 0; i < 14; i++) {
+          const f = document.createElement('span');
+          Object.assign(f.style, {
+            flex: '1 1 0', height: '20px', background: inks[i % 3],
+            clipPath: 'polygon(0 0, 100% 0, 50% 100%)'
+          });
+          flags.appendChild(f);
+        }
+        wowBand.after(flags);
+        // hang the bunting straight off the band's bottom edge
+        requestAnimationFrame(() => {
+          const gap = flags.getBoundingClientRect().top - wowBand.getBoundingClientRect().bottom;
+          if (Math.abs(gap) > 0.5) {
+            const cur = parseFloat(getComputedStyle(flags).marginTop) || 0;
+            flags.style.setProperty('margin-top', Math.round(cur - gap) + 'px', 'important');
+          }
+        });
+      }
+    }
+
+    // UA and Coven set their level numeral small for their type; match the others' weight
+    ['ua', 'coven'].forEach((slug) => {
+      const card = cardOf('[data-header-std="' + slug + '"]');
+      if (!card) return;
+      const lab = [...card.querySelectorAll('span,div')].find((e) => !e.children.length && /^level$/i.test(e.textContent.trim()));
+      const num = lab && lab.parentElement
+        ? [...lab.parentElement.querySelectorAll('span,div')].find((e) => !e.children.length && /^\d+$/.test(e.textContent.trim()))
+        : null;
+      if (num && !num.dataset.numGrown) {
+        num.dataset.numGrown = '1';
+        num.style.setProperty('font-size', '44px', 'important');
+        num.style.setProperty('line-height', '1', 'important');
+      }
+    });
+
+    // Wow + Ephemerists — header sigils take the gold of their wordmark / CTA
+    const wowSig = document.querySelector('svg path[d^="M12 88L12 24"]');
+    if (wowSig) {
+      const slot = wowSig.closest('span') || wowSig.closest('svg').parentElement;
+      if (slot) slot.style.setProperty('color', 'var(--faction-wow-gilt-mid, #e7b94e)', 'important');
+    }
+    const ephSig = document.querySelector('#eph-scope [data-masthead] svg');
+    if (ephSig) {
+      const GOLD = 'var(--faction-ephemerists-plate-cta-bg, #c9a24b)';
+      if (ephSig.parentElement) ephSig.parentElement.style.setProperty('color', GOLD, 'important');
+      ephSig.style.setProperty('color', GOLD, 'important');
+      ephSig.setAttribute('fill', 'currentColor');
+      ephSig.querySelectorAll('path,circle,ellipse,rect,polygon').forEach((n) => {
+        if (n.getAttribute('fill') && n.getAttribute('fill') !== 'none') n.setAttribute('fill', 'currentColor');
+        if (n.getAttribute('stroke') && n.getAttribute('stroke') !== 'none') n.setAttribute('stroke', 'currentColor');
+      });
+    }
+
+    // Everymen — stamped points seal, and a sparking cog beside the CTA
+    const evCard = cardOf('[href="/tasks/107"]') || [...document.querySelectorAll('#dc-root article')]
+      .find((c) => /everymen/i.test(c.textContent || ''));
+    if (evCard) {
+      // the sunburst converges on the card's centre, not its upper third
+      const burstBg = [...evCard.querySelectorAll('*')]
+        .find((e) => /repeating-conic/.test(getComputedStyle(e).backgroundImage));
+      if (burstBg && !burstBg.dataset.burstCentred) {
+        burstBg.dataset.burstCentred = '1';
+        burstBg.style.setProperty('background-image',
+          getComputedStyle(burstBg).backgroundImage.replace('at 50% 16%', 'at 50% 50%'), 'important');
+      }
+      const seal = [...evCard.querySelectorAll('div')].find((d) => {
+        const s = d.getAttribute('style') || '';
+        return /border-radius:\s*50%/.test((d.firstElementChild && d.firstElementChild.getAttribute('style')) || '')
+          && /position:\s*relative/.test(s);
+      });
+      if (seal && !seal.dataset.stamped) {
+        seal.dataset.stamped = '1';
+        seal.classList.add('evm-stamp');
+      }
+      const btn = evCard.querySelector('button');
+      if (btn && btn.dataset.cogSpark !== 'v29') {
+        btn.dataset.cogSpark = 'v29';
+        evCard.querySelectorAll('.evm-cog, [data-cog-row]').forEach((n) => {
+          if (n.dataset && n.dataset.cogRow) { n.replaceWith(...n.childNodes); } else { n.remove(); }
+        });
+        const row = document.createElement('div');
+        row.dataset.cogRow = '1';
+        Object.assign(row.style, {
+          position: 'relative', display: 'flex', alignItems: 'center',
+          justifyContent: 'space-evenly', gap: '4px', width: '100%'
+        });
+        btn.parentElement.insertBefore(row, btn);
+        row.appendChild(btn);
+        btn.style.setProperty('font-size', '1.05rem', 'important');
+        btn.style.setProperty('padding', '0.85em 1.4em', 'important');
+        btn.style.setProperty('white-space', 'nowrap', 'important');
+        btn.style.setProperty('flex', '0 0 auto', 'important');
+        const red = 'var(--everymen-red, #c1382c)';
+        const wrap = document.createElement('span');
+        wrap.className = 'evm-cog';
+        Object.assign(wrap.style, {
+          position: 'relative', flex: '0 0 auto', alignSelf: 'center',
+          width: '104px', height: '101px', lineHeight: '0', pointerEvents: 'none'
+        });
+        const gold = 'var(--everymen-gold, #e0a33c)';
+        // traced from the supplied vector: the fist and, as its own subpath, the bolt
+        const BOLT = 'M4390 4284 c-420 -315 -766 -577 -768 -583 -2 -6 125 -75 282 -153 157 -79 286 -145 286 -148 0 -3 -45 -29 -99 -58 l-99 -54 40 -86 c22 -48 42 -89 44 -91 2 -2 29 6 60 18 67 25 124 27 192 5 68 -22 121 -76 162 -163 19 -39 35 -71 36 -71 1 0 65 22 141 49 362 129 883 314 1020 362 118 42 150 57 140 66 -11 10 -418 259 -684 417 -56 34 -103 63 -103 66 0 3 187 91 415 196 l415 191 -337 289 c-185 159 -346 296 -357 305 -20 16 -49 -4 -786 -557z M2515 2471 c-66 -37 -302 -168 -525 -291 -672 -372 -886 -492 -865 -487 17 4 342 119 1365 482 135 48 253 90 262 94 16 6 10 22 -44 139 -33 72 -63 132 -67 131 -3 0 -60 -31 -126 -68z';
+        const FIST = 'M3705 3400 c-93 -46 -97 -111 -17 -291 31 -71 60 -129 65 -129 11 0 231 100 241 110 8 8 -83 223 -116 271 -17 26 -82 59 -116 59 -9 0 -35 -9 -57 -20z M3309 3357 c-45 -30 -71 -82 -66 -128 3 -20 58 -153 122 -295 65 -143 124 -272 131 -289 29 -69 85 -115 142 -115 29 0 92 18 92 27 0 2 -12 15 -28 28 -79 67 -103 216 -49 308 l28 47 -82 181 c-46 99 -91 192 -102 205 -44 57 -129 71 -188 31z M3032 3093 c-54 -26 -77 -68 -77 -138 1 -55 10 -81 110 -299 120 -262 137 -284 218 -293 56 -7 107 16 143 62 51 67 43 104 -76 365 -56 124 -113 240 -127 258 -46 61 -122 79 -191 45z M4000 2992 c-253 -115 -257 -117 -276 -154 -21 -40 -14 -120 13 -156 64 -86 118 -88 297 -8 70 31 136 56 145 54 10 -2 16 -13 16 -33 0 -28 -6 -32 -150 -97 -82 -37 -162 -68 -176 -68 -14 0 -43 -13 -63 -29 -60 -48 -116 -64 -194 -59 l-68 5 -32 -49 c-37 -55 -73 -81 -149 -105 -51 -16 -96 -13 -178 11 -15 5 -26 -3 -47 -33 -33 -49 -105 -92 -164 -99 -40 -4 -44 -7 -38 -26 20 -63 160 -336 207 -404 95 -134 244 -265 389 -342 31 -16 52 -36 63 -60 21 -43 181 -391 362 -790 73 -162 137 -298 141 -302 5 -5 270 -7 589 -6 l582 3 -272 475 c-150 261 -341 595 -425 741 -97 170 -152 275 -152 294 0 15 38 130 84 254 145 390 143 459 -28 830 -42 91 -84 174 -94 184 -26 31 -92 57 -142 57 -35 0 -87 -19 -240 -88z M2750 2823 c-47 -24 -80 -76 -80 -126 0 -49 139 -363 177 -402 82 -82 225 -32 240 85 5 32 -6 64 -67 202 -73 164 -105 219 -139 238 -38 20 -95 21 -131 3z';
+        // the discharge: arcs crackling off the bolt
+        const cx = 400, cy = 230, spark = [];
+        const cluster = (ox, oy, n, seed) => {
+          for (let i = 0; i < n; i++) {
+            const a = (i * (360 / n) + (i % 3) * 11 + seed) * Math.PI / 180;
+            const r0 = 34 + (i % 3) * 8, len = 30 + (i % 4) * 16;
+            let px = ox + Math.cos(a) * r0, py = oy + Math.sin(a) * r0;
+            let d = 'M' + px.toFixed(1) + ' ' + py.toFixed(1);
+            for (let k = 1; k <= 4; k++) {
+              const j = (k % 2 ? 1 : -1) * (7 + (i % 3) * 3);
+              px += Math.cos(a) * (len / 4) - Math.sin(a) * j;
+              py += Math.sin(a) * (len / 4) + Math.cos(a) * j;
+              d += ' L' + px.toFixed(1) + ' ' + py.toFixed(1);
+            }
+            spark.push('<path class="evm-arc" d="' + d + '" fill="none" stroke="' + (i % 2 ? gold : '#fff2cc')
+              + '" stroke-width="' + (i % 2 ? 5 : 3.2) + '" stroke-linecap="round" stroke-linejoin="round"'
+              + ' style="animation-delay:' + (i * 137 + seed * 3) + 'ms"></path>');
+          }
+        };
+        cluster(cx, cy, 10, 0);
+        // the charge running off the right of the fist
+        cluster(430, 360, 7, 47);
+        // and off the left of the fist
+        cluster(250, 400, 7, 113);
+        wrap.innerHTML = '<svg viewBox="96 74 505 491" width="104" height="101" aria-hidden="true" style="overflow:visible">'
+          + '<g class="evm-shake">'
+          + spark.join('')
+          + '</g>'
+          + '<g transform="translate(0,575) scale(0.1,-0.1)" stroke="' + red + '" stroke-width="70" stroke-linejoin="round">'
+          + '<path d="' + FIST + '" fill="#c96b5c"></path>'
+          + '<g class="evm-shake-b"><path class="evm-bolt" d="' + BOLT + '" fill="' + gold + '"></path></g>'
+          + '</g>'
+          + '</svg>';
+        row.appendChild(wrap);
+        // the same mark, mirrored, on the other side of the button
+        const mirror = wrap.cloneNode(true);
+        mirror.style.transform = 'scaleX(-1)';
+        row.insertBefore(mirror, btn);
+      }
+    }
+
+    // Everymen — the CTA's trailing cog stands down
+    document.querySelectorAll('a svg path[fill="var(--everymen-red)"]').forEach((p) => {
+      const svg = p.closest('svg');
+      if (svg) svg.style.setProperty('display', 'none', 'important');
+    });
+
+    // Coven — the score sits in a bubbling cauldron
+    const cov = cardOf('[data-header-std="coven"]');
+    if (cov) {
+      // watermark: the pentacle becomes a line-art cat, same slow turn
+      const wheel = cov.querySelector('.cvn-wheel');
+      if (wheel && wheel.dataset.cat !== 'v1') {
+        wheel.dataset.cat = 'v1';
+        // the pentacle could bleed off the card; a face can't — pull it fully inside
+        const cw = cov.getBoundingClientRect().width;
+        const side = Math.round(Math.min(cw * 0.62, 260));
+        wheel.setAttribute('width', side);
+        wheel.setAttribute('height', side);
+        Object.assign(wheel.style, {
+          right: Math.round(cw * 0.04) + 'px', bottom: '10px',
+          width: side + 'px', height: side + 'px'
+        });
+        wheel.style.setProperty('opacity', '0.13', 'important');
+        const p0 = wheel.querySelector('path');
+        const stroke = (p0 && p0.getAttribute('stroke')) || 'var(--faction-coven-slip-deep)';
+        const seg = (d, w) => '<path d="' + d + '" fill="none" stroke="' + stroke
+          + '" stroke-width="' + (w || 1.9) + '" stroke-linecap="round" stroke-linejoin="round"></path>';
+        wheel.innerHTML = [
+          seg('M50 24 C68 24 80 37 80 52 C80 70 66 82 50 82 C34 82 20 70 20 52 C20 37 32 24 50 24 Z', 2.2),
+          seg('M28 31 L25 10 L44 23'),
+          seg('M72 31 L75 10 L56 23'),
+          seg('M38 47 L38 55'),
+          seg('M62 47 L62 55'),
+          seg('M50 60 L46 64 M50 60 L54 64 M50 60 L50 67'),
+          seg('M21 57 L3 52 M21 63 L3 67 M79 57 L97 52 M79 63 L97 67')
+        ].join('');
+      }
+      const lab = cov.querySelector('[data-points-label]');
+      const stack = lab && lab.parentElement;
+      const badge = stack && stack.parentElement;
+      const svg = badge && badge.querySelector('svg');
+      if (badge && badge.dataset.bare !== 'v1') {
+        badge.dataset.bare = 'v1';
+        badge.querySelectorAll(':scope > span[aria-hidden="true"]').forEach((n) => {
+          if (/border-radius:\s*50%/.test(n.getAttribute('style') || '')) n.style.setProperty('display', 'none', 'important');
+        });
+      }
+      if (svg && svg.dataset.cauldron !== 'v3') {
+        svg.dataset.cauldron = 'v3';
+        svg.style.setProperty('transform', 'scale(1.16)', 'important');
+        svg.style.setProperty('transform-origin', 'center', 'important');
+        const ink = 'var(--faction-coven-slip-pk, #f472b6)';
+        const soft = 'var(--faction-coven-slip-cta-to, #f9a8d4)';
+        svg.setAttribute('viewBox', '0 0 100 100');
+        svg.innerHTML = [
+          // bubbles leaving the brew
+          '<circle class="cvn-bub" cx="34" cy="34" r="3.6" fill="none" stroke="' + ink + '" stroke-width="1.6"></circle>',
+          '<circle class="cvn-bub" cx="52" cy="32" r="2.4" fill="none" stroke="' + soft + '" stroke-width="1.4"></circle>',
+          '<circle class="cvn-bub" cx="66" cy="35" r="4.4" fill="none" stroke="' + ink + '" stroke-width="1.4"></circle>',
+          // legs
+          '<path d="M28 84 L20 97" stroke="' + ink + '" stroke-width="3" stroke-linecap="round" fill="none"></path>',
+          '<path d="M72 84 L80 97" stroke="' + ink + '" stroke-width="3" stroke-linecap="round" fill="none"></path>',
+          // bowl
+          '<path d="M12 46 A38 9 0 0 0 88 46 C88 74 72 88 50 88 C28 88 12 74 12 46 Z" fill="' + soft + '" fill-opacity="0.22" stroke="' + ink + '" stroke-width="2.4"></path>',
+          // rim
+          '<ellipse cx="50" cy="46" rx="40" ry="9" fill="none" stroke="' + ink + '" stroke-width="3"></ellipse>'
+        ].join('');
+      }
+      if (stack && stack.dataset.inCauldron !== 'v2') {
+        stack.dataset.inCauldron = 'v2';
+        stack.style.setProperty('transform', 'translateY(17px)', 'important');
+      }
+    }
+
+    // Coven — the slip's CTA reads as a rounded box
+    const coven = cardOf('[data-header-std="coven"]');
+    if (coven) {
+      const cb = coven.querySelector('button');
+      if (cb && !cb.dataset.rounded) {
+        cb.dataset.rounded = '1';
+        cb.style.setProperty('border-radius', '12px', 'important');
+        cb.style.setProperty('padding', '10px 26px', 'important');
+      }
+    }
+
+    // Ephemerists — sigil on the wordmark's row, so the header sits tighter
+    const ephBand = document.querySelector('#eph-scope [data-masthead]');
+    const ephCard = document.querySelector('#eph-scope article, #eph-scope [style*="praxis-card-basis"]');
+    if (ephBand) {
+      Object.assign(ephBand.style, {
+        display: 'flex', flexDirection: 'row', alignItems: 'center',
+        gap: '10px', padding: '7px 14px'
+      });
+      if (ephCard) {
+        // paint the band with the card's own ground and match its box
+        let bg = '', el = ephCard;
+        for (let i = 0; i < 5 && el; i++) {
+          const c = getComputedStyle(el).backgroundColor;
+          if (c && !/rgba\(0, 0, 0, 0\)|transparent/.test(c)) { bg = c; break; }
+          el = el.firstElementChild;
+        }
+        if (bg && ephBand.style.backgroundColor !== bg) {
+          ephBand.style.setProperty('background', bg, 'important');
+          ephBand.style.setProperty('border-color', 'var(--faction-ephemerists-plate-brass)', 'important');
+          [...ephBand.querySelectorAll('*')].forEach((n) => {
+            if (n.dataset.sigilSlot === undefined && n.textContent.trim()) {
+              n.style.setProperty('color', 'var(--faction-ephemerists-plate-band-ink, #efe4c8)', 'important');
+            }
+          });
+        }
+        const w = Math.round(ephCard.getBoundingClientRect().width);
+        if (w && ephBand.style.width !== w + 'px') {
+          ephBand.style.width = w + 'px';
+          ephBand.style.alignSelf = 'flex-start';
+        }
+        // the card repeats the wordmark the band now carries
+        [...ephCard.querySelectorAll('span,div')].forEach((n) => {
+          if (n.children.length > 2 || !/^(the\s+)?ephemerists$/i.test(n.textContent.trim())) return;
+          const row = n.parentElement && n.parentElement.textContent.trim().length <= 20 ? n.parentElement : n;
+          row.style.setProperty('display', 'none', 'important');
+        });
+      }
+    }
+  }
+  fixEverymenMast() {
+    document.querySelectorAll('#dc-root article span').forEach((sp) => {
+      if (sp.children.length || sp.dataset.mastRenamed) return;
+      if (!/^help wanted!?$/i.test((sp.textContent || '').trim())) return;
+      sp.dataset.mastRenamed = '1';
+      sp.textContent = 'Everymen';
+      const row = sp.parentElement;
+      if (row) row.style.setProperty('gap', '20px', 'important');
+    });
+  }
+  componentDidMount() {
+    import(new URL('sigils.js', document.baseURI).href)
+      .then((m) => { this._sigils = m.SIGILS; })
+      .catch((e) => console.error('sigils', e));
+    const url = new URL('eph-dress.js', document.baseURI).href;
+    import(url).then((m) => {
+      let tries = 0;
+      const tick = () => {
+        const el = document.getElementById('eph-scope');
+        if (el) {
+          this._undress = m.dressEphemerists(el, {});
+          return;
+        }
+        if (++tries < 400) setTimeout(tick, 120);
+      };
+      tick();
+    }).catch((e) => console.error('eph-dress', e));
+
+    const root = document.getElementById('dc-root') || document.body;
+    let t, running = false;
+    const run = () => {
+      if (running) return;
+      running = true;
+      this._btnObs.disconnect();
+      try { this.normalizeSignups(); this.normalizePointsLabels(); this.normalizeLevelLabels(); this.addCtaDividers(); this.fixEverymenMast(); this.addUaMasthead(); this.addWowMasthead(); this.growUaScoreRing(); this.rotateEphWordmark(); this.rotateEphPoints(); this.rotateEphSignup(); this.ephCompassBadge(); this.bandCovenMast(); this.trimMarks(); this.standardizeHeaders(); this.factionFlourishes(); this.pruneDividers(); } finally {
+        running = false;
+        this._btnObs.observe(root, { childList: true, subtree: true, characterData: true });
+      }
+    };
+    this._btnObs = new MutationObserver(() => { clearTimeout(t); t = setTimeout(run, 200); });
+    run();
+  }
+  componentWillUnmount() {
+    if (this._undress) this._undress();
+    if (this._btnObs) this._btnObs.disconnect();
+  }
+  renderVals() {
+    const signup = this.props.showSignup ?? true;
+    return {
+      points: this.props.pointValue ?? 30,
+      multiplier: this.props.multiplier ?? 1,
+      inProgress: this.props.inProgressCount ?? 0,
+      onSignup: signup ? (() => {}) : undefined,
+      naTask: this.task("na", 101),
+      uaTask: this.task("ua", 102),
+      wowTask: this.task("wow", 103),
+      snideTask: this.task("snide", 104),
+      ephTask: this.task("ephemerists", 105),
+      singTask: this.task("singularity", 106),
+      everyTask: this.task("everymen", 107),
+      covenTask: this.task("coven", 108),
+      albTask: this.task("albescent", 109)
+    };
+  }
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
Prerequisite for the task-cards epic. Adds `.design-sync/task-cards/` only — nothing ships to users.

The design is a **specimen sheet**, not an implementation: it mounts the existing kit cards via `<x-import component-from-global-scope="WZ.CovenTaskCard">` and then runs ~1,090 lines of `DCLogic` that mutate them in the DOM — finding the CTA with `button[data-boxed]` and identifying the faction by reading the spec sheet's own heading text.

That is why the brief leads with *"read the design for what changes, write the change in the real component"*. An agent reading the file cold could plausibly port the scaffolding.

`eph-dress.css`, `eph-dress.js` and `sigils.js` are deliberately **not** vendored — same reason, and they are the worst offenders (`svg:has(> ellipse[transform="rotate(-24 12 12)"])`, `:nth-child(22n+7)::before { content: "Ψ" }`).

The brief also annotates two stale claims in the vendored file, per policy step 2:
- `normalizeSignups()` matches CTA phrases that are **invitation-letter copy**, not task-card copy — the #1863/#1909/#1939 sweep retired them. Its only real effect is Albescent's "acknowledge".
- `rotateEphWordmark()` says in its own body that the wordmark rotation is retired. Only the points label and the CTA rotate.

The epic's last PR removes this directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)