### PR TITLE
Cozy Coven's vote plate gets a sun by day, and keeps its moon by night (#2020)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -906,6 +906,18 @@ Controlled by `data-theme="dark"` attribute on `<html>`. All colors reference CS
 
 **Implementation rule:** Do NOT use `const dark = theme === 'dark'` to pick colors. Use CSS variables. The only place `useTheme()` should drive color decisions is for truly structural differences (e.g., Singularity card is always dark regardless of theme).
 
+### A theme may pick GEOMETRY, and then it owes a one-motif token family (#2020)
+
+The rule above is about colour, and it stands. What it does not cover is the case Coven's vote plate became: light draws a **sun**, rays counted round a disc, and dark draws the **moon phases** that shipped. No custom property carries a `<path d>`, so the cascade cannot express that swap — `useTheme()` picks the motif, and every colour on whichever plate is built is still a token (`--faction-coven-{sun,moon}-*`). The test of whether a fork is legitimate is exactly that: **could a variable have done it?** A different fill is a variable's job; a different shape is not.
+
+Three things follow, and each is a way to get this wrong.
+
+- **Build ONE motif, never both.** Rendering both plates and hiding one with `display: none` looks equivalent and is not: it puts ten rating controls in the markup where the viewer has five, and the SSR harness counts markup. The a11y tree is the smaller half of what a doubled control set breaks.
+- **Mirror the role names, one for one.** The sun's family is `-plate-from`, `-disc-on`, `-gold`, `-ring-on`, `-face`, `-star`, `-dust` … because the moon's is. Two motifs whose token names diverge are two palettes nobody can diff, and the second one silently stops being maintained with the first.
+- **A one-motif family gets NO dark block, and the comment has to say why.** The moon family declares nothing under `[data-theme="dark"]` because it is a night surface in both cascades; the sun declares nothing because *it is never mounted in dark at all*. Those are opposite reasons with identical diffs, and the next sweep to find an undarkened family is owed the difference in writing — otherwise it either adds a value nothing can read or deletes one that is load-bearing.
+
+**What the plate owes is 1.4.11, not AA.** Nothing on a vote plate is text — the caption sits below it on the card — so the floor is 3:1 on the *reached* state, and the unlit marks are allowed to recede (the shipped moon's lit gold reads 9.82:1 on its night plate and its unlit ring 1.28:1). Held to that, the sun's design values failed the same way #2019's did: bright gold rays read **1.26:1** on cream, and there is no yellow that clears near-white paper. What is worth adding to that section is the second half. The design drew the disc's limb as **the same hue** as the rays, one and a half stops darker — and AA spends exactly the lightness that separation was made of. Walked to the floor on its own hue the limb lands **ΔE 15.5** from the rays; at the design's own value it is ΔE 17.6 *with the same luminance as them*. Lightness was spent, so the axis left is hue, and the palette already held one — the face's. The limb walks there and lands **ΔE 22.1**, keeping the drawn relationship (limb darker and warmer than rays). Where #2019 spent chroma, this spent hue; the general move is that **the axis a floor did not consume is the one to pay separation out of**, and which axis that is depends on which floor bit.
+
 ---
 
 ## 9. Page Summaries

--- a/frontend/src/components/__tests__/cardHeadingOutline.test.tsx
+++ b/frontend/src/components/__tests__/cardHeadingOutline.test.tsx
@@ -41,6 +41,13 @@ import '../../i18n'
 // Task cards read the form factor; SSR runs no effects, so it has to be stubbed
 // rather than measured. Registered before the card modules are imported.
 vi.mock('../../hooks/useFormFactor', () => ({ useFormFactor: () => 'desktop' }))
+// `useTheme` throws outside its provider by design (#701), and the Coven card
+// mounts `CovenVote`, which reads it to pick sun or moon (#2020). Dark is what
+// an unconfigured visitor gets (`DEFAULT_THEME`); the headings this file counts
+// are the same under either motif.
+vi.mock('../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'dark' as const, toggle: () => {} }),
+}))
 
 import { FACTION_MANIFESTS, surfaceMap } from '../../factions'
 import { pickVariant } from '../../utils/factionDispatch'

--- a/frontend/src/components/vote/CovenVote.tsx
+++ b/frontend/src/components/vote/CovenVote.tsx
@@ -1,5 +1,6 @@
-import { useState, type CSSProperties } from 'react'
+import { useState, type CSSProperties, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useTheme } from '../../hooks/useTheme'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
 import { VoteLoginGate, VoteSummary } from './VoteShell'
@@ -11,12 +12,29 @@ import { VOTE_REFRAMES } from './voteReframes'
  * little face and sparkles. No recombination was ever needed here: the
  * moon phases were always the PINK faction's metaphor. The prototype files them
  * under a "WOW" heading only because both identities were still called Warriors
- * of Whimsy when it was drawn (ADR-0050). The plate is a night surface that reads in both themes, so
- * its inner colours do not flip — only the caption ink does.
+ * of Whimsy when it was drawn (ADR-0050).
+ *
+ * THE PLATE NOW FLIPS (#2020), which reverses the decision the line above used
+ * to end with — "a night surface that reads in both themes, so its inner colours
+ * do not flip". Dark keeps the moon, unchanged to the byte. LIGHT GETS A SUN:
+ * the same 1-5 climb told in RAYS, `level * 2 + 2` of them around a disc that
+ * grows with the level, and the same little face on rank 5.
+ *
+ * WHY A TERNARY AND NOT THE CASCADE. A `[data-theme]` rule can repaint a shape;
+ * it cannot swap one. Rays counted round a disc and a phase swept across one are
+ * different GEOMETRY, and no custom property carries a `<path d>`. So `useTheme`
+ * picks the MOTIF and nothing else — every colour on either plate is still a
+ * token, and `--faction-coven-{sun,moon}-*` are the two families. Only one plate
+ * is ever built: rendering both and hiding one with CSS would put ten rating
+ * controls in the markup where the viewer has five.
  *
  * Plugs into the vote dispatcher via the shared {@link useVote} hook so the
  * cast logic lives in exactly one place. All motion is a reduced-motion-
- * gated CSS class (never inline `animation:`); a stilled plate still fills.
+ * gated CSS class (never inline `animation:`); a stilled plate still fills. The
+ * sun reuses the moon's two — `.coven-moon-dust` and `.coven-moon-sparkle` are
+ * motion only, the fill comes from the SVG — so it adds no keyframes, and it
+ * takes no cast burst: the design draws one, but the shipped widget has none in
+ * either theme and a click must not feel different by daylight (#2020).
  *
  * #840 restored two things from the source: the PROMPT the design writes above
  * the plate ("how'd this land?"), and the caption at the prototype's own 19px
@@ -54,8 +72,203 @@ const DUST_SPOTS = [
 
 const TIERS = VOTE_REFRAMES['coven'].tiers
 
+/**
+ * The sun's geometry, ported from `.design-sync/coven-stamps/VoteStamp.dc.html`
+ * rather than re-derived: `level * 2 + 2` rays around a disc of `7 + level*0.9`,
+ * each ray a stroke between two radii of the same 30x30 field the moon uses.
+ * The rank-5 sun overflows that field, which is why both motifs draw with
+ * `overflow: visible`.
+ */
+function sunRays(level: number): { x1: number; y1: number; x2: number; y2: number }[] {
+  const disc = 7 + level * 0.9
+  const total = level * 2 + 2
+  return Array.from({ length: total }, (_unused, index) => {
+    const angle = (index / total) * Math.PI * 2
+    return {
+      x1: 15 + Math.cos(angle) * (disc + 2.4),
+      y1: 15 + Math.sin(angle) * (disc + 2.4),
+      x2: 15 + Math.cos(angle) * (disc + 5.6),
+      y2: 15 + Math.sin(angle) * (disc + 5.6),
+    }
+  })
+}
+
+/** Ornament geometry shared by both motifs; only the fill token differs. */
+function dustMotes(fill: string): ReactNode {
+  return DUST_SPOTS.map(([x, y], index) => (
+    <span
+      key={`dust${index}`}
+      aria-hidden
+      className="coven-moon-dust"
+      style={{
+        position: 'absolute',
+        left: x,
+        top: y,
+        width: 5,
+        height: 5,
+        opacity: 0.7,
+        pointerEvents: 'none',
+        ['--tw-delay' as string]: `${index * 0.4}s`,
+      }}
+    >
+      <svg viewBox="0 0 24 24" width={5} height={5}>
+        <path d={SPARK_D} fill={fill} />
+      </svg>
+    </span>
+  ))
+}
+
+/** The four sparkles a REACHED rank 5 wears, in either motif. */
+function rankSparkles(fill: string): ReactNode {
+  return SPARK_SPOTS.map((spot, index) => (
+    <span
+      key={`sp${index}`}
+      aria-hidden
+      className="coven-moon-sparkle"
+      style={{
+        position: 'absolute',
+        ...spot,
+        width: index % 2 ? 8 : 11,
+        height: index % 2 ? 8 : 11,
+        pointerEvents: 'none',
+        ['--tw-delay' as string]: `${index * 0.18}s`,
+      }}
+    >
+      <svg viewBox="0 0 24 24" width="100%" height="100%">
+        <path d={SPARK_D} fill={fill} />
+      </svg>
+    </span>
+  ))
+}
+
+const PLATE: CSSProperties = {
+  position: 'relative',
+  display: 'flex',
+  gap: 'var(--space-sm)',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 'var(--space-sm) var(--space-md)',
+  borderRadius: 12,
+}
+
+const MOON_PLATE: CSSProperties = {
+  ...PLATE,
+  background:
+    'radial-gradient(120% 150% at 50% -20%, var(--faction-coven-moon-plate-from), var(--faction-coven-moon-plate-to))',
+  border: '1px solid var(--faction-coven-moon-plate-border)',
+  boxShadow: 'inset 0 1px 8px rgba(0, 0, 0, 0.5)',
+}
+
+const SUN_PLATE: CSSProperties = {
+  ...PLATE,
+  background:
+    'radial-gradient(120% 150% at 50% -20%, var(--faction-coven-sun-plate-from), var(--faction-coven-sun-plate-to))',
+  border: '1px solid var(--faction-coven-sun-plate-border)',
+  // The moon spells its inset shadow inline, which is a colour outside the
+  // cascade; new paint goes in index.css even where the ratchet grandfathers
+  // the file (#1853).
+  boxShadow: 'var(--faction-coven-sun-plate-shadow)',
+}
+
+/** One night rank: the phase disc, its face at rank 5, its sparkles (#821). */
+function moonMark(value: number, reached: boolean, top: boolean, size: number): ReactNode {
+  return (
+    <>
+      <svg
+        viewBox="0 0 30 30"
+        width={size}
+        height={size}
+        style={{
+          overflow: 'visible',
+          filter: reached ? 'drop-shadow(0 0 6px rgba(190, 120, 225, 0.6))' : 'none',
+        }}
+      >
+        <circle
+          cx={15}
+          cy={15}
+          r={R}
+          fill={reached ? 'var(--faction-coven-moon-disc-on)' : 'var(--faction-coven-moon-disc-off)'}
+        />
+        <path
+          d={phasePath(value / 5)}
+          fill={reached ? 'var(--faction-coven-moon-gold)' : 'var(--faction-coven-moon-lit-off)'}
+        />
+        <circle
+          cx={15}
+          cy={15}
+          r={R}
+          fill="none"
+          stroke={reached ? 'var(--faction-coven-moon-ring-on)' : 'var(--faction-coven-moon-ring-off)'}
+          strokeWidth={1.2}
+        />
+        {reached && top && (
+          <g>
+            <path d="M10.6 13.6 Q11.9 12.1 13.2 13.6" fill="none" stroke="var(--faction-coven-moon-face)" strokeWidth={1.2} strokeLinecap="round" />
+            <path d="M16.8 13.6 Q18.1 12.1 19.4 13.6" fill="none" stroke="var(--faction-coven-moon-face)" strokeWidth={1.2} strokeLinecap="round" />
+            <path d="M12 17.4 Q15 20 18 17.4" fill="none" stroke="var(--faction-coven-moon-face)" strokeWidth={1.3} strokeLinecap="round" />
+            <circle cx={10.6} cy={16.4} r={1.6} fill="var(--faction-coven-moon-cheek)" />
+            <circle cx={19.4} cy={16.4} r={1.6} fill="var(--faction-coven-moon-cheek)" />
+            <path d={SPARK_D} transform="translate(21 7) scale(0.22) translate(-12 -12)" fill="var(--faction-coven-moon-star)" />
+          </g>
+        )}
+      </svg>
+      {reached && top && rankSparkles('var(--faction-coven-moon-gold)')}
+    </>
+  )
+}
+
+/** One day rank: the ray fan, the disc, its face at rank 5, its sparkles (#2020). */
+function sunMark(value: number, reached: boolean, top: boolean, size: number): ReactNode {
+  return (
+    <>
+      <svg
+        viewBox="0 0 30 30"
+        width={size}
+        height={size}
+        style={{
+          overflow: 'visible',
+          filter: reached ? 'drop-shadow(0 0 6px var(--faction-coven-sun-glow))' : 'none',
+        }}
+      >
+        {sunRays(value).map((ray, index) => (
+          <line
+            key={`ray${index}`}
+            x1={ray.x1}
+            y1={ray.y1}
+            x2={ray.x2}
+            y2={ray.y2}
+            stroke={reached ? 'var(--faction-coven-sun-gold)' : 'var(--faction-coven-sun-lit-off)'}
+            strokeWidth={1.6}
+            strokeLinecap="round"
+          />
+        ))}
+        <circle
+          cx={15}
+          cy={15}
+          r={7 + value * 0.9}
+          fill={reached ? 'var(--faction-coven-sun-disc-on)' : 'var(--faction-coven-sun-disc-off)'}
+          stroke={reached ? 'var(--faction-coven-sun-ring-on)' : 'var(--faction-coven-sun-ring-off)'}
+          strokeWidth={1.2}
+        />
+        {reached && top && (
+          <g>
+            <path d="M11.2 13.8 Q12.4 12.4 13.6 13.8" fill="none" stroke="var(--faction-coven-sun-face)" strokeWidth={1.2} strokeLinecap="round" />
+            <path d="M16.4 13.8 Q17.6 12.4 18.8 13.8" fill="none" stroke="var(--faction-coven-sun-face)" strokeWidth={1.2} strokeLinecap="round" />
+            <path d="M12.2 17.2 Q15 19.6 17.8 17.2" fill="none" stroke="var(--faction-coven-sun-face)" strokeWidth={1.3} strokeLinecap="round" />
+            <circle cx={11} cy={16.4} r={1.5} fill="var(--faction-coven-sun-cheek)" />
+            <circle cx={19} cy={16.4} r={1.5} fill="var(--faction-coven-sun-cheek)" />
+            <path d={SPARK_D} transform="translate(21 7) scale(0.22) translate(-12 -12)" fill="var(--faction-coven-sun-star)" />
+          </g>
+        )}
+      </svg>
+      {reached && top && rankSparkles('var(--faction-coven-sun-gold)')}
+    </>
+  )
+}
+
 export default function CovenVote({ praxisId, currentValue, points, totalVotes }: VoteUIProps) {
   const { t } = useTranslation('votes')
+  const { theme } = useTheme()
   const { user, selected, saving, error, vote } = useVote(praxisId, currentValue)
   const [hovered, setHovered] = useState(0)
 
@@ -63,6 +276,8 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
     return <VoteLoginGate />
   }
 
+  // The whole fork. Everything downstream reads `sun` and never the theme.
+  const sun = theme === 'light'
   const active = hovered || selected
   const caption = active ? TIERS[active - 1].label : t('chrome.idle')
 
@@ -72,43 +287,10 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
           the whole `chrome.{F}.prompt` slot: three of nine factions rendered
           one, two more held dead strings, and six ship none at all — so the
           prompt was never a widget feature, it was three exceptions. */}
-      <div
-        onMouseLeave={() => setHovered(0)}
-        style={{
-          position: 'relative',
-          display: 'flex',
-          gap: 'var(--space-sm)',
-          alignItems: 'center',
-          justifyContent: 'center',
-          padding: 'var(--space-sm) var(--space-md)',
-          borderRadius: 12,
-          background:
-            'radial-gradient(120% 150% at 50% -20%, var(--faction-coven-moon-plate-from), var(--faction-coven-moon-plate-to))',
-          border: '1px solid var(--faction-coven-moon-plate-border)',
-          boxShadow: 'inset 0 1px 8px rgba(0, 0, 0, 0.5)',
-        }}
-      >
-        {DUST_SPOTS.map(([x, y], index) => (
-          <span
-            key={`dust${index}`}
-            aria-hidden
-            className="coven-moon-dust"
-            style={{
-              position: 'absolute',
-              left: x,
-              top: y,
-              width: 5,
-              height: 5,
-              opacity: 0.7,
-              pointerEvents: 'none',
-              ['--tw-delay' as string]: `${index * 0.4}s`,
-            }}
-          >
-            <svg viewBox="0 0 24 24" width={5} height={5}>
-              <path d={SPARK_D} fill="var(--faction-coven-moon-dust)" />
-            </svg>
-          </span>
-        ))}
+      <div onMouseLeave={() => setHovered(0)} style={sun ? SUN_PLATE : MOON_PLATE}>
+        {sun
+          ? dustMotes('var(--faction-coven-sun-dust)')
+          : dustMotes('var(--faction-coven-moon-dust)')}
 
         {TIERS.map((tier) => {
           const reached = active >= tier.value
@@ -128,7 +310,7 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
                 border: 'none',
                 background: 'transparent',
                 padding: 0,
-                // ≥44px touch target; the moon floats centred inside.
+                // ≥44px touch target; the mark floats centred inside.
                 minWidth: 44,
                 minHeight: 44,
                 display: 'flex',
@@ -139,65 +321,9 @@ export default function CovenVote({ praxisId, currentValue, points, totalVotes }
                 transition: 'transform 150ms',
               }}
             >
-              <svg
-                viewBox="0 0 30 30"
-                width={size}
-                height={size}
-                style={{
-                  overflow: 'visible',
-                  filter: reached ? 'drop-shadow(0 0 6px rgba(190, 120, 225, 0.6))' : 'none',
-                }}
-              >
-                <circle
-                  cx={15}
-                  cy={15}
-                  r={R}
-                  fill={reached ? 'var(--faction-coven-moon-disc-on)' : 'var(--faction-coven-moon-disc-off)'}
-                />
-                <path
-                  d={phasePath(tier.value / 5)}
-                  fill={reached ? 'var(--faction-coven-moon-gold)' : 'var(--faction-coven-moon-lit-off)'}
-                />
-                <circle
-                  cx={15}
-                  cy={15}
-                  r={R}
-                  fill="none"
-                  stroke={reached ? 'var(--faction-coven-moon-ring-on)' : 'var(--faction-coven-moon-ring-off)'}
-                  strokeWidth={1.2}
-                />
-                {reached && top && (
-                  <g>
-                    <path d="M10.6 13.6 Q11.9 12.1 13.2 13.6" fill="none" stroke="var(--faction-coven-moon-face)" strokeWidth={1.2} strokeLinecap="round" />
-                    <path d="M16.8 13.6 Q18.1 12.1 19.4 13.6" fill="none" stroke="var(--faction-coven-moon-face)" strokeWidth={1.2} strokeLinecap="round" />
-                    <path d="M12 17.4 Q15 20 18 17.4" fill="none" stroke="var(--faction-coven-moon-face)" strokeWidth={1.3} strokeLinecap="round" />
-                    <circle cx={10.6} cy={16.4} r={1.6} fill="var(--faction-coven-moon-cheek)" />
-                    <circle cx={19.4} cy={16.4} r={1.6} fill="var(--faction-coven-moon-cheek)" />
-                    <path d={SPARK_D} transform="translate(21 7) scale(0.22) translate(-12 -12)" fill="var(--faction-coven-moon-star)" />
-                  </g>
-                )}
-              </svg>
-              {reached &&
-                top &&
-                SPARK_SPOTS.map((spot, index) => (
-                  <span
-                    key={`sp${index}`}
-                    aria-hidden
-                    className="coven-moon-sparkle"
-                    style={{
-                      position: 'absolute',
-                      ...spot,
-                      width: index % 2 ? 8 : 11,
-                      height: index % 2 ? 8 : 11,
-                      pointerEvents: 'none',
-                      ['--tw-delay' as string]: `${index * 0.18}s`,
-                    }}
-                  >
-                    <svg viewBox="0 0 24 24" width="100%" height="100%">
-                      <path d={SPARK_D} fill="var(--faction-coven-moon-gold)" />
-                    </svg>
-                  </span>
-                ))}
+              {sun
+                ? sunMark(tier.value, reached, top, size)
+                : moonMark(tier.value, reached, top, size)}
             </button>
           )
         })}

--- a/frontend/src/components/vote/__tests__/covenVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/covenVote.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * CovenVote (#2020) — THE MOTIF SEAM.
+ *
+ * The widget drew moon phases on a night plate in both themes. It now draws a
+ * SUN in light and the same moon in dark, and the seam under test is that
+ * choice: `useTheme()` picks which geometry renders, and nothing else about the
+ * widget forks. Three things can go wrong there and only one of them looks
+ * broken on screen —
+ *
+ *   - the dark path changes at all (the moon is out of scope for #2020);
+ *   - both plates render and one is hidden with CSS, which puts TEN rating
+ *     buttons in the a11y-visible markup where there are five controls;
+ *   - a colour arrives as a literal instead of a token, so it has no cascade.
+ *
+ * The harness is SSR-only (renderToStaticMarkup, no DOM, effects never run), so
+ * this is also the reduced-motion reading: every animation is a CSS class gated
+ * in index.css, and the markup below is what a stilled plate looks like.
+ * `useTheme()` throws outside a `ThemeProvider` by design (#701), so it is
+ * mocked rather than wrapped — the theme is an INPUT to this component, and a
+ * provider would only hide which value produced which markup.
+ *
+ * The second describe measures the ink the sun is drawn with. It is not in
+ * `factionContrast.test.ts` because that manifest is a (surface, TEXT) contract
+ * and nothing on this plate is text; what the plate owes is 1.4.11 on the
+ * reached state, and index.css records the walk that buys it.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import type { CurrentUser } from '../../../api/auth'
+import { AA_LARGE, contrastRatio, deltaE76, parseColor } from '../../../utils/contrast'
+import { readThemes, resolveVar } from '../../../utils/__tests__/cssVars'
+
+const mocks = vi.hoisted(() => ({
+  user: null as CurrentUser | null,
+  theme: 'light' as 'light' | 'dark',
+  castVote: vi.fn(async () => ({}) as unknown),
+}))
+
+vi.mock('../../../auth/AuthContext', () => ({
+  useAuth: () => ({ user: mocks.user, refetch: async () => {} }),
+}))
+vi.mock('../../../api/votes', () => ({
+  castVote: mocks.castVote,
+}))
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: mocks.theme, toggle: () => {} }),
+}))
+
+import CovenVote from '../CovenVote'
+
+/** No hex may reach the markup — every colour is a token. */
+const HEX = /#[0-9a-fA-F]{3,8}\b/
+
+function currentUser(): CurrentUser {
+  return {
+    account_id: 1,
+    character: {
+      id: 9,
+      username: 'ada',
+      display_name: 'Ada',
+      bio: '',
+      tagline: '',
+      avatar_url: '',
+      location: '',
+      level: 8,
+      score: 100,
+      all_time_score: 100,
+      faction_slug: 'coven',
+      status: 'active',
+      created_at: '2026-01-01T00:00:00Z',
+      badges: [],
+      invitations: [],
+    },
+    is_admin: false,
+    can_create_additional_character: false,
+    can_start_as_albescent: false,
+    albescent_revealed: false,
+    can_propose_task: false,
+    can_propose_metatask: false,
+    can_apply_metatask: false,
+    can_see_retired_tasks: false,
+    can_see_pending_tasks: false,
+    can_comment: true,
+    second_character_level_required: 5,
+    era_name: 'Era 1',
+    level_jump_reach: 0,
+    level_jump_available: false,
+  }
+}
+
+function render(theme: 'light' | 'dark', currentValue?: number): string {
+  mocks.theme = theme
+  return renderToStaticMarkup(
+    <CovenVote praxisId={7} currentValue={currentValue} points={16} totalVotes={4} />,
+  )
+}
+
+const count = (html: string, pattern: RegExp): number => (html.match(pattern) ?? []).length
+
+describe('CovenVote picks a motif from the theme (#2020)', () => {
+  it('draws the sun in light and nothing of the moon', () => {
+    mocks.user = currentUser()
+    const html = render('light', 5)
+    expect(html).toContain('--faction-coven-sun-plate-from')
+    expect(html).toContain('--faction-coven-sun-gold')
+    expect(html).not.toContain('--faction-coven-moon-')
+  })
+
+  it('draws the moon in dark and nothing of the sun', () => {
+    mocks.user = currentUser()
+    const html = render('dark', 5)
+    expect(html).toContain('--faction-coven-moon-plate-from')
+    expect(html).toContain('--faction-coven-moon-gold')
+    expect(html).not.toContain('--faction-coven-sun-')
+  })
+
+  /**
+   * The trap the grill named: rendering both plates and hiding one with CSS.
+   * `display:none` spares the a11y tree but not the markup, and five rating
+   * controls that arrive as ten is the shape no visual check catches.
+   */
+  it('renders exactly five rating buttons in BOTH themes', () => {
+    mocks.user = currentUser()
+    for (const theme of ['light', 'dark'] as const) {
+      expect(count(render(theme, 3), /<button/g)).toBe(5)
+    }
+  })
+
+  /**
+   * The climb is told in rays: `level * 2 + 2` around a disc that grows with the
+   * level, so the five suns carry 4 + 6 + 8 + 10 + 12 = 40 ray strokes whatever
+   * is selected. Pinned because it is the one part of the geometry a reader
+   * cannot check by eye — miscounting rays still renders a plausible sun.
+   */
+  it('fans level * 2 + 2 rays per sun, 40 across the plate', () => {
+    mocks.user = currentUser()
+    expect(count(render('light', 5), /<line/g)).toBe(40)
+    expect(count(render('light'), /<line/g)).toBe(40)
+    // The moon is a phase path, not a fan — no rays anywhere on the night plate.
+    expect(count(render('dark', 5), /<line/g)).toBe(0)
+  })
+
+  /**
+   * The flourish is the moon's, REUSED — six dust motes across the plate and
+   * four sparkles around the rank-5 disc, both driven by classes that already
+   * exist inside `@media (prefers-reduced-motion: no-preference)`. A sun with
+   * its own keyframes would be the same twinkle declared twice.
+   */
+  it('reuses the moon dust and sparkle classes on the sun', () => {
+    mocks.user = currentUser()
+    const html = render('light', 5)
+    expect(count(html, /class="coven-moon-dust"/g)).toBe(6)
+    expect(count(html, /class="coven-moon-sparkle"/g)).toBe(4)
+    // The sun's own tokens fill them; the classes carry motion only.
+    expect(html).toContain('--faction-coven-sun-dust')
+    // The sparkles belong to a REACHED rank 5 and to nothing else — the dust
+    // is plate furniture and stays whatever the viewer picked.
+    expect(count(render('light', 4), /class="coven-moon-sparkle"/g)).toBe(0)
+    expect(count(render('light'), /class="coven-moon-sparkle"/g)).toBe(0)
+    expect(count(render('light', 4), /class="coven-moon-dust"/g)).toBe(6)
+  })
+
+  it('lets no colour literal into either plate', () => {
+    mocks.user = currentUser()
+    expect(render('light', 5)).not.toMatch(HEX)
+    expect(render('dark', 5)).not.toMatch(HEX)
+  })
+
+  it('still returns the shared login gate for an anonymous viewer', () => {
+    mocks.user = null
+    const html = render('light')
+    expect(html.replace(/<[^>]*>/g, '')).toContain('Log in to vote')
+    expect(html).not.toContain('aria-label="Rate')
+  })
+})
+
+const CSS = readFileSync(fileURLToPath(new URL('../../../index.css', import.meta.url)), 'utf8')
+const THEMES = readThemes(CSS)
+const ink = (name: string): string => {
+  const value = resolveVar(name, 'light', THEMES)
+  if (!value) throw new Error(`${name} is not declared in the light cascade`)
+  return value
+}
+const solid = (name: string) => {
+  const colour = parseColor(ink(name))
+  if (!colour) throw new Error(`${name} does not resolve to a solid colour: ${ink(name)}`)
+  return colour
+}
+
+describe('the sun plate is a LIGHT-ONLY family, and its lit inks clear 1.4.11', () => {
+  /**
+   * The moon family has no dark block because it is a night surface in both
+   * cascades. The sun has none for the opposite reason: in dark the component
+   * renders the moon, so a `--faction-coven-sun-*` under `[data-theme="dark"]`
+   * would be a value nothing can read. index.css says so in a comment; this is
+   * the comment with teeth.
+   */
+  it('declares no sun token in the dark cascade', () => {
+    const darkSunTokens = [...THEMES.dark.keys()].filter((name) =>
+      name.startsWith('--faction-coven-sun-'),
+    )
+    expect(darkSunTokens).toEqual([])
+  })
+
+  /**
+   * Ratios on `-plate-to`, the radial gradient's darker stop and the worst
+   * ground for a dark ink. Nothing here is text, so the floor is the non-text
+   * 3:1 — what has to survive is "this rating is reached", and a hue swap alone
+   * does not survive a reading that cannot see hue.
+   */
+  it('holds the rays, the limb and the face to 3:1 on the plate foot', () => {
+    const foot = solid('--faction-coven-sun-plate-to')
+    for (const name of [
+      '--faction-coven-sun-gold',
+      '--faction-coven-sun-ring-on',
+      '--faction-coven-sun-face',
+    ]) {
+      expect(contrastRatio(solid(name), foot)).toBeGreaterThanOrEqual(AA_LARGE)
+    }
+    // The rank-5 face and the star are drawn on the disc, not on the plate.
+    const disc = solid('--faction-coven-sun-disc-on')
+    expect(contrastRatio(solid('--faction-coven-sun-face'), disc)).toBeGreaterThanOrEqual(AA_LARGE)
+    expect(contrastRatio(solid('--faction-coven-sun-star'), disc)).toBeGreaterThanOrEqual(AA_LARGE)
+  })
+
+  /**
+   * #2019's lesson, one issue later on the same faction: AA spends lightness,
+   * and a pair separated by lightness alone collapses when it does. The rays
+   * and the limb are the pair — the design drew them one hue apart in name only
+   * — so the limb walks onto the palette's warmer hue and this is the floor
+   * (§3, ΔE 20) that walk was chosen to clear.
+   */
+  it('keeps the rays and the limb ΔE 20 apart, the axis AA did not spend', () => {
+    const distance = deltaE76(
+      solid('--faction-coven-sun-gold'),
+      solid('--faction-coven-sun-ring-on'),
+    )
+    expect(distance).toBeGreaterThanOrEqual(20)
+  })
+
+  /**
+   * The state code itself. Lit vs unlit is the one distinction the plate cannot
+   * lose, so it is pinned on BOTH axes — the hue jump a sighted reader sees and
+   * the luminance step a monochrome one does.
+   */
+  it('separates a lit ray from an unlit one by hue AND by luminance', () => {
+    const lit = solid('--faction-coven-sun-gold')
+    const unlit = solid('--faction-coven-sun-lit-off')
+    expect(deltaE76(lit, unlit)).toBeGreaterThanOrEqual(20)
+    expect(contrastRatio(lit, unlit)).toBeGreaterThanOrEqual(AA_LARGE)
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1448,6 +1448,81 @@
   --faction-coven-vote-on: #d63f86;
   --faction-coven-vote-off: #a76389;
 
+  /* ── Coven — the DAY plate (#2020) ──
+     The line above ("night plate; same in both themes") was a decision, and
+     this reverses it for LIGHT ONLY: light gets a sun, dark keeps the moon,
+     unchanged. The two are different GEOMETRY — rays counted round a disc
+     against a phase swept across one — so a variable cannot carry the swap and
+     `useTheme()` picks the motif in `CovenVote.tsx`. Every colour it draws with
+     is still a token, and these are them.
+
+     THERE IS NO DARK BLOCK FOR THIS FAMILY, on purpose. The moon family has
+     none because it is a night surface in both cascades; this one has none
+     because it is never mounted in dark at all — the component renders the moon
+     there. A dark value here would be a value nothing can read, and the first
+     sweep to find one would be right to delete it.
+
+     ROLE NAMES MIRROR THE MOON'S ONE FOR ONE so the two motifs stay legibly
+     parallel; `-plate-shadow` and `-glow` are the two the moon spells inline as
+     raw rgba, and this file is where a new surface's colours go.
+
+     WHAT IS MEASURED, AND ON WHAT. Nothing on this plate is text — the caption
+     lives below it on the card and keeps `--faction-coven-vote-*`. What the
+     plate owes is 1.4.11: the rating buttons' REACHED state has to be readable
+     as more than a hue swap. So the LIT inks are held to 3:1 and the unlit ones
+     deliberately are not, which is exactly the shape the shipped moon already
+     has (its gold reads 9.82:1 on the night plate and its unlit ring 1.28:1).
+     Ratios are taken on `-plate-to`, the gradient's darker stop and the worst
+     ground for a dark ink; the head is quoted second.
+
+     TWO INKS MOVED, AND THE SECOND ONE IS #2019's LESSON ARRIVING A DAY LATER
+     ON THE SAME FACTION. The design's rays `#f4c430` read 1.26:1 here: there is
+     no bright yellow that clears cream, the ceiling is arithmetic, so the rays
+     walk down their own hue (h45) to 3.24:1. That is the routine half. The
+     design then drew the disc's limb `#d99a1f` as the SAME hue one and a half
+     stops darker — and AA spends exactly the lightness that separation was made
+     of. Walked to the floor on h40 the limb lands ΔE 15.5 from the rays, and at
+     the design's own value it is ΔE 17.6 with the same luminance as them: two
+     strokes of one drawing that a viewer cannot tell apart. Lightness was
+     spent, so the axis left is hue, and the palette already holds one — the
+     face's h32. The limb walks there instead and lands ΔE 22.1, over §3's floor
+     of 20, keeping the drawn relationship (limb darker and warmer than rays).
+     Everything else is the design's own hex. */
+  --faction-coven-sun-plate-from: #fdf1d6;
+  --faction-coven-sun-plate-to: #f6dfae;
+  --faction-coven-sun-plate-border: #e6c78a;
+  --faction-coven-sun-plate-shadow: inset 0 1px 8px rgba(170, 120, 30, 0.16);
+  --faction-coven-sun-disc-on: #fbe6a8;
+  --faction-coven-sun-disc-off: #efe6fa;
+  /* The rays. Walked from the design's #f4c430 (1.26:1) down h45 — 3.24:1 on
+     the foot, 3.77 on the head, 3.42 on `-disc-on`. Against the unlit rays it
+     is ΔE 79.0 AND 3.06:1, so lit-vs-unlit survives a reading that sees no
+     hue at all. */
+  --faction-coven-sun-gold: #9a7608;
+  /* Unlit: the design's, unwalked and deliberately a whisper — 1.06:1, the
+     moon's own unlit inks read 1.28–1.33 on their plate. The design dimmed
+     these a further 0.7 inline; that alpha is folded away rather than ported,
+     because two places to tune one whisper is one too many. */
+  --faction-coven-sun-lit-off: #e3d6f6;
+  /* The limb. See the walk above: h32 at 4.85:1 on the foot, 5.65 on the head,
+     ΔE 22.1 from the rays. */
+  --faction-coven-sun-ring-on: #8b5214;
+  --faction-coven-sun-ring-off: #c3a9e8;
+  /* The rank-5 face, the design's own and needing no walk: 3.27:1 on the foot
+     and 3.45:1 on `-disc-on`, which is the ground it is actually drawn on. */
+  --faction-coven-sun-face: #b06a1a;
+  --faction-coven-sun-cheek: rgba(236, 95, 153, 0.4);
+  /* The glint on the rank-5 disc — the rays' own gold, 3.42:1 there. An alias
+     rather than a second near-identical hex: the moon's star and gold differ by
+     ΔE 4, which is a distinction only the token names can see. */
+  --faction-coven-sun-star: var(--faction-coven-sun-gold);
+  /* The six motes across the plate: the design's edge gold, freed when the limb
+     walked off it. 1.87:1 on the foot — a mote is decoration, not state, so
+     1.4.11 does not reach it, and a mote that outshouted the rays would be the
+     defect. */
+  --faction-coven-sun-dust: #d99a1f;
+  --faction-coven-sun-glow: rgba(244, 196, 48, 0.55);
+
   /* ══ Coven — THE CANDLELIT SPELL SLIP (task card v2, #1023) ══
      The v2 task card retires the lo-fi `coven.exe` window above; a slip of
      pink-to-lavender paper under a gold twinkle field, with the points held in

--- a/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/covenPraxisDetail.test.tsx
@@ -33,6 +33,15 @@ vi.mock('../../../hooks/useFormFactor', () => ({
   useFormFactor: () => mocks.formFactor,
 }))
 
+// `useTheme` throws outside its provider by design (#701), and the page mounts
+// `CovenVote`, which reads it to pick its motif — sun by day, moon by night
+// (#2020). Dark is what an unconfigured visitor gets (`DEFAULT_THEME`), so this
+// keeps the page under test exactly as it renders today; the motif fork itself
+// belongs to `components/vote/__tests__/covenVote.test.tsx`.
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'dark' as const, toggle: () => {} }),
+}))
+
 // Imported after the mock so the archetype picks it up.
 const { default: CovenPraxisDetail } = await import('../archetypes/CovenPraxisDetail')
 


### PR DESCRIPTION
Closes #2020

Cozy Coven's vote plate was a night surface in both themes — `index.css` said so
in a comment ("night plate; same in both themes"), and that was a decision, not
an oversight. This reverses it **for light mode only**: light gets a sun, dark
keeps the moon, byte-identical to today.

The geometry is ported from `.design-sync/coven-stamps/VoteStamp.dc.html`:
`level * 2 + 2` rays around a disc of `7 + level * 0.9`, rank 5 at 40px against
30px, and the same little face the rank-5 moon wears.

## The seam I tested at

**The motif fork** — `useTheme()` picks which geometry renders, and nothing else
about the widget forks. `frontend/src/components/vote/__tests__/covenVote.test.tsx`
went red on exactly the three sun facts (no sun tokens in light, no ray fan, no
sun dust) before the component moved, then green. It pins the two failures that
do not look broken on screen: **ten rating buttons instead of five** if both
plates render and one is hidden with CSS, and a colour arriving as a literal
with no cascade behind it. `useTheme()` throws outside a `ThemeProvider` by
design (#701), so the theme is mocked — it is an *input* to this component.

I also diffed the dark markup at three selection states against `origin/main`:
**identical byte for byte**. The moon path was not opened.

## What changed

- **`frontend/src/index.css`** — a `--faction-coven-sun-*` family of 15 tokens in
  one contiguous block beside the moon family, role names mirroring it one for
  one. **No dark block, and the comment says why**: the moon has none because it
  is a night surface in both cascades, the sun has none because it is never
  mounted in dark at all. `covenVote.test.tsx` asserts that emptiness rather than
  trusting the comment.
- **`frontend/src/components/vote/CovenVote.tsx`** — one `const sun = theme === 'light'`
  and two mark renderers. The dust motes and the rank-5 sparkles are shared
  helpers taking a fill token, so the sun reuses `.coven-moon-dust` and
  `.coven-moon-sparkle` verbatim: **no new keyframes**, and no cast burst in
  either theme.
- **`WORLD_ZERO_STYLE.md` §8** — when a theme may pick *geometry*, and what a
  one-motif family owes.
- Two suites that mount `CovenVote` (`covenPraxisDetail`, `cardHeadingOutline`)
  now state which theme they mount it in.

`votes.json`, `voteReframes.ts` and `useVote` are untouched — no copy changed, no
eyebrow built, no mechanic added.

## Two deviations from the vendored design, both measured

1. **The rays and the limb are walked.** Nothing on this plate is text, so the
   floor is 1.4.11's 3:1 on the *reached* state, not AA. The design's rays
   `#f4c430` read **1.26:1** on the plate's darker stop — there is no yellow that
   clears cream — so they walk down their own hue to **3.24:1**. The limb is the
   #2019 lesson arriving a day later on the same faction: the design drew it the
   *same hue* as the rays, separated by lightness, and AA spends exactly that.
   Walked on its own hue it sits **ΔE 15.5** from the rays; at the design's own
   value, **ΔE 17.6 with the same luminance**. So the limb walks onto the
   palette's warmer hue — the face's — and lands **ΔE 22.1**, over §3's floor of
   20, keeping the drawn relationship. Every other value is the design's own hex.
2. **The unreached rays' inline `opacity: 0.7` is folded away.** The ink is
   already a 1.06:1 whisper (the shipped moon's unlit inks read 1.28–1.33 on
   theirs); two places to tune one whisper is one too many.

## The premise that was wrong

The issue says *"no existing test renders `CovenVote`"*. True of the vote suite;
**false of the tree** — `covenPraxisDetail.test.tsx` and `cardHeadingOutline.test.tsx`
both mount it through the page and the card, and both went red with
`useTheme must be used within a ThemeProvider` the moment the hook arrived. They
are mocked to `dark`, which is `DEFAULT_THEME` and so is what they were already
asserting.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(302 files / 5,244 tests), `npm run build`, `npm run budget` all pass.

**CSS byte budget: 23.4 KB gzipped** against `warn>23.0 / fail>24.4`. `origin/main`
measures **23.2 KB** on the same build, so this is **+0.2 KB**; main was already on
the warn side of the line before it.

**Visual QA is outstanding** — I have no browser and no dev stack, so every claim
above is from tests, tsc, eslint, the emitted stylesheet and arithmetic. Nobody
has looked at this sun.

## What to eyeball

- **Light mode, a Coven task's praxis** — the plate should read as warm daylight
  paper, and the ray fan should visibly densify 4 → 6 → 8 → 10 → 12 as the discs
  grow. That climb is the whole rating scale.
- **The walked golds against the cream.** The rays land on an olive-gold and the
  disc's limb on a deeper terracotta; both are darker than the design drew.
  Arithmetic says they had to be — but whether the sun still reads *sunny* is a
  question only an eye answers.
- **The unreached suns.** They are a lavender disc with near-invisible ghost
  rays, deliberately, mirroring how the moon's unlit ranks recede. Check that
  five controls still read as five.
- **Rank 5** — face, cheeks, star glint, and four sparkles, and that they sit
  inside the bigger disc rather than clipping.
- **Flip to dark and back.** The moon must be exactly what it was, and the
  caption ink below the plate is the one thing that always flipped.
- **Reduced motion.** With it on, the six dust motes and the four sparkles
  should be drawn and still — no new keyframes were added, so this is the moon's
  existing behaviour wearing sun colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
