### PR TITLE
Coven's task card: the score bubbles in the shared cauldron, the CTA becomes a box (#2033)

### DIFF
--- a/frontend/src/components/taskCard/CovenTaskCard.tsx
+++ b/frontend/src/components/taskCard/CovenTaskCard.tsx
@@ -4,6 +4,7 @@ import type { CardProps } from "./TaskCard";
 import CardMasthead from "./CardMasthead";
 import { CARD_CTA, CARD_CTA_ROW } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
+import CovenCauldron from "../factionMarks/CovenCauldron";
 import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
@@ -14,10 +15,10 @@ import { useFormFactor } from "../../hooks/useFormFactor";
  *
  * A slip of paper that fades pink → lavender under a gold twinkle field, headed
  * by a pentagram badge and the coven's name hand-lettered in Caveat. A celtic
- * braid, hearts tied off at both ends, rules off each section; the points sit in
- * a glowing arcane sigil; a slow pentagram watermark turns behind the copy; and
- * the call to action is a full-bleed pink band. Grenze Gotisch carries the
- * title, Cormorant Garamond the reading copy, Quicksand the chrome.
+ * braid, hearts tied off at both ends, rules off each section; the points bubble
+ * in a cauldron; a slow pentagram watermark turns behind the copy; and the call
+ * to action is a rounded pink box. Grenze Gotisch carries the title, Cormorant
+ * Garamond the reading copy, Quicksand the chrome.
  *
  * This REPLACES the lo-fi `coven.exe` window archetype wholesale (ADR-0055 /
  * ADR-0056 — a full metaphor swap, not a tweak). The `--faction-coven-win-*`
@@ -52,8 +53,17 @@ interface SizeSet {
   bodyPad: string;
   titleSize: string;
   levelSize: string;
-  /** Outer box of the arcane sigil. Geometry. */
-  sigil: number;
+  /**
+   * Rendered side of {@link CovenCauldron}. Geometry, and the ONLY dial the
+   * mark takes — everything in it, text included, is inside the viewBox.
+   *
+   * Bigger than the arcane sigil's 100/88 box it replaces, because the design
+   * scales its own cauldron to 1.16× the badge and the shared mark draws a
+   * little tighter inside its 132-unit square. At 116 the caption sets at
+   * ~8.8px, in line with the slip's other captions; below about 100 it drops
+   * under 8px and the vessel stops reading as one.
+   */
+  cauldron: number;
 }
 
 const SIZES: Record<"desktop" | "mobile", SizeSet> = {
@@ -62,15 +72,17 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
     /* Top pad is the band's now: the floating wordmark used to carry the gap. */
     bodyPad: "var(--space-md) var(--space-xl) var(--space-lg)",
     titleSize: "var(--text-heading)",
-    levelSize: "var(--text-heading)",
-    sigil: 100,
+    /* One rung up (#2033): the numeral was set small for Cormorant's eye and
+       read two steps behind Everymen's and Snide's. */
+    levelSize: "var(--text-display)",
+    cauldron: 116,
   },
   mobile: {
     cardWidth: 340,
     bodyPad: "var(--space-md) var(--space-lg) var(--space-lg)",
     titleSize: "var(--text-title)",
-    levelSize: "var(--text-title)",
-    sigil: 88,
+    levelSize: "var(--text-heading)",
+    cauldron: 100,
   },
 };
 
@@ -135,79 +147,6 @@ function TwinkleField() {
         <path key={`${x}-${y}`} d={starPath(x, y, r)} fill="var(--faction-coven-slip-gold)" opacity={0.8} />
       ))}
     </svg>
-  );
-}
-
-/** The points, held in a glowing arcane sigil. */
-function Sigil({ size, points }: { size: number; points: number }) {
-  const sparkles: [number, number, number][] = [
-    [50, 4, 3.4],
-    [88, 26, 2.4],
-    [14, 74, 2.8],
-    [84, 78, 1.9],
-    [16, 24, 1.7],
-  ];
-  return (
-    <div
-      style={{
-        position: "relative",
-        flex: "0 0 auto",
-        width: size,
-        height: size,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      <span
-        aria-hidden="true"
-        style={{ position: "absolute", inset: 0, borderRadius: "50%", background: "var(--faction-coven-slip-sigil-halo)" }}
-      />
-      <span
-        aria-hidden="true"
-        style={{ position: "absolute", inset: "18%", borderRadius: "50%", background: "var(--faction-coven-slip-sigil-core)" }}
-      />
-      <svg
-        width={size}
-        height={size}
-        viewBox="0 0 100 100"
-        aria-hidden="true"
-        style={{ position: "absolute", inset: 0, overflow: "visible" }}
-      >
-        <circle cx="50" cy="50" r="32" fill="none" stroke="var(--faction-coven-slip-pk)" strokeWidth="1.6" opacity="0.9" />
-        <g stroke="var(--faction-coven-slip-gold)" strokeWidth="1.1" strokeLinecap="round" opacity="0.8">
-          <path d="M50 8 v6" />
-          <path d="M50 86 v6" />
-          <path d="M8 50 h6" />
-          <path d="M86 50 h6" />
-        </g>
-        {sparkles.map(([x, y, r]) => (
-          <path key={`${x}-${y}`} d={starPath(x, y, r)} fill="var(--faction-coven-slip-gold)" opacity={0.9} />
-        ))}
-      </svg>
-      <div
-        style={{
-          position: "relative",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          lineHeight: 0.85,
-        }}
-      >
-        <span
-          className="content-title"
-          style={{ fontFamily: READING, fontWeight: 600, color: "var(--faction-coven-slip-deep)" }}
-        >
-          {points}
-        </span>
-        {/* Ornament: the unit caption inside the drawn sigil, sized to the disc
-            rather than to the label ramp (WORLD_ZERO_STYLE §4a). */}
-        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: caption engraved inside the sigil. */}
-        <span style={{ ...CAPTION, fontSize: 8, marginTop: "var(--space-xs)" }}>
-          {i18n.t("feed:taskCard.pointsUnit")}
-        </span>
-      </div>
-    </div>
   );
 }
 
@@ -348,7 +287,20 @@ export default function CovenTaskCard({
                 </div>
               )}
 
-              <Sigil size={size.sigil} points={basePoints} />
+              {/* THE SCORE MOVES INTO THE CAULDRON (#2033). It sat in a drawn
+                  arcane sigil — a halo disc, a pale core, a ringed circle of
+                  gold ticks and sparkles, with the numeral floated over the
+                  middle. All of it goes: the vessel is #2019's, by owner
+                  ruling, because Coven draws the same pot on the praxis card's
+                  score stamp and two cauldrons is the outcome that ruling
+                  exists to prevent. Everything the sigil painted, the mark
+                  paints — including the numeral and its caption, which are
+                  typeset INSIDE the viewBox so one `size` scales the lot. */}
+              <CovenCauldron
+                total={String(basePoints)}
+                caption={i18n.t("feed:taskCard.pointsUnit")}
+                size={size.cauldron}
+              />
             </div>
 
             <h2
@@ -405,12 +357,17 @@ export default function CovenTaskCard({
           </Link>
         </div>
 
-        {/* The pink band ran the slip's full width. #2030 tucks it in with
-            clearance under it, rounded to the same 20 the modifier chip takes —
-            the slip has no square corner on it anywhere. No rule above: the
-            braid under the description is the section's own tie-off, and the
-            dotted-with-a-gem rule the design defines for Coven is dead code it
-            skips in the same pass. */}
+        {/* The pink band ran the slip's full width. #2030 tucked it in with
+            clearance under it; #2033 gives it its final shape — A ROUNDED BOX,
+            not a pill. At the 20 it inherited from the modifier chip a 44px-tall
+            button is within 2px of fully round, so the two controls read as the
+            same object at different lengths; 12 keeps a corner soft enough for a
+            slip that has no square one on it while letting the CTA be the one
+            BOX on the card. The chip keeps its 20 and stays a chip.
+
+            No rule above: the braid under the description is the section's own
+            tie-off, and the dotted-with-a-gem rule the design defines for Coven
+            is dead code it skips in the same pass. */}
         {cta && (
           <div style={{ ...CARD_CTA_ROW, position: "relative", zIndex: 2 }}>
             <button
@@ -432,7 +389,7 @@ export default function CovenTaskCard({
                 textTransform: "uppercase",
                 padding: "var(--space-sm) var(--space-xl)",
                 border: "1.5px solid var(--faction-coven-slip-cta-to)",
-                borderRadius: 20,
+                borderRadius: 12,
                 boxShadow: "0 3px 8px var(--faction-coven-slip-glow)",
               }}
             >

--- a/frontend/src/components/taskCard/__tests__/covenTaskCardV3.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/covenTaskCardV3.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Task cards v3, Phase 2 — Cozy Coven's ornament (#2033, epic #2027).
+ *
+ * Three changes, and the first is the one worth a test file of its own: the
+ * score moves OUT of the card's private arcane sigil and INTO the shared
+ * cauldron #2019 built (`factionMarks/CovenCauldron`). The owner ruling on that
+ * issue is that the two surfaces mount ONE vessel — so the assertion that
+ * matters is not "a cauldron is drawn here" (a hand-rolled twin would pass
+ * that) but "the markup the shared component emits appears verbatim in the
+ * card". A fork drifts by one path attribute and this goes red.
+ *
+ * The seam is the one `factionTaskCardsV2.test.tsx` and `taskCardsV3.test.tsx`
+ * already work at: rendered markup via `renderToStaticMarkup`. No jsdom, so
+ * geometry is out of reach; what is checkable is which elements exist and which
+ * inline declarations they carry, which is all three changes.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+// Imported after the mock is registered.
+import CovenTaskCard from '../CovenTaskCard'
+import CovenCauldron from '../../factionMarks/CovenCauldron'
+import { aTask } from '../../../test/fixtures'
+
+/**
+ * The two sizes the card mounts the vessel at, written out rather than imported
+ * so the component keeps its `SIZES` private. They are the numbers a reviewer
+ * eyeballs, so a change to them SHOULD land here.
+ */
+const CAULDRON = { desktop: 116, mobile: 100 }
+
+const TASK = aTask({
+  description: 'Leave something small and honest where a stranger will find it.',
+  in_progress_count: 4,
+})
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <CovenTaskCard
+        task={TASK}
+        basePoints={TASK.point_value}
+        multiplier={1}
+        inProgressCount={TASK.in_progress_count}
+        onSignup={() => {}}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('the score sits in the SHARED cauldron (#2033, ruling on #2019)', () => {
+  it('mounts CovenCauldron verbatim rather than drawing a second vessel', () => {
+    mocks.formFactor = 'desktop'
+    const mark = renderToStaticMarkup(
+      <CovenCauldron
+        total={String(TASK.point_value)}
+        caption={i18n.t('feed:taskCard.pointsUnit')}
+        size={CAULDRON.desktop}
+      />,
+    )
+    expect(render()).toContain(mark)
+  })
+
+  it('mounts it at the mobile size too, from the same component', () => {
+    mocks.formFactor = 'mobile'
+    const mark = renderToStaticMarkup(
+      <CovenCauldron
+        total={String(TASK.point_value)}
+        caption={i18n.t('feed:taskCard.pointsUnit')}
+        size={CAULDRON.mobile}
+      />,
+    )
+    expect(render()).toContain(mark)
+    mocks.formFactor = 'desktop'
+  })
+
+  it('retires the arcane sigil the cauldron replaces — halo, core and ring', () => {
+    mocks.formFactor = 'desktop'
+    const html = render()
+    // The two discs the design hides when the cauldron arrives. Both tokens
+    // survive in index.css: the Coven task-detail and praxis-detail still paint
+    // with them, so this is a mount change and not a token deletion.
+    expect(html).not.toContain('--faction-coven-slip-sigil-halo')
+    expect(html).not.toContain('--faction-coven-slip-sigil-core')
+    // The band's ground is a different `-sigil-` token and stays.
+    expect(html).toContain('--faction-coven-slip-sigil-ground')
+  })
+})
+
+describe("Coven's CTA reads as a rounded box (#2033)", () => {
+  it('drops the pill radius while keeping the shared 44px tap floor', () => {
+    mocks.formFactor = 'desktop'
+    const html = render()
+    const button = html.slice(html.indexOf('<button'))
+    expect(button).toContain('border-radius:12px')
+    expect(button).not.toContain('border-radius:20px')
+    expect(button).toContain('min-height:44px')
+  })
+
+  it('leaves no rule above it — the braid is the slip’s own tie-off', () => {
+    expect(render()).not.toContain('data-cta-rule')
+  })
+})
+
+describe("Coven's level numeral matches the kit's weight (#2033)", () => {
+  /** The numeral's own declaration run — `line-height:0.8` pins it to that span. */
+  const numeral = (rung: string) =>
+    `font-family:var(--font-faction-serif);font-weight:600;font-size:var(--${rung});line-height:0.8`
+
+  it('is set on the display rung at desktop, as Everymen and Snide are', () => {
+    mocks.formFactor = 'desktop'
+    expect(render()).toContain(numeral('text-display'))
+  })
+
+  it('steps down one rung on mobile rather than staying two behind', () => {
+    mocks.formFactor = 'mobile'
+    expect(render()).toContain(numeral('text-heading'))
+    mocks.formFactor = 'desktop'
+  })
+})


### PR DESCRIPTION
Task cards v3, **Phase 2** — Cozy Coven's ornament pass. Three changes, all inside
`frontend/src/components/taskCard/CovenTaskCard.tsx`. **Zero CSS bytes minted.**

Closes #2033

## The seam, and the test at it

The seam is the rendered markup of the skin via `renderToStaticMarkup` — the one
`factionTaskCardsV2.test.tsx` and `taskCardsV3.test.tsx` already work at. No jsdom,
so geometry is out of reach; what is checkable is which elements exist and which
inline declarations they carry, and all three changes are structural.

New file: `src/components/taskCard/__tests__/covenTaskCardV3.test.tsx`. Its own test
file rather than a sixth edit to the shared `taskCardsV3.test.tsx`, because six
sibling Phase-2 agents are in flight tonight and that file is the obvious collision.

The load-bearing assertion is deliberately not "a cauldron is drawn here" — a
hand-rolled twin would pass that. It renders `<CovenCauldron …>` standalone and
asserts **that exact markup is a substring of the card's html**. A fork that drifts
by one path attribute goes red. It went red on the real defect first (6 of 7 failing
against `main`; the one that passed was `not.toContain('data-cta-rule')`, which
Phase 1 already had right).

## 1. The score moves into the shared cauldron

**Mounted, not drawn.** Per the owner ruling on #2033 and the extraction in #2019 /
PR #2044, `factionMarks/CovenCauldron` is canonical and this card mounts it at its
own scale. It fits with no changes to the mark and no note back to #2019.

What goes: the whole private `Sigil()` — the halo disc, the pale core disc, the
ringed circle with its four gold ticks and five sparkles, and the numeral/caption
stack floated over the middle. That matches the design, which hides the two discs
(`badge.dataset.bare`), replaces the sigil's SVG body, and drops the numeral into
the pot. All of it is now one element.

The numeral and the caption stay **inside the viewBox**, as the mark's author
flagged — no overlaid HTML re-introduced, so one `size` scales the lot.

`--faction-coven-slip-sigil-halo` / `-core` are **not** deleted from `index.css`:
`CovenTaskDetail` and `CovenPraxisDetail` still paint with them. This is a mount
change, not a token change. (`-sigil-ground` is a different token and still dresses
the masthead band; the test pins that distinction.)

**Size: 116 desktop / 100 mobile**, up from the sigil box's 100 / 88. The design
scales its own cauldron to 1.16× the badge, and the shared mark draws a little
tighter inside its 132-unit square, so the same box would read smaller. At 116 the
in-viewBox caption sets at ~8.8px, in line with the slip's other captions (8 / 8.5px);
below ~100 it drops under 8px and the vessel stops reading as one.

## 2. The CTA reads as a rounded box

`borderRadius` 20 → **12**. At 20 a 44px-tall button is within 2px of fully round, so
the CTA and the ×-modifier chip read as the same object at different lengths. 12 keeps
a corner soft enough for a slip that has no square one on it while letting the CTA be
the one *box* on the card. The chip keeps its 20 and stays a chip.

Everything else about the button is Phase 1's and untouched: `CARD_CTA` (the 44px tap
floor and the centring) and `CARD_CTA_ROW` (the clearance beneath). The row is still
the button's only occupant and a sibling of the card-wide `<Link>`, neither positioned
— **no two hit boxes overlap at any card width**.

**No rule above the CTA**, per Phase 1's reconciled table. The dotted `✦` rule the
design defines for coven and skips in the same pass is dead code and is not built.
The braid under the description is still the section's own tie-off.

## 3. The level numeral matches the kit's weight

`--text-heading` → `--text-display` (desktop), `--text-title` → `--text-heading`
(mobile). Coven was set two rungs behind Everymen / Snide / Ephemerists; this puts it
on the same rung. The design's literal `44px` is not a rung of the ramp — `--text-display`
is 42px and is the token that means this.

## Deviations from the vendored design

- **The cauldron geometry is #2019's, not `TaskCards.dc.html`'s.** Owner ruling on
  #2033. The design's own pot (viewBox 100, `scale(1.16)`, `.cvn-bub`) is not ported.
- **`line-height: 1` on the level numeral is not ported.** The design sets it because
  it forces 44px onto a live DOM; the stack's `0.8` is what the kit's other skins use
  (0.8–0.85) and it stays.
- **The watermark cat is not here.** #2041 owns it, across both surfaces. `.cvn-wheel`
  is untouched.

## Byte budget

`npm run budget`, on this branch:

```
    126.4 KB  js   assets/index-BVsukW1M.js
     23.4 KB  css  assets/index-0x4uvXhz.css

  ok   JS     126.4 KB   warn>130.9 KB  fail>175.8 KB  target 117.2 KB
  WARN CSS     23.4 KB   warn>23.0 KB  fail>24.4 KB  target 19.5 KB
```

Measured against a build of `main`'s component in the same tree, same config:

| asset | main | this branch | delta |
|---|---|---|---|
| `index-*.css` | 139,513 B | 139,513 B | **0** |
| `index-*.js` | 409,498 B | 409,542 B | **+44 B** |

**The CSS is byte-identical** — nothing was minted and nothing was reflowed. The
existing `WARN CSS` is `main`'s, not this PR's. All the ornament is inline SVG inside
the shared component (JS, which has headroom); the two motions reuse
`.cvn-cauldron-sigil` / `.cvn-cauldron-bub`, already inside the reduced-motion gate.
No inline `animation:` anywhere.

## Verification

Every step `.github/workflows/test.yml` names for the frontend, run locally:

- `npm run lint` — clean (`local/no-raw-style-values` included)
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **304 files, 5,334 passed, 1 skipped**
- `npm run build` — clean
- `npm run budget` — above

No backend change and no API-surface change, so `api-schema` has nothing to regenerate.

**Visual QA is outstanding.** I have no browser and did not run `npm run dev`; nothing
here has been looked at, only asserted.

## What to eyeball

1. **The cauldron at both form factors.** Desktop 116, mobile 340px card. Does it
   crowd the braid between it and the level numeral, or the card's right edge?
2. **Its caption.** ~8.8px desktop, ~7.6px mobile. Legible next to the `LEVEL` caption
   beside it (8.5px)?
3. **The pot on the slip's gradient.** The belly fills with `--faction-coven-ward-card`
   at 94% — near-white on the pink in light, near-black in dark. It was drawn for the
   ward's paper; check it reads as a vessel on the *slip* and not as a hole.
4. **Dark mode**, both of the above.
5. **The bubbles rising.** They leave the pot with `overflow: visible`, inside an
   `article` with `overflow: hidden`. Nothing should clip.
6. **The 42px level numeral** in Cormorant Garamond at `line-height: 0.8` — does the
   `LEVEL` caption still tuck under it, or does the numeral's descender collide?
7. **The CTA at radius 12** beside the ×-modifier chip at 20 (only visible if a
   multiplier is ever un-neutralised — `era_1` pins it at ×1.00).
8. **`prefers-reduced-motion`** — the glow and the bubbles should be still, and the
   cauldron fully drawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
