### PR TITLE
WOW task card: gold wordmark, edge-breaking sigil, bunting and balloon knights (#2032)

### DIFF
--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -7,7 +7,7 @@ import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
-import { BalloonBunch, Zig } from "../factionMarks/wowOrnament";
+import { BalloonBunch, Bunting, Zig } from "../factionMarks/wowOrnament";
 
 /**
  * Warriors of Whimsy — THE QUEST DECREE (task card v2, #1023).
@@ -31,11 +31,39 @@ import { BalloonBunch, Zig } from "../factionMarks/wowOrnament";
  * MedievalSharp, sword-and-shield and balloons are WOW's. Coven is wave A's
  * pink spell slip.
  *
- * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set, and
- * on mobile the balloons drop — the design's own conditional ornament, and the
- * corner they need is the corner a 340px card does not have. There is no mobile
- * twin: ADR-0056 was accepted and the `mobileTaskCard` surface retired, so this
- * file serves both form factors.
+ * ONE RESPONSIVE COMPONENT (ADR-0056): `useFormFactor` picks the size set.
+ * There is no mobile twin: ADR-0056 was accepted and the `mobileTaskCard`
+ * surface retired, so this file serves both form factors. The balloons used to
+ * drop on mobile because the corner they were tucked into is the corner a 340px
+ * card does not have; #2032 moves them into the sign-up row, which both form
+ * factors do have, so the size set no longer forks over them.
+ *
+ * THE ORNAMENT PASS (#2032, task cards v3 phase 2). Four changes, all of them
+ * dress on anatomy #2029 and #2030 already fixed:
+ *
+ *  - THE WORDMARK AND THE MARK GO GOLD, and it is one token for both — the
+ *    issue's "the header sigil takes the gold of the wordmark". This also
+ *    settles a live phase-1 defect: the mark shipped in
+ *    `--faction-wow-stamp-total`, which is #8a5a16 in LIGHT against the
+ *    theme-invariant plum band, i.e. **1.08:1** — invisible by day. The
+ *    replacement `--faction-wow-gilt-mid` (#e7b94e) is itself theme-invariant
+ *    and measures 3.47:1 on that plum, clearing both the AA-large floor the
+ *    24px wordmark needs and the 1.4.11 floor the mark needs.
+ *  - THE MARK SITS ON THE CARD'S EDGE. The band drops its horizontal inset, so
+ *    the sigil breaks the banner's left line and stands on the gold frame.
+ *    Zeroing BOTH sides rather than just the left is what keeps #2029's centred
+ *    title on the CARD's centreline instead of shifting it half an inset over.
+ *  - THE BAND REGAINS A BOTTOM RULE, in gold. Phase 1 dropped it because the
+ *    design drew it in `--faction-wow-card-accent`, which in light IS the band's
+ *    own ground to the hex; drawn in the gilt it is a real line, and it is the
+ *    string the bunting hangs from.
+ *  - BUNTING FOR THE BARBER RIBBON. The 6px gold/plum stripe is the ≤8px
+ *    gradient strip the design hides in favour of the pennant run. `Bunting` is
+ *    WOW's shipped pennant primitive (§6: one device, never redrawn per
+ *    surface), so the swap adds no geometry and no CSS.
+ *  - THE BALLOONS BECOME KNIGHTS FLANKING THE SIGN-UP. Flex SIBLINGS of the
+ *    button, never absolute over it: the pair is decorative and carries no hit
+ *    box, and siblings-with-gap cannot overlap the 44px target at any width.
  *
  * THE DESIGN'S `ctaGold` A/B PROP IS NOT SHIPPED. It is canvas experimentation
  * rather than part of {@link CardProps}, and the choice it offers is already
@@ -59,6 +87,13 @@ const PLUM = "var(--faction-wow-card-accent)";
 const GOLD = "var(--faction-wow-chronicle-gold)";
 const PLUM_SURFACE = "var(--faction-wow-plum-surface)";
 const GILT = "var(--faction-wow-stamp-total)";
+/**
+ * The banner's ink — lettering AND mark (#2032). The page kit's gilt button
+ * stop, theme-invariant like the plum it stands on, so one measurement (3.47:1)
+ * covers both themes. NOT `-stamp-total`, which is an ink that flips: see the
+ * docblock.
+ */
+const GILT_MID = "var(--faction-wow-gilt-mid)";
 
 interface SizeSet {
   /** Card width. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
@@ -69,9 +104,15 @@ interface SizeSet {
   pointsSize: string;
   /** Minimum width of the crowned plaque. Geometry. */
   plaque: number;
-  /** The design's conditional ornament: the corner bundle is desktop-only. */
-  balloons: boolean;
 }
+
+/**
+ * A balloon knight's drawn width; the bunch is 1.25x as tall, so 32 stands 40
+ * high against a 44px button. Geometry (§4a), and ONE number for both form
+ * factors — the narrower card's sign-up row still has ~180px of slack with the
+ * pair in it, so there is nothing for a size fork to fix.
+ */
+const KNIGHT = 32;
 
 const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   desktop: {
@@ -81,7 +122,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
     levelSize: "var(--text-heading)",
     pointsSize: "var(--text-heading)",
     plaque: 112,
-    balloons: true,
   },
   mobile: {
     cardWidth: 340,
@@ -90,7 +130,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
     levelSize: "var(--text-title)",
     pointsSize: "var(--text-title)",
     plaque: 100,
-    balloons: false,
   },
 };
 
@@ -155,34 +194,43 @@ export default function WowTaskCard({
           color: INK,
         }}
       >
-        {/* THE DECREE GAINS A MASTHEAD (#2029). WOW shipped none — the ribbon
-            was the card's whole top note — so this is a new band on the kit's
-            shared anatomy: the mark hard left, the faction's name centred, on
-            the theme-invariant plum the CTA already stands on (5.16:1 against
-            `-on-plum`, both themes).
+        {/* THE DECREE'S MASTHEAD (#2029), dressed (#2032). The kit's shared
+            anatomy — mark hard left, the faction's name centred — on the
+            theme-invariant plum the CTA already stands on, and lettered in the
+            gilt the mark now takes with it.
 
-            NO BOTTOM RULE ON THE BAND, where the design draws a 2px
-            `--faction-wow-card-accent` one: in light that token IS
-            `--faction-wow-plum-surface` to the hex, so the rule would be an
-            invisible line on its own ground. The barber ribbon underneath is
-            already the band's edge and says it in the decree's own voice.
+            THE HORIZONTAL INSET IS ZERO, which is the issue's edge-breaking
+            sigil: the mark stands on the card's own gold frame rather than
+            inside the band's type block. Both sides, not just the left —
+            #2029's centred title is centred on the band's content box, so an
+            asymmetric inset would walk it off the card's centreline.
 
-            The mark takes the gilt rather than the sigil's default plum, which
-            would vanish into the banner — the same pairing `SwordAndShield`
-            already draws on this plum. */}
+            THE BOTTOM RULE COMES BACK IN GOLD. Phase 1 dropped the design's 2px
+            `--faction-wow-card-accent` line because in light that token IS the
+            band's own ground to the hex; `-gilt-mid` on the same plum is
+            3.47:1, so drawn in the gilt it is a line you can see — and it is
+            the string the bunting below hangs from. */}
         <CardMasthead
           slug="wow"
-          markColor={GILT}
-          style={{ background: PLUM_SURFACE, color: "var(--faction-wow-on-plum)" }}
+          markColor={GILT_MID}
+          style={{
+            background: PLUM_SURFACE,
+            color: "var(--faction-wow-on-plum)",
+            padding: "var(--space-sm) 0",
+            borderBottom: `2px solid ${GILT_MID}`,
+          }}
         >
-          <span style={{ fontFamily: MED, fontSize: "var(--text-title)", letterSpacing: "0.04em", lineHeight: 1 }}>
+          <span style={{ fontFamily: MED, fontSize: "var(--text-title)", letterSpacing: "0.04em", lineHeight: 1, color: GILT_MID }}>
             {factionName("wow")}
           </span>
         </CardMasthead>
 
-        {/* The barber ribbon. A 6px stripe carrying NO text, which is what lets
-            the undimmed gold/plum ship as drawn (§3, #840). */}
-        <div aria-hidden="true" style={{ height: 6, background: "var(--faction-wow-quest-ribbon)" }} />
+        {/* The pennants, strung under the band (#2032) where the 6px barber
+            ribbon used to run — the design's own swap. `Bunting` is WOW's one
+            pennant device (§6), already strung across the muster bill and the
+            chronicle entry, so this is the same run at the same density and
+            costs no new geometry. */}
+        <Bunting />
 
         <div style={{ padding: size.pad }}>
           {/* Everything but the CTA reads the full call — a card-sized target
@@ -316,7 +364,28 @@ export default function WowTaskCard({
           </Link>
 
           {cta && (
-            <div style={{ display: "flex", justifyContent: "center", marginTop: "var(--space-lg)" }}>
+            <div
+              style={{
+                display: "flex",
+                alignItems: "flex-end",
+                justifyContent: "center",
+                gap: "var(--space-md)",
+                marginTop: "var(--space-lg)",
+              }}
+            >
+              {/* THE BALLOON KNIGHTS (#2032). Two bunches keeping the muster,
+                  one either side of the call. FLEX SIBLINGS with a gap, never
+                  absolutely positioned over the button: they are `aria-hidden`
+                  ornament with no hit box of their own, and a sibling cannot
+                  land on the 44px target at any card width — which is the
+                  overlap `docs/agents/design-fidelity.md` records going wrong
+                  on a plate drawn for smaller marks.
+
+                  Still, not bobbing, for the same reason the corner bunch was:
+                  a flex-wrap grid of forty cards is not a place to run eighty
+                  infinite animations. The googly eyes still wiggle, on the
+                  faction's reduced-motion-gated `.wow-balloon-eye`. */}
+              <BalloonBunch size={KNIGHT} bob={false} style={{ transform: "rotate(-6deg)" }} />
               <button
                 type="button"
                 onClick={cta.onPress}
@@ -337,19 +406,11 @@ export default function WowTaskCard({
               >
                 {cta.label}
               </button>
+              {/* The second knight, mirrored so the pair faces the call. */}
+              <BalloonBunch size={KNIGHT} bob={false} style={{ transform: "rotate(-6deg) scaleX(-1)" }} />
             </div>
           )}
         </div>
-
-        {size.balloons && (
-          <BalloonBunch
-            size={64}
-            /* Still, not bobbing: a flex-wrap grid of forty cards is not a place
-               to run forty infinite animations. The eyes still wiggle. */
-            bob={false}
-            style={{ position: "absolute", right: 14, bottom: 10, zIndex: 2, transform: "rotate(4deg)" }}
-          />
-        )}
       </article>
     </div>
   );

--- a/frontend/src/components/taskCard/__tests__/wowTaskCardV3.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/wowTaskCardV3.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Task cards v3, Phase 2 — WOW's ornament pass (#2032, epic #2027).
+ *
+ * The seam is the kit's usual one (`taskCardsV3.test.tsx`): the rendered markup
+ * of the skin via `renderToStaticMarkup`, plus — for the one claim a render
+ * cannot settle — the declared token values read straight out of `index.css`,
+ * the way `factionContrast.test.ts` and `wowBalloonPlate.test.ts` do. This repo
+ * has no jsdom, so effects never run and geometry is out of reach; what is
+ * checkable is which elements exist and which inline declarations they carry.
+ *
+ * THE DEFECT THIS OPENED ON. Phase 1 (#2029) gave WOW a masthead and painted
+ * its mark `--faction-wow-stamp-total` — a token that is #8a5a16 in LIGHT while
+ * the band it stands on is the theme-INVARIANT `--faction-wow-plum-surface`
+ * (#7a4a9e). That pairing measures **1.08:1**: on a light-theme card the mark
+ * was, to the eye, not there. #2032's "the header sigil takes the gold of the
+ * wordmark" is the fix, and the first test below is the one that was red.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+// Imported after the mock is registered.
+import WowTaskCard from '../WowTaskCard'
+import { aTask } from '../../../test/fixtures'
+import { AA_LARGE, contrastRatio, formatRatio, parseColor } from '../../../utils/contrast'
+import { readThemes, resolveVar, type Theme } from '../../../utils/__tests__/cssVars'
+
+const CSS_PATH = fileURLToPath(new URL('../../../index.css', import.meta.url))
+const THEMES = readThemes(readFileSync(CSS_PATH, 'utf8'))
+const BOTH: Theme[] = ['light', 'dark']
+
+const TASK = aTask({
+  description: 'Leave something small and honest where a stranger will find it.',
+  in_progress_count: 4,
+})
+
+function render(formFactor: 'desktop' | 'mobile' = 'desktop'): string {
+  mocks.formFactor = formFactor
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <WowTaskCard
+        task={TASK}
+        basePoints={TASK.point_value}
+        multiplier={1}
+        inProgressCount={TASK.in_progress_count}
+        onSignup={() => {}}
+      />
+    </MemoryRouter>,
+  )
+  mocks.formFactor = 'desktop'
+  return html
+}
+
+/** The one ink the banner uses for both its lettering and its mark. */
+const GILT = '--faction-wow-gilt-mid'
+/** The band's ground. Theme-invariant on purpose (index.css, WOW page note 1). */
+const PLUM = '--faction-wow-plum-surface'
+
+function band(html: string): string {
+  const at = html.indexOf('data-card-masthead="wow"')
+  expect(at, 'the shared band from #2029').toBeGreaterThan(-1)
+  return html.slice(at, html.indexOf('</div>', at))
+}
+
+describe('the WOW banner is legible in the gold it is lettered in (#2032)', () => {
+  it.each(BOTH)('clears AA-large on the plum in %s', (theme) => {
+    const ink = parseColor(resolveVar(GILT, theme, THEMES) ?? '')
+    const ground = parseColor(resolveVar(PLUM, theme, THEMES) ?? '')
+    expect(ink, `${GILT} resolves`).not.toBeNull()
+    expect(ground, `${PLUM} resolves`).not.toBeNull()
+    const ratio = contrastRatio(ink!, ground!)
+    expect(
+      ratio,
+      // The wordmark is `--text-title` (24px) MedievalSharp, which is WCAG
+      // large text; the mark is a graphical object, whose 1.4.11 floor is the
+      // same 3:1. So one number covers both.
+      `${GILT} on ${PLUM} in ${theme} — ${formatRatio(ratio)}`,
+    ).toBeGreaterThanOrEqual(AA_LARGE)
+  })
+
+  it('paints the mark, the wordmark and the rule with that one token', () => {
+    const head = band(render())
+    // Three, not one: #2032 says the sigil takes the gold OF THE WORDMARK, and
+    // a card that gilded only the lettering would leave the mark at the 1.08:1
+    // `--faction-wow-stamp-total` Phase 1 shipped. The third is the band's
+    // restored bottom rule, which is the same gold for the same reason.
+    expect(
+      head.match(new RegExp(`var\\(${GILT}\\)`, 'g')) ?? [],
+      'mark + wordmark + rule',
+    ).toHaveLength(3)
+    expect(head, 'the burnt stamp gold is not a banner ink').not.toContain('--faction-wow-stamp-total')
+  })
+
+  it('sets the mark on the card edge rather than inside the band inset', () => {
+    // The edge-breaking sigil (#2032): the band drops its horizontal inset
+    // entirely, so the mark sits on the card's own gold frame. Zeroing BOTH
+    // sides is what keeps #2029's centred title on the card's centreline.
+    expect(band(render())).toContain('padding:var(--space-sm) 0')
+  })
+})
+
+describe('the bunting replaces the barber ribbon (#2032)', () => {
+  it('strings pennants under the band and retires the 6px stripe', () => {
+    const html = render()
+    expect(html, 'the strip the flags replace').not.toContain('--faction-wow-quest-ribbon')
+    // Derived, not redrawn: WORLD_ZERO_STYLE §6 says a faction's device is one
+    // primitive, and `wowOrnament`'s `Bunting` is it. The pennant's mitred
+    // border is that component's signature and no hand-rolled twin's.
+    expect((html.match(/border-left:7px solid transparent/g) ?? []).length).toBeGreaterThan(20)
+  })
+})
+
+describe('the balloon knights flank the sign-up (#2032)', () => {
+  it.each(['desktop', 'mobile'] as const)('mounts exactly two bunches on %s', (formFactor) => {
+    const html = render(formFactor)
+    // `viewBox="0 0 44 56"` is `BalloonBunch`'s own canvas — two of them is the
+    // pair, and any other count is either the retired corner bunch still hanging
+    // on or a redraw. The pair ships on BOTH form factors now: the corner a
+    // 340px card does not have was the old reason to drop them, and the CTA row
+    // is not that corner.
+    expect((html.match(/viewBox="0 0 44 56"/g) ?? []).length, formFactor).toBe(2)
+  })
+
+  it('keeps them out of every hit box on the card', () => {
+    const html = render()
+    // 44x44 targets may not overlap (design-fidelity.md). The knights are flex
+    // SIBLINGS of the button — never absolutely positioned over it — and they
+    // sit outside the card-wide <Link>, so there is nothing to overlap and
+    // nothing for a screen reader to read.
+    const row = html.slice(html.lastIndexOf('</a>'))
+    expect((row.match(/viewBox="0 0 44 56"/g) ?? []).length, 'both are below the link').toBe(2)
+    expect(row, 'a flex row, so a knight cannot sit on the button').toContain('display:flex')
+    expect(row.slice(row.indexOf('<button')), 'nothing absolute over the CTA').not.toContain('position:absolute')
+  })
+})


### PR DESCRIPTION
Task cards v3, **Phase 2** — WOW's ornament pass. Dress only, on the anatomy #2028/#2029/#2030 landed in `afd05a65`. No behaviour changes: no payload field, no service, no scoring, no sign-up logic; `signupAffordance.ts` untouched.

Closes #2032

## The seam, and the test that was red first

The seam is the kit's usual one — the rendered markup of the skin via `renderToStaticMarkup` (`taskCardsV3.test.tsx`), plus, for the one claim a render cannot settle, the declared token values read straight out of `index.css` the way `factionContrast.test.ts` and `wowBalloonPlate.test.ts` do.

**The loop went red on a live defect, not on a missing decoration.** Phase 1 gave WOW a masthead and painted its mark `--faction-wow-stamp-total`. That token is `#8a5a16` in **light**, and the band under it is the theme-invariant `--faction-wow-plum-surface` (`#7a4a9e`):

| pairing | ratio |
|---|---|
| `-stamp-total` on `-plum-surface`, **light** | **1.08:1** — the mark is not there |
| `-stamp-total` on `-plum-surface`, dark | 3.40:1 |
| `-gilt-mid` on `-plum-surface`, either theme | **3.47:1** |

So #2032's "the header sigil takes the gold of the wordmark" is also the fix. `--faction-wow-gilt-mid` is theme-invariant like the plum it stands on, so one measurement covers both themes, and 3.47:1 clears both the AA-large floor the 24px (`--text-title`) MedievalSharp wordmark needs and the 1.4.11 graphical-object floor the mark needs.

## What changed

Everything is in `frontend/src/components/taskCard/WowTaskCard.tsx`. **No other card file touched. `index.css` not touched at all.**

- **Gold wordmark + gold mark**, one token (`--faction-wow-gilt-mid`) for both.
- **Edge-breaking sigil** — the band's horizontal inset goes to zero (`padding: var(--space-sm) 0`), so the mark stands on the card's own gold frame instead of inside the band's type block. Zeroed on **both** sides, not just the left: #2029 centres the title on the band's content box, so an asymmetric inset would walk it off the card's centreline.
- **The band's bottom rule comes back, in gold.** Phase 1 dropped it (correctly) because the design drew it in `--faction-wow-card-accent`, which in light IS `--faction-wow-plum-surface` to the hex — an invisible line on its own ground. Measured before restoring, per the phase-1 note: in the gilt it is 3.47:1, and it is the string the bunting hangs from.
- **Bunting replaces the barber ribbon.** The 6px `--faction-wow-quest-ribbon` stripe is exactly the "≤8px gradient strip the flags replace" the design hides. `Bunting` is WOW's shipped pennant primitive (`wowOrnament.tsx`), already strung across the muster bill and the chronicle entry — WORLD_ZERO_STYLE §6, one device, never redrawn per surface. The token keeps four other consumers, so nothing is orphaned.
- **Balloon knights flank the sign-up.** The corner bunch moves into the CTA row as a mirrored pair, using the same `BalloonBunch` primitive. They are **flex siblings with a gap, never absolutely positioned over the button** — `aria-hidden`, no hit box of their own, so nothing can overlap the 44px target at any card width (the failure `docs/agents/design-fidelity.md` records). Still, not bobbing, for the reason the corner bunch was still; the googly eyes keep the existing reduced-motion-gated `.wow-balloon-eye`.
- **`SizeSet.balloons` deleted.** Its reason was "the corner a 340px card does not have"; the sign-up row is not that corner, so the pair ships on both form factors and the size set stops forking over it. Slack check at the narrow width: 340px card − 4px border − 32px padding = 304px, against ~117px button + 2×32px knights + 2×12px gaps ≈ 205px.

## Byte budget

**No new CSS classes, no `index.css` edit at all** — every change is inline SVG/geometry inside the `.tsx`, and even that is net-neutral because it reuses two primitives already in the bundle. `npm run budget` on this branch prints:

```
  ok   JS    126.4 KB   warn>130.9 KB  fail>175.8 KB  target 117.2 KB
  WARN CSS    23.4 KB   warn>23.0 KB   fail>24.4 KB   target 19.5 KB
```

The CSS **WARN is main's, inherited unchanged** — this branch adds zero bytes to `index.css`, so the figure is byte-for-byte what `main` already prints. Nothing here moves the sheet toward the 24.4 KB fail.

## Deviations from the vendored design

Listed per `docs/agents/design-fidelity.md`.

1. **The sigil does not physically overhang the card's outer edge.** The design's own code only nudges it (`margin-left: 2px`, promptly re-pinned to 14px by `standardizeHeaders()`'s rAF), so there is no drawn overhang to port. A true overhang would need the article's `overflow: hidden` removed and the mark's 20px box — which belongs to the shared `CardMasthead` — changed, both out of scope for a phase-2 ornament pass. Implemented as a zero inset: the mark on the frame, breaking the band's left line.
2. **Bunting density is `Bunting`'s 30 pennants, not the design's 14.** §6 says the faction's device is one primitive; redrawing a wider pennant here is exactly what that rule forbids, and it would cost JS the shared component already spends. The run clips at the card's right edge, as it already does on the muster bill.
3. **The knights are the shipped `BalloonBunch`**, mirrored, not a new "knight" figure — the design draws no such figure; Singularity's block calls the WOW slot "where Wow keeps its balloons".
4. **Nothing in the design's `DCLogic` was ported.** No `[style*=…]` selector, no DOM-mutating effect.

## Verification

`npm run lint` · `npm run typecheck` · `npm run typecheck:design-sync` · `npm test` (**304 files, 5335 passed**, 1 skipped) · `npm run build` · `npm run budget` — all run locally, all as `.github/workflows/test.yml` names them. No backend, schema or generated-type files touched, so `test` and `api-schema` are unaffected.

**Visual QA is outstanding.** I have no browser and no dev stack; nothing here has been looked at on a screen.

## What to eyeball

- The **gold-on-plum wordmark** at 3.47:1 in MedievalSharp — it passes AA-large by the numbers, but it is a thin decorative face and a human should confirm it reads. Both themes.
- The **mark on the card's left frame**: does it read as ornament breaking the banner's line, or as a clipping bug? And confirm the wordmark still sits on the card's centreline with the inset zeroed.
- The **bunting** at 384px and at 340px — 30 pennants is dense and the last one is cut by the card edge. Check the clip looks strung rather than broken, and that the gold rule above reads as the string.
- The **knights beside the sign-up** at both widths: no crowding of the button, no collision with a long localized CTA label, and the pair reads as facing the call rather than as two random bunches.
- The card is now ~16px taller (22px bunting for a 6px ribbon). Check WOW cards still sit right in the equal-height tasks grid beside other factions.
- Dark mode across all of the above — the gilt and the plum are both theme-invariant, so they should look identical by night.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
