### PR TITLE
Singularity's task card gets a little robot idling beside the sign-up key (#2036)

### DIFF
--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -49,6 +49,15 @@ import SingularityLamps from "../factionMarks/SingularityLamps";
 
 const MONO = "var(--faction-singularity-card-font)"; /* Share Tech Mono */
 
+/**
+ * The face that idles beside the sign-up key (#2036) — three lines of
+ * characters, which is why this ornament costs the bundle almost nothing.
+ *
+ * Text, and therefore ornament for assistive tech: the element that carries it
+ * is `aria-hidden` and is not inside the button.
+ */
+const BOT = "[^-^]\n /|_|\\\n  d b";
+
 const BG = "var(--faction-singularity-term-bg)";
 const BRIGHT = "var(--faction-singularity-term-bright)";
 const DIM = "var(--faction-singularity-term-dim)";
@@ -296,13 +305,22 @@ export default function SingularityTaskCard({
           </Link>
 
           {cta && (
-            <div style={{ display: "flex", justifyContent: "center", marginTop: "var(--space-lg)" }}>
+            <div
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr auto 1fr",
+                alignItems: "center",
+                gap: "var(--space-sm)",
+                marginTop: "var(--space-lg)",
+              }}
+            >
               <button
                 type="button"
                 onClick={cta.onPress}
                 aria-disabled={cta.denied || undefined}
                 style={{
                   ...CARD_CTA,
+                  gridColumn: 2,
                   cursor: cta.denied ? "not-allowed" : "pointer",
                   whiteSpace: "nowrap",
                   fontFamily: MONO,
@@ -332,6 +350,40 @@ export default function SingularityTaskCard({
                   }}
                 />
               </button>
+
+              {/* The little robot idling in the right gutter (#2036). It is
+                  ornament: `aria-hidden`, and OUTSIDE the button, so it never
+                  joins the control's accessible name (epic #2027, ruling 4).
+                  Its drift is `.sg-ascii` in index.css, behind the shared
+                  reduced-motion gate — stilled it stays parked, drawn.
+
+                  WHY A GRID COLUMN AND NOT `position:absolute`. The design
+                  parks it at `right:18px` over a centred flex row, which is
+                  what a spec sheet mutating someone else's DOM has to do. Here
+                  the two are siblings in two columns of one grid, so they
+                  cannot overlap at any card width and the 44px tap target stays
+                  whole — the same reasoning `CardMasthead` uses for its equal
+                  `1fr` gutters, and the button sits on the card's centreline
+                  for the same reason. `minWidth: 0` lets the gutter collapse
+                  under the longest denial label ("Applied to praxis, not
+                  claimed"): the ornament clips, the control never does. */}
+              <pre
+                aria-hidden="true"
+                className="sg-ascii"
+                style={{
+                  gridColumn: 3,
+                  justifySelf: "center",
+                  minWidth: 0,
+                  overflow: "hidden",
+                  margin: 0,
+                  fontFamily: MONO,
+                  fontSize: "var(--text-lg)",
+                  lineHeight: 1.2,
+                  color: DIM,
+                }}
+              >
+                {BOT}
+              </pre>
             </div>
           )}
         </div>

--- a/frontend/src/components/taskCard/__tests__/singularityAscii.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/singularityAscii.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Singularity task card, v3 ornament (#2036) — an ASCII face drifts beside the
+ * sign-up key.
+ *
+ * ## The seam
+ *
+ * The card's RENDERED MARKUP (`renderToStaticMarkup`, the same SSR-only harness
+ * `taskCardsV3.test.tsx` works at — no DOM, no layout, no computed styles),
+ * plus `index.css` read as source text for the motion gate. Both halves are
+ * needed and neither is sufficient:
+ *
+ *  1. the markup has to put the face OUTSIDE the button and hide it from
+ *     assistive tech, or a screen reader reads punctuation soup as the control's
+ *     name (epic #2027, ruling 4);
+ *  2. the markup has to place it in its own grid column rather than positioning
+ *     it over the row, which is the only way an SSR harness can prove "no two
+ *     hit boxes overlap at any card width" — geometry is out of reach here, so
+ *     the proof is structural: two siblings in two different columns of one
+ *     grid cannot overlap, at any width, without anyone measuring;
+ *  3. the sheet has to gate the drift on `prefers-reduced-motion`, and the
+ *     component must not write `animation:` inline, which would bypass the gate
+ *     while every render test stayed green.
+ *
+ * What is NOT checkable here is whether it looks right. That is visual QA and
+ * is stated as outstanding on the PR.
+ */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+import i18n from '../../../i18n'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+// Imported after the mock is registered.
+import SingularityTaskCard from '../SingularityTaskCard'
+import { aTask } from '../../../test/fixtures'
+import { ruleBodies, stripComments } from '../../../utils/__tests__/cssVars'
+
+const CSS = stripComments(
+  readFileSync(fileURLToPath(new URL('../../../index.css', import.meta.url)), 'utf8'),
+)
+
+const TASK = aTask({
+  description: 'Leave something small and honest where a stranger will find it.',
+  in_progress_count: 4,
+})
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <SingularityTaskCard
+        task={TASK}
+        basePoints={TASK.point_value}
+        multiplier={1}
+        inProgressCount={TASK.in_progress_count}
+        onSignup={() => {}}
+      />
+    </MemoryRouter>,
+  )
+}
+
+/** The button element's own markup, opening tag included. */
+function button(html: string): string {
+  const open = html.indexOf('<button')
+  expect(open, 'a control to stand beside').toBeGreaterThan(-1)
+  return html.slice(open, html.indexOf('</button>', open))
+}
+
+/** The ornament's element, opening tag included. */
+function face(html: string): string {
+  const open = html.indexOf('<pre')
+  expect(open, 'the ASCII face is drawn').toBeGreaterThan(-1)
+  return html.slice(open, html.indexOf('</pre>', open))
+}
+
+/** The three lines of the little robot, as the design draws it. */
+const BOT = ['[^-^]', '/|_|\\', 'd b']
+
+describe('the ASCII face is ornament, not the button\'s name (#2036)', () => {
+  it('draws the robot', () => {
+    const html = render()
+    for (const line of BOT) expect(html, line).toContain(line)
+  })
+
+  it('hides it from assistive tech and keeps it out of the control', () => {
+    const html = render()
+    expect(face(html)).toContain('aria-hidden="true"')
+    // The accessible name of the CTA is the i18n string and nothing else — a
+    // face rendered INSIDE the button would be read as part of it.
+    for (const line of BOT) expect(button(html), line).not.toContain(line)
+    expect(button(html)).toContain(i18n.t('feed:taskCard.signup'))
+  })
+
+  it('stands in its own grid column, never over the button', () => {
+    // Both form factors: the card is one responsive component (ADR-0056) and
+    // the narrow set is where an absolutely positioned ornament would land on
+    // the tap target.
+    for (const formFactor of ['desktop', 'mobile'] as const) {
+      mocks.formFactor = formFactor
+      const html = render()
+      const row = html.slice(0, html.indexOf('<button')).lastIndexOf('<div')
+      const markup = html.slice(row, html.indexOf('</pre>'))
+      expect(markup, formFactor).toContain('grid-template-columns:1fr auto 1fr')
+      expect(button(html), formFactor).toContain('grid-column:2')
+      expect(face(html), formFactor).toContain('grid-column:3')
+      // Nothing in the CTA row is taken out of flow, so no hit box can be
+      // covered by ornament at any card width.
+      expect(face(html), formFactor).not.toContain('position:absolute')
+    }
+    mocks.formFactor = 'desktop'
+  })
+})
+
+describe('the drift is gated on reduced motion (#2036)', () => {
+  /** How many `.sg-ascii` rules in `source` set an `animation`. */
+  const animates = (source: string): number =>
+    [...source.matchAll(/\.sg-ascii\s*\{([^}]*)\}/g)].filter((rule) =>
+      /animation/.test(rule[1]),
+    ).length
+
+  it('carries the class and writes no inline animation', () => {
+    const html = render()
+    expect(face(html)).toContain('class="sg-ascii"')
+    expect(html, 'an inline animation bypasses the media query').not.toContain('animation:')
+  })
+
+  it('declares the motion only inside the no-preference gate', () => {
+    const gated = ruleBodies(CSS, '@media (prefers-reduced-motion: no-preference)').join('\n')
+    expect(animates(gated), 'the drift is inside the gate').toBe(1)
+    // Same count sheet-wide, so there is no ungated twin outside it. A reader
+    // who asks for less motion gets the face STILLED, not removed.
+    expect(animates(CSS), 'and nowhere else').toBe(1)
+  })
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4332,6 +4332,12 @@
 @media (prefers-reduced-motion: no-preference) {
   .sg-scan { animation: sg-scan-sweep 5s linear infinite; }
   .sg-cursor { animation: wz-blink 1s step-end infinite; }
+  /* The task card's ASCII face drifts beside the sign-up key (#2036). No new
+     keyframe: `spec-rise` is already a bob to a tunable height, and this file
+     already reuses across factions where the motion is the same shape
+     (`.coven-moon-dust` runs `eph-twinkle`). Stilled, the robot stays parked
+     and drawn — it is ornament, not an indicator. */
+  .sg-ascii { --spec-bounce: -5px; animation: spec-rise 6s ease-in-out infinite; }
 }
 
 /* ══ Praxis-card redesign vote widgets (#821) ══


### PR DESCRIPTION
Closes #2036

Phase 2 of the task-cards v3 epic (#2027), built on Phase 1 (`afd05a65`). The
Singularity card gains the one thing the design gives it: a little ASCII robot
idling beside the sign-up key.

```
[^-^]
 /|_|\
  d b
```

## The seam I tested at

The card's **rendered markup** (`renderToStaticMarkup` — this repo has no jsdom,
so effects never run and geometry is out of reach) plus **`index.css` read as
source text** for the motion gate. New file
`frontend/src/components/taskCard/__tests__/singularityAscii.test.tsx`; it went
red on all five assertions before the component changed.

Structural, because that is what an SSR harness can actually prove:

1. the face is drawn, is `aria-hidden`, and is **outside** the `<button>` — so it
   never joins the control's accessible name (epic ruling 4);
2. it sits in its own column of a three-column grid, on **both** form factors,
   with nothing in the row taken out of flow — two siblings in two columns of one
   grid cannot overlap at any card width, which is the only way to pin "the
   ornament never drifts into the 44px tap box" without measuring;
3. the drift is `.sg-ascii` in `index.css` and the sheet declares its
   `animation` **only** inside `@media (prefers-reduced-motion: no-preference)`,
   with no ungated twin anywhere and no inline `animation:` in the component.

## What changed

`frontend/src/components/taskCard/SingularityTaskCard.tsx`
- The CTA row becomes `grid-template-columns: 1fr auto 1fr` — button in column 2,
  face in column 3. Same reasoning `CardMasthead` uses for its equal `1fr`
  gutters: the button stays on the card's centreline whatever stands beside it.
- `minWidth: 0` + `overflow: hidden` on the ornament, so under the longest denial
  label ("Applied to praxis, not claimed") the **ornament** clips and the control
  never does.
- Ink is `--faction-singularity-term-dim`, the caption green this card already
  uses — quieter than the lit CTA, and no colour minted. Nothing near the LED
  palette #1998 unified (`--faction-singularity-led-*` is untouched).
- Type is `var(--text-lg)`, so the three lines come to ~43px and the row's height
  is still the button's 44px floor.

`frontend/src/index.css` — **one line plus a comment**, inside the Singularity
motion block that already exists (lines ~4330–4341). No reflow, no re-sort.

```css
.sg-ascii { --spec-bounce: -5px; animation: spec-rise 6s ease-in-out infinite; }
```

No new keyframe: `spec-rise` is already a bob to a tunable height, and this sheet
already reuses across factions where the motion is the same shape
(`.coven-moon-dust` runs `eph-twinkle`). Reduced motion leaves the robot parked
and **drawn** — it is ornament, not an indicator.

## Byte budget (`npm run budget`, level-9 gzip, exact bytes)

| | baseline (`afd05a65`) | this branch | delta | ceilings |
|---|---|---|---|---|
| CSS | 23,936 | **23,952** | **+16** | warn 23,600 · fail 25,000 |
| JS  | 129,412 | **129,434** | **+22** | warn 134,000 · fail 180,000 |

The script prints `WARN CSS 23.4 KB` — that warning is **inherited from `main`**,
which is already past the 23,600 line; this change adds 16 gzipped bytes and
leaves 1,048 bytes of headroom under FAIL. An ASCII face is characters, so the
ornament itself lands in the JS column, where there is ~4.5 KB before warn.

## Deviations from the vendored design

- The design parks the robot at `right: 18px` over a centred flex row and sets
  `position: absolute` — what a spec sheet mutating someone else's DOM has to do.
  Built as a grid column instead, for the overlap guarantee. On desktop it lands
  ~40px in from the card edge, which is about where the design draws it.
- The design's `sgFloat` oscillates opacity 0.45 → 0.8 as well as translating.
  Dropped: the dim-green token does that job statically, and reusing `spec-rise`
  is a keyframe not minted on a nearly-full CSS budget.
- 13px → `var(--text-lg)` (12px). `local/no-raw-style-values` flags a raw
  `fontSize`, and the nearest rung reads the same at this size.

## Verified

Every step in `.github/workflows/test.yml`'s frontend job, locally: `npm run
lint` · `npm run typecheck` · `npm run typecheck:design-sync` · `npm test`
(**304 files, 5,332 passed**, including `singularityLamps.test.tsx` — the five
mounts still stand, the header did not move) · `npm run build` · `npm run
budget`. No backend files touched, so no `api-schema` artifacts and no test DB.

**Visual QA is outstanding** — I have no browser and no dev stack, and did not
run `npm run dev`.

## What to eyeball

- The robot beside the sign-up key on a **wide** card and on the **mobile** size
  set: is it in the gutter, not crowding the button, not falling off the chassis?
- The drift itself — 6s, 5px of travel. Too much? Too little?
- The row when sign-up is **denied**: "Applied to praxis, not claimed" is the
  longest label, and the face is meant to clip rather than push the button.
- **Reduced motion on**: the robot should be parked and still clearly drawn.
- Dark theme: the face is `--faction-singularity-term-dim`, which is a different
  green in each cascade. Is it legible against the chassis, and still quieter
  than the CTA?
- It must never be announced by a screen reader, and the button must read exactly
  "Sign up".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
