### PR TITLE
Task cards v3, Coven: the turning pentagram watermark becomes a turning cat (#2041)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/covenCat.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/covenCat.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * The Coven watermark is ONE drawing, on every surface that turns it (#2041).
+ *
+ * The pentacle became a cat, and the owner ruling behind that swap is not about
+ * the artwork — it is that a player moving between two Coven pages may not meet
+ * two different watermarks. #2041 states that ruling over a mount list of two
+ * (`CovenTaskCard`, `CovenProfileBody`); `grep` says five, because both detail
+ * pages and the praxis composer draw it too. The ruling is what generalises, so
+ * all five swapped.
+ *
+ * That is exactly the shape that decays one mount at a time, and a render test
+ * cannot see it: a sixth surface pasting the old pentacle path renders fine,
+ * typechecks fine, and is only wrong when you hold two pages side by side. So
+ * this is a source scan — cheap enough to keep, and it reads the thing that
+ * actually went wrong.
+ *
+ * Two assertions, and the second is the one with a future:
+ *
+ *   1. the retired pentagram path appears in no component; and
+ *   2. every `.cvn-wheel` mount in the app comes from {@link CovenCat}.
+ *
+ * (2) is deliberately not "no inline `<svg className="cvn-wheel">`" — it is the
+ * positive form, so a mount drawing some THIRD device under the class fails as
+ * loudly as one drawing the pentagram again. `SigilMark`'s badge keeps its own
+ * pentagram and is not in scope: it is the faction's mark of identity in a
+ * header, not the watermark, and it never turns.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+
+import { CovenCat } from "../covenSlip";
+
+const SRC = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+/** The five-pointed star every Coven surface used to turn. */
+const PENTAGRAM = "M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z";
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...sourceFiles(path));
+    else if (/\.tsx?$/.test(entry.name) && !/\.test\.tsx?$/.test(entry.name)) out.push(path);
+  }
+  return out;
+}
+
+const FILES = sourceFiles(SRC).map((path) => [path, readFileSync(path, "utf8")] as const);
+
+describe("the Coven watermark", () => {
+  it("draws the retired pentagram nowhere", () => {
+    const offenders = FILES.filter(([, source]) => source.includes(PENTAGRAM)).map(([path]) => path);
+    expect(offenders, "the watermark pentagram survives in these files").toEqual([]);
+  });
+
+  it("is mounted only through CovenCat", () => {
+    // `covenSlip.tsx` is where the class legitimately appears as a literal.
+    const offenders = FILES.filter(
+      ([path, source]) => source.includes("cvn-wheel") && !path.endsWith("covenSlip.tsx"),
+    ).map(([path]) => path);
+    expect(offenders, "these mount `.cvn-wheel` without going through CovenCat").toEqual([]);
+  });
+
+  it("keeps the class that owns the turn and the reduced-motion gate", () => {
+    // index.css carries `@keyframes cvn-wheel` and the
+    // `prefers-reduced-motion: no-preference` guard around it; the mark's only
+    // job is to wear the class (#911 — no component-injected <style>).
+    expect(renderToStaticMarkup(<CovenCat size={190} />)).toContain('class="cvn-wheel"');
+  });
+
+  it("is decoration, so it carries no accessible name", () => {
+    const html = renderToStaticMarkup(<CovenCat size={190} />);
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).not.toContain("<title");
+    expect(html).not.toContain("aria-label");
+  });
+
+  it("keeps the whole face inside its box", () => {
+    // The design's reason for re-placing the mark: "a face can't bleed off the
+    // card the way the pentacle did." Every coordinate is inside 0..100, so a
+    // mount that sits the box on its container cannot clip the drawing.
+    const numbers = renderToStaticMarkup(<CovenCat size={190} />)
+      .match(/d="([^"]+)"/g)!
+      .flatMap((d) => d.match(/-?\d+(\.\d+)?/g)!.map(Number));
+    expect(Math.min(...numbers)).toBeGreaterThanOrEqual(0);
+    expect(Math.max(...numbers)).toBeLessThanOrEqual(100);
+  });
+});

--- a/frontend/src/components/factionMarks/__tests__/covenCat.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/covenCat.test.tsx
@@ -57,9 +57,12 @@ describe("the Coven watermark", () => {
   });
 
   it("is mounted only through CovenCat", () => {
-    // `covenSlip.tsx` is where the class legitimately appears as a literal.
+    // The class as a `className`, not the string — every one of these files
+    // discusses `.cvn-wheel` in a comment and should go on doing so.
+    // `covenSlip.tsx` is where it legitimately appears as a literal.
+    const worn = /className\s*[=:]\s*["'`{ ]*["'`]?cvn-wheel/;
     const offenders = FILES.filter(
-      ([path, source]) => source.includes("cvn-wheel") && !path.endsWith("covenSlip.tsx"),
+      ([path, source]) => worn.test(source) && !path.endsWith("covenSlip.tsx"),
     ).map(([path]) => path);
     expect(offenders, "these mount `.cvn-wheel` without going through CovenCat").toEqual([]);
   });

--- a/frontend/src/components/factionMarks/covenSlip.tsx
+++ b/frontend/src/components/factionMarks/covenSlip.tsx
@@ -155,6 +155,100 @@ export function SigilMark({ size }: { size: number }) {
   );
 }
 
+/**
+ * The turning watermark — A CAT, line-drawn, replacing the pentagram (#2041).
+ *
+ * The pentacle was the corner watermark on FIVE surfaces (the task card, the
+ * character profile, both detail pages and the praxis composer), and each of
+ * them held its own copy of the same path. That is the duplication this module
+ * exists to end, and it is why the swap lands here rather than five times over:
+ * a watermark a player meets on two pages they move between may not be two
+ * different drawings (#2041 ruling 1, applied to the real mount list — the
+ * issue names two mounts and there are five).
+ *
+ * The drawing is the design's own, lifted verbatim from `TaskCards.dc.html`'s
+ * `DCLogic` — head, ears, eyes, muzzle, whiskers, each an open stroke with a
+ * round cap. Nothing is filled: at watermark strength a filled shape is a
+ * smudge, and the cat has to survive being 9% present.
+ *
+ * ## Placement is the mount's, and the reason is the design's
+ *
+ * "A face can't bleed off the card the way the pentacle did." A pentagram is
+ * radially symmetric and abstract, so a cropped one still reads as itself; a
+ * half-cropped face reads as a mistake. So every mount now sits the mark FULLY
+ * INSIDE its container, where four of the five used to hang a third of the
+ * drawing off the right edge. Nothing here pins that — the mount passes `size`
+ * and the offsets, because a card, a profile band, a detail sheet and a
+ * composer are four different scales.
+ *
+ * The one thing that may leave the frame is a whisker tip: the outermost is at
+ * x=97 of a 100-unit box, i.e. 3% in, so a mount with a small negative `right`
+ * grazes the cap and nothing else. The head sits at x∈[20,80] and cannot reach
+ * an edge before the whiskers do.
+ *
+ * ## `.cvn-wheel` is untouched, and that is the whole motion story
+ *
+ * The class, its `transform-origin`, the `@keyframes cvn-wheel` and the
+ * `prefers-reduced-motion: no-preference` gate around them are index.css's and
+ * are unchanged (#911 — no component-injected `<style>`). The cat turns once
+ * every two minutes where motion is welcome and is simply drawn, still, where
+ * it is not. Owner: "it's silly but it's cute."
+ *
+ * ## Opacity is the MOUNT's, and it is a contrast decision (#1302)
+ *
+ * `DEEP` is the sheet's own hue, so a wash of it under the copy can only
+ * tighten the reading. Measured with `utils/contrast.ts` against the two
+ * gradient stops the corner of the slip actually runs (`-slip-lav` 74%,
+ * `-slip-vio` 100%), for `--faction-coven-slip-soft`, the brief's ink:
+ *
+ *   alpha   light lav / vio      dark lav / vio
+ *   0.09    4.68 / 4.51          5.10 / 5.38     ← what every mount ships
+ *   0.13    4.44 / 4.28          4.65 / 4.91
+ *   0.15    4.33 / 4.17          4.44 / 4.68
+ *
+ * 0.09 is the last step that keeps the brief clear of AA on both stops in both
+ * cascades, which is why no mount raises it: the design's 0.15 buys a louder
+ * ornament with 0.33 of a body ink's margin, and Coven has already made this
+ * call once — the ward's gold bloom is mixed to 55% for the same reason
+ * (see `--faction-coven-ward-haze` in index.css). The title ink clears either
+ * way (5.07 / 4.89 light at 0.15).
+ */
+export function CovenCat({ size, style }: { size: number; style?: CSSProperties }) {
+  return (
+    <svg
+      className="cvn-wheel"
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      aria-hidden="true"
+      style={{ position: "absolute", zIndex: 0, pointerEvents: "none", ...style }}
+    >
+      {CAT.map(([d, width]) => (
+        <path
+          key={d}
+          d={d}
+          fill="none"
+          stroke={DEEP}
+          strokeWidth={width}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ))}
+    </svg>
+  );
+}
+
+/** `[path, stroke-width]`, in draw order. See {@link CovenCat}. */
+const CAT: ReadonlyArray<readonly [string, number]> = [
+  ["M50 24 C68 24 80 37 80 52 C80 70 66 82 50 82 C34 82 20 70 20 52 C20 37 32 24 50 24 Z", 2.2],
+  ["M28 31 L25 10 L44 23", 1.9],
+  ["M72 31 L75 10 L56 23", 1.9],
+  ["M38 47 L38 55", 1.9],
+  ["M62 47 L62 55", 1.9],
+  ["M50 60 L46 64 M50 60 L54 64 M50 60 L50 67", 1.9],
+  ["M21 57 L3 52 M21 63 L3 67 M79 57 L97 52 M79 63 L97 67", 1.9],
+];
+
 /** Initials for a name with no uploaded portrait — two letters at most. */
 export function initialsOf(name: string): string {
   return (

--- a/frontend/src/components/taskCard/CovenTaskCard.tsx
+++ b/frontend/src/components/taskCard/CovenTaskCard.tsx
@@ -5,6 +5,7 @@ import CardMasthead from "./CardMasthead";
 import { CARD_CTA, CARD_CTA_ROW } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import CovenCauldron from "../factionMarks/CovenCauldron";
+import { CovenCat } from "../factionMarks/covenSlip";
 import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
@@ -16,8 +17,8 @@ import { useFormFactor } from "../../hooks/useFormFactor";
  * A slip of paper that fades pink → lavender under a gold twinkle field, headed
  * by a pentagram badge and the coven's name hand-lettered in Caveat. A celtic
  * braid, hearts tied off at both ends, rules off each section; the points bubble
- * in a cauldron; a slow pentagram watermark turns behind the copy; and the call
- * to action is a rounded pink box. Grenze Gotisch carries the title, Cormorant
+ * in a cauldron; a slow-turning cat watches from the corner; and the call to
+ * action is a rounded pink box. Grenze Gotisch carries the title, Cormorant
  * Garamond the reading copy, Quicksand the chrome.
  *
  * This REPLACES the lo-fi `coven.exe` window archetype wholesale (ADR-0055 /
@@ -182,24 +183,24 @@ export default function CovenTaskCard({
           fontFamily: CHROME,
         }}
       >
-        {/* The turning pentagram watermark. `.cvn-wheel` owns the motion and its
-            reduced-motion guard (#911 — no component-injected <style>). */}
-        <svg
-          className="cvn-wheel"
-          width={420}
-          height={420}
-          viewBox="0 0 100 100"
-          aria-hidden="true"
-          style={{ position: "absolute", right: -118, bottom: -64, zIndex: 0, pointerEvents: "none", opacity: 0.09 }}
-        >
-          <path
-            d="M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z"
-            fill="none"
-            stroke="var(--faction-coven-slip-deep)"
-            strokeWidth="1.2"
-            strokeLinejoin="round"
-          />
-        </svg>
+        {/* THE WATERMARK IS A CAT NOW (#2041) — same slow turn, new drawing.
+            `.cvn-wheel` still owns the motion and its reduced-motion guard
+            (#911 — no component-injected <style>); only the artwork moved, and
+            it moved into `covenSlip` because four other surfaces turn it too.
+
+            It also SHRINKS AND COMES INSIDE. The pentacle was 420px hung 118px
+            off the right edge and 64px below the bottom, which is fine for a
+            radially-symmetric abstract mark and fatal for a face: the design's
+            own note is that "a face can't bleed off the card the way the
+            pentacle did". 190px at -6/-4 is #2041's placement verbatim. The
+            only thing that leaves the card is the right whisker's round cap —
+            its tip is at x=97 of the 100-unit box, so 5.7px inside a box whose
+            edge sits 6px out, leaving ~2px of a 3.6px cap clipped. The face is
+            38px clear of the edge.
+
+            Opacity holds at 0.09 rather than taking #2041's 0.15; the reason,
+            with the measurements, is at {@link CovenCat}. */}
+        <CovenCat size={190} style={{ right: -6, bottom: -4, opacity: 0.09 }} />
 
         {/* Masthead. THE WORDMARK MOVES (#2029): it floated over the slip under
             a pentagram badge, with a braid tied off beneath it; v3 pins it into
@@ -210,9 +211,9 @@ export default function CovenTaskCard({
             kit's own `CovenSigil`, because a card may not draw two faction
             marks in its header; and the braid under the wordmark goes, because
             a band that already names the coven does not need an ornament run
-            repeating it. Both marks live on elsewhere on the slip — the braid
-            rules off every section below, and the pentagram still turns as the
-            watermark.
+            repeating it. The braid lives on below, ruling off every section.
+            The pentagram does not: it was still turning as the watermark when
+            #2029 wrote this, and #2041 has since made that a cat.
 
             The twinkle field moves INTO the band, over its ground: with a
             painted band the stars would otherwise be hidden behind it. */}

--- a/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/CovenProfileBody.tsx
@@ -2,7 +2,7 @@
  * CovenProfileBody — the Cozy Coven player profile, on the coven's own paper
  * (#460, re-dressed by #1209).
  *
- * The candlelit page under a turning pentagram watermark, every block a panel of
+ * The candlelit page under a slow-turning cat watermark, every block a panel of
  * ward paper inside the slip's pink edge, braided thread heading each section,
  * and the player's name hand-lettered in Caveat.
  *
@@ -13,10 +13,12 @@
  * they were painted in. Structure is DefaultProfileBody's locked spine via
  * `ProfileSkin`, unchanged — #1209 swaps the dress, not the layout.
  *
- * Two things kept on purpose. The **watermark** is `.cvn-wheel`, the same
- * slow-turning pentagram the task card and both detail pages draw, mounted as
- * the header's decoration where the pushpins were; index.css owns its motion and
- * its reduced-motion guard. And the **spectrum laurel** stays the shared
+ * Two things kept on purpose. The **watermark** is `.cvn-wheel`, mounted as the
+ * header's decoration where the pushpins were; index.css owns its motion and its
+ * reduced-motion guard. THE SHARING IS THE POINT AND IT IS WIDER THAN IT LOOKS —
+ * the same mark turns on the task card, both detail pages and the praxis
+ * composer, five surfaces in all, which is why #2041's pentagram-to-cat swap is
+ * one edit in `covenSlip` rather than five. And the **spectrum laurel** stays the shared
  * `SpectrumLaurel` — the top-praxis mark is site furniture (ADR-0028), not
  * faction ornament, and only its medallion is tinted.
  *
@@ -37,6 +39,7 @@ import {
   CAPTION,
   CARD,
   BORDER,
+  CovenCat,
   DEEP,
   DISPLAY,
   HAND,
@@ -96,27 +99,24 @@ function Sparkfield() {
   )
 }
 
-/** The slow-turning pentagram, watermarking the identity banner. */
+/**
+ * The slow-turning cat, watermarking the identity banner (#2041).
+ *
+ * SIZE IS NOT THE CARD'S. #2041 pins 190px on the task card and says in the
+ * same breath to pick this one by the mark's weight on the page rather than by
+ * pasting that number. The pentacle here was 420px with a ringed circle around
+ * it, hung 140px off the right and 80px above the top of a header that clips —
+ * about a 280×340 visible figure. 240px fully inside is the closest thing to
+ * that footprint the banner can hold without guessing at its height: the header
+ * carries a credential card and the progression panel stacked inside
+ * `var(--space-2xl)` of padding, so it never comes near 240 + 16 short.
+ *
+ * The ring goes with the pentacle. It was there to close the star's silhouette;
+ * a cat's head already closes its own, and a circle behind it reads as a second
+ * device rather than a frame.
+ */
 function Watermark() {
-  return (
-    <svg
-      className="cvn-wheel"
-      width={420}
-      height={420}
-      viewBox="0 0 100 100"
-      aria-hidden="true"
-      style={{ position: 'absolute', right: -140, top: -80, zIndex: 0, pointerEvents: 'none', opacity: 0.08 }}
-    >
-      <circle cx="50" cy="50" r="44" fill="none" stroke={DEEP} strokeWidth="0.8" />
-      <path
-        d="M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z"
-        fill="none"
-        stroke={DEEP}
-        strokeWidth="1.1"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
+  return <CovenCat size={240} style={{ right: 16, top: 16, opacity: 0.08 }} />
 }
 
 /** Section heading — the display face, a braid, then the gloss. */

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -5,9 +5,9 @@
  *
  * The shared composer layout (`shared.tsx`) wearing Coven's dress: a centred
  * masthead of a turning pentacle disc under a twinkle field, a glow-and-lavender
- * ground carrying the coven wheel and a scatter of arcane glyphs, one braid of
- * thread closing the sheet, an 88px haloed ward for the points, a 40px pentacle
- * for the stage mark, and a full-bleed band for the cast.
+ * ground carrying the coven wheel's cat and a scatter of arcane glyphs, one
+ * braid of thread closing the sheet, an 88px haloed ward for the points, a 40px
+ * pentacle for the stage mark, and a full-bleed band for the cast.
  *
  * ## This REPLACES the `wow.exe` window wholesale
  *
@@ -55,7 +55,7 @@
  * Motion is reached by CLASS only: `.ep-spin` (the masthead disc at 42s, the
  * ward's spokes at 30s, both re-timed through `--ep-spin-dur`), `.ep-twinkle`
  * (the ward's five stars, staggered through `--ep-delay`) and `.cvn-wheel` (the
- * ground's pentagram, Coven's own 120s turn). Every keyframe already lives in
+ * ground's cat, Coven's own 120s turn). Every keyframe already lives in
  * `index.css` behind the shared `prefers-reduced-motion` guard; an inline
  * `animation:` would bypass that guard (#1003).
  *
@@ -71,6 +71,7 @@ import { useTranslation } from "react-i18next";
 import { mediaUrl } from "../../../utils/media";
 import { type PraxisType } from "../../../api/praxis";
 import MediaArt from "../blocks/MediaArt";
+import { CovenCat } from "../../../components/factionMarks/covenSlip";
 import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
@@ -472,29 +473,18 @@ export default function CovenEditPraxis({ state }: Props) {
               background={`radial-gradient(62% 48% at 12% 0%, ${PINK}, transparent 70%), radial-gradient(58% 46% at 100% 100%, var(--faction-coven-slip-lav), transparent 72%)`}
             />
             {/* The wheel and the glyphs, on their own layer so each keeps its
-                own strength instead of inheriting the wash's. */}
+                own strength instead of inheriting the wash's.
+
+                THE WHEEL TURNS A CAT NOW (#2041) — the drawing is `covenSlip`'s
+                because five Coven surfaces share it, and it comes inside: 520px
+                hung 150px right and 110px below put a third of the mark off the
+                sheet, which is survivable for a star and not for a face. 240 at
+                a 16px inset is the size that fits the composer at its narrowest
+                (this file has no form-factor branch to size against, so the
+                figure is the narrow one and the wide sheet simply carries a
+                quieter mark). */}
             <ComposerGround inset={0}>
-              <svg
-                className="cvn-wheel"
-                width={520}
-                height={520}
-                viewBox="0 0 100 100"
-                aria-hidden="true"
-                style={{
-                  position: "absolute",
-                  right: -150,
-                  bottom: -110,
-                  opacity: 0.1,
-                }}
-              >
-                <path
-                  d="M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z"
-                  fill="none"
-                  stroke={DEEP}
-                  strokeWidth="1.2"
-                  strokeLinejoin="round"
-                />
-              </svg>
+              <CovenCat size={240} style={{ right: 16, bottom: 16, opacity: 0.1 }} />
               <GlyphScatter />
             </ComposerGround>
           </>

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -6,7 +6,7 @@
  * page `DefaultPraxisDetail` draws — same regions, same slots, same API
  * contract (ADR-0061) — wearing the ward the task detail (#1031) and the spell
  * slip (#1023) already established for this faction: a candlelight haze
- * drifting over the column, a pentagram watermark turning behind the copy,
+ * drifting over the column, a cat watermark turning behind the copy,
  * braided thread rules heading every section, and a candle flicker under the
  * score. Grenze Gotisch carries the display, Cormorant Garamond the reading
  * voice, Caveat the hand, Quicksand the chrome.
@@ -80,6 +80,7 @@ import VoteUI, { voteRegionVisible } from '../../../components/vote/VoteUI'
 import ScoreStamp from '../../../components/praxisCard/scoreStamp/ScoreStamp'
 import MetataskSeal from '../../../components/metataskSeal/MetataskSeal'
 import { CollabRoster } from '../../../components/collab/CollabRoster'
+import { CovenCat } from '../../../components/factionMarks/covenSlip'
 import { DuelCard } from '../DuelCard'
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
@@ -118,7 +119,14 @@ const ASIDE_TRACK = 330
 interface SizeSet {
   /** The byline's ringed disc. Ornament geometry (WORLD_ZERO_STYLE §4a). */
   disc: number
-  /** The turning pentagram watermark. Ornament geometry. */
+  /**
+   * The turning cat watermark. Ornament geometry.
+   *
+   * It shrank with #2041: the pentacle was 620/420 with a quarter of it hung
+   * off the right edge, and a face may not be cropped that way. These are the
+   * sizes that sit wholly on the sheet — mobile's 240 + a 24px inset clears a
+   * 320px viewport, where 420 could not.
+   */
   wheel: number
   titleSize: string
   headingSize: string
@@ -127,13 +135,13 @@ interface SizeSet {
 const SIZES: Record<'desktop' | 'mobile', SizeSet> = {
   desktop: {
     disc: 46,
-    wheel: 620,
+    wheel: 400,
     titleSize: 'var(--text-display)',
     headingSize: 'var(--text-title)',
   },
   mobile: {
     disc: 38,
-    wheel: 420,
+    wheel: 240,
     titleSize: 'var(--text-heading)',
     headingSize: 'var(--text-title)',
   },
@@ -727,32 +735,18 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
           boxSizing: 'border-box',
         }}
       >
-        {/* The pentagram watermark, turning once every two minutes. `.cvn-wheel`
-            carries the motion and its reduced-motion guard (#911/#1023). */}
-        <svg
-          className="cvn-wheel"
-          width={size.wheel}
-          height={size.wheel}
-          viewBox="0 0 100 100"
-          aria-hidden="true"
-          style={{
-            position: 'absolute',
-            right: desktop ? -170 : -140,
-            top: 140,
-            zIndex: 0,
-            pointerEvents: 'none',
-            opacity: 0.09,
-          }}
-        >
-          <circle cx="50" cy="50" r="44" fill="none" stroke={DEEP} strokeWidth="0.8" />
-          <path
-            d="M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z"
-            fill="none"
-            stroke={DEEP}
-            strokeWidth="1.1"
-            strokeLinejoin="round"
-          />
-        </svg>
+        {/* The cat watermark, turning once every two minutes (#2041 — it was a
+            pentagram, and the drawing lives in `covenSlip` because five Coven
+            surfaces turn the same one). `.cvn-wheel` still carries the motion
+            and its reduced-motion guard (#911/#1023).
+
+            IT COMES INSIDE. `size.wheel` was 620/420 hung 170/140px off the
+            right edge, so a quarter of the mark was clipped — which a
+            radially-symmetric star survives and a face does not. The values
+            below are what fits wholly on the sheet at each width; `right`
+            stops being a form-factor branch because the offset no longer has
+            to hide a crop. */}
+        <CovenCat size={size.wheel} style={{ right: 24, top: 140, opacity: 0.09 }} />
 
         <div style={{ position: 'relative', zIndex: 1 }}>
           {banners}

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -2,6 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
+import { CovenCat } from "../../../components/factionMarks/covenSlip";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { factionCssVar, factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
@@ -19,7 +20,7 @@ import type { TaskDetailState } from "../useTaskDetail";
  * Cozy Coven — THE CANDLELIT WARD (task detail v2, #1031).
  *
  * The spell slip opened out to a full page: a candlelight haze washes the
- * viewport, a pentagram watermark turns slowly behind the copy, braided thread
+ * viewport, a cat watermark turns slowly behind the copy, braided thread
  * rules head every section, and the points are held inside a glowing pentagram
  * ward on a 452px action plate. Grenze Gotisch carries the display, Cormorant
  * Garamond the numerals and the brief, Caveat the hand, Quicksand the chrome —
@@ -932,32 +933,21 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
           boxSizing: "border-box",
         }}
       >
-        {/* The pentagram watermark, turning once every two minutes. `.cvn-wheel`
-            carries the motion and its reduced-motion guard (#911/#1023). */}
-        <svg
-          className="cvn-wheel"
-          width={640}
-          height={640}
-          viewBox="0 0 100 100"
-          aria-hidden="true"
-          style={{
-            position: "absolute",
-            right: -180,
-            top: 120,
-            zIndex: 0,
-            pointerEvents: "none",
-            opacity: 0.09,
-          }}
-        >
-          <circle cx="50" cy="50" r="44" fill="none" stroke={DEEP} strokeWidth="0.8" />
-          <path
-            d="M50 12 L73.5 84.3 L11.9 39.7 L88.1 39.7 L26.5 84.3 Z"
-            fill="none"
-            stroke={DEEP}
-            strokeWidth="1.1"
-            strokeLinejoin="round"
-          />
-        </svg>
+        {/* The cat watermark, turning once every two minutes (#2041 — it was a
+            pentagram, and the swap is `covenSlip`'s because five Coven surfaces
+            turn the same mark). `.cvn-wheel` still carries the motion and its
+            reduced-motion guard (#911/#1023).
+
+            IT COMES INSIDE, and the size becomes responsive to make that
+            possible. The pentacle was a fixed 640px hung 180px off the right,
+            so a quarter of it was clipped — fine for an abstract star, wrong
+            for a face. `right: 24` puts the whole drawing on the sheet, which
+            means the size now has to fit the narrow sheet too: 240 + 24 clears
+            a 320px viewport, where 400 would not. */}
+        <CovenCat
+          size={desktop ? 400 : 240}
+          style={{ right: 24, top: 120, opacity: 0.09 }}
+        />
 
         <div
           style={{


### PR DESCRIPTION
Coven's turning pentagram watermark becomes a turning cat. Phase 3 of task cards v3 (#2027).

Closes #2041

## The seam I tested at

**"The Coven watermark is one drawing, on every surface that turns it."**

That is the seam because it is where the defect lives and where the owner ruling
lives. `frontend/src/components/factionMarks/__tests__/covenCat.test.tsx` went red
first and named all five mounts; it is green now.

A render test cannot see this class of drift — a sixth surface pasting the old
pentacle renders fine and typechecks fine, and is only wrong when you hold two
pages side by side. So the guard is a source scan with two assertions, the second
in the positive form so a mount drawing some *third* device fails as loudly as one
drawing the pentagram again:

1. the retired pentagram path appears in no component;
2. every `.cvn-wheel` mount comes through `CovenCat`.

## ⚠️ The issue says two mounts. There are five.

`grep -rn "cvn-wheel" frontend/src` — the full mount list, before and after:

| surface | file | before | after |
|---|---|---|---|
| task card | `components/taskCard/CovenTaskCard.tsx` | 420px, `right:-118 bottom:-64`, op .09 | **190px, `right:-6 bottom:-4`, op .09** |
| character profile | `pages/characterProfile/archetypes/CovenProfileBody.tsx` | 420px, `right:-140 top:-80`, op .08 | **240px, `right:16 top:16`, op .08** |
| task detail | `pages/taskDetail/archetypes/CovenTaskDetail.tsx` | 640px, `right:-180 top:120`, op .09 | **400/240px, `right:24 top:120`, op .09** |
| praxis detail | `pages/praxisDetail/archetypes/CovenPraxisDetail.tsx` | 620/420px, `right:-170/-140 top:140`, op .09 | **400/240px, `right:24 top:140`, op .09** |
| praxis composer | `pages/editPraxis/archetypes/CovenEditPraxis.tsx` | 520px, `right:-150 bottom:-110`, op .10 | **240px, `right:16 bottom:16`, op .10** |

**Decision: all five take the cat.** This is the issue's own ruling 1 applied to
the real list, not an expansion of it. Ruling 1's reason is *"splitting it would
show a player two different Coven watermarks on two pages they move between"* —
and a player moves task card → task detail constantly. Leaving three surfaces on
a pentacle would produce exactly the split the ruling forbids. `CovenProfileBody`'s
own docblock already named four of the five (*"the same slow-turning pentagram the
task card and both detail pages draw"*); the composer is the fifth it missed.

Epic ruling 5 ("Task Details is out of scope") is about not building the sibling
`Task Details.dc.html` redesign. It is not a fence around a shared watermark, and
reading it as one is what would break ruling 1 here. **Flag if you disagree — it is
the one call in this PR that goes past the issue's literal acceptance list.**

The drawing therefore lands **once**, in `components/factionMarks/covenSlip.tsx` —
the module whose own docblock exists because *"thirteen private copies of a
pentagram badge is how a faction acquires a second identity again."* Five private
copies of the path are deleted; one `CovenCat` replaces them.

## The artwork

Lifted verbatim from the vendored design — `TaskCards.dc.html` lines 1063–1071,
the `seg(...)` calls inside the Coven `DCLogic` block. Head, ears, eyes, muzzle,
whiskers; seven open strokes, round caps, nothing filled. (The cat *is* in the
vendored file. The issue expected it to be in the un-vendored `sigils.js`; it is
not, so nothing had to be redrawn from the screenshot.)

No DOM-mutating effect and no `[style*=…]` selector: the design was read for what
changes, and the change is written in the real components.

**The ring around the star is gone** on the three surfaces that drew one. It closed
the pentagram's silhouette; a cat's head closes its own, and a circle behind it
reads as a second device rather than a frame.

## Why every mount came inside

The design's own reason, kept: **"a face can't bleed off the card the way the
pentacle did."** A pentagram is radially symmetric and abstract, so a cropped one
still reads as itself. Four of the five mounts hung a quarter to a third of the
drawing off the right edge.

The card takes #2041's placement verbatim. The other four are sized per surface,
because #2041 says so in as many words — *"the profile is a different surface at a
different scale … pick the cat's size to match its weight on the page, rather than
pasting 190px into both."* Both detail pages became responsive so the mark fits the
narrow sheet: **240 + a 24px inset clears a 320px viewport, where 400/420 could not.**

One deliberate exception, and it is arithmetic rather than a judgement call: on the
task card the **right whisker's round cap** loses about 2px. Its tip is at x=97 of
the 100-unit box → 5.7px inside a box edge that sits 6px out. The face is 38px clear
of the edge. #2041 specifies `right:-6` knowing the box hangs off; the acceptance
criterion is about the cat, and the cat's *face* is what a crop would ruin.

## ⚠️ Deviation: opacity stays 0.09, not 0.15

**This is the one place I did not follow the issue's numbers, and it is a contrast
call.** #2041 asks for `opacity: 0.15` and, in the same breath, asks me to *"verify
it reads as texture behind the card's text rather than competing with the title."*
I verified it, and it does compete.

`--faction-coven-slip-deep` is the sheet's own hue, so a wash of it under the copy
can only *tighten* the reading (WORLD_ZERO_STYLE, #1302). Measured with
`utils/contrast.ts` against the two gradient stops the **corner** of the slip
actually runs (`-slip-lav` 74%, `-slip-vio` 100% — the `mid` stop is up by the
masthead, which the watermark no longer reaches), for `--faction-coven-slip-soft`,
the ink `.card-description` and the in-progress line wear:

| alpha | light lav / vio | dark lav / vio |
|---|---|---|
| **0.09** (shipped) | **4.68 / 4.51** | **5.10 / 5.38** |
| 0.13 (the design's `DCLogic`) | 4.44 / 4.28 | 4.65 / 4.91 |
| 0.15 (the issue) | 4.33 / 4.17 | 4.44 / 4.68 |

0.09 is the last step that keeps the brief clear of **AA 4.5 on both stops in both
cascades**. 0.15 buys a louder ornament with 0.33 of a body ink's margin. The title
ink clears either way (5.07 / 4.89 light at 0.15), so it is only the brief that
gates. Coven has already made this exact call once: the ward's gold bloom is mixed
to 55 % before it lands, for the same reason, recorded at
`--faction-coven-ward-haze` in `index.css`.

The figures and the reasoning are in `CovenCat`'s docblock, not just here. **If you
want the louder mark, the one-line change is the `opacity` on each mount — but it
costs the description ink AA in light.**

## Untouched, on purpose

- `.cvn-wheel`, `@keyframes cvn-wheel`, the `120s linear infinite`, and the
  `prefers-reduced-motion: no-preference` gate — all still `index.css`'s, all
  unchanged. The cat turns where motion is welcome and is simply drawn, still,
  where it is not. **Zero CSS bytes changed** (`dist` CSS hash identical).
- `aria-hidden="true"`, no `<title>`, no `aria-label` — asserted, per epic ruling 4.
- `SigilMark`'s pentagram **badge** keeps its star. That is the faction's mark of
  identity in a header, not the watermark, and it never turns.
- #2033's cauldron / boxed CTA / lifted level numeral and #2029's pinned masthead:
  merged with, not reverted. Their docblock prose was edited only where it made a
  now-false factual claim about the watermark.

## Byte budget

`npm run budget`, gzipped critical path, measured on both sides:

| | `origin/main` | this branch | delta |
|---|---|---|---|
| CSS | 23,974 | 23,974 | **+0** |
| JS | 129,447 | 129,479 | **+32** |

Verdicts unchanged: `ok JS 126.4 KB`, `WARN CSS 23.4 KB`. **The CSS WARN is
pre-existing on `main`** — I reproduced it at the baseline commit before touching
anything. CSS is 426 bytes under the 24,400 FAIL and this PR spends none of it: the
cat is inline SVG in `.tsx`, and the motion reuses the class that already exists.

## CI, run locally

Every step in `.github/workflows/test.yml`'s frontend job: `npm run lint` (incl. the
`local/no-raw-style-values` ratchet) · `npm run typecheck` · `npm run
typecheck:design-sync` · `npm test` (**311 files, 5,374 passed, 1 skipped**) · `npm
run build` · `npm run budget`. No schema artifacts touched, so `api-schema` is not
in play. `tsc --noEmit` was run after each file, not batched.

## ⚠️ Visual QA is outstanding

I have no browser and no dev stack. Nothing here has been *looked at* — every claim
above is from tests, `tsc`, eslint, the build, and contrast arithmetic.

## What to eyeball

1. **Does the cat read as a cat at watermark strength?** It is 0.09–0.10 opaque and
   smaller than the pentacle it replaces (190px vs 420px on the card). This is the
   risk the byte-and-ratio checks cannot touch: it may be too faint. If it is,
   thickening the strokes in `CAT` costs no contrast margin, where raising opacity
   does.
2. **Both themes, on the card**: the cat behind the description and the in-progress
   line. Texture, or competition?
3. **The whisker at the card's right edge** — ~2px of the cap should be clipped and
   nothing else.
4. **The character profile header**, especially on a narrow viewport: 240px + 16px
   inset assumes the header is at least ~256px tall. It holds a credential card and
   the progression panel inside `--space-2xl` padding, so it should be, but that is
   a reasoned guess, not a measurement.
5. **The praxis composer at its narrowest** — the one surface with no form-factor
   branch to size against, so 240 is the narrow figure and a wide sheet carries a
   quieter mark than it could.
6. **All five surfaces side by side** — the whole point of the ruling is that they
   are one drawing.
7. **`prefers-reduced-motion: reduce`**: the cat should still be *drawn*, just
   still. The gate is untouched, but confirm it survived.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
