### PR TITLE
A superseded ADR says so at the top, not only in the ADR that replaced it

### DIFF
--- a/docs/adr/0014-praxis-scoring-is-per-character-contribution.md
+++ b/docs/adr/0014-praxis-scoring-is-per-character-contribution.md
@@ -1,6 +1,26 @@
 # ADR-0014: Praxis scoring is per-character Contribution; the card shows Merit
 
-Status: Accepted (2026-06-24)
+> **Superseded in part — the *Merit (the card number)* section only.** The half
+> of this ADR the title's second clause names is retired;
+> [ADR-0047](0047-praxis-card-shows-computed-total-not-merit.md) moved the card
+> to the computed total, and
+> [ADR-0053](0053-a-praxis-has-one-number-merit-is-retired.md) then retired
+> **Merit** as a live concept entirely: a praxis has one number, `score`, the
+> computed total resolved for its author, for every praxis type. `PraxisOut.score`
+> / `PraxisCardOut.score` are no longer Merit, and Merit is no longer the
+> collab-card number or the task-submission sort key.
+>
+> **Everything else here stands.** The Contribution model — scoring is
+> per-`(character, praxis)`, `(base + metatasks) × faction × duel + votes`,
+> computed by the `compute_contributions` batch primitive over a frozen breakdown
+> dataclass — the vote-tally read-model, and the `stars` → `value` vocabulary are
+> all live. ADR-0053 removed the *second* number, not the per-character one.
+>
+> The argument below is preserved as written, including the Merit section that
+> ADR-0047 and ADR-0053 had to answer.
+
+Status: Accepted (2026-06-24); the *Merit (the card number)* section superseded by
+ADR-0047 (2026-07-19) and retired by ADR-0053 (2026-07-21).
 
 ## Context
 

--- a/docs/adr/0028-task-crown-replaces-faction-distinction-laurel.md
+++ b/docs/adr/0028-task-crown-replaces-faction-distinction-laurel.md
@@ -1,6 +1,6 @@
 # ADR-0028 — The Task Crown replaces the Faction Distinction Laurel
 
-**Status:** Accepted
+**Status:** Accepted, amended 2026-07-29 by [ADR-0054](0054-one-theme-aware-task-crown.md) — the crown's per-card recolour of its inner disc + glyph only; everything else here stands.
 **Date:** 2026-07-03
 **Supersedes:** the cross-task "faction champion" semantics of the Faction Distinction Laurel (`FdlLaurel` / `topPraxisIndex`)
 **Relates to:** #354 (this mark), #390 / Albescent secrecy ([ADR-0027](0027-albescent-is-a-secret-society.md) — the revealed Albescent faction page carries the Task Crown like the other six)

--- a/docs/adr/0035-mobile-form-factor-tinting-and-real-fields.md
+++ b/docs/adr/0035-mobile-form-factor-tinting-and-real-fields.md
@@ -1,6 +1,26 @@
 # ADR-0035: Mobile is a form-factor axis on the same surface seam, tinted by a theme×treatment cascade, showing only real domain fields
 
-Status: Accepted (2026-07-14)
+> **Superseded per surface, not in whole.** The tinting cascade, the mandatory
+> `Default` (na) skin and the real-domain-fields rule below still govern every
+> mobile surface. What has moved is the **form-factor split itself**: surface by
+> surface, the parallel `MOBILE_ARCHETYPE_BY_SLUG` registry is being replaced by
+> one responsive component per faction. Each of these supersedes ADR-0035 for its
+> own surface and no other:
+>
+> - task cards — [ADR-0056](0056-task-cards-collapse-to-one-responsive-component-per-faction.md)
+> - task detail — [ADR-0058](0058-task-detail-collapses-to-one-responsive-component-per-faction.md)
+> - praxis cards — [ADR-0067](0067-praxis-cards-collapse-to-one-responsive-component-per-faction.md)
+> - the edit-praxis composer — [ADR-0065](0065-the-edit-praxis-composer-is-one-shared-layout-every-faction-dresses.md)
+> - the character profile and the duel seal — [ADR-0069](0069-the-character-profile-and-the-duel-seal-collapse-to-one-responsive-component-per-faction.md)
+> - faction detail — [ADR-0078](0078-faction-detail-collapses-to-one-responsive-component-per-faction.md)
+>
+> [ADR-0063](0063-praxis-detail-collapses-to-one-responsive-component-per-faction.md)
+> did the same to **praxis detail** (#1089 retired its mobile archetypes) without
+> writing a supersession line; treat that surface as moved too.
+>
+> ADR-0035 remains the live decision for every surface not listed above.
+
+Status: Accepted (2026-07-14); superseded per surface — see the banner above.
 
 ## Context
 

--- a/docs/adr/0047-praxis-card-shows-computed-total-not-merit.md
+++ b/docs/adr/0047-praxis-card-shows-computed-total-not-merit.md
@@ -1,6 +1,31 @@
 # ADR-0047 — The praxis card shows the computed total, not Merit
 
-**Status:** Accepted
+> **Superseded by [ADR-0053](0053-a-praxis-has-one-number-merit-is-retired.md)**
+> — a praxis has exactly one number, `score`, the computed total resolved for its
+> author, for every praxis type with no carve-out.
+>
+> This ADR moved the *card* to the computed total while leaving
+> `PraxisCardOut.score` as Merit, shipping the same number twice under two names.
+> ADR-0053 collapsed the two: Merit is retired as a live concept, the collab
+> carve-out below is gone (`display_multiplier` is a plain float, never `None`),
+> and the detail page's `(score − votePoints) / base` derivation — which that
+> interim state silently pinned at ×1.0 — is deleted.
+>
+> **The row policy below outlived the number it was written for.** ADR-0053 kept
+> the conditional stamp and made `scoreBreakdown()` its only resolver, so the
+> rules in *Decision* still describe live behaviour — read them through ADR-0049
+> and ADR-0053 for where they now live. One clause has since gone:
+> [ADR-0076](0076-a-base-only-score-reads-as-a-bare-total.md) overturned the
+> **votes row always shows** exception (re-affirmed below on 2026-07-20), so a
+> base-only praxis now reads as a bare total instead of a total plus `+0 from
+> votes`.
+>
+> The argument below is preserved as written. It is the record of what was
+> decided in July 2026 and of what ADR-0053 and ADR-0076 had to answer; it is not
+> the live decision.
+
+**Status:** Superseded by ADR-0053 (2026-07-21); the votes-row clause separately
+superseded by ADR-0076 (2026-08-15). Accepted 2026-07-19.
 **Date:** 2026-07-19
 **Supersedes:** the "Merit (the card number)" decision in **ADR-0014**
 **Relates to:** ADR-0014 (Contribution vs Merit), ADR-0011 (duel = two solo sides),


### PR DESCRIPTION
`Supersedes` lines named their target, but the target still read `Status: Accepted` with no banner — so a reader who opened a retired ADR directly had no way to learn it was retired. Only ADR-0010 and ADR-0009 carried one.

Banners match the style of `0010-ui-copy-catalog.md` and the one #1925 added to `0009-blocks-are-mutual-and-visible.md`. **No argument text is rewritten or deleted** — the record of what was decided and later changed is the point of the format.

### Banners added

- **ADR-0047** — superseded by ADR-0053 (Merit retired, collab carve-out gone, the two-names-one-number interim killed). The banner says which half is still live: the *row policy* outlived the number it was written for and survived into `scoreBreakdown()`; only ADR-0076 took the votes-row clause.
- **ADR-0014** — partial, the `Merit (the card number)` section only. The Contribution model, the vote-tally read-model and the `stars` → `value` vocabulary all stand.
- **ADR-0035** — partial, per surface, listing the six declaring ADRs: 0056 task cards, 0058 task detail, 0067 praxis cards, 0065 edit composer, 0069 profile + duel seal, 0078 faction detail. The tinting cascade, mandatory `Default` (na) skin and real-fields rule stay live for every unlisted surface.
- **ADR-0028** — `Status:` line only; ADR-0054 declares `Amends:` with no back-pointer.

### Audit findings, no edit made

- **ADR-0063 collapsed praxis detail off the form-factor split but never wrote a supersession line** — it says only "Parallel to ADR-0056, ADR-0058". Recorded inside ADR-0035's banner as moved-in-fact rather than editing 0063's own declaration; that's a live ADR's claim.
- Already bidirectional: 0009←0077, 0010←0032, 0067←0069, 0018 (clause-level `⚠️ SUPERSEDED` inline), 0059 (inline), 0046 (`Status: Reversed` + its own banner).
- Not ADR targets: 0001 (a session draft), 0028's own `Supersedes` (the `FdlLaurel` code concept), 0071 ("Supersedes nothing").

Docs only — no code, no CI inputs, and no ADR index in `CLAUDE.md` (thin pointer doc by design). Re-ran the audit after rebasing onto main's 49 new commits: no new drift, and the faction-detail link follows main's `0077` → `0078` rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)