### PR TITLE
Ephemerists task card: the restrained masthead, a shared rune strip at the CTA, and the rose's three needle values (#2067)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -951,6 +951,24 @@ A faction shows a figure twice — the score stamp's total on a praxis card, and
 
 **Ornament for a LAZY archetype belongs in the `.tsx`, and this is measured, not stylistic.** The nine task cards are lazy (`factions/*.ts` → `lazyArchetype`), so `EverymenTaskCard` ships in its own 3.7 KB chunk the initial load never fetches — bytes drawn there cost the budget nothing. A rule in `index.css` lands in the one blocking stylesheet, which sits ~1 KB under its FAIL line. So geometry goes inline as SVG, and only MOTION has to be CSS, because a reduced-motion gate cannot be expressed inline. The corollary is that dropping a design's animation is sometimes the *whole* saving: Everymen's fists-and-lightning is drawn and not played, and jagged arcs thrown off a bolt read as a discharge standing perfectly still.
 
+### Ornament can MOVE, and where it lands decides whether it is still card-local (#2067)
+
+The Ephemerists card headed itself with a 110px night band carrying a winged sun disc between two twelve-sign glyph registers. The re-pulled design strips the band to the kit's plain `CardMasthead` and returns the motif as two shimmering rows of mathematical marks bracketing the sign-up button. Three things follow, and none of them is "delete the ornament".
+
+**A band's fixed height is usually the ornament's canvas, so it goes with the ornament.** `masthead: 110 / 98` existed only to give the registers somewhere to march; with them gone the right value is not a smaller number but *no field* — the band is `CardMasthead`'s own height. The same is true of `discWidth`, which measured the disc and nothing else. A size-set field that survives its only reader is how a band stays tall for a year after the reason left.
+
+**Where the motif lands decides its scope.** The registers were card-local *and correctly so*: the page cycles one 16-sign register to fill its width, so the two orders were composition. At the CTA the same motif is on **every** Ephemerists surface that paints a button through `--faction-ephemerists-plate-cta-bg` — the task card, the task page, the composer — so it is a component in `components/factionMarks/` on the fourth-consumer rule (#1634), not three transcriptions. The surface that has no button gets no strip; the surface that has a button it does not paint with the plate CTA is not one of the three. **Ask what the ornament is attached to, not which file you found it in.**
+
+**A per-instance cycle splits: numbers inline, the ramp in the sheet.** Peak opacity and phase are one value per mark and belong inline (`--epg-op`, `--epg-delay` — the register's own names, reused because it is the same motif). A 9/10/11/9/10 px size cycle is *not* per-instance: it is three `nth-child` rules, and putting it in `index.css` is what keeps 32 spans from each needing an `eslint-disable` for ornament type off the ramp. The hatch above is for a site, not for a loop.
+
+**And a bare glyph is a terrible proxy for a concept in a test.** `ephemeristsDetail.test.tsx` asserted the page's text did not contain `×` to mean "no modifier row at ×1.00". A decorative row of mathematical symbols contains `×`, is `aria-hidden`, and reads to nobody — the assertion was measuring a character where the concept is `×{{multiplier}}`. `/×\d/` is the same guard against the thing it was actually for.
+
+### A rose says which way is up exactly ONCE (#2067)
+
+`CompassRose` shipped with four needles in three treatments: north filled in the register's teal, south outlined in `-brass` at 0.9, east and west outlined in `-brass-light` at 0.7. Three answers to one question, and the reader has to work out which difference carries meaning. The design gives the three open needles **one ink at one weight** and fills only north — so the single contrast in the drawing is the single fact it states.
+
+**North took the plate's gold rather than the register's teal, and the ratio is why.** `-plate-gold` measures 13.07:1 on the rose's own `-plate-disc` against the teal's 7.36:1: the one point that carries meaning is also the one that reads first. A second design file draws that needle `var(--faction-ephemerists-plate-nile, #1e3a6e)` — a navy at **1.64:1** on the same disc, i.e. invisible. When two design files disagree about a colour, **the one naming a variable is the one to follow**, and a hex fallback that measures under 2:1 on the ground it lands on is a value from another cascade, not an alternative. (Here, almost certainly the eventual light mode — which #1627/#1636 keep out of this register until its own epic.)
+
 ---
 
 ## 7. Components

--- a/frontend/src/components/factionMarks/EphemeristsRuneStrip.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsRuneStrip.tsx
@@ -1,0 +1,88 @@
+import type { CSSProperties } from "react";
+import { CAPTION, QUIET } from "./ephemeristsPlate";
+
+/**
+ * THE RUNE STRIP — the Ephemerists' glyph motif, moved off the masthead and onto
+ * the call to action (#2067).
+ *
+ * The task card used to march two twelve-sign registers across a 110px night
+ * band. The re-pulled design strips that band back to the kit's plain
+ * `CardMasthead` and returns the motif here: a shimmering row of mathematical
+ * marks immediately before the plate's primary button and another immediately
+ * after, so the ornament brackets the one thing on the sheet you can act on.
+ *
+ * IT IS A COMPONENT BECAUSE THREE SURFACES MOUNT IT (owner ruling, #2067). The
+ * strips bracket the CTA on every Ephemerists surface that paints a button
+ * through `--faction-ephemerists-plate-cta-bg` — the task card, the task detail
+ * and the composer — and §6's rule is that a device is drawn once and consumed
+ * everywhere. Three skins each transcribing this row is the failure mode that
+ * `ephemeristsPlate.tsx` was extracted to end: a strip redrawn in one file and
+ * left standing in the others drifts silently, invisibly to the import graph.
+ *
+ * `EphemeristsPraxisDetail` gets none — it has no button, so there is nothing to
+ * bracket. `EphemeristsFieldDesk` has one button but does not paint it with the
+ * plate CTA, so it is not one of the three.
+ *
+ * WHAT LIVES WHERE, and the split is deliberate:
+ *
+ *  • `index.css` owns the strip's BOX (`[data-eph-runes]`), the per-rune flex
+ *    cell and the size cycle (`.eph-rune` + three `nth-child` rungs), and the
+ *    opacity animation. The animation is behind
+ *    `@media (prefers-reduced-motion: no-preference)` — the repo's inverted form
+ *    of the design's always-on rule, the same shape `.cvn-wheel` and
+ *    `.epg-glyph` use. There is never an inline `animation:`, and stilled the
+ *    strip is a static row of marks at its own peak opacity, which is what it is
+ *    at any single frame of the cycle.
+ *  • THIS FILE owns the sequence, the two inks and the two per-instance custom
+ *    properties. `--epg-op` and `--epg-delay` are numbers per rune, not colours,
+ *    so a stylesheet has nowhere to put them; the same two names already carry
+ *    the register's peak and phase on `.epg-glyph`, and reusing them keeps one
+ *    vocabulary for one motif (the two never nest, so nothing inherits across).
+ *
+ * IT IS DECORATION AND MUST STAY SO. Thirty-two mathematical symbols read aloud
+ * between the brief and the sign-up button would be worse than useless, so the
+ * row is `aria-hidden` and holds no text node any assistive technology reaches.
+ */
+
+/**
+ * The sequence, in the design's own order.
+ *
+ * The issue calls this "31 spans" and then lists thirty-two marks. The SEQUENCE
+ * is the drawing and the count is a number someone wrote down beside it, so the
+ * sequence wins; nothing here reads the length, and the per-rune cycles below
+ * are indexed rather than distributed, so a mark either way changes only where
+ * the shimmer falls.
+ */
+const RUNES =
+  "∇ × Ψ ≡ ∂ Φ ∕ ∂ τ · ∮ ⟨ ψ ‖ Θ ‖ ψ ⟩ ∝ Σ μ ν · ⊗ Δ λ ≥ ϖ · ∫ ρ ∂".split(" ");
+
+/** Which side of the button this strip sits on. The only thing that differs. */
+export type RuneStripSide = "top" | "bottom";
+
+export default function EphemeristsRuneStrip({ side }: { side: RuneStripSide }) {
+  return (
+    <div aria-hidden="true" data-eph-runes={side}>
+      {RUNES.map((rune, index) => (
+        <span
+          key={`${side}-${index}`}
+          className="eph-rune"
+          style={
+            {
+              /* Every third mark takes the caption gold and the rest the quiet
+                 ink — both tokens, so the row has no colour of its own to go
+                 stale. `-brass` is absent on purpose: it is a rule colour and
+                 the module forbids painting it as a mark. */
+              color: index % 3 === 0 ? CAPTION : QUIET,
+              /* Peak opacity, 0.34–0.79, and phase, 0–11.5s. Coprime strides
+                 over the index so no two neighbours breathe together. */
+              "--epg-op": 0.34 + ((index * 7) % 10) / 20,
+              "--epg-delay": `${((index * 13) % 47) / 4}s`,
+            } as CSSProperties
+          }
+        >
+          {rune}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsRuneStrip.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsRuneStrip.test.tsx
@@ -1,0 +1,239 @@
+/**
+ * THE RUNE STRIP (#2067) — the Ephemerists' glyph motif off the masthead and
+ * onto the call to action.
+ *
+ * THREE SEAMS, because the failure modes are in three different places and no
+ * one of them can see the others:
+ *
+ *   • the strip's own RENDERED MARKUP (`renderToStaticMarkup`; this repo has no
+ *     jsdom, so effects never run and geometry is out of reach) — the sequence,
+ *     the two inks, the two per-instance custom properties, and the fact that it
+ *     is decoration;
+ *   • `index.css` AS TEXT, for the reduced-motion gate. The design writes the
+ *     animation always-on with `opacity: .16` as the base, which stills to an
+ *     unreadable row; the repo's inversion cannot be asserted from markup,
+ *     because the markup is identical either way;
+ *   • the SOURCE TREE, for "drawn once, mounted three times". That is the ruling
+ *     this component exists to satisfy, and a transcription into a fourth file
+ *     would render perfectly, pass every assertion above, and drift the first
+ *     time the strip is redrawn.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../i18n";
+
+const mocks = vi.hoisted(() => ({ formFactor: "desktop" as "mobile" | "desktop" }));
+
+vi.mock("../../../hooks/useFormFactor", () => ({
+  useFormFactor: () => mocks.formFactor,
+}));
+
+// Imported after the mock is registered.
+import EphemeristsRuneStrip from "../EphemeristsRuneStrip";
+import EphemeristsTaskCard from "../../taskCard/EphemeristsTaskCard";
+import { aTask } from "../../../test/fixtures";
+
+const SRC = fileURLToPath(new URL("../../..", import.meta.url));
+const CSS = readFileSync(fileURLToPath(new URL("../../../index.css", import.meta.url)), "utf8");
+const STRIP = fileURLToPath(new URL("../EphemeristsRuneStrip.tsx", import.meta.url));
+
+/** No hex may reach the markup — every colour is a token. */
+const HEX = /#[0-9a-fA-F]{3,8}\b/;
+
+/** The head of the design's sequence: the signature a transcription cannot lose. */
+const SEQUENCE_HEAD = "∇ × Ψ ≡ ∂";
+
+const TASK = aTask({ in_progress_count: 2 });
+
+function card(formFactor: "mobile" | "desktop"): string {
+  mocks.formFactor = formFactor;
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <EphemeristsTaskCard
+        task={TASK}
+        basePoints={TASK.point_value}
+        multiplier={1}
+        inProgressCount={TASK.in_progress_count}
+        onSignup={() => {}}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("the rune strip's own drawing (#2067)", () => {
+  const html = renderToStaticMarkup(<EphemeristsRuneStrip side="top" />);
+
+  it("marches the design's whole sequence, one span per mark", () => {
+    // The issue says "31 spans" and lists 32 marks. The sequence is the drawing
+    // and the count is a number written beside it, so the sequence wins — but a
+    // silently TRUNCATED row would look plausible at any length, which is why
+    // this counts rather than eyeballing.
+    expect(html.match(/class="eph-rune"/g)).toHaveLength(32);
+    expect(html).toContain("∇");
+    expect(html).toContain("ϖ");
+  });
+
+  it("is decoration, and carries no reachable text", () => {
+    // Thirty-two mathematical symbols read aloud between the brief and the
+    // sign-up button would be worse than useless.
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).not.toContain("aria-label");
+    expect(html).not.toContain("sr-only");
+  });
+
+  it("names its side, so the stylesheet can offset it", () => {
+    expect(html).toContain('data-eph-runes="top"');
+    expect(renderToStaticMarkup(<EphemeristsRuneStrip side="bottom" />)).toContain(
+      'data-eph-runes="bottom"',
+    );
+  });
+
+  it("paints from tokens only, with every third mark in the caption gold", () => {
+    expect(html).not.toMatch(HEX);
+    const inks = [...html.matchAll(/color:var\(--faction-ephemerists-plate-(\w+)\)/g)].map(
+      (match) => match[1],
+    );
+    expect(inks).toHaveLength(32);
+    expect(inks.filter((ink) => ink === "caption")).toHaveLength(11);
+    expect(new Set(inks)).toEqual(new Set(["caption", "quiet"]));
+  });
+
+  it("declares no animation inline — the stylesheet owns the motion", () => {
+    // #911's rule, and the reason the reduced-motion gate below can exist at
+    // all: an inline `animation:` is outside every media query.
+    expect(html).not.toContain("animation");
+  });
+
+  it("stays inside the design's peak and phase ranges", () => {
+    const peaks = [...html.matchAll(/--epg-op:([\d.]+)/g)].map((match) => Number(match[1]));
+    const delays = [...html.matchAll(/--epg-delay:([\d.]+)s/g)].map((match) => Number(match[1]));
+    expect(peaks).toHaveLength(32);
+    expect(delays).toHaveLength(32);
+    expect(Math.min(...peaks)).toBeCloseTo(0.34);
+    expect(Math.max(...peaks)).toBeCloseTo(0.79);
+    expect(Math.min(...delays)).toBe(0);
+    expect(Math.max(...delays)).toBeCloseTo(11.5);
+  });
+});
+
+describe("index.css owns the shimmer, and opting in is the point", () => {
+  it("declares the keyframe", () => {
+    expect(CSS).toContain("@keyframes eph-rune-shift");
+  });
+
+  it("adds the animation only under `prefers-reduced-motion: no-preference`", () => {
+    // The whole gate: every `.eph-rune` rule carrying `animation` must sit
+    // inside a no-preference block. Written the design's way round — the
+    // animation unconditional and `opacity: .16` as the base — a reader who
+    // asked for less motion gets a row at 16% and reads nothing.
+    const gated = CSS.slice(CSS.indexOf("@keyframes eph-rune-shift"));
+    const blocks = gated.split("@media (prefers-reduced-motion: no-preference)");
+    expect(blocks[0], "an ungated `.eph-rune` animation").not.toMatch(
+      /\.eph-rune[^}]*animation:/,
+    );
+    expect(blocks[1], "the gated rule").toMatch(/\.eph-rune\s*{[^}]*animation: eph-rune-shift/);
+  });
+
+  it("leaves a stilled strip visible at its own peak", () => {
+    // The base state IS the stilled state. `opacity: var(--epg-op)` outside the
+    // media query is what makes a reduced-motion strip a static row of marks
+    // rather than a blank 12px band.
+    expect(CSS).toMatch(/\.eph-rune\s*{[^}]*opacity: var\(--epg-op/);
+  });
+
+  it("carries the size cycle, so no site needs a suppression", () => {
+    // 9 / 10 / 11 / 9 / 10 per mark. Only 9 and 11 are rungs (--text-sm,
+    // --text-md), so inline this would be ornament type off the ramp behind an
+    // `eslint-disable` at 32 sites. Three selectors say it in the sheet instead.
+    expect(CSS).toMatch(/\.eph-rune\s*{[^}]*font-size: 9px/);
+    expect(CSS).toContain(".eph-rune:nth-child(5n + 3) { font-size: 11px; }");
+  });
+});
+
+describe("it is drawn once and mounted where a plate CTA is (#2067)", () => {
+  /** Every source file under `src/`, tests excluded. */
+  const files: [string, string][] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "__tests__") continue;
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (/\.tsx?$/.test(entry.name)) files.push([full, readFileSync(full, "utf8")]);
+    }
+  };
+  walk(SRC);
+
+  it("declares the sequence in exactly one file", () => {
+    // The sequence is the sharp half: a copy can be renamed, split up or
+    // inlined, and a component-name sweep misses every one of those. These
+    // five marks are the same five characters however they are smuggled.
+    const found = files.filter(([, source]) => source.includes(SEQUENCE_HEAD)).map(([path]) => path);
+    expect(found).toEqual([STRIP]);
+  });
+
+  it("is mounted on the three surfaces that paint the plate CTA, and no others", () => {
+    // The owner's ruling names these three. `EphemeristsComment` reads the same
+    // token as an ACCENT rather than as a button, and `EphemeristsPraxisDetail`
+    // has no button at all — neither is a mount, and a fourth one appearing
+    // here is a design decision that should fail rather than land quietly.
+    const mounts = files
+      .filter(([path, source]) => path !== STRIP && source.includes("EphemeristsRuneStrip"))
+      .map(([path]) => path.slice(SRC.length).replace(/\\/g, "/"));
+    expect(mounts.sort()).toEqual([
+      "components/taskCard/EphemeristsTaskCard.tsx",
+      "pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx",
+      "pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx",
+    ]);
+  });
+});
+
+describe("the task card's restrained masthead (#2067)", () => {
+  it("brackets the sign-up button with both strips, at both form factors", () => {
+    for (const factor of ["desktop", "mobile"] as const) {
+      const html = card(factor);
+      expect(html, factor).toContain('data-eph-runes="top"');
+      expect(html, factor).toContain('data-eph-runes="bottom"');
+      // Two strips, not four: `bottom` also has to appear exactly once, or a
+      // second CTA block has quietly grown a pair.
+      expect(html.match(/data-eph-runes=/g), factor).toHaveLength(2);
+    }
+  });
+
+  it("no longer marches the registers or crowns the band with the winged disc", () => {
+    const html = card("desktop");
+    expect(html, "the winged disc's own wing geometry").not.toContain(
+      'viewBox="-88 -20 176 40"',
+    );
+    expect(html, "the band's glyph registers").not.toContain("epg-glyph");
+    expect(html, "the registers' own hairlines").not.toContain("M8 24 H332");
+  });
+
+  it("grounds the band on the disc, keeps the band ink, and rules it in brass", () => {
+    const html = card("desktop");
+    const band = html.slice(html.indexOf('data-card-masthead="ephemerists"'));
+    const opened = band.slice(0, band.indexOf(">"));
+    expect(opened).toContain("background:var(--faction-ephemerists-plate-disc)");
+    expect(opened).toContain("color:var(--faction-ephemerists-plate-band-ink)");
+    expect(opened).toContain("border:1px solid var(--faction-ephemerists-plate-brass)");
+    // `border-box`, or the 2px of border pushes the band wider than the card
+    // and the article's `overflow: hidden` shaves the right-hand rule off.
+    expect(opened).toContain("box-sizing:border-box");
+  });
+
+  it("lets the band find its own height on both form factors", () => {
+    // The 110/98 canvas existed for the registers. A size-set field creeping
+    // back would pin the band to a number again, and roughly 75px of the ~75px
+    // this issue reclaims is exactly that field.
+    for (const factor of ["desktop", "mobile"] as const) {
+      const band = card(factor);
+      const opened = band
+        .slice(band.indexOf('data-card-masthead="ephemerists"'))
+        .slice(0, 400);
+      expect(opened.slice(0, opened.indexOf(">")), factor).not.toMatch(/height:\s*\d/);
+    }
+  });
+});

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -732,9 +732,10 @@ export function EmblemOctagon({ size }: { size: number }) {
  * THE COMPASS ROSE — the plate's points medallion (#2037, task cards v3).
  *
  * A brass-ruled disc with four needles on the cardinals, the north one struck
- * solid in the register's nile and the other three left open. It replaces the
- * stepped octagon the score sat in: the plate is a FIELD JOURNAL out of the
- * Valley, and the instrument a surveyor's plate reaches for is a rose.
+ * solid in the plate's gold and the other three left open in one ink at one
+ * weight (#2067). It replaces the stepped octagon the score sat in: the plate is
+ * a FIELD JOURNAL out of the Valley, and the instrument a surveyor's plate
+ * reaches for is a rose.
  *
  * IT IS A SHARED MARK, and that is why `size` is a prop rather than a constant.
  * The octagon medallion it replaces is drawn identically on two surfaces — the
@@ -774,14 +775,26 @@ export function CompassRose({ size }: { size: number }) {
         <path d="M16.8 83.2 L21 79" />
         <path d="M83.2 83.2 L79 79" />
       </g>
-      {/* North alone is filled, which is how a rose says which way is up. The
-          design's own fallback for this fill is a navy that would vanish into
-          the night field; `-plate-nile` is the register's teal and reads on it,
-          so the TOKEN is the drawing and the fallback was never reached. */}
-      <path d="M50 8 L55.5 26 L44.5 26 Z" fill={NILE} />
-      <path d="M50 92 L55.5 74 L44.5 74 Z" fill="none" stroke={BRASS} strokeWidth="0.9" />
-      <path d="M8 50 L26 44.5 L26 55.5 Z" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.7" />
-      <path d="M92 50 L74 44.5 L74 55.5 Z" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.7" />
+      {/* North alone is filled, which is how a rose says which way is up — and
+          the other three are ONE ink at ONE weight, so the rose says it exactly
+          once (#2067). It shipped saying it three ways: north in the register's
+          teal, south in `-brass` at 0.9, east and west in `-brass-light` at 0.7.
+          North is `-plate-gold` now, which is the ink the winged disc and the
+          registers are drawn in and the brightest mark the plate has: 13.07:1 on
+          the rose's own disc against the teal's 7.36:1, so the one point that
+          carries meaning is also the one that reads first.
+
+          A SECOND DESIGN FILE DRAWS THIS NEEDLE NAVY (`ephCompassBadge()`, as
+          `var(--faction-ephemerists-plate-nile, #1e3a6e)`) and it is not the one
+          to follow: that navy measures 1.64:1 on `-plate-disc` and the needle
+          would be invisible. The two files disagree, the gold one is the one
+          naming a variable, and the navy is most likely the eventual LIGHT-mode
+          value being carried into that epic (#1627/#1636 keep this register
+          theme-invariant until then). */}
+      <path d="M50 8 L55.5 26 L44.5 26 Z" fill={GOLD} />
+      <path d="M50 92 L55.5 74 L44.5 74 Z" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.9" />
+      <path d="M8 50 L26 44.5 L26 55.5 Z" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.9" />
+      <path d="M92 50 L74 44.5 L74 55.5 Z" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.9" />
       {/* The card the figure is struck on. */}
       <circle cx="50" cy="50" r="29" fill={DISC} stroke={BRASS_LIGHT} strokeWidth="0.7" />
     </svg>

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -10,10 +10,10 @@ import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
+import EphemeristsRuneStrip from "../factionMarks/EphemeristsRuneStrip";
 import {
   CompassRose,
   Cornice,
-  Glyph,
   GLYPHS,
   Tally,
 } from "../factionMarks/ephemeristsPlate";
@@ -22,14 +22,22 @@ import {
  * The Ephemerists — THE VALLEY PLATE (task card v2, #1023). Deco × Egypt: the
  * deco-space card carried into a field journal out of the Valley.
  *
- * A papyrus plate ruled in brass, headed by a cavetto cornice whose night band
- * holds a winged sun disc between two incised registers of glyphs — Egypt,
- * Greece, the middle ages, 1925 — that surface and recede on a long, staggered
- * cycle. The points ride a compass rose — v3 (#2037) struck them on the
- * surveyor's instrument in place of the v2 card's stepped octagon; the level is
- * a numeral over tally strokes; the call to action is an inset cartouche under
- * a double brass rule. Poiret One for display, Cinzel for the small caps,
+ * A papyrus plate ruled in brass, headed by a short cavetto-topped band that
+ * says only whose card this is. The points ride a compass rose — v3 (#2037)
+ * struck them on the surveyor's instrument in place of the v2 card's stepped
+ * octagon; the level is a numeral over tally strokes; the call to action is an
+ * inset cartouche under a double brass rule, bracketed by two shimmering rows of
+ * mathematical marks. Poiret One for display, Cinzel for the small caps,
  * Spectral for the reading copy.
+ *
+ * THE MASTHEAD IS RESTRAINED (#2067). It carried a winged sun disc between two
+ * incised twelve-sign registers on a 110px night band, over a tick strip — all
+ * of it drawn in the design the card was built from and all of it stripped by the
+ * re-pull. The band is the kit's plain `CardMasthead` now, on the medallion's own
+ * disc rather than the cornice band, and the glyph motif moved to the CTA as
+ * `EphemeristsRuneStrip`. The band's fixed height went with the registers: it was
+ * only ever the canvas they marched across, so the band is `CardMasthead`'s own
+ * height and no size-set field names it.
  *
  * This REPLACES "The Discordant Map" wholesale (ADR-0055 / ADR-0056 — a full
  * metaphor swap). The `--eph-*` illuminated-codex family stays DECLARED but is
@@ -59,10 +67,6 @@ const READING = "var(--font-faction-spectral)"; /* Spectral */
 interface SizeSet {
   /** Card width. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
   cardWidth: number;
-  /** Masthead band height. Geometry. */
-  masthead: number;
-  /** Winged-disc width — the ornament narrows on the phone. Geometry. */
-  discWidth: number;
   /**
    * The points plate's box. Geometry — and the size that makes the compass rose
    * legible: the needles reach in to 26/74 of a 100-unit viewBox, so the clear
@@ -80,8 +84,6 @@ interface SizeSet {
 const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   desktop: {
     cardWidth: 384,
-    masthead: 110,
-    discWidth: 176,
     medallion: 128,
     bodyPad: "0 var(--space-xl) var(--space-xl)",
     titleSize: "var(--text-title)",
@@ -90,8 +92,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   },
   mobile: {
     cardWidth: 340,
-    masthead: 98,
-    discWidth: 154,
     medallion: 112,
     bodyPad: "0 var(--space-xl) var(--space-lg)",
     titleSize: "var(--text-title)",
@@ -219,68 +219,20 @@ function Turning({
  * identical path for identical path. #1654 collapsed it: `GLYPHS` is imported
  * from `factionMarks/ephemeristsPlate`, which is where the signs are drawn.
  *
- * The card's registers are still the CARD's, and deliberately: the design
- * marches two named 12-sign rows here where the page cycles one 16-sign
- * register to fill its width. Those orders are composition, not vocabulary.
+ * `REGISTER_TOP`, `REGISTER_BOTTOM` and the `register()` helper stood here too —
+ * two named 12-sign orders and the 20px lead-in that marched them across the
+ * night band. #2067 struck all three: the re-pulled design's masthead carries no
+ * ornament, and the motif is `EphemeristsRuneStrip` at the CTA. They were
+ * card-local (the page cycles one 16-sign register to fill its width instead), so
+ * nothing else lost a register when they went.
+ *
+ * `Wing` went with them — one wing of the winged sun disc, drawn as deco stepped
+ * bars over a 176px `viewBox="-88 -20 176 40"`. It is NOT the kit's
+ * `WingedDiscSign`, which is a separate drawing on an 24-unit square that
+ * `EmblemOctagon` and the metatask seal still read; this was the wordmark's crown
+ * on this card alone, and `ephemeristsDetail.test.tsx` already pinned that the
+ * detail page does not draw it. `discWidth` measured nothing else and went too.
  */
-
-const REGISTER_TOP = [
-  "ankh", "water", "feather", "eye", "djed", "greekKey",
-  "reed", "offering", "alchemy", "chevrons", "scarab", "sun",
-];
-const REGISTER_BOTTOM = [
-  "scarab", "greekKey", "sun", "reed", "chevrons", "ankh",
-  "water", "djed", "eye", "alchemy", "offering", "feather",
-];
-
-/**
- * A register of signs marching across the band. The SIGN is the kit's `Glyph`;
- * only the order, the 20px lead-in and the 0.72 off-beat are this card's.
- */
-function register(names: string[], y: number, strength: number, keyPrefix: string) {
-  return names.map((name, index) => (
-    <Glyph
-      key={`${keyPrefix}${index}`}
-      name={name}
-      x={20 + index * 27.5}
-      y={y}
-      strength={strength * (index % 3 === 0 ? 1 : 0.72)}
-      delay={((index * 7) % 12) * 1.6}
-    />
-  ));
-}
-
-/** One wing of the sun disc, drawn as deco stepped bars. */
-function Wing({ flip }: { flip?: boolean }) {
-  return (
-    <g transform={flip ? "scale(-1,1)" : undefined}>
-      {[0, 1, 2, 3, 4].map((i) => (
-        <rect
-          key={i}
-          x={13 + i * 11.4}
-          y={-6 + i * 1.5}
-          width={9.6}
-          height={8.4 - i * 1.4}
-          rx={1.4}
-          fill="var(--faction-ephemerists-plate-gold)"
-          opacity={0.9 - i * 0.13}
-        />
-      ))}
-      {[0, 1, 2, 3].map((i) => (
-        <rect
-          key={`covert-${i}`}
-          x={15 + i * 11.4}
-          y={4.2 + i * 1.6}
-          width={8}
-          height={3.4 - i * 0.5}
-          rx={1}
-          fill="var(--faction-ephemerists-plate-brass-light)"
-          opacity={0.62 - i * 0.11}
-        />
-      ))}
-    </g>
-  );
-}
 
 /* The stepped `Octagon` and the cavetto `Cornice` stood here — the octagon
    identical to the kit's, the cornice identical but for its FLUTE COUNT. Both
@@ -298,11 +250,17 @@ function Wing({ flip }: { flip?: boolean }) {
    column between the description and the in-progress line.
 
    #1638 converts the kit's fluted rules to RUNE BANDS, and this is the one mount
-   that is DROPPED rather than converted: the masthead 300px above it already
-   marches two full registers of the same signs, so a third row of them below the
-   description would read as the band repeating rather than as a divider. The
-   description's own bottom margin is the separation the rule was carrying, and
-   `ruleBleed` went with it — it measured nothing else. */
+   that is DROPPED rather than converted: the card already marched two full
+   registers of the same signs, so a third row of them mid-leaf would read as the
+   band repeating rather than as a divider. The description's own bottom margin is
+   the separation the rule was carrying, and `ruleBleed` went with it — it
+   measured nothing else.
+
+   #2067 does NOT reopen this. The registers left the masthead, so the argument
+   above now points at the two rune strips bracketing the CTA rather than at the
+   band — the card still carries the motif twice, and a third row of it between
+   the description and the in-progress line would still be the repeat rather than
+   the divider. Restoring a rule here is a design decision, not a consequence. */
 
 export default function EphemeristsTaskCard({
   task,
@@ -339,79 +297,50 @@ export default function EphemeristsTaskCard({
           boxShadow: "var(--faction-ephemerists-plate-shadow)",
         }}
       >
-        {/* Masthead — the night band, its glyph registers, the winged disc. */}
-        <div
+        {/* THE RESTRAINED MASTHEAD (#2067) — the kit's shared anatomy and
+            nothing else: the mark hard left at the kit's 20, the wordmark on the
+            card's centreline. No wrapper box, because the box existed to hold
+            the registers and to pin a 110px canvas for them to march across;
+            the band is `CardMasthead`'s own height now, which is what makes the
+            hero row rise ~75px.
+
+            THE GROUND IS THE MEDALLION'S DISC, not the cornice band. `-plate-disc`
+            is two values lighter than `-plate-band`, so the header reads as a
+            brass-edged plate rather than as a night strip, and the compass rose
+            below it is struck on the same field. THE INK IS UNCHANGED:
+            `-plate-band-ink` is the gold measured on the band and it clears the
+            disc by more than it clears the plate (14.2:1 — the pairing is
+            recorded in `factionContrast.test.ts`). The sigil takes
+            `currentColor`, so it is that same gold.
+
+            `boxSizing` is load-bearing next to the border: the band is a block
+            child of a card with `overflow: hidden`, so a content-box border
+            would push it 2px wider than the card and be clipped on the right. */}
+        <CardMasthead
+          slug="ephemerists"
           style={{
-            position: "relative",
-            overflow: "hidden",
-            height: size.masthead,
-            background: "var(--faction-ephemerists-plate-band)",
+            boxSizing: "border-box",
+            background: "var(--faction-ephemerists-plate-disc)",
             color: "var(--faction-ephemerists-plate-band-ink)",
+            border: "1px solid var(--faction-ephemerists-plate-brass)",
           }}
         >
-          <svg
-            width="100%"
-            height={size.masthead}
-            viewBox="0 0 340 110"
-            preserveAspectRatio="xMidYMid slice"
-            aria-hidden="true"
-            style={{ position: "absolute", inset: 0, zIndex: 1 }}
+          <span
+            style={{
+              fontFamily: DECO,
+              fontSize: "var(--text-xl)",
+              letterSpacing: "0.3em",
+              textTransform: "uppercase",
+              whiteSpace: "nowrap",
+            }}
           >
-            <path d="M8 24 H332 M8 86 H332" stroke="var(--faction-ephemerists-plate-brass-light)" strokeWidth="0.6" opacity="0.28" />
-            {register(REGISTER_TOP, 13, 0.34, "top")}
-            {register(REGISTER_BOTTOM, 97, 0.3, "bottom")}
-          </svg>
-
-          {/* The plate band on the kit's shared anatomy (#2029) — the mark hard
-              left, the winged disc and the wordmark centred on the band. The
-              night band's own backdrop stays where it was, behind this: the
-              glyph registers are painted by the box around us, so the anatomy
-              needs no ornament slot of its own. The sigil takes `currentColor`,
-              which is the band's gold ink. */}
-          <CardMasthead
-            slug="ephemerists"
-            style={{ height: "100%", padding: "0 var(--space-lg)" }}
-          >
-            <span
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                gap: "var(--space-xs)",
-              }}
-            >
-              <svg
-                width={size.discWidth}
-                height={40}
-                viewBox="-88 -20 176 40"
-                aria-hidden="true"
-                style={{ display: "block", flex: "0 0 auto" }}
-              >
-                <Wing />
-                <Wing flip />
-                <circle r={10} fill="none" stroke="var(--faction-ephemerists-plate-gold)" strokeWidth="1.5" />
-                <circle r={5} fill="var(--faction-ephemerists-plate-gold)" opacity={0.8} />
-                <path d="M-13 0 H-10.5 M10.5 0 H13" stroke="var(--faction-ephemerists-plate-brass-light)" strokeWidth="1" />
-              </svg>
-              <span
-                style={{
-                  fontFamily: DECO,
-                  fontSize: "var(--text-xl)",
-                  letterSpacing: "0.3em",
-                  textTransform: "uppercase",
-                  whiteSpace: "nowrap",
-                }}
-              >
-                {/* #1910: the band spells the faction's name, so it reads the
-                    one key that stays per-faction rather than a second copy.
-                    The `textTransform` above already carried the plate's upper
-                    case, so the band reads THE EPHEMERISTS either way. */}
-                {factionName("ephemerists")}
-              </span>
-            </span>
-          </CardMasthead>
-        </div>
+            {/* #1910: the band spells the faction's name, so it reads the one
+                key that stays per-faction rather than a second copy. The
+                `textTransform` above already carried the plate's upper case, so
+                the band reads THE EPHEMERISTS either way. */}
+            {factionName("ephemerists")}
+          </span>
+        </CardMasthead>
         <Cornice flutes={40} />
 
         {/* The journal leaf. */}
@@ -577,9 +506,19 @@ export default function EphemeristsTaskCard({
         {/* The plate's CTA was a full-bleed band closing the leaf. #2030 sets
             it as an inset cartouche with air under it, beneath the plate's own
             double brass rule — two hairlines, which is how this card rules
-            everything it rules (the hero's stepped lead-in, the cornice). */}
+            everything it rules (the hero's stepped lead-in, the cornice).
+
+            #2067 BRACKETS IT WITH THE MASTHEAD'S OWN MOTIF. The two rune strips
+            are the registers that came off the band, and they are the reason this
+            block no longer sits inside one `bodyPad` box: `[data-eph-runes]` is
+            `calc(100% - 40px)` wide of ITS OWN parent, which is the design's
+            20px inset from the CARD's edges. Nested inside a box already inset by
+            `--space-xl` they would have come out 44px in each side and read as a
+            short line rather than as a register. So the wrapper is bare, the
+            brass rule carries its own inset as a margin, and the trailing strip's
+            18px is what closes the card in place of `bodyPad`'s bottom. */}
         {cta && (
-          <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
+          <div style={{ position: "relative", zIndex: 2 }}>
             <div
               aria-hidden="true"
               data-cta-rule="ephemerists"
@@ -587,9 +526,10 @@ export default function EphemeristsTaskCard({
                 height: 3,
                 borderTop: "1px solid var(--faction-ephemerists-plate-brass)",
                 borderBottom: "1px solid var(--faction-ephemerists-plate-brass)",
-                margin: "0 0 var(--space-md)",
+                margin: "0 var(--space-xl) var(--space-md)",
               }}
             />
+            <EphemeristsRuneStrip side="top" />
             <div style={{ display: "flex", justifyContent: "center" }}>
               <button
                 type="button"
@@ -600,6 +540,9 @@ export default function EphemeristsTaskCard({
                   cursor: cta.denied ? "not-allowed" : "pointer",
                   display: "flex",
                   gap: "var(--space-md)",
+                  /* The design's 14px, on the rung below it: the air between the
+                     button and the two strips it sits between. */
+                  margin: "var(--space-md) auto",
                   background: "var(--faction-ephemerists-plate-cta-bg)",
                   color: "var(--faction-ephemerists-plate-cta-ink)",
                   border: "2px solid var(--faction-ephemerists-plate-brass)",
@@ -635,6 +578,7 @@ export default function EphemeristsTaskCard({
                 </svg>
               </button>
             </div>
+            <EphemeristsRuneStrip side="bottom" />
           </div>
         )}
       </article>

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -308,10 +308,11 @@ export default function EphemeristsTaskCard({
             is two values lighter than `-plate-band`, so the header reads as a
             brass-edged plate rather than as a night strip, and the compass rose
             below it is struck on the same field. THE INK IS UNCHANGED:
-            `-plate-band-ink` is the gold measured on the band and it clears the
-            disc by more than it clears the plate (14.2:1 — the pairing is
-            recorded in `factionContrast.test.ts`). The sigil takes
-            `currentColor`, so it is that same gold.
+            `-plate-band-ink` is the gold measured on the band, and moving the
+            ground under it spends 0.93 of a very large margin — 14.00:1 on the
+            band, 13.07:1 on the disc. That is a NEW pairing rather than the old
+            row wearing a new ground, so `factionContrast.test.ts` records it.
+            The sigil takes `currentColor`, so it is that same gold.
 
             `boxSizing` is load-bearing next to the border: the band is a block
             child of a card with `overflow: hidden`, so a content-box border

--- a/frontend/src/components/taskCard/__tests__/ephemeristsCompassRose.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/ephemeristsCompassRose.test.tsx
@@ -98,6 +98,49 @@ describe('the Ephemerists points plate is a compass rose (#2037)', () => {
 })
 
 /**
+ * THE THREE NEEDLE VALUES (#2067). The rose shipped saying "north" three ways —
+ * north filled in the register's teal, south outlined in `-brass` at 0.9, east
+ * and west outlined in `-brass-light` at 0.7 — where the design says it once:
+ * one ink at one weight on the three open needles, and only north filled.
+ *
+ * Asserted on the RENDERED needle paths rather than on the file, because the
+ * question is which ink reaches which of four otherwise identical triangles, and
+ * the paths are what carry the answer to the screen.
+ */
+describe('the rose says which way is up exactly once (#2067)', () => {
+  /** The `fill`/`stroke` on the `<path>` whose `d` is given. */
+  function needle(html: string, d: string): string {
+    const at = html.indexOf(`d="${d}"`)
+    expect(at, `the ${d} needle is drawn`).toBeGreaterThan(-1)
+    return html.slice(at, html.indexOf('/>', at))
+  }
+
+  const SOUTH = 'M50 92 L55.5 74 L44.5 74 Z'
+  const EAST = 'M8 50 L26 44.5 L26 55.5 Z'
+  const WEST = 'M92 50 L74 44.5 L74 55.5 Z'
+
+  it('fills north in the plate gold, not the register teal', () => {
+    // 13.07:1 on the rose's own disc against the teal's 7.36:1 — the one point
+    // that carries meaning is also the one that reads first. The design's OTHER
+    // file draws this navy (`-plate-nile`'s 1.64:1 fallback), which would make
+    // the needle invisible; the gold file is the one naming a variable.
+    const north = needle(render('desktop'), NORTH)
+    expect(north).toContain('fill="var(--faction-ephemerists-plate-gold)"')
+    expect(north).not.toContain('plate-nile')
+  })
+
+  it('outlines the other three in one ink at one weight', () => {
+    const html = render('desktop')
+    for (const d of [SOUTH, EAST, WEST]) {
+      const open = needle(html, d)
+      expect(open, d).toContain('fill="none"')
+      expect(open, d).toContain('stroke="var(--faction-ephemerists-plate-brass-light)"')
+      expect(open, d).toContain('stroke-width="0.9"')
+    }
+  })
+})
+
+/**
  * #1654's rule, applied ahead of the surface that is about to want the mark.
  * The path string is the sharp half: a copy can be renamed, inlined or split up
  * and a component-name sweep misses it; the north needle is the same 24

--- a/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/factionTaskCardsV2.test.tsx
@@ -356,11 +356,15 @@ describe('the Ephemerists card keeps its own ornament densities (#1654)', () => 
     expect(card().match(/height:3\.5px/g)).toHaveLength(20)
   })
 
-  it('marches two registers of 12 signs — the card order, not the page cycle', () => {
-    // The page fills its width from a cycled 16-sign register; the card names
-    // its two rows. `Glyph` is shared, the ORDER is not, which is why the kit
-    // exports the sign as well as the register.
-    expect(card().match(/class="epg-glyph"/g)).toHaveLength(24)
+  it('marches no register at all — the motif is at the CTA now (#2067)', () => {
+    // It used to march two named 12-sign rows across a 110px night band, where
+    // the page fills its width from a cycled 16-sign register. The re-pulled
+    // design's masthead carries no ornament and the motif returns as
+    // `EphemeristsRuneStrip`, so the card's own orders and the `register()`
+    // helper are gone with the canvas they needed. `Glyph` is still kit
+    // vocabulary and four other Ephemerists surfaces still cut it — what this
+    // asserts is that no register creeps back onto THIS band.
+    expect(card()).not.toContain('class="epg-glyph"')
   })
 
   it('draws the level as the kit tally, one stroke per level', () => {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4718,7 +4718,16 @@
    `no-preference`. Written the design's way round (0.16 as the base, the
    animation always on) a reduced-motion reader gets a row at 0.16 and reads
    nothing. Nothing pins the pre-delay state either: a mark holds at its peak
-   until its own cycle starts, which is legible from first paint. */
+   until its own cycle starts, which is legible from first paint.
+
+   THE DESIGN'S `user-select: none` IS DROPPED, and it is a budget decision. It
+   would ship prefixed (`-webkit-user-select` beside it) into the one stylesheet
+   that blocks first paint, and what it buys is that a drag-select across the card
+   does not pick up 32 mathematical symbols — a copy-paste nicety on a row that is
+   already `aria-hidden`. §6's lazy-ornament rule says the blocking sheet is the
+   wrong place to spend, and this is the cheapest thing here to not spend it on.
+   ponytail: if the junk-in-clipboard ever matters, the upgrade is one
+   `user-select: none` here, ~20 gzipped bytes, not a rethink. */
 @keyframes eph-rune-shift {
   0%, 100% { opacity: 0.16; }
   50% { opacity: var(--epg-op, 0.8); }
@@ -4728,21 +4737,22 @@
   align-items: center;
   height: 12px;
   overflow: hidden;
-  white-space: nowrap;
-  user-select: none;
   width: calc(100% - 40px);
   margin: 0 auto;
 }
 [data-eph-runes="top"] { margin-top: -7px; }
 [data-eph-runes="bottom"] { margin-bottom: 18px; }
+/* The design also sets `white-space: nowrap` here. It is a provable no-op on
+   this markup and so is not carried: the marks arrive from a `.map()` with no
+   whitespace text nodes between them, and a flex row does not wrap by default. */
 .eph-rune {
-  flex: 1 1 auto;
+  flex: auto;
   text-align: center;
   line-height: 1;
   font-size: 9px;
   opacity: var(--epg-op, 0.8);
 }
-.eph-rune:nth-child(5n + 2), .eph-rune:nth-child(5n + 5) { font-size: 10px; }
+.eph-rune:nth-child(5n + 2), .eph-rune:nth-child(5n) { font-size: 10px; }
 .eph-rune:nth-child(5n + 3) { font-size: 11px; }
 @media (prefers-reduced-motion: no-preference) {
   .eph-rune {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4699,6 +4699,58 @@
   }
 }
 
+/* Ephemerists — THE RUNE STRIP (#2067). The two registers above came OFF the
+   task card's masthead, and the motif returns as a pair of rows bracketing the
+   plate's call to action on the three surfaces that paint one. The only mount is
+   `components/factionMarks/EphemeristsRuneStrip.tsx`; nothing else wears these.
+
+   THE SIZE CYCLE IS HERE RATHER THAN INLINE. The design cycles 9/10/11/9/10px
+   per mark and only two of those are rungs (--text-sm, --text-md), so inline it
+   would be ornament type off the ramp — allowed by §4a's hatch, but only behind
+   an `eslint-disable` at every site. Three `nth-child` selectors say the same
+   thing in the sheet where raw lengths belong, and the component carries no
+   suppression. `--epg-op` (peak) and `--epg-delay` (phase) still arrive inline:
+   they are numbers per instance, which a stylesheet has nowhere to put.
+
+   MOTION IS OPT-IN, and note the inversion against the design for the same
+   reason `.epg-glyph` above states it. The base state IS the stilled state —
+   every mark present at its own peak — and the shimmer is added under
+   `no-preference`. Written the design's way round (0.16 as the base, the
+   animation always on) a reduced-motion reader gets a row at 0.16 and reads
+   nothing. Nothing pins the pre-delay state either: a mark holds at its peak
+   until its own cycle starts, which is legible from first paint. */
+@keyframes eph-rune-shift {
+  0%, 100% { opacity: 0.16; }
+  50% { opacity: var(--epg-op, 0.8); }
+}
+[data-eph-runes] {
+  display: flex;
+  align-items: center;
+  height: 12px;
+  overflow: hidden;
+  white-space: nowrap;
+  user-select: none;
+  width: calc(100% - 40px);
+  margin: 0 auto;
+}
+[data-eph-runes="top"] { margin-top: -7px; }
+[data-eph-runes="bottom"] { margin-bottom: 18px; }
+.eph-rune {
+  flex: 1 1 auto;
+  text-align: center;
+  line-height: 1;
+  font-size: 9px;
+  opacity: var(--epg-op, 0.8);
+}
+.eph-rune:nth-child(5n + 2), .eph-rune:nth-child(5n + 5) { font-size: 10px; }
+.eph-rune:nth-child(5n + 3) { font-size: 11px; }
+@media (prefers-reduced-motion: no-preference) {
+  .eph-rune {
+    animation: eph-rune-shift 5.2s ease-in-out infinite;
+    animation-delay: var(--epg-delay, 0s);
+  }
+}
+
 /* Ephemerists — the sheet a page-sized Valley plate is printed on (task detail
    v2, #1032). The archetype's own content column wears it: this whole page IS
    the plate, so the papyrus is the column's surface, not a tint under it.

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -161,6 +161,7 @@ import {
   Sign,
 } from "../../../components/factionMarks/ephemeristsPlate";
 import { EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
+import EphemeristsRuneStrip from "../../../components/factionMarks/EphemeristsRuneStrip";
 import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
@@ -803,35 +804,50 @@ export default function EphemeristsEditPraxis({ state }: Props) {
             </>
           }
           end={
-            <PublishButton
-              state={state}
-              skin={{
-                idleLabel: t("editPraxis.composer.submit"),
-                busyLabel: t("editPraxis.composer.submitBusy"),
-                trailingOrnament: (
-                  <Sign
-                    name="openEye"
-                    size={SUBMIT_SIGN}
-                    color={CTA_INK}
-                    weight={1.4}
-                  />
-                ),
-                style: {
-                  ...composerBandStyle(sizes, {
-                    /* Design band: 12 / 500 / 0.24em — the engraved label
-                       metrics exactly, which is the one skin whose band and
-                       label agree, and 12 is the --text-lg rung. */
-                    fontFamily: CAPS,
-                    fontWeight: 500,
-                    letterSpacing: "0.24em",
-                    frame: LINE,
-                    color: CTA_INK,
-                    background: CTA,
-                  }),
-                  cursor: state.submitting ? "wait" : "pointer",
-                },
-              }}
-            />
+            <>
+              {/* The rune strip ahead of the cast (#2067) — the same component
+                  the task card and the task page mount, so the motif is one
+                  drawing on all three surfaces that paint a plate CTA.
+
+                  ONLY THE LEADING STRIP, and that is a reported gap rather than
+                  a choice. #1828 makes this skin's cast a FULL-BLEED BAND that
+                  closes the sheet: `composerBandStyle` gives it
+                  `margin-bottom: calc(-1 * padBottom)`, so a trailing sibling is
+                  pulled back up over the brass instead of sitting under it.
+                  There is no room below the band inside the sheet, and taking it
+                  would mean undoing #1828 — which this issue puts out of scope.
+                  The card and the task page carry both strips. */}
+              <EphemeristsRuneStrip side="top" />
+              <PublishButton
+                state={state}
+                skin={{
+                  idleLabel: t("editPraxis.composer.submit"),
+                  busyLabel: t("editPraxis.composer.submitBusy"),
+                  trailingOrnament: (
+                    <Sign
+                      name="openEye"
+                      size={SUBMIT_SIGN}
+                      color={CTA_INK}
+                      weight={1.4}
+                    />
+                  ),
+                  style: {
+                    ...composerBandStyle(sizes, {
+                      /* Design band: 12 / 500 / 0.24em — the engraved label
+                         metrics exactly, which is the one skin whose band and
+                         label agree, and 12 is the --text-lg rung. */
+                      fontFamily: CAPS,
+                      fontWeight: 500,
+                      letterSpacing: "0.24em",
+                      frame: LINE,
+                      color: CTA_INK,
+                      background: CTA,
+                    }),
+                    cursor: state.submitting ? "wait" : "pointer",
+                  },
+                }}
+              />
+            </>
           }
         />
       </ComposerSheet>

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -160,7 +160,13 @@ describe("Ephemerists task detail — the Valley plate", () => {
 
   it("hides the modifier row at the identity factor and shows it off it", () => {
     const neutral = render(<EphemeristsTaskDetail state={baseState()} />);
-    expect(neutral.text).not.toContain("×");
+    // `×\d`, not a bare `×`. The modifier row's whole copy is `×{{multiplier}}`
+    // (`tasks.json`), so the FACTOR is what makes the row a row — and #2067's
+    // rune strips march a `×` of their own through the page's text content as
+    // ornament. A bare-character proxy for the concept fails the moment the
+    // sheet grows a decorative row of mathematical symbols, which is exactly
+    // what happened; the ornament is `aria-hidden` and reads to nobody.
+    expect(neutral.text).not.toMatch(/×\d/);
     expect(neutral.text, "the base is legible regardless").toContain("30");
 
     const modified = render(

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
 import { EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
+import EphemeristsRuneStrip from "../../../components/factionMarks/EphemeristsRuneStrip";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { factionCssVar, factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
@@ -705,11 +706,19 @@ export default function EphemeristsTaskDetail({
       {canSignUp && (
         <div>
           <LevelJumpBanner state={state} />
-          <button onClick={handleSignup} style={primaryButton}>
+          {/* The rune strips bracket the plate's CTA on every surface that
+              paints one (#2067) — the same component the task card mounts, so
+              the motif cannot drift between the card and the page it opens.
+              Only the SIGN-UP button is bracketed: "continue" and "view your
+              praxis" below wear the same `primaryButton` paint but are exits
+              from a task already taken, not the summons. */}
+          <EphemeristsRuneStrip side="top" />
+          <button onClick={handleSignup} style={{ ...primaryButton, margin: "var(--space-md) auto" }}>
             <Sign name="platinum" size={15} color={CTA_INK} weight={1.3} />
             <span style={{ whiteSpace: "nowrap" }}>{t(signupCtaKey(task.signup_reason))}</span>
             <Sign name="planet" size={14} color={CTA_INK} weight={1.4} />
           </button>
+          <EphemeristsRuneStrip side="bottom" />
           <div style={{ ...quietItalic, marginTop: "var(--space-sm)" }}>
             {t("detail.signup.slots", { open: slotsOpen, max: maxTaskSlots })}
             {!levelJumpSignup && (

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -645,7 +645,8 @@ const ARCHETYPE_PAIRS: Pair[] = [
   // that was measured on #0a0c15 is now also asked to clear #12151f. It does,
   // by a wide margin either way; the row exists so that the NEXT move of this
   // band cannot repeat #1627's failure, where an ink stayed put while the ground
-  // under it changed and every row in this file went on passing.
+  // under it changed and every row in this file went on passing. 14.00:1 on the
+  // band, 13.07:1 on the disc — 0.93 of a very large margin.
   { what: "ephemerists card masthead band, wordmark", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-band-ink" },
   { what: "ephemerists medallion disc, points", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-ink" },
   { what: "ephemerists medallion disc, unit", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-muted" },

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -638,6 +638,15 @@ const ARCHETYPE_PAIRS: Pair[] = [
   { what: "ephemerists plate, brief", surface: "--faction-ephemerists-plate-bg", text: "--faction-ephemerists-plate-muted" },
   { what: "ephemerists plate, caption", surface: "--faction-ephemerists-plate-bg", text: "--faction-ephemerists-plate-caption" },
   { what: "ephemerists cornice band, masthead", surface: "--faction-ephemerists-plate-band", text: "--faction-ephemerists-plate-band-ink" },
+  // THE TASK CARD'S BAND IS THE DISC NOW (#2067), and that is a NEW pairing
+  // rather than the row above wearing a different ground. The restrained
+  // masthead grounds on `-plate-disc` — the medallion's own field, two values
+  // lighter than the cornice band — and keeps `-plate-band-ink`, so the gold
+  // that was measured on #0a0c15 is now also asked to clear #12151f. It does,
+  // by a wide margin either way; the row exists so that the NEXT move of this
+  // band cannot repeat #1627's failure, where an ink stayed put while the ground
+  // under it changed and every row in this file went on passing.
+  { what: "ephemerists card masthead band, wordmark", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-band-ink" },
   { what: "ephemerists medallion disc, points", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-ink" },
   { what: "ephemerists medallion disc, unit", surface: "--faction-ephemerists-plate-disc", text: "--faction-ephemerists-plate-muted" },
   { what: "ephemerists plate CTA band", surface: "--faction-ephemerists-plate-cta-bg", text: "--faction-ephemerists-plate-cta-ink" },


### PR DESCRIPTION
The Ephemerists task card kept ornament the design had already stripped, and its
compass rose shipped three needle values the design does not use. Both are fixed,
and the glyph motif the masthead loses comes back at the call to action as a
shared device on all three Ephemerists surfaces that paint a plate CTA.

## Seams tested

Three, because the failure modes sit in three places and none can see the others.

1. **Rendered markup** (`renderToStaticMarkup`; no jsdom here, so effects never
   run and geometry is out of reach) — the sequence, the two inks, the two
   per-instance custom properties, the band's ground/ink/rule, the strips at both
   form factors, the four needle paths.
2. **`index.css` as text** — the reduced-motion gate. The design writes the
   animation always-on with `opacity: .16` as the base; the repo's inversion
   cannot be asserted from markup, because the markup is identical either way.
3. **The source tree** — "drawn once, mounted on exactly these three files". A
   transcription into a fourth would render perfectly, pass every assertion
   above, and drift the first time the strip is redrawn.

New: `frontend/src/components/factionMarks/__tests__/ephemeristsRuneStrip.test.tsx`
(16 tests). Extended: `ephemeristsCompassRose.test.tsx` (the needles).

## 1 · The restrained masthead

`EphemeristsTaskCard` is now plain `CardMasthead` — mark hard left at the kit's
20, wordmark on the card's centreline — grounded on `--faction-ephemerists-plate-disc`
with a `-plate-brass` border. Deleted with it:

| gone | was |
| --- | --- |
| `REGISTER_TOP` / `REGISTER_BOTTOM` / `register()` | two 12-sign rows across the band |
| the winged sun disc + `Wing` | `viewBox="-88 -20 176 40"` over the wordmark |
| the registers' own hairlines | `M8 24 H332 M8 86 H332` |
| `SizeSet.masthead` (110 / 98) | the canvas the registers marched across |
| `SizeSet.discWidth` (176 / 154) | measured the disc and nothing else |

Both fields are **removed rather than reduced**: with the registers gone the band
is `CardMasthead`'s own height, and `discWidth` had one reader. Grepped before
deleting, as asked — `Wing` was card-local and is **not** the kit's
`WingedDiscSign` (a separate 24-unit drawing that `EmblemOctagon` and the
metatask seal still read, untouched). `ephemeristsDetail.test.tsx` already pinned
that the detail page does not draw the card's disc.

The ink is unchanged. `-plate-band-ink` was measured on `-plate-band`; the disc
is a **new pairing** and `factionContrast.test.ts` gains a row for it —
**14.00:1 on the band, 13.07:1 on the disc**, so 0.93 of a very large margin.

## 1b · The rune strip, built once and mounted three times

`frontend/src/components/factionMarks/EphemeristsRuneStrip.tsx` — 32 `aria-hidden`
spans from the design's sequence, one prop (`side`). Mounted on the three
surfaces that paint a button through `--faction-ephemerists-plate-cta-bg`:

- `components/taskCard/EphemeristsTaskCard.tsx` — **both** strips, around the CTA;
- `pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx` — **both**, around the
  sign-up button only (the "continue" / "view your praxis" buttons wear the same
  paint but are exits from a task already taken);
- `pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx` — **the leading strip
  only. See the two flags below.**

`EphemeristsPraxisDetail` gets none (no button). `EphemeristsFieldDesk` is left
alone (its button is not plate-CTA paint) and looks fine as-is.
`EphemeristsMasthead` is untouched. `EphemeristsComment` reads `-plate-cta-bg` as
an *accent*, not a button, so it is not a fourth mount — the test asserts the
mount list is exactly those three.

**House rules, all three obeyed.** Motion is `index.css` behind
`@media (prefers-reduced-motion: no-preference)`, never inline — the base state
is the stilled state (every mark at its own peak), the inversion `.epg-glyph`
documents. `--epg-op` / `--epg-delay` stay inline as per-instance numbers, reusing
the register's own names for the same motif. The strips are `aria-hidden` and
hold no reachable text.

**One deviation, deliberate: the 9/10/11/9/10 size cycle went into `index.css`**
as `.eph-rune` + two `nth-child` rules, not inline. Only 9 and 11 are rungs
(`--text-sm`, `--text-md`), so inline it is ornament type off the ramp — which
§4a's hatch allows, but only behind an `eslint-disable` at 32 sites. Acceptance
asks for **no new suppressions**; there are none in this PR.

## 2 · The compass rose — three needle values

`CompassRose` in `factionMarks/ephemeristsPlate.tsx`. Measured with the repo's own
`contrastRatio` on `-plate-disc`:

| needle | was | now | on the disc |
| --- | --- | --- | --- |
| north, filled | `NILE` | **`GOLD`** | 7.36 → **13.07** |
| south, outlined | `BRASS` @ 0.9 | **`BRASS_LIGHT`** @ 0.9 | 7.59 → **11.18** |
| east + west, outlined | `BRASS_LIGHT` @ **0.7** | `BRASS_LIGHT` @ **0.9** | 11.18 (unchanged) |

Both go up, as the issue predicts. Geometry, viewBox, ring radii, the four 45°
ticks and the 128px size are untouched. The navy trap was avoided: `#1e3a6e` on
`#12151f` measures **1.64:1** — confirmed with the same helper, invisible.

**`CompassRose` mount list — exactly one**, re-verified on the rebased tree:
`components/taskCard/EphemeristsTaskCard.tsx:500` (`<CompassRose size={size.medallion} />`).
No other surface mounts it, so nothing else moved.
`ephemeristsCompassRose.test.tsx`'s existing source scan still holds that the
needle path is declared only in the kit.

## CSS budget

Measured with `bundle-budget.mjs`'s own gzip (level 9), before and after, on the
rebased tree:

```
origin/main (c0dc4fbb)   23,230 bytes   ->   this branch   23,383 bytes   (+153)
warn > 23,400            fail > 25,000                     verdict: ok
```

**1,617 bytes before FAIL, 17 before WARN.** Nothing was shaved from unrelated
CSS and the ceiling was not touched. Two things worth knowing:

- `origin/main` is *already* 170 bytes off WARN, so this register's next addition
  trips WARN whatever this PR does. That is not a reason to stop here — WARN is
  not a gate — but it is the number the next author needs.
- The design's `user-select: none` on the strip is **dropped**, with a `ponytail:`
  at the site naming the ~20-byte upgrade. It would ship prefixed into the one
  blocking stylesheet to buy a copy-paste nicety on an `aria-hidden` row.
  `white-space: nowrap` is dropped too, as a provable no-op on this markup (the
  marks come from a `.map()` with no whitespace text nodes, and a flex row does
  not wrap by default).

No font work: the marks specify no family and inherit, so `fonts.faction.css` and
the `factionFaceSplit` boundary are untouched.

## Two tests changed, and why neither is a fixture edited to match

- `factionTaskCardsV2.test.tsx` pinned `24 × class="epg-glyph"` on the card — the
  registers this issue deletes. Inverted to assert the card marches **no**
  register, so a register creeping back onto this band still fails.
- `ephemeristsDetail.test.tsx` asserted the page's text did not contain `×` to
  mean "no modifier row at ×1.00". The rune sequence contains `×` (U+00D7). The
  assertion was measuring a **character** where the concept is `×{{multiplier}}`,
  so it is `/×\d/` now — the same guard against the thing it was actually for.
  The ornament is `aria-hidden` and reads to nobody.

**No contrast fixture was edited to match anything.** One row was *added* for the
new (ink, ground) pairing; all 743 contrast tests were green before and after.

## Two things held back, both reportable rather than guessed

**1 · The tick strip.** The issue's fourth deletion is "the tick strip — the
`height: 7px` / `align-items: flex-end` row". That row is **not in the card**: it
is `Cornice`'s flute row in `factionMarks/ephemeristsPlate.tsx`, and the card's
mount is `<Cornice flutes={40} />`. So the literal instruction would delete the
cavetto cornice from this card. **I kept it**, because:

- the issue names every other component precisely (`CardMasthead`, `CompassRose`,
  `EphemeristsMasthead`, `REGISTER_TOP`) and never names the cornice;
- **two tests pin the mount** — `ephemeristsPlateSurfaces.test.tsx` asserts the
  card contains `<Cornice flutes={40} />`, and `factionTaskCardsV2.test.tsx`
  counts its 20 short flutes;
- `WORLD_ZERO_STYLE.md` §6 ("Two designs drawing one ornament at two densities is
  not drift", #1654) **cites this mount as its example**. Delete it and `flutes`
  has zero callers at 40 and the ruling loses its case.

Deleting a shipped, twice-tested, doctrinally-cited device on an inference is the
one move worth stopping for. **If the owner confirms the tick strip is the
cornice, it is a one-line deletion plus those two tests** — say so and I will.

**2 · The composer's trailing strip.** #1828 makes that skin's cast a full-bleed
band that closes the sheet: `composerBandStyle` gives it
`margin-bottom: calc(-1 * padBottom)`, so a trailing sibling is pulled back up
*over* the brass instead of sitting under it. There is no room below the band
inside the sheet, and taking it would mean undoing #1828 — which this issue puts
out of scope. The composer carries the **leading** strip; the card and the task
page carry both. Noted at the site as well as here.

## What to eyeball

Visual QA is **outstanding**. There is no browser and no dev stack here, and
`npm run dev` verifies nothing without one, so every claim below is reasoned from
the markup and the stylesheet rather than seen.

1. **The band's height.** ~110px → `CardMasthead`'s own box (`--space-sm` padding
   over a `--text-xl` line), so roughly **75px of card disappears**. The hero row
   (level / hairlines / compass rose) and the title now sit under a short band —
   nothing about that row changed, and its `padding: var(--space-md) 0 var(--space-lg)`
   is unchanged, so it should simply rise. Confirm it does not now crowd the
   cornice.
2. **The wordmark's centreline under a short band.** It is the `1fr auto 1fr`
   grid's centre cell, so it is on the *card's* centreline, not beside the mark —
   but the wordmark lost the winged disc it used to sit under, so this is the
   first time it is alone in that cell. Check it reads centred rather than
   floating.
3. **The band's brass border.** Written as the issue words it: a full
   `border: 1px solid -plate-brass` with `box-sizing: border-box` (without which
   the card's `overflow: hidden` shaves the right-hand rule). On the top and sides
   that 1px sits immediately inside the card's *own* brass border, so it may read
   as a 2px edge rather than as two hairlines. **If it reads heavy, `borderBottom`
   alone is a one-line change.** Also note the band is now `-plate-disc` while the
   cornice under it stays `-plate-band` — a deliberate two-value tonal step, in
   scope only as "does it read as a step or as a mistake".
4. **The three needles.** North should be the brightest mark on the rose (plate
   gold, filled); south, east and west should be indistinguishable from each other
   — one ink, one weight. If south still looks heavier than east/west, the 0.9/0.7
   split survived somewhere.
5. **The rune strips, at both form factors.** 384px desktop / 340px mobile. Each
   strip is `calc(100% - 40px)` of the card, so the marks flex to fill 344 / 300px;
   on the phone they are 12% tighter. Check they read as a *register* and not as a
   crowded line, that the 12px box does not clip the deep descenders on `∮` and
   `∫`, and that the top strip's `-7px` pull sits it against the brass rule rather
   than on it. The trailing strip's 18px is what closes the card now (it was
   `bodyPad`'s 24px) — confirm the bottom air still looks like air.
6. **Reduced motion.** With "reduce motion" on, both strips must still be a
   visible static row of symbols at 0.34–0.79 opacity, not a blank 12px band. The
   dimmest mark computes to ~1.79:1 on the plate, which is ornament-visible by
   design; the brightest caption-gold marks carry the row.
7. **The task page and the composer.** Same two questions one surface over: the
   strips on the task page bracket the sign-up button inside a panel cell, and the
   composer's single strip sits between the exits row and the full-bleed cast.

## Out of scope, confirmed untouched

No `[data-theme="dark"]` half was added for any `--faction-ephemerists-plate-*`
token (#1627/#1636 — the register stays theme-invariant).
`--faction-ephemerists` and `-plate-nile` are not touched, so #2075's hue change
stands; `NILE` is still exported and still read by other surfaces. The CTA's
colours are unchanged — the button gains only its `var(--space-md) auto` margin
(the design's 14px, on the rung below it) so the strips sit against it. No other
Ephemerists surface, and not the card's body ground.

## Verified locally

Every step `.github/workflows/test.yml` names for the `frontend` job, on the
rebased tree: `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`,
`npm test` (**316 files / 5,431 passing**, 1 skipped), `npm run build`,
`npm run budget` (**ok**). No backend, route, `response_model` or Pydantic schema
was touched, so `api-schema` and the backend `test` job have nothing to
regenerate.

Closes #2067
