### PR TITLE
index.css's WOW note said the rainbow sort was an open owner call; #2078 closed it

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -509,8 +509,11 @@
      It buys the plate: Ephemerists' hue on its own near-black plate went
      2.91:1 → 7.22:1. It does NOT touch --faction-default-stop-1…7 — the
      rainbow is a separately tuned spectrum whose yellow (#ca8a04) and teal
-     (#1d6e72) answer to nobody's hue but their own — nor FACTION_RAINBOW_ORDER,
-     whose spectral sort is now stale by two slots and is an owner call.
+     (#1d6e72) answer to nobody's hue but their own. FACTION_RAINBOW_ORDER DID
+     follow, in #2078: the owner ruled the re-sort in, so the Ephemerists' brass
+     moved to index 2 and WOW's plum to index 5. There is no teal in that
+     spectrum now, and the na stops above still have theirs — the two lists are
+     separate on purpose, which is why only one of them moved.
 
      THE SKIN. WOW's surfaces are the CHRONICLE: cream parchment, a gold frame
      (#c8a02a, theme-invariant — it does not lift in dark) and plum ink (#7a4a9e


### PR DESCRIPTION
A one-line comment fix, found by #2082's author and deliberately left by them because two sibling PRs held `index.css` in the same batch.

#2075 (#2068) recorded in the WOW spine note that `FACTION_RAINBOW_ORDER` was spectrally stale by two slots and that re-sorting was *"an owner call"*. The owner made that call and #2082 (#2078) shipped the re-sort. The sentence now describes the opposite of the code, which is the exact rot the repo's own convention about measurement comments warns about — a stale comment is worse than none.

Replaced with what is true: the re-sort happened in #2078, the Ephemerists' brass is at index 2 and WOW's plum at index 5. The clause also now says why `--faction-default-stop-1…7` still has a teal that no faction owns — the two lists are tuned separately on purpose, which is the thing a future reader is most likely to "tidy up" wrongly.

### Verified

- `npm run lint` clean, `npm run build` clean.
- **Byte delta zero.** The minifier strips CSS comments; the budget reads **22.8 KB gzipped ok (warn>22.9, fail>24.4)** both before and after.
- Comment-only: no declaration, no selector, no value touched anywhere in the diff.

### What to eyeball

Nothing renders differently — this is a comment. No visual QA is owed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)