### PR TITLE
The sixth Singularity window bar: the edit-praxis composer wears the kit's lamps too (#1979)

### DIFF
--- a/frontend/src/components/factionMarks/SingularityLamps.tsx
+++ b/frontend/src/components/factionMarks/SingularityLamps.tsx
@@ -6,15 +6,21 @@
  *
  * WORLD_ZERO_STYLE §6 draws a device ONCE, and `EphemeristsMasthead` is the
  * same rule one level up: what repeats here is not a mark but an ARRANGEMENT of
- * marks. Five surfaces drew this arrangement in five places — the praxis card,
- * the task card, the praxis detail, the task detail and the feed frame — and
- * four of them declared a private `Lamp` to do it. Five copies is how the
- * palettes drifted apart: the feed frame's cluster was
- * `-term-dim` / `-term-blue` / `-term-bright` (green, blue, green) while the
- * other four were `-led-red` / `-led-amber` / `-led-green`, and nothing linked
- * them. A second declaration is invisible to the import graph and invisible to
- * rendered markup, which comes out perfectly either way — the exact failure
- * #1638/#1654 pinned for the Ephemerists plate.
+ * marks. SIX surfaces drew this arrangement in six places — the praxis card,
+ * the task card, the praxis detail, the task detail, the feed frame and the
+ * edit-praxis composer — and four of them declared a private `Lamp` to do it.
+ * Six copies is how the palettes drifted apart: the feed frame's cluster and
+ * the composer's were `-term-dim` / `-term-blue` / `-term-bright` (green, blue,
+ * green) while the other four were `-led-red` / `-led-amber` / `-led-green`,
+ * and nothing linked them. A second declaration is invisible to the import
+ * graph and invisible to rendered markup, which comes out perfectly either way
+ * — the exact failure #1638/#1654 pinned for the Ephemerists plate.
+ *
+ * The composer was the one the first pass missed, and it is worth saying how:
+ * it had no `Lamp` identifier and no LED token, so it read as clean to both
+ * source scans at once. What found it was a reporter looking at the screen.
+ * `singularityLamps.test.tsx` now names all six surfaces rather than counting
+ * them.
  *
  * ## The cluster takes no props, deliberately
  *
@@ -23,7 +29,8 @@
  * the palette would still live at the call sites, and a sixth surface could
  * still invent a trio. So the KIT owns the whole cluster — the three hues, the
  * wrapper, the pitch — and a caller mounts it. There is nothing to pass and so
- * nothing to disagree about.
+ * nothing to disagree about. That "sixth surface" was not hypothetical: the
+ * composer already existed, and it had invented exactly that trio.
  *
  * ## Colour
  *

--- a/frontend/src/components/factionMarks/__tests__/singularityLamps.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/singularityLamps.test.tsx
@@ -119,12 +119,25 @@ describe("the lamp cluster is declared once, and in the kit (#1979)", () => {
     expect(restating.map((file) => file.path)).toEqual([]);
   });
 
-  it("mounts the kit on all five window bars", () => {
-    // Praxis card, task card, praxis detail, task detail, feed frame. The issue
-    // named four; the task detail carried a fifth copy nobody had counted, and
-    // the praxis card's was an inline twin with no `Lamp` in it at all — which
-    // is why this counts MOUNTS and not just declarations.
+  it("mounts the kit on every window bar the faction draws", () => {
+    // Named rather than counted, because a count is what let the census be
+    // wrong twice. The issue named four sites; the first pass found five (the
+    // task detail carried a copy nobody had counted, and the praxis card's was
+    // an inline twin with no `Lamp` in it at all — which is why this counts
+    // MOUNTS and not declarations). It was SIX. The edit-praxis composer mapped
+    // its own `[MUTED, BLUE, ACCENT]` onto three dots, so it was invisible to
+    // both scans above at once: no `Lamp` identifier to find, and no LED token
+    // to find either. Only a roll-call of the surfaces can see that, and only
+    // if it is written down.
+    const rel = (path: string) => path.slice(SRC.length).replace(/\\/g, "/");
     const mounts = sources().filter(({ source }) => source.includes("<SingularityLamps"));
-    expect(mounts.map((file) => file.path).sort()).toHaveLength(5);
+    expect(mounts.map((file) => rel(file.path)).sort()).toEqual([
+      "components/feed/SingularityFeedFrame.tsx",
+      "components/praxisCard/desktop/SingularityPraxisCard.tsx",
+      "components/taskCard/SingularityTaskCard.tsx",
+      "pages/editPraxis/archetypes/SingularityEditPraxis.tsx",
+      "pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx",
+      "pages/taskDetail/archetypes/SingularityTaskDetail.tsx",
+    ]);
   });
 });

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -48,7 +48,21 @@
  *
  * ## Colour
  *
- * Every value is a `--faction-singularity-term-*` token, the two-theme contract
+ * Every value here is a `--faction-singularity-term-*` token — with one
+ * deliberate exception, the three window lamps, which are the kit's
+ * `SingularityLamps` and its theme-invariant `--faction-singularity-led-*`
+ * trio (#1979). This bar used to map its own `[MUTED, BLUE, ACCENT]` onto
+ * three dots, which came out green/blue/green while the faction's five other
+ * window bars came out red/amber/green. Nothing in this docblock ever argued
+ * for that palette: the blanket "every value is a `term-*` token" rule above
+ * is what produced it, and the lamps are the one place it was wrong. The
+ * cluster is ORNAMENT (see the copy note) rather than this chassis' ink, so it
+ * belongs to the faction's mark kit and not to this skin. Its invariance is
+ * safe on this bar specifically because `term-chrome` is near-black in BOTH
+ * halves (#0c2016 light / #0a1a10 dark), so a fixed bright dot reads on it
+ * either way — the pairing, not the family, is what had to be checked.
+ *
+ * Everything else is the two-theme contract
  * the v2 task card minted (#1023) and the task/praxis details extended (#1034).
  * WORLD_ZERO_STYLE §6 is explicit that this family is NOT theme-invariant even
  * though both its halves are near-black: the chassis stays black and the
@@ -143,6 +157,7 @@ import {
   WriteUpTabs,
   type ComposerTab,
 } from "./controls";
+import SingularityLamps from "../../../components/factionMarks/SingularityLamps";
 import { MetataskSealStack } from "../../../components/metataskSeal/MetataskSealStack";
 import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
@@ -315,18 +330,7 @@ export default function SingularityEditPraxis({ state }: Props) {
                 gap: "var(--space-sm)",
               }}
             >
-              {[MUTED, BLUE, ACCENT].map((tone) => (
-                <span
-                  key={tone}
-                  style={{
-                    width: 8,
-                    height: 8,
-                    borderRadius: "50%",
-                    background: tone,
-                    flexShrink: 0,
-                  }}
-                />
-              ))}
+              <SingularityLamps />
               <span
                 style={termLabel({
                   color: MUTED,

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/singularityComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/singularityComposer.test.tsx
@@ -169,6 +169,35 @@ describe("Singularity composer — structure", () => {
     expect(html).not.toMatch(/#[0-9a-fA-F]{6}\b/);
   });
 
+  // #1979, second pass. #1998 made the three window lamps one kit drawing and
+  // repainted five bars with it; this bar was the sixth and nobody had counted
+  // it, so the composer went on mapping its own `[MUTED, BLUE, ACCENT]` onto
+  // three dots — green, blue, green, the exact trio the feed frame had just
+  // given up. Invisible to BOTH source scans in `singularityLamps.test.tsx`:
+  // there was no `Lamp` identifier to find and no LED token to find. The
+  // rendered bar is the only place the two palettes can be compared, so the
+  // assertion lives here, in the shape the feed frame's uses.
+  it("wears the kit's LED lamps on the window bar, not the chassis' phosphor", () => {
+    const html = render("desktop", state());
+    const TRIO = [
+      "--faction-singularity-led-red",
+      "--faction-singularity-led-amber",
+      "--faction-singularity-led-green",
+    ];
+    for (const token of TRIO) expect(html, `${token} is unpainted`).toContain(token);
+    // Scoped to the CLUSTER, not the frame: `term-dim` / `term-blue` /
+    // `term-bright` are the chassis' inks and stay everywhere else in this file
+    // (the process name, the titles, the breathing session lamp). What must not
+    // come back is a LAMP drawn in them.
+    const open = html.indexOf(TRIO[0]);
+    const close = html.indexOf(TRIO[2]);
+    // Both ends located, or the slice below is the empty string and this test
+    // asserts nothing — the shape that passes loudest while the bug ships.
+    expect(open, "the cluster is on the bar at all").toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    expect(html.slice(open, close)).not.toContain("--faction-singularity-term-");
+  });
+
   it("renders at both widths with one breadcrumb", () => {
     for (const width of ["desktop", "mobile"] as const) {
       const html = render(width, state());


### PR DESCRIPTION
Singularity's window lamps were drawn in **six** places, not five. #1998 consolidated five of them and closed this issue; the reporter reopened it because the edit-praxis composer still showed the old colours. This is that sixth bar.

## Read this first: the brief I was given was stale

My dispatch brief described the consolidation as unbuilt — four sites, three `Lamp` copies, put a shared component in `factionMarks/`. **All of that is already on `main`.** `frontend/src/components/factionMarks/SingularityLamps.tsx` and its test landed in #1998 (merged 2026-08-17T07:36Z), which said `Closes #1979`. water-ghosts reopened the issue at 21:11Z the same day with "When editing a Praxis, I still see the old colors."

So this PR is **not** the consolidation. It is the one site the consolidation missed. Verified against `origin/main` rather than trusting either list.

## The verified census — six surfaces

| site | on `origin/main` before this PR |
|---|---|
| `components/praxisCard/desktop/SingularityPraxisCard.tsx` | ✅ mounts `SingularityLamps` (#1998) |
| `components/taskCard/SingularityTaskCard.tsx` | ✅ mounts `SingularityLamps` (#1998) |
| `pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx` | ✅ mounts `SingularityLamps` (#1998) |
| `pages/taskDetail/archetypes/SingularityTaskDetail.tsx` | ✅ mounts `SingularityLamps` (#1998) |
| `components/feed/SingularityFeedFrame.tsx` | ✅ mounts `SingularityLamps` (#1998) |
| **`pages/editPraxis/archetypes/SingularityEditPraxis.tsx:318`** | ❌ **`[MUTED, BLUE, ACCENT].map(...)`** — `term-dim` / `term-blue` / `term-bright`, green/blue/green |

I also swept every other `borderRadius: "50%"` in a `Singularity*` file to be sure there is no seventh cluster. There is not — the remaining circles are single process lights, avatars, glows and the faction body's node glyphs, none of them a three-lamp arrangement.

## Why two source scans and a whole test file did not see it

`singularityLamps.test.tsx` had two source-level guards, and the composer walked between them:

- **"no second `Lamp` anywhere"** — the composer had no `Lamp` identifier. It mapped an array of three tone constants over one `<span>`.
- **"no surface restates the trio"** — that scan looks for the *LED* tokens. The composer used the `term-*` family, so it had none to find.

Clean to both, at once. What found it was a person looking at the screen. The kit's own docblock had predicted this exact surface in the abstract — "a sixth surface could still invent a trio" — while the sixth surface already existed and had already invented it.

## The seam I tested at

**Two, split by where each harness already lives** rather than duplicating a heavy composer render into the mark kit's test.

1. **Rendered markup** — `pages/editPraxis/archetypes/__tests__/singularityComposer.test.tsx`, in the same shape the feed frame's assertion uses: the bar paints all three LED tokens, and the slice *between* the first and last lamp contains no `--faction-singularity-term-`. Scoped to the cluster, not the frame, because `term-dim`/`term-blue`/`term-bright` are the chassis' real inks everywhere else in that file and must stay. Both slice ends are asserted found first, or the slice is `""` and the test passes loudest while the bug ships.

   It went red on the real defect before any source was touched:

   ```
   → --faction-singularity-led-red is unpainted
   ```

   and the received markup showed the three dots as `term-dim` / `term-blue` / `term-bright` exactly as reported.

2. **Source census** — `singularityLamps.test.tsx` now **names all six surfaces** instead of `toHaveLength(5)`. A count is what let the census be wrong twice (four → five → six). This assertion also went red on my change (`expected […(6)] to have a length of 5`), which is the version of this test that would have named the composer in the first place.

## What `SingularityFeedFrame`'s docblock said

The brief asked me to read it before overriding it. #1998 already did that, and recorded the answer in the file (lines 31-39): *"Read against THIS docblock as the issue asked: nothing here ever argued for the chassis inks as lamps. What the closing section argues is that no NEW token be minted, and the LED trio was already shipped and already named, so the trio satisfies it and the local constants were drift."* Nothing to override, and I did not touch that file.

**`SingularityEditPraxis`'s docblock is the one that mattered here, and its answer is the same but more interesting.** It did not argue for `DIM`/`BLUE`/`BRIGHT` for the lamps either — it made a *blanket* claim, "Every value is a `--faction-singularity-term-*` token", and separately called the three lamps ORNAMENT in the same class as the `praxis.proc` process name. The blanket rule is what produced the wrong palette: it is true of every ink on the chassis and wrong about the one thing on the bar that is a faction mark rather than this skin's ink. I corrected that section to record the exception and why it is one, rather than deleting the claim.

## Variant differences I reconciled, and which won

Only two, both small, both resolved in the kit's favour — the kit owning the pitch is the point of the kit:

| | composer, before | kit | kept |
|---|---|---|---|
| dot size | 8px | 8px | — identical, nothing to reconcile |
| intra-cluster pitch | `var(--space-sm)` (inherited from the bar's own flex `gap`) | `var(--space-xs)` (the cluster's own `gap`) | **kit — `--space-xs`.** The other five bars are already at this pitch; leaving the composer wider is a visible difference of exactly the kind this issue is about. |
| shrink | `flexShrink: 0` | `flex: "none"` | kit — same effect |

The gap between the last lamp and the `praxis.proc` label is **unchanged**: it was `--space-sm` (bar gap) + `--space-sm` (label `marginLeft`) before, and the cluster is now a single flex child at that same gap with the same label margin.

`ACCENT` / `MUTED` / `BLUE` all stay as module constants — they have many other jobs in that file (titles, labels, the level pill, the breathing session lamp).

## One thing I checked rather than assumed: theme invariance

The LED trio is theme-**invariant**; the composer's whole colour story is the `term-*` family, which **flips**. That is the pairing that has burned this repo before, so I measured it rather than trusting the family: `--faction-singularity-term-chrome` is `#0c2016` in light and `#0a1a10` in dark — near-black in **both** halves. A fixed bright dot reads on it either way, same as on the five bars already doing this. Recorded at the site.

## Report: the `#ff5f56` design question — NOT decided here

Stating it, as asked, and deliberately not nudging it.

`index.css:1192-1194` shows the trio is a hybrid:

- `--faction-singularity-led-red: #ff5f56` — **exactly** the macOS red
- `--faction-singularity-led-amber: #f0c400` — macOS is `#ffbd2e`
- `--faction-singularity-led-green: #4ade80` — macOS is `#27c93f`

That red is the only borrowed-OS literal anywhere in the tree; the amber and green are the kit's own (and both are reused elsewhere — `#f0c400` is also `--faction-snide-amber`, `#4ade80` is the repo's `--color-success` and Singularity's own phosphor). **My read, for the owner to accept or reject: now that all six bars agree, one borrowed hue sitting beside two invented ones is the most likely remaining reason the cluster still reads as "macOS style".** But it is a look decision, so it is not in this diff. **No token value changed in this PR, and `index.css` is untouched** (#2073 and a sibling hold that file).

## Also reported, not fixed — the reporter's other two observations

water-ghosts' reopen named two more things about the composer. Both are design calls and neither is a colour, so I left them:

1. **"square corners instead of rounded corners"** — deliberate and documented at the site: `const RADIUS = 2` with the comment *"The design's geometry: radius 2, borderW 1. A terminal has square corners."* It comes from the design project (`Singularity Edit Praxis.dc.html`). If the faction's other surfaces have since moved to a rounder corner this is a real divergence, but reversing a stated design intent is not mine to do.
2. **"including the dot in the upper right"** — that is the `ep-pulse` session lamp, and it is a faction convention rather than a composer invention: the task card (`sg-pulse`) and the task detail (*"the process light — the terminal's one live thing"*) both draw one too. **There is a smaller genuine inconsistency in it, though, which I am reporting and not touching:** the composer's process light is `term-bright` (green) while the task card's and task detail's are `term-blue-bright`. Same device, three surfaces, two hues. Worth its own issue if the owner agrees it is one.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` | clean — **`local/no-raw-style-values` passes with no new suppressions** |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **316 files, 5432 passed**, 1 skipped |
| `npm run build` | ✅ built |
| `npm run budget` | within budget — JS 126.5 KB (fail > 175.8), CSS 22.8 KB (fail > 24.4), both unchanged |

`backend` and `api-schema` are unaffected: no route, `response_model` or Pydantic schema is in this diff, so no regenerated artifacts are needed.

`frontend/src/utils/__tests__/factionContrast.test.ts` **agrees** — 743 tests pass unedited. No fixture was touched.

## ⚠️ Visual QA is outstanding

This is a bug reported from a screenshot, so **the fix is only confirmed on screen and I cannot look at a screen.** Everything above is structural: tokens resolve to real declarations in rendered markup, and a source census names the surfaces. Neither can tell you the dots look right.

### What to eyeball — six surfaces × both themes

Every window bar should show **red, amber, green**, left to right, same size and same pitch, on all of these, in **light and dark**:

1. **Edit praxis composer** — `/praxis/:id/edit` on a Singularity task. **This is the one that was wrong; check it first.** Also confirm the pitch change (`--space-sm` → `--space-xs`) did not crowd the `praxis.proc` label, and check it at mobile width as well as desktop.
2. **Praxis card** (desktop feed/list)
3. **Task card** — `/tasks`, Singularity task
4. **Praxis detail** — `/praxis/:id`
5. **Task detail** — `/tasks/:id`
6. **Feed frame** — `/updates`

The comparison that matters is **surface against surface**, not just "does this one look plausible" — the defect was only ever visible by putting two bars side by side.

Closes #1979
