### PR TITLE
The composer stops claiming to save on the way out: "save draft" becomes "Finish later" (#2088)

### DIFF
--- a/frontend/src/locales/en/forms.json
+++ b/frontend/src/locales/en/forms.json
@@ -285,7 +285,7 @@
       "link": "link"
     },
     "dropTask": "drop task",
-    "saveDraft": "save draft",
+    "saveDraft": "Finish later",
     "composer": {
       "statusDraft": "Draft",
       "statusSaved": "Saved {{ago}}",


### PR DESCRIPTION
Closes #2095
Closes #2088

**Item 1 of #2095 only.** Items 2, 3, 4 and 5 (#2085, #2086, #2093, #2089) shipped earlier tonight in PR #2097 (`f5cfb697`). I verified all four on `origin/main` before touching anything: the write-up label is off the page (the key survives as the textarea's `aria-label` at `controls.tsx:894`), no `wordCount` reference remains anywhere in `frontend/src`, `titleLabel` reads `"Title (required)"` with `required` on the input at `controls.tsx:801`, and `proofButtonMobile` exists at `forms.json:318`. Nothing was redone.

## The change

```diff
-    "saveDraft": "save draft",
+    "saveDraft": "Finish later",
```

One line, `frontend/src/locales/en/forms.json:288`. Nothing else in the diff.

`useEditPraxis.ts:407`'s `saveDraft` has been a pure `navigate` since #1743 — the file's own header says so (*"plus `saveDraft`, which since #1743 only leaves"*) — so the button wrote nothing and only the label lied. That is precisely the confusion #2088 reported (*"is the site only autosaving the body while I have to manually save the title?"*).

**Rename, not removal.** The reporter asked for the button to go; #2095's ruling keeps it, because it is the composer's only graceful exit. Where the report and #2095 disagree, #2095 wins.

`forms.json` has a **second** `saveDraft` at line 110 — the error string *"Could not save your draft…"*, in a different block. It is untouched.

## The seam, and why there is no new test

The seam is the i18n catalog read at `controls.tsx:693` — `skin?.label ?? t("editPraxis.saveDraft")`. `archetypes/__tests__/SaveDraftButton.test.tsx` already tests exactly there, and it is **catalog-relative** (`LABEL = i18n.t("forms:editPraxis.saveDraft")`), which is the repo's convention: copy changes are not supposed to redden tests. So there was no failing assertion to turn red and none to update, and I did not add a literal pin — a hardcoded `"Finish later"` would fight that convention and become the stale assertion the brief warns about. Per the brief's own carve-out, this is the trivial line: the check is the diff plus the eyeball list below.

I grepped the whole repo (excluding `node_modules`/`.git`) for the literal `save draft` case-insensitively before finishing. The only user-facing occurrence was `forms.json:288`. The other hits are prose in doc comments inside `DefaultEditPraxis.tsx`, `SingularityEditPraxis.tsx`, `UaEditPraxis.tsx` and `controls.tsx:1401` describing the footer region — those are stale-ish comments in files another agent holds for #2092, so I left them alone. No test, e2e spec or `.design-sync` preview asserts the string.

## Two claims in #2095, checked

- **"each archetype mounts `SaveDraftButton` twice (two layout branches)" — this is wrong.** `grep -c '<SaveDraftButton'` is exactly **1** in each of the eight archetypes (Coven, Default, Ephemerists, Everymen, Singularity, Snide, Ua, Wow); the only file with more is `__tests__/SaveDraftButton.test.tsx` with 3. It changes nothing about the fix, but the issue's reasoning rested on it. One responsive component per faction, as ADR-0056 says.
- **`SaveDraftButtonSkin.label` — I did NOT remove it, deliberately.** The "dead API" premise is half right: no archetype passes `label`, so the one catalog string really is the single source for all eight skins. But it is **not unexercised** — `SaveDraftButton.test.tsx:94` (*"takes a faction's own voice when an archetype supplies one"*) passes `skin={{ label: "PARK IT" }}`, and `controls.tsx:645-648` documents it as an intentional escape hatch (*"The optional skin is the escape hatch if a faction later wants its own voice"*). That turns the tidy from "delete unreferenced code" into "retract a documented extension point and delete its passing test", which is a design call the owner should make rather than a copy PR. It is a two-line follow-up whenever you want it.

## Verification

Every step named in `.github/workflows/test.yml`'s `frontend` job, run locally in this worktree:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean (`tsc --version` → 5.9.3 confirmed running, not an absent-binary false pass) |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **321 files, 5,596 passed, 1 skipped** |
| `npm run build` | built in 4.97s |
| `npm run budget` | within budget |

The `test` and `api-schema` jobs are unaffected — no Python, no route signature, no Pydantic schema, so nothing for `regen_api_client.py` to change.

**Byte budget: zero cost, as predicted.** Critical-path CSS is **22,429 B gzip level 9**, byte-identical to `origin/main` (`css.warn` 22,700 / `css.fail` 25,000). No threshold touched. A catalog string is not in the blocking sheet.

## One note for the owner — not acted on

The new wording lands in a footer next to the autosave line, which reads `statusSaved: "Saved {{ago}}"` (`forms.json:291`). "Finish later" beside "Saved a moment ago" is a coherent pair — the status says the writing is kept, the button says you may go — and it is a strict improvement on a "save draft" button that saved nothing. But it is the one place a reader could still ask what the relationship is, and #2088's underlying complaint was about that adjacency, not only about the word. Flagging rather than acting: I did not touch the autosave copy, move the button, or redesign the exit.

Second, smaller: `.label-caption` sets `text-transform: none`, so "Finish later" renders sentence-cased beside its lowercase sibling `dropTask: "drop task"` in the same footer row. The ruling specified this exact capitalisation so I used it verbatim; some archetypes override `className` and may case it differently, which is on the eyeball list.

## What to eyeball

**No browser or dev stack is available to me — visual QA is outstanding.**

- The composer's footer exit on **all eight** faction skins — Coven, Default, Ephemerists, Everymen, Singularity, S.N.I.D.E., na/UA, WOW — in **both form factors** (ADR-0056: one responsive component per faction, so a check on Default only is not a check).
- **The pairing.** "Finish later" sits beside the autosave line, so the thing to judge is "Finish later" next to "saved a moment ago" — does the footer now read as one coherent statement, or does it still invite #2088's question?
- Casing and fit next to "drop task" in the same row, and whether any skin's own `className` uppercases it.
- Wrap risk is low at two words, but the Ephemerists and WOW footers are the tightest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
