### PR TITLE
One door out of a published praxis: the detail page's "edit this praxis" link goes (#2136)

### DIFF
--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -118,7 +118,6 @@
       "confirm": "confirm"
     },
     "owner": {
-      "edit": "edit this praxis",
       "submitting": "Unsubmitting…",
       "unsubmit": "unsubmit to edit",
       "unsubmitDuelLive": "pull my entry back",

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -289,7 +289,7 @@ describe("the CAST control is gone from the owner actions (#521 → #1089)", () 
     expect(t).not.toContain("owner.submit");
   });
 
-  it("keeps the edit affordance and the quiet reopen — the published controls", () => {
+  it("keeps the quiet reopen — the one published control (#2136)", () => {
     const t = text(
       <PraxisOwnerActions
         state={state({
@@ -299,7 +299,7 @@ describe("the CAST control is gone from the owner actions (#521 → #1089)", () 
         })}
       />,
     );
-    expect(t).toContain("edit this praxis");
     expect(t).toContain("unsubmit");
+    expect(t).not.toContain("edit this praxis");
   });
 });

--- a/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
@@ -264,7 +264,9 @@ describe('owner controls carry the action cluster for every praxis (#1090)', () 
         state={state({ duel: duel('settled', true), showWithdrawConfirm: true })}
       />,
     )
-    expect(t).toMatch(/Edit/i)
+    // #2136 deleted the edit link that used to sit beside it, so the cluster is
+    // the forfeit escalation and nothing else.
+    expect(t).not.toMatch(/edit this praxis/i)
     // The forfeit escalation reaches the player through the owner controls now.
     expect(t).toMatch(/FORFEITS the duel/i)
     expect(t).toMatch(/Rax wins by default/i)

--- a/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
@@ -1,23 +1,24 @@
 /**
- * The owner's "edit this praxis" link only shows when `/edit` has something to
- * draw (#1397).
+ * A published praxis offers its owner ONE control, and it is not a link to
+ * `/edit` (#2136).
  *
- * `/praxis/:id/edit` renders `EditPraxis`, which `<Navigate replace>`s back to
- * `/praxis/:id` whenever `deriveEditPraxisPhase` answers `handoff` (#1164). The
- * link here was gated on `isOwner` alone, and this page only ever renders a
- * PUBLISHED praxis (ADR-0062 redirects both open statuses to the composer) — so
- * on a submitted solo it round-tripped every single time it was visible, with
- * `replace` swallowing even the history trace. "It did not route me anywhere."
+ * #1397 hid the link on the `handoff` phase only, so the pair survived wherever
+ * `/edit` still drew something: a published collab and a settled duel reach
+ * `completed`, a live duel side reaches `waiting`, a moderated praxis reaches
+ * the locked composer. Every one of those surfaces is READ-ONLY, so "edit this
+ * praxis" named an outcome it could not deliver, beside a control that could.
+ * The ruling deleted the link rather than re-gating it: "There is no reason for
+ * the player to go back to the edit page unless they are going to edit. One
+ * button only."
  *
- * The seam under test is `PraxisOwnerActions`: given a state, is a
- * `/praxis/:id/edit` href in the markup? The fix is a hide, not a removal, so
- * every non-handoff phase below is asserted to KEEP its link — otherwise this
- * file could not tell "dropped the dead link" from "dropped editing".
+ * The seam under test is `PraxisOwnerActions`: given an owner's state, is a
+ * `/praxis/:id/edit` href anywhere in the markup? The phases named below are
+ * the ones #1397 deliberately KEPT — they are exactly what this change removes,
+ * so they are the ones worth spelling out.
  *
- * The way to edit a published praxis is the control in the same flex row:
- * unsubmit → confirm → `PraxisDetail` redirects the now-`in_progress` praxis
- * straight into the composer. So the unsubmit trigger must survive wherever the
- * edit link goes.
+ * The way to edit a published praxis is the surviving control: unsubmit →
+ * confirm → `PraxisDetail` redirects the now-`in_progress` praxis straight into
+ * the composer. So the unsubmit trigger must survive everywhere the link went.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
@@ -190,20 +191,20 @@ function state(overrides: Partial<PraxisDetailState>): PraxisDetailState {
 
 const COLLAB_MEMBERS = [member(1, 'Ada'), member(2, 'Beth')]
 
-describe('the dead edit link is gone (#1397)', () => {
-  it('a submitted solo praxis offers its owner no link to /edit', () => {
+describe('no owner state offers a link to /edit (#2136)', () => {
+  it('a submitted solo praxis', () => {
     const { html } = render(<PraxisOwnerActions state={state({})} />)
     expect(html).not.toContain(EDIT_HREF)
   })
 
-  it('a one-member collab hands off the same way, so it loses the link too', () => {
+  it('a one-member collab', () => {
     const { html } = render(
       <PraxisOwnerActions state={state({ praxis: praxis({ type: 'collab' }) })} />,
     )
     expect(html).not.toContain(EDIT_HREF)
   })
 
-  it('a declined challenge is an ordinary published solo — no link', () => {
+  it('a declined challenge', () => {
     const { html } = render(
       <PraxisOwnerActions
         state={state({ praxis: praxis({ duel_id: 5 }), duel: duel('declined') })}
@@ -212,40 +213,69 @@ describe('the dead edit link is gone (#1397)', () => {
     expect(html).not.toContain(EDIT_HREF)
   })
 
-  it('the way to edit — the unsubmit control — survives beside it', () => {
-    const { text } = render(<PraxisOwnerActions state={state({})} />)
-    expect(text.toLowerCase()).toContain('unsubmit')
-  })
-})
-
-describe('every phase that /edit still draws keeps its link (#1397)', () => {
-  it('a published collab reaches the completed reading', () => {
+  // The four below are the phases #1397 kept: `/edit` still draws a real
+  // surface for each, and every one of those surfaces is read-only.
+  it('a published collab, which used to reach the completed reading', () => {
     const { html } = render(
       <PraxisOwnerActions
         state={state({ praxis: praxis({ type: 'collab', members: COLLAB_MEMBERS }) })}
       />,
     )
-    expect(html).toContain(EDIT_HREF)
+    expect(html).not.toContain(EDIT_HREF)
   })
 
   it.each<DuelStatus>(['pending', 'active'])(
-    'a duel side at %s reaches the waiting surface',
+    'a duel side at %s, which used to reach the waiting surface',
     (status) => {
       const { html } = render(
         <PraxisOwnerActions
           state={state({ praxis: praxis({ duel_id: 5 }), duel: duel(status) })}
         />,
       )
-      expect(html).toContain(EDIT_HREF)
+      expect(html).not.toContain(EDIT_HREF)
     },
   )
 
-  it('a moderated praxis reaches its own locked composer', () => {
+  it('a settled duel side, which used to reach the completed reading too', () => {
+    const { html } = render(
+      <PraxisOwnerActions
+        state={state({ praxis: praxis({ duel_id: 5 }), duel: duel('settled') })}
+      />,
+    )
+    expect(html).not.toContain(EDIT_HREF)
+  })
+
+  it('a moderated praxis, which used to reach its own locked composer', () => {
     const { html } = render(
       <PraxisOwnerActions
         state={state({ praxis: praxis({ moderation_status: 'failed' }) })}
       />,
     )
-    expect(html).toContain(EDIT_HREF)
+    expect(html).not.toContain(EDIT_HREF)
+  })
+
+  it('and the copy goes with the href', () => {
+    const { text } = render(
+      <PraxisOwnerActions
+        state={state({ praxis: praxis({ type: 'collab', members: COLLAB_MEMBERS }) })}
+      />,
+    )
+    expect(text).not.toContain('edit this praxis')
+  })
+})
+
+describe('the one control that remains (#2136)', () => {
+  it('is the quiet unsubmit, on a published solo', () => {
+    const { text } = render(<PraxisOwnerActions state={state({})} />)
+    expect(text.toLowerCase()).toContain('unsubmit')
+  })
+
+  it('and on a published collab, where the link used to sit beside it', () => {
+    const { text } = render(
+      <PraxisOwnerActions
+        state={state({ praxis: praxis({ type: 'collab', members: COLLAB_MEMBERS }) })}
+      />,
+    )
+    expect(text.toLowerCase()).toContain('unsubmit')
   })
 })

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -10,7 +10,7 @@
  *   - Failed note (ADR-0062 removed the open-state banners: detail is
  *     published-only, so there is no IN EDITING / PENDING PUBLISH to draw; the
  *     crown hero went with #1710 and the mark lives on the score stamp)
- *   - Owner actions (edit / reopen)
+ *   - Owner actions (reopen)
  *   - Comments region (ADR-0061)
  *   - Voter breakdown
  *   - Flag block
@@ -35,9 +35,6 @@ import { Link } from 'react-router-dom'
 import CommentThread from '../../components/comments/CommentThread'
 import DuelSealConfirm from '../../components/duel/DuelSealConfirm'
 import type { PraxisDetailState } from './usePraxisDetail'
-// The LEAF module, not `useEditPraxis` — reaching for the hook's barrel would
-// drag the composer's api and upload plumbing onto every praxis-detail load.
-import { deriveEditPraxisPhase } from '../editPraxis/editPraxisPhase'
 import { UNSCORED_MODERATION_STATUSES } from '../../api/praxis'
 import type { PraxisMemberOut, PraxisOut } from '../../api/praxis'
 import type { DuelDetailOut } from '../../api/duel'
@@ -464,35 +461,25 @@ export function PraxisStatusBanners({ state }: { state: PraxisDetailState }) {
 // ── Owner actions ─────────────────────────────────────────────────────────────
 
 export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
-  const { t } = useTranslation('praxis')
-  const { praxis, isOwner, duel, user, withdrawError } = state
+  const { praxis, isOwner, withdrawError } = state
   if (!praxis || !isOwner) return null
 
-  // THE EDIT LINK ONLY SHOWS WHEN `/edit` HAS SOMETHING TO DRAW (#1397).
+  // ONE CONTROL, AND IT IS THE UNSUBMIT (#2136).
   //
-  // `EditPraxis` redirects straight back here whenever `deriveEditPraxisPhase`
-  // answers `handoff` (#1164), and `replace` means the redirect leaves no
-  // history trace — the page simply did not change. This page renders a
-  // PUBLISHED praxis only (ADR-0062), and `handoff` is exactly "published, with
-  // nobody to wait for": a solo, a one-member collab, a declined challenge. So
-  // the link was gated on `isOwner` alone and round-tripped every time it was
-  // visible.
+  // There was an "edit this praxis" link here beside it. #1397 hid it on the
+  // `handoff` phase — published with nobody to wait for, i.e. every solo — but
+  // the phases it left alone all draw READ-ONLY surfaces too: `completed` for a
+  // published collab or a settled duel, `waiting` for a live duel side, a
+  // locked composer for a moderated praxis. So the pair advertised the same
+  // outcome and only one of them delivered it. Owner ruling: the link is not
+  // re-gated by phase, it is gone. "There is no reason for the player to go
+  // back to the edit page unless they are going to edit."
   //
-  // Asking the composer's own predicate rather than re-deriving the statuses is
-  // the point: the two can't drift, and the phases that still draw a real
-  // surface — the waiting surface for a live duel, the completed reading for a
-  // published collab, the locked composer for a moderated praxis — keep their
-  // link untouched.
-  //
-  // The way to EDIT a published praxis is the control beside it: unsubmit →
-  // confirm → `PraxisDetail` redirects the now-`in_progress` praxis into the
-  // composer. That journey already worked; it was just outshouted by a link
-  // that promised the same thing and did nothing. Deliberately NOT an
-  // auto-unsubmit on click — that would silently spend the two-step confirm
-  // #1094 wrote to keep this beat truthful, and on a settled duel side the same
-  // click would be a permanent forfeit.
-  const handsOff =
-    deriveEditPraxisPhase(praxis, duel, user?.character?.id) === 'handoff'
+  // The way to EDIT a published praxis is what is left: unsubmit → confirm →
+  // `PraxisDetail` redirects the now-`in_progress` praxis into the composer.
+  // Deliberately NOT an auto-unsubmit on some other control — that would spend
+  // the two-step confirm #1094 wrote to keep this beat truthful, and on a
+  // settled duel side the same click would be a permanent forfeit.
 
   // EVERY praxis keeps the cluster here, duel or not (#1090). #752 had moved it
   // into the duel RAIL — "the state and the control that changes it share a
@@ -507,12 +494,10 @@ export function PraxisOwnerActions({ state }: { state: PraxisDetailState }) {
   // the forfeit dialog on a settled duel, wherever it renders.
   return (
     <div>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-md)', marginBottom: 'var(--space-lg)' }}>
-        {!handsOff && (
-          <Link to={`/praxis/${praxis.id}/edit`} className="font-body label-caption hover:underline">
-            {t('detail.owner.edit')}
-          </Link>
-        )}
+      {/* Still a flex row with one child: `gap` went with the link, but the
+          shrink-to-fit box is what keeps the confirm state's own wrapping row
+          from spanning the whole column. */}
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: 'var(--space-lg)' }}>
         <PraxisSubmitControls state={state} />
       </div>
       {withdrawError && <p className="font-body content-text mb-3" style={{ color: wallInk(praxis, 'alarm') }}>{withdrawError}</p>}


### PR DESCRIPTION
Closes #2136

A published praxis showed its owner two controls that advertised the same outcome — **"edit this praxis"** and **"unsubmit to edit"** — and only the second one delivered it. #1397 hid the link on the `handoff` phase (published, nobody to wait for: every solo), but the phases it left alone all land on read-only surfaces too:

| Phase | When | What `/edit` draws |
|---|---|---|
| `completed` | published collab; settled duel | the completed reading — read-only |
| `waiting` | live duel side | the waiting surface |
| `composing` | moderated (hidden/failed) praxis | a LOCKED composer — read-only |

Per the ruling, the link is **not re-gated by phase — it is deleted**. `PraxisSubmitControls` is now the only child of `PraxisOwnerActions`.

## The seam

`PraxisOwnerActions` rendered to static markup: given an owner's state, is a `/praxis/:id/edit` href anywhere in the output, and does the unsubmit control survive? `ownerEditLink.test.tsx` was inverted at that seam first and went red on 6 of 11 cases — exactly the phases #1397 kept — before the component changed.

## What changed

- `frontend/src/pages/praxisDetail/shared.tsx` — removed the `<Link>`, its `{!handsOff && …}` wrapper, the `handsOff` const, the `deriveEditPraxisPhase` call and import, the now-unused `t`/`duel`/`user` bindings, and the 24-line comment block documenting the #1397 gate (replaced by a shorter note recording why the link is gone, so it does not come back). The module docblock's slot list now says "Owner actions (reopen)".
- The wrapper: the outer `<div>` stays (it groups the row and `withdrawError`). The inner flex row also stays — with one child its `gap` is dead so that went, but `display: flex` is what keeps the confirm state's own wrapping row shrink-to-fit instead of spanning the column, and `marginBottom` still separates the cluster from what follows.
- `frontend/src/locales/en/praxis.json` — removed `detail.owner.edit`. It had exactly one consumer (`shared.tsx:513`); the other `owner.edit*` hits are `owner.editing` in the comment components, untouched.
- Tests inverted: `ownerEditLink.test.tsx` (now asserts absence across solo, one-member collab, declined challenge, published collab, duel `pending`/`active`/`settled`, moderated — plus the unsubmit surviving), `collabSubmitIndicators.test.tsx:302`, and **`duelForfeitWarning.test.tsx:267`**, which was not in the issue's list — its settled-duel case asserted `toMatch(/Edit/i)` on the owner cluster, so it went red on the full suite.
- `uaPraxisDetail.test.tsx` and `wowPraxisDetail.test.tsx` already asserted the link is absent and were not touched.

## Deliberately not changed

- **`deriveEditPraxisPhase` stays exported** — `useEditPraxis` is still its caller.
- **"unsubmit to edit" keeps its wording.** The confusion was the pairing, and the pairing is gone; "unsubmit" is also the word the model uses (`unsubmit_praxis`, `unsubmitCase`).
- **The confirm prompts are untouched.** #2094 is open on `detail.owner.confirmPrompt`'s points wording — separate fix, same locale block.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (323 files / 5614 passing), `npm run build` and `npm run budget` (JS 126.6 KB, CSS 22.0 KB — both ok) all pass locally. No backend, route or schema change, so `api-schema` is unaffected.

**Visual QA is outstanding** — no browser or dev stack in this environment.

## What to eyeball

For each state below, confirm the owner sees **exactly one control** where two used to sit, and that it still works:

- **Published solo** — should be unchanged (the link was already hidden here); "unsubmit to edit" alone, confirm still reopens into the composer.
- **Published collab** — the link used to sit to the left of "unsubmit to edit"; check the row does not look left-shifted or oddly spaced now that it holds one item, and that the group-reopen confirm ("Yes, reopen for everyone") still wraps sensibly.
- **Live duel side** (`pending` or `active`) — "pull my entry back" is the only control; the player can still read their own write-up on the page.
- **Settled duel side** — the forfeit trigger and its `DuelSealConfirm` overlay are the only control; the overlay still mounts over the trigger.
- **Moderated praxis** (hidden or failed) — the failed banner plus one control, no route out to the locked composer.
- Any one of the above with a **withdraw error** showing, to confirm the error paragraph still sits below the row with the same gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
