### PR TITLE
S.N.I.D.E.'s pen circle was drawn three times: the task detail page mounts the shared mark (#2042)

### DIFF
--- a/frontend/src/components/factionMarks/snideAtoms.tsx
+++ b/frontend/src/components/factionMarks/snideAtoms.tsx
@@ -61,34 +61,57 @@ export function SnideSigil({
  * is the device the figure sits INSIDE, and this is S.N.I.D.E.'s: the only DRAWN
  * one it has.
  *
- * IT IS A SHARED MARK, BY OWNER RULING (#2042). The task card drew the loop and
- * the praxis-card score stamp drew a bare Anton numeral with a misregistered pink
- * offset shadow — one faction, two devices — and the ruling is that the point card
- * reflects the card's total look. So the loop is drawn once, here, and both
- * surfaces mount it. The pink SHADOW does not come along: the pink is the loop
- * now, and a second pink pass under a pink line reads as mud rather than as
- * misregistration.
+ * IT IS A SHARED MARK, BY OWNER RULING (#2042), ON THREE SURFACES. The task card
+ * drew the loop, the praxis-card score stamp drew a bare Anton numeral with a
+ * misregistered pink offset shadow, and the TASK DETAIL page drew the loop a third
+ * time by hand — one faction, three drawings, and #2042's own survey only ever
+ * counted two. The ruling is that the point card reflects the card's total look,
+ * so the loop is drawn once, here, and all three surfaces mount it. The pink
+ * SHADOW does not come along: the pink is the loop now, and a second pink pass
+ * under a pink line reads as mud rather than as misregistration.
  *
  * THE INKS ARE PROPS AND THAT IS NOT OPTIONAL. This is the pairing trap #2042
- * warns about, and S.N.I.D.E. is where it bites hardest. The card's numeral ink is
- * `--faction-snide-note-ink`, which FLIPS (#14110b by day, #f4f1e8 by night); the
- * score stamp's plate is `--faction-snide-stamp-bg`, a translucent black over the
- * near-black `-card-bg` in BOTH themes. The card's ink on the stamp's plate
- * measures **1.05:1 in light** — an invisible figure that passes every guard,
- * exactly the shape that shipped at 1.08:1 earlier in this epic. The caption ink
- * is no better: `-note-pink-ink` reads 3.27:1 there, under AA.
+ * warns about, and S.N.I.D.E. is where it bites hardest — on BOTH the surfaces the
+ * loop travelled to. The card's numeral ink is `--faction-snide-note-ink`, which
+ * FLIPS (#14110b by day, #f4f1e8 by night), and both other grounds are black in
+ * BOTH themes, so it is legible on them in exactly one:
  *
- * So the stamp passes its own inks and they are measured on its own plate:
- *   figure  `--faction-snide-acid`        16.31:1 light · 16.81:1 dark
- *   caption `--faction-snide-card-muted`  13.52:1 light · 12.74:1 dark
- *   loop    `--faction-snide-pink`         5.65:1 light ·  5.82:1 dark
- * The loop is theme-invariant, which is why it needs no prop.
+ *   score stamp   `-stamp-bg` over `-card-bg`   `-note-ink` **1.05:1 light**
+ *   task detail   `-card-bg`, the punched slab  `-note-ink` **1.00:1 light**
+ *
+ * 1.00:1 is not a near miss: on the detail page's slab the default figure ink is
+ * the identical hex to the ground. The caption default is no better — 3.27:1 on
+ * the stamp, 3.12:1 on the slab, both under AA. This is the shape that shipped at
+ * 1.08:1 earlier in this epic, and it passes every guard that does not measure the
+ * PAIR.
+ *
+ * So each mount passes its own inks, measured on its own ground:
+ *
+ *   score stamp (`-stamp-bg` over `-card-bg`)
+ *     figure  `--faction-snide-acid`        16.31:1 light · 16.81:1 dark
+ *     caption `--faction-snide-card-muted`  13.52:1 light · 12.74:1 dark
+ *     loop    `--faction-snide-pink`         5.65:1 light ·  5.82:1 dark
+ *   task detail (`-card-bg`, the slab punched into the acid plate — #2066)
+ *     figure  `--faction-snide-card-text`   16.68:1 light · 17.51:1 dark
+ *     caption `--faction-snide-card-accent` 15.55:1 light · 16.32:1 dark
+ *     loop    `--faction-snide-pink`         5.38:1 light ·  5.65:1 dark
+ *
+ * The loop is theme-invariant and clears 1.4.11's 3:1 on every ground, which is
+ * why it alone needs no prop.
+ *
+ * `valueSize` IS A PROP BECAUSE THE THREE SURFACES DRAW AT DIFFERENT SCALES —
+ * the pattern `SingularityReadout`, `DefaultPointsRing` and `UaEnsoScore` already
+ * set. The two cards take the default; the detail page's desktop total is the
+ * page's headline figure and keeps `--text-display`.
  *
  * NO NUMERAL CEILING, unlike UA's ensō. Anton is condensed enough that the widest
  * total the era can bank still clears the loop: at `--text-heading` a four-glyph
- * `13.6` is ~47px against the loop's ~77px of inner span at the 96 both surfaces
- * draw. If a future era ever banks a five-figure total, `UaEnsoScore.ringCeilingPx`
- * is the upgrade path — ponytail: measured, not machined.
+ * `13.6` is ~47px against the loop's ~77px of inner span at the 96 the two cards
+ * draw. The detail page asks more of it — `--text-display` on a 128 loop — and
+ * that is the ratio the 1.18× growth below was built for, so it is the surface the
+ * growth belongs on MOST. If a future era ever banks a five-figure total,
+ * `UaEnsoScore.ringCeilingPx` is the upgrade path — ponytail: measured, not
+ * machined.
  */
 export function PenCircle({
   size,
@@ -96,6 +119,7 @@ export function PenCircle({
   unit,
   valueColor = "var(--faction-snide-note-ink)",
   unitColor = "var(--faction-snide-note-pink-ink)",
+  valueSize = "var(--text-heading)",
   style,
 }: {
   /** The loop's drawn width in px. Ornament geometry (§4a). */
@@ -108,6 +132,8 @@ export function PenCircle({
   valueColor?: string;
   /** The caption's ink. Defaults to the clipping's walked pink. */
   unitColor?: string;
+  /** The figure's type ramp rung. The two cards take the default. */
+  valueSize?: string;
   style?: CSSProperties;
 }) {
   return (
@@ -150,7 +176,7 @@ export function PenCircle({
         style={{
           position: "relative",
           fontFamily: "var(--faction-snide-font-impact)",
-          fontSize: "var(--text-heading)",
+          fontSize: valueSize,
           lineHeight: 0.9,
           color: valueColor,
           letterSpacing: "-0.01em",

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/pointsMarkUnification.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/pointsMarkUnification.test.tsx
@@ -3,14 +3,20 @@
  *
  * ## The two seams
  *
- * 1. THE MOUNT SEAM — the rendered markup of a faction's TWO surfaces: its task
- *    card and its praxis-card score stamp. #2042's finding was that each faction
- *    drew its points mark on both with almost no sharing, so what has to hold is
- *    that one drawing now appears on both and the second copy is GONE. Both
- *    surfaces are named per faction below; nothing here asserts a count of
- *    unified factions, because #1998 shipped a `toHaveLength(5)` census that was
- *    clean while a sixth wrong mount sat beside it (#2090 replaced it with an
- *    explicit list). A faction that unifies has to be added here by name.
+ * 1. THE MOUNT SEAM — the rendered markup of every surface a faction draws its
+ *    points mark on: its task card, its praxis-card score stamp, and — for
+ *    S.N.I.D.E. — its TASK DETAIL page. #2042's finding was that each faction drew
+ *    its points mark on each with almost no sharing, so what has to hold is that
+ *    one drawing now appears on all of them and the other copies are GONE. Every
+ *    surface is named per faction below; nothing here asserts a count of unified
+ *    factions, because #1998 shipped a `toHaveLength(5)` census that was clean
+ *    while a sixth wrong mount sat beside it (#2090 replaced it with an explicit
+ *    list). A faction that unifies has to be added here by name.
+ *
+ *    THE LIST IS THE ONLY CENSUS, and it has already been wrong once: #2042's own
+ *    survey counted TWO S.N.I.D.E. surfaces while the task detail page hand-drew
+ *    the loop a third time, so PR #2105 unified a mark that was still being copied
+ *    somewhere it had not looked. A surface omitted here is invisible, not red.
  *
  * 2. THE PAIRING SEAM — the ruling settles WHETHER the mark propagates, not WHAT
  *    it looks like on the way. A mark drawn for a card lands on a score stamp
@@ -59,6 +65,8 @@ import DefaultScoreStamp from "../DefaultScoreStamp";
 import SingularityScoreStamp from "../SingularityScoreStamp";
 import SnideScoreStamp from "../SnideScoreStamp";
 import WowScoreStamp from "../WowScoreStamp";
+import SnideTaskDetail from "../../../../pages/taskDetail/archetypes/SnideTaskDetail";
+import type { TaskDetailState } from "../../../../pages/taskDetail/useTaskDetail";
 import { aTask } from "../../../../test/fixtures";
 
 const TASK = aTask({ description: "Leave something small where a stranger finds it." });
@@ -92,8 +100,69 @@ function stamp(Stamp: ComponentType<ScoreStampProps>): string {
   return renderToStaticMarkup(<Stamp praxis={PRAXIS} />);
 }
 
+/**
+ * S.N.I.D.E.'s THIRD surface. The total here is `modifiedPoints`, four glyphs
+ * wide on purpose: this page draws the widest figure the loop has to hold, which
+ * is the argument for the shared 1.18× growth landing here rather than the
+ * argument against it.
+ */
+function snideDetail(): string {
+  const state: TaskDetailState = {
+    loading: false,
+    task: TASK,
+    fetchError: null,
+    submissions: [],
+    comments: null,
+    friends: new Set(),
+    foes: new Set(),
+    mySubmission: undefined,
+    isInProgress: false,
+    inProgressPraxisId: null,
+    canSignUp: true,
+    levelJumpSignup: false,
+    slotsOpen: 4,
+    maxTaskSlots: 13,
+    basePoints: 120,
+    factionMultiplier: 1.0,
+    modifiedPoints: 1080,
+    inProgressCount: 9,
+    topScore: 0,
+    voteCount: 0,
+    submissionSort: "score",
+    setSubmissionSort: () => {},
+    sortedSubmissions: [],
+    signupError: null,
+    handleSignup: async () => {},
+    handleDrop: async () => {},
+  };
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <SnideTaskDetail state={state} />
+    </MemoryRouter>,
+  );
+}
+
 function occurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
+}
+
+/** The pen loop's own first stroke — drawn nowhere else on any of its surfaces. */
+const PEN_LOOP = "M14 40 C13 19";
+
+/**
+ * Just the pen circle, cut out of a whole surface's markup.
+ *
+ * A `not.toContain` over a whole PAGE is the wrong instrument here and says so
+ * loudly: the S.N.I.D.E. task detail prints `--faction-snide-note-ink` all over
+ * the WALL, correctly — that family is what the flipping wall is for (#2066). The
+ * defect is that ink reaching the SLAB the mark stands on, so the assertion has to
+ * be scoped to the mark. `PenCircle` emits `<svg>` then two `<span>`s inside one
+ * `<div>`, so the first `</div>` after the loop is the mark's own.
+ */
+function penCircle(markup: string): string {
+  const at = markup.indexOf(PEN_LOOP);
+  expect(at, "the pen loop must be drawn at all").toBeGreaterThan(-1);
+  return markup.slice(markup.lastIndexOf("<div", at), markup.indexOf("</div>", at) + 6);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -126,11 +195,11 @@ const UNIFIED = [
   {
     faction: "snide",
     mark: "components/factionMarks/snideAtoms.tsx (PenCircle)",
-    // The pen loop's own first stroke — drawn nowhere else in these two surfaces.
-    fragment: "M14 40 C13 19",
+    fragment: PEN_LOOP,
     surfaces: {
       "components/taskCard/SnideTaskCard.tsx": () => card(SnideTaskCard),
       "components/praxisCard/scoreStamp/SnideScoreStamp.tsx": () => stamp(SnideScoreStamp),
+      "pages/taskDetail/archetypes/SnideTaskDetail.tsx": snideDetail,
     },
     // The misregistered pink second pass: the pink is the loop now.
     retired: ["text-shadow:2px 2px 0 var(--faction-snide-pink)"],
@@ -172,7 +241,7 @@ describe.each(UNIFIED)("$faction draws its points mark once (#2042)", (entry) =>
  * red for that, and it is the one that would have caught the 1.08:1 masthead ink
  * this epic shipped.
  */
-describe("the stamp mounts override what its ground demands (#2042)", () => {
+describe("each mount overrides what its ground demands (#2042)", () => {
   it("S.N.I.D.E. passes its own two inks rather than the clipping's", () => {
     const chronicle = stamp(SnideScoreStamp);
     expect(chronicle, "the acid figure").toContain("color:var(--faction-snide-acid)");
@@ -189,6 +258,29 @@ describe("the stamp mounts override what its ground demands (#2042)", () => {
     // reads as struck into this surface rather than as a patch laid on it.
     expect(sheet).toContain("background:var(--faction-default-stamp-bg)");
     expect(sheet).not.toContain("var(--faction-default-card-bg)");
+  });
+
+  it("S.N.I.D.E.'s task detail passes the SLAB's inks, not the wall's", () => {
+    // A different ground again from the stamp's, and the trap is sharper here:
+    // `-note-ink` is the SAME HEX as `-card-bg` in light, so a dropped prop paints
+    // the total in the ground colour. Measured below.
+    const mark = penCircle(snideDetail());
+    expect(mark, "the cream figure").toContain("color:var(--faction-snide-card-text)");
+    expect(mark, "the acid caption").toContain("color:var(--faction-snide-card-accent)");
+    expect(mark).not.toContain("--faction-snide-note-ink");
+    expect(mark).not.toContain("--faction-snide-note-pink-ink");
+  });
+
+  it("S.N.I.D.E.'s task detail draws the SHARED loop, growth and all", () => {
+    const mark = penCircle(snideDetail());
+    // The 1.18× growth (#2035) lives on the SVG alone and is the one thing the
+    // hand-drawn third copy lacked, so it is what tells the two drawings apart.
+    // Deliberate: this page shows `modifiedPoints` at `--text-display`, the widest
+    // figure the loop carries anywhere, so the growth belongs here most.
+    expect(mark, "the shared loop's growth").toContain("scale(1.18)");
+    // The size branch survives the mount rather than flattening to the cards' 96.
+    expect(mark, "the desktop loop").toContain("width:128px");
+    expect(mark, "the page's headline figure").toContain("font-size:var(--text-display)");
   });
 
   it("Singularity needs no ink override — the well carries its own ground", () => {
@@ -253,15 +345,16 @@ function opaque(token: string, theme: Theme, under?: string): Rgba {
 }
 
 /**
- * Every ink each shared mark puts on the SCORE STAMP's ground — the surface whose
- * ground the mark was NOT drawn for. `floor` is the WCAG rung the role owes:
- * AA_LARGE for a display numeral, AA_NORMAL for a caption.
+ * Every ink each shared mark puts on a ground it was NOT drawn for — the score
+ * stamp's plate, and for S.N.I.D.E. the task detail page's slab as well. `floor`
+ * is the WCAG rung the role owes: AA_LARGE for a display numeral, AA_NORMAL for a
+ * caption.
  *
  * The measured figures are in the marks' own docblocks beside the pairings, as
  * this repo does; the numbers here are the floors, so a repaint that walks a token
  * fails on the ratio rather than on a stale comment.
  */
-const ON_THE_STAMP: Array<{
+const ON_A_BORROWED_GROUND: Array<{
   what: string;
   ink: string;
   ground: string;
@@ -303,6 +396,26 @@ const ON_THE_STAMP: Array<{
     under: "--faction-snide-card-bg",
     floor: AA_LARGE,
   },
+  // S.N.I.D.E.'s task detail — the slab punched into the acid plate (#2066).
+  // A third ground for one drawing, opaque this time and black in both themes.
+  {
+    what: "snide detail total figure in the pen circle",
+    ink: "--faction-snide-card-text",
+    ground: "--faction-snide-card-bg",
+    floor: AA_LARGE,
+  },
+  {
+    what: "snide detail pen-circle caption",
+    ink: "--faction-snide-card-accent",
+    ground: "--faction-snide-card-bg",
+    floor: AA_NORMAL,
+  },
+  {
+    what: "snide detail pen loop (non-text, 1.4.11)",
+    ink: "--faction-snide-pink",
+    ground: "--faction-snide-card-bg",
+    floor: AA_LARGE,
+  },
   // na — the ring's ground is a prop, so the plate shows through the annulus.
   {
     what: "na total figure in the spectrum ring",
@@ -318,7 +431,7 @@ const ON_THE_STAMP: Array<{
   },
 ];
 
-describe.each(ON_THE_STAMP)("$what clears its floor on the stamp's ground", (pair) => {
+describe.each(ON_A_BORROWED_GROUND)("$what clears its floor on the ground it lands on", (pair) => {
   it.each(BOTH)("in %s", (theme) => {
     const ratio = contrastRatio(
       opaque(pair.ink, theme, pair.under),
@@ -352,6 +465,23 @@ describe("the S.N.I.D.E. card's own inks do NOT survive the move (#2042)", () =>
   it("puts the caption under AA in light", () => {
     const light = contrastRatio(opaque("--faction-snide-note-pink-ink", "light"), plate("light"));
     expect(light, formatRatio(light)).toBeLessThan(AA_NORMAL);
+  });
+
+  it("is not merely dim on the task detail's slab in light — it is the SAME HEX", () => {
+    // `--faction-snide-note-ink` and `--faction-snide-card-bg` are both #14110b in
+    // the light cascade. The wall flips and the slab does not (#2066), so the
+    // clipping's ink on the slab is 1.00:1 — the total painted in the ground
+    // colour, on the page that shows the widest total the loop ever holds.
+    const slab = (theme: Theme) => opaque("--faction-snide-card-bg", theme);
+    const light = contrastRatio(opaque("--faction-snide-note-ink", "light"), slab("light"));
+    expect(light, formatRatio(light)).toBeLessThan(1.01);
+    // And legible in dark, which is exactly what makes it invisible to a
+    // single-theme eyeball and to every guard that does not measure the pair.
+    const dark = contrastRatio(opaque("--faction-snide-note-ink", "dark"), slab("dark"));
+    expect(dark, formatRatio(dark)).toBeGreaterThan(AA_NORMAL);
+    // The caption default lands under AA there too: 3.12:1.
+    const caption = contrastRatio(opaque("--faction-snide-note-pink-ink", "light"), slab("light"));
+    expect(caption, formatRatio(caption)).toBeLessThan(AA_NORMAL);
   });
 });
 

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -2,6 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
+import { PenCircle } from "../../../components/factionMarks/snideAtoms";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
@@ -364,6 +365,22 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
   // pink they used to wear falls to 3.1:1 on black, so they take the acid the
   // slab admits as ink (#2066).
   //
+  // THE LOOP IS THE SHARED `PenCircle` (#2042). This page hand-drew the same two
+  // paths at the same viewBox until then, which made three copies of one drawing
+  // rather than the two #2042's survey counted. Two things travel with the mount:
+  //  - **The 1.18× growth** the shared loop carries (#2035). This page never had
+  //    it, so the loop is now visibly bigger here. That is a fix, not a
+  //    regression: the growth exists to clear a wide total, and this is the
+  //    surface with the widest — `modifiedPoints` at `--text-display` on desktop,
+  //    where the cards show a narrower figure a rung down. The growth is on the
+  //    SVG alone and the loop still lands inside its own box, so nothing moves.
+  //  - **The inks, as props, non-negotiably.** `PenCircle` defaults to the
+  //    clipping's `-note-*` family, which is the WALL's, and the wall flips while
+  //    this slab does not. `-note-ink` on `-card-bg` is **1.00:1 in light** — the
+  //    identical hex — and `-note-pink-ink` is 3.12:1. `PLATE_TEXT` reads 16.68:1
+  //    light / 17.51:1 dark and `PLATE_ACCENT` 15.55:1 / 16.32:1, which is the
+  //    same pairing this block already had; the mount must keep passing them.
+  //
   // The base chip's photocopier-black fill is LEFT ALONE and is worth knowing
   // about: `--faction-snide-ink` is the same `#14110b` as `-card-bg` in light, so
   // in light theme the chip's ground now matches the sheet under it exactly and
@@ -421,61 +438,16 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
         </div>
       )}
 
-      {/* The total, circled in pink pen. */}
-      <div
-        style={{
-          position: "relative",
-          flex: "0 0 auto",
-          width: desktop ? 128 : 104,
-          height: desktop ? 100 : 81,
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          transform: "rotate(-5deg)",
-        }}
-      >
-        <svg
-          width="100%"
-          height="100%"
-          viewBox="0 0 100 78"
-          aria-hidden="true"
-          style={{ position: "absolute", inset: 0, overflow: "visible" }}
-        >
-          <g fill="none" stroke={PINK} strokeLinecap="round">
-            <path
-              d="M14 40 C13 19 38 7 56 9 C79 11 91 24 89 40 C87 59 61 71 43 68 C23 65 12 55 13 37 C13 28 18 19 27 13"
-              strokeWidth="2.6"
-            />
-            <path d="M27 12 C16 18 11 28 11 39" strokeWidth="1.8" opacity="0.75" />
-          </g>
-        </svg>
-        <span
-          style={{
-            position: "relative",
-            fontFamily: IMPACT,
-            fontSize: desktop ? "var(--text-display)" : "var(--text-heading)",
-            lineHeight: 0.9,
-            color: PLATE_TEXT,
-          }}
-        >
-          {modifiedPoints}
-        </span>
-        <span
-          style={{
-            position: "relative",
-            fontFamily: IMPACT,
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: pen-circle caption, sized to the drawn loop rather than the label ramp (§4a).
-            fontSize: 10,
-            letterSpacing: "0.22em",
-            // eslint-disable-next-line local/no-raw-style-values -- ornament: the caption's lead inside the drawn loop; a 4px rung pushes it off the numeral.
-            marginTop: 3,
-            color: PLATE_ACCENT,
-          }}
-        >
-          {t("detail.points.total")}
-        </span>
-      </div>
+      {/* The total, circled in pink pen — the SHARED loop (#2042), not a third
+          hand-drawn copy of it. See the note above `worth` for the inks. */}
+      <PenCircle
+        size={desktop ? 128 : 104}
+        value={modifiedPoints}
+        unit={t("detail.points.total")}
+        valueColor={PLATE_TEXT}
+        unitColor={PLATE_ACCENT}
+        valueSize={desktop ? "var(--text-display)" : "var(--text-heading)"}
+      />
     </div>
   );
 


### PR DESCRIPTION
Part of #2042

S.N.I.D.E.'s task detail page hand-drew the pen circle — the same two paths, the same
`viewBox="0 0 100 78"`, the same `rotate(-5deg)` — so after PR #2105 unified the task card
and the score stamp, the faction's one mark was still being drawn **three** times. #2042's
survey only ever counted two surfaces, which is how PR #2105 could unify a mark that was
still being copied somewhere it had not looked. This mounts the shared `PenCircle` on the
third surface and deletes the copy.

## The seam

**The mount seam** — the rendered markup of every surface a faction draws its points mark
on, asserted in `pointsMarkUnification.test.tsx`, plus **the pairing seam**: the mark's inks
measured against the ground it lands on, in both themes, read off `index.css` itself.

The failing test came first and is the growth, not the path — a hand-rolled copy of the same
`d` attribute passes a "does it draw the loop" check:

```
× S.N.I.D.E.'s task detail draws the SHARED loop, growth and all
  → the shared loop's growth: expected '<div style="position:relative;flex:0 …' to contain 'scale(1.18)'
```

## The three questions the brief asked, answered

### 1. The 1.18× growth comes along — and it belongs here most

`PenCircle` scales the loop 1.18× (#2035); this page never did. **The loop is now visibly
bigger on the task detail page.** That is a fix rather than a per-surface intent:

- The growth exists to clear a wide total. This is the surface with the **widest** — it
  shows `modifiedPoints` at `--text-display` (42px) on desktop, where the two cards show a
  narrower figure a rung down at `--text-heading` (32px). The mark was under-drawn here,
  not over-drawn elsewhere.
- The growth is on the SVG alone, and the loop spans 80 of the 100 viewBox units, so at
  1.18× it reaches 94.4 — still inside its own box. **Nothing beside it moves**, the box
  keeps its 128 × 99.84 footprint, and the numeral and caption stay put.

### 2. The inks: this site's ground is a THIRD ground, and it is the sharpest case yet

`PenCircle` defaults to `--faction-snide-note-ink` / `-note-pink-ink` — the WALL's family,
which flips. This mark stands on the **slab** punched into the acid plate
(`--faction-snide-card-bg`, #2066), which is black in both cascades. Measured off
`index.css`:

| role | ink | light | dark |
|---|---|---|---|
| figure | `--faction-snide-card-text` (passed) | **16.68:1** | **17.51:1** |
| caption | `--faction-snide-card-accent` (passed) | **15.55:1** | **16.32:1** |
| loop | `--faction-snide-pink` (invariant, non-text 1.4.11) | **5.38:1** | **5.65:1** |
| — figure if the prop is dropped — | `--faction-snide-note-ink` | **1.00:1** | 17.51:1 |
| — caption if the prop is dropped — | `--faction-snide-note-pink-ink` | **3.12:1** | 7.41:1 |

`1.00:1` is not a near miss: in the light cascade `--faction-snide-note-ink` and
`--faction-snide-card-bg` are **the same hex**, `#14110b`. A dropped prop paints the page's
headline total in the ground colour, legibly in dark and invisibly in light — the exact
theme-invariant-surface shape #2042 warns about, worse here than the 1.05:1 it recorded on
the score stamp. So the mount passes `PLATE_TEXT`/`PLATE_ACCENT`, which is the pairing this
block already had, and both failure figures are asserted **as failures**.

The whole-page `not.toContain` you would reach for first is wrong and the test says so: this
page prints `-note-ink` all over the wall, correctly. The assertion is scoped to the mark's
own subtree.

### 3. Desktop/mobile sizing passes through

`size={desktop ? 128 : 104}` — not flattened. `PenCircle`'s `size × 0.78` gives 99.84 / 81.12
against the hand-rolled 100 / 81, i.e. the same ratio to sub-pixel.

## The one prop added

`PenCircle` gains `valueSize?: string` (default `var(--text-heading)`), so this page keeps
its `--text-display` desktop figure. This is not reshaping the component to fit the site:
`SingularityReadout`, `DefaultPointsRing` and `UaEnsoScore` **all three** already carry
`valueSize?: string` defaulting to `var(--text-heading)`, for exactly this reason — the
surfaces draw at different scales. The two cards take the default and are byte-identical.

## Net

~40 lines of hand-rolled SVG and layout replaced by one `<PenCircle>` mount, and the two
`eslint-disable local/no-raw-style-values` lines this site carried for the caption's
`fontSize: 10` / `marginTop: 3` are gone — the shared component owns them now.
`SnideTaskDetail.tsx` is 82 lines changed for a net deletion of the drawing. **No CSS was
edited**; the critical-path budget is unchanged (CSS 22.0 KB, JS 126.6 KB, "Within budget").

## Not in scope

- **WOW stays stopped.** It needs an owner call on giving the score stamp a plate distinct
  from the card's plaque (`--faction-wow-stamp-bg` is `var(--faction-wow-chronicle-panel)`,
  so the plaque would sit at 1.00:1 on the plate in both themes). Untouched, and #2042 stays
  open for it — hence `Part of`, not `Closes`.
- **`--faction-default-gold` retirement** (follow-up 2) — a token-retirement style call.
  Left alone.

## Verification

Every step in the `frontend` job of `.github/workflows/test.yml`, locally: `npm run lint`,
`npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (**323 files, 5622 passed**),
`npm run build`, `npm run budget`. No backend, route or Pydantic change, so `test` and
`api-schema` are untouched.

**Visual QA is outstanding** — no browser and no dev stack in this environment.

## What to eyeball

1. **S.N.I.D.E. task detail, desktop, light theme** — the loop is now ~18% wider than it was.
   Confirm it still sits inside the punched box on the acid action plate and does not
   collide with the box's 3px printed border or the "base 120" chip above it.
2. **The same at mobile width** (`useFormFactor()` → the 104 loop, figure at
   `--text-heading`). The growth applies there too.
3. **Both themes on both widths.** The slab does not flip and the wall does — the total
   should read cream on black in *both*, and the caption acid on black in both. A total that
   vanishes in light is the 1.00:1 failure above.
4. **A wide total.** Sign the figure up past four glyphs (the test renders `1080` at
   `--text-display`) and check the numeral still clears the loop's inner span. This is the
   surface the growth was argued for, so it is the one to prove it on.
5. **The caption's lead** — the shared component uses `marginTop: 2` where this site used 3.
   A 1px difference, but it is the only geometry that changed other than the growth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

