### PR TITLE
The praxis card's flex-basis is a width: the WOW phone profile stops stacking it on a column main axis (#2149)

### DIFF
--- a/frontend/src/components/praxisCard/__tests__/columnMountGuard.test.ts
+++ b/frontend/src/components/praxisCard/__tests__/columnMountGuard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * No praxis-card mount may be the direct child of a COLUMN flex container (#2149).
+ *
+ * `frameBase` carries `flex: 1 1 var(--praxis-card-basis, 394px)` (#1137).
+ * `flex-basis` sizes along the MAIN axis, so that 394px is a width in a row —
+ * which is every surface it was written for — and a HEIGHT the moment the
+ * container is a column. In a column stack with an auto height there is no free
+ * space to grow into, so each card is pinned at exactly 394px tall: whitespace
+ * under a short card, and on the two archetypes whose frame is `overflow:
+ * hidden` (WOW, Albescent) the byline and vote row are simply cut off.
+ *
+ * WHY THE GUARD IS AT THE MOUNT AND NOT IN `frameBase`. The obvious fix — move
+ * the 394 off the basis onto `width` and pin `flex: 0 0 auto` — was measured
+ * against the surfaces that mount the card and rejected: the feed rows (`Home`,
+ * `/praxis` on both form factors, `DefaultFactionBody`) are direct-child flex
+ * rows that GROW the card to fill the line, and `flex-shrink: 0` at a fixed
+ * 394px would also overflow a phone sideways. `width: 100%` is load-bearing too
+ * — the six faction bodies and both profile bodies nest the card in a
+ * `position: relative` wrapper and let it fill that wrapper, which is what keeps
+ * the wrapper's absolutely-positioned Task Crown on the card's corner. No
+ * item-side declaration can tell a row from a column, so the axis is the
+ * CONTAINER's business, exactly as `--praxis-card-basis` already is.
+ *
+ * CEILING (`renderToStaticMarkup`, no jsdom, no layout, no computed styles):
+ * clipping is a layout fact and cannot be observed in this harness. This scans
+ * the source instead and pins the one structural precondition for it — the card
+ * being a flex item on a column main axis. It cannot prove nothing is clipped;
+ * it proves no mount is shaped so that it can be.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+const SRC = fileURLToPath(new URL("../../../", import.meta.url));
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = `${dir}${entry.name}`;
+    if (entry.isDirectory()) return tsxFiles(`${path}/`);
+    return entry.isFile() && path.endsWith(".tsx") && !path.includes("__tests__")
+      ? [path]
+      : [];
+  });
+}
+
+/** A line that opens a JSX element — the mount's nearest enclosing candidate. */
+const OPENS_ELEMENT = /^<[A-Za-z]/;
+
+/**
+ * The full text of the element that encloses `line`, opening tag only.
+ *
+ * Walking back from a mount, everything between it and its parent's opening tag
+ * is a `{...map(...)}`, a comment or a conditional — never another element open
+ * — so the first line that starts with a tag IS the parent. That tag may span
+ * several lines (attributes one per line), so read forward to the `>` that ends
+ * it.
+ */
+function enclosingTag(lines: string[], line: number): string {
+  let open = line - 1;
+  while (open >= 0 && !OPENS_ELEMENT.test(lines[open].trim())) open -= 1;
+  if (open < 0) return "";
+  const tag: string[] = [];
+  for (let i = open; i < line; i += 1) {
+    tag.push(lines[i].trim());
+    if (lines[i].trim().endsWith(">")) break;
+  }
+  return tag.join(" ");
+}
+
+/** `flexDirection: 'column'` (inline style) or Tailwind's `flex-col`. */
+const COLUMN = /flexDirection\s*:\s*["']column["']|\bflex-col\b/;
+
+type Mount = { file: string; line: number; tag: string };
+
+/** Doc blocks name the card constantly; only real JSX is a mount. */
+const isComment = (text: string) => /^(\*|\/\/|\/\*)/.test(text.trim());
+
+/** The element, not `PraxisCardOut` in a `useState<PraxisCardOut[]>`. */
+const MOUNT = /<PraxisCard(?!Out)/;
+
+const mounts: Mount[] = tsxFiles(SRC).flatMap((file) => {
+  const lines = readFileSync(file, "utf8").split(/\r?\n/);
+  return lines.flatMap((text, i) =>
+    MOUNT.test(text) && !isComment(text)
+      ? [{ file: file.slice(SRC.length), line: i + 1, tag: enclosingTag(lines, i) }]
+      : [],
+  );
+});
+
+describe("praxis-card mounts (#2149)", () => {
+  it("finds every mount, so the guard cannot pass by scanning nothing", () => {
+    // A rename or a moved directory must fail loudly here, not quietly stop
+    // checking. The number is a floor, not a fixture: adding a surface is fine.
+    expect(mounts.length).toBeGreaterThanOrEqual(20);
+  });
+
+  for (const { file, line, tag } of mounts) {
+    it(`${file}:${line} does not stack the card on a column main axis`, () => {
+      expect(
+        COLUMN.test(tag),
+        `the container at ${file}:${line} is a column flex, so frameBase's ` +
+          `flex-basis becomes a height cap on the card. Stack with ` +
+          `display: grid (or wrap the card in a block) instead — see #2149.\n` +
+          `  ${tag}`,
+      ).toBe(false);
+    });
+  }
+});

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -71,6 +71,14 @@ export type ArchetypeProps = {
  * `minWidth` deliberately stays out of it. It is the floor that keeps one card
  * per row on a phone, and it is also the clamp that would silently swallow any
  * basis below 280 — so the variable is only ever useful in [280, 394].
+ *
+ * THE BASIS IS A MAIN-AXIS SIZE, so it is only a WIDTH while the container is a
+ * ROW (#2149). Stack these cards with `display: grid`, never a flex COLUMN: on
+ * a column main axis the same 394px becomes a height cap and clips the card.
+ * The width cannot move to `width` to make that safe — `width: 100%` is what
+ * fills the wrapper the faction and profile bodies nest the card in, and the
+ * feed rows need the grow — so the axis stays the container's business, and
+ * `praxisCard/__tests__/columnMountGuard.test.ts` holds every mount to it.
  */
 export const frameBase: CSSProperties = {
   width: "100%",

--- a/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx
@@ -529,7 +529,16 @@ function MobileProfile({
           submissions.length === 0 ? (
             <Empty>{t('profile.praxisEmptyTitle')}</Empty>
           ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-lg)' }}>
+            /* `grid` and not a flex COLUMN (#2149). A praxis card carries
+               `flex: 1 1 var(--praxis-card-basis, 394px)` (#1137), and a
+               flex-basis sizes along the MAIN axis — a width in the rows it was
+               written for, a HEIGHT here. This stack has an auto height, so
+               there is no free space to grow into and every chronicle was
+               pinned at exactly 394px tall: whitespace under a short one, and
+               the byline and vote row cut off a long one, because the WOW frame
+               is `overflow: hidden`. A grid stack lays the same single column
+               out without claiming the card's block size. */
+            <div style={{ display: 'grid', gap: 'var(--space-lg)' }}>
               {submissions.map((praxis) => (
                 <PraxisCard key={praxis.id} praxis={praxis} />
               ))}


### PR DESCRIPTION
## The audit

24 praxis-card mounts, every one checked for its container's `flex-direction`.
**One is a column**, and it is not an Ephemerists surface:

`pages/characterProfile/archetypes/WowProfileBody.tsx:532` — the WOW **phone**
profile's Chronicles stack, `display: flex; flexDirection: column`, with
`<PraxisCard>` as a *direct* child. `frameBase`'s `flex: 1 1 var(--praxis-card-basis,
394px)` is a height there; the stack's height is auto, so free space is zero, no
card grows or shrinks, and every chronicle is pinned at exactly 394px tall. The
archetype is chosen by *task* faction, so any of the nine can appear in it — and
`WowPraxisCard` / `AlbescentPraxisCard` set `overflow: hidden`, which is what turns
the cap into the clip the design saw (a flex item's automatic minimum size is zero
once overflow is not `visible`, so nothing clamps it back up).

Everything else is safe, and two different reasons matter:

| Mount | Container | Verdict |
|---|---|---|
| `Home.tsx:222`, `Praxes.tsx:77`, `praxes/MobilePraxisFeed.tsx:94` | `flex flex-wrap` (row) | row |
| `taskDetail/archetypes/*.tsx` ×8 (`:774`/`:898`/`:925`/`:902`/`:827`/`:968`/`:814`/`:844`) | `praxis-gallery flex flex-wrap` (row) | row |
| `factionDetail/archetypes/*.tsx` ×8 (`:215`/`:240`/`:244`/`:225`/`:249`/`:263`/`:279`/`:193`) | `display: flex; flexWrap: wrap` (row) | row |
| `characterProfile/archetypes/DefaultProfileBody.tsx:341`, `profileSkin.tsx:493` | `flex flex-wrap` (row) | row |
| `characterProfile/archetypes/DefaultProfileBody.tsx:863` | `flex flex-col` **but** the card sits inside a `position: relative` block wrapper | safe — the card is not a flex item |
| `FieldDesk.tsx:632` | `display: grid` | safe — flex properties do not apply |

`DefaultProfileBody`'s mobile stack is the near miss: it *is* a column, and it is
only safe because #1960's laurel wrapper happens to sit between it and the card.

## The seam

**A praxis-card mount must not be a flex item on a column main axis.** Clipping is
a layout fact and this harness has no jsdom, no layout and no computed styles, so
the test scans the source for that structural precondition instead — the failing
run named `WowProfileBody.tsx:534` and nothing else, and it holds all 24 mounts,
not just the one that was broken.

## Why the fix is at the mount and not in `frameBase`

The issue's `flex: 0 0 auto` + `width: var(--praxis-card-basis)` was measured
against the mounts first, as instructed, and the row surfaces **do** want the flex:

- `Home`, `/praxis` (both form factors) and `DefaultFactionBody` are direct-child
  rows with no `max-width` cap, so `flex-grow: 1` is what fills the line. At 1200px
  two cards grow to ~590px each today; pinned they would be 394px with ~370px of
  dead space.
- `flex-shrink: 0` at a fixed 394px **overflows a phone sideways** — the mobile feed
  relies on the shrink to come down to the viewport, floored by `minWidth: 280`.
- `width` is not free either: the diff's new `width` key replaces `frameBase`'s
  existing `width: "100%"` (same object literal), and that 100% is what makes the
  card fill the `position: relative` wrapper the six faction bodies and both profile
  bodies nest it in — the wrapper carries the absolutely-positioned Task Crown, so a
  card narrower than its wrapper detaches the crown from the card's corner.

No item-side declaration can tell a row from a column, so the axis stays the
container's business — which is already true of `--praxis-card-basis` itself.
`frameBase` is unchanged apart from a note recording that, and pointing at the guard.

## Changes

- `frontend/src/pages/characterProfile/archetypes/WowProfileBody.tsx` — the phone
  Chronicles stack becomes `display: grid` (same single column, same gap; a grid
  stack does not claim its children's block size).
- `frontend/src/components/praxisCard/__tests__/columnMountGuard.test.ts` — new;
  25 assertions.
- `frontend/src/components/praxisCard/desktop/shared.tsx` — comment only.

`tsc --noEmit` clean, `typecheck:design-sync` clean, lint clean, `npm test`
325 files / 5665 passed, build clean, budget within (JS 126.6 KB, CSS 22.0 KB —
unchanged; this ships no CSS).

**Visual QA is outstanding** — I have no browser. The clipping itself was reasoned
from the flex algorithm, not observed.

## What to eyeball

1. **A WOW character's profile on a phone, Chronicles tab** — the only surface this
   PR changes. Cards should now be their own height (short ones short, long ones
   showing byline and vote row) instead of a column of identical 394px blocks. Check
   with a mix of praxis whose *tasks* belong to different factions, since the card
   archetype follows the task, and specifically with a WOW or Albescent one (those
   two clip rather than pad).
2. The **Quests** tab beside it, to confirm the task column's `alignItems: center`
   (#1964) is untouched.
3. Sanity-only, since no shared code changed: `/praxis` and `Home` at desktop and
   phone width, one task detail gallery, one faction page's "recently completed"
   with exactly one and exactly two entries, and the FieldDesk praxis tab.

Closes #2149
