### PR TITLE
The profile's Praxis/Tasks toggle stops printing white on cream: the inverted pill takes the page as its ink (#2107)

### DIFF
--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -883,6 +883,25 @@ function MobileProfile({
   )
 }
 
+/**
+ * One segment of the Praxis/Tasks toggle. The ON half INVERTS — it fills with
+ * the page's primary ink and prints the page itself, the same two lines every
+ * other inverted pill in the app carries (`.btn-primary`, `.chip-active`,
+ * `ScoreToggle`, `ProposeTaskLink`, the Field Desk's own browse switch).
+ *
+ * IT USED TO INK WITH `--color-text-on-accent` AND THAT WAS #2107. That neutral
+ * is `#ffffff` in `:root` alone and never flips, while `--color-text-primary`
+ * flips to a warm cream (`#f0e6d0`) in dark — so the dark pill was white on
+ * cream at **1.24:1**, the label all but gone, while light read a fine 18.51:1.
+ * `--color-bg-page` is the ground that neutral is measured against and flips
+ * with it: 16.86:1 light, 15.00:1 dark. Identical defect to the faction page's
+ * join button (#1819); the guard at the bottom of `factionContrast.test.ts` is
+ * what stops the third copy.
+ *
+ * The OFF half is unchanged and was never in question: `--color-text-secondary`
+ * over the rail's `--color-bg-surface-alt` composite is 7.31:1 / 7.21:1, the
+ * AAA pairing `factionContrast.test.ts` already gates as "app alt surface".
+ */
 function SegTab({ on, onClick, children }: { on: boolean; onClick: () => void; children: React.ReactNode }) {
   return (
     <button
@@ -895,7 +914,7 @@ function SegTab({ on, onClick, children }: { on: boolean; onClick: () => void; c
         fontWeight: on ? 700 : 400,
         letterSpacing: '0.08em',
         textTransform: 'uppercase',
-        color: on ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
+        color: on ? 'var(--color-bg-page)' : 'var(--color-text-secondary)',
         background: on ? 'var(--color-text-primary)' : 'transparent',
         border: 'none',
         borderRadius: 999,

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1459,6 +1459,30 @@ const ARCHETYPE_PAIRS: Pair[] = [
     },
   ]),
 
+  // ── THE SAME TWO NEUTRALS, THE OTHER WAY UP (#2107) ──────────────────────
+  //
+  // Every row above measures an ink ON the page. Nothing measured the page AS
+  // an ink, and ten shipped controls print it that way: `.btn-primary`,
+  // `.chip-active`, `.requests-queue__badge`, `.filter-factions__box[data-on]`,
+  // `.filter-factions__done`, `.filter-empty__action`, and inline in
+  // `FeedRowActions`, `ScoreToggle`, `ProposeTaskLink`, `DefaultTaskDetail`,
+  // the Field Desk's browse switch and the profile's segmented toggle. All of
+  // them fill with `--color-text-primary` and ink with `--color-bg-page` — the
+  // page's own pair, inverted, and so the one pairing that survives a repaint
+  // of EITHER token only if both move together.
+  //
+  // It is one row rather than eleven because there is one pairing: the surface
+  // is opaque in both cascades (#1a1209 / #f0e6d0) and no mount lays anything
+  // over the fill. 16.86:1 light, 15.00:1 dark. The wrong ink for this ground
+  // is `--color-text-on-accent`, which the source guard at the bottom of this
+  // file forbids; this row is what makes "take the page instead" a measurement
+  // rather than a claim in a comment.
+  {
+    what: "inverted pill, the page as ink",
+    surface: "--color-text-primary",
+    text: "--color-bg-page",
+  },
+
   // ── THE FEED ROW'S ACTOR NAME, on the four chassis #1252 left (#1341) ────
   //
   // `resolveFeedRowInk` defaults `actor` to `factionCssVar(slug)` — the raw

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -2428,3 +2428,48 @@ describe("UA's display-only vermilion stays on display type (#1766)", () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * The inverted pill's ink is the PAGE, never `--color-text-on-accent` (#2107).
+ *
+ * WHY THIS IS A SOURCE GUARD AND NOT A ROW. `--color-text-primary` is a
+ * statement about the page ground and nothing else; the moment a control FILLS
+ * with it, the ink it needs is the ground that neutral was measured against —
+ * `--color-bg-page`, which flips with the cascade exactly as the fill does
+ * (16.86:1 light, 15.00:1 dark). `--color-text-on-accent` is `#ffffff` in
+ * `:root` alone and never flips, so the same two lines read "near-black pill,
+ * white label" in light and WHITE ON CREAM in dark, at **1.24:1**.
+ *
+ * Part A can only ask "does this token clear on the surface its documentation
+ * names", and no documentation pairs those two — the pairing exists only at a
+ * call site. Part B (`e2e/contrast.spec.ts`) would see it rendered, but it is
+ * nightly-only and outside PR CI, and a player profile is not on its route
+ * walk. So the defect shipped twice: #1819 fixed the faction page's join
+ * button, and the profile's segmented Praxis/Tasks toggle — the same two lines,
+ * copied — survived to be reported by eye as #2107.
+ *
+ * A FILE-LEVEL INTERSECTION, deliberately. `ponytail:` the guard asks whether
+ * one file both fills with the primary neutral and inks with `-on-accent`,
+ * which is coarser than "in the same style object" and could false-positive on
+ * a file that legitimately does both to different elements. There is no such
+ * file today, and the coarse question needs no parser; if one appears, read the
+ * pairing and add it here with the reason. The precise version is a JSX/AST
+ * walk, which is a dependency this suite does not carry.
+ */
+describe("a --color-text-primary fill takes the page as its ink (#2107)", () => {
+  const FILL = /background[A-Za-z]*:[^;\n]*var\(--color-text-primary\)/;
+  const WRONG_INK = "var(--color-text-on-accent)";
+
+  it("no file inks the primary neutral's fill with the accent's white", () => {
+    const found = sourceFiles()
+      .filter((path) => {
+        const source = readStripped(path);
+        return FILL.test(source) && source.includes(WRONG_INK);
+      })
+      .map(toRelative);
+    expect(
+      found,
+      "`--color-text-on-accent` is #ffffff in BOTH themes and `--color-text-primary` flips to cream (#f0e6d0) in dark — the pair is 1.24:1 there (#1819, #2107). Ink a primary-neutral fill with `--color-bg-page`, the ground that neutral is measured against.",
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #2107

## The selector is not where the brief guessed, and the ink was the bug

The report is a symptom ("white text on a cream background"). The screenshot orders the tabs **PRAXIS · TASKS**; `FieldDesk.tsx`'s `BROWSE_TABS` is `['tasks', 'praxis']` and it already inks its active pill correctly. Following the label keys (`profile.mobile.tabPraxis` / `tabTasks`) lands on the real control:

`frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx` → `SegTab`, the segmented Praxis/Tasks toggle in the phone branch of the **unaffiliated player profile**.

```
color:      on ? 'var(--color-text-on-accent)' : 'var(--color-text-secondary)',
background: on ? 'var(--color-text-primary)'   : 'transparent',
```

`--color-text-on-accent` is `#ffffff` declared in `:root` **alone** — it never flips. `--color-text-primary` flips to a warm cream `#f0e6d0` in dark. So the active pill was **white on cream**.

This is a **pairing** defect, not a token defect: both tokens measure fine on the grounds their documentation names, and neither is wrong on its own. It is also the *second* copy — #1819 fixed the byte-identical two lines on the faction page's join button and quoted the same 1.24:1. The surviving twin is what got reported.

## Seam I tested at

The **call site**, not the token value — which is exactly why neither existing guard saw it:

- `frontend/src/utils/__tests__/factionContrast.test.ts` (Part A, in PR CI) measures a token against the surface its *documentation* names. Nothing documents `-on-accent` on the primary neutral, so no row of that manifest could ever have named this pairing.
- `frontend/e2e/contrast.spec.ts` (Part B) *does* catch pairings, but it is nightly-only, outside PR CI, and a player profile is not on its route walk.

So the failing test is a **source guard** in Part A, written first. It went red on exactly one file and no others:

```
AssertionError: expected [ Array(1) ] to deeply equal []
+ Array [ "pages/characterProfile/archetypes/DefaultProfileBody.tsx" ]
```

Then green after the one-token fix.

## Ratios, both cascades

Measured with `frontend/src/utils/contrast.ts`'s own maths.

| pairing | light | dark |
|---|---|---|
| **active tab, BEFORE** — `--color-text-on-accent` on `--color-text-primary` | 18.51:1 | **1.24:1 ✗** |
| **active tab, AFTER** — `--color-bg-page` on `--color-text-primary` | 16.86:1 | **15.00:1 ✓** |
| inactive tab (unchanged) — `--color-text-secondary` over the rail composite | 7.31:1 | 7.21:1 |

**The real ground was computed, not read naively.** The rail behind both tabs is `--color-bg-surface-alt`, which is `rgba(255,255,255,0.06)` in dark and has no ground of its own — composited over `--color-bg-page` `#13121a` it resolves to `rgb(33,32,40)`. That is the figure above; the inactive half was never in question and clears the AAA floor Part A already gates it at (`app alt surface, secondary ink`). The **active** pill's ground is `--color-text-primary`, opaque in both cascades, so no compositing applies there.

## Extent — every skin, not the one in the screenshot

`--color-text-primary` used as a **fill** appears at 16 shipped sites. Fifteen already ink with `--color-bg-page`: `.btn-primary`, `.chip-active`, `.requests-queue__badge`, `.filter-factions__box[data-on]`, `.filter-factions__done`, `.filter-empty__action` in `index.css`, and inline in `FeedRowActions`, `ScoreToggle`, `ProposeTaskLink`, `DefaultTaskDetail`, `DefaultFieldDesk`, `CreateCharacter`, `DefaultCreateCharacter`, `DefaultEditCharacter` and the Field Desk browse switch. `SegTab` was the **lone outlier in the repo**, and the guard now proves that.

Every faction skin was checked rather than assumed:

- All eight faction slugs declare their own `profileBody`, so `DefaultProfileBody` serves **na / unaffiliated** — which is the skin in the screenshot.
- The only other consumer of these two labels is `WowProfileBody`'s own `SegTab`. It is **sound and untouched**: `--faction-wow-quest-text` `#2a1d02` on the quest gradient stops `#f5d583` / `#ce9a2a` measures **11.55:1 / 6.49:1**, and all three tokens are theme-invariant, so the pair moves together.
- No field-desk archetype carries a Praxis/Tasks selector at all.

**No Ephemerists file is touched** — the fix is one line in the na skin, so epic #2140 is unaffected. **`CovenFieldDesk.tsx` is untouched**; `.coven-candle-backdrop` is not in the diff.

## The guards added

1. **A source guard** (`a --color-text-primary fill takes the page as its ink (#2107)`) — no file may both fill with `--color-text-primary` and ink with `--color-text-on-accent`. This is the one that would have caught #1819 *and* #2107. It uses the existing `test/sourceScan` harness, so it is a predicate and not a ninth copy of a directory walk. A `ponytail:` comment names the ceiling: it is a file-level intersection rather than a same-style-object one, which needs no parser and has zero false positives today; the precise version is an AST walk this suite carries no dependency for.

2. **A value row** — `inverted pill, the page as ink`: `--color-bg-page` on `--color-text-primary`, gated in both themes. Every existing row measures an ink *on* the page; nothing measured the page *as* an ink, though sixteen controls print it that way. This makes "take the page instead" a measurement rather than a claim in a comment, and it fills a real hole: a repaint of either neutral alone would have moved all sixteen unmeasured.

`index.css` is **not touched** — the tokens were already right; only the call site named the wrong one.

## Byte budget

`node scripts/bundle-budget.mjs`, gzip level 9, measured against a build of `origin/main`'s `DefaultProfileBody` in the same tree:

```
  ok   JS     126.6 KB   warn>130.9 KB  fail>175.8 KB  target 117.2 KB
  ok   CSS     22.0 KB   warn>22.2 KB  fail>24.4 KB  target 19.5 KB
```

**Delta: 0 B on both.** `index.css` is unchanged, so the blocking sheet cannot move; the JS change is one shorter token string plus comments the minifier drops.

## CI run locally

Every step named in `.github/workflows/test.yml`'s `frontend` job:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **324 files, 5643 passed**, 1 skipped
- `npm run build` — clean
- `npm run budget` — within budget (above)

`test` and `api-schema` are untouched: no backend file, route signature or Pydantic schema is in the diff.

## One thing left standing on purpose

`frontend/e2e/contrastBaseline.ts:118` carries `"dark | rgb(255, 255, 255) on rgb(240, 230, 208) @4.5"` at ratio **1.24** — literally white on `--color-text-primary`'s dark cream, i.e. this exact colour pair. I have **not** deleted it. That file's own doctrine is that entries are machine-produced by the sweep and keyed on the colour pair rather than the DOM node, its breadcrumb points at a #651-era DOM that no longer exists, and the nightly sweep does not walk a player profile — so I cannot prove from here that no other rendered node still produces that pair. Deleting it by hand would risk reddening the nightly on no evidence. **Flagging it as a candidate for the next baseline regeneration.**

## Visual QA is outstanding

No browser and no dev stack here — everything above is tests, `tsc`, eslint and arithmetic. Nothing in this PR has been seen rendered.

## What to eyeball

The segmented **Praxis / Tasks** toggle on an **unaffiliated (na) player profile, phone width** — `/characters/<username>` for a character with no faction:

- [ ] **Praxis selected, light** — dark pill, cream label, legible
- [ ] **Praxis selected, dark** — cream pill, **dark** label (this is the fix; it was white-on-cream)
- [ ] **Tasks selected, light** — the inversion follows the tab
- [ ] **Tasks selected, dark** — same
- [ ] the **inactive** half in both themes — unchanged, but confirm it still reads against the rail
- [ ] **WOW's** profile toggle, both themes — untouched, confirm no drift
- [ ] an **albescent** profile, both themes — it also falls through to this skin

🤖 Generated with [Claude Code](https://claude.com/claude-code)
