### PR TITLE
A proposer can see their own proposal: the pending gate exempts the author, at every door (#2126)

### DIFF
--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -72,7 +72,14 @@ async def list_tasks(
     # that echoed their own character id back made the page fetch twice — once
     # before /auth/me settled and once after. An explicit value still wins;
     # anonymous callers get None, which excludes nothing.
-    if exclude_character_id is None and viewer is not None:
+    #
+    # `created_by` is the one read that is not a browse (#2126): it asks "what
+    # did this character propose", and the answer cannot depend on which of
+    # those tasks the *reader* happens to be working. Defaulting it here dropped
+    # a proposer's own accepted-and-started task off their own profile, and
+    # dropped rows off a stranger's profile according to the visitor's praxis
+    # bank. An explicit value still wins, on every route.
+    if exclude_character_id is None and viewer is not None and created_by is None:
         exclude_character_id = viewer.id
     tasks = await service_list_tasks(
         session,

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -489,7 +489,10 @@ def viewer_sees_pending_tasks(
 
 
 def pending_visibility_clause(
-    viewer_level: int, is_admin: bool, era: EraConfig = CURRENT_ERA
+    viewer_level: int,
+    is_admin: bool,
+    era: EraConfig = CURRENT_ERA,
+    viewer_id: Optional[int] = None,
 ):
     """The whole pending rule as one WHERE clause: the level AND the window.
 
@@ -515,6 +518,11 @@ def pending_visibility_clause(
     (:func:`services.admin_service.update_task_status`), so on that path the "no
     admin has looked yet" premise this window protects is already false.
 
+    ``viewer_id`` is the reading character's id, or ``None`` for an anonymous
+    caller, and exempts the rows that character *wrote* (#2126). Pass it at every
+    door: a carve-out one caller states and another forgets is how the profile
+    and the browse came to disagree about the same row in the first place.
+
     ponytail: if a NON-admin path ever sends a task back to ``pending``,
     ``created_at`` stops being the proposal clock and this wants a dedicated
     ``pending_since`` column stamped on every transition into the status.
@@ -523,14 +531,23 @@ def pending_visibility_clause(
         # Exempt, not merely early: the window exists to give admins the first
         # look, so holding it against them defeats the feature.
         return true()
+    # The author is exempt for the same reason (#2126): the window withholds a
+    # proposal from *other players* — which is what the propose-success screen
+    # promises in so many words — and its author is not one of them. They wrote
+    # the row and were just told it is under review, so there is nothing left to
+    # withhold, and hiding it made "Proposed tasks" answer "none" to the one
+    # person who knows better. This is a per-ROW carve-out, not a level, so it
+    # rides in the clause with the window rather than becoming another boolean.
+    own = false() if viewer_id is None else Task.created_by == viewer_id
     if viewer_sees_pending_tasks(viewer_level, is_admin, era):
         return or_(
             Task.status != TaskStatus.pending,
             Task.created_at
             <= datetime.now(timezone.utc)
             - timedelta(hours=era.pending_task_admin_review_hours),
+            own,
         )
-    return Task.status != TaskStatus.pending
+    return or_(Task.status != TaskStatus.pending, own)
 
 
 async def get_task_for_viewer(
@@ -568,7 +585,9 @@ async def get_task_for_viewer(
     visible = await session.scalar(
         select(Task.id).where(
             Task.id == task_id,
-            pending_visibility_clause(viewer_level, is_admin, era),
+            pending_visibility_clause(
+                viewer_level, is_admin, era, viewer_id=viewer.id if viewer else None
+            ),
         )
     )
     return task if visible is not None else None
@@ -717,7 +736,11 @@ async def list_tasks(
     # is not a gate — and the redundant `status == "all"` restatement of the
     # level rule is gone because this clause subsumes it. `get_task_for_viewer`
     # passes the same clause for the same reason (#1725).
-    query = query.where(pending_visibility_clause(viewer_level, is_admin, era))
+    query = query.where(
+        pending_visibility_clause(
+            viewer_level, is_admin, era, viewer_id=viewer.id if viewer else None
+        )
+    )
 
     if status and status != "all":
         try:
@@ -744,7 +767,17 @@ async def list_tasks(
             # task anywhere on the site. This surface is one character's own
             # proposals, reached by knowing their id, and hiding a proposer's
             # accepted work from newcomers reads as a bug rather than a reward.
-            query = query.where(Task.status != TaskStatus.pending)
+            #
+            # "All viewers" was one viewer too many (#2126): on your OWN profile
+            # this clause hid the proposal you had just written, so the section
+            # headed "Proposed tasks" said "No proposed tasks yet" and no amount
+            # of waiting fixed it — unlike the review window, this one never
+            # expired. Skipping it for the owner does not widen what anyone ELSE
+            # sees here; the shared pending clause above is still the only thing
+            # that decides whether a pending row is reachable at all, and it
+            # exempts the same author for the same reason.
+            if viewer is None or viewer.id != created_by:
+                query = query.where(Task.status != TaskStatus.pending)
         else:
             query = query.where(Task.status == TaskStatus.active)
     else:

--- a/backend/tests/integration/test_task_visibility_gates.py
+++ b/backend/tests/integration/test_task_visibility_gates.py
@@ -336,3 +336,103 @@ async def test_the_detail_door_opens_for_an_admin_immediately(
     response = await client.get(f"/tasks/{fresh.id}", headers=auth_headers)
     assert response.status_code == 200, response.text
     assert response.json()["id"] == fresh.id
+
+
+# ---------------------------------------------------------------------------
+# The author's own proposals (#2126)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_proposer_sees_their_own_proposal_the_moment_they_write_it(
+    client: AsyncClient,
+    character: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+    db_session: AsyncSession,
+):
+    """#2126 — "No proposed tasks yet" said to the one person who knows better.
+
+    TWO gates hid a proposal from its own author. The #1695 window withheld it
+    for its first `pending_task_admin_review_hours`, and the proposer's-profile
+    branch of `list_tasks` withheld pending from *every* viewer for good — so
+    the profile section headed "Proposed tasks" answered "none", and unlike the
+    window, waiting never fixed that one.
+
+    The propose-success screen already promises the narrower rule in so many
+    words: only admins see it at first, "other players see it after that". The
+    author is not one of the other players.
+
+    Asserted against the FRESH row at BOTH doors: a carve-out that only reaches
+    the ripe rows is the same bug with a 48-hour delay on it.
+    """
+    await _set_level_and_faction(
+        db_session, character, era, CURRENT_ERA.level_to_propose_task, "ua"
+    )
+    fresh = await _gated_task(db_session, character, TaskStatus.pending, FRESH_AGE)
+
+    mine = await _ids(client, f"/tasks?created_by={character.id}", auth_headers)
+    assert fresh.id in mine
+
+    detail = await client.get(f"/tasks/{fresh.id}", headers=auth_headers)
+    assert detail.status_code == 200, detail.text
+    assert detail.json()["id"] == fresh.id
+
+
+@pytest.mark.asyncio
+async def test_the_carve_out_is_authorship_and_not_a_hole_in_the_window(
+    client: AsyncClient,
+    character: Character,
+    character2: Character,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers2: dict,
+    db_session: AsyncSession,
+):
+    """What #2126 must NOT widen: somebody else's profile.
+
+    `character2` reads `character`'s profile at the level that opens the review
+    queue. One row is inside the window and one is past it, and BOTH stay off a
+    profile that is not the reader's own — the proposer's-profile branch still
+    withholds other people's pending rows exactly as it did before. The
+    exemption is per-ROW authorship, so it can only ever reach rows the reader
+    wrote.
+    """
+    await _set_level_and_faction(
+        db_session, character2, era, CURRENT_ERA.level_to_see_pending_tasks, "ua"
+    )
+    fresh = await _gated_task(db_session, character, TaskStatus.pending, FRESH_AGE)
+    ripe = await _gated_task(db_session, character, TaskStatus.pending, RIPE_AGE)
+
+    theirs = await _ids(client, f"/tasks?created_by={character.id}", auth_headers2)
+    assert fresh.id not in theirs
+    assert ripe.id not in theirs
+
+    # The detail door keeps the window against a row you did not write, and the
+    # anonymous web is still below every gate.
+    other = await client.get(f"/tasks/{fresh.id}", headers=auth_headers2)
+    assert other.status_code == 404
+    assert (await client.get(f"/tasks/{fresh.id}")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_profile_keeps_a_proposal_its_author_is_also_working(
+    client: AsyncClient,
+    character: Character,
+    active_task: Task,
+    praxis_solo,
+    auth_headers: dict,
+):
+    """The browse's exclusion is not a fact about authorship (#2126).
+
+    `GET /tasks` defaults `exclude_character_id` to the reader (#1229) so the
+    browse hides what they have already started. `created_by` is not a browse:
+    it asks what a character PROPOSED, and the answer cannot depend on which of
+    those tasks the *reader* happens to be working. `active_task` is authored by
+    `character` and carries their praxis, so it dropped off their own profile
+    the moment they started it — and off a stranger's profile according to
+    whatever the visitor had in their own praxis bank.
+    """
+    mine = await _ids(client, f"/tasks?created_by={character.id}", auth_headers)
+    assert active_task.id in mine


### PR DESCRIPTION
## Root cause

A proposal is written `pending`, and **nothing in the read path exempts its own author** — so the one person guaranteed to know the task exists was the only one the site refused to show it to. Two gates stacked: `pending_visibility_clause` withholds a pending row for its first `era.pending_task_admin_review_hours` (48h), and the proposer's-profile branch of `list_tasks` withheld pending from *every* viewer permanently. The profile section headed "Proposed tasks" therefore answered "No proposed tasks yet" to the author, and unlike the review window, waiting never cleared it.

The shipped copy is the spec, and the code disagreed with it. `proposeTask.successTask.body` already promises the narrower rule in so many words: *"Only admins can see it for its first {{hours}} hours; **other players** see it after that."* The author is not one of the other players. So this is a defect against stated intent, not a product call about which statuses belong in the list — the status set every *other* viewer sees is unchanged.

A second, independent defect sits on the same query: `GET /tasks` defaults `exclude_character_id` to the reader (#1229) so the browse can hide what they have already started. `created_by` is not a browse — it asks what a character *proposed* — so that default silently filtered a profile's proposal list by the **reader's** praxis bank. An author's own proposal vanished off their profile the moment they started working it, and a visitor's profile view was narrowed by whatever the *visitor* happened to be doing.

## Seam

`GET /tasks?created_by=<id>` and `GET /tasks/{id}` — the HTTP doors the profile actually calls, in `backend/tests/integration/test_task_visibility_gates.py` (the existing pending-gate suite). Asserted against the **fresh** row at both doors: a carve-out that only reaches the ripe rows is the same bug with a 48-hour delay on it. Both new tests fail on `origin/main` (`assert 30 in set()`) and pass after.

## The fix

Once, at the shared site. `pending_visibility_clause` is the single authority on pending visibility and is already applied at every door; it gains a `viewer_id` author exemption alongside the existing admin one, so the browse, the `status=pending` tab and the detail read all agree without restating the rule. `list_tasks`' profile branch then skips its own extra `!= pending` only when the reader is the profile's owner.

`grep`ed every caller: `service_list_tasks` has exactly one (`routers/tasks.py`), and `pending_visibility_clause` has two (`list_tasks`, `get_task_for_viewer`) — both now pass `viewer_id`.

**Deliberately not widened.** Other people's pending rows still stay off a profile exactly as before, including the ripe ones a level-3 reader can see on the `/tasks` pending tab. `test_the_carve_out_is_authorship_and_not_a_hole_in_the_window` pins that, and it passes both before and after this change. The exemption is per-row authorship against the authenticated character id, so it can only ever reach rows the reader wrote; anonymous callers get `false()` and are unaffected.

## On #2025 — checked, and it is NOT the same cause

I traced it before touching anything. #2025's eligibility default lives in `frontend/src/pages/tasks/useTasks.ts` and applies only to the `/tasks` board; the backend route default is `can_sign_up: bool = False`, and `CharacterProfile.tsx` calls `listTasks({ created_by: cid })` with no eligibility filter at all. The two never meet. **#2025 is not closable by this change** and still needs its own ruling. (I also ruled out the array-param shape — `created_by` is a scalar and arrives fine.)

## Verification

- Full backend suite: **1456 passed**, coverage 94.05% (gate is 80%), on a dedicated `wz2126_test` DB.
- `api-schema`: regenerated `backend/openapi.json` — **byte-identical**, no route signature, `response_model` or Pydantic schema was touched, so `schema.d.ts` is untouched too.
- Zero frontend files in the diff, so the frontend jobs see main's state.
- **Visual QA is outstanding** — I have no browser or dev stack here.

## What to eyeball

- Propose a task, then open your own profile: the proposal should now appear under "Proposed tasks" immediately, and the count in the eyebrow should agree.
- The card renders through the shared `TaskCard` with **no pending marker for a non-admin** — a pending row looks like any other task, minus its signup CTA (`can_sign_up` is false, so `signupAffordance` returns null). Deliberately not changed: a status pill would touch all ten faction card skins and is a design decision, not a bug fix. Worth a look at whether the author needs an "in review" cue.
- Someone *else's* profile should look exactly as it does today — no pending rows, at any level.
- A task you proposed **and** are working on should now stay on your profile (it used to disappear); confirm the `/tasks` browse still hides your in-progress tasks as before.
- Adjacent gap, not fixed here: the profile query sends no `task_type`, so it is standard-only — a **metatask** proposal never appears under "Proposed tasks" either. Out of scope for this report (the reporter is level 3; metatasks need level 5) and it is a product question about what that list is for.

Closes #2126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
