### PR TITLE
A duel shows two faces: the rival's portrait on the card, both sides in the composer (#2128)

### DIFF
--- a/frontend/src/components/collab/RosterAvatar.tsx
+++ b/frontend/src/components/collab/RosterAvatar.tsx
@@ -12,7 +12,15 @@
  * muted ink otherwise, dashed while an invite is unanswered); the duel side
  * paints the SIDE's faction, never the page's. One component cannot know which,
  * and guessing is what would have made it a third idiom instead of a shared one.
+ *
+ * THE MONOGRAM IS THE FALLBACK, NOT THE DEFAULT (#2128). Pass `avatarUrl` and
+ * the circle wears the face; the monogram is what an absent portrait falls back
+ * to. Both duel surfaces route through here, so the rule is written once —
+ * `avatarUrl` answers only WHAT to draw, never WHETHER there is a person to
+ * draw, which is why it is optional and an empty string is a portrait-less
+ * person rather than no person at all.
  */
+import { mediaUrl } from '../../utils/media'
 import { rosterInitials } from './rosterRows'
 
 export function RosterAvatar({
@@ -22,6 +30,7 @@ export function RosterAvatar({
   borderColor,
   dashed = false,
   color,
+  avatarUrl,
 }: {
   /** Display name; the monogram is derived, never passed in. */
   name: string
@@ -32,7 +41,29 @@ export function RosterAvatar({
   /** An unanswered invite is drawn as a dashed outline, like its status pill. */
   dashed?: boolean
   color?: string
+  /** The person's portrait. Empty/absent falls back to the monogram. */
+  avatarUrl?: string | null
 }) {
+  if (avatarUrl) {
+    return (
+      <img
+        aria-hidden="true"
+        alt=""
+        src={mediaUrl(avatarUrl)}
+        style={{
+          width: size,
+          height: size,
+          borderRadius: '50%',
+          flexShrink: 0,
+          objectFit: 'cover',
+          // The ring is the caller's state read (faction, done, unanswered), so
+          // the portrait keeps wearing it exactly as the monogram did.
+          border: `1px ${dashed ? 'dashed' : 'solid'} ${borderColor}`,
+          boxSizing: 'border-box',
+        }}
+      />
+    )
+  }
   return (
     <span
       aria-hidden="true"

--- a/frontend/src/components/praxisCard/__tests__/duelBanner.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/duelBanner.test.tsx
@@ -28,7 +28,7 @@ function praxis(overrides: Partial<PraxisCardOut>): PraxisCardOut {
 function render(p: PraxisCardOut): string {
   return renderToStaticMarkup(
     <MemoryRouter>
-      <PraxisDuelBanner praxis={p} accent="#123456" paper="#ffffff" />
+      <PraxisDuelBanner praxis={p} accent="#123456" />
     </MemoryRouter>,
   )
 }
@@ -76,5 +76,50 @@ describe('duel banner', () => {
     )
     expect(text(html)).toContain('Rax Vandal')
     expect(html).not.toContain('href=')
+  })
+})
+
+/**
+ * #2128 — the banner drew a monogram where the rival's face belongs.
+ *
+ * `opponent_avatar_url` (#2172) joined the three fields that "ALL ARRIVE
+ * TOGETHER OR NOT AT ALL", but it is NOT one of them: it is non-nullable and
+ * defaults to `""`. It answers WHAT to draw and never WHETHER to draw, so the
+ * gate above stays on `opponent_display_name` — the last case below is the one
+ * that would break if a future edit folded the portrait into that gate.
+ */
+describe('duel banner — the rival wears their face', () => {
+  const rival = {
+    duel_id: 7,
+    opponent_display_name: 'Rax Vandal',
+    opponent_praxis_id: 42,
+    opponent_faction_slug: 'snide',
+  }
+
+  it("draws the rival's portrait when the wire carries one", () => {
+    const html = render(praxis({ ...rival, opponent_avatar_url: 'avatars/rax.png' }))
+    expect(html).toContain('<img')
+    expect(html).toContain('avatars/rax.png')
+  })
+
+  it('falls back to the monogram for a rival with no portrait', () => {
+    const html = render(praxis({ ...rival, opponent_avatar_url: '' }))
+    expect(html).not.toContain('<img')
+    expect(text(html)).toContain('Rax Vandal')
+  })
+
+  it('still draws the banner during the pending window, portrait or not', () => {
+    // A duel accepted but not yet cast: no `opponent_praxis_id`, no portrait.
+    // Neither absence is "no rival" — the NAME is, and it is here.
+    const html = render(
+      praxis({
+        duel_id: 7,
+        opponent_display_name: 'Rax Vandal',
+        opponent_praxis_id: null,
+        opponent_avatar_url: '',
+      }),
+    )
+    expect(text(html)).toContain('Rax Vandal')
+    expect(text(html)).toContain('vs.')
   })
 })

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -217,7 +217,7 @@ export function PraxisBody({
        * siblings rather than behind a ternary that would have to re-derive the
        * duel test the banner already owns.
        */}
-      <PraxisDuelBanner praxis={praxis} accent={tint} paper={paper} fonts={fonts} />
+      <PraxisDuelBanner praxis={praxis} accent={tint} fonts={fonts} />
       <PraxisRoster praxis={praxis} accent={tint} paper={paper} />
       {/* Every card shows the media slot — a drop target when empty (#821). */}
       <PraxisMediaGallery

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -220,7 +220,7 @@ export function PraxisTaskLink({
 }
 
 /**
- * The praxis author as the shared avatar surface wants them (#888).
+ * A face on this card as the shared avatar surface wants them (#888).
  *
  * `FactionAvatar` reads only username / avatar_url / faction_slug off a
  * `CharacterOut`; a card payload carries those three under different names, so
@@ -230,17 +230,25 @@ export function PraxisTaskLink({
  *
  * `display_name` stands in for `username` deliberately: it is what the byline
  * shows, so it is what the monogram initial and the img alt should follow.
+ *
+ * `id` is padded with 0 for the rival (#2128): the card payload carries no
+ * character id for them, and no avatar skin reads it — the field is `CharacterOut`
+ * shape, not data this surface has or needs.
  */
-function authorAsCharacter(praxis: PraxisCardOut): CharacterOut {
-  const name = praxis.created_by_display_name || `#${praxis.created_by_id}`;
+function faceAsCharacter(face: {
+  id: number;
+  name: string;
+  avatarUrl: string | null | undefined;
+  factionSlug: string | null | undefined;
+}): CharacterOut {
   return {
-    id: praxis.created_by_id,
-    username: name,
-    display_name: name,
-    avatar_url: praxis.created_by_avatar_url || "",
+    id: face.id,
+    username: face.name,
+    display_name: face.name,
+    avatar_url: face.avatarUrl || "",
     // Unaffiliated is a slug, not a missing one (ADR-0030), and `CharacterOut`
     // says so now that it IS the generated type (#1400).
-    faction_slug: praxis.created_by_faction_slug ?? "na",
+    faction_slug: face.factionSlug ?? "na",
     bio: "",
     tagline: "",
     location: "",
@@ -252,6 +260,15 @@ function authorAsCharacter(praxis: PraxisCardOut): CharacterOut {
     badges: [],
     invitations: [],
   };
+}
+
+function authorAsCharacter(praxis: PraxisCardOut): CharacterOut {
+  return faceAsCharacter({
+    id: praxis.created_by_id,
+    name: praxis.created_by_display_name || `#${praxis.created_by_id}`,
+    avatarUrl: praxis.created_by_avatar_url,
+    factionSlug: praxis.created_by_faction_slug,
+  });
 }
 
 /**
@@ -570,11 +587,26 @@ export function PraxisRoster({
  *
  * ONE SHARED SLOT, NOT NINE TREATMENTS (owner ruling, 2026-08-01). It sits in
  * the composition where {@link PraxisRoster} sits and is themed the same way —
- * the frame's own `accent`/`paper` for the avatar, `factionCssVar` off
- * `task_faction_slug` for the ink — so a faction gets its duel banner from the
- * archetype it already passes, with no per-archetype edit. The Snide mock in
- * #596 was reference for tone; it also assumed the rival was findable in
- * `members`, which the schema never supported.
+ * `factionCssVar` off `task_faction_slug` for the ink — so a faction gets its
+ * duel banner from the archetype it already passes, with no per-archetype edit.
+ * The Snide mock in #596 was reference for tone; it also assumed the rival was
+ * findable in `members`, which the schema never supported.
+ *
+ * THE RIVAL'S FACE IS `FactionAvatar`, NOT THE ROSTER DISC (#2128). It was the
+ * accent-ringed monogram, which meant this card drew its two people two ways:
+ * the byline eight inches above already renders its author through the shared
+ * avatar surface, and a rival in a different idiom read as a different KIND of
+ * thing. `FactionAvatar` brings the faction skin and the membership sigil with
+ * it, and here that is the point rather than a cost — a duel is the one surface
+ * two factions share, the wire carries `opponent_faction_slug` for exactly this,
+ * and both composer duel surfaces already paint each side in its OWN faction.
+ * (The praxis-detail byline in #2106 declined the same dress; it draws one
+ * person inside a bespoke kit frame, where a second faction's colours would be
+ * noise. Different question, different answer.)
+ *
+ * `opponent_avatar_url` is `""` for a rival with no portrait, and the shared
+ * surface's own fallback (monogram, else spectrum ring) takes it from there —
+ * no second fallback rule is written here.
  *
  * NO NEW TOKEN IS MINTED (ADR-0061). The "vs." mark reads in `card-notice`, the
  * sheet's cautionary ink — the same ink the duel mode chip directly above it
@@ -592,12 +624,10 @@ export function PraxisRoster({
 export function PraxisDuelBanner({
   praxis,
   accent,
-  paper,
   fonts,
 }: {
   praxis: PraxisCardOut;
   accent: string;
-  paper?: string;
   fonts?: PraxisCardFonts;
 }) {
   const { t } = useTranslation("praxis");
@@ -634,7 +664,17 @@ export function PraxisDuelBanner({
       >
         {t("duelBanner.versus")}
       </span>
-      <RosterAvatar name={name} accent={accent} paper={paper} />
+      <FactionAvatar
+        character={faceAsCharacter({
+          id: 0,
+          name,
+          avatarUrl: praxis.opponent_avatar_url,
+          factionSlug: praxis.opponent_faction_slug,
+        })}
+        // The diameter the accent-ringed disc drew at, said in the shared
+        // surface's own size vocabulary rather than as a fresh number.
+        size="sm"
+      />
       <span style={{ fontSize: "var(--text-content)", minWidth: 0 }}>
         {praxis.opponent_praxis_id != null ? (
           <Link

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/InviteSearch.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/InviteSearch.test.tsx
@@ -147,6 +147,27 @@ describe("InviteSearch — the compose-stage duel pair (#1417)", () => {
 });
 
 /**
+ * #2128 — a duel drew two monograms where two faces belong.
+ *
+ * `DuelSideOut.avatar_url` has been on the wire the whole time; the pair simply
+ * never read it. Both sides render in ONE pass because the rule is per-side, not
+ * per-surface: the side with a portrait gets the portrait, and the side without
+ * one keeps the monogram it always had rather than falling to a blank disc.
+ */
+describe("InviteSearch — the duel pair draws faces, not initials (#2128)", () => {
+  it("draws the portrait for the side that has one, the monogram for the side that does not", () => {
+    const state = duelState(1, { status: "pending" });
+    state.duel!.opponent.avatar_url = "avatars/rax.png";
+    const html = chipHtml(state);
+    expect(html).toContain("avatars/rax.png");
+    expect(html).toContain("<img");
+    // The challenger's `avatar_url` is still "", so their circle keeps its
+    // monogram: an absent portrait is not an absent side.
+    expect(html).toContain(">CN<");
+  });
+});
+
+/**
  * #1274 — the composer's collab block for a crew of ONE.
  *
  * Two facts have to survive together on this surface, which is why they are

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -71,8 +71,12 @@ export interface InviteSearchSkin {
  *
  * The circle is `RosterAvatar` at 52 rather than a third avatar idiom, and it
  * takes the SIDE's own faction — a duel is the one surface two factions share,
- * and the monogram is who is speaking. That is the same call the waiting
+ * and the face is who is speaking. That is the same call the waiting
  * surface's `SideAvatar` makes at 28.
+ *
+ * It draws the side's PORTRAIT and falls back to the monogram (#2128): this is
+ * the surface the report screenshotted, two initials where two faces belong.
+ * `DuelSideOut.avatar_url` was already on the wire; the pair just never read it.
  *
  * The filing word is `duelPill*`, the pair the waiting surface already speaks:
  * one fact, one wording. The design labelled these "Submitted" / "Not yet
@@ -96,6 +100,7 @@ function DuelPairSide({
     <div className="flex flex-col items-center gap-1" style={{ minWidth: 0 }}>
       <RosterAvatar
         name={side.display_name}
+        avatarUrl={side.avatar_url}
         size={DUEL_PAIR_AVATAR_SIZE}
         background={factionCssVar(side.faction_slug, "light")}
         borderColor={factionCssVar(side.faction_slug, "border")}

--- a/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
+++ b/frontend/src/pages/editPraxis/waiting/PraxisWaitingSurface.tsx
@@ -284,6 +284,9 @@ function SideAvatar({ side }: { side: DuelSideOut }) {
   return (
     <RosterAvatar
       name={side.display_name}
+      // The portrait, with the monogram as the fallback (#2128) — the same read
+      // the composer's duel pair makes at 52, through the same leaf.
+      avatarUrl={side.avatar_url}
       size={28}
       // The SIDE's own faction, never the page's: a duel is the one place two
       // factions share a surface, and the avatar is who is speaking.


### PR DESCRIPTION
Closes #2128

A duel drew initials where two faces belong. Owner ruling: yes, avatars — the monogram becomes the **fallback**, not the default.

## The seam I tested at

**The duel avatar disc** — every place a duel side or a duel rival is drawn as a circle. I wrote the failing test at each of the two components that own one, and both went red on the real defect before anything was fixed.

## The screenshot is NOT the praxis card

Worth stating plainly, because the brief pointed only at `components/praxisCard/*`. The image on #2128 is the **composer's** duel pair — `DuelPair` / `DuelPairSide` in `pages/editPraxis/archetypes/controls.tsx`: "HOW IT WAS DONE / SOLO · COLLAB · DUEL", "OPPONENT", the dashed "Challenge sent" pill, two 52px circles facing across a `vs`, "you · still writing". The two-letter monograms (`HE`, `PI`) are `rosterInitials`, which only `collab/RosterAvatar` draws; the praxis card's own disc draws ONE letter. So the reported surface is the composer, and fixing only the praxis card would have closed this issue without fixing what was reported.

Grepping the symptom rather than the file gave four sites, of which three needed work:

| site | before | after |
|---|---|---|
| `editPraxis/archetypes/controls.tsx` `DuelPairSide` (52px) — **the screenshot** | monogram | portrait, else monogram |
| `editPraxis/waiting/PraxisWaitingSurface.tsx` `SideAvatar` (28px) | monogram | portrait, else monogram |
| `praxisCard/shared.tsx` `PraxisDuelBanner` (24px) | accent-ringed one-letter disc | `FactionAvatar` |
| `praxisDetail/DuelCard.tsx` `SideAvatar` | already draws the portrait | untouched |

## Fixed once, where they route through

The first two are the same read at two sizes — both files' own comments already say so ("that is the same call the waiting surface's `SideAvatar` makes at 28"). So the rule is written **once, in the leaf**: `collab/RosterAvatar` gains an optional `avatarUrl`, draws `mediaUrl(avatarUrl)` when it is truthy and falls through to the monogram when it is not. The caller's ring — faction, done, unanswered-dashed — still wraps the portrait exactly as it wrapped the monogram. Optional and additive: `CollabRoster` and the invite dropdown pass nothing and are unchanged.

## The gate is untouched

`opponent_avatar_url` (#2172) answers **what to draw**, never **whether to draw**. `PraxisDuelBanner` still gates on `opponent_display_name` alone — not on `opponent_praxis_id` (NULL through the whole `pending` window) and not on the portrait (`""` for a rival with no face is a portrait-less rival, not the absence of a rival). Two of the three new banner tests exist to pin exactly that, and both were green before the fix — they are there to catch a future edit that folds the portrait into the gate.

## Why the duel banner takes the faction dress and #2106 did not

`FactionAvatar` brings the per-faction avatar skin **and** the membership sigil corner badge. The sibling agent on #2106 judged that wrong for the praxis-detail byline, and I think they are right there: that byline draws one person inside a bespoke kit frame, where a second faction's colours are noise.

The duel banner is the opposite case, and I reached it independently:

- **The card already draws its author that way.** `PraxisByline`, a few rows up in the same card, renders through `FactionAvatar` + `authorAsCharacter`. Leaving the rival on a bespoke ring meant one card drawing its two people in two idioms, so the rival read as a different *kind* of thing rather than as the other person.
- **A duel is the one surface where two factions are the story.** `opponent_faction_slug` is on the wire for precisely this, and both composer duel surfaces already paint each side in its OWN faction ("a duel is the one place two factions share a surface, and the avatar is who is speaking").
- **No second fallback rule.** `FactionAvatar` already does portrait → monogram → spectrum ring. The banner hands it the four fields and stops.

`authorAsCharacter` is split into a shared `faceAsCharacter({id, name, avatarUrl, factionSlug})` so the rival is padded the same way the author is, in one place. Size is `"sm"` = 24px, the diameter the old disc drew at, said in `FactionAvatar`'s own size vocabulary rather than as a fresh number. WOW's rank pill has a 64px floor, so no skin prints a "level 0" from the padded record at this size. The now-unused `paper` prop is dropped from the banner's signature.

## Both sides of the banner

The praxis card's banner names only the rival — the viewer's own side is the byline, which already had its face. In the composer and the waiting surface both sides are drawn, and both now read `side.avatar_url`, so `you` and the rival get identical treatment. The `InviteSearch` test renders both in one pass: rival with a portrait, viewer without, and asserts the `<img>` for one and the `CN` monogram for the other.

## Verification

`npm run lint` · `npm run typecheck` · `npm run typecheck:design-sync` · `npm test` (326 files, 5706 passing) · `npm run build` · `npm run budget` — all green locally on the rebased branch. No backend, schema or `response_model` touched, so `api-schema` has nothing to regenerate. Byte budget unmoved (JS 126.6 KB, CSS 22.0 KB — CSS untouched, no new class or token).

**No visual QA has been done** — I have no browser and no dev stack. Everything below is unverified by eye.

## What to eyeball

- A duel at **`pending`** — challenge sent, not yet accepted. Composer: the pair draws, "Challenge sent" dashed, both circles. Praxis card: the banner is still SILENT (no `opponent_display_name` yet) — the mode chip alone, unchanged.
- A duel at **`active`** and at **`settled`** — the praxis card banner now draws a face; the waiting surface's 28px discs draw faces.
- A rival **WITH** a portrait — the image fills the circle, `object-fit: cover`, still round, still wearing the caller's ring.
- A rival **WITHOUT** a portrait — the monogram (`CN`) at 52 and 28, and on the praxis card the faction skin's own fallback letter (spectrum ring for `na`).
- **Both sides** of the composer pair — the viewer's side and the rival's, one with a face and one without, to confirm the ring/dress still distinguishes them.
- The **sigil badge at 24px** on the praxis-card banner. This is the one thing I would most like a human eye on: `FactionAvatar` hangs the badge 3px outside a 12px circle, which is proportionally larger at 24 than at the byline's 28. If it crowds the "vs." mark or the rival's name, that is a size/placement call for `frontend-style`, not a reason to go back to the monogram.
- **`CollabRoster` and the invite dropdown** — they pass no `avatarUrl`, so they must look byte-identical. Worth one glance to confirm the leaf change is inert for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
