### PR TITLE
The praxis-detail byline shows the author's face, not just their first letter (#2106)

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/bylinePortrait.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/bylinePortrait.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * #2106 — the praxis-detail byline shows the author's FACE, not just a letter.
+ *
+ * The reported symptom: the top of a praxis drew the author as `H` while the
+ * comment box at the bottom of the same page drew their portrait. Every
+ * archetype called its local `initials`/`initialsOf` unconditionally; the `img`
+ * branch each one's *"Initials fallback for a member with no uploaded avatar"*
+ * comment promised was never written, and `created_by_avatar_url` only reached
+ * the CARD wire until #2172 put it on `PraxisOut` too.
+ *
+ * ## The seam
+ *
+ * `bylineFaces()` — the shared list of who the byline draws — plus each
+ * archetype's own monogram frame. Walked across `surfaceMap('praxisDetail')`
+ * rather than asserted once, for the reason `archetypeSlots.test.tsx` gives:
+ * the rule has to reach all nine dressed pages, and the portrait branch is
+ * exactly what a bespoke skin can quietly fail to mount. The FALLBACK is
+ * asserted in the same loop because it is the half a screenshot cannot show.
+ *
+ * `FactionAvatar` is deliberately NOT mounted: it would bring one generic disc
+ * (plus its sigil corner badge) in place of eight bespoke kit monograms —
+ * S.N.I.D.E.'s tilted xerox square, the Ephemerists' brass octagon, Everymen's
+ * framed plate, Singularity's terminal cell. What travels is the RULE, drawn
+ * inside each archetype's existing frame.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+// Initialize the catalog so shared-chrome copy keys resolve to English.
+import '../../../i18n'
+import { surfaceMap } from '../../../factions'
+import DefaultPraxisDetail from '../archetypes/DefaultPraxisDetail'
+import { bylineFaces } from '../shared'
+import type { PraxisDetailState } from '../usePraxisDetail'
+import { aPraxis, aMember, AUTHOR } from '../../../test/fixtures'
+import { mediaUrl } from '../../../utils/media'
+
+/** A two-word name so the monogram is a distinctive pair a substring can find. */
+const NAME = 'Zev Quist'
+const MONOGRAM = 'ZQ'
+const PORTRAIT = 'avatars/zev.png'
+/** A second member, who has no avatar field on the wire at all (see below). */
+const CREWMATE = { id: 44, name: 'Ilse Ronan' }
+
+function render(element: ReactElement): string {
+  return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
+}
+
+function state(over: Partial<Parameters<typeof aPraxis>[0]> = {}): PraxisDetailState {
+  return {
+    loading: false,
+    praxis: aPraxis({
+      created_by_display_name: NAME,
+      members: [aMember({ character_display_name: NAME })],
+      ...over,
+    }),
+    fetchError: null,
+    comments: null,
+    voters: [],
+    duel: null,
+    isOwner: false,
+    showAdminBar: false,
+    user: null,
+    withdrawing: false,
+    showWithdrawConfirm: false,
+    setShowWithdrawConfirm: () => {},
+    withdrawError: null,
+    adminFailNote: '',
+    setAdminFailNote: () => {},
+    showFailInput: false,
+    setShowFailInput: () => {},
+    moderating: false,
+    moderateError: null,
+    showFlagForm: false,
+    setShowFlagForm: () => {},
+    flagReason: null,
+    setFlagReason: () => {},
+    flagDetail: '',
+    setFlagDetail: () => {},
+    flagging: false,
+    flagError: null,
+    setFlagError: () => {},
+    flagSubmitted: false,
+    handleModerate: async () => {},
+    handleWithdraw: async () => {},
+    handleFlag: async () => {},
+    handleKickMember: async () => {},
+  }
+}
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1
+}
+
+// Default is a registered renderable too — walk it alongside the map.
+const archetypes = { ...surfaceMap('praxisDetail'), __default__: DefaultPraxisDetail }
+
+describe('praxis-detail byline portrait (#2106)', () => {
+  const src = mediaUrl(PORTRAIT)
+
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} draws the author's portrait when they have one`, () => {
+      const html = render(<Archetype state={state({ created_by_avatar_url: PORTRAIT })} />)
+      expect(html, 'the portrait is mounted').toContain(`src="${src}"`)
+      expect(html, 'alt is the display name').toContain(`alt="${NAME}"`)
+      expect(html, 'and the monogram gives way to it').not.toContain(MONOGRAM)
+    })
+
+    it(`${slug} keeps its own monogram when they have none`, () => {
+      const html = render(<Archetype state={state({ created_by_avatar_url: '' })} />)
+      expect(html, "the archetype's bespoke initials still draw").toContain(MONOGRAM)
+      expect(html, 'and no empty portrait is mounted').not.toContain('src=""')
+    })
+  }
+})
+
+// ─── The collab limitation, asserted rather than assumed ─────────────────────
+//
+// `PraxisMemberOut` carries no avatar field, so only the CREATOR can get a
+// face. On a collab byline that is one portrait among monograms. That is the
+// narrow read of #2106 and it is flagged on the issue; this test pins the
+// behaviour so the day the members' avatars reach the wire, it fails here and
+// says where to look.
+describe('collab byline: only the creator has a face today', () => {
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} draws exactly one portrait on a two-member collab`, () => {
+      const html = render(
+        <Archetype
+          state={state({
+            type: 'collab',
+            created_by_avatar_url: PORTRAIT,
+            members: [
+              aMember({ character_display_name: NAME }),
+              aMember({
+                id: 102,
+                character_id: CREWMATE.id,
+                character_display_name: CREWMATE.name,
+                joined_at: '2026-01-02T00:00:00Z',
+              }),
+            ],
+          })}
+        />,
+      )
+      expect(occurrences(html, `src="${mediaUrl(PORTRAIT)}"`), 'one face').toBe(1)
+      expect(html, "the crewmate keeps a monogram").toContain('IR')
+    })
+  }
+})
+
+// ─── The shared rule, unit-tested once ───────────────────────────────────────
+describe('bylineFaces', () => {
+  it('gives the portrait to the creator and to nobody else', () => {
+    const faces = bylineFaces(
+      aPraxis({
+        created_by_display_name: NAME,
+        created_by_avatar_url: PORTRAIT,
+        members: [
+          aMember({ character_display_name: NAME }),
+          aMember({
+            id: 102,
+            character_id: CREWMATE.id,
+            character_display_name: CREWMATE.name,
+            joined_at: '2026-01-02T00:00:00Z',
+          }),
+        ],
+      }),
+    )
+    expect(faces).toEqual([
+      { id: AUTHOR.id, name: NAME, avatarUrl: PORTRAIT },
+      { id: CREWMATE.id, name: CREWMATE.name, avatarUrl: '' },
+    ])
+  })
+
+  it('credits the creator when the payload carries no member rows', () => {
+    const faces = bylineFaces(
+      aPraxis({
+        created_by_display_name: NAME,
+        created_by_avatar_url: PORTRAIT,
+        members: [],
+      }),
+    )
+    expect(faces).toEqual([{ id: AUTHOR.id, name: NAME, avatarUrl: PORTRAIT }])
+  })
+
+  it('falls back to `#id` for a member with no display name', () => {
+    const faces = bylineFaces(
+      aPraxis({
+        created_by_avatar_url: '',
+        members: [aMember({ character_display_name: '' })],
+      }),
+    )
+    expect(faces).toEqual([{ id: AUTHOR.id, name: `#${AUTHOR.id}`, avatarUrl: '' }])
+  })
+})

--- a/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/CovenPraxisDetail.tsx
@@ -89,14 +89,15 @@ import { CovenCat, SLIP_SHEET } from '../../../components/factionMarks/covenSlip
 import { DuelCard } from '../DuelCard'
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
+import { mediaUrl } from '../../../utils/media'
 import {
+  bylineFaces,
   PraxisAdminBar,
   PraxisStatusBanners,
   PraxisOwnerActions,
   PraxisFlagBlock,
   PraxisDetailComments,
   MemberByline,
-  orderedMembers,
   scoreWasBanked,
   taskRefMeta,
 } from '../shared'
@@ -186,7 +187,15 @@ function initials(name: string): string {
  * hand-lettered inside. Collab bylines stack these, overlapping, so a shared
  * praxis reads as shared before a single name is parsed.
  */
-function MemberDisc({ name, size }: { name: string; size: number }) {
+function MemberDisc({
+  name,
+  avatarUrl,
+  size,
+}: {
+  name: string
+  avatarUrl: string
+  size: number
+}) {
   return (
     <span
       aria-hidden
@@ -203,21 +212,30 @@ function MemberDisc({ name, size }: { name: string; size: number }) {
         boxShadow: '0 3px 10px var(--faction-coven-slip-glow)',
       }}
     >
-      <span
-        className="flex items-center justify-center"
-        style={{
-          width: '100%',
-          height: '100%',
-          borderRadius: '50%',
-          background: CARD,
-          fontFamily: HAND,
-          fontSize: 'var(--text-content)',
-          fontWeight: 700,
-          color: DEEP,
-        }}
-      >
-        {initials(name)}
-      </span>
+      {avatarUrl ? (
+        <img
+          src={mediaUrl(avatarUrl)}
+          alt={name}
+          className="object-cover"
+          style={{ display: 'block', width: '100%', height: '100%', borderRadius: '50%' }}
+        />
+      ) : (
+        <span
+          className="flex items-center justify-center"
+          style={{
+            width: '100%',
+            height: '100%',
+            borderRadius: '50%',
+            background: CARD,
+            fontFamily: HAND,
+            fontSize: 'var(--text-content)',
+            fontWeight: 700,
+            color: DEEP,
+          }}
+        >
+          {initials(name)}
+        </span>
+      )}
     </span>
   )
 }
@@ -232,7 +250,6 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
   // Guarded non-null by the dispatcher.
   if (!praxis) return null
 
-  const members = orderedMembers(praxis)
   // A collab is a collab at ONE member (#1274). This used to read
   // `members.length > 1`, which hid the whole Members section from a collab
   // nobody had joined yet while the heading still counted them. Tested
@@ -393,13 +410,7 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
         {/* Stacked discs, one per member. A payload with no member rows still
             credits its creator, so the author is always reachable here. */}
         <span style={{ display: 'flex', alignItems: 'center' }}>
-          {(members.length > 0
-            ? members.map((member) => ({
-                id: member.character_id,
-                name: member.character_display_name || `#${member.character_id}`,
-              }))
-            : [{ id: praxis.created_by_id, name: praxis.created_by_display_name }]
-          ).map((author, index) => (
+          {bylineFaces(praxis).map((author, index) => (
             <Link
               key={author.id}
               to={`/characters/${author.id}`}
@@ -411,7 +422,11 @@ export default function CovenPraxisDetail({ state }: { state: PraxisDetailState 
                 zIndex: index,
               }}
             >
-              <MemberDisc name={author.name} size={size.disc} />
+              <MemberDisc
+                name={author.name}
+                avatarUrl={author.avatarUrl}
+                size={size.disc}
+              />
             </Link>
           ))}
         </span>

--- a/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/DefaultPraxisDetail.tsx
@@ -106,14 +106,15 @@ import { CollabRoster } from '../../../components/collab/CollabRoster'
 import { DuelCard } from '../DuelCard'
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
+import { mediaUrl } from '../../../utils/media'
 import {
+  bylineFaces,
   PraxisAdminBar,
   PraxisStatusBanners,
   PraxisOwnerActions,
   PraxisFlagBlock,
   PraxisDetailComments,
   MemberByline,
-  orderedMembers,
   scoreWasBanked,
   taskRefMeta,
 } from '../shared'
@@ -153,7 +154,15 @@ function initials(name: string): string {
  * One spectrum-ringed initials disc. Collab bylines stack these, overlapping,
  * so a shared praxis reads as shared before a single name is parsed.
  */
-function MemberDisc({ name, size }: { name: string; size: number }) {
+function MemberDisc({
+  name,
+  avatarUrl,
+  size,
+}: {
+  name: string
+  avatarUrl: string
+  size: number
+}) {
   return (
     <span
       aria-hidden
@@ -167,19 +176,28 @@ function MemberDisc({ name, size }: { name: string; size: number }) {
         flexShrink: 0,
       }}
     >
-      <span
-        className="flex items-center justify-center font-display italic"
-        style={{
-          width: '100%',
-          height: '100%',
-          borderRadius: '50%',
-          background: 'var(--faction-default-card-bg)',
-          fontSize: 'var(--text-lg)',
-          color: 'var(--faction-default-card-text)',
-        }}
-      >
-        {initials(name)}
-      </span>
+      {avatarUrl ? (
+        <img
+          src={mediaUrl(avatarUrl)}
+          alt={name}
+          className="object-cover"
+          style={{ display: 'block', width: '100%', height: '100%', borderRadius: '50%' }}
+        />
+      ) : (
+        <span
+          className="flex items-center justify-center font-display italic"
+          style={{
+            width: '100%',
+            height: '100%',
+            borderRadius: '50%',
+            background: 'var(--faction-default-card-bg)',
+            fontSize: 'var(--text-lg)',
+            color: 'var(--faction-default-card-text)',
+          }}
+        >
+          {initials(name)}
+        </span>
+      )}
     </span>
   )
 }
@@ -199,7 +217,6 @@ export default function DefaultPraxisDetail({
   // Guarded non-null by the dispatcher.
   if (!praxis) return null
 
-  const members = orderedMembers(praxis)
   // A collab is a collab at ONE member (#1274). This used to read
   // `members.length > 1`, which hid the whole Members section from a collab
   // nobody had joined yet while the heading still counted them. Tested
@@ -378,13 +395,7 @@ export default function DefaultPraxisDetail({
             single name is parsed. A payload with no member rows still credits
             its creator, so the author is always reachable from the byline. */}
         <span style={{ display: 'flex', alignItems: 'center' }}>
-          {(members.length > 0
-            ? members.map((member) => ({
-                id: member.character_id,
-                name: member.character_display_name || `#${member.character_id}`,
-              }))
-            : [{ id: praxis.created_by_id, name: praxis.created_by_display_name }]
-          ).map((author, index) => (
+          {bylineFaces(praxis).map((author, index) => (
             <Link
               key={author.id}
               to={`/characters/${author.id}`}
@@ -396,7 +407,11 @@ export default function DefaultPraxisDetail({
                 zIndex: index,
               }}
             >
-              <MemberDisc name={author.name} size={desktop ? 44 : 38} />
+              <MemberDisc
+                name={author.name}
+                avatarUrl={author.avatarUrl}
+                size={desktop ? 44 : 38}
+              />
             </Link>
           ))}
         </span>

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -128,6 +128,7 @@ import { EphemeristsMasthead } from "../../../components/factionMarks/Ephemerist
 import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
+import { mediaUrl } from "../../../utils/media";
 import {
   PraxisAdminBar,
   PraxisStatusBanners,
@@ -135,6 +136,7 @@ import {
   PraxisFlagBlock,
   PraxisDetailComments,
   MemberByline,
+  bylineFaces,
   orderedMembers,
   scoreWasBanked,
   taskRefMeta,
@@ -202,7 +204,23 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
  * set these in a row, so a shared record reads as shared before a single name is
  * parsed.
  */
-function AuthorOctagon({ name, size }: { name: string; size: number }) {
+/**
+ * The inner (`inset={7}`) octagon of the cartouche below, restated in percent so
+ * a portrait can be clipped to it: `Octagon`'s path over a 100-unit box, scaled
+ * 0.86 about the centre — p' = 50 + 0.86 × (p − 50). Geometry, not dress.
+ */
+const OCTAGON_CLIP =
+  "polygon(32.8% 10.44%, 67.2% 10.44%, 89.56% 32.8%, 89.56% 67.2%, 67.2% 89.56%, 32.8% 89.56%, 10.44% 67.2%, 10.44% 32.8%)";
+
+function AuthorOctagon({
+  name,
+  avatarUrl,
+  size,
+}: {
+  name: string;
+  avatarUrl: string;
+  size: number;
+}) {
   return (
     <span
       aria-hidden
@@ -224,22 +242,37 @@ function AuthorOctagon({ name, size }: { name: string; size: number }) {
         <Octagon inset={0} stroke={BRASS} width={2} fill={DISC} />
         <Octagon inset={7} stroke={BRASS_LIGHT} width={0.8} />
       </svg>
-      <span
-        style={{
-          position: "absolute",
-          inset: 0,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          fontFamily: CAPS,
-          fontWeight: 500,
-          fontSize: "var(--text-md)",
-          letterSpacing: "0.08em",
-          color: INK,
-        }}
-      >
-        {initialsOf(name)}
-      </span>
+      {avatarUrl ? (
+        <img
+          src={mediaUrl(avatarUrl)}
+          alt={name}
+          className="object-cover"
+          style={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            clipPath: OCTAGON_CLIP,
+          }}
+        />
+      ) : (
+        <span
+          style={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontFamily: CAPS,
+            fontWeight: 500,
+            fontSize: "var(--text-md)",
+            letterSpacing: "0.08em",
+            color: INK,
+          }}
+        >
+          {initialsOf(name)}
+        </span>
+      )}
     </span>
   );
 }
@@ -262,17 +295,12 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   const isCollab = praxis.type === "collab";
 
   // A payload with no member rows still credits its creator, so the byline is
-  // never empty and the author is always reachable from it. Initials only:
-  // `PraxisOut` carries no avatar for either a member or the creator (that field
-  // is the CARD payload's, `PraxisCardOut.created_by_avatar_url`), and a
-  // monogram cut into a cartouche is the plate's own answer anyway.
-  const authors =
-    members.length > 0
-      ? members.map((member) => ({
-          id: member.character_id,
-          name: member.character_display_name || `#${member.character_id}`,
-        }))
-      : [{ id: praxis.created_by_id, name: praxis.created_by_display_name }];
+  // never empty and the author is always reachable from it. NOT initials only
+  // any more: #2172 put `created_by_avatar_url` on `PraxisOut` (it was the CARD
+  // payload's alone, which is what the note here used to record), so the
+  // creator's portrait is clipped into the cartouche and the monogram cut is
+  // what a plateless author still gets.
+  const authors = bylineFaces(praxis);
 
   /** The page-ground label voice. `-quiet`: the caption gold is measured on the
    *  PLATE and does not clear on the darker page this surface introduces. */
@@ -506,7 +534,11 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
         <span style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
           {authors.map((author) => (
             <Link key={author.id} to={`/characters/${author.id}`} style={{ display: "block" }}>
-              <AuthorOctagon name={author.name} size={size.disc} />
+              <AuthorOctagon
+                name={author.name}
+                avatarUrl={author.avatarUrl}
+                size={size.disc}
+              />
             </Link>
           ))}
         </span>

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -85,6 +85,7 @@ import { CollabRoster } from "../../../components/collab/CollabRoster";
 import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
+import { mediaUrl } from "../../../utils/media";
 import { factionName } from "../../../utils/factions";
 import {
   PraxisAdminBar,
@@ -93,7 +94,7 @@ import {
   PraxisFlagBlock,
   PraxisDetailComments,
   MemberByline,
-  orderedMembers,
+  bylineFaces,
   scoreWasBanked,
   taskRefMeta,
 } from "../shared";
@@ -174,7 +175,15 @@ function initialsOf(name: string): string {
  * struck in Bebas. Square, not a disc — this is a filing photo pasted onto a
  * report, and the round discs belong to the Unaffiliated sheet.
  */
-function MemberPlate({ name, size }: { name: string; size: number }) {
+function MemberPlate({
+  name,
+  avatarUrl,
+  size,
+}: {
+  name: string;
+  avatarUrl: string;
+  size: number;
+}) {
   return (
     <span
       aria-hidden
@@ -193,7 +202,16 @@ function MemberPlate({ name, size }: { name: string; size: number }) {
         color: ACCENT,
       }}
     >
-      {initialsOf(name)}
+      {avatarUrl ? (
+        <img
+          src={mediaUrl(avatarUrl)}
+          alt={name}
+          className="object-cover"
+          style={{ display: "block", width: "100%", height: "100%" }}
+        />
+      ) : (
+        initialsOf(name)
+      )}
     </span>
   );
 }
@@ -210,7 +228,6 @@ export default function EverymenPraxisDetail({
   // Guarded non-null by the dispatcher.
   if (!praxis) return null;
 
-  const members = orderedMembers(praxis);
   // A collab is a collab at ONE member (#1274). This used to read
   // `members.length > 1`, which hid the whole Members section from a collab
   // nobody had joined yet while the heading still counted them. Tested
@@ -454,21 +471,11 @@ export default function EverymenPraxisDetail({
             single name is parsed. A payload with no member rows still credits
             its creator, so the author is always reachable from the byline. */}
         <span style={{ display: "flex", gap: "var(--space-xs)" }}>
-          {(members.length > 0
-            ? members.map((member) => ({
-                id: member.character_id,
-                name: member.character_display_name || `#${member.character_id}`,
-              }))
-            : [
-                {
-                  id: praxis.created_by_id,
-                  name: praxis.created_by_display_name,
-                },
-              ]
-          ).map((author) => (
+          {bylineFaces(praxis).map((author) => (
             <Link key={author.id} to={`/characters/${author.id}`}>
               <MemberPlate
                 name={author.name}
+                avatarUrl={author.avatarUrl}
                 size={desktop ? PLATE_DESKTOP : PLATE_MOBILE}
               />
             </Link>

--- a/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx
@@ -11,6 +11,7 @@ import { CollabRoster } from "../../../components/collab/CollabRoster";
 import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
+import { mediaUrl } from "../../../utils/media";
 import {
   PraxisAdminBar,
   PraxisStatusBanners,
@@ -18,7 +19,7 @@ import {
   PraxisFlagBlock,
   PraxisDetailComments,
   MemberByline,
-  orderedMembers,
+  bylineFaces,
   scoreWasBanked,
   taskRefMeta,
 } from "../shared";
@@ -227,7 +228,15 @@ function Cursor({ height }: { height: number }) {
 }
 
 /** One member's initials, framed as a terminal cell rather than a soft disc. */
-function MemberCell({ name, size }: { name: string; size: number }) {
+function MemberCell({
+  name,
+  avatarUrl,
+  size,
+}: {
+  name: string;
+  avatarUrl: string;
+  size: number;
+}) {
   return (
     <span
       aria-hidden
@@ -237,6 +246,9 @@ function MemberCell({ name, size }: { name: string; size: number }) {
         height: size,
         flex: "none",
         borderRadius: 4,
+        // Clips the portrait to the cell's own corner radius, so the img needs
+        // no radius of its own.
+        overflow: "hidden",
         boxSizing: "border-box",
         background: PANEL,
         border: `1px solid ${BORDER}`,
@@ -245,7 +257,16 @@ function MemberCell({ name, size }: { name: string; size: number }) {
         color: BRIGHT,
       }}
     >
-      {initialsOf(name)}
+      {avatarUrl ? (
+        <img
+          src={mediaUrl(avatarUrl)}
+          alt={name}
+          className="object-cover"
+          style={{ display: "block", width: "100%", height: "100%" }}
+        />
+      ) : (
+        initialsOf(name)
+      )}
     </span>
   );
 }
@@ -258,7 +279,6 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
   // Guarded non-null by the dispatcher.
   if (!praxis) return null;
 
-  const members = orderedMembers(praxis);
   // A collab is a collab at ONE member (#1274). This used to read
   // `members.length > 1`, which hid the whole Members section from a collab
   // nobody had joined yet while the heading still counted them. Tested
@@ -429,15 +449,13 @@ export default function SingularityPraxisDetail({ state }: { state: PraxisDetail
             single name is parsed. A payload with no member rows still credits
             its creator, so the author is always reachable from the byline. */}
         <span style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)" }}>
-          {(members.length > 0
-            ? members.map((member) => ({
-                id: member.character_id,
-                name: member.character_display_name || `#${member.character_id}`,
-              }))
-            : [{ id: praxis.created_by_id, name: praxis.created_by_display_name }]
-          ).map((author) => (
+          {bylineFaces(praxis).map((author) => (
             <Link key={author.id} to={`/characters/${author.id}`} style={{ display: "block" }}>
-              <MemberCell name={author.name} size={desktop ? 40 : 34} />
+              <MemberCell
+                name={author.name}
+                avatarUrl={author.avatarUrl}
+                size={desktop ? 40 : 34}
+              />
             </Link>
           ))}
         </span>

--- a/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/SnidePraxisDetail.tsx
@@ -126,6 +126,7 @@ import { CollabRoster } from "../../../components/collab/CollabRoster";
 import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
+import { mediaUrl } from "../../../utils/media";
 import {
   PraxisAdminBar,
   PraxisStatusBanners,
@@ -133,6 +134,7 @@ import {
   PraxisFlagBlock,
   PraxisDetailComments,
   MemberByline,
+  bylineFaces,
   orderedMembers,
   scoreWasBanked,
   taskRefMeta,
@@ -242,7 +244,17 @@ function initialsOf(name: string): string {
  * rounded. Both pigments are theme-invariant, so the chip measures 16.8:1 in
  * either theme without the cascade having to agree with the wall behind it.
  */
-function PosterChip({ name, size, tilt }: { name: string; size: number; tilt: number }) {
+function PosterChip({
+  name,
+  avatarUrl,
+  size,
+  tilt,
+}: {
+  name: string;
+  avatarUrl: string;
+  size: number;
+  tilt: number;
+}) {
   return (
     <span
       aria-hidden="true"
@@ -262,7 +274,16 @@ function PosterChip({ name, size, tilt }: { name: string; size: number; tilt: nu
         boxShadow: `3px 3px 0 ${PINK}`,
       }}
     >
-      {initialsOf(name)}
+      {avatarUrl ? (
+        <img
+          src={mediaUrl(avatarUrl)}
+          alt={name}
+          className="object-cover"
+          style={{ display: "block", width: "100%", height: "100%" }}
+        />
+      ) : (
+        initialsOf(name)
+      )}
     </span>
   );
 }
@@ -486,16 +507,11 @@ export default function SnidePraxisDetail({ state }: { state: PraxisDetailState 
             single name is parsed. A payload with no member rows still credits
             its creator, so the author is always reachable from the byline. */}
         <span style={{ display: "flex", alignItems: "center", gap: "var(--space-xs)" }}>
-          {(members.length > 0
-            ? members.map((member) => ({
-                id: member.character_id,
-                name: member.character_display_name || `#${member.character_id}`,
-              }))
-            : [{ id: praxis.created_by_id, name: praxis.created_by_display_name }]
-          ).map((author, index) => (
+          {bylineFaces(praxis).map((author, index) => (
             <Link key={author.id} to={`/characters/${author.id}`} style={{ display: "block" }}>
               <PosterChip
                 name={author.name}
+                avatarUrl={author.avatarUrl}
                 size={desktop ? 44 : 38}
                 tilt={index % 2 === 0 ? -3 : 2.5}
               />

--- a/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/UaPraxisDetail.tsx
@@ -19,6 +19,7 @@ import {
 import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
+import { mediaUrl } from "../../../utils/media";
 import {
   PraxisAdminBar,
   PraxisStatusBanners,
@@ -26,7 +27,7 @@ import {
   PraxisFlagBlock,
   PraxisDetailComments,
   MemberByline,
-  orderedMembers,
+  bylineFaces,
   scoreWasBanked,
   taskRefMeta,
 } from "../shared";
@@ -230,7 +231,15 @@ function initials(name: string): string {
  * Deliberately NOT ringed with the ensō: the mark is reserved for the score and
  * the faction mark, and an avatar ring is neither (§6/#849).
  */
-function LeafDisc({ name, size }: { name: string; size: number }) {
+function LeafDisc({
+  name,
+  avatarUrl,
+  size,
+}: {
+  name: string;
+  avatarUrl: string;
+  size: number;
+}) {
   return (
     <span
       aria-hidden
@@ -251,7 +260,16 @@ function LeafDisc({ name, size }: { name: string; size: number }) {
         boxShadow: "0 0 0 1.5px var(--faction-ua-card-frame)",
       }}
     >
-      {initials(name)}
+      {avatarUrl ? (
+        <img
+          src={mediaUrl(avatarUrl)}
+          alt={name}
+          className="object-cover"
+          style={{ display: "block", width: "100%", height: "100%" }}
+        />
+      ) : (
+        initials(name)
+      )}
     </span>
   );
 }
@@ -266,7 +284,6 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
   // Guarded non-null by the dispatcher.
   if (!praxis) return null;
 
-  const members = orderedMembers(praxis);
   // A collab is a collab at ONE member (#1274). This used to read
   // `members.length > 1`, which hid the whole Members section from a collab
   // nobody had joined yet while the heading still counted them. Tested
@@ -463,13 +480,7 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
         {/* Stacked discs, one per member. A payload with no member rows still
             credits its creator, so the author is always reachable from here. */}
         <span style={{ display: "flex", alignItems: "center" }}>
-          {(members.length > 0
-            ? members.map((member) => ({
-                id: member.character_id,
-                name: member.character_display_name || `#${member.character_id}`,
-              }))
-            : [{ id: praxis.created_by_id, name: praxis.created_by_display_name }]
-          ).map((author, index) => (
+          {bylineFaces(praxis).map((author, index) => (
             <Link
               key={author.id}
               to={`/characters/${author.id}`}
@@ -481,7 +492,11 @@ export default function UaPraxisDetail({ state }: { state: PraxisDetailState }) 
                 zIndex: index,
               }}
             >
-              <LeafDisc name={author.name} size={size.disc} />
+              <LeafDisc
+                name={author.name}
+                avatarUrl={author.avatarUrl}
+                size={size.disc}
+              />
             </Link>
           ))}
         </span>

--- a/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/WowPraxisDetail.tsx
@@ -11,14 +11,15 @@ import { BalloonBunch, Bunting, Zig } from '../../../components/factionMarks/wow
 import { DuelCard } from '../DuelCard'
 import { useFormFactor } from '../../../hooks/useFormFactor'
 import { formatTimestamp } from '../../../utils/dates'
+import { mediaUrl } from '../../../utils/media'
 import {
+  bylineFaces,
   PraxisAdminBar,
   PraxisStatusBanners,
   PraxisOwnerActions,
   PraxisFlagBlock,
   PraxisDetailComments,
   MemberByline,
-  orderedMembers,
   scoreWasBanked,
   taskRefMeta,
 } from '../shared'
@@ -228,7 +229,15 @@ function initials(name: string): string {
  * parsed — the same move the Unaffiliated page makes with its spectrum ring,
  * wearing WOW's coin mount instead.
  */
-function ChronicleDisc({ name, size }: { name: string; size: number }) {
+function ChronicleDisc({
+  name,
+  avatarUrl,
+  size,
+}: {
+  name: string
+  avatarUrl: string
+  size: number
+}) {
   return (
     <span
       aria-hidden
@@ -242,20 +251,29 @@ function ChronicleDisc({ name, size }: { name: string; size: number }) {
         flexShrink: 0,
       }}
     >
-      <span
-        className="flex items-center justify-center"
-        style={{
-          width: '100%',
-          height: '100%',
-          borderRadius: '50%',
-          background: 'var(--faction-wow-avatar-field)',
-          fontFamily: MED,
-          fontSize: 'var(--text-lg)',
-          color: PLUM,
-        }}
-      >
-        {initials(name)}
-      </span>
+      {avatarUrl ? (
+        <img
+          src={mediaUrl(avatarUrl)}
+          alt={name}
+          className="object-cover"
+          style={{ display: 'block', width: '100%', height: '100%', borderRadius: '50%' }}
+        />
+      ) : (
+        <span
+          className="flex items-center justify-center"
+          style={{
+            width: '100%',
+            height: '100%',
+            borderRadius: '50%',
+            background: 'var(--faction-wow-avatar-field)',
+            fontFamily: MED,
+            fontSize: 'var(--text-lg)',
+            color: PLUM,
+          }}
+        >
+          {initials(name)}
+        </span>
+      )}
     </span>
   )
 }
@@ -269,7 +287,6 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
   // Guarded non-null by the dispatcher.
   if (!praxis) return null
 
-  const members = orderedMembers(praxis)
   // A collab is a collab at ONE member (#1274). This used to read
   // `members.length > 1`, which hid the whole Members section from a collab
   // nobody had joined yet while the heading still counted them. Tested
@@ -432,13 +449,7 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
         {/* Stacked discs, one per member. A payload with no member rows still
             credits its creator, so the author is always reachable from here. */}
         <span style={{ display: 'flex', alignItems: 'center' }}>
-          {(members.length > 0
-            ? members.map((member) => ({
-                id: member.character_id,
-                name: member.character_display_name || `#${member.character_id}`,
-              }))
-            : [{ id: praxis.created_by_id, name: praxis.created_by_display_name }]
-          ).map((author, index) => (
+          {bylineFaces(praxis).map((author, index) => (
             <Link
               key={author.id}
               to={`/characters/${author.id}`}
@@ -450,7 +461,11 @@ export default function WowPraxisDetail({ state }: { state: PraxisDetailState })
                 zIndex: index,
               }}
             >
-              <ChronicleDisc name={author.name} size={size.disc} />
+              <ChronicleDisc
+                name={author.name}
+                avatarUrl={author.avatarUrl}
+                size={size.disc}
+              />
             </Link>
           ))}
         </span>

--- a/frontend/src/pages/praxisDetail/shared.tsx
+++ b/frontend/src/pages/praxisDetail/shared.tsx
@@ -176,6 +176,57 @@ export function orderedMembers(praxis: PraxisOut): PraxisMemberOut[] {
   return creator ? [creator, ...rest] : rest
 }
 
+/** One face in the byline's stack of discs/plates/octagons. */
+export interface BylineFace {
+  id: number
+  name: string
+  /**
+   * The raw wire path, NOT a resolved URL — the archetype calls `mediaUrl()`
+   * at the `img` so this stays comparable to `created_by_avatar_url` itself.
+   * `''` means "draw the monogram".
+   */
+  avatarUrl: string
+}
+
+/**
+ * Who the byline draws, and which of them has a face (#2106).
+ *
+ * Every archetype used to build this list inline with the same ternary, and
+ * every one of them then drew initials unconditionally — which is why the top
+ * of a praxis showed `H` while the comment box below it showed the portrait.
+ * The rule the praxis CARD byline already follows is the one that travels here:
+ * portrait when the path is non-empty, monogram otherwise. The COMPONENT does
+ * not travel — `FactionAvatar` would replace eight bespoke kit monograms with
+ * one generic disc, so each archetype draws the `img` inside its own frame.
+ *
+ * `ponytail:` only the CREATOR can have a face. `PraxisMemberOut` carries no
+ * avatar column, so a collab byline is one portrait among monograms. That is
+ * the narrow read of #2106 and is flagged on the issue; the upgrade path is an
+ * avatar field on `PraxisMemberOut` populated in `build_praxis_out`, after
+ * which this maps `member.character_avatar_url` and the special case goes away.
+ */
+export function bylineFaces(praxis: PraxisOut): BylineFace[] {
+  const members = orderedMembers(praxis)
+  // `|| ''` for the same reason the card byline does it: a cached payload from
+  // before #2172 has no such key, and `undefined` would reach `img src`.
+  const portrait = praxis.created_by_avatar_url || ''
+  if (members.length === 0) {
+    return [
+      {
+        id: praxis.created_by_id,
+        name: praxis.created_by_display_name,
+        avatarUrl: portrait,
+      },
+    ]
+  }
+  return members.map((member) => ({
+    id: member.character_id,
+    name: member.character_display_name || `#${member.character_id}`,
+    avatarUrl:
+      member.character_id === praxis.created_by_id ? portrait : '',
+  }))
+}
+
 export function MemberByline({
   praxis,
   linkStyle,


### PR DESCRIPTION
The report: at the top of a praxis the author was drawn as a single letter (`H`), while the comment box at the bottom of the *same page* showed their portrait. Owner ruling: **yes, avatars.**

Closes #2106

## The seam

**`bylineFaces()` in `pages/praxisDetail/shared.tsx`, plus each archetype's own monogram frame.** All eight archetypes built the same author list inline with the same ternary and then drew initials unconditionally — the `img` branch every one of their *"Initials fallback for a member with no uploaded avatar"* comments has promised since #1085 was simply never written.

The failing test was written there first: `__tests__/bylinePortrait.test.tsx` walks the real `surfaceMap('praxisDetail')` registry (the pattern `archetypeSlots.test.tsx` established) and went red 21/30 on the real defect — every archetype's has-portrait case, none of the fallback cases.

## What travels from the praxis card is the RULE, not the component

**`FactionAvatar` is deliberately not mounted.** It would bring the faction avatar skin *and* its sigil corner badge, replacing eight bespoke kit monograms — S.N.I.D.E.'s tilted xerox photo corner, the Ephemerists' stepped brass octagon, Everymen's framed filing plate, Singularity's terminal cell — with one generic disc. That contradicts the ruling's *"fallback is unchanged"* and the per-faction archetype rule. What travels is: portrait when `created_by_avatar_url` is non-empty, monogram otherwise, `mediaUrl()` on the path, `alt` = display name — drawn inside each archetype's existing frame. `initialsOf` / `initials` stay exactly where they are; the monogram became the fallback rather than the default.

Each frame keeps its own edge treatment:

- **Default / Coven / WOW** — ring-plus-field discs; the img lands in the field and the spectrum / pink-gold / gilt ring is untouched.
- **UA** — already clips with `overflow: hidden`, so the img needed nothing.
- **Everymen** — the plate is `border-box`, so the img fills the content box inside the 2px frame.
- **S.N.I.D.E.** — the chip stays tilted and square with its pink drop shadow.
- **Singularity** — the cell gains `overflow: hidden` so its own 4px corner radius clips the face, rather than the img growing a radius of its own.
- **Ephemerists** — the portrait is clipped to the cartouche's inner `Octagon inset={7}`, restated once in percent (`p' = 50 + 0.86 × (p − 50)` over `Octagon`'s 100-unit box) with a comment naming the derivation. Minimum needed for the feature; nothing else on that page is touched, per the #2140 epic's scope.

## The wire

`PraxisOut.created_by_avatar_url` exists as of #2172 (`c55e08a0`) — the ruling on #2106 named the right field on the wrong schema class (it was `PraxisCardOut`'s). No backend change here, no new endpoint consumed, no schema regeneration.

`bylineFaces` reads `praxis.created_by_avatar_url || ''` for the same reason the card byline does: a cached payload from before #2172 has no such key, and `undefined` would reach `img src`.

## Accessibility: unchanged on purpose

The discs are `aria-hidden` today, and correctly so — the adjacent `MemberByline` link carries the name. The `img` was swapped in **inside** that wrapper rather than growing a competing accessible name for the same person.

## Known limitation, pinned by a test

`PraxisMemberOut` carries no avatar field, so **only the creator can have a face**. On a collab byline that is one portrait sitting among monograms. That is the narrow read of this issue and it is flagged on #2106 for the owner; the wire was not extended to fix it. `bylineFaces` carries a `ponytail:` note naming the ceiling and the upgrade path, and the test asserts the behaviour so the day members' avatars reach the wire it fails there and says where to look.

## Verification

- `tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **5740 passed | 1 skipped (328 files)**
- `npm run build` — clean
- `npm run budget` — JS 126.4 KB / CSS 22.0 KB, within budget
- `api-schema` — not applicable; the diff is `frontend/src/pages/praxisDetail/` only

**Visual QA is outstanding** — no browser tooling here, so everything above is tests, types and bytes.

## What to eyeball

Both cases on every archetype — the fallback is the half a screenshot will not show you. Open a praxis by an author **with** an uploaded portrait, then one by an author **without** one, on each of:

1. **Default / Unaffiliated** — has-portrait: face inside the spectrum ring, ring intact. no-portrait: the italic display-face monogram on the card field.
2. **Coven** — has-portrait: face inside the pink→gold ring, slip-glow shadow intact. no-portrait: the hand-lettered initials on the candle-lit field.
3. **Ephemerists** — has-portrait: face clipped to the octagon, no square corners poking past the brass rules. no-portrait: small-caps monogram centred in the cartouche.
4. **Everymen** — has-portrait: face filling the framed square, 2px frame and hairline drop shadow intact. no-portrait: Bebas initials on panel stock.
5. **Singularity** — has-portrait: face clipped to the cell's rounded corners, 1px terminal border intact. no-portrait: mono initials in the cell.
6. **S.N.I.D.E.** — has-portrait: face square and tilted with the chip, pink offset shadow intact. no-portrait: Impact initials on xerox stock.
7. **UA** — has-portrait: face in the round sienna-ringed field. no-portrait: Cormorant initials; no ensō (still reserved, §6/#849).
8. **WOW** — has-portrait: face inside the gilt rope coin. no-portrait: plum initials on the coin field.

Also worth a look on each: a **collab** praxis, where the creator's face sits first and co-authors keep monograms (the known limitation above); a **mobile** width, where the same byline renders at the smaller size (one responsive component, ADR-0063 — there is no mobile twin); and **dark mode**, where nothing should move since no new colour was introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
