### PR TITLE
A praxis byline does not link to the character page you are already on (#2125)

### DIFF
--- a/frontend/src/components/praxisCard/__tests__/authorBylineSelfLink.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/authorBylineSelfLink.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * #2125 — the praxis byline's author name must not be an anchor pointing at the
+ * page the reader is already on.
+ *
+ * The seam is `PraxisByline` itself: every faction praxis card composes it
+ * through `desktop/shared`'s `PraxisBody`, so this is the single place the
+ * author name becomes a link. The condition is destination-vs-location, which
+ * is why these cases vary only the router's current entry.
+ *
+ * SSR-rendered in isolation. No effects run, so these pin markup — which is the
+ * whole point: the defect is that an `<a>` exists at all.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { PraxisByline } from '../shared'
+
+const AUTHOR_ID = 7
+
+function praxis(overrides: Partial<PraxisCardOut> = {}): PraxisCardOut {
+  return {
+    id: 1,
+    created_by_id: AUTHOR_ID,
+    created_by_display_name: 'Isolde',
+    created_by_faction_slug: 'ua',
+    created_by_avatar_url: '',
+    task_faction_slug: 'ua',
+    task_level_required: 0,
+    task_point_value: 5,
+    member_count: 1,
+    score: 12.5,
+    voter_count: 3,
+    applied_metatasks: [],
+    ...overrides,
+  } as PraxisCardOut
+}
+
+const at = (path: string) =>
+  renderToStaticMarkup(
+    <MemoryRouter initialEntries={[path]}>
+      <PraxisByline praxis={praxis()} />
+    </MemoryRouter>,
+  )
+
+const text = (html: string) => html.replace(/<[^>]*>/g, '')
+
+describe('the author byline does not link to the page you are on (#2125)', () => {
+  it('is plain text on that author’s own character page', () => {
+    const html = at(`/characters/${AUTHOR_ID}`)
+    expect(text(html)).toContain('Isolde')
+    // Not an anchor at all: removing it is what fixes the screen-reader
+    // announcement. A disabled/pointer-events-none link would still announce.
+    expect(html).not.toContain('<a ')
+    expect(html).not.toContain(`href="/characters/${AUTHOR_ID}"`)
+  })
+
+  it('still links on a DIFFERENT character’s page', () => {
+    // Constraint 1 of the ruling: character-to-character, never account-to-
+    // account. A player viewing their own other character's page gets a link.
+    const html = at('/characters/9')
+    expect(html).toContain(`href="/characters/${AUTHOR_ID}"`)
+  })
+
+  it('still links where the id collides with a non-character route', () => {
+    // Guards the lazy-but-wrong version of this fix: comparing bare ids from
+    // `useParams` would silently kill the link on /praxis/7 too.
+    const html = at(`/praxis/${AUTHOR_ID}`)
+    expect(html).toContain(`href="/characters/${AUTHOR_ID}"`)
+  })
+
+  it('still links on every other surface', () => {
+    expect(at('/praxis')).toContain(`href="/characters/${AUTHOR_ID}"`)
+  })
+})

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import type { CharacterOut } from "../../api/auth";
 import type { PraxisCardOut } from "../../api/praxis";
 import { factionCssVar, factionName } from "../../utils/factions";
@@ -302,6 +302,52 @@ export function PraxisByline({
   // the factions.json catalog (factionName), never a hardcoded map.
   const authorFaction = praxis.created_by_faction_slug;
   const showFaction = !!authorFaction && authorFaction !== praxis.task_faction_slug;
+  const authorHref = `/characters/${praxis.created_by_id}`;
+  const authorName = praxis.created_by_display_name || `#${praxis.created_by_id}`;
+  /*
+   * #2125 — an anchor whose destination is the page you are already on is not a
+   * broken link, it is a link that should not have been an anchor: it takes the
+   * underline, the pointer and focus, and then does nothing, and a screen
+   * reader still announces it as a link. So on the author's OWN character page
+   * the name is plain text; everywhere else it stays a link. Not a "self"
+   * variant, and NOT a disabled anchor — dropping the `<a>` is what fixes the
+   * announcement.
+   *
+   * The test is destination-vs-location, character to character. Deliberately
+   * NOT account-to-account: a player viewing their own OTHER character's page
+   * is looking at a different page, and going there is meaningful (the ruling
+   * says so explicitly). Comparing the whole path rather than a bare id also
+   * keeps the link alive on `/praxis/7` when the author happens to be #7.
+   */
+  const here = useLocation().pathname.replace(/\/+$/, "");
+  const onAuthorsOwnPage = here === authorHref;
+  // Shared by both branches so the two render identically apart from the
+  // anchor: the truncation pair, and the padding that keeps it off the glyphs
+  // (#1633). `overflow: hidden` is doing two jobs: it clips, and it is what
+  // makes this a shrinkable flex item at all (min-width: auto resolves to 0
+  // rather than to the whole nowrap string), so a name too long for the card
+  // ellipsizes instead of shoving the portrait out of the frame.
+  //
+  // But it clips at the PADDING box while `text-overflow` measures the CONTENT
+  // box, and the two coincided while the 8px lived on the row as `gap`. A
+  // display face's final glyph can carry ink past its own advance width — the
+  // Ephemerists card sets this line in Poiret One — so that overhang was shaved
+  // off flush against the portrait beside it, with no ellipsis to explain it,
+  // which is what "a letter clipped behind its own avatar" looks like. Carrying
+  // the same 8px as padding here renders identically and gives the ink
+  // somewhere to land.
+  //
+  // The Ephemerists kit's own fix was `overflow: visible` + `text-overflow:
+  // clip`. It does not port: visible overflow restores min-width: auto to
+  // min-content, the name stops yielding, and a long one paints straight over
+  // the portrait and the faction tag. That is the symptom, caused on purpose.
+  const nameStyle: CSSProperties = {
+    fontFamily: fonts?.display,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    paddingInlineEnd: "var(--space-sm)",
+  };
   return (
     <div
       className="flex justify-between items-center font-body"
@@ -328,46 +374,26 @@ export function PraxisByline({
        * carried as padding on the name itself. See the link below.
        */}
       <span className="flex items-center" style={{ minWidth: 0 }}>
-        <Link
-          to={`/characters/${praxis.created_by_id}`}
-          // A person's name is readable text, not scanned chrome: content tier
-          // (18px). It ties the task link's size, and separates from it by
-          // weight and by the faction's own display face instead.
-          className="content-text font-semibold hover:underline"
-          style={{
-            fontFamily: fonts?.display,
-            /*
-             * The truncation pair, and the padding that keeps it off the
-             * glyphs (#1633). `overflow: hidden` is doing two jobs: it clips,
-             * and it is what makes this a shrinkable flex item at all
-             * (min-width: auto resolves to 0 rather than to the whole nowrap
-             * string), so a name too long for the card ellipsizes instead of
-             * shoving the portrait out of the frame.
-             *
-             * But it clips at the PADDING box while `text-overflow` measures
-             * the CONTENT box, and the two coincided while the 8px lived on
-             * the row as `gap`. A display face's final glyph can carry ink
-             * past its own advance width — the Ephemerists card sets this line
-             * in Poiret One — so that overhang was shaved off flush against
-             * the portrait beside it, with no ellipsis to explain it, which is
-             * what "a letter clipped behind its own avatar" looks like.
-             * Carrying the same 8px as padding here renders identically and
-             * gives the ink somewhere to land.
-             *
-             * The Ephemerists kit's own fix was `overflow: visible` +
-             * `text-overflow: clip`. It does not port: visible overflow
-             * restores min-width: auto to min-content, the name stops yielding,
-             * and a long one paints straight over the portrait and the faction
-             * tag. That is the symptom, caused on purpose.
-             */
-            overflow: "hidden",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            paddingInlineEnd: "var(--space-sm)",
-          }}
-        >
-          {praxis.created_by_display_name || `#${praxis.created_by_id}`}
-        </Link>
+        {/*
+         * A person's name is readable text, not scanned chrome: content tier
+         * (18px). It ties the task link's size, and separates from it by
+         * weight and by the faction's own display face instead. `hover:underline`
+         * is the only thing the link branch adds — a name that goes nowhere
+         * must not offer one.
+         */}
+        {onAuthorsOwnPage ? (
+          <span className="content-text font-semibold" style={nameStyle}>
+            {authorName}
+          </span>
+        ) : (
+          <Link
+            to={authorHref}
+            className="content-text font-semibold hover:underline"
+            style={nameStyle}
+          >
+            {authorName}
+          </Link>
+        )}
         <FactionAvatar
           character={authorAsCharacter(praxis)}
           size={BYLINE_PORTRAIT_SIZE}


### PR DESCRIPTION
Closes #2125

On a character page each praxis names its author, and that name was an anchor pointing at the page you are already on. Per the ruling: an anchor whose destination is the current URL is not a broken link, it is a link that should not have been an anchor. It takes the underline, the pointer and focus, and then does nothing — and a screen reader announces it as a link too, so the confusion is not only visual.

## The seam

**`PraxisByline` in `frontend/src/components/praxisCard/shared.tsx`.** That is the one place a praxis card names its author: all nine faction praxis cards compose it through `desktop/shared`'s `PraxisBody` (Albescent wraps Default and adds only sparks). There is no second hand-rolled byline anchor to patch — I grepped every `/characters/` link and every `created_by_display_name` render, and the card's roster and duel banner name people without linking them. So this is one condition, in one file, not a "self" variant.

The failing test went in first at that seam and went red on the real defect (`expected '<div class="flex justify-between item…' not to contain '<a '`), then green.

## The condition

```
const here = useLocation().pathname.replace(/\/+$/, "");
const onAuthorsOwnPage = here === `/characters/${praxis.created_by_id}`;
```

Destination-vs-location, **character to character**. Deliberately not `account_id`: a player with several characters viewing their own *other* character's page still gets a working link, because that is a different page and going there is meaningful (constraint 1 of the ruling). The link is also not repointed anywhere else (constraint 2) — it is simply not a link.

Comparing whole paths rather than bare ids is what keeps the link alive on `/praxis/7` when the author happens to be character #7; a `useParams().id` version would have silently killed it there, which is why that case has its own test.

## Accessibility

The name renders as a plain `<span>` — no anchor, no `role` patch, no `pointer-events: none`, no disabled link. Dropping the `<a>` is what fixes the screen-reader announcement, which the ruling names as part of the defect. Both branches share one `nameStyle`, so the two render identically apart from the anchor; `hover:underline` is the only class the link branch adds, since a name that goes nowhere must not offer one.

## Same shape elsewhere — flagged, not widened

Per the scope note I looked and did **not** touch any of it:

- **Faction page linking to itself** — does not exist. The byline's faction tag is already plain text, and the six faction bodies link only to characters.
- **Task detail linking to the task** — praxis cards are not mounted on task detail, so the case does not arise there.
- **Comment bylines** (`components/comments/voices/*`) each build their own `/characters/${comment.author.id}` anchor — nine of them, real duplication — but comments render on praxis and task detail, never on a character page, so none of them can currently point at the page you are on. Worth collapsing on its own issue; out of scope here.
- The character profile bodies themselves render no `<Link>` at all.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **332 files, 5796 passed**, 1 skipped
- `npm run build` — ok
- `npm run budget` — within budget (JS 126.5 KB, CSS 22.0 KB, unchanged; no CSS touched)

No backend, route or schema change, so `api-schema` and the `test` job are untouched.

**Visual QA is outstanding** — I have no browser or dev stack here, so the checks above are markup-level only.

## What to eyeball

1. **A character's own praxis on their own page** — `/characters/3`, an entry authored by character 3: the name above the dashed byline rule is plain text. No underline on hover, no pointer, not focusable by Tab, and no colour shift. The portrait beside it and the spacing between them must look exactly as before.
2. **Someone else's praxis on a character page** — a collab entry on `/characters/3` authored by a different character: that name **still links**, still underlines on hover, and still lands on the author's page.
3. **The multi-character case (constraint 1)** — signed in as an account with two characters, view your *other* character's page. Its praxis bylines must still be working links, because that is a different character's page. This is the one that would break if the comparison had reached for `account_id`.
4. **Every other surface is unchanged** — `/praxis`, the praxis detail page, a faction page, the home feed: the byline name links as it always did. Check `/praxis/3` in particular, where the praxis id collides with a character id.
5. **Truncation still works** — a very long author name on a narrow card ellipsizes rather than shoving the portrait out of the frame, in *both* branches (the style is shared, but the Ephemerists card's Poiret One is the one that showed the old clipping bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
