### PR TITLE
The In Progress row: points lose their leading +, and titles stop clipping their descenders

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -128,7 +128,7 @@
       "questsHeading": "In progress",
       "questsEmpty": "Nothing in progress yet — pick up a task.",
       "viewAll": "All tasks",
-      "taskMeta": "{{faction}} · +{{points}} pts",
+      "taskMeta": "{{faction}} · {{points}} pts",
       "pending_one": "{{count}} pending request",
       "pending_other": "{{count}} pending requests",
       "notifications": "New updates",

--- a/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx
@@ -120,6 +120,19 @@ function occurrences(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1
 }
 
+/**
+ * The open tag of the element that directly holds `text` — the last `<…>` in
+ * the markup before it. Every skin renders the task title as the sole child of
+ * its title element, so this is that element and its inline style.
+ */
+function openTagOf(html: string, text: string): string {
+  const at = html.indexOf(text)
+  if (at < 0) throw new Error(`the skin never printed ${JSON.stringify(text)}`)
+  const open = html.lastIndexOf('<', at)
+  const close = html.indexOf('>', open)
+  return html.slice(open, close + 1)
+}
+
 /** The text of every `<h1>` the skin drew, in document order. */
 function h1s(html: string): string[] {
   return [...html.matchAll(/<h1\b[^>]*>(.*?)<\/h1>/gs)].map((m) => m[1].replace(/<[^>]*>/g, '').trim())
@@ -283,6 +296,48 @@ describe('mobile FieldDesk-home content-slot invariant', () => {
       // Zero-because-unknown must not render as "All caught up" over a queue
       // with four invites in it, then swap under the reader.
       expect(text, 'nothing claimed while loading').not.toContain('All caught up')
+    })
+
+    /**
+     * #2113 — the row's figure is a QUANTITY, not a signed delta. Points cannot
+     * be negative (`backend/services/scoring.py:50` — every term in
+     * `compute_praxis_score` is non-negative), so a leading `+` distinguished
+     * nothing. Asserted on the row rather than on the catalog string so a skin
+     * that goes back to writing its own `+{formatPoints(...)}` fails too.
+     */
+    it(`${slug} prints the row's points as a figure, not a signed delta`, () => {
+      const voted = { ...ACTIVE_TASK, score: 47.3 }
+      const { text } = render(<Skin state={baseState({ activeTasks: [voted] })} />)
+      expect(text, 'the figure still reads').toContain('47.3')
+      expect(text, 'and carries no sign').not.toContain('+47.3')
+      expect(text, 'nor a spaced one').not.toContain('+ 47.3')
+    })
+
+    /**
+     * #2112 — the `y` and `p` of an in-progress title were cut off at the
+     * bottom. The cause is the pair, not either half: the title is a
+     * single-line `.truncate` (`overflow: hidden`, which ellipsis requires) AND
+     * it pinned a line-height under its own font's content box, so the tails
+     * sat outside the box the overflow then clipped. Measured from the shipped
+     * woff2 metrics — Lora's content box is 1.280em against a line-height of
+     * 1.2, and its `y` inks to 0.271em below the baseline against a box floor
+     * of 0.234em.
+     *
+     * The invariant is therefore: a title that CLIPS may not pin a number.
+     * `line-height: normal` is the font's own content box, which is per-face
+     * correct without a magic number per skin and stays correct while the
+     * webfont is still loading and a fallback with different metrics is drawn.
+     * WOW is exempt by the same rule read forwards — its title wraps
+     * (`overflow-wrap: anywhere`) instead of clipping, so nothing cuts it.
+     */
+    it(`${slug} leaves room for the descenders of a clipped title`, () => {
+      const { html } = render(<Skin state={baseState()} />)
+      const tag = openTagOf(html, ACTIVE_TASK.task_title)
+      if (!/\btruncate\b|overflow:\s*hidden/.test(tag)) return
+      expect(
+        tag,
+        'a clipped title takes the font\'s own line box, not a tighter number',
+      ).not.toMatch(/line-height:\s*[\d.]/)
     })
   }
 })

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/CovenFieldDesk.tsx
@@ -401,7 +401,7 @@ export default function CovenFieldDesk({ state }: { state: FieldDeskHomeState })
                     <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
                   </span>
                   <div className="min-w-0 flex-1">
-                    <div className="truncate" style={{ fontFamily: HAND, fontSize: 'var(--text-content)', lineHeight: 1, color: INK }}>
+                    <div className="truncate" style={{ fontFamily: HAND, fontSize: 'var(--text-content)', lineHeight: 'normal' /* the face's own content box, so nothing clips the tails (#2112) */, color: INK }}>
                       {praxis.task_title}
                     </div>
                     <div className="truncate" style={{ ...CAPTION, marginTop: 'var(--space-xs)' }}>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/DefaultFieldDesk.tsx
@@ -327,7 +327,7 @@ export default function DefaultFieldDesk({ state }: { state: FieldDeskHomeState 
                   <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <div className="font-display truncate content-text" style={{ lineHeight: 1.2, color: 'var(--color-text-primary)' }}>
+                  <div className="font-display truncate content-text" style={{ lineHeight: 'normal' /* the face's own content box, so nothing clips the tails (#2112) */, color: 'var(--color-text-primary)' }}>
                     {praxis.task_title}
                   </div>
                   <div

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
@@ -298,7 +298,7 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
                   <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: DECO, fontSize: 'var(--text-content)', lineHeight: 1.15, color: INK }}>
+                  <div className="truncate" style={{ fontFamily: DECO, fontSize: 'var(--text-content)', lineHeight: 'normal' /* the face's own content box, so nothing clips the tails (#2112) */, color: INK }}>
                     {praxis.task_title}
                   </div>
                   <div className="truncate" style={{ marginTop: 'var(--space-xs)', ...SMALL_CAPS, fontSize: 'var(--text-md)', letterSpacing: '0.1em', color: QUIET }}>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
@@ -367,7 +367,7 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
                   <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', lineHeight: 1.05, color: PAPER_TEXT }}>
+                  <div className="truncate" style={{ fontFamily: ACCENT_FONT, fontSize: 'var(--text-content)', lineHeight: 'normal' /* the face's own content box, so nothing clips the tails (#2112) */, color: PAPER_TEXT }}>
                     {praxis.task_title}
                   </div>
                   <div className="truncate" style={{ ...kicker, marginTop: 'var(--space-xs)' }}>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SingularityFieldDesk.tsx
@@ -312,7 +312,7 @@ export default function SingularityFieldDesk({ state }: { state: FieldDeskHomeSt
                   <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 1.2, color: PHOSPHOR }}>
+                  <div className="truncate" style={{ fontFamily: FONT, fontSize: 'var(--text-content)', lineHeight: 'normal' /* the face's own content box, so nothing clips the tails (#2112) */, color: PHOSPHOR }}>
                     {praxis.task_title}
                   </div>
                   <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: FONT, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: signal(55) }}>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/SnideFieldDesk.tsx
@@ -282,7 +282,7 @@ export default function SnideFieldDesk({ state }: { state: FieldDeskHomeState })
                   <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.02em', lineHeight: 1.15, color: TEXT }}>
+                  <div className="truncate" style={{ fontFamily: COND, fontSize: 'var(--text-content)', letterSpacing: '0.02em', lineHeight: 'normal' /* the face's own content box, so nothing clips the tails (#2112) */, color: TEXT }}>
                     {praxis.task_title}
                   </div>
                   <div className="truncate" style={{ marginTop: 'var(--space-xs)', fontFamily: TYPE, fontSize: 'var(--text-md)', letterSpacing: '0.1em', textTransform: 'uppercase', color: MUTED }}>

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/UaFieldDesk.tsx
@@ -311,7 +311,7 @@ export default function UaFieldDesk({ state }: { state: FieldDeskHomeState }) {
                   <FactionSigil slug={praxis.task_faction_slug} size={ROW_SIGIL} />
                 </span>
                 <div className="min-w-0 flex-1">
-                  <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-content)', lineHeight: 1.15, color: INK }}>
+                  <div className="truncate" style={{ fontFamily: DISPLAY, fontWeight: 600, fontSize: 'var(--text-content)', lineHeight: 'normal' /* the face's own content box, so nothing clips the tails (#2112) */, color: INK }}>
                     {praxis.task_title}
                   </div>
                   <div className="truncate" style={{ ...smallCaps, marginTop: 'var(--space-xs)' }}>


### PR DESCRIPTION
Two defects on one surface — the mobile FieldDesk home's **In progress** card — so one PR.

Closes #2113
Closes #2112

## The seam

`src/pages/fieldDesk/__tests__/mobileArchetypeSlots.test.tsx`, the existing walk over every mobile home skin (`surfaceMap('mobileFieldDesk')` + Default). Both fixes get a test inside that loop, so all eight skins are asserted, not just the one the report was taken on. The loop went red on the real defect first: 14 failures (7 skins printing `+47.3`, 7 pinning a line-height on a clipped title), then green.

## #2113 — the leading `+`

The `+` was not in any component. It lived once, in the shared catalog string:

```
"taskMeta": "{{faction}} · +{{points}} pts"   →   "{{faction}} · {{points}} pts"
```

One line in `locales/en/common.json`, which is every skin that draws the row. WOW never used it — its row prints the kit's own `✦47.3` figure — so it was already right.

**Deliberately not swept up** (they are genuine arithmetic against a stated base, per the ruling): the praxis score stamp's `+ N habit bonus` / `+N PTS` (`praxis.json`), the metatask bonus lines (`forms.json`), `feed:*.pointsEarned`, and the desktop home's `Draft · +N pts` (`home.json`), which is a different surface and pairs against a `Submitted · N pts` sibling that has no sign.

The test asserts the row, not the string, so a skin that goes back to writing its own `+{formatPoints(...)}` fails too.

## #2112 — the clipped descenders

**It was the third cause on your list, and it needs both halves to bite.** The title is a single-line `.truncate` — `overflow: hidden`, which `text-overflow: ellipsis` requires — *and* it pinned a `line-height` below its own font's content box, so the tails sat outside the box the overflow then clipped. Neither alone does it: the meta line under the title is also `.truncate` but leaves its line-height at `normal`, and is fine.

Measured off the shipped woff2s (`hhea` metrics plus the actual glyph bbox of `y g p q`), in `em`:

| skin | face | line-height | content box | `y`/`g` inks to | box floor | clipped by |
|---|---|---|---|---|---|---|
| Default (the report) | Lora | 1.2 | 1.280 | 0.271 | 0.234 | **0.037em ≈ 0.7px** |
| Coven | Caveat | 1.0 | 1.260 | 0.226 | 0.170 | **0.056em ≈ 1.0px** |
| UA | Cormorant Garamond | 1.15 | 1.211 | 0.281 | 0.256 | **0.025em ≈ 0.4px** |
| Ephemerists | Poiret One | 1.15 | 1.170 | 0.208 | 0.198 | **0.010em ≈ 0.2px** |
| Everymen / S.N.I.D.E. | Bebas Neue | 1.05 / 1.15 | 1.200 | 0.065 | — | no (the face has no lowercase) |
| Singularity | Share Tech Mono | 1.2 | 1.127 | 0.170 | 0.279 | no |
| WOW | — | 1.15 | — | — | — | no: it wraps (`overflow-wrap: anywhere`), nothing clips it |

At `--text-content` (18px) Default's 0.7px is 2 device px on a 3× phone — which is the partial tail in the screenshot, and why the `y` reads worse than the `g` (its diagonal loses its point, the `g`'s bowl loses a flat sliver).

**The fix is `line-height: normal` on the truncated title in all seven clipping-capable skins** — the treatment, once, rather than seven bespoke numbers. `normal` *is* the font's own content box, so it is per-face correct with no magic number, it stays correct while the webfont is still loading and a fallback with different metrics is being drawn, and a future faction swapping its display face cannot silently re-clip. No padding, no height, no colour, no raw values.

The test states the invariant: **a title that clips may not pin a numeric line-height.** WOW is exempt by the same rule read forwards.

## Layout impact — worth your eyes

The rows carry no fixed height (`padding: var(--space-md) 0`, no `height`/`minHeight`), so each grows by the leading delta rather than overflowing:

- Coven **+0.26em** (≈4.7px per row) — the largest, it was on `1.0`
- Everymen +0.15em, Default +0.08em, UA / S.N.I.D.E. / Ephemerists +0.02–0.06em
- Singularity **−0.07em** (Share Tech Mono's box is tighter than the 1.2 it pinned)

With a full task bank that is a few px of card height on Coven and under 2px elsewhere. Nothing reflows or re-wraps — these are single-line rows.

## Coordination

Ephemerists' `EphemeristsFieldDesk.tsx` is touched: one token on one line, because it is in the clipping set and the shared fix forces it. Nothing else Ephemerists-side is changed (#2140–#2148 untouched). `components/vote/*`, `CharacterProfile.tsx` and `utils/levelTrack.ts` are untouched.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (331 files / 5808 tests), `npm run build`, `npm run budget` — all green; budget unchanged (JS 126.4 KB, CSS 22.0 KB). No API contract touched, so no schema regen.

**Visual QA is outstanding — I have no browser.** Everything above is measured from font metrics and asserted in static markup; nobody has looked at a rendered pixel.

## What to eyeball

1. The **In progress** card on the mobile home with a task whose title carries descenders — `y g p q` (e.g. "Player Photograph", the report's own row). The tails should be whole.
2. **Several point values in the row**: a fresh 0, a whole number, and a voted score with a decimal — all should read `Unaffiliated · 10 pts`, no sign.
3. **Both themes**, since the clip was only ever visible against the row's own ground.
4. **Coven and Everymen especially** — the two biggest leading changes. Check the gap between the title and the small-caps line under it still looks deliberate.
5. **Singularity**, the one row that got *tighter*.
6. A **long title that actually truncates**, to confirm the ellipsis still sits right.
