### PR TITLE
S.N.I.D.E. wears one ground: the wall on the composer and the praxis card, black on task detail

### DIFF
--- a/frontend/src/components/factionMarks/snideAtoms.tsx
+++ b/frontend/src/components/factionMarks/snideAtoms.tsx
@@ -8,6 +8,36 @@
  */
 import type { CSSProperties } from "react";
 
+/**
+ * THE FLYPOSTED WALL — S.N.I.D.E.'s one ground (#2177).
+ *
+ * Five layers bottom-to-top over the `-wall` ramp: the diagonal xerox raster, a
+ * vertical scanline, an acid wash off the top-left corner and a pink one off the
+ * bottom-right. It FLIPS — xerox stock by day, pitch black by night — which is
+ * why every pigment is a token and none of it is a `dark ? a : b` (§8).
+ *
+ * IT LIVES HERE BECAUSE THREE SURFACES WEAR IT. The recipe was inline in
+ * `SnideTaskCard` while the card was its only mount, and the owner's ruling on
+ * #2177 gives it to the composer and the praxis card as well. Three inline
+ * copies is how a faction acquires a second identity, so it is drawn once, in
+ * the shape `covenSlip`'s `SLIP_SHEET` already established for Coven's four
+ * mounts. It stays in JS rather than becoming a class for the reason the task
+ * card's comment gave: five gradients is a lot of BLOCKING stylesheet.
+ *
+ * THE INKS THAT GO ON IT ARE THE `-note-*` FAMILY, which flips with it — never
+ * `-card-*`, which is pinned near-black in both themes for the slabs pasted ON
+ * the wall (#2066). The two ends of that rule are measured against all four of
+ * this ground's readings (both ramp stops and both washed corners, both themes)
+ * in `utils/__tests__/factionContrast.test.ts`.
+ */
+export const WALL = [
+  "repeating-linear-gradient(115deg, var(--faction-snide-note-grain) 0 2px, transparent 2px 7px)",
+  "repeating-linear-gradient(0deg, var(--faction-snide-note-scan) 0 1px, transparent 1px 4px)",
+  "radial-gradient(120% 80% at 8% -10%, var(--faction-snide-note-wash-acid), transparent 60%)",
+  "radial-gradient(90% 70% at 100% 110%, var(--faction-snide-note-wash-pink), transparent 62%)",
+  "linear-gradient(180deg, var(--faction-snide-wall) 0%, var(--faction-snide-wall-deep) 100%)",
+].join(", ");
+
 interface SnideSigilProps {
   size?: number;
   color?: string;

--- a/frontend/src/components/praxisCard/__tests__/snideOneGround.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/snideOneGround.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * #2177 — S.N.I.D.E. wears ONE ground, with one exception.
+ *
+ * THE SEAM IS THE CARD'S RENDERED FRAME plus the class the container hangs the
+ * exception on. Both halves need a test and neither is visible to the other:
+ *
+ *  - the FRAME's dress is markup this file can read. What it cannot read is the
+ *    cascade, so the assertion is that every value the two dresses disagree
+ *    about arrives through the `--snd-praxis-*` channel WITH the wall as its
+ *    fallback. A dress that hard-coded the wall would render identically here
+ *    and ignore the detail row entirely;
+ *  - the HOOK is `.snd-detail-praxis` on the task-detail gallery row. The issue
+ *    rules out `.praxis-gallery` explicitly — `WowFactionBody` mounts that one
+ *    too, and a Snide-task praxis lands on the WOW faction page — so this file
+ *    also asserts the negative: no rule in index.css paints a praxis card black
+ *    off `.praxis-gallery`.
+ *
+ * WHAT IS NOT HERE: the ratios. `factionContrast.test.ts` (SNIDE_WALL_PAIRS)
+ * measures both dresses' inks on all four readings of the wall and on the slab,
+ * in both themes, which is the half that actually gates the ruling.
+ *
+ * SSR-only harness (renderToStaticMarkup, no DOM, effects never run), so these
+ * are assertions about markup given props — never interaction.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../i18n";
+import { ruleBodies, stripComments } from "../../../utils/__tests__/cssVars";
+import type { PraxisCardOut } from "../../../api/praxis";
+import SnidePraxisCard from "../desktop/SnidePraxisCard";
+
+// `useTheme()` throws outside a `ThemeProvider` by design (#701) and the score
+// stamp reaches for it. Mocked rather than wrapped, the shape `covenSlipSheet`
+// established: the theme is an input here, and nothing this file asserts
+// depends on which half it gets — that is the point of a token dress.
+vi.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ theme: "light", toggle: () => {} }),
+}));
+
+/** Comments stripped: this file reads RULES, and every claim below is also
+ *  spelt out in prose beside the rules it is about. */
+const CSS = stripComments(
+  readFileSync(fileURLToPath(new URL("../../../index.css", import.meta.url)), "utf8"),
+);
+
+function praxis(overrides: Partial<PraxisCardOut> = {}): PraxisCardOut {
+  return {
+    id: 1,
+    title: "Fly-posted the whole of Corporation Street",
+    task_id: 4,
+    task_title: "Say the thing nobody will put their name to",
+    created_by_id: 7,
+    created_by_display_name: "Vex",
+    created_by_faction_slug: "snide",
+    created_by_avatar_url: "",
+    task_faction_slug: "snide",
+    task_level_required: 2,
+    task_point_value: 12,
+    member_count: 1,
+    score: 13.6,
+    display_multiplier: 1,
+    metatask_points: 0,
+    points_from_votes: 4,
+    voter_count: 3,
+    is_top_for_task: false,
+    media_items: [],
+    applied_metatasks: [],
+    ...overrides,
+  } as PraxisCardOut;
+}
+
+const adminProps = {
+  praxis: praxis(),
+  showAdminControls: false,
+  onHide: () => {},
+  onFail: () => {},
+} as unknown as Parameters<typeof SnidePraxisCard>[0]["adminProps"];
+
+const html = () =>
+  renderToStaticMarkup(
+    <MemoryRouter>
+      <SnidePraxisCard praxis={praxis()} adminProps={adminProps} />
+    </MemoryRouter>,
+  );
+
+/** Four proof tiles, which is one past the three the gallery shows: the "+N"
+ *  badge is the slot that paints the frame's `paper`. */
+const withMedia = () =>
+  renderToStaticMarkup(
+    <MemoryRouter>
+      <SnidePraxisCard
+        praxis={praxis({
+          media_items: [1, 2, 3, 4].map((id) => ({
+            id,
+            file_path: `proof-${id}.jpg`,
+            type: "image",
+          })),
+        } as Partial<PraxisCardOut>)}
+        adminProps={adminProps}
+      />
+    </MemoryRouter>,
+  );
+
+const frame = () => {
+  const markup = html();
+  return markup.slice(0, markup.indexOf(">"));
+};
+
+describe("the S.N.I.D.E. praxis card wears the wall (#2177)", () => {
+  it("grounds on the five-layer wall, not the evidence plate", () => {
+    const outer = frame();
+    expect(outer, "the ramp").toContain("var(--faction-snide-wall)");
+    expect(outer, "the acid corner").toContain("var(--faction-snide-note-wash-acid)");
+    expect(outer, "the pink corner").toContain("var(--faction-snide-note-wash-pink)");
+    // The plate the card used to print on, and the 3px dot tooth over it: the
+    // wall carries its own raster, and stacking both is noise.
+    expect(outer, "the retired plate").not.toContain("background:var(--faction-snide-card-bg)");
+    expect(outer, "the retired tooth").not.toContain("--faction-snide-slab-tooth");
+  });
+
+  it("reads the inks that FLIP with that ground, not the slab's", () => {
+    // The trap #2066 named, from the other side: `-card-text` is cream in both
+    // themes because its ground is black in both. On a ground that flips it is
+    // cream type on a cream wall for half the day.
+    const markup = html();
+    expect(markup, "the card's own copy").toContain("--faction-snide-note-ink");
+    expect(markup, "the card's muted tier").toContain("--faction-snide-note-muted");
+    expect(markup, "the accent that is text on the wall").toContain(
+      "--faction-snide-note-pink-ink",
+    );
+  });
+
+  it("takes each of those from the container's channel, wall as the fallback", () => {
+    // The dress the detail row overrides. Hard-coding the wall renders the same
+    // markup and silently ignores the exception, which is why the FALLBACK form
+    // is what this asserts rather than the value.
+    const markup = html();
+    for (const channel of ["ground", "ink", "muted", "accent"]) {
+      expect(markup, `--snd-praxis-${channel}`).toContain(`var(--snd-praxis-${channel},`);
+    }
+    // `paper` — the disc behind a proof tile's "+N" and a roster monogram — only
+    // renders with something to count, so it takes a card that has proof on it.
+    expect(withMedia(), "--snd-praxis-paper").toContain("var(--snd-praxis-paper,");
+    // The frame that re-points the shared slots' functional inks (`sheetInk`
+    // takes no prop), which is the other half of the switch.
+    expect(markup, "the frame class").toContain("snd-praxis-frame");
+  });
+});
+
+describe("the black exception is scoped to task detail alone (#2177)", () => {
+  it("hangs on the detail row's own class", () => {
+    const [block] = ruleBodies(CSS, ".snd-detail-praxis");
+    expect(block, ".snd-detail-praxis rule must exist").toBeDefined();
+    expect(block, "the black ground").toContain("--snd-praxis-ground: var(--faction-snide-card-bg)");
+    // Black is a TOKEN and the ink family that was measured on it comes with it.
+    expect(block, "the slab's ink").toContain("--snd-praxis-ink: var(--faction-snide-card-text)");
+    expect(block, "no literal").not.toContain("#000");
+  });
+
+  it("does NOT reach for .praxis-gallery, which WowFactionBody also mounts", () => {
+    // `.praxis-gallery` reads like "the task-detail row" and is not: scoping the
+    // exception there would blacken Snide praxis cards on the WOW faction page.
+    // It keeps its one job — narrowing `--praxis-card-basis` to 320px (#1137).
+    for (const body of [
+      ...ruleBodies(CSS, ".praxis-gallery"),
+      ...ruleBodies(CSS, ".praxis-gallery > *"),
+    ]) {
+      expect(body, "the gallery row stays out of S.N.I.D.E.'s dress").not.toContain("--snd-praxis-");
+      expect(body).not.toContain("--faction-snide");
+    }
+  });
+});

--- a/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
@@ -1,54 +1,92 @@
+import { WALL } from "../../factionMarks/snideAtoms";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
 /**
- * S.N.I.D.E. — THE EVIDENCE SLAB (#842). A photocopier-black plate ruled in
- * deep acid, printed onto the page with a hard 6px/8px drop shadow (no blur: it
- * is stuck down, not floating) over a 3px dot tooth, with the case title struck
- * in Anton and skewed -3deg.
+ * S.N.I.D.E. — THE EVIDENCE SLAB (#842), REPOSTED ON THE WALL (#2177).
  *
- * Three pieces of chrome came off, all inventions with no counterpart in the
- * vendored prototype and all pulling the slab toward a different archetype:
+ * The slab is guillotined — square corners, unbroken acid rule — with the case
+ * title struck in Anton and skewed -3deg, printed onto its ground with a hard
+ * 6px/8px drop shadow (no blur: it is stuck down, not floating).
  *
- *  • the TORN-PAPER top/bottom edges (a 25-point clip-path). The design's slab
- *    is guillotined — square corners, unbroken acid rule. The tearing read as
- *    the Updates feed's aged-paper foe note;
- *  • the TAPE strip (and there is no strip to reconsider: #1708 retired tape
- *    from every SNIDE surface);
- *  • the `Special Elite` MASTHEAD block. The design's running head was a single
- *    Courier eyebrow line in acid, inside the text column, where it stopped at
- *    the score tag instead of running under it — passed to {@link PraxisBody} as
- *    `eyebrow`, the seam #841 opened for the codex. #1909 CUT its string
- *    (`card.masthead.snide`, "evidence locker"), so the slot ships empty.
+ * ## The ground, and its one exception
+ *
+ * The owner's ruling on #2177 is that S.N.I.D.E. wears ONE ground, and it is the
+ * flyposted wall ({@link WALL}) the task card already wore — so the plate this
+ * card printed on, `--faction-snide-card-bg`, is gone from here and the 3px
+ * `-slab-tooth` dot texture goes with it: the wall carries its own raster and
+ * scanline, and stacking both is noise rather than xerox.
+ *
+ * THE INKS COME WITH THE GROUND, and that is the whole of the work. The wall
+ * FLIPS — cream by day, pitch black by night — while `-card-*` is pinned
+ * near-black in BOTH themes for the slabs pasted ON that wall (#2066). Left as
+ * they were, every reading ink on this card would have been cream type on a
+ * cream wall in light. So the card reads the `-note-*` family, which flips with
+ * the wall, and the wall's own alarm/notice/credit for the marks the shared
+ * slots paint. All of it is measured on the ramp's two stops AND its two washed
+ * corners, in both themes, in `factionContrast.test.ts` (SNIDE_WALL_PAIRS).
+ *
+ * ON TASK DETAIL IT IS BLACK. That page's column already wears the wall, and a
+ * wall inside a wall stops reading as a thing pasted ON something. The switch is
+ * the container's to make, so it arrives the way `--praxis-card-basis` does
+ * (#1137): the detail row sets `--snd-praxis-*`, this file supplies the wall
+ * half as each fallback, and `.snd-praxis-frame` / `.snd-detail-praxis` in
+ * index.css carry the rest. Nothing here branches on the THEME — that is still
+ * the `[data-theme]` cascade's job, and every value below is a token.
+ *
+ * TEXT ON THE BLACK CARD READS AS REDACTION and that is the intent, not a
+ * side-effect (owner, #2177): the black IS the censor bar S.N.I.D.E. already
+ * paints in `--faction-snide-note-bar`, and the card's copy is knocked out of
+ * it. What it does not license is a bar over anything the reader needs, or
+ * "redacted-looking" as an excuse for 2:1 type — every ink on either dress
+ * clears AA in both themes, which is what the manifest above pins.
+ *
+ * ## What is not here
+ *
+ * Three pieces of chrome came off in #842, all inventions with no counterpart in
+ * the vendored prototype and all pulling the slab toward a different archetype:
+ * the TORN-PAPER top/bottom edges (a 25-point clip-path — the design's slab is
+ * guillotined, and the tearing read as the Updates feed's aged-paper foe note);
+ * the TAPE strip (and there is no strip to reconsider: #1708 retired tape from
+ * every SNIDE surface); and the `Special Elite` MASTHEAD block, whose running
+ * head was a single Courier eyebrow line in acid inside the text column — passed
+ * to {@link PraxisBody} as `eyebrow`, the seam #841 opened for the codex. #1909
+ * CUT its string (`card.masthead.snide`, "evidence locker"), so the slot ships
+ * empty.
  *
  * The dashed acid rule above the vote widget is the design's, and is the one
  * divider the slab carries.
  */
+const GROUND = `var(--snd-praxis-ground, ${WALL})`;
+const INK = "var(--snd-praxis-ink, var(--faction-snide-note-ink))";
+const MUTED = "var(--snd-praxis-muted, var(--faction-snide-note-muted))";
+/** The pink that is TEXT on the wall; acid is an ink only on a slab (#2066). */
+const ACCENT = "var(--snd-praxis-accent, var(--faction-snide-note-pink-ink))";
+const PAPER = "var(--snd-praxis-paper, var(--faction-snide-note-paper))";
+
 export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
   return (
     <div
+      className="snd-praxis-frame"
       style={{
         ...frameBase,
         // No borderRadius: the evidence slab has hard corners in the prototype.
         position: "relative",
-        background: "var(--faction-snide-card-bg)",
+        background: GROUND,
         border: "1.5px solid var(--faction-snide-acid-deep)",
         boxShadow: "6px 8px 0 var(--faction-snide-slab-shadow)",
-        // The plate's xerox tooth — ornament geometry, raw by §4a.
-        backgroundImage: "radial-gradient(var(--faction-snide-slab-tooth) 1px, transparent 1px)",
-        backgroundSize: "3px 3px",
         padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
         fontFamily: "var(--faction-snide-font-type)",
-        color: "var(--faction-snide-card-text)",
+        color: INK,
         transition: "background 150ms, color 150ms",
       }}
     >
       <AdminOverlay {...adminProps} />
       <PraxisBody
         praxis={praxis}
-        tint="var(--faction-snide-card-accent)"
-        muted="var(--faction-snide-card-muted)"
-        paper="var(--faction-snide-card-bg)"
+        tint={ACCENT}
+        muted={MUTED}
+        paper={PAPER}
         showCrown={showCrown}
         // The split earning its keep (#888): Permanent Marker is S.N.I.D.E.'s
         // declared card font and it finally reaches the card — but only where
@@ -64,7 +102,7 @@ export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
           letterSpacing: "0.04em",
           lineHeight: 1,
           transform: "skewX(-3deg)",
-          color: "var(--faction-snide-card-text)",
+          color: INK,
         }}
         /* The eyebrow read "evidence locker" (`card.masthead.snide`). #1909 cut
            the slot — once generic it says "Praxis" on a praxis card — so the

--- a/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
@@ -163,10 +163,16 @@ export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) 
 
           THE INKS ARE THIS SURFACE'S, NOT THE ATOM'S DEFAULTS, and the difference
           is not cosmetic: the card's `-note-ink` figure measures 1.05:1 on this
-          plate in LIGHT and its `-note-pink-ink` caption 3.27:1. The tag keeps the
-          two inks it already printed — acid at 16.31:1 light / 16.81:1 dark, the
-          faded newsprint caption at 13.52:1 / 12.74:1, both composited over the
-          translucent plate on the S.N.I.D.E. praxis card's own `-card-bg`.
+          plate in LIGHT and its `-note-pink-ink` caption 3.27:1. The figure keeps
+          the acid it always printed (16.31:1 light / 16.81:1 dark).
+
+          THE CAPTION LEFT `-card-muted` IN #2177. The card around this tag wears
+          the flyposted wall now, and the frame re-points `-card-muted` at the
+          wall's family for the shared slots that cannot take an ink prop — which
+          would have put the wall's dark grey on this black plate. So the caption
+          joins `-vote-off`, the typed-label ink the BASE line above it already
+          uses on this same tag (6.46:1 on the plate, invariant like the plate).
+          The plate itself is opaque since that issue; see `-stamp-bg`.
 
           The loop is drawn at 96, which is the desktop task card's own width, so
           the tag's `minWidth: 116` grows to fit it rather than clipping it. */}
@@ -176,7 +182,7 @@ export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) 
           value={formatPoints(total)}
           unit={t("card.stamp.pointsShort")}
           valueColor="var(--faction-snide-acid)"
-          unitColor="var(--faction-snide-card-muted)"
+          unitColor="var(--faction-snide-vote-off)"
         />
       </div>
     </div>

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/pointsMarkUnification.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/pointsMarkUnification.test.tsx
@@ -245,7 +245,13 @@ describe("each mount overrides what its ground demands (#2042)", () => {
   it("S.N.I.D.E. passes its own two inks rather than the clipping's", () => {
     const chronicle = stamp(SnideScoreStamp);
     expect(chronicle, "the acid figure").toContain("color:var(--faction-snide-acid)");
-    expect(chronicle, "the newsprint caption").toContain("color:var(--faction-snide-card-muted)");
+    // The caption left `-card-muted` in #2177: the card around this tag wears
+    // the flyposted wall now and its frame re-points that property at the wall's
+    // family for the shared slots that take no ink prop, which would have landed
+    // the wall's dark grey on this black plate. `-vote-off` is the typed-label
+    // ink the BASE line on this same tag already prints, and it is invariant
+    // like the plate. Still an OVERRIDE, which is what this assertion guards.
+    expect(chronicle, "the typed caption").toContain("color:var(--faction-snide-vote-off)");
     // `-note-ink` is 1.05:1 on this plate in light and `-note-pink-ink` is 3.27:1.
     // Neither may reach this surface, at any theme, ever.
     expect(chronicle).not.toContain("--faction-snide-note-ink");

--- a/frontend/src/components/taskCard/SnideTaskCard.tsx
+++ b/frontend/src/components/taskCard/SnideTaskCard.tsx
@@ -8,7 +8,7 @@ import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
-import { PenCircle } from "../factionMarks/snideAtoms";
+import { PenCircle, WALL } from "../factionMarks/snideAtoms";
 
 /**
  * S.N.I.D.E. — THE RANSOM CLIPPING (task card v2, #1023).
@@ -163,13 +163,10 @@ export default function SnideTaskCard({
       style={{ width: size.cardWidth, maxWidth: "100%", boxSizing: "border-box" }}
     >
       {/* THE GROUND IS THE FLYPOSTED WALL (#2065), not a second sheet of the
-          clipping's own stock. Five layers over the `-wall` ramp: the diagonal
-          xerox raster, a vertical scanline, an acid wash off the top-left and a
-          pink one off the bottom-right. One recipe, and it FLIPS — xerox stock by
-          day, pitch black by night — which is why every pigment is a token and
-          none of it is a `dark ? a : b`. The recipe stays inline rather than
-          earning a class: `.snd-backdrop` has three mounts, this has one, and
-          five gradients is a lot of BLOCKING stylesheet for one component.
+          clipping's own stock. The five-layer recipe is {@link WALL}, drawn once
+          in `factionMarks/snideAtoms` since #2177 gave the same ground to the
+          composer and to the praxis card: this card was its only mount when it
+          was written inline here, and it is one of three now.
 
           THE EDGE AND THE SHADOW ARE LOAD-BEARING. On the S.N.I.D.E. faction
           page `useFactionBackdrop` paints the page with this same wall, so these
@@ -183,13 +180,7 @@ export default function SnideTaskCard({
           boxSizing: "border-box",
           width: "100%",
           color: INK,
-          background: [
-            "repeating-linear-gradient(115deg, var(--faction-snide-note-grain) 0 2px, transparent 2px 7px)",
-            "repeating-linear-gradient(0deg, var(--faction-snide-note-scan) 0 1px, transparent 1px 4px)",
-            "radial-gradient(120% 80% at 8% -10%, var(--faction-snide-note-wash-acid), transparent 60%)",
-            "radial-gradient(90% 70% at 100% 110%, var(--faction-snide-note-wash-pink), transparent 62%)",
-            "linear-gradient(180deg, var(--faction-snide-wall) 0%, var(--faction-snide-wall-deep) 100%)",
-          ].join(", "),
+          background: WALL,
           border: "1px solid var(--faction-snide-note-wall-edge)",
           boxShadow: "var(--faction-snide-note-wall-shadow)",
           transform: "rotate(-0.4deg)",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -942,7 +942,21 @@
      Dark keeps the faction's night pink and amber unchanged; light was the only
      miss, exactly as in #1449 and #1231. */
   --faction-snide-wall-alarm: #9d174d;
-  --faction-snide-wall-notice: #92400e;
+  /* Walked once more by #2177. The praxis card's mode chip prints this ink on
+     an 8% wash OF ITSELF, and a wash of the mark's own polarity only ever
+     tightens the reading: #92400e measured 4.04:1 that way in the wall's pink
+     corner (4.47:1 bare). At #78350f the chip clears every reading of the wall
+     — 5.10:1 in that corner — and the detail page's failed banner, which reads
+     this ink under the danger veil, only gains. */
+  --faction-snide-wall-notice: #78350f;
+  /* The third of that trio, minted by #2177 for the same ground and the same
+     reason: the praxis card wears the wall now, and its collab chip reads
+     `-card-credit`, which is pinned bright (#4ade80) for the black slab and
+     measures 1.86:1 on the light wall. This is the value the five paper
+     factions already carry, measured here on both ends of the ramp and both
+     washed corners under the chip's own 8% wash. The frame re-points
+     `-card-credit` at it in `.snd-praxis-wall`; nothing reads it directly. */
+  --faction-snide-wall-credit: #14532d;
   /* SNIDE font set — a ransom note mixes many faces in one surface */
   --faction-snide-font-impact: "Anton", Impact, sans-serif;
   --faction-snide-font-cond: var(--font-accent); /* Bebas Neue */
@@ -972,7 +986,15 @@
      themes, so only the two shadow alphas deepen under [data-theme="dark"]. */
   --faction-snide-slab-shadow: rgba(0, 0, 0, 0.4);
   --faction-snide-slab-tooth: rgba(244, 241, 232, 0.05);
-  --faction-snide-stamp-bg: rgba(0, 0, 0, 0.4);
+  /* THE SCORE WELL IS OPAQUE (#2177), and that is a pairing fix rather than a
+     repaint: #0c0a07 is exactly what rgba(0,0,0,0.4) computed to over the black
+     `-card-bg` it used to be punched into, so the tag looks identical where it
+     always sat. The praxis card's ground flips to the wall now, and a 40% black
+     over the wall's LIGHT half composited to mid-grey — which took the tag's
+     acid figure to 2.71:1 and its typed working with it. An opaque plate keeps
+     every ink on this tag measured against the tag, whichever dress the card
+     around it is wearing. */
+  --faction-snide-stamp-bg: #0c0a07;
   --faction-snide-stamp-shadow: rgba(0, 0, 0, 0.5);
 
   /* ══ S.N.I.D.E. — THE RANSOM CLIPPING (task card v2, #1023) ══
@@ -997,15 +1019,34 @@
          serves both themes because the chip's pink does not flip.
      The bright pink survives everywhere it is a DRAWN LINE — the pen circle,
      the struck-out cross — where it is ornament and owes nothing. */
+  /* RE-MEASURED ON THE WALL (#2177). These tiers were read on `-note-paper`,
+     and since #2065 the clipping's GROUND is the flyposted wall — a 180deg ramp
+     with an acid wash off one corner and a pink one off the other. #2177 gives
+     that same ground to the praxis card and the composer, so three surfaces'
+     copy now lands on it and the ramp's deep end under the pink wash is the
+     reading that gates. Two tiers missed there and are walked below; the rest
+     clear on all four readings in both themes (`factionContrast.test.ts`,
+     SNIDE_WALL_PAIRS). Dark was never the miss, exactly as in #1449/#1231. */
   --faction-snide-note-paper: #f4f1e8; /* the clipping's stock (FLIPS) */
-  --faction-snide-note-ink: #14110b; /* headline, level, points numeral (FLIPS) */
-  --faction-snide-note-muted: #5f5c50; /* brief + in-progress copy */
+  --faction-snide-note-ink: #14110b; /* headline, level, points numeral (FLIPS) — 9.87:1 in the pink corner */
+  /* Brief + in-progress copy. #5f5c50 read 5.93:1 on the stock and 4.23:1 in
+     the wall's pink corner; walked until the corner clears — 5.03:1 there,
+     6.75:1 at the top of the ramp. */
+  --faction-snide-note-muted: #545143;
   --faction-snide-note-rule: rgba(20, 17, 11, 0.28);
   --faction-snide-note-grain: rgba(20, 17, 11, 0.045); /* the xerox raster */
   --faction-snide-note-bar: #14110b; /* the header bar */
   --faction-snide-note-bar-ink: #f4f1e8; /* the ordinal on that bar */
-  /* The pink that is TEXT, as opposed to the pink that is a drawn line. */
-  --faction-snide-note-pink-ink: #be185d;
+  /* The pink that is TEXT, as opposed to the pink that is a drawn line. Walked
+     for the wall for the third time in this faction's history and for the same
+     reason each time (#1451, #1231): the value was measured on a stock this ink
+     no longer sits on. #be185d read 5.35:1 on the note stock, 4.44:1 flat at the
+     ramp's deep end and 3.81:1 in the pink corner. It lands on the SAME hex as
+     `--faction-snide-wall-alarm` by measurement rather than by borrowing, and
+     stays its own token for #1181's reason — one is the clipping's caption ink,
+     the other is the wall's destructive mark, and a shared value today is not a
+     shared contract tomorrow. 4.98:1 in the corner, 6.67:1 at the ramp's top. */
+  --faction-snide-note-pink-ink: #9d174d;
   /* The headline's four cuts. Cut 2 is knocked out of the near-black ink and
      cut 1 sits on acid: both are stated as their own pair rather than reusing
      `-paper`/`-ink`, because those two SWAP under the dark cascade and a
@@ -1068,16 +1109,29 @@
      slip's field rather than the sheet (#1028: contrast is a pairing): 4.7:1 on
      the field, 5.2:1 on the stock. Acid stays bright everywhere it is a DRAWN
      THING: the masthead rule, the blobs, the submit bar. */
-  --faction-snide-composer-sheet: #f4f1e8; /* the xerox stock (FLIPS) */
-  --faction-snide-composer-ink: #14110b; /* type on that stock (FLIPS) */
-  --faction-snide-composer-muted: #5f5c50; /* the task's prose, the pill */
-  /* Counter, autosave line, body placeholder. #1232 walked the light value from
-     #6e6b5d: that reading was taken on the SHEET (4.74:1) and the ink also lands
-     on the FIELD — the placeholder inside the write-up box, and `quietStyle` over
-     `panelStyle` on the waiting surface — where the same hue was 4.28:1. Walked
-     until it clears the tighter ground: 4.62:1 on the field, 5.11:1 on the stock,
-     still a tier under -composer-muted (5.36 / 5.93). Dark was never the miss. */
-  --faction-snide-composer-faint: #696658;
+  /* THE SHEET IS THE WALL SINCE #2177, and these tiers were measured on the
+     stock below it. The owner's ruling puts the composer on the ground the task
+     card already wore, so the sheet token survives for the ONE opaque block that
+     still needs a stock of its own — the invite dropdown, which must not let the
+     raster read through a floating list — and every ink is re-measured on the
+     wall's four readings instead. Two missed and are walked; see
+     `factionContrast.test.ts`, SNIDE_WALL_PAIRS. The composer is the surface
+     that gates this ground, because it is the only one of the three carrying
+     form fields and placeholder text, and it is tall enough to put its footer
+     inside the pink corner. */
+  --faction-snide-composer-sheet: #f4f1e8; /* the invite dropdown's stock (FLIPS) */
+  --faction-snide-composer-ink: #14110b; /* type on the wall (FLIPS) — 9.87:1 in the pink corner */
+  /* The task's prose, the pill, every section label. #5f5c50 read 5.36:1 on the
+     old stock and 4.23:1 in the wall's pink corner; walked to clear the corner
+     at 5.03:1. Same walk as `-note-muted`, still its own token (#1181). */
+  --faction-snide-composer-muted: #545143;
+  /* Counter, autosave line, body placeholder, the save-draft and drop exits.
+     #1232 walked this from #6e6b5d for the FIELD (4.28:1) rather than the sheet,
+     and #2177 walks it again for the same reason one rung out: the sheet is the
+     wall now, where #696658 read 3.64:1 in the pink corner. 4.58:1 there, 6.14:1
+     at the top of the ramp, 5.81:1 on the field — still a tier under
+     `-composer-muted` (5.03 / 6.75 / 6.38). Dark was never the miss. */
+  --faction-snide-composer-faint: #5a5749;
   --faction-snide-composer-field: #eae6d8; /* an input, a shade off the sheet */
   --faction-snide-composer-rule: rgba(20, 17, 11, 0.5); /* a drawn hairline */
   --faction-snide-composer-bar: #14110b; /* masthead bar + the censor stripe */
@@ -1087,10 +1141,12 @@
      second ground"). Seven skins hand that banner their existing
      `--faction-{key}-card-alarm`; this faction cannot, because its CARD is
      photocopier-black in BOTH themes (§6) so `-card-alarm` is pinned bright and
-     reads 1.56:1 on the light xerox stock, while this sheet FLIPS. Same hue as
-     `-slip-pink-ink` today and declared rather than borrowed for #1181's
-     reason. Measured under `--color-danger-veil`: 4.97:1 light, 5.83:1 dark. */
-  --faction-snide-composer-alarm: #be185d;
+     reads 1.56:1 on the light xerox stock, while this sheet FLIPS. Declared
+     rather than borrowed for #1181's reason. #2177 walks the light value with
+     the sheet — under `--color-danger-veil` #be185d read 3.58:1 in the wall's
+     pink corner — to 4.67:1 there and 6.21:1 at the top of the ramp. Dark is
+     unchanged at 5.83:1. */
+  --faction-snide-composer-alarm: #9d174d;
 
   /* ══ S.N.I.D.E. — THE INTERCEPTED SLIP (feed chassis + comment sheet, #1198) ══
      Design: `Snide Comment + Update Cards.dc.html` — a flyposted xerox slip
@@ -2735,10 +2791,13 @@
      near-black wall the light values would be the miss, so only light moved. */
   --faction-snide-wall-alarm: #ff69ac;
   --faction-snide-wall-notice: #fbbf24;
+  --faction-snide-wall-credit: #4ade80;
   /* The evidence slab, lights out (#842): the plate itself is already ink, so
      only its printed shadow and the score well deepen. */
   --faction-snide-slab-shadow: rgba(0, 0, 0, 0.5);
-  --faction-snide-stamp-bg: rgba(0, 0, 0, 0.5);
+  /* The opaque night value of the same well: what rgba(0,0,0,0.5) computed to
+     over the dark `-card-bg` (#0c0a07). See the light declaration. */
+  --faction-snide-stamp-bg: #060504;
   --faction-snide-stamp-shadow: rgba(0, 0, 0, 0.6);
 
   /* ── The ransom clipping, lights out (#1023) ──
@@ -3381,6 +3440,57 @@
   z-index: -1;
   border-radius: inherit;
   pointer-events: none;
+}
+
+/* ══ The S.N.I.D.E. praxis card's TWO DRESSES (#2177) ══
+   The owner's ruling gives the card the faction's one ground — the flyposted
+   wall, drawn by `WALL` in `factionMarks/snideAtoms` — everywhere it appears,
+   with a single exception: on the TASK DETAIL page it is black. That page's
+   column already wears the wall (`.snd-detail-sheet` above), and a wall inside
+   a wall stops reading as a thing pasted ON something (#2066's ruling, which
+   this restates rather than reverses). Black is `--faction-snide-card-bg`, the
+   same slab every other sheet on that page is cut from — no new pigment, and
+   the ink family it was measured with comes with it.
+
+   `.praxis-gallery` IS NOT THE HOOK. It reads like the task-detail row, but
+   `WowFactionBody` mounts it too, and a Snide-task praxis lands on the WOW
+   faction page; scoping black there would blacken those cards as well. So the
+   detail row carries its own class and `.praxis-gallery` keeps doing its one
+   job (narrowing `--praxis-card-basis` to 320px, #1137).
+
+   WHY A CHANNEL RATHER THAN TWO RULESETS ON THE CARD. The switch is made by the
+   CONTAINER, and a container cannot give a child a class — the same problem
+   `--praxis-card-basis` solved with a custom property, for the same reason
+   (#1137). Every value the two dresses disagree about travels down one, and the
+   card supplies the WALL half as each channel's fallback, in the file the wall
+   itself lives in. The row resolves the slab half from `:root`, where it is
+   still the plain `-card-*` family — the card is the only element that
+   re-points those, which is what keeps this out of a var() cycle. */
+.snd-praxis-frame {
+  /* The shared slots inside the frame (`sheetInk` in praxisCard/shared.tsx)
+     type `--faction-{slug}-card-{role}` and take no ink prop. For seven
+     factions that names the sheet's own family; for S.N.I.D.E. it names the
+     SLAB's, which is pinned near-black in both themes (§6) — 1.86:1 to 1.41:1
+     on the light wall. The frame re-points them at the wall's family, which is
+     the cascade doing what a missing prop cannot (#1153). */
+  --faction-snide-card-notice: var(--snd-praxis-notice, var(--faction-snide-wall-notice));
+  --faction-snide-card-alarm: var(--snd-praxis-alarm, var(--faction-snide-wall-alarm));
+  --faction-snide-card-credit: var(--snd-praxis-credit, var(--faction-snide-wall-credit));
+  --faction-snide-card-muted: var(--snd-praxis-muted, var(--faction-snide-note-muted));
+}
+
+/* The exception, set on the ROW and read by the card. Each value is resolved
+   here, one element above the card, so it is the plain `:root` family rather
+   than the re-point above — a var() cycle needs one element, not two. */
+.snd-detail-praxis {
+  --snd-praxis-ground: var(--faction-snide-card-bg);
+  --snd-praxis-ink: var(--faction-snide-card-text);
+  --snd-praxis-muted: var(--faction-snide-card-muted);
+  --snd-praxis-accent: var(--faction-snide-card-accent);
+  --snd-praxis-paper: var(--faction-snide-card-bg);
+  --snd-praxis-notice: var(--faction-snide-card-notice);
+  --snd-praxis-alarm: var(--faction-snide-card-alarm);
+  --snd-praxis-credit: var(--faction-snide-card-credit);
 }
 
 /* ══ Default (Unaffiliated / na) spectrum backdrop (faction-context pages; theme-aware) ══

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1135,7 +1135,10 @@
   --faction-snide-composer-field: #eae6d8; /* an input, a shade off the sheet */
   --faction-snide-composer-rule: rgba(20, 17, 11, 0.5); /* a drawn hairline */
   --faction-snide-composer-bar: #14110b; /* masthead bar + the censor stripe */
-  --faction-snide-composer-grain: rgba(20, 17, 11, 0.09); /* the raster */
+  /* `--faction-snide-composer-grain` stood here — the sheet's own 1px/3px
+     raster, printed on a stock that had none. #2177 gives this surface the wall,
+     which carries a raster AND a scanline of its own, and a third stripe over
+     those two is moiré rather than xerox. The layer went, so the pigment did. */
   --faction-snide-composer-acid-ink: #457000; /* acid that is TEXT, not a line */
   /* The error banner's ink, and the ONE mint #1231 needed (§3, "same ink,
      second ground"). Seven skins hand that banner their existing
@@ -2844,7 +2847,6 @@
   --faction-snide-composer-field: #1e1a12;
   --faction-snide-composer-rule: rgba(244, 241, 232, 0.32);
   --faction-snide-composer-bar: #080706;
-  --faction-snide-composer-grain: rgba(244, 241, 232, 0.07);
   --faction-snide-composer-acid-ink: #b6ff2e;
   --faction-snide-composer-alarm: #ff69ac;
 

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -2,10 +2,10 @@
  * S.N.I.D.E. edit praxis — composer v2 (#1184, epic #1179; design project
  * c491945e, `Snide Edit Praxis.dc.html`, the `snide` row of `SKINS`).
  *
- * The same page `DefaultEditPraxis` draws, wearing SNIDE's dress: a xerox sheet
- * flyposted to the wall. Every region, every control and every word is shared
- * (ADR-0065); what belongs to this file is the frame, the type, the ornament and
- * the marks.
+ * The same page `DefaultEditPraxis` draws, wearing SNIDE's dress: THE FLYPOSTED
+ * WALL ITSELF since #2177, where it used to be a xerox sheet flyposted to one.
+ * Every region, every control and every word is shared (ADR-0065); what belongs
+ * to this file is the frame, the type, the ornament and the marks.
  *
  * ## The dress
  *
@@ -20,13 +20,15 @@
  * underneath it. The zine says DRAFT twice on purpose; a screen reader hears it
  * once.
  *
- * **Ground** — the photocopier raster, flush with the sheet, and nothing else on
- * that layer. Grain only is what the design kit draws as well — its own comment
- * on this ground reads "Grain only; the tape strips are dropped" — so shipped
- * and kit agree, and a fidelity pass has nothing to restore here. The raster
- * stays inside the stock because `ComposerSheet` owns the `overflow: hidden`
- * clip: the ground is the COLUMN's, never the viewport's (#1028, the trap six of
- * eight task-detail skins fell into).
+ * **Ground** — nothing on that layer since #2177. It was the photocopier raster,
+ * flush with the sheet, drawn on a stock that had none of its own; the wall
+ * carries a raster AND a scanline, and a second 1px/3px stripe over those is
+ * moiré rather than xerox. (The design kit draws the raster because it draws the
+ * xerox stock: "Grain only; the tape strips are dropped". Both moved together.)
+ * The dress still names its `ground` slot for the skins that use it — the layer
+ * clips inside the stock because `ComposerSheet` owns the `overflow: hidden`,
+ * so a ground here is the COLUMN's and never the viewport's (#1028, the trap six
+ * of eight task-detail skins fell into).
  *
  * **Rule** — the censor stripe, a solid redaction bar rather than a hairline,
  * struck ONCE above the footer (#1707) rather than between the sections.
@@ -47,12 +49,33 @@
  *
  * ## Colour
  *
- * Every value is a `--faction-snide-*` token, so the sheet flips through the
+ * Every value is a `--faction-snide-*` token, so the ground flips through the
  * `[data-theme="dark"]` cascade with no `dark ?` branch anywhere below. Two
- * families are deliberately kept apart: `-composer-*` is the SHEET (it flips),
- * and `-acid`/`-ink`/`-pink` are the PRESS (they do not). Type printed on an
- * acid ground reads the press's ink in both themes — paper-white on acid green
- * measures 1.2:1.
+ * families are deliberately kept apart: `-composer-*` is the SHEET'S ink (it
+ * flips), and `-acid`/`-ink`/`-pink` are the PRESS (they do not). Type printed
+ * on an acid ground reads the press's ink in both themes — paper-white on acid
+ * green measures 1.2:1.
+ *
+ * **THE STOCK IS THE WALL, AND THAT REVERSES WHAT THIS BLOCK USED TO SAY.**
+ * It read "the sheet is xerox stock by day, photocopier black by night", drawn
+ * from `-composer-sheet` — a sheet flyposted TO the wall. The owner's ruling on
+ * #2177 is that S.N.I.D.E. wears ONE ground across its three authoring and
+ * reading surfaces, so the composer wears the wall itself ({@link WALL}, drawn
+ * once in `factionMarks/snideAtoms`). Restoring the separate stock is drift, not
+ * a fix. `-composer-sheet` survives for the one block that still needs an opaque
+ * stock of its own — the invite dropdown, a floating list the raster must not
+ * read through.
+ *
+ * **THE SWAP IS THE SMALL HALF; THE INKS ARE THE WORK.** This is the only one of
+ * the three surfaces carrying form fields and placeholder text, and every tier
+ * was measured on flat stock. The wall is a ramp with an acid wash off one
+ * corner and a pink one off the other, and this page is tall enough to put its
+ * footer inside the pink one — where `-composer-muted` read 4.23:1 and
+ * `-composer-faint` 3.64:1. Both are walked in index.css, along with the error
+ * banner's alarm; all four readings of the ground, in both themes, are pinned in
+ * `factionContrast.test.ts` (SNIDE_WALL_PAIRS). What did NOT need walking is
+ * every block that already sits on `FIELD`: an input, the task slip, the panels.
+ * A field ground under type is this ruling working, not failing.
  *
  * ## Type
  *
@@ -78,7 +101,6 @@ import { pickArtKey } from "../blocks/useMediaArt";
 import {
   Breadcrumb,
   ComposerFooter,
-  ComposerGround,
   ComposerMasthead,
   ComposerPage,
   ComposerRule,
@@ -111,14 +133,16 @@ import {
   type ComposerTab,
 } from "./controls";
 import { MetataskSealStack } from "../../../components/metataskSeal/MetataskSealStack";
+import { WALL } from "../../../components/factionMarks/snideAtoms";
 import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
 interface Props {
   state: EditPraxisState;
 }
 
-/* THE SHEET — flips with the theme (xerox stock by day, photocopier black by
- * night), so nothing below branches on it. */
+/* THE STOCK the invite dropdown floats on — the one block that still needs an
+ * opaque sheet of its own now the page's ground is the wall (#2177). It flips
+ * with the theme like everything else here, so nothing below branches on it. */
 const SHEET = "var(--faction-snide-composer-sheet)";
 const INK = "var(--faction-snide-composer-ink)";
 const MUTED = "var(--faction-snide-composer-muted)";
@@ -126,14 +150,14 @@ const FAINT = "var(--faction-snide-composer-faint)";
 const FIELD = "var(--faction-snide-composer-field)";
 const RULE = "var(--faction-snide-composer-rule)";
 const BAR = "var(--faction-snide-composer-bar)";
-const GRAIN = "var(--faction-snide-composer-grain)";
 /* Acid as TEXT: deep in the light half, bright on the dark stock. */
 const ACID_INK = "var(--faction-snide-composer-acid-ink)";
 /* The error banner's ink (#1231), and the one skin in the set that could not
  * take `--faction-snide-card-alarm`: the CARD is photocopier-black in both
  * themes (§6) so that rung is pinned bright and reads 1.56:1 on the light
- * xerox stock, while THIS sheet flips. 4.97:1 light / 5.83:1 dark under the
- * neutral veil, which — per ADR-0061 — stays neutral. */
+ * xerox stock, while THIS ground flips. Walked again with the ground in #2177:
+ * 4.67:1 in the wall's pink corner, 6.21:1 at the top of the ramp, 5.83:1 dark,
+ * all under the neutral veil — which, per ADR-0061, stays neutral. */
 const ALARM = "var(--faction-snide-composer-alarm)";
 
 /* THE PRESS — theme-invariant pigments. `ACID` is acid as a DRAWN THING (the
@@ -245,8 +269,9 @@ export default function SnideEditPraxis({ state }: Props) {
      times, so the acid bar and the raster cannot drift between the
      two stages. The masthead's stage word travels with them — it reads
      SUBMITTED, not DRAFT, once your part is filed. */
-  /* radius 0, borderW 0 — the sheet has no edge but its own stock. */
-  const sheetStyle = { background: SHEET, borderRadius: 0 };
+  /* radius 0, borderW 0 — the sheet has no edge but its own stock, and the
+     stock is the wall (#2177). */
+  const sheetStyle = { background: WALL, borderRadius: 0 };
   const statusMark = <SnideBlob width={52} height={40} struck />;
   const slip = {
     style: {
@@ -329,16 +354,13 @@ export default function SnideEditPraxis({ state }: Props) {
             </span>
           </ComposerMasthead>
   );
-  const ground = (
-          <ComposerGround
-            background={`repeating-linear-gradient(0deg, ${GRAIN} 0 1px, transparent 1px 3px)`}
-            /* Flush, not overhanging: the raster is printed ON the sheet, so it
-               stops where the stock does. The shared component's negative
-               default inset is for grounds that overhang their stock; this one
-               is grain only — the kit's ground too — so it takes a flush 0. */
-            inset={0}
-          />
-  );
+  /* NO SECOND RASTER (#2177). This was `<ComposerGround>` printing a 1px/3px
+     stripe flush on the stock, which the stock did not have. The wall brings its
+     own raster and its own scanline, and a third stripe over those two is moiré
+     rather than xerox — the same call the praxis card's dot tooth got in that
+     ruling. The dress's `ground` slot is optional (#1153's rule: a skin that
+     passes nothing renders as if the slot did not exist), so the surface loses a
+     layer rather than gaining an empty one. */
 
   const dress: ComposerDress = {
     accent: ACID_INK,
@@ -346,7 +368,6 @@ export default function SnideEditPraxis({ state }: Props) {
     pageStyle: { fontFamily: BODY_FACE, color: INK },
     sheetStyle,
     masthead,
-    ground,
     rule: () => censorStripe,
     mark: statusMark,
     statusStyle: { color: INK, fontWeight: 700, letterSpacing: "0.2em" },
@@ -383,12 +404,7 @@ export default function SnideEditPraxis({ state }: Props) {
         />
       }
     >
-      <ComposerSheet
-        sizes={sizes}
-        style={sheetStyle}
-        masthead={masthead}
-        ground={ground}
-      >
+      <ComposerSheet sizes={sizes} style={sheetStyle} masthead={masthead}>
         {/* The stage word, alone (#1828). It is `composerStageWord` rather than
             the bare `Draft` key because SNIDE also prints it in the masthead,
             and the two must not contradict each other. */}

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/snideComposer.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/snideComposer.test.tsx
@@ -148,12 +148,20 @@ describe("SNIDE's dress", () => {
     expect(markup).not.toContain("--faction-snide-border");
   });
 
-  it.each(WIDTHS)("paints on the composer's own token family on %s", (width) => {
+  it.each(WIDTHS)("grounds on the flyposted WALL, not a sheet of its own on %s", (width) => {
+    // #2177 REVERSES what this assertion used to make: the composer was a xerox
+    // sheet flyposted TO the wall (`-composer-sheet`, with the clipping's family
+    // asserted ABSENT), and the owner's ruling is that S.N.I.D.E. wears one
+    // ground. The wall's pigments are `-note-*` because the task card drew it
+    // first; the file's own INK family is unchanged and still `-composer-*`.
     const markup = render(width);
-    expect(markup).toContain("--faction-snide-composer-sheet");
-    expect(markup).toContain("--faction-snide-composer-grain");
-    // The clipping's family belongs to the praxis card, not to this surface.
-    expect(markup).not.toContain("--faction-snide-note-");
+    expect(markup, "the wall's ramp").toContain("--faction-snide-wall");
+    expect(markup, "the acid corner").toContain("--faction-snide-note-wash-acid");
+    expect(markup, "the pink corner").toContain("--faction-snide-note-wash-pink");
+    expect(markup, "the ink family").toContain("--faction-snide-composer-ink");
+    // The wall brings a raster and a scanline; the composer's own 1px/3px
+    // stripe over those two was moiré, so the ground layer went with the swap.
+    expect(markup, "no second raster").not.toContain("--faction-snide-composer-grain");
   });
 
   it("bleeds the submit bar to the sheet's edge at each width", () => {

--- a/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/snideDetail.test.tsx
@@ -144,6 +144,31 @@ describe("SNIDE task detail — the ransom dossier", () => {
     );
   });
 
+  it("hangs the praxis gallery's own hook, so its cards are black too (#2177)", () => {
+    // S.N.I.D.E.'s praxis card wears the WALL everywhere else. This page's
+    // column already is the wall, and a wall inside a wall stops reading as a
+    // thing pasted on something — so the row sets `--snd-praxis-*` back to the
+    // slab. The class is the row's OWN: `.praxis-gallery` is not a safe hook,
+    // because `WowFactionBody` mounts that one and a Snide-task praxis lands
+    // there. `snideOneGround.test.tsx` holds the other end.
+    const filed = {
+      id: 91,
+      task_id: TASK.id,
+      task_title: TITLE,
+      task_faction_slug: "snide",
+      title: "Posted it at the depot gate",
+      created_by_id: 31,
+      created_by_display_name: "Wren Abalone",
+      score: 12,
+      media_items: [],
+      applied_metatasks: [],
+    } as unknown as TaskDetailState["submissions"][number];
+    const { html } = render(
+      <SnideTaskDetail state={baseState({ submissions: [filed], sortedSubmissions: [filed] })} />,
+    );
+    expect(html).toContain("praxis-gallery snd-detail-praxis");
+  });
+
   it("speaks the shared neutral copy, not the retired case-file voice", () => {
     const { text } = render(<SnideTaskDetail state={baseState()} />);
     expect(text).toContain("Task Description");

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -960,7 +960,12 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
         </p>
       ) : (
         <>
-          <div className="praxis-gallery flex flex-wrap gap-4 items-start">
+          {/* `snd-detail-praxis` is the ONE surface where the praxis card is
+              black rather than the wall (#2177). It is this row's own class, not
+              `.praxis-gallery`: that one is mounted by `WowFactionBody` too, and
+              a Snide-task praxis lands there. The class carries no paint — it
+              sets the `--snd-praxis-*` channel the card reads (index.css). */}
+          <div className="praxis-gallery snd-detail-praxis flex flex-wrap gap-4 items-start">
             {(showAllPraxis
               ? sortedSubmissions
               : sortedSubmissions.slice(0, GALLERY_PREVIEW)

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -268,14 +268,44 @@ const PRAXIS_CARD_SHEET: Record<(typeof CARD_KEYS)[number], string> = {
   ua: "--faction-ua-panel",
   everymen: "--faction-everymen-card-bg",
   coven: "--faction-coven-ward-card",
-  snide: "--faction-snide-card-bg",
+  // The FLYPOSTED WALL since #2177, at the ramp's deep stop — its other three
+  // readings (the top of the ramp and the two washed corners) are measured in
+  // SNIDE_WALL_PAIRS below, and the black dress the card wears on task detail
+  // is measured there too.
+  snide: "--faction-snide-wall-deep",
   wow: "--faction-wow-chronicle-bg",
   ephemerists: "--faction-ephemerists-plate-bg",
   singularity: "--faction-singularity-card-bg",
 };
 
-/** The four whose sheet is a different TOKEN from `--faction-{key}-card-bg`. */
-const OWN_SHEET_KEYS = ["ua", "coven", "wow", "ephemerists"] as const;
+/** The five whose sheet is a different TOKEN from `--faction-{key}-card-bg`. */
+const OWN_SHEET_KEYS = ["ua", "coven", "wow", "ephemerists", "snide"] as const;
+
+/**
+ * WHICH INK THE CARD'S SHARED SLOTS ACTUALLY RESOLVE (#2177).
+ *
+ * `sheetInk` types `--faction-{key}-card-{role}` and nothing else, so for seven
+ * factions the name in the component IS the token measured here. S.N.I.D.E. is
+ * the eighth: its card wears a ground that FLIPS (the wall) while `-card-*` is
+ * pinned near-black in both themes for the slabs pasted ON that wall (#2066), so
+ * the frame RE-POINTS those four custom properties on its own root to the wall's
+ * family. The cascade is the seam — `.snd-praxis-*` in index.css — and this map
+ * is what keeps the manifest measuring the token the cascade delivers rather
+ * than the name the shared component happens to type.
+ */
+const PRAXIS_CARD_INK: Partial<
+  Record<(typeof CARD_KEYS)[number], Record<"notice" | "alarm" | "credit" | "muted", string>>
+> = {
+  snide: {
+    notice: "--faction-snide-wall-notice",
+    alarm: "--faction-snide-wall-alarm",
+    credit: "--faction-snide-wall-credit",
+    muted: "--faction-snide-note-muted",
+  },
+};
+
+const cardInk = (key: (typeof CARD_KEYS)[number], role: "notice" | "alarm" | "credit" | "muted") =>
+  PRAXIS_CARD_INK[key]?.[role] ?? `--faction-${key}-card-${role}`;
 
 /**
  * The chip's own wash, as a fraction of the ink printed on it. 8%, not the 12%
@@ -288,8 +318,8 @@ const CHIP_WASH = 0.08;
 const PRAXIS_CARD_PAIRS: Pair[] = [
   ...CARD_KEYS.flatMap((key) => {
     const surface = PRAXIS_CARD_SHEET[key];
-    const notice = `--faction-${key}-card-notice`;
-    const alarm = `--faction-${key}-card-alarm`;
+    const notice = cardInk(key, "notice");
+    const alarm = cardInk(key, "alarm");
     return [
       // The two moderation badges, and the two moderator controls that sit side
       // by side above them (#1449). Each mark is measured under THE VEIL IT IS
@@ -335,8 +365,8 @@ const PRAXIS_CARD_PAIRS: Pair[] = [
       {
         what: `${key} praxis card mode chip, credit ink on its own wash`,
         surface,
-        veil: { token: `--faction-${key}-card-credit`, alpha: CHIP_WASH },
-        text: `--faction-${key}-card-credit`,
+        veil: { token: cardInk(key, "credit"), alpha: CHIP_WASH },
+        text: cardInk(key, "credit"),
       },
     ];
   }),
@@ -355,9 +385,147 @@ const PRAXIS_CARD_PAIRS: Pair[] = [
     {
       what: `${key} praxis card sheet, muted ink`,
       surface: PRAXIS_CARD_SHEET[key],
-      text: `--faction-${key}-card-muted`,
+      text: cardInk(key, "muted"),
     },
   ]),
+];
+
+/**
+ * ── S.N.I.D.E. WEARS ONE GROUND: THE FLYPOSTED WALL (#2177) ─────────────────
+ *
+ * The owner's ruling puts the composer and the praxis card on the same ground
+ * the task card already wore, so three surfaces' worth of ink lands on one
+ * stock — and the ink each of them brought was measured on a stock it no longer
+ * has. The composer's tiers were read on `-composer-sheet` (flat xerox stock);
+ * the praxis card's were read on `-card-bg`, which is near-black in BOTH themes
+ * while the wall FLIPS.
+ *
+ * THE WALL IS FOUR GROUNDS, NOT ONE, and that is why this block exists rather
+ * than one row per ink. It is a 180deg ramp from `-wall` to `-wall-deep` with an
+ * acid wash off the top-left corner and a pink one off the bottom-right, so an
+ * ink that clears at the top of the ramp can miss in a corner — the shape #1028
+ * names and #1451 already hit once on the detail page's own ramp. Measured
+ * flat, `-note-muted` reads 4.92:1 in light; under the pink wash it is 4.22:1,
+ * and that corner is where a tall composer puts its footer.
+ *
+ * WHAT IS NOT MODELLED: the raster and the scanline. Both are ~5% of a near-
+ * black over the whole stock at a 1-in-4 duty, so no glyph sits on one — they
+ * average into the ground rather than becoming it, and treating a 2px stripe as
+ * a surface would gate every ink on a texture no reader resolves. The corner
+ * washes are solid area tints and are modelled.
+ */
+const SNIDE_WALL_GROUNDS: { where: string; surface: string; wash?: string }[] = [
+  { where: "wall", surface: "--faction-snide-wall" },
+  { where: "deep wall", surface: "--faction-snide-wall-deep" },
+  {
+    where: "acid corner",
+    surface: "--faction-snide-wall",
+    wash: "--faction-snide-note-wash-acid",
+  },
+  {
+    where: "pink corner",
+    surface: "--faction-snide-wall-deep",
+    wash: "--faction-snide-note-wash-pink",
+  },
+];
+
+/**
+ * Every ink S.N.I.D.E. prints straight on that wall, across the three surfaces.
+ * The `-note-*` tiers are the clipping's (task card, praxis card, both detail
+ * columns); the `-composer-*` tiers are the sheet's. They carry the same values
+ * today and stay two families for #1181's reason.
+ */
+const SNIDE_WALL_INKS = [
+  ["headline and title", "--faction-snide-note-ink"],
+  ["brief and excerpt", "--faction-snide-note-muted"],
+  ["the pink that is text", "--faction-snide-note-pink-ink"],
+  ["composer ink", "--faction-snide-composer-ink"],
+  ["composer prose", "--faction-snide-composer-muted"],
+  ["composer faint ink", "--faction-snide-composer-faint"],
+] as const;
+
+const SNIDE_WALL_PAIRS: Pair[] = [
+  ...SNIDE_WALL_GROUNDS.flatMap(({ where, surface, wash }) => [
+    ...SNIDE_WALL_INKS.map(([role, text]) => ({
+      what: `snide ${where}, ${role}`,
+      surface,
+      veil: wash,
+      text,
+    })),
+    // The praxis card's three functional inks, on the ground the frame's
+    // re-point measures them against (see PRAXIS_CARD_INK). The generated rows
+    // above cover the deep stop; these are the other three readings.
+    {
+      what: `snide ${where}, flagged badge alarm ink under the danger veil`,
+      surface,
+      veil: [wash, "--color-danger-veil"].filter((layer) => layer !== undefined) as Veil[],
+      text: "--faction-snide-wall-alarm",
+    },
+    {
+      what: `snide ${where}, mode chip notice ink on its own wash`,
+      surface,
+      veil: [wash, { token: "--faction-snide-wall-notice", alpha: CHIP_WASH }].filter(
+        (layer) => layer !== undefined,
+      ) as Veil[],
+      text: "--faction-snide-wall-notice",
+    },
+    {
+      what: `snide ${where}, mode chip credit ink on its own wash`,
+      surface,
+      veil: [wash, { token: "--faction-snide-wall-credit", alpha: CHIP_WASH }].filter(
+        (layer) => layer !== undefined,
+      ) as Veil[],
+      text: "--faction-snide-wall-credit",
+    },
+    // The composer's error banner, which moved stock with the composer.
+    {
+      what: `snide ${where}, composer error banner alarm ink under the danger veil`,
+      surface,
+      veil: [wash, "--color-danger-veil"].filter((layer) => layer !== undefined) as Veil[],
+      text: "--faction-snide-composer-alarm",
+    },
+  ]),
+  // ── THE ONE EXCEPTION: the praxis card on TASK DETAIL is black ───────────
+  //
+  // A wall inside a wall stops reading as a thing pasted ON something (#2066's
+  // ruling, restated by #2177), so on the detail page the card is a slab and
+  // its shared slots resolve the `-card-*` family they were always measured on.
+  // `{key} card body/muted/accent` already pin the three reading inks on that
+  // ground; these are the three functional inks the generator used to cover for
+  // snide before its sheet became the wall.
+  {
+    what: "snide detail slab, flagged badge alarm ink under the danger veil",
+    surface: "--faction-snide-card-bg",
+    veil: "--color-danger-veil",
+    text: "--faction-snide-card-alarm",
+  },
+  {
+    what: "snide detail slab, mode chip notice ink on its own wash",
+    surface: "--faction-snide-card-bg",
+    veil: { token: "--faction-snide-card-notice", alpha: CHIP_WASH },
+    text: "--faction-snide-card-notice",
+  },
+  {
+    what: "snide detail slab, mode chip credit ink on its own wash",
+    surface: "--faction-snide-card-bg",
+    veil: { token: "--faction-snide-card-credit", alpha: CHIP_WASH },
+    text: "--faction-snide-card-credit",
+  },
+  // The score stamp is a black well punched into the card, and it is the one
+  // thing inside the frame that keeps the slab's inks on BOTH dresses — which
+  // is only true while its plate is OPAQUE. It was a 40% black over the card,
+  // so on the wall's light half it composited to mid-grey and took the acid
+  // figure to 2.71:1. See `--faction-snide-stamp-bg`.
+  {
+    what: "snide score stamp plate, acid figure",
+    surface: "--faction-snide-stamp-bg",
+    text: "--faction-snide-acid",
+  },
+  {
+    what: "snide score stamp plate, typed caption",
+    surface: "--faction-snide-stamp-bg",
+    text: "--faction-snide-vote-off",
+  },
 ];
 
 /**
@@ -1602,6 +1770,7 @@ const PAIRS: Pair[] = [
   ...ACCENT_PAIRS,
   ...ROSTER_PAIRS,
   ...PRAXIS_CARD_PAIRS,
+  ...SNIDE_WALL_PAIRS,
   ...ARCHETYPE_PAIRS,
 ];
 


### PR DESCRIPTION
Closes #2177

S.N.I.D.E.'s three authoring and reading surfaces wear one ground — the flyposted wall — with the ruled exception: the praxis card on task detail is black.

## The seam I tested at

`utils/__tests__/factionContrast.test.ts` — **the wall is four grounds, not one**, and every ink that lands on it is now measured on all four in both themes (`SNIDE_WALL_PAIRS`): the ramp's two stops, plus the acid wash off one corner and the pink wash off the other. The loop went red on the real defect first — **15 failures, every one in light**, e.g. `-note-muted` 4.23:1 and `-composer-faint` 3.64:1 in the pink corner, `-composer-alarm` 3.58:1 veiled, and `-stamp-bg` failing the "a surface must be opaque" guard outright. Then green.

The raster and the scanline are deliberately NOT modelled as grounds: ~5% of a near-black at a 1-in-4 duty averages into the ground rather than becoming it, and gating an ink on a 2px stripe no reader resolves would be theatre. The corner washes are solid area tints, so they are.

## What changed

**The wall is extracted.** `WALL` in `components/factionMarks/snideAtoms.tsx`, exported the way `covenSlip` exports `SLIP_SHEET`. It was inline in `SnideTaskCard` (one mount); it has three now. No pixel moves in that commit.

**The composer swaps stock, and its docstring records the reversal.** The `## Colour` block documented the sheet/press split — "`-composer-*` is the SHEET (it flips)" — and now says the stock is the wall, that restoring the separate stock is drift, and why. `-composer-sheet` survives for the one block that still needs an opaque stock: the invite dropdown. Its own 1px/3px raster went with the swap (the wall carries a raster AND a scanline; a third stripe is moiré), and `--faction-snide-composer-grain` went with the layer.

**The praxis card gets two dresses.** Its ground was `-card-bg`, near-black in BOTH themes; the wall flips. Left alone, every reading ink on it would have been cream type on a cream wall for half the day — so the card reads the `-note-*` family, which flips with the ground, and the wall's own alarm/notice/credit for the marks the shared slots paint. The 3px dot tooth goes.

**Contrast was the work.** Six inks walked, all light-half only, each with its measurement in `index.css`:

| token | was | now | why |
|---|---|---|---|
| `-note-muted` | `#5f5c50` | `#545143` | 4.23:1 → 5.03:1, pink corner |
| `-note-pink-ink` | `#be185d` | `#9d174d` | 3.81 → 4.98; converges on `-wall-alarm` by measurement, stays its own token (#1181) |
| `-composer-muted` | `#5f5c50` | `#545143` | same walk, own family |
| `-composer-faint` | `#696658` | `#5a5749` | 3.64 → 4.58 |
| `-composer-alarm` | `#be185d` | `#9d174d` | 3.58 → 4.67 under the danger veil |
| `-wall-notice` | `#92400e` | `#78350f` | 4.04 → 5.10 under the mode chip's own 8% wash |

Two more: `--faction-snide-wall-credit` is minted (the collab chip's ink; `-card-credit` is pinned bright and reads 1.86:1 on the light wall), and `--faction-snide-stamp-bg` goes **opaque** — `#0c0a07` is exactly what `rgba(0,0,0,.4)` computed to over the black plate it used to be punched into, so the tag looks identical where it always sat, but over the wall's light half that 40% black composited to mid-grey and took the acid figure to 2.71:1.

**The task-detail hook is the row's own.** `.praxis-gallery` is not safe — `WowFactionBody` mounts it too and a Snide-task praxis lands on the WOW faction page — so the row carries `.snd-detail-praxis` and `.praxis-gallery` keeps its one job (#1137). The switch travels as a `--snd-praxis-*` custom property because a container cannot give a child a class; the card supplies the wall half as each fallback. Black is `--faction-snide-card-bg`, no new pigment: it is the same slab every other sheet on that page is cut from, which is #2066's ruling rather than a second one.

**Redaction (the owner's comment).** I read it as: the black card is not a ground to keep clear, and the black IS the censor bar — the card's copy is knocked out of it, which is what `-note-bar` would have drawn if it were not already the same near-black as the ground. So no new drawn bars: nothing covers a value, and every ink on both dresses clears AA in both themes. Recorded in the card's docstring. **If the ruling wanted drawn bars as well, say so and I'll add them** — the limit that would stay is the second one in your comment.

## Byte budget

CSS **+158 B gzipped** (22,616 → 22,774), which prints the WARN block: the line is 22,700 and FAIL is 25,000, so this is 74 B over the warn and 2,226 B from the wall. That is a second dress for one faction's card, paid for in two rulesets; `-composer-grain` came off in the same diff.

## Verified

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (336 files, 5,927 passing), `npm run build`, `npm run budget` — all on the rebased tree. **Visual QA is outstanding**: I have no browser, so nothing below was looked at.

## What to eyeball

- **Snide composer** (`/praxis/:id/edit` on a Snide task), light AND dark — the wall behind form fields is the surface this ruling asks the most of. Look at section labels near the FOOTER (the pink corner) and the autosave line, and at the invite dropdown, which is the one block still on the old stock.
- **Snide praxis card in the feed** (`/praxes`), light AND dark — the card is a light object in light mode now where it was black. Check the mode chip on a collab/duel praxis, the score tag (its plate is opaque now), and the pen circle's `pts` caption, which changed ink.
- **A Snide praxis card on task detail** (a Snide task with filed praxis), light AND dark — black on the wall, and the one place the two dresses can be compared side by side against the page around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
