### PR TITLE
Task detail reads title, description, then who-and-level, then the points and sign-up panel (#2120)

### DIFF
--- a/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx
@@ -309,3 +309,48 @@ describe("na / Default task detail — the reference anatomy", () => {
     expect(text).not.toContain("counts for everyone");
   });
 });
+
+/**
+ * The page's reading order (#2120) — one sequence, both form factors.
+ *
+ * Owner ruling: title and description answer *what is this*; byline, level and
+ * headcount answer *can I, and who else*; the points-and-signup panel answers
+ * *do I*. The page runs in that order:
+ *
+ *     breadcrumb · title · description · author/level/headcount · panel
+ *
+ * The seam is DOM order, not CSS. Every skin lays its header and its action
+ * column out as flex siblings with `flexDirection: desktop ? "row" : "column"`,
+ * so on mobile the DOM order IS the reading order — which is how the whole panel
+ * came to sit between the title and the description — while on desktop the same
+ * DOM reads down the left column with the panel beside it. Asserting on the
+ * markup therefore pins both form factors at once, which is what the ruling asks
+ * for: a page whose order depends on width comes back as its own bug report.
+ *
+ * Anchored on shared neutral copy (ADR-0057) and fixture values, so a skin that
+ * re-dresses its labels still passes and a skin that re-sequences fails.
+ */
+describe("task-detail reading order", () => {
+  /** First occurrence; an absent anchor fails by name rather than as `-1 < n`. */
+  function at(text: string, needle: string): number {
+    const index = text.indexOf(needle);
+    expect(index, `missing anchor: ${needle}`).toBeGreaterThanOrEqual(0);
+    return index;
+  }
+
+  for (const [slug, Archetype] of Object.entries(archetypes)) {
+    it(`${slug} runs title, description, who-and-level, then the panel`, () => {
+      const { text } = render(<Archetype state={baseState()} />);
+      const title = at(text, TASK.title);
+      const description = at(text, "Make something small and honest.");
+      const byline = at(text, "Wren Abalone");
+      const headcount = at(text, "people working on this");
+      const panel = at(text, "POINTS");
+
+      expect(title, "description after the title").toBeLessThan(description);
+      expect(description, "byline after the description").toBeLessThan(byline);
+      expect(byline, "headcount after the byline").toBeLessThan(headcount);
+      expect(headcount, "panel after the headcount").toBeLessThan(panel);
+    });
+  }
+});

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -689,7 +689,15 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
           {t("detail.metataskFor", { faction: factionName(task.metatask_faction_slug) })}
         </p>
       )}
+    </div>
+  );
 
+  // ── Who and at what level: the byline, the level, the headcount ──
+  //
+  // Split out of `header` by #2120 so the DESCRIPTION reads between them. See
+  // `DefaultTaskDetail` for the whole sequence and why it is this one.
+  const credentials = (
+    <div>
       {/* Author row — the proposing character's byline (#1029). */}
       {authorName && (
         <div
@@ -966,7 +974,11 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
             marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
           }}
         >
-          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {header}
+            {brief}
+            {credentials}
+          </div>
           <div
             style={{
               ...actionColumnSize({ desktop, hasAction, width: size.plate }),
@@ -979,7 +991,6 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
         </div>
 
         <div style={{ position: "relative", zIndex: 1, minWidth: 0 }}>
-          {brief}
           {gallery}
           {/* The cat watermark, turning once every two minutes (#2041 — it was a
               pentagram, and the swap is `covenSlip`'s because five Coven

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -594,7 +594,7 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
     </div>
   );
 
-  // ── Header: breadcrumb, faction line, title, author, stats ──
+  // ── Header: breadcrumb, faction line, title ── (byline + stats: `credentials`, below the brief — #2120)
   const stat = (label: string, value: ReactNode, valueSize: string) => (
     <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-xs)" }}>
       <span style={eyebrow}>{label}</span>
@@ -1001,13 +1001,16 @@ export default function CovenTaskDetail({ state }: { state: TaskDetailState }) {
               which is #2041's "not two different drawings" a level up. It was
               `right: 24, top: 120`.
 
-              THE ANCHOR IS THE BRIEF-AND-GALLERY REGION, which is why the
-              discussion moved out into a block of its own below rather than
-              staying in here: the sheet's true bottom-right is behind the
-              comment composer, which paints an opaque `ward-card` panel and
-              would swallow the mark. This is the lowest point on the page it is
-              still visible at. `right: 24` is unchanged and is what keeps the
-              whole face on the sheet at both widths.
+              THE ANCHOR IS THE GALLERY REGION, which is why the discussion
+              moved out into a block of its own below rather than staying in
+              here: the sheet's true bottom-right is behind the comment
+              composer, which paints an opaque `ward-card` panel and would
+              swallow the mark. This is the lowest point on the page it is still
+              visible at. `right: 24` is unchanged and is what keeps the whole
+              face on the sheet at both widths. (It read BRIEF-AND-GALLERY until
+              #2120 moved the brief up into the header column; the anchor is
+              `bottom: 0`, so losing a block off the TOP of this wrapper leaves
+              the mark exactly where it was.)
 
               `zIndex: -1` puts it back UNDER the copy: this wrapper IS a
               stacking context (position + z-index), so the negative index lands

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -542,7 +542,28 @@ export default function DefaultTaskDetail({
           })}
         </p>
       )}
+    </div>
+  );
 
+  // ── Who and at what level: the byline, the level, the headcount ──
+  //
+  // Split out of `header` by #2120, which re-sequenced this page in every skin:
+  //
+  //     breadcrumb · title · description · author/level/headcount · panel
+  //
+  // Owner's reasoning: the page groups by the question the reader is asking.
+  // Title and description answer *what is this*; byline, level and headcount
+  // answer *can I, and who else*; the panel answers *do I*. The old order
+  // interleaved the first and third and put the second at the top, stating a
+  // level requirement before the reader knew what the task was.
+  //
+  // It was never a content decision — the header and the action column are flex
+  // siblings under `flexDirection: desktop ? "row" : "column"`, so on mobile the
+  // column stacked the WHOLE panel between the title and the description. The
+  // fix is DOM order, which is why desktop's left column re-sequences too: one
+  // sequence at both widths, not a page that reorders itself at a breakpoint.
+  const credentials = (
+    <div>
       {/* Author row — the proposing character's byline (#1029). */}
       {authorName && (
         <div
@@ -836,7 +857,11 @@ export default function DefaultTaskDetail({
             marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
           }}
         >
-          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {header}
+            {brief}
+            {credentials}
+          </div>
           <div
             style={{
               ...actionColumnSize({ desktop, hasAction, width: 440 }),
@@ -848,7 +873,6 @@ export default function DefaultTaskDetail({
         </div>
 
         <div style={{ minWidth: 0 }}>
-          {brief}
           {gallery}
           <TaskDetailComments
             state={state}

--- a/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/DefaultTaskDetail.tsx
@@ -440,7 +440,7 @@ export default function DefaultTaskDetail({
     </div>
   );
 
-  // ── Header: breadcrumb, faction line, title, author, stats ──
+  // ── Header: breadcrumb, faction line, title ── (byline + stats: `credentials`, below the brief — #2120)
   //
   // The breadcrumb is one crumb, not two. It read `TASKS / Task №{id}` until
   // #1124 retired the task id from this page; the trail's second crumb WAS the

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -426,7 +426,7 @@ export default function EphemeristsTaskDetail({
     </div>
   );
 
-  // ── Header: breadcrumb, faction line, title, author, stats ──
+  // ── Header: breadcrumb, faction line, title ── (byline + stats: `credentials`, below the brief — #2120)
   const header = (
     <div>
       <nav

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -509,7 +509,15 @@ export default function EphemeristsTaskDetail({
           })}
         </p>
       )}
+    </div>
+  );
 
+  // ── Who and at what level: the byline, the level, the headcount ──
+  //
+  // Split out of `header` by #2120 so the DESCRIPTION reads between them. See
+  // `DefaultTaskDetail` for the whole sequence and why it is this one.
+  const credentials = (
+    <div>
       {/* Author row — the proposing character's byline (#1029). */}
       {authorName && (
         <div
@@ -976,7 +984,11 @@ export default function EphemeristsTaskDetail({
               marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
             }}
           >
-            <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              {header}
+              {brief}
+              {credentials}
+            </div>
             <div
               style={{
                 // 420 with a summons to answer; with none, the plate goes to its
@@ -992,7 +1004,6 @@ export default function EphemeristsTaskDetail({
           </div>
 
           <div style={{ minWidth: 0 }}>
-            {brief}
             {gallery}
             <TaskDetailComments
               state={state}

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -379,7 +379,15 @@ export default function EverymenTaskDetail({
           })}
         </p>
       )}
+    </div>
+  );
 
+  // ── Who and at what level: the byline, the level, the headcount ──
+  //
+  // Split out of `header` by #2120 so the DESCRIPTION reads between them. See
+  // `DefaultTaskDetail` for the whole sequence and why it is this one.
+  const credentials = (
+    <div>
       {/* Byline — the character who proposed the job (#1029). */}
       {authorName && (
         <div
@@ -955,7 +963,11 @@ export default function EverymenTaskDetail({
             marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
           }}
         >
-          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {header}
+            {brief}
+            {credentials}
+          </div>
           <div
             style={{
               ...actionColumnSize({ desktop, hasAction, width: 520 }),
@@ -967,7 +979,6 @@ export default function EverymenTaskDetail({
         </div>
 
         <div style={{ minWidth: 0 }}>
-          {brief}
           {gallery}
           {/* Comments — the shared slot, active-task gated (ADR-0006, #1030),
               under the sheet's own dressed section head. */}

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -129,12 +129,13 @@ function initialsOf(name: string): string {
  * bar flanked by cogs; Bebas Neue headlines over a Courier Prime dispatch;
  * dashed red rules between everything; the points struck as a rubber stamp.
  *
- * Anatomy is #1030's contract, unchanged and in its order — breadcrumb ·
- * masthead · title · author byline · Level / In-progress stats · action plate
- * (base + the usually-absent `×mult` badge + the stamped total, sign-up /
- * in-progress / submitted, slots, level-met, {@link LevelJumpBanner},
- * {@link ErrorBanner}) · the brief in full · the praxis gallery with its sort
- * toggle · comments. Only the dress is the Everymen's.
+ * Anatomy is #1030's contract — breadcrumb · masthead · title · the brief in
+ * full · author byline · Level / In-progress stats · action plate (base + the
+ * usually-absent `×mult` badge + the stamped total, sign-up / in-progress /
+ * submitted, slots, level-met, {@link LevelJumpBanner}, {@link ErrorBanner})
+ * · the praxis gallery with its sort toggle · comments. Only the dress is the
+ * Everymen's. #2120 re-sequenced that order in every skin: the brief rose to
+ * sit under the title, and the byline and stats came down below it.
  *
  * Four contract points worth not re-deriving:
  * - **No in-progress roster.** The header's count is the only place that number
@@ -275,7 +276,7 @@ export default function EverymenTaskDetail({
     </div>
   );
 
-  // ── Header: breadcrumb, masthead, title, byline, stats ──
+  // ── Header: breadcrumb, masthead, title ── (byline + stats: `credentials`, below the brief — #2120)
   //
   // One crumb, not two: the trail read `TASKS / Task №{id}` until #1124 retired
   // the task id, and the id WAS the second crumb, so the separator went with it

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -301,7 +301,8 @@ export default function SingularityTaskDetail({
     </div>
   );
 
-  // ── Header: faction line, title, author, Level / In progress ──
+  // ── Header: faction line, title ── (author + Level / In progress:
+  // `credentials`, below the brief — #2120)
   const header = (
     <div>
       <div

--- a/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SingularityTaskDetail.tsx
@@ -366,7 +366,15 @@ export default function SingularityTaskDetail({
           })}
         </p>
       )}
+    </div>
+  );
 
+  // ── Who and at what level: the byline, the level, the headcount ──
+  //
+  // Split out of `header` by #2120 so the DESCRIPTION reads between them. See
+  // `DefaultTaskDetail` for the whole sequence and why it is this one.
+  const credentials = (
+    <div>
       {/* Author row — the proposing character's byline (#1029). */}
       {authorName && (
         <div
@@ -918,7 +926,11 @@ export default function SingularityTaskDetail({
               marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
             }}
           >
-            <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              {header}
+              {brief}
+              {credentials}
+            </div>
             <div
               style={{
                 ...actionColumnSize({ desktop, hasAction, width: 440 }),
@@ -930,7 +942,6 @@ export default function SingularityTaskDetail({
           </div>
 
           <div style={{ minWidth: 0 }}>
-            {brief}
             {gallery}
             {/* Comments — the shared slot, active-task gated (ADR-0006, #1030). */}
             <TaskDetailComments

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -635,7 +635,7 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
     </div>
   );
 
-  // ── Header: breadcrumb, the bar, the cut-up headline, author, stats ──
+  // ── Header: breadcrumb, the bar, the cut-up headline ── (byline + stats: `credentials`, below the brief — #2120)
   //
   // One crumb, not two: the trail read `TASKS / Task №{id}` until #1124 retired
   // the task id, and the id WAS the second crumb, so the separator went with it

--- a/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/SnideTaskDetail.tsx
@@ -764,7 +764,15 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
           })}
         </p>
       )}
+    </div>
+  );
 
+  // ── Who and at what level: the byline, the level, the headcount ──
+  //
+  // Split out of `header` by #2120 so the DESCRIPTION reads between them. See
+  // `DefaultTaskDetail` for the whole sequence and why it is this one.
+  const credentials = (
+    <div>
       {/* Author row — the proposing character's byline (#1029). */}
       {authorName && (
         <div
@@ -1032,7 +1040,11 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
             marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
           }}
         >
-          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {header}
+            {brief}
+            {credentials}
+          </div>
           <div
             style={{
               ...actionColumnSize({ desktop, hasAction, width: 452 }),
@@ -1044,7 +1056,6 @@ export default function SnideTaskDetail({ state }: { state: TaskDetailState }) {
         </div>
 
         <div style={{ minWidth: 0 }}>
-          {brief}
           {gallery}
           <TaskDetailComments
             state={state}

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -573,7 +573,15 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
           })}
         </p>
       )}
+    </div>
+  );
 
+  // ── Who and at what level: the byline, the level, the headcount ──
+  //
+  // Split out of `header` by #2120 so the DESCRIPTION reads between them. See
+  // `DefaultTaskDetail` for the whole sequence and why it is this one.
+  const credentials = (
+    <div>
       {/* The proposing character's byline (#1029). */}
       {authorName && (
         <div
@@ -897,7 +905,11 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
             marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)",
           }}
         >
-          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {header}
+            {brief}
+            {credentials}
+          </div>
           <div
             style={{
               ...actionColumnSize({ desktop, hasAction, width: size.panel }),
@@ -909,7 +921,6 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
         </div>
 
         <div style={{ minWidth: 0 }}>
-          {brief}
           {gallery}
           {/* Comments — the shared slot, active-task gated (ADR-0006, #1030),
               under UA's own section head so the thread draws no second one. */}

--- a/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/UaTaskDetail.tsx
@@ -31,9 +31,10 @@ import type { TaskDetailState } from "../useTaskDetail";
  * The shared v2 anatomy (#1030) in UA's language: a sheet of mesa-sand vellum
  * with a lotus bleeding off the left edge, sienna rules running out from every
  * label, Cormorant Garamond on the title and the numerals, EB Garamond on
- * everything read. The header sits beside one 460px action panel that holds the
- * base value, the (usually absent) ×mult badge and the total inside an ensō.
- * Then the brief in full, the praxis gallery, the discussion.
+ * everything read. Title, then the brief in full, then the byline and the two
+ * counts, all beside one 460px action panel that holds the base value, the
+ * (usually absent) ×mult badge and the total inside an ensō (#2120). Then the
+ * praxis gallery, the discussion.
  *
  * WHAT THIS REPLACES: the 681-line "sheet" archetype built on `ua.*` voice keys
  * (`salonWallHeading`, `critiqueHeading`, `commissionHeading`,
@@ -478,7 +479,8 @@ export default function UaTaskDetail({ state }: { state: TaskDetailState }) {
     </div>
   );
 
-  // ── Header: breadcrumb, faction line, title, author, the two counts ──
+  // ── Header: breadcrumb, faction line, title ── (byline + the two counts:
+  // `credentials`, below the brief — #2120)
   //
   // One crumb, not two: the trail read `TASKS / Task №{id}` until #1124 retired
   // the task id, and the id WAS the second crumb, so the separator went with it

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -638,7 +638,15 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
           {t("detail.metataskFor", { faction: factionName(task.metatask_faction_slug) })}
         </p>
       )}
+    </div>
+  );
 
+  // ── Who and at what level: the byline, the level, the headcount ──
+  //
+  // Split out of `header` by #2120 so the DESCRIPTION reads between them. See
+  // `DefaultTaskDetail` for the whole sequence and why it is this one.
+  const credentials = (
+    <div>
       {/* Author row — the proposing character's byline (#1029). */}
       {authorName && (
         <div
@@ -899,7 +907,11 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
             marginBottom: size.sectionGap,
           }}
         >
-          <div style={{ flex: 1, minWidth: 0 }}>{header}</div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {header}
+            {brief}
+            {credentials}
+          </div>
           <div
             style={{
               ...actionColumnSize({ desktop, hasAction, width: size.plate }),
@@ -911,7 +923,6 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
         </div>
 
         <div style={{ minWidth: 0 }}>
-          {brief}
           {gallery}
           <TaskDetailComments
             state={state}

--- a/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/WowTaskDetail.tsx
@@ -550,7 +550,7 @@ export default function WowTaskDetail({ state }: { state: TaskDetailState }) {
     </div>
   );
 
-  // ── Header: breadcrumb · shield + faction line · title · author · stats ──
+  // ── Header: breadcrumb · shield + faction line · title ── (byline + stats: `credentials`, below the brief — #2120)
   const header = (
     <div>
       <nav


### PR DESCRIPTION
Closes #2120

The task **detail** page now reads in one sequence at every width and in every archetype:

```
breadcrumb
title
description
author  ·  level  ·  people working on this
points + sign up panel
```

Owner's ruling, verbatim in the issue: the page groups by the question the reader is asking. Title and description answer *what is this*; byline, level and headcount answer *can I, and who else*; the panel answers *do I*.

## The seam

**DOM order across every archetype**, asserted in `frontend/src/pages/taskDetail/__tests__/detailContract.test.tsx` — the file that already walks the whole `surfaceMap("taskDetail")` registry plus the `Default` fallback.

That is the honest seam because the defect was never a content decision. Every skin lays its header and its action column out as flex siblings under `flexDirection: desktop ? "row" : "column"`. On mobile the column stacks them, so DOM order **is** reading order and the whole panel landed between the title and the description. On desktop the same DOM reads down the left column with the panel beside it. Pinning the markup therefore pins both form factors in one assertion, which is what "both form factors, deliberately" asks for — a page whose order depends on width comes back as its own bug report.

The test went red first, on all nine, on the real defect:

```
AssertionError: byline after the description: expected 169 to be less than 37
```

(the description rendered *last*, below the panel). Then green.

## The change

Verified against `origin/main` first: the pattern the ruling describes is exactly what the code does, and it is uniform across all eight files that own a layout. `AlbescentTaskDetail` renders `DefaultTaskDetail` and inherits the fix — so it has the pattern after all, just not a copy of it.

Per file, two edits:

1. `header` is split at the byline into `header` (breadcrumb, faction line, title, metatask eyebrow) and a new `credentials` (byline, level, in-progress headcount).
2. The left column becomes `{header}{brief}{credentials}`; `{brief}` leaves the block below, which now opens on the gallery.

No CSS, no new components, no copy changes, no new tokens, no `dark ? a : b`. The dress, the panel widths, the ornament geometry and every faction's own marks are untouched.

**Not in scope, per the ruling:** shrinking the points figure. Nothing here touches the panel's scale, and it does not pre-empt the compact/inline treatments being explored in design.

### Two comments corrected because my change invalidated what they asserted

- `CovenTaskDetail` — the cat watermark's note said "THE ANCHOR IS THE BRIEF-AND-GALLERY REGION". It is now the gallery region. **The mark does not move**: it is anchored `bottom: 0, right: 24`, so losing a block off the *top* of that wrapper leaves it exactly where #2135 put it.
- `UaTaskDetail` and `EverymenTaskDetail` file docstrings spelled the old order out in prose ("Then the brief in full…", "breadcrumb · masthead · title · author byline · … · the brief in full").

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally in this worktree:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` (`tsc --noEmit`) | 0 errors (`tsc` 5.9.3 confirmed running, not a phantom pass) |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **338 files, 5952 passed**, 1 skipped |
| `npm run build` | built in 4.77s |
| `npm run budget` | JS 126.6 KB ok; CSS 22.2 KB **WARN, pre-existing** — this PR touches zero CSS and adds zero bytes to the sheet |

`api-schema` is not implicated: no route, `response_model` or Pydantic schema is touched, so `backend/openapi.json` and `schema.d.ts` are untouched by design.

**Visual QA is outstanding** — I have no browser and no dev stack. Everything above is markup, types and bytes.

## What to eyeball

Open a task detail page **at mobile width and at desktop width** and check the order reads title → description → byline/level/headcount → panel, with no odd gap where the brief used to sit:

- **UA** (`/tasks/:id` on a UA task) — the surface in the report's screenshot. Mobile especially. Watch the vellum column's lotus wash and the 460px ensō panel.
- **Everymen** — the second archetype the ruling calls out. The dashed rule between the byline and the stats now travels *with* them, below the brief.
- **Albescent** — did not have its own copy of the pattern; it renders `DefaultTaskDetail`, so this is the check that the inherited fix landed and that the aurora / foil / edge overlays still sit over the right band.
- **Coven** — the cat should still sit bottom-right of the gallery, unmoved (#2135). On a task with **no praxis yet** the gallery region is short, so if the 400px cat overhangs upward, say so — that overhang predates this PR but this makes it easier to hit.
- **S.N.I.D.E.** — #2177 just landed `.snd-detail-praxis` here. The praxis gallery should still be on its black ground.
- **Desktop, any archetype**: the description now sits in the **left column** beside the panel rather than spanning the full 1200 sheet. That is the ruling's "its left column re-sequences to match", but it is the one visible width change and is the thing most worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
