### PR TITLE
S.N.I.D.E.'s select card and faction hero wear the Anarchy A, and the second sigil is deleted (#2119)

### DIFF
--- a/frontend/src/components/factionHero/SnideFactionHero.tsx
+++ b/frontend/src/components/factionHero/SnideFactionHero.tsx
@@ -1,4 +1,4 @@
-import { SnideSigil } from "../factionMarks/snideAtoms";
+import { SnideSigil } from "../sigil/SnideSigil";
 import i18n from "../../i18n";
 
 /**

--- a/frontend/src/components/factionMarks/snideAtoms.tsx
+++ b/frontend/src/components/factionMarks/snideAtoms.tsx
@@ -1,7 +1,10 @@
 /**
- * Shared S.N.I.D.E. craft atoms — the struck-through circle-S sigil reused
- * across SNIDE surfaces (task detail, faction hero), and the pink pen loop the
- * faction circles a figure in. Mirrors
+ * Shared S.N.I.D.E. craft atoms — the flyposted wall the faction's surfaces
+ * stand on, and the pink pen loop it circles a figure in. It does NOT hold the
+ * faction's sigil: a struck-through circle-S lived here until #2119 and was a
+ * second `SnideSigil` competing with the real one in `components/sigil/`, which
+ * two surfaces then imported by mistake. A faction gets one mark, from one
+ * module. Mirrors
  * components/factionMarks/ephemeristsPlate.tsx. Colors come from the namespaced
  * --faction-snide-* tokens in index.css. Filter-free (matches the faction's
  * CSS-only craft layers — no SVG feTurbulence).
@@ -37,51 +40,6 @@ export const WALL = [
   "radial-gradient(90% 70% at 100% 110%, var(--faction-snide-note-wash-pink), transparent 62%)",
   "linear-gradient(180deg, var(--faction-snide-wall) 0%, var(--faction-snide-wall-deep) 100%)",
 ].join(", ");
-
-interface SnideSigilProps {
-  size?: number;
-  color?: string;
-}
-
-/** A sprayed, struck-through circle-S — the defiant SNIDE mark. */
-export function SnideSigil({
-  size = 48,
-  color = "var(--faction-snide-acid)",
-}: SnideSigilProps) {
-  return (
-    <svg
-      viewBox="0 0 48 48"
-      width={size}
-      height={size}
-      style={{ display: "block" }}
-      aria-hidden="true"
-    >
-      <circle cx="24" cy="24" r="19" fill="none" stroke={color} strokeWidth="3" />
-      <text
-        x="24"
-        y="34"
-        textAnchor="middle"
-        style={{
-          fontFamily: "var(--faction-snide-font-impact)",
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: sigil letterform drawn into the 48px SVG
-          fontSize: 30,
-        }}
-        fill={color}
-      >
-        S
-      </text>
-      <line
-        x1="9"
-        y1="40"
-        x2="39"
-        y2="8"
-        stroke={color}
-        strokeWidth="3"
-        strokeLinecap="round"
-      />
-    </svg>
-  );
-}
 
 /**
  * The pen circle — S.N.I.D.E.'s points mark (#2035, shared by #2042).

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -12,7 +12,7 @@ import { UaSigil } from "../sigil/UaSigil";
 import UaMandala from "../factionMarks/UaMandala";
 import { UA_DISPLAY, UA_EYEBROW, UA_TEXT, uaShade } from "../factionMarks/uaAtoms";
 import * as coven from "../factionMarks/covenSlip";
-import { SnideSigil } from "../factionMarks/snideAtoms";
+import { SnideSigil } from "../sigil/SnideSigil";
 import { EphemeristsSigil } from "../sigil/EphemeristsSigil";
 import * as eph from "../factionMarks/ephemeristsPlate";
 import { SingularitySigil } from "../sigil/SingularitySigil";

--- a/frontend/src/components/sigil/__tests__/snideSigilIsTheAnarchyA.test.tsx
+++ b/frontend/src/components/sigil/__tests__/snideSigilIsTheAnarchyA.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * The seam: the mark each S.N.I.D.E. surface actually RENDERS (#2119).
+ *
+ * The faction had two exports both called `SnideSigil` — the Anarchy A in
+ * `components/sigil/SnideSigil` (the mark since #1989's Sigil Studies v2) and a
+ * leftover circled-S in `components/factionMarks/snideAtoms`. Nothing was
+ * missing and nothing was broken; two consumers simply imported the wrong one,
+ * and the ambiguity is the defect. The old export is deleted, so a repeat of
+ * this bug is now a compile error rather than a wrong drawing — but tsc cannot
+ * tell you a surface stopped drawing the faction's mark, only that it drew
+ * SOMETHING. Hence an assertion on the markup at every mount.
+ *
+ * `renderToStaticMarkup` only — no DOM, no layout — so nothing here can observe
+ * optical weight. What it CAN hold is the size each mount asks for, and those
+ * numbers are a measurement, not taste (see SIZES).
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import { describe, it, expect } from 'vitest'
+
+import '../../../i18n'
+import { factionName } from '../../../utils/factions'
+import { SnideSelectCard } from '../../selectCard/FactionSelectCard'
+import SnideFactionHero from '../../factionHero/SnideFactionHero'
+
+const render = (el: ReactElement) => renderToStaticMarkup(<MemoryRouter>{el}</MemoryRouter>)
+
+/** The Anarchy A's own geometry: the bleeding viewBox and the design's cant. */
+const ANARCHY_A = [/viewBox="-8 -8 116 116"/, /rotate\(-22 50 50\)/]
+
+/**
+ * The retired circled-S, pinned by its compass circle rather than by its
+ * viewBox — a `0 0 48 48` box is common enough that asserting on it alone would
+ * catch some unrelated ornament instead.
+ */
+const CIRCLED_S = /<circle cx="24" cy="24" r="19"/
+
+/**
+ * WHY THESE NUMBERS. Both mounts keep the size the circled-S was tuned at,
+ * because the two drawings happen to fill their boxes almost identically in the
+ * axis that governs the fit.
+ *
+ * The old mark was a stroked circle: outer radius 19 + half of a 3-unit stroke =
+ * 20.5, so its ink spanned 41 of its 48 units — 0.854 of the box, square.
+ *
+ * The Anarchy A is four straight-edged fills (every path is `L` commands, so the
+ * listed points ARE the extents) cantered -22° about (50,50). Rotated, its ink
+ * spans y 3.0–100.9 and x 11.6–94.5 inside the 116-unit box: 0.844 tall, 0.715
+ * wide. Height parity with the old mark is therefore within ~1% at the SAME
+ * size, and height is what has to hold — the select card sets its mark beside a
+ * wordmark in a centred flex row, and the hero centres it in a 94px medallion.
+ * The A is narrower in the cross axis because a cantered A IS narrower; the
+ * solid fills carry the weight the outline used to get from its width.
+ *
+ * So the fix is the import, and the sizes stay put. Anyone retuning them should
+ * move BOTH knowingly — the drawn height is 0.844x whatever is written here.
+ */
+const SIZES = { selectCard: 40, hero: 54 } as const
+
+describe('every S.N.I.D.E. surface wears the Anarchy A', () => {
+  const MOUNTS: ReadonlyArray<[label: string, html: () => string, size: number]> = [
+    [
+      'faction-directory select card',
+      () => render(<SnideSelectCard state="eligible" members={3} />),
+      SIZES.selectCard,
+    ],
+    [
+      'faction-page hero',
+      () =>
+        render(
+          <SnideFactionHero name={factionName('snide')} members={214} tasks={9} praxes={1489} />,
+        ),
+      SIZES.hero,
+    ],
+  ]
+
+  it.each(MOUNTS)('%s draws the A, not the retired circled-S', (_label, html) => {
+    const markup = html()
+    for (const mark of ANARCHY_A) {
+      expect(markup, 'the surface draws the Anarchy A').toMatch(mark)
+    }
+    expect(markup, 'the retired circled-S is gone from this surface').not.toMatch(CIRCLED_S)
+  })
+
+  it.each(MOUNTS)('%s asks for its measured size', (_label, html, size) => {
+    // Read the width off the sigil's own <svg>, which is the one carrying the
+    // bleeding viewBox — the surfaces around it draw plenty of other SVGs.
+    const markup = html()
+    const box = markup.indexOf('viewBox="-8 -8 116 116"')
+    const tag = markup.slice(markup.lastIndexOf('<svg', box), markup.indexOf('>', box) + 1)
+    expect(tag, 'the mark is drawn square at its measured size').toContain(`width="${size}"`)
+    expect(tag).toContain(`height="${size}"`)
+  })
+})


### PR DESCRIPTION
Closes #2119

## The defect

Not a missing drawing — an ambiguous name. The tree held **two** exports called `SnideSigil`, and two surfaces imported the wrong one:

| module | mark | consumers on `main` |
|---|---|---|
| `components/sigil/SnideSigil` | the Anarchy A (Sigil Studies v2, #1989) | avatar, faction archetype registry |
| `components/factionMarks/snideAtoms` | a leftover struck-through circle-S | **select card, faction hero** |

The report named the faction directory. It was in **two** places: `FactionSelectCard.tsx` (the tile in the screenshot) and `SnideFactionHero.tsx` (the medallion on the faction page) — the same surface family, noticed in one of them. A fresh grep of `origin/main` found those two and no others; every other `snideAtoms` importer takes only `WALL` or `PenCircle`, and the folder barrel deliberately re-exports neither.

## The seam

**The mark each S.N.I.D.E. surface actually renders.** Not the import statement — tsc is happy either way, and after the deletion a repeat is a compile error, but tsc still cannot tell you a surface stopped drawing the faction's mark. So the test renders both mounts and asserts the Anarchy A's own geometry is in the markup and the retired circled-S is not.

`frontend/src/components/sigil/__tests__/snideSigilIsTheAnarchyA.test.tsx` — **4 tests, red on `main` for the real reason** (neither surface drew the A), green after.

## The size check

Both mounts keep the size the circled-S was tuned at. That is a measurement, not an omission, and it is written into the test docblock:

- **Old mark** — a stroked circle, outer radius 19 + half a 3-unit stroke = 20.5, so its ink spanned **41 of 48 units = 0.854** of the box, square.
- **Anarchy A** — four straight-edged fills (every path is `L` commands, so the listed points *are* the extents) cantered −22° about (50,50). Rotated, the ink spans y 3.0–100.9 and x 11.6–94.5 in the 116-unit box: **0.844 tall, 0.715 wide.**

Height parity is therefore within **~1%** at the same size, and height is the axis that governs both fits — the select card sets the mark beside a wordmark in a centre-aligned flex row, the hero centres it in a 94px medallion. The A is narrower across because a cantered A *is* narrower; the solid fills carry the weight the old outline got from its width. So `size={40}` and `size={54}` stand.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally: `lint`, `typecheck`, `typecheck:design-sync`, `test` (**339 files / 5956 passing**), `build`, `budget`. No backend or schema surface touched, so `test` / `api-schema` are unaffected.

`budget` reports the CSS line on WARN. **That is pre-existing and not from this PR** — I A/B-built `HEAD` against `HEAD~1` and the blocking stylesheet is byte-identical, 22645 B gzip-9, same content hash. This diff moves zero CSS.

**No visual QA has been done** — no browser, no dev stack. Everything below is unverified by eye.

## Out of scope, but found on a surface this PR touches

The hero medallion's sigil ink is an **unguarded pairing that fails in both themes**, worst in dark. `SnideFactionHero.tsx:235` passes `var(--faction-snide)`, which flips (`#6fae00` light → `#b6ff2e` dark), onto `var(--faction-snide-paper)`, which is **theme-invariant** `#f4f1e8`. Against the medallion's real composite ground (paper under the `ht-dots` wash, ≈`#e6e3db`):

- light **2.1:1**
- dark **1.06:1** — effectively invisible

`utils/__tests__/factionContrast.test.ts:570` already rules on what goes on this paper — `--faction-snide-ink` — and this mount is not following it. **Pre-existing: the circled-S wore the identical token on the identical ground**, so this PR neither causes nor worsens it. Left alone deliberately: it is a separate defect carrying a design question (which ink does the slapped sticker wear?), and it does not belong inside an import fix. Worth its own issue.

## What to eyeball

Light **and** dark for each, checking the mark's optical weight against its neighbours:

- [ ] **Snide tile on `/factions`** — the A at `size={40}` beside the Anton wordmark. It should read at the same visual size the circled-S did; watch the cross-axis, since the A is ~17% narrower and sits in a `gap: var(--space-md)` flex row.
- [ ] **Snide faction hero** (`/factions/snide`) — the A at `size={54}` in the tilted 94px medallion. Confirm it clears the 2px rim and the medallion still reads as a slapped sticker. **Note the contrast finding above — expect it to look weak in dark; that is the pre-existing pairing, not the repoint.**
- [ ] **Snide avatar and the faction archetype sigil** — untouched, already on the Anarchy A. Worth a glance only as the reference for what "correct optical weight" looks like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
