### PR TITLE
Praxis cards wear the task card's masthead band (seven factions; na and Albescent stay bare)

### DIFF
--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -261,7 +261,7 @@
     "SingularityProcessLight": "src/components/factionMarks/SingularityProcessLight.tsx",
     "SingularityReadout": "src/components/factionMarks/SingularityReadout.tsx",
     "PendingBadge": "src/components/layout/PendingBadge.tsx",
-    "CardMasthead": "src/components/taskCard/CardMasthead.tsx",
+    "CardMasthead": "src/components/cardMasthead/CardMasthead.tsx",
     "RelationshipBlockControl": "src/pages/characterProfile/RelationshipBlockControl.tsx",
     "PlayersFilterBar": "src/pages/players/PlayersFilterBar.tsx",
     "ScoreToggle": "src/pages/players/ScoreToggle.tsx",

--- a/frontend/.ds-kit/index.tsx
+++ b/frontend/.ds-kit/index.tsx
@@ -16,7 +16,7 @@ export { default as AlbescentVote } from "../src/components/vote/AlbescentVote";
 export { default as AuthCard } from "../src/pages/onboarding/AuthCard";
 export { BackdropProvider } from "../src/components/backdrop/BackdropContext";
 export { default as CanSignUpEmpty } from "../src/pages/tasks/CanSignUpEmpty";
-export { default as CardMasthead } from "../src/components/taskCard/CardMasthead";
+export { default as CardMasthead } from "../src/components/cardMasthead/CardMasthead";
 export { default as CharacterBadge } from "../src/components/CharacterBadge";
 export { default as CharacterSwitcherSheet } from "../src/components/CharacterSwitcherSheet";
 export { ChipRow } from "../src/components/ui/ChipRow";

--- a/frontend/src/components/cardMasthead/CardMasthead.tsx
+++ b/frontend/src/components/cardMasthead/CardMasthead.tsx
@@ -5,12 +5,22 @@ import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 
 /**
- * The one masthead anatomy the task-card kit shares (#2029, task cards v3):
+ * The one masthead anatomy the CARD KITS share (#2029, task cards v3):
  * **the faction's mark hard left, the faction's title centred on the band.**
+ *
+ * TWO KITS MOUNT IT NOW, which is why it lives here rather than under
+ * `taskCard/` (#2185): the owner ruled that a praxis card wears the same band
+ * its task card does, so the praxis kit stopped being a stranger to this file
+ * and the file stopped belonging to one kit. The PAINT is not repeated across
+ * the two — `FactionMasthead` beside this module holds one painted band per
+ * faction and both kits mount that, so "the same band" is an identity rather
+ * than a promise two directories make to each other.
  *
  * Seven of the nine cards carry one. `na` and `albescent` mount none — that is
  * deliberate (ADR-0048: the Albescent card IS the unaffiliated sheet plus a
- * drift, and a band naming the society would un-hide it), not an omission.
+ * drift, and a band naming the society would un-hide it), not an omission. On a
+ * praxis card that reasoning binds harder, not softer: the card is PUBLIC, so a
+ * band naming Albescent would reveal the society on a stranger's feed.
  *
  * THE BAND IS A LINK TO THE FACTION (#2167). A card has three regions and three
  * destinations: the body reads the task, the CTA signs up, and the band — which
@@ -18,11 +28,17 @@ import { factionName } from "../../utils/factions";
  * from the `slug` every mount already passes rather than wired seven times, so
  * one change lands on seven surfaces and no skin can drift.
  *
- * It is valid HTML because the band is a SIBLING of the card-wide task link in
- * every archetype, never inside it — `mastheadFactionLink.test.tsx` holds that,
- * and it is the one thing that would make an anchor here illegal. The two
- * bandless cards get no such link and must not grow one: `/factions/albescent`
- * is an in-world dead end, not a faction page.
+ * It is valid HTML because the band is a SIBLING of the links inside the card,
+ * never inside one — the task card's card-wide task link, the praxis card's
+ * task line and byline. `taskCard/__tests__/mastheadFactionLink.test.tsx` and
+ * `praxisCard/__tests__/praxisMasthead.test.tsx` hold that on both kits, and it
+ * is the one thing that would make an anchor here illegal. It is also why a
+ * frame that pads itself has to move that padding to an inner box before it
+ * mounts a band: the band is full-bleed, and the two praxis frames that wrapped
+ * their whole body in padding got an inner box rather than an inset band.
+ *
+ * The two bandless cards get no such link and must not grow one:
+ * `/factions/albescent` is an in-world dead end, not a faction page.
  *
  * WHY A COMPONENT AND NOT A CONVENTION. The epic's sequencing ruling exists
  * because seven agents each inventing this shape yields seven slightly

--- a/frontend/src/components/cardMasthead/CardMasthead.tsx
+++ b/frontend/src/components/cardMasthead/CardMasthead.tsx
@@ -12,7 +12,7 @@ import { factionName } from "../../utils/factions";
  * `taskCard/` (#2185): the owner ruled that a praxis card wears the same band
  * its task card does, so the praxis kit stopped being a stranger to this file
  * and the file stopped belonging to one kit. The PAINT is not repeated across
- * the two — `FactionMasthead` beside this module holds one painted band per
+ * the two — `factionBands` beside this module holds one painted band per
  * faction and both kits mount that, so "the same band" is an identity rather
  * than a promise two directories make to each other.
  *
@@ -64,9 +64,11 @@ import { factionName } from "../../utils/factions";
  * S.N.I.D.E.'s broken acid rule and Everymen's pair of cogs both occupied the
  * space the centred title now takes. Ornament that sits BESIDE the mark without
  * reaching the centre survives, which is why Singularity keeps its lamps. Where
- * a band carries a backdrop (the Ephemerists' glyph registers, Coven's twinkle
- * field), the skin wraps this component in its own positioned box and paints
- * there — no ornament slot is needed here, and none is offered.
+ * a band carries a backdrop — Coven's twinkle field is the only one left, since
+ * #2067 took the Ephemerists' glyph registers off the card tier — the BAND
+ * wraps this component in its own positioned box and paints there. That wrapper
+ * lives with the band in `factionBands`, so both kits inherit it; no ornament
+ * slot is needed here, and none is offered.
  *
  * NO CARD RENDERS TWO FACTION MARKS IN ITS HEADER. The mark below is the kit's
  * `FactionSigil`, so a card that drew its own header mark hands it over rather

--- a/frontend/src/components/cardMasthead/FactionMasthead.tsx
+++ b/frontend/src/components/cardMasthead/FactionMasthead.tsx
@@ -1,0 +1,411 @@
+import type { CSSProperties } from "react";
+import CardMasthead from "./CardMasthead";
+import SingularityLamps from "../factionMarks/SingularityLamps";
+import { UA_DISPLAY } from "../factionMarks/uaAtoms";
+import { useFormFactor } from "../../hooks/useFormFactor";
+import { factionName } from "../../utils/factions";
+
+/**
+ * THE SEVEN PAINTED BANDS — one per faction, mounted by BOTH card kits (#2185).
+ *
+ * `CardMasthead` beside this file owns the ANATOMY and carries no paint. This
+ * file owns the paint: each faction's ground, rule, wordmark face and size, the
+ * mark's ink where the sigil's own default cannot be seen, and the backdrop a
+ * band is drawn over where it has one.
+ *
+ * WHY THE PAINT IS HERE AND NOT IN THE SKINS. The owner's ruling on #2185 is
+ * that a praxis card wears **the same band its task card wears** — same ground,
+ * same rule, same wordmark face and size. Written as two inline copies that is
+ * a promise; written once and mounted twice it is an identity, and the identity
+ * is what the ruling actually asked for. The failure mode is not hypothetical:
+ * before this file, `EverymenPraxisCard` drew its own red bar in
+ * `--everymen-red` at 15px with two flanking cogs while `EverymenTaskCard` drew
+ * `--faction-everymen-bill-mast` in Bebas at `--text-title` with a double rule —
+ * two mastheads for one faction, exactly what #2029 created `CardMasthead` to
+ * prevent, arrived anyway through the seam the component did not cover.
+ *
+ * ONLY SEVEN SLUGS ARE HERE, and {@link BandedSlug} is why the eighth and ninth
+ * cannot be added by accident. `na` and `albescent` mount no band by RULE
+ * (ADR-0048): the Albescent card IS the unaffiliated sheet plus a drift, and a
+ * band naming the society would un-hide it. On a praxis card — a public card, on
+ * other people's feeds — that is a disclosure, not a style choice. A runtime
+ * `return null` would have let a future mount ask for one and get silence; a
+ * union makes `<FactionMasthead slug="albescent" />` fail to compile.
+ *
+ * The ORNAMENT that rides BELOW a band is not here — WOW's bunting, the
+ * Ephemerists' cornice. Those are strung under the band by the surface that
+ * wants them, and the two kits do not agree about them; what the ruling binds is
+ * the band itself.
+ */
+
+/** The seven factions that wear a band. Not a faction list — see the docblock. */
+export type BandedSlug =
+  | "coven"
+  | "ephemerists"
+  | "everymen"
+  | "singularity"
+  | "snide"
+  | "ua"
+  | "wow";
+
+/* ── Coven ─────────────────────────────────────────────────────────────── */
+
+const HAND = "var(--font-faction-script)"; /* Caveat */
+
+/**
+ * The band the twinkle field is confined to, so no star lands in copy.
+ *
+ * It was 72px while the wordmark floated over the slip with a braid tied under
+ * it. #2029 pinned the wordmark into a band of its own and dropped the braid, so
+ * the field shrank to the band it dresses. Geometry (§4a).
+ */
+const COVEN_BAND_HEIGHT = 44;
+
+/** A four-point star, centred on (x, y) with arm length r. */
+function starPath(x: number, y: number, r: number): string {
+  const long = r * 2.6;
+  return `M${x} ${y - long} l${r} ${long} ${long} ${r} -${long} ${r} -${r} ${long} -${r} -${long} -${long} -${r} ${long} -${r} z`;
+}
+
+/** The gold twinkle field, clipped to the masthead band. */
+function TwinkleField() {
+  const stars: [number, number, number][] = [
+    [38, 16, 2.6],
+    [296, 21, 2],
+    [120, 11, 1.4],
+    [212, 27, 1.6],
+    [264, 10, 1.2],
+    [74, 29, 1.6],
+  ];
+  return (
+    <svg
+      width="100%"
+      height={COVEN_BAND_HEIGHT}
+      viewBox={`0 0 340 ${COVEN_BAND_HEIGHT}`}
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      style={{ position: "absolute", left: 0, top: 0, right: 0, zIndex: 1, pointerEvents: "none" }}
+    >
+      {stars.map(([x, y, r]) => (
+        <path key={`${x}-${y}`} d={starPath(x, y, r)} fill="var(--faction-coven-slip-gold)" opacity={0.8} />
+      ))}
+    </svg>
+  );
+}
+
+/**
+ * The twinkle field moves INTO the band, over its ground: with a painted band
+ * the stars would otherwise be hidden behind it. This is the wrapper the #2185
+ * ruling means by "where a task card wraps the component to paint a backdrop,
+ * the praxis card does the same" — it comes with the band rather than being
+ * rebuilt beside it.
+ */
+function CovenBand() {
+  return (
+    <div
+      style={{
+        position: "relative",
+        zIndex: 2,
+        height: COVEN_BAND_HEIGHT,
+        background: "var(--faction-coven-slip-sigil-ground)",
+        borderBottom: "1px solid var(--faction-coven-slip-pk)",
+        /* The twinkle box is the one wrapper standing between a card's root and
+           its band, so since #2167 made the band a link it matches
+           `:has(a[href])` on the equal-height row's slack chain (index.css) and
+           would stretch past its 44px. The band inside pins its own growth for
+           the same reason; this pins the box. */
+        flexGrow: 0,
+      }}
+    >
+      <TwinkleField />
+      <CardMasthead slug="coven" style={{ height: "100%" }}>
+        {/* The slip's own `feed:taskCard.coven.masthead` held a second copy of
+            the faction's name ("the cozy coven") and is gone with #1910. The
+            lower case belonged to the hand-lettering rather than to the word, so
+            it lives in `textTransform`, where casing belongs — the name itself
+            comes from the one place that owns it (ADR-0038). */}
+        <div style={{ fontFamily: HAND, fontSize: "var(--text-title)", lineHeight: 1, textTransform: "lowercase" }}>
+          {factionName("coven")}
+        </div>
+      </CardMasthead>
+    </div>
+  );
+}
+
+/* ── The Ephemerists ───────────────────────────────────────────────────── */
+
+const DECO = "var(--font-faction-deco)";
+
+/**
+ * THE RESTRAINED MASTHEAD (#2067) — the kit's shared anatomy and nothing else.
+ *
+ * THE GROUND IS THE MEDALLION'S DISC, not the cornice band. `-plate-disc` is two
+ * values lighter than `-plate-band`, so the header reads as a brass-edged plate
+ * rather than as a night strip. THE INK IS UNCHANGED: `-plate-band-ink` is the
+ * gold measured on the band, and moving the ground under it spends 0.93 of a
+ * very large margin — 14.00:1 on the band, 13.07:1 on the disc.
+ * `factionContrast.test.ts` records the pairing. The sigil takes `currentColor`.
+ *
+ * `boxSizing` is load-bearing next to the border: the band is a block child of a
+ * card with `overflow: hidden`, so a content-box border would push it 2px wider
+ * than the card and be clipped on the right.
+ */
+function EphemeristsBand() {
+  return (
+    <CardMasthead
+      slug="ephemerists"
+      style={{
+        boxSizing: "border-box",
+        background: "var(--faction-ephemerists-plate-disc)",
+        color: "var(--faction-ephemerists-plate-band-ink)",
+        border: "1px solid var(--faction-ephemerists-plate-brass)",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: DECO,
+          fontSize: "var(--text-xl)",
+          letterSpacing: "0.3em",
+          textTransform: "uppercase",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {/* #1910: the band spells the faction's name, so it reads the one key
+            that stays per-faction rather than a second copy. The
+            `textTransform` above already carried the plate's upper case. */}
+        {factionName("ephemerists")}
+      </span>
+    </CardMasthead>
+  );
+}
+
+/* ── The Everymen ──────────────────────────────────────────────────────── */
+
+const POSTER = "var(--faction-everymen-card-font)"; /* Bebas Neue */
+
+/** Poster label voice — condensed caps, the bill's whole chrome. */
+const EVERYMEN_LABEL: CSSProperties = {
+  fontFamily: POSTER,
+  letterSpacing: "0.16em",
+  textTransform: "uppercase",
+};
+
+/**
+ * The union's red bar. The band read "Help Wanted!" between two cogs until
+ * #1909 cut the slot as generic, which left the cogs alone on the bar; v3
+ * answers the same objection the other way round — the band names THE FACTION —
+ * and the pair of cogs stands down, because they flanked the centre the wordmark
+ * now holds. The cog stays the bill's motif elsewhere.
+ *
+ * THE PADDING IS THE ONE FORM-FACTOR BRANCH IN THIS FILE, and it is the bill's
+ * own: the mast is deeper on the desktop sheet. Everything else here is one
+ * value at both sizes.
+ */
+function EverymenBand() {
+  const formFactor = useFormFactor();
+  return (
+    <CardMasthead
+      slug="everymen"
+      /* On the red mast the sigil's own `--everymen-red` is invisible. */
+      markColor="var(--faction-everymen-bill-mast-ink)"
+      style={{
+        padding:
+          formFactor === "desktop"
+            ? "var(--space-md) var(--space-lg)"
+            : "var(--space-sm) var(--space-lg)",
+        background: "var(--faction-everymen-bill-mast)",
+        color: "var(--faction-everymen-bill-mast-ink)",
+        borderBottom: "3px double var(--faction-everymen-bill-cta-bg)",
+        boxShadow: "inset 0 -6px 0 -4px var(--everymen-paper-deep)",
+      }}
+    >
+      <span style={{ ...EVERYMEN_LABEL, fontSize: "var(--text-title)", lineHeight: 1 }}>
+        {factionName("everymen")}
+      </span>
+    </CardMasthead>
+  );
+}
+
+/* ── Singularity ───────────────────────────────────────────────────────── */
+
+const MONO = "var(--faction-singularity-card-font)"; /* Share Tech Mono */
+
+/**
+ * The window chrome. The bar read "task.proc — singularity" until #1909 cut it
+ * as generic, leaving the lamps alone; v3 gives it back the one title that is
+ * not generic and is not a second copy of anything — the faction's own name,
+ * from the one place that owns it (ADR-0038).
+ *
+ * THE LAMPS RIDE WITH THE MARK rather than standing down: they are the window,
+ * not a faction mark, and the grid centres the title on the BAND, so a wider
+ * left cluster does not push it off true.
+ */
+function SingularityBand() {
+  return (
+    <CardMasthead
+      slug="singularity"
+      leading={<SingularityLamps />}
+      style={{
+        padding: "var(--space-sm) var(--space-md)",
+        background: "var(--faction-singularity-term-chrome)",
+        borderBottom: "1px solid var(--faction-singularity-term-hair)",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: MONO,
+          letterSpacing: "0.14em",
+          textTransform: "uppercase",
+          color: "var(--faction-singularity-term-dim)",
+          fontSize: "var(--text-xl)",
+          lineHeight: 1,
+        }}
+      >
+        {factionName("singularity")}
+      </span>
+    </CardMasthead>
+  );
+}
+
+/* ── S.N.I.D.E. ────────────────────────────────────────────────────────── */
+
+const IMPACT = "var(--faction-snide-font-impact)"; /* Anton */
+
+/**
+ * The note bar. The broken acid rule that used to fill its right end is gone
+ * with the centring: it was a flex filler taking the width #1124's retired
+ * ordinal left behind, and that width is exactly where the centred wordmark now
+ * sits. The clipping keeps its acid elsewhere.
+ */
+function SnideBand() {
+  return (
+    <CardMasthead
+      slug="snide"
+      /* The brushed A is drawn 24 where the kit draws 20 (#2035), and it bleeds
+         2px into the band's inset on each side — which is the mark doing what it
+         was drawn to do: `SnideSigil`'s four shapes break out of their own circle
+         at four points. This used to be a stylesheet hook reaching into the
+         sigil's markup; #2056 made it the prop. */
+      markSize={24}
+      style={{
+        background: "var(--faction-snide-note-bar)",
+        color: "var(--faction-snide-note-bar-ink)",
+      }}
+    >
+      {/* eslint-disable-next-line local/no-raw-style-values -- ornament: cut-out wordmark; Anton at a label-ramp size stops reading as a masthead. */}
+      <span style={{ fontFamily: IMPACT, fontSize: 22, letterSpacing: "0.06em", lineHeight: 1, color: "var(--faction-snide-acid)" }}>
+        {factionName("snide")}
+      </span>
+    </CardMasthead>
+  );
+}
+
+/* ── UA ────────────────────────────────────────────────────────────────── */
+
+/**
+ * The leaf's hairline band.
+ *
+ * THE WORDMARK TAKES THE BODY INK, NOT THE ACCENT. The design sets it in
+ * `--faction-ua-card-accent` on `--faction-ua-hair`, which measures 4.46:1 in
+ * light — under AA for a 24px non-bold face, and the band's whole job is to be
+ * read. `-card-text` is 10.35:1 on the same ground (11.45:1 in dark) and is the
+ * leaf's own ink; the accent keeps the band's bottom rule, where a hairline owes
+ * nothing.
+ */
+function UaBand() {
+  return (
+    <CardMasthead
+      slug="ua"
+      style={{
+        background: "var(--faction-ua-hair)",
+        borderBottom: "1px solid var(--faction-ua-card-accent)",
+      }}
+    >
+      <span
+        style={{
+          fontFamily: UA_DISPLAY,
+          fontWeight: 600,
+          fontSize: "var(--text-title)",
+          letterSpacing: "0.08em",
+          lineHeight: 1,
+        }}
+      >
+        {factionName("ua")}
+      </span>
+    </CardMasthead>
+  );
+}
+
+/* ── Warriors of Whimsy ────────────────────────────────────────────────── */
+
+const MED = "var(--faction-wow-card-font)"; /* MedievalSharp */
+/**
+ * The banner's ink — lettering AND mark (#2032). The page kit's gilt button
+ * stop, theme-invariant like the plum it stands on, so one measurement (3.47:1)
+ * covers both themes. NOT `-stamp-total`, which is an ink that flips.
+ */
+const GILT_MID = "var(--faction-wow-gilt-mid)";
+
+/**
+ * The plum banner (#2029), dressed (#2032) — the kit's shared anatomy on the
+ * theme-invariant plum the CTA already stands on, lettered in the gilt the mark
+ * takes with it.
+ *
+ * THE HORIZONTAL INSET IS SYMMETRIC, AND IT IS NO LONGER ZERO (#2070). #2032
+ * zeroed it so the mark would break the banner's left line and stand on the
+ * card's own gold frame; in production that read as touching the border, and the
+ * owner's ruling is that it overshot. The mark sits inboard with clearance now —
+ * `--space-sm`, which is the band's own vertical inset, so the mark keeps a
+ * uniform 8px surround instead of 2px of frame. Still half the kit's
+ * `--space-lg` default, so the sigil stays nearer the edge than the type block,
+ * which is the half of #2032 that was right.
+ *
+ * BOTH INSETS MOVE TOGETHER. #2029's title is centred on the band's CONTENT box,
+ * so left-only clearance walks the centred wordmark off the card's centreline by
+ * half the inset — symmetry is what keeps the title true, and it was #2032's
+ * reason for zeroing both rather than just the left. `--space-xs` was the
+ * smaller candidate and is only 2px past the frame's own 2px weight, i.e. the
+ * reported symptom again at half strength.
+ *
+ * THE BOTTOM RULE IS GOLD. In light `--faction-wow-card-accent` IS the band's
+ * own ground to the hex; `-gilt-mid` on the same plum is 3.47:1, so drawn in the
+ * gilt it is a line you can see — and on the task card it is the string the
+ * bunting below hangs from.
+ */
+function WowBand() {
+  return (
+    <CardMasthead
+      slug="wow"
+      markColor={GILT_MID}
+      style={{
+        background: "var(--faction-wow-plum-surface)",
+        color: "var(--faction-wow-on-plum)",
+        padding: "var(--space-sm) var(--space-sm)",
+        borderBottom: `2px solid ${GILT_MID}`,
+      }}
+    >
+      <span style={{ fontFamily: MED, fontSize: "var(--text-title)", letterSpacing: "0.04em", lineHeight: 1, color: GILT_MID }}>
+        {factionName("wow")}
+      </span>
+    </CardMasthead>
+  );
+}
+
+const BANDS: Record<BandedSlug, () => React.ReactElement> = {
+  coven: CovenBand,
+  ephemerists: EphemeristsBand,
+  everymen: EverymenBand,
+  singularity: SingularityBand,
+  snide: SnideBand,
+  ua: UaBand,
+  wow: WowBand,
+};
+
+/**
+ * Mount a faction's band. One line on a task card, the same line on its praxis
+ * card, and no way to spell a slug that has no band.
+ */
+export default function FactionMasthead({ slug }: { slug: BandedSlug }) {
+  const Band = BANDS[slug];
+  return <Band />;
+}

--- a/frontend/src/components/cardMasthead/factionBands.tsx
+++ b/frontend/src/components/cardMasthead/factionBands.tsx
@@ -24,29 +24,26 @@ import { factionName } from "../../utils/factions";
  * two mastheads for one faction, exactly what #2029 created `CardMasthead` to
  * prevent, arrived anyway through the seam the component did not cover.
  *
- * ONLY SEVEN SLUGS ARE HERE, and {@link BandedSlug} is why the eighth and ninth
- * cannot be added by accident. `na` and `albescent` mount no band by RULE
- * (ADR-0048): the Albescent card IS the unaffiliated sheet plus a drift, and a
- * band naming the society would un-hide it. On a praxis card — a public card, on
- * other people's feeds — that is a disclosure, not a style choice. A runtime
- * `return null` would have let a future mount ask for one and get silence; a
- * union makes `<FactionMasthead slug="albescent" />` fail to compile.
+ * SEVEN NAMED EXPORTS, AND NO SLUG→COMPONENT MAP. #782 removed surface-owned
+ * registries and `factions/__tests__/addAFaction.test.tsx` enforces it, but the
+ * rule is not the only reason there is no dispatch here: there is nothing to
+ * dispatch ON. Both callers of a band are per-faction files that already know
+ * their own faction — `WowTaskCard` and `WowPraxisCard` both want the WOW band
+ * and neither has a slug to look one up with. A record keyed by slug would have
+ * been a lookup table with seven constant keys.
+ *
+ * ONLY SEVEN BANDS EXIST, and the eighth and ninth are absent by RULE (ADR-0048,
+ * NOT superseded by #2185): the Albescent card IS the unaffiliated sheet plus a
+ * drift, and a band naming the society would un-hide it. On a praxis card — a
+ * public card, on other people's feeds — that is a disclosure, not a style
+ * choice. There is no `DefaultBand` and no `AlbescentBand` to import, which is
+ * the strongest form the rule can take in a module.
  *
  * The ORNAMENT that rides BELOW a band is not here — WOW's bunting, the
  * Ephemerists' cornice. Those are strung under the band by the surface that
  * wants them, and the two kits do not agree about them; what the ruling binds is
  * the band itself.
  */
-
-/** The seven factions that wear a band. Not a faction list — see the docblock. */
-export type BandedSlug =
-  | "coven"
-  | "ephemerists"
-  | "everymen"
-  | "singularity"
-  | "snide"
-  | "ua"
-  | "wow";
 
 /* ── Coven ─────────────────────────────────────────────────────────────── */
 
@@ -391,21 +388,12 @@ function WowBand() {
   );
 }
 
-const BANDS: Record<BandedSlug, () => React.ReactElement> = {
-  coven: CovenBand,
-  ephemerists: EphemeristsBand,
-  everymen: EverymenBand,
-  singularity: SingularityBand,
-  snide: SnideBand,
-  ua: UaBand,
-  wow: WowBand,
+export {
+  CovenBand,
+  EphemeristsBand,
+  EverymenBand,
+  SingularityBand,
+  SnideBand,
+  UaBand,
+  WowBand,
 };
-
-/**
- * Mount a faction's band. One line on a task card, the same line on its praxis
- * card, and no way to spell a slug that has no band.
- */
-export default function FactionMasthead({ slug }: { slug: BandedSlug }) {
-  const Band = BANDS[slug];
-  return <Band />;
-}

--- a/frontend/src/components/factionMarks/__tests__/singularityLamps.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/singularityLamps.test.tsx
@@ -129,12 +129,20 @@ describe("the lamp cluster is declared once, and in the kit (#1979)", () => {
     // both scans above at once: no `Lamp` identifier to find, and no LED token
     // to find either. Only a roll-call of the surfaces can see that, and only
     // if it is written down.
+    //
+    // IT IS FIVE NOW, AND THAT IS A MERGE RATHER THAN A LOSS (#2185). The task
+    // card and the praxis card wear the SAME window bar, mounted from
+    // `cardMasthead/factionBands` — so the two card mounts became one and the
+    // bar they share is `SingularityBand`. Four window bars still draw their own
+    // (the feed frame and the three page surfaces). A future reader shortening
+    // this list further should check they are removing a mount and not a
+    // SURFACE: a card that stopped drawing the bar at all is the regression this
+    // roll-call exists to catch, and it looks identical to this edit from here.
     const rel = (path: string) => path.slice(SRC.length).replace(/\\/g, "/");
     const mounts = sources().filter(({ source }) => source.includes("<SingularityLamps"));
     expect(mounts.map((file) => rel(file.path)).sort()).toEqual([
+      "components/cardMasthead/factionBands.tsx",
       "components/feed/SingularityFeedFrame.tsx",
-      "components/praxisCard/desktop/SingularityPraxisCard.tsx",
-      "components/taskCard/SingularityTaskCard.tsx",
       "pages/editPraxis/archetypes/SingularityEditPraxis.tsx",
       "pages/praxisDetail/archetypes/SingularityPraxisDetail.tsx",
       "pages/taskDetail/archetypes/SingularityTaskDetail.tsx",

--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -108,21 +108,38 @@ describe('the Ephemerists praxis card wears the Valley plate (#1207)', () => {
     // belongs to the sweep, not to this card.
   })
 
-  it('carries the night-band masthead: the engraved title over an incised register', () => {
+  it('heads the record with the CARD TIER band, on the medallion disc', () => {
+    // #2185: a praxis card wears the same band its task card wears, and #2067
+    // restrained `EphemeristsTaskCard` to the kit's plain `CardMasthead` on the
+    // plate DISC. So the 110px night band with its incised `GlyphRegister` is
+    // off this card, and the engraved masthead with it.
     const markup = html()
-    // The register's signs and the cornice are the kit's, not a second copy.
-    expect(markup).toContain('class="epg-glyph"')
-    expect(markup).toContain('var(--faction-ephemerists-plate-band)')
+    expect(markup, 'the kit band from #2029').toContain('data-card-masthead="ephemerists"')
+    expect(markup, "the medallion's disc, not the cornice band").toContain(
+      'var(--faction-ephemerists-plate-disc)',
+    )
+    // The DATUM ROW's ink is the engraving's tell — it exists nowhere else on
+    // this card — so its absence is what says the night band really went rather
+    // than merely moving. `epg-glyph` would NOT say it: the drift strip above
+    // the vote block carries that class too, so asserting on it would pass
+    // whether the register were here or not.
+    expect(markup, 'no engraved datum row on a card').not.toContain(
+      'var(--faction-ephemerists-plate-band-quiet)',
+    )
   })
 
-  it('heads the record with the engraved masthead, and says the wordmark ONCE', () => {
-    // #1634 replaced the winged disc + Poiret One wordmark with the engraved
-    // masthead, and retired the brass cartouche pill that repeated the faction's
-    // name 40px below it. Both halves are asserted here because a mount that
-    // adds the masthead and leaves the pill is the failure that still renders:
-    // it looks like a masthead with a subtitle.
+  it('says the wordmark ONCE', () => {
+    // #1634 retired the brass cartouche pill that repeated the faction's name
+    // 40px under the masthead. The band still names the faction, so the pill
+    // must still be gone: a header plus a subtitle saying the same word is the
+    // failure that renders perfectly.
     const rendered = text(html())
-    expect(rendered).toContain(i18n.t('factions:names.ephemerists'))
+    const name = i18n.t('factions:names.ephemerists')
+    expect(rendered).toContain(name)
+    expect(
+      rendered.split(new RegExp(name, 'i')).length - 1,
+      'the band names the faction; nothing else on the card does',
+    ).toBe(1)
     // The pill's own copy, spelled out: `praxis:card.masthead.ephemerists` was
     // deleted with the pill, and a key kept alive by a negative assertion is a
     // key the next dead-key sweep cannot tell from a live one.
@@ -133,7 +150,6 @@ describe('the Ephemerists praxis card wears the Valley plate (#1207)', () => {
     // generic. Asserted as an absence so a voice pass cannot quietly put a
     // faction-only band back on a surface ruled shared.
     expect(rendered).not.toContain('星')
-    expect(html()).toContain('var(--faction-ephemerists-plate-band-quiet)')
   })
 
   /* The plate gloss ("for:", `praxis:card.ephemerists.for`) and the card's own

--- a/frontend/src/components/praxisCard/__tests__/praxisMasthead.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/praxisMasthead.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Praxis cards wear the task card's masthead band (#2185).
+ *
+ * THE SEAM IS THE BAND'S RENDERED MARKUP, reached through the nine praxis skins
+ * — the mirror of `taskCard/__tests__/mastheadFactionLink.test.tsx`, which works
+ * the same seam on the other kit. Two kits mount one component now, so the
+ * interesting assertions are the ones that can only be made with both in view.
+ *
+ * THE CENTRAL TEST IS BAND-FOR-BAND IDENTITY. The owner's ruling is not "a
+ * praxis card gets a band", it is "a praxis card gets THE SAME BAND its task
+ * card wears — same ground, same rule, same wordmark face and size". Asserting
+ * the paint value by value would restate seven skins in a test file and go stale
+ * the first time a token moved; asserting that the two kits emit the IDENTICAL
+ * band markup is the property itself, and it fails the moment either side grows
+ * a copy of its own. That is the failure this file exists for: before #2185,
+ * `EverymenPraxisCard` drew its own red bar (`--everymen-red`, 15px,
+ * `--font-accent`, two cogs, no name) while `EverymenTaskCard` drew
+ * `--faction-everymen-bill-mast` in Bebas at `--text-title` under a double rule.
+ * Both branches were green. Two mastheads for one faction shipped anyway.
+ *
+ * `na` AND `albescent` MOUNT NO BAND, and that is a rule rather than a gap
+ * (ADR-0048, NOT superseded by #2185). A praxis card is PUBLIC — it lands on
+ * other players' feeds — so a band naming Albescent would reveal a secret
+ * society to a stranger. The negative is asserted here for the same reason the
+ * task-card file asserts it: it is the assertion a future "finish the set" sweep
+ * has to read before it can delete it.
+ *
+ * SSR-only harness (renderToStaticMarkup, no DOM, effects never run), so these
+ * are assertions about markup given props — never interaction. What a static
+ * render cannot see is the hover affordance (a pointer handler) and the cascade;
+ * both are eyeballed.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import type { ComponentType } from "react";
+import { describe, it, expect, vi } from "vitest";
+import "../../../i18n";
+import i18n from "../../../i18n";
+import type { CardProps } from "../../taskCard/TaskCard";
+import type { ArchetypeProps } from "../desktop/shared";
+
+vi.mock("../../../hooks/useFormFactor", () => ({ useFormFactor: () => "desktop" }));
+// `useTheme()` throws outside a `ThemeProvider` by design (#701) and the score
+// stamp reaches for it. Nothing here depends on which half it returns — the band
+// is a token dress, and the theme is the cascade's business.
+vi.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ theme: "light", toggle: () => {} }),
+}));
+
+// Imported after the mocks are registered.
+import CovenTaskCard from "../../taskCard/CovenTaskCard";
+import EphemeristsTaskCard from "../../taskCard/EphemeristsTaskCard";
+import EverymenTaskCard from "../../taskCard/EverymenTaskCard";
+import SingularityTaskCard from "../../taskCard/SingularityTaskCard";
+import SnideTaskCard from "../../taskCard/SnideTaskCard";
+import UaTaskCard from "../../taskCard/UaTaskCard";
+import WowTaskCard from "../../taskCard/WowTaskCard";
+
+import AlbescentPraxisCard from "../desktop/AlbescentPraxisCard";
+import CovenPraxisCard from "../desktop/CovenPraxisCard";
+import DefaultPraxisCard from "../desktop/DefaultPraxisCard";
+import EphemeristsPraxisCard from "../desktop/EphemeristsPraxisCard";
+import EverymenPraxisCard from "../desktop/EverymenPraxisCard";
+import SingularityPraxisCard from "../desktop/SingularityPraxisCard";
+import SnidePraxisCard from "../desktop/SnidePraxisCard";
+import UaPraxisCard from "../desktop/UaPraxisCard";
+import WowPraxisCard from "../desktop/WowPraxisCard";
+
+import { aTask, aPraxisCard } from "../../../test/fixtures";
+import { factionName } from "../../../utils/factions";
+
+interface Skin {
+  slug: string;
+  Praxis: ComponentType<ArchetypeProps>;
+  Task?: ComponentType<CardProps>;
+}
+
+/** The seven bands. */
+const BANDED: Skin[] = [
+  { slug: "coven", Praxis: CovenPraxisCard, Task: CovenTaskCard },
+  { slug: "ephemerists", Praxis: EphemeristsPraxisCard, Task: EphemeristsTaskCard },
+  { slug: "everymen", Praxis: EverymenPraxisCard, Task: EverymenTaskCard },
+  { slug: "singularity", Praxis: SingularityPraxisCard, Task: SingularityTaskCard },
+  { slug: "snide", Praxis: SnidePraxisCard, Task: SnideTaskCard },
+  { slug: "ua", Praxis: UaPraxisCard, Task: UaTaskCard },
+  { slug: "wow", Praxis: WowPraxisCard, Task: WowTaskCard },
+];
+
+/** The two that mount no band, and must not grow one. */
+const BANDLESS: Skin[] = [
+  { slug: "na", Praxis: DefaultPraxisCard },
+  { slug: "albescent", Praxis: AlbescentPraxisCard },
+];
+
+const adminProps = {
+  showAdminControls: false,
+  onHide: () => {},
+  onFail: () => {},
+} as unknown as ArchetypeProps["adminProps"];
+
+function renderPraxis({ slug, Praxis }: Skin): string {
+  const praxis = aPraxisCard({ task_faction_slug: slug });
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Praxis praxis={praxis} adminProps={{ ...adminProps, praxis }} showCrown />
+    </MemoryRouter>,
+  );
+}
+
+function renderTask(skin: Skin): string {
+  const Task = skin.Task as ComponentType<CardProps>;
+  const task = aTask();
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Task
+        task={task}
+        basePoints={task.point_value}
+        multiplier={1}
+        inProgressCount={task.in_progress_count}
+        onSignup={() => {}}
+      />
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * The band's whole element, from its opening `<a` to its closing `</a>`.
+ *
+ * The first `</a>` after the marker IS the band's own: the band contains a
+ * sigil, a wordmark and (for Singularity) three lamps, and no anchor — which is
+ * the invariant that makes it legal HTML in the first place.
+ */
+function band(html: string, slug: string): string {
+  const at = html.indexOf(`data-card-masthead="${slug}"`);
+  expect(at, "the shared band from #2029").toBeGreaterThan(-1);
+  const open = html.lastIndexOf("<", at);
+  const close = html.indexOf("</a>", at);
+  expect(close, "the band is closed").toBeGreaterThan(-1);
+  return html.slice(open, close + "</a>".length);
+}
+
+describe.each(BANDED)("$slug praxis card wears its task card's band (#2185)", (skin) => {
+  it("emits the identical band markup the task card does", () => {
+    // The ruling, as a property. Not "a band exists" and not "the ground is
+    // this hex" — the SAME band, which is what one shared painted component
+    // makes true and two inline copies only promise.
+    expect(band(renderPraxis(skin), skin.slug)).toBe(band(renderTask(skin), skin.slug));
+  });
+
+  it("names the faction and goes to the faction page", () => {
+    const tag = band(renderPraxis(skin), skin.slug);
+    expect(tag, "the band itself is the hit target").toMatch(/^<a /);
+    expect(tag, "and it reads the faction it names").toContain(`href="/factions/${skin.slug}"`);
+    expect(tag, "the wordmark is the faction's name").toContain(factionName(skin.slug));
+    const label = i18n.t("feed:taskCard.mastheadLink", { faction: factionName(skin.slug) });
+    expect(tag, "labelled with the destination, not the furniture").toContain(
+      `aria-label="${label}"`,
+    );
+  });
+
+  it("nests no anchor inside another", () => {
+    // A band inside the card's own links — the task line, the byline — would be
+    // invalid HTML, and the praxis frames vary in how they nest. The band is a
+    // top-of-frame SIBLING in every one, so it closes before any other opens.
+    const html = renderPraxis(skin);
+    const at = html.indexOf(`data-card-masthead="${skin.slug}"`);
+    // Cut at the band's own `<`, not at its marker attribute — the marker sits
+    // INSIDE the opening tag, so slicing at it would count the band itself as
+    // an unclosed anchor and the test would fail on correct markup.
+    const before = html.slice(0, html.lastIndexOf("<", at));
+    const opened = (before.match(/<a[\s>]/g) ?? []).length;
+    const closed = (before.match(/<\/a>/g) ?? []).length;
+    expect(opened, "no anchor is still open where the band starts").toBe(closed);
+  });
+});
+
+describe.each(BANDLESS)("$slug praxis card grows no band (#2185, ADR-0048)", (skin) => {
+  it("mounts no masthead and links to no faction page", () => {
+    const html = renderPraxis(skin);
+    // A praxis card is public. A band naming Albescent on a stranger's feed is
+    // a disclosure, not a style choice — and `/factions/albescent` is an
+    // in-world dead end rather than a faction page.
+    expect(html, "no band to hang a link on").not.toContain("data-card-masthead");
+    expect(html, "and no faction page anywhere on the card").not.toContain("/factions/");
+  });
+});

--- a/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
@@ -1,7 +1,7 @@
+import FactionMasthead from "../../cardMasthead/FactionMasthead";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 import {
-  Braid,
   CARD,
   BORDER,
   CovenCat,
@@ -17,9 +17,19 @@ import {
  * Cozy Coven — THE SPELL SLIP, filed (#1209).
  *
  * The praxis card is the coven's proof written onto the same candle-lit paper
- * the task slip is issued on: the four-stop pink→lavender sheet, a braided
- * thread under the dispatch line, the cat turning in the corner, Grenze Gotisch
+ * the task slip is issued on: the four-stop pink→lavender sheet, the hand-
+ * lettered band across the head, the cat turning in the corner, Grenze Gotisch
  * for the title and Cormorant Garamond for the reading voice.
+ *
+ * ## IT WEARS A MASTHEAD AGAIN — #1909's reasoning is SUPERSEDED (#2185)
+ *
+ * This docstring used to carry #1909's note that the praxis masthead was cut
+ * because "a generic one just says 'Praxis' on a praxis card". THE OWNER HAS
+ * SINCE DECIDED A PRAXIS CARD DOES WANT A BAND, and it is the faction's own —
+ * the same one `CovenTaskCard` wears, mounted from the same module. Nothing
+ * about #1909 was wrong at the time; the decision changed, and #2185 is the
+ * record. Do not reconstruct the old argument beside the band it argues against,
+ * and do not restore the braid the band displaced.
  *
  * ## IT WEARS THE SHEET NOW — #1209's decision is REVERSED (#2135)
  *
@@ -84,7 +94,11 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
         border: `2px solid ${BORDER}`,
         boxShadow: SHADOW,
         fontFamily: READING,
-        padding: "var(--space-xl)",
+        /* NO PADDING ON THE FRAME since #2185: the band is full-bleed, and an
+           inset frame would have floated it off three edges. The slip's inset
+           moved to the body box below. The cat does not move with it — an
+           absolutely positioned child resolves against the PADDING box, which
+           dropping padding leaves where it was. */
         transition: "background 150ms, color 150ms",
       }}
     >
@@ -94,12 +108,19 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
           {@link CovenCat}). `.cvn-wheel` owns the turn and its reduced-motion
           guard in index.css; the body below sits above it on its own layer. */}
       <CovenCat size={190} style={{ right: -6, bottom: -4, opacity: 0.09 }} />
+
+      {/* THE SLIP'S BAND (#2185) — the same one `CovenTaskCard` wears, twinkle
+          field and all, mounted from the shared module. The field is the band's
+          BACKDROP, so it travels with the band rather than being rebuilt beside
+          it; that is what keeps the stars off the copy on both cards. */}
+      <FactionMasthead slug="coven" />
+
       <AdminOverlay {...adminProps} />
       {/* The copy takes a layer of its own, for the reason `CovenTaskCard`'s
           body does: the mark is absolutely positioned, so in-flow siblings would
           paint UNDER it. A watermark that crosses the type is the one thing the
           0.09 was chosen to avoid. */}
-      <div style={{ position: "relative", zIndex: 1 }}>
+      <div style={{ position: "relative", zIndex: 1, padding: "var(--space-xl)" }}>
         <PraxisBody
           praxis={praxis}
           tint={INK}
@@ -116,13 +137,13 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
             display: DISPLAY,
             body: READING,
           }}
-          /* The eyebrow's dispatch line ("dispatch no. {{id}} · all done!",
+          /* NO EYEBROW. The dispatch line ("dispatch no. {{id}} · all done!",
              `card.masthead.coven`) and the empty gallery's "Drop a happy little
-             photo" (`card.coven.mediaEmpty`) were both CUT by #1909 — the
-             masthead because a generic one just says "Praxis" on a praxis card,
-             the media label because Coven was one of two factions with the slot.
-             The braid stays: it is drawn, not written. */
-          eyebrow={<Braid style={{ marginBottom: "var(--space-sm)" }} />}
+             photo" (`card.coven.mediaEmpty`) were both CUT by #1909, and the
+             BRAID that outlived them went with #2185: a band that already names
+             the coven does not need an ornament run repeating it — the same
+             reasoning that untied the braid from under the task card's wordmark
+             in #2029. The braid lives on below, ruling off sections. */
           mediaEmptyStyle={{
             height: 158,
             borderRadius: 12,

--- a/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
@@ -1,4 +1,4 @@
-import FactionMasthead from "../../cardMasthead/FactionMasthead";
+import { CovenBand } from "../../cardMasthead/factionBands";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 import {
@@ -113,7 +113,7 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
           field and all, mounted from the shared module. The field is the band's
           BACKDROP, so it travels with the band rather than being rebuilt beside
           it; that is what keeps the stars off the copy on both cards. */}
-      <FactionMasthead slug="coven" />
+      <CovenBand />
 
       <AdminOverlay {...adminProps} />
       {/* The copy takes a layer of its own, for the reason `CovenTaskCard`'s

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -1,13 +1,10 @@
 import type { CSSProperties } from "react";
 import {
-  BAND,
-  BAND_INK,
   BRASS,
   BRASS_LIGHT,
   CAPTION,
   Cornice,
   DECO,
-  GlyphRegister,
   INK,
   LotusSign,
   OCHRE,
@@ -16,20 +13,35 @@ import {
   READING,
   SHADOW,
 } from "../../factionMarks/ephemeristsPlate";
-import { EphemeristsMasthead } from "../../factionMarks/EphemeristsMasthead";
+import { EphemeristsBand } from "../../cardMasthead/factionBands";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
 /**
  * The Ephemerists — THE FIELD-JOURNAL PLATE (#1207, the Valley plate at card
- * size). A papyrus leaf under a night-band masthead: the ENGRAVED MASTHEAD at
- * card scale (#1634) over an incised register of glyphs, a cavetto cornice
- * ruling it off, the Poiret One title over its Spectral gloss, and the tally
- * cell cut into the right column.
+ * size). A papyrus leaf under a brass-edged masthead, a cavetto cornice ruling
+ * it off, the Poiret One title over its Spectral gloss, and the tally cell cut
+ * into the right column.
  *
- * The masthead replaced two things at once: the winged sun disc over a
- * letterspaced Poiret One wordmark that headed the band, and the brass cartouche
- * pill below the cornice that said "THE EPHEMERISTS" a second time.
+ * ## THE MASTHEAD IS THE CARD TIER'S NOW (#2185)
+ *
+ * This card headed itself with the ENGRAVED MASTHEAD at card scale (#1634) — the
+ * kite sigil beside a stacked wordmark and datum row — over a 110px night band
+ * carrying an incised `GlyphRegister`. Its task card does not: #2067 restrained
+ * `EphemeristsTaskCard` to the kit's plain `CardMasthead` on the medallion's
+ * disc. The owner's #2185 ruling is that a praxis card wears THE SAME BAND ITS
+ * TASK CARD WEARS, so the plate joins the card tier and the night band goes.
+ *
+ * THE ENGRAVED MASTHEAD IS NOT RETIRED — it is the PAGE tier's, and it still
+ * heads task detail, praxis detail and the edit-praxis page (each at
+ * `scale={desktop ? "page" : "card"}`, so the card scale stays live). The split
+ * that leaves is: a CARD wears the kit band, a PAGE wears the engraving. The
+ * datum row's date is not lost with it — `PraxisStats` already carries the date
+ * as a fact.
+ *
+ * The engraving replaced two things at once when it arrived: the winged sun disc
+ * over a letterspaced Poiret One wordmark, and the brass cartouche pill below
+ * the cornice that said "THE EPHEMERISTS" a second time.
  *
  * It replaces THE CODEX (#841) — the vellum folio painted out of the retired
  * `--eph-*` family. That family is still declared and still worn by every other
@@ -62,12 +74,6 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  * its string: #1909 CUT `card.ephemerists.for`, so there is no gloss to set.
  */
 
-/** Masthead band, and the field its register is drawn across. Geometry (§4a).
- *  A FLOOR since #1634, not a height: the engraved masthead sizes itself from
- *  its own padding, and a fixed band would crop it. */
-const MASTHEAD = 110;
-const MASTHEAD_VIEW = 340;
-
 /**
  * The drifting strip above the vote block — a run of marks from the plate's
  * other eras (nabla, psi, the integral), breathing out of phase on `.epg-glyph`.
@@ -96,40 +102,10 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
         transition: "background 150ms, color 150ms",
       }}
     >
-      {/* The masthead: the engraved title over an incised register, on night. */}
-      <div
-        style={{
-          position: "relative",
-          overflow: "hidden",
-          minHeight: MASTHEAD,
-          background: BAND,
-          color: BAND_INK,
-        }}
-      >
-        <svg
-          width="100%"
-          height="100%"
-          viewBox={`0 0 ${MASTHEAD_VIEW} ${MASTHEAD}`}
-          preserveAspectRatio="xMidYMid slice"
-          aria-hidden="true"
-          style={{ position: "absolute", inset: 0, zIndex: 1 }}
-        >
-          <path
-            d={`M33 86 H${MASTHEAD_VIEW - 33}`}
-            stroke={BRASS_LIGHT}
-            strokeWidth="0.6"
-            opacity="0.28"
-          />
-          <GlyphRegister width={MASTHEAD_VIEW} y={97} strength={0.3} keyPrefix="card" />
-        </svg>
-        <div style={{ position: "relative", zIndex: 2 }}>
-          <EphemeristsMasthead
-            slug={praxis.task_faction_slug}
-            scale="card"
-            date={praxis.submitted_at ?? praxis.created_at}
-          />
-        </div>
-      </div>
+      {/* THE RESTRAINED MASTHEAD (#2185) — the same band `EphemeristsTaskCard`
+          wears, mounted from `cardMasthead/factionBands`, with the cornice
+          ruling it off exactly as it does there. */}
+      <EphemeristsBand />
       <Cornice />
 
       <div

--- a/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { factionCssVar } from "../../../utils/factions";
+import FactionMasthead from "../../cardMasthead/FactionMasthead";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -14,7 +15,9 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  *
  *  • the MASTHEAD was absent entirely — the loudest single thing the design
  *    gives this faction, and the reason the card reads as a newspaper rather
- *    than as a beige panel;
+ *    than as a beige panel. What #841 put back was a hand-rolled bar that did
+ *    not match the task card's; #2185 replaced it with the shared band, which
+ *    is the same correction made once for both kits;
  *  • the frame's border was `--color-border`, the app's neutral chrome. On a
  *    broadsheet the rule around the sheet is part of the PRINTING, so it is the
  *    faction ink (`--everymen-frame`);
@@ -22,7 +25,8 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  *    invented, and it clipped the foot of every card it was on.
  *
  * The masthead is kept deliberately low and tightly tracked so it frames the
- * report rather than shouting over the headline.
+ * report rather than shouting over the headline — and since #2185 that setting
+ * is the task card's, not a second one measured here.
  */
 
 /** The red margin rule down the ruled sheet. Static (#586). */
@@ -58,39 +62,19 @@ export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeP
         transition: "background 150ms, color 150ms",
       }}
     >
-      {/* Masthead — the paper's name across the head of the sheet. */}
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          gap: "var(--space-md)",
-          padding: "var(--space-xs) var(--space-lg)",
-          background: "var(--everymen-red)",
-          color: "var(--everymen-masthead-text)",
-          fontFamily: "var(--font-accent)",
-          // eslint-disable-next-line local/no-raw-style-values -- ornament: masthead lettering at the design's 15, kept low so it frames rather than shouts (§4a)
-          fontSize: 15,
-          letterSpacing: "0.3em",
-          textTransform: "uppercase",
-          // ornament (#1609): a printed RULE under the masthead, drawn as a
-          // zero-blur shadow. Nothing is lifted, so no cast token. Stays raw.
-          boxShadow: "0 2px 0 rgba(34, 26, 18, 0.22)",
-        }}
-      >
-        {/* Cogs flank the name — a drawn glyph, not an icon (§7). The name
-            itself ("The Everymen", `card.masthead.everymen`) was CUT by #1909:
-            once the masthead is generic it reads "Praxis" on a praxis card, and
-            Everymen's was only ever the faction's own name. The cogs stay. */}
-        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: flanking cog glyph, sized under the lettering (§4a) */}
-        <span aria-hidden style={{ fontSize: 12, opacity: 0.85 }}>
-          ⚙
-        </span>
-        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: flanking cog glyph, sized under the lettering (§4a) */}
-        <span aria-hidden style={{ fontSize: 12, opacity: 0.85 }}>
-          ⚙
-        </span>
-      </div>
+      {/* THE MASTHEAD IS THE BILL'S OWN NOW (#2185).
+
+          This card drew its own red bar — `--everymen-red`, `--font-accent` at
+          15px, two flanking cogs and no name — while `EverymenTaskCard` drew
+          `--faction-everymen-bill-mast` in Bebas at `--text-title` under a
+          double rule. Two mastheads for one faction, which is exactly what
+          `CardMasthead` was created to prevent. The band is mounted from
+          `cardMasthead/FactionMasthead` now, so there is one of them.
+
+          THE COGS STAND DOWN, for the reason they did on the task card (#2029):
+          they flanked the centre the wordmark now holds. The cog stays the
+          bill's motif on the hero rule and the in-progress line. */}
+      <FactionMasthead slug="everymen" />
 
       <div
         style={{

--- a/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EverymenPraxisCard.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
 import { factionCssVar } from "../../../utils/factions";
-import FactionMasthead from "../../cardMasthead/FactionMasthead";
+import { EverymenBand } from "../../cardMasthead/factionBands";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -69,12 +69,12 @@ export function EverymenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeP
           `--faction-everymen-bill-mast` in Bebas at `--text-title` under a
           double rule. Two mastheads for one faction, which is exactly what
           `CardMasthead` was created to prevent. The band is mounted from
-          `cardMasthead/FactionMasthead` now, so there is one of them.
+          `cardMasthead/factionBands` now, so there is one of them.
 
           THE COGS STAND DOWN, for the reason they did on the task card (#2029):
           they flanked the centre the wordmark now holds. The cog stays the
           bill's motif on the hero rule and the in-progress line. */}
-      <FactionMasthead slug="everymen" />
+      <EverymenBand />
 
       <div
         style={{

--- a/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
+import { SingularityBand } from "../../cardMasthead/factionBands";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
-import SingularityLamps from "../../factionMarks/SingularityLamps";
 
 /**
  * Singularity — THE SYSTEM SLAB (#842). A booted terminal: near-black glass on
@@ -29,6 +29,16 @@ import SingularityLamps from "../../factionMarks/SingularityLamps";
  *
  * Both motions are class-gated on reduced-motion in `index.css` — the sweep
  * parks off-slab, the cursor stops blinking but stays drawn.
+ *
+ * ## THE HEADER IS THE KIT'S BAND NOW (#2185)
+ *
+ * #1909's reasoning is SUPERSEDED by owner ruling: the praxis masthead was
+ * removed on the judgement that a card answering a task does not need a band,
+ * and the owner has since decided it does. Nothing about #1909 was wrong at the
+ * time — the decision changed. So the hand-rolled LED bar this file drew is
+ * gone and `SingularityTaskCard`'s own window chrome stands in its place,
+ * mounted from `cardMasthead/factionBands`. The lamps did not stand down:
+ * they are the window, not a faction mark, and they ride beside the sigil.
  */
 
 /** The viewfinder brackets — ornament geometry, raw px by §4a. */
@@ -94,7 +104,9 @@ export function SingularityPraxisCard({ praxis, adminProps, showCrown }: Archety
         // The standing raster — ornament geometry, raw by §4a.
         backgroundImage:
           "repeating-linear-gradient(to bottom, transparent 0 2px, var(--faction-singularity-scanline) 2px 3px)",
-        padding: "var(--space-lg)",
+        /* NO PADDING ON THE FRAME since #2185: the window chrome is full-bleed,
+           and an inset frame would have floated it off three edges. The slab's
+           inset moved to the body box below. */
         fontFamily: "var(--font-faction-terminal)",
         color: "var(--faction-singularity-terminal-ink)",
       }}
@@ -105,29 +117,18 @@ export function SingularityPraxisCard({ praxis, adminProps, showCrown }: Archety
       <span aria-hidden style={bracketBottomLeft} />
       <span aria-hidden style={bracketBottomRight} />
 
-      <div style={{ position: "relative", zIndex: 2 }}>
-        {/* Window chrome: three LEDs, then the log line pushed to the rail. */}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            paddingBottom: "var(--space-sm)",
-            marginBottom: "var(--space-md)",
-            borderBottom: "1px solid var(--faction-singularity-rule)",
-          }}
-        >
-          {/* #1979: three spans spreading a local `ledStyle` — 7px dots at a 6px
-              pitch, the one surface that drew the cluster without a `Lamp` at
-              all. The kit's 8px/`--space-xs` is what the other four already
-              drew, and the bar's own `gap` went with the copy: the cluster is
-              now this row's only child and carries its own pitch. */}
-          <SingularityLamps />
-          {/* "singularity protocol" closed this LED bar
-              (`card.masthead.singularity`). #1909 cut the slot: once the praxis
-              masthead is generic it reads "Praxis" on a praxis card, and this
-              one was the faction naming itself. The lamps stay. */}
-        </div>
+      {/* THE WINDOW CHROME (#2185) — the same bar `SingularityTaskCard` wears,
+          mounted from the shared module.
 
+          IT REPLACES THIS CARD'S OWN LED BAR rather than sitting above it. That
+          bar was three lamps on a hairline rule with nothing else on it once
+          #1909 cut "singularity protocol" from it, and the shared band IS that
+          bar plus the one title that is not generic — the faction's own name,
+          with the lamps riding beside the mark as `leading`. Two chrome bars
+          stacked would have been two windows on one screen. */}
+      <SingularityBand />
+
+      <div style={{ position: "relative", zIndex: 2, padding: "var(--space-lg)" }}>
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}

--- a/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
@@ -1,3 +1,4 @@
+import { SnideBand } from "../../cardMasthead/factionBands";
 import { WALL } from "../../factionMarks/snideAtoms";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
@@ -54,6 +55,17 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  * CUT its string (`card.masthead.snide`, "evidence locker"), so the slot ships
  * empty.
  *
+ * ## THE NOTE BAR IS BACK, AS A BAND (#2185)
+ *
+ * #1909's reasoning is SUPERSEDED by owner ruling: the praxis masthead was
+ * removed on the judgement that a card answering a task does not need a band,
+ * and the owner has since decided it does. Nothing about #1909 was wrong at the
+ * time — the decision changed. What heads the slab is the SAME band
+ * `SnideTaskCard` wears, mounted from `cardMasthead/factionBands`, not a
+ * revival of the eyebrow line: a band across the head, the brushed A hard left
+ * at 24, the wordmark centred in Anton on the censor bar. The `eyebrow` slot
+ * stays empty.
+ *
  * The dashed acid rule above the vote widget is the design's, and is the one
  * divider the slab carries.
  */
@@ -75,51 +87,64 @@ export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
         background: GROUND,
         border: "1.5px solid var(--faction-snide-acid-deep)",
         boxShadow: "6px 8px 0 var(--faction-snide-slab-shadow)",
-        padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
+        /* NO PADDING ON THE FRAME since #2185: the band is full-bleed, and an
+           inset frame would have floated it off three edges. The slab's inset
+           moved to the body box below. */
         fontFamily: "var(--faction-snide-font-type)",
         color: INK,
         transition: "background 150ms, color 150ms",
       }}
     >
-      <AdminOverlay {...adminProps} />
-      <PraxisBody
-        praxis={praxis}
-        tint={ACCENT}
-        muted={MUTED}
-        paper={PAPER}
-        showCrown={showCrown}
-        // The split earning its keep (#888): Permanent Marker is S.N.I.D.E.'s
-        // declared card font and it finally reaches the card — but only where
-        // identity belongs. A two-line excerpt set in it is unreadable, so the
-        // body stays on the slab's Special Elite.
-        fonts={{
-          display: "var(--faction-snide-card-font)",
-          body: "var(--faction-snide-font-type)",
-        }}
-        titleStyle={{
-          fontFamily: "var(--faction-snide-font-impact)",
-          textTransform: "uppercase",
-          letterSpacing: "0.04em",
-          lineHeight: 1,
-          transform: "skewX(-3deg)",
-          color: INK,
-        }}
-        /* The eyebrow read "evidence locker" (`card.masthead.snide`). #1909 cut
-           the slot — once generic it says "Praxis" on a praxis card — so the
-           shared eyebrow is left unfilled here. */
-        voteRule={
-          <div
-            aria-hidden
-            style={{
-              height: 2,
-              opacity: 0.7,
-              background:
-                "repeating-linear-gradient(90deg, var(--faction-snide-acid-deep) 0 6px, transparent 6px 11px)",
-              margin: "var(--space-lg) 0 var(--space-md)",
-            }}
-          />
-        }
-      />
+      {/* THE NOTE BAR (#2185) — the same band `SnideTaskCard` wears, mounted
+          from the shared module. Its ground is `--faction-snide-note-bar`, the
+          censor bar, which is a PAINTED band rather than the wall showing
+          through: the bar does not read `--snd-praxis-*`, so it is the same
+          strip on the feed's wall and on task detail's black. The brushed A
+          rides at 24 there and here. */}
+      <SnideBand />
+
+      <div style={{ padding: "var(--space-xl) var(--space-xl) var(--space-lg)" }}>
+        <AdminOverlay {...adminProps} />
+        <PraxisBody
+          praxis={praxis}
+          tint={ACCENT}
+          muted={MUTED}
+          paper={PAPER}
+          showCrown={showCrown}
+          // The split earning its keep (#888): Permanent Marker is S.N.I.D.E.'s
+          // declared card font and it finally reaches the card — but only where
+          // identity belongs. A two-line excerpt set in it is unreadable, so the
+          // body stays on the slab's Special Elite.
+          fonts={{
+            display: "var(--faction-snide-card-font)",
+            body: "var(--faction-snide-font-type)",
+          }}
+          titleStyle={{
+            fontFamily: "var(--faction-snide-font-impact)",
+            textTransform: "uppercase",
+            letterSpacing: "0.04em",
+            lineHeight: 1,
+            transform: "skewX(-3deg)",
+            color: INK,
+          }}
+          /* The eyebrow read "evidence locker" (`card.masthead.snide`). #1909
+             cut the slot, and #2185 answered it a different way: the running
+             head is a BAND across the head of the slab now, not a line inside
+             the text column, so the shared eyebrow stays unfilled. */
+          voteRule={
+            <div
+              aria-hidden
+              style={{
+                height: 2,
+                opacity: 0.7,
+                background:
+                  "repeating-linear-gradient(90deg, var(--faction-snide-acid-deep) 0 6px, transparent 6px 11px)",
+                margin: "var(--space-lg) 0 var(--space-md)",
+              }}
+            />
+          }
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
@@ -1,4 +1,5 @@
 import { Lotus } from "../../factionMarks";
+import FactionMasthead from "../../cardMasthead/FactionMasthead";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -38,7 +39,12 @@ export function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
         border: "2px solid var(--faction-ua-card-frame)",
         boxShadow:
           "0 14px 40px -22px color-mix(in srgb, var(--faction-ua-card-text) 50%, transparent)",
-        padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
+        /* NO PADDING ON THE FRAME since #2185: the band is full-bleed, and an
+           inset frame would have floated it off three edges. The sheet's inset
+           moved to the body box below, which is the only thing that ever wanted
+           it. The lotus does not move with it — an absolutely positioned child
+           resolves against the PADDING box, which dropping padding leaves where
+           it was. */
         fontFamily: "var(--faction-ua-body-font)",
         color: "var(--faction-ua-card-text)",
       }}
@@ -63,7 +69,15 @@ export function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
         }}
       />
 
-      <div style={{ position: "relative" }}>
+      {/* THE LEAF'S BAND (#2185) — the same hairline band `UaTaskCard` wears,
+          mounted from the shared module rather than restated here. The ensō is
+          not a second mark and does not stand down: it carries the total in the
+          right column, where it is the score's device rather than the header's.
+          What the band replaced on the task card was the EYEBROW ensō, which was
+          a header mark. */}
+      <FactionMasthead slug="ua" />
+
+      <div style={{ position: "relative", padding: "var(--space-xl) var(--space-xl) var(--space-lg)" }}>
         <AdminOverlay {...adminProps} />
         <PraxisBody
           praxis={praxis}
@@ -86,9 +100,10 @@ export function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
            * The running head ("Acquisition · filed", `card.masthead.ua`) sat
            * INSIDE the text column, above the title, so it stopped at the score
            * box rather than running under the ensō — the `eyebrow` slot #841
-           * added for exactly that shape. #1909 CUT the string: once the praxis
-           * masthead is generic it reads "Praxis" on a praxis card. The slot
-           * stays for whatever fills it next.
+           * added for exactly that shape. #1909 CUT the string, and the slot
+           * stays empty: what heads this card now is the faction's own band
+           * across the top of the sheet (#2185), not a line inside the text
+           * column.
            */
         />
       </div>

--- a/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/UaPraxisCard.tsx
@@ -1,5 +1,5 @@
 import { Lotus } from "../../factionMarks";
-import FactionMasthead from "../../cardMasthead/FactionMasthead";
+import { UaBand } from "../../cardMasthead/factionBands";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -75,7 +75,7 @@ export function UaPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) 
           right column, where it is the score's device rather than the header's.
           What the band replaced on the task card was the EYEBROW ensō, which was
           a header mark. */}
-      <FactionMasthead slug="ua" />
+      <UaBand />
 
       <div style={{ position: "relative", padding: "var(--space-xl) var(--space-xl) var(--space-lg)" }}>
         <AdminOverlay {...adminProps} />

--- a/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import FactionMasthead from "../../cardMasthead/FactionMasthead";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -10,10 +11,9 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  *
  *  • the GRADIENT RUNNING-HEAD BAND with the masthead set in it. The design's
  *    running head is a 6px gold/plum STRIPE carrying no text at all, and the
- *    masthead is an eyebrow LINE inside the text column ("CHRONICLE OF PROOF ·
- *    № 663"), where it stops at the score stamp instead of running under it.
- *    That band is also what forced #838 to deepen four header stops for
- *    contrast — nothing needs protecting once no text sits on the gold;
+ *    eyebrow LINE it replaced sat inside the text column ("CHRONICLE OF PROOF ·
+ *    № 663"). The stripe stays; what sits above it now is the faction's own
+ *    band (see below), which is a different thing in the same place.
  *  • the PLUM FRAME. `ChronicleTheme` carried a single `accent` doing duty as
  *    border AND rule AND ink tint, so the card bound itself in plum and the
  *    design's gold frame never shipped (#860 ask 2). The border is its own token
@@ -22,6 +22,13 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  *  • the shared ChroniclePraxisCard itself. It existed only because Coven was
  *    wearing WOW's frame; with Coven on its own sticker, one indirection for one
  *    caller was just a place for the two palettes to meet again.
+ *
+ * IT WEARS THE DECREE'S BANNER NOW (#2185). The praxis card had no masthead at
+ * all: #1909 removed the praxis-card masthead on the judgement that a card
+ * answering a task does not need a band. THE OWNER HAS SINCE DECIDED IT DOES,
+ * and this card wears the same plum-and-gilt banner `WowTaskCard` wears. Nothing
+ * about #1909 was wrong at the time — the decision changed, and #2185 is the
+ * record. Do not restore the old rationale beside the band it argues against.
  *
  * THE ARCHAIC REGISTER IS GONE (#1909). Four strings fed the shared slots —
  * `card.masthead.wow` ("Chronicle of proof · № {{id}}"), `card.wow.forQuest`
@@ -54,7 +61,15 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
         transition: "background 150ms, color 150ms",
       } as CSSProperties}
     >
-      {/* The running head: a woven gold/plum stripe. No text — see the note above. */}
+      {/* THE BANNER (#2185) — the same band `WowTaskCard` wears, mounted from
+          `cardMasthead/FactionMasthead` rather than restated, so the chronicle
+          and the decree cannot drift apart. */}
+      <FactionMasthead slug="wow" />
+
+      {/* The running head: a woven gold/plum stripe. No text — see the note
+          above. It survives the band because it is not a masthead: it is the
+          chronicle's own woven rule, and on the task card the same place under
+          the band is where `Bunting` hangs. */}
       <div
         aria-hidden
         style={{

--- a/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/WowPraxisCard.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import FactionMasthead from "../../cardMasthead/FactionMasthead";
+import { WowBand } from "../../cardMasthead/factionBands";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -62,9 +62,9 @@ export function WowPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps)
       } as CSSProperties}
     >
       {/* THE BANNER (#2185) — the same band `WowTaskCard` wears, mounted from
-          `cardMasthead/FactionMasthead` rather than restated, so the chronicle
+          `cardMasthead/factionBands` rather than restated, so the chronicle
           and the decree cannot drift apart. */}
-      <FactionMasthead slug="wow" />
+      <WowBand />
 
       {/* The running head: a woven gold/plum stripe. No text — see the note
           above. It survives the band because it is not a masthead: it is the

--- a/frontend/src/components/taskCard/CovenTaskCard.tsx
+++ b/frontend/src/components/taskCard/CovenTaskCard.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import FactionMasthead from "../cardMasthead/FactionMasthead";
+import { CovenBand } from "../cardMasthead/factionBands";
 import { CARD_CTA, CARD_CTA_ROW } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import CovenCauldron from "../factionMarks/CovenCauldron";
@@ -175,8 +175,8 @@ export default function CovenTaskCard({
             Mounted from the shared band (#2185) so the Coven praxis card wears
             the identical one, twinkle field and all — the field is the band's
             backdrop, so it travels with it rather than being rebuilt beside it.
-            The paint lives at `cardMasthead/FactionMasthead`. */}
-        <FactionMasthead slug="coven" />
+            The paint lives at `cardMasthead/factionBands`. */}
+        <CovenBand />
 
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/CovenTaskCard.tsx
+++ b/frontend/src/components/taskCard/CovenTaskCard.tsx
@@ -1,13 +1,12 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import CardMasthead from "./CardMasthead";
+import FactionMasthead from "../cardMasthead/FactionMasthead";
 import { CARD_CTA, CARD_CTA_ROW } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import CovenCauldron from "../factionMarks/CovenCauldron";
 import { CovenCat, SLIP_SHEET } from "../factionMarks/covenSlip";
 import i18n from "../../i18n";
-import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
 
@@ -36,17 +35,8 @@ import { useFormFactor } from "../../hooks/useFormFactor";
 
 const CHROME = "var(--font-faction-rounded)"; /* Quicksand */
 const READING = "var(--font-faction-serif)"; /* Cormorant Garamond */
-const HAND = "var(--font-faction-script)"; /* Caveat */
 const DISPLAY = "var(--font-faction-witch)"; /* Grenze Gotisch */
 
-/**
- * The masthead band the twinkle field is confined to, so no star lands in copy.
- *
- * It was 72px while the wordmark floated over the slip with a braid tied under
- * it. #2029 pins the wordmark into a band of its own and drops the braid, so
- * the field shrinks to the band it dresses. Geometry (§4a).
- */
-const MASTHEAD_HEIGHT = 44;
 
 interface SizeSet {
   /** Card width. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
@@ -96,11 +86,6 @@ const CAPTION: CSSProperties = {
   color: "var(--faction-coven-slip-label)",
 };
 
-/** A four-point star, centred on (x, y) with arm length r. */
-function starPath(x: number, y: number, r: number): string {
-  const long = r * 2.6;
-  return `M${x} ${y - long} l${r} ${long} ${long} ${r} -${long} ${r} -${r} ${long} -${r} -${long} -${long} -${r} ${long} -${r} z`;
-}
 
 /** One heart, tied off at an end of the braid. */
 function Heart({ size = 10 }: { size?: number }) {
@@ -125,31 +110,6 @@ function Thread({ style }: { style?: CSSProperties }) {
   );
 }
 
-/** The gold twinkle field, clipped to the masthead band. */
-function TwinkleField() {
-  const stars: [number, number, number][] = [
-    [38, 16, 2.6],
-    [296, 21, 2],
-    [120, 11, 1.4],
-    [212, 27, 1.6],
-    [264, 10, 1.2],
-    [74, 29, 1.6],
-  ];
-  return (
-    <svg
-      width="100%"
-      height={MASTHEAD_HEIGHT}
-      viewBox={`0 0 340 ${MASTHEAD_HEIGHT}`}
-      preserveAspectRatio="none"
-      aria-hidden="true"
-      style={{ position: "absolute", left: 0, top: 0, right: 0, zIndex: 1, pointerEvents: "none" }}
-    >
-      {stars.map(([x, y, r]) => (
-        <path key={`${x}-${y}`} d={starPath(x, y, r)} fill="var(--faction-coven-slip-gold)" opacity={0.8} />
-      ))}
-    </svg>
-  );
-}
 
 export default function CovenTaskCard({
   task,
@@ -204,48 +164,19 @@ export default function CovenTaskCard({
             with the measurements, is at {@link CovenCat}. */}
         <CovenCat size={190} style={{ right: -6, bottom: -4, opacity: 0.09 }} />
 
-        {/* Masthead. THE WORDMARK MOVES (#2029): it floated over the slip under
-            a pentagram badge, with a braid tied off beneath it; v3 pins it into
-            a band at the top of the card on the kit's shared anatomy — the mark
-            hard left, the hand-lettered name centred on the band.
+        {/* Masthead. THE WORDMARK MOVES (#2029): it floated over the slip
+            under a pentagram badge, with a braid tied off beneath it; v3 pins it
+            into a band at the top of the card. The badge is retired in favour of
+            the kit's own `CovenSigil` (a card may not draw two faction marks in
+            its header), and the braid under the wordmark goes with it — a band
+            that already names the coven does not need an ornament run repeating
+            it. The braid lives on below, ruling off every section.
 
-            Two things go with the move. The badge is retired in favour of the
-            kit's own `CovenSigil`, because a card may not draw two faction
-            marks in its header; and the braid under the wordmark goes, because
-            a band that already names the coven does not need an ornament run
-            repeating it. The braid lives on below, ruling off every section.
-            The pentagram does not: it was still turning as the watermark when
-            #2029 wrote this, and #2041 has since made that a cat.
-
-            The twinkle field moves INTO the band, over its ground: with a
-            painted band the stars would otherwise be hidden behind it. */}
-        <div
-          style={{
-            position: "relative",
-            zIndex: 2,
-            height: MASTHEAD_HEIGHT,
-            background: "var(--faction-coven-slip-sigil-ground)",
-            borderBottom: "1px solid var(--faction-coven-slip-pk)",
-            /* The twinkle box is the one wrapper standing between a card's
-               <article> and its band, so since #2167 made the band a link it
-               matches `:has(a[href])` on the equal-height row's slack chain
-               (index.css) and would stretch past its 44px. The band inside
-               pins its own growth for the same reason; this pins the box. */
-            flexGrow: 0,
-          }}
-        >
-          <TwinkleField />
-          <CardMasthead slug="coven" style={{ height: "100%" }}>
-            {/* The slip's own `feed:taskCard.coven.masthead` held a second copy
-                of the faction's name ("the cozy coven") and is gone with #1910.
-                The lower case belonged to the hand-lettering rather than to the
-                word, so it lives in `textTransform`, where casing belongs — the
-                name itself comes from the one place that owns it (ADR-0038). */}
-            <div style={{ fontFamily: HAND, fontSize: "var(--text-title)", lineHeight: 1, textTransform: "lowercase" }}>
-              {factionName("coven")}
-            </div>
-          </CardMasthead>
-        </div>
+            Mounted from the shared band (#2185) so the Coven praxis card wears
+            the identical one, twinkle field and all — the field is the band's
+            backdrop, so it travels with it rather than being rebuilt beside it.
+            The paint lives at `cardMasthead/FactionMasthead`. */}
+        <FactionMasthead slug="coven" />
 
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -1,13 +1,12 @@
 import { useState, type CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import CardMasthead from "./CardMasthead";
+import FactionMasthead from "../cardMasthead/FactionMasthead";
 /* No `CARD_CTA_ROW` here: the plate's rule and its button share one inset box,
    so the clearance comes from that box's own `bodyPad` bottom. */
 import { CARD_CTA } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
-import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
 import EphemeristsRuneStrip from "../factionMarks/EphemeristsRuneStrip";
@@ -298,50 +297,11 @@ export default function EphemeristsTaskCard({
         }}
       >
         {/* THE RESTRAINED MASTHEAD (#2067) — the kit's shared anatomy and
-            nothing else: the mark hard left at the kit's 20, the wordmark on the
-            card's centreline. No wrapper box, because the box existed to hold
-            the registers and to pin a 110px canvas for them to march across;
-            the band is `CardMasthead`'s own height now, which is what makes the
-            hero row rise ~75px.
-
-            THE GROUND IS THE MEDALLION'S DISC, not the cornice band. `-plate-disc`
-            is two values lighter than `-plate-band`, so the header reads as a
-            brass-edged plate rather than as a night strip, and the compass rose
-            below it is struck on the same field. THE INK IS UNCHANGED:
-            `-plate-band-ink` is the gold measured on the band, and moving the
-            ground under it spends 0.93 of a very large margin — 14.00:1 on the
-            band, 13.07:1 on the disc. That is a NEW pairing rather than the old
-            row wearing a new ground, so `factionContrast.test.ts` records it.
-            The sigil takes `currentColor`, so it is that same gold.
-
-            `boxSizing` is load-bearing next to the border: the band is a block
-            child of a card with `overflow: hidden`, so a content-box border
-            would push it 2px wider than the card and be clipped on the right. */}
-        <CardMasthead
-          slug="ephemerists"
-          style={{
-            boxSizing: "border-box",
-            background: "var(--faction-ephemerists-plate-disc)",
-            color: "var(--faction-ephemerists-plate-band-ink)",
-            border: "1px solid var(--faction-ephemerists-plate-brass)",
-          }}
-        >
-          <span
-            style={{
-              fontFamily: DECO,
-              fontSize: "var(--text-xl)",
-              letterSpacing: "0.3em",
-              textTransform: "uppercase",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {/* #1910: the band spells the faction's name, so it reads the one
-                key that stays per-faction rather than a second copy. The
-                `textTransform` above already carried the plate's upper case, so
-                the band reads THE EPHEMERISTS either way. */}
-            {factionName("ephemerists")}
-          </span>
-        </CardMasthead>
+            nothing else, mounted from the shared band (#2185). The wrapper box
+            that used to pin a 110px canvas for the glyph registers went with
+            #2067, which is what makes the hero row rise ~75px. The paint and the
+            disc-vs-band ruling live at `cardMasthead/FactionMasthead`. */}
+        <FactionMasthead slug="ephemerists" />
         <Cornice flutes={40} />
 
         {/* The journal leaf. */}

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -1,7 +1,7 @@
 import { useState, type CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import FactionMasthead from "../cardMasthead/FactionMasthead";
+import { EphemeristsBand } from "../cardMasthead/factionBands";
 /* No `CARD_CTA_ROW` here: the plate's rule and its button share one inset box,
    so the clearance comes from that box's own `bodyPad` bottom. */
 import { CARD_CTA } from "./cardCta";
@@ -300,8 +300,8 @@ export default function EphemeristsTaskCard({
             nothing else, mounted from the shared band (#2185). The wrapper box
             that used to pin a 110px canvas for the glyph registers went with
             #2067, which is what makes the hero row rise ~75px. The paint and the
-            disc-vs-band ruling live at `cardMasthead/FactionMasthead`. */}
-        <FactionMasthead slug="ephemerists" />
+            disc-vs-band ruling live at `cardMasthead/factionBands`. */}
+        <EphemeristsBand />
         <Cornice flutes={40} />
 
         {/* The journal leaf. */}

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -1,12 +1,11 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import CardMasthead from "./CardMasthead";
+import FactionMasthead from "../cardMasthead/FactionMasthead";
 import PointsRoundel from "../factionMarks/PointsRoundel";
 import { CARD_CTA, CARD_CTA_ROW } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
-import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
 
@@ -60,7 +59,6 @@ const INK = "var(--everymen-paper-text)";
 interface SizeSet {
   /** Card width. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
   cardWidth: number;
-  mastPad: string;
   bodyPad: string;
   titleSize: string;
   levelSize: string;
@@ -78,7 +76,6 @@ interface SizeSet {
 const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   desktop: {
     cardWidth: 384,
-    mastPad: "var(--space-md) var(--space-lg)",
     bodyPad: "var(--space-lg) var(--space-xl) var(--space-xl)",
     titleSize: "var(--text-heading)",
     levelSize: "var(--text-display)",
@@ -87,7 +84,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   },
   mobile: {
     cardWidth: 340,
-    mastPad: "var(--space-sm) var(--space-lg)",
     bodyPad: "var(--space-lg) var(--space-lg) var(--space-lg)",
     titleSize: "var(--text-title)",
     levelSize: "var(--text-heading)",
@@ -350,33 +346,12 @@ export default function EverymenTaskCard({
             }}
           />
 
-          {/* Masthead — the union's red bar, on the kit's shared anatomy
-              (#2029): the mark hard left, the faction's name centred.
-
-              The band read "Help Wanted!" between two cogs
-              (`feed:taskCard.everymen.billMasthead`) until #1909 cut the slot
-              as generic, which left the cogs alone on the bar. v3 answers the
-              same objection the other way round — the band names THE FACTION,
-              which is the one thing on it no other card says — and the pair of
-              cogs stands down with the naming, because they flanked the centre
-              the wordmark now holds. The cog stays the bill's motif on the
-              hero rule and the in-progress line. */}
-          <CardMasthead
-            slug="everymen"
-            /* On the red mast the sigil's own `--everymen-red` is invisible. */
-            markColor="var(--faction-everymen-bill-mast-ink)"
-            style={{
-              padding: size.mastPad,
-              background: "var(--faction-everymen-bill-mast)",
-              color: "var(--faction-everymen-bill-mast-ink)",
-              borderBottom: "3px double var(--faction-everymen-bill-cta-bg)",
-              boxShadow: "inset 0 -6px 0 -4px var(--everymen-paper-deep)",
-            }}
-          >
-            <span style={{ ...LABEL, fontSize: "var(--text-title)", lineHeight: 1 }}>
-              {factionName("everymen")}
-            </span>
-          </CardMasthead>
+          {/* Masthead — the union's red bar, mounted from the shared band
+              (#2185) so the Everymen praxis card wears the identical one. It
+              did not: the praxis card drew its own bar in `--everymen-red` with
+              two cogs and no name. The paint, and why the cogs stood down, live
+              at `cardMasthead/FactionMasthead`. */}
+          <FactionMasthead slug="everymen" />
 
           <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
             {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import FactionMasthead from "../cardMasthead/FactionMasthead";
+import { EverymenBand } from "../cardMasthead/factionBands";
 import PointsRoundel from "../factionMarks/PointsRoundel";
 import { CARD_CTA, CARD_CTA_ROW } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
@@ -350,8 +350,8 @@ export default function EverymenTaskCard({
               (#2185) so the Everymen praxis card wears the identical one. It
               did not: the praxis card drew its own bar in `--everymen-red` with
               two cogs and no name. The paint, and why the cogs stood down, live
-              at `cardMasthead/FactionMasthead`. */}
-          <FactionMasthead slug="everymen" />
+              at `cardMasthead/factionBands`. */}
+          <EverymenBand />
 
           <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
             {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import FactionMasthead from "../cardMasthead/FactionMasthead";
+import { SingularityBand } from "../cardMasthead/factionBands";
 import { CARD_CTA } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
@@ -169,8 +169,8 @@ export default function SingularityTaskCard({
         {/* Window chrome, mounted from the shared band (#2185) so the
             Singularity praxis card wears the identical one — the three lamps
             included, since they ride with the mark rather than standing down.
-            The paint lives at `cardMasthead/FactionMasthead`. */}
-        <FactionMasthead slug="singularity" />
+            The paint lives at `cardMasthead/factionBands`. */}
+        <SingularityBand />
 
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -1,14 +1,12 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import CardMasthead from "./CardMasthead";
+import FactionMasthead from "../cardMasthead/FactionMasthead";
 import { CARD_CTA } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
-import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
-import SingularityLamps from "../factionMarks/SingularityLamps";
 import SingularityProcessLight from "../factionMarks/SingularityProcessLight";
 import SingularityReadout from "../factionMarks/SingularityReadout";
 
@@ -168,30 +166,11 @@ export default function SingularityTaskCard({
           }}
         />
 
-        {/* Window chrome, on the kit's shared anatomy (#2029) — the mark hard
-            left, the window's title centred on the bar.
-
-            The bar read "task.proc — singularity"
-            (`feed:taskCard.singularity.windowTitle`) until #1909 cut it as
-            generic, leaving the lamps alone. v3 gives it back the one title
-            that is not generic and is not a second copy of anything: the
-            faction's own name, from the one place that owns it (ADR-0038). The
-            lamps ride with the mark rather than standing down — they are the
-            window, not a faction mark, and the grid centres the title on the
-            BAND, so a wider left cluster does not push it off true. */}
-        <CardMasthead
-          slug="singularity"
-          leading={<SingularityLamps />}
-          style={{
-            padding: "var(--space-sm) var(--space-md)",
-            background: "var(--faction-singularity-term-chrome)",
-            borderBottom: `1px solid ${HAIR}`,
-          }}
-        >
-          <span style={{ ...LABEL, fontSize: "var(--text-xl)", lineHeight: 1 }}>
-            {factionName("singularity")}
-          </span>
-        </CardMasthead>
+        {/* Window chrome, mounted from the shared band (#2185) so the
+            Singularity praxis card wears the identical one — the three lamps
+            included, since they ride with the mark rather than standing down.
+            The paint lives at `cardMasthead/FactionMasthead`. */}
+        <FactionMasthead slug="singularity" />
 
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/SnideTaskCard.tsx
+++ b/frontend/src/components/taskCard/SnideTaskCard.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import FactionMasthead from "../cardMasthead/FactionMasthead";
+import { SnideBand } from "../cardMasthead/factionBands";
 import { CARD_CTA, CARD_CTA_ROW } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
@@ -188,8 +188,8 @@ export default function SnideTaskCard({
         {/* The header bar, mounted from the shared band (#2185) so the
             S.N.I.D.E. praxis card wears the identical one. The broken acid rule
             that used to fill the bar's right end went with the centring; the
-            paint and the 24px mark live at `cardMasthead/FactionMasthead`. */}
-        <FactionMasthead slug="snide" />
+            paint and the 24px mark live at `cardMasthead/factionBands`. */}
+        <SnideBand />
 
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/SnideTaskCard.tsx
+++ b/frontend/src/components/taskCard/SnideTaskCard.tsx
@@ -1,11 +1,10 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import CardMasthead from "./CardMasthead";
+import FactionMasthead from "../cardMasthead/FactionMasthead";
 import { CARD_CTA, CARD_CTA_ROW } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
-import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
 import { PenCircle, WALL } from "../factionMarks/snideAtoms";
@@ -186,32 +185,11 @@ export default function SnideTaskCard({
           transform: "rotate(-0.4deg)",
         }}
       >
-        {/* The header bar, on the kit's shared anatomy (#2029) — the mark hard
-            left, the wordmark centred on the band.
-
-            The broken acid rule that used to fill the bar's right end is gone
-            with the centring: it was a flex filler taking the width #1124's
-            retired ordinal left behind, and that width is exactly where the
-            centred wordmark now sits. The clipping keeps its acid elsewhere —
-            the CTA, the knockout cuts, the pen circle. */}
-        <CardMasthead
-          slug="snide"
-          /* The brushed A is drawn 24 where the kit draws 20 (#2035), and it
-             bleeds 2px into the band's inset on each side — which is the mark
-             doing what it was drawn to do: `SnideSigil`'s four shapes break out
-             of their own circle at four points. This used to be a stylesheet
-             hook reaching into the sigil's markup; #2056 made it the prop. */
-          markSize={24}
-          style={{
-            background: "var(--faction-snide-note-bar)",
-            color: "var(--faction-snide-note-bar-ink)",
-          }}
-        >
-          {/* eslint-disable-next-line local/no-raw-style-values -- ornament: cut-out wordmark; Anton at a label-ramp size stops reading as a masthead. */}
-          <span style={{ fontFamily: IMPACT, fontSize: 22, letterSpacing: "0.06em", lineHeight: 1, color: "var(--faction-snide-acid)" }}>
-            {factionName("snide")}
-          </span>
-        </CardMasthead>
+        {/* The header bar, mounted from the shared band (#2185) so the
+            S.N.I.D.E. praxis card wears the identical one. The broken acid rule
+            that used to fill the bar's right end went with the centring; the
+            paint and the 24px mark live at `cardMasthead/FactionMasthead`. */}
+        <FactionMasthead slug="snide" />
 
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/UaTaskCard.tsx
+++ b/frontend/src/components/taskCard/UaTaskCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import FactionMasthead from "../cardMasthead/FactionMasthead";
+import { UaBand } from "../cardMasthead/factionBands";
 import { CARD_CTA } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
@@ -186,8 +186,8 @@ export default function UaTaskCard({
             it, because the ensō it held is the same mark the band carries and no
             card draws two. Mounted from the shared band (#2185) so the UA praxis
             card wears the identical one; the paint and the ink measurement live
-            at `cardMasthead/FactionMasthead`. */}
-        <FactionMasthead slug="ua" />
+            at `cardMasthead/factionBands`. */}
+        <UaBand />
 
         <div style={{ position: "relative", padding: size.pad }}>
           {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/UaTaskCard.tsx
+++ b/frontend/src/components/taskCard/UaTaskCard.tsx
@@ -1,10 +1,9 @@
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import CardMasthead from "./CardMasthead";
+import FactionMasthead from "../cardMasthead/FactionMasthead";
 import { CARD_CTA } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
-import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
 import { Lotus } from "../factionMarks";
@@ -183,36 +182,12 @@ export default function UaTaskCard({
 
         {/* THE LEAF GAINS A MASTHEAD (#2029). UA shipped none: the top of the
             card was a bare eyebrow holding the ensō alone, once #1124 took the
-            "Task {id}" ordinal that stood beside it. The band is the kit's
-            shared anatomy — the mark hard left, the faction's name centred — and
-            the eyebrow stands down with it, because the ensō it held is the
-            same mark the band now carries and no card draws two.
-
-            THE WORDMARK TAKES THE BODY INK, NOT THE ACCENT. The design sets it
-            in `--faction-ua-card-accent` on `--faction-ua-hair`, which measures
-            4.46:1 in light — under AA for a 24px non-bold face, and the band's
-            whole job is to be read. `-card-text` is 10.35:1 on the same ground
-            (11.45:1 in dark) and is the leaf's own ink; the accent keeps the
-            band's bottom rule, where a hairline owes nothing. */}
-        <CardMasthead
-          slug="ua"
-          style={{
-            background: "var(--faction-ua-hair)",
-            borderBottom: "1px solid var(--faction-ua-card-accent)",
-          }}
-        >
-          <span
-            style={{
-              fontFamily: UA_DISPLAY,
-              fontWeight: 600,
-              fontSize: "var(--text-title)",
-              letterSpacing: "0.08em",
-              lineHeight: 1,
-            }}
-          >
-            {factionName("ua")}
-          </span>
-        </CardMasthead>
+            "Task {id}" ordinal that stood beside it. The eyebrow stood down with
+            it, because the ensō it held is the same mark the band carries and no
+            card draws two. Mounted from the shared band (#2185) so the UA praxis
+            card wears the identical one; the paint and the ink measurement live
+            at `cardMasthead/FactionMasthead`. */}
+        <FactionMasthead slug="ua" />
 
         <div style={{ position: "relative", padding: size.pad }}>
           {/* Everything but the CTA reads the full call — a card-sized target

--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import FactionMasthead from "../cardMasthead/FactionMasthead";
+import { WowBand } from "../cardMasthead/factionBands";
 import { CARD_CTA } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
@@ -193,8 +193,8 @@ export default function WowTaskCard({
         {/* THE DECREE'S MASTHEAD — the plum banner, mounted from the shared
             band (#2185) so the WOW praxis card wears the identical one. Its
             paint, and the #2032/#2070 inset rulings behind it, live at
-            `cardMasthead/FactionMasthead`. */}
-        <FactionMasthead slug="wow" />
+            `cardMasthead/factionBands`. */}
+        <WowBand />
 
         {/* The pennants, strung under the band (#2032) where the 6px barber
             ribbon used to run — the design's own swap. `Bunting` is WOW's one

--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -1,10 +1,9 @@
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
-import CardMasthead from "./CardMasthead";
+import FactionMasthead from "../cardMasthead/FactionMasthead";
 import { CARD_CTA } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
-import { factionName } from "../../utils/factions";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
 import { BalloonBunch, Bunting, Zig } from "../factionMarks/wowOrnament";
@@ -91,13 +90,6 @@ const PLUM = "var(--faction-wow-card-accent)";
 const GOLD = "var(--faction-wow-chronicle-gold)";
 const PLUM_SURFACE = "var(--faction-wow-plum-surface)";
 const GILT = "var(--faction-wow-stamp-total)";
-/**
- * The banner's ink — lettering AND mark (#2032). The page kit's gilt button
- * stop, theme-invariant like the plum it stands on, so one measurement (3.47:1)
- * covers both themes. NOT `-stamp-total`, which is an ink that flips: see the
- * docblock.
- */
-const GILT_MID = "var(--faction-wow-gilt-mid)";
 
 interface SizeSet {
   /** Card width. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
@@ -198,48 +190,11 @@ export default function WowTaskCard({
           color: INK,
         }}
       >
-        {/* THE DECREE'S MASTHEAD (#2029), dressed (#2032). The kit's shared
-            anatomy — mark hard left, the faction's name centred — on the
-            theme-invariant plum the CTA already stands on, and lettered in the
-            gilt the mark now takes with it.
-
-            THE HORIZONTAL INSET IS SYMMETRIC, AND IT IS NO LONGER ZERO (#2070).
-            #2032 zeroed it so the mark would break the banner's left line and
-            stand on the card's own gold frame; in production that read as
-            touching the border, and the owner's ruling is that it overshot. The
-            mark sits inboard with clearance now — `--space-sm`, which is the
-            band's own vertical inset, so the mark keeps a uniform 8px surround
-            instead of 2px of frame. Still half the kit's `--space-lg` default,
-            so the sigil stays nearer the edge than the type block, which is the
-            half of #2032 that was right.
-
-            WHAT DOES NOT CHANGE IS THAT BOTH SIDES MOVE TOGETHER. #2029's title
-            is centred on the band's CONTENT box, so left-only clearance walks
-            the centred wordmark off the card's centreline by half the inset —
-            symmetry is what keeps the title true, and it was #2032's reason for
-            zeroing both rather than just the left. `--space-xs` was the smaller
-            candidate and is only 2px past the frame's own 2px weight, i.e. the
-            reported symptom again at half strength.
-
-            THE BOTTOM RULE COMES BACK IN GOLD. Phase 1 dropped the design's 2px
-            `--faction-wow-card-accent` line because in light that token IS the
-            band's own ground to the hex; `-gilt-mid` on the same plum is
-            3.47:1, so drawn in the gilt it is a line you can see — and it is
-            the string the bunting below hangs from. */}
-        <CardMasthead
-          slug="wow"
-          markColor={GILT_MID}
-          style={{
-            background: PLUM_SURFACE,
-            color: "var(--faction-wow-on-plum)",
-            padding: "var(--space-sm) var(--space-sm)",
-            borderBottom: `2px solid ${GILT_MID}`,
-          }}
-        >
-          <span style={{ fontFamily: MED, fontSize: "var(--text-title)", letterSpacing: "0.04em", lineHeight: 1, color: GILT_MID }}>
-            {factionName("wow")}
-          </span>
-        </CardMasthead>
+        {/* THE DECREE'S MASTHEAD — the plum banner, mounted from the shared
+            band (#2185) so the WOW praxis card wears the identical one. Its
+            paint, and the #2032/#2070 inset rulings behind it, live at
+            `cardMasthead/FactionMasthead`. */}
+        <FactionMasthead slug="wow" />
 
         {/* The pennants, strung under the band (#2032) where the 6px barber
             ribbon used to run — the design's own swap. `Bunting` is WOW's one


### PR DESCRIPTION
Closes #2185

Praxis cards now wear the masthead band their task card wears — seven factions, `na` and `albescent` deliberately bare.

## The seam I tested at

**The band's rendered markup, reached through both card kits at once.** The ruling is not "a praxis card gets a band", it is "a praxis card gets *the same band* its task card wears". So the central assertion in the new `praxisCard/__tests__/praxisMasthead.test.tsx` is **band-for-band markup identity** between `WowTaskCard` and `WowPraxisCard`, and so on for all seven:

```
expect(band(renderPraxis(skin), slug)).toBe(band(renderTask(skin), slug))
```

Asserting the paint value by value would restate seven skins in a test file and go stale the first time a token moved. Identity *is* the property, and it fails the moment either kit grows a copy of its own.

The loop went red on the real defect first: **`EverymenPraxisCard` was already drawing its own masthead**, and it was not the task card's. It painted `--everymen-red` at 15px in `--font-accent` with two flanking cogs and no faction name, while `EverymenTaskCard` painted `--faction-everymen-bill-mast` in Bebas at `--text-title` under a 3px double rule. Two mastheads for one faction — exactly what `CardMasthead` was created to prevent — shipped anyway, because the component covered the anatomy and nothing covered the paint.

## What changed

**`CardMasthead` moved** from `components/taskCard/` to a shared `components/cardMasthead/`, since two kits import it now.

**The paint moved with it.** `cardMasthead/factionBands.tsx` holds one painted band per faction, and both kits mount it. This is the part that makes "the same band" an identity rather than a promise two directories make to each other. The task cards render **byte-identically** after the move — the existing 326 task-card tests pass untouched, which is what says the extraction was faithful.

No slug→component registry: `factionBands` exports seven **named** components (`WowBand`, `CovenBand`, …). Both callers of a band are per-faction files that already know their faction, so there was nothing to dispatch on — and `factions/__tests__/addAFaction.test.tsx` (#782) rightly failed my first attempt, which used a `Record<slug, Component>`. There is no `DefaultBand` and no `AlbescentBand` to import, which is the strongest form ADR-0048 can take in a module.

**Consequential stand-downs**, each for the reason its task card already used:
- **Coven's `Braid` eyebrow** goes — a band that already names the coven does not need an ornament run repeating it. The braid lives on below, ruling off sections.
- **Everymen's two cogs** go — they flanked the centre the wordmark now holds.
- **Singularity's LED bar** goes — it was three lamps on a hairline rule with nothing else on it once #1909 cut "singularity protocol". The shared band *is* that bar plus the faction's name, with the lamps riding as `leading`. Two chrome bars stacked would be two windows on one screen.

**Coven's twinkle field travels with the band**, not beside it: the backdrop wrapper lives in `factionBands`, so both kits inherit it and the stars stay off the copy on both cards.

**Frame padding moved to an inner box** on UA, Coven, Snide and Singularity — their frames padded themselves, and a full-bleed band inside an inset frame would float off three edges. Absolutely positioned ornaments (UA's lotus, Coven's cat) do not move: they resolve against the padding box, which dropping padding leaves where it was.

**Docstrings record the new decision, not the old argument.** Per the owner's comment, `CovenPraxisCard`, `SnidePraxisCard`, `SingularityPraxisCard` and `WowPraxisCard` now say plainly that **#1909's reasoning is superseded by owner ruling** and cite this issue. I did not try to reconcile the two.

## ⚠️ One judgement call you should check: the Ephemerists

**The issue's example is stale here, and I had to choose.** #2185 says "where a task card wraps the component to paint a backdrop — Coven's twinkle field, *the Ephemerists' glyph registers* — the praxis card does the same". But **#2067 removed the glyph registers from the Ephemerists task card** six hours before this issue was filed; the task card has worn the plain kit band on `--faction-ephemerists-plate-disc` since then.

Meanwhile the **praxis card** was the surface with a 110px night band and a `GlyphRegister` behind it, headed by the engraved `EphemeristsMasthead` (#1634).

I applied the rule ("match your task card") over its own example, so **the Ephemerists praxis card loses the engraved masthead and takes the restrained kit band.** My reasoning: the engraved masthead's other three mounts — task detail, praxis detail, edit-praxis — all use `scale={desktop ? "page" : "card"}`, so the `card` scale stays live and the split becomes coherent: **a card wears the kit band, a page wears the engraving.** The datum row's date is not lost — `PraxisStats` already carries the date as a fact.

**If you'd rather keep #1634's engraving on the praxis card, this is a one-file revert** and the other six are unaffected. I updated `ephemeristsPlateSurfaces.test.tsx` to assert the new truth; note its old "carries the night-band masthead" test was passing *vacuously* (it keyed on `epg-glyph`, which the drift strip above the vote block also carries), so it would not have caught this either way. The replacement keys on `--faction-ephemerists-plate-band-quiet`, the datum row's ink, which exists nowhere else on the card.

## The band is a link (#2167 landed first)

#2167 merged before this, so the praxis band is a link to the faction page on the same terms as the task card's — it comes free, since both mount the same component. `praxisMasthead.test.tsx` also asserts **no anchor nests in another**: the praxis frames vary, and the band is a top-of-frame sibling in every one.

## Byte budget

**CSS is unchanged — zero bytes.** The emitted stylesheet is byte-identical to `main`: same hash, `assets/index--cfcSnKh.css`, 22.2 KB gzip on both. Measured with the repo's own `npm run budget` (gzip level 9) against a `main` build in the same tree.

The CSS budget **prints WARN, and it does so on `main` too** — this branch does not move it. JS is 126.6 KB on both, well inside `ok`. Everything here is inline style, which lands in JS, and the extraction is close to net-neutral there.

## Verification

`tsc --noEmit`, `npm run lint` (incl. the `no-raw-style-values` ratchet), `npm run typecheck:design-sync`, `npm test` (339 files pass), `npm run build`, `npm run budget` — all green, run after the rebase onto `cb3d3006`.

Also repointed `.design-sync/config.json` and `.ds-kit/index.tsx` at `CardMasthead`'s new path, and updated the `singularityLamps` roll-call from six mounts to five (the two card mounts merged into one shared band — a merge, not a lost surface; the comment says so, since this edit looks identical to the regression that guard exists to catch).

**Visual QA is outstanding.** I have no browser and did not run a dev server; everything above is markup, types and bytes.

## What to eyeball

A praxis card in the feed for each banded faction, **light and dark**:

1. **Warriors of Whimsy** — plum banner, gilt lettering and mark, 2px gilt bottom rule, sitting above the chronicle's 6px woven gold/plum stripe.
2. **Cozy Coven** — 44px band, hand-lettered lowercase name, gold twinkle stars over the band's ground and none in the copy.
3. **The Everymen** — red bill mast, Bebas caps, 3px double rule. Confirm the **old 15px cog bar is gone** and not stacked above or below.
4. **S.N.I.D.E.** — censor-bar band, brushed A at 24 bleeding into the inset, acid Anton wordmark. Check it on **both** grounds: the flyposted wall in the feed, and the black on task detail (#2177) — the band should look the same on each.
5. **Singularity** — window chrome with the three lamps left of the mark. Confirm there is **only one** chrome bar now.
6. **UA** — hairline band on `--faction-ua-hair`, body ink not accent. The ensō should still be in the score column and *not* duplicated in the header.
7. **The Ephemerists** — the judgement call above. Restrained band on the plate disc, cornice below it. Confirm the wordmark appears **once**.

Then:

8. **`na` and `albescent` praxis cards are still bare** — no band, no faction link. This is the ADR-0048 check and the one that matters most, since an Albescent band would out a secret society on a stranger's feed.
9. **The band's link target** — clicking any of the seven bands goes to `/factions/<slug>`, and hovering underlines it. Confirm the task card and praxis card for the same faction go to the same place.
10. **Frame insets** — UA, Coven, Snide and Singularity had their padding moved inward. Check the band is genuinely full-bleed (touching all three edges) and the body copy still has its old breathing room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
