### PR TITLE
Ephemerists voters panel: each metal in its own ink, and the word beside the chip (#2147)

### DIFF
--- a/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
@@ -30,7 +30,7 @@ vi.mock("../../../hooks/useFormFactor", () => ({
 }));
 
 // Imported after the mock so the archetype picks it up.
-const { default: EphemeristsPraxisDetail } = await import(
+const { default: EphemeristsPraxisDetail, voterMetalWordFits } = await import(
   "../archetypes/EphemeristsPraxisDetail"
 );
 
@@ -291,8 +291,8 @@ describe("Ephemerists praxis detail — the state axes", () => {
 
   /**
    * #1638 — "who voted" is THE STRUCK METAL: the sigil for the metal that voter
-   * cast, in a brass-ringed disc, with the tier WORD carried to assistive tech
-   * on a visually-hidden label rather than on `title`.
+   * cast, in a brass-ringed disc, with the tier WORD carried as real text
+   * rather than on `title`.
    *
    * The name reaching text is the load-bearing half, and it is the half the
    * design's `title` would have failed silently: an attribute is not text
@@ -303,13 +303,62 @@ describe("Ephemerists praxis detail — the state axes", () => {
     const { text, html } = render(state());
     // The word still comes from the shipped `reframeLabel` — no invented copy —
     // and reaches the accessibility tree as text rather than as a tooltip.
-    expect(html, "visually hidden, not withheld").toContain('class="sr-only"');
     expect(text, "the tier for 5").toContain("platinum");
     expect(text, "the tier for 3").toContain("silver");
     expect(html, "and never as a hover-only title").not.toContain('title="platinum"');
     // The roman numerals went with the vote plate's own pips: the sigil in the
     // disc is what says which rank, on both surfaces.
     expect(text, "no numeral beside the mark").not.toContain("III");
+  });
+
+  /**
+   * #2147 — the chip is the readable column down the right margin, so each
+   * metal is inked in ITS OWN token. Shipped with all five stroked in one
+   * `-plate-ochre`, which made the glyph the sole difference between a lead
+   * vote and a platinum one; at 16px Saturn and Venus are too close for that.
+   *
+   * A colour is normally an eyeball check, but "which of five" is not: this
+   * asserts the two fixture rows do not share an ink, which is exactly what a
+   * regression back to one shared constant would break.
+   */
+  it("inks each vote's sigil in its own metal, on a rule-brass rim", () => {
+    const { html } = render(state());
+    expect(html, "rank 5").toContain(
+      'stroke="var(--faction-ephemerists-metal-platinum)"',
+    );
+    expect(html, "rank 3").toContain('stroke="var(--faction-ephemerists-metal-silver)"');
+    // A border is a LINE, so it takes the rule brass and not the mark brass
+    // (#2140's split, landed by #2141).
+    expect(html, "the chip's rim").toContain(
+      "1px solid var(--faction-ephemerists-plate-brass-rule)",
+    );
+  });
+
+  /**
+   * #2147 — the metal's word prints between the name and the chip where the row
+   * has room and drops where it does not, and it is ONE span either way so the
+   * row reads "name, platinum" exactly once at every width.
+   *
+   * The width itself arrives from a `ResizeObserver`, which this harness has no
+   * DOM to run, so the decision is tested at the pure predicate and the DOM is
+   * asserted in the unmeasured state the harness actually renders. The narrow
+   * render is the eyeball check named on the PR.
+   */
+  it("prints the metal's word only where the row has room", () => {
+    expect(voterMetalWordFits(330), "a desktop aside").toBe(true);
+    expect(voterMetalWordFits(200), "a 320px phone").toBe(false);
+    // Unmeasured — first paint, SSR, and this harness. Reads as roomy: the word
+    // is the same span either way, so the failure mode is a visible word on a
+    // cramped row, never a row that cannot say which metal.
+    expect(voterMetalWordFits(null), "not measured yet").toBe(true);
+
+    const { html, text } = render(state());
+    expect(html, "printed, not hidden, at the unmeasured default").not.toContain(
+      'class="sr-only">platinum',
+    );
+    // One span, not a visible copy beside a hidden one. Counted on the TEXT:
+    // the markup names the metal a second time in the sigil's stroke token.
+    expect(text.match(/platinum/g)?.length, "said once").toBe(1);
   });
 
   it("credits every co-author and shows the members section on a collab", () => {

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -87,6 +87,7 @@
  * around the component (WORLD_ZERO_STYLE §5, the #1028 ruling).
  */
 import type { CSSProperties, ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import MediaGallery from "../../../components/MediaGallery";
@@ -98,6 +99,7 @@ import MetataskSeal from "../../../components/metataskSeal/MetataskSeal";
 import { CollabRoster } from "../../../components/collab/CollabRoster";
 import {
   BRASS,
+  BRASS_RULE,
   CAPS,
   CAPTION,
   Cornice,
@@ -153,6 +155,53 @@ const ASIDE_WIDTH = 330;
  */
 const VOTER_DISC = 28;
 const VOTER_SIGIL = 16;
+
+/**
+ * The narrowest voter row that still PRINTS the metal's word beside the name
+ * (#2147). Arithmetic on the row's own flex track: the chip (28) + the leader
+ * rule's 10px floor + three 8px gaps + roughly 66px for "platinum" in the
+ * label ramp's small caps leaves ~130px for the name, about eight characters
+ * at `--text-content` before the ellipsis takes over. The 330px aside clears
+ * it comfortably; a 320px phone does not.
+ *
+ * Below it the word DROPS — it is not shrunk, ellipsed or hover-gated. It stays
+ * in the accessibility tree on the same span, visually hidden, so the row still
+ * reads "wanderingclock, platinum" at every width.
+ */
+const VOTER_WORD_MIN = 260;
+
+/**
+ * Does the metal's word fit? A WIDTH decision, not a breakpoint: this panel is
+ * a fixed 330px aside on desktop but the full page column on mobile, so the
+ * form factor is not the predicate — a wide phone has more room here than a
+ * desktop, and `useFormFactor` would drop the word on exactly the rows that
+ * have space for it.
+ *
+ * `null` is "not measured yet" — first paint, and forever where there is no
+ * `ResizeObserver` (SSR, the static test harness). It reads as ROOMY: the word
+ * is the same span either way, so the failure mode is a visible word on a
+ * cramped row rather than a row that never says which metal.
+ */
+export function voterMetalWordFits(rowWidth: number | null): boolean {
+  return rowWidth === null || rowWidth >= VOTER_WORD_MIN;
+}
+
+/**
+ * The observed width of one element, and the ref callback that observes it.
+ * A ref callback rather than `useRef` so the effect re-runs when the node
+ * arrives — the panel is conditional on there being voters at all.
+ */
+function useObservedWidth(): [(node: HTMLElement | null) => void, number | null] {
+  const [node, setNode] = useState<HTMLElement | null>(null);
+  const [width, setWidth] = useState<number | null>(null);
+  useEffect(() => {
+    if (!node || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(([entry]) => setWidth(entry.contentRect.width));
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [node]);
+  return [setNode, width];
+}
 
 interface SizeSet {
   /** Masthead band height, and the width its registers are drawn to fill. */
@@ -282,6 +331,9 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   const { t } = useTranslation("praxis");
   const desktop = useFormFactor() !== "mobile";
   const size = SIZES[desktop ? "desktop" : "mobile"];
+  // The voters panel measures ITSELF - see `voterMetalWordFits`. Declared up
+  // here with the other hooks, above the `!praxis` return.
+  const [votersRef, votersWidth] = useObservedWidth();
   const { praxis, voters } = state;
 
   // Guarded non-null by the dispatcher.
@@ -706,8 +758,17 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   // drawing the vote widget strikes, out of the same `METAL_SIGILS`, so the
   // mark a voter chose and the mark their vote is filed under cannot diverge.
   //
+  // The sigil is inked in ITS OWN METAL (#2147) rather than in one shared
+  // ochre. One ink made the glyph the only difference between a lead vote and a
+  // platinum one, and at 16px the Saturn and Venus marks are close enough that
+  // the right margin stopped being scannable. The metals can keep full strength
+  // here — and only here on this sheet, where silver measures 1.32:1 and
+  // platinum 1.02:1 — because the disc's ground is `-plate-disc`, dark in BOTH
+  // themes (#2141). Its rim is the RULE brass, not the mark brass: a border is
+  // a line (#2140).
+  //
   // THE METAL'S NAME IS THE ONLY IDENTIFYING INFORMATION in the row, so it is
-  // carried by a VISUALLY-HIDDEN LABEL and not by `title`. That is a deliberate
+  // carried by A REAL SPAN OF TEXT and not by `title`. That is a deliberate
   // departure from `GlossedGlyph`, which the kit uses for the masthead's kanji:
   // a `title` is a pointer affordance — unreliably announced, unreachable on
   // touch — and `GlossedGlyph`'s own justification is that the English it hides
@@ -716,19 +777,38 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
   // first: hiding the word behind a hover would leave a screen-reader user a
   // row that reads a name and stops. `reframeLabel` still produces the word —
   // the vocabulary is not invented here, only its rendering.
+  //
+  // That word is ONE span in both renderings — printed between the name and the
+  // chip where the row has room, `sr-only` where it does not (#2147). One span
+  // rather than a visible copy plus a hidden one is what keeps the row reading
+  // "name, platinum" exactly once at every width. #2147 asked for the word in
+  // the ROW's `aria-label`; that is NOT built, because a `div` has no role and
+  // an `aria-label` on a role-less generic is dropped rather than announced —
+  // the in-flow text is what actually delivers the row it describes.
+  const metalWordFits = voterMetalWordFits(votersWidth);
   const votersBlock = voters.length > 0 && (
     <section style={panel}>
       {sectionHead(
         t("detail.voters.heading"),
         <span style={plateEyebrow}>{t("detail.voters.count", { count: voters.length })}</span>,
       )}
-      <div style={{ display: "flex", flexDirection: "column", gap: "var(--space-md)" }}>
+      <div
+        ref={votersRef}
+        style={{ display: "flex", flexDirection: "column", gap: "var(--space-md)" }}
+      >
         {voters.map((voter) => {
           const metal = METAL_SIGILS[voter.value - 1] ?? METAL_SIGILS[0];
           return (
             <div
               key={voter.character_id}
-              style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}
+              style={{
+                // Positioned so the `sr-only` word below is clipped against the
+                // ROW and cannot escape to the page's origin.
+                position: "relative",
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-sm)",
+              }}
             >
               <Link
                 to={`/characters/${voter.character_id}`}
@@ -748,8 +828,18 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
               </Link>
               <span aria-hidden style={{ flex: 1, minWidth: 10, height: 1, background: LINE }} />
               <span
+                className={metalWordFits ? undefined : "sr-only"}
+                style={
+                  metalWordFits
+                    ? { ...plateEyebrow, flexShrink: 0, whiteSpace: "nowrap" }
+                    : undefined
+                }
+              >
+                {reframeLabel(praxis.task_faction_slug, voter.value)}
+              </span>
+              <span
+                aria-hidden
                 style={{
-                  position: "relative",
                   flexShrink: 0,
                   display: "flex",
                   alignItems: "center",
@@ -757,7 +847,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
                   width: VOTER_DISC,
                   height: VOTER_DISC,
                   borderRadius: "50%",
-                  border: `1px solid ${BRASS}`,
+                  border: `1px solid ${BRASS_RULE}`,
                   background: DISC,
                 }}
               >
@@ -771,15 +861,12 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
                   <path
                     d={metal.glyph}
                     fill="none"
-                    stroke={OCHRE}
+                    stroke={metal.color}
                     strokeWidth={metal.weight}
                     strokeLinecap="round"
                     strokeLinejoin="round"
                   />
                 </svg>
-                <span className="sr-only">
-                  {reframeLabel(praxis.task_faction_slug, voter.value)}
-                </span>
               </span>
             </div>
           );


### PR DESCRIPTION
Closes #2147

## Most of this issue was already true in `main` — per #2140, saying so instead of re-deriving it

The issue opens *"Today each row states the metal in words."* That has not been true
since **#1638**. Verified against `main` before writing anything:

| the issue asks for | state in `main` |
|---|---|
| a 28px disc chip | **already there** — `VOTER_DISC = 28`, `borderRadius: "50%"` |
| ground `-plate-disc` | **already there** |
| the metal's alchemical glyph at 16px | **already there** — `VOTER_SIGIL = 16`, out of the shared `METAL_SIGILS` |
| name left, chip right | **already there**, with a flex leader rule between them |
| "Never `title`" | **already rejected** — the word was in an `sr-only` span, with a nine-line comment explaining why `title` is wrong here |

So none of that is rebuilt. What was genuinely missing is below.

## What this actually changes

1. **Each metal is inked in its own colour.** All five sigils were stroked in one
   shared `-plate-ochre`. That made the glyph the *only* difference between a lead
   vote and a platinum one, and at 16px the Saturn and Venus marks are close enough
   that the right margin stopped being scannable. Each now takes
   `--faction-ephemerists-metal-{lead,copper,silver,gold,platinum}` — the value
   `METAL_SIGILS` already carries and the vote plate already strikes. **No token was
   added or edited**; this reads what #2141 declared.
2. **The disc rim moves from the mark brass to `-plate-brass-rule`.** A border is a
   line, per #2140's mark/rule split.
3. **The metal's word is printed** between the name and the chip where the row has
   room, and dropped where it is not — never shrunk, ellipsed or hover-gated.

## The row's accessible name — a judgement, not a skip

#2147 asks for the metal in the row's `aria-label`. **Not built, deliberately.** A
row here is a `div` with no role, and `aria-label` on a role-less generic is dropped
rather than announced — it would have been a silent no-op that renders identically,
which is exactly the failure mode the issue's own "Never `title`" section is about.

What delivers "wanderingclock, platinum" is the word being *in the row's flow as
text*, which `main` already achieved inside the chip. This keeps that guarantee and
promotes it: it is now **one span in both renderings** — visible when there is room,
`sr-only` when there is not — rather than a visible copy beside a hidden one. The row
therefore says the metal exactly once at every width, and the word still comes from
the shipped `reframeLabel`, so no copy is invented.

## The seam

**`voterMetalWordFits(rowWidth: number | null): boolean`** — exported and tested
directly. Room is a **width** decision, not a breakpoint: this panel is a fixed 330px
aside on desktop but the **full page column** on mobile, so a wide phone has more room
here than a desktop does and `useFormFactor` would have dropped the word on exactly
the rows that have space for it. The width arrives from one `ResizeObserver` on the
rows container; `null` (first paint, SSR, the static test harness) reads as roomy, so
the failure mode is a visible word on a cramped row, never a row that cannot say which
metal.

The loop went red on the real defect first: reverting the stroke to `OCHRE` fails
`inks each vote's sigil in its own metal, on a rule-brass rim` — checked, not assumed.

`frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx` gains:
- both metals in the fixture stroked in **different** metal tokens, plus the rule-brass rim;
- the predicate at a desktop aside, a 320px phone, and unmeasured;
- the word printed rather than hidden at the unmeasured default, and said **once**.

The existing `class="sr-only"` assertion was rewritten: with the word now printed at
the unmeasured default it would have gone on passing off an unrelated `sr-only`
elsewhere in the page.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(340 files, 5978 tests), `npm run build`, `npm run budget` — all green locally.
The budget's CSS **WARN is pre-existing** and non-blocking (exit 0); this diff touches
no CSS and adds no new Tailwind class name (`sr-only` was already in the file).

**Visual QA is outstanding** — no browser or dev stack in this environment.

## What to eyeball

- [ ] A **five-row voters panel, one row per metal** (lead / copper / silver / gold /
      platinum) in **light**: the five glyphs are five distinct colours down the right
      margin and the distribution reads before any word does.
- [ ] The **same panel in dark**. The chip's ground is `-plate-disc`, dark in both
      themes — the metals should read at identical strength in both, and the chip
      should *not* have turned into a light disc.
- [ ] **Lead beside copper**, adjacent rows, light: Saturn and Venus are the pair that
      collided under one ink — they should now be unmistakable at a glance.
- [ ] The **chip rim** against the panel's other hairlines: one rule brass, no
      brighter ring around the disc than the section rules beside it.
- [ ] The **printed word** between the name and the chip in a 330px desktop aside —
      small caps, caption gold, on the plate. It must not be an ink the metals use.
- [ ] A **long display name** in that aside: the *name* takes the ellipsis, the word
      and the chip do not shrink.
- [ ] A **narrow render (~320px viewport)**: the word drops out entirely — no clipped
      or half-drawn word — leaving name, leader rule and chip.
- [ ] In that narrow render, a **screen reader still reads "name, platinum"** for the
      row, and the word is announced exactly once.
- [ ] **Resize across the threshold** with the panel on screen: the word appears and
      disappears cleanly, with no layout jump in the chip column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
