### PR TITLE
The Ephemerists ground is the warped ephemeris net, not a seven-layer wash (#2144)

### DIFF
--- a/frontend/src/components/backdrop/EphemeristsBackdrop.tsx
+++ b/frontend/src/components/backdrop/EphemeristsBackdrop.tsx
@@ -1,9 +1,27 @@
+import EphemerisNet from "../factionMarks/EphemerisNet";
+
 /**
- * The Ephemerists full-page backdrop — the page as a sheet of the ephemeris:
- * aged vellum, faint foxing, astrolabe rings bleeding from opposite corners,
- * and ghost scribe-lines. Theme-aware via the `.eph-backdrop` rule in
- * index.css. Fixed behind page content at z-index 0.
+ * The Ephemerists full-page backdrop — the page as a sheet of the ephemeris.
+ *
+ * NOT aged vellum any more (#2144). This was a seven-layer wash — a gold corner
+ * bleed, a nile corner bleed, two partial astrolabe rings, dot foxing, a
+ * straight 26px ruling and a closing gradient — and all seven are replaced by
+ * ONE layer: {@link EphemerisNet}, the warped chart. Owner ruling on #2140: a
+ * chart is a thing an ephemerist made, where foxing is only something that
+ * happened to the paper.
+ *
+ * The sheet COLOUR stays, in `.eph-backdrop` in index.css, and is the one thing
+ * on that list not counted as a wash layer: it is what makes this page vellum
+ * rather than the site's neutral ground, and dropping it would take the faction's
+ * stock with it in both themes.
+ *
+ * 0.17 is the page's weight of the three the owner ruled — see the net's header
+ * for the other two and why they differ.
  */
 export default function EphemeristsBackdrop() {
-  return <div className="eph-backdrop" aria-hidden="true" />;
+  return (
+    <div className="eph-backdrop" aria-hidden="true">
+      <EphemerisNet opacity={0.17} />
+    </div>
+  );
 }

--- a/frontend/src/components/factionMarks/EphemerisNet.tsx
+++ b/frontend/src/components/factionMarks/EphemerisNet.tsx
@@ -1,0 +1,144 @@
+/**
+ * THE WARPED EPHEMERIS NET (#2144) — the Ephemerists' one ground.
+ *
+ * The page stopped being aged paper and became a chart. Owner ruling on the
+ * epic (#2140): "A says this is aged paper, B says this is a chart — and a chart
+ * is a thing an ephemerist MADE, where foxing is just something that happened to
+ * the paper." So the seven-layer wash `.eph-backdrop` used to carry (a gold
+ * corner bleed, two astrolabe rings, dot foxing, a straight 26px ruling and a
+ * closing gradient) is gone, and this is what replaces all of it.
+ *
+ * Three families, all drawn about ONE pole off the right edge of the sheet:
+ * meridians and parallels bent around it, and a fan of straight rays converging
+ * on it. That is the whole drawing — the bend is what separates a chart from
+ * graph paper, and the pole being off-canvas is what makes the sheet read as a
+ * detail of something larger.
+ *
+ * ── DEVIATION (`docs/agents/design-fidelity.md` §"Vendor, build, delete") ──
+ * The design bundle for #2140 is NOT vendored under `.design-sync/`, so the
+ * geometry here is authored from #2144's prose description of `eph-backdrop.js`
+ * (1000×600, `preserveAspectRatio="none"`, stroked at 0.7) rather than ported
+ * from the source. Prose cannot carry geometry: the FAMILIES are the design's,
+ * the pole's coordinates and the line counts are an interpretation and are the
+ * first thing to correct against the bundle when it lands.
+ *
+ * ── WHY A COMPONENT AND NOT A `url()` IN THE TOKEN ──
+ * `--faction-ephemerists-grid` publishes the STRAIGHT graticule and its ponytail
+ * names "point this at a url() of a hosted SVG" as the upgrade path. Two things
+ * make that the wrong shape for the net and they are both about the ink: an
+ * externally-referenced SVG cannot read a CSS custom property, so its stroke
+ * would be a baked hex — and this ruling's ink FLIPS (`-plate-brass-light` is
+ * `#6f5620` on the vellum and `#e6c877` on the night plate), which is the whole
+ * reason #2141 theme-scoped the token. A baked hex would either need two assets
+ * of the same drawing or a mask, and drawn inline it needs neither: the stroke
+ * is a `var()` and follows the stock. `docs/agents/load-time.md`'s cost note
+ * applies and is paid the cheap way — this module is imported only from
+ * archetypes the ephemerists manifest loads lazily, so it is in that faction's
+ * chunk and not on anyone else's critical path, and the drawing is a LOOP rather
+ * than a dumped path list.
+ *
+ * ── OPACITY IS NOT ONE NUMBER, AND IS NOT IN THE DRAWING ──
+ * Same rule the grid token states: a wash baked into the image cannot be dialled
+ * by its mount. The owner's three weights are 0.17 on the page ground, 0.10 on a
+ * card or plate ground, and 0.17 on the task brief — so `opacity` is required,
+ * not defaulted, and every mount has to say which surface it is.
+ */
+import { BRASS_LIGHT } from "./ephemeristsPlate";
+
+/** The sheet, in the design's own units. Stretched to the host box, never fitted. */
+const W = 1000;
+const H = 600;
+
+/**
+ * The pole the chart is drawn about — off the right edge, and above centre.
+ * Everything on this sheet bends toward it or points at it.
+ */
+const POLE_X = 1190;
+const POLE_Y = 232;
+
+/**
+ * One graticule line as a quadratic whose control point is the segment's own
+ * midpoint pulled `k` of the way toward the pole. `k = 0` is the straight
+ * ruling this replaces; `k = 1` would collapse the line onto the pole. The bend
+ * is the only thing separating a chart from graph paper, so it is the one
+ * parameter, and it is per-line rather than global — a projection warps hardest
+ * near its pole.
+ */
+function bent(x1: number, y1: number, x2: number, y2: number, k: number): string {
+  const mx = (x1 + x2) / 2;
+  const my = (y1 + y2) / 2;
+  const cx = mx + (POLE_X - mx) * k;
+  const cy = my + (POLE_Y - my) * k;
+  return `M${x1} ${y1}Q${cx.toFixed(1)} ${cy.toFixed(1)} ${x2} ${y2}`;
+}
+
+/**
+ * Meridians — 15 near-vertical curves, bending harder the closer they run to the
+ * pole. They start and end outside the sheet so no line terminates in view: a
+ * chart is a detail of something larger, and a graticule that stops at the edge
+ * reads as a border.
+ */
+const MERIDIANS = Array.from({ length: 15 }, (_, i) => {
+  const x = -60 + i * 80;
+  return bent(x, -40, x, H + 40, 0.05 + 0.16 * ((x + 60) / 1120));
+});
+
+/**
+ * Parallels — 11 near-horizontal curves bowing toward the pole's latitude.
+ * Deliberately fewer and further apart than the meridians: they are the family
+ * the eye reads as "the sheet", and matching the pitch in both directions is
+ * what would put graph paper back.
+ */
+const PARALLELS = Array.from({ length: 11 }, (_, j) => {
+  const y = -80 + j * 80;
+  return bent(-60, y, W + 60, y, 0.06 + 0.12 * (1 - Math.min(1, Math.abs(y - POLE_Y) / 520)));
+});
+
+/**
+ * The fan — 15 straight rays converging on the pole from off the left edge.
+ * Straight, where the graticule is bent, and that contrast is the point: these
+ * are sightlines taken from the sheet, not lines of the projection.
+ */
+const RAYS = Array.from({ length: 15 }, (_, i) => ({ x: -80, y: -260 + i * 100 }));
+
+/**
+ * @param opacity how far back the net sits — see the header. There is no
+ * default: the three weights are a ruling, and a mount that has not decided
+ * which surface it is has not finished.
+ */
+export default function EphemerisNet({ opacity }: { opacity: number }) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      style={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        // A GROUND, NOT A VEIL — the same contract `.eph-grid-ground` states in
+        // index.css: between the host's own fill and everything printed on it,
+        // and inert. The host must be a stacking context (`isolation: isolate`,
+        // or any positioned element with a z-index) or this escapes below the
+        // fill; that is the mechanism the design's `z-index: 1` lift replaces,
+        // and the lift is wrong here because lifting static children needs
+        // `position: relative` on them, which overrides the absolutely
+        // positioned ornament the plate skins are full of.
+        zIndex: -1,
+        pointerEvents: "none",
+        opacity,
+      }}
+    >
+      <g stroke={BRASS_LIGHT} strokeWidth={0.7} fill="none">
+        {[...MERIDIANS, ...PARALLELS].map((d) => (
+          <path key={d} d={d} />
+        ))}
+        {RAYS.map((origin) => (
+          <line key={origin.y} x1={origin.x} y1={origin.y} x2={POLE_X} y2={POLE_Y} />
+        ))}
+      </g>
+    </svg>
+  );
+}

--- a/frontend/src/components/factionMarks/__tests__/ephemerisNet.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemerisNet.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * THE WARPED EPHEMERIS NET (#2144) — one drawing, mounted at ruled weights.
+ *
+ * THE SEAM: `a surface that wants the Ephemerists ground` → `the net it draws
+ * there, and how far back it sits`. Two halves, because the ruling has two
+ * halves and only one of them is markup.
+ *
+ * The JS half is the drawing itself and its two live mounts. What can silently
+ * break is a mount going back to hand-rolling its own ruling — which is exactly
+ * what the brief did before this issue (a `repeating-linear-gradient` pitched to
+ * `BRIEF_LEADING`) and exactly the failure #2185 caught elsewhere in this kit:
+ * one faction, two drawings, free to drift.
+ *
+ * The CSS half is `.eph-backdrop`. Its seven-layer wash is invisible to
+ * `renderToStaticMarkup` — the page ground's whole metaphor lives in index.css —
+ * so "the wash is gone and the sheet colour is not" is asserted against the
+ * stylesheet on disk.
+ *
+ * The owner's three weights are the thing most likely to be edited back by
+ * someone reading the design rather than the ruling (the design says 0.17 on a
+ * card and 0.42 on the brief), so each is pinned to its number here.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import EphemerisNet from "../EphemerisNet";
+import EphemeristsBackdrop from "../../backdrop/EphemeristsBackdrop";
+
+const CSS = readFileSync(fileURLToPath(new URL("../../../index.css", import.meta.url)), "utf8");
+
+/** The declaration body of one rule, by selector. */
+function ruleFor(selector: string): string {
+  const match = CSS.match(new RegExp(`\\${selector}\\s*\\{([^}]*)\\}`));
+  if (!match) throw new Error(`no rule for ${selector} in index.css`);
+  return match[1];
+}
+
+describe("the net is a ground, not a veil", () => {
+  const html = renderToStaticMarkup(<EphemerisNet opacity={0.17} />);
+
+  it("is inert: hidden from assistive tech, and untouchable", () => {
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain("pointer-events:none");
+  });
+
+  it("sits behind everything printed on its host", () => {
+    expect(html).toContain("z-index:-1");
+  });
+
+  it("takes its ink from the plate's brass rather than a raw hue", () => {
+    expect(html).toContain("var(--faction-ephemerists-plate-brass-light)");
+    expect(html).not.toMatch(/#[0-9a-f]{3,8}\b/i);
+  });
+
+  it("stretches to its host's box rather than keeping the sheet's aspect", () => {
+    expect(html).toContain('preserveAspectRatio="none"');
+    expect(html).toContain('viewBox="0 0 1000 600"');
+  });
+
+  it("draws all three families — bent meridians, bent parallels, a straight fan", () => {
+    // Curves are paths with one quadratic each; the fan is straight lines.
+    expect((html.match(/<path/g) ?? []).length).toBeGreaterThan(20);
+    expect((html.match(/<line/g) ?? []).length).toBeGreaterThan(8);
+  });
+
+  it("carries no opacity of its own — the mount decides how far back it sits", () => {
+    expect(renderToStaticMarkup(<EphemerisNet opacity={0.1} />)).toContain("opacity:0.1");
+    expect(html).toContain("opacity:0.17");
+  });
+});
+
+describe("the page ground", () => {
+  it("draws the net at the page's weight", () => {
+    const html = renderToStaticMarkup(<EphemeristsBackdrop />);
+    expect(html).toContain('class="eph-backdrop"');
+    expect(html).toContain("opacity:0.17");
+    expect(html).toContain('viewBox="0 0 1000 600"');
+  });
+
+  it("keeps the sheet colour and nothing else — the wash is gone", () => {
+    const backdrop = ruleFor(".eph-backdrop");
+    expect(backdrop).toContain("background-color: var(--faction-ephemerists-plate-page)");
+    // The seven layers the net replaces. Any of these back means the page is
+    // aged paper again rather than a chart.
+    expect(backdrop).not.toContain("background-image");
+    expect(backdrop).not.toContain("repeating-radial-gradient");
+    expect(backdrop).not.toContain("repeating-linear-gradient");
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4831,20 +4831,26 @@
    `--eph-*` while their plates moved would have been the second
    identity in its most visible form: papyrus floating on vellum.
 
-   It is now `-plate-page`, the same ground the task detail's sheet
-   sits on, wearing the plate's own marks: a gold bloom off the top
-   edge, a set of surveyor's rings bleeding from the top corner in
-   brass, papyrus grain, and the journal's ruling. The vignette
-   follows `-plate-page` itself rather than a second sheet colour,
-   because the plate family has no "deep" twin.
+   It became `-plate-page`, the same ground the task detail's sheet
+   sits on, and #2144 then took every mark off it. The wash was a
+   gold bloom off the top edge, surveyor's rings bleeding from the
+   top corner, papyrus grain and the journal's ruling (plus two nile
+   layers #2141 deleted with the token). All of it is replaced by ONE
+   layer, and that layer is not here: it is `EphemerisNet`, drawn in
+   JS by `components/backdrop/EphemeristsBackdrop.tsx`.
 
-   #2144 OWNS THE REWRITE OF THIS RECIPE — the warped ephemeris net
-   replaces the seven-layer wash outright. What #2141 did here is the
-   minimum that leaves `main` green and the faction aqua-free: the
-   two nile layers (a 12% corner bloom and a 10% ring set)
-   are DELETED with the token, not repointed onto a brass that the
-   layer above them already carries. Five layers, not seven; do not
-   read the reduced stack as the design's intent, read #2144's.
+   THIS RULE IS NOW THE SHEET COLOUR AND NOTHING ELSE, on purpose.
+   The colour is the one item on that list which was never a wash
+   layer — it is what makes this page vellum by day and the night
+   plate after dark, and dropping it would drop the faction's stock
+   back to the site's neutral ground. Everything ABOVE the colour is
+   the chart, and the chart has to follow the theme through a var(),
+   which an image can only do while it is drawn in the document —
+   see the net's header for why that ruled out a `url()` here.
+
+   `z-index: 0` on a fixed element makes this a stacking context,
+   which is what keeps the net's `z-index: -1` above this colour
+   instead of behind the page.
    ══════════════════════════════════════════════════════════════ */
 .eph-backdrop {
   position: fixed;
@@ -4852,13 +4858,6 @@
   z-index: 0;
   pointer-events: none;
   background-color: var(--faction-ephemerists-plate-page);
-  background-image:
-    radial-gradient(40% 32% at 100% 0%, color-mix(in srgb, var(--faction-ephemerists-plate-gold) 18%, transparent), transparent 72%),
-    repeating-radial-gradient(circle at 90% 8%, transparent 0 33px, color-mix(in srgb, var(--faction-ephemerists-plate-brass) 12%, transparent) 33px 34px),
-    radial-gradient(var(--faction-ephemerists-plate-rule) 0.6px, transparent 0.9px),
-    repeating-linear-gradient(0deg, var(--faction-ephemerists-plate-rule) 0 1px, transparent 1px 26px),
-    linear-gradient(170deg, var(--faction-ephemerists-plate-bg), var(--faction-ephemerists-plate-page));
-  background-size: 100% 100%, 100% 100%, 5px 5px, 100% 100%, 100% 100%;
 }
 
 /* ══════════════════════════════════════════════════════════════

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -188,6 +188,22 @@ describe("Ephemerists task detail — the Valley plate", () => {
     expect(text).toContain(long);
   });
 
+  it("stands the brief on the chart, at the PAGE's weight and not the design's (#2144)", () => {
+    const { html } = render(<EphemeristsTaskDetail state={baseState()} />);
+    // The net, not the journal ruling this leaf used to draw for itself.
+    expect(html).toContain('viewBox="0 0 1000 600"');
+    expect(html).not.toContain("repeating-linear-gradient(180deg");
+    // 0.17. The design says 0.42, which puts the net's diagonals at the weight
+    // of a 13px serif's strokes over what is body copy; the owner walked it
+    // down to the page's own number. The upgrade path if the brief ever needs
+    // to read as more written-on is BOTH grounds, never a heavier net.
+    expect(html).toContain("opacity:0.17");
+    expect(html).not.toContain("opacity:0.42");
+    // A ground, not a veil: the leaf isolates so the net's negative layer lands
+    // above the plate's fill and below every ink printed on it.
+    expect(html).toContain("isolation:isolate");
+  });
+
   it("never links the gallery out at the task_id feed filter", () => {
     // The gallery expands in place instead (#1030's fix, inherited here) — the
     // reader stays on the task, even now that the URL filters (#1050).

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
 import { EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
 import EphemeristsRuneStrip from "../../../components/factionMarks/EphemeristsRuneStrip";
+import EphemerisNet from "../../../components/factionMarks/EphemerisNet";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
@@ -35,8 +36,8 @@ import type { TaskDetailState } from "../useTaskDetail";
  * field journal out of the Valley. A cavetto-cornice masthead whose night band
  * holds the ENGRAVED MASTHEAD (#1634, page scale on desktop and card scale on a
  * phone) between two incised registers of glyphs; the level a numeral over tally
- * strokes; the worth on a stepped octagon medallion; the brief on a ruled leaf
- * with a red margin rule. Poiret One display, Cinzel small caps, Spectral
+ * strokes; the worth on a stepped octagon medallion; the brief on a leaf of the
+ * chart with a red margin rule. Poiret One display, Cinzel small caps, Spectral
  * reading.
  *
  * The winged sun disc appeared TWICE on this page — over the wordmark, and 400px
@@ -104,7 +105,6 @@ const DISC = "var(--faction-ephemerists-plate-disc)";
 const OCHRE = "var(--faction-ephemerists-plate-ochre)";
 const CTA_BG = "var(--faction-ephemerists-plate-cta-bg)";
 const CTA_INK = "var(--faction-ephemerists-plate-cta-ink)";
-const RULE = "var(--faction-ephemerists-plate-rule)";
 const LINE = "var(--faction-ephemerists-plate-line)";
 const SHADOW = "var(--faction-ephemerists-plate-shadow)";
 /* `--faction-ephemerists-plate-wash` filled the breadcrumb cartouche and nothing
@@ -120,11 +120,13 @@ const SHADOW = "var(--faction-ephemerists-plate-shadow)";
 const GALLERY_PREVIEW = 3;
 
 /**
- * The brief's leading, in px, and the pitch of the journal ruling under it.
- * These are ONE number by construction: a ruled leaf whose rules miss the text's
- * baselines reads as a printing error rather than as stationery. The design's 28
- * was drawn for 15.5px type; `--text-content` is 18px (the #627 floor), so the
- * ruling opens to match rather than the type closing to fit.
+ * The brief's leading, in px. It used to be TWO things — the leading and the
+ * pitch of the journal ruling beneath it, one number by construction so no rule
+ * missed a baseline. #2144 took the ruling away (the net replaces it), and the
+ * leading it was pitched to is what stays: the design's 28 was drawn for 15.5px
+ * type and `--text-content` is 18px (the #627 floor), so the line opened to
+ * match rather than the type closing to fit. Nothing tracks it any more, which
+ * is why it is now a plain number and not a pair.
  */
 const BRIEF_LEADING = 32;
 
@@ -179,9 +181,8 @@ interface SizeSet {
   tapTarget: number
   cellPadding: string
   briefPadding: string
-  /** Where the ochre margin rule is struck, and where the ruling starts. */
+  /** Where the ochre margin rule is struck down the gutter. */
   marginRule: number
-  rulingOffset: number
   titleSize: string
   levelSize: string
   pointsSize: string
@@ -198,7 +199,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
     cellPadding: "var(--space-lg)",
     briefPadding: "var(--space-xl) var(--space-xl) var(--space-lg) var(--space-3xl)",
     marginRule: 26,
-    rulingOffset: 30,
     titleSize: "var(--text-display)",
     levelSize: "var(--text-heading)",
     pointsSize: "var(--text-heading)",
@@ -213,7 +213,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
     cellPadding: "var(--space-md)",
     briefPadding: "var(--space-lg) var(--space-lg) var(--space-md) var(--space-xl)",
     marginRule: 18,
-    rulingOffset: 22,
     titleSize: "var(--text-heading)",
     levelSize: "var(--text-title)",
     pointsSize: "var(--text-title)",
@@ -827,7 +826,24 @@ export default function EphemeristsTaskDetail({
     </div>
   );
 
-  // ── The brief, in full, on a ruled leaf with a red margin rule ──
+  // ── The brief, in full, on a leaf of the chart with a red margin rule ──
+  //
+  // The leaf used to be RULED NOTEPAPER: a `repeating-linear-gradient` pitched
+  // to `BRIEF_LEADING` so every rule met a baseline. #2144 replaces it with the
+  // page's own net — one drawing across the whole faction, where the rules were
+  // a second ruling this page drew for itself.
+  //
+  // 0.17, WHICH IS THE PAGE'S WEIGHT AND NOT THE DESIGN'S 0.42. Owner ruling:
+  // at 0.42 the net's diagonals land at roughly the weight of a 13px serif's
+  // strokes, and this is body copy. If the brief later needs to read as more
+  // written-on than the page around it, the honest fix is to keep BOTH — the
+  // rules for the writing line, the net for the material — and NOT to double
+  // the net's weight; 0.42 has already been tried and ruled out once.
+  //
+  // `isolation: isolate` is the whole mount: it makes this leaf a stacking
+  // context, so the net's `z-index: -1` lands above the plate's fill and below
+  // the copy, the margin rule and everything else printed here. The design's
+  // `z-index: 1` lift is not used — see the net's header.
   const brief = (
     <section style={{ marginBottom: desktop ? "var(--space-2xl)" : "var(--space-xl)" }}>
       {sectionHead(t("detail.brief.heading"))}
@@ -836,11 +852,11 @@ export default function EphemeristsTaskDetail({
           style={{
             ...plate,
             position: "relative",
+            isolation: "isolate",
             padding: size.briefPadding,
-            backgroundImage: `repeating-linear-gradient(180deg, transparent 0 ${BRIEF_LEADING - 1}px, ${RULE} ${BRIEF_LEADING - 1}px ${BRIEF_LEADING}px)`,
-            backgroundPosition: `0 ${size.rulingOffset}px`,
           }}
         >
+          <EphemerisNet opacity={0.17} />
           {/* The margin rule, struck in ochre down the gutter. */}
           <span
             aria-hidden


### PR DESCRIPTION
The Ephemerists page stops being aged paper and becomes a chart. `.eph-backdrop`'s
wash — a gold corner bleed, two partial astrolabe rings, dot foxing, a straight
26px ruling and a closing gradient (plus the two nile layers #2141 already
deleted) — is replaced by one layer: the warped ephemeris net.

Closes #2144

## The seam

`a surface that wants the Ephemerists ground` -> `the net it draws there, and how
far back it sits`.

Two halves, and the tests are split the same way. The JS half is the drawing and
its mounts — what silently breaks is a mount going back to hand-rolling its own
ruling, which is exactly what the brief did before this issue and exactly the
failure #2185 caught elsewhere in this kit. The CSS half is `.eph-backdrop`,
whose whole metaphor lives in index.css and is invisible to
`renderToStaticMarkup`, so "the wash is gone and the sheet colour is not" is
asserted against the stylesheet on disk. Both went red on the real defect first.

## What shipped

**`components/factionMarks/EphemerisNet.tsx` (new)** — a `1000x600`,
`preserveAspectRatio="none"` SVG drawn about one pole off the right edge:
meridians and parallels bent around it, and a fan of straight rays converging on
it. `aria-hidden`, `pointer-events: none`, `z-index: -1`, `opacity` required with
no default.

**`.eph-backdrop`** is now the sheet colour and nothing else. The colour is the
one item on the seven-layer list that was never a wash layer — it is what makes
the page vellum by day and the night plate after dark, and dropping it takes the
faction's stock down to the site's neutral ground. `z-index: 0` on a fixed
element already makes the rule a stacking context, which is what holds the net's
negative layer above the colour.

**The brief** (`EphemeristsTaskDetail.tsx`) drops its `repeating-linear-gradient`
notepaper for the net at 0.17, mounted with `isolation: isolate`. `RULE` and the
`rulingOffset` size-set field are now dead and deleted; `BRIEF_LEADING` stays as
the leading alone and its docblock says so.

The three weights are the owner's, not the design's, and the walked-down two
carry the reasoning at the call site so nobody re-derives 0.42 — including the
ruling that if the brief ever needs to read as more written-on than the page, the
honest fix is to keep **both** grounds (rules for the writing line, net for the
material) rather than doubling the net's weight.

## Deviations

**The design bundle is not vendored.** `.design-sync/` has no `2140` directory,
and `docs/agents/design-fidelity.md` is explicit that prose cannot carry
geometry. The three families are the design's; the pole's coordinates, the line
counts and the bend law are an interpretation of #2144's description of
`eph-backdrop.js`, and are the first thing to correct against the bundle. The
header says so at the drawing.

**"stroked `#c9a24b` at 0.7" is read as stroke-*width* 0.7**, matching the
hero's own fan at 0.6. If 0.7 was an opacity, that is a one-line change.

**Drawn inline rather than as a `url()` in `--faction-ephemerists-grid`.** That
token's ponytail names the hosted-SVG `url()` as its upgrade path, and it is the
wrong shape for *this* drawing for one reason: an externally-referenced SVG
cannot read a CSS custom property, and this ruling's ink flips
(`-plate-brass-light` is `#6f5620` on the vellum, `#e6c877` on the night plate —
the whole reason #2141 theme-scoped that token). A baked hex would need either
two copies of the drawing or a mask; drawn in the document the stroke is a
`var()` and follows the stock. **No `--faction-ephemerists-*` token is added or
edited by this PR.**

## Payload

Measured against `origin/main` @ `6edc10f2`, gzip level 9, both builds run here.

| | main | this PR | delta |
|---|---|---|---|
| blocking CSS | 22,742 B | 22,667 B | **-75 B** |
| blocking JS (entry chunk) | 129,438 B | 129,461 B | +23 B |
| `EphemerisNet-*.js` (new chunk) | — | 622 B | +622 B, off the critical path |

**Nothing crosses a budget.** `npm run budget` reports the same
`WARN CSS 22.3 KB` on `main` and on this branch — that warning is pre-existing,
and this change moves it 75 B in the right direction. JS stays `ok` with ~4 KB of
head.

The +23 B on the entry chunk is not the net: `grep -c 1190` (the pole's x) on
`dist/assets/index-*.js` is **0**, and the drawing lands in its own
`EphemerisNet-*.js`, which Vite split out because both importers
(`EphemeristsBackdrop`, `EphemeristsTaskDetail`) are lazy archetypes. It is
chunk-hash churn in the preload map. Per `docs/agents/load-time.md` the inline
SVG counts toward JS, and it is paid the cheap way: the drawing is a loop over
15 + 11 + 15 lines, not a dumped path list, and it is on the Ephemerists chunk
rather than anyone's critical path.

## Not in this PR — the third weight has no mount

The ruling names three weights and this PR ships two. **0.10, "a card or plate
ground", has nowhere to land inside this issue's file scope:**

- `.eph-grid-ground` — the published card contract in index.css — is at `0.17`
  and **nothing in the repo mounts it**. It also still paints the *straight*
  graticule, so changing only its opacity would put the owner's net number on a
  drawing that is not the net.
- `EphemeristsTaskCard.tsx` is the surface the acceptance criteria screenshot,
  and it is held by the sibling issues running in parallel.

Left untouched deliberately rather than half-done. The follow-up is one decision:
whether `--faction-ephemerists-grid` retires in favour of the net (which would
also make `EphemeristsFactionHero`'s own 21-line converging fan redundant, since
the net carries one) or the two grounds stay separate.

`WORLD_ZERO_STYLE.md` is likewise untouched: "aged paper -> chart" and the
three-weights rule are epic-level entries, and six parallel PRs restating rows in
one shared file is how every branch goes green and `main` goes red.

## Verification

Every step `.github/workflows/test.yml` names for the `frontend` job, run locally:
`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(341 files, 5,984 passed), `npm run build`, `npm run budget`. No backend or
schema surface is touched, so `test` and `api-schema` are unaffected.

**Visual QA is outstanding.** I have no browser and no dev stack; a green build
proves the net renders as markup and takes its ink from a token, and proves
nothing about how it looks.

## What to eyeball

Light **and** dark for each, with the net visible at its weight:

1. **The page ground, 0.17** — a faction page (`/factions/ephemerists`) and an
   Ephemerists member's profile. The chart should read as one drawing bending
   toward a point off the right edge, with no line terminating in view. Check the
   vellum/night sheet is still the faction's own stock and not the site's page
   colour, and that the ruling does not fight the plates standing on it.
2. **A task card, 0.10** — **expected to show NO net**, per the section above.
   Worth eyeballing precisely so, so the gap is confirmed rather than assumed.
3. **The task brief, 0.17** — an Ephemerists task detail with a long
   description. The net must sit above the plate's fill and below the copy, the
   ochre margin rule and the plate border, and the copy must still read as body
   copy: this is the pairing 0.42 was walked down from.
4. **Both, at the theme flip.** The net's stroke is `-plate-brass-light`, which
   flips `#6f5620` -> `#e6c877`. A net that stays dark on the night plate means
   the ink stopped following the stock.
5. **The faction hero**, which still draws the straight graticule and its own
   fan — check the page ground under it does not now read as two charts.
