### PR TITLE
The Ephemerists masthead: a notation band replaces the datum row, which moves to the foot as the plate's provenance (#2143)

### DIFF
--- a/.design-sync/previews/EphemeristsMasthead.tsx
+++ b/.design-sync/previews/EphemeristsMasthead.tsx
@@ -1,25 +1,31 @@
 import { EphemeristsMasthead } from 'worldzero-frontend'
 
 // The Ephemerists' engraved masthead (#1656) — the almanac plate that replaced
-// the deco wordmark. An ensō-ruled sigil, the faction wordmark, a four-glyph
-// register row, and a datum row carrying the surface's own timestamp.
+// the deco wordmark. An ensō-ruled sigil, the faction wordmark, and the NOTATION
+// BAND: a row of mathematical marks whose count is measured off the band's own
+// rendered width and whose draw is seeded per surface (#2143).
 //
 // Two size tables: `page` for a surface header, `card` for the reduced cut that
-// rides on a card. `date` is optional — a surface with no timestamp of its own
-// (a praxis still being drafted) leaves the datum cell empty rather than
-// inventing one.
+// rides on a card. `seed` is required and must be stable per surface — a task or
+// praxis id. Two surfaces with different seeds wear different rows; one surface
+// wears the same row across every re-render, which is what makes a screenshot of
+// it reproducible.
+//
+// The datum row — date, right ascension, declination — used to sit here. It
+// moved to `EphemeristsColophon` at the foot of the sheet, where it is labelled
+// as the PLATE's provenance rather than left as a bare coordinate pair (#2124).
 
 // The page cut: the full plate as a surface header.
 export function PageHeader() {
-  return <EphemeristsMasthead slug="ephemerists" scale="page" date="2026-07-14T09:20:00Z" />
+  return <EphemeristsMasthead slug="ephemerists" scale="page" seed="task:314" />
 }
 
 // The reduced cut that rides on a card surface.
 export function CardHeader() {
-  return <EphemeristsMasthead slug="ephemerists" scale="card" date="2026-07-14T09:20:00Z" />
+  return <EphemeristsMasthead slug="ephemerists" scale="card" seed="task:314" />
 }
 
-// No timestamp — the datum cell is deliberately left empty.
-export function Undated() {
-  return <EphemeristsMasthead slug="ephemerists" scale="card" date={null} />
+// A second surface at the same scale — the band differs because the seed does.
+export function CardHeaderOtherSurface() {
+  return <EphemeristsMasthead slug="ephemerists" scale="card" seed="praxis:314" />
 }

--- a/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsMasthead.tsx
@@ -1,10 +1,12 @@
+import { useTranslation } from "react-i18next";
 import { EphemeristsSigil } from "../sigil/EphemeristsSigil";
+import { EphemeristsNotationBand } from "./EphemeristsNotationBand";
 import {
   BAND_INK,
-  BAND_QUIET,
   BRASS,
   CAPS,
   GOLD,
+  QUIET,
   READING,
 } from "./ephemeristsPlate";
 import { factionName } from "../../utils/factions";
@@ -15,10 +17,17 @@ import { formatDate } from "../../utils/dates";
  * end of the deco wordmark it replaces.
  *
  * A row: the kite sigil on the left, and a column holding two stacked bands —
- * the wordmark in incised small caps, and a datum row of date, right ascension
- * and declination, ruled off above and below and closed by the sigil again at
- * inline scale. A four-kanji register sat between them until #1909 cut all eight
- * of its strings; the note below the coordinates records what went.
+ * the wordmark in incised small caps, and the NOTATION BAND, a row of
+ * mathematical marks ruled off above and below. A four-kanji register sat
+ * between them until #1909 cut all eight of its strings; the note below the
+ * coordinates records what went.
+ *
+ * A DATUM ROW held the third slot until #2143 — date, right ascension and
+ * declination, closed by the sigil again at inline scale. It did not die: it
+ * moved to {@link EphemeristsColophon} at the foot of the sheet, gained a label
+ * naming it the PLATE's provenance, and left its two brass rules behind for the
+ * notation band to inherit. See the colophon for why the move is a requirement
+ * and not a layout preference.
  *
  * WHAT IT REPLACED, AND WHY IT IS ONE COMPONENT. Four surfaces each drew the
  * same centred stack — a 150–176px winged sun disc over the faction's name in
@@ -28,27 +37,40 @@ import { formatDate } from "../../utils/dates";
  * rather than a fifth copy. The winged disc goes with it: #1634's ruling is that
  * the sigil is the only mark, and the disc was only ever the wordmark's crown.
  *
- * IT MOUNTS ON THE CORNICE BAND. Its two inks — {@link BAND_INK} for the
- * wordmark, {@link BAND_QUIET} for the datum row — are the pair measured against
- * `--faction-ephemerists-plate-band`, and all four mounts are that band. A plate
- * mount would be a different (ink, ground) pairing and therefore a prop, not an
- * assumption to leave standing: WORLD_ZERO_STYLE §3's rule is that a component's
- * inks belong to the sheet they were measured on. Nothing here flips with the
- * theme; the whole plate register is theme-invariant (#1627).
+ * IT MOUNTS ON THE CORNICE BAND. Its ink is {@link BAND_INK}, measured 7.59:1
+ * against `--faction-ephemerists-plate-band`, and all its mounts are that band.
+ * A plate mount would be a different (ink, ground) pairing and therefore a prop,
+ * not an assumption to leave standing: WORLD_ZERO_STYLE §3's rule is that a
+ * component's inks belong to the sheet they were measured on — which is exactly
+ * why {@link EphemeristsColophon} below, on the SHEET, takes different inks.
+ *
+ * NOTHING ON THE BAND FLIPS WITH THE THEME, and the reason narrowed in #2141.
+ * It used to be that the whole plate register was theme-invariant (#1627); that
+ * is no longer true — the register gained a light half, and `[data-theme="dark"]`
+ * now declares `-plate-bg`, `-plate-ink`, `-plate-brass` and a dozen more. What
+ * survives is smaller and load-bearing: `-plate-band`, `-plate-band-ink`,
+ * `-plate-band-quiet` and `-plate-brass-rule` are declared once at `:root` and
+ * absent from the dark cascade ON PURPOSE (#2140's compass-blue ruling). Their
+ * absence down there is the decision, not an omission.
  *
  * TWO SCALES, ONE PROP. `page` heads a whole page, `card` heads a sheet. The
  * design carries both, and every rung of both tables below is on the type or
  * spacing scale — see {@link SIZES} for the three places the scale had no step.
  */
 
-/** The design's grid. It was shared by the glyph row and the datum row so their
- *  cells lined up; the glyph row is gone (#1909) and the datum row keeps it. The
- *  fourth column is narrower and right-aligned: it is the row's closing mark
- *  rather than a fourth reading. */
-const COLUMNS = "1.1fr 1fr 1fr 0.9fr";
+/*
+ * THE DESIGN'S FOUR-COLUMN GRID WENT WITH THE DATUM ROW (#2143).
+ *
+ * `1.1fr 1fr 1fr 0.9fr` was shared by the glyph row and the datum row so their
+ * cells lined up. The glyph row left in #1909 and the datum row in #2143, and
+ * neither of the two things that replaced them wants a grid: the notation band
+ * spaces itself from a measured width, and the colophon is one sentence with a
+ * mark after it. Recorded as an absence so the next reader does not re-derive
+ * four columns for a row that no longer has four cells.
+ */
 
 /**
- * THE DATUM ROW'S COORDINATES — an easter egg, and a fixed pair.
+ * THE COLOPHON'S COORDINATES — an easter egg, and a fixed pair.
  *
  * The design hardcoded a different plausible pair per surface, which is
  * decoration wearing the appearance of data. Owner ruling: the date is real (the
@@ -65,8 +87,15 @@ const COLUMNS = "1.1fr 1fr 1fr 0.9fr";
  *    as a POSITIVE hour angle, which is what keeps the figure inside 0–24ʰ;
  *    measured eastward the same place reads 15ʰ 47ᵐ.
  *
- * It is never labelled in user-visible copy, and it must not become one. An egg
- * rewards noticing; a caption spends it.
+ * THE "NEVER LABEL IT" RULE IS REVERSED (#2124, closed into #2143). It used to
+ * read: an egg rewards noticing, a caption spends it. #2124 reported the bare
+ * `+44° 03′` sitting beside a player's name and date as a privacy risk — that
+ * the site was publishing that player's location. The value cannot leak
+ * anything; it is one constant, identical on every surface for every player.
+ * But the misreading is real and it comes from PLACEMENT: a coordinate next to
+ * a byline reads as belonging to that byline. So the owner's ruling is that the
+ * line MUST now say whose position it is. The label is the fix, and the egg is
+ * spent on purpose.
  */
 const RIGHT_ASCENSION = "8ʰ 13ᵐ";
 const DECLINATION = "+44° 03′";
@@ -79,13 +108,14 @@ const DECLINATION = "+44° 03′";
  * the four English glosses that `title`'d them. No other faction had a register
  * row, and the audit ruled the masthead a generic surface, so the slot goes
  * rather than settling to a shared wording — there is nothing shared to settle
- * onto. The wordmark now sits straight above the datum row.
+ * onto. The wordmark now sits straight above the notation band.
  *
- * ponytail: this leaves a masthead of two bands where the design drew three, and
- * the datum row inherits none of the register's rules. Ceiling: I have no
- * browser, so the two-band proportion is unverified at either scale. Upgrade
- * path: `frontend-style` re-rules the wordmark/datum seam, or the audit's own
- * "put it back in intentionally" restores a register under keys of its own.
+ * ponytail: this leaves a masthead of two bands where the design drew three.
+ * Ceiling: I have no browser, so the two-band proportion is unverified at either
+ * scale — and #2143's 5px-to-9px opening was ruled precisely to give the band
+ * room the register used to hold. Upgrade path: `frontend-style` re-rules the
+ * wordmark/band seam, or the audit's own "put it back in intentionally" restores
+ * a register under keys of its own.
  */
 
 export type MastheadScale = "page" | "card";
@@ -96,14 +126,16 @@ interface MastheadSize {
    *  dimensions and the mark is ~15% wider here than it was. Ornament. */
   sigil: number;
   wordmark: string;
+  /** The datum row's type rung. It went to the foot with the row it sized
+   *  (#2143), so this table now feeds {@link EphemeristsColophon} as well as
+   *  the masthead — one table, because the two are one lockup split across the
+   *  sheet and a colophon a rung off its own masthead reads as a stray. */
   datum: string;
   padding: string;
   gap: string;
-  /** The grid's own column gap. Ornament geometry rounded to the scale. */
-  columnGap: string;
-  /** The datum row's closing sigil. It used to sit below #1635's 20px reduced
-   *  cut on purpose; v2 is filled rather than stroked and has no cut, so this
-   *  is now simply the size the datum row was drawn at. */
+  /** The datum row's closing sigil, and now the colophon's. It used to sit
+   *  below #1635's 20px reduced cut on purpose; v2 is filled rather than
+   *  stroked and has no cut, so this is simply the size the row was drawn at. */
   inlineSigil: number;
 }
 
@@ -133,7 +165,6 @@ const SIZES: Record<MastheadScale, MastheadSize> = {
     datum: "var(--text-md)",
     padding: "var(--space-xl) var(--space-xl) var(--space-lg)",
     gap: "var(--space-xl)",
-    columnGap: "var(--space-lg)",
     inlineSigil: 14,
   },
   card: {
@@ -142,40 +173,40 @@ const SIZES: Record<MastheadScale, MastheadSize> = {
     datum: "var(--text-base)",
     padding: "var(--space-md) var(--space-lg) var(--space-sm)",
     gap: "var(--space-lg)",
-    columnGap: "var(--space-md)",
     inlineSigil: 12,
   },
 };
 
 /**
- * The datum row's date cell, from the surface's own timestamp.
+ * The colophon's date, from the surface's own timestamp.
  *
  * Owner ruling: the date is REAL — a praxis's submission, a task's filing —
- * where the surface has one, and the cell is left EMPTY where it has none. So
- * the guard is not defensive tidiness, it is the ruling: `formatDate` renders an
- * absent or malformed timestamp as the literal string "Invalid Date", which is
- * an invention rather than a blank, and the masthead is exactly the surface a
+ * where the surface has one, and it is left OUT where it has none. So the guard
+ * is not defensive tidiness, it is the ruling: `formatDate` renders an absent or
+ * malformed timestamp as the literal string "Invalid Date", which is an
+ * invention rather than a blank, and a provenance line is exactly the place a
  * player would read it off as data. Guarded here rather than at each mount,
- * because four mounts guarding separately is three chances to forget.
+ * because mounts guarding separately is a chance each to forget.
  */
 function datumDate(iso: string | null | undefined): string | undefined {
   if (!iso || Number.isNaN(new Date(iso).getTime())) return undefined;
   return formatDate(iso);
 }
 
-export function EphemeristsMasthead({ slug, scale, date }: {
+export function EphemeristsMasthead({ slug, scale, seed }: {
   /** The faction whose name the wordmark carries — the mounts' own slug. */
   slug: string | null | undefined;
   scale: MastheadScale;
   /**
-   * The surface's OWN timestamp, ISO. Optional because a surface may genuinely
-   * have none (the composer drafting a praxis that does not exist yet); the cell
-   * is then left empty rather than filled with an invention.
+   * Stable per SURFACE — a task or praxis id, prefixed so a task 7 and a praxis
+   * 7 do not draw one band. It seeds the notation band's draw, and it is a
+   * REQUIRED prop rather than an optional one with a fallback: a mount that
+   * forgets it would fall back to a shared default, and every Ephemerists
+   * surface in the app would wear the same row of marks.
    */
-  date?: string | null;
+  seed: string;
 }) {
   const size = SIZES[scale];
-  const grid = { display: "grid", gridTemplateColumns: COLUMNS, gap: `0 ${size.columnGap}` } as const;
 
   return (
     <div
@@ -204,37 +235,101 @@ export function EphemeristsMasthead({ slug, scale, date }: {
           {factionName(slug)}
         </div>
 
-        {/* The datum row. It used to sit under the four-kanji register, which
-            carried the design's 1px + 3px-double rules; #1909 cut all eight of
-            the register's strings, so the rules move here to keep the wordmark
-            reading as an engraved band rather than free type.
-
-            `tabular-nums` is the design's, and it is doing real
-            work: three of the four cells are figures that must not shimmy as the
-            date changes underneath them. */}
-        <div
-          style={{
-            ...grid,
-            marginTop: "var(--space-xs)",
-            padding: "var(--space-sm) 0",
-            borderTop: `1px solid ${BRASS}`,
-            borderBottom: `3px double ${BRASS}`,
-            fontFamily: READING,
-            fontSize: size.datum,
-            fontVariantNumeric: "tabular-nums",
-            color: BAND_QUIET,
-            lineHeight: 1,
-            alignItems: "center",
-          }}
-        >
-          <span>{datumDate(date)}</span>
-          <span>{RIGHT_ASCENSION}</span>
-          <span>{DECLINATION}</span>
-          <span style={{ justifySelf: "end" }}>
-            <EphemeristsSigil size={size.inlineSigil} color={GOLD} />
-          </span>
-        </div>
+        {/* The notation band, which is where the design's 1px + 3px-double
+            rules now live. They were the four-kanji register's; #1909 cut the
+            register and left them to the datum row, and #2143 moved the datum
+            row to the foot and left them here. Three tenants, one pair of
+            rules, and the reason has not changed once: without them the
+            wordmark reads as free type rather than as an engraved band. */}
+        <EphemeristsNotationBand seed={seed} />
       </div>
+    </div>
+  );
+}
+
+/**
+ * THE COLOPHON (#2143 + #2124) — the datum row, at the foot of the sheet, said
+ * out loud.
+ *
+ * The masthead's third band was the datum row and the notation band took its
+ * slot. The row did not die: the coordinates are a standing owner ruling, and
+ * they are the one reading on an Ephemerists surface that is real rather than
+ * decorative, so they move to where a plate's provenance line belongs — the
+ * foot — rather than to the bin.
+ *
+ * IT IS LABELLED, AND THAT IS THE POINT OF THE MOVE. #2124 read the bare
+ * `+44° 03′` as the site publishing a player's location. It cannot be: the pair
+ * is a constant, byte-identical on every surface for every player. But a
+ * coordinate beside a byline reads as belonging to that byline, so the owner
+ * ruled the line must name whose position it is. Two consequences bind any
+ * future mount of this component:
+ *
+ *  • it says "the Ephemerists' station" in its own copy, so a reader can tell it
+ *    describes the INSTRUMENT and not the author; and
+ *  • it may not sit beside the author, the submission date, or any other
+ *    player-scoped field, on any surface or form factor. The foot of the sheet
+ *    is the placement that satisfies that, and the brass rule above it is what
+ *    separates it from whatever the sheet's last section happened to be.
+ *
+ * ITS INKS ARE THE SHEET'S, NOT THE BAND'S, which is §3's rule arriving one
+ * component later: the masthead was measured on the compass blue and this is
+ * mounted on the vellum plate and the dark plate. {@link QUIET} is the ink
+ * measured on both of the sheet's own stops (`ephemerists plate, quiet ink` and
+ * `ephemerists page ground, quiet ink` in `factionContrast.test.ts`), and
+ * {@link BRASS} is the rule the sheet's other rules already take. The band's
+ * `GOLD` would read 1.02:1 here and `BAND_INK` is not a sheet ink at all.
+ *
+ * NOT MOUNTED ON THE COMPOSER, and that is a structural block rather than a
+ * choice: #1828 makes the composer's cast a full-bleed band that closes the
+ * sheet with a negative bottom margin, so a trailing sibling is pulled back up
+ * over the brass instead of sitting under it. The skin's own rune-strip comment
+ * records the same block for the same reason. The composer therefore heads with
+ * the notation band and carries no colophon.
+ */
+export function EphemeristsColophon({ scale, date }: {
+  scale: MastheadScale;
+  /** The surface's OWN timestamp, ISO. See {@link datumDate} for why an absent
+   *  or unreadable one drops the whole clause rather than blanking a cell. */
+  date?: string | null;
+}) {
+  const { t } = useTranslation("factions");
+  const size = SIZES[scale];
+  const struck = datumDate(date);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "var(--space-md)",
+        marginTop: "var(--space-xl)",
+        paddingTop: "var(--space-md)",
+        borderTop: `1px solid ${BRASS}`,
+        fontFamily: READING,
+        fontSize: size.datum,
+        // The design's, and it is doing real work: the line is mostly figures
+        // and they must not shimmy as the date changes underneath them.
+        fontVariantNumeric: "tabular-nums",
+        letterSpacing: "0.08em",
+        color: QUIET,
+        lineHeight: 1.4,
+      }}
+    >
+      <span>
+        {struck
+          ? t("ephemerists.plate.provenance", {
+              date: struck,
+              rightAscension: RIGHT_ASCENSION,
+              declination: DECLINATION,
+            })
+          : t("ephemerists.plate.provenanceUndated", {
+              rightAscension: RIGHT_ASCENSION,
+              declination: DECLINATION,
+            })}
+      </span>
+      {/* The datum row's closing mark, moved with the row it closed. */}
+      <EphemeristsSigil size={size.inlineSigil} color={BRASS} />
     </div>
   );
 }

--- a/frontend/src/components/factionMarks/EphemeristsNotationBand.tsx
+++ b/frontend/src/components/factionMarks/EphemeristsNotationBand.tsx
@@ -1,0 +1,204 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { BAND_INK, BRASS_RULE, READING } from "./ephemeristsPlate";
+
+/**
+ * THE NOTATION BAND (#2143) — the masthead's last line, and the datum row's
+ * replacement.
+ *
+ * A row of mathematical marks, each at its own size, ruled off by a `1px` brass
+ * hairline above and a `3px double` brass rule below. It inherits those rules
+ * from the datum row it replaces; what it does NOT inherit is the datum row's
+ * `5px` lead, which opens to `9px` so the rules sit clear of the ascenders and
+ * descenders the varied sizes throw. The asymmetry — hairline above, heavy rule
+ * below — is deliberate: the heavy rule closes the head against the sheet, so
+ * the band reads as the masthead's last line rather than the body's first.
+ *
+ * THE MARKS ARE ON THE BAND, so their ink is {@link BAND_INK} — the same
+ * `-plate-band-ink` the wordmark takes, measured 7.59:1 on the compass blue in
+ * BOTH cascades (#2140/#2141). The rules take `-plate-brass-rule`, the faction's
+ * one line brass, 3.73:1 on that blue. Neither flips with the theme, because the
+ * band does not.
+ *
+ * `aria-hidden`, and it holds no text node assistive technology reaches: the
+ * marks are ornament with no reading, and a screen reader spelling out
+ * "integral, sum, therefore" across every Ephemerists surface would be noise.
+ */
+
+/**
+ * The pool. ~34 marks, all from the mathematical operators the plate's metaphor
+ * would plausibly carry — a field journal's working, not a font specimen. The
+ * pool's SIZE is the point rather than its membership: at 34 marks a band of 13
+ * repeats rarely enough to read as handwriting.
+ */
+const MARKS = [
+  "∫", "∑", "∏", "√", "∮", "∇", "∂", "≡", "≈", "∝", "∞",
+  "⊕", "⊗", "⊙", "⊥", "∠", "∴", "∵", "±", "∓", "×", "÷",
+  "⊂", "⊃", "∪", "∩", "∈", "∀", "∃", "∅", "≪", "≫", "∷", "∡",
+];
+
+/**
+ * The size cycle, in raw pixels, and it stays four steps wide.
+ *
+ * Ornament type (WORLD_ZERO_STYLE, "the ornament escape hatch"): these are the
+ * optical sizes of a drawn mark, not a tier of the type ramp — 11 happens to sit
+ * on `--text-md` and still is not label-tier text. The SPREAD is what makes the
+ * row read as a hand rather than as a font sample, so #2143 rules it may not be
+ * compressed to four adjacent sizes.
+ */
+const MARK_SIZES = [11, 13, 15, 17];
+
+/**
+ * One mark's share of the row, in px. The design drew 26; the owner HALVED the
+ * density to 52 (#2143), which lands a page masthead near 13 marks and a card
+ * near 8 — the SPACING constant across the scales, and the count varying.
+ */
+const PITCH = 52;
+
+/** The floor keeps a 260px phone card from spreading five marks into a row of
+ *  bullets; the ceiling is the pool's own size, and also the length of the draw
+ *  below, so no band ever runs out of marks. */
+const FLOOR = 7;
+const CEILING = MARKS.length;
+
+/**
+ * How many marks a band of this width carries. Exported for its test: this is
+ * the one piece of arithmetic here, and it is measured off a real element, so
+ * the only place it can be checked without a browser is at the function.
+ *
+ * An unmeasured band (width 0, before the layout effect runs, or under the
+ * SSR-only test harness where effects never run) draws NOTHING rather than the
+ * floor — a band that paints seven marks and then jumps to thirteen is the
+ * twitch this issue exists to remove.
+ */
+export function markCount(width: number): number {
+  if (!(width > 0)) return 0;
+  return Math.min(CEILING, Math.max(FLOOR, Math.round(width / PITCH)));
+}
+
+/** FNV-1a over the seed's code units — a hash, not a checksum: all it owes is a
+ *  well-spread 32-bit state for the generator below. */
+function hashSeed(seed: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < seed.length; index += 1) {
+    hash ^= seed.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/** mulberry32 — 32 bits of state, one multiply-shift round. Chosen because it
+ *  is short enough to read in one sitting and needs no dependency; nothing here
+ *  is cryptographic and nothing depends on the distribution beyond "looks
+ *  unpatterned at 34 draws". */
+function mulberry32(state: number): () => number {
+  let a = state;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+export interface NotationMark {
+  glyph: string;
+  /** Raw px — ornament geometry. See {@link MARK_SIZES}. */
+  size: number;
+}
+
+/**
+ * The draw, seeded from something stable about the SURFACE — a task or praxis
+ * id, never `Math.random()` at render.
+ *
+ * Two things follow from the seed, and both are the reason for it. A band that
+ * redrew itself every render would twitch whenever anything unrelated moved on
+ * the page — a vote lands, a filter changes, a hover fires — and a screenshot of
+ * it would never reproduce, which is exactly what this epic's visual QA needs.
+ *
+ * It draws the FULL ceiling and the band slices it, rather than drawing `n`.
+ * That is what makes a resize add and remove marks at the tail instead of
+ * redrawing the whole row: the first mark of a 7-mark band and of a 13-mark band
+ * from the same seed are the same mark.
+ */
+export function drawNotation(seed: string): NotationMark[] {
+  const next = mulberry32(hashSeed(seed));
+  return Array.from({ length: CEILING }, () => ({
+    glyph: MARKS[Math.floor(next() * MARKS.length)],
+    size: MARK_SIZES[Math.floor(next() * MARK_SIZES.length)],
+  }));
+}
+
+/** The twin of `SegmentedRail`'s: a layout effect measures before the browser
+ *  paints, so the band fills in without a frame of emptiness, and `useEffect` is
+ *  the Node-side fallback where there is no layout to read. */
+const useMeasureEffect = typeof document === "undefined" ? useEffect : useLayoutEffect;
+
+export function EphemeristsNotationBand({ seed }: {
+  /**
+   * Stable per SURFACE. Every distinct value draws a different row, and one
+   * value draws the same row forever — see {@link drawNotation}.
+   */
+  seed: string;
+}) {
+  const band = useRef<HTMLDivElement>(null);
+  const [width, setWidth] = useState(0);
+
+  const measure = useCallback(() => {
+    const element = band.current;
+    if (element) setWidth(element.clientWidth);
+  }, []);
+
+  useMeasureEffect(measure);
+
+  useEffect(() => {
+    const element = band.current;
+    // Guarded as `SegmentedRail` guards its own: the constructor is a browser
+    // global and this module is imported by a Node-side harness.
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [measure]);
+
+  const marks = useMemo(() => drawNotation(seed), [seed]);
+
+  return (
+    <div
+      ref={band}
+      aria-hidden="true"
+      style={{
+        display: "flex",
+        alignItems: "baseline",
+        justifyContent: "space-between",
+        marginTop: "var(--space-xs)",
+        // eslint-disable-next-line local/no-raw-style-values -- ornament: #2143 opens the datum row's 5px lead to 9px so the two brass rules clear the ascenders and descenders the size cycle throws. Off both neighbouring rungs (8 and 12) and in register with the raw mark sizes below.
+        padding: "9px 0",
+        borderTop: `1px solid ${BRASS_RULE}`,
+        borderBottom: `3px double ${BRASS_RULE}`,
+        fontFamily: READING,
+        color: BAND_INK,
+        lineHeight: 1,
+        // Ornament geometry: the tallest mark in the cycle, so the band holds
+        // its box between the first layout pass and the measured draw and the
+        // masthead below it never reflows.
+        minHeight: MARK_SIZES[MARK_SIZES.length - 1],
+        overflow: "hidden",
+      }}
+    >
+      {marks.slice(0, markCount(width)).map((mark, index) => (
+        <span
+          key={index}
+          // ornament: the 11/13/15/17 optical cycle, which #2143 rules may not
+          // be compressed. See MARK_SIZES. A plain comment rather than a
+          // directive because the value arrives through `mark.size` — the rule
+          // reads literals, and an unused directive fails the lint run.
+          style={{ fontSize: mark.size }}
+        >
+          {mark.glyph}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default EphemeristsNotationBand;

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsMasthead.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsMasthead.test.tsx
@@ -1,37 +1,44 @@
 /**
- * THE ENGRAVED MASTHEAD (#1634).
+ * THE ENGRAVED MASTHEAD (#1634), and the COLOPHON that #2143 split off it.
  *
- * The seam is the component's rendered markup given props — a masthead has no
- * behaviour, so what can be wrong about it is what it emits. Four claims are
- * worth a test rather than an eyeball, and the first two are the ones a
- * screenshot would pass:
+ * The seam is the components' rendered markup given props — neither has any
+ * behaviour, so what can be wrong about them is what they emit. The claims worth
+ * a test rather than an eyeball, and the first two are the ones a screenshot
+ * would pass:
  *
  *  • THE TWO SCALES MUST DIFFER. `page` and `card` are one prop apart and every
  *    value in both tables is a `var()`, so a table typo renders a perfectly
  *    plausible masthead at the wrong size on half the surfaces. Pin the sigil's
  *    emitted box, which is a NUMBER and therefore the one thing here a
  *    stylesheet cannot silently absorb.
- *  • THE DATUM ROW'S INLINE SIGIL MUST TAKE THE REDUCED CUT. Both inline sizes
- *    (14 and 12) sit under #1635's 20px threshold, so the mark must arrive
- *    without its crossed axes. A full cut at 12px still renders — as a smudge —
- *    which is exactly what no markup assertion catches unless it counts.
- *  • THE COORDINATES ARE FIXED AND THE DATE IS THE SURFACE'S. The easter egg is
- *    only an egg if both cells point at the same real place on every surface;
- *    the moment one of them starts varying it is decoration again.
- *  • EVERY KANJI CARRIES ITS ENGLISH. The row is unreadable to most players by
- *    design, and `title` is the whole of the reveal (#1637).
+ *  • THE CLOSING SIGIL MUST TAKE THE REDUCED CUT. Both inline sizes (14 and 12)
+ *    sit under #1635's 20px threshold, so the mark must arrive without its
+ *    crossed axes. A full cut at 12px still renders — as a smudge — which is
+ *    exactly what no markup assertion catches unless it counts.
+ *  • THE COORDINATES ARE FIXED, THE DATE IS THE SURFACE'S, AND THEY ARE NOW
+ *    LABELLED. The easter egg is only an egg if both cells point at the same
+ *    real place on every surface. #2124 then reversed the "never label it" half:
+ *    a bare coordinate pair reads as belonging to whatever byline is near it, so
+ *    the line must name the PLATE as whose station it is. An unlabelled
+ *    provenance line is the defect that issue was filed about.
+ *  • AND THE COORDINATES MUST HAVE LEFT THE MASTHEAD. The whole of #2124's fix
+ *    is placement; a masthead that still prints them has moved nothing.
  *
- * SSR-only harness (renderToStaticMarkup, no DOM, effects never run).
+ * SSR-only harness (renderToStaticMarkup, no DOM, effects never run) — which is
+ * why the notation band renders EMPTY here and is tested at its own arithmetic
+ * in `ephemeristsNotationBand.test.tsx`.
  */
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it, expect } from "vitest";
 import "../../../i18n";
-import { EphemeristsMasthead } from "../EphemeristsMasthead";
+import { EphemeristsColophon, EphemeristsMasthead } from "../EphemeristsMasthead";
 
 /** The v2 kite's opening move — the swept sail, first of its six shapes. */
 const SAIL = "M19.1 30.8";
-const render = (scale: "page" | "card", date?: string | null) =>
-  renderToStaticMarkup(<EphemeristsMasthead slug="ephemerists" scale={scale} date={date} />);
+const render = (scale: "page" | "card") =>
+  renderToStaticMarkup(<EphemeristsMasthead slug="ephemerists" scale={scale} seed="task:1" />);
+const colophon = (scale: "page" | "card", date?: string | null) =>
+  renderToStaticMarkup(<EphemeristsColophon scale={scale} date={date} />);
 
 describe("EphemeristsMasthead — the two scales", () => {
   it("hands the sigil one number and gets a square box back at each scale", () => {
@@ -42,46 +49,100 @@ describe("EphemeristsMasthead — the two scales", () => {
     expect(render("card")).toContain('width="44" height="44"');
   });
 
-  it("draws the datum row's closing sigil at its own inline size", () => {
-    expect(render("page")).toContain('width="14" height="14"');
-    expect(render("card")).toContain('width="12" height="12"');
-    // Two marks per masthead — the big one and the datum row's closer — and
-    // BOTH are now the full drawing. #1635's reduced cut drew a sparser mark
-    // below 20px because its stroke went sub-pixel; v2 is filled and has no
-    // cut, so the two mounts differ only in size.
-    for (const scale of ["page", "card"] as const) {
-      expect(render(scale).match(new RegExp(SAIL, "g")) ?? []).toHaveLength(2);
-    }
-  });
-
   it("carries the wordmark at a different rung on each scale", () => {
     expect(render("page")).toContain("font-size:var(--text-title)");
     expect(render("card")).toContain("font-size:var(--text-content)");
   });
+
+  it("draws ONE mark, because the second one left with the datum row", () => {
+    // #2143 moved the datum row and its closing sigil to the foot of the sheet.
+    // Two marks in a masthead now means the colophon has been mounted inside it.
+    for (const scale of ["page", "card"] as const) {
+      expect(render(scale).match(new RegExp(SAIL, "g")) ?? []).toHaveLength(1);
+    }
+  });
 });
 
-describe("EphemeristsMasthead — the datum row", () => {
-  it("prints the surface's own date and leaves the cell empty when there is none", () => {
-    expect(render("page", "2026-08-02T09:00:00Z")).toContain("2026");
-    expect(render("page")).not.toContain("2026");
-    expect(render("page", null)).not.toContain("2026");
+describe("EphemeristsMasthead — the notation band", () => {
+  const html = render("page");
+
+  it("keeps the datum row's two brass rules, which the band inherits", () => {
+    expect(html).toContain("border-top:1px solid var(--faction-ephemerists-plate-brass-rule)");
+    expect(html).toContain("border-bottom:3px double var(--faction-ephemerists-plate-brass-rule)");
+  });
+
+  it("opens the datum row's lead from 5px to 9px", () => {
+    // The ruled asymmetry only works if the rules clear the marks' ascenders
+    // and descenders; `var(--space-sm)` (8px) is the value this replaced and is
+    // what a well-meaning tokenizing pass would put back.
+    expect(html).toContain("padding:9px 0");
+  });
+
+  it("hides the band from assistive technology entirely", () => {
+    // The marks are ornament with no reading. A screen reader spelling out
+    // "integral, sum, therefore" on every Ephemerists surface is noise.
+    expect(html).toMatch(/aria-hidden="true"[^>]*style="display:flex;align-items:baseline/);
+  });
+
+  it("prints no coordinate at all — they left for the foot of the sheet", () => {
+    for (const scale of ["page", "card"] as const) {
+      expect(render(scale)).not.toContain("8ʰ 13ᵐ");
+      expect(render(scale)).not.toContain("+44° 03′");
+    }
+  });
+});
+
+describe("EphemeristsColophon — the plate's provenance", () => {
+  it("points both coordinates at one place, at both scales", () => {
+    // 44.0534 N / 123.3704 W — the fairgrounds. Never varied.
+    for (const scale of ["page", "card"] as const) {
+      expect(colophon(scale, "2026-08-02T09:00:00Z")).toContain("8ʰ 13ᵐ");
+      expect(colophon(scale, "2026-08-02T09:00:00Z")).toContain("+44° 03′");
+    }
+  });
+
+  it("names whose station it is, so it cannot read as the author's position", () => {
+    // #2124's whole ruling: the value is a constant and leaks nothing, but a
+    // bare coordinate pair beside a byline reads as belonging to that byline.
+    // A regression that drops the label is invisible to every other assertion
+    // in this file, because the figures would still be right.
+    // Both keys, because the dated one opens with the striking and the undated
+    // one opens with the station — the label may not be a casualty of the
+    // branch that drops the date.
+    for (const html of [colophon("page", "2026-08-02T09:00:00Z"), colophon("card")]) {
+      expect(html).toMatch(/[Ss]tation of the Ephemerists/);
+    }
+  });
+
+  it("prints the surface's own date and drops the clause when there is none", () => {
+    expect(colophon("page", "2026-08-02T09:00:00Z")).toContain("2026");
+    expect(colophon("page")).not.toContain("2026");
+    expect(colophon("page", null)).not.toContain("2026");
   });
 
   it("prints nothing rather than 'Invalid Date' for a timestamp it cannot read", () => {
-    // The owner's ruling is that the date is REAL or the cell is empty, and
+    // The owner's ruling is that the date is REAL or the clause is absent, and
     // `formatDate` renders an unparseable value as that literal string — an
-    // invention, on the one row a player would read as data.
+    // invention, on the one line a player would read as data.
     for (const bad of ["", "not a date"]) {
-      expect(render("page", bad)).not.toContain("Invalid Date");
+      expect(colophon("page", bad)).not.toContain("Invalid Date");
     }
   });
 
-  it("points both coordinates at one place, on every surface and both scales", () => {
-    // 44.0534 N / 123.3704 W — the fairgrounds. Never labelled, never varied.
-    for (const scale of ["page", "card"] as const) {
-      expect(render(scale)).toContain("8ʰ 13ᵐ");
-      expect(render(scale)).toContain("+44° 03′");
-    }
+  it("closes with the datum row's own mark, at its own inline size", () => {
+    expect(colophon("page")).toContain('width="14" height="14"');
+    expect(colophon("card")).toContain('width="12" height="12"');
+  });
+
+  it("takes the SHEET's inks, not the band's", () => {
+    // §3: a component's inks belong to the sheet they were measured on, and
+    // this one left the compass blue. `-plate-gold` reads 1.02:1 on the vellum
+    // and `-plate-band-ink` was never measured on a sheet at all.
+    const html = colophon("page", "2026-08-02T09:00:00Z");
+    expect(html).toContain("--faction-ephemerists-plate-quiet");
+    expect(html).toContain("--faction-ephemerists-plate-brass)");
+    expect(html).not.toContain("--faction-ephemerists-plate-gold");
+    expect(html).not.toContain("--faction-ephemerists-plate-band-ink");
   });
 });
 
@@ -109,22 +170,17 @@ describe("EphemeristsMasthead — the register, deleted", () => {
     expect(html).not.toContain('class="eph-gloss"');
     expect(html).not.toContain("</abbr>");
   });
-
-  it("still rules the datum row off, top and bottom", () => {
-    // The register carried the design's 1px + 3px-double band; those rules moved
-    // to the datum row rather than leaving with the copy.
-    expect(html).toContain("3px double");
-  });
 });
 
 describe("EphemeristsMasthead — ink", () => {
-  it("hardcodes no colour and no raw size", () => {
-    const html = render("card", "Aug 2, 2026");
+  it("hardcodes no colour", () => {
+    const html = render("card");
     expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
     // The retired illuminated-codex family may never reach a plate surface.
     expect(html).not.toMatch(/--eph-[a-z]/);
-    // Every ink is a band-measured token; nothing here flips with the theme.
+    // Every ink is a band-measured token; nothing on the band flips with the
+    // theme, and #2141 narrowed the reason without changing the fact.
     expect(html).toContain("--faction-ephemerists-plate-band-ink");
-    expect(html).toContain("--faction-ephemerists-plate-band-quiet");
+    expect(html).toContain("--faction-ephemerists-plate-brass-rule");
   });
 });

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * THE NOTATION BAND (#2143).
+ *
+ * TWO SEAMS, and neither of them is the markup. The band's whole behaviour is
+ * arithmetic that runs against a MEASURED element, and the harness is SSR-only
+ * (renderToStaticMarkup, no DOM, effects never run), so a rendered band here is
+ * an empty band by construction. What can be wrong is therefore checked at the
+ * two exported functions:
+ *
+ *  • THE COUNT. `n = clamp(round(width / 52), 7, 34)` — the owner HALVED the
+ *    design's density, so a `/ 26` that survives review renders a plausible band
+ *    at twice the count on every surface. The floor and the ceiling are the two
+ *    rungs a browser would never show you: a 260px card and a 3000px monitor.
+ *  • THE DRAW IS SEEDED, and that is the whole reason the seed exists. Same
+ *    seed, same row, forever — otherwise a screenshot never reproduces and the
+ *    ornament twitches on every unrelated re-render. Different seeds, different
+ *    rows — otherwise every card in a list wears one band.
+ *
+ * The third claim is the one that makes a RESIZE cheap: the draw is a fixed
+ * 34-mark sequence the band slices, so growing a band appends rather than
+ * redraws. Asserted as a prefix relation, which is the only way to see it.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import {
+  EphemeristsNotationBand,
+  drawNotation,
+  markCount,
+} from "../EphemeristsNotationBand";
+
+describe("EphemeristsNotationBand — the count is measured", () => {
+  it("takes one mark per 52px, which is the owner's halving of the design's 26", () => {
+    // 676 = 13 x 52, the page masthead's own neighbourhood.
+    expect(markCount(676)).toBe(13);
+    // 416 = 8 x 52, the card's. A `/ 26` renders 26 and 16 here.
+    expect(markCount(416)).toBe(8);
+    expect(markCount(690)).toBe(13); // rounds down
+    expect(markCount(702)).toBe(14); // rounds up
+  });
+
+  it("floors at seven so a phone card is a band and not a row of bullets", () => {
+    // 260px / 52 is exactly 5.
+    expect(markCount(260)).toBe(7);
+    expect(markCount(1)).toBe(7);
+  });
+
+  it("ceilings at the pool's own size, so no band outruns the draw", () => {
+    expect(markCount(30_000)).toBe(34);
+    expect(drawNotation("any")).toHaveLength(34);
+  });
+
+  it("draws nothing at all before it has been measured", () => {
+    // Not the floor: a band that paints seven marks and then jumps to thirteen
+    // is the twitch the seeding exists to remove, arriving by another door.
+    expect(markCount(0)).toBe(0);
+    expect(renderToStaticMarkup(<EphemeristsNotationBand seed="task:1" />)).not.toMatch(
+      /<span/,
+    );
+  });
+});
+
+describe("EphemeristsNotationBand — the draw is seeded per surface", () => {
+  const row = (seed: string) => drawNotation(seed).map((mark) => `${mark.glyph}${mark.size}`);
+
+  it("hands the same seed the same row every time", () => {
+    expect(row("praxis:41")).toEqual(row("praxis:41"));
+  });
+
+  it("hands three neighbouring surfaces three different rows", () => {
+    const rows = ["task:1", "task:2", "task:3"].map((seed) => row(seed).join(""));
+    expect(new Set(rows).size).toBe(3);
+  });
+
+  it("varies the size as well as the glyph, across the whole 11/13/15/17 cycle", () => {
+    // A draw that only varied the glyph would still pass every test above; the
+    // spread is what makes the row read as a hand rather than a font sample.
+    const sizes = new Set(drawNotation("task:7").map((mark) => mark.size));
+    expect([...sizes].sort((a, b) => a - b)).toEqual([11, 13, 15, 17]);
+  });
+
+  it("grows at the tail, so a resize appends marks rather than redrawing them", () => {
+    // The draw takes no count — the band slices it — which is what makes the
+    // narrow row a PREFIX of the wide one. A `drawNotation(seed, n)` that
+    // reseeded per length would break this and nothing else.
+    const full = drawNotation("task:9");
+    const narrow = full.slice(0, markCount(260));
+    const wide = full.slice(0, markCount(676));
+    expect(narrow).toHaveLength(7);
+    expect(wide).toHaveLength(13);
+    expect(wide.slice(0, narrow.length)).toEqual(narrow);
+  });
+});

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -98,6 +98,10 @@
     }
   },
   "ephemerists": {
+    "plate": {
+      "provenance": "Plate struck {{date}} · station of the Ephemerists, {{rightAscension}} {{declination}}",
+      "provenanceUndated": "Station of the Ephemerists, {{rightAscension}} {{declination}}"
+    },
     "road": {
       "heading": "The Road",
       "memberTitle": "Your name is in the codex",

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -353,10 +353,19 @@ export default function EphemeristsEditPraxis({ state }: Props) {
                 color: BAND_INK,
               }}
             >
+              {/* NO COLOPHON ON THIS SURFACE, and it is a structural block
+                  rather than a choice: #1828 makes the cast a full-bleed band
+                  that closes the sheet with a negative bottom margin, so a
+                  trailing sibling is pulled back up over the brass instead of
+                  sitting under it — the same block the trailing rune strip
+                  records at the footer below. The composer therefore keeps the
+                  notation band and loses the coordinates, which is also the
+                  placement #2124 wanted least: this is the one Ephemerists
+                  surface whose every field is the author's own. */}
               <EphemeristsMasthead
                 slug={praxis.task_faction_slug}
                 scale={sizes.isMobile ? "card" : "page"}
-                date={praxis.submitted_at ?? praxis.created_at}
+                seed={`praxis:${praxis.id}`}
               />
             </ComposerMasthead>
             {/* The cavetto cornice, beneath the band, carrying the one motion. */}

--- a/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ephemeristsDetail.test.tsx
@@ -381,3 +381,26 @@ describe("Ephemerists praxis detail — the state axes", () => {
     expect(bare.text).not.toContain("Write-up");
   });
 });
+
+describe("Ephemerists praxis detail — the colophon is undated here (#2124)", () => {
+  /**
+   * #2143 moved the datum row to the foot of the sheet and #2124 closed into it
+   * with a PLACEMENT requirement: the coordinates must not sit adjacent to the
+   * author, the date-of-submission, or any other player-scoped field. On a
+   * praxis the surface's own date IS `submitted_at`, so passing it to
+   * `EphemeristsColophon` puts a player's posting date and a real latitude in
+   * ONE SENTENCE — which is the inference #2124 was filed about, not merely
+   * adjacency to it.
+   *
+   * The undated form is therefore a requirement of this surface and not a
+   * styling choice, and nothing else would notice it going away: the component's
+   * own tests cover both branches, and a `date` prop restored here would render
+   * perfectly and read wrong. `EphemeristsTaskDetail` keeps its date — a task's
+   * `created_at` belongs to the task, not to a player.
+   */
+  it("prints the station but never strikes it with a date", () => {
+    const { text } = render(state());
+    expect(text, "the provenance line still names the station").toContain("+44° 03′");
+    expect(text, "and carries no struck date beside it").not.toContain("Plate struck");
+  });
+});

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -123,7 +123,7 @@ import {
   BAND_INK,
   BRASS_LIGHT,
 } from "../../../components/factionMarks/ephemeristsPlate";
-import { EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
+import { EphemeristsColophon, EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
 import { DuelCard } from "../DuelCard";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { formatTimestamp } from "../../../utils/dates";
@@ -395,7 +395,7 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
           <EphemeristsMasthead
             slug={praxis.task_faction_slug}
             scale={desktop ? "page" : "card"}
-            date={praxis.submitted_at ?? praxis.created_at}
+            seed={`praxis:${praxis.id}`}
           />
         </div>
       </div>
@@ -966,6 +966,17 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
             state={state}
             heading={sectionHead(t("detail.sections.comments"))}
             style={{ marginTop: size.sectionGap }}
+          />
+
+          {/* The plate's provenance, at the foot of the sheet (#2143) — the
+              masthead's old datum row, labelled. #2124's requirement is about
+              PLACEMENT as much as wording, and this page is where it bites: the
+              byline, the submission date and the crew all live in the two
+              columns above, and the colophon sits below every one of them,
+              outside both, behind its own rule. See `EphemeristsColophon`. */}
+          <EphemeristsColophon
+            scale={desktop ? "page" : "card"}
+            date={praxis.submitted_at ?? praxis.created_at}
           />
         </div>
       </div>

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -1060,11 +1060,20 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
               PLACEMENT as much as wording, and this page is where it bites: the
               byline, the submission date and the crew all live in the two
               columns above, and the colophon sits below every one of them,
-              outside both, behind its own rule. See `EphemeristsColophon`. */}
-          <EphemeristsColophon
-            scale={desktop ? "page" : "card"}
-            date={praxis.submitted_at ?? praxis.created_at}
-          />
+              outside both, behind its own rule. See `EphemeristsColophon`.
+
+              UNDATED HERE, AND ONLY HERE. #2143's body says "keep the date real
+              (the surface's own)", but #2124's comment — filed later and closed
+              INTO this issue — says the line must not sit adjacent to "the
+              author, the date-of-submission, or any other player-scoped field".
+              On a praxis the surface's own date IS `submitted_at`, so passing it
+              does not merely place the coordinates NEAR a player-scoped field,
+              it puts the two in one sentence: "Plate struck <the day this player
+              posted> ... +44 03'". That is the exact inference #2124 raised, and
+              a reader cannot be expected to unpick it from the label alone.
+              `EphemeristsTaskDetail` still passes its date: a task's
+              `created_at` belongs to the task, not to any player. */}
+          <EphemeristsColophon scale={desktop ? "page" : "card"} />
         </div>
       </div>
     </div>

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -2,7 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
-import { EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
+import { EphemeristsColophon, EphemeristsMasthead } from "../../../components/factionMarks/EphemeristsMasthead";
 import EphemeristsRuneStrip from "../../../components/factionMarks/EphemeristsRuneStrip";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { factionFill, factionName } from "../../../utils/factions";
@@ -418,7 +418,7 @@ export default function EphemeristsTaskDetail({
           <EphemeristsMasthead
             slug={slug}
             scale={desktop ? "page" : "card"}
-            date={task.created_at}
+            seed={`task:${task.id}`}
           />
         </div>
       </div>
@@ -1012,6 +1012,17 @@ export default function EphemeristsTaskDetail({
               heading={sectionHead(t("detail.comments.heading"))}
             />
           </div>
+
+          {/* The plate's provenance, at the foot of the sheet (#2143). It is
+              the masthead's old datum row, labelled — see `EphemeristsColophon`
+              for why the label and this placement are a requirement (#2124) and
+              not a layout preference. It sits OUTSIDE the two-column region and
+              below the comment thread, so nothing player-scoped is beside it,
+              and its own rule separates it from whatever ended above. */}
+          <EphemeristsColophon
+            scale={desktop ? "page" : "card"}
+            date={task.created_at}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #2143

The Ephemerists masthead becomes **kite, wordmark, notation band**. The datum row does not die — it moves to the foot of the sheet as a labelled colophon.

## The seam I tested at

The band's whole behaviour is arithmetic run against a **measured element**, and the frontend harness is SSR-only (`renderToStaticMarkup`, no DOM, effects never run) — so a band rendered in a test is an *empty* band by construction. Testing "does it render 13 marks" is unreachable here. The seam is therefore the two exported pure functions, `markCount(width)` and `drawNotation(seed)`, plus the components' emitted markup for everything that is not the count.

Red first, at that seam:
- `markCount(676) === 13` and `markCount(416) === 8` fail against the design's `/ 26` (they return 26 and 16). That is the owner's halving, and it is the one number a plausible-looking band would hide.
- `colophon(...)` containing `station of the Ephemerists` fails against a bare coordinate pair — the exact defect #2124 was filed about, and one that every figure-checking assertion passes straight over.

## What changed

**New — `frontend/src/components/factionMarks/EphemeristsNotationBand.tsx`**
- `n = clamp(round(measuredWidth / 52), 7, 34)`, measured off the band's own `clientWidth` via a ref + `ResizeObserver`, not off a prop or a breakpoint. The layout effect measures before paint (the `SegmentedRail` idiom), so there is no frame of emptiness; the row carries `minHeight: 17` so the masthead never reflows during that pass.
- The draw is seeded from the surface (`task:<id>` / `praxis:<id>`) through FNV-1a to mulberry32. Never `Math.random()` at render.
- It draws the **full 34** and the band slices, so a resize appends at the tail rather than redrawing the row. That is asserted as a prefix relation.
- Glyph *and* size are drawn; the size cycle stays `11 / 13 / 15 / 17`, uncompressed, under the style guide's ornament hatch.
- `1px` brass hairline above, `3px double` brass rule below, both `--faction-ephemerists-plate-brass-rule`; the datum row's `5px` lead opens to `9px` (per-line ornament hatch — 9 is off both neighbouring rungs and in register with the raw mark sizes).
- `aria-hidden`, no text node assistive technology reaches.

**`EphemeristsMasthead.tsx`**
- Takes a required `seed`; the `date` prop leaves with the datum row. Required rather than optional-with-a-fallback: a defaulted seed would put one row of marks on every Ephemerists surface in the app.
- The four-column grid is gone — recorded as an absence, since neither of the things that replaced it wants a grid.
- **The docstring's "the whole plate register is theme-invariant (#1627)" line is now false and is corrected.** #2141 gave the register a light half; what survives theme-invariant is `-plate-band`, `-band-ink`, `-band-quiet` and `-brass-rule`, and their absence from `[data-theme="dark"]` is the decision rather than an omission.
- New `EphemeristsColophon` — the datum row at the foot of the sheet, with its closing sigil, on the **sheet's** inks rather than the band's (`-plate-quiet`, `-plate-brass`; `-plate-gold` reads 1.02:1 on the vellum). No new token and no new contrast pairing — both are already rows in `factionContrast.test.ts`.

**#2124's added requirement, both halves**
- *Labelled:* new copy at `factions.json` → `ephemerists.plate.provenance` / `provenanceUndated` — "Plate struck {{date}} · station of the Ephemerists, {{ra}} {{dec}}". A reader can tell it describes the instrument.
- *Placed:* the colophon sits below the comment thread, **outside** the two-column region, behind its own rule — clear of the byline, the crew and the submission-date metadata on every surface and both form factors. The coordinates themselves are unchanged.

**Mounts** — `EphemeristsTaskDetail` (`task:<id>`, colophon), `EphemeristsPraxisDetail` (`praxis:<id>`, colophon), `EphemeristsEditPraxis` (`praxis:<id>`, **no colophon**).

## One thing I did not do, and why

**The composer carries no colophon.** #1828 makes its cast a full-bleed band that closes the sheet with a negative bottom margin, so a trailing sibling is pulled back up over the brass instead of sitting under it — the same structural block the skin's own trailing-rune-strip comment already records. Undoing #1828 is out of this issue's scope. It is also the placement #2124 wanted least: the composer is the one Ephemerists surface where every field is the author's own. Called out here rather than buried: the composer keeps the notation band and loses the coordinates.

I also did **not** touch `ephemeristsPlate.tsx` (owned by #2142/#2145 in parallel — the masthead only imports from it), any `--faction-ephemerists-*` token, or `components/cardMasthead/factionBands.tsx` (a different component, #2067's restrained card band, which #2143 does not mention).

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (**341 files / 5990 tests green**), `npm run build`, `npm run budget` — all run locally, all pass.

On the budget: it prints `WARN CSS 22.3 KB`. **That WARN is inherited from `origin/main`.** I built `origin/main` in a scratch worktree and it emits the byte-identical stylesheet (same content hash, `index-JhcR8B8z.css`) with the same WARN — it is #2141's token block, which epic #2140 predicted and told me to report rather than shave. This PR adds **zero** CSS bytes; JS moves 126.6 to 126.7 KB, well inside the line.

**Visual QA is outstanding.** I have no browser and no dev stack, so the count arithmetic is verified at the function and never as pixels.

## What to eyeball

1. **`page` scale on the vellum plate** (light) — task detail, desktop. The band should land near 13 marks, and the `9px` lead should keep the rules clear of the tallest marks' ascenders.
2. **`page` scale on the dark plate** — same surface, dark theme. The band's ground, ink and rules must be **identical** to (1): the compass blue does not flip.
3. **`card` scale on the vellum plate** — praxis detail at phone width. Near 8 marks, and the *spacing* should read the same as (1) even though the count does not.
4. **`card` scale on the dark plate** — same, dark.
5. **The floor** — a 260px-wide card scale: 7 marks, not 5 spread out like bullets.
6. **Three cards, captured twice.** Load a task-detail gallery / praxis list, screenshot three Ephemerists surfaces at `card` scale, then vote or hover or filter on the page and screenshot the same three again. **The three bands must differ from each other, and each must be byte-identical between the two captures.** That is the seeding claim, and it is the one thing no test in this PR can see.
7. **The colophon on both detail pages, both themes** — it should read as the plate's own line at the foot, ruled off, with nothing player-scoped beside it. Check that it is *not* mistakable for a caption on the last comment.
8. **The composer** — masthead with the band, no colophon, and no gap left where the coordinates used to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
