### PR TITLE
The Ephemerists compass rose gains a tick limb; the score stamp reads working-then-total (#2145, #2122)

### DIFF
--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -737,13 +737,61 @@ export function EmblemOctagon({ size }: { size: number }) {
 }
 
 /**
+ * THE LIMB'S GRADUATION (#2145) — 48 ticks at 7.5°, long every sixth, i.e. one
+ * long tick on each 45°. It is what turns an ornament into an instrument, and
+ * it is the detail that earns the faction its name.
+ *
+ * Built once at module load rather than mapped per render: the geometry is a
+ * constant, the mark is drawn on two surfaces, and forty `<path>` nodes is a
+ * silly amount of markup for a figure that never moves. Two `d` strings, two
+ * weights.
+ */
+const TICK_STEP_DEG = 7.5;
+const TICK_OUTER = 47.2;
+/** Where a long tick starts — ON the inner rim — and where a short one does. */
+const TICK_LONG_INNER = 43;
+const TICK_SHORT_INNER = 45.4;
+/**
+ * The inner rim, moved r41 -> r43 by #2145. The north needle's tip is r42
+ * (`M50 8` on a 100-unit box), so at r41 the rim ran straight through it.
+ */
+const INNER_RIM = 43;
+
+function limb(long: boolean): string {
+  const marks: string[] = [];
+  const inner = long ? TICK_LONG_INNER : TICK_SHORT_INNER;
+  for (let i = 0; i < 360 / TICK_STEP_DEG; i += 1) {
+    if ((i % 6 === 0) !== long) continue;
+    const radians = (i * TICK_STEP_DEG * Math.PI) / 180;
+    const sin = Math.sin(radians);
+    const cos = Math.cos(radians);
+    const at = (r: number) =>
+      `${(50 + r * sin).toFixed(2)} ${(50 - r * cos).toFixed(2)}`;
+    marks.push(`M${at(inner)}L${at(TICK_OUTER)}`);
+  }
+  return marks.join(" ");
+}
+
+const LONG_TICKS = limb(true);
+const SHORT_TICKS = limb(false);
+
+/**
+ * Below this the short ticks are not drawn at all (#2145). At the praxis card's
+ * 84px each of the forty renders about 0.4px wide and the browser resolves the
+ * limb into a grey wash; the eight long ones survive and still read as
+ * graduated. Above it — the task card's 128px plate, and the phone's 112px —
+ * the full 48 come back.
+ */
+const FULL_LIMB_MIN_PX = 100;
+
+/**
  * THE COMPASS ROSE — the plate's points medallion (#2037, task cards v3).
  *
- * A brass-ruled disc with four needles on the cardinals, the north one struck
- * solid in the plate's gold and the other three left open in one ink at one
- * weight (#2067). It replaces the stepped octagon the score sat in: the plate is
- * a FIELD JOURNAL out of the Valley, and the instrument a surveyor's plate
- * reaches for is a rose.
+ * A brass-ruled disc with a graduated limb and four needles on the cardinals,
+ * the north one struck solid in the faction's mark and the other three left
+ * open in one ink at one weight (#2067). It replaces the stepped octagon the
+ * score sat in: the plate is a FIELD JOURNAL out of the Valley, and the
+ * instrument a surveyor's plate reaches for is a rose.
  *
  * IT IS A SHARED MARK, and that is why `size` is a prop rather than a constant.
  * The octagon medallion it replaces is drawn identically on two surfaces — the
@@ -763,6 +811,20 @@ export function EmblemOctagon({ size }: { size: number }) {
  * and west to x=26 and x=74, so the inner disc (r=29) is the clear field and the
  * host has to be big enough that the figure fits inside 48 of the 100 units.
  * That is why the design grows the box to 128px where the octagon was 104.
+ *
+ * EVERY LINE ON IT IS `-plate-brass-rule` NOW (#2145, #2141), and that is a
+ * contrast fix as much as a repaint. The disc is `-plate-disc` #12151f in BOTH
+ * cascades and `-brass-light` FLIPS (#6f5620 by day, #e6c877 by night), so the
+ * rims and the three open needles read 2.63:1 in light and ~11:1 in dark — the
+ * theme-invariant-ground-with-a-flipping-ink shape this repo has shipped once
+ * before and caught an hour later. The rule brass does not flip: 3.73:1 on the
+ * compass blue, in both, clear of the 3:1 a non-text mark owes. The outer rim
+ * keeps `-brass`, which is the same #8a6d2c by day and brighter by night.
+ *
+ * NORTH IS `-plate-band-ink` (#2145). It was `-plate-gold`, which reads 13.07:1
+ * on the disc and was never the problem; the faction's mark is brass now
+ * (#2140), and gold on the one drawing that carries the total would have been
+ * the last place the old identity survived. 7.59:1, in both cascades.
  */
 export function CompassRose({ size }: { size: number }) {
   return (
@@ -774,37 +836,32 @@ export function CompassRose({ size }: { size: number }) {
       style={{ position: "absolute", inset: 0 }}
     >
       <circle cx="50" cy="50" r="47" fill={DISC} stroke={BRASS} strokeWidth="1.6" />
-      <circle cx="50" cy="50" r="41" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.7" />
-      {/* The ordinals, struck as ticks between the two rims rather than as
-          needles — the design gives the quarter winds a mark, not a point. */}
-      <g stroke={BRASS_LIGHT} strokeWidth="0.7" opacity="0.7">
-        <path d="M16.8 16.8 L21 21" />
-        <path d="M83.2 16.8 L79 21" />
-        <path d="M16.8 83.2 L21 79" />
-        <path d="M83.2 83.2 L79 79" />
-      </g>
+      <circle cx="50" cy="50" r={INNER_RIM} fill="none" stroke={BRASS_RULE} strokeWidth="0.7" />
+      {/* The graduated limb. The FOUR ORDINAL TICKS STOOD HERE and are retired
+          rather than kept: every 45° is already a long tick, so the old
+          diagonal marks were the same statement twice. */}
+      <path d={LONG_TICKS} stroke={BRASS_RULE} strokeWidth="0.9" fill="none" />
+      {size >= FULL_LIMB_MIN_PX && (
+        <path d={SHORT_TICKS} stroke={BRASS_RULE} strokeWidth="0.6" fill="none" />
+      )}
       {/* North alone is filled, which is how a rose says which way is up — and
           the other three are ONE ink at ONE weight, so the rose says it exactly
           once (#2067). It shipped saying it three ways: north in the register's
           teal, south in `-brass` at 0.9, east and west in `-brass-light` at 0.7.
-          North is `-plate-gold` now, which is the ink the winged disc and the
-          registers are drawn in and the brightest mark the plate has: 13.07:1 on
-          the rose's own disc against the teal's 7.36:1, so the one point that
-          carries meaning is also the one that reads first.
 
           A SECOND DESIGN FILE DREW THIS NEEDLE NAVY (`ephCompassBadge()`, as
           the register's aqua with a `#1e3a6e` fallback) and it was never the one
           to follow: that navy measures 1.64:1 on `-plate-disc` and the needle
-          would be invisible. #2141 settled it by deleting the aqua outright, so
-          only the gold reading survives. #2145 owns what the rose looks like
-          next; if north moves, it moves to `-plate-band-ink`, the MARK the
-          faction now sets every glyph and numeral in. */}
-      <path d="M50 8 L55.5 26 L44.5 26 Z" fill={GOLD} />
-      <path d="M50 92 L55.5 74 L44.5 74 Z" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.9" />
-      <path d="M8 50 L26 44.5 L26 55.5 Z" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.9" />
-      <path d="M92 50 L74 44.5 L74 55.5 Z" fill="none" stroke={BRASS_LIGHT} strokeWidth="0.9" />
+          would be invisible. #2141 settled it by deleting the aqua outright.
+          The design fills all four needles in gold with north one unit longer,
+          which is not a difference anyone can see at 84px and which stops the
+          needle leading — #2067's ruling stands and #2145 restates it. */}
+      <path d="M50 8 L55.5 26 L44.5 26 Z" fill={BAND_INK} />
+      <path d="M50 92 L55.5 74 L44.5 74 Z" fill="none" stroke={BRASS_RULE} strokeWidth="0.9" />
+      <path d="M8 50 L26 44.5 L26 55.5 Z" fill="none" stroke={BRASS_RULE} strokeWidth="0.9" />
+      <path d="M92 50 L74 44.5 L74 55.5 Z" fill="none" stroke={BRASS_RULE} strokeWidth="0.9" />
       {/* The card the figure is struck on. */}
-      <circle cx="50" cy="50" r="29" fill={DISC} stroke={BRASS_LIGHT} strokeWidth="0.7" />
+      <circle cx="50" cy="50" r="29" fill={DISC} stroke={BRASS_RULE} strokeWidth="0.7" />
     </svg>
   );
 }

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -72,7 +72,7 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * this is a deliberate deviation, reported on the PR rather than shipped.
  * `-band-quiet` is a DISC ink (#c2ae7e, theme-invariant, minted for the compass
  * blue) and this line sits on `-plate-inner`, the panel cell — #f2e8ce in
- * light, where it measures **1.80:1**. `-plate-quiet` is the ink minted for
+ * light, where it measures **1.78:1**. `-plate-quiet` is the ink minted for
  * this exact ground and gated by `factionContrast`'s "ephemerists panel cell,
  * quiet ink" row. The two names differ by one word and the grounds differ by
  * everything.

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -2,16 +2,15 @@ import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import {
   BRASS,
+  BAND_INK,
   BAND_QUIET,
   BRASS_LIGHT,
   CAPTION,
+  CompassRose,
   DECO,
-  DISC,
   INK,
   INNER,
-  LotusSign,
   OCHRE,
-  Octagon,
   QUIET,
   READING,
   SMALL_CAPS,
@@ -23,8 +22,9 @@ import { formatPoints } from "../../../utils/points";
 import type { ScoreStampProps } from "./ScoreStamp";
 
 /**
- * The Ephemerists score stamp (#1207) — the Valley plate's TALLY CELL: a cut
- * panel of working with the total struck in a stepped octagon on a lotus base.
+ * The Ephemerists score stamp (#1207, redrawn by #2145) — the Valley plate's
+ * TALLY CELL: a cut panel of WORKING, with the total struck last in the
+ * faction's compass rose.
  *
  * It replaces the codex's rubric box (#841), which painted the retired
  * `--eph-*` illuminated-codex family onto a card that is papyrus everywhere
@@ -33,15 +33,49 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * stays a rule colour and never an ink, and every label takes `-caption` or
  * `-quiet`.
  *
- * The design files this faction under the shared box pattern ("Ephemerists …
- * follow the Unaffiliated mechanism exactly"), so the ROWS are
- * {@link DefaultScoreStamp}'s: base with the multiplier beside it, the metatask
- * line, the votes tally, the total. Row selection stays in `scoreBreakdown`
- * (ADR-0047/0053/0076) — this file is presentation only, and each row is its own
- * line so the cell reads as a shorter or longer entry in all five conditional
- * states rather than as a form with gaps. The BASE line is optional since #1131
- * and the TALLY since ADR-0076: with nothing moving the figure, the cell is the
- * octagon alone, and it needs no rule above it to say so.
+ * ## The working comes FIRST (#2145 §4)
+ *
+ * The stamp used to lead with the total and file the derivation under it, which
+ * is every other faction's score box. The owner's ruling is that the Ephemerists
+ * are the faction whose conceit is that the WORKING is worth showing, so the
+ * order is base, ratio, the foreign award, the tally — and then the rose. It
+ * also puts the rose against the panel's chamfered corner, where the disc and
+ * the cut belong together.
+ *
+ * WITH NOTHING BUT A TOTAL THE PLATE FALLS AWAY and the rose stands alone.
+ * `base === null` is `scoreBreakdown`'s own predicate for "no working at all"
+ * (it is null precisely when mult, meta, habit and votes are too), so the panel
+ * is drawn on exactly the condition the other eight skins gate their separating
+ * rule on: with zero rows left, a chamfered plate would rule off an empty block
+ * (ADR-0076).
+ *
+ * Row selection stays in `scoreBreakdown` (ADR-0047/0053/0076) — this file is
+ * presentation only.
+ *
+ * ## Two pairings this redraw moves, both measured
+ *
+ * THE TOTAL WAS `-plate-ochre` ON `-plate-disc`, 3.0007:1. It cleared the
+ * LARGE-text floor by seven ten-thousandths, at `--text-title` (24px), which is
+ * a coincidence and not a design. The disc's ink budget is the BAND's (#2141),
+ * so the figure is `-band-ink` at 7.59:1 and the unit `-band-quiet` at 8.37:1 —
+ * the same two the task card's rose already prints, in both cascades, on a chip
+ * that does not flip.
+ *
+ * THE METATASK LINE WAS THE SAME PAIRING INVERTED — `-plate-disc` on an ochre
+ * chip, therefore also 3.0007:1 — at `--text-md`, which is **11px** and owes
+ * AA_NORMAL's 4.5:1, not 3:1. That row is now ochre INK on the panel cell:
+ * 4.97:1 in light, 4.99:1 in dark. It is still the plate's one accent, still
+ * marking a foreign award rather than the task's own, and it no longer asks an
+ * 11px label to live on a large-text ratio.
+ *
+ * THE VOTES LINE KEEPS `-plate-quiet` AND THE ISSUE SAYS `-plate-band-quiet`;
+ * this is a deliberate deviation, reported on the PR rather than shipped.
+ * `-band-quiet` is a DISC ink (#c2ae7e, theme-invariant, minted for the compass
+ * blue) and this line sits on `-plate-inner`, the panel cell — #f2e8ce in
+ * light, where it measures **1.80:1**. `-plate-quiet` is the ink minted for
+ * this exact ground and gated by `factionContrast`'s "ephemerists panel cell,
+ * quiet ink" row. The two names differ by one word and the grounds differ by
+ * everything.
  *
  * DEVIATIONS from the vendored frame, both named in the PR:
  *  • the multiplier chip is labelled from the SHARED `card.stamp.mult` key
@@ -51,8 +85,11 @@ import type { ScoreStampProps } from "./ScoreStamp";
  *    it would fork one number's name between two surfaces.
  *  • the design draws no metatask row (its sample has none). One is drawn here,
  *    in the box pattern's own place, because the stamp must stay legible in all
- *    five states — its chip is ochre, the plate's one accent, since brass is
- *    never an ink and a gold chip would pay under 3:1 behind a label.
+ *    five states.
+ *
+ * THE LABEL IS "points", IN ENGLISH (#2145 §5). The design sets `PVNCTA`; the
+ * faction's script rotation is its own mechanism and this label is one of its
+ * consumers, not a place to hardcode Latin.
  *
  * THE FIVE KANJI ARE GONE (#1909). Four rows were labelled 基 / 票 / 習 / 点 as
  * {@link GlossedGlyph}s with the shared English on `title`. The copy audit ruled
@@ -62,32 +99,43 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * `+ N` still sets its figure outside the label, so #1637's bound holds.
  */
 
-/** The octagon medallion, and its inner rule. Ornament geometry (§4a). */
-const MEDALLION = 104;
-const MEDALLION_INSET = 6;
+/**
+ * The cell's width, and the rose struck in it. Ornament geometry (§4a).
+ *
+ * They are two numbers now rather than one: the rose no longer sets the cell's
+ * width, because the working sits above it instead of around it. 84px is the
+ * praxis card's size for this mark — the size at which `CompassRose` drops the
+ * forty short ticks — against the task card's 128.
+ */
+const STAMP_WIDTH = 128;
+const ROSE = 84;
 
 export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
   const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
+  const working = base !== null;
 
   /** The cell's label voice: incised caps, at the plate's caption gold. */
   const label = { ...SMALL_CAPS, fontSize: "var(--text-md)", color: CAPTION };
 
   return (
+    /*
+     * THE CROWN IS A SIBLING OF THE CLIPPED PANEL, NOT A CHILD OF IT (#2122).
+     * `clip-path` clips descendants, and the crown is hung at `top:-13
+     * right:-12` precisely so it overhangs — so as a child it was the one part
+     * of the cell guaranteed to be cut away, which is what the issue's
+     * screenshot shows. The overhang is the design; the clip moved off it.
+     * This is the shape `EphemeristsFactionBody` already uses for its own
+     * crown, one relatively-positioned wrapper around the thing being crowned.
+     */
     <div
       style={{
         position: "relative",
         flexShrink: 0,
         width: "100%",
-        maxWidth: MEDALLION + 24,
-        boxSizing: "border-box",
-        background: INNER,
-        border: `1px solid ${BRASS}`,
-        padding: "var(--space-sm) var(--space-md)",
-        clipPath: stepClip(7),
-        lineHeight: 1.1,
+        maxWidth: working ? STAMP_WIDTH : ROSE,
       }}
     >
       {crowned && (
@@ -99,173 +147,164 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
         />
       )}
 
-      {/* Base, with the figure set against its label across the cell. */}
-      {base !== null && (
+      {working && (
         <div
           style={{
-            display: "flex",
-            alignItems: "baseline",
-            justifyContent: "space-between",
-            gap: "var(--space-sm)",
-          }}
-        >
-          {/* 基 stood here, glossed "base". #1909 cut all five of this cell's
-              kanji: they were the only faction-specific score-stamp labels in
-              the app, on a surface the audit ruled generic. The shared gloss
-              each one carried is now the visible label. */}
-          <span style={label}>{t("card.stamp.base")}</span>
-          <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", lineHeight: 0.8, color: INK }}>
-            {base}
-          </span>
-        </div>
-      )}
-
-      {/* The multiplier, in its own ruled chip — the design's "ratio" cell. */}
-      {mult !== null && (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "var(--space-xs)",
-            marginTop: "var(--space-sm)",
-            padding: "var(--space-xs) var(--space-sm)",
+            boxSizing: "border-box",
+            background: INNER,
             border: `1px solid ${BRASS}`,
-            background: WASH,
-            clipPath: stepClip(5),
+            padding: "var(--space-sm) var(--space-md)",
+            clipPath: stepClip(7),
+            lineHeight: 1.1,
           }}
         >
-          <span style={{ ...label, letterSpacing: "0.2em" }}>{t("card.stamp.mult")}</span>
-          <span aria-hidden style={{ width: 1, height: 11, background: BRASS_LIGHT }} />
-          <span style={{ fontFamily: DECO, fontSize: "var(--text-lg)", lineHeight: 1, color: INK }}>
-            {formatMult(mult)}
-          </span>
-        </div>
-      )}
-
-      {meta !== null && (
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: "var(--space-xs)",
-            marginTop: "var(--space-sm)",
-          }}
-        >
-          <span
-            style={{
-              ...SMALL_CAPS,
-              fontWeight: 600,
-              fontSize: "var(--text-md)",
-              letterSpacing: "0.16em",
-              color: DISC,
-              background: OCHRE,
-              padding: "0 var(--space-xs)",
-            }}
-          >
-            {t("card.stamp.meta")}
-          </span>
-          <span style={{ fontFamily: READING, fontStyle: "italic", fontSize: "var(--text-md)", color: QUIET }}>
-            +{meta}
-          </span>
-        </div>
-      )}
-
-      {/* The tally, cut only when there are votes to record (ADR-0076). The `+`
-          and the figure are arithmetic, not copy, so they are set here rather
-          than interpolated into a sentence: this is the one line where a label
-          and a numeral sit together, and #1637's whole bound is that only the
-          label is encoded. */}
-      {votes !== null && (
-        <div
-          style={{
-            fontFamily: READING,
-            fontStyle: "italic",
-            fontSize: "var(--text-md)",
-            color: QUIET,
-            marginTop: "var(--space-sm)",
-          }}
-        >
-          + {votes} <span style={label}>{t("card.stamp.votes")}</span>
-        </div>
-      )}
-
-      {/* The habit bonus (#1617), cut after the tally: flat, outside the ratio.
-          Labelled from the shared key like every other row of this cell — the
-          #1637 bound holds, so the LABEL is encoded and the figure stays a
-          Western numeral. */}
-      {habit !== null && (
-        <div
-          style={{
-            fontFamily: READING,
-            fontStyle: "italic",
-            fontSize: "var(--text-md)",
-            color: QUIET,
-            marginTop: "var(--space-xs)",
-          }}
-        >
-          + {habit} <span style={label}>{t("card.stamp.habit")}</span>
-        </div>
-      )}
-
-      {/* The total, struck in the stepped octagon on its lotus base. */}
-      <div
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          gap: "var(--space-xs)",
-          marginTop: "var(--space-sm)",
-        }}
-      >
-        <div
-          style={{
-            position: "relative",
-            width: MEDALLION,
-            height: MEDALLION,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <svg
-            width={MEDALLION}
-            height={MEDALLION}
-            viewBox="0 0 100 100"
-            aria-hidden="true"
-            style={{ position: "absolute", inset: 0 }}
-          >
-            <Octagon inset={0} stroke={BRASS} width={1.6} fill={DISC} />
-            <Octagon inset={MEDALLION_INSET} stroke={BRASS_LIGHT} width={0.7} />
-            <circle cx={50} cy={50} r={34} fill="none" stroke={BRASS_LIGHT} strokeWidth={0.7} opacity={0.55} />
-            {/* The lotus base the medallion rests on. */}
-            <path d="M18 74 H82" stroke={BRASS_LIGHT} strokeWidth={0.7} opacity={0.5} />
-          </svg>
+          {/* Base, with the figure set against its label across the cell. */}
           <div
             style={{
-              position: "relative",
               display: "flex",
-              flexDirection: "column",
-              alignItems: "center",
-              lineHeight: 0.82,
+              alignItems: "baseline",
+              justifyContent: "space-between",
+              gap: "var(--space-sm)",
             }}
           >
-            <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", color: OCHRE }}>
-              {formatPoints(total)}
+            {/* 基 stood here, glossed "base". #1909 cut all five of this cell's
+                kanji: they were the only faction-specific score-stamp labels in
+                the app, on a surface the audit ruled generic. The shared gloss
+                each one carried is now the visible label. */}
+            <span style={label}>{t("card.stamp.base")}</span>
+            <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", lineHeight: 0.8, color: INK }}>
+              {base}
             </span>
-            <span
+          </div>
+
+          {/* The multiplier, in its own ruled chip — the design's "ratio" cell. */}
+          {mult !== null && (
+            <div
               style={{
-                ...SMALL_CAPS,
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-xs)",
+                marginTop: "var(--space-sm)",
+                padding: "var(--space-xs) var(--space-sm)",
+                border: `1px solid ${BRASS}`,
+                background: WASH,
+                clipPath: stepClip(5),
+              }}
+            >
+              <span style={{ ...label, letterSpacing: "0.2em" }}>{t("card.stamp.mult")}</span>
+              <span aria-hidden style={{ width: 1, height: 11, background: BRASS_LIGHT }} />
+              <span style={{ fontFamily: DECO, fontSize: "var(--text-lg)", lineHeight: 1, color: INK }}>
+                {formatMult(mult)}
+              </span>
+            </div>
+          )}
+
+          {/* The metatask award, struck in the plate's one accent — a foreign
+              award, not the task's. See the ochre measurement above. */}
+          {meta !== null && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "var(--space-xs)",
+                marginTop: "var(--space-sm)",
+                color: OCHRE,
+              }}
+            >
+              <span
+                style={{
+                  ...SMALL_CAPS,
+                  fontWeight: 600,
+                  fontSize: "var(--text-md)",
+                  letterSpacing: "0.16em",
+                }}
+              >
+                {t("card.stamp.meta")}
+              </span>
+              <span style={{ fontFamily: READING, fontStyle: "italic", fontSize: "var(--text-md)" }}>
+                +{meta}
+              </span>
+            </div>
+          )}
+
+          {/* The tally, cut only when there are votes to record (ADR-0076). The `+`
+              and the figure are arithmetic, not copy, so they are set here rather
+              than interpolated into a sentence: this is the one line where a label
+              and a numeral sit together, and #1637's whole bound is that only the
+              label is encoded. */}
+          {votes !== null && (
+            <div
+              style={{
+                fontFamily: READING,
+                fontStyle: "italic",
                 fontSize: "var(--text-md)",
-                color: BAND_QUIET,
+                color: QUIET,
+                marginTop: "var(--space-sm)",
+              }}
+            >
+              + {votes} <span style={label}>{t("card.stamp.votes")}</span>
+            </div>
+          )}
+
+          {/* The habit bonus (#1617), cut after the tally: flat, outside the ratio.
+              Labelled from the shared key like every other row of this cell — the
+              #1637 bound holds, so the LABEL is encoded and the figure stays a
+              Western numeral. */}
+          {habit !== null && (
+            <div
+              style={{
+                fontFamily: READING,
+                fontStyle: "italic",
+                fontSize: "var(--text-md)",
+                color: QUIET,
                 marginTop: "var(--space-xs)",
               }}
             >
-              {t("card.stamp.points")}
-            </span>
-          </div>
+              + {habit} <span style={label}>{t("card.stamp.habit")}</span>
+            </div>
+          )}
         </div>
-        {/* The lotus itself, closing the cell. */}
-        <LotusSign width={18} color={BRASS_LIGHT} />
+      )}
+
+      {/* The total, struck LAST, in the shared compass rose (#2042, #2145). The
+          figure and its unit stay HTML laid over the plate rather than `<text>`
+          inside its viewBox — that is what keeps the unit one replaceable node
+          for the faction's script rotation. */}
+      <div
+        style={{
+          position: "relative",
+          width: ROSE,
+          height: ROSE,
+          margin: working ? "var(--space-sm) auto 0" : "0 auto",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <CompassRose size={ROSE} />
+        <div
+          style={{
+            position: "relative",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            lineHeight: 0.82,
+          }}
+        >
+          <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", color: BAND_INK }}>
+            {formatPoints(total)}
+          </span>
+          <span
+            style={{
+              ...SMALL_CAPS,
+              fontSize: "var(--text-md)",
+              color: BAND_QUIET,
+              marginTop: "var(--space-xs)",
+            }}
+          >
+            {t("card.stamp.points")}
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
@@ -100,8 +100,14 @@ describe('the stamp reads working-then-total (#2145)', () => {
   it('puts every working row ABOVE the rose', () => {
     const html = render()
     const rose = html.indexOf(NORTH)
-    for (const row of ['card.stamp.base', 'card.stamp.mult', 'card.stamp.meta', 'card.stamp.votes']) {
-      const at = html.indexOf(i18n.t(`praxis:${row}`))
+    const rows = [
+      i18n.t('praxis:card.stamp.base'),
+      i18n.t('praxis:card.stamp.mult'),
+      i18n.t('praxis:card.stamp.meta'),
+      i18n.t('praxis:card.stamp.votes'),
+    ]
+    for (const row of rows) {
+      const at = html.indexOf(row)
       expect(at, `${row} is printed`).toBeGreaterThan(-1)
       expect(at, `${row} comes before the rose`).toBeLessThan(rose)
     }

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
@@ -130,7 +130,7 @@ describe('the stamp reads working-then-total (#2145)', () => {
     const html = render()
     // The foreign award, ochre — 4.97:1 light / 4.99:1 dark on the panel cell.
     expect(html).toContain('color:var(--faction-ephemerists-plate-ochre)')
-    // NOT `-plate-band-quiet`, which is a DISC ink: 1.80:1 on this panel in
+    // NOT `-plate-band-quiet`, which is a DISC ink: 1.78:1 on this panel in
     // light. See the note in the stamp for the measurement.
     expect(html).toContain('color:var(--faction-ephemerists-plate-quiet)')
     // The ochre chip is gone: it was `-plate-disc` on `-plate-ochre`, 3.00:1,

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * The Ephemerists score stamp reads WORKING-THEN-TOTAL, and its crown stops
+ * being cut off (#2145, #2122).
+ *
+ * THE SEAM IS THE RENDERED MARKUP of `EphemeristsScoreStamp`
+ * (`renderToStaticMarkup`; this repo has no jsdom, so effects never run and no
+ * geometry is measurable) plus, for the compass rose's limb, the rose rendered
+ * on its own at both sizes it is mounted at.
+ *
+ * ## Why the crown is asserted by ORDER and not by a subtree
+ *
+ * #2122 is a screenshot with no words: the Ephemerists task crown is sliced
+ * along a diagonal. The cause is one CSS fact — **`clip-path` clips
+ * descendants** — meeting one layout fact: the stamp's panel carried
+ * `stepClip(7)` and the crown was a child of it, deliberately hung outside the
+ * box at `top:-13 right:-12` so it overhangs. Everything outside the polygon is
+ * cut, so the overhang is exactly the part that disappears.
+ *
+ * A string of markup cannot see a clip. What it CAN see is that a node appears
+ * before the opening tag of the clipped element, and a descendant never can —
+ * so `crown index < clip index` is a one-directional proof that the crown is
+ * not inside the clipped panel. That is the whole fix and the whole assertion.
+ *
+ * THE FIX BELONGS HERE AND NOWHERE ELSE, which is a finding rather than an
+ * assumption. `stepClip` has two consumers (this stamp and `EphemeristsVote`,
+ * which mounts no crown), no other faction's stamp clips at all, and the one
+ * other Ephemerists crown — `EphemeristsFactionBody`'s at `top:-14 right:-10`
+ * — is already a sibling of the card inside a `position:relative` wrapper,
+ * which is the shape this file adopts.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import '../../../../i18n'
+import i18n from '../../../../i18n'
+import type { PraxisCardOut } from '../../../../api/praxis'
+import EphemeristsScoreStamp from '../EphemeristsScoreStamp'
+import { CompassRose } from '../../../factionMarks/ephemeristsPlate'
+
+function praxis(overrides: Record<string, unknown>): PraxisCardOut {
+  return {
+    task_point_value: 12,
+    display_multiplier: 1.5,
+    metatask_points: 3,
+    points_from_votes: 4,
+    habit_bonus_points: 0,
+    is_top_for_task: false,
+    score: 26.5,
+    ...overrides,
+  } as PraxisCardOut
+}
+
+const render = (overrides: Record<string, unknown> = {}) =>
+  renderToStaticMarkup(<EphemeristsScoreStamp praxis={praxis(overrides)} />)
+
+/** The rose's north needle — the mark only `CompassRose` draws. */
+const NORTH = 'M50 8 L55.5 26 L44.5 26 Z'
+/** The stepped octagon the rose replaces on this surface. */
+const OCTAGON = 'M30 4 L70 4 L96 30'
+/** `TaskCrown`'s own disc token — the crown, wherever it lands. */
+const CROWN = 'var(--fdl-disc)'
+/** The panel's chamfer, and the thing that was doing the cutting. */
+const CLIP = 'clip-path:polygon(7px 0'
+
+describe('the crown is not a child of the clipped panel (#2122)', () => {
+  it('renders the crown BEFORE the clipped panel opens', () => {
+    const html = render({ is_top_for_task: true })
+    const crown = html.indexOf(CROWN)
+    const clip = html.indexOf(CLIP)
+    expect(crown, 'the crown is drawn at all').toBeGreaterThan(-1)
+    expect(clip, 'the panel is still chamfered').toBeGreaterThan(-1)
+    // A descendant cannot precede its ancestor's opening tag.
+    expect(crown, 'the crown must sit outside the clip').toBeLessThan(clip)
+  })
+
+  it('still hangs the crown outside the panel, which is the design', () => {
+    // The overhang is the point — #2122 is fixed by moving the clip, never by
+    // pulling the crown inside the box or shrinking it.
+    expect(render({ is_top_for_task: true })).toContain('top:-13px;right:-12px')
+  })
+
+  it('draws no crown when the praxis is not top for its task', () => {
+    expect(render()).not.toContain(CROWN)
+  })
+
+  it('still lets the mounting surface suppress it (ADR-0028)', () => {
+    const suppressed = renderToStaticMarkup(
+      <EphemeristsScoreStamp praxis={praxis({ is_top_for_task: true })} showCrown={false} />,
+    )
+    expect(suppressed).not.toContain(CROWN)
+  })
+})
+
+describe('the stamp reads working-then-total (#2145)', () => {
+  it('strikes the total in the compass rose, not the stepped octagon', () => {
+    const html = render()
+    expect(html, 'the rose').toContain(NORTH)
+    expect(html, 'the octagon it replaces').not.toContain(OCTAGON)
+  })
+
+  it('puts every working row ABOVE the rose', () => {
+    const html = render()
+    const rose = html.indexOf(NORTH)
+    for (const row of ['card.stamp.base', 'card.stamp.mult', 'card.stamp.meta', 'card.stamp.votes']) {
+      const at = html.indexOf(i18n.t(`praxis:${row}`))
+      expect(at, `${row} is printed`).toBeGreaterThan(-1)
+      expect(at, `${row} comes before the rose`).toBeLessThan(rose)
+    }
+  })
+
+  it('lets the plate fall away when there is nothing but a total', () => {
+    // `base === null` is `scoreBreakdown`'s own "no working at all" predicate.
+    const bare = render({
+      task_point_value: 10,
+      display_multiplier: 1,
+      metatask_points: 0,
+      points_from_votes: 0,
+      score: 10,
+    })
+    expect(bare, 'the rose stands alone').toContain(NORTH)
+    expect(bare, 'no chamfered panel around an empty block').not.toContain(CLIP)
+  })
+
+  it('inks the metatask line in the ochre and the votes line in the quiet', () => {
+    const html = render()
+    // The foreign award, ochre — 4.97:1 light / 4.99:1 dark on the panel cell.
+    expect(html).toContain('color:var(--faction-ephemerists-plate-ochre)')
+    // NOT `-plate-band-quiet`, which is a DISC ink: 1.80:1 on this panel in
+    // light. See the note in the stamp for the measurement.
+    expect(html).toContain('color:var(--faction-ephemerists-plate-quiet)')
+    // The ochre chip is gone: it was `-plate-disc` on `-plate-ochre`, 3.00:1,
+    // at 11px — a normal-text pairing scraping the LARGE-text floor.
+    expect(html).not.toContain('background:var(--faction-ephemerists-plate-ochre)')
+  })
+
+  it('sets the figure and its unit in the disc’s own two inks', () => {
+    const html = render()
+    expect(html, 'the total, 7.59:1 on the disc').toContain(
+      'color:var(--faction-ephemerists-plate-band-ink)',
+    )
+    expect(html, 'the unit, 8.37:1 on the disc').toContain(
+      'color:var(--faction-ephemerists-plate-band-quiet)',
+    )
+  })
+
+  it('labels the total “points”, in English (#2145 §5)', () => {
+    expect(render().replace(/<[^>]*>/g, '')).toContain(i18n.t('praxis:card.stamp.points'))
+    expect(render()).not.toContain('PVNCTA')
+  })
+})
+
+/**
+ * THE LIMB (#2145 §1). 48 ticks at 7.5°, long every sixth, and only the eight
+ * long ones below 100px — at the stamp's 84px the 40 short ticks render about
+ * 0.4px each and the browser turns the limb into a grey wash.
+ *
+ * Counted off the rendered `d`, because the count IS the graduation: a limb
+ * that drops to 24 ticks or forgets the size rule renders perfectly and is a
+ * different instrument.
+ */
+describe('the compass rose carries a graduated limb (#2145)', () => {
+  const rose = (size: number) => renderToStaticMarkup(<CompassRose size={size} />)
+  const ticks = (html: string) => (html.match(/M[\d.]+ [\d.]+L[\d.]+ [\d.]+/g) ?? []).length
+
+  it('draws all 48 at the task card’s 128px', () => {
+    expect(ticks(rose(128))).toBe(48)
+  })
+
+  it('draws the eight long ones alone at the praxis card’s 84px', () => {
+    expect(ticks(rose(84))).toBe(8)
+  })
+
+  it('keeps the full limb at the phone task card’s 112px', () => {
+    expect(ticks(rose(112))).toBe(48)
+  })
+
+  it('rules the limb in the rule brass, which is one value in both themes', () => {
+    expect(rose(128)).toContain('var(--faction-ephemerists-plate-brass-rule)')
+  })
+
+  it('moves the inner rim clear of the north needle’s tip', () => {
+    // The tip is r42 (`M50 8`), so the r41 rim it shipped with ran through it.
+    const html = rose(128)
+    expect(html).toContain('r="43"')
+    expect(html).not.toContain('r="41"')
+  })
+
+  it('retires the four ordinal ticks — every 45° is already a long one', () => {
+    expect(rose(128)).not.toContain('M16.8 16.8')
+  })
+})

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/pointsMarkUnification.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/pointsMarkUnification.test.tsx
@@ -58,10 +58,12 @@ vi.mock("../../../../hooks/useFormFactor", () => ({ useFormFactor: () => "deskto
 
 // Imported after the mock is registered.
 import DefaultTaskCard from "../../../taskCard/DefaultTaskCard";
+import EphemeristsTaskCard from "../../../taskCard/EphemeristsTaskCard";
 import SingularityTaskCard from "../../../taskCard/SingularityTaskCard";
 import SnideTaskCard from "../../../taskCard/SnideTaskCard";
 import WowTaskCard from "../../../taskCard/WowTaskCard";
 import DefaultScoreStamp from "../DefaultScoreStamp";
+import EphemeristsScoreStamp from "../EphemeristsScoreStamp";
 import SingularityScoreStamp from "../SingularityScoreStamp";
 import SnideScoreStamp from "../SnideScoreStamp";
 import WowScoreStamp from "../WowScoreStamp";
@@ -215,6 +217,25 @@ const UNIFIED = [
     },
     // The struck disc's tilt and its rainbow-clipped numeral.
     retired: ["rotate(-7deg)", "var(--faction-default-total-rainbow)"],
+  },
+  {
+    // THE FOURTH FACTION TO UNIFY (#2145), added here by name because a surface
+    // this list omits is invisible rather than red. `CompassRose` replaced the
+    // task card's octagon in #2037 and the stamp kept striking its own copy of
+    // that octagon until now; the ruling in #2042 is that a faction's points
+    // mark is one drawing, and `ephemeristsCompassRose.test.tsx` holds the other
+    // half — that the north needle's path is declared in exactly one file.
+    faction: "ephemerists",
+    mark: "components/factionMarks/ephemeristsPlate.tsx (CompassRose)",
+    // The one filled needle, which is the rose's signature.
+    fragment: "M50 8 L55.5 26 L44.5 26 Z",
+    surfaces: {
+      "components/taskCard/EphemeristsTaskCard.tsx": () => card(EphemeristsTaskCard),
+      "components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx": () =>
+        stamp(EphemeristsScoreStamp),
+    },
+    // The stepped octagon on its lotus base — the stamp's own second copy.
+    retired: ["M30 4 L70 4 L96 30", "M18 74 H82"],
   },
 ] as const;
 

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -491,12 +491,15 @@ describe('#841 stamps across the conditional states (ADR-0047)', () => {
    * family. A skin that still reads `--eph-*` is painting the retired
    * illuminated-codex ground on a papyrus card, which renders fine and is wrong.
    */
-  it('strikes the Ephemerists total in the plate octagon, not the codex rubric', () => {
+  it('strikes the Ephemerists total in the plate compass rose, not the codex rubric', () => {
     const markup = renderToStaticMarkup(<EphemeristsScoreStamp praxis={praxis({})} />)
     expect(markup).toContain('--faction-ephemerists-plate-')
     expect(markup).not.toMatch(/--eph-[a-z]/)
-    // The stepped octagon on its lotus base, carrying the total.
-    expect(markup).toContain('M30 4 L70 4 L96 30')
+    // The shared `CompassRose`, carrying the total (#2145). The stepped octagon
+    // on its lotus base stood here; the rose is the mark the task card already
+    // struck, and #2042's ruling is that a faction's points mark is ONE drawing.
+    expect(markup).toContain('M50 8 L55.5 26 L44.5 26 Z')
+    expect(markup).not.toContain('M30 4 L70 4 L96 30')
     // The codex's stuck-label tilt is gone: this cell is cut, not stuck on.
     expect(markup).not.toContain('rotate(-1deg)')
   })

--- a/frontend/src/components/taskCard/__tests__/ephemeristsCompassRose.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/ephemeristsCompassRose.test.tsx
@@ -119,16 +119,20 @@ describe('the rose says which way is up exactly once (#2067)', () => {
   const EAST = 'M8 50 L26 44.5 L26 55.5 Z'
   const WEST = 'M92 50 L74 44.5 L74 55.5 Z'
 
-  it('fills north in the plate gold, not the register teal', () => {
-    // 13.07:1 on the rose's own disc against the teal's 7.36:1 — the one point
-    // that carries meaning is also the one that reads first. The design's OTHER
-    // file drew this navy (the register's aqua, 1.64:1 on the disc), which would
-    // make the needle invisible; #2141 deleted that token outright, so the
-    // assertion below is now the only reading the rose has. #2145 owns what the
-    // rose becomes; if north moves it moves to the MARK, `-plate-band-ink`.
+  it('fills north in the faction MARK, not the plate gold and not the teal', () => {
+    // It moved gold -> `-plate-band-ink` in #2145, which is the move this file
+    // predicted: the faction's ink is BRASS since #2140 and the rose carries the
+    // total, so gold here would have been the last place the old identity
+    // survived. 7.59:1 on the disc, in BOTH cascades, against gold's 13.07 —
+    // this spends contrast on purpose and stays far clear of any floor.
+    //
+    // The design's OTHER file drew this needle navy (the register's aqua, 1.64:1
+    // on the disc), which would make it invisible; #2141 deleted that token
+    // outright, so the assertion below is the only reading the rose has.
     const north = needle(render('desktop'), NORTH)
-    expect(north).toContain('fill="var(--faction-ephemerists-plate-gold)"')
+    expect(north).toContain('fill="var(--faction-ephemerists-plate-band-ink)"')
     expect(north).not.toContain('nile')
+    expect(north).not.toContain('plate-gold')
   })
 
   it('outlines the other three in one ink at one weight', () => {
@@ -136,7 +140,12 @@ describe('the rose says which way is up exactly once (#2067)', () => {
     for (const d of [SOUTH, EAST, WEST]) {
       const open = needle(html, d)
       expect(open, d).toContain('fill="none"')
-      expect(open, d).toContain('stroke="var(--faction-ephemerists-plate-brass-light)"')
+      // `-brass-light` stood here and was the FORKED half of a theme-invariant
+      // ground: it flips (#6f5620 / #e6c877) and `-plate-disc` does not, so the
+      // three open needles read 2.63:1 in light and ~11:1 in dark. The rule
+      // brass (#2141) is one value on all three of the faction's grounds —
+      // 3.73:1 on this one, clear of the 3:1 a non-text mark owes (#2145).
+      expect(open, d).toContain('stroke="var(--faction-ephemerists-plate-brass-rule)"')
       expect(open, d).toContain('stroke-width="0.9"')
     }
   })

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -941,6 +941,17 @@ const ARCHETYPE_PAIRS: Pair[] = [
   { what: "ephemerists panel cell, caption", surface: "--faction-ephemerists-plate-inner", text: "--faction-ephemerists-plate-caption" },
   { what: "ephemerists panel cell, quiet ink", surface: "--faction-ephemerists-plate-inner", text: "--faction-ephemerists-plate-quiet" },
   { what: "ephemerists panel cell, links", surface: "--faction-ephemerists-plate-inner", text: "--faction-ephemerists-plate-brass-light" },
+  // OCHRE AS AN INK, which is new in #2145 and is the reason it gets a row.
+  // `EphemeristsDuelSealConfirm` records "ochre is a mark, never an ink HERE"
+  // and the scope of that word is the papyrus: #a6432b measures 4.46:1 on
+  // `-plate-bg`, a near miss, which is why nothing legible is set in it there.
+  // The score stamp's metatask line lands on the PANEL CELL, one sheet lighter,
+  // at 4.97:1 light and 4.99:1 dark. It reaches this ground by REPLACING a
+  // worse reading rather than by relaxing a rule: the row shipped as an
+  // 11px `-plate-disc` label on an ochre CHIP, which is the same two colours
+  // inverted and therefore the same 3.0007:1 — a normal-text pairing sitting on
+  // the LARGE-text floor, and clearing it by seven ten-thousandths at that.
+  { what: "ephemerists panel cell, metatask award", surface: "--faction-ephemerists-plate-inner", text: "--faction-ephemerists-plate-ochre" },
   // `ephemerists medallion disc, caption` STOOD HERE and is retired rather than
   // repointed (#2141). It measured `-plate-caption` on the disc, and the caption
   // is a SHEET ink — #6f5620 by day, 2.63:1 on a chip that does not flip — so


### PR DESCRIPTION
Closes #2145
Closes #2122

## The seam

Two seams, both named before any code was written.

1. **The rendered markup of `EphemeristsScoreStamp` and of `CompassRose`** (`renderToStaticMarkup` — this repo has no jsdom, so effects never run and no geometry is measurable). New file: `frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx`. It went red on 12 of 16 before any source change — the crown inside the clip, the octagon still struck, the ochre chip, the missing limb.
2. **The pairing seam** — `factionContrast.test.ts` and `pointsMarkUnification.test.tsx`, because a mark that moves to a new ground has to be re-measured on it in both themes.

### #2122's cause, verified

The dispatcher's trace was right and is now the docblock. `clip-path` clips **descendants**; the stamp's panel carried `stepClip(7)` and the `TaskCrown` was a child of it, hung at `top:-13 right:-12` so it overhangs — which makes the overhang exactly the part guaranteed to be cut away.

**Fixed once, where the callers route through, not per symptom.** I swept for the pattern rather than assuming:

| site | clipped? | verdict |
|---|---|---|
| `EphemeristsScoreStamp` | `stepClip(7)` over the crown | **the defect** |
| `EphemeristsVote` (the other `stepClip` consumer) | yes | mounts no crown |
| the other 7 score stamps | no `clipPath`, no `overflow` | clean |
| `EphemeristsFactionBody` (~line 237, `top:-14 right:-10`) | crown is a **sibling** of `<PraxisCard>` inside a `position:relative` wrapper | already correct — and it is the shape this PR adopts |

So the fix is one edit in one file: the crown lifts out of the clipped panel into a relatively-positioned wrapper alongside it. The overhang is untouched — a test asserts `top:-13px;right:-12px` survives, precisely so nobody "fixes" this later by shrinking the crown or tucking it inside.

Markup cannot see a clip, so the assertion is `crownIndex < clipIndex`: a descendant can never precede its ancestor's opening tag.

## What changed

**`factionMarks/ephemeristsPlate.tsx` — the `CompassRose` function only** (the `METAL_SIGILS` region #2142 owns is untouched; no reformatting).

- **The limb.** 48 ticks at 7.5°, long every sixth (so every 45°), r43→r47.2 long / r45.4→r47.2 short. Built once at module load into two `d` strings, two weights — the geometry is a constant drawn on two surfaces, and 48 `<path>` nodes per render for a figure that never moves is silly.
- **Below 100px, only the eight long ticks.** The stamp's 84px drops the forty; the task card's 128px and the phone's 112px keep them.
- **Inner rim r41 → r43.** The north needle's tip is r42, so r41 ran through it.
- **The four ordinal ticks retired** — every 45° is already a long tick.
- **North → `-plate-band-ink`**, filled, alone. South/east/west ruled in `-plate-brass-rule`.

**`praxisCard/scoreStamp/EphemeristsScoreStamp.tsx` — rewritten.** Order: base, multiplier band, metatask line, votes line, habit line, then the rose carrying the total with "points" beneath. Rows are still `scoreBreakdown`'s; the file is still presentation-only. With nothing but a total the panel is not drawn at all and the cell narrows to the rose — `base === null` is `scoreBreakdown`'s own "no working" predicate, the same one the other eight skins gate their separating rule on.

The stamp now mounts the **shared** `CompassRose` instead of striking its own octagon, so the Ephemerists join the #2042 census in `pointsMarkUnification.test.tsx` by name, with the octagon and its lotus base listed as `retired`.

**No token was added or edited.** `index.css` is byte-identical to `main`.

## Three contrast pairings this moves, all measured off `index.css`

The handed-over measurement checks out to the digit — and it belongs to **two** sites, because contrast is symmetric and ochre↔disc appeared twice.

| pairing | was | now |
|---|---|---|
| the total figure, on the disc | `-plate-ochre` — **3.0007:1**, at `--text-title` (24px), so genuinely large text scraping `AA_LARGE` by seven ten-thousandths | `-plate-band-ink` — **7.59:1**, both themes |
| the metatask row | `-plate-disc` ink on an ochre **chip** — the same two colours inverted, therefore the same **3.0007:1** — at `--text-md`, which is **11px** and owes `AA_NORMAL`'s 4.5:1, not 3:1 | ochre as the line's **ink** on `-plate-inner` — **4.975:1** light, **4.993:1** dark |
| the rose's three open needles and its two inner rims | `-plate-brass-light`, which **flips** (#6f5620 / #e6c877) on a disc that does not — **2.63:1** in light, 11.18:1 in dark | `-plate-brass-rule` — **3.73:1**, both themes |

So the answer to "does the metatask row still qualify as large text" is that **it never did**: 11px on a 3.0007:1 pairing was already under `AA_NORMAL` before this PR. It is fixed by moving the row to the ink #2145 §4 asks for, not by tuning a hex and not by touching a fixture. One new row in `factionContrast.test.ts` gates it (`ephemerists panel cell, metatask award`); the ochre↔disc pairing now appears nowhere.

## Two deviations, both deliberate, neither shipped silently

1. **The votes line keeps `-plate-quiet`; #2145 §4 says `-plate-band-quiet`.** `-band-quiet` is a **disc** ink — #c2ae7e, theme-invariant, minted for the compass blue — and this line sits on `-plate-inner`, the panel cell, which is #f2e8ce in light. Measured: **1.78:1**. `-plate-quiet` is the ink minted for this exact ground and already gated by `factionContrast`'s "ephemerists panel cell, quiet ink" row (8.21:1 light / 5.52:1 dark). The two token names differ by one word and the grounds differ by everything. **Reporting rather than shipping it** — say the word and I'll change it.
2. **I repainted the rose's two inner rims** (the r43 ring and the r29 disc stroke) from `-brass-light` to `-brass-rule`, alongside the needles and ticks #2145 names explicitly. Flagging it because the dispatcher asked me to: this changes **dark** pixels too (#e6c877 → #8a6d2c), and #2140 §2 lists "idle disc rims" under the rule brass. The case for doing it here is that the rim is inside the function this issue owns, that it is a live 2.63:1 light-mode failure of the theme-invariant-ground/flipping-ink shape this epic has already shipped once, and that leaving one rim at brass-light between brass-rule ticks would be visibly incoherent. **The `Cornice`'s flutes are untouched** — those are #2143's, and I did not go near them.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (341 files, 5998 passed), `npm run build`, `npm run budget` — all green locally, run individually as each file landed.

The budget's `WARN CSS 22.3 KB` is **pre-existing on `main`, not this PR**: I built `main` in the same worktree and the emitted stylesheet is byte-identical (118 104 raw, 22 875 gzip-9), and the JS bundle hash is unchanged too — the faction surfaces are lazily chunked, so this lands nothing on the critical path.

**No visual QA.** I have no browser and no dev stack; `npm run dev` verifies nothing from here.

## What to eyeball

All five `scoreBreakdown` states, **both themes**, so the sub-100px tick rule is visible in the captures:

1. **base + mult + meta + votes** (everything on) — panel above, 84px rose below, and the limb showing **eight** long ticks only.
2. **base + mult** only — no metatask, no tally.
3. **base + votes** only (×1.0) — the multiplier band absent.
4. **base + habit** (a UA-style bonus) — the habit line under the tally.
5. **bare total** (no working at all) — **the panel should be gone entirely** and the rose standing alone, with the cell narrowed to 84px.

Then:

6. **A crowned praxis card** (`is_top_for_task`) — the crown whole at the stamp's top-right corner, overhanging, **not sliced along the chamfer**. This is #2122.
7. **The task card at 128px and the phone card at 112px** — the full **48**-tick limb, next to the praxis card's 84px eight, so the size rule is visible side by side.
8. **The metatask row** — it is now ochre *type* rather than a dark label on an ochre chip.
9. **Dark mode on the rose specifically** — the limb and the three open needles are a darker brass than they were (#8a6d2c against the old #e6c877). This is the deliberate deviation in §2 above and is the thing most worth a second look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
