### PR TITLE
The Ephemerists wear one glyph vocabulary: the register retires into the notation band (#2210)

### DIFF
--- a/WORLD_ZERO_STYLE.md
+++ b/WORLD_ZERO_STYLE.md
@@ -1143,6 +1143,14 @@ The rune strips bracketing that button marched thirty-two marks in a fixed order
 
 **One generator, in the kit.** #2143 wrote FNV-1a + mulberry32 inside the notation band; the second reader moved it to `ephemeristsPlate`. A second copy of a PRNG can be tuned in one file and not the other and **the drift is invisible, because both rows still look random** — which is why the guard for it is a source-tree assertion on the magic constant rather than anything you could see.
 
+### An ornament that REPLACES another is not shipped until the other is deleted (#2210)
+
+#2143 hung the notation band under the Ephemerists wordmark *in place of* the datum row, and retired none of the astro/alchemical glyph register the faction had been marching across the same bands. Both drew. The owner found it by looking: *"the task detail and praxis detail pages didn't remove the old runes before putting on new runes"*, *"faint overlapping old sigils all over the site"*. Nothing failed — every surface rendered perfectly, and the tests of the day asserted the register was **present**, so the suite was green on the defect.
+
+**Two vocabularies at once is the failure; the overlap is only how you notice.** The rows collided because the old ones were positioned to clear a datum row the band had already replaced, and the band's lead had opened 5px → 9px — but repositioning them would have left the real problem, one faction wearing two alphabets, looking fixed. The ruling is total retirement: **a faction has one ornament row, and a replacement's job is not done until its predecessor has no mounts.** The seam that can hold that is the source tree (§6, #1654), not markup — eight mounts across six files each render fine alone.
+
+**And the replacement travels with its CARRIER, so a surface without the carrier gets nothing.** The band's whole argument is that it is the masthead's last line: it inherits the datum row's two brass rules and closes the head against the sheet. The surfaces that mount `EphemeristsMasthead` get the band with it; the faction hero, the feed chassis and the select tile head themselves by hand, so they lost a register and gained nothing, because a band mounted where there is no lockup is ornament filling a hole. The same test kills the wrapper — the kit's rune band drew exactly one register and nothing else, so it retired too, and its seven section-head mounts kept the brass hairline that already flexed across each heading row. **Delete the row, then ask each surface what it still needs; do not assume the answer is "a replacement".**
+
 ---
 
 ## 7. Components

--- a/frontend/src/components/comments/voices/EphemeristsComment.tsx
+++ b/frontend/src/components/comments/voices/EphemeristsComment.tsx
@@ -64,7 +64,6 @@ import {
   BRASS_LIGHT,
   CAPS,
   CAPTION,
-  RuneRule,
   INK,
   INNER,
   LINE,
@@ -125,10 +124,12 @@ function Leaf({
           color: INK,
         }}
       >
-        {/* The cavetto flute at the head of the leaf — this sheet's answer to the
-            na sheet's spectrum hairline, and the same mark the feed chassis wears
-            under its masthead. Reused from `ephemeristsPlate`, not redrawn. */}
-        <RuneRule />
+        {/* A rune band headed this leaf — the cavetto flute's replacement
+            (#1638), and the OLD glyph vocabulary. #2210 retires that vocabulary
+            kit-wide in favour of the masthead's notation band, and this leaf has
+            no masthead, so the head of the sheet takes nothing in its place: the
+            leaf's own 1px border already rules it off, and a hairline struck
+            directly under that border would read as a doubled edge. */}
         {/* The gold wash rides the leaf's own background: the dark plate takes no
             wash at all (`--plate-wash: none`), so there is nothing for a ternary
             or a positioned overlay to decide. NO `overflow: hidden` anywhere on

--- a/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
+++ b/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
@@ -11,7 +11,6 @@ import {
   EmblemOctagon,
   GOLD,
   GRID,
-  GlyphRegister,
   MARGINALIA,
   READING,
   SMALL_CAPS,
@@ -53,13 +52,14 @@ function HeroGrids() {
           ))}
         </g>
       </svg>
-      {/* The design's own register, marching the band rather than a card's. */}
-      <svg width="100%" height={26} viewBox="0 0 1000 26" preserveAspectRatio="xMidYMid slice" style={{ position: "absolute", left: 0, top: 8, opacity: 0.6 }}>
-        <GlyphRegister width={1000} y={13} strength={0.34} keyPrefix="hero-a" />
-      </svg>
-      <svg width="100%" height={26} viewBox="0 0 1000 26" preserveAspectRatio="xMidYMid slice" style={{ position: "absolute", left: 0, bottom: 6, opacity: 0.6 }}>
-        <GlyphRegister width={1000} y={13} strength={0.3} keyPrefix="hero-b" />
-      </svg>
+      {/* TWO INCISED REGISTERS STOOD HERE (#2210), one along the top of the
+          band and one along the bottom. They were the OLD glyph vocabulary, and
+          #2143's notation band is the faction's only ornament row now. Nothing
+          replaces them on this hero: the band is the MASTHEAD's last line, and
+          this hero heads itself — it draws its own wordmark and stat ledger and
+          mounts no `EphemeristsMasthead`, so a band here would be ornament
+          filling a gap rather than a lockup closing itself off. What the ground
+          keeps is the graticule and the survey rays above. */}
     </div>
   );
 }

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -316,84 +316,23 @@ export const GLYPHS: Record<string, string> = {
   platinum: PLATINUM.glyph,
 };
 
-/** The order the signs march in — the design's own register. */
-export const REGISTER = [
-  "ankh", "water", "feather", "eye", "djed", "greekKey", "reed", "offering",
-  "alchemy", "chevrons", "scarab", "sun", "ankh", "water", "djed", "eye",
-];
-
-/** Distance between two signs in a register, and their drawn size. Geometry. */
-const GLYPH_PITCH = 27.5;
-const GLYPH_SIZE = 13;
-
-/**
- * One incised sign, at its own strength and its own phase in the cycle.
+/*
+ * THE INCISED REGISTER IS GONE (#2210) — `REGISTER`, `Glyph` and `GlyphRegister`
+ * were here, marching the astro/alchemical signs across a masthead band.
  *
- * Exported for the ONE caller that composes its own register rather than taking
- * {@link GlyphRegister}: the task card's masthead marches two named 12-sign
- * rows at its own pitch, which is the card design's drawing and not the page's.
- * Everything else wants the register.
- */
-export function Glyph({ name, x, y, strength, delay, color }: {
-  name: string
-  x: number
-  y: number
-  strength: number
-  delay: number
-  color?: string
-}) {
-  return (
-    <g
-      className="epg-glyph"
-      transform={`translate(${x} ${y}) scale(${GLYPH_SIZE / 24}) translate(-12 -12)`}
-      style={{ ["--epg-op"]: strength, ["--epg-delay"]: `${delay}s` } as CSSProperties}
-    >
-      <path
-        d={GLYPHS[name]}
-        fill="none"
-        stroke={color ?? GOLD}
-        strokeWidth="1.6"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </g>
-  );
-}
-
-/**
- * A register of signs marching the full width of a band. The count follows the
- * viewBox rather than a fixed number, so the register reaches the edge at any
- * width instead of stopping short or blowing every sign up under `slice`.
+ * #2143 gave the masthead the NOTATION BAND (mathematical marks, ruled top and
+ * bottom) and retired none of this, so both vocabularies drew at once and
+ * overlapped: the register rows were positioned to clear a datum row the band
+ * had already replaced, and the band's lead had opened from 5px to 9px. The
+ * owner's ruling is that the register retires ENTIRELY rather than moving out
+ * of the way — the band is the faction's only ornament row, carried by the
+ * masthead wherever there is one, and nothing takes its place on the surfaces
+ * that head themselves by hand.
  *
- * `color` defaults to the gold every masthead band strikes its register in.
- * {@link RuneRule} is the one caller that overrides it: a rune band rules a
- * PAGE rather than a night band, and gold on papyrus is a stain where brass is
- * a rule.
+ * {@link GLYPHS} above SURVIVES: the signs are still the kit's vocabulary for a
+ * single mark, drawn one at a time by {@link Sign} and read directly by the task
+ * card. What retired is the ROW, not the drawings.
  */
-export function GlyphRegister({ width, y, strength, keyPrefix, color }: {
-  width: number
-  y: number
-  strength: number
-  keyPrefix: string
-  color?: string
-}) {
-  const count = Math.ceil(width / GLYPH_PITCH);
-  return (
-    <>
-      {Array.from({ length: count }).map((_, index) => (
-        <Glyph
-          key={`${keyPrefix}${index}`}
-          name={REGISTER[index % REGISTER.length]}
-          x={18 + index * GLYPH_PITCH}
-          y={y}
-          strength={strength * (index % 3 === 0 ? 1 : 0.7)}
-          delay={((index * 7) % 12) * 1.6}
-          color={color}
-        />
-      ))}
-    </>
-  );
-}
 
 /* ── The gravity field (#1830) ──
  *
@@ -542,54 +481,17 @@ export function Cornice({ glow, flutes = 52 }: { glow?: boolean; flutes?: number
   );
 }
 
-/**
- * THE RUNE BAND — the divider under every section head (#1638).
+/*
+ * THE RUNE BAND IS GONE (#2210) — `RUNE_SPAN`, `RUNE_HEIGHT` and `RuneRule`
+ * stood here. It was the divider under every section head, and it drew exactly
+ * one thing: a `GlyphRegister` in brass. With the register retired the band had
+ * nothing left to draw, so it goes with it rather than staying as an empty box.
  *
- * It replaces `FlutedRule`, which was the cavetto band reused as a rule: 48
- * brass strokes at alternating heights. The plate's own register of incised
- * signs takes its place, so a section is divided by the kit's SIGNS rather than
- * by a second drawing of its cornice — one ornament vocabulary reaching down
- * from the masthead instead of two doing the same job.
- *
- * The band SHIFTS on `.epg-glyph`, the register's shared opacity cycle, already
- * opt-in under `prefers-reduced-motion: no-preference`. Nothing here declares
- * motion, so a stilled reader gets the signs rather than a blank strip.
- *
- * NO `viewBox`, deliberately, and this is the whole reason the band fits every
- * column at one size. A viewBox plus `slice` scales by `max(w/vbW, h/vbH)`, and
- * the height here is fixed, so `h/vbH` is 1 and any column WIDER than the
- * viewBox blows every sign up — a 16px band of 32px glyphs on the 1200px task
- * page, which is precisely the failure `EphemeristsTaskDetail` documented when
- * it stopped using a fixed sign count. Without a viewBox, user units are CSS
- * pixels, the signs are drawn at their own size at every width, and the SVG
- * viewport crops the overspill for free. {@link RUNE_SPAN} is therefore a
- * CEILING — enough signs to reach the widest column the site has (the 1200px
- * page cap), not a count anyone reads.
- *
- * `rule` pairs the band with the brass hairline the write-up header carries
- * above it (`sectionHead` draws its own). A rune band mounted WITHOUT a heading
- * reads as a loose row of marks; the composer is the surface that does that, so
- * it asks for the rule and gets the same two-part divider the record has.
+ * Its seven mounts lose a row of marks and no structure: every section head
+ * that carried it already rules itself off with the brass hairline that flexes
+ * across the heading row, and the composer — the one mount with no heading —
+ * keeps that hairline through the shared `ComposerRule`.
  */
-const RUNE_SPAN = 1280;
-const RUNE_HEIGHT = 16;
-
-export function RuneRule({ rule }: { rule?: boolean }) {
-  return (
-    <div aria-hidden="true">
-      {rule && <div style={{ height: 1, background: BRASS, opacity: 0.5 }} />}
-      <svg width="100%" height={RUNE_HEIGHT} aria-hidden="true" style={{ display: "block" }}>
-        <GlyphRegister
-          width={RUNE_SPAN}
-          y={RUNE_HEIGHT / 2}
-          strength={0.42}
-          keyPrefix="rune"
-          color={BRASS}
-        />
-      </svg>
-    </div>
-  );
-}
 
 /**
  * The lotus — the plate's closing mark, drawn on its own 18×13 field. It sits

--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -25,7 +25,7 @@
  * band.
  *
  * Every mark is REUSED from the kit, never redrawn: `EphemeristsSigil`,
- * `Cornice`, `GlyphRegister`. No new SVG.
+ * `Cornice`. No new SVG.
  *
  * The band's mark was the winged sun disc until #1634 retired it kit-wide — the
  * sigil is the only mark, and this row was its last caller anywhere. It takes
@@ -63,7 +63,6 @@ import {
   BRASS,
   BRASS_LIGHT,
   Cornice,
-  GlyphRegister,
   INK,
   LINE,
   OCHRE,
@@ -107,26 +106,23 @@ import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
 const ROW_SKIN: FeedRowSkin = { ink: { actor: BRASS_LIGHT } }
 
 interface BandSize {
-  /** Masthead height, and the width its register is drawn to fill. Geometry. */
+  /** Band height, and the width its ruled hairline is drawn to fill. Geometry. */
   height: number
   view: number
   /** The sigil at the head of the band. Its HEIGHT — the mark owns its ratio
    *  (#1635) — so there is one number, not two. */
   discHeight: number
-  /** Strength of the incised register behind the label. */
-  register: number
   bandPadding: string
   labelSize: string
 }
 
 const SIZES: Record<'desktop' | 'mobile', BandSize> = {
   // 452 is the feed column's own basis (the sheet's `minmax(452px, 1fr)`), so
-  // the register's signs land at their drawn pitch instead of being sliced short.
+  // the band's hairline is drawn to the width it is actually shown at.
   desktop: {
     height: 30,
     view: 452,
     discHeight: 14,
-    register: 0.24,
     bandPadding: 'var(--space-xs) var(--space-md)',
     labelSize: 'var(--text-md)',
   },
@@ -134,7 +130,6 @@ const SIZES: Record<'desktop' | 'mobile', BandSize> = {
     height: 26,
     view: 360,
     discHeight: 10,
-    register: 0.2,
     bandPadding: 'var(--space-xs) var(--space-sm)',
     labelSize: 'var(--text-base)',
   },
@@ -153,8 +148,8 @@ export default function EphemeristsFeedFrame({
     <div
       style={{
         position: 'relative',
-        // The ornament z-indexes (the register behind the label, the cornice's
-        // own layer) stay inside this card. Without it they order against
+        // The ornament z-indexes (the band's hairline behind the label, the
+        // cornice's own layer) stay inside this card. Without it they order against
         // whatever stacking context the feed column happens to establish, which
         // is how a positioned ornament ends up over unrelated copy (§5).
         isolation: 'isolate',
@@ -164,7 +159,7 @@ export default function EphemeristsFeedFrame({
         color: INK,
       }}
     >
-      {/* ── The masthead: night sky, one incised register, the winged disc ── */}
+      {/* ── The chassis band: night sky, ruled off, four chrome slots ── */}
       <div
         style={{
           position: 'relative',
@@ -177,8 +172,8 @@ export default function EphemeristsFeedFrame({
         <svg
           width="100%"
           height={size.height}
-          // The viewBox tracks the band's own height so `slice` crops the
-          // register at the edges rather than through the middle of every sign.
+          // The viewBox tracks the band's own height, so `slice` crops the
+          // hairline at the edges rather than scaling it off the band.
           viewBox={`0 0 ${size.view} ${size.height}`}
           preserveAspectRatio="xMidYMid slice"
           aria-hidden="true"
@@ -190,12 +185,14 @@ export default function EphemeristsFeedFrame({
             strokeWidth="0.6"
             opacity="0.24"
           />
-          <GlyphRegister
-            width={size.view}
-            y={size.height - 7}
-            strength={size.register}
-            keyPrefix="feed"
-          />
+          {/* AN INCISED REGISTER RAN ALONG THE FOOT OF THIS BAND (#2210). It
+              was the old glyph vocabulary, which #2143 replaced on the masthead
+              with the notation band and then left standing everywhere else —
+              two vocabularies at once, overlapping wherever they shared a band.
+              The register retires; nothing replaces it here, because the
+              notation band is the MASTHEAD's last line and this frame has no
+              masthead: it places its four chrome slots by hand. The hairline
+              above still rules the band's head. */}
         </svg>
 
         {/* The four chrome slots, placed by hand rather than through

--- a/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
+++ b/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
@@ -90,16 +90,27 @@ describe('EphemeristsFeedFrame — the Valley plate ground', () => {
 
   it('reuses the kit ornament rather than drawing new marks', () => {
     const html = frame()
-    // The kite sigil (#1635) and the incised register (`epg-glyph`, whose
-    // breathe cycle + reduced-motion gate live in index.css). The band's mark
-    // was the winged sun disc until #1634 retired it kit-wide; this row was its
-    // last caller anywhere, so the disc's own `plate-disc` medallion fill must
-    // not survive here.
+    // The kite sigil (#1635). The band's mark was the winged sun disc until
+    // #1634 retired it kit-wide; this row was its last caller anywhere, so the
+    // disc's own `plate-disc` medallion fill must not survive here.
     // The kite's opening move. Redrawn brushed by Sigil Studies v2 — six fills
     // on a square 100-unit box, where #1635's was a stroked diamond on 486x560.
     expect(html).toContain('M19.1 30.8')
     expect(html).not.toContain('--faction-ephemerists-plate-disc')
-    expect(html).toContain('epg-glyph')
+  })
+
+  it('carries no glyph register — this band has no masthead to hang one on', () => {
+    // An incised register (`epg-glyph`) ran along the foot of the band until
+    // #2210. It was the OLD vocabulary: #2143 gave the masthead the notation
+    // band and left this one standing, so the faction wore two at once. The
+    // register retires and NOTHING replaces it here — the notation band is the
+    // masthead's last line, and this frame places its four chrome slots by
+    // hand rather than mounting `EphemeristsMasthead`.
+    const html = frame()
+    expect(html, 'the retired incised register').not.toContain('epg-glyph')
+    expect(html, 'a band mounted where there is no lockup').not.toContain('3px double')
+    // What still rules the band's head is its own hairline.
+    expect(html).toContain('stroke-width="0.6"')
   })
 
   it('takes the sigil at the REDUCED cut, since the band is 10-14px tall', () => {

--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -254,36 +254,49 @@ function sources(): { path: string; source: string }[] {
   return found
 }
 
-describe('the fluted rule is retired kit-wide (#1638)', () => {
-  it('leaves no FlutedRule anywhere — not a mount, not a second declaration', () => {
+describe('one ornament vocabulary, and it is the notation band (#2210)', () => {
+  it('leaves no FlutedRule anywhere — not a mount, not a second declaration (#1638)', () => {
     expect(sources().filter(({ source }) => source.includes('FlutedRule'))).toEqual([])
   })
 
-  it('mounts the rune band on every surface the flute had', () => {
-    // Six imports plus the task page, whose local copy #1638 collapsed into the
-    // shared one. Counted as FILES rather than mounts because the task page
-    // draws it twice, and the number that can silently drift is how many
-    // surfaces reach the kit at all.
-    //
-    // Seven until #1314. `EphemeristsFactionPage` was one of them and is gone
-    // with the whole `mobileFactionPage` surface (ADR-0078) — the band it drew
-    // is still on the phone, because `EphemeristsFactionBody` (already counted)
-    // now serves both widths. A DELETED surface is the one way this number may
-    // fall; it must never fall because a mount was dropped.
-    const mounts = sources().filter(({ source }) => source.includes('<RuneRule'))
-    expect(mounts.length).toBe(6)
+  /**
+   * #2143 gave the masthead the NOTATION BAND — mathematical marks — and
+   * retired none of the astro/alchemical register it replaced, so both drew and
+   * they overlapped wherever they shared a band. The owner's ruling is that the
+   * register retires ENTIRELY rather than moving clear: the band is the
+   * faction's only ornament row.
+   *
+   * The seam is the SOURCE tree for the same reason #1638's was. Eight mounts
+   * across eight files render perfectly on their own; only a sweep of the tree
+   * can say that none of them is left, and only a sweep catches a NEW mount
+   * appearing later.
+   */
+  it('leaves no glyph register anywhere — not a mount, not a declaration', () => {
+    const files = sources()
+    for (const retired of ['GlyphRegister', 'RuneRule']) {
+      const alive = files.filter(({ source }) => new RegExp(`\\b${retired}\\b`).test(source))
+      expect(alive.map((file) => file.path), `${retired} still ships`).toEqual([])
+    }
+    // `Glyph` drew one sign for the register and had no other caller: the task
+    // card and the task page both reach `GLYPHS` directly, and `Sign` is the
+    // kit's one-mark component. Word-bounded, or `GlyphRegister` (gone above)
+    // and `GlossedGlyph` would answer for it.
+    const glyph = files.filter(({ source }) => /\b(?:function|const)\s+Glyph\b/.test(source))
+    expect(glyph.map((file) => file.path), 'Glyph still ships').toEqual([])
   })
 
-  it('draws the band out of the kit register, in brass rather than gold', () => {
-    // Gold is the masthead's ink on a night band; on the papyrus page it is a
-    // stain. `-brass` is the plate's rule colour and never an ink.
-    const kit = readFileSync(KIT, 'utf8')
-    const rule = kit.slice(kit.indexOf('export function RuneRule'))
-    expect(rule).toContain('<GlyphRegister')
-    expect(rule).toContain('color={BRASS}')
-    // The shift is the register's own `.epg-glyph` cycle, already gated on
-    // reduced-motion — the band declares no animation of its own.
-    expect(rule.slice(0, rule.indexOf('\n}'))).not.toContain('animation')
+  /**
+   * The band is THE MASTHEAD'S LAST LINE — that is the whole argument for it
+   * (#2143), and it is why the surfaces with no lockup get nothing in the
+   * register's place rather than a band mounted to fill the space. The faction
+   * hero, the feed frame and the select tile each head themselves by hand; none
+   * of them takes `EphemeristsMasthead`, so none of them takes the band.
+   */
+  it('mounts the notation band from the masthead and nowhere else', () => {
+    const mounts = sources().filter(({ source }) => source.includes('<EphemeristsNotationBand'))
+    expect(mounts.map(({ path }) => path.split(/[\\\/]/).pop())).toEqual([
+      'EphemeristsMasthead.tsx',
+    ])
   })
 })
 
@@ -317,7 +330,7 @@ describe('the Ephemerists mark vocabulary is declared once (#1654)', () => {
     // and the ORDER is the card's. Word-bounded, or `AuthorOctagon`,
     // `GlossedGlyph` and `LotusSign` would each answer for their base name.
     const files = sources()
-    for (const mark of ['Glyph', 'GlyphRegister', 'Octagon', 'Cornice', 'Tally', 'Sign']) {
+    for (const mark of ['Octagon', 'Cornice', 'Tally', 'Sign']) {
       const declared = files.filter(({ source }) =>
         new RegExp(`\\b(?:function|const)\\s+${mark}\\b`).test(source),
       )

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -57,9 +57,10 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  * shows, one card per row. Nothing here is form-factor branched.
  *
  * The ornament is the shared kit's (`ephemeristsPlate`), not a second copy:
- * `GlyphRegister`, `WingedDisc`, `Cornice`, `LotusSign`, `stepClip`. The
- * register's breathing is `.epg-glyph`, whose reduced-motion gate and resting
- * state live in index.css.
+ * `Cornice`, `LotusSign`, `stepClip`. The drifting strip below breathes on
+ * `.epg-glyph`, whose reduced-motion gate and resting state live in index.css —
+ * the class outlived the incised register it was named for (#2210), and the
+ * marks it now paces are the plate's mathematical ones.
  *
  * DEVIATIONS from the vendored `#eph` / `#ephD` frames, all four in the PR body:
  *  • the drifting strip's marks are ochre and CAPTION gold, not ochre and brass

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -234,8 +234,8 @@ export function SnideSelectCard({ state = "locked", members, onVisit }: Omit<Fac
 
 /**
  * The Ephemerists tile — the cornice masthead the plate hangs under, standing on
- * its own (#1208). The night band, an incised glyph register above the footer,
- * the sigil ruled in brass, and the CTA in the plate’s gold. Nothing legible is
+ * its own (#1208). The night band, the sigil ruled in brass, and the CTA in the
+ * plate’s gold. Nothing legible is
  * set in `brass`; on this ground the inks are `band-ink` (12.4:1), `gold` (9.4)
  * and `band-quiet` (8.6).
  */
@@ -248,9 +248,10 @@ export function EphemeristsSelectCard({ state = "locked", members, onVisit }: Om
       border: `1px solid ${eph.BRASS}`, boxShadow: eph.SHADOW, display: "flex", flexDirection: "column",
     }}>
       <div style={{ position: "absolute", inset: 9, border: `1px solid color-mix(in srgb, ${eph.BRASS_LIGHT} 35%, transparent)`, pointerEvents: "none" }} />
-      <svg width="100%" height={26} viewBox="0 0 360 26" preserveAspectRatio="xMinYMid slice" aria-hidden="true" style={{ position: "absolute", left: 0, bottom: 62, opacity: 0.55 }}>
-        <eph.GlyphRegister width={360} y={13} strength={0.5} keyPrefix="sel" />
-      </svg>
+      {/* An incised glyph register ran above the footer until #2210. It was
+          the OLD vocabulary the notation band replaced on the masthead, and it
+          retires kit-wide; nothing takes its place here, because this tile
+          heads itself by hand and mounts no `EphemeristsMasthead`. */}
       <div style={{ position: "absolute", top: 16, right: 18, fontSize: "var(--text-md)", letterSpacing: "0.1em", color: eph.BAND_QUIET, textAlign: "right", lineHeight: 1.5 }}>{i18n.t("feed:factionSelect.ephemerists.coords")}<br />{i18n.t("feed:factionSelect.ephemerists.coordsPolar")}</div>
       <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-xl) 0" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)" }}>

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -155,7 +155,6 @@ import {
   PLATE,
   QUIET,
   READING,
-  RuneRule,
   SHADOW,
   Sign,
 } from "../../../components/factionMarks/ephemeristsPlate";
@@ -271,16 +270,20 @@ export default function EphemeristsEditPraxis({ state }: Props) {
   /** Section heads sit on the plate, where the caption gold is measured. */
   const sectionLabel = { ...label, color: CAPTION };
   /**
-   * The rune band is this skin's rule (#1638, replacing the flute), drawn ONCE
-   * above the footer (#1707) rather than at the head of every section — the
-   * design calls its rule once and parts the regions with the sheet's own gap.
+   * The skin's rule, drawn ONCE above the footer (#1707) rather than at the head
+   * of every section — the design calls its rule once and parts the regions with
+   * the sheet's own gap.
    *
-   * PAIRED with the brass hairline, which the plate's other mounts are not:
-   * each of those sits under a section HEAD whose own filler rule already draws
-   * that line, while the composer's rule closes a column of bare field labels.
-   * On its own the band reads as a loose row of marks rather than as a rule.
+   * IT IS THE BRASS HAIRLINE ALONE SINCE #2210. The rule used to be that
+   * hairline PAIRED with the kit's rune band, and the pairing was the point: the
+   * plate's other mounts sat under a section HEAD whose own filler rule already
+   * drew the line, while this one closes a column of bare field labels, where a
+   * band on its own read as a loose row of marks. #2210 retires the band's glyph
+   * vocabulary kit-wide, so what is left is the half that was doing the ruling —
+   * the same 1px brass the section heads draw, through the shared
+   * `ComposerRule` rather than a second declaration of it here.
    */
-  const runes = <RuneRule rule />;
+  const composerRule = <ComposerRule style={{ background: BRASS, opacity: 0.5 }} />;
 
   /** Radius 0, borderW 1.5 — the skin's whole geometry row. */
   const fieldBox = {
@@ -448,7 +451,7 @@ export default function EphemeristsEditPraxis({ state }: Props) {
     sheetStyle,
     masthead,
     ground,
-    rule: () => runes,
+    rule: () => composerRule,
     mark: statusMark,
     statusStyle: { ...label, color: INK },
     metaStyle: { fontFamily: READING, color: QUIET },
@@ -770,9 +773,9 @@ export default function EphemeristsEditPraxis({ state }: Props) {
 
         <ErrorBanner message={state.error} style={{ color: ALARM }} />
 
-        {/* The footer's own divider. `ComposerRule` hands its whole box over
-            when it is given children, so the rune band replaces the hairline. */}
-        <ComposerRule>{runes}</ComposerRule>
+        {/* The footer's own divider — the plate's brass, at the shared rule's
+            own 1px. */}
+        {composerRule}
 
         {/* [Cancel] … [Submit] — the global order from #646. The cast is a
             full-bleed band (#1828) with the open eye following the word. */}

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -15,7 +15,6 @@ import {
   CAPS,
   CAPTION,
   DECO,
-  RuneRule,
   GOLD,
   INK,
   LINE,
@@ -48,8 +47,9 @@ import type { FactionDetailState } from "../useFactionDetail";
  *
  * SWEPT OFF THE CODEX (#1208). Every mark is the plate kit's rather than a
  * private drawing: the roster's circular vellum medallions are `AuthorOctagon`,
- * the level beside a keeper's name gains the `Tally`, and every section rule is
- * `RuneRule`. Two faction grounds carry ink here — the plate (`ink` 13.91:1,
+ * the level beside a keeper's name gains the `Tally`, and every section rule was
+ * the kit's rune band until #2210 retired the old glyph vocabulary and left the
+ * section heads as bare type. Two faction grounds carry ink here — the plate (`ink` 13.91:1,
  * `quiet` 5.98, `caption` 7.22, `nile` 7.00) and the night band under the
  * spotlight (`band-ink` 14.00, `gold` 14.00, `band-quiet` 8.97). Every one of
  * those eight numbers was stale when #1793 re-derived them: they were measured
@@ -119,14 +119,16 @@ const SECTION_HEADING: CSSProperties = {
   color: "var(--color-text-primary)",
 };
 
-/** Section title in the plate's display face, over the design's fluted rule. */
+/**
+ * Section title in the plate's display face.
+ *
+ * It stood over a rune band until #2210, which retires the old glyph vocabulary
+ * kit-wide: the notation band is the faction's only ornament row and it is the
+ * MASTHEAD's last line, so a page that heads its sections with bare type takes
+ * nothing in the band's place.
+ */
 function SectionHeading({ children }: { children: ReactNode }) {
-  return (
-    <>
-      <h2 style={SECTION_HEADING}>{children}</h2>
-      <RuneRule />
-    </>
-  );
+  return <h2 style={SECTION_HEADING}>{children}</h2>;
 }
 
 // `romanLevel` formatted the roster and spotlight levels as "level {roman}".

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EphemeristsFieldDesk.tsx
@@ -13,7 +13,6 @@ import {
   BRASS_LIGHT,
   CAPTION,
   DECO,
-  RuneRule,
   INK,
   INNER,
   LINE,
@@ -128,9 +127,10 @@ export default function EphemeristsFieldDesk({ state }: { state: FieldDeskHomeSt
         <h1 style={{ fontFamily: DECO, fontSize: 'var(--text-title)', lineHeight: 1.05, letterSpacing: '0.04em', color: INK, margin: 'var(--space-xs) 0 0' }}>
           {t('fieldDesk.home.title')}
         </h1>
-        <div style={{ marginTop: 'var(--space-sm)' }}>
-          <RuneRule />
-        </div>
+        {/* A rune band closed the running head until #2210 retired the old
+            glyph vocabulary kit-wide. The desk mounts no masthead, so nothing
+            takes its place — the column's own `--space-lg` gap parts the head
+            from the first leaf. */}
       </header>
 
       {/* ── Observer leaf ── */}

--- a/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx
@@ -106,8 +106,6 @@ import {
   DECO,
   DISC,
   METAL_SIGILS,
-  RuneRule,
-  GlyphRegister,
   initialsOf,
   INK,
   INNER,
@@ -204,9 +202,8 @@ function useObservedWidth(): [(node: HTMLElement | null) => void, number | null]
 }
 
 interface SizeSet {
-  /** Masthead band height, and the width its registers are drawn to fill. */
+  /** Masthead band height. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
   masthead: number
-  mastheadView: number
   /** A byline octagon. Geometry. */
   disc: number
   titleSize: string
@@ -221,7 +218,6 @@ interface SizeSet {
 const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   desktop: {
     masthead: 84,
-    mastheadView: 1200,
     disc: 46,
     titleSize: "var(--text-display)",
     pagePadding: "var(--space-2xl)",
@@ -231,7 +227,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   },
   mobile: {
     masthead: 68,
-    mastheadView: 440,
     disc: 40,
     titleSize: "var(--text-heading)",
     pagePadding: "var(--space-lg)",
@@ -408,14 +403,21 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
         <span aria-hidden style={{ flex: 1, minWidth: 24, height: 1, background: BRASS, opacity: 0.5 }} />
         {trailing}
       </div>
-      <RuneRule />
+      {/* A rune band ruled the head off under this row until #2210. The band's
+          glyph vocabulary retires kit-wide, and the head keeps its rule: the
+          brass hairline above already flexes the width of the row. */}
     </div>
   );
 
-  // ── The masthead: night band, one incised register, the engraved title ────
+  // ── The masthead: the night band and the engraved title ──────────────────
   //
-  // Shorter than the task page's: a record is filed ON the plate, not the plate
-  // itself, so it carries one register rather than two.
+  // AN ORNAMENT LAYER SAT BEHIND THE LOCKUP UNTIL #2210 — an absolutely
+  // positioned SVG carrying one incised glyph register plus the pair of faint
+  // brass rules that ruled it off from the title. The whole layer goes, not
+  // just the register: those two rules existed to bracket it, and #2143's
+  // notation band brought the masthead its own `1px` / `3px double` pair, which
+  // is the head's rule now. What is left on the band is the lockup, which no
+  // longer needs a stacking layer to sit above.
   const masthead = (
     <div>
       <div
@@ -427,29 +429,11 @@ export default function EphemeristsPraxisDetail({ state }: { state: PraxisDetail
           color: BAND_INK,
         }}
       >
-        <svg
-          width="100%"
-          height="100%"
-          viewBox={`0 0 ${size.mastheadView} 84`}
-          preserveAspectRatio="xMidYMid slice"
-          aria-hidden="true"
-          style={{ position: "absolute", inset: 0, zIndex: 1 }}
-        >
-          <path
-            d={`M8 20 H${size.mastheadView - 8} M8 64 H${size.mastheadView - 8}`}
-            stroke={BRASS_LIGHT}
-            strokeWidth="0.6"
-            opacity="0.28"
-          />
-          <GlyphRegister width={size.mastheadView} y={72} strength={0.3} keyPrefix="rec" />
-        </svg>
-        <div style={{ position: "relative", zIndex: 2 }}>
-          <EphemeristsMasthead
-            slug={praxis.task_faction_slug}
-            scale={desktop ? "page" : "card"}
-            seed={`praxis:${praxis.id}`}
-          />
-        </div>
+        <EphemeristsMasthead
+          slug={praxis.task_faction_slug}
+          scale={desktop ? "page" : "card"}
+          seed={`praxis:${praxis.id}`}
+        />
       </div>
       <Cornice glow />
     </div>

--- a/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/ephemeristsDetail.test.tsx
@@ -123,11 +123,13 @@ describe("Ephemerists task detail — the Valley plate", () => {
     }
   });
 
-  it("wears the Valley dress — masthead band, incised registers, engraved title", () => {
+  it("wears the Valley dress — masthead band, notation band, engraved title", () => {
     const { html, text } = render(<EphemeristsTaskDetail state={baseState()} />);
     expect(html, "papyrus page sheet").toContain("eph-plate-sheet");
     expect(html, "cornice masthead band").toContain("--faction-ephemerists-plate-band");
-    expect(html, "incised glyph registers").toContain("epg-glyph");
+    // Two incised glyph registers (`epg-glyph`) were asserted here. #2210
+    // retired them: the notation band is the head's only ornament row, and the
+    // block further down is what says so.
     expect(html, "the stepped octagon medallion").toContain("M30 4 L70 4 L96 30");
     expect(text, "the masthead wordmark").toContain("The Ephemerists");
     // The kite's opening move; brushed rather than ruled since Sigil Studies v2.
@@ -295,7 +297,7 @@ describe("the Valley plate's tokens", () => {
  * #1654 — the page draws the kit's marks, at the PAGE's densities.
  *
  * Seven of this file's declarations were transcriptions of `ephemeristsPlate`'s
- * — `GLYPHS`, `Glyph`, `GlyphRegister`, `Octagon`, `Cornice`, `Tally`, `Sign` —
+ * — `GLYPHS`, the register and its marks, `Octagon`, `Cornice`, `Tally`, `Sign` —
  * so a mark redrawn in the kit left this page on the old one, silently. The
  * source-tree guard against a fresh copy lives in
  * `praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx`; what only rendering
@@ -313,14 +315,17 @@ describe("the Valley page's ornament comes from the kit unchanged (#1654)", () =
     expect(page().match(/height:3\.5px/g)).toHaveLength(26);
   });
 
-  it("fills both masthead registers from the width, not a fixed 16", () => {
-    // `Math.ceil(1200 / 27.5)` = 44 signs a row, twice. A fixed count would
-    // stop short of the page edge at the 1200 cap; the design's own 16 is the
-    // number the local copy documented itself as NOT using. Sliced to the
-    // masthead's own svg so the page's rune bands — one per section head, and
-    // a section count this has no opinion about — cannot move it.
-    const masthead = page().slice(0, page().indexOf("</svg>"));
-    expect(masthead.match(/class="epg-glyph"/g)).toHaveLength(44 * 2);
+  it("heads the page with the notation band and no glyph register (#2210)", () => {
+    // This asserted the OPPOSITE until #2210: 44 signs a row, twice, filled
+    // from the 1200px cap. #2143 hung the mathematical notation band under the
+    // wordmark and left both registers standing, so the page wore two glyph
+    // vocabularies at once and the lower row ran through the band's own marks.
+    // The registers retire; the band is the head's last line and its only
+    // ornament row, and the page's section heads keep the brass hairline that
+    // already flexes across each heading row.
+    const html = page();
+    expect(html, "the retired incised registers").not.toContain("epg-glyph");
+    expect(html, "the notation band's closing rule").toContain("3px double");
   });
 
   it("strikes the summons in platinum, off the shared sign table", () => {

--- a/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx
@@ -17,10 +17,8 @@ import {
 } from "./shared";
 import {
   Cornice,
-  GlyphRegister,
   initialsOf,
   Octagon,
-  RuneRule,
   Sign,
   SMALL_CAPS,
   Tally,
@@ -132,11 +130,12 @@ const BRIEF_LEADING = 32;
 
 /* The glyph library, its 16-sign register and their pitch stood here — a
    transcription of the kit's, path for path, which is exactly the shape that
-   lets one surface keep drawing last month's mark. #1654 collapsed it along
-   with `Glyph`, `GlyphRegister`, `Octagon`, `Cornice`, `Tally` and `Sign`: all
-   seven now come from `factionMarks/ephemeristsPlate`, imported at the top of
-   this file. Nothing on this page draws differently — the kit's `GlyphRegister`
-   defaults its ink to the same gold the local one hardcoded. */
+   lets one surface keep drawing last month's mark. #1654 collapsed all seven
+   into `factionMarks/ephemeristsPlate`, imported at the top of this file.
+   #2210 then retired the REGISTER itself, kit and copies together: the
+   mathematical notation band #2143 hung under the wordmark is the faction's
+   only ornament row, and `GLYPHS` survives as the vocabulary for a single mark
+   drawn by `Sign`. */
 
 /* The page's own `SMALL_CAPS` stood here — the kit's constant to the byte, and
    the last thing in this file that restated the plate's typography. It is now
@@ -154,16 +153,14 @@ const BRIEF_LEADING = 32;
 /* The page's own hand-copied `FlutedRule` stood here — a second, byte-identical
    declaration of the kit's divider that no import-following sweep could see, so
    #1638's "fluted rules become shifting runes" would have converted six mounts
-   and silently left this page's two on the old drawing. The rule is now
-   `RuneRule` from `factionMarks/ephemeristsPlate`, imported at the top of this
-   file: one divider, seven mounts, one place to change it. #1654 did the same
-   for the other eleven, so nothing in this file declares a mark any more. */
+   and silently left this page's two on the old drawing. Its replacement, the
+   kit's rune band, retired with the rest of the old glyph vocabulary in #2210;
+   this page's two section heads keep the brass hairline that already flexes
+   across each heading row. Nothing in this file declares a mark. */
 
 interface SizeSet {
   /** Masthead band height. Geometry, so a raw px number (WORLD_ZERO_STYLE §4a). */
   masthead: number
-  /** Width the masthead's registers are drawn to fill. Geometry. */
-  mastheadView: number
   /** The wordmark's winged disc. Geometry. */
   wordmarkDisc: number
   /** The disc crowning the action panel, and the room reserved above it. */
@@ -191,7 +188,6 @@ interface SizeSet {
 const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   desktop: {
     masthead: 108,
-    mastheadView: 1200,
     wordmarkDisc: 176,
     medallion: 104,
     ledgerWidth: 150,
@@ -205,7 +201,6 @@ const SIZES: Record<"desktop" | "mobile", SizeSet> = {
   },
   mobile: {
     masthead: 92,
-    mastheadView: 440,
     wordmarkDisc: 150,
     medallion: 88,
     ledgerWidth: 116,
@@ -390,11 +385,26 @@ export default function EphemeristsTaskDetail({
         <span aria-hidden style={{ flex: 1, minWidth: 24, height: 1, background: BRASS, opacity: 0.5 }} />
         {gloss !== undefined && <span style={eyebrow}>{gloss}</span>}
       </div>
-      <RuneRule />
+      {/* A rune band closed this head until #2210 retired the old glyph
+          vocabulary. The hairline above rules the head off on its own. */}
     </div>
   );
 
-  // ── The masthead: the night band, its two registers, the engraved title ──
+  // ── The masthead: the night band and the engraved title ──────────────────
+  //
+  // AN ORNAMENT LAYER SAT BEHIND THE LOCKUP UNTIL #2210 — an absolutely
+  // positioned SVG carrying two incised glyph registers, one along the top of
+  // the band and one along the foot, with a pair of faint brass rules bracketing
+  // them off from the title. This is the surface the owner reported: #2143 put
+  // the NOTATION BAND under the wordmark and left the registers standing, so the
+  // page wore two glyph vocabularies at once and the lower register ran through
+  // the band's own marks — the row had been placed to clear a datum row the band
+  // had already replaced, and the band's lead had opened from 5px to 9px.
+  //
+  // The whole layer goes, not just the two registers: the pair of rules existed
+  // to bracket them, and the notation band brought the masthead its own `1px` /
+  // `3px double` pair, which is the head's rule now. What is left on the band is
+  // the lockup, which no longer needs a stacking layer to sit above.
   const masthead = (
     <div style={{ marginBottom: desktop ? "var(--space-xl)" : "var(--space-lg)" }}>
       <div
@@ -406,30 +416,11 @@ export default function EphemeristsTaskDetail({
           color: BAND_INK,
         }}
       >
-        <svg
-          width="100%"
-          height="100%"
-          viewBox={`0 0 ${size.mastheadView} 108`}
-          preserveAspectRatio="xMidYMid slice"
-          aria-hidden="true"
-          style={{ position: "absolute", inset: 0, zIndex: 1 }}
-        >
-          <path
-            d={`M8 24 H${size.mastheadView - 8} M8 84 H${size.mastheadView - 8}`}
-            stroke={BRASS_LIGHT}
-            strokeWidth="0.6"
-            opacity="0.28"
-          />
-          <GlyphRegister width={size.mastheadView} y={13} strength={0.34} keyPrefix="top" />
-          <GlyphRegister width={size.mastheadView} y={95} strength={0.3} keyPrefix="bottom" />
-        </svg>
-        <div style={{ position: "relative", zIndex: 2 }}>
-          <EphemeristsMasthead
-            slug={slug}
-            scale={desktop ? "page" : "card"}
-            seed={`task:${task.id}`}
-          />
-        </div>
+        <EphemeristsMasthead
+          slug={slug}
+          scale={desktop ? "page" : "card"}
+          seed={`task:${task.id}`}
+        />
       </div>
       <Cornice />
     </div>
@@ -946,7 +937,6 @@ export default function EphemeristsTaskDetail({
             </span>
           )}
         </div>
-        <RuneRule />
       </div>
 
       {sortedSubmissions.length === 0 ? (


### PR DESCRIPTION
The Ephemerists were wearing two glyph vocabularies at once. #2143 gave the masthead the **notation band** (mathematical marks) in place of the datum row and retired **none** of the old astro/alchemical register, so both drew — and they overlapped, because the old rows were placed to clear a datum row the band had already replaced and the band's lead had opened from 5px to 9px. Owner ruling: `GlyphRegister` retires **entirely**; the notation band is the faction's only ornament row, carried by the masthead wherever there is one.

Closes #2210

## The seam I tested at

The **source tree**, in `praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx` — the same seam #1638 and #1654 used, and for the same reason: eight mounts across six files each render perfectly on their own, so only a sweep of the tree can say none is left, and only a sweep catches a new mount appearing later. The first commit is that test going red on the real defect (six files still carrying `GlyphRegister`), including one the issue's table did not list. Two render-level tests moved with it: the task page and the feed frame each asserted `epg-glyph` was **present**, which is the suite being green *on* the defect.

## Every mount, and what took its place

The issue's table was enumerated before #2146 merged, so I re-grepped. Two corrections:

- **`praxisCard/desktop/EphemeristsPraxisCard.tsx` no longer mounts one** — #2185 moved that card onto the shared `EphemeristsBand`, so line 123 is now unrelated. Only its prose named the register. Its drifting strip (∇ Ψ ∂ …) is the *mathematical* vocabulary and stays.
- **`components/selectCard/FactionSelectCard.tsx:252` mounts one and is not in the table** (`<eph.GlyphRegister … keyPrefix="sel">`, above the tile's footer). Retired with the rest.

| surface | had | now |
|---|---|---|
| `EphemeristsTaskDetail` masthead | 2 registers + their bracketing rules | **nothing** — the notation band is already there, inside `EphemeristsMasthead` |
| `EphemeristsPraxisDetail` masthead | 1 register + its bracketing rules | **nothing** — same |
| `EphemeristsFactionHero` | 2 registers | **nothing** — no lockup |
| `EphemeristsFeedFrame` | 1 register | **nothing** — no lockup; the band's own top hairline stays |
| `FactionSelectCard` (Ephemerists tile) | 1 register | **nothing** — no lockup |
| `RuneRule` (kit) → 7 mounts | a register in brass | **retired** — see below |

## The judgement calls, stated

**The whole ornament LAYER goes on the two detail mastheads, not just the registers.** Each was an absolutely-positioned SVG holding the register(s) *plus* a pair of faint brass rules whose only job was to bracket them off from the title. With the register gone those rules rule nothing off, and the notation band brought the masthead its own `1px` / `3px double` pair — which is the head's rule now. Leaving two floating hairlines across a band would have been debris from the same geometry the owner reported. The lockup's `z-index: 2` wrapper goes with the layer it was stacking above, and `mastheadView` (the width the registers were drawn to fill) falls out of both `SizeSet`s.

**Nothing replaces the row on the hero, the feed frame or the select tile.** The band's whole argument is that it is the *masthead's* last line — it inherits the datum row's rules and closes the head against the sheet. All three of those surfaces head themselves by hand and mount no `EphemeristsMasthead`, so a band there would be ornament filling a hole. A test pins this: `<EphemeristsNotationBand` may appear in exactly one file.

**`RuneRule` retires too, and so do its seven mounts.** It drew exactly one thing — a `GlyphRegister` in brass — plus an optional hairline. With the register gone it is an empty box. What each mount keeps:

- **both detail pages' section heads and the task page's gallery head** — already rule themselves off with the brass hairline that flexes across the heading row. Delete outright; a second rule would have doubled it.
- **the composer (`EphemeristsEditPraxis`)** — the one mount that had no heading, and the one that asked for the hairline (`<RuneRule rule />`). It keeps exactly that hairline, through the shared `ComposerRule` rather than a new declaration: `<ComposerRule style={{ background: BRASS, opacity: 0.5 }} />`, which is the same `height: 1` / `BRASS` / `0.5` the band's `rule` half drew.
- **the comment leaf, the faction body's `SectionHeading`, the field desk's running head** — drew no rule at all, so nothing is added. On the leaf in particular a hairline struck directly under the leaf's own 1px border would read as a doubled edge.

Nothing new was invented: existing rules survive, the glyph row goes.

## Not touched

`EphemeristsNotationBand` is untouched and still seeded per surface (`task:{id}` / `praxis:{id}`). `seededRandom` stays in `ephemeristsPlate.tsx` with its two readers. `EphemeristsRuneStrip` (16 seeded turning slots bracketing the CTA, #2146) is a different component and stays. `GLYPHS` stays — `Sign` and the task card read it directly; what retired is the ROW, not the drawings. No `--faction-ephemerists-*` token added or edited; `index.css` is byte-identical (same build hash on both sides).

`.epg-glyph` stays in `index.css`: the praxis card's drifting strip and the rune strip both pace on it.

## Payload

`node scripts/bundle-budget.mjs` (gzip level 9, run from `frontend/`), against a build of `main` at 94c5262:

| | main | this branch |
|---|---|---|
| blocking JS (gzip -9) | 129,536 B | 129,535 B (**−1 B**) |
| blocking CSS | 22.2 KB — **same file hash** | unchanged |
| `dist/` total (raw) | 3,655,052 B | 3,651,941 B (**−3,111 B**) |

The saving is real but lands in the lazy route chunks, which is where the plate lives. **`WARN CSS` is pre-existing**: I built `main` and it reports the identical warning and the identical `index-DVqDplN5.css`.

## Verification

`tsc --noEmit` ✓ · `tsc -p tsconfig.design-sync.json` ✓ · `eslint src .ds-kit e2e` ✓ · `vitest run` — **344 files, 6043 passed** ✓ · `npm run build` ✓ · byte budget above.

**No visual QA.** I have no browser and did not run `npm run dev`; everything above is source, type and markup evidence.

## What to eyeball

Both themes on each, one ornament vocabulary and no overlap:

1. **Faction hero** (`/factions/ephemerists`) — the night band should carry the graticule and survey rays only; no glyph rows top or bottom.
2. **Feed frame** (any Ephemerists feed item) — the chassis band keeps its top hairline and its four chrome slots; no marks along its foot.
3. **Praxis card** — unchanged; check the drifting strip above the vote block still reads as the plate's own marks.
4. **Praxis detail** — the masthead band: sigil, wordmark, notation band with its `1px` / `3px double` rules, and nothing behind them. Section heads keep their brass hairline.
5. **Task detail** — the same masthead, plus the two section heads and the gallery head; this is the surface the overlap was reported on.

Worth a glance while you are there, since their rune band went: the **Ephemerists comment leaf**, the **faction page's section headings**, the **mobile field desk's running head**, and the **composer's footer rule** (now a plain brass hairline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
