### PR TITLE
A lone praxis card takes half the gallery row, not 320px (#2229)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4667,16 +4667,40 @@
      ONE filed praxis had that card stretch across the whole gallery row and
      dominate the page (#1897). One card should read like one of three.
 
+     HALF THE ROW, NOT THE BASIS (#2229). The cap first read
+     `--praxis-card-basis`, which reused one number for two questions and got
+     the second one wrong: 320px is where three cards should WRAP, but as a
+     ceiling in a ~1136px column it left a lone card stranded — clamped to a
+     quarter of the row and reading as squished rather than as one of three. A
+     fraction answers the actual question, "how much of the row may one card
+     take", at every column width instead of at one. So the two numbers are now
+     separate on purpose: the variable above still means where the row wraps and
+     stays at 320px, and this cap no longer reads it. Do not re-point it at the
+     variable to make them one knob again — that is the bug.
+
+     50% NEVER BITES A FULL ROW. Three items cannot each exceed half a row, so
+     the 3-across case is untouched and still wraps on the basis; the cap only
+     shows up once a row is under-filled, which is exactly when it is wanted.
+
      `max-width` and not `width`: it clamps a flex item regardless of flex-grow,
      and it constrains a different property than the card's inline `width: 100%`,
      so the cap lands without a specificity fight and without touching any of the
-     nine bespoke frames. Empty space to the right of a lone card is the point —
-     a gallery with one item in it, which is the truth.
+     nine bespoke frames. Empty space to the right of a lone card is still the
+     point — a gallery with one item in it, which is the truth. Half a row of it
+     rather than three quarters.
 
      No `min-width` here on purpose: `frameBase`'s 280px floor must keep winning
-     under a 320px viewport, one card per row on a phone. */
+     under a 320px viewport, one card per row on a phone. A percentage cap makes
+     that floor matter MORE, not less — 50% of a 320px viewport is 160px, and
+     the only reason the card does not collapse to it is that `min-width` beats
+     `max-width` in the cascade. Adding one here would fight the floor that is
+     already doing the job.
+
+     ONE RULE, ALL EIGHT KITS, deliberately: `.praxis-gallery` is mounted by
+     every task-detail archetype and by `WowFactionBody`. Forking it per faction
+     to spare seven pages would be worse than the bug it fixed. */
   .praxis-gallery > * {
-    max-width: var(--praxis-card-basis);
+    max-width: 50%;
   }
   /* ── Leaderboard row hover ── */
 

--- a/frontend/src/pages/taskDetail/__tests__/praxisGalleryBasis.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/praxisGalleryBasis.test.tsx
@@ -20,9 +20,14 @@
  * Drop either and the other is decorative: a class nobody reads, or a variable
  * nobody sets.
  *
- * #1897 added a third fact: the gallery also CAPS its children at that basis.
- * `frameBase` carries `flex-grow: 1`, so a task with exactly one praxis had that
- * card stretch across the whole row — one card should look like one of three.
+ * #1897 added a third fact: the gallery also CAPS its children. `frameBase`
+ * carries `flex-grow: 1`, so a task with exactly one praxis had that card
+ * stretch across the whole row — one card should look like one of three.
+ *
+ * #2229 refined that cap without reversing it. It was `var(--praxis-card-basis)`,
+ * which made one number answer two questions; it is now a flat 50%, so the
+ * variable means only "where the row wraps" and the cap means only "how much of
+ * the row one card may take". The pair is the fourth fact this file pins.
  *
  * CEILING (`renderToStaticMarkup`, no jsdom, no layout, no computed styles):
  * this cannot prove a card got smaller, that three land in a row, or that a skin
@@ -156,23 +161,41 @@ describe("task-detail praxis gallery basis (#1137)", () => {
   });
 });
 
-describe("a lone praxis card is capped at the gallery basis (#1897)", () => {
+describe("a lone praxis card takes half the row (#1897, refined by #2229)", () => {
   const capped = ruleBodies(css, ".praxis-gallery > *");
+  const gallery = ruleBodies(css, ".praxis-gallery");
 
-  it("the gallery caps its children at the basis it sets", () => {
+  it("the gallery caps its children at half the row", () => {
     // `frameBase` is `flex: 1 1 var(--praxis-card-basis)` — the leading grow is
-    // why a single card ate the whole row. The cap is the same variable, so the
-    // basis stays the one knob and one card matches one of three.
+    // why a single card ate the whole row (#1897). #2229 keeps that cap and
+    // changes its VALUE: 320px in a full-width row clamped a lone card to
+    // something that read as squished, so the cap is a fraction of the row.
     expect(capped.length, ".praxis-gallery > * rule must exist").toBeGreaterThan(0);
     for (const body of capped) {
-      expect(body).toMatch(/max-width\s*:\s*var\(\s*--praxis-card-basis\s*\)/);
+      expect(body).toMatch(/max-width\s*:\s*50%/);
     }
+  });
+
+  it("the cap no longer reads the wrap basis", () => {
+    // The two numbers answer different questions, and #2229 separated them: the
+    // basis says where the row WRAPS, the cap says how wide a lone card may
+    // grow. Re-pointing the cap at the variable re-couples them.
+    for (const body of capped) {
+      expect(body).not.toMatch(/--praxis-card-basis/);
+    }
+  });
+
+  it("leaves the wrap basis at 320px", () => {
+    // Unchanged by #2229 on purpose: three cards still wrap where they did, and
+    // a 50% cap cannot bite three items that each hold under half a row.
+    expect(gallery.length, ".praxis-gallery rule must exist").toBeGreaterThan(0);
+    expect(gallery.join("\n")).toMatch(/--praxis-card-basis\s*:\s*320px/);
   });
 
   it("leaves the card's 280px phone floor alone", () => {
     // ACCEPTANCE, not an oversight: `min-width` beats `max-width`, so under a
-    // 320px viewport the card still renders at 280, one per row. The cap must
-    // not restate or lower that floor.
+    // 320px viewport the card still renders at 280, one per row — a percentage
+    // cap cannot crush it either. The cap must not restate or lower that floor.
     expect(frameBase.minWidth).toBe(280);
     for (const body of capped) {
       expect(body).not.toMatch(/min-width/);


### PR DESCRIPTION
Closes #2229

`.praxis-gallery > *` capped its children at `var(--praxis-card-basis)`, which
made one number answer two questions and got the second one wrong. 320px is
where three cards should *wrap*; reused as a ceiling in the ~1136px content
column it left a task with exactly one filed praxis clamped to about a quarter
of the row — stranded in empty space and reading as squished.

The cap becomes a flat `max-width: 50%`. This **refines #1897, it does not
reverse it**: a lone card still must not span the row.

## Three things this deliberately does not change

1. **The 3-across case.** Three items cannot each exceed half a row, so the cap
   never bites and the 320px basis still governs where the row wraps.
2. **The phone floor.** No `min-width` was added. `frameBase`'s 280px
   `min-width` beats `max-width` in the cascade, which is the only reason a
   percentage cap cannot crush the card (50% of a 320px viewport is 160px).
3. **`--praxis-card-basis`.** Still 320px, still means "where the row wraps".
   Only the cap stopped reading it.

Scope is all eight kits on purpose — `.praxis-gallery` is one shared rule
mounted by every task-detail archetype and by `WowFactionBody`. Not forked per
faction.

#1897's rule comment said *"Empty space to the right of a lone card is the
point"* while describing the now-retired pixel cap. It has been rewritten so it
documents the fraction, says why the two numbers are now separate, and says not
to re-point the cap at the variable — a stale comment beside a changed rule is
how this comes back.

## Seam tested at

The declared body of `.praxis-gallery > *` in `frontend/src/index.css`, read via
`ruleBodies()` in the existing
`frontend/src/pages/taskDetail/__tests__/praxisGalleryBasis.test.tsx` — the same
seam #1897 pinned. That file already asserted the old
`max-width: var(--praxis-card-basis)`, so it was updated first and went red on
exactly the two assertions about the cap's value, then green.

Its coverage is now four facts, not three: the cap is `50%`, the cap no longer
mentions `--praxis-card-basis`, the basis is still `320px`, and the rule still
carries no `min-width` and no `width`.

**Ceiling, unchanged from #1897:** the harness is `renderToStaticMarkup` with no
jsdom, no layout and no computed styles. It proves the declaration, not the
pixels.

## Verification

Every step in the `frontend` job of `.github/workflows/test.yml`, run locally:
`lint`, `typecheck`, `typecheck:design-sync`, `test` (344 files, 6045 passed),
`build`, `budget`. No backend, route or Pydantic schema was touched, so
`api-schema` has nothing to regenerate.

The byte budget reports a **pre-existing** CSS `WARN` that this PR does not
cause. Measured at gzip level 9 against a build of `origin/main`'s `index.css`:
main **22763 B**, this branch **22762 B** — one byte smaller, since
`max-width: 50%` is shorter than the `var()` it replaced and comments are
stripped from the built sheet.

**Visual QA is outstanding** — I have no browser and did not run a dev server,
so nothing here confirms how the card actually looks.

## What to eyeball

- A task with **one** filed praxis at desktop width — the card fills half the
  row (this is the fix).
- The same task with **three** filed praxis — unchanged from today.
- **One card at a 320px viewport** — still 280px wide, one per row.
