### PR TITLE
The praxis heading row yields, the avatar does not (#2114, #2232)

### DIFF
--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -32,11 +32,32 @@ export function avatarDim(size: FactionAvatarProps['size']): number {
   return size === 'sm' ? 24 : 32
 }
 
+/**
+ * THE ROOT NEVER YIELDS ITS WIDTH (#2232), on either skin below.
+ *
+ * An avatar is a circle at a stated diameter, and it is nearly always mounted
+ * in a flex row beside a name the player typed — the praxis byline, the duel
+ * banner's rival face, the comment leaves. A flex item's initial `flex-shrink`
+ * is 1, and this root's automatic minimum size is its CONTENT's min-content:
+ * zero, because Tailwind's preflight gives every `img` a `max-width: 100%` and
+ * the monogram branch is a `width: 100%` span. So the root gave ground to a
+ * long name while the img kept the height it was handed inline, and the circle
+ * painted as an ellipse.
+ *
+ * `flex-shrink: 0` is inert wherever the parent is not a flex container, so
+ * this is the whole fix for every mount at once rather than a prop for the two
+ * that reported it. It is what `RosterAvatar` (praxis card) already says as
+ * `flex: none`. Note the direction is the OPPOSITE of the score stamp's on the
+ * same praxis-card row (#2114): the stamp is a panel and must give ground, this
+ * is a fixed disc and must not.
+ */
+const AVATAR_ROOT = { position: 'relative', display: 'inline-block', flexShrink: 0 } as const
+
 function DefaultAvatar({ character, size = 'md' }: FactionAvatarProps) {
   const dim = avatarDim(size)
   const badge = Math.max(12, Math.round(dim * 0.44))
   return (
-    <span style={{ position: 'relative', display: 'inline-block', width: dim, height: dim }}>
+    <span style={{ ...AVATAR_ROOT, width: dim, height: dim }}>
       {/*
         Spectrum ring around the portrait / monogram. CONIC, not the 90deg linear
         ramp: this is a disc, and a left-to-right ramp smears the spectrum across
@@ -176,7 +197,8 @@ export function BadgedAvatar({
   const isSmall = dim <= 24
   const badge = Math.max(12, Math.round(dim * 0.5))
   return (
-    <span style={{ position: 'relative', display: 'inline-block', width: dim, height: dim }}>
+    // Same root, same reason — see AVATAR_ROOT (#2232).
+    <span style={{ ...AVATAR_ROOT, width: dim, height: dim }}>
       <FactionCircle
         character={character}
         dim={dim}

--- a/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
+++ b/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
@@ -96,3 +96,45 @@ describe("FactionAvatar — Coven wears the hat (#2217)", () => {
     expect(html).not.toContain("M16.5 12a6.5");
   });
 });
+
+/**
+ * #2232 — the byline portrait rendered as an ellipse.
+ *
+ * Every avatar root is a `width: dim; height: dim` inline-block, and every
+ * surface that shows a name beside a face is a flex row: the praxis card's
+ * byline, the duel banner's rival face, the comment leaves. As a flex item the
+ * root took the initial `flex-shrink: 1`, and its automatic minimum size is its
+ * CONTENT's min-content — which for a portrait is zero, because Tailwind's
+ * preflight gives every `img` a `max-width: 100%`. So a long display name (the
+ * reporter's wraps to two lines) pulled the root narrower while the img kept
+ * the height it was handed inline: a 28px circle painted 20 x 28.
+ *
+ * The monogram fallback has the same root and the same exposure — its `<span>`
+ * is sized `width: 100%` of that root — so the guard belongs on the root, the
+ * one thing both branches and all eight skins share. `RosterAvatar` on the
+ * praxis card already carried `flex: none` for this reason; the shared surface
+ * did not.
+ *
+ * A layout assertion is impossible in this harness (no DOM, no fonts), so the
+ * seam is the declaration. Both roots are covered: `DefaultAvatar` (na, in
+ * FactionAvatar.tsx) and `BadgedAvatar` (the seven registered skins).
+ */
+describe("an avatar is a circle in a flex row (#2232)", () => {
+  const root = (html: string) => html.match(/^<[a-z]+[^>]*>/)?.[0] ?? "";
+
+  it.each([
+    ["the unaffiliated ring", "na"],
+    ["a registered skin", "singularity"],
+  ])("%s does not yield its width to the name beside it", (_label, slug) => {
+    const monogram = renderToStaticMarkup(
+      <FactionAvatar character={character({ faction_slug: slug })} />,
+    );
+    const portrait = renderToStaticMarkup(
+      <FactionAvatar
+        character={character({ faction_slug: slug, avatar_url: "/media/isolde.png" })}
+      />,
+    );
+    expect(root(monogram)).toContain("flex-shrink:0");
+    expect(root(portrait)).toContain("flex-shrink:0");
+  });
+});

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -190,7 +190,7 @@ describe('the meta line (#888)', () => {
  * cannot see it. `stampRestatesTaskPoints` is the rule both ends share, and it
  * is #1131's `baseRestatesTotal` reused rather than a second comparison.
  */
-describe('the meta line does not restate the stamp (#1833)', () => {
+describe("the meta line does not restate the stamp (#1833, widened by #2114)", () => {
   const body = (over: Partial<PraxisCardOut>) =>
     text(render(<PraxisBody praxis={aPraxisCard(over)} tint="#000" muted="#555" />))
 
@@ -207,12 +207,10 @@ describe('the meta line does not restate the stamp (#1833)', () => {
     expect(html).toContain('solo')
   })
 
-  it('keeps both figures once votes move the total off the base', () => {
-    // base 12 + 4 from votes = 16: two figures answering two questions.
-    const html = body({ score: 16, points_from_votes: 4 })
-    expect(html, 'what the task is worth').toContain('12 pts')
-    expect(html, 'what this praxis scored').toContain('16points')
-  })
+  // "keeps both figures once votes move the total off the base" was here, and
+  // #2114 retired it: a voted stamp prints the base as its own labelled BASE
+  // row, so the meta figure was a restatement in that case too — just of a row
+  // instead of the total. `headingRoom.test.tsx` holds the wider rule.
 
   it('keeps the base figure on a praxis with no stamp at all', () => {
     // #1444 gates the stamp off a `failed` praxis, so the meta line is the only

--- a/frontend/src/components/praxisCard/__tests__/headingRoom.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/headingRoom.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * #2114 — the praxis card's heading row, and how little of it the preview got.
+ *
+ * The row is `[text column] [score stamp]`. The text column was `flex: 1` —
+ * basis 0% — and every stamp declared `flex-shrink: 0` behind a 150px cap, so
+ * the row never had negative free space to distribute and the stamp held its
+ * full width at EVERY card width: 184px of text at the 394px `frameBase`
+ * default, 110px in a 320px cell, 70px at the 280px phone floor. The excerpt
+ * ran out of words before the card ran out of card.
+ *
+ * WHAT THESE PIN IS THE FLEX CONTRACT, not a rendered width: the suite is
+ * `renderToStaticMarkup` with no layout engine behind it, so the seam that can
+ * be asserted is the declaration each side makes. Both halves are load-bearing
+ * and neither works alone — a basis on the text column with a frozen stamp
+ * still cannot shrink anything, and an unfrozen stamp beside a basis-0 column
+ * never sees a deficit to shrink into.
+ *
+ * The FLOOR is deliberately not asserted: every stamp's `min-width` stays
+ * `auto`, which is its own drawn min-content size, so each skin gives up
+ * exactly the slack it has (the na plate's padding around a 96px mark) and no
+ * more (Coven's arched plate, which is 150px of ornament and yields nothing).
+ * A number here would be a second, rottable copy of eight bespoke geometries.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactElement } from 'react'
+import '../../../i18n'
+import type { PraxisCardOut } from '../../../api/praxis'
+import { PraxisBody, TEXT_MEASURE } from '../desktop/shared'
+import { aPraxisCard } from '../../../test/fixtures'
+import CovenScoreStamp from '../scoreStamp/CovenScoreStamp'
+import DefaultScoreStamp from '../scoreStamp/DefaultScoreStamp'
+import EphemeristsScoreStamp from '../scoreStamp/EphemeristsScoreStamp'
+import EverymenScoreStamp from '../scoreStamp/EverymenScoreStamp'
+import SingularityScoreStamp from '../scoreStamp/SingularityScoreStamp'
+import SnideScoreStamp from '../scoreStamp/SnideScoreStamp'
+import UaScoreStamp from '../scoreStamp/UaScoreStamp'
+import WowScoreStamp from '../scoreStamp/WowScoreStamp'
+
+const render = (node: ReactElement) =>
+  renderToStaticMarkup(<MemoryRouter>{node}</MemoryRouter>)
+
+const body = (over: Partial<PraxisCardOut> = {}) =>
+  render(<PraxisBody praxis={aPraxisCard(over)} tint="#000" muted="#555" />)
+
+const text = (html: string) => html.replace(/<[^>]*>/g, '')
+
+/** The `style` attribute of the first element matching `pattern`. */
+function styleOf(html: string, pattern: RegExp): string {
+  const tag = html.match(pattern)
+  expect(tag, `no element matched ${pattern}`).toBeTruthy()
+  return tag![0].match(/style="([^"]*)"/)?.[1] ?? ''
+}
+
+/** Every registered stamp skin, so the freeze cannot come back in one file. */
+const STAMPS = {
+  coven: CovenScoreStamp,
+  default: DefaultScoreStamp,
+  ephemerists: EphemeristsScoreStamp,
+  everymen: EverymenScoreStamp,
+  singularity: SingularityScoreStamp,
+  snide: SnideScoreStamp,
+  ua: UaScoreStamp,
+  wow: WowScoreStamp,
+}
+
+describe('the heading row can redistribute (#2114)', () => {
+  it('the text column asks for a measure rather than a basis of zero', () => {
+    // `flex: 1` is `1 1 0%`: the column starts at nothing and grows into
+    // whatever the stamp leaves, which is why the stamp never had to yield.
+    expect(body()).toContain(`flex:1 1 ${TEXT_MEASURE}px`)
+  })
+
+  // The ROOT element only: several skins freeze an inner piece against their own
+  // ornament (the Singularity readout, the Ephemerists rose), which is a
+  // decision inside a box whose outer size is already settled.
+  it.each(Object.entries(STAMPS))('the %s stamp is not frozen', (_slug, Stamp) => {
+    const root = styleOf(render(<Stamp praxis={aPraxisCard({ score: 16 })} />), /^<[a-z]+[^>]*>/)
+    expect(root).not.toContain('flex-shrink:0')
+  })
+})
+
+describe('the task line and the excerpt are told apart (#2114)', () => {
+  const withExcerpt = () => body({ body_text: 'A short account of the sweeping.' })
+
+  it('the task reference takes the sheet ink and the excerpt stays muted', () => {
+    const html = withExcerpt()
+    const task = styleOf(html, /<a[^>]*href="\/tasks\/\d+"[^>]*>/)
+    const excerpt = styleOf(html, /<p[^>]*class="[^"]*card-description[^"]*"[^>]*>/)
+    expect(task, 'the task line no longer wears the excerpt colour').not.toContain('#555')
+    expect(task).toContain('color:inherit')
+    expect(excerpt, 'the excerpt is the quiet one').toContain('#555')
+  })
+})
+
+describe('the meta line does not restate the stamp (#2114 supersedes #1833)', () => {
+  it('drops the points term whenever a stamp is mounted', () => {
+    // base 12 + 4 from votes: the stamp prints BASE 12 and totals 16, so the
+    // meta line's `12 pts` is the stamp's own base read out a second time.
+    const html = text(body({ score: 16, points_from_votes: 4 }))
+    expect(html, 'the stamp still carries both figures').toContain('12')
+    expect(html, 'the meta line does not').not.toContain('12 pts')
+    expect(html, 'level, mode and date stay').toContain('L2')
+    expect(html).toContain('solo')
+  })
+
+  it('keeps the points term on a praxis with no stamp at all', () => {
+    // #1444 gates the stamp off a `failed` praxis, so the meta line is the only
+    // points readout left and suppressing it would leave the card silent.
+    const html = text(body({ score: 12, points_from_votes: 0, moderation_status: 'failed' }))
+    expect(html, 'no total was banked').not.toContain('12points')
+    expect(html, 'so what the task is worth stays').toContain('12 pts')
+  })
+})

--- a/frontend/src/components/praxisCard/desktop/shared.tsx
+++ b/frontend/src/components/praxisCard/desktop/shared.tsx
@@ -93,6 +93,35 @@ export const frameBase: CSSProperties = {
 };
 
 /**
+ * What the heading's text column ASKS FOR before the score stamp starts giving
+ * ground (#2114).
+ *
+ * It is a flex BASIS, not a width: the column still grows into every spare
+ * pixel above this and still shrinks below it once the stamp has yielded all
+ * the slack it has, so nothing about a roomy card moves. What it buys is the
+ * one thing `flex: 1` (basis 0%) could not — a DEFICIT. With a basis of zero
+ * the row's hypothetical sizes always fitted, so there was never negative free
+ * space to distribute, the stamp's `flex-shrink` was never consulted, and it
+ * held its full 150px cap into a 280px card while the text column absorbed the
+ * whole loss: 184px of text at the 394px `frameBase` default, 110px in a 320px
+ * cell, 70px at the phone floor. Three words of preview, which is what #2114
+ * reported.
+ *
+ * So dropping `flex-shrink: 0` from the eight stamps is HALF the fix and does
+ * nothing on its own; this is the other half. Below roughly a 370px card the
+ * two now shrink together until the stamp reaches its own `min-width: auto` —
+ * its drawn min-content size, which is per-skin and correct by construction
+ * (the na plate's padding around a 96px mark yields ~28px; Coven's arched
+ * plate is 150px of ornament and yields nothing). No skin is ever squeezed
+ * below what it draws, and no number here has to know any of their geometries.
+ *
+ * 160px is a measure, not a magic constant: at the `--text-content` floor (18px,
+ * §4a) it is about fourteen characters, and it is deliberately well under the
+ * 184px the default basis already gives so a card at 394px renders unchanged.
+ */
+export const TEXT_MEASURE = 160;
+
+/**
  * Shared content body for every faction's praxis card: title + task link on the
  * left, the score hero (`{base} + {votes}` points) on the right, then a
  * points/mode line and the byline. Each faction's own frame wraps this; tint /
@@ -176,12 +205,31 @@ export function PraxisBody({
           gap: "var(--space-md)",
         }}
       >
-        <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ flex: `1 1 ${TEXT_MEASURE}px`, minWidth: 0 }}>
           {eyebrow}
           <PraxisTitle praxis={praxis} style={titleStyle} fonts={fonts} />
+          {/*
+           * TWO LINES, TWO INKS (#2114). These were both handed `muted` — same
+           * face, same `--text-content` size, same colour, separated by a
+           * margin — so a reader could not tell the task being answered from
+           * the answer's first words. The type CANNOT carry the distinction:
+           * both are content and the floor is the floor (§4a), and a wash on
+           * either is the mute-a-muted-token mistake #1675 already undid.
+           *
+           * So the split is the ink, and it costs no new token. The task line
+           * inherits the sheet's own `--faction-{slug}-card-text` — every frame
+           * sets it on the card root, it is the best-measured pairing each
+           * faction has, and it is what `currentColor` already means on this
+           * card (the byline's dashed rule reads it). `inherit` rather than a
+           * prop because the value differs per faction and the frame is
+           * already holding it. The excerpt keeps `muted`, so the hierarchy
+           * reads title → task → preview on all nine sheets and in both
+           * cascades. The link keeps `hover:underline`, so colour is not the
+           * only thing telling it apart from the prose under it.
+           */}
           <PraxisTaskLink
             praxis={praxis}
-            style={{ color: muted }}
+            style={{ color: "inherit" }}
             lead={taskLead}
             fonts={fonts}
           />

--- a/frontend/src/components/praxisCard/scoreStamp/CovenScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/CovenScoreStamp.tsx
@@ -164,7 +164,6 @@ export default function CovenScoreStamp({ praxis, showCrown }: ScoreStampProps) 
     <div
       style={{
         position: "relative",
-        flexShrink: 0,
         display: "flex",
         flexDirection: "column",
         alignItems: "center",

--- a/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/DefaultScoreStamp.tsx
@@ -115,7 +115,6 @@ export default function DefaultScoreStamp({ praxis, showCrown }: ScoreStampProps
       style={{
         position: "relative",
         boxSizing: "border-box",
-        flexShrink: 0,
         width: "100%",
         maxWidth: STAMP_WIDTH,
         border: "1px solid var(--faction-default-card-line)",

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -133,7 +133,6 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
     <div
       style={{
         position: "relative",
-        flexShrink: 0,
         width: "100%",
         maxWidth: working ? STAMP_WIDTH : ROSE,
       }}

--- a/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EverymenScoreStamp.tsx
@@ -70,7 +70,6 @@ export default function EverymenScoreStamp({ praxis, showCrown }: ScoreStampProp
     <div
       style={{
         position: "relative",
-        flexShrink: 0,
         display: "flex",
         flexDirection: "column",
         alignItems: "center",

--- a/frontend/src/components/praxisCard/scoreStamp/ScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/ScoreStamp.tsx
@@ -26,6 +26,18 @@ import DefaultScoreStamp from "./DefaultScoreStamp";
  * The stamp is SIZE-AGNOSTIC: mobile renders this same component (the design's
  * mobile guidance reuses the card's score presentation unchanged), which is why
  * the invented mobile `BASE ∣ MULT ∣ VOTES ∣ TOT` strip is gone.
+ *
+ * NO SKIN DECLARES `flex-shrink: 0`, AND THAT IS THE CONTRACT (#2114). All eight
+ * did, which froze the widest of them at its cap in every mount that lays the
+ * stamp beside something else — the praxis card's heading row, the composer's
+ * task slip, the detail rail's centring flex — so the text next to it absorbed
+ * every pixel a narrow surface was short. Unfrozen, a stamp still cannot be
+ * squeezed below what it draws: `min-width` stays `auto`, whose used value is
+ * the skin's own min-content size (the na plate's padding around its 96px mark,
+ * Coven's 150px arch, S.N.I.D.E.'s 116px tag). That floor is per-skin, correct
+ * by construction and needs no number written down anywhere. Re-adding the
+ * freeze to "protect" a skin re-breaks its neighbour instead; if a skin ever
+ * genuinely must not yield, give it a `min-width` and say why.
  */
 /**
  * Everything ANY stamp reads off a praxis — structural, like the `ScoredPraxis`

--- a/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SingularityScoreStamp.tsx
@@ -106,7 +106,6 @@ export default function SingularityScoreStamp({ praxis, showCrown }: ScoreStampP
     <div
       style={{
         position: "relative",
-        flexShrink: 0,
         minWidth: 120,
         boxSizing: "border-box",
         background: "var(--faction-singularity-stamp-bg)",

--- a/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/SnideScoreStamp.tsx
@@ -46,7 +46,6 @@ export default function SnideScoreStamp({ praxis, showCrown }: ScoreStampProps) 
     <div
       style={{
         position: "relative",
-        flexShrink: 0,
         minWidth: 116,
         boxSizing: "border-box",
         // No borderRadius: the tag is cut, not rounded.

--- a/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/UaScoreStamp.tsx
@@ -92,7 +92,6 @@ export default function UaScoreStamp({ praxis, showCrown }: ScoreStampProps) {
     <div
       style={{
         position: "relative",
-        flexShrink: 0,
         display: "flex",
         flexDirection: "column",
         alignItems: "center",

--- a/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/WowScoreStamp.tsx
@@ -71,7 +71,6 @@ export default function WowScoreStamp({ praxis, showCrown }: ScoreStampProps) {
     <div
       style={{
         position: "relative",
-        flexShrink: 0,
         minWidth: 116,
         boxSizing: "border-box",
         transform: "rotate(-2deg)",

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -2,9 +2,9 @@ import type { CSSProperties, MouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router-dom";
 import type { CharacterOut } from "../../api/auth";
-import type { PraxisCardOut } from "../../api/praxis";
+import { UNSCORED_MODERATION_STATUSES, type PraxisCardOut } from "../../api/praxis";
 import { factionCssVar, factionName } from "../../utils/factions";
-import { isDuelPraxis, stampRestatesTaskPoints } from "../../utils/praxis";
+import { isDuelPraxis } from "../../utils/praxis";
 import { mediaUrl } from "../../utils/media";
 import FactionAvatar from "../avatar/FactionAvatar";
 import VoteUI from "../vote/VoteUI";
@@ -448,13 +448,22 @@ export function PraxisVotedByMarker({
  * count changed card to card — a ragged line across a wall of cards. `L0` is a
  * real answer to "what does this need?", so it renders.
  *
- * The POINTS segment is the one exception, for the opposite reason (#1833): it
- * drops when the stamp beside it already prints that same figure as its total,
- * which under Era 1's neutral multiplier is most unvoted cards on the site.
- * #888 was about a segment that always says something being hidden anyway; this
- * is a segment that, in that one state, says nothing. `stampRestatesTaskPoints`
- * owns the test, and it is #1131's rule — see it for why the figure comes back
- * on its own the moment the two numbers diverge.
+ * The POINTS segment is the one exception, for the opposite reason (#1833, and
+ * now #2114): it drops whenever the stamp beside it is printing that figure.
+ * #1833 read "printing" as `total === base` — the stamp restating the task's
+ * value as its own total — which left `L0 · 10 pts` sitting under a stamp whose
+ * BASE row already said `10` on every card a vote had touched. The owner's
+ * ruling on #2114 is the wider form of the same rule: the stamp states the base
+ * either as a labelled row or, when nothing has moved it, as the total itself,
+ * so wherever a stamp is MOUNTED the meta figure is a second printing. On a
+ * 110px text column that restatement cost a quarter of the line.
+ *
+ * What survives from #1833 is its first clause, and it is the whole predicate
+ * now: `ScoreStamp` renders nothing on a praxis that banked no points (#1444),
+ * and on those two states the meta figure is the only points readout the card
+ * has left. So the segment tracks the STAMP's presence rather than a comparison
+ * between two figures. Praxis DETAIL keeps `stampRestatesTaskPoints` — its task
+ * reference is a different line on a page with room for it.
  */
 export function PraxisStats({
   praxis,
@@ -484,7 +493,7 @@ export function PraxisStats({
       <span style={{ fontWeight: 600 }}>
         {t("card.level", { level: praxis.task_level_required })}
       </span>
-      {!stampRestatesTaskPoints(praxis) && (
+      {UNSCORED_MODERATION_STATUSES.has(praxis.moderation_status) && (
         <>
           <span aria-hidden>·</span>
           <span style={{ fontWeight: 700 }}>


### PR DESCRIPTION
Two fixes that both land in the praxis card's heading row, paired into one PR so
they cannot rebase-fight.

Closes #2114
Closes #2232

## The seam I tested at

`PraxisBody` (`praxisCard/desktop/shared.tsx`) — the one composition all nine
skins render their heading through — plus the eight score-stamp modules and the
two shared avatar roots, SSR-rendered with `renderToStaticMarkup` and the real
i18n catalog. New/changed cases: `praxisCard/__tests__/headingRoom.test.tsx`,
`avatar/__tests__/factionAvatar.test.tsx`, `praxisCard/__tests__/cardChrome.test.tsx`.

There is no layout engine in that harness, so what the tests pin is each side's
flex **declaration**, not a measured width. Everything about pixels below is
read off the cascade, not observed — see "what to eyeball".

## #2114 — the preview had almost no room

**A correction to the issue's mechanism, and it changed the fix.** The root
cause table is exactly right (150px held at every width; 184 / 110 / **70**px of
text), but dropping `flex-shrink: 0` from the stamps is a **no-op on its own**.
The text column was `flex: 1` — basis `0%` — so the row's hypothetical sizes
always fitted, there was never negative free space, and a flex item's shrink
factor is only consulted when there is. The stamp was not winning a fight; there
was no fight.

So the fix is both halves:

1. **The text column asks for a 160px measure** (`flex: 1 1 160px`), which is
   what creates a deficit at narrow widths, **and the eight stamps drop the
   freeze**. They now shrink together until each stamp reaches its own
   `min-width: auto` — its drawn min-content size. That floor is per-skin and
   correct by construction: the na plate yields the padding around its 96px mark
   (~150 to ~122), Coven's arched plate is 150px of ornament and yields nothing,
   S.N.I.D.E.'s tag floors at its declared 116. **No stamp is squeezed below what
   it draws, and no number in the shared file knows any of their geometries.**
   A 394px card is unchanged (the deficit only starts below a ~370px card).
   The stamp keeps its current shape — no form work here, per the owner's note.
2. **The task line and the excerpt are told apart by ink.** Both were handed
   `muted`. The task reference now inherits the sheet's own
   `--faction-{slug}-card-text` (every archetype already sets it on the card
   root) and the excerpt keeps `muted`, so the hierarchy reads title, then task,
   then preview on all nine sheets in both cascades. Type could not carry it —
   both are content and 18px is the floor (§4a) — and a wash on either is the
   mute-a-muted-token mistake #1675 undid. No new token; the link keeps
   `hover:underline`, so colour is not the only cue.
3. **The meta line drops `pts` wherever a stamp is mounted.** #1833 dropped it
   only when the stamp restated the base *as its total*; a voted stamp prints
   the same figure as a labelled `BASE` row, which is the case the screenshot
   shows. #1444's clause survives and is now the whole predicate — a `failed` /
   `hidden` praxis has no stamp, so its meta figure is the only points readout
   left and stays. Praxis **detail** keeps `stampRestatesTaskPoints`: its task
   reference is a different line on a page with room for it.

Not done, per the issue: removing the preview.

## #2232 — the squished avatar

Confirmed from the screenshot (a S.N.I.D.E. card whose author's display name
wraps to two lines, with a portrait painted taller than wide). The cause is the
one the brief guessed, one layer down: **both** avatar roots are a
`width: dim; height: dim` inline-block with the initial `flex-shrink: 1`, and
their automatic minimum size is the *content's* min-content — which is zero,
because Tailwind preflight gives every `img` a `max-width: 100%` and the
monogram branch is a `width: 100%` span. So the root gave ground to the name
while the img kept the height it was handed inline.

Fixed on the two shared roots in `FactionAvatar.tsx` (`DefaultAvatar` +
`BadgedAvatar`), which is every skin and every mount — the reporter's byline,
the duel banner's **rival face** (same exposure, no screenshot), the comment
leaves, the roster. `flex-shrink: 0` is inert where the parent is not a flex
container.

**The two fixes point opposite ways on the same row, deliberately: the stamp is
a panel and must give ground; the avatar is a fixed disc and must not.** Both
files say so at the site.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(345 files / 6056 tests), `npm run build`, `npm run budget` — all pass.
The budget's CSS `WARN` is pre-existing: this branch touches no stylesheet, and
the emitted CSS is byte-identical to the pre-change build (same content hash).

Untouched by design: `.praxis-gallery` and `--praxis-card-basis` (#2229's
territory). The fix holds at whatever width that cell ends up being, which is
the point of making the stamp yield rather than picking new pixel numbers.

## What to eyeball — visual QA is outstanding

I have no browser, so nothing below has been seen. A praxis card at **394px**
(the `frameBase` default), at **320px** (a `.praxis-gallery` cell) and at the
**280px** phone floor, in **both themes**:

- the preview has real words at 320 and 280, not three;
- 394 looks exactly as it does on `main` — nothing should have moved there;
- the task line and the excerpt are visibly different lines;
- the meta line reads `L0 · solo · Aug 16, 2026` with no `pts`, and a **failed**
  praxis still shows its points;
- the byline avatar is a circle at every width — best seen on a card whose
  author has a long display name and a portrait — and so is the duel banner's
  rival face;
- **Cozy Coven** specifically (the reporter's second screenshot): its arched
  plate is 150px of ornament and yields nothing, so its text column gains the
  least of any faction. If that card still reads as wasted space, the remaining
  waste is vertical and belongs to the horizontal-stamp exploration, not here;
- the stamps that now shrink should never clip or overlap their own ornament at
  280px — that is the one thing the `min-width: auto` floor is doing unobserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
