### PR TITLE
WOW joins the shared badge: portrait in the gilt ring, crown at the corner (#2241, #2242)

### DIFF
--- a/frontend/src/components/avatar/FactionAvatar.tsx
+++ b/frontend/src/components/avatar/FactionAvatar.tsx
@@ -33,7 +33,9 @@ export function avatarDim(size: FactionAvatarProps['size']): number {
 }
 
 /**
- * THE ROOT NEVER YIELDS ITS WIDTH (#2232), on either skin below.
+ * THE ROOT NEVER YIELDS ITS WIDTH (#2232), on both skins below and on the one
+ * skin that wraps `BadgedAvatar` in chrome of its own (`WowAvatar`, #2241) —
+ * which is why this is exported rather than private.
  *
  * An avatar is a circle at a stated diameter, and it is nearly always mounted
  * in a flex row beside a name the player typed — the praxis byline, the duel
@@ -51,7 +53,11 @@ export function avatarDim(size: FactionAvatarProps['size']): number {
  * same praxis-card row (#2114): the stamp is a panel and must give ground, this
  * is a fixed disc and must not.
  */
-const AVATAR_ROOT = { position: 'relative', display: 'inline-block', flexShrink: 0 } as const
+export const AVATAR_ROOT = {
+  position: 'relative',
+  display: 'inline-block',
+  flexShrink: 0,
+} as const
 
 function DefaultAvatar({ character, size = 'md' }: FactionAvatarProps) {
   const dim = avatarDim(size)

--- a/frontend/src/components/avatar/WowAvatar.tsx
+++ b/frontend/src/components/avatar/WowAvatar.tsx
@@ -1,33 +1,52 @@
 import i18n from "../../i18n";
-import { mediaUrl } from "../../utils/media";
 import { WowSigil } from "../sigil/WowSigil";
-import { avatarDim, type FactionAvatarProps } from "./FactionAvatar";
+import { AVATAR_ROOT, BadgedAvatar, avatarDim, type FactionAvatarProps } from "./FactionAvatar";
 
 /**
  * WowAvatar — the player seal (kit §"Faction Avatar", #897).
  *
- * WOW does not wear the shared `BadgedAvatar` (a plain circle plus a corner
- * membership sigil). Its avatar is a bespoke composition: the crest set in a
- * GILT ROPE RING — a conic gradient struck from 210deg — behind a PLUM INNER
- * RIM, with the RANK PILL riding the hem. Four of the five parts are the ring;
- * the sigil is not a corner mark here, it is the field.
+ * WOW WEARS THE SHARED `BadgedAvatar` (#2241, #2242 — the veto flagged in #897,
+ * now taken). This file used to draw the crest IN THE FIELD and the portrait
+ * only when there was one, so crest and portrait competed for a single slot:
+ * a member with a portrait wore no faction mark at all (#2241), and a member
+ * without one never got the house monogram (#2242). One defect, reported from
+ * both ends. The exemption was argued against the OLD gilt crest — a coin whose
+ * own `MOTTO_FLOOR_PX` conceded it could not hold below ~40px — and `WowSigil`
+ * is now a Sigil Studies v2 mark drawn, like the Coven hat, to survive badge
+ * size. The rule outlived its reason:
  *
- * WHAT SITS IN THE FIELD. The kit draws the crest there, because a mock has no
- * portrait to draw. A real player usually does, so: portrait when there is one,
- * the CREST when there is not. The house fallback elsewhere is a monogram
- * initial, and this deliberately departs from it — the kit's own composition is
- * ring-plus-crest, and a WOW player with no portrait wearing the faction seal is
- * the drawing as designed. The cost is that two portrait-less WOW players look
- * alike at a glance; every surface that renders an avatar renders a name beside
- * it, so the seal is never the only identifier. Flagged for veto in #897.
+ *   > This rule made sense with the old WOW sigil, but we redesigned sigils in
+ *   > part to stop things like this.
+ *
+ * So the field carries the PORTRAIT, or the monogram initial when there is
+ * none, and the crown is the corner membership badge — exactly as the Everymen,
+ * S.N.I.D.E., Singularity, Ephemerists, Coven and UA avatars carry theirs. Two
+ * portrait-less WOW members no longer look alike at a glance, which is the cost
+ * the old note conceded rather than a new one.
+ *
+ * THE PLATE IS NOT FLATTENED. Adopting the shared badge is not licence to drop
+ * the composition to a plain circle: the GILT ROPE RING — a conic gradient
+ * struck from 210deg — still wraps it, the PLUM INNER RIM is the shared
+ * circle's own border, and the RANK PILL still rides the hem. What changed is
+ * what sits in the field and where the crown goes.
+ *
+ * THE BADGE IS A STRUCK MEDALLION, not a plum chip: cream field, gilt rim, the
+ * crown in its own declared plum (5.79:1 on that cream). Every one of those
+ * three is a theme-INVARIANT `--faction-wow-crest-*` / `-chronicle-gold` token,
+ * for the same reason the ring and the pill are — struck metal does not repaint
+ * itself for the dark page.
  *
  * SIZING. The kit draws one 118px plate. Everything below is that plate's own
  * proportion of 118, so the seal holds together from the 24px comment avatar up
- * to a profile header — nothing is a fixed pixel borrowed from the mock.
+ * to a profile header — nothing is a fixed pixel borrowed from the mock. The
+ * shared badge takes the diameter INSIDE the ring, so its own corner mark lands
+ * on the ring's edge rather than inside the field.
  *
- * THEME. The ring, the rim and the pill are struck metal and do not flip (see
- * the crest note in index.css); the FIELD the coin is mounted on does, cream to
- * the kit's dark ground, straight off the `[data-theme="dark"]` cascade.
+ * THEME. The ring, the rim, the badge and the pill are struck metal and do not
+ * flip (see the crest note in index.css); the FIELD the coin is mounted on
+ * does, cream to the kit's dark ground, straight off the `[data-theme="dark"]`
+ * cascade — and `--faction-wow-card-text` is the ink that flips with it
+ * (14.02:1 light, 13.8:1 dark).
  */
 
 /**
@@ -39,6 +58,11 @@ import { avatarDim, type FactionAvatarProps } from "./FactionAvatar";
  * the disc below 64px, which costs the crest more than the rank is worth: the
  * level is already written next to the avatar on every surface that has room for
  * it. So the pill appears on the big plates and nowhere else.
+ *
+ * ponytail: at or above this floor the hem is now shared with the corner badge,
+ * and the two would touch. No mount in the app reaches 64 (the largest is the
+ * players roster's 54), so the collision is unreachable outside the preview
+ * kit; a real large plate wants a design call on which of the two yields.
  */
 const RANK_PILL_FLOOR_PX = 64;
 
@@ -47,20 +71,19 @@ const RANK_PILL_MIN_FONT_PX = 9;
 
 export default function WowAvatar({ character, size }: FactionAvatarProps) {
   const dim = avatarDim(size);
-  // The kit's plate: 5px of ring round a 2px-rimmed field, on 118px.
+  // The kit's plate: 5px of ring round the field, on 118px. The 2px rim inside
+  // it is the shared circle's border.
   const ring = Math.max(2, Math.round(dim * 0.042));
   const rim = Math.max(1, Math.round(dim * 0.017));
-  const field = dim - 2 * ring - 2 * rim;
-  // 94 of the field's 104 — the coin nearly fills it, and the corners of its
-  // box are clipped by the round field exactly as they are in the kit.
-  const crest = Math.round(field * 0.9);
   const pillFont = Math.max(RANK_PILL_MIN_FONT_PX, Math.round(dim * 0.102));
 
   return (
-    <span style={{ position: "relative", display: "inline-block", width: dim, height: dim }}>
+    <span style={{ ...AVATAR_ROOT, width: dim, height: dim }}>
       <span
         style={{
-          display: "block",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
           width: dim,
           height: dim,
           borderRadius: "50%",
@@ -70,31 +93,21 @@ export default function WowAvatar({ character, size }: FactionAvatarProps) {
           boxShadow: `0 ${Math.round(dim * 0.085)}px ${Math.round(dim * 0.186)}px ${-Math.round(dim * 0.085)}px var(--faction-wow-chronicle-shadow)`,
         }}
       >
-        <span
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: "100%",
-            height: "100%",
-            borderRadius: "50%",
-            background: "var(--faction-wow-avatar-field)",
-            border: `${rim}px solid var(--faction-wow-crest-field-rim)`,
-            boxSizing: "border-box",
-            overflow: "hidden",
+        <BadgedAvatar
+          character={character}
+          size={dim - 2 * ring}
+          circle={{
+            borderColor: "var(--faction-wow-crest-field-rim)",
+            bg: "var(--faction-wow-avatar-field)",
+            textColor: "var(--faction-wow-card-text)",
+            fontFamily: "var(--faction-wow-card-font)",
           }}
-        >
-          {character.avatar_url ? (
-            <img
-              src={mediaUrl(character.avatar_url)}
-              alt={character.username}
-              className="rounded-full object-cover"
-              style={{ width: "100%", height: "100%", display: "block" }}
-            />
-          ) : (
-            <WowSigil size={crest} />
-          )}
-        </span>
+          badgeBg="var(--faction-wow-crest-field)"
+          badgeRing="var(--faction-wow-chronicle-gold)"
+          // The badge's rim is gilt, so the crown is NOT knocked out of it: the
+          // mark keeps the plum it is declared in on all eight of its mounts.
+          glyph={(s) => <WowSigil size={s} />}
+        />
       </span>
 
       {dim >= RANK_PILL_FLOOR_PX && (

--- a/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
+++ b/frontend/src/components/avatar/__tests__/factionAvatar.test.tsx
@@ -125,6 +125,9 @@ describe("an avatar is a circle in a flex row (#2232)", () => {
   it.each([
     ["the unaffiliated ring", "na"],
     ["a registered skin", "singularity"],
+    // WOW's plate is its own root — the gilt ring wraps the shared badge, so
+    // the rule has to be restated on the outer span (#2241).
+    ["the WOW plate", "wow"],
   ])("%s does not yield its width to the name beside it", (_label, slug) => {
     const monogram = renderToStaticMarkup(
       <FactionAvatar character={character({ faction_slug: slug })} />,
@@ -136,5 +139,57 @@ describe("an avatar is a circle in a flex row (#2232)", () => {
     );
     expect(root(monogram)).toContain("flex-shrink:0");
     expect(root(portrait)).toContain("flex-shrink:0");
+  });
+});
+
+/**
+ * #2241 / #2242 — WOW wore its crest IN THE FIELD, so the crest and the
+ * portrait competed for one slot: a member WITH a portrait wore no faction
+ * mark (#2241), a member WITHOUT one never got a monogram (#2242). One defect,
+ * reported from both ends.
+ *
+ * The exemption `WowAvatar` carried was written against the OLD gilt crest and
+ * flagged for veto in #897; `WowSigil` is a Sigil Studies v2 mark drawn to
+ * survive badge size, so the owner vetoed it. The seam is the dispatcher's
+ * rendered markup, because that is where both halves are visible at once: the
+ * crown must be a CORNER badge on both branches, never the field.
+ *
+ * The gilt rope ring, the plum inner rim and the rank pill stay — adopting the
+ * shared badge is not licence to flatten the plate into a plain circle — so
+ * the chrome is asserted too.
+ */
+describe("FactionAvatar — WOW wears its crown at the corner (#2241, #2242)", () => {
+  /** The opening subpath of `WowSigil`'s one path: the three-peaked crown. */
+  const CROWN = "M12 88L12 24L33 46";
+
+  it("badges a portrait-bearing member with the crown (#2241)", () => {
+    const html = renderToStaticMarkup(
+      <FactionAvatar
+        character={character({ faction_slug: "wow", avatar_url: "/media/isolde.png" })}
+      />,
+    );
+    expect(html).toContain("isolde.png");
+    expect(html).toContain(CROWN);
+  });
+
+  it("falls back to the house monogram, not the crown, in the field (#2242)", () => {
+    const html = renderToStaticMarkup(
+      <FactionAvatar character={character({ faction_slug: "wow" })} />,
+    );
+    // The initial, in the chronicle's own hand on the flipping field.
+    expect(html).toContain(">I<");
+    expect(html).toContain("var(--faction-wow-card-font)");
+    expect(html).toContain("var(--faction-wow-avatar-field)");
+    // Still marked — the crown is the corner badge, not the field.
+    expect(html).toContain(CROWN);
+  });
+
+  it("keeps the gilt rope ring, the plum rim and the rank pill", () => {
+    const html = renderToStaticMarkup(
+      <FactionAvatar character={character({ faction_slug: "wow" })} size={72} />,
+    );
+    expect(html).toContain("var(--faction-wow-avatar-ring)");
+    expect(html).toContain("var(--faction-wow-crest-field-rim)");
+    expect(html).toContain("var(--faction-wow-avatar-pill-text)");
   });
 });


### PR DESCRIPTION
Closes #2241
Closes #2242

Two reports, one defect. `WowAvatar` drew the crest **in the field** and the portrait only when there was one, so crest and portrait competed for a single slot:

- with a portrait -> the crest was displaced and WOW members wore no faction mark (#2241);
- without one -> the crest filled the field and the monogram never appeared (#2242).

The file's own docstring documented the exemption and flagged it for veto in #897. The owner has taken the veto:

> This rule made sense with the old WOW sigil, but we redesigned sigils in part to stop things like this.

`WowSigil` is a Sigil Studies v2 mark drawn — like the Coven hat — to survive badge size, so the exemption was written against a sigil that no longer exists.

## What changed

**WOW now wears the shared `BadgedAvatar`** — portrait in the field, house monogram initial when there is no portrait, crown as the lower-right membership badge, exactly as Everymen / S.N.I.D.E. / Singularity / Ephemerists / Coven / UA do. `BadgedAvatar` is reused as-is; it gained no props.

**The plate is not flattened.** The gilt rope ring (conic from 210deg) still wraps the whole thing, the plum inner rim is now the shared circle's own border, and the rank pill still rides the hem. The ring takes `dim`, the shared badge takes `dim - 2 * ring`, so the corner mark lands on the ring's edge rather than inside the field.

**Portrait-less WOW players get the monogram.** That is the cost the old docstring conceded ("two portrait-less WOW players look alike at a glance") being *paid off*, not a new one.

**The badge is a struck medallion, not a plum chip:** cream field (`--faction-wow-crest-field`), gilt rim (`--faction-wow-chronicle-gold`), crown in its own declared plum — 5.79:1, the same pair `--faction-wow-card-accent` on `--faction-wow-card-bg` is already measured at. All three are theme-invariant `:root` tokens, like the ring and the pill; only the field flips, and the monogram ink flips with it (`--faction-wow-card-text`: 14.02:1 light, 13.8:1 dark).

Docstring rewritten so the veto note no longer reads as open — it records that #2241/#2242 closed it.

No CSS was touched: the built `index-*.css` is byte-identical to `main`'s (same Vite content hash on both builds). No new tokens minted, no new API endpoints consumed.

## The seam I tested at

`FactionAvatar`'s **rendered markup for a `wow` character** — that is the one place where both halves of the defect are visible at once, and it is where the dispatcher actually hands out the skin. The loop went red on the real defect first: the portrait branch contained no crown path, and the portrait-less branch contained the crown but no `>I<`. Three cases in `frontend/src/components/avatar/__tests__/factionAvatar.test.tsx`:

1. portrait branch carries the crown badge (#2241);
2. portrait-less branch carries the monogram in the chronicle hand on the flipping field, and still carries the crown (#2242);
3. the ring, the plum rim and the pill tokens all still render at 72px.

The `#2232` "root never yields its width" `it.each` also gained a `wow` row — the WOW plate has its own outer root, which was NOT covered by that guard and did not carry `flex-shrink: 0`. It does now, via the (newly exported) shared `AVATAR_ROOT`.

## Surfaces this changes

Every mount of `FactionAvatar` for a WOW character:

- `pages/players/DesktopPlayers.tsx` — roster lead/row (54 / 42) and the compact list (34)
- `pages/players/MobilePlayers.tsx` — cards (42) and the compact list (28)
- `pages/factionDetail/archetypes/DefaultFactionBody.tsx` — the member roster, via `CharacterBadge`
- `components/praxisCard/shared.tsx` — the praxis-card byline portrait, and the duel banner's rival face
- `components/comments/CommentThread.tsx` + all eight `comments/voices/*Comment.tsx` — composer and comment-leaf avatars (WOW's own voice uses 44px)
- `components/comments/useMentionAutocomplete.tsx` — the @-mention row
- `pages/editPraxis/archetypes/controls.tsx` — the collaborator control
- `.design-sync/previews/WowAvatar.tsx` — unchanged, props are identical

Not touched, and deliberately: `pages/characterProfile/archetypes/WowProfileBody.tsx` and `components/layout/Sidebar.tsx` draw the portrait directly rather than through `FactionAvatar`, so neither ever had this bug.

## Verification

- `npm run lint` — clean
- `npm run typecheck` (`tsc --noEmit`, v5.9.3 confirmed running) — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — 351 files / 6166 tests pass
- `npm run build` — clean
- `npm run budget` — JS ok, CSS `WARN` at 22.2 KB. **Pre-existing**: this PR touches no CSS and the built stylesheet has the identical content hash on `main` and on this branch.

**Visual QA is outstanding** — no browser or dev stack in this environment.

## One thing for `frontend-style`

At `>= 64px` (the rank pill's floor) the pill and the new corner badge share the hem and would touch. No mount in the app reaches 64 — the largest is the players roster's 54 — so it is unreachable outside the preview kit; it is marked with a `ponytail:` comment naming the ceiling. If a large WOW plate is ever mounted, someone needs to decide which of the two yields.

## What to eyeball

A WOW character **with** a portrait and one **without**, in **light** and **dark**, on each of:

- [ ] the homepage
- [ ] the players roster (`/players`) — desktop cards and the compact list
- [ ] a faction page (`/factions/wow`) — the member roster
- [ ] a feed row / praxis-card byline

Specifically: the crown reads as a crown at 24px and at 42px; the cream badge is still legible against the cream page ground in light (the gilt rim is what defines it); the monogram initial is legible on the dark field in dark mode; and the gilt ring is not visually crowded by the badge sitting on its edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
