### PR TITLE
The moderation cluster joins the card's foot instead of hovering over it (#2049)

### DIFF
--- a/frontend/src/components/taskCard/TaskCard.tsx
+++ b/frontend/src/components/taskCard/TaskCard.tsx
@@ -208,11 +208,36 @@ export default function TaskCard({
           </span>
         </div>
       )}
+      {/* MODERATION SITS IN THE FOOT, IT DOES NOT HOVER OVER IT (#2049). This
+          cluster was `position: absolute; bottom: 4; right: 4; zIndex: 10`,
+          which was survivable only because the sign-up affordance was a
+          full-bleed footer BAR: the cluster covered it corner to corner, and
+          did so at every width. #2030 turned that bar into a discrete, inset,
+          CENTRED button, and a centred control beneath a bottom-right overlay
+          is two hit boxes that meet at narrow widths — the overlap
+          `docs/agents/design-fidelity.md` names as a failure outright. More
+          `bottom:` only moves the width at which they touch, so the overlay is
+          gone instead: the cluster is a strip in this wrapper's own flow, after
+          the skin's frame, and no width can bring it onto the button.
+
+          IT STAYS ON THE DISPATCHER, one level out from the card, rather than
+          moving inside a skin's foot. Nine skins draw nine different feet;
+          threading an admin slot through all of them to place two
+          moderator-only buttons is the larger change, not the smaller one, and
+          it is the dispatcher that owns this control in the first place.
+
+          The wrapper keeps `position: relative` (the marks above need it) and
+          gains NO inline `display`: `.task-card-row > *` in index.css makes it
+          a column so every card on the board stretches (#1945), and an inline
+          display would beat that rule silently. In that column the skin root
+          takes the slack (`flex: 1 1 auto`) and this strip keeps its own
+          height, so admin mode adds a row under the card instead of moving
+          anything inside it. */}
       {showAdminControls && (
         <div
           style={{
-            position: 'absolute', bottom: 4, right: 4,
-            display: 'flex', gap: 'var(--space-xs)', zIndex: 10,
+            display: 'flex', justifyContent: 'flex-end',
+            gap: 'var(--space-xs)', marginTop: 'var(--space-xs)',
           }}
         >
           {shown.status ==='active' && (

--- a/frontend/src/components/taskCard/__tests__/taskCardAdminStatus.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/taskCardAdminStatus.test.tsx
@@ -92,3 +92,51 @@ describe('no full-document reload behind a one-field write', () => {
     expect(source.replace(/\/\*[\s\S]*?\*\//g, '')).not.toContain('window.location.reload')
   })
 })
+
+/**
+ * The moderation cluster is part of the card's foot, not an overlay on it
+ * (#2049).
+ *
+ * SEAM: the dispatcher's own markup — specifically the box that holds the
+ * retire/activate buttons. It used to be `position:absolute; bottom:4; right:4;
+ * z-index:10`, which was survivable while the sign-up affordance was a
+ * full-bleed footer BAR: the cluster covered it edge to edge, predictably.
+ * #2030 made that affordance a discrete, inset, CENTRED button, so a
+ * bottom-right overlay and a centred control can now collide at narrow widths —
+ * the overlapping hit boxes `docs/agents/design-fidelity.md` names as a failure.
+ *
+ * NOTHING HERE MEASURES A BOX. `renderToStaticMarkup` runs no layout, so no
+ * test in this repo can prove two rectangles stop overlapping. What is
+ * assertable is the SHAPE that makes overlap impossible: the cluster is a
+ * normal-flow sibling below the card's frame rather than an absolutely
+ * positioned overlay, and the wrapper stays the plain positioned box the
+ * equal-height row lays out (`pages/tasks/__tests__/equalHeightRow.test.tsx`).
+ * VISUAL QA IS OUTSTANDING and stated as such on the PR.
+ */
+describe('the moderation cluster sits in the foot, not over it (#2049)', () => {
+  it('is a normal-flow box: no absolute positioning, no stacking context', () => {
+    const out = card(TASK)
+    const at = out.indexOf('>retire<')
+    const open = out.lastIndexOf('<div', at)
+    const tag = out.slice(open, out.indexOf('>', open) + 1)
+    expect(tag, 'the cluster is laid out, not floated over the card').not.toContain(
+      'position:absolute',
+    )
+    expect(tag, 'nothing to raise it above the sign-up button').not.toContain('z-index')
+  })
+
+  it('follows the card frame instead of sitting inside it', () => {
+    const out = card(TASK)
+    // The skin owns everything up to its </article>; the dispatcher appends the
+    // cluster after it. Putting it INSIDE the frame would need a slot prop on
+    // all nine skins — see the PR for why that was not the fix taken.
+    expect(out.indexOf('>retire<')).toBeGreaterThan(out.lastIndexOf('</article>'))
+  })
+
+  it('leaves the wrapper the plain positioned box the equal-height row needs', () => {
+    // An inline `display` here would beat `.task-card-row > *` in index.css and
+    // silently stop every card on the board from stretching (#1945).
+    const out = card(TASK)
+    expect(out.slice(0, out.indexOf('>') + 1)).toBe('<div style="position:relative">')
+  })
+})


### PR DESCRIPTION
Closes #2049

The admin retire/activate cluster on the task-card dispatcher stops being an
absolutely-positioned overlay and becomes a real part of the card's foot layout.

## The decision, not a nudge

The cluster was `position: absolute; bottom: 4; right: 4; zIndex: 10` on
`components/taskCard/TaskCard.tsx` (verified on `main` @ `a90d27b4` — the issue's
description matches the code exactly). That shape only ever worked because the
sign-up affordance below it was a **full-bleed footer bar**: the cluster covered
it corner to corner, at every width, predictably. #2030 (PR #2048) turned that
bar into a **discrete, inset, centred** button, so a centred control and a
bottom-right overlay can now meet at narrow widths.

`docs/agents/design-fidelity.md` (§ Known standing carve-outs, "Touch targets
win, but re-solve the layout") names overlapping hit boxes as a failure outright,
and it names the *fix* too: re-solve the layout rather than shim the geometry.
A larger `bottom:` only moves the width at which the two boxes touch — it does
not remove the overlap, so it does not clear the bar. **The overlay goes
instead:** the cluster is now a normal-flow, right-aligned strip rendered after
the skin's frame, inside the dispatcher's existing wrapper. Two boxes in the same
block flow cannot overlap at any width.

## Where it landed, and why there

Grepped every task-card archetype: **the cluster exists in exactly one place.**
`TaskCard.tsx` (the dispatcher) draws it for all nine skins — none of
`Default`/`Albescent`/`Coven`/`Ephemerists`/`Everymen`/`Singularity`/`Snide`/`Ua`/`Wow`
renders retire/activate itself, and `updateTaskStatus` has only two call sites in
the tree (this file and the admin `TasksTab`, which is a different surface). So
the fix is one edit at the shared chassis, and **no faction card file is touched
— including `EphemeristsTaskCard.tsx`**, which another agent in this batch owns.

It stays on the dispatcher, one level out from the card, rather than moving
*inside* a skin's foot. The nine skins do lay their feet out differently (the na
sheet closes with a hairline rule then a centred button; Coven a slip-CTA;
Ephemerists an `.eph-cta` enclosure), and threading an admin slot prop through
all nine to place two moderator-only buttons is the larger change, not the
smaller one — and would have required editing the one file this batch reserves.

The wrapper keeps `position: relative` (the `start_here` and META marks above it
need it) and deliberately gains **no inline `display`**: `.task-card-row > *` in
`index.css` makes that wrapper a flex column so every card on the board stretches
(#1945), and an inline `display` would beat that rule silently. In that column
the skin root still takes the slack (`flex: 1 1 auto`) and the new strip keeps
its intrinsic height, so admin mode adds a row *under* the card and moves nothing
inside it.

Behaviour, the dynamic `api/admin` import, the moderator's own echo
(`displayedTask`) and the `user?.is_admin && adminMode` condition are all
untouched. This is a layout change only.

## The seam I tested at

The dispatcher's rendered markup — specifically the box that holds the
retire/activate buttons. The new test in
`components/taskCard/__tests__/taskCardAdminStatus.test.tsx` went **red on the
real defect first** (`expected '<div style="position:absolute;bottom:…' not to
contain 'position:absolute'`), then green.

The harness is `renderToStaticMarkup` with no jsdom and no layout, so **no test
here can prove two rectangles stop overlapping.** What it asserts is the shape
that makes overlap impossible, plus the invariants around it:

- the cluster's own box carries no `position:absolute` and no `z-index`;
- it renders after the skin's `</article>`, i.e. in flow rather than inside the
  frame;
- the wrapper is still exactly `<div style="position:relative">` — the contract
  `pages/tasks/__tests__/equalHeightRow.test.tsx` depends on;
- the existing admin-only and status-follows-the-echo tests still pass unchanged.

**Visual confirmation is outstanding** — I have no browser and no dev stack.

## Checks

- `tsc --noEmit`: clean. `npm run typecheck:design-sync`: clean.
- `npm run lint`: clean. `npm test`: 351 files, 6165 passed, 1 skipped.
- `npm run build`: ok. `npm run budget`: JS ok; CSS **WARN at 22.2 KB**, which is
  pre-existing and unrelated — this PR touches no CSS and adds zero bytes to the
  stylesheet.

## Deferred to `frontend-style`

- The `AdminStatusButton`s themselves are below the 44×44 minimum (`--space-xs` /
  `--space-sm` padding on `label-caption`). Pre-existing, unchanged here, and not
  what #2049 asks for — but now that they sit in flow they could be grown without
  colliding with anything. Worth a style-tier issue.
- The strip's spacing is `var(--space-xs)` above the card's bottom edge, chosen to
  be quiet rather than designed. If admin chrome deserves a real register, that is
  a style call.

## What to eyeball

1. A task card **as an admin, at a narrow width** (mobile / narrow viewport) on a
   task that **can** be signed up for: the centred sign-up button and the
   retire/activate strip should be clearly separate rows, no touching.
2. The same card **at desktop width**, in the `/tasks` equal-height row: cards in
   a row should still be the same height, with the strip hanging under each.
3. An admin on a task that **cannot** be signed up for (no CTA slot at all — e.g.
   a faction page's roster, which passes no `onSignup`): the strip should still
   sit tidily under the card with nothing above it to clash with.
4. A **pending** task as an admin: two buttons (activate + retire) side by side,
   still right-aligned and still clear of the CTA.
5. A **non-admin** (or an admin with admin mode off) on any of the above: no
   change whatsoever from `main` — no strip, no extra height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
