### PR TITLE
The Coven ward's star comes inside its circle (#2237)

### DIFF
--- a/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
+++ b/frontend/src/pages/taskDetail/__tests__/covenTaskDetail.test.tsx
@@ -133,6 +133,75 @@ describe("Coven task detail — the dress", () => {
   });
 });
 
+describe("Coven task detail — the ward's geometry (#2237)", () => {
+  /**
+   * The seam is the EMITTED SVG: the ward's pentagram and the pink ring it is
+   * inscribed in, both read straight out of the markup and measured against each
+   * other. Layout is unreachable in this harness, but "is this vertex inside that
+   * circle" is arithmetic on two attributes, so it is the part of "the star
+   * escapes the circle" a test can actually hold.
+   *
+   * It escaped because the path was typed by hand — vertices at radius 34.0 to
+   * 34.9 inside a ring of 33, poking out at all five tips. Re-nudging those
+   * numbers is what this guards: the star's radius must stay DERIVED from the
+   * ring's, or the next hand-tuned `d` walks straight back out.
+   */
+
+  /** The `<svg>` chunk holding the ward — the one that draws the pink ring. */
+  function wardSvg(html: string): string {
+    const svg = html.split("<svg").find((chunk) => /cx="50" cy="50" r="[\d.]+"/.test(chunk));
+    expect(svg, "the ward's svg is in the markup").toBeTruthy();
+    return svg as string;
+  }
+
+  /** The pentagram is the only five-vertex ABSOLUTE path here — the twinkles are
+   * relative (`l`) and the numeral is text. */
+  function starVertices(svg: string): [number, number][] {
+    const star = svg.match(/d="(M[\d.]+ [\d.]+(?: L[\d.]+ [\d.]+){4} Z)"/);
+    expect(star, "the pentagram is drawn").toBeTruthy();
+    const vertices = [...star![1].matchAll(/([\d.]+) ([\d.]+)/g)].map(
+      ([, x, y]) => [Number(x), Number(y)] as [number, number],
+    );
+    expect(vertices, "five points").toHaveLength(5);
+    return vertices;
+  }
+
+  it("inscribes the pentagram inside the ring — every tip, stroke included", () => {
+    const svg = wardSvg(render(<CovenTaskDetail state={baseState()} />).html);
+
+    const ring = svg.match(/cx="50" cy="50" r="([\d.]+)"[^>]*?stroke-width="([\d.]+)"/);
+    expect(ring, "the ring carries a radius and a stroke").toBeTruthy();
+    const ringR = Number(ring![1]);
+    const ringStroke = Number(ring![2]);
+
+    const starStroke = Number(
+      svg.match(/d="M[\d.]+ [\d.]+(?: L[\d.]+ [\d.]+){4} Z"[\s\S]*?stroke-width="([\d.]+)"/)![1],
+    );
+
+    // A round join puts a tip's outer edge at radius + strokeWidth / 2; the
+    // ring's inner face sits at its radius - strokeWidth / 2. Inside is inside
+    // of both, which is the whole sum.
+    const ceiling = ringR - ringStroke / 2 - starStroke / 2;
+    const radii = starVertices(svg).map(([x, y]) => Math.hypot(x - 50, y - 50));
+    for (const radius of radii) {
+      expect(radius, `a tip at radius ${radius} stays inside the ring`).toBeLessThanOrEqual(
+        ceiling + 0.01,
+      );
+    }
+    // ...and it is still a pentacle rather than a shrunken dot: the tips reach.
+    expect(Math.min(...radii), "the tips still touch the ring").toBeGreaterThan(ceiling - 0.5);
+  });
+
+  it("centres the star on the ring, not below it", () => {
+    const vertices = starVertices(wardSvg(render(<CovenTaskDetail state={baseState()} />).html));
+    // A regular pentagram's vertices average to its own centre. The old path
+    // averaged to y = 50.64 — a hand-nudge that dropped the whole figure.
+    const mean = (values: number[]) => values.reduce((a, b) => a + b, 0) / values.length;
+    expect(mean(vertices.map(([x]) => x))).toBeCloseTo(50, 1);
+    expect(mean(vertices.map(([, y]) => y))).toBeCloseTo(50, 1);
+  });
+});
+
 describe("Coven task detail — the copy", () => {
   it("uses the shared neutral headings, not Coven's retired detail voice", () => {
     const { text } = render(<CovenTaskDetail state={baseState()} />);

--- a/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/CovenTaskDetail.tsx
@@ -143,6 +143,31 @@ function starPath(x: number, y: number, r: number): string {
   return `M${x} ${y - long} l${r} ${long} ${long} ${r} -${long} ${r} -${r} ${long} -${r} -${long} -${long} -${r} ${long} -${r} z`;
 }
 
+/**
+ * A five-point star, points up, drawn on the circle of radius `r` about
+ * (cx, cy) — every vertex lands ON that circle by construction.
+ */
+function pentagramPath(cx: number, cy: number, r: number): string {
+  const vertex = (i: number) => {
+    const angle = ((-90 + i * 144) * Math.PI) / 180;
+    return `${(cx + r * Math.cos(angle)).toFixed(2)} ${(cy + r * Math.sin(angle)).toFixed(2)}`;
+  };
+  return `M${[0, 1, 2, 3, 4].map(vertex).join(" L")} Z`;
+}
+
+/* ── The ward's two concentric drawings, in its own 0 0 100 100 box. ────────
+ * The pentagram's radius is DERIVED from the ring's, never typed: its tips land
+ * on the ring's inner face, so the two strokes kiss and neither crosses. A typed
+ * radius is exactly how the star got outside the circle (#2237) — it was on 34.9
+ * against a ring of 33, which reads as a mistake at both ward sizes and at every
+ * zoom. Round joins put a tip's outer edge at radius + strokeWidth / 2, so that
+ * is the whole of the sum.
+ */
+const RING_R = 33;
+const RING_STROKE = 1.8;
+const STAR_STROKE = 1;
+const WARD_STAR = pentagramPath(50, 50, RING_R - RING_STROKE / 2 - STAR_STROKE / 2);
+
 /** Initials fallback for an author with no uploaded avatar. */
 function initialsOf(name: string): string {
   return name
@@ -244,14 +269,22 @@ function Ward({
         style={{ position: "absolute", inset: 0, overflow: "visible" }}
       >
         <path
-          d="M50 16 L69.8 78.5 L16.5 40.1 L83.5 40.1 L30.2 78.5 Z"
+          d={WARD_STAR}
           fill="none"
           stroke={GOLD}
-          strokeWidth="1"
+          strokeWidth={STAR_STROKE}
           strokeLinejoin="round"
           opacity="0.55"
         />
-        <circle cx="50" cy="50" r="33" fill="none" stroke={PINK} strokeWidth="1.8" opacity="0.9" />
+        <circle
+          cx="50"
+          cy="50"
+          r={RING_R}
+          fill="none"
+          stroke={PINK}
+          strokeWidth={RING_STROKE}
+          opacity="0.9"
+        />
         {twinkles.map(([x, y, r]) => (
           <path key={`${x}-${y}`} d={starPath(x, y, r)} fill={GOLD} opacity="0.9" />
         ))}


### PR DESCRIPTION
The Cozy Coven task-detail **ward** — the pink circle with a gold pentagram
holding the point total — drew its star outside its own circle.

Closes #2237

## The cause

The pentagram's `d` was typed by hand:

```
M50 16 L69.8 78.5 L16.5 40.1 L83.5 40.1 L30.2 78.5 Z
```

Measured against the ring it is inscribed in (`cx=50 cy=50 r=33`), those five
vertices sit at radius **34.0, 34.7, 34.9, 34.9, 34.7** — every tip outside the
circle, the horizontal bar poking through on both sides, before the two stroke
widths are even counted. Their centroid is `y = 50.64`, so the whole figure was
also nudged down off the ring's centre.

Not a `viewBox` mismatch and not a missing `overflow` — the star and the ring
share one `0 0 100 100` box, and clipping it would chop the tips rather than fix
them. It is a typed radius that was never checked against the ring's.

## The fix

Derive the radius instead of typing it, and generate the path from it:

```ts
const RING_R = 33;
const RING_STROKE = 1.8;
const STAR_STROKE = 1;
const WARD_STAR = pentagramPath(50, 50, RING_R - RING_STROKE / 2 - STAR_STROKE / 2);
```

The tips land on the ring's **inner face**: a round join (which this path already
uses) puts a tip's outer edge at `radius + strokeWidth / 2`, and the ring's inner
face is at `radius - strokeWidth / 2`, so the two strokes kiss and neither
crosses. It still reads as a pentacle — points touching the circle — rather than
a shrunken star floating in a hoop. `pentagramPath` also puts the vertex centroid
back on `(50, 50)`, concentric with the ring by construction.

Nudging the old literal until it looked right was the failure mode to avoid here:
the ward renders at two sizes, and a magic number tuned at one is a scale bug at
the other.

## Scope — every mount I checked

The Coven kit has exactly **two** pentagram drawings, and I grepped both paths
repo-wide:

| drawing | where | ring | star radius | verdict |
|---|---|---|---|---|
| the ward's, `0 0 100 100` | `CovenTaskDetail.tsx` only — one `<Ward>` mount, two sizes (desktop 120px, mobile 96px) | `r=33` | **34.0–34.9** | the bug; fixed |
| the 44-box `M22 8 L30.2 33.3 …` | `covenSlip.tsx` (`SigilMark`), `CovenFeedFrame.tsx`, `CovenEditPraxis.tsx` (x2), `CovenTaskDetail.tsx` (`SigilMark`) | dashed `r=15` | 14.0 | already inside; untouched |

So the shared Coven pentagram was never wrong; only the ward's own larger copy
was. Left deliberately alone: that 44-box literal is pasted in five files and is
a dedupe candidate, but every copy renders correctly and re-pointing five
surfaces at one export is a different change from this one.

## The seam I tested at

**The emitted SVG.** The harness is `renderToStaticMarkup` with no layout, so no
test can prove the star *looks* right — but "is this vertex inside that circle"
is arithmetic on two attributes that are both in the markup. The new tests in
`covenTaskDetail.test.tsx` read the ward's `<circle r>`, its `stroke-width`, and
the pentagram's `d` straight out of the render, and assert:

1. every tip's radius + its half-stroke is inside the ring's inner face;
2. the tips still *reach* the ring (it is a pentacle, not a dot);
3. the vertices' centroid is `(50, 50)`.

Written first, and confirmed red on the old path before the fix went in:

```
x inscribes the pentagram inside the ring — every tip, stroke included
  -> a tip at radius 34 stays inside the ring: expected 34 to be <= 31.61
x centres the star on the ring, not below it
  -> expected 50.64 to be close to 50
```

## Checks

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`,
`npm test` (351 files / 6164 tests), `npm run build` — all green.

`npm run budget`: **zero CSS byte delta** — the built stylesheet is byte- and
hash-identical to `main`'s (`index-D7d1Pr19.css`, 117280 B raw / 22.2 KB gzip).
The CSS `WARN` the budget prints is pre-existing on `main`, not from this change;
no CSS file is touched.

## Visual QA is outstanding

I have no browser. Nothing here has been looked at — only measured.

## What to eyeball

The ward is one component with one mount, but it renders at two sizes and in two
themes:

- [ ] **Task detail, any Coven-primary task, desktop** (ward 120px) — light
- [ ] **Task detail, any Coven-primary task, desktop** — dark
- [ ] **Task detail, same task, mobile** (ward 96px) — light
- [ ] **Task detail, same task, mobile** — dark

At each: the gold star sits wholly inside the pink circle with its tips touching
it, the star is centred on the circle rather than riding low, and the numeral +
`POINTS` caption still clear the star's arms. Worth checking a 3-digit total
(e.g. `120`) as well as the 2-digit `10` in the issue's screenshot, since the
numeral is what the star has to sit around.

Also worth a glance, unchanged but adjacent:

- [ ] the four gold twinkles still sit where they did (one deliberately overhangs
      the top of the box — that is `overflow: visible`, not the bug)
- [ ] the small `SigilMark` pentacles elsewhere on the page and on the faction
      hero / select card, to confirm this PR moved none of them

🤖 Generated with [Claude Code](https://claude.com/claude-code)
