### PR TITLE
The composer draws a focus ring, and a praxis body stops running out of its box (#2266, #2268)

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6953,6 +6953,52 @@
   .ep-blink { animation: epBlink 1s step-end infinite; }
 }
 
+/* ══ The composer's focus ring (#2266) ══
+   WCAG 2.4.7 Focus Visible is Level AA — the tier this repo already enforces
+   for contrast — and the composer was the one surface that owed it and paid
+   nothing. All eight skins' `fieldBox` set `outline: none` inline, the invite
+   input set a ninth and the CodeMirror theme a tenth, and NOTHING replaced any
+   of them: the title, the write-up and the invite search all took focus
+   invisibly on every skin. That is why clicking into the write-up box looked
+   like nothing had happened, and why tabbing through the sheet was worse.
+
+   ONE rule, not ten, because ten copies of `outline: none` is what the bug was.
+   The eight inline suppressions are deleted (an inline declaration wins over
+   any stylesheet, so they had to go for this to reach anything), and the next
+   skin inherits the ring rather than having to remember it.
+
+   `:focus-visible`, never a bare `:focus` — the app's own convention, stated at
+   `.eph-gloss` and worn by `.filter-bar__toggle` and its siblings: a pointer
+   user who clicks into a field is not asking to be told where the caret went.
+
+   `[data-composer-body]` takes `:focus-within` instead, and that is the same
+   decision rather than a second convention. The host div never receives focus
+   itself — CodeMirror's contenteditable pane inside it does — so there is no
+   `:focus-visible` for the host to match, and the only focusable thing under it
+   is that pane. On a text-entry surface `:focus-visible` matches on every focus
+   route anyway, which is what makes the two equivalent here.
+
+   `currentColor`, so this costs no token and needs no eight-way measurement:
+   each skin already sets its field's `color` against its own `fieldBox` ground,
+   and that pairing is measured as body text. A distinct focus hue would need
+   measuring against eight field grounds in both themes, which is a bigger job
+   than this bug — and the blocking sheet has no room for a per-skin token set.
+
+   The offset is NEGATIVE for the same reason: the ring is drawn just inside the
+   box, on the ground the ink was measured against, rather than out on whatever
+   sheet the field happens to sit on. It follows the skin's own border-radius.
+
+   `bodyEditorTheme.ts` keeps its `&.cm-focused { outline: none }`. That one is
+   not a suppression this replaces but the reason this exists: CodeMirror's base
+   theme draws its dotted default on the editor PANE, inside the padding, rather
+   than around the field box the player sees. It is paired now, which is the
+   whole of #2266. */
+[data-composer-field]:focus-visible,
+[data-composer-body]:focus-within {
+  outline: 2px solid currentColor;
+  outline-offset: -2px;
+}
+
 /* ══════════════════════════════════════════
    FILTER BAR (#1365, epic #1361)
    One responsive filter surface for tasks and praxes. Chrome, not a faction

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4772,6 +4772,28 @@
 
   /* ── Markdown preview ── */
 
+  /* The body a player typed, so it wraps wherever it has to (#2268). Without
+     this the class carried type-scale rules only, `normal` wrapping applied,
+     and a pasted URL or a keysmash — which has no word boundary to break at —
+     ran straight out of its panel. One declaration on the one shared class
+     reaches all eleven surfaces that mount it: the composer's Preview tab, the
+     duel/collab waiting panel, the Ephemerists composer and all eight
+     praxis-detail archetypes.
+
+     `anywhere` rather than `break-word`: it also lets min-content width shrink,
+     so a long token cannot force a flex or grid sibling wider. The duel panels
+     are a two-column pair, where `break-word` wraps the text and still blows
+     the column out.
+
+     Scoped to prose on purpose. §"A wordmark is a MARK" (#2000) is the other
+     half of this rule: a faction name must never carry `anywhere`, because a
+     break that invents a new word is worse than an overflow. `pre` is exempt by
+     construction — `white-space: pre` disallows wrapping, so this cannot reach
+     it and its own `overflow-x-auto` below is what a code block gets instead. */
+  .markdown-preview {
+    overflow-wrap: anywhere;
+  }
+
   .markdown-preview h1 {
     @apply font-display text-2xl font-bold mt-4 mb-2;
   }

--- a/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/CovenEditPraxis.tsx
@@ -374,7 +374,6 @@ export default function CovenEditPraxis({ state }: Props) {
     border: RULE,
     borderRadius: FIELD_RADIUS,
     padding: "var(--space-md)",
-    outline: "none",
     boxSizing: "border-box",
   } as const;
   /* The braid, for the dress the waiting surface wears. On THIS page the one

--- a/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/DefaultEditPraxis.tsx
@@ -256,7 +256,6 @@ export default function DefaultEditPraxis({ state }: Props) {
     border: `1px solid ${BORDER}`,
     borderRadius: 10,
     padding: "var(--space-md)",
-    outline: "none",
     boxSizing: "border-box",
   } as const;
   /* Your part is in, so the composer is not a composer any more (ADR-0059).

--- a/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx
@@ -293,7 +293,6 @@ export default function EphemeristsEditPraxis({ state }: Props) {
     border: `1.5px solid ${LINE}`,
     borderRadius: 0,
     padding: "var(--space-md)",
-    outline: "none",
     boxSizing: "border-box",
   } as const;
 

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -293,7 +293,6 @@ export default function EverymenEditPraxis({ state }: Props) {
     border: `2px solid ${FRAME}`,
     borderRadius: 0,
     padding: "var(--space-md)",
-    outline: "none",
     boxSizing: "border-box",
   } as const;
 

--- a/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SingularityEditPraxis.tsx
@@ -245,7 +245,6 @@ export default function SingularityEditPraxis({ state }: Props) {
     borderRadius: RADIUS,
     padding: "var(--space-md)",
     fontFamily: FACE,
-    outline: "none",
     boxSizing: "border-box",
   } as const;
 

--- a/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/SnideEditPraxis.tsx
@@ -255,7 +255,6 @@ export default function SnideEditPraxis({ state }: Props) {
     border: `1px solid ${RULE}`,
     borderRadius: 0,
     padding: "var(--space-md)",
-    outline: "none",
     boxSizing: "border-box",
   } as const;
 

--- a/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/UaEditPraxis.tsx
@@ -207,7 +207,6 @@ export default function UaEditPraxis({ state }: Props) {
     border: `1px solid ${RULE}`,
     borderRadius: RADIUS,
     padding: "var(--space-md)",
-    outline: "none",
     boxSizing: "border-box",
   } as const;
 

--- a/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/WowEditPraxis.tsx
@@ -277,7 +277,6 @@ export default function WowEditPraxis({ state }: Props) {
     border: `1.5px solid ${GOLD}`,
     borderRadius: 6,
     padding: "var(--space-md)",
-    outline: "none",
     boxSizing: "border-box",
   } as const;
 

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerFocusRing.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerFocusRing.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * The composer's focus ring — a WCAG 2.4.7 (Level AA) contract (#2266).
+ *
+ * The composer suppressed the focus outline on every field of every skin and
+ * put nothing in its place: eight faction `fieldBox` objects each carried an
+ * inline `outline: "none"`, the invite input carried a ninth, and grepping the
+ * whole of `pages/editPraxis` for a replacement found only a behavioural
+ * `onFocus` handler. Clicking into the write-up box therefore looked like
+ * nothing had happened, and a keyboard user tabbed through the sheet blind.
+ *
+ * The seam under test is the STYLESHEET CONTRACT, not a rendered ring: this
+ * harness is `renderToStaticMarkup` in a DOM-less node environment, so no test
+ * here can focus anything or measure a pixel. What it CAN pin is the pair —
+ * every suppression that survives is answered by a rule in `index.css`, the
+ * markup carries the hooks that rule selects on, and the rule uses the
+ * convention this app already standardised on (`:focus-visible`, never a bare
+ * `:focus` — see `.filter-bar__toggle` and the reasoning at `.eph-gloss`).
+ *
+ * Verified against the BUILT stylesheet by hand as well, per #1941: a
+ * brace-balanced source edit proves nothing about the Tailwind layer merge.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+import "../../../../i18n";
+import type { EditPraxisState } from "../../useEditPraxis";
+import { BodyTextarea, TitleField } from "../controls";
+import { stripComments } from "../../../../utils/__tests__/cssVars";
+
+const CSS = stripComments(
+  readFileSync(fileURLToPath(new URL("../../../../index.css", import.meta.url)), "utf8"),
+);
+
+const ARCHETYPE_DIR = fileURLToPath(new URL("..", import.meta.url));
+
+/** Every source file the composer is built from (the eight skins + the shared controls). */
+function composerSources(): Array<{ name: string; source: string }> {
+  return readdirSync(ARCHETYPE_DIR)
+    .filter((name) => name.endsWith(".tsx") || name.endsWith(".ts"))
+    .map((name) => ({
+      name,
+      source: readFileSync(`${ARCHETYPE_DIR}/${name}`, "utf8"),
+    }));
+}
+
+/** An `outline: "none"` in an inline style object, in any spacing. */
+const SUPPRESSION = /outline:\s*["']none["']/;
+
+// The controls only read the handful of state fields they bind to.
+const state = {
+  title: "Caught the papers",
+  setTitle: () => {},
+  body: "## What I did",
+  setBody: () => {},
+} as unknown as EditPraxisState;
+
+describe("the composer's focus ring", () => {
+  it("leaves no unpaired outline suppression in any faction skin", () => {
+    const offenders = composerSources()
+      .filter(({ source }) => SUPPRESSION.test(source))
+      .map(({ name }) => name);
+
+    // `bodyEditorTheme.ts` keeps ONE, deliberately: CodeMirror's base theme
+    // draws its dotted default on the editor pane rather than on the field box
+    // the player sees, which is the wrong box by a whole padding. That one is
+    // answered by the `[data-composer-body]` rule asserted below — every other
+    // file's suppression was answered by nothing, which was the bug.
+    expect(offenders).toEqual(["bodyEditorTheme.ts"]);
+  });
+
+  it("answers both suppressions with one rule in index.css", () => {
+    expect(CSS).toContain("[data-composer-field]:focus-visible");
+    expect(CSS).toContain("[data-composer-body]:focus-within");
+    // `currentColor`: each skin already measured its field's ink against its
+    // own field ground, so the ring is legible on all eight by construction —
+    // no new token, no eight-way measurement, no byte of faction CSS.
+    expect(CSS).toMatch(
+      /\[data-composer-body\]:focus-within\s*\{[^}]*outline:[^;]*currentColor/,
+    );
+  });
+
+  it("never reaches for a bare :focus, which is the app's own convention", () => {
+    const composerRules = CSS.match(/\[data-composer-[a-z]+\]:[a-z-]+/g) ?? [];
+    expect(composerRules.length, "the composer focus rule exists").toBeGreaterThan(0);
+    // `:focus` alone would ring a pointer user who merely clicked into the box.
+    expect(composerRules.filter((rule) => rule.endsWith(":focus"))).toEqual([]);
+  });
+
+  it("puts the hook the rule selects on the title input and the body's host", () => {
+    const title = renderToStaticMarkup(
+      <TitleField state={state} skin={{ inputStyle: {} }} />,
+    );
+    expect(title).toContain("data-composer-field");
+
+    const body = renderToStaticMarkup(
+      <BodyTextarea state={state} skin={{ textareaStyle: {} }} />,
+    );
+    expect(body).toContain("data-composer-body");
+  });
+
+  it("puts the same hook on the invite search input", () => {
+    // Rendering `InviteSearch` needs a whole duel/collab state fixture; the
+    // claim here is only that the attribute is on the element, so the source is
+    // the cheaper seam for it.
+    const controls = readFileSync(`${ARCHETYPE_DIR}/controls.tsx`, "utf8");
+    const inviteInput = controls.slice(controls.indexOf("autoFocus={pickerOpen}"));
+    expect(inviteInput.slice(0, inviteInput.indexOf("/>"))).toContain(
+      "data-composer-field",
+    );
+  });
+});

--- a/frontend/src/pages/editPraxis/archetypes/__tests__/composerFocusRing.test.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/__tests__/composerFocusRing.test.tsx
@@ -104,9 +104,14 @@ describe("the composer's focus ring", () => {
     // claim here is only that the attribute is on the element, so the source is
     // the cheaper seam for it.
     const controls = readFileSync(`${ARCHETYPE_DIR}/controls.tsx`, "utf8");
-    const inviteInput = controls.slice(controls.indexOf("autoFocus={pickerOpen}"));
-    expect(inviteInput.slice(0, inviteInput.indexOf("/>"))).toContain(
-      "data-composer-field",
+    // `autoFocus={pickerOpen}` is the invite input's own tell; the element runs
+    // from the `<input` before it to the `/>` after it.
+    const tell = controls.indexOf("autoFocus={pickerOpen}");
+    expect(tell, "the invite search input is still here").toBeGreaterThan(-1);
+    const element = controls.slice(
+      controls.lastIndexOf("<input", tell),
+      controls.indexOf("/>", tell),
     );
+    expect(element).toContain("data-composer-field");
   });
 });

--- a/frontend/src/pages/editPraxis/archetypes/bodyEditorTheme.ts
+++ b/frontend/src/pages/editPraxis/archetypes/bodyEditorTheme.ts
@@ -69,8 +69,14 @@ const BODY_EDITOR_SKIN_THEME = EditorView.theme({
     // The skin's box is drawn by the host; the editor is a pane inside it.
     backgroundColor: "transparent",
   },
-  // Every skin's `fieldBox` sets `outline: none`, and the base theme's dotted
-  // default sits on the editor rather than on the host, out of that reach.
+  // The base theme's dotted default sits on the editor PANE — inside the
+  // skin's padding — rather than around the field box the player sees, so it
+  // marks the wrong box. This is the ONE outline suppression in the composer
+  // that survives #2266, and it is paired: `[data-composer-body]:focus-within`
+  // in index.css draws the ring on the host, where the field's edge is.
+  // (The eight skins' `fieldBox` each carried one of these too, replaced by
+  // that same rule — an inline declaration wins over any stylesheet, so they
+  // had to go for it to reach anything.)
   "&.cm-focused": { outline: "none" },
   ".cm-scroller": {
     fontFamily: "inherit",

--- a/frontend/src/pages/editPraxis/archetypes/controls.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/controls.tsx
@@ -380,6 +380,10 @@ export function InviteSearch({
       <div style={{ position: "relative" }}>
         <input
           type="text"
+          // The composer's shared focus ring selects on this (#2266). See the
+          // rule in index.css for why it is one attribute rather than a class
+          // and why the ring is `currentColor`.
+          data-composer-field
           // Opened by the chip, so it takes the caret with it — the click that
           // asked for a search box is not also a request to go and find it.
           autoFocus={pickerOpen}
@@ -404,7 +408,6 @@ export function InviteSearch({
             background: skin.inputBg ?? "transparent",
             color: skin.inputColor ?? "inherit",
             border: skin.inputBorder ?? "1px solid currentColor",
-            outline: "none",
           }}
           onFocus={() => {
             if (state.inviteResults.length > 0) state.setInviteOpen(true);
@@ -826,6 +829,10 @@ export function TitleField({
         (skin.id ? undefined : t("editPraxis.composer.titleLabel"))
       }
       className="content-text"
+      // The composer's shared focus ring selects on this (#2266) — one rule in
+      // index.css for all eight skins, in place of the eight inline
+      // `outline: none` declarations that used to sit in every `fieldBox`.
+      data-composer-field
       value={state.title}
       onChange={(event) => {
         const next = event.target.value;

--- a/frontend/src/pages/praxisDetail/__tests__/markdownPreviewWrap.test.ts
+++ b/frontend/src/pages/praxisDetail/__tests__/markdownPreviewWrap.test.ts
@@ -1,0 +1,52 @@
+/**
+ * A rendered praxis body wraps an unbroken string (#2268).
+ *
+ * `.markdown-preview` carried type-scale rules and no wrapping rule at all, so
+ * `normal` wrapping applied — which breaks at word boundaries, and a pasted URL
+ * or a keysmash has none. The body then ran straight out of its panel. Reported
+ * on an Everymen duel rail; the class is mounted by eleven surfaces (the
+ * composer's Preview tab, the duel/collab waiting panel, the Ephemerists
+ * composer, and all eight praxis-detail archetypes), so it reproduced on all of
+ * them.
+ *
+ * The seam under test is the STYLESHEET CONTRACT. This harness is
+ * `renderToStaticMarkup` with no layout engine, so no test here can observe an
+ * overflow (the limitation #1942 records) — what it can pin is that the one
+ * shared class declares the one property, which is where all eleven surfaces
+ * meet. Verified against the BUILT stylesheet by hand too, per #1941.
+ *
+ * `anywhere` rather than `break-word`, deliberately: `anywhere` also lets the
+ * element's min-content width shrink, so a long token cannot force a flex or
+ * grid sibling wider. The duel panels are a two-column pair, where `break-word`
+ * would wrap the text and still blow the column out.
+ *
+ * NOT a licence to break words anywhere in the app — see WORLD_ZERO_STYLE.md
+ * (#2000): a faction wordmark is a MARK and must never carry this. It belongs
+ * on prose the player typed, which is exactly what this class dresses.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+import { ruleBodies, stripComments } from "../../../utils/__tests__/cssVars";
+
+const CSS = stripComments(
+  readFileSync(fileURLToPath(new URL("../../../index.css", import.meta.url)), "utf8"),
+);
+
+describe(".markdown-preview", () => {
+  it("wraps an unbroken string rather than overflowing its panel", () => {
+    const bodies = ruleBodies(CSS, ".markdown-preview");
+    expect(bodies.length, "a bare `.markdown-preview` rule exists").toBe(1);
+    expect(bodies[0]).toMatch(/overflow-wrap:\s*anywhere/);
+  });
+
+  it("keeps a code block scrolling instead, so a snippet is not broken mid-token", () => {
+    // `pre` defaults to `white-space: pre`, which disallows wrapping outright —
+    // so the inherited `overflow-wrap` above cannot reach it and the existing
+    // `overflow-x-auto` is already the right answer. Pinned because deleting it
+    // would silently hand code blocks the prose rule.
+    const pre = ruleBodies(CSS, ".markdown-preview pre");
+    expect(pre.length).toBe(1);
+    expect(pre[0]).toContain("overflow-x-auto");
+  });
+});


### PR DESCRIPTION
Two stylesheet-contract bugs on the same surface family, fixed as two shared rules rather than twenty patches.

Closes #2266
Closes #2268

## The seam

**The stylesheet contract**, not a rendered pixel. The frontend harness is `renderToStaticMarkup` in a DOM-less node environment: it cannot focus a field, cannot lay out a box, and therefore cannot prove a ring or an overflow. What it can prove is that the one shared class/attribute declares the one property, that every surviving suppression is paired, and that the markup carries the hook the rule selects on. Both new tests are written at that seam and both went red on the real defect first.

Because a brace-balanced source edit proves nothing about the Tailwind layer merge (#1941's own correction), both rules were then grepped out of the **built** sheet after `npm run build`:

```
.markdown-preview{overflow-wrap:anywhere}
[data-composer-field]:focus-visible,[data-composer-body]:focus-within{outline:2px solid currentColor;outline-offset:-2px}
```

## #2266 - the composer's focus ring

Verified the issue's table against the code: all ten sites were there, all ten still `outline: "none"`, and grepping `pages/editPraxis` for a replacement still found only the invite dropdown's behavioural `onFocus`. The code agreed with the issue.

Nine suppressions deleted - the eight faction `fieldBox` objects and the invite input - because an inline declaration beats any stylesheet, so they had to go for a rule to reach anything. **The tenth stays**: `bodyEditorTheme.ts`'s `&.cm-focused { outline: none }` is not the bug, it is the reason the bug is hard - CodeMirror's base theme draws its dotted default on the editor *pane*, inside the skin's padding, rather than around the field box the player sees. It is paired now, which is the whole of the issue.

One rule replaces all nine, per the issue's "one rule, not ten":

- **`:focus-visible`, never a bare `:focus`** - read `.filter-bar__toggle` / `.filter-factions__trigger` / `.feed-load-more` and the reasoning written at `.eph-gloss` first, and matched them. No second convention invented.
- **`[data-composer-body]` takes `:focus-within`, and that is the same decision.** The host div never receives focus itself - CodeMirror's contenteditable pane inside it does - so there is no `:focus-visible` for the host to wear, and the only focusable thing under it is that pane. On a text-entry surface `:focus-visible` matches on every focus route anyway.
- **`currentColor`**, per the issue's cheapest-correct suggestion: each skin already sets its field's `color` against its own `fieldBox` ground and that pairing is measured as body text, so the ring is legible on all eight by construction - no token, no eight-way measurement.
- **The offset is negative on purpose.** Drawn just inside the box, the ring sits on the ground the ink was measured against, rather than out on whatever sheet the field happens to sit on. It follows each skin's own border-radius.

Two `data-composer-field` attributes were added in `controls.tsx` (the title input and the invite input) as the hook the rule selects on; the body host already carried `data-composer-body`. Those are the only `.tsx` markup additions - everything else in that file is a deletion.

## #2268 - a praxis body that wraps

One declaration on `.markdown-preview`, reaching all eleven mounts. `anywhere` rather than `break-word` because it also lets min-content width shrink, so a long token cannot force a flex or grid sibling wider - which is exactly the two-column duel pair the report came from.

**The `code`/`pre` question the issue asked to check: already answered, no second rule needed.** `.markdown-preview pre` carries `overflow-x-auto` today, and `pre` defaults to `white-space: pre`, which disallows wrapping outright - so the inherited `overflow-wrap` cannot reach it and a code block scrolls rather than breaking mid-token. That is pinned by a test so deleting the `overflow-x-auto` does not silently hand code blocks the prose rule.

Scoped deliberately: WORLD_ZERO_STYLE.md's "A wordmark is a MARK" (#2000) is the other half of this rule - a faction name must never carry `anywhere`. This is on prose the player typed, which is what the class dresses. The CSS comment says so, so the next reader does not generalise it.

## Byte budget

Measured gzip **level 9**, blocking sheet, both sides built from this worktree:

| | raw | gzip-9 |
|---|---|---|
| `origin/main` | 117,313 B | 22,776 B |
| this branch | 117,475 B | **22,826 B** |
| delta | +162 B | **+50 B** |

`npm run budget` prints `WARN CSS` on **both** - main is already 44 B past the 22.2 KB warn line. This PR does not cross a threshold (fail is 24.4 KB) and adds 50 B for two AA fixes across nineteen surfaces.

## Checks run locally

`npm run lint` - `npm run typecheck` - `npm run typecheck:design-sync` - `npm test` (353 files, 6169 passing) - `npm run build` - `npm run budget`. No backend, route or schema change, so `api-schema` is untouched.

## Visual QA is outstanding

No browser and no dev stack here, and the harness cannot see a focus ring or an overflow. Everything below needs an eyeball.

### What to eyeball

**The ring - click into the write-up box on each of the eight composers**, light and dark, and check the ring reads against that skin's own field ground and does not collide with its border or ornament:

- Unaffiliated (`Default`, the aurora sheet)
- UA (parchment)
- WOW (cream)
- Coven (ward)
- Ephemerists (the near-black plate - the darkest field, worth looking at first)
- Singularity (terminal)
- S.N.I.D.E. (the flyposted wall, where the field is a shade off the sheet)
- Everymen (the work-order plate, radius 0 throughout - the ring should follow the square corner)

**Tab through title then body then invite** on at least one light-fielded and one dark-fielded skin, and confirm each stop is visible. The formatting toolbar is deliberately not a tab stop (#693), so the run should be three stops.

**Click vs. tab**, on one skin: a pointer click into the title should still ring it (a text field matches `:focus-visible` on every route) - that is intended, and it is what the reported "it doesn't change" was missing.

**The invite input** with the results dropdown open - the ring is inset, so it should not fight the dropdown's top edge.

**The wrap - a praxis detail body containing a 30+ character unbroken string**, light and dark, on the Everymen duel rail where it was reported and on one other archetype. Then the same string in the composer's Preview tab, and inside a fenced code block, where it should **scroll horizontally rather than break**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
