### PR TITLE
GET /tasks stops hiding the tasks you started from every list in the app (#2264)

### DIFF
--- a/backend/routers/tasks.py
+++ b/backend/routers/tasks.py
@@ -67,20 +67,25 @@ async def list_tasks(
     is_admin = account is not None and await account_has_admin_role(
         account.id, session
     )
-    # The viewer is the exclusion default (#1229): the browse hides tasks you
-    # have already started, and the server already knows who you are. Clients
-    # that echoed their own character id back made the page fetch twice — once
-    # before /auth/me settled and once after. An explicit value still wins;
-    # anonymous callers get None, which excludes nothing.
+    # `exclude_character_id` is passed through untouched (#2264). The route used
+    # to default it to the viewer for #1229's "the browse hides tasks you have
+    # already started" — but a route default reaches EVERY caller of GET /tasks,
+    # not the browse, and it was applied unconditionally on `can_sign_up`. So a
+    # faction page rendered a viewer-relative task COUNT (`Tasks · 0` where the
+    # reader held a praxis on every one of that faction's tasks), the browse's
+    # own `can_sign_up=0` escape hatch could not undo it, and Home's teaser and
+    # random jump could never land on a task you were working. #2126 had already
+    # carved out `created_by` by hand; a second carve-out per caller is not a
+    # contract, it is a list of the surfaces somebody remembered.
     #
-    # `created_by` is the one read that is not a browse (#2126): it asks "what
-    # did this character propose", and the answer cannot depend on which of
-    # those tasks the *reader* happens to be working. Defaulting it here dropped
-    # a proposer's own accepted-and-started task off their own profile, and
-    # dropped rows off a stranger's profile according to the visitor's praxis
-    # bank. An explicit value still wins, on every route.
-    if exclude_character_id is None and viewer is not None and created_by is None:
-        exclude_character_id = viewer.id
+    # #1229's behaviour is not deleted, it is stated where it is true: the
+    # exclusion IS gate 5 of the sign-up predicate, so `services.task.list_tasks`
+    # arms it from the viewer whenever `can_sign_up` is on and the caller named
+    # nobody. The browse asks for that filter by default, so it keeps the exact
+    # list it had; every viewer-independent read now gets a viewer-independent
+    # answer. #1229's other reason — clients echoing their own character id back
+    # made the page fetch twice, once before /auth/me settled and once after — is
+    # a client concern, and no client needs to send the id at all.
     tasks = await service_list_tasks(
         session,
         status=status,

--- a/backend/services/task.py
+++ b/backend/services/task.py
@@ -846,8 +846,12 @@ async def list_tasks(
         if viewer.faction_slug not in era.allow_praxis_on_pending_task_factions:
             query = query.where(Task.status != TaskStatus.pending)
         # Gate 5 is the exclude_character_id clause below — reused, not rewritten.
-        # The route already defaults it to the viewer (#1229); this only arms it
-        # for a direct service caller that did not.
+        # This is the ONLY place the viewer becomes that default (#2264). The
+        # route used to do it first, for every caller and regardless of
+        # `can_sign_up`, which made a faction's task count depend on who was
+        # reading it. Armed here it is scoped to the question that actually asks
+        # it: "which tasks could I claim right now" — and a task you are already
+        # working is not one of them, which is #1229's browse behaviour intact.
         if exclude_character_id is None:
             exclude_character_id = viewer.id
 

--- a/backend/tests/integration/test_task_can_sign_up_filter.py
+++ b/backend/tests/integration/test_task_can_sign_up_filter.py
@@ -359,3 +359,94 @@ async def test_anonymous_viewer_gets_nothing(
         db_session, can_sign_up=True, viewer=None, status="all", task_type="all"
     )
     assert filtered == []
+
+
+# ---------------------------------------------------------------------------
+# The route's half of the agreement (#2264)
+# ---------------------------------------------------------------------------
+# Everything above tests the service. The flag and the enforcement can still
+# disagree one layer up: until #2264 the ROUTE defaulted `exclude_character_id`
+# to the viewer for EVERY caller, unconditionally on `can_sign_up`, so gate 5
+# was applied to reads that had never asked for the sign-up predicate at all.
+# `GET /tasks?can_sign_up=0` is the browse's own escape hatch and it did not
+# work; a faction page, which sends no `can_sign_up`, reported a viewer-relative
+# task COUNT. The route now passes the parameter through untouched and the
+# service arms gate 5 itself when — and only when — `can_sign_up` is on.
+
+
+async def _route_task_ids(client, url: str, headers: dict | None = None) -> list[int]:
+    resp = await client.get(url, headers=headers or {})
+    assert resp.status_code == 200, resp.text
+    return [task["id"] for task in resp.json()]
+
+
+@pytest.mark.asyncio
+async def test_route_all_tasks_shows_a_task_the_viewer_started(
+    client,
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    """#2264 — "All tasks" means all tasks, including the ones you are working."""
+    await _seed_in_progress_praxis(db_session, character, active_task)
+
+    ids = await _route_task_ids(client, "/tasks?can_sign_up=0", auth_headers)
+    assert active_task.id in ids, (
+        "the viewer switched the eligibility filter off; the task they started "
+        "is still one of the tasks that exist"
+    )
+
+
+@pytest.mark.asyncio
+async def test_route_eligibility_browse_still_hides_a_started_task(
+    client,
+    db_session: AsyncSession,
+    character: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+):
+    """#1229 must survive #2264 — the browse's DEFAULT view still hides it.
+
+    Gate 5 is part of the sign-up predicate, so `can_sign_up=1` carries the
+    exclusion on its own. This is the half that proves #2264 moved the default
+    rather than deleting the behaviour.
+    """
+    await _seed_in_progress_praxis(db_session, character, active_task)
+
+    ids = await _route_task_ids(client, "/tasks?can_sign_up=1", auth_headers)
+    assert active_task.id not in ids
+
+
+@pytest.mark.asyncio
+async def test_route_faction_task_list_is_the_same_for_every_viewer(
+    client,
+    db_session: AsyncSession,
+    character: Character,
+    character2: Character,
+    active_task: Task,
+    era: Era,
+    faction_ua: Faction,
+    auth_headers: dict,
+    auth_headers2: dict,
+):
+    """The invariant the reported `Tasks · 0` broke (#2264).
+
+    `useFactionDetail` sends exactly this query and renders its LENGTH as the
+    faction's task count. A count is a fact about the faction, so two readers —
+    one of them holding a praxis on one of its tasks — must be told the same
+    number, and an anonymous visitor must be told it too.
+    """
+    await _seed_in_progress_praxis(db_session, character, active_task)
+    url = "/tasks?faction=ua&status=active"
+
+    holder = await _route_task_ids(client, url, auth_headers)
+    stranger = await _route_task_ids(client, url, auth_headers2)
+    anonymous = await _route_task_ids(client, url)
+
+    assert active_task.id in holder
+    assert holder == stranger == anonymous

--- a/backend/tests/integration/test_task_visibility_gates.py
+++ b/backend/tests/integration/test_task_visibility_gates.py
@@ -426,13 +426,17 @@ async def test_a_profile_keeps_a_proposal_its_author_is_also_working(
 ):
     """The browse's exclusion is not a fact about authorship (#2126).
 
-    `GET /tasks` defaults `exclude_character_id` to the reader (#1229) so the
-    browse hides what they have already started. `created_by` is not a browse:
-    it asks what a character PROPOSED, and the answer cannot depend on which of
-    those tasks the *reader* happens to be working. `active_task` is authored by
-    `character` and carries their praxis, so it dropped off their own profile
-    the moment they started it — and off a stranger's profile according to
-    whatever the visitor had in their own praxis bank.
+    The eligibility browse hides what the reader has already started, because
+    that is gate 5 of the sign-up predicate (#1229). `created_by` is not a
+    browse: it asks what a character PROPOSED, and the answer cannot depend on
+    which of those tasks the *reader* happens to be working. `active_task` is
+    authored by `character` and carries their praxis, so it dropped off their
+    own profile the moment they started it — and off a stranger's profile
+    according to whatever the visitor had in their own praxis bank.
+
+    #2126 fixed that by carving `created_by` out of a route-level default;
+    #2264 removed the default itself, so this route no longer needs a
+    carve-out to be right. The assertion is unchanged and still guards it.
     """
     mine = await _ids(client, f"/tasks?created_by={character.id}", auth_headers)
     assert active_task.id in mine

--- a/backend/tests/integration/test_tasks.py
+++ b/backend/tests/integration/test_tasks.py
@@ -465,14 +465,21 @@ async def test_list_tasks_exclude_character_id(
 
 
 @pytest.mark.asyncio
-async def test_list_tasks_defaults_exclusion_to_viewer(
+async def test_list_tasks_is_the_same_list_for_every_reader(
     client: AsyncClient,
     character: Character,
     active_task: Task,
     auth_headers: dict,
 ):
-    """An authenticated browse excludes the viewer's own started tasks without
-    the client passing exclude_character_id (#1229) — anonymous excludes none."""
+    """A plain `GET /tasks` does not depend on who is reading it (#2264).
+
+    The route used to default `exclude_character_id` to the viewer (#1229), so
+    a signed-in reader and an anonymous one were handed different lists — and
+    the surfaces that render a COUNT off this call reported a different number
+    per reader. The exclusion now belongs to `can_sign_up`, which is where it is
+    actually true: it is gate 5 of the sign-up predicate, asserted in
+    tests/integration/test_task_can_sign_up_filter.py.
+    """
     create_resp = await client.post(
         "/praxes",
         json={"task_id": active_task.id, "type": "solo"},
@@ -482,37 +489,11 @@ async def test_list_tasks_defaults_exclusion_to_viewer(
 
     resp = await client.get("/tasks", headers=auth_headers)
     assert resp.status_code == 200
-    assert active_task.id not in [t["id"] for t in resp.json()]
+    assert active_task.id in [t["id"] for t in resp.json()]
 
     anon_resp = await client.get("/tasks")
     assert anon_resp.status_code == 200
-    assert active_task.id in [t["id"] for t in anon_resp.json()]
-
-
-@pytest.mark.asyncio
-async def test_list_tasks_explicit_exclusion_beats_viewer_default(
-    client: AsyncClient,
-    character: Character,
-    character2: Character,
-    active_task: Task,
-    auth_headers: dict,
-):
-    """An explicitly passed exclude_character_id wins over the viewer default,
-    so the viewer's own started task stays visible when another id is named."""
-    create_resp = await client.post(
-        "/praxes",
-        json={"task_id": active_task.id, "type": "solo"},
-        headers=auth_headers,
-    )
-    assert create_resp.status_code == 201
-
-    resp = await client.get(
-        "/tasks",
-        params={"exclude_character_id": character2.id},
-        headers=auth_headers,
-    )
-    assert resp.status_code == 200
-    assert active_task.id in [t["id"] for t in resp.json()]
+    assert [t["id"] for t in anon_resp.json()] == [t["id"] for t in resp.json()]
 
 
 @pytest.mark.asyncio

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -429,9 +429,13 @@ export function useTasks(): TasksState {
             sort: sort === TASK_SORT_DEFAULT ? undefined : sort,
             can_sign_up: canSignUp || undefined,
             q: trimmedQuery || undefined,
-            // The server excludes the authenticated viewer's own started tasks
-            // by default (#1229). Echoing the character id back here added an
-            // auth-dependent dep that made the page fetch twice.
+            // No `exclude_character_id`, deliberately (#2264). "A task you are
+            // already working" is gate 5 of the sign-up predicate, so the
+            // `can_sign_up` above already carries it and #1229's hiding is
+            // intact on the default view. Switching the eligibility filter off
+            // drops the whole predicate, gate 5 with it, which is what makes
+            // "All tasks" mean all tasks. Echoing the character id back here
+            // would add an auth-dependent dep and buy nothing.
             limit,
           }),
     [taskType, sort, status, factionKey, canSignUp, trimmedQuery, viewerPending],


### PR DESCRIPTION
Closes #2264

## The seam

`GET /tasks` — the **route** layer, not the service. The defect was a route-level default,
so the failing test had to be an HTTP-level one; a service test could not see it.
The new cases live in `backend/tests/integration/test_task_can_sign_up_filter.py`, which is
the standing check that the `can_sign_up` flag and its enforcement never disagree — the route
was the layer that broke that agreement.

Red first, on the real defect. `test_route_faction_task_list_is_the_same_for_every_viewer`
failed with `assert 3 in []` — literally the reported `Tasks · 0`.

## The fix

`backend/routers/tasks.py` no longer defaults `exclude_character_id` to the viewer.
The parameter is passed through untouched, and `#1229`'s behaviour is stated where it is
actually true instead: in `backend/services/task.py`, where the exclusion **already was**
gate 5 of the sign-up predicate and already armed itself from the viewer when `can_sign_up`
is on and the caller named nobody.

## One deviation from the issue's recommended fix — worth a look

The issue recommends the route stop guessing **and** `useTasks` start passing
`exclude_character_id` when `canSignUp` is on. The first half is done exactly as written.
**The second half turned out to be unnecessary, so it is not in this PR.**

The browse's default already sends `can_sign_up=1` (`readTaskFilters`: the axis is ON for
any viewer holding a character), and `services/task.py` already sets
`exclude_character_id = viewer.id` inside its `can_sign_up` branch. So the browse's default
view keeps the exact list it had, byte for byte, with no client change. Adding the param
would be a redundant round-trip of an id the server already has — and would reintroduce the
auth-dependent fetch dependency that `#1229` and the existing comment in `useTasks.ts` both
warn against.

The rejected narrower alternative (keep the route default, clear it when `can_sign_up=0`)
is **not** what this is. That one leaves the faction page, FieldDesk and Home wrong because
they send no `can_sign_up` at all. Here the route default is gone outright, so every
viewer-independent read gets a viewer-independent answer.

The only frontend edit is a comment correction: the old one claimed the server excludes
"by default", which is no longer true.

## One correction to the issue's blast-radius table

**FieldDesk does not change behaviour, and should not.** It sends
`BROWSE_TASK_FILTERS = { can_sign_up: true }` (`pages/FieldDesk.tsx:343`), so gate 5 still
applies to it — correctly, because its board is "tasks you can sign up for", and a task you
have already started is not one of them. The issue lists it as an affected surface; the
recommended fix would not have changed it either, for the same reason.

The four surfaces that **do** change: faction detail, the browse's "All tasks" toggle,
Home's teaser + random jump, and the onboarding hand-off.

`pages/CharacterProfile.tsx` (`created_by`) is untouched, as asked.

## `api-schema`: no artifact change

The route **signature** is unmodified — `exclude_character_id: Optional[int] = None` stays;
only the body's defaulting logic moved. `python scripts/regen_api_client.py` was run from
the repo root and produced **no diff** in `backend/openapi.json` or
`frontend/src/api/generated/schema.d.ts`, so there is nothing to commit for that job.

## Tests

Added to `test_task_can_sign_up_filter.py`:

- `test_route_all_tasks_shows_a_task_the_viewer_started` — `can_sign_up=0` must show T. **(was red)**
- `test_route_eligibility_browse_still_hides_a_started_task` — `can_sign_up=1` must still hide T,
  so #1229's deliberate behaviour is proven to survive rather than assumed.
- `test_route_faction_task_list_is_the_same_for_every_viewer` — the faction-page query, three
  readers (praxis holder / stranger / anonymous), one identical list. This is the invariant the
  count depends on. **(was red)**

Changed:

- `test_tasks.py::test_list_tasks_defaults_exclusion_to_viewer` pinned the defect itself. Rewritten
  as `test_list_tasks_is_the_same_list_for_every_reader`.
- `test_tasks.py::test_list_tasks_explicit_exclusion_beats_viewer_default` **deleted** — it tested
  that an explicit value beat a default that no longer exists, and what remained duplicated
  `test_list_tasks_exclude_character_id` one function above it.
- `test_task_visibility_gates.py` — docstring only; it described the removed default. Assertion unchanged.

## Verification run locally

Every step named in `.github/workflows/test.yml`, against a dedicated `wz2264_test` database:

- `pytest --cov=. --cov-fail-under=80` — **1484 passed**, 94.06% coverage
- `npm run lint` / `npm run typecheck` / `npm run typecheck:design-sync` — clean
- `npm test` — **6162 passed**, 1 skipped
- `npm run build` — clean
- `npm run budget` — JS 126.8 KB ok, CSS 22.2 KB WARN. **The CSS warning is pre-existing**:
  I rebuilt with my change stashed and got the identical figure and the identical asset hash.
  This PR moves zero bytes.

## Visual QA is outstanding

I have no browser and no dev stack in this environment. Everything above is tests, tsc and
eslint. The behaviour change is server-side and unmistakable in the fixtures, but nobody has
looked at it.

## What to eyeball

1. **A faction detail page's task count** — the reported defect. `/factions/ua` signed in as a
   character holding a praxis on `#4 Make a practice of art`, then the same page in a private
   window. The two `Tasks · N` readouts must now agree, and neither should say `0`. (Per the
   issue's prod check, UA has 2 tasks and the owner is on both.) `MEMBERS · 0` beside it is
   correct and not part of this.
2. **The task browse "All tasks" toggle** — `/tasks`, flip the eligibility filter off. Tasks you
   have started must now appear. Flip it back on: they must vanish again. Both directions,
   because one direction alone cannot tell "fixed" from "exclusion deleted".
3. **Mobile FieldDesk** — the browse board. Expect **no visible change**; this is a regression
   check, not a fix. Started tasks should still be absent.
4. **Home's newest-task teaser** — if the newest active task is one you have started, it must now
   be the one shown.
5. **Home's random jump** — press it repeatedly; it must now be able to land on a task you are
   working. Previously it could never reach one.
6. **Your own character profile** (`/characters/<you>`) — proposals list. Unchanged, and the
   check that `created_by` stayed carved out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
