### PR TITLE
Lead reads as a Saturn again, and platinum's crescent moves to the left (#2235)

### DIFF
--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -222,7 +222,7 @@ export const SMALL_CAPS: CSSProperties = {
  *
  * Classical alchemical sigils on the plate's 24-unit square — Saturn for lead,
  * Venus for copper, the crescent for silver, the sun for gold, and the
- * moon-and-Mercury compound for platinum. They lived in `EphemeristsVote` while
+ * sun-and-moon compound for platinum. They lived in `EphemeristsVote` while
  * the ladder was their only reader; #1660 gave them two more (the voters panel
  * strikes one per vote, and the sign-up summons strikes platinum), which is the
  * threshold the kit exists for.
@@ -242,8 +242,15 @@ export const SMALL_CAPS: CSSProperties = {
 export const METAL_SIGILS = [
   {
     name: "lead",
+    // SATURN, REDRAWN (#2235). Saturn is the right metal for lead and was never
+    // in question; the DRAWING was wrong. Rank 1 shipped as a single scythe
+    // stroke with a bar through it, and it was reported from outside as reading
+    // "a lowercase t" — a letter, not a sigil. This is the letterform Saturn
+    // instead: a straight stem, a crossbar crossing it near the top, and a bowl
+    // hanging off the stem to the right. Structure over flourish, because the
+    // rung is struck as small as 15-16px on the voters panel and the summons.
     color: "var(--faction-ephemerists-metal-lead)",
-    glyph: "M6.2 7.4 C7.4 4.6 10.2 4.8 10.2 7.8 C10.2 10.8 9 14.6 9.4 17.6 C9.8 20.4 11.8 21 13.8 19.4 M6.4 10.8 H13.4",
+    glyph: "M10.4 4.4 V19.6 M7 8.2 H13.8 M10.4 13 C11.2 10.4 16.8 10.6 16.4 14.2 C16.1 16.6 14.4 18 14.4 19.6",
     weight: 1.5,
     burstStep: 60,
   },
@@ -270,13 +277,18 @@ export const METAL_SIGILS = [
   },
   {
     name: "platinum",
-    // THE HAND (#2142). Platinum is the sun-and-moon compound, and it was drawn
-    // mirrored: the dotted sun sat on the RIGHT at x=15.6 with the crescent
-    // opening the path on the left. Owner checked it against a reference and it
-    // is sun-with-dot LEFT, crescent RIGHT. The other four sigils are unchanged
-    // and must stay byte-identical — they were already correct.
+    // THE HAND, REVERSED (#2235 reverses #2142). #2142 found this sigil drawn
+    // mirrored (dotted sun on the RIGHT at x=15.6), checked it against a
+    // reference, and pinned it here as sun-with-dot LEFT, crescent RIGHT.
+    // THAT RULING IS WITHDRAWN. The classical platinum compound is
+    // crescent-LEFT, its back against a sun-with-dot on the right, per the
+    // reference image on #2235; the owner reversed her own call on the report.
+    // The path below is #2142's geometry mirrored about x=12 — every x becomes
+    // 24-x and both crescent sweep flags invert with it, which is why they read
+    // 1 and 0 where they used to read 0 and 1. Do not "restore" #2142: it is
+    // the earlier answer, not the current one.
     color: "var(--faction-ephemerists-metal-platinum)",
-    glyph: "M6.4 7.2 a4.8 4.8 0 1 0 0.01 0 Z M6.4 10.85 a1.15 1.15 0 1 0 0.01 0 Z M16.8 7.2 A4.8 4.8 0 1 0 16.8 16.8 A6.5 6.5 0 0 1 16.8 7.2 Z",
+    glyph: "M7.2 7.2 A4.8 4.8 0 1 1 7.2 16.8 A6.5 6.5 0 0 0 7.2 7.2 Z M17.6 7.2 a4.8 4.8 0 1 0 0.01 0 Z M17.6 10.85 a1.15 1.15 0 1 0 0.01 0 Z",
     weight: 1.3,
     burstStep: 22.5,
   },

--- a/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
@@ -373,28 +373,77 @@ describe('EphemeristsVote markup', () => {
   })
 
   /**
-   * #2142 — THE PLATINUM SIGIL WAS MIRRORED. The compound is sun-with-dot on the
-   * LEFT and crescent on the RIGHT; it shipped the other hand round, with the
-   * dotted sun at x=15.6. Owner checked it against a reference image.
+   * #2235 REVERSES #2142 — THE PLATINUM SIGIL IS CRESCENT-LEFT.
    *
-   * The four sigils that were already correct are pinned by their opening move
-   * as well, because "fix platinum" is exactly the edit that quietly renumbers a
-   * neighbour — and a mirrored sigil renders perfectly.
+   * #2142 pinned this the other hand round, sun-with-dot LEFT and crescent
+   * RIGHT, on an owner reference check. That ruling is WITHDRAWN: the classical
+   * platinum compound puts the crescent on the LEFT with its back against a
+   * sun-and-dot on the right, which is what the reference image on #2235 shows.
+   * Do not "restore" #2142 as a regression fix.
+   *
+   * Measured, not matched: the crescent's cusps sit left of the sun's leftmost
+   * point, so the compound reads moon-then-sun at every size. The four other
+   * sigils are pinned by their opening move as well, because "fix platinum" is
+   * exactly the edit that quietly renumbers a neighbour — and a mirrored sigil
+   * renders perfectly.
    */
-  it('draws platinum sun-left, crescent-right (#2142)', () => {
+  it('draws platinum crescent-left, sun-right (#2235, reversing #2142)', () => {
     const platinum = METAL_SIGILS[4].glyph
-    // The sun and its dot open the path on the left; the crescent's big arc
-    // follows on the right.
-    expect(platinum).toContain('a1.15')
-    expect(platinum.indexOf('M6.4')).toBeLessThan(platinum.indexOf('M16.8'))
-    expect(platinum).not.toContain('15.6')
+    const parts = platinum.match(/M[^M]+/g) ?? []
+    const startX = (d: string) => Number.parseFloat(d.slice(1))
+    // Three subpaths: the crescent's two arcs, the sun's circle, and its dot.
+    const crescent = parts.find((part) => part.includes('A6.5'))
+    const sun = parts.find((part) => part.includes('a4.8'))
+    const dot = parts.find((part) => part.includes('a1.15'))
+    expect([crescent, sun, dot].every(Boolean)).toBe(true)
+    // The crescent's cusps clear the sun entirely: centre less the 4.8 radius.
+    expect(startX(crescent!)).toBeLessThan(startX(sun!) - 4.8)
+    // Sun and dot are concentric — a dot off-centre reads as a second moon.
+    expect(startX(dot!)).toBe(startX(sun!))
     expect(METAL_SIGILS.map((metal) => metal.glyph.slice(0, 8))).toEqual([
-      'M6.2 7.4',
+      'M10.4 4.',
       'M12 4.4 ',
       'M15.8 4.',
       'M12 5 a7',
-      'M6.4 7.2',
+      'M7.2 7.2',
     ])
+  })
+
+  /**
+   * #2235 — LEAD READ AS A LOWERCASE "t". Right metal, wrong drawing: Saturn
+   * is correct for lead and was never in question, but rank 1 shipped as one
+   * hand-drawn scythe stroke with a bar through it, and was reported as a
+   * letter rather than a sigil. Redrawn as the classical Saturn — a straight
+   * stem, a crossbar crossing it near the top, and a bowl hanging off the stem
+   * to the right.
+   *
+   * No test can prove a glyph is LEGIBLE: this harness has no layout, no
+   * rasteriser and no eyes. What is assertable is the structure that makes the
+   * mark a Saturn rather than a letter, and it is arithmetic on the path's own
+   * coordinates.
+   */
+  it('draws lead as a Saturn — stem, crossing bar, bowl to the right (#2235)', () => {
+    const [stem = '', bar = '', bowl = ''] = METAL_SIGILS[0].glyph.match(/M[^M]+/g) ?? []
+    const [, stemX, stemTop, stemFoot] = /^M([\d.]+) ([\d.]+) V([\d.]+)/
+      .exec(stem)!
+      .map(Number)
+    const [, barLeft, barY, barRight] = /^M([\d.]+) ([\d.]+) H([\d.]+)/.exec(bar)!.map(Number)
+    // The bar CROSSES the stem — it overhangs on both sides.
+    expect(barLeft).toBeLessThan(stemX)
+    expect(barRight).toBeGreaterThan(stemX)
+    // The stem rises above its bar and runs on well below it.
+    expect(stemTop).toBeLessThan(barY)
+    expect(stemFoot).toBeGreaterThan(barY + 8)
+    // The bowl leaves the stem below the bar and swings clear to the right.
+    const pairs = bowl.match(/[\d.]+ [\d.]+/g) ?? []
+    const bowlXs = pairs.map((pair) => Number(pair.split(' ')[0]))
+    const bowlYs = pairs.map((pair) => Number(pair.split(' ')[1]))
+    expect(bowlXs[0]).toBe(stemX)
+    expect(bowlYs[0]).toBeGreaterThan(barY)
+    expect(Math.max(...bowlXs)).toBeGreaterThan(stemX + 3)
+    // ...and stays inside the 24-unit square every sigil is drawn on.
+    expect(Math.max(...bowlXs)).toBeLessThan(24)
+    expect(Math.max(...bowlYs)).toBeLessThanOrEqual(stemFoot)
   })
 
   /**


### PR DESCRIPTION
Closes #2235

Two rungs of the Ephemerists metal ladder, per the amended ruling on the issue.

## Item 1 — lead is redrawn as a legible Saturn

Saturn is the right metal for lead and was never in question; the *drawing* was
wrong. Rank 1 shipped as a single hand-drawn scythe stroke with a bar through it
(`M6.2 7.4 C7.4 4.6 …`) and was reported from outside as reading "a lowercase t".

It is now the letterform Saturn: a straight stem, a crossbar crossing it near the
top, and a bowl hanging off the stem to the right — the shape in the reporter's
reference image.

## Item 5 — platinum flips to crescent-LEFT, reversing #2142

`ephemeristsPlate.tsx` carried a standing note from #2142 recording an owner
reference check: *sun-with-dot LEFT, crescent RIGHT*. That ruling is **withdrawn**
on #2235 — the classical compound is crescent-LEFT with its back against a
sun-with-dot on the right. The new path is #2142's geometry mirrored about x=12
(every x becomes 24−x, and both crescent sweep flags invert with it, which is why
they now read `1` and `0` where they read `0` and `1`).

The #2142 comment is **rewritten to record the reversal**, not deleted: the next
reader needs to know the old note was the earlier answer, so nobody "restores" it
as a regression fix.

## Out of scope, and untouched

- **Rank 2 stays copper** — `METAL_SIGILS[1]`, the Venus glyph, the
  "Venus for copper" comment, and `--faction-ephemerists-metal-copper` are all
  byte-identical.
- **Silver and gold** are byte-identical.
- **`PLANETS`** (the rank-5 orbit of the seven planetary metals) is untouched.

One incidental doc fix in the same block: its docstring called platinum "the
moon-and-Mercury compound". It is the sun-and-moon compound — the very thing the
#2142 note under it already said. One word, no pixels.

## Where these two glyphs render (every mount of `METAL_SIGILS`)

| Surface | What it strikes | Size |
|---|---|---|
| `frontend/src/components/vote/EphemeristsVote.tsx` | the whole five-rung ladder, reached and unreached | glyph at `size * 0.5` → **22px** (ranks 1–4, `DISC_SIZE` 44) and **25px** (rank 5, `TOP_DISC_SIZE` 50) |
| `frontend/src/pages/praxisDetail/archetypes/EphemeristsPraxisDetail.tsx` | one sigil per vote in the voters panel | **16px** (`VOTER_SIGIL`) |
| `frontend/src/pages/taskDetail/archetypes/EphemeristsTaskDetail.tsx:731` | the sign-up summons, `<Sign name="platinum">`, via `GLYPHS.platinum = PLATINUM.glyph` | **15px** — platinum only |

`CastBurst` reads `color` and `burstStep` only, never the glyph, so the cast
animation is unaffected. Read against the post-#2278 file: that PR made the plate
a container-query container and stopped the discs squashing, and touched neither
`METAL_SIGILS` nor any glyph geometry.

## The seam, and what the tests can and cannot prove

The seam is **`METAL_SIGILS`' path geometry** in `ephemeristsPlate.tsx` — the one
declaration all three surfaces read (there is no second copy; `ephemeristsPlateSurfaces.test.tsx`
pins that). Both tests went red on the real defect before the fix landed
(`expected 16.8 to be less than 1.6` for platinum; the lead regex found no `V`
stem at all), then green.

**No test can prove a glyph is legible.** The harness is `renderToStaticMarkup`
with no layout, no rasteriser and no eyes. So the tests assert arithmetic on the
path's own coordinates, the way #2237's ward test measured its star:

- *platinum* — the crescent's cusps sit left of the sun's leftmost point
  (`crescentX < sunX − 4.8`), and the sun and its dot are concentric.
- *lead* — the bar overhangs the stem on both sides, the stem rises above the bar
  and runs well below it, and the bowl leaves the stem below the bar and swings
  clear to the right, inside the 24-unit square.
- the five-sigil pin (`glyph.slice(0, 8)` for all five) still stands, updated for
  the two that moved — "fix platinum" is exactly the edit that quietly renumbers
  a neighbour.

The old `draws platinum sun-left, crescent-right (#2142)` test is replaced rather
than left failing, and its docstring says which ruling reversed it.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`,
`npm test` (357 files / 6224 passed), `npm run build` — all green locally.

`node scripts/bundle-budget.mjs`: **no delta.** JS 126.9 KB and CSS 22.3 KB both
before and after; the CSS emits the *same hash* (`index-Bc5h2qmp.css`) on this
branch as on `origin/main`, since no CSS was touched. The `WARN CSS 22.3 KB
(warn > 22.2 KB)` line is pre-existing on `main` and this change neither helps
nor worsens it.

**Visual QA is outstanding** — no browser here, and legibility is precisely the
thing the harness cannot see.

## What to eyeball

The five-rung metal ladder wherever it renders, in **light and dark**:

1. **The vote plate** (`EphemeristsVote`, praxis + task surfaces) at 22px glyphs,
   and rank 5 at 25px — the size the ladder is actually used at.
2. **Rung I specifically:** does it read as ♄ and not as a lowercase `t`? Check
   that the bowl's counter stays open at 22px and that the crossbar does not fuse
   into the bowl.
3. **Rung V specifically:** crescent on the **left**, sun-with-dot on the
   **right**, the crescent's back nearly touching the sun — compare against the
   reference image on #2235.
4. **The voters panel** on an Ephemerists praxis detail at 16px, which strikes
   whichever metal each voter cast — the smallest the lead glyph ever draws.
5. **The sign-up summons** on an Ephemerists task detail (`Sign name="platinum"`
   at 15px): the flipped platinum at its smallest, over the CTA ink.
6. The reached/unreached pair for rung I — the glow filter on a reached disc
   thickens thin strokes, so check the redrawn Saturn both lit and idle.
