### PR TITLE
Everymen gets one cog, drawn once, and the system-font gear goes (#2121)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/everymenCogs.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/everymenCogs.test.tsx
@@ -111,7 +111,9 @@ describe("the Everymen cog is drawn once", () => {
     // shared mark, move it into MOUNTS; if this assertion is what fails, the
     // reason in `everymenCogs.tsx` is what needs revisiting first.
     const vote = read("components/vote/EverymenVote.tsx");
-    expect(vote).not.toContain("everymenCogs");
+    expect(vote).not.toMatch(/^import .*everymenCogs/m);
+    // The refusal is written down at BOTH ends, so neither can drift alone.
+    expect(vote).toContain("everymenCogs");
     expect(read("components/factionMarks/everymenCogs.tsx")).toContain(
       "components/vote/EverymenVote",
     );

--- a/frontend/src/components/factionMarks/__tests__/everymenCogs.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/everymenCogs.test.tsx
@@ -80,7 +80,7 @@ describe("the Everymen cog is drawn once", () => {
   it.each(MOUNTS)("%s reads the shared mark and draws none of its own", (rel) => {
     const source = read(rel);
 
-    expect(source).toMatch(/from\s+"[^"]*factionMarks\/everymenCogs"/);
+    expect(source).toMatch(/from\s+["'][^"']*factionMarks\/everymenCogs["']/);
     expect(source).toContain("EverymenCog");
 
     for (const [label, pattern] of PRIVATE_DRAWINGS) {

--- a/frontend/src/components/factionMarks/__tests__/everymenCogs.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/everymenCogs.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * One Everymen cog, drawn once, read by every surface (#2121).
+ *
+ * ## The seam
+ *
+ * The defect is a SOURCE defect: six Everymen surfaces each held a private
+ * drawing of the faction's cog, three of them generating byte-identical paths
+ * from copy-pasted arithmetic, one drawing a different device under the same
+ * name, and one printing the literal character U+2699 GEAR — a system-font glyph, a different
+ * gear on every OS, which is the pair of shapes the bug report screenshotted.
+ * Nothing rendered was "wrong" at any one mount, so a per-mount render assertion
+ * cannot see the bug. What has to hold is that the drawing exists ONCE and each
+ * mount reaches it, so this tests at the module seam: the surface files
+ * themselves, read off disk.
+ *
+ * A render assertion rides along at the cheapest mount (the task card) so the
+ * source grep is not the only evidence that the shared path is what actually
+ * reaches the DOM.
+ *
+ * ## The list below is the census, and a census has been wrong here before
+ *
+ * A surface omitted from `MOUNTS` is invisible to this file, not red. #2121's
+ * own census named `EverymenPraxisCard` as holding two of those characters; by the
+ * time the issue ran, #2185's masthead band had stood those cogs down and the
+ * praxis card draws no gear at all — so it is deliberately NOT in the list. Add
+ * a surface here when it starts wearing the mark.
+ *
+ * `components/vote/EverymenVote` is the one Everymen surface that draws a gear
+ * and does NOT read this module, for the reason recorded in `everymenCogs.tsx`:
+ * the rating row needs an outline state this solid mark has no mode for. It is
+ * asserted as a deliberate exception rather than left unmentioned, so that a
+ * future sweep meets the reason instead of the omission.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+
+import "../../../i18n";
+import { EVERYMEN_COG_PATH } from "../everymenCogs";
+
+vi.mock("../../../hooks/useFormFactor", () => ({ useFormFactor: () => "desktop" }));
+
+// Imported after the mock is registered.
+import EverymenTaskCard from "../../taskCard/EverymenTaskCard";
+import { aTask } from "../../../test/fixtures";
+
+const SRC = fileURLToPath(new URL("../../../", import.meta.url));
+
+/** Built from its codepoint, so this file is not itself a hit for it. */
+const GLYPH = String.fromCodePoint(0x2699);
+
+/** Every Everymen surface that draws the ornament cog, and where it lives. */
+const MOUNTS = [
+  "components/taskCard/EverymenTaskCard.tsx",
+  "pages/editPraxis/archetypes/EverymenEditPraxis.tsx",
+  "pages/taskDetail/archetypes/EverymenTaskDetail.tsx",
+  "pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx",
+  "pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx",
+];
+
+const read = (rel: string): string => readFileSync(SRC + rel, "utf8");
+
+/**
+ * The shapes a private cog takes. Each one is a drawing that was really in this
+ * codebase before #2121, named so a re-introduction reports which copy came back
+ * rather than "a file changed".
+ */
+const PRIVATE_DRAWINGS: Array<[label: string, pattern: RegExp]> = [
+  ["a local gear-path generator", /function\s+(build)?[Gg]ear[Pp]ath\b/],
+  ["a local <Gear> component", /function\s+Gear\s*\(/],
+  ["a local <Cog>/<CogSeal> component", /function\s+Cog(Seal)?\s*\(/],
+  ["the eight-teeth constant block", /GEAR_TEETH\b/],
+  ["a hand-rolled teeth ring", /rotate\(\$\{deg\}\s+12\s+12\)/],
+];
+
+describe("the Everymen cog is drawn once", () => {
+  it.each(MOUNTS)("%s reads the shared mark and draws none of its own", (rel) => {
+    const source = read(rel);
+
+    expect(source).toMatch(/from\s+"[^"]*factionMarks\/everymenCogs"/);
+    expect(source).toContain("EverymenCog");
+
+    for (const [label, pattern] of PRIVATE_DRAWINGS) {
+      expect(
+        pattern.test(source),
+        `${rel} still defines ${label} — the point of #2121 is that it does not`,
+      ).toBe(false);
+    }
+  });
+
+  it("prints the glyph nowhere: it is a system font, not our drawing", () => {
+    const offenders = MOUNTS.filter((rel) => read(rel).includes(GLYPH));
+    expect(offenders).toEqual([]);
+  });
+
+  it("keeps the identity sigil a separate device", () => {
+    // Two cogs in mesh (the badge) vs one cog (the furniture). Collapsing them
+    // is explicitly out of bounds, so the sigil must not reach for this module
+    // and this module must not draw a sigil.
+    expect(read("components/sigil/EverymenSigil.tsx")).not.toContain("everymenCogs");
+    expect(read("components/factionMarks/everymenCogs.tsx")).not.toContain(
+      "EverymenSigil({",
+    );
+  });
+
+  it("leaves the gearworks vote row out, on the record", () => {
+    // Not an omission — a refusal with a reason. If the vote row ever adopts the
+    // shared mark, move it into MOUNTS; if this assertion is what fails, the
+    // reason in `everymenCogs.tsx` is what needs revisiting first.
+    const vote = read("components/vote/EverymenVote.tsx");
+    expect(vote).not.toContain("everymenCogs");
+    expect(read("components/factionMarks/everymenCogs.tsx")).toContain(
+      "components/vote/EverymenVote",
+    );
+  });
+});
+
+describe("what the shared mark actually renders", () => {
+  it("is the eight-tooth path on a 24-unit square", () => {
+    // Pins the geometry: eight teeth means eight rim arcs and one closed path.
+    expect(EVERYMEN_COG_PATH.startsWith("M")).toBe(true);
+    expect(EVERYMEN_COG_PATH.endsWith("Z")).toBe(true);
+    expect(EVERYMEN_COG_PATH.match(/A9\.5,9\.5 0 0 1 /g)).toHaveLength(8);
+  });
+
+  it("reaches the DOM from a real surface", () => {
+    const markup = renderToStaticMarkup(
+      <MemoryRouter>
+        <EverymenTaskCard
+          task={aTask({ description: "Fix the lamp on the corner nobody owns." })}
+          basePoints={137}
+          multiplier={1}
+          inProgressCount={0}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(markup).toContain(`d="${EVERYMEN_COG_PATH}"`);
+    // Every cog the card draws is the SAME cog: no second `d=` on a 24-square.
+    const drawn = new Set(
+      [...markup.matchAll(/<path d="(M[^"]*A9\.5,9\.5[^"]*Z)"/g)].map((m) => m[1]),
+    );
+    expect([...drawn]).toEqual([EVERYMEN_COG_PATH]);
+  });
+});

--- a/frontend/src/components/factionMarks/everymenCogs.tsx
+++ b/frontend/src/components/factionMarks/everymenCogs.tsx
@@ -1,0 +1,144 @@
+import type { CSSProperties } from "react";
+
+/**
+ * The Everymen's ORNAMENT cog, drawn once (#2121).
+ *
+ * Everymen was the last of the four dressed factions with no shared kit module,
+ * and it cost exactly what the others' modules were created to stop: six
+ * surfaces, six private drawings of the same device. The census on #2121 (and
+ * re-derived against `main` before this landed) found
+ *
+ *   • the task card, the composer and the task-detail sheet each generating an
+ *     eight-tooth gear from the SAME arithmetic in three separate copies — the
+ *     composer's copy carries a comment saying so and naming this extraction;
+ *   • the mobile field desk drawing a `CogSeal`: eight detached rect teeth
+ *     around a stroked ring, a different device wearing the same name;
+ *   • the praxis-detail sheet printing the literal character U+2699 GEAR under a
+ *     comment claiming "a drawn character, not an icon (§7)". It is neither drawn nor
+ *     ours: it renders in whatever the system font has, which is a different
+ *     gear on every OS and the pair of shapes the bug report screenshotted.
+ *
+ * So the mark is drawn ONCE here, in the shape `covenSlip` / `snideAtoms` /
+ * `wowMobile` already established. Change the geometry here and every Everymen
+ * surface follows; add a seventh mount and it is already correct.
+ *
+ * ## This is NOT the faction's sigil, and must not become it
+ *
+ * `components/sigil/EverymenSigil` is TWO COGS IN MESH and it is the identity
+ * mark — the hero seal, the avatar badge, the faction card. This is one cog and
+ * it is FURNITURE: it flanks a masthead, it strikes a rule, it heads a section.
+ * Two devices, two jobs, exactly as Coven keeps `SigilMark` apart from `Spark`,
+ * and #2119's lesson in `snideAtoms` — a module holding a second copy of a
+ * faction's sigil is how surfaces import the wrong mark — is why this module
+ * holds no sigil at all. Do not collapse them.
+ *
+ * ## What is deliberately NOT here
+ *
+ * `components/vote/EverymenVote` draws its own gear and keeps it. The gearworks
+ * rating row needs a gear with TWO states — a filled one for a reached tier and
+ * a thin edge-only outline for an unreached one — built from detached teeth so
+ * the outline reads as a rim rather than as a filled disc's silhouette. This
+ * mark is a solid single path with an opaque hub and has no outline mode; giving
+ * it one would be a second drawing living in one file, which is the thing #2121
+ * closed. That is the reason, recorded at the mount as the ruling asks.
+ */
+
+/* ── The geometry. Eight teeth on a hub, on a 24-unit square, generated rather
+ *    than drawn: no hand-written path holds this legibly at the six sizes the
+ *    surfaces mount it at (13, 14, 15, 16, 40), and a hand-written copy drifts
+ *    from the arithmetic silently. The numbers are the design's own and are the
+ *    values all three generating copies already agreed on — this consolidation
+ *    repaints nothing. Ornament geometry, kept raw (§4a). ── */
+const TEETH = 8;
+const RADIUS = 9.5;
+const TIP_LENGTH = 5;
+const TIP_HALF = 1.6;
+const ROOT_HALF = 2.6;
+
+function buildCogPath(): string {
+  const point = (radius: number, angle: number): string =>
+    `${12 + radius * Math.cos(angle)},${12 + radius * Math.sin(angle)}`;
+  const step = (Math.PI * 2) / TEETH;
+  const tipRadius = RADIUS + TIP_LENGTH;
+  let path = "";
+  for (let tooth = 0; tooth < TEETH; tooth++) {
+    const start = tooth * step;
+    const rootBefore = point(RADIUS, start - ROOT_HALF / RADIUS);
+    const tipBefore = point(tipRadius, start - TIP_HALF / tipRadius);
+    const tipAfter = point(tipRadius, start + TIP_HALF / tipRadius);
+    const rootAfter = point(RADIUS, start + ROOT_HALF / RADIUS);
+    const nextRoot = point(RADIUS, start + step - ROOT_HALF / RADIUS);
+    path += `${tooth === 0 ? "M" : "L"}${rootBefore}L${tipBefore}L${tipAfter}L${rootAfter}`;
+    path += `A${RADIUS},${RADIUS} 0 0 1 ${nextRoot}`;
+  }
+  return `${path}Z`;
+}
+
+/**
+ * The one Everymen cog path, on `viewBox="0 0 24 24"`. Built once at module
+ * load — it is a constant, not a render-time computation.
+ *
+ * Exported so a test can assert that what a surface renders IS this string, and
+ * so a caller that needs the outline without {@link EverymenCog}'s `<svg>`
+ * wrapper can reach the drawing rather than re-deriving it.
+ */
+export const EVERYMEN_COG_PATH = buildCogPath();
+
+export interface EverymenCogProps {
+  /** Drawn width and height in px. Ornament geometry (§4a). */
+  size: number;
+  /** The teeth and rim. A token, never a hex. */
+  fill: string;
+  /**
+   * The bore. Named `hub` rather than `hole`, which two of the copies called it:
+   * it is an OPAQUE disc painted in the ground behind it, not a punch-through.
+   * (The sigil's bores really are punched, by `fill-rule: evenodd` — a different
+   * mark making a different promise.) Pass the colour the cog is sitting ON.
+   */
+  hub: string;
+  /**
+   * Turn the cog. Reaches the shared `ep-spin` / `ep-spin-rev` classes rather
+   * than an inline `animation:`, so the mark stills itself under
+   * `prefers-reduced-motion` (#1003). Only the composer turns its cogs.
+   */
+  spin?: "forward" | "reverse";
+  /** Re-times the turn via `--ep-spin-dur`, without a second keyframe. */
+  duration?: string;
+  /** Ornament dimming, where a mount wants the cog to recede. */
+  opacity?: number;
+}
+
+/**
+ * The union cog. ORNAMENT ONLY — it is `aria-hidden` here rather than at each
+ * call site, because there is no reading of this mark that carries meaning a
+ * screen reader needs; the label it flanks is always the content.
+ */
+export function EverymenCog({
+  size,
+  fill,
+  hub,
+  spin,
+  duration,
+  opacity,
+}: EverymenCogProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden
+      className={
+        spin === "forward" ? "ep-spin" : spin === "reverse" ? "ep-spin-rev" : undefined
+      }
+      style={{
+        display: "block",
+        flex: "0 0 auto",
+        opacity,
+        ...(duration ? ({ "--ep-spin-dur": duration } as CSSProperties) : {}),
+      }}
+    >
+      <path d={EVERYMEN_COG_PATH} fill={fill} />
+      <circle cx="12" cy="12" r="3" fill={hub} />
+    </svg>
+  );
+}

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
 import { EverymenBand } from "../cardMasthead/factionBands";
 import PointsRoundel from "../factionMarks/PointsRoundel";
+import { EverymenCog } from "../factionMarks/everymenCogs";
 import { CARD_CTA, CARD_CTA_ROW } from "./cardCta";
 import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
@@ -98,57 +99,6 @@ const LABEL: CSSProperties = {
   letterSpacing: "0.16em",
   textTransform: "uppercase",
 };
-
-/**
- * A toothed gear on a 24-unit square, built rather than drawn: eight long teeth
- * on a hub, which no hand-written path holds legibly at three different sizes.
- */
-function gearPath(): string {
-  const teeth = 8;
-  const radius = 9.5;
-  const tipLength = 5;
-  const tipHalf = 1.6;
-  const rootHalf = 2.6;
-  const point = (r: number, angle: number): [number, number] =>
-    [12 + r * Math.cos(angle), 12 + r * Math.sin(angle)];
-
-  let path = "";
-  for (let n = 0; n < teeth; n += 1) {
-    const start = (n / teeth) * Math.PI * 2;
-    const step = (Math.PI * 2) / teeth;
-    const rootA = point(radius, start - rootHalf / radius);
-    const tipA = point(radius + tipLength, start - tipHalf / (radius + tipLength));
-    const tipB = point(radius + tipLength, start + tipHalf / (radius + tipLength));
-    const rootB = point(radius, start + rootHalf / radius);
-    const nextRoot = point(radius, start + step - rootHalf / radius);
-    path += `${n === 0 ? "M" : "L"}${rootA[0]},${rootA[1]}`
-      + `L${tipA[0]},${tipA[1]}L${tipB[0]},${tipB[1]}L${rootB[0]},${rootB[1]}`
-      + `A${radius},${radius} 0 0 1 ${nextRoot[0]},${nextRoot[1]}`;
-  }
-  return `${path}Z`;
-}
-
-const GEAR_PATH = gearPath();
-
-function Gear({ size, fill, hub, opacity }: {
-  size: number
-  fill: string
-  hub: string
-  opacity?: number
-}) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      style={{ display: "block", flex: "0 0 auto", opacity }}
-    >
-      <path d={GEAR_PATH} fill={fill} />
-      <circle cx="12" cy="12" r="3" fill={hub} />
-    </svg>
-  );
-}
 
 /**
  * The union's fist gripping a bolt, traced from the design's supplied vector:
@@ -387,7 +337,7 @@ export default function EverymenTaskCard({
                   <span aria-hidden="true" style={{ flex: 1, height: 0, borderTop: "2px dashed var(--everymen-red)" }} />
                 </div>
 
-                <Gear size={15} fill="var(--everymen-red)" hub="var(--everymen-paper)" />
+                <EverymenCog size={15} fill="var(--everymen-red)" hub="var(--everymen-paper)" />
 
                 <div style={{ flex: "1 1 0", display: "flex", alignItems: "center", gap: "var(--space-md)" }}>
                   <span aria-hidden="true" style={{ flex: 1, height: 0, borderTop: "2px dashed var(--everymen-red)" }} />
@@ -474,7 +424,7 @@ export default function EverymenTaskCard({
 
               {inProgressCount > 0 && (
                 <div style={{ display: "flex", alignItems: "center", gap: "var(--space-sm)" }}>
-                  <Gear size={15} fill="var(--everymen-red)" hub="var(--everymen-paper)" />
+                  <EverymenCog size={15} fill="var(--everymen-red)" hub="var(--everymen-paper)" />
                   <span style={{ fontFamily: TYPED, fontSize: "var(--text-lg)", color: "var(--everymen-muted)" }}>
                     {i18n.t("feed:taskCard.inProgress", { count: inProgressCount })}
                   </span>

--- a/frontend/src/components/vote/EverymenVote.tsx
+++ b/frontend/src/components/vote/EverymenVote.tsx
@@ -63,7 +63,19 @@ const SPARK_DIRS: [number, number][] = [
 
 const TIERS = VOTE_REFRAMES['everymen'].tiers
 
-/** Eight gear teeth — filled (reached) or a thin edge outline (unreached). */
+/**
+ * Eight gear teeth — filled (reached) or a thin edge outline (unreached).
+ *
+ * THE ONE EVERYMEN GEAR THAT IS NOT `factionMarks/everymenCogs` (#2121). That
+ * consolidation gave the faction a single ornament cog and repointed all five
+ * of its other surfaces at it; this row keeps its own because the shared mark
+ * has no OUTLINE mode and cannot grow one honestly. It is a solid single path
+ * with an opaque hub, so an unreached tier drawn from it would read as the
+ * filled gear's silhouette rather than as a cold rim — and the reached vs
+ * unreached contrast IS this widget's whole sentence. Detached teeth are what
+ * make the outline state legible. A measured refusal, not "it was already
+ * there".
+ */
 function teeth(fill: string, stroke: string | undefined) {
   return [0, 1, 2, 3, 4, 5, 6, 7].map((k) => (
     <rect

--- a/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
+++ b/frontend/src/pages/editPraxis/archetypes/EverymenEditPraxis.tsx
@@ -121,6 +121,7 @@ import {
   WriteUpTabs,
   type ComposerTab,
 } from "./controls";
+import { EverymenCog } from "../../../components/factionMarks/everymenCogs";
 import { MetataskSealStack } from "../../../components/metataskSeal/MetataskSealStack";
 import { isWaitingStage, type EditPraxisState } from "../useEditPraxis";
 
@@ -164,87 +165,10 @@ const SHADOW = "var(--faction-everymen-bill-shadow)";
 const BEBAS = "var(--faction-everymen-card-font)"; /* Bebas Neue */
 const COURIER = "var(--font-body)"; /* Courier Prime */
 
-/* ── The cog, the union's one glyph on this surface. Eight teeth around a hub,
- *    generated once at module load: the arithmetic is the design's own and a
- *    hand-written path would drift from it silently. The same construction the
- *    v2 task card and task detail draw — a THIRD caller now, which by
- *    WORLD_ZERO_STYLE §6 ("the module is the enforcement") is the point at which
- *    the three should collapse into one `everymenOrnament` module. That
- *    extraction touches two shipped Everymen surfaces and is outside this
- *    issue's footprint; it is raised in the PR rather than done here. ── */
-const GEAR_TEETH = 8;
-const GEAR_RADIUS = 9.5;
-const GEAR_TIP_LENGTH = 5;
-const GEAR_TIP_HALF = 1.6;
-const GEAR_ROOT_HALF = 2.6;
-
-function buildGearPath(): string {
-  const point = (radius: number, angle: number): string =>
-    `${12 + radius * Math.cos(angle)},${12 + radius * Math.sin(angle)}`;
-  const step = (Math.PI * 2) / GEAR_TEETH;
-  const tipRadius = GEAR_RADIUS + GEAR_TIP_LENGTH;
-  let path = "";
-  for (let tooth = 0; tooth < GEAR_TEETH; tooth++) {
-    const start = tooth * step;
-    const rootBefore = point(GEAR_RADIUS, start - GEAR_ROOT_HALF / GEAR_RADIUS);
-    const tipBefore = point(tipRadius, start - GEAR_TIP_HALF / tipRadius);
-    const tipAfter = point(tipRadius, start + GEAR_TIP_HALF / tipRadius);
-    const rootAfter = point(GEAR_RADIUS, start + GEAR_ROOT_HALF / GEAR_RADIUS);
-    const nextRoot = point(
-      GEAR_RADIUS,
-      start + step - GEAR_ROOT_HALF / GEAR_RADIUS,
-    );
-    path += `${tooth === 0 ? "M" : "L"}${rootBefore}L${tipBefore}L${tipAfter}L${rootAfter}`;
-    path += `A${GEAR_RADIUS},${GEAR_RADIUS} 0 0 1 ${nextRoot}`;
-  }
-  return `${path}Z`;
-}
-
-const GEAR_PATH = buildGearPath();
-
-/** The cogs' period, the design's own 22s. It had drifted to 26 (#1830). */
+/** The cogs' period, the design's own 22s. It had drifted to 26 (#1830). The
+ *  cog itself is {@link EverymenCog}, shared since #2121 — this surface is the
+ *  only one that turns it, so the timing stays here with the callers. */
 const COG_PERIOD = "22s";
-
-/**
- * The union cog. Ornament only — aria-hidden at every call site.
- *
- * `spin` reaches the shared `ep-spin` / `ep-spin-rev` classes rather than an
- * inline `animation:`, so the pair stills itself under `prefers-reduced-motion`
- * (#1003). `--ep-spin-dur` re-times both without a second keyframe.
- */
-function Gear({
-  size,
-  fill,
-  hole,
-  spin,
-  duration,
-}: {
-  size: number;
-  fill: string;
-  hole: string;
-  spin?: "forward" | "reverse";
-  duration?: string;
-}) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      aria-hidden
-      className={
-        spin === "forward" ? "ep-spin" : spin === "reverse" ? "ep-spin-rev" : undefined
-      }
-      style={{
-        display: "block",
-        flex: "0 0 auto",
-        ...(duration ? ({ "--ep-spin-dur": duration } as CSSProperties) : {}),
-      }}
-    >
-      <path d={GEAR_PATH} fill={fill} />
-      <circle cx="12" cy="12" r="3" fill={hole} />
-    </svg>
-  );
-}
 
 export default function EverymenEditPraxis({ state }: Props) {
   const { t } = useTranslation("forms");
@@ -325,10 +249,10 @@ export default function EverymenEditPraxis({ state }: Props) {
      (#1830). It is a mark on a plate, not type, so the accent's 4.49:1 on the
      paper is not the measurement that governs it. */
   const statusMark = (
-    <Gear
+    <EverymenCog
       size={40}
       fill={ACCENT}
-      hole={PANEL}
+      hub={PANEL}
       spin="forward"
       duration={COG_PERIOD}
     />
@@ -384,7 +308,7 @@ export default function EverymenEditPraxis({ state }: Props) {
               boxShadow: `inset 0 -6px 0 -4px ${PAPER_DEEP}`,
             }}
           >
-            <Gear size={16} fill={MAST_INK} hole={MAST} spin="forward" duration={COG_PERIOD} />
+            <EverymenCog size={16} fill={MAST_INK} hub={MAST} spin="forward" duration={COG_PERIOD} />
             <span
               style={{
                 fontFamily: BEBAS,
@@ -397,7 +321,7 @@ export default function EverymenEditPraxis({ state }: Props) {
             >
               {factionName(slug)}
             </span>
-            <Gear size={16} fill={MAST_INK} hole={MAST} spin="reverse" duration={COG_PERIOD} />
+            <EverymenCog size={16} fill={MAST_INK} hub={MAST} spin="reverse" duration={COG_PERIOD} />
           </ComposerMasthead>
   );
   const ground = (

--- a/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
+++ b/frontend/src/pages/fieldDesk/mobileArchetypes/EverymenFieldDesk.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import CharacterSwitcherSheet from '../../../components/CharacterSwitcherSheet'
 import FactionSigil from '../../../components/sigil/FactionSigil'
+import { EverymenCog } from '../../../components/factionMarks/everymenCogs'
 import { factionName } from '../../../utils/factions'
 import { mediaUrl } from '../../../utils/media'
 import { formatPoints } from '../../../utils/points'
@@ -110,21 +111,6 @@ const trackMetaStyle: CSSProperties = {
 /** The union's own band — the section rule's red/gold run, at track scale. */
 const TRACK_FILL = `repeating-linear-gradient(90deg, ${RED} 0 12px, ${GOLD} 12px 20px)`
 
-/** The Everymen cog seal — a riveted gear, the union's mark. */
-function CogSeal({ size = 16 }: { size?: number }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" aria-hidden>
-      <g fill={GOLD}>
-        {[0, 45, 90, 135, 180, 225, 270, 315].map((deg) => (
-          <rect key={deg} x="11" y="0.5" width="2" height="5" rx="0.5" transform={`rotate(${deg} 12 12)`} />
-        ))}
-      </g>
-      <circle cx="12" cy="12" r="6.5" fill="none" stroke={GOLD} strokeWidth="2.4" />
-      <circle cx="12" cy="12" r="2" fill={GOLD} />
-    </svg>
-  )
-}
-
 /** Cream newsprint plate framed in union ink. */
 function Plate({ children, style }: { children: ReactNode; style?: CSSProperties }) {
   return (
@@ -179,7 +165,7 @@ export default function EverymenFieldDesk({ state }: { state: FieldDeskHomeState
             padding: 'var(--space-sm) var(--space-lg)',
           }}
         >
-          <CogSeal size={16} />
+          <EverymenCog size={16} fill={GOLD} hub={INK} />
           {/* "The Union Desk" (`fieldDesk.home.everymen.masthead`) was stamped
               on this band. It is the only desk with a second title slot — the
               h1 below already reads the shared `fieldDesk.home.title` — so

--- a/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
+++ b/frontend/src/pages/praxisDetail/archetypes/EverymenPraxisDetail.tsx
@@ -77,6 +77,7 @@ import type { CSSProperties, ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import MediaGallery from "../../../components/MediaGallery";
+import { EverymenCog } from "../../../components/factionMarks/everymenCogs";
 import MarkdownPreview from "../../editPraxis/blocks/MarkdownPreview";
 import VoteUI, { voteRegionVisible } from "../../../components/vote/VoteUI";
 import ScoreStamp from "../../../components/praxisCard/scoreStamp/ScoreStamp";
@@ -120,6 +121,8 @@ const MAST = "var(--faction-everymen-bill-mast)";
 const MAST_INK = "var(--faction-everymen-bill-mast-ink)";
 /** A FILL only — the voter bars' track. Never a ground for text (see docstring). */
 const TRACK = "var(--everymen-paper)";
+/** The pasted-on sheet the section heads and their cogs sit on. */
+const PANEL = "var(--faction-everymen-sheet-panel)";
 
 const BEBAS = "var(--font-accent)";
 // Courier Prime is the sheet's chrome face and is never named here: every label
@@ -133,28 +136,6 @@ const PROSE = "var(--font-display)";
 /** Ornament geometry — the drawn side of one member's byline plate. */
 const PLATE_DESKTOP = 42;
 const PLATE_MOBILE = 36;
-
-/**
- * The union cog, set as a typographic glyph (§7 — a drawn character, not an
- * icon library and not an emoji). One size, because it does one job: flanking a
- * label. Ornament, so every caller marks it aria-hidden.
- */
-function Cog({ color }: { color: string }) {
-  return (
-    <span
-      aria-hidden
-      style={{
-        // eslint-disable-next-line local/no-raw-style-values -- ornament: cog glyph at the design's optical size, flanking a label rather than being read (§4a)
-        fontSize: 12,
-        lineHeight: 1,
-        color,
-        flex: "0 0 auto",
-      }}
-    >
-      ⚙
-    </span>
-  );
-}
 
 /** Initials fallback for a member with no uploaded avatar. */
 function initialsOf(name: string): string {
@@ -258,7 +239,7 @@ export default function EverymenPraxisDetail({
         flexWrap: "wrap",
       }}
     >
-      <Cog color={RED} />
+      <EverymenCog size={14} fill={RED} hub={PANEL} />
       <span
         style={{
           ...label,
@@ -392,7 +373,7 @@ export default function EverymenPraxisDetail({
           borderRadius: 2,
         }}
       >
-        <Cog color={MAST_INK} />
+        <EverymenCog size={14} fill={MAST_INK} hub={MAST} />
         <span
           style={{
             ...label,
@@ -404,7 +385,7 @@ export default function EverymenPraxisDetail({
         >
           {factionName(praxis.task_faction_slug)}
         </span>
-        <Cog color={MAST_INK} />
+        <EverymenCog size={14} fill={MAST_INK} hub={MAST} />
       </div>
       <div
         aria-hidden

--- a/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
+++ b/frontend/src/pages/taskDetail/archetypes/EverymenTaskDetail.tsx
@@ -2,6 +2,7 @@ import { useState, type CSSProperties, type ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import PraxisCard from "../../../components/praxisCard/PraxisCard";
+import { EverymenCog } from "../../../components/factionMarks/everymenCogs";
 import { useFormFactor } from "../../../hooks/useFormFactor";
 import { factionFill, factionName } from "../../../utils/factions";
 import { mediaUrl } from "../../../utils/media";
@@ -52,63 +53,6 @@ const SHADOW = "var(--faction-everymen-bill-shadow)";
 
 const BEBAS = "var(--font-accent)";
 const COURIER = "var(--font-body)";
-
-// ── The cog, the union's one glyph. Eight teeth around a hub, generated once at
-//    module load rather than per render: it is a constant, and the arithmetic is
-//    the design's own (a hand-written path would drift from it silently).
-const GEAR_TEETH = 8;
-const GEAR_RADIUS = 9.5;
-const GEAR_TIP_LENGTH = 5;
-const GEAR_TIP_HALF = 1.6;
-const GEAR_ROOT_HALF = 2.6;
-
-function buildGearPath(): string {
-  const point = (radius: number, angle: number): string =>
-    `${12 + radius * Math.cos(angle)},${12 + radius * Math.sin(angle)}`;
-  const step = (Math.PI * 2) / GEAR_TEETH;
-  const tipRadius = GEAR_RADIUS + GEAR_TIP_LENGTH;
-  let path = "";
-  for (let tooth = 0; tooth < GEAR_TEETH; tooth++) {
-    const start = tooth * step;
-    const rootBefore = point(GEAR_RADIUS, start - GEAR_ROOT_HALF / GEAR_RADIUS);
-    const tipBefore = point(tipRadius, start - GEAR_TIP_HALF / tipRadius);
-    const tipAfter = point(tipRadius, start + GEAR_TIP_HALF / tipRadius);
-    const rootAfter = point(GEAR_RADIUS, start + GEAR_ROOT_HALF / GEAR_RADIUS);
-    const nextRoot = point(
-      GEAR_RADIUS,
-      start + step - GEAR_ROOT_HALF / GEAR_RADIUS,
-    );
-    path += `${tooth === 0 ? "M" : "L"}${rootBefore}L${tipBefore}L${tipAfter}L${rootAfter}`;
-    path += `A${GEAR_RADIUS},${GEAR_RADIUS} 0 0 1 ${nextRoot}`;
-  }
-  return `${path}Z`;
-}
-
-const GEAR_PATH = buildGearPath();
-
-/** The union cog. Ornament only — every caller marks it aria-hidden. */
-function Gear({
-  size,
-  fill,
-  hole,
-}: {
-  size: number;
-  fill: string;
-  hole: string;
-}) {
-  return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      aria-hidden
-      style={{ display: "block", flex: "0 0 auto" }}
-    >
-      <path d={GEAR_PATH} fill={fill} />
-      <circle cx="12" cy="12" r="3" fill={hole} />
-    </svg>
-  );
-}
 
 /** Initials fallback for an author with no uploaded avatar. */
 function initialsOf(name: string): string {
@@ -252,7 +196,7 @@ export default function EverymenTaskDetail({
         flexWrap: "wrap",
       }}
     >
-      <Gear size={14} fill={RED} hole={PANEL} />
+      <EverymenCog size={14} fill={RED} hub={PANEL} />
       <span
         style={{
           ...label,
@@ -318,13 +262,13 @@ export default function EverymenTaskDetail({
           boxShadow: `inset 0 -6px 0 -4px ${PAPER_DEEP}`,
         }}
       >
-        <Gear size={14} fill={MAST_INK} hole={MAST} />
+        <EverymenCog size={14} fill={MAST_INK} hub={MAST} />
         <span
           style={{ ...label, fontSize: "var(--text-content)", color: MAST_INK }}
         >
           {factionName(slug)}
         </span>
-        <Gear size={14} fill={MAST_INK} hole={MAST} />
+        <EverymenCog size={14} fill={MAST_INK} hub={MAST} />
       </div>
 
       {isMetatask && (
@@ -694,7 +638,7 @@ export default function EverymenTaskDetail({
               marginBottom: "var(--space-sm)",
             }}
           >
-            <Gear size={13} fill={OLIVE} hole={PANEL} />
+            <EverymenCog size={13} fill={OLIVE} hub={PANEL} />
             <span
               style={{
                 fontFamily: COURIER,
@@ -726,7 +670,7 @@ export default function EverymenTaskDetail({
               marginBottom: "var(--space-sm)",
             }}
           >
-            <Gear size={13} fill={OLIVE} hole={PANEL} />
+            <EverymenCog size={13} fill={OLIVE} hub={PANEL} />
             <span
               style={{
                 fontFamily: COURIER,


### PR DESCRIPTION
Everymen was the last of the four dressed factions with no shared kit module, and it cost exactly what Coven's `covenSlip`, S.N.I.D.E.'s `snideAtoms` and WOW's `wowMobile` were created to stop: every surface drew its own cog. `components/factionMarks/everymenCogs.tsx` now holds the one drawing, and five surfaces mount it.

Closes #2121

## The seam I tested at

**The module seam, not the render seam.** Nothing rendered was *wrong* at any one mount — three of them were emitting a byte-identical path — so a per-mount render assertion cannot see this bug. What has to hold is that the drawing exists ONCE and each mount reaches it, so `factionMarks/__tests__/everymenCogs.test.tsx` reads the five surface files off disk and asserts each imports the shared mark and defines none of the five shapes a private cog took here. It went red on all five plus the glyph before any surface was touched. A render assertion rides along at the cheapest mount (the task card) so the source read is not the only evidence the shared path reaches the DOM.

## My census, and where it differs from the issue's

Re-derived against `origin/main` at `0ef9260`. **Two rows of the issue's seven-row table are wrong now, and one measurement in it was wrong when it was written.** The code won in both cases.

| Issue's census | What `main` actually has |
|---|---|
| `EverymenSigil.tsx` — the kit sigil | ✅ unchanged, and untouched by this PR |
| `EverymenTaskCard.tsx:110` — `gearPath()` + local `Gear` | ✅ there |
| `EverymenEditPraxis.tsx:181` — `buildGearPath()` + local `Gear` | ✅ there |
| `EverymenTaskDetail.tsx:65` — `buildGearPath()` + `GEAR_PATH` | ✅ there |
| `EverymenFieldDesk.tsx:102` — `CogSeal` | ✅ there |
| `EverymenPraxisDetail.tsx:141` — `Cog` | ✅ there — **and `Cog` IS the `⚙`**, not a sixth drawing |
| `EverymenPraxisCard.tsx:86` — the literal `⚙`, twice | ❌ **gone.** #2185's masthead band stood the praxis card's cogs down; it draws no gear at all |

So it is **six** private drawings across **six** files, not seven across seven. The praxis card is deliberately absent from the test's `MOUNTS` list, with the reason written there — a census has already been wrong on this faction once.

**The one measurement I disagree with.** The issue says "`EverymenTaskCard`'s `gearPath()` **differs** from that pair. That is the second drawing the report saw." It does not. I ran both generators side by side: the task card's `gearPath()` and the pair's `buildGearPath()` emit **byte-identical** 1605-character strings — same eight teeth, same `radius 9.5 / tip 5 / tipHalf 1.6 / rootHalf 2.6`, same `12,12` centre. The two functions differ only in local variable names and string-building style, which is what a whitespace-normalised md5 of the *source* sees; the *drawing* was already unanimous across three mounts. So the canonical was 3-of-6 before this PR, not 2-of-6, and the two shapes the report screenshotted are the solid generated gear versus either the field desk's riveted `CogSeal` or the praxis sheet's system-font `⚙`.

Nothing in the ruling turns on either correction — `buildGearPath()` is still the canonical, and it is now a stronger majority than the issue credited it with.

## The diff of the remaining four (ruling §5)

| Mount | Verdict |
|---|---|
| `EverymenTaskCard` `gearPath` + `Gear` | **Adopted.** Byte-identical output; the copy was pure duplication |
| `EverymenTaskDetail` `buildGearPath` | **Adopted.** Byte-identical to the composer's |
| `EverymenFieldDesk` `CogSeal` | **Adopted.** Eight detached rect teeth around a stroked ring — a genuinely different device wearing the faction's name at 16px in the masthead. There is no reason for the field desk's cog to be a different cog |
| `EverymenPraxisDetail` `Cog` (the `⚙`) | **Adopted**, unconditionally per §4. It sat under a comment claiming "a drawn character, not an icon (§7)" and was neither drawn nor ours |
| `components/vote/EverymenVote` — **not in the issue's census** | **Kept, with the reason recorded at the mount.** The gearworks rating row needs a gear with two states, and the *unreached* one is a thin edge-only outline. The shared mark is a solid single path with an opaque hub; an unreached tier drawn from it would read as the filled gear's silhouette rather than a cold rim, and that contrast is the widget's whole sentence. Written down at both ends — in `everymenCogs.tsx` and in `EverymenVote.tsx` — and asserted by the test, so a future sweep meets the reason instead of the omission |

`EverymenSigil` is **not** merged in (§3) and the test pins that: two cogs in mesh is the identity mark, one cog is furniture. The module deliberately holds no sigil at all — that is #2119's lesson in `snideAtoms`, where a second copy of a faction's sigil in a kit module was what made two surfaces import the wrong mark.

## What changed visually

Two things, both consequences of adopting the canonical rather than choices of mine:

- **the field desk masthead** — the riveted ring becomes the solid eight-tooth cog, still 16px, still `GOLD` on the ink band;
- **the praxis-detail sheet** — the `⚙` becomes the drawn cog at **14px**, matching the size its sibling `EverymenTaskDetail` already uses for exactly the same two jobs (a section head and the flanks of the masthead nameplate). The old `Cog` was a 12px glyph, whose gear is optically smaller than its em box; 14 is what the sibling sheet draws.

No token changed, no layout changed, no CSS was touched. One `eslint-disable local/no-raw-style-values` disappears with the glyph.

## Byte budget

`node scripts/bundle-budget.mjs`, gzip level 9:

- **blocking JS 126.9 KB → 126.9 KB** (129,705 B → 129,726 B, **+21 B**). The shared module lands in its own chunk (`everymenCogs-*.js`), not in `index`; the 21 bytes are that chunk's entry in the manifest.
- **blocking CSS unchanged** — same content hash (`index-47d_B42r.css`), byte-identical. The pre-existing CSS `WARN` is on `main` too and is not this PR's.
- **total shipped JS across all chunks: 586,886 B → 586,266 B gzipped, −620 B.** Net deletion, as the ruling expected.

Source: **−241 lines from the six surfaces**, +144 for the module and +150 for the test.

## Verification

`tsc --noEmit` clean, run after each file. Every step in `.github/workflows/test.yml`'s `frontend` job run locally: `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (**357 files, 6226 passed, 1 skipped**), `npm run build`, `npm run budget`. No backend or schema surface touched, so `test` and `api-schema` are unaffected.

**Visual QA is outstanding** — I have no browser and no dev stack. The harness here is `renderToStaticMarkup` with no layout, so nothing above measures a box or a colour.

## What to eyeball

Everymen only, **light and dark** on each:

1. **Task card** — the cog struck on the dashed rule between LEVEL and the points seal, and the one on the in-progress line. Should be unchanged.
2. **Composer (edit praxis)** — the two counter-rotating cogs on the masthead plate, and the 40px hero cog on the waiting surface. Confirm they still turn, still counter-turn, and still still themselves under reduced motion.
3. **Task detail** — the section-head cog, the pair flanking the masthead nameplate, and the two olive 13px cogs in the stats. Should be unchanged.
4. **Field desk (mobile)** — the masthead band's cog seal. **Changed**: solid gear instead of the riveted ring, gold on the ink band.
5. **Praxis detail** — every section head, and the pair flanking the masthead. **Changed**: a drawn cog instead of the OS's `⚙`, at 14px.
6. **Praxis card** — should draw no gear at all. If one appears, the census is wrong again.

And to confirm the identity mark is untouched:

7. **Faction hero seal** (`/factions/everymen`) and the **avatar badge** — both still the two-cogs-in-mesh `EverymenSigil`, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
