### PR TITLE
The task board opens narrowed only in the tutorial state (#2025)

### DIFF
--- a/.design-sync/previews/_fixtures.tsx
+++ b/.design-sync/previews/_fixtures.tsx
@@ -175,6 +175,7 @@ export const mockUser: CurrentUser = {
   // which is the correct render for this character, not a missing value.
   level_jump_reach: 0,
   level_jump_available: false,
+  task_browse_defaults_to_eligible: false,
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1672,6 +1672,11 @@
             "default": 0,
             "title": "Second Character Level Required",
             "type": "integer"
+          },
+          "task_browse_defaults_to_eligible": {
+            "default": false,
+            "title": "Task Browse Defaults To Eligible",
+            "type": "boolean"
           }
         },
         "required": [
@@ -1690,7 +1695,8 @@
           "can_comment",
           "can_apply_metatask",
           "level_jump_reach",
-          "level_jump_available"
+          "level_jump_available",
+          "task_browse_defaults_to_eligible"
         ],
         "title": "CurrentUser",
         "type": "object"

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -42,6 +42,12 @@ class CurrentUser(WireModel):
     # is_admin — the jump is a faction perk, not a level gate.
     level_jump_reach: int = 0
     level_jump_available: bool = False
+    # Does the task browse OPEN narrowed to "tasks I can sign up for" (#2025)?
+    # True only for a level-0 character — the tutorial state, which has exactly
+    # one task to do. A DEFAULT, not a gate: GET /tasks still takes can_sign_up
+    # from the client and no server branch is paired with this. Not
+    # short-circuited by is_admin — see character_capabilities.
+    task_browse_defaults_to_eligible: bool = False
 
 
 class LogoutOut(WireModel):

--- a/backend/services/character_capabilities.py
+++ b/backend/services/character_capabilities.py
@@ -8,8 +8,9 @@ Design choices:
 - Takes ``character_level: int | None`` rather than a Character + stats row
   because the live-game level actually lives on CharacterStats, not Character.
   Passing the int keeps the function pure and DB-free (unit-testable).
-- ``is_admin=True`` short-circuits every flag to True. Mirrors the existing
-  ``skip_level_check`` admin escape hatch in ``services.task.propose_task``.
+- ``is_admin=True`` short-circuits the propose/see flags to True. Mirrors the
+  existing ``skip_level_check`` admin escape hatch in
+  ``services.task.propose_task``. The fields whose comments say so opt out.
 - ``character_level=None`` (no active character) makes every flag False.
 - The faction level-jump fields (#811) take ``faction_slug`` and the stats row's
   ``level_jump_used_at_level`` for the same reason — passing the two scalars
@@ -50,6 +51,17 @@ class CharacterCapabilities:
     # ability their faction does not grant would be a lie in the UI.
     level_jump_reach: int
     level_jump_available: bool
+    # Does the task browse OPEN narrowed to "tasks I can sign up for" (#2025)?
+    # A default, not a gate: ``GET /tasks`` still takes ``can_sign_up`` from the
+    # client and there is no server branch paired with this, so nothing here is
+    # enforcement. Named for what it decides rather than the level that decides
+    # it, per the house rule at ``frontend/src/api/auth.ts`` — the client must
+    # not compare ``character.level`` itself.
+    #
+    # Not short-circuited by is_admin, like the two fields above: an admin at
+    # level 5 has run the loop like everyone else, and the tutorial board would
+    # be a lie for them.
+    task_browse_defaults_to_eligible: bool
 
 
 def compute_capabilities(
@@ -67,6 +79,14 @@ def compute_capabilities(
         faction_bypasses_metatask_level(faction_slug, era)
         or character_level >= era.metatask_apply_level
     )
+    # Level 0 is the tutorial state, and it has precisely one thing to do: a
+    # character reaches level 1 *by* signing up for the game-wide level-0
+    # onboarding task and posting a praxis for it (era_1.py, level profiles).
+    # Not an EraConfig value — level 0 is the bottom of the scale itself
+    # (`level_thresholds[0] = 0`, "everyone starts at level 0"), so there is no
+    # `era.*` to read here. ``None == 0`` is False, which is the answer a viewer
+    # carrying no character wants: no character, no eligibility to compute.
+    browse_defaults_to_eligible = character_level == 0
     if character_level is None:
         jump_available = False
     else:
@@ -87,6 +107,7 @@ def compute_capabilities(
             can_apply_metatask=can_apply_metatask,
             level_jump_reach=granted_reach,
             level_jump_available=jump_available,
+            task_browse_defaults_to_eligible=browse_defaults_to_eligible,
         )
 
     if character_level is None:
@@ -99,6 +120,7 @@ def compute_capabilities(
             can_apply_metatask=False,
             level_jump_reach=granted_reach,
             level_jump_available=False,
+            task_browse_defaults_to_eligible=browse_defaults_to_eligible,
         )
 
     return CharacterCapabilities(
@@ -124,4 +146,5 @@ def compute_capabilities(
         can_apply_metatask=can_apply_metatask,
         level_jump_reach=granted_reach,
         level_jump_available=jump_available,
+        task_browse_defaults_to_eligible=browse_defaults_to_eligible,
     )

--- a/backend/tests/unit/test_character_capabilities.py
+++ b/backend/tests/unit/test_character_capabilities.py
@@ -91,6 +91,9 @@ def test_compute_capabilities_reads_from_era_arg() -> None:
         # No faction_slug passed, so no faction grants a jump (#811).
         level_jump_reach=0,
         level_jump_available=False,
+        # Level 9 is well past the tutorial state, and no era value moves that
+        # line — level 0 is the bottom of the scale, not a threshold (#2025).
+        task_browse_defaults_to_eligible=False,
     )
 
 
@@ -211,3 +214,40 @@ def test_admin_in_wow_still_reports_its_real_allowance() -> None:
 def test_no_active_character_has_no_level_jump() -> None:
     result = compute_capabilities(None, is_admin=False, faction_slug="wow")
     assert result.level_jump_available is False
+
+
+def test_task_browse_default_belongs_to_the_tutorial_state() -> None:
+    """The eligibility default is ON for level 0 only (#2025).
+
+    Level 0 is the tutorial state and it has exactly one thing to do: a
+    character reaches level 1 *by* signing up for the game-wide onboarding task
+    and posting a praxis for it (``eras/era_1.py``, level profiles). From level
+    1 the player has done the loop once, and a board that quietly hides rows is
+    the surprise #1367 spent an epic removing.
+    """
+    assert compute_capabilities(0, is_admin=False).task_browse_defaults_to_eligible is True
+    assert compute_capabilities(1, is_admin=False).task_browse_defaults_to_eligible is False
+    assert compute_capabilities(7, is_admin=False).task_browse_defaults_to_eligible is False
+
+
+def test_no_active_character_gets_no_browse_default() -> None:
+    # /tasks is public and it is the shop window: a viewer with nothing to ask
+    # the question about gets the whole board.
+    assert (
+        compute_capabilities(None, is_admin=False).task_browse_defaults_to_eligible
+        is False
+    )
+
+
+def test_admin_does_not_short_circuit_the_browse_default() -> None:
+    # Unlike the propose/see flags: this is a UI default, not a permission, and
+    # an admin at level 5 has done the loop like everybody else. The level-0
+    # admin keeps it for the same reason a level-0 player does — which is the
+    # one viewer who can still intersect it with the retired/pending tabs
+    # (#2025 names that corner and rules it not worth designing for).
+    assert compute_capabilities(5, is_admin=True).task_browse_defaults_to_eligible is False
+    assert compute_capabilities(0, is_admin=True).task_browse_defaults_to_eligible is True
+    assert (
+        compute_capabilities(None, is_admin=True).task_browse_defaults_to_eligible
+        is False
+    )

--- a/frontend/.ds-kit/provider.tsx
+++ b/frontend/.ds-kit/provider.tsx
@@ -63,6 +63,7 @@ const MOCK_USER: CurrentUser = {
   // so the affordance is correctly absent.
   level_jump_reach: 0,
   level_jump_available: false,
+  task_browse_defaults_to_eligible: false,
 };
 
 /** The signed-in viewer a preview is drawn for, with no request behind it. */

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -2524,6 +2524,11 @@ export interface components {
              * @default 0
              */
             second_character_level_required: number;
+            /**
+             * Task Browse Defaults To Eligible
+             * @default false
+             */
+            task_browse_defaults_to_eligible: boolean;
         };
         /**
          * DevLoginOut

--- a/frontend/src/components/vote/__tests__/albescentVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/albescentVote.test.tsx
@@ -69,6 +69,7 @@ function currentUser(): CurrentUser {
     era_name: 'Era 3',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/components/vote/__tests__/covenVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/covenVote.test.tsx
@@ -88,6 +88,7 @@ function currentUser(): CurrentUser {
     era_name: 'Era 1',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
+++ b/frontend/src/components/vote/__tests__/ephemeristsVote.test.tsx
@@ -72,6 +72,7 @@ function currentUser(): CurrentUser {
     era_name: 'Era 1',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/components/vote/__tests__/voteUI.test.tsx
+++ b/frontend/src/components/vote/__tests__/voteUI.test.tsx
@@ -66,6 +66,7 @@ function currentUser(): CurrentUser {
     era_name: 'Era 3',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/components/vote/__tests__/voteWidgetSilent.test.tsx
+++ b/frontend/src/components/vote/__tests__/voteWidgetSilent.test.tsx
@@ -129,6 +129,7 @@ function currentUser(): CurrentUser {
     era_name: 'Era 3',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskDispatch.test.tsx
@@ -94,6 +94,7 @@ function currentUser(faction_slug: string, canCreateAdditional = false): Current
     era_name: 'Era 3',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/pages/fieldDesk/__tests__/fieldDeskRosterGate.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/fieldDeskRosterGate.test.tsx
@@ -96,6 +96,7 @@ function currentUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
     era_name: 'Era 1',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
     ...overrides,
   }
 }

--- a/frontend/src/pages/fieldDesk/__tests__/homeDestinations.test.ts
+++ b/frontend/src/pages/fieldDesk/__tests__/homeDestinations.test.ts
@@ -15,18 +15,23 @@
  * is ever renamed, or `CAN_SIGN_UP_ON` stops being `'1'`, this fails here rather
  * than turning the home screen's buttons into a plain browse in production.
  *
- * `readTaskFilters` takes the viewer's has-a-character answer since #1972, and
- * `true` is the only honest value here: the field desk is the signed-in home,
- * and eligibility is exactly the axis a viewer without a character cannot use.
+ * `readTaskFilters` takes the viewer's eligibility default since #1972, and
+ * `'off'` — a player past level 0 — is the value worth driving here since
+ * #2025. The field desk is the signed-in home, so a viewer with no character is
+ * not the case; and a level-0 one would pass on their default alone, proving
+ * nothing about whether the link's `can_sign_up=1` was read at all.
  */
 import { describe, it, expect } from 'vitest'
 import { CAST_VOTES_LINK, FIND_TASK_LINK, UPDATES_LINK } from '../homeDestinations'
-import { readTaskFilters } from '../../tasks/useTasks'
+import { readTaskFilters, type EligibilityDefault } from '../../tasks/useTasks'
 import { readFeedFilters } from '../../praxes/feedFilterParams'
 
 /** Split a same-origin app link into its path and its parsed query. */
-/** The field desk only renders for a signed-in viewer carrying a character. */
-const HAS_CHARACTER = true
+/**
+ * A player past the tutorial: their board opens WHOLE, so the axis coming out
+ * on can only be the link's doing.
+ */
+const LEVELLED_PLAYER: EligibilityDefault = 'off'
 
 function parse(link: string): { path: string; params: URLSearchParams } {
   const [path, query = ''] = link.split('?')
@@ -37,7 +42,7 @@ describe('the mobile home CTA destinations', () => {
   it('sends "Find a Task" to the task browse with the eligibility axis on', () => {
     const { path, params } = parse(FIND_TASK_LINK)
     expect(path, 'the task browse').toBe('/tasks')
-    expect(readTaskFilters(params, HAS_CHARACTER).canSignUp, 'can-sign-up axis').toBe(
+    expect(readTaskFilters(params, LEVELLED_PLAYER).canSignUp, 'can-sign-up axis').toBe(
       true,
     )
   })
@@ -47,7 +52,7 @@ describe('the mobile home CTA destinations', () => {
     // faction ability bend the level bar (the Ephemerists reach retired tasks).
     // A `status=active` riding along would cancel that silently.
     const { params } = parse(FIND_TASK_LINK)
-    const filters = readTaskFilters(params, HAS_CHARACTER)
+    const filters = readTaskFilters(params, LEVELLED_PLAYER)
     expect(filters.status, 'no status narrowing').toBe('All')
     expect(filters.factions, 'no faction narrowing').toEqual([])
   })

--- a/frontend/src/pages/fieldDesk/__tests__/homeTrackBand.test.tsx
+++ b/frontend/src/pages/fieldDesk/__tests__/homeTrackBand.test.tsx
@@ -80,6 +80,7 @@ function currentUser(faction_slug: string): CurrentUser {
     era_name: 'Era 3',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/collabSubmitIndicators.test.tsx
@@ -141,6 +141,7 @@ function user(characterId: number): CurrentUser {
     era_name: "Era 1",
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   };
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/duelForfeitWarning.test.tsx
@@ -177,6 +177,7 @@ function user(): CurrentUser {
     era_name: 'Era 1',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/ownerEditLink.test.tsx
@@ -149,6 +149,7 @@ function user(): CurrentUser {
     era_name: 'Era 1',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/unsubmitConfirmCopy.test.tsx
@@ -166,6 +166,7 @@ function user(): CurrentUser {
     era_name: 'Era 1',
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   }
 }
 

--- a/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/voteRegionGate.test.tsx
@@ -95,6 +95,7 @@ function viewer(): CurrentUser {
     era_name: "Era 3",
     level_jump_reach: 0,
     level_jump_available: false,
+    task_browse_defaults_to_eligible: false,
   };
 }
 

--- a/frontend/src/pages/tasks/CanSignUpEmpty.tsx
+++ b/frontend/src/pages/tasks/CanSignUpEmpty.tsx
@@ -17,11 +17,11 @@ const DEFAULT_MAX_TASK_SLOTS = 20
  *
  * Mounted ONLY from the `canSignUp && tasks.length === 0` branch — an EMPTY
  * eligible list, which is what keeps `useMyActiveTasks`'s fetch off the page
- * load that has tasks to show. Since #1972 the filter defaults ON for a viewer
- * carrying a character, so this is no longer a corner: a level-0 player who has
- * claimed their one task lands here on their second screen of the game, and the
- * round trip #1218 is clawing back is only paid on a board that came back with
- * nothing to draw.
+ * load that has tasks to show. Since #1972 the filter defaults ON — and since
+ * #2025 for a level-0 character only, which is precisely the viewer this
+ * sentence was written for: they claim their one task and land here on their
+ * second screen of the game. The round trip #1218 is clawing back is only paid
+ * on a board that came back with nothing to draw.
  *
  * That is also why the button says "see everything" rather than "clear all
  * filters": the player did not apply this filter, the default did, and a button

--- a/frontend/src/pages/tasks/TaskFilterBar.tsx
+++ b/frontend/src/pages/tasks/TaskFilterBar.tsx
@@ -46,10 +46,11 @@ const ELIGIBILITY_ON = 'canSignUp'
  * The eligibility rail (#1130) is gated on carrying a CHARACTER (#1972): the
  * server answers `[]` for an anonymous viewer, so it is a control that cannot
  * work logged out, and this page hides unusable controls rather than disabling
- * them (STYLE §1.4). It is also the one rail that does not open on its
- * `defaultValue` — the filter defaults ON for a character, which raises its
- * applied chip in the bar, and that chip's `×` is the one-tap way back to the
- * whole board.
+ * them (STYLE §1.4). It is also the one rail that need not open on its
+ * `defaultValue` — the filter defaults ON for a LEVEL-0 character (#2025),
+ * which raises its applied chip in the bar, and that chip's `×` is the one-tap
+ * way back to the whole board. For every other player it opens on
+ * `defaultValue` like the rest of the bar.
  * Status keeps its viewer-gated segment count for the same reason — `retired`
  * and `pending` are a permission boundary, and a logged-out viewer gets two
  * segments, not four.

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -53,6 +53,7 @@ const VIEWER: CurrentUser = {
   era_name: 'Era 1',
   level_jump_reach: 0,
   level_jump_available: false,
+  task_browse_defaults_to_eligible: false,
 }
 
 // Canned task-browse state. Tests that only exercise the dispatch branch leave

--- a/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/dispatch.test.tsx
@@ -232,9 +232,11 @@ describe('task-browse card + CTA parity (ADR-0056)', () => {
  * could only ever empty the page) — `eligibilityRailGate.test.tsx` holds the
  * account-with-no-character half of that gate.
  *
- * It defaults ON for a viewer who carries one since #1972; which viewer gets
- * which default is `readTaskFilters`' call and is pinned in
- * `taskFilterParams.test.ts`. This page takes `canSignUp` as a given.
+ * It defaults ON for a level-0 character and OFF for anyone past that (#1972,
+ * narrowed by #2025); which viewer gets which default is `readTaskFilters`'
+ * call and is pinned in `taskFilterParams.test.ts`. This page takes `canSignUp`
+ * as a given — VIEWER here is level 2, and the tests that want the filter on
+ * say so.
  */
 describe('can-sign-up filter (#1130)', () => {
   const CAN_SIGN_UP = i18n.t('tasks:browse.canSignUp')

--- a/frontend/src/pages/tasks/__tests__/eligibilityRailGate.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/eligibilityRailGate.test.tsx
@@ -38,12 +38,18 @@ const BASE_VIEWER: CurrentUser = {
   era_name: 'Era 1',
   level_jump_reach: 0,
   level_jump_available: false,
+  task_browse_defaults_to_eligible: false,
 }
 
-/** The brand-new player the default exists for: level 0, one startable task. */
+/**
+ * The brand-new player the default exists for: level 0, one startable task —
+ * which since #2025 is exactly the viewer the server sets
+ * `task_browse_defaults_to_eligible` for.
+ */
 const WITH_CHARACTER: CurrentUser = {
   ...BASE_VIEWER,
   character: { level: 0, faction_slug: 'na' } as never,
+  task_browse_defaults_to_eligible: true,
 }
 
 function mkState(user: CurrentUser | null, canSignUp: boolean): TasksState {

--- a/frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx
@@ -72,6 +72,7 @@ const VIEWER: CurrentUser = {
   era_name: 'Era 1',
   level_jump_reach: 0,
   level_jump_available: false,
+  task_browse_defaults_to_eligible: false,
 }
 
 const CANNED: TasksState = {

--- a/frontend/src/pages/tasks/__tests__/metataskFilterGate.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/metataskFilterGate.test.tsx
@@ -36,6 +36,7 @@ const BASE_VIEWER: CurrentUser = {
   era_name: 'Era 1',
   level_jump_reach: 0,
   level_jump_available: false,
+  task_browse_defaults_to_eligible: false,
 }
 
 function mkState(user: CurrentUser | null): TasksState {

--- a/frontend/src/pages/tasks/__tests__/proposeEntryPoint.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/proposeEntryPoint.test.tsx
@@ -49,6 +49,7 @@ const VIEWER: CurrentUser = {
   era_name: 'Era 1',
   level_jump_reach: 0,
   level_jump_available: false,
+  task_browse_defaults_to_eligible: false,
 }
 
 const CANNED: TasksState = {

--- a/frontend/src/pages/tasks/__tests__/taskFilterParams.test.ts
+++ b/frontend/src/pages/tasks/__tests__/taskFilterParams.test.ts
@@ -12,10 +12,12 @@
  *   2. non-default values only — a clean browse has a clean address
  *   3. faction is REPEATED (`?faction=a&faction=b`), the union B2 (#1364) reads
  *   4. "clear all" clears search too, and touches nothing it does not own
- *   5. eligibility is the one VIEWER-RELATIVE axis (#1972): the default is ON
- *      for a viewer who carries a character and unavailable for everyone else,
- *      so the param is a tri-state and a pasted link cannot force an empty
- *      board on a stranger
+ *   5. eligibility is the one VIEWER-RELATIVE axis (#1972, narrowed by #2025):
+ *      the default is ON for a level-0 character, OFF for one past that, and
+ *      the axis is unavailable to a viewer carrying none — so the param is a
+ *      tri-state, a pasted link cannot force an empty board on a stranger, and
+ *      "clear all" spells out the `0` for exactly the viewer whose default
+ *      would otherwise undo it
  */
 import { describe, it, expect } from 'vitest'
 import {
@@ -28,13 +30,19 @@ import {
   nextFactionParams,
   nextFilterParams,
   readTaskFilters,
+  type EligibilityDefault,
 } from '../useTasks'
 
 const params = (query: string) => new URLSearchParams(query)
 
-/** The two viewers this axis distinguishes, spelled out at every call site. */
-const WITH_CHARACTER = true
-const NO_CHARACTER = false
+/**
+ * The three viewers this axis distinguishes, spelled out at every call site.
+ * `LEVELLED` is the majority of players and, since #2025, the one whose board
+ * opens whole.
+ */
+const ONBOARDING: EligibilityDefault = 'on'
+const LEVELLED: EligibilityDefault = 'off'
+const NO_CHARACTER: EligibilityDefault = 'unavailable'
 
 describe('readTaskFilters — a missing param IS the default', () => {
   it('reads a bare URL as the whole default filter set', () => {
@@ -59,7 +67,9 @@ describe('readTaskFilters — a missing param IS the default', () => {
       params(
         `type=metatask&sort=oldest&status=retired&faction=ua&faction=coven&can_sign_up=${CAN_SIGN_UP_ON}`,
       ),
-      WITH_CHARACTER,
+      // The levelled viewer on purpose: an explicit `1` has to beat a default
+      // of off, or every shared narrowed link lands wide.
+      LEVELLED,
     )
     expect(filters).toEqual({
       taskType: 'metatask',
@@ -105,20 +115,26 @@ describe('readTaskFilters — an unrecognised value CLAMPS (#1537)', () => {
   })
 
   it('clamps an unrecognised eligibility value to the viewer default', () => {
-    expect(readTaskFilters(params('can_sign_up=yes'), WITH_CHARACTER).canSignUp).toBe(
-      true,
-    )
+    expect(readTaskFilters(params('can_sign_up=yes'), ONBOARDING).canSignUp).toBe(true)
+    expect(readTaskFilters(params('can_sign_up=yes'), LEVELLED).canSignUp).toBe(false)
     expect(readTaskFilters(params('can_sign_up=yes'), NO_CHARACTER).canSignUp).toBe(
       false,
     )
   })
 })
 
-describe('readTaskFilters — eligibility is VIEWER-RELATIVE (#1972)', () => {
-  it('defaults ON for a viewer who carries a character', () => {
-    // The whole point of the issue: a level-0 character opens the board on the
-    // one task they can start, not on all 65.
-    expect(readTaskFilters(params(''), WITH_CHARACTER).canSignUp).toBe(true)
+describe('readTaskFilters — eligibility is VIEWER-RELATIVE (#1972, #2025)', () => {
+  it('defaults ON in the tutorial state, and only there', () => {
+    // The ruling: a level-0 character opens the board on the one task they can
+    // start, not on all 65. That is the whole of what the default is for.
+    expect(readTaskFilters(params(''), ONBOARDING).canSignUp).toBe(true)
+  })
+
+  it('defaults OFF once the player is past level 0', () => {
+    // They have run the loop once. A board that quietly hides rows from them is
+    // the surprise #1367 spent an epic removing — and it is what made the
+    // pending/retired tabs intersect to nothing.
+    expect(readTaskFilters(params(''), LEVELLED).canSignUp).toBe(false)
   })
 
   it('stays OFF for a viewer with no character — /tasks is the shop window', () => {
@@ -127,9 +143,16 @@ describe('readTaskFilters — eligibility is VIEWER-RELATIVE (#1972)', () => {
 
   it('honours an explicit OFF, so turning it off survives a paste', () => {
     expect(
-      readTaskFilters(params(`can_sign_up=${CAN_SIGN_UP_OFF}`), WITH_CHARACTER)
-        .canSignUp,
+      readTaskFilters(params(`can_sign_up=${CAN_SIGN_UP_OFF}`), ONBOARDING).canSignUp,
     ).toBe(false)
+  })
+
+  it('honours an explicit ON for a levelled player, so a narrowed link lands narrowed', () => {
+    // The field desk's "Find a Task" CTA is this link, and it is sent to
+    // players of every level (`homeDestinations.test.ts` drives the real URL).
+    expect(
+      readTaskFilters(params(`can_sign_up=${CAN_SIGN_UP_ON}`), LEVELLED).canSignUp,
+    ).toBe(true)
   })
 
   it('never lets a pasted ON empty the board for a viewer who has no character', () => {
@@ -215,12 +238,31 @@ describe('clearedFilterParams — every axis home, search included', () => {
     expect(next.toString()).toBe('ref=newsletter')
   })
 
-  it('SPELLS OUT eligibility-off for a viewer whose default is on', () => {
+  it('SPELLS OUT eligibility-off for the one viewer whose default is on', () => {
     // "Clear all filters" has to leave a list with no filters on it. Deleting
-    // the param would hand a character-holder straight back to the default,
+    // the param would hand a level-0 character straight back to the default,
     // which is ON — a button that says it cleared and did not.
-    const next = clearedFilterParams(params('faction=ua&q=moss'), WITH_CHARACTER)
+    const next = clearedFilterParams(params('faction=ua&q=moss'), ONBOARDING)
     expect(next.toString()).toBe(`can_sign_up=${CAN_SIGN_UP_OFF}`)
-    expect(readTaskFilters(next, WITH_CHARACTER).canSignUp).toBe(false)
+    expect(readTaskFilters(next, ONBOARDING).canSignUp).toBe(false)
+  })
+
+  it('DELETES the param for a levelled player, whose default is already off', () => {
+    // The inversion #2025 names: spelling out `0` here would leave a param on
+    // the address of the majority of clears, for no effect at all. What has to
+    // hold is the round trip, not the string — and it holds either way.
+    const next = clearedFilterParams(
+      params(`faction=ua&q=moss&can_sign_up=${CAN_SIGN_UP_ON}`),
+      LEVELLED,
+    )
+    expect(next.toString()).toBe('')
+    expect(readTaskFilters(next, LEVELLED).canSignUp).toBe(false)
+  })
+
+  it('clears to the same PLACE for both viewers, whatever the address says', () => {
+    for (const viewer of [ONBOARDING, LEVELLED, NO_CHARACTER]) {
+      const next = clearedFilterParams(params(`can_sign_up=${CAN_SIGN_UP_ON}`), viewer)
+      expect(readTaskFilters(next, viewer).canSignUp, viewer).toBe(false)
+    }
   })
 })

--- a/frontend/src/pages/tasks/useTasks.ts
+++ b/frontend/src/pages/tasks/useTasks.ts
@@ -27,11 +27,16 @@
  * game actually answers; every rule stays backend-side, so nothing here reads
  * an era value and #1046's "never hardcode an EraConfig value" is not reopened.
  *
- * Eligibility is the ONE axis whose default is viewer-relative (#1972): ON for
- * a viewer who carries a character, unavailable for everyone else. A level-0
- * character can start exactly one of the era's tasks, so the unfiltered board
- * is 65 rows with no way to tell which. See {@link readTaskFilters} for the
- * tri-state that costs, and what a shared link does about it.
+ * Eligibility is the ONE axis whose default is viewer-relative (#1972, narrowed
+ * by #2025): ON while the character is at level 0, OFF once it is past that,
+ * unavailable to a viewer carrying no character at all. Level 0 is the tutorial
+ * state with exactly one task to do, so opening the board on that one task is
+ * the whole point; from level 1 the player has run the loop once and a board
+ * that quietly hides rows is the surprise #1367 spent an epic removing. The
+ * server answers which of the three this viewer is —
+ * {@link EligibilityDefault}, never a `character.level` compared here. See
+ * {@link readTaskFilters} for the tri-state param that costs, and what a shared
+ * link does about it.
  */
 import { useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
@@ -106,6 +111,23 @@ export const CAN_SIGN_UP_ON = '1'
 export const CAN_SIGN_UP_OFF = '0'
 
 /**
+ * What eligibility means for THIS viewer — the one viewer-relative input the
+ * two readers below take (#2025). Three states, not two booleans, because the
+ * middle one is exactly the case the pair would let you spell wrongly:
+ *
+ *   - `'unavailable'` — no character. There is nothing to ask the server about,
+ *     so the axis is forced off whatever the URL says, and the rail is hidden.
+ *   - `'off'` — a character past the tutorial. The axis works; the board opens
+ *     whole.
+ *   - `'on'` — a level-0 character. The board opens on what they can start.
+ *
+ * Which one a viewer is comes from `/auth/me`'s
+ * `task_browse_defaults_to_eligible` plus whether a character is carried at all
+ * — never a level compared here, per the capability-flag rule in `api/auth.ts`.
+ */
+export type EligibilityDefault = 'unavailable' | 'off' | 'on'
+
+/**
  * The legal value of each enumerated axis, for {@link readOneOf} (#1537). A URL
  * is untrusted input: `GET /tasks` 422s on an unknown `sort` (#1443), so a stale
  * bookmark or a hand-edited link has to degrade to the default view here rather
@@ -146,15 +168,23 @@ export interface TaskFilterAxes {
  * The three enumerated axes go through the shared whitelist, so an unknown value
  * clamps to the default instead of riding out to a route that 422s on it.
  *
- * `hasCharacter` is the only viewer-relative input, and it decides the whole
- * eligibility axis (#1972):
+ * `eligibilityDefault` is the only viewer-relative input, and it decides the
+ * whole eligibility axis (#1972, narrowed by #2025):
  *
- *   - **No character, no eligibility.** There is no question to ask the server,
- *     so the axis is forced off whatever the URL says. `/tasks` is public and it
- *     is the shop window — a stranger gets all 65 tasks, never an empty page.
- *   - **With a character it is ON unless the URL says `0`.** A brand-new
- *     character can start one task out of 65; opening the board on that one is
- *     the point.
+ *   - **`'unavailable'`: no character, no eligibility.** There is no question to
+ *     ask the server, so the axis is forced off whatever the URL says. `/tasks`
+ *     is public and it is the shop window — a stranger gets all 65 tasks, never
+ *     an empty page.
+ *   - **`'on'`: a level-0 character, so ON unless the URL says `0`.** The
+ *     tutorial state can start one task out of 65; opening the board on that
+ *     one is the point.
+ *   - **`'off'`: a character past level 0, so OFF unless the URL says `1`.**
+ *     They have run the loop once and know the board exists; hiding rows from
+ *     them is the surprise, not the help.
+ *
+ * The URL still wins over the default in both directions — that is what makes
+ * the axis shareable at all, and what keeps the field desk's
+ * `/tasks?can_sign_up=1` CTA landing narrowed for a player of any level.
  *
  * That answers the shareable-link question the ruling leaves open. The axis is
  * viewer-relative, so it cannot round-trip faithfully; what it round-trips
@@ -164,12 +194,13 @@ export interface TaskFilterAxes {
  * recipient honours only if they carry a character — for anyone else it
  * degrades to the full board rather than to nothing at all. A bare `/tasks`
  * link means "the board, as it opens for you", which is now different for a
- * player and a stranger by design.
+ * brand-new player, a levelled one and a stranger by design.
  */
 export function readTaskFilters(
   params: URLSearchParams,
-  hasCharacter: boolean,
+  eligibilityDefault: EligibilityDefault,
 ): TaskFilterAxes {
+  const asked = params.get(TASK_FILTER_PARAMS.canSignUp)
   return {
     taskType: readOneOf(
       params.get(TASK_FILTER_PARAMS.taskType),
@@ -185,8 +216,13 @@ export function readTaskFilters(
     // Unknown slugs are left alone, as on the praxis feed: `/factions` is
     // fetched separately and a slug that matches nothing simply returns no rows.
     factions: params.getAll(TASK_FILTER_PARAMS.faction).filter((slug) => slug !== ''),
+    // Anything the axis cannot read — absent, blank, hand-typed nonsense —
+    // falls through to the viewer's default, the same clamp the enumerated
+    // axes get above.
     canSignUp:
-      hasCharacter && params.get(TASK_FILTER_PARAMS.canSignUp) !== CAN_SIGN_UP_OFF,
+      eligibilityDefault !== 'unavailable' &&
+      (asked === CAN_SIGN_UP_ON ||
+        (asked !== CAN_SIGN_UP_OFF && eligibilityDefault === 'on')),
   }
 }
 
@@ -222,20 +258,28 @@ export function nextFactionParams(
  * Every axis off, search included — what "clear all filters" means. Params this
  * page does not own are left alone.
  *
- * Note "off", not "back to its default": for a viewer whose eligibility default
- * is ON, deleting that param would hand them straight back to the filtered
- * board, so clear-all writes the explicit `0` instead (#1972). A button that
- * says it cleared the filters has to leave a list with no filters on it — and
- * this is the same tap `CanSignUpEmpty` offers as "see everything".
+ * "Off", not "back to its default", and which of the two takes the extra write
+ * INVERTS with the default (#2025). A button that says it cleared the filters
+ * has to leave a list with no filters on it — and this is the same tap
+ * `CanSignUpEmpty` offers as "see everything" — so:
+ *
+ *   - `'on'` (a level-0 character): deleting the param would hand them straight
+ *     back to the filtered board, so the explicit `0` is written out.
+ *   - `'off'` / `'unavailable'`: off IS the default, so spelling it out would
+ *     leave a param behind on the majority of clears for no effect. Deleting is
+ *     both the honest clear and the clean address `nextFilterParams` aims for.
+ *
+ * Both branches end in the same place — `readTaskFilters` reading `false` — and
+ * `taskFilterParams.test.ts` asserts that round trip rather than the string.
  */
 export function clearedFilterParams(
   previous: URLSearchParams,
-  hasCharacter: boolean,
+  eligibilityDefault: EligibilityDefault,
 ): URLSearchParams {
   const next = new URLSearchParams(previous)
   for (const key of Object.values(TASK_FILTER_PARAMS)) next.delete(key)
   next.delete(SEARCH_QUERY_PARAM)
-  if (hasCharacter) next.set(TASK_FILTER_PARAMS.canSignUp, CAN_SIGN_UP_OFF)
+  if (eligibilityDefault === 'on') next.set(TASK_FILTER_PARAMS.canSignUp, CAN_SIGN_UP_OFF)
   return next
 }
 
@@ -328,8 +372,9 @@ export interface TasksState {
   selectedFactions: string[]
   setSelectedFactions: (slugs: string[]) => void
   /**
-   * "Tasks I can sign up for" (#1130). Defaults **ON** for a viewer who carries
-   * a character and is unavailable to everyone else (#1972) — see
+   * "Tasks I can sign up for" (#1130). Defaults **ON** for a level-0 character,
+   * OFF for one past that, and is unavailable to a viewer carrying none
+   * (#1972, #2025) — see {@link EligibilityDefault} and
    * {@link readTaskFilters}. Callers hide the control entirely for a viewer
    * with no character: the server answers `[]` for an anonymous viewer, so it
    * is a control that cannot work.
@@ -368,7 +413,15 @@ export interface TasksState {
 export function useTasks(): TasksState {
   const { user, loading: authLoading } = useAuth()
   const navigate = useNavigate()
-  const hasCharacter = Boolean(user?.character)
+  // The server's answer, not a level compared here (`api/auth.ts`). The flag is
+  // false for a viewer carrying no character, so the character check is what
+  // separates 'unavailable' from 'off' — the axis being absent from a
+  // stranger's board is a different fact from it opening wide for a player.
+  const eligibilityDefault: EligibilityDefault = !user?.character
+    ? 'unavailable'
+    : user.task_browse_defaults_to_eligible
+      ? 'on'
+      : 'off'
 
   /**
    * Hold the read while the viewer is still unknown (#1972).
@@ -401,7 +454,7 @@ export function useTasks(): TasksState {
     status,
     factions: selectedFactions,
     canSignUp,
-  } = readTaskFilters(searchParams, hasCharacter)
+  } = readTaskFilters(searchParams, eligibilityDefault)
   const [query, setQueryState] = useSearchQueryParam()
   const [signupMsg, setSignupMsg] = useState<SignupMessage | null>(null)
 
@@ -473,7 +526,7 @@ export function useTasks(): TasksState {
     )
   const setQuery = (next: string) => { setQueryState(next); resetWindow() }
   const clearFilters = () =>
-    writeParams((previous) => clearedFilterParams(previous, hasCharacter))
+    writeParams((previous) => clearedFilterParams(previous, eligibilityDefault))
 
   const handleSignup = async (id: number) => {
     setSignupMsg(null)


### PR DESCRIPTION
Closes #2025

Molly's ruling, not one of the three options in the body: the eligibility default itself narrows to level 0. #1972's flip is not reverted — it is scoped to the viewer it was right for. Level 0 is the tutorial state and it has precisely one thing to do (a character reaches level 1 *by* signing up for the game-wide onboarding task and posting a praxis for it), so a board narrowed to "what you can start" is genuinely helpful there. From level 1 the player has run the loop once, and a board that quietly hides rows is the surprise #1367 spent an epic removing.

## The seam

Two, both driven by existing pure-function tests:

1. **`compute_capabilities`** (`backend/tests/unit/test_character_capabilities.py`) — the new flag. Red first: three failing tests on a missing attribute, then the flag.
2. **The task browse's URL-param contract** (`frontend/src/pages/tasks/__tests__/taskFilterParams.test.ts`) — `readTaskFilters` / `clearedFilterParams`, which are the hook's whole decision and the only part of it the no-DOM harness can drive.

## A capability flag, not a level comparison

`/auth/me` gains `task_browse_defaults_to_eligible`, computed from the character's level in `services/character_capabilities.py` and named for what it decides rather than the level that decides it. The client never compares `character.level`, per the house rule stated in `frontend/src/api/auth.ts`.

- **Not short-circuited by `is_admin`**, like `level_jump_*` and `can_apply_metatask`: this is a UI default, not a permission, and an admin at level 5 has run the loop like everybody else. A level-0 admin keeps it — which is the residual corner the issue names and rules not worth designing for.
- **Not an `EraConfig` value.** Level 0 is the bottom of the scale itself (`level_thresholds[0] = 0`, "everyone starts at level 0"), so there is no `era.*` to read. The unit test pins that a stricter era does not move the line.
- **No server-side enforcement branch.** This is a default, not a gate: `GET /tasks` still takes `can_sign_up` from the client, exactly as it does today, and gate 5 of the sign-up predicate in `services/task.py` (post-#2264) is untouched.

## The trap: `clearedFilterParams` inverts

The two readers stop taking `hasCharacter` and take an `EligibilityDefault` instead — `'unavailable'` (no character), `'off'` (past level 0), `'on'` (level 0). Three states rather than two booleans, because the pair would let a call site spell the middle case wrongly and tsc would not notice; as a union it caught all 24 call sites at once.

"Clear all filters" used to write an explicit `can_sign_up=0` for every character-holder, because deleting the param handed them back to an ON default. That reasoning inverts: for a levelled player, off IS the default, so spelling it out would leave a param on the address of the majority of clears for no effect. Now only `'on'` takes that write. What the tests assert is the round trip back through `readTaskFilters` rather than the string, plus a loop proving all three viewers clear to the same *place* — so "clear all filters" means the same thing for a level-0 and a level-1+ viewer either way.

A URL still beats the default in both directions, which is what keeps the field desk's `/tasks?can_sign_up=1` CTA landing narrowed for a player of any level. `homeDestinations.test.ts` now drives that link as a **levelled** viewer, so the axis coming out on can only be the link's doing — it would have passed on the default alone before.

## Verification

Every job in `.github/workflows/test.yml`, run locally:

- `pytest --cov` on a dedicated `wz2025_test` DB — **1487 passed**, coverage 94.15%
- `regen_api_client.py` then `git diff --exit-code` — clean (`backend/openapi.json` + `frontend/src/api/generated/schema.d.ts` committed, script-produced)
- `npm run lint` / `typecheck` / `typecheck:design-sync` / `test` (**6238 passed**) / `build` / `budget`

The budget's CSS **WARN is pre-existing on `main`, not this branch**: building `origin/main`'s `frontend/src` in the same tree produces a byte-identical stylesheet (`index-Bc5h2qmp.css`, 117452 B), so this diff adds zero CSS bytes. JS stays `ok`.

**Visual QA is outstanding** — no browser or dev stack in this environment.

## What to eyeball

**As a level-0 character (a brand-new life):**

- `/tasks` opens narrowed to the one task you can start, with the eligibility chip raised in the filter bar and its `×` as the way out — unchanged from today.
- **Clear all filters** → the address becomes `?can_sign_up=0` and the board shows everything. Same for "see everything" on the `CanSignUpEmpty` state after you claim your one task.

**As a level-1+ character:**

- `/tasks` now opens on the **whole board**, no eligibility chip, no rows quietly hidden. The rail is still there, still switchable to "can sign up".
- **Clear all filters** → the address goes clean (no `can_sign_up=0` left behind) and the board is still the whole board. The tap means the same thing it does at level 0; only the URL it writes differs.
- Switch the rail to "can sign up", then clear — the param is removed rather than set to `0`.
- The retired/pending tabs (admins only) no longer intersect an on-by-default eligibility filter for a levelled admin.

**As a signed-out visitor:** `/tasks` is unchanged — whole board, no eligibility rail, and a pasted `?can_sign_up=1` still degrades to the whole board rather than an empty one.

**Shared links:** `?can_sign_up=1` lands narrowed for any player of any level (the mobile home's "Find a Task" CTA); `?can_sign_up=0` shows everyone the full board; a bare `/tasks` means "the board as it opens for you", which is now different for a brand-new player, a levelled one and a stranger — by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
