### PR TITLE
Albescent's letter names its CTA at the same slots as the other seven (#2300)

### DIFF
--- a/frontend/src/components/AlbescentInvitation.tsx
+++ b/frontend/src/components/AlbescentInvitation.tsx
@@ -187,7 +187,7 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
       {/* answer */}
       <div style={{ position: 'relative', padding: 'var(--space-xl) var(--space-3xl) var(--space-2xl)' }}>
         {joined ? (
-          <div style={{ ...serifItalic, fontSize: 'var(--text-title)', color: INK, textAlign: 'center' }}>{t('albescent.letter.joined')}</div>
+          <div style={{ ...serifItalic, fontSize: 'var(--text-title)', color: INK, textAlign: 'center' }}>{t('albescent.letter.cta.joined')}</div>
         ) : (
           <>
             <div style={{
@@ -220,7 +220,7 @@ export default function AlbescentInvitation({ lives, onJoined }: AlbescentInvita
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-lg)', flexWrap: 'wrap', justifyContent: 'center' }}>
               <button type="button" onClick={() => void handleAccept()} disabled={submitting} style={acceptButton}>
-                {submitting ? t('albescent.letter.acceptBusy') : t('albescent.letter.acceptIdle')}
+                {submitting ? t('albescent.letter.cta.busy') : t('albescent.letter.cta.join')}
               </button>
               <span style={{ ...serifItalic, fontSize: 'var(--text-content)', color: ACCENT }}>{t('albescent.letter.reassurance')}</span>
             </div>

--- a/frontend/src/components/__tests__/albescentInvitation.test.ts
+++ b/frontend/src/components/__tests__/albescentInvitation.test.ts
@@ -4,9 +4,13 @@
  * the Order has nothing left to accept. Pure filter, tested directly (no jsdom
  * in this repo — see vite.config.ts).
  */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
 import { describe, it, expect } from 'vitest'
 import { eligibleLives } from '../AlbescentInvitation'
 import type { CharacterOut } from '../../api/auth'
+import factions from '../../locales/en/factions.json'
 
 function life(overrides: Partial<CharacterOut>): CharacterOut {
   return {
@@ -51,5 +55,61 @@ describe('eligibleLives', () => {
 
   it('returns empty when nobody is fit to answer', () => {
     expect(eligibleLives([life({ status: 'banned' })])).toEqual([])
+  })
+})
+
+/* ========================================================================== *
+ * #2300 — ALBESCENT'S LETTER NAMES THE SAME SLOTS AS THE OTHER SEVEN.
+ *
+ * THE SEAM IS THE CATALOG LEAF NAME PLUS THE CALL SITE THAT WRITES IT. The
+ * seven shared letters (`InvitationLetterPopup`) reach for
+ * `<slug>.invitation.cta.join` / `.cta.joined`; Albescent's own letter reached
+ * for flat `letter.acceptIdle` / `letter.joined`, so one copy change meant two
+ * edits in two vocabularies. The components stay separate — the character
+ * picker, the account-level `can_start_as_albescent` trigger, ADR-0027 secrecy,
+ * and the letter's own vellum tokens — but the vocabulary does not have to be.
+ *
+ * Two assertions, because a key rename has two halves and each fails silently
+ * on its own: `tsc` sees neither, and a missed call site renders the literal
+ * key string onto the vellum rather than throwing. So the leaf names are
+ * pinned, AND every `albescent.letter.*` literal in the component is required
+ * to resolve. The dynamic `tDynamic` stems (terms, perks) carry no literal and
+ * are out of this check's reach by construction — `scripts/i18nKeyRefs.py` is
+ * the tool for those.
+ * ========================================================================== */
+describe("Albescent's letter names the same invitation slots as the other seven (#2300)", () => {
+  const SOURCE = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '../AlbescentInvitation.tsx'),
+    'utf8',
+  )
+
+  const leaf = (path: string): unknown =>
+    path
+      .split('.')
+      .reduce<unknown>(
+        (node, part) =>
+          node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined,
+        factions,
+      )
+
+  it('nests the accept control under letter.cta.*, with the copy unchanged', () => {
+    expect(leaf('albescent.letter.cta.join')).toBe('Accept the order')
+    expect(leaf('albescent.letter.cta.joined')).toBe('You are of the Order')
+    // `busy` has no counterpart to align to — the shared popup reuses its idle
+    // label while disabled — so it joins the nest rather than taking a name
+    // from it.
+    expect(leaf('albescent.letter.cta.busy')).toBe('Entering the record…')
+  })
+
+  it('leaves nothing behind under the old flat names', () => {
+    expect(leaf('albescent.letter.acceptIdle')).toBeUndefined()
+    expect(leaf('albescent.letter.acceptBusy')).toBeUndefined()
+    expect(leaf('albescent.letter.joined')).toBeUndefined()
+  })
+
+  it('resolves every albescent.letter key the component writes as a literal', () => {
+    const literals = [...SOURCE.matchAll(/albescent\.letter\.([A-Za-z][\w.]*)/g)].map((m) => m[1])
+    expect(literals.length).toBeGreaterThan(0)
+    expect(literals.filter((key) => typeof leaf(`albescent.letter.${key}`) !== 'string')).toEqual([])
   })
 })

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -89,11 +89,13 @@
         "duties": "Every other house's privilege, held at once — and a door that never locks behind you.",
         "witnessed": "Your account, witnessed and inscribed"
       },
-      "joined": "You are of the Order",
       "whoHeading": "Who takes up the work",
       "lifeMeta": "@{{username}} · {{faction}}",
-      "acceptBusy": "Entering the record…",
-      "acceptIdle": "Accept the order",
+      "cta": {
+        "join": "Accept the order",
+        "joined": "You are of the Order",
+        "busy": "Entering the record…"
+      },
       "reassurance": "you need not persuade us.",
       "declineError": "The order declined, and gave no reason."
     }


### PR DESCRIPTION
Albescent's invitation letter and the seven shared letters named the same
control differently, so every copy change had to be made twice in two
vocabularies. Three leaves move onto the shared names. **No copy string
changes** — the values are byte-identical, only their key paths move.

| before | after | why |
|---|---|---|
| `albescent.letter.acceptIdle` | `albescent.letter.cta.join` | matches `<slug>.invitation.cta.join` |
| `albescent.letter.joined` | `albescent.letter.cta.joined` | matches `<slug>.invitation.cta.joined` |
| `albescent.letter.acceptBusy` | `albescent.letter.cta.busy` | no shared counterpart (the popup reuses its idle label while disabled) — joins the same nest |

Done standalone rather than riding #2298, which the issue suggested: #2298 is
`needs-info` and not dispatchable, and these three keys are disjoint from the
nine it removes, so there was nothing to wait for.

Untouched, per the issue's own reasoning: `letter.wordmark` (not a duplicate of
`names.albescent` — the leading slash is the #1975 unaffiliated-fold
convention), `letter.aria`, `letter.whoHeading`, `letter.lifeMeta`,
`letter.reassurance`, `letter.declineError` (Albescent-only, no counterpart to
align to), `letter.headline` / `letter.pitch` (already match), and `perks`
(#2298's). The two components stay separate.

## Seam

**The catalog leaf name plus the call site that writes it.** A key rename has
two halves and each fails silently on its own — `tsc` sees neither, and a
missed call site renders the literal key string onto the vellum rather than
throwing. So `albescentInvitation.test.ts` gained three cases: the new leaves
resolve to the unchanged strings, the old flat names are gone, and every
`albescent.letter.*` literal in `AlbescentInvitation.tsx` resolves in the
catalog. The first two went red on the real defect before the rename landed —
the first commit here is that red.

The dynamic `tDynamic` stems for `terms.*` / `perks.*` carry no literal and are
out of that check's reach by construction; `frontend/scripts/i18nKeyRefs.py` is
the tool for those, and neither stem can build a `cta.*` key.

## Verification

Every step named by the `frontend` job in `.github/workflows/test.yml`, run
locally: `lint` clean, `typecheck` clean (tsc 5.9.3), `typecheck:design-sync`
clean, `npm test` 358 files / 6252 passed, `build` clean, `budget` — the CSS
line WARNs at 22.4 KB against a 22.2 KB warn line, which is **pre-existing on
`main`**; this PR touches no CSS and moves zero bytes.

No visual QA — no browser or dev stack available in this environment.

## Not done

The issue's DoD asks for `python frontend/scripts/copyReview.py export` to be
re-run. **That script does not exist in the repo** (`frontend/scripts/` holds
`bundle-budget.mjs`, `fetch-fonts.mjs`, `i18nKeyRefs.py`, `measure-load.mjs`,
`measure-nightly.sh`), and its apparent outputs — `docs/copy/*.csv`, which do
carry `{F}.letter.acceptIdle` rows — sit outside this change's file scope. The
three stale rows in `docs/copy/faction-copy-decisions.csv` (:29, :32, :33) and
`docs/copy/faction-copy-voiced.csv` (:49, :50, :55) are untouched: they are a
dated decision record, not a live catalog, and nothing renders from them.

## What to eyeball

- The Albescent invitation letter's accept button reads **"Accept the order"**,
  not the raw string `albescent.letter.cta.join`.
- Press it: the in-flight label reads **"Entering the record…"**.
- After the join lands, the letter's answer block reads **"You are of the
  Order"**.
- Nothing else on the vellum changed — wordmark, letterhead, terms slip, perks,
  the life chooser and the reassurance line should all read exactly as before.

Closes #2300
