### PR TITLE
The Ephemerists masthead sizes to its contents, so the shared dismiss control reaches 44 (#2100)

### DIFF
--- a/frontend/src/components/feed/EphemeristsFeedFrame.tsx
+++ b/frontend/src/components/feed/EphemeristsFeedFrame.tsx
@@ -106,8 +106,19 @@ import { FeedRowSkinContext, type FeedRowSkin } from './feedRowSkin'
 const ROW_SKIN: FeedRowSkin = { ink: { actor: BRASS_LIGHT } }
 
 interface BandSize {
-  /** Band height, and the width its ruled hairline is drawn to fill. Geometry. */
-  height: number
+  /**
+   * The head hairline's OWN drawing box: the ornament SVG's height, and the
+   * height of the viewBox it is struck in. The two must stay equal — `slice`
+   * scales to cover, so a mismatch silently magnifies the rule and eats the
+   * 6px insets it is drawn with rather than erroring.
+   *
+   * THIS IS NOT THE BAND'S HEIGHT (#2100). The band has none: it sizes to its
+   * tallest child, the way the other eight feed frames always have. The
+   * ornament is pinned to the band's head and keeps its own proportion
+   * whatever the band grows to.
+   */
+  ruleHeight: number
+  /** The width the hairline is drawn to fill. Geometry. */
   view: number
   /** The sigil at the head of the band. Its HEIGHT — the mark owns its ratio
    *  (#1635) — so there is one number, not two. */
@@ -120,14 +131,14 @@ const SIZES: Record<'desktop' | 'mobile', BandSize> = {
   // 452 is the feed column's own basis (the sheet's `minmax(452px, 1fr)`), so
   // the band's hairline is drawn to the width it is actually shown at.
   desktop: {
-    height: 30,
+    ruleHeight: 30,
     view: 452,
     discHeight: 14,
     bandPadding: 'var(--space-xs) var(--space-md)',
     labelSize: 'var(--text-md)',
   },
   mobile: {
-    height: 26,
+    ruleHeight: 26,
     view: 360,
     discHeight: 10,
     bandPadding: 'var(--space-xs) var(--space-sm)',
@@ -159,25 +170,41 @@ export default function EphemeristsFeedFrame({
         color: INK,
       }}
     >
-      {/* ── The chassis band: night sky, ruled off, four chrome slots ── */}
+      {/* ── The chassis band: night sky, ruled off, four chrome slots ──
+          IT DECLARES NO HEIGHT (#2100), and that is the whole of the fix. It
+          sizes to its tallest child, which is how the other eight feed frames
+          have always worked — so a 44px control makes a 44px band, and the next
+          thing that needs more gets more without a second decision. The fixed
+          30/26 this carried was the ONLY numeric masthead height in the nine
+          frames, and under `overflow: hidden` it clipped anything taller than
+          itself for hit-testing as well as visually, by any mechanism. That is
+          what held the shared dismiss control down to a 24px target against
+          §6's non-negotiable 44.
+
+          `overflow: hidden` goes with it. With an intrinsic height there is
+          nothing left for it to clip — the ornament below is an `<svg>`, which
+          clips its own viewport, and the kicker carries its own ellipsis — so
+          it is inert, and an inert property that re-arms the trap the moment
+          someone puts a height back is worse than no property. */}
       <div
         style={{
           position: 'relative',
-          overflow: 'hidden',
-          height: size.height,
           background: BAND,
           color: BAND_INK,
         }}
       >
         <svg
           width="100%"
-          height={size.height}
-          // The viewBox tracks the band's own height, so `slice` crops the
-          // hairline at the edges rather than scaling it off the band.
-          viewBox={`0 0 ${size.view} ${size.height}`}
+          height={size.ruleHeight}
+          // The hairline keeps its OWN box, pinned to the band's head, rather
+          // than reading a band height that no longer exists. Element height
+          // and viewBox height are one number for that reason: `slice` crops
+          // rather than erroring, so a viewBox that disagreed with its box
+          // would magnify the rule and read as a design choice, not a bug.
+          viewBox={`0 0 ${size.view} ${size.ruleHeight}`}
           preserveAspectRatio="xMidYMid slice"
           aria-hidden="true"
-          style={{ position: 'absolute', inset: 0, zIndex: 1 }}
+          style={{ position: 'absolute', top: 0, left: 0, zIndex: 1 }}
         >
           <path
             d={`M6 4 H${size.view - 6}`}
@@ -205,8 +232,14 @@ export default function EphemeristsFeedFrame({
           style={{
             position: 'relative',
             zIndex: 2,
-            height: '100%',
             display: 'flex',
+            // This row IS the band's height now (#2100) — it is the only
+            // in-flow child, so its content plus this padding is what the night
+            // ground measures. It carried `height: 100%` to fill the old fixed
+            // band; against an intrinsic parent that is inert at best and the
+            // second place the ceiling would come back. `center` is what keeps
+            // the sigil, kicker, tag and time on one optical line beside the
+            // tallest thing in the row rather than stretching to meet it.
             alignItems: 'center',
             gap: 'var(--space-sm)',
             padding: size.bandPadding,
@@ -260,10 +293,10 @@ export default function EphemeristsFeedFrame({
               `currentColor` and arrives finished (boxed, labelled, keyboard
               reachable, and `null` on a card that cannot be archived, which is
               `awaiting_submission`). Placed, never rebuilt. BAND_INK is what it
-              spends, at full strength since #2091 — 14.00:1 here in both themes,
-              and this band is also the reason that control's target is 24px and
-              not 44: the masthead's `height` is fixed and clipped, so nothing
-              taller than it can be hit. */}
+              spends, at full strength since #2091 — 14.00:1 here in both themes.
+              It is also the tallest thing in this row at §6's 44px, so it is the
+              control that sets the band's height rather than the one the band
+              used to cut down to 24 (#2100). */}
           {archive}
         </div>
       </div>

--- a/frontend/src/components/feed/FeedArchiveButton.tsx
+++ b/frontend/src/components/feed/FeedArchiveButton.tsx
@@ -52,16 +52,15 @@ import i18n from '../../i18n'
  * tag. It is what makes the ✕ read as a control rather than as punctuation after
  * the timestamp, and it needs no colour of its own.
  *
- * ponytail: the hit target is 24px, not the 44px this repo applies everywhere
- * else (`identityActionStyle`, every vote key). 44 is unreachable from here and
- * not by a near miss: `EphemeristsFeedFrame` gives its masthead a FIXED
- * `height` (30px desktop, 26px mobile) with `overflow: hidden`, so anything
- * taller than the band is clipped — visually and for hit-testing, by any
- * mechanism, including a padded box or an absolutely-positioned extender. 24px
- * is the largest square that fits that band's border box on a phone and is
- * WCAG 2.5.8's (AA) target minimum; 2.5.5's 44 is AAA. The upgrade path is to
- * grow that band in an Ephemerists dress issue and then raise the two numbers
- * below — this control does not need a second code path to get there.
+ * THE HIT TARGET IS §6's 44px on all nine chassis, and one code path gets it
+ * there (#2100). It shipped at 24 — WCAG 2.5.8's AA minimum, short of the house
+ * rule — for exactly one reason: `EphemeristsFeedFrame` was the only frame of
+ * the nine that gave its masthead a fixed numeric height, and under
+ * `overflow: hidden` that clipped anything taller for hit-testing as well as
+ * visually. That band now sizes to its contents like the other eight, so one
+ * faction's dress no longer sets the target size of a control shared across
+ * all of them, and raising the two numbers below was the whole of the change
+ * here. The band grows to fit them.
  */
 /**
  * The hover / focus wash, as a percentage of the control's own ink.
@@ -105,8 +104,8 @@ export default function FeedArchiveButton({
         // it is a raw number and deliberately off the --space-* ramp (§4a), the
         // same call `identityActionStyle` makes for its 44.
         boxSizing: 'border-box',
-        minWidth: 24,
-        minHeight: 24,
+        minWidth: 44,
+        minHeight: 44,
         background: lit
           ? `color-mix(in srgb, currentColor ${LIT_WASH_PCT}%, transparent)`
           : 'transparent',

--- a/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
+++ b/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
@@ -17,6 +17,8 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, it, expect } from 'vitest'
 import EphemeristsFeedFrame from '../EphemeristsFeedFrame'
+import FeedArchiveButton from '../FeedArchiveButton'
+import '../../../i18n'
 
 function frame({
   tag = null,
@@ -124,5 +126,68 @@ describe('EphemeristsFeedFrame — the Valley plate ground', () => {
     // stacking context; without `isolation` that is whatever the feed column
     // established, which is how an ornament lands over unrelated copy (§5).
     expect(frame()).toContain('isolation:isolate')
+  })
+})
+
+/**
+ * SEAM: the masthead band's own inline style declaration, read back out of the
+ * rendered markup.
+ *
+ * #2100. This band carried the ONE numeric masthead height across all nine feed
+ * frames (30px desktop / 26px mobile) under `overflow: hidden`, so it clipped
+ * anything taller than itself — visually AND for hit-testing, by any mechanism.
+ * That held `FeedArchiveButton`, a control shared by all nine chassis, down to
+ * a 24px target where §6 makes 44x44 non-negotiable.
+ *
+ * The fix is structural rather than a bigger number: the band declares no
+ * height at all and sizes to its tallest child, which is how the other eight
+ * frames get this right for free. So what is asserted is the ABSENCE of a
+ * height on that box. A test pinned to `44px` would be the same magic number
+ * in a second place, and would go green again the day a control needs 46.
+ *
+ * There is no DOM here (`renderToStaticMarkup`), so nothing can be MEASURED.
+ * What is checkable is that the band declares no height and that the control it
+ * holds declares a 44px minimum — together, the whole of the fix.
+ */
+function styleOf(html: string, pattern: RegExp): string {
+  const match = new RegExp(`style="([^"]*${pattern.source}[^"]*)"`).exec(html)
+  if (!match) throw new Error(`no element whose style matches ${pattern}`)
+  return match[1]
+}
+
+/** The masthead: the box that paints the night ground. */
+const BAND = /background:var\(--faction-ephemerists-plate-band\)/
+
+describe('EphemeristsFeedFrame — the masthead sizes to its contents (#2100)', () => {
+  it('declares NO height on the band, so nothing placed in it can be clipped', () => {
+    // The defect, exactly: `height: 30` / `height: 26` on this box.
+    expect(styleOf(frame(), BAND)).not.toMatch(/(^|;)height:/)
+  })
+
+  it('pins no height on the chrome row inside it either', () => {
+    // The row carried `height: 100%` to fill the fixed band. Against an
+    // intrinsic parent that is at best inert, and it is the second place the
+    // ceiling would come back.
+    const row = styleOf(frame(), /padding:var\(--space-xs\) var\(--space-md\)/)
+    expect(row).not.toMatch(/(^|;)height:/)
+  })
+
+  it('holds the REAL 44px control, with no number left that could refuse it', () => {
+    const html = frame({ archive: <FeedArchiveButton onAct={() => {}} /> })
+    expect(html).toContain('min-width:44px')
+    expect(html).toContain('min-height:44px')
+    expect(styleOf(html, BAND)).not.toMatch(/(^|;)height:/)
+  })
+
+  it("keeps the head hairline on the ornament's OWN box, not on the band's", () => {
+    // The SVG viewBox used to track the band's height. `slice` crops rather
+    // than erroring, so a viewBox reading a height that no longer exists looks
+    // like a design choice instead of a bug (#2100, consequence 4). The
+    // ornament keeps its own constant, and the element height and the viewBox
+    // height must stay equal or the hairline scales and loses its inset.
+    const html = frame()
+    expect(html).toContain('height="30"')
+    expect(html).toContain('viewBox="0 0 452 30"')
+    expect(html).toContain('stroke-width="0.6"')
   })
 })

--- a/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
+++ b/frontend/src/components/feed/__tests__/ephemeristsFeedFrame.test.tsx
@@ -115,9 +115,11 @@ describe('EphemeristsFeedFrame — the Valley plate ground', () => {
     expect(html).toContain('stroke-width="0.6"')
   })
 
-  it('takes the sigil at the REDUCED cut, since the band is 10-14px tall', () => {
-    // Both band heights sit under #1635's 20px threshold, so the mark drops its
-    // crossed axes and vertex discs rather than drawing them at half a pixel.
+  it('takes the sigil at the REDUCED cut, since the MARK is 10-14px tall', () => {
+    // Both sigil heights sit under #1635's 20px threshold, so the mark drops
+    // its crossed axes and vertex discs rather than drawing them at half a
+    // pixel. This is the mark's own size and never the band's — the band has
+    // no height to read since #2100, and it did not set this one before.
     expect(frame()).not.toContain('M100 272 L392 272')
   })
 

--- a/frontend/src/components/feed/__tests__/feedArchiveControl.test.tsx
+++ b/frontend/src/components/feed/__tests__/feedArchiveControl.test.tsx
@@ -182,10 +182,16 @@ describe('the shared dismiss control', () => {
     expect(CONTROL).not.toMatch(/#[0-9a-fA-F]{3}|rgba?\(/)
   })
 
-  it('is at least a 24px square target (WCAG 2.5.8)', () => {
+  it('is a 44px square target — the house floor, not WCAG 2.5.8 (#2100)', () => {
+    // It shipped at 24 (2.5.8, AA) because `EphemeristsFeedFrame`'s masthead
+    // was a FIXED height that clipped anything taller, for hit-testing as well
+    // as visually. #2100 made that band intrinsic, so the ceiling is gone and
+    // §6's non-negotiable 44 (2.5.5, AAA) is reachable from the one shared
+    // control on all nine chassis. The floor is asserted at 44, not at
+    // "≥ 24", so a regression to the old number goes red here.
     expect(declared('box-sizing')).toBe('border-box')
-    expect(Number.parseFloat(declared('min-width') ?? '0')).toBeGreaterThanOrEqual(24)
-    expect(Number.parseFloat(declared('min-height') ?? '0')).toBeGreaterThanOrEqual(24)
+    expect(Number.parseFloat(declared('min-width') ?? '0')).toBeGreaterThanOrEqual(44)
+    expect(Number.parseFloat(declared('min-height') ?? '0')).toBeGreaterThanOrEqual(44)
   })
 
   it('sets the glyph at the tier the timestamp beside it reads at', () => {


### PR DESCRIPTION
Option 1 from the ruling, built as the ruling specified the mechanism: the masthead stops carrying a number and starts sizing to its contents.

## The measurement, re-verified against `origin/main` @ `d78d4072`

The grep in the ruling was a snapshot, so I re-ran it before editing. It holds — across all nine feed frames, `EphemeristsFeedFrame` is the only one that sets a numeric masthead height:

| frame | numeric masthead height |
|---|---|
| **EphemeristsFeedFrame** | **`height: 30` desktop, `height: 26` mobile** (`:123`, `:130`) |
| Albescent · Coven · Everymen · Faction · Singularity · Snide · UA · WOW | **none** |

One faction's dress was setting the target size of `FeedArchiveButton`, a control shared by all nine chassis.

## The seam under test

**The masthead band's own inline style declaration, read back out of the rendered markup** — plus the two numbers the shared control emits.

The failing test went red on the real defect first: `height:30px` on the band, `height:100%` on the chrome row, `min-width:24px` on the control. What is asserted is the **absence** of a height on the band, not the presence of `44px`. A test pinned to 44 would be the same magic number in a second place, and would go green again the day some control needs 46.

The harness has no DOM (`renderToStaticMarkup`, effects never run), so nothing is measured — the checkable claim is that the band declares no height and the control it holds declares a 44px minimum, which together are the whole of the fix.

## What changed

- **`EphemeristsFeedFrame`** — the band's `height` is deleted rather than raised. It sizes to its tallest child.
- **`FeedArchiveButton`** — `minWidth` / `minHeight` 24 → 44, and the `ponytail:` block naming this upgrade path is deleted. No second code path: the same control serves all nine chassis, and the other eight simply grow.
- The stale comment at the archive slot is rewritten, as is a test comment that attributed the sigil's 10–14px to the band.

## `overflow: hidden` — removed, and why

The issue asked me to work out whether it was still needed. **It is not, and it is gone.**

Once the height is intrinsic there is nothing for it to clip: the ornament is an `<svg>`, which clips its own viewport by the UA default, and the kicker carries its own `overflow: hidden` + ellipsis. So the property is inert — and an inert property that re-arms the trap the moment someone puts a height back is worse than no property. Note the other eight bands do carry `overflow: hidden`; it was never the problem on its own, only in the pairing with a fixed height.

## Consequences handled, not discovered

1. **The SVG viewBox** (the part flagged most likely to break quietly). It tracked the band's height, and `slice` crops rather than errors, so a wrong viewBox looks like a design choice. The hairline now keeps its **own** drawing box — `ruleHeight`, the same 30/26 — pinned to the band's head, with element height and viewBox height held as one number. Rendering is unchanged at every width: the scale factor is identical to before.
2. **Contrast is untouched and re-verified.** `feedArchiveControl.test.tsx` re-measures all fourteen ink/ground pairings and is green; the Ephemerists band stays at `BAND_INK`'s full strength.
3. **Nothing stretches.** `alignItems: 'center'` was already there, so the sigil, kicker, tag and time centre beside the 44px control rather than stretching to meet it.
4. **No CSS.** `index.css` is untouched. The byte budget's CSS `WARN` is **pre-existing on `main`** — I built both and the CSS asset is byte-identical (`index-yPe-UbHi.css`, 22.4 KB on each), so this PR adds zero CSS bytes.

## The number this produces

The band was 30px desktop / 26px mobile. It is now **52px on both** — the 44px control plus the band's existing `var(--space-xs)` vertical padding, which I left alone as dress. That is a real growth of the masthead and it is the visible half of this change.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (358 files, 6253 passed), `npm run build`, `npm run budget` — all run locally, all clean.

**Visual QA is outstanding.** I have no browser and no dev stack; nothing here has been looked at.

## What to eyeball

- **The masthead at 52px, on desktop and on a phone.** It is nearly double its old mobile height. Does the plate still read as a masthead over a card, or does the band now dominate the leaf below it?
- **The cornice against the taller band.** The two are meant to "read as one architectural element". `Cornice` is a fixed ~12px stack and renders identically, so the ratio of band to cornice has changed a lot. The ruling called this a real drawing question rather than a number to nudge, so I did not touch it — it may want its own proportion revisited in a follow-up.
- **The head hairline's position.** It still sits 4px from the band's top edge, exactly where it always did, because it rules the band's *head*. But the chrome row now centres in a 52px band, so the gap between the rule and the content has opened from roughly nothing to ~18px. Check whether the rule now reads as detached.
- **The dismiss ✕ itself** — that its 44px box does not crowd the timestamp beside it, and that it is no longer clipped at the band's edge on a phone.
- **The other eight frames.** They are untouched by this diff but they all grow, because the shared control grew. Their bands were already intrinsic, so this should be free — worth a glance at UA and Everymen, the two tightest pairings.

Closes #2100
