### PR TITLE
The e2e suite gets a typecheck, chained onto the script CI already runs (#1780)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "budget": "node scripts/bundle-budget.mjs",
     "measure": "node scripts/measure-load.mjs",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.e2e.json --noEmit",
     "typecheck:design-sync": "tsc -p tsconfig.design-sync.json --noEmit",
     "test": "vitest run",
     "lint": "eslint src .ds-kit e2e",

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,0 +1,30 @@
+// Typecheck for the Playwright suite (issue #1780).
+//
+// `tsconfig.json` is `include: ["src"]`, so nothing in CI has ever looked at
+// `frontend/e2e/`. That matters because the suite is not all thin driver:
+// `contrastScan.ts`, `contrastBaseline.ts` and `triageFindings` hold real
+// decisions, and #1762 changed `BaselineEntry.ratio` across two of them with
+// no check able to catch getting it wrong.
+//
+// A separate config rather than widening `tsconfig.json`'s `include`: the
+// specs import `@playwright/test`, and the app's own build graph must not
+// reach a test-runner package. Same reasoning, and the same shape, as
+// `tsconfig.design-sync.json`.
+//
+// Wired into CI by being chained onto the `typecheck` npm script, which the
+// `frontend` job already runs as its "Typecheck (tsc --noEmit)" step —
+// `.github/workflows/**` is owner-only, so this needed no workflow edit.
+//
+// This does NOT put the Playwright *run* on the PR-blocking path; that is
+// nightly-only on purpose (see `e2e.yml`'s header). Only the compiler runs here.
+{
+  "extends": "./tsconfig.json",
+  // `e2e` only. Files under `src` still arrive — the contrast modules import
+  // `src/utils/contrast` — but they arrive as dependencies of the specs,
+  // checked with the same options `npm run typecheck` already applies to them.
+  "include": ["e2e"],
+  // `tsconfig.json` references `tsconfig.node.json`, which is `composite` and
+  // owns `vite.config.ts`. Nothing under `e2e` needs it, and inheriting the
+  // reference makes this config depend on a build artifact it never reads.
+  "references": []
+}


### PR DESCRIPTION
`frontend/tsconfig.json` is `include: ["src"]`, so no CI step has ever compiled `frontend/e2e/`. That is the gap #1780 records: `contrastScan.ts`, `contrastBaseline.ts` and `triageFindings` are not thin drivers, they hold real decisions, and #1762 changed `BaselineEntry.ratio` across two of them with nothing in CI able to catch getting it wrong.

## What this does

Two files.

- **`frontend/tsconfig.e2e.json`** (new) — extends the app's compiler options, `include: ["e2e"]`, `references: []`. `@playwright/test` resolves because the config sits in `frontend/`, next to the only `node_modules` in the repo. Same shape and same reasoning as the existing `tsconfig.design-sync.json`.
- **`frontend/package.json`** — `"typecheck": "tsc --noEmit && tsc -p tsconfig.e2e.json --noEmit"`.

Deliberately **not** widening `tsconfig.json`'s `include`: that pulls `e2e/` into the app's own build graph, and the specs import `@playwright/test`, which the app must not reach.

## No workflow edit

`.github/workflows/**` is owner-only in this repo (`deny_ci_config_edits.py` blocks agent writes; `main` auto-deploys). So this chains onto the `typecheck` npm script instead of adding a step — the `frontend` job already runs `npm run typecheck` as its "Typecheck (tsc --noEmit)" step, so the coverage lands today with no diff Molly has to sign. `test.yml` is untouched.

The Playwright **run** stays nightly-only, as ruled. Only the compiler moves onto the PR path; it adds a couple of seconds.

## The seam being tested

The seam is the CI wiring itself — "does `npm run typecheck` compile `frontend/e2e/**`" — not any product behaviour. A config that includes nothing passes vacuously, which is the exact false green this repo has been bitten by, so both directions are proven:

- **It sees the files.** `tsc -p tsconfig.e2e.json --listFiles` lists all 11 files under `e2e/` (9 specs/helpers + `contrastScan.ts` + `contrastBaseline.ts`), plus `src/utils/contrast.ts` pulled in as a dependency. Nothing else from `src`.
- **It fails on a real error.** With a planted `const x: number = fn()` returning `string` in `smoke.spec.ts`, `npm run typecheck` exits 2 with `e2e/smoke.spec.ts(42,7): error TS2322`. Reverted before commit.
- `tsc --version` → 5.9.3, confirmed running (a wrong `node_modules` junction depth silently makes the binary absent and reports a false pass).

## It found zero errors

The suite is genuinely clean under the app's `strict` options today — no `// @ts-expect-error`, no loosened flags, no config carve-outs. That is a slightly boring result but it is the honest one: #1762's agent typechecked by hand, and the guard now keeps that true without anyone remembering to.

## The rotting count

The issue records `contrastBaseline.ts`'s header claiming 269 entries when the file held 241. **It has since been corrected** — the header now says 185 and `RENDERED_BASELINE` holds exactly 185. Nothing to fix, so nothing changed here.

## Local runs (every step `test.yml`'s `frontend` job names)

| Step | Result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean — **now covers `e2e/`** |
| `npm run typecheck:design-sync` | clean |
| `npm test` | 358 files, 6249 passed, 1 skipped |
| `npm run build` | built in 5.16s |
| `npm run budget` | JS ok; CSS WARN 22.4 KB (pre-existing on `main`, non-blocking — this PR touches zero CSS) |

The `test` (backend) and `api-schema` jobs are untouched by this diff — no Python, no API client, no generated artifact.

## What to eyeball

**Nothing visual. This is CI-only** — no component, no route, no style, no user-facing surface. Browser QA is N/A rather than outstanding.

What is worth a reviewer's eye is the wiring judgement, not pixels:

1. **The chained script rather than a CI step.** `"typecheck": "tsc --noEmit && tsc -p tsconfig.e2e.json --noEmit"` — if you would rather see this as its own named step in `test.yml`, that is an owner edit and I have not made it. The trade is one line here vs. a legible step name in the job log.
2. **`references: []` in `tsconfig.e2e.json`.** Dropped so the config does not inherit a dependency on `tsconfig.node.json`'s composite build info, which nothing under `e2e/` reads.
3. **`include: ["e2e"]` excludes `playwright.config.ts`**, which is still in no tsconfig. Left alone as out of scope — say the word and it is a one-word diff.

Closes #1780
