### PR TITLE
The praxis-card byline portrait moves to the left of the name (#2309)

### DIFF
--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -141,7 +141,7 @@ describe('the byline portrait (#888)', () => {
  *
  * What stays here is the part that is still only about this portrait.
  */
-describe('the byline name is not shaved against its portrait (#1633)', () => {
+describe('the byline name is not shaved against its portrait (#1633, #2309)', () => {
   const nameLink = (html: string) => html.match(/<a [^>]*>/)?.[0] ?? ''
   const byline = (name: string) =>
     nameLink(render(<PraxisByline praxis={praxis({ created_by_display_name: name })} />))
@@ -151,12 +151,66 @@ describe('the byline name is not shaved against its portrait (#1633)', () => {
     // can carry ink past its own advance width — the Ephemerists card sets this
     // line in Poiret One — and the 8px is what gives that overhang somewhere to
     // land instead of being shaved flush against the portrait beside it.
-    expect(byline('Isolde')).toContain('padding-inline-end:var(--space-sm)')
+    //
+    // #2309 moved the portrait to the name's LEFT, so the same 8px is now the
+    // name's INLINE-START padding. It stayed on the name and stayed logical:
+    // what it buys is a glyph's overhang, which is a property of the name.
+    expect(byline('Isolde')).toContain('padding-inline-start:var(--space-sm)')
     // Still true of a name long enough to reach the portrait, which is the only
     // case where it is observable.
     expect(byline('Bartholomew Featherstonehaugh-Wentworth')).toContain(
-      'padding-inline-end:var(--space-sm)',
+      'padding-inline-start:var(--space-sm)',
     )
+    // And it is not quietly the old side as well.
+    expect(byline('Isolde')).not.toContain('padding-inline-end')
+  })
+})
+
+/**
+ * #2309 — owner ruling on a screenshot of the Ephemerists card: the portrait
+ * goes to the LEFT of the name. The faction tag keeps the far edge, the slot the
+ * score vacated in #888.
+ *
+ * The seam is `PraxisByline`'s own markup, and it has to be: no DOM and no
+ * layout here, so what is observable is source ORDER — which is what decides
+ * the painted order inside a plain flex row that sets no `order`.
+ */
+describe('the byline reads portrait, then name, then faction tag (#2309)', () => {
+  const bylineAt = (path: string) =>
+    renderToStaticMarkup(
+      <MemoryRouter initialEntries={[path]}>
+        <PraxisByline
+          praxis={praxis({
+            created_by_avatar_url: 'avatars/isolde.png',
+            created_by_faction_slug: 'coven',
+            task_faction_slug: 'ua',
+          })}
+        />
+      </MemoryRouter>,
+    )
+  // `>Isolde<` is the name's own text node: the portrait's `alt` carries the
+  // same string, so a bare indexOf would match the img and prove nothing.
+  const nameAt = (html: string) => html.indexOf('>Isolde<')
+
+  it('puts the portrait before the name when the name is a link', () => {
+    const html = bylineAt('/praxis/1')
+    expect(html, 'the link branch').toContain('<a ')
+    expect(nameAt(html), 'the name renders').toBeGreaterThan(-1)
+    expect(html.indexOf('<img')).toBeLessThan(nameAt(html))
+  })
+
+  it("puts the portrait before the name on the author's own page (#2125)", () => {
+    // The plain-text branch renders a different element, so the order has to be
+    // asserted against it too — one of the two is where #2132 was reported.
+    const html = bylineAt('/characters/7')
+    expect(html, 'the plain-text branch').not.toContain('<a ')
+    expect(html.indexOf('<img')).toBeLessThan(nameAt(html))
+  })
+
+  it('leaves the faction tag on the far edge', () => {
+    const html = bylineAt('/praxis/1')
+    expect(html).toContain('Cozy Coven')
+    expect(nameAt(html)).toBeLessThan(html.indexOf('Cozy Coven'))
   })
 })
 

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -280,13 +280,19 @@ function authorAsCharacter(praxis: PraxisCardOut): CharacterOut {
 const BYLINE_PORTRAIT_SIZE = 28;
 
 /**
- * Slot: the author byline (dashed rule on top) — name, portrait, faction tag.
+ * Slot: the author byline (dashed rule on top) — portrait, name, faction tag.
  *
  * The praxis TOTAL used to sit at the right of this row. It is gone (#888,
  * closing #663): the score stamp is the card's sole owner of that number, and
  * a card that states its total twice invites the reader to check whether the
- * two agree. The portrait takes the name's right-hand side; the author's
- * faction tag takes the far edge the score vacated.
+ * two agree. The author's faction tag takes the far edge the score vacated,
+ * and it keeps it.
+ *
+ * The portrait led the name's right-hand side and now LEADS the row (#2309,
+ * owner ruling on the Ephemerists card): a face before a name is how every
+ * other byline on the site reads. Source order is the whole change — the row
+ * is a plain flex line that sets no `order` — plus the side the name's own
+ * separation padding sits on.
  */
 export function PraxisByline({
   praxis,
@@ -325,7 +331,10 @@ export function PraxisByline({
   // anchor: how the name yields, and the padding that keeps it off the glyphs
   // (#1633 — that 8px lives here rather than as `gap` on the row because a
   // display face's final glyph can carry ink past its own advance width, and
-  // the Ephemerists card sets this line in Poiret One).
+  // the Ephemerists card sets this line in Poiret One). With the portrait now
+  // leading the row (#2309) the same 8px is the name's INLINE-START padding:
+  // it flipped side, it did not become a `gap`, because what it buys is a
+  // glyph's overhang and that belongs to the name.
   //
   // #2132 — THE NAME WRAPS; it used to ellipsize, and the ellipsis was the
   // defect. `overflow: hidden` + `white-space: nowrap` is a bound on how the
@@ -354,7 +363,7 @@ export function PraxisByline({
   const nameStyle: CSSProperties = {
     fontFamily: fonts?.display,
     overflowWrap: "anywhere",
-    paddingInlineEnd: "var(--space-sm)",
+    paddingInlineStart: "var(--space-sm)",
   };
   return (
     <div
@@ -379,9 +388,13 @@ export function PraxisByline({
     >
       {/*
        * No `gap` here on purpose (#1633) — the separation from the portrait is
-       * carried as padding on the name itself. See the link below.
+       * carried as padding on the name itself. See `nameStyle` above.
        */}
       <span className="flex items-center" style={{ minWidth: 0 }}>
+        <FactionAvatar
+          character={authorAsCharacter(praxis)}
+          size={BYLINE_PORTRAIT_SIZE}
+        />
         {/*
          * A person's name is readable text, not scanned chrome: content tier
          * (18px). It ties the task link's size, and separates from it by
@@ -402,10 +415,6 @@ export function PraxisByline({
             {authorName}
           </Link>
         )}
-        <FactionAvatar
-          character={authorAsCharacter(praxis)}
-          size={BYLINE_PORTRAIT_SIZE}
-        />
       </span>
       {showFaction && (
         <span


### PR DESCRIPTION
The praxis-card byline reads `[name][portrait] … [faction tag]`. The owner's
ruling on a screenshot of the Ephemerists card is that the portrait goes to the
LEFT: `[portrait][name] … [faction tag]`.

`PraxisByline` in `frontend/src/components/praxisCard/shared.tsx` has exactly one
mount (`PraxisBody` in `praxisCard/desktop/shared.tsx`) and every faction praxis
card renders through it, so this lands on all nine skins at once, in both form
factors (ADR-0067: one card, no mobile twin).

## The change

Two lines of substance:

1. `<FactionAvatar>` moves ahead of the two name branches inside the same inner
   span. Source order is the whole of it — the row is a plain flex line that sets
   no `order`.
2. #1633's 8px separation flips from `paddingInlineEnd` to `paddingInlineStart`.
   It stays **on the name** and stays a **logical property**, and deliberately
   does not become a `gap` on the row: what it buys is a display face's final
   glyph carrying ink past its own advance width (the Ephemerists card sets this
   line in Poiret One), which is a property of the name, not of the row.

Both name branches take it — the `<Link>` and the plain `<span>` used on the
author's own character page (#2125) — because `nameStyle` is shared by the two.

Untouched, each load-bearing: `overflowWrap: "anywhere"` (#2132 — `break-word`
is not a substitute, the two differ in exactly the property that bug was about),
`minWidth: 0` on the inner span, `BYLINE_PORTRAIT_SIZE = 28`, and the faction
tag's far edge (the slot the score vacated in #888).

Praxis DETAIL is out of scope and is not touched: it deliberately mounts no
`FactionAvatar` (#2106), and `pages/praxisDetail/__tests__/bylinePortrait.test.tsx`
still guards that.

## The seam under test

`PraxisByline`'s own emitted markup. The harness has no DOM and no layout, so
what is observable is source ORDER and the declaration on the name — which is
exactly what decides the painted order in a flex row that sets no `order`. The
test went red first on all three counts (portrait after the name in both
branches, `padding-inline-end` on the name) and is green now:

- `src/components/praxisCard/__tests__/cardChrome.test.tsx` — the #1633 case flips
  to `padding-inline-start` and now also asserts the old side is gone; a new
  `#2309` block pins portrait-before-name in both branches and the faction tag on
  the far edge as a regression guard. Order is asserted against the name's own
  text node (`>Isolde<`) because the portrait's `alt` carries the same string.
- `src/components/__tests__/displayNameMinContent.test.tsx` (#2132) passes
  unchanged on both branches — the wrap guarantee is untouched.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally: `npm run
lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(358 files, 6263 passed), `npm run build`, `npm run budget`.

**Byte budget: zero delta.** No CSS file is touched, and I measured it rather
than assuming — the blocking sheet is 22918 B gzip-9 on this branch and 22918 B
with the two files reverted to `origin/main`. CSS stays at the WARN `main`
already carries (22.4 KB vs the 22.2 KB line); this change does not move it.

**Visual QA is outstanding.** I have no browser and no dev stack, so nothing here
has been looked at — only tests, tsc, eslint and the build.

## What to eyeball

- The byline on a praxis card reads portrait, then name, then the author's
  faction tag at the far right — on all nine skins, light and dark.
- The gap between portrait and name looks the same size as before (8px), and the
  Ephemerists card's Poiret One name is not shaved against the portrait now that
  the padding is on its leading edge.
- The faction tag has not moved off the far edge.
- A ~30-character display name still wraps inside the card at 375px and at
  desktop width, rather than inflating the card or the embedded video past the
  viewport (#2132).
- The author's own character page, where the name is plain text rather than a
  link: same order, same spacing.
- A monogram (no uploaded avatar) sits in the same leading slot as a photo.

Closes #2309
