### PR TITLE
Two praxis to a row on a faction page: six archetypes stop reinventing the basis (#2313)

### DIFF
--- a/frontend/src/pages/factionDetail/__tests__/factionDetailResponsive.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/factionDetailResponsive.test.tsx
@@ -320,3 +320,37 @@ describe('UA carries no gold at either width', () => {
     })
   }
 })
+
+/**
+ * The praxis row wraps at TWO on a faction page, not three (#2313).
+ *
+ * The seam is the flex BASIS each archetype emits on the praxis card's wrapper.
+ * Six of the eight hardcoded `1 1 280px` there — a second number beside the one
+ * `frameBase` already asks for, and 280 is the card's own MIN-WIDTH, the floor
+ * that keeps a phone at one card per row. Used as a basis it says where the row
+ * WRAPS, so three of them fitted the ~956px main column.
+ *
+ * CEILING (`renderToStaticMarkup`, no jsdom, no layout, no computed styles):
+ * nothing here can be MEASURED, so this asserts the declaration rather than a
+ * box. The arithmetic it stands in for: `--shell-max-width` 1392px less `px-10`
+ * a side, with `.wz-faction-grid` at `1fr 322px` and a 34px gap, tops the main
+ * column near 956px — under the 1182px three 394px cards need and under the
+ * 992px three 320px ones need, so the row wraps at two at every supported width.
+ *
+ * The NEGATIVE is the load-bearing half: it is what stops a ninth archetype, or
+ * a rebase, reintroducing a hardcoded basis on whatever wrapper it writes.
+ */
+describe('the faction praxis row asks the container where to wrap (#2313)', () => {
+  for (const slug of SLUGS) {
+    it(`${slug} takes its praxis basis from --praxis-card-basis`, () => {
+      const { html } = page(slug, 'desktop')
+      expect(html, 'the container decides the basis').toContain(
+        'flex:1 1 var(--praxis-card-basis, 394px)',
+      )
+      expect(html, 'no archetype reinvents the basis as the min-width floor').not.toContain(
+        '1 1 280px',
+      )
+      expect(html, 'the 280px floor stays').toContain('min-width:280px')
+    })
+  }
+})

--- a/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/CovenFactionBody.tsx
@@ -212,7 +212,7 @@ export default function CovenFactionBody({ state }: { state: FactionDetailState 
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-xl)", alignItems: "flex-start" }}>
               {recentPraxis.map((praxis) => (
-                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 var(--praxis-card-basis, 394px)", minWidth: 280 }}>
                   {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
                       so the card's built-in stamp is suppressed. */}
                   {praxis.is_top_for_task && (

--- a/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EphemeristsFactionBody.tsx
@@ -253,7 +253,7 @@ export default function EphemeristsFactionBody({ state }: { state: FactionDetail
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-lg)", alignItems: "flex-start" }}>
               {recentPraxis.map((praxis) => (
-                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 var(--praxis-card-basis, 394px)", minWidth: 280 }}>
                   {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
                       so the card's built-in stamp is suppressed. */}
                   {praxis.is_top_for_task && (

--- a/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/EverymenFactionBody.tsx
@@ -306,7 +306,7 @@ export default function EverymenFactionBody({ state }: { state: FactionDetailSta
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-lg)", alignItems: "flex-start" }}>
               {recentPraxis.map((praxis) => (
-                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 var(--praxis-card-basis, 394px)", minWidth: 280 }}>
                   {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
                       so the card's built-in stamp is suppressed. */}
                   {praxis.is_top_for_task && (

--- a/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SingularityFactionBody.tsx
@@ -268,7 +268,7 @@ export default function SingularityFactionBody({ state }: { state: FactionDetail
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-lg)", alignItems: "flex-start" }}>
               {recentPraxis.map((praxis) => (
-                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 var(--praxis-card-basis, 394px)", minWidth: 280 }}>
                   {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
                       so the card's built-in stamp is suppressed. */}
                   {praxis.is_top_for_task && (

--- a/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/SnideFactionBody.tsx
@@ -313,7 +313,7 @@ export default function SnideFactionBody({ state }: { state: FactionDetailState 
           ) : (
             <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-lg)", alignItems: "flex-start" }}>
               {recentPraxis.map((praxis) => (
-                <div key={praxis.id} style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}>
+                <div key={praxis.id} style={{ position: "relative", flex: "1 1 var(--praxis-card-basis, 394px)", minWidth: 280 }}>
                   {/* ⑤ Task Crown (ADR-0028) — the skin's own corner medallion,
                       so the card's built-in stamp is suppressed. */}
                   {praxis.is_top_for_task && (

--- a/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
+++ b/frontend/src/pages/factionDetail/archetypes/UaFactionBody.tsx
@@ -280,7 +280,7 @@ export default function UaFactionBody({ state }: { state: FactionDetailState }) 
               {recentPraxis.map((praxis) => (
                 <div
                   key={praxis.id}
-                  style={{ position: "relative", flex: "1 1 280px", minWidth: 280 }}
+                  style={{ position: "relative", flex: "1 1 var(--praxis-card-basis, 394px)", minWidth: 280 }}
                 >
                   {/* Task Crown (ADR-0028) — the skin's own corner medallion,
                       so the card's built-in stamp is suppressed. */}


### PR DESCRIPTION
Six of the eight faction archetypes wrapped their praxis card in a hardcoded
flex item — `flex: "1 1 280px", minWidth: 280` — instead of the basis
`frameBase` already asks for. 280 is the card's own MIN-WIDTH, the floor
`index.css` calls "the floor that keeps a phone at one card per row"; used as a
BASIS it is where the row wraps, which is what fitted three cards to the
faction page's main column. Each wrapper now carries the one number the card
already asks the container for:

    flex: "1 1 var(--praxis-card-basis, 394px)"

`position: relative` and `minWidth: 280` stay — the wrapper exists to anchor the
archetype's Task Crown, and the 280px floor is still the phone's guarantee. No
third number is minted, no fixed width, no grid.

Changed: `CovenFactionBody` · `EphemeristsFactionBody` · `EverymenFactionBody` ·
`SingularityFactionBody` · `SnideFactionBody` · `UaFactionBody`.

Verified rather than edited, and both are already correct: `WowFactionBody`
renders into `className="praxis-gallery"` (320px basis) and `DefaultFactionBody`
into a plain wrap row with no override (394px default). `.praxis-gallery` on the
task-detail page is untouched and still fits three.

## Why two is stable

`--shell-max-width` 1392px, less `px-10` a side, with `.wz-faction-grid` at
`1fr 322px` and a 34px gap, tops the main column near 956px. Three cards at
394px need 1182px; three at 320px need 992px. Neither fits at any supported
width, so the row wraps at two everywhere and degrades to one below 860px where
the grid goes single-column. A lone praxis still grows to fill its row — that is
`frameBase`'s existing `flex-grow: 1`, unchanged. #2229's half-the-row cap is a
different surface and out of scope.

## The seam under test

The emitted flex basis on the praxis wrapper in each archetype. The guard
appended to `factionDetail/__tests__/factionDetailResponsive.test.tsx` renders
all eight faction pages through the existing harness and asserts each emits
`flex:1 1 var(--praxis-card-basis, 394px)`, keeps `min-width:280px`, and emits
NO `1 1 280px`. The negative is the load-bearing half — it is what stops a ninth
archetype reintroducing the floor as a basis. Confirmed non-vacuous by putting
the old value back on Coven: the guard goes red on that faction only.

The harness has no DOM (`renderToStaticMarkup`, no layout, no computed styles),
so this asserts the DECLARATION, not a rendered box. The arithmetic above is the
part a test cannot see.

## Checks

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`,
`npm test` (358 files / 6268 passed), `npm run build`, `npm run budget` all
green locally. The budget's CSS WARN (22.4 KB against a 22.2 KB line) is
pre-existing on `main` — this PR touches zero CSS, so the delta is 0 B on both
assets.

**Visual QA is outstanding.** No browser and no dev stack here; everything above
is tests, tsc and eslint.

## Downstream, not fixed here

#2315 (Ephemerists vote discs squishing at 280px) can now be verified against a
card that is not the reported one: widening this surface takes the Ephemerists
vote plate over its 372px container-query threshold, so the faction page stops
squeezing. That is NOT the fix for #2315 — the praxis card is one card on every
surface (ADR-0067) and is still narrow on the character profile and at 375px.

## Collision note

#2311 adds disclosures to the Tasks and Praxis headings across the same eight
archetypes. This diff is one line per file, on the wrapper only, so the rebase
is a no-op on the heading lines.

## What to eyeball

- `/factions/coven`, `/factions/ephemerists`, `/factions/everymen`,
  `/factions/singularity`, `/factions/snide`, `/factions/ua` at 1440px and at
  1280px — the Praxis section should read TWO cards to a row, not three.
- `/factions/wow` (320px basis) and `/factions/albescent` (the Default
  fall-through, 394px) at the same widths — unchanged, and also two to a row.
- Any of the six at ~900px, where `.wz-faction-grid` collapses — one card per
  row, nothing narrower than 280px, no sideways overflow.
- At 375px — still one per row, unchanged.
- The Task Crown medallion on a top-for-task praxis, on each of the six: it must
  still sit on the card's own corner, not drift now that the wrapper is wider.
- A faction page whose Praxis section holds exactly ONE card — it should still
  grow across the row, as it does today.
- `/tasks/<id>` — `.praxis-gallery` must still fit three; this PR must not have
  moved it.

Closes #2313
