### PR TITLE
Delete the Recent Invitations panel from the factions directory, both form factors (#2310)

### DIFF
--- a/.design-sync/previews/_state.tsx
+++ b/.design-sync/previews/_state.tsx
@@ -124,7 +124,6 @@ export function factionsDirectoryState(): FactionsDirectoryState {
   return {
     factions: factionOuts,
     factionPage: null,
-    invitations: [],
     loading: false,
     error: null,
   }

--- a/frontend/src/__tests__/factionHueAsInkMounts.test.tsx
+++ b/frontend/src/__tests__/factionHueAsInkMounts.test.tsx
@@ -15,23 +15,23 @@
  *   - `TaskCard` and the task details reach the hue through `surfaceMap`
  *     dispatch, off a *different* faction's slug (`metatask_faction_slug`) than
  *     the one dressing the page: eight hues against nine grounds.
- *   - the two invitation rows put the hue in a `<Trans>` interpolation component,
- *     where the ink and the copy are assembled in different files.
  *
  * WHY BOTH HALVES ARE ASSERTED. The careless sweep here is not "miss one ink" —
  * it is "strip the colour". These surfaces are meant to be loudly faction-coded,
  * and every one of them keeps the hue on its fill, wash, rule or border. A guard
  * that only forbade would be satisfied by deleting the identity.
  *
- * ONE OF THE TWELVE SITES IS NOT REACHABLE FROM HERE, and it is the clearest
- * argument for shipping the lint rule beside this file. `pages/Factions.tsx`
- * draws the desktop invitation row inside `invitationsExpanded &&`, whose
- * `useState` starts false — and this harness has no DOM, so no click can open
- * it (§ the mobile twin is a pure view component and IS rendered below). A
- * render guard cannot see a state no route walk produces, which is #694's
- * lesson: "the surface is skinned by a faction" is not the same claim as "the
- * sweep has been there". `local/no-faction-hue-as-ink` reads it out of the
- * source and does not care whether it renders.
+ * TWO MORE SITES ARE GONE RATHER THAN FIXED, and their section with them: the
+ * pair of "Recent Invitations" rows, desktop (`pages/Factions.tsx`) and mobile
+ * (`FactionsDirectoryView`). #2310 deleted that panel from both form factors —
+ * the letter is already actionable on the Updates feed card, the faction detail
+ * page and the arrival popup, so the row carried no action of its own. The
+ * desktop one was never reachable from this harness anyway (it sat inside
+ * `invitationsExpanded &&`, a `useState` starting false, and there is no DOM
+ * here to click the toggle) — which was the clearest argument for shipping
+ * `local/no-faction-hue-as-ink` beside this file: the rule reads source and does
+ * not care whether a surface renders. That argument stands; only the specimen is
+ * gone.
  *
  * ONE GROUP OF SITES IS GONE RATHER THAN FIXED, and its section with it. Three
  * of #2077's twelve were `StatusBadge` / `InvitationNote` inside
@@ -46,8 +46,8 @@
  *
  * A NOTE ON WHICH FACTION THE FIXTURES USE. `ephemerists` is the metatask
  * faction throughout, because #2068 handed it the plate brass and that is the
- * slot that fails — 2.19:1 on the app's page in light, 2.04:1 on the faction
- * wash the invitation rows lay down. It is a fixture choice and NOT the subject:
+ * slot that fails — 2.19:1 on the app's page in light. It is a fixture choice
+ * and NOT the subject:
  * the slot changed hands once already (WOW vacated it, 1.96 -> 5.80), so the
  * loops below walk every slug and the assertion is about the ROLE.
  */
@@ -56,7 +56,6 @@ import { MemoryRouter } from 'react-router-dom'
 import type { ReactElement } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import '../i18n'
-import type { InvitationLetterOut } from '../api/factions'
 import type { TaskOut } from '../api/tasks'
 import type { TaskDetailState } from '../pages/taskDetail/useTaskDetail'
 import { fillUses, inkOffenders } from '../utils/__tests__/inkSeam'
@@ -73,7 +72,6 @@ vi.mock('../auth/AdminModeContext', () => ({
 import TaskCard from '../components/taskCard/TaskCard'
 import { surfaceMap } from '../factions'
 import DefaultTaskDetail from '../pages/taskDetail/archetypes/DefaultTaskDetail'
-import FactionsDirectoryView from '../pages/factions/mobileArchetypes/FactionsDirectoryView'
 
 function render(element: ReactElement): string {
   return renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
@@ -183,51 +181,5 @@ describe('every task-detail metatask byline reads its own surface (#2077)', () =
     // `PINK_INK` rather than the hue. Counting here is what stops a future
     // reader trusting the report's number over the registry's.
     expect(Object.keys(DETAILS).length).toBeGreaterThanOrEqual(9)
-  })
-})
-
-// ── The two invitation rows ────────────────────────────────────────────────
-
-const LETTERS: InvitationLetterOut[] = SLUGS.filter((slug) => slug !== 'na').map((slug) => ({
-  faction_slug: slug,
-  delivered_at: '2026-01-01T00:00:00Z',
-  note: 'Come and see',
-}))
-
-describe('the invitation rows mark the faction name by WEIGHT, not hue (#2077)', () => {
-  it('mobile: the directory view inks no faction name in its own hue', () => {
-    const html = render(
-      <FactionsDirectoryView
-        factions={LETTERS.map(({ faction_slug }) => ({ slug: faction_slug, status: 'visible' }))}
-        factionPage={null}
-        invitations={LETTERS}
-        loading={false}
-        error={null}
-        unaffiliated
-        onVisit={() => {}}
-      />,
-    )
-    expect(inkOffenders(html)).toEqual([])
-    // The row's wash and its 3px left rule are the hue's, and they are what make
-    // the row readable AS an invitation from that faction.
-    expect(fillUses(html).length).toBeGreaterThan(0)
-  })
-
-  it('the name still carries a weight of its own', () => {
-    // The fix deletes a `color` from a two-declaration span. Delete the other
-    // one by accident and the name stops being marked out at all — which no ink
-    // assertion would notice.
-    const html = render(
-      <FactionsDirectoryView
-        factions={[{ slug: META_SLUG, status: 'visible' }]}
-        factionPage={null}
-        invitations={[LETTERS[0]]}
-        loading={false}
-        error={null}
-        unaffiliated
-        onVisit={() => {}}
-      />,
-    )
-    expect(html).toContain('font-weight:700')
   })
 })

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -23,9 +23,6 @@
   },
   "index": {
     "loading": "Loading...",
-    "recentInvitations": "Recent Invitations ({{count}})",
-    "inviteBadge": "INVITE",
-    "invitedToJoin": "You've been invited to join <1>{{faction}}</1>",
     "loggedOutHint": "Everyone starts unaffiliated. Earn an invitation through task work to join a faction."
   },
   "detail": {

--- a/frontend/src/pages/Factions.tsx
+++ b/frontend/src/pages/Factions.tsx
@@ -1,13 +1,9 @@
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Trans, useTranslation } from 'react-i18next'
-import type { InvitationLetterOut } from '../api/factions'
+import { useTranslation } from 'react-i18next'
 import PageTitle from '../components/ui/PageTitle'
 import FactionSelectCard from '../components/selectCard/FactionSelectCard'
 import type { SelectState } from '../components/selectCard/FactionSelectCard'
 import { extractError } from '../utils/errors'
-import { factionCssVar, factionName } from '../utils/factions'
-import { relativeTime } from '../utils/dates'
 import { useAuth } from '../auth/AuthContext'
 import { useFormFactor } from '../hooks/useFormFactor'
 import DefaultFactionsDirectory from './factions/mobileArchetypes/DefaultFactionsDirectory'
@@ -46,17 +42,17 @@ export default function Factions() {
   return <DesktopFactions state={state} />
 }
 
-function DesktopFactions({ state }: { state: FactionsDirectoryState }) {
+/** Exported for tests: the desktop grid over a controlled directory state, the
+ *  same seam `FactionsDirectoryView` gives the phone skin. The page's own fetch
+ *  lives in `useFactionsDirectory`, above the form-factor switch. */
+export function DesktopFactions({ state }: { state: FactionsDirectoryState }) {
   const { t } = useTranslation('factions')
   const { user } = useAuth()
   const character = user?.character ?? null
   const navigate = useNavigate()
 
-  const { factions, factionPage, invitations, loading } = state
+  const { factions, factionPage, loading } = state
   const error = state.error ? extractError(state.error, 'Could not load factions.') : null
-
-  // Invitations panel (collapsed by default once each card surfaces its own status)
-  const [invitationsExpanded, setInvitationsExpanded] = useState(false)
 
   const statusFor = (slug: string): string => {
     if (!factionPage) return STATUS_NOT_INVITED
@@ -65,12 +61,6 @@ function DesktopFactions({ state }: { state: FactionsDirectoryState }) {
   }
 
   if (loading) return <div className="py-8 font-body text-muted">{t('index.loading')}</div>
-
-  // Index invitations by slug for quick per-card lookup
-  const invitationBySlug: Record<string, InvitationLetterOut> = {}
-  for (const letter of invitations) {
-    invitationBySlug[letter.faction_slug] = letter
-  }
 
   // Build the visible faction list (exclude hidden system factions)
   const visibleFactions = factions.filter((f) => !HIDDEN_SLUGS.has(f.slug))
@@ -89,12 +79,25 @@ function DesktopFactions({ state }: { state: FactionsDirectoryState }) {
     return sa - sb
   })
 
-  // Map the invite-gated status (+ any open letter) to the select-card's
-  // three-state model. Joining itself happens on the faction detail page.
+  // Map the invite-gated status to the select-card's three-state model. Joining
+  // itself happens on the faction detail page.
+  //
+  // The status alone decides it. There used to be a third `|| invitationBySlug[slug]`
+  // arm here; #2310 removed it after checking that a held letter can never land
+  // outside the two states above. `get_invitation_status` (backend
+  // services/faction_service.py) builds the status map and the letters list from
+  // ONE `InvitationLetter` select in one response (#1384), so the two cannot skew:
+  // `invited_slugs` IS the letter set. Of the branches that can win ahead of
+  // `invited` in that map, `member` and `can_return` are both handled above, and
+  // `defected` cannot hold a letter at all since #2218 — walking out of a
+  // non-rejoinable faction DELETES its letter (`defect_to_faction`) and
+  // `maybe_deliver_invitations` subtracts `unjoinable_faction_slugs` before
+  // posting a new one. So a letter implies member / can_return / invited, and the
+  // arm could only ever re-derive `eligible` for a card already reading it.
   const selectState = (slug: string): SelectState => {
     const status = statusFor(slug)
     if (status === STATUS_MEMBER) return 'member'
-    if (status === STATUS_INVITED || status === STATUS_CAN_RETURN || invitationBySlug[slug]) return 'eligible'
+    if (status === STATUS_INVITED || status === STATUS_CAN_RETURN) return 'eligible'
     return 'locked'
   }
 
@@ -104,80 +107,6 @@ function DesktopFactions({ state }: { state: FactionsDirectoryState }) {
 
       {error && (
         <p className="font-body content-text danger-text border-2 danger-edge px-3 py-2 mb-4">{error}</p>
-      )}
-
-      {/* Invitation letters — collapsible; each card also surfaces its own status below */}
-      {character && invitations.length > 0 && (
-        <div className="mb-6">
-          <button
-            onClick={() => setInvitationsExpanded((v) => !v)}
-            className="label-heading"
-            style={{
-              background: 'transparent',
-              border: 'none',
-              padding: 0,
-              cursor: 'pointer',
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: 'var(--space-sm)',
-              marginBottom: invitationsExpanded ? 'var(--space-sm)' : 0,
-            }}
-            aria-expanded={invitationsExpanded}
-          >
-            <span>{invitationsExpanded ? '▾' : '▸'}</span>
-            <span>
-              {t('index.recentInvitations', { count: invitations.length })}
-            </span>
-          </button>
-          {invitationsExpanded && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
-              {invitations.map((inv) => {
-                return (
-                  <div
-                    key={inv.faction_slug}
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 'var(--space-sm)',
-                      padding: 'var(--space-sm) var(--space-md)',
-                      background: `linear-gradient(135deg, ${factionCssVar(inv.faction_slug, 'light')}, transparent)`,
-                      borderLeft: `3px solid ${factionCssVar(inv.faction_slug, 'border')}`,
-                    }}
-                  >
-                    <span className="label-caption">{t('index.inviteBadge')}</span>
-                    <span className="font-body" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)', flex: 1 }}>
-                      <Trans
-                        t={t}
-                        i18nKey="index.invitedToJoin"
-                        values={{ faction: factionName(inv.faction_slug) }}
-                        components={[
-                          <span key="0" />,
-                          // WEIGHT, NOT HUE (#2077). The faction name used to
-                          // print `factionCssVar(slug)` — the bare spine hue,
-                          // which is a FILL (§3, #1932). The row already lays
-                          // that hue down as a wash and rules its left edge in
-                          // it; measured ON that wash over the page, the hue as
-                          // ink is 2.04:1 for the Ephemerists brass, 2.41 for
-                          // the S.N.I.D.E. acid, 2.59 Coven, 3.80 UA, 4.12
-                          // Singularity and 4.26 for `na` in light — six of
-                          // eight under AA, and all eight clear in dark, which
-                          // is the cascade tell #1932 names. The ink inherited
-                          // from the parent span is `--color-text-primary` at
-                          // 14.26–16.44:1 on the same wash. `fontWeight: 700`
-                          // is what still marks the name out.
-                          <span key="1" style={{ fontWeight: 700 }} />,
-                        ]}
-                      />
-                    </span>
-                    <span className="label-caption">
-                      {relativeTime(inv.delivered_at)}
-                    </span>
-                  </div>
-                )
-              })}
-            </div>
-          )}
-        </div>
       )}
 
       {/* Logged-out hint */}

--- a/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
+++ b/frontend/src/pages/factions/__tests__/factionsDirectory.test.tsx
@@ -1,11 +1,21 @@
 /**
- * Mobile factions directory (#732 grid + #733 letters, tested #743). Renders the
- * pure `FactionsDirectoryView` skin directly over controlled rows — the same seam
- * DefaultPlayers gives the players directory. The live `DefaultFactionsDirectory`
- * container self-fetches inside a useEffect, and this harness is node +
- * renderToStaticMarkup (no DOM, effects never fire), so a direct container render
- * only ever reaches the loading state; feeding the view controlled props is the
- * only way to assert the four things merge review had to catch by hand.
+ * The factions directory, BOTH form factors (#732 grid, tested #743).
+ *
+ * SEAM: what each renderer draws from a controlled directory state. Mobile has
+ * always had one — the pure `FactionsDirectoryView` skin, the same shape
+ * DefaultPlayers gives the players directory. #2310 gave desktop the matching
+ * one by exporting `DesktopFactions`, because the deletion it makes has to be
+ * asserted on the renderer that carried the risk. The live containers fetch
+ * inside a `useEffect`, and this harness is node + renderToStaticMarkup (no DOM,
+ * effects never fire), so a direct container render only ever reaches the
+ * loading state; feeding controlled props is the only way in.
+ *
+ * The "Recent Invitations" panel is gone from both (#2310) and the two guards
+ * below are what keep it gone. The second is the load-bearing one: deleting the
+ * panel also deleted desktop's `|| invitationBySlug[slug]` arm out of
+ * `selectState`, and getting that wrong would silently strip an invited player's
+ * route into a faction. The assertion is that an `invited` status alone still
+ * reads `eligible`.
  */
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
@@ -13,8 +23,11 @@ import type { ReactElement } from 'react'
 import { describe, it, expect } from 'vitest'
 import '../../../i18n'
 import type { FactionOut, FactionPageOut, FactionStatusOut, InvitationLetterOut } from '../../../api/factions'
+import type { CurrentUser } from '../../../api/auth'
+import { AuthContext } from '../../../auth/AuthContext'
 import FactionsDirectoryView from '../mobileArchetypes/FactionsDirectoryView'
 import DefaultFactionsDirectory from '../mobileArchetypes/DefaultFactionsDirectory'
+import { DesktopFactions } from '../../Factions'
 
 function render(element: ReactElement): { html: string; text: string } {
   const html = renderToStaticMarkup(<MemoryRouter>{element}</MemoryRouter>)
@@ -39,9 +52,12 @@ const FACTIONS: FactionOut[] = [
 // The status half of a row is the schema's five-value membership enum, not any
 // string — spelling it that way is what stops a typo reaching a card state the
 // server cannot report (#1400).
-function status(rows: Array<[string, FactionStatusOut['status']]>): FactionPageOut {
+function status(
+  rows: Array<[string, FactionStatusOut['status']]>,
+  invitations: InvitationLetterOut[] = [],
+): FactionPageOut {
   const all_factions: FactionStatusOut[] = rows.map(([slug, status]) => ({ slug, status }))
-  return { current_faction_slug: 'coven', all_factions, invitations: [] }
+  return { current_faction_slug: 'coven', all_factions, invitations }
 }
 
 // A viewer who is a Coven member, recruited by S.N.I.D.E., and not invited by
@@ -55,14 +71,20 @@ const STATUS = status([
   ['singularity', 'not_invited'],
 ])
 
-const NO_INVITES: InvitationLetterOut[] = []
+// A viewer holding two live letters. `snide` is the one the status map also
+// reports `invited` for; `coven` is the faction they are already in, which is the
+// pairing that used to make desktop's dead `|| invitationBySlug[slug]` arm look
+// load-bearing. Both are letters the panel would have drawn a row for.
+const LETTERS: InvitationLetterOut[] = [
+  { faction_slug: 'snide', delivered_at: '2026-01-01T00:00:00Z' },
+  { faction_slug: 'coven', delivered_at: '2026-01-02T00:00:00Z' },
+]
 
 function view(overrides: Partial<React.ComponentProps<typeof FactionsDirectoryView>> = {}) {
   return render(
     <FactionsDirectoryView
       factions={FACTIONS}
       factionPage={STATUS}
-      invitations={NO_INVITES}
       loading={false}
       error={null}
       unaffiliated={false}
@@ -141,23 +163,17 @@ describe('mobile factions directory — real card state (#743)', () => {
   })
 })
 
-describe('mobile factions directory — invitation letters panel (#743)', () => {
-  it('draws nothing when the invite list is empty', () => {
-    const { text } = view({ invitations: [] })
-    // The panel is header + rows only when a letter exists — an empty feed is silent.
-    expect(text).not.toContain('Recent Invitations')
-    expect(text, 'no INVITE badge without a letter').not.toContain('INVITE')
-  })
-
-  it('renders a row per letter, linking to the faction detail page', () => {
-    const invitations: InvitationLetterOut[] = [
-      { faction_slug: 'snide', delivered_at: '2026-01-01T00:00:00Z' },
-      { faction_slug: 'coven', delivered_at: '2026-01-02T00:00:00Z' },
-    ]
-    const { html, text } = view({ invitations })
-    expect(text, 'panel header appears with a count').toContain('Recent Invitations')
-    expect(html, 'S.N.I.D.E. letter links to its detail page').toContain('href="/factions/snide"')
-    expect(html, 'Coven letter links to its detail page').toContain('href="/factions/coven"')
+describe('mobile factions directory — no invitation panel (#2310)', () => {
+  it('draws no panel even for a viewer holding letters', () => {
+    // The letters are on the payload — the backend still sends them, and the
+    // faction detail page still reads them. This surface just stopped drawing
+    // them, so none of the panel's three strings may appear at any state.
+    const { html, text } = view({ factionPage: status(STATUS.all_factions.map((r) => [r.slug, r.status]), LETTERS) })
+    expect(text, 'no panel header').not.toContain('Recent Invitations')
+    expect(text, 'no INVITE badge').not.toContain('INVITE')
+    expect(text, 'no invite sentence').not.toContain('been invited to join')
+    // The rows were the only links on this screen; the cards navigate by handler.
+    expect(html, 'no letter row linking to a detail page').not.toContain('href="/factions/')
   })
 })
 
@@ -194,10 +210,64 @@ describe('mobile factions directory — the container', () => {
     // takes the same still-loading state it used to produce for itself.
     const { text } = render(
       <DefaultFactionsDirectory
-        state={{ factions: [], factionPage: null, invitations: [], loading: true, error: null }}
+        state={{ factions: [], factionPage: null, loading: true, error: null }}
       />,
     )
     expect(text).toContain('Factions')
     expect(text).toContain('Unaffiliated')
+  })
+})
+
+/**
+ * The DESKTOP renderer over the same controlled state. `useAuth` has a default
+ * context value, so a viewer with no character is the cheap case; the panel was
+ * drawn behind `character &&`, so the letters case needs a real one.
+ */
+describe('desktop factions grid — no invitation panel (#2310)', () => {
+  // Only the field the grid reads; the rest of /auth/me is irrelevant here.
+  const VIEWER = { character: { faction_slug: 'coven' } } as unknown as CurrentUser
+
+  const desktop = (page: FactionPageOut) =>
+    render(
+      <AuthContext.Provider
+        value={{
+          user: VIEWER,
+          loading: false,
+          refetch: async () => {},
+          applyUser: () => {},
+          signOut: async () => {},
+        }}
+      >
+        <DesktopFactions state={{ factions: FACTIONS, factionPage: page, loading: false, error: null }} />
+      </AuthContext.Provider>,
+    )
+
+  it('draws no panel even for a viewer holding letters', () => {
+    const { html, text } = desktop(status(STATUS.all_factions.map((r) => [r.slug, r.status]), LETTERS))
+    expect(text, 'no panel header').not.toContain('Recent Invitations')
+    expect(text, 'no INVITE badge').not.toContain('INVITE')
+    expect(text, 'no invite sentence').not.toContain('been invited to join')
+    // The collapse toggle was the only button on the page that is not a tile CTA.
+    expect(html, 'no expand/collapse triangle').not.toContain('aria-expanded')
+  })
+
+  it('still reads an invited faction as eligible with the letter arm gone', () => {
+    // THE ASSERTION THAT PROTECTS THE DELETION. `snide` is `invited` in the
+    // status map AND holds a letter; `everymen` is `not_invited` and holds none.
+    // With `|| invitationBySlug[slug]` removed, the status map alone must still
+    // separate them — an eligible card that fell back to locked would take away
+    // the only route an invited player has into that faction from this page.
+    const { text } = desktop(status(STATUS.all_factions.map((r) => [r.slug, r.status]), LETTERS))
+    expect(text, 'S.N.I.D.E. is eligible on its status alone').toContain('Consider yourself recruited.')
+    expect(text, 'Coven still reads member').toContain('You’re one of us now')
+    expect(text, 'Everymen stays locked').toContain('Put in the shift and there’s a place for you.')
+  })
+
+  it('reads the same with no letters on the payload at all', () => {
+    // The other half of the claim: the letters were never what produced
+    // `eligible`, so dropping them changes nothing.
+    const withLetters = desktop(status(STATUS.all_factions.map((r) => [r.slug, r.status]), LETTERS)).text
+    const without = desktop(STATUS).text
+    expect(without).toBe(withLetters)
   })
 })

--- a/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
+++ b/frontend/src/pages/factions/mobileArchetypes/DefaultFactionsDirectory.tsx
@@ -19,15 +19,13 @@ const NA_SLUG = 'na'
  * wiring — all layout still lives in the pure `FactionsDirectoryView`, which is
  * what keeps the surface testable over controlled rows (#743).
  *
- * The invitations feed backs the letters PANEL only — never card state.
- * Desktop's extra `|| invitationBySlug[slug]` arm in its `selectState` is dead
- * code: `_NON_INVITE_FACTION_SLUGS = {"na", "albescent"}` (backend
- * services/character_stats.py) means no letter is ever written for those two,
- * and `get_account_invited_faction_slugs` excludes the same pair while being
- * ACCOUNT-pooled — strictly broader than the character-scoped letters. So every
- * slug this feed can return already reports `invited` in the same payload's
- * status map: since #1384 the letters and that map are one `/factions/status`
- * response, built from one query. The view's selectState stays as-is (#733).
+ * Card state comes from the status map and nothing else. The "Recent Invitations"
+ * panel this container used to feed is gone from both form factors (#2310) — the
+ * letter is actionable on the Updates feed card, the faction detail page and the
+ * arrival popup, and it was actionable on none of them here. Desktop's matching
+ * `|| invitationBySlug[slug]` arm went with it: the letters and the status map are
+ * one `/factions/status` response built from one query (#1384), so a held letter
+ * always reads `member`, `can_return` or `invited` already.
  */
 export default function DefaultFactionsDirectory({ state }: { state: FactionsDirectoryState }) {
   const { t } = useTranslation('factions')
@@ -36,13 +34,12 @@ export default function DefaultFactionsDirectory({ state }: { state: FactionsDir
   const currentSlug = user?.character?.faction_slug ?? null
   const unaffiliated = !currentSlug || currentSlug === NA_SLUG
 
-  const { factions, factionPage, invitations, loading } = state
+  const { factions, factionPage, loading } = state
 
   return (
     <FactionsDirectoryView
       factions={factions}
       factionPage={factionPage}
-      invitations={invitations}
       loading={loading}
       error={state.error ? extractError(state.error, t('mobile.loadError')) : null}
       unaffiliated={unaffiliated}

--- a/frontend/src/pages/factions/mobileArchetypes/FactionsDirectoryView.tsx
+++ b/frontend/src/pages/factions/mobileArchetypes/FactionsDirectoryView.tsx
@@ -1,12 +1,6 @@
-import { Link } from 'react-router-dom'
-import { Trans, useTranslation } from 'react-i18next'
-import type {
-  FactionOut,
-  FactionPageOut,
-  InvitationLetterOut,
-} from '../../../api/factions'
-import { factionCssVar, factionName, sortFactionsByRainbowOrder } from '../../../utils/factions'
-import { relativeTime } from '../../../utils/dates'
+import { useTranslation } from 'react-i18next'
+import type { FactionOut, FactionPageOut } from '../../../api/factions'
+import { factionCssVar, sortFactionsByRainbowOrder } from '../../../utils/factions'
 import FactionSelectCard, { type SelectState } from '../../../components/selectCard/FactionSelectCard'
 
 const NA_SLUG = 'na'
@@ -21,8 +15,6 @@ export interface FactionsDirectoryViewProps {
   factions: FactionOut[]
   /** Per-faction viewer status from GET /factions/status — drives card state. */
   factionPage: FactionPageOut | null
-  /** Invitation letters the viewer holds — backs the letters PANEL only. */
-  invitations: InvitationLetterOut[]
   loading: boolean
   error: string | null
   /** Whether the viewer has not yet sworn to a faction (shows the banner). */
@@ -34,10 +26,9 @@ export interface FactionsDirectoryViewProps {
 /**
  * Pure presentational skin for the Default MOBILE factions directory — the phone
  * twin of the desktop Factions grid. A single-column screen, in render order: a
- * title, the faction stripe bar, any invitation letters the player holds (#733),
- * an "unaffiliated" banner (shown only while the viewer hasn't sworn to a
- * faction), then a vertical stack of the SAME bespoke FactionSelectCard
- * archetypes desktop uses (#732), each visiting its faction's detail page where
+ * title, the faction stripe bar, an "unaffiliated" banner (shown only while the
+ * viewer hasn't sworn to a faction), then a vertical stack of the SAME bespoke
+ * FactionSelectCard archetypes desktop uses (#732), each visiting its detail page where
  * all membership actions live (#347). Member counts are intentionally dropped —
  * no cheap per-faction count query exists (ADR-0035: real fields only).
  *
@@ -57,7 +48,6 @@ export interface FactionsDirectoryViewProps {
 export default function FactionsDirectoryView({
   factions,
   factionPage,
-  invitations,
   loading,
   error,
   unaffiliated,
@@ -109,63 +99,6 @@ export default function FactionsDirectoryView({
         >
           {visible.map((f) => (
             <span key={f.slug} style={{ flex: 1, background: factionCssVar(f.slug) }} />
-          ))}
-        </div>
-      )}
-
-      {/* Invitation letters. Rendered only when the player actually holds one —
-          an empty list draws NOTHING (no header, no empty state).
-
-          ponytail: NO collapse toggle, unlike desktop's collapsed-by-default
-          panel. Desktop can collapse because its grid is fully visible above
-          the fold and each tile already shows `eligible`; on a phone the cards
-          are a tall vertical stack, so this panel is the only thing that tells
-          an invited player a letter exists without scrolling. A collapsed
-          `▸ Recent Invitations (1)` would defeat the point of the issue, and
-          one or two rows never need collapsing. Rows link to the detail page,
-          which owns Accept/Decline (ADR-0030, #347). */}
-      {invitations.length > 0 && (
-        <div className="mb-4" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-sm)' }}>
-          <span className="label-heading">
-            {t('index.recentInvitations', { count: invitations.length })}
-          </span>
-          {invitations.map((inv) => (
-            <Link
-              key={inv.faction_slug}
-              to={`/factions/${inv.faction_slug}`}
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 'var(--space-sm)',
-                padding: 'var(--space-md)',
-                textDecoration: 'none',
-                background: `linear-gradient(135deg, ${factionCssVar(inv.faction_slug, 'light')}, transparent)`,
-                borderLeft: `3px solid ${factionCssVar(inv.faction_slug, 'border')}`,
-              }}
-            >
-              <span className="label-caption">{t('index.inviteBadge')}</span>
-              <span
-                className="font-body"
-                style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-primary)', flex: 1, lineHeight: 1.4 }}
-              >
-                <Trans
-                  t={t}
-                  i18nKey="index.invitedToJoin"
-                  values={{ faction: factionName(inv.faction_slug) }}
-                  components={[
-                    <span key="0" />,
-                    // WEIGHT, NOT HUE (#2077) — the desktop twin in
-                    // `pages/Factions.tsx` carries the measurements. The wash
-                    // and the left rule keep the hue; the name inherits
-                    // `--color-text-primary` from the span around it.
-                    <span key="1" style={{ fontWeight: 700 }} />,
-                  ]}
-                />
-              </span>
-              <span className="label-caption">
-                {relativeTime(inv.delivered_at)}
-              </span>
-            </Link>
           ))}
         </div>
       )}

--- a/frontend/src/pages/factions/useFactionsDirectory.ts
+++ b/frontend/src/pages/factions/useFactionsDirectory.ts
@@ -1,10 +1,5 @@
 import { useEffect, useState } from 'react'
-import {
-  getFactionStatus,
-  type FactionOut,
-  type FactionPageOut,
-  type InvitationLetterOut,
-} from '../../api/factions'
+import { getFactionStatus, type FactionOut, type FactionPageOut } from '../../api/factions'
 import { useAuth } from '../../auth/AuthContext'
 import { useFactions } from '../../hooks/useFactions'
 
@@ -13,10 +8,16 @@ import { useFactions } from '../../hooks/useFactions'
  *
  * `/factions` itself is no longer fetched here: it comes from the app-wide
  * `useFactions` cache (#1284), so arriving from any other surface costs nothing.
- * What this hook still owns is the viewer's membership status + invitations,
- * which are per-character and not cacheable app-wide. Those two arrive together
- * on `/factions/status` (#1384) — the letters ride on the same payload as the
- * status map they were derived from, so this is one request, not two.
+ * What this hook still owns is the viewer's per-faction membership status, which
+ * is per-character and not cacheable app-wide.
+ *
+ * The response's `invitations` array is no longer read here. #2310 deleted the
+ * "Recent Invitations" panel that was its only consumer on this page, and the
+ * request stays exactly as it was: `/factions/status` is fetched for the STATUS
+ * MAP, and the letters have ridden along on that same payload since #1384. So
+ * there is no dead request to drop — only a field the directory stopped
+ * exposing. `pages/factionDetail/useFactionDetail.ts` still reads the letters off
+ * its own copy of the response.
  *
  * The desktop grid and the phone directory used to own a private copy of this
  * effect, which made `/factions` the one page dispatcher whose data lived BELOW
@@ -28,14 +29,10 @@ import { useFactions } from '../../hooks/useFactions'
  * The failure is returned raw rather than as a message: the two surfaces phrase
  * their own fallback copy, and a shared hook has no business picking one.
  */
-/** Stable identity for the signed-out / not-yet-loaded case. */
-const NO_INVITATIONS: InvitationLetterOut[] = []
-
 export interface FactionsDirectoryState {
   readonly factions: FactionOut[]
   /** The viewer's per-faction membership status; null while signed out. */
   readonly factionPage: FactionPageOut | null
-  readonly invitations: InvitationLetterOut[]
   readonly loading: boolean
   readonly error: unknown
 }
@@ -58,7 +55,6 @@ export function useFactionsDirectory(): FactionsDirectoryState {
 
     const load = async () => {
       if (characterId == null) return
-      // The invitations feed backs the letters PANEL only — never card state.
       const statusData = await getFactionStatus()
       if (cancelled) return
       setFactionPage(statusData)
@@ -80,7 +76,6 @@ export function useFactionsDirectory(): FactionsDirectoryState {
   return {
     factions: factions ?? [],
     factionPage,
-    invitations: factionPage?.invitations ?? NO_INVITATIONS,
     // Still one flag, and it still means "nothing to draw yet": the grid needs
     // the faction list, so a settled membership read with `factions` still null
     // is not loaded. Keeping the two apart would flash an empty grid.


### PR DESCRIPTION
The factions directory drew a "Recent Invitations (N)" panel above the grid, on both form factors. It is gone.

Owner ruling: *"These should go away. If you want to join a faction, you can go to their page, and it also shows up in notifications."*

The panel carried no action — a badge, a sentence, a relative timestamp. The letter is still delivered three ways, all of them actionable: `InvitationWatcher` -> `InvitationLetterPopup` on arrival, the `invitation_letter` feed card on Updates (Accept / Not now inline), and the faction detail page (ADR-0030, #347). None of those changed.

Frontend only. `GET /factions/page` keeps returning `invitations` — `pages/factionDetail/useFactionDetail.ts` and the feed both read it off their own copy of the response.

## The eligibility OR — what I actually checked

Desktop's `selectState` had a third arm:

    if (status === STATUS_INVITED || status === STATUS_CAN_RETURN || invitationBySlug[slug]) return 'eligible'

The issue asserted it was dead. I did not take its word for it, because the wrong call here silently strips an invited player's route into a faction. What I read on `origin/main`:

1. **One source, one response.** `get_invitation_status` (`backend/services/faction_service.py`) runs ONE `InvitationLetter` select and returns the status map and the letter rows from it — `invited_slugs = {letter.faction_slug for letter in letters}`. Since #1384 both halves ride one `/factions/status` payload, so the map and the letters cannot skew across requests. The frontend's `invitations` and `all_factions` come from the same object.
2. **Which branches can outrank `invited` in that map.** `member` (the slug is the current faction) and `can_return` (defected + `can_always_rejoin`) are both handled by the two clauses above, so the arm could only ever re-derive a state the card already had.
3. **The one case that could have diverged, and why it can't.** `defected` (defected + NOT `can_always_rejoin`) wins over `invited` in the map, and a stale letter there would have made desktop read `eligible` while mobile read `locked` — a real fork. **#2218 closed both halves of it**: `defect_to_faction` DELETEs the letter when you walk out of a non-rejoinable faction, and `maybe_deliver_invitations` (`services/character_stats.py`) subtracts `unjoinable_faction_slugs` before posting a new one, so it cannot be re-issued afterwards either. `defected` therefore never holds a letter.

Conclusion: a held letter implies `member` / `can_return` / `invited`, all handled above. The arm is dead and is removed. The reasoning is written into the code at the deletion site rather than only here.

I also removed the matching claim from `DefaultFactionsDirectory`'s docstring, which argued the same conclusion from a *different* premise (`_NON_INVITE_FACTION_SLUGS`) that does not cover the defection case.

## Rung zero: does the fetch still need to happen?

Yes, and nothing to delete. `invitations` was never its own request — `useFactionsDirectory` calls `getFactionStatus()` for the STATUS MAP, which drives every card, and the letters have ridden along on that payload since #1384. Deleting the field removes an unused derivation, not a request.

## The mobile docstring

`FactionsDirectoryView`'s comment argued for keeping the panel: *"on a phone the cards are a tall vertical stack, so this panel is the only thing that tells an invited player a letter exists without scrolling."* That predates the feed card being a place to accept from, and the owner has ruled against it. Deleted with the panel rather than left as an orphaned rationale.

## Seam under test

**What each renderer draws from a controlled directory state, and what the hook exposes.** Mobile already had that seam (`FactionsDirectoryView`, a pure skin). Desktop did not, so `DesktopFactions` is now a named export taking the same `FactionsDirectoryState` — the deletion that carried the risk lives there, and the harness is node + `renderToStaticMarkup` with no DOM, so a container render only ever reaches its loading state.

Three new assertions in `pages/factions/__tests__/factionsDirectory.test.tsx`:

- neither renderer emits any of the three panel strings, *for a viewer whose payload still carries letters*;
- **the load-bearing one:** with the letter arm gone, a faction that is `invited` in the status map still renders the eligible voice, `member` still renders member, `not_invited` still renders locked;
- the desktop render is byte-identical with and without letters on the payload — the other half of the same claim.

The old "invitation letters panel" describe block and the `#2077` hue-as-ink section covering those rows are deleted with their subject; the `factionHueAsInkMounts` docstring records that the specimen is gone but the lint rule's rationale stands.

## Verification

- `tsc --noEmit` (`npm run typecheck`, app + e2e) — clean
- `npm run typecheck:design-sync` — clean (`.design-sync/previews/_state.tsx` dropped the field in the same change)
- `npm run lint` — clean
- `npm test` — 359 files / 6316 passed, 1 skipped
- `npm run build` — clean
- `npm run budget` — JS ok; the CSS WARN is pre-existing on `main` (identical CSS hash before and after; this change touches no CSS)
- No backend change, so no `regen_api_client.py` artifacts

**Visual QA is outstanding** — I have no browser or dev stack here.

## What to eyeball

- `/factions` on desktop, signed in as an account holding an invitation: no "Recent Invitations" header, no collapse triangle above the grid, and the grid starts flush under the page title with no leftover gap.
- The same account at phone width: no panel between the stripe bar and the unaffiliated banner / card stack, and the spacing between the stripe bar and what follows it still reads.
- **The invited faction's tile still reads eligible on both widths** — the recruited voice, not the locked one. This is the deletion worth staring at.
- The member tile and a not-invited tile are unchanged beside it, and card ORDER is unchanged (member, invited, can_return, rest on desktop; rainbow order on mobile).
- Signed out at `/factions`: the logged-out hint still shows and nothing else moved.
- The letter is still reachable and still acceptable from the Updates feed card, the faction detail page, and the popup on arrival.

Closes #2310

🤖 Generated with [Claude Code](https://claude.com/claude-code)
