### PR TITLE
Chamfered plates are framed by their ground, not by a border a clip shaves away (#2150, #2314)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/ephemeristsChamferPlate.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsChamferPlate.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * A CHAMFERED PLATE IS FRAMED BY ITS GROUND, NEVER BY A BORDER (#2150, #2314).
+ *
+ * `stepClip` cuts the top-left and bottom-right corners, and `clip-path` cuts an
+ * element at its BORDER BOX — so a `border` is shaved away along both diagonals
+ * and the plate ships with two open corners and a rule that stops short. #1638
+ * found this on the vote plate and fixed it there, in a comment; #2314 is the
+ * owner reporting the same defect on the score stamp ("gold border is missing on
+ * the sides"); #2150 is the class.
+ *
+ * ## Three seams, because the visible defect is not decidable here
+ *
+ * The harness is `renderToStaticMarkup` with no DOM and no layout, so no test in
+ * this repo can see an open corner. A SCREENSHOT is the acceptance. What is
+ * decidable is the structure that produces the corner, and it is asserted at the
+ * three levels a future edit can break it:
+ *
+ *  1. **The arithmetic**, as a pure function. `chamferSheetLeg` is the part an
+ *     edit gets wrong, because an equal leg looks obviously right and reopens
+ *     both corners.
+ *  2. **The rendered markup** of a surface that had the bug — the mount/sheet
+ *     pair, the rule brass, and the absence of any `border` on either.
+ *  3. **The source tree**, which is the only place the CLASS is visible. A
+ *     markup assertion pins the plates that exist today; the failure mode #2150
+ *     describes is the NEXT plate hand-rolling a chamfer and a border again.
+ */
+import { readFileSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import '../../../i18n'
+import type { PraxisCardOut } from '../../../api/praxis'
+import EphemeristsScoreStamp from '../../praxisCard/scoreStamp/EphemeristsScoreStamp'
+import { chamferMount, chamferSheet, chamferSheetLeg } from '../ephemeristsPlate'
+
+/** The rule brass — a frame is a line, so never the mark brass (#2141/#2142). */
+const RULE = 'var(--faction-ephemerists-plate-brass-rule)'
+
+/** Every `clip-path: polygon(Npx 0, …)` leg in a rendered string, in order. */
+function legs(html: string): number[] {
+  return [...html.matchAll(/clip-path:polygon\(([\d.]+)px 0/g)].map(([, n]) => Number(n))
+}
+
+function praxis(overrides: Record<string, unknown> = {}): PraxisCardOut {
+  return {
+    task_point_value: 12,
+    display_multiplier: 1.5,
+    metatask_points: 3,
+    points_from_votes: 4,
+    habit_bonus_points: 0,
+    is_top_for_task: false,
+    score: 26.5,
+    ...overrides,
+  } as PraxisCardOut
+}
+
+describe('the leg arithmetic (#2150)', () => {
+  /**
+   * An inset chamfer with an EQUAL leg puts the sheet's cut corner ON the
+   * mount's, and the frame opens at both corners exactly as the clipped border
+   * did. The shortening is `inset × (2 − √2)`, which is what makes the brass
+   * read the same width across the diagonal as it does down the straights.
+   */
+  it('shortens the sheet leg by inset × (2 − √2), never by inset', () => {
+    expect(chamferSheetLeg(7)).toBeCloseTo(7 - (2 - Math.SQRT2), 10)
+    expect(chamferSheetLeg(7)).toBeCloseTo(6.41421356, 6)
+    // The trap, stated: not `step - inset`, and not `step` either.
+    expect(chamferSheetLeg(7)).not.toBeCloseTo(6, 3)
+    expect(chamferSheetLeg(7)).not.toBeCloseTo(7, 3)
+  })
+
+  it('scales with the inset, so the formula holds at any rule width', () => {
+    expect(chamferSheetLeg(7, 2)).toBeCloseTo(7 - 2 * (2 - Math.SQRT2), 10)
+    expect(chamferSheetLeg(7, 0)).toBe(7)
+  })
+
+  /**
+   * The geometric claim, restated as a measurement rather than as the formula
+   * again: `stepClip(s)` cuts along `x + y = s`, the sheet's clip cuts along
+   * `x + y = t + 2i` in the mount's coordinates, and the perpendicular distance
+   * between them must equal the inset — otherwise the diagonal draws a
+   * different width from the straights, which is the taper #1638 tolerated.
+   */
+  it('puts the diagonal exactly one inset from the mount, like the straights', () => {
+    for (const step of [5, 6, 7, 12]) {
+      const inset = 1
+      const gap = Math.abs(chamferSheetLeg(step, inset) + 2 * inset - step) / Math.SQRT2
+      expect(gap, `step ${step}`).toBeCloseTo(inset, 10)
+    }
+  })
+})
+
+describe('the treatment emits a ground and an inset sheet, never a border (#2150)', () => {
+  it('mounts the RULE brass and clips the sheet exactly one step tighter', () => {
+    const mount = chamferMount(7)
+    const sheet = chamferSheet(7, 'var(--faction-ephemerists-plate-inner)')
+    expect(mount.background).toBe(RULE)
+    expect(mount.padding).toBe(1)
+    expect(mount.clipPath).toContain('polygon(7px 0')
+    // The sheet takes the MOUNT's leg and derives its own, so they cannot drift.
+    expect(sheet.clipPath).toContain(`polygon(${chamferSheetLeg(7)}px 0`)
+    expect(mount).not.toHaveProperty('border')
+    expect(sheet).not.toHaveProperty('border')
+  })
+})
+
+describe('the Ephemerists score stamp carries its rule through the clip (#2314)', () => {
+  const html = (overrides: Record<string, unknown> = {}) =>
+    renderToStaticMarkup(<EphemeristsScoreStamp praxis={praxis(overrides)} />)
+
+  /**
+   * The owner's report is "gold border is missing on the sides of the score
+   * stamps". The panel painted `border: 1px solid ${BRASS}` under `stepClip(7)`
+   * and the multiplier chip did the same under `stepClip(5)`.
+   */
+  it('paints no border on either chamfered element', () => {
+    expect(html()).not.toContain('border:1px solid')
+  })
+
+  it('pairs every chamfer with a sheet one step tighter', () => {
+    // The panel (7) and the ratio chip (5), each a mount followed by its sheet.
+    expect(legs(html())).toEqual([
+      7,
+      chamferSheetLeg(7),
+      5,
+      chamferSheetLeg(5),
+    ])
+  })
+
+  it('frames both in the rule brass, not the mark brass', () => {
+    const markup = html()
+    expect((markup.match(new RegExp(`background:${RULE.replace(/[()]/g, '\\$&')}`, 'g')) ?? []).length)
+      .toBe(2)
+  })
+
+  it('leaves the panel with no chip when there is no multiplier', () => {
+    // One plate, still a pair — the sweep must not depend on the chip existing.
+    expect(legs(html({ display_multiplier: 1 }))).toEqual([7, chamferSheetLeg(7)])
+  })
+})
+
+const SRC = fileURLToPath(new URL('../../..', import.meta.url))
+const KIT = fileURLToPath(new URL('../ephemeristsPlate.tsx', import.meta.url))
+
+/** Every shipped `.ts`/`.tsx` under `src/`, comments stripped, tests skipped. */
+function sources(): { path: string; source: string }[] {
+  const found: { path: string; source: string }[] = []
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === '__tests__') continue
+      const full = join(dir, entry.name)
+      if (entry.isDirectory()) walk(full)
+      else if (/\.tsx?$/.test(entry.name)) {
+        found.push({
+          path: full,
+          source: readFileSync(full, 'utf8')
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/^\s*\/\/.*$/gm, ''),
+        })
+      }
+    }
+  }
+  walk(SRC)
+  return found
+}
+
+describe('the chamfer has exactly one door (#2150)', () => {
+  /**
+   * `stepClip` is what the four defective plates called directly, and calling it
+   * directly is what let each of them paint a border beside it. It is module
+   * private now: the only way to chamfer a plate is `chamferMount` +
+   * `chamferSheet`, which cannot emit a border because neither returns one.
+   */
+  it('leaves no consumer of the raw clip outside the kit', () => {
+    const offenders = sources()
+      .filter(({ path }) => path !== KIT)
+      .filter(({ source }) => /\bstepClip\s*\(/.test(source))
+      .map(({ path }) => path)
+    expect(offenders).toEqual([])
+  })
+
+  /**
+   * The other half of the same door, and the one `EphemeristsTaskCard` walked
+   * through: its multiplier chip typed the chamfer out by hand rather than
+   * calling anything, so an import graph could not see it.
+   */
+  it('leaves no hand-typed chamfer polygon anywhere', () => {
+    const offenders = sources()
+      .filter(({ path }) => path !== KIT)
+      .filter(({ source }) => /polygon\(\s*[\d.]+px 0/.test(source))
+      .map(({ path }) => path)
+    expect(offenders).toEqual([])
+  })
+})

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -225,8 +225,14 @@ export function chamferSheetLeg(step: number, inset: number = MOUNT_INSET): numb
  *
  * NOTHING ABOUT THE PLATE'S SIZE MOVES. The mount's 1px padding is the border's
  * 1px, so the outer box and the content box are where they were.
+ *
+ * The `padding: 1` carried an `eslint-disable local/no-raw-style-values` at the
+ * vote plate and carries none here — not because the value stopped being raw,
+ * but because that rule's only visitor is `JSXAttribute` and this is a
+ * `CSSProperties` factory. The justification stands on its own: the padding IS
+ * the rule's stroke width, not spacing, and the smallest `--space-*` rung is 4px,
+ * which would draw a four-pixel mount.
  */
-// eslint-disable-next-line local/no-raw-style-values -- ornament: the padding IS the brass rule's stroke width, not spacing. The smallest space rung is 4px, which would draw a four-pixel mount.
 export const chamferMount = (step: number): CSSProperties => ({
   background: BRASS_RULE,
   padding: MOUNT_INSET,

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -162,8 +162,14 @@ export function GlossedGlyph({ glyph, gloss, size, style }: {
  * reads as cut from stone rather than rounded. The design draws it on the score
  * box (7), the ratio chip inside it (5), the byline cartouche (7) and the vote
  * plate (7); `step` is the chamfer's leg in px, which is ornament geometry.
+ *
+ * MODULE PRIVATE SINCE #2150, and the privacy is the fix rather than tidiness.
+ * Every surface that called this directly also painted a `border` beside it, and
+ * a border is shaved away by its own clip — four plates, four open corners. The
+ * door out of this module is {@link chamferMount} + {@link chamferSheet}, and
+ * neither can emit a border.
  */
-export function stepClip(step: number): string {
+function stepClip(step: number): string {
   return `polygon(${step}px 0, 100% 0, 100% calc(100% - ${step}px), calc(100% - ${step}px) 100%, 0 100%, 0 ${step}px)`;
 }
 

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -168,6 +168,72 @@ export function stepClip(step: number): string {
 }
 
 /**
+ * How far the sheet is laid inside the brass, in px. It is the RULE'S STROKE
+ * WIDTH rather than spacing — the rule is what shows through the inset — which
+ * is why it is a bare number and not a `--space-*` rung.
+ */
+const MOUNT_INSET = 1;
+
+/**
+ * The SHEET'S chamfer leg, for a sheet laid `inset` px inside a `step`-legged
+ * mount (#1638, #2150). The one piece of arithmetic in the treatment below, and
+ * the part a future edit gets wrong.
+ *
+ * An inset chamfer with an EQUAL leg puts the sheet's cut corner ON the mount's
+ * and the frame opens at both corners — exactly the defect the clipped border
+ * had. `stepClip(s)` cuts along `x + y = s`; the same clip on a box inset by `i`
+ * cuts along `x + y = t + 2i` in the mount's own coordinates, and the two lines
+ * are `|t + 2i − s| / √2` apart. Setting that equal to `i` — so the brass reads
+ * the same width across the diagonal as it does down the straights — gives
+ *
+ *     t = s − i·(2 − √2)     ≈ s − 0.5858·i
+ *
+ * which is the figure the design's `chamferFrames()` pass arrived at
+ * independently. `EphemeristsVote` shipped the rounded-down 6 against `stepClip(7)`
+ * and its own comment names the cost: a 0.7px hairline where the straights draw
+ * 1px. Computing it removes the reason to round, so the taper goes with it.
+ */
+export function chamferSheetLeg(step: number, inset: number = MOUNT_INSET): number {
+  return step - inset * (2 - Math.SQRT2);
+}
+
+/**
+ * THE FRAME, AS A GROUND RATHER THAN A BORDER (#1638, extracted by #2150).
+ *
+ * `stepClip` chamfers the top-left and bottom-right corners, and `clip-path`
+ * cuts the element at its BORDER BOX — so a `border` is shaved away along both
+ * diagonals and the plate ships with two open corners and a rule that stops
+ * short. Every chamfered plate in this kit had that bug; the vote plate fixed it
+ * once, in a comment, and this is that fix with a name.
+ *
+ * A chamfered plate is therefore TWO elements: a brass MOUNT and, one pixel
+ * inside it, the SHEET carrying the panel's real ground. The clip then carries
+ * the rule instead of shaving it, because the rule is the mount showing through.
+ *
+ *     <div style={chamferMount(7)}>
+ *       <div style={{ ...chamferSheet(7, INNER), padding: "var(--space-sm)" }}>
+ *
+ * Both take the MOUNT's leg, so the two clips cannot drift apart. The mount is
+ * the RULE brass since #2141's mark/rule split (#2142): a frame is a line, and
+ * the mark brass is reserved for things that are read.
+ *
+ * NOTHING ABOUT THE PLATE'S SIZE MOVES. The mount's 1px padding is the border's
+ * 1px, so the outer box and the content box are where they were.
+ */
+// eslint-disable-next-line local/no-raw-style-values -- ornament: the padding IS the brass rule's stroke width, not spacing. The smallest space rung is 4px, which would draw a four-pixel mount.
+export const chamferMount = (step: number): CSSProperties => ({
+  background: BRASS_RULE,
+  padding: MOUNT_INSET,
+  clipPath: stepClip(step),
+});
+
+/** The sheet inside a {@link chamferMount}. `step` is the MOUNT's leg. */
+export const chamferSheet = (step: number, ground: string): CSSProperties => ({
+  background: ground,
+  clipPath: stepClip(chamferSheetLeg(step)),
+});
+
+/**
  * A SEEDED GENERATOR — the faction's one source of random-looking ornament.
  *
  * Two devices draw an unpatterned row of mathematical marks: the masthead's

--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import {
-  BRASS,
   BAND_INK,
   BAND_QUIET,
   BRASS_LIGHT,
@@ -15,7 +14,8 @@ import {
   READING,
   SMALL_CAPS,
   WASH,
-  stepClip,
+  chamferMount,
+  chamferSheet,
 } from "../../factionMarks/ephemeristsPlate";
 import { scoreBreakdown, formatMult } from "./scoreBreakdown";
 import { formatPoints } from "../../../utils/points";
@@ -147,121 +147,132 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
       )}
 
       {working && (
-        <div
-          style={{
-            boxSizing: "border-box",
-            background: INNER,
-            border: `1px solid ${BRASS}`,
-            padding: "var(--space-sm) var(--space-md)",
-            clipPath: stepClip(7),
-            lineHeight: 1.1,
-          }}
-        >
-          {/* Base, with the figure set against its label across the cell. */}
+        /*
+         * THE PANEL'S RULE IS ITS GROUND, NOT A BORDER (#2314, treatment #2150).
+         * `clip-path` cuts at the border box, so the `border: 1px solid` that
+         * stood here was shaved away along both chamfers — the owner's report is
+         * "gold border is missing on the sides of the score stamps". The brass
+         * is the MOUNT and the panel is laid a pixel inside it; the clip then
+         * carries the rule instead of shaving it. Nothing about the panel's box
+         * moves: the mount's 1px padding is the border's 1px.
+         */
+        <div style={chamferMount(7)}>
           <div
             style={{
-              display: "flex",
-              alignItems: "baseline",
-              justifyContent: "space-between",
-              gap: "var(--space-sm)",
+              ...chamferSheet(7, INNER),
+              boxSizing: "border-box",
+              padding: "var(--space-sm) var(--space-md)",
+              lineHeight: 1.1,
             }}
           >
-            {/* 基 stood here, glossed "base". #1909 cut all five of this cell's
-                kanji: they were the only faction-specific score-stamp labels in
-                the app, on a surface the audit ruled generic. The shared gloss
-                each one carried is now the visible label. */}
-            <span style={label}>{t("card.stamp.base")}</span>
-            <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", lineHeight: 0.8, color: INK }}>
-              {base}
-            </span>
-          </div>
-
-          {/* The multiplier, in its own ruled chip — the design's "ratio" cell. */}
-          {mult !== null && (
+            {/* Base, with the figure set against its label across the cell. */}
             <div
               style={{
                 display: "flex",
-                alignItems: "center",
-                gap: "var(--space-xs)",
-                marginTop: "var(--space-sm)",
-                padding: "var(--space-xs) var(--space-sm)",
-                border: `1px solid ${BRASS}`,
-                background: WASH,
-                clipPath: stepClip(5),
+                alignItems: "baseline",
+                justifyContent: "space-between",
+                gap: "var(--space-sm)",
               }}
             >
-              <span style={{ ...label, letterSpacing: "0.2em" }}>{t("card.stamp.mult")}</span>
-              <span aria-hidden style={{ width: 1, height: 11, background: BRASS_LIGHT }} />
-              <span style={{ fontFamily: DECO, fontSize: "var(--text-lg)", lineHeight: 1, color: INK }}>
-                {formatMult(mult)}
+              {/* 基 stood here, glossed "base". #1909 cut all five of this cell's
+                  kanji: they were the only faction-specific score-stamp labels in
+                  the app, on a surface the audit ruled generic. The shared gloss
+                  each one carried is now the visible label. */}
+              <span style={label}>{t("card.stamp.base")}</span>
+              <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", lineHeight: 0.8, color: INK }}>
+                {base}
               </span>
             </div>
-          )}
 
-          {/* The metatask award, struck in the plate's one accent — a foreign
-              award, not the task's. See the ochre measurement above. */}
-          {meta !== null && (
-            <div
-              style={{
-                display: "flex",
-                alignItems: "center",
-                gap: "var(--space-xs)",
-                marginTop: "var(--space-sm)",
-                color: OCHRE,
-              }}
-            >
-              <span
+            {/* The multiplier, in its own ruled chip — the design's "ratio" cell. */}
+            {mult !== null && (
+              /* Same treatment, one rung down — the chip had the same clipped
+                 border. The margin belongs to the MOUNT, which is the chip's
+                 outer box now. */
+              <div style={{ ...chamferMount(5), marginTop: "var(--space-sm)" }}>
+                <div
+                  style={{
+                    ...chamferSheet(5, WASH),
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "var(--space-xs)",
+                    padding: "var(--space-xs) var(--space-sm)",
+                  }}
+                >
+                  <span style={{ ...label, letterSpacing: "0.2em" }}>{t("card.stamp.mult")}</span>
+                  <span aria-hidden style={{ width: 1, height: 11, background: BRASS_LIGHT }} />
+                  <span style={{ fontFamily: DECO, fontSize: "var(--text-lg)", lineHeight: 1, color: INK }}>
+                    {formatMult(mult)}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {/* The metatask award, struck in the plate's one accent — a foreign
+                award, not the task's. See the ochre measurement above. */}
+            {meta !== null && (
+              <div
                 style={{
-                  ...SMALL_CAPS,
-                  fontWeight: 600,
-                  fontSize: "var(--text-md)",
-                  letterSpacing: "0.16em",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: "var(--space-xs)",
+                  marginTop: "var(--space-sm)",
+                  color: OCHRE,
                 }}
               >
-                {t("card.stamp.meta")}
-              </span>
-              <span style={{ fontFamily: READING, fontStyle: "italic", fontSize: "var(--text-md)" }}>
-                +{meta}
-              </span>
-            </div>
-          )}
+                <span
+                  style={{
+                    ...SMALL_CAPS,
+                    fontWeight: 600,
+                    fontSize: "var(--text-md)",
+                    letterSpacing: "0.16em",
+                  }}
+                >
+                  {t("card.stamp.meta")}
+                </span>
+                <span style={{ fontFamily: READING, fontStyle: "italic", fontSize: "var(--text-md)" }}>
+                  +{meta}
+                </span>
+              </div>
+            )}
 
-          {/* The tally, cut only when there are votes to record (ADR-0076). The `+`
-              and the figure are arithmetic, not copy, so they are set here rather
-              than interpolated into a sentence: this is the one line where a label
-              and a numeral sit together, and #1637's whole bound is that only the
-              label is encoded. */}
-          {votes !== null && (
-            <div
-              style={{
-                fontFamily: READING,
-                fontStyle: "italic",
-                fontSize: "var(--text-md)",
-                color: QUIET,
-                marginTop: "var(--space-sm)",
-              }}
-            >
-              + {votes} <span style={label}>{t("card.stamp.votes")}</span>
-            </div>
-          )}
+            {/* The tally, cut only when there are votes to record (ADR-0076). The `+`
+                and the figure are arithmetic, not copy, so they are set here rather
+                than interpolated into a sentence: this is the one line where a label
+                and a numeral sit together, and #1637's whole bound is that only the
+                label is encoded. */}
+            {votes !== null && (
+              <div
+                style={{
+                  fontFamily: READING,
+                  fontStyle: "italic",
+                  fontSize: "var(--text-md)",
+                  color: QUIET,
+                  marginTop: "var(--space-sm)",
+                }}
+              >
+                + {votes} <span style={label}>{t("card.stamp.votes")}</span>
+              </div>
+            )}
 
-          {/* The habit bonus (#1617), cut after the tally: flat, outside the ratio.
-              Labelled from the shared key like every other row of this cell — the
-              #1637 bound holds, so the LABEL is encoded and the figure stays a
-              Western numeral. */}
-          {habit !== null && (
-            <div
-              style={{
-                fontFamily: READING,
-                fontStyle: "italic",
-                fontSize: "var(--text-md)",
-                color: QUIET,
-                marginTop: "var(--space-xs)",
-              }}
-            >
-              + {habit} <span style={label}>{t("card.stamp.habit")}</span>
-            </div>
-          )}
+            {/* The habit bonus (#1617), cut after the tally: flat, outside the ratio.
+                Labelled from the shared key like every other row of this cell — the
+                #1637 bound holds, so the LABEL is encoded and the figure stays a
+                Western numeral. */}
+            {habit !== null && (
+              <div
+                style={{
+                  fontFamily: READING,
+                  fontStyle: "italic",
+                  fontSize: "var(--text-md)",
+                  color: QUIET,
+                  marginTop: "var(--space-xs)",
+                }}
+              >
+                + {habit} <span style={label}>{t("card.stamp.habit")}</span>
+              </div>
+            )}
+          </div>
         </div>
       )}
 

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -16,6 +16,9 @@ import {
   Cornice,
   GLYPHS,
   Tally,
+  WASH,
+  chamferMount,
+  chamferSheet,
 } from "../factionMarks/ephemeristsPlate";
 
 /**
@@ -361,21 +364,26 @@ export default function EphemeristsTaskCard({
                   (ADR-0055). */}
               {showMultiplier && (
                 <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "center", gap: "var(--space-xs)" }}>
-                  <span
-                    style={{
-                      display: "inline-flex",
-                      alignItems: "center",
-                      padding: "var(--space-xs) var(--space-sm)",
-                      background: "var(--faction-ephemerists-plate-wash)",
-                      border: "1px solid var(--faction-ephemerists-plate-brass)",
-                      clipPath: "polygon(6px 0, 100% 0, 100% calc(100% - 6px), calc(100% - 6px) 100%, 0 100%, 0 6px)",
-                      fontFamily: CAPS,
-                      fontWeight: 600,
-                      fontSize: "var(--text-lg)",
-                      lineHeight: 1,
-                    }}
-                  >
-                    {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
+                  {/* The chip's rule is its GROUND, not a border (#2150). It
+                      typed its own chamfer out by hand and painted a border
+                      under it, so `clip-path` shaved the rule along both cuts
+                      and the chip opened at two corners. Same treatment as the
+                      score stamp's ratio chip, which is the same drawing. */}
+                  <span style={{ ...chamferMount(6), display: "inline-flex" }}>
+                    <span
+                      style={{
+                        ...chamferSheet(6, WASH),
+                        display: "inline-flex",
+                        alignItems: "center",
+                        padding: "var(--space-xs) var(--space-sm)",
+                        fontFamily: CAPS,
+                        fontWeight: 600,
+                        fontSize: "var(--text-lg)",
+                        lineHeight: 1,
+                      }}
+                    >
+                      {i18n.t("feed:taskCard.multiplier", { value: multiplier.toFixed(2) })}
+                    </span>
                   </span>
                   <span style={{ ...SMALL_CAPS, fontSize: "var(--text-md)", color: "var(--faction-ephemerists-plate-caption)" }}>
                     {i18n.t("feed:taskCard.modifierCaption")}

--- a/frontend/src/components/vote/EphemeristsVote.tsx
+++ b/frontend/src/components/vote/EphemeristsVote.tsx
@@ -5,7 +5,8 @@ import {
   GOLD,
   OCHRE,
   METAL_SIGILS,
-  stepClip,
+  chamferMount,
+  chamferSheet,
 } from '../factionMarks/ephemeristsPlate'
 import type { VoteUIProps } from './VoteUI'
 import { useVote } from './useVote'
@@ -83,15 +84,15 @@ const BURST_MARGIN = 24
 const FILING_ORBIT = 13
 /**
  * The chamfer leg of the plate's stepped silhouette, and of the brass ground
- * one pixel behind it. The inner leg is a pixel shorter so the two chamfers run
- * parallel: a 1px inset with an equal leg would put the sheet's cut corner ON
- * the ground's, and the frame would open at both corners exactly as the clipped
- * border it replaces did. (Strictly the parallel leg is 6.41 — 1px of normal
- * clearance across a 45° cut — so 6 draws the chamfer's hairline at 0.7px
- * against the straights' 1px. That is a taper on a brass rule, not a gap.)
+ * one pixel behind it.
+ *
+ * The sheet's own leg used to stand beside this as a hand-rounded 6, with a
+ * comment naming what that cost: the parallel leg is 6.41, so 6 drew the
+ * chamfer's hairline at 0.7px against the straights' 1px — a taper on a brass
+ * rule rather than a gap, but a taper. `chamferSheet` computes it (#2150), and
+ * the reason to round went with the hand-typing.
  */
 const PLATE_STEP = 7
-const SHEET_STEP = 6
 
 /**
  * THE SEVEN PLANETARY METALS, orbiting the fully transmuted disc (#2142).
@@ -318,8 +319,7 @@ export default function EphemeristsVote({
         /* The plate is also the QUERY CONTAINER for the row inside it (#2236):
            `container-type: inline-size` is in index.css, on this class. */
         className="eph-vote-plate"
-        // eslint-disable-next-line local/no-raw-style-values -- ornament: the padding IS the brass rule's stroke width, not spacing. The smallest space rung is 4px, which draws the plate a four-pixel brass mount.
-        style={{ background: BRASS_RULE, padding: 1, clipPath: stepClip(PLATE_STEP) }}
+        style={chamferMount(PLATE_STEP)}
       >
         <div
           className="eph-metal-row"
@@ -376,15 +376,16 @@ export default function EphemeristsVote({
              * belonged to no other Ephemerists surface. Still a radial recess,
              * not a flat fill.
              */
-            background:
+            ...chamferSheet(
+              PLATE_STEP,
               'radial-gradient(130% 170% at 50% -20%, var(--faction-ephemerists-plate-band), var(--faction-ephemerists-vote-plate-to))',
+            ),
             // ornament (#1609): the same inset well the Coven and S.N.I.D.E.
             // vote plates carry — a recess INSIDE a plate that is dark in both
             // cascades, not a cast onto a ground that flips. This one is also
             // tinted to its own plate (30,34,51 is the valley blue-black, not
             // neutral), which is the drawing rather than a stray alpha. Raw.
             boxShadow: 'inset 0 1px 8px rgba(30, 34, 51, 0.7)',
-            clipPath: stepClip(SHEET_STEP),
           }}
         >
           {/* The dashed brass rail threading the metals stood here, carrying a


### PR DESCRIPTION
The Ephemerists' chamfered plates cut their top-left and bottom-right corners
with `clip-path`, and `clip-path` cuts an element at its **border box** — so a
`border` painted beside one is shaved away along both diagonals. The plate ships
with two open corners and a rule that stops short. That is the owner's report on
#2314: *"Gold border is missing on the sides of the score stamps for
ephemerists."*

#1638 diagnosed this on the vote plate and fixed it there — in a comment, in one
component. #2150 is the class. This is one PR because #2314 is one instance of
it, and both go through one helper.

## The treatment, extracted

`factionMarks/ephemeristsPlate.tsx` gains `chamferMount(step)` and
`chamferSheet(step, ground)`. A chamfered plate is two elements: a brass MOUNT,
and one pixel inside it the SHEET carrying the panel's real ground. The clip then
carries the rule instead of shaving it, because the rule is the mount showing
through. Both take the **mount's** leg, so the two clips cannot drift apart.

The rule is `BRASS_RULE`, not `BRASS` — #2142's mark/rule split reserves the mark
brass for things that are READ, and a frame is a line. `BRASS` stays wherever a
file uses it as an ink.

**Nothing about any plate's size or padding moves.** The mount's 1px padding is
the border's 1px, so every outer box and every content box is where it was.

### The arithmetic, which was the point of extracting it

The sheet's chamfer leg is shortened by `inset x (2 - sqrt2)` ~ `0.5858 x inset`.
An inset chamfer with an *equal* leg puts the sheet's cut corner ON the mount's
and the frame opens at both corners — exactly the defect the clipped border had.
It now lives in `chamferSheetLeg`, derived in the docblock: `stepClip(s)` cuts
along `x + y = s`, the inset clip cuts along `x + y = t + 2i`, the lines are
`|t + 2i - s| / sqrt2` apart, and setting that equal to `i` gives
`t = s - i*(2 - sqrt2)`. Same figure the design's `chamferFrames()` reached
independently.

`EphemeristsVote` had hand-rounded that to `SHEET_STEP = 6` against
`stepClip(7)`, and its own comment named the cost: a 0.7px hairline across the
diagonal against the straights' 1px — "a taper on a brass rule, not a gap".
Computing it removes the reason to round, so the taper goes too. That is the only
place this PR changes something that was not broken, and it changes it toward
what the file already said was correct.

## Repointed, and the door closed behind them

Four chamfered plates, found by grep rather than from a list:

| Surface | Was |
|---|---|
| `EphemeristsScoreStamp` — breakdown panel | `border: 1px solid BRASS` + `stepClip(7)` |
| `EphemeristsScoreStamp` — multiplier chip | `border: 1px solid BRASS` + `stepClip(5)` |
| `EphemeristsTaskCard` — multiplier chip | a border + a **hand-typed** 6px chamfer polygon |
| `EphemeristsVote` — the plate | already correct; repointed, and its rounding dropped |

`stepClip` is **module private** now. Every surface that called it directly also
painted a border beside it, four for four, and privacy is what stops the fifth:
the only door out of the module is `chamferMount` + `chamferSheet`, and neither
can emit a border.

## Other factions do not chamfer

Checked, because if any did the helper would belong somewhere shared rather than
in the Ephemerists module. `clip-path` appears in five other faction files and
none of them is a chamfered plate owing a rule:

- `SnideFactionHero` — a 6px acid torn strip. Decoration with no border and no
  ground behind it.
- `AlbescentVote` — `polyClipN`, morphing polygon blobs. An animation.
- `EverymenPraxisCard`, `SnidePraxisCard`, `AlbescentSigil` — **comments only**,
  each describing a `clip-path` that was deliberately removed or replaced.

The one near-miss worth naming is the Ephemerists' own `OCTAGON_CLIP`: it is a
clipped shape that *does* carry a rule, but the rule is an SVG `stroke` and the
clipped `<img>` is deliberately clipped to the **inner** octagon so the photo
stops inside the ring. Immune to this bug by construction. The helper stays in
`ephemeristsPlate.tsx`.

## The seam

**No chamfered plate emits a `border` alongside a `clip-path`, and every one
emits the ground/inset pair with the inner step exactly one tighter.** Asserted
at three levels in `factionMarks/__tests__/ephemeristsChamferPlate.test.tsx`:

1. **The arithmetic, as a pure function** — `chamferSheetLeg` against the
   formula, against `step - inset` (the trap), and re-derived as a perpendicular
   distance so the geometric claim is measured rather than restated.
2. **The rendered markup** of the score stamp — no `border:1px solid` anywhere,
   the legs pairing as `[7, 6.414..., 5, 4.414...]`, and two rule-brass mounts.
3. **The source tree** — no `stepClip(` consumer and no hand-typed chamfer
   polygon outside the kit. This is the half that pins the *class*: a markup
   assertion only sees the plates that exist today, and the failure mode #2150
   describes is the NEXT plate hand-rolling a chamfer and a border again. The
   task card's chip is exactly that, and an import graph could not see it because
   it called nothing.

The loop went red on the real defect first: 6 failed / 4 passed, with the sweep
naming all three offending files and every score-stamp assertion failing.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test`
(362 files, 6372 passed), `npm run build`, `npm run budget` — all clean, run
after the rebase onto current `main`.

**Byte budget:** CSS is **byte-identical** to `main` (22918 B gzip-9, same
content hash, zero `.css` files touched) — the pre-existing WARN is `main`'s and
this PR neither helps nor hurts it. JS is **+18 B** gzip-9 (130071 -> 130089),
measured by building `main`'s four files in the same tree.

One incidental finding, reported rather than fixed: `local/no-raw-style-values`
visits `JSXAttribute` only, so hoisting an inline style into a `CSSProperties`
factory takes it out of the ratchet's view. The vote plate's `padding: 1`
disable directive became unused for that reason. I did **not** widen the rule —
the justification moved into the docblock instead.

## A screenshot is the acceptance and I cannot take one

The frontend harness is `renderToStaticMarkup` with no DOM and no layout, so
**no test in this repo can see an open corner**. Everything above is structural.
Visual QA is outstanding.

## What to eyeball

`stepClip` chamfers the **top-left** and the **bottom-right** — those are the two
corners that were open, so check them specifically, not just the straights.

For each of the following, in **light and dark**:

- **The score stamp's breakdown panel** — the four straight edges (top, right,
  bottom, left) carry an unbroken 1px brass rule, and it turns the **top-left**
  and **bottom-right** chamfers without thinning or breaking.
- **The score stamp's multiplier chip** — same six edges, on a praxis that
  carries a multiplier.
- **The stamp at both sizes**: the **working panel** (base / meta / votes
  breakdown) and the **rose form** (score only, no working — the panel falls
  away and the rose stands alone; nothing should have gained a frame).
- **The task card's multiplier chip** — same six edges, at desktop and mobile
  size sets.
- **The vote plate** — it was already correct; confirm the diagonal hairline now
  reads the same weight as the straights rather than slightly thinner.
- **The crown** on a top-for-task praxis still overhangs the panel's top-right
  and is not clipped (#2122's fix is a sibling, and it survives the new wrapper).

Closes #2150
Closes #2314
