### PR TITLE
The Ephemerists working reads as one column of figures against one of words (#2285)

### DIFF
--- a/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/EphemeristsScoreStamp.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 import { TaskCrown } from "../../factionMarks/TaskCrown";
 import {
@@ -10,8 +11,6 @@ import {
   INK,
   INNER,
   OCHRE,
-  QUIET,
-  READING,
   SMALL_CAPS,
   WASH,
   chamferMount,
@@ -68,14 +67,43 @@ import type { ScoreStampProps } from "./ScoreStamp";
  * marking a foreign award rather than the task's own, and it no longer asks an
  * 11px label to live on a large-text ratio.
  *
- * THE VOTES LINE KEEPS `-plate-quiet` AND THE ISSUE SAYS `-plate-band-quiet`;
- * this is a deliberate deviation, reported on the PR rather than shipped.
- * `-band-quiet` is a DISC ink (#c2ae7e, theme-invariant, minted for the compass
- * blue) and this line sits on `-plate-inner`, the panel cell — #f2e8ce in
- * light, where it measures **1.78:1**. `-plate-quiet` is the ink minted for
- * this exact ground and gated by `factionContrast`'s "ephemerists panel cell,
- * quiet ink" row. The two names differ by one word and the grounds differ by
- * everything.
+ * ## ONE ARRANGEMENT FOR EVERY LINE (#2285)
+ *
+ * The cell showed three numbers three ways: the base label and its figure at
+ * opposite ends of a `space-between` row, the metatask word BEFORE its figure,
+ * the tally figure before its word — so a simple addition was read three ways.
+ * The owner's ruling is a two-column read, **numbers on the left, words on the
+ * right, for every line**, at one face and one size across the figures and one
+ * across the labels: the column position tells a figure from its word, so
+ * neither the type nor a second colour has to.
+ *
+ * The columns are the CELL's grid, not each row's — {@link WorkingRow} emits
+ * two grid cells and no wrapper, because a per-row flexbox lines a figure up
+ * with its own label and with nothing else. That is also why a fourth row
+ * (habit) cannot arrive off-pattern: there is one row component and it has no
+ * arrangement to choose.
+ *
+ * TWO FIGURES CHANGE INK, and only because the ruling forbids a number and its
+ * label in two colours to tell them apart. The label tier's caption gold stays
+ * — it is the plate's label voice everywhere — so the figures join their
+ * labels rather than the other way round: base was `-plate-ink` (14.93:1 light
+ * / 12.84:1 dark) and the tally `-plate-quiet` (8.21:1 / 5.52:1), and both are
+ * now `-plate-caption`, **5.68:1 in light and 6.67:1 in dark on `-plate-inner`**
+ * — AA_NORMAL at the labels' 11px and at the figures' 14px alike, and already
+ * gated as `factionContrast`'s "ephemerists panel cell, caption" row. No ink is
+ * introduced and the metatask row, whose word and figure were already one
+ * colour, is untouched.
+ *
+ * THE MULTIPLIER CHIP KEEPS ITS OWN SHAPE. It is not one of the addends and it
+ * is not a line of the working — it is a ruled chip with a brass hairline
+ * between its word and its ratio, rebuilt one commit ago (#2150/#2314) — so it
+ * spans both columns and is otherwise left alone.
+ *
+ * `-plate-quiet` therefore leaves this cell. It was here because the vendored
+ * frame asked for `-plate-band-quiet`, which is a DISC ink (#c2ae7e, minted for
+ * the compass blue) and measures **1.78:1** on this panel; that deviation still
+ * stands wherever the two names are confused, it simply no longer has a reader
+ * here.
  *
  * DEVIATIONS from the vendored frame, both named in the PR:
  *  • the multiplier chip is labelled from the SHARED `card.stamp.mult` key
@@ -110,15 +138,41 @@ import type { ScoreStampProps } from "./ScoreStamp";
 const STAMP_WIDTH = 128;
 const ROSE = 84;
 
+/** The cell's label voice: incised caps at the label tier's 11px (#1608). */
+const LABEL: CSSProperties = { ...SMALL_CAPS, fontSize: "var(--text-md)" };
+
+/**
+ * The cell's figure voice: the plate's display face, at ONE size for every row.
+ *
+ * `--text-xl` (14px) is the smallest step of the plate's own ramp that reads as
+ * a figure rather than as another label — the base figure used to be `--text-title`
+ * and shout over the total struck in the rose, and the tally's used to be set in
+ * running italic at the LABEL's 11px.
+ */
+const FIGURE: CSSProperties = { fontFamily: DECO, fontSize: "var(--text-xl)", lineHeight: 1 };
+
+/**
+ * ONE LINE OF THE WORKING: the figure, then the word (#2285).
+ *
+ * Two grid cells and no wrapper — see the cell's grid above. `ink` is the whole
+ * line's colour, one per row: the ruling forbids a number and its label being
+ * told apart by colour, so a row never carries two.
+ */
+function WorkingRow({ figure, label, ink }: { figure: string; label: string; ink: string }) {
+  return (
+    <>
+      <span style={{ ...FIGURE, color: ink }}>{figure}</span>
+      <span style={{ ...LABEL, color: ink }}>{label}</span>
+    </>
+  );
+}
+
 export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampProps) {
   const { t } = useTranslation("praxis");
   if (praxis.score === null || praxis.score === undefined) return null;
   const { base, mult, meta, habit, votes, total } = scoreBreakdown(praxis);
   const crowned = praxis.is_top_for_task && showCrown !== false;
   const working = base !== null;
-
-  /** The cell's label voice: incised caps, at the plate's caption gold. */
-  const label = { ...SMALL_CAPS, fontSize: "var(--text-md)", color: CAPTION };
 
   return (
     /*
@@ -163,33 +217,32 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
               boxSizing: "border-box",
               padding: "var(--space-sm) var(--space-md)",
               lineHeight: 1.1,
+              /*
+               * THE FIGURES ARE ONE COLUMN AND THE WORDS ANOTHER (#2285), which
+               * is a property of the CELL and cannot be one of a row: two
+               * independent flex rows align a figure with its own label and with
+               * nothing above or below it.
+               */
+              display: "grid",
+              gridTemplateColumns: "auto 1fr",
+              alignItems: "baseline",
+              columnGap: "var(--space-sm)",
+              rowGap: "var(--space-sm)",
             }}
           >
-            {/* Base, with the figure set against its label across the cell. */}
-            <div
-              style={{
-                display: "flex",
-                alignItems: "baseline",
-                justifyContent: "space-between",
-                gap: "var(--space-sm)",
-              }}
-            >
-              {/* 基 stood here, glossed "base". #1909 cut all five of this cell's
-                  kanji: they were the only faction-specific score-stamp labels in
-                  the app, on a surface the audit ruled generic. The shared gloss
-                  each one carried is now the visible label. */}
-              <span style={label}>{t("card.stamp.base")}</span>
-              <span style={{ fontFamily: DECO, fontSize: "var(--text-title)", lineHeight: 0.8, color: INK }}>
-                {base}
-              </span>
-            </div>
+            {/* 基 stood at the base row, glossed "base". #1909 cut all five of this
+                cell's kanji: they were the only faction-specific score-stamp labels
+                in the app, on a surface the audit ruled generic. The shared gloss
+                each one carried is now the visible label. */}
+            <WorkingRow figure={`${base}`} label={t("card.stamp.base")} ink={CAPTION} />
 
-            {/* The multiplier, in its own ruled chip — the design's "ratio" cell. */}
+            {/* The multiplier, in its own ruled chip — the design's "ratio" cell.
+                Not an addend and not a line of the working, so it spans both
+                columns and keeps its word-then-ratio shape. */}
             {mult !== null && (
-              /* Same treatment, one rung down — the chip had the same clipped
-                 border. The margin belongs to the MOUNT, which is the chip's
-                 outer box now. */
-              <div style={{ ...chamferMount(5), marginTop: "var(--space-sm)" }}>
+              /* The chamfer treatment of #2150/#2314, one rung down — the chip had
+                 the same clipped border. */
+              <div style={{ ...chamferMount(5), gridColumn: "1 / -1" }}>
                 <div
                   style={{
                     ...chamferSheet(5, WASH),
@@ -199,7 +252,9 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
                     padding: "var(--space-xs) var(--space-sm)",
                   }}
                 >
-                  <span style={{ ...label, letterSpacing: "0.2em" }}>{t("card.stamp.mult")}</span>
+                  <span style={{ ...LABEL, color: CAPTION, letterSpacing: "0.2em" }}>
+                    {t("card.stamp.mult")}
+                  </span>
                   <span aria-hidden style={{ width: 1, height: 11, background: BRASS_LIGHT }} />
                   <span style={{ fontFamily: DECO, fontSize: "var(--text-lg)", lineHeight: 1, color: INK }}>
                     {formatMult(mult)}
@@ -211,29 +266,7 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
             {/* The metatask award, struck in the plate's one accent — a foreign
                 award, not the task's. See the ochre measurement above. */}
             {meta !== null && (
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "var(--space-xs)",
-                  marginTop: "var(--space-sm)",
-                  color: OCHRE,
-                }}
-              >
-                <span
-                  style={{
-                    ...SMALL_CAPS,
-                    fontWeight: 600,
-                    fontSize: "var(--text-md)",
-                    letterSpacing: "0.16em",
-                  }}
-                >
-                  {t("card.stamp.meta")}
-                </span>
-                <span style={{ fontFamily: READING, fontStyle: "italic", fontSize: "var(--text-md)" }}>
-                  +{meta}
-                </span>
-              </div>
+              <WorkingRow figure={`+${meta}`} label={t("card.stamp.meta")} ink={OCHRE} />
             )}
 
             {/* The tally, cut only when there are votes to record (ADR-0076). The `+`
@@ -242,17 +275,7 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
                 and a numeral sit together, and #1637's whole bound is that only the
                 label is encoded. */}
             {votes !== null && (
-              <div
-                style={{
-                  fontFamily: READING,
-                  fontStyle: "italic",
-                  fontSize: "var(--text-md)",
-                  color: QUIET,
-                  marginTop: "var(--space-sm)",
-                }}
-              >
-                + {votes} <span style={label}>{t("card.stamp.votes")}</span>
-              </div>
+              <WorkingRow figure={`+${votes}`} label={t("card.stamp.votes")} ink={CAPTION} />
             )}
 
             {/* The habit bonus (#1617), cut after the tally: flat, outside the ratio.
@@ -260,17 +283,7 @@ export default function EphemeristsScoreStamp({ praxis, showCrown }: ScoreStampP
                 #1637 bound holds, so the LABEL is encoded and the figure stays a
                 Western numeral. */}
             {habit !== null && (
-              <div
-                style={{
-                  fontFamily: READING,
-                  fontStyle: "italic",
-                  fontSize: "var(--text-md)",
-                  color: QUIET,
-                  marginTop: "var(--space-xs)",
-                }}
-              >
-                + {habit} <span style={label}>{t("card.stamp.habit")}</span>
-              </div>
+              <WorkingRow figure={`+${habit}`} label={t("card.stamp.habit")} ink={CAPTION} />
             )}
           </div>
         </div>

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/ephemeristsScoreStamp.test.tsx
@@ -126,13 +126,15 @@ describe('the stamp reads working-then-total (#2145)', () => {
     expect(bare, 'no chamfered panel around an empty block').not.toContain(CLIP)
   })
 
-  it('inks the metatask line in the ochre and the votes line in the quiet', () => {
+  it('inks the metatask line in the ochre, and every other line in the caption', () => {
     const html = render()
-    // The foreign award, ochre — 4.97:1 light / 4.99:1 dark on the panel cell.
+    // The foreign award, ochre — 4.98:1 light / 4.99:1 dark on the panel cell.
     expect(html).toContain('color:var(--faction-ephemerists-plate-ochre)')
-    // NOT `-plate-band-quiet`, which is a DISC ink: 1.78:1 on this panel in
-    // light. See the note in the stamp for the measurement.
-    expect(html).toContain('color:var(--faction-ephemerists-plate-quiet)')
+    // #2285 put each line's figure in its LABEL's colour, so the caption gold is
+    // now the cell's ink and `-plate-quiet` has no reader here. It was never
+    // `-plate-band-quiet`, a DISC ink measuring 1.78:1 on this panel in light.
+    expect(html).toContain('color:var(--faction-ephemerists-plate-caption)')
+    expect(html).not.toContain('color:var(--faction-ephemerists-plate-quiet)')
     // The ochre chip is gone: it was `-plate-disc` on `-plate-ochre`, 3.00:1,
     // at 11px — a normal-text pairing scraping the LARGE-text floor.
     expect(html).not.toContain('background:var(--faction-ephemerists-plate-ochre)')
@@ -151,6 +153,96 @@ describe('the stamp reads working-then-total (#2145)', () => {
   it('labels the total “points”, in English (#2145 §5)', () => {
     expect(render().replace(/<[^>]*>/g, '')).toContain(i18n.t('praxis:card.stamp.points', { count: 26.5 }))
     expect(render()).not.toContain('PVNCTA')
+  })
+})
+
+/**
+ * ONE ARRANGEMENT FOR EVERY LINE (#2285).
+ *
+ * THE SEAM IS THE SAME RENDERED MARKUP, read as an ordered list of `<span>`s.
+ * The defect is not that any one row is wrong — each was internally coherent —
+ * but that the three rows of a three-term addition disagreed with each other:
+ * base put its word first and its figure at the far end of a `space-between`
+ * row, metatask put its word first and its figure beside it, the tally put its
+ * figure first, and two of the three coloured a figure differently from its own
+ * label. So the assertions below are made PER ROW against one shared shape,
+ * which is what makes a fourth row (the habit bonus) unable to arrive
+ * off-pattern: adding a row that disagrees fails the same three checks.
+ *
+ * A string of markup cannot see a column, but it can see everything the column
+ * is made of: the figure's span opening before its label's, the same face and
+ * size on every figure and on every label, and one colour inside a row. The
+ * cell's `grid-template-columns` is asserted once, on the panel itself.
+ */
+describe('every line of the working reads figure-then-word (#2285)', () => {
+  type Span = { style: string; text: string }
+
+  /** Every styled `<span>` in document order. */
+  const spans = (html: string): Span[] =>
+    [...html.matchAll(/<span style="([^"]*)"[^>]*>([^<]*)<\/span>/g)].map((m) => ({
+      style: m[1],
+      text: m[2],
+    }))
+
+  const decl = (span: Span, prop: string) =>
+    span.style.split(';').find((d) => d.startsWith(`${prop}:`)) ?? `no ${prop}`
+
+  /** A row, found by its label — and the span that opened immediately before it. */
+  function row(html: string, label: string) {
+    const all = spans(html)
+    const at = all.findIndex((s) => s.text === label)
+    expect(at, `the ${label} row is printed`).toBeGreaterThan(0)
+    return { figure: all[at - 1], label: all[at] }
+  }
+
+  /** Base, the multiplier's two terms aside, and the three lines added to it. */
+  const ROWS = [
+    { label: 'base', figure: '18' },
+    { label: 'meta', figure: '+3' },
+    { label: 'votes', figure: '+4' },
+    { label: 'habit', figure: '+2' },
+  ]
+  // 12 base points, ×1.5, +3 metatask, +4 votes, +2 habit — every row at once,
+  // which is the only state in which the four can be compared to each other.
+  const html = render({ habit_bonus_points: 2, task_point_value: 18, display_multiplier: 1.5 })
+
+  for (const { label, figure } of ROWS) {
+    it(`puts the figure before the word on the ${label} row`, () => {
+      const cells = row(html, label)
+      expect(cells.figure.text, `${label}'s figure opens before its word`).toBe(figure)
+    })
+
+    it(`sets the ${label} row's figure and word in ONE ink`, () => {
+      // The ruling: the column position tells a number from its label, so
+      // colour never has to — and no row may carry two.
+      const cells = row(html, label)
+      expect(decl(cells.figure, 'color')).toBe(decl(cells.label, 'color'))
+    })
+
+    it(`sets the ${label} row in the shared figure and label voices`, () => {
+      const cells = row(html, label)
+      // One face and one size across the figures...
+      expect(decl(cells.figure, 'font-family')).toBe('font-family:var(--font-faction-deco)')
+      expect(decl(cells.figure, 'font-size')).toBe('font-size:var(--text-xl)')
+      // ...and one across the labels.
+      expect(decl(cells.label, 'font-family')).toBe('font-family:var(--font-faction-engraved)')
+      expect(decl(cells.label, 'font-size')).toBe('font-size:var(--text-md)')
+    })
+  }
+
+  it('lays the cell out as two columns, figures against words', () => {
+    // Per-row flexboxes cannot do this: each would size its own two columns.
+    expect(html).toContain('grid-template-columns:auto 1fr')
+    expect(html, 'the base row no longer pushes its figure to the far end').not.toContain(
+      'justify-content:space-between',
+    )
+  })
+
+  it('still keeps the multiplier out of the addition, spanning both columns', () => {
+    // It is a ratio in a ruled chip, not a term being added, so it is the one
+    // thing in the cell that is not a figure-then-word row.
+    expect(html).toContain('grid-column:1 / -1')
+    expect(html).toContain(i18n.t('praxis:card.stamp.mult'))
   })
 })
 

--- a/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
+++ b/frontend/src/components/praxisCard/scoreStamp/__tests__/scoreStamp.test.tsx
@@ -981,7 +981,10 @@ describe('the Ephemerists score stamp reads in the shared words (#1909)', () => 
     const html = text(full())
     expect(html).toContain('40')
     expect(html).toContain('×1.20')
-    expect(html).toContain('+ 4 ')
+    // #2285 made the tally figure a cell of its own — the sign and the numeral
+    // are one figure now, and the label is the next cell along, so the space
+    // that separated them in one run of text is gone with the run.
+    expect(html).toContain('+4')
     // Whole, so no decimal — the kanji labels do not change the notation (#1866).
     expect(html).toContain('52')
     expect(html).not.toContain('52.0')
@@ -1034,7 +1037,10 @@ describe('every stamp shows the habit bonus when one is banked (#1617)', () => {
   const STAMPS = [
     ['the unaffiliated sheet', DefaultScoreStamp, 'habit', '+ 5 habit bonus'],
     ['Everymen', EverymenScoreStamp, 'habit', 'habit+5'],
-    ['the Ephemerists', EphemeristsScoreStamp, 'habit', '+ 5 habit'],
+    // #2285 put the figure and the word in two columns of the cell's grid, so
+    // they butt together once the tags are stripped — the same shape Coven's
+    // note below describes. The label and the notation are unchanged.
+    ['the Ephemerists', EphemeristsScoreStamp, 'habit', '+5habit'],
     ['S.N.I.D.E.', SnideScoreStamp, 'habit', 'habit +5'],
     ['Singularity', SingularityScoreStamp, 'habit', 'habit+05'],
     ['WOW', WowScoreStamp, 'habit', 'habit +5'],
@@ -1066,7 +1072,7 @@ describe('every stamp shows the habit bonus when one is banked (#1617)', () => {
 
   it('leaves the Ephemerists numeral Western, like every other figure of theirs', () => {
     const html = text(renderToStaticMarkup(<EphemeristsScoreStamp praxis={banked} />))
-    expect(html).toContain('+ 5')
+    expect(html).toContain('+5')
     expect(html).not.toMatch(/[〇一二三四五六七八九十百千万]/)
   })
 


### PR DESCRIPTION
The Ephemerists tally cell showed three numbers three ways: the base label and its figure at opposite ends of a `space-between` row, the metatask word **before** its figure, the tally figure before its word — and two of the three coloured a figure differently from its own label. A three-term addition was read three ways.

Per the owner's ruling, the cell is now a two-column read — **numbers on the left, words on the right, one face and one size across the figures and one across the labels**:

```
15   BASE
+10  META
+5   VOTES
```

## What changed

- The panel cell is a **grid** (`grid-template-columns: auto 1fr`), not a stack of independently-arranged rows. The columns belong to the CELL, because a per-row flexbox lines a figure up with its own label and with nothing above or below it.
- One `WorkingRow` emits two grid cells and no wrapper. Four bespoke row layouts (base / meta / votes / habit) collapse into it — **net −33 lines of layout**.
- Figures: one voice, `DECO` at `--text-xl` (14px). Base was `--text-title` (24px) and shouted over the total struck in the rose; the tally and habit figures were running italic at the *label's* 11px.
- The multiplier chip is untouched except for `grid-column: 1 / -1`. It is a ratio in a ruled chip, not an addend, and #2150/#2314 rebuilt its chamfer an hour ago — **flagging it rather than restyling it**: it still reads word-then-ratio, with the brass hairline doing the separating. Say the word and it can follow the rows.

## Inks — two figures move, and only because the ruling forbids two colours in a line

The label tier's caption gold stays (it is the plate's label voice everywhere), so the figures join their labels rather than the other way round. Measured on `--faction-ephemerists-plate-inner`, both cascades:

| line | was | now | light | dark |
|---|---|---|---|---|
| base | `-plate-ink` figure, `-plate-caption` label | `-plate-caption` | 14.93 → **5.68** | 12.84 → **6.67** |
| meta | `-plate-ochre`, both | unchanged | 4.98 | 4.99 |
| votes / habit | `-plate-quiet` figure, `-plate-caption` label | `-plate-caption` | 8.21 → **5.68** | 5.52 → **6.67** |

Both new pairings clear AA_NORMAL (4.5:1) at the labels' 11px and at the figures' 14px, and both are `factionContrast`'s existing "ephemerists panel cell, caption" row — no ink is introduced, and `--faction-ephemerists-*` tokens only. `-plate-quiet` simply loses its reader here.

## The seam, and the test

**The seam is the rendered markup of `EphemeristsScoreStamp`** (`renderToStaticMarkup`; no DOM in this harness, so nothing is measured — order and declared styles only). The assertions are made **per row** against one shared shape — figure span opens before its label, same face and size on every figure and on every label, one colour inside a row — which is what makes a fourth row (the habit bonus) unable to arrive off-pattern. The suite went **red on 14 cases** against the pre-fix component before it went green.

Three assertions in `scoreStamp.test.tsx` moved from `+ 5 habit` to `+5habit`: the sign and the numeral are one figure cell now and the label is the next cell along, so the space that separated them inside one run of text went with the run. No copy changed.

## Verified

`npm run lint` · `npm run typecheck` · `npm run typecheck:design-sync` · `npm test` (362 files, 6454 passing) · `npm run build` — all green. Byte budget: **CSS byte-identical to `main`** (22918 B gzip level 9, both), no stylesheet touched.

**Visual QA is outstanding** — I have no browser.

## What to eyeball

- [ ] The working panel, **light**: the figures line up as one column and the words as another, across base / meta / votes (and habit, on a UA praxis).
- [ ] The working panel, **dark**: same, and the caption gold reads as a figure at 14px — Poiret One is a thin face and this is the size it has never been set at here.
- [ ] The base figure no longer competing with the total in the rose, now that it is 14px rather than 24px.
- [ ] The metatask row still reading as the plate's one accent among gold rows, both cascades.
- [ ] The multiplier chip spanning both columns and sitting between base and meta as it did — its chamfer and brass hairline unchanged from #2331.
- [ ] The **compass rose** below the panel, both cascades: total, unit and limb untouched, and the crown still overhanging on a top-for-task praxis.
- [ ] The panel at its 128px ceiling with the longest label (`votes` / `habit`) — no wrap.

Closes #2285
