### PR TITLE
The Ephemerists tile gets its own file and its task card's vellum plate, and its light half is measured for the first time (#2323)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/ephemeristsCta.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsCta.test.tsx
@@ -147,13 +147,18 @@ describe("every bordered plate CTA wears it, and the list is the assertion", () 
 
   const WEARS = /className[=:]\s*[{`"']?[^"'`]*eph-cta/;
 
-  it("is mounted on the five surfaces that draw one, and no others", () => {
+  it("is mounted on the six surfaces that draw one, and no others", () => {
     // The issue names three (card, task detail, composer). The grep found two
     // more painting the identical button — the faction page's join/leave pair
     // and the phone's field desk — and #2067's own note that the field desk
     // "does not paint it with the plate CTA" is simply out of date. A ruling
     // about one control does not stop at the surfaces someone happened to
     // list; leaving either behind is the drift the extraction exists to end.
+    //
+    // The SIXTH is the faction-directory tile (#2323). It drew a brass-outlined
+    // ghost button in `-plate-gold` on the cornice band, which is what a tile
+    // painted in the wrong register looks like from here: not a variant of this
+    // control, a different one. Repainting it onto the plate made it this one.
     const mounts = files
     // Matched at the `className`, not on the bare string: half the Ephemerists
     // kit names this class in prose, and a census a comment can join is a
@@ -161,6 +166,7 @@ describe("every bordered plate CTA wears it, and the list is the assertion", () 
       .filter(([, source]) => WEARS.test(source))
       .map(([path]) => path.slice(SRC.length).replace(/\\/g, "/"));
     expect(mounts.sort()).toEqual([
+      "components/selectCard/EphemeristsSelectCard.tsx",
       "components/taskCard/EphemeristsTaskCard.tsx",
       "pages/editPraxis/archetypes/EphemeristsEditPraxis.tsx",
       "pages/factionDetail/archetypes/EphemeristsFactionBody.tsx",

--- a/frontend/src/components/factionMarks/ephemeristsPlate.tsx
+++ b/frontend/src/components/factionMarks/ephemeristsPlate.tsx
@@ -23,14 +23,23 @@
  * this vocabulary left in `src/`, and `ephemeristsPlateSurfaces.test.tsx` pins
  * that against the SOURCE tree, because an import-graph sweep cannot see a copy.
  *
- * Every colour is a `--faction-ephemerists-plate-*` token, never a ternary — but
- * do not expect a theme flip. This register is THEME-INVARIANT BY DESIGN (#1627
- * + #1636): every plate var is declared once at `:root`, and `[data-theme="dark"]`
- * declares no plate token at all. The dark block in `index.css` says so where
- * the night half used to be — the half was removed because "the register is
- * theme-invariant and lives entirely in `:root`", the polarity argument being
- * set out beside the `:root` declarations. The register IS the design's night
- * half, so these values already read on the dark page.
+ * Every colour is a `--faction-ephemerists-plate-*` token, never a ternary — and
+ * the register DOES flip. It used to say the opposite here: "THEME-INVARIANT BY
+ * DESIGN (#1627 + #1636)", every plate var declared once at `:root` and
+ * `[data-theme="dark"]` declaring "no plate token at all". That was true when it
+ * was written and #2141 reversed it; the dark block declares FIFTEEN of them
+ * today. The sheet is the vellum #eadcb6 by day and #171a26 by night, and the
+ * inks flip with it. Corrected in #2323, because anyone trusting the old
+ * sentence skips a dark measurement that matters — and skipping it is exactly
+ * how the faction's directory tile spent this epic grounded on a band.
+ *
+ * FOUR ABSENCES FROM THE DARK BLOCK ARE STILL THE POINT and must not be
+ * "completed": `-band` / `-band-ink` / `-band-quiet` are the compass blue and
+ * its two inks, theme-invariant because the masthead is the faction rather than
+ * a mode; `-plate-disc` is the dark chip the metals are struck on; `-brass-rule`
+ * is one value across all three grounds by construction; and `-plate-gold` and
+ * `-plate-wash` have no light value to differ from. The full reasoning is beside
+ * both halves in `index.css`.
  */
 import type { CSSProperties } from "react";
 import { mediaUrl } from "../../utils/media";

--- a/frontend/src/components/selectCard/EphemeristsSelectCard.tsx
+++ b/frontend/src/components/selectCard/EphemeristsSelectCard.tsx
@@ -1,0 +1,57 @@
+import i18n from "../../i18n";
+import { factionName } from "../../utils/factions";
+import type { FactionSelectCardProps } from "./FactionSelectCard";
+import { EphemeristsSigil } from "../sigil/EphemeristsSigil";
+import * as eph from "../factionMarks/ephemeristsPlate";
+
+/**
+ * The Ephemerists tile — the cornice masthead the plate hangs under, standing on
+ * its own (#1208). The night band, the sigil ruled in brass, and the CTA in the
+ * plate’s gold. Nothing legible is
+ * set in `brass`; on this ground the inks are `band-ink` (12.4:1), `gold` (9.4)
+ * and `band-quiet` (8.6).
+ */
+export default function EphemeristsSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
+  const status = i18n.t(`feed:factionSelect.ephemerists.status.${state}` as const);
+  return (
+    <div style={{
+      width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
+      background: eph.BAND, color: eph.BAND_INK, fontFamily: eph.READING,
+      border: `1px solid ${eph.BRASS}`, boxShadow: eph.SHADOW, display: "flex", flexDirection: "column",
+    }}>
+      <div style={{ position: "absolute", inset: 9, border: `1px solid color-mix(in srgb, ${eph.BRASS_LIGHT} 35%, transparent)`, pointerEvents: "none" }} />
+      {/* An incised glyph register ran above the footer until #2210. It was
+          the OLD vocabulary the notation band replaced on the masthead, and it
+          retires kit-wide; nothing takes its place here, because this tile
+          heads itself by hand and mounts no `EphemeristsMasthead`. */}
+      <div style={{ position: "absolute", top: 16, right: 18, fontSize: "var(--text-md)", letterSpacing: "0.1em", color: eph.BAND_QUIET, textAlign: "right", lineHeight: 1.5 }}>{i18n.t("feed:factionSelect.ephemerists.coords")}<br />{i18n.t("feed:factionSelect.ephemerists.coordsPolar")}</div>
+      <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-xl) 0" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)" }}>
+          <span style={{ width: 46, height: 46, borderRadius: "50%", border: `1.5px solid ${eph.BRASS}`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+            <EphemeristsSigil size={26} color={eph.GOLD} />
+          </span>
+          <div>
+            <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.24em", color: eph.GOLD }}>{i18n.t("feed:factionSelect.ephemerists.eyebrow")}</div>
+            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the plate’s masthead wordmark — Poiret One letterspaced until the width is the mark */}
+            <div style={{ fontFamily: eph.DECO, fontSize: 24, lineHeight: 1.1, letterSpacing: "0.22em", textTransform: "uppercase", color: eph.BAND_INK, marginTop: "var(--space-xs)" }}>{factionName("ephemerists")}</div>
+          </div>
+        </div>
+        <div style={{ height: 1.5, background: `linear-gradient(90deg, ${eph.BRASS_LIGHT} 0%, transparent 100%)`, margin: "var(--space-lg) 0 var(--space-md)" }} />
+        <p className="content-text" style={{ margin: 0, fontFamily: eph.READING, fontStyle: "italic", lineHeight: 1.45, color: eph.BAND_INK }}>
+          {i18n.t("feed:factionSelect.ephemerists.blurb")}
+        </p>
+      </div>
+      <div style={{ position: "relative", padding: "0 var(--space-xl) var(--space-lg)" }}>
+        <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.14em", color: eph.BAND_QUIET, marginBottom: "var(--space-md)" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.ephemerists.members", { count: members })}`}</div>
+        <button onClick={onVisit} style={{
+          width: "100%", cursor: "pointer", border: `1px solid ${eph.BRASS}`, background: "transparent", color: eph.GOLD,
+          ...eph.SMALL_CAPS, fontSize: "var(--text-xl)", letterSpacing: "0.16em", padding: "var(--space-md)",
+        }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = eph.GOLD; e.currentTarget.style.color = eph.BAND; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = eph.GOLD; }}
+        >{i18n.t("feed:factionSelect.ephemerists.cta")}</button>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/selectCard/EphemeristsSelectCard.tsx
+++ b/frontend/src/components/selectCard/EphemeristsSelectCard.tsx
@@ -2,56 +2,159 @@ import i18n from "../../i18n";
 import { factionName } from "../../utils/factions";
 import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { EphemeristsSigil } from "../sigil/EphemeristsSigil";
+import EphemerisNet from "../factionMarks/EphemerisNet";
 import * as eph from "../factionMarks/ephemeristsPlate";
 
 /**
- * The Ephemerists tile — the cornice masthead the plate hangs under, standing on
- * its own (#1208). The night band, the sigil ruled in brass, and the CTA in the
- * plate’s gold. Nothing legible is
- * set in `brass`; on this ground the inks are `band-ink` (12.4:1), `gold` (9.4)
- * and `band-quiet` (8.6).
+ * The Ephemerists — the faction-DIRECTORY tile (#2323, a child of #2321).
+ *
+ * One file per faction, mirroring `components/taskCard/`. `FactionSelectCard`
+ * keeps only the dispatcher, the shared types and `LEGACY_SLUG`.
+ *
+ * THE TILES ARE NOT ALL DARK, whatever the dispatcher's docstring used to say.
+ * Coven's is pink and UA's is cream, and that false premise is exactly what let
+ * a dark-only register look correct on a surface that flips. This tile had only
+ * ever run dark; every pairing below is now measured in BOTH cascades.
+ *
+ * ── IT WAS PAINTED WITH THE WRONG REGISTER, NOT A BROKEN ONE ───────────────
+ *
+ * The tile drew entirely from the BAND: `BAND` as the sheet, `BAND_INK` and
+ * `BAND_QUIET` as its inks, `BRASS` as a rule and `GOLD` as an ink.
+ * `-plate-band` is #12151f, the cornice masthead's ground, and it is dark on
+ * purpose in both cascades (its own declaration says so, and says not to
+ * "complete" it). So the tile was never failing to flip — it was wearing a band
+ * where a sheet belongs.
+ *
+ * WHY NO SWEEP COULD SEE IT, and why this defect is NOT S.N.I.D.E.'s (#2322).
+ * Snide's tile was a FORKED FAMILY: two `--faction-snide-*` families, one of
+ * which flips. Here the band and the plate are the SAME family, so #2321's
+ * acceptance as literally worded — "references no token family its own task
+ * card does not use" — is VACUOUSLY TRUE of the old tile and of this one. The
+ * invariant that actually holds is one rung sharper and is what the guard next
+ * door pins: **the sheet is a token that flips**, and the three inks measured
+ * only on the band do not appear on a card that has no band.
+ *
+ * ── THE REGISTER IS THE TASK CARD'S, NOT A NEW ONE ─────────────────────────
+ *
+ * `EphemeristsTaskCard` paints the PLATE — a papyrus sheet ruled in brass,
+ * whose whole family flips through `[data-theme="dark"]` with no ternary.
+ * Gathered from it, role for role (light / dark):
+ *
+ *   sheet      `BAND` #12151f    -> {@link eph.PLATE}, the vellum — #eadcb6 by
+ *                                  day, #171a26 by night.
+ *   frame      `BRASS`           -> unchanged; the card's own frame brass.
+ *   inner rule a `color-mix` of the link brass at 35% -> {@link eph.LINE},
+ *                                  the register's declared "hairline borders",
+ *                                  which flips and needs no mix.
+ *   body ink   `BAND_INK`        -> {@link eph.INK}          13.37 / 13.91
+ *   blurb      `BAND_INK`        -> {@link eph.QUIET}         7.35 /  5.98
+ *   coords     `BAND_QUIET`      -> {@link eph.QUIET}         7.35 /  5.98
+ *   eyebrow    `GOLD`            -> {@link eph.CAPTION}       5.09 /  7.22
+ *   status     `BAND_QUIET`      -> {@link eph.CAPTION}       5.09 /  7.22
+ *   rule       a brass-to-nothing gradient -> the plate's DOUBLE BRASS RULE in
+ *                                  {@link eph.BRASS_RULE}, which is how this
+ *                                  card rules everything it rules.
+ *   sigil      `GOLD` on the band -> `GOLD` on a {@link eph.DISC} chip, 13.07:1.
+ *                                  `-plate-gold` HAS NO LIGHT VALUE and needs
+ *                                  none: the metals are struck only on a dark
+ *                                  chip, and `-plate-disc` is that chip — the
+ *                                  one sheet in the register that does not
+ *                                  flip, declared for exactly this. Without it
+ *                                  the gilt reads 1.02:1 on the vellum, which
+ *                                  is this tile's real light-half defect.
+ *   CTA        a brass-outlined ghost button in `GOLD` -> `.eph-cta`, THE ONE
+ *                                  PLATE CTA (#2146), worn by five other
+ *                                  surfaces. 7.59:1 in both cascades, and the
+ *                                  enclosure changes WIDTH between them, which
+ *                                  no token can carry — which is why it is a
+ *                                  class and why nothing here sets `background`,
+ *                                  `color` or `border` inline over it.
+ *   ground     nothing           -> {@link EphemerisNet} at 0.10, the faction's
+ *                                  one ground, at the card/plate weight its
+ *                                  own header rules for a card.
+ *
+ * EVERY TEXT PAIRING HERE WAS ALREADY PINNED, in both themes, by the task card's
+ * rows in `utils/__tests__/factionContrast.test.ts` — `ephemerists plate, ink`,
+ * `…, quiet ink`, `…, caption` and `ephemerists plate CTA band`. That is the
+ * point of gathering a register rather than inventing one: this repaint adds no
+ * contrast row, because it introduces no colour the plate had not already
+ * measured. The tightest reading on the tile is 5.09:1.
+ *
+ * WHERE THE TASK CARD HAS NO ANSWER, and nothing is invented for it:
+ *   • NO HOVER. `.eph-cta` declares none, on any of its six surfaces, so the
+ *     ghost button's two `onMouseEnter`/`onMouseLeave` handlers are DELETED
+ *     rather than re-tinted. Giving this one tile a hover the other five lack is
+ *     how a shared control starts becoming six again (#2146).
+ *   • NO CORNICE. `Cornice` is the register's band-as-a-band and would be the
+ *     literal reading of "the band may still appear as a band" (#2323). It is
+ *     left off because the tile's coordinate block is absolutely positioned at
+ *     the sheet's top edge, where a fluted band would land on it — a geometry
+ *     question this repaint has no way to eyeball. The band survives here as the
+ *     sigil's chip and as the CTA bar, both of which are the compass blue.
+ *   • The MARGINALIA face (EB Garamond) is the register's fourth cut and the
+ *     tile has no marginal gloss, so it wears three of the four faces.
+ *
+ * The sigil is the shared canonical `EphemeristsSigil` and is never re-drawn
+ * inline. The box is FLUID at a uniform 360x300 ceiling — `width: 100%` to a
+ * 360 max and `minHeight` rather than a fixed height — so the 375px
+ * single-column mobile directory still works (#732). Nothing here changes the
+ * grid.
  */
 export default function EphemeristsSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
   const status = i18n.t(`feed:factionSelect.ephemerists.status.${state}` as const);
   return (
     <div style={{
       width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
-      background: eph.BAND, color: eph.BAND_INK, fontFamily: eph.READING,
+      /* THE NET'S MOUNT, the task card's own call: isolating makes the tile its
+         own stacking context, so the net's `z-index: -1` paints after the sheet's
+         fill and before every descendant — including the two absolutely
+         positioned ornaments below, which carry no z-index of their own. */
+      isolation: "isolate",
+      background: eph.PLATE, color: eph.INK, fontFamily: eph.READING,
       border: `1px solid ${eph.BRASS}`, boxShadow: eph.SHADOW, display: "flex", flexDirection: "column",
     }}>
-      <div style={{ position: "absolute", inset: 9, border: `1px solid color-mix(in srgb, ${eph.BRASS_LIGHT} 35%, transparent)`, pointerEvents: "none" }} />
+      {/* 0.10 — the card/plate weight. The three weights are a ruling and the
+          prop has no default, so a mount that has not decided which surface it
+          is has not finished. This is a plate. */}
+      <EphemerisNet opacity={0.1} />
+      <div style={{ position: "absolute", inset: 9, border: `1px solid ${eph.LINE}`, pointerEvents: "none" }} />
       {/* An incised glyph register ran above the footer until #2210. It was
           the OLD vocabulary the notation band replaced on the masthead, and it
           retires kit-wide; nothing takes its place here, because this tile
           heads itself by hand and mounts no `EphemeristsMasthead`. */}
-      <div style={{ position: "absolute", top: 16, right: 18, fontSize: "var(--text-md)", letterSpacing: "0.1em", color: eph.BAND_QUIET, textAlign: "right", lineHeight: 1.5 }}>{i18n.t("feed:factionSelect.ephemerists.coords")}<br />{i18n.t("feed:factionSelect.ephemerists.coordsPolar")}</div>
+      <div style={{ position: "absolute", top: 16, right: 18, fontSize: "var(--text-md)", letterSpacing: "0.1em", color: eph.QUIET, textAlign: "right", lineHeight: 1.5 }}>{i18n.t("feed:factionSelect.ephemerists.coords")}<br />{i18n.t("feed:factionSelect.ephemerists.coordsPolar")}</div>
       <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-xl) 0" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)" }}>
-          <span style={{ width: 46, height: 46, borderRadius: "50%", border: `1.5px solid ${eph.BRASS}`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
+          {/* The dark chip, filled rather than merely rimmed. Its ink budget is
+              the BAND's and not the sheet's — see `-plate-disc` in index.css —
+              which is what keeps the gilt gilt on a vellum plate. */}
+          <span style={{ width: 46, height: 46, borderRadius: "50%", background: eph.DISC, border: `1.5px solid ${eph.BRASS_RULE}`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
             <EphemeristsSigil size={26} color={eph.GOLD} />
           </span>
           <div>
-            <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.24em", color: eph.GOLD }}>{i18n.t("feed:factionSelect.ephemerists.eyebrow")}</div>
+            <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.24em", color: eph.CAPTION }}>{i18n.t("feed:factionSelect.ephemerists.eyebrow")}</div>
             {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the plate’s masthead wordmark — Poiret One letterspaced until the width is the mark */}
-            <div style={{ fontFamily: eph.DECO, fontSize: 24, lineHeight: 1.1, letterSpacing: "0.22em", textTransform: "uppercase", color: eph.BAND_INK, marginTop: "var(--space-xs)" }}>{factionName("ephemerists")}</div>
+            <div style={{ fontFamily: eph.DECO, fontSize: 24, lineHeight: 1.1, letterSpacing: "0.22em", textTransform: "uppercase", color: eph.INK, marginTop: "var(--space-xs)" }}>{factionName("ephemerists")}</div>
           </div>
         </div>
-        <div style={{ height: 1.5, background: `linear-gradient(90deg, ${eph.BRASS_LIGHT} 0%, transparent 100%)`, margin: "var(--space-lg) 0 var(--space-md)" }} />
-        <p className="content-text" style={{ margin: 0, fontFamily: eph.READING, fontStyle: "italic", lineHeight: 1.45, color: eph.BAND_INK }}>
+        {/* The plate's own closing pair — a hairline above, a `3px double`
+            below, both in the LINE brass. The task card opens its masthead and
+            closes its CTA block on this exact rule. */}
+        {/* The 3px is the gap inside the stepped double rule — ornament
+            geometry, carved out of the spacing ratchet (§4a). */}
+        <div aria-hidden="true" style={{ height: 3, borderTop: `1px solid ${eph.BRASS_RULE}`, borderBottom: `3px double ${eph.BRASS_RULE}`, margin: "var(--space-lg) 0 var(--space-md)" }} />
+        <p className="content-text" style={{ margin: 0, fontFamily: eph.READING, fontStyle: "italic", lineHeight: 1.45, color: eph.QUIET }}>
           {i18n.t("feed:factionSelect.ephemerists.blurb")}
         </p>
       </div>
       <div style={{ position: "relative", padding: "0 var(--space-xl) var(--space-lg)" }}>
-        <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.14em", color: eph.BAND_QUIET, marginBottom: "var(--space-md)" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.ephemerists.members", { count: members })}`}</div>
-        <button onClick={onVisit} style={{
-          width: "100%", cursor: "pointer", border: `1px solid ${eph.BRASS}`, background: "transparent", color: eph.GOLD,
+        <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.14em", color: eph.CAPTION, marginBottom: "var(--space-md)" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.ephemerists.members", { count: members })}`}</div>
+        <button onClick={onVisit} className="eph-cta" style={{
+          width: "100%", cursor: "pointer",
           ...eph.SMALL_CAPS, fontSize: "var(--text-xl)", letterSpacing: "0.16em", padding: "var(--space-md)",
         }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = eph.GOLD; e.currentTarget.style.color = eph.BAND; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = eph.GOLD; }}
         >{i18n.t("feed:factionSelect.ephemerists.cta")}</button>
       </div>
     </div>
   );
 }
-

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -5,15 +5,12 @@ import i18n from "../../i18n";
 // every card with no archetype dispatch to ask for the sheet.
 import "../../factionFaces";
 import { pickVariant } from "../../utils/factionDispatch";
-import { factionName } from "../../utils/factions";
 import { hasOwnKey } from "../../utils/hasOwnKey";
 import { surfaceMap } from "../../factions";
 import { UaSigil } from "../sigil/UaSigil";
 import UaMandala from "../factionMarks/UaMandala";
 import { UA_DISPLAY, UA_EYEBROW, UA_TEXT, uaShade } from "../factionMarks/uaAtoms";
 import * as coven from "../factionMarks/covenSlip";
-import { EphemeristsSigil } from "../sigil/EphemeristsSigil";
-import * as eph from "../factionMarks/ephemeristsPlate";
 import { SingularitySigil } from "../sigil/SingularitySigil";
 import { EverymenSigil } from "../sigil/EverymenSigil";
 import { WowSigil } from "../sigil/WowSigil";
@@ -186,57 +183,6 @@ export function COVENSelectCard({ state = "locked", members, onVisit }: Omit<Fac
           fontFamily: coven.CHROME, fontWeight: 700, fontSize: "var(--text-lg)", letterSpacing: "0.12em", textTransform: "uppercase",
           padding: "var(--space-md) var(--space-lg)", boxShadow: `0 8px 18px -8px ${coven.GLOW}`,
         }}>{i18n.t("feed:factionSelect.coven.cta")}</button>
-      </div>
-    </div>
-  );
-}
-
-/**
- * The Ephemerists tile — the cornice masthead the plate hangs under, standing on
- * its own (#1208). The night band, the sigil ruled in brass, and the CTA in the
- * plate’s gold. Nothing legible is
- * set in `brass`; on this ground the inks are `band-ink` (12.4:1), `gold` (9.4)
- * and `band-quiet` (8.6).
- */
-export function EphemeristsSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
-  const status = i18n.t(`feed:factionSelect.ephemerists.status.${state}` as const);
-  return (
-    <div style={{
-      width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
-      background: eph.BAND, color: eph.BAND_INK, fontFamily: eph.READING,
-      border: `1px solid ${eph.BRASS}`, boxShadow: eph.SHADOW, display: "flex", flexDirection: "column",
-    }}>
-      <div style={{ position: "absolute", inset: 9, border: `1px solid color-mix(in srgb, ${eph.BRASS_LIGHT} 35%, transparent)`, pointerEvents: "none" }} />
-      {/* An incised glyph register ran above the footer until #2210. It was
-          the OLD vocabulary the notation band replaced on the masthead, and it
-          retires kit-wide; nothing takes its place here, because this tile
-          heads itself by hand and mounts no `EphemeristsMasthead`. */}
-      <div style={{ position: "absolute", top: 16, right: 18, fontSize: "var(--text-md)", letterSpacing: "0.1em", color: eph.BAND_QUIET, textAlign: "right", lineHeight: 1.5 }}>{i18n.t("feed:factionSelect.ephemerists.coords")}<br />{i18n.t("feed:factionSelect.ephemerists.coordsPolar")}</div>
-      <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-xl) 0" }}>
-        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)" }}>
-          <span style={{ width: 46, height: 46, borderRadius: "50%", border: `1.5px solid ${eph.BRASS}`, display: "flex", alignItems: "center", justifyContent: "center", flexShrink: 0 }}>
-            <EphemeristsSigil size={26} color={eph.GOLD} />
-          </span>
-          <div>
-            <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.24em", color: eph.GOLD }}>{i18n.t("feed:factionSelect.ephemerists.eyebrow")}</div>
-            {/* eslint-disable-next-line local/no-raw-style-values -- ornament: the plate’s masthead wordmark — Poiret One letterspaced until the width is the mark */}
-            <div style={{ fontFamily: eph.DECO, fontSize: 24, lineHeight: 1.1, letterSpacing: "0.22em", textTransform: "uppercase", color: eph.BAND_INK, marginTop: "var(--space-xs)" }}>{factionName("ephemerists")}</div>
-          </div>
-        </div>
-        <div style={{ height: 1.5, background: `linear-gradient(90deg, ${eph.BRASS_LIGHT} 0%, transparent 100%)`, margin: "var(--space-lg) 0 var(--space-md)" }} />
-        <p className="content-text" style={{ margin: 0, fontFamily: eph.READING, fontStyle: "italic", lineHeight: 1.45, color: eph.BAND_INK }}>
-          {i18n.t("feed:factionSelect.ephemerists.blurb")}
-        </p>
-      </div>
-      <div style={{ position: "relative", padding: "0 var(--space-xl) var(--space-lg)" }}>
-        <div style={{ ...eph.SMALL_CAPS, fontSize: "var(--text-md)", letterSpacing: "0.14em", color: eph.BAND_QUIET, marginBottom: "var(--space-md)" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.ephemerists.members", { count: members })}`}</div>
-        <button onClick={onVisit} style={{
-          width: "100%", cursor: "pointer", border: `1px solid ${eph.BRASS}`, background: "transparent", color: eph.GOLD,
-          ...eph.SMALL_CAPS, fontSize: "var(--text-xl)", letterSpacing: "0.16em", padding: "var(--space-md)",
-        }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = eph.GOLD; e.currentTarget.style.color = eph.BAND; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = eph.GOLD; }}
-        >{i18n.t("feed:factionSelect.ephemerists.cta")}</button>
       </div>
     </div>
   );

--- a/frontend/src/components/selectCard/__tests__/ephemeristsWearsThePlateRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/ephemeristsWearsThePlateRegister.test.ts
@@ -1,0 +1,166 @@
+/**
+ * THE SEAM: the Ephemerists tile grounds on a SHEET, not on the band (#2323).
+ *
+ * A source sweep, not a ratio, for the reason #2322 gives — but sharpened,
+ * because this faction's defect is not S.N.I.D.E.'s and the sibling test next
+ * door would pass the bug.
+ *
+ * S.N.I.D.E. had a FORKED FAMILY: two `--faction-snide-*` families, one of which
+ * flips, so "does the tile name a family its task card does not?" finds it. The
+ * Ephemerists' band and plate are the SAME family — `--faction-ephemerists-plate-*`
+ * — and both are named by the task card, which paints a band at its head and a
+ * plate under it. So #2321's acceptance as literally worded is VACUOUSLY TRUE of
+ * the broken tile: it grounded on `-plate-band`, a token that is dark on purpose
+ * in BOTH cascades, and no lint, census, family sweep or contrast row could see
+ * that a sheet's job had been handed to a masthead's ground.
+ *
+ * The invariant one rung sharper, and the two halves this file pins:
+ *
+ *  1. THE SHEET FLIPS. The tile's ground resolves to different values under
+ *     `:root` and `[data-theme="dark"]`. `-plate-bg` does (#eadcb6 / #171a26);
+ *     `-plate-band` does not, and its own declaration in index.css says not to
+ *     "complete" it. This is the assertion that goes red if anyone acts on
+ *     `ephemeristsPlate.tsx`'s STALE claim that the register is theme-invariant
+ *     and that dark "declares no plate token at all" — it declares fifteen.
+ *  2. NO BAND INK ON A CARD WITH NO BAND. `-plate-band-ink` and
+ *     `-plate-band-quiet` are measured on the compass blue and nowhere else. The
+ *     tile paints no band ground, so naming either is an ink measured against a
+ *     ground this surface does not have. (`-plate-disc` IS the compass blue and
+ *     the tile does mount it, under the sigil; if a label is ever struck on that
+ *     chip it takes a band ink and this list is what should be edited, with the
+ *     reading written down — the disc's own declaration sets out why.)
+ *
+ * The tile spells its colour through `ephemeristsPlate`'s named exports rather
+ * than as `var(--…)` strings, so a literal-only sweep would read ZERO custom
+ * properties in it and pass on an empty set. Every check below resolves the
+ * `eph.*` identifiers through that module first.
+ *
+ * No DOM: `renderToStaticMarkup` is the harness's ceiling and nothing here even
+ * needs that — reading the sources is enough.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+import { readThemes, resolveVar, stripComments } from "../../../utils/__tests__/cssVars";
+
+const read = (relative: string): string =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
+
+/** Comments are the decision record and cite the retired roles on purpose. */
+const code = (relative: string): string => stripComments(read(relative));
+
+const TILE = "../EphemeristsSelectCard.tsx";
+const PLATE_MODULE = "../../factionMarks/ephemeristsPlate.tsx";
+
+/**
+ * `ephemeristsPlate.tsx`'s palette, as `{ EXPORT_NAME: '--custom-property' }`.
+ * Only the one-line `export const X = "var(--…)"` declarations — the module's
+ * components and style objects are not colour.
+ */
+function paletteExports(): Map<string, string> {
+  const source = code(PLATE_MODULE);
+  const map = new Map<string, string>();
+  for (const [, name, prop] of source.matchAll(
+    /export const (\w+) = "var\((--[\w-]+)\)";/g,
+  )) {
+    map.set(name, prop);
+  }
+  expect(map.size, "no palette exports parsed out of ephemeristsPlate.tsx").toBeGreaterThan(10);
+  return map;
+}
+
+/** Every `eph.X` the tile names, resolved to the custom property behind it. */
+function tokensNamedByTile(): Map<string, string> {
+  const source = code(TILE);
+  const palette = paletteExports();
+  const used = new Map<string, string>();
+  for (const [, name] of source.matchAll(/\beph\.(\w+)\b/g)) {
+    const prop = palette.get(name);
+    if (prop !== undefined) used.set(name, prop);
+  }
+  return used;
+}
+
+describe("the Ephemerists tile wears the plate's register (#2323)", () => {
+  it("grounds on a sheet that FLIPS, not on the theme-invariant band", () => {
+    // The root style object is the first one in the file, and its `background`
+    // is the sheet. Anchored on `maxWidth: 360` so this cannot drift onto the
+    // sigil chip's own `background`, which is the dark chip by design.
+    const source = code(TILE);
+    const root = source.slice(source.indexOf("maxWidth: 360"));
+    const ground = /background: eph\.(\w+),/.exec(root)?.[1];
+    expect(ground, "no `background: eph.X` on the tile's root box").toBeDefined();
+
+    const prop = paletteExports().get(ground!);
+    expect(prop, `eph.${ground} is not a palette export`).toBeDefined();
+
+    const themes = readThemes(read("../../../index.css"));
+    const [light, dark] = (["light", "dark"] as const).map((theme) =>
+      resolveVar(prop!, theme, themes),
+    );
+    expect(light, `${prop} is undeclared in the light cascade`).not.toBeNull();
+    expect(
+      dark,
+      `${prop} resolves to ${light} in BOTH cascades — it is a ground that does
+not flip, which is the whole defect #2323 exists to fix. The tile spent this
+epic on \`-plate-band\` (#12151f, the cornice masthead), so it was not failing
+to flip; it was wearing a band where a sheet belongs. Take the sheet the task
+card paints (\`eph.PLATE\`), not a band, and re-measure every ink on it.`,
+    ).not.toBe(light);
+  });
+
+  it("names no ink that is only ever measured on the band", () => {
+    const strays = [...tokensNamedByTile().keys()].filter((name) =>
+      ["BAND", "BAND_INK", "BAND_QUIET"].includes(name),
+    );
+    expect(
+      strays,
+      `These inks are measured on \`-plate-band\` and on nothing else. This tile
+paints no band, so each one is an ink measured against a ground the surface
+does not have — the shape that made the old tile look correct while it was
+dark-only. Find the PLATE role that answers the same question (\`INK\`,
+\`QUIET\`, \`CAPTION\`), not a wider test.`,
+    ).toEqual([]);
+  });
+
+  it("names no token family its own task card does not use", () => {
+    // #2322's sweep, kept so the eight siblings encode one rule — and applied to
+    // the RESOLVED names, since this tile spells none of them literally.
+    const register = [code("../../taskCard/EphemeristsTaskCard.tsx"), code(PLATE_MODULE)].join("\n");
+    const strays = [...tokensNamedByTile().values()].filter((prop) => !register.includes(prop));
+    expect(strays).toEqual([]);
+  });
+
+  it("leaves no `--eph-*` codex consumer in the tile", () => {
+    // The retired illuminated codex. Its family is still DECLARED and has no
+    // dark override tuned for the plate, so a stray reader is a silent
+    // single-cascade paint (`ephemeristsPlate.tsx` states the rule).
+    expect(code(TILE)).not.toMatch(/--eph-/);
+  });
+
+  it("sets no ground, ink or border inline over `.eph-cta`", () => {
+    // The one plate CTA (#2146) inverts between the cascades and its enclosure
+    // changes WIDTH, which no token can carry. An inline property at any of its
+    // six mounts beats the class and pins the light half in both themes on that
+    // surface alone.
+    const source = code(TILE);
+    const cta = source.slice(source.indexOf('className="eph-cta"'));
+    const button = cta.slice(0, cta.indexOf("}}"));
+    for (const property of ["background", "color", "border"]) {
+      expect(button, `\`${property}\` inline beats .eph-cta`).not.toMatch(
+        new RegExp(`\\b${property}:`),
+      );
+    }
+  });
+
+  it("keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
+    // Not a colour question, and the one geometry the epic promised not to move:
+    // the 375px single-column mobile directory depends on all three.
+    const source = code(TILE);
+    expect(source).toContain('width: "100%"');
+    expect(source).toContain("maxWidth: 360");
+    expect(source).toContain("minHeight: 300");
+    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
+  });
+});

--- a/frontend/src/factions/ephemerists.ts
+++ b/frontend/src/factions/ephemerists.ts
@@ -29,7 +29,7 @@ const EphemeristsPraxisDetail = lazyArchetype(() => import('../pages/praxisDetai
 const EphemeristsScoreStamp = lazyArchetype(() => import('../components/praxisCard/scoreStamp/EphemeristsScoreStamp'))
 const EphemeristsSeal = lazyArchetype(() => import('../components/metataskSeal/skins/EphemeristsSeal'))
 const EphemeristsSigil = lazyArchetype(() => import('../components/sigil/EphemeristsSigil'))
-const EphemeristsSelectCard = lazyArchetype(() => import('../components/selectCard/FactionSelectCard').then((m) => ({ default: m.EphemeristsSelectCard })))
+const EphemeristsSelectCard = lazyArchetype(() => import('../components/selectCard/EphemeristsSelectCard'))
 
 export const EPHEMERISTS_MANIFEST: FactionManifest = {
   slug: 'ephemerists',


### PR DESCRIPTION
Closes #2323

Child of #2321, following the pattern #2322 set. Two commits: the extraction is pure and **proved byte-identical** before a single colour moves, so the repaint is reviewable on its own.

## 1. Extract (`895d4737`)

`EphemeristsSelectCard` leaves `FactionSelectCard.tsx` for its own file, matching `components/taskCard/`'s layout. The manifest row keeps its shape and drops the `.then((m) => ({ default: … }))` unwrap, because the new file default-exports it the way every task card does. `factionName` leaves the dispatcher's imports with the block — the wordmark on this tile was its last reader there.

**Proof:** `renderToStaticMarkup` of `<FactionSelectCard faction="ephemerists" />` across all six `state` × `members` combinations is byte-identical before and after — 47,526 bytes, `diff` clean. The probe was a throwaway.

## 2. Repaint: band → plate (`7d929713`)

The tile was painted with the **wrong** register, not a broken one. It grounded on `--faction-ephemerists-plate-band` — #12151f, the cornice masthead's ground, dark on purpose in *both* cascades, and whose own declaration says not to "complete" it under `[data-theme="dark"]`. It was never failing to flip; it was wearing a band where a sheet belongs, so its light half had never been drawn, let alone measured.

Gathered from `EphemeristsTaskCard`, role for role. **Every ratio measured on its real ground, in both cascades:**

| role | was | now | light | dark |
|---|---|---|---|---|
| sheet | `BAND` #12151f | `PLATE` — #eadcb6 / #171a26 | — | — |
| body ink | `BAND_INK` | `INK` | **13.37** | **13.91** |
| blurb | `BAND_INK` | `QUIET` | **7.35** | **5.98** |
| coords | `BAND_QUIET` | `QUIET` | **7.35** | **5.98** |
| eyebrow | `GOLD` | `CAPTION` | **5.09** | **7.22** |
| status | `BAND_QUIET` | `CAPTION` | **5.09** | **7.22** |
| CTA | brass-outlined ghost in `GOLD` | `.eph-cta` | **7.59** | **7.59** |
| sigil | `GOLD` on the band | `GOLD` on a filled `DISC` chip | **13.07** | 13.07 |
| rules | `BRASS` + a fade gradient | the plate's double rule in `BRASS_RULE` | 3.58 *(line)* | 3.55 *(line)* |
| inner hairline | a `color-mix` of the link brass at 35% | `LINE`, the register's declared "hairline borders" | *ornament* | *ornament* |
| ground | nothing | `EphemerisNet` at 0.10, the card/plate weight | — | — |

**The tightest reading on the tile is 5.09:1**, and every text pairing clears AA for its size in both halves.

**No contrast row is added, and that is the point** of gathering a register rather than inventing one: all four text pairings were already pinned in both themes by the task card's own rows — `ephemerists plate, ink`, `…, quiet ink`, `…, caption`, `ephemerists plate CTA band`. The repaint introduces no colour the plate had not already measured.

**The gilt needed a chip, and the register already had one.** `-plate-gold` has no light value and needs none — the metals are struck only on a dark ground — so a gold sigil on the new vellum reads **1.02:1**. That was this tile's real light-half defect. `-plate-disc` is the register's one non-flipping sheet, declared for exactly this, so the 46px ring is *filled* with it rather than merely rimmed.

## Where the task card has no answer, nothing is invented

- **No hover.** `.eph-cta` declares none on any of its now six surfaces, so the ghost button's two `onMouseEnter`/`onMouseLeave` handlers are **deleted** rather than re-tinted. Giving this one tile a hover the other five lack is how a shared control starts becoming six again (#2146).
- **No cornice.** `Cornice` is the register's band-as-a-band and would be the literal reading of "the band may still appear as a band". It is left off because the tile's coordinate block is absolutely positioned at the sheet's top edge, where a fluted band would land on it — a geometry question this repaint has no way to eyeball. **The band survives as the sigil's chip and as the CTA bar**, both of which are the compass blue. If you want the cornice, it is one line plus a `top:` on the coords.
- The **MARGINALIA** face (EB Garamond) is the register's fourth cut; the tile has no marginal gloss, so it wears three of four.

## `ephemeristsPlate.tsx`'s docstring was stale, and it is corrected here

It claimed the register is *"THEME-INVARIANT BY DESIGN (#1627 + #1636)"* and that `[data-theme="dark"]` *"declares no plate token at all"*. **#2141 reversed that** — the dark block declares fifteen. Anyone trusting the old sentence skips a dark measurement, which is one way a tile ends up grounded on a band. The four absences that *are* still deliberate (`-band`/`-band-ink`/`-band-quiet`, `-plate-disc`, `-brass-rule`, `-plate-gold`/`-plate-wash`) are named so nobody "completes" them.

## The seams tested

**(a) The directory renders byte-identically after the pure extraction** — its own commit, proved above; the standing guard is `factionSelectCardDispatch.test.tsx`.

**(b) A source sweep, sharpened — because #2322's would pass this bug.** S.N.I.D.E.'s defect was a *forked family*, so "does the tile name a family its task card does not?" finds it. Here the band and the plate are the **same** family and the task card names both, which makes #2321's acceptance *as literally worded* **vacuously true of the broken tile**. `ephemeristsWearsThePlateRegister.test.ts` pins the invariant one rung sharper:

1. **The sheet flips** — the tile's ground must resolve to *different* values under `:root` and `[data-theme="dark"]`. This is also what goes red if anyone acts on the stale docstring above and deletes the night half.
2. **No band ink on a card with no band** — `-plate-band`/`-band-ink`/`-band-quiet` are measured on the compass blue and nowhere else.

Plus: no inline `background`/`color`/`border` over `.eph-cta`, no `--eph-*` codex reader, and the fluid 360×300 box.

It resolves the `eph.*` identifiers through the palette module first, since this tile spells no `var(--…)` literally and a literal-only sweep would pass on an empty set.

**Mutation-checked:** repointing the root back to `background: eph.BAND, color: eph.BAND_INK` fails *both* assertions (verified, then reverted).

`ephemeristsCta.test.tsx`'s named census goes from five mounts to six — the tile is now one of them, which is what "repainted onto the register" means for a shared control.

## Verification

`npm run lint` · `npm run typecheck` · `npm run typecheck:design-sync` · `npm test` (**369 files, 6,566 passing**) · `npm run build` — all green, all steps from `.github/workflows/test.yml`'s `frontend` job.

**Byte budget: the blocking stylesheet is byte-identical.** Built `origin/main`'s tree and this branch's in the same worktree: both emit `assets/index-B3WghElz.css`, **the same content hash**. CSS 22.3 KB, JS 127.1 KB — the CSS `WARN` is `main`'s pre-existing state and this PR moves it **0 bytes** in either direction. No token is minted and none loses its last reader.

## Scope / collisions

Touches only the Ephemerists block and the imports it owned. The dispatcher is not reformatted and no sibling's block is tidied. Rebased on `c263f6b7`; #2324 / #2325 / #2326 had not landed at that point.

## What to eyeball

Visual QA is **outstanding** — there is no browser or dev stack here, so everything above is tests, `tsc`, ESLint and arithmetic on the tokens' own declared hexes.

- [ ] **Light mode, `/factions`.** The Ephemerists tile should now be a **vellum sheet** like its task card, not a night band. Check the wordmark, the eyebrow, the blurb and the two coordinate lines all read on #eadcb6.
- [ ] **Dark mode, same page.** The sheet goes #171a26. Confirm the tile still reads as *a plate*, not as a hole — and specifically that the **CTA inverts** (blue-on-brass by night, brass-on-blue by day) the way the task card's does.
- [ ] **The sigil's chip, in LIGHT.** This is the change most likely to look wrong: a near-black disc on a pale sheet. It is deliberate — the gilt has nowhere else to live — but it is the one mark worth a second look.
- [ ] **375px, single column.** The box is unchanged (`width: 100%` → 360 max, `minHeight: 300`), but the ephemeris net is new behind the copy: confirm its lines do not cross letterforms at phone width in either theme.
- [ ] **The absolutely positioned coordinates** at the top-right, in both themes — they sit over the net now, and the inner hairline frame moved to `-plate-line`.
- [ ] **Hover the CTA.** It no longer changes. Intentional (see above) — flag it if the tile feels dead without one, and the fix belongs on `.eph-cta` for all six surfaces rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
