### PR TITLE
The Singularity tile gets its own file and its task card's two-theme register (#2326)

### DIFF
--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -8,7 +8,6 @@ import { pickVariant } from "../../utils/factionDispatch";
 import { hasOwnKey } from "../../utils/hasOwnKey";
 import { surfaceMap } from "../../factions";
 import * as coven from "../factionMarks/covenSlip";
-import { SingularitySigil } from "../sigil/SingularitySigil";
 import { EverymenSigil } from "../sigil/EverymenSigil";
 import { WowSigil } from "../sigil/WowSigil";
 import FactionSigil from "../sigil/FactionSigil";
@@ -120,82 +119,6 @@ export function COVENSelectCard({ state = "locked", members, onVisit }: Omit<Fac
     </div>
   );
 }
-
-/**
- * The Singularity tile's palette (#1609).
- *
- * This tile was the last select card still painting itself in hexes — a
- * `const green = "#4ade80"` plus `#050f08`, `#2563eb`, `#8fe6ac` and `#60a5fa`
- * — while the S.N.I.D.E. tile that then stood directly above it already read
- * `var(--snide-*)` throughout. (That tile left for its own file in #2322, and
- * moved off those bare names onto `--faction-snide-note-*` while it went.) The
- * module constant is why a colour grep found the tile clean:
- * `green` reaches four style objects and two hover handlers as an Identifier,
- * which the colour rule's `someStringIn` walk cannot see (§4a, "a module
- * constant is Gap D's indirection wearing paint").
- *
- * These are `var()` strings rather than values, so the names below carry no
- * colour of their own. Every one is theme-INVARIANT in `index.css` — Singularity
- * is always-dark, and this tile is near-black in both cascades, so an ink that
- * flipped underneath it would be the #1792 defect (a token that moves on a
- * ground that does not).
- */
-const TERM_VOID = "var(--faction-singularity-card-bg)";
-const TERM_GREEN = "var(--faction-singularity-card-text)";
-const TERM_BLUE = "var(--faction-singularity-border-hard)";
-const TERM_CYAN = "var(--faction-singularity-card-muted)";
-const TERM_CTA_BG = `color-mix(in srgb, ${TERM_BLUE} 14%, transparent)`;
-
-export function SingularitySelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
-  const status = i18n.t(`feed:factionSelect.singularity.status.${state}` as const);
-  return (
-    <div style={{
-      width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
-      background: TERM_VOID, color: TERM_GREEN, fontFamily: "var(--font-faction-terminal)",
-      border: `1px solid ${TERM_BLUE}`, boxShadow: `0 8px 26px ${CAST}`, display: "flex", flexDirection: "column",
-    }}>
-      <div style={{ position: "absolute", inset: 0, pointerEvents: "none",
-        background: "repeating-linear-gradient(var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)" }} />
-      <div style={{ display: "flex", justifyContent: "space-between", padding: "var(--space-sm) var(--space-md)", borderBottom: `1px solid color-mix(in srgb, ${TERM_CYAN} 40%, transparent)` }}>
-        {Array.from({ length: 9 }).map((_, i) => <i key={i} style={{ width: 6, height: 6, borderRadius: 1, background: `color-mix(in srgb, ${TERM_CYAN} 50%, transparent)` }} />)}
-      </div>
-      <div style={{ position: "relative", flex: 1, padding: "var(--space-lg) var(--space-lg) 0" }}>
-        {/* The card opened on "singularity protocol" with the blinking cursor
-            after it (`feed:identity.singularity.protocol`). That key is on
-            #1864's CUT list, so #1909 removed it here too — the surface KEPT by
-            the audit is `feed:factionSelect.*`, every one of which this card
-            still reads; the `identity.*` overline was a different, single-faction
-            slot on top of it. */}
-        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginTop: "var(--space-md)" }}>
-          <SingularitySigil size={30} color={TERM_GREEN} />
-          {/* eslint-disable-next-line local/no-raw-style-values -- ornament: terminal-printout faction name — display-size mono, the archetype's banner */}
-          <span style={{ fontSize: 30, color: TERM_GREEN, letterSpacing: "0.02em" }}>{i18n.t("feed:factionSelect.singularity.name")}</span>
-        </div>
-        {/* `#8fe6ac` stood here (#1609) — a fourth green, and BRIGHTER than the
-            phosphor accent above it (13.06:1 against the accent's 11.18:1),
-            which inverts the weighting every other Singularity surface uses.
-            `--faction-singularity-phosphor-dim` is the token minted for exactly
-            this slot: a SOLID dim green so prose can sit below the accent
-            without sitting below AA (7.31:1 on this ground). */}
-        <p className="content-text" style={{ margin: "var(--space-lg) 0 0", lineHeight: 1.65, color: "var(--faction-singularity-phosphor-dim)" }}>
-          &gt; {i18n.t("feed:factionSelect.singularity.blurb")}
-        </p>
-      </div>
-      <div style={{ position: "relative", padding: "0 var(--space-lg) var(--space-lg)" }}>
-        <div style={{ fontSize: "var(--text-md)", color: TERM_CYAN, marginBottom: "var(--space-md)" }}>{status}{members != null && <span style={{ float: "right", color: TERM_GREEN }}>{i18n.t("feed:factionSelect.singularity.members", { count: members })}</span>}</div>
-        <button onClick={onVisit} style={{
-          display: "flex", alignItems: "center", width: "100%", cursor: "pointer", gap: "var(--space-sm)",
-          border: `1px solid ${TERM_BLUE}`, background: TERM_CTA_BG, color: TERM_GREEN,
-          fontFamily: "var(--font-faction-terminal)", fontSize: "var(--text-xl)", letterSpacing: "0.06em", padding: "var(--space-sm) var(--space-md)",
-        }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = TERM_GREEN; e.currentTarget.style.color = TERM_VOID; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = TERM_CTA_BG; e.currentTarget.style.color = TERM_GREEN; }}
-        ><span style={{ opacity: 0.7 }}>$</span> {i18n.t("feed:factionSelect.singularity.cta")}</button>
-      </div>
-    </div>
-  );
-}
-
 export function EverymenSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
   const status = i18n.t(`feed:factionSelect.everymen.status.${state}` as const);
   return (

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -119,6 +119,7 @@ export function COVENSelectCard({ state = "locked", members, onVisit }: Omit<Fac
     </div>
   );
 }
+
 export function EverymenSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
   const status = i18n.t(`feed:factionSelect.everymen.status.${state}` as const);
   return (

--- a/frontend/src/components/selectCard/SingularitySelectCard.tsx
+++ b/frontend/src/components/selectCard/SingularitySelectCard.tsx
@@ -3,32 +3,126 @@ import type { FactionSelectCardProps } from "./FactionSelectCard";
 import { SingularitySigil } from "../sigil/SingularitySigil";
 
 /**
- * The Singularity tile's palette (#1609).
+ * Singularity — the faction-DIRECTORY tile (#2326, a child of #2321).
  *
- * These are `var()` strings rather than values, so the names below carry no
- * colour of their own. Every one is theme-INVARIANT in `index.css` — Singularity
- * is always-dark, and this tile is near-black in both cascades, so an ink that
- * flipped underneath it would be the #1792 defect (a token that moves on a
- * ground that does not).
+ * One file per faction, mirroring `components/taskCard/`. `FactionSelectCard`
+ * keeps only the dispatcher, the shared types and `LEGACY_SLUG`.
+ *
+ * THE TILES ARE NOT ALL DARK, whatever the dispatcher's docstring used to say.
+ * Coven's is pink and UA's is cream, and that false premise is what let
+ * dark-only registers look correct on a surface that flips. This one IS dark in
+ * both cascades — but that is a fact about the Singularity metaphor, not about
+ * the grid, and it is exactly why the drift below could hide for so long.
+ *
+ * ── THE REGISTER IS THE TASK CARD'S, NOT A NEW ONE ─────────────────────────
+ *
+ * `SingularityTaskCard` paints in `--faction-singularity-term-*`, "a real
+ * two-theme contract" whose light half is a slightly LIGHTER chassis with inks
+ * walked up to pay for it. This tile was painting in `--faction-singularity-
+ * card-*` plus `-border-hard` and `-phosphor-dim`, every one of which is
+ * theme-INVARIANT. A forked family: both halves are real, declared tokens, so
+ * no lint, census or contrast sweep could see the two drift apart.
+ *
+ * IT IS NOT THE SAME FORK S.N.I.D.E. AND THE EPHEMERISTS HAD, and the PR says
+ * so rather than manufacturing a failure. Their tiles were painted on grounds
+ * that were never meant to carry them, and S.N.I.D.E.'s status line measured
+ * 2.96:1 by day. Nothing here was ever illegible: the old invariant tile
+ * measured 11.18 / 7.31 / 7.66 in both cascades. What was wrong is narrower and
+ * still worth fixing — a card whose chassis is frozen at the DARK half's value
+ * while the card it is a pitch for lifts to `#07130c` by day, and whose inks
+ * therefore never take the walk the light chassis was tuned around.
+ *
+ * What was gathered, role for role:
+ *
+ *   ground     `-card-bg` (#050f08 in both) -> `-term-bg`, the chassis: #07130c
+ *                                by day, #050f08 by night.
+ *   edge       `-border-hard`, a SOLID #2563eb -> `-term-border`, the rgba
+ *                                blue the chassis is drawn with in each theme.
+ *   lift       `0 8px 26px --color-cast-shadow` -> `-term-shadow`, which is the
+ *                                same role (what the chassis throws onto the
+ *                                page behind it) plus the inset phosphor ring
+ *                                the task card leans on for its edge.
+ *   rule       `color-mix(-card-muted 40%)` -> `-term-hair`, the one name every
+ *                                rule on this chassis reads — the window band's
+ *                                border and the task card's dashed `Rule` both.
+ *   name/sigil `-card-text` -> `-term-bright`, the task card's title ink.
+ *   brief      `-phosphor-dim` -> `-term-dim`, "captions + brief".
+ *   status     `-card-muted` (#60a5fa flat) -> `-term-blue`, which IS that blue
+ *                                walked up for the lighter chassis (#4c7fef by
+ *                                day, #60a5fa by night) — the two-theme twin of
+ *                                the token this line was already reading.
+ *   CTA fill   `color-mix(-border-hard 14%)` -> the same wash on `-term-blue`.
+ *   CTA edge   `1px solid -border-hard` -> `-term-bright`, the ink the task
+ *                                card's CTA is bordered in.
+ *   CTA press  a green flood, hand-mixed -> `-term-cta-bg` / `-term-cta-ink`,
+ *                                the lit key the task card wears at rest. The
+ *                                tile already inverted to this pairing; it just
+ *                                spelt it as two other tokens that happen to
+ *                                hold the same value TODAY.
+ *   face       `--font-faction-terminal` -> `--faction-singularity-card-font`,
+ *                                the ROLE name the task card, the band, the
+ *                                readout and the comment voice all read. Same
+ *                                face; the family token stays, because the role
+ *                                token is an alias to it.
+ *
+ * EVERY PAIRING IS MEASURED IN BOTH CASCADES, and almost all of them were
+ * measured already — the payoff of gathering a register instead of minting one.
+ * `singularity terminal chassis, title / brief / boot line` and `singularity
+ * CTA, prompt` in `utils/__tests__/factionContrast.test.ts` cover the name, the
+ * brief, the status line and the pressed key. Two rows are new, because this
+ * tile is the only surface that draws them: the CTA at REST (its wash is only
+ * 1.16:1 against the chassis, so the control's affordance is its `-term-bright`
+ * edge at 9.35:1 light / 11.41:1 dark, well over 1.4.11's 3:1) and the CTA's
+ * label on that wash.
+ *
+ * WHERE THE TASK CARD HAS NO ANSWER, and nothing is invented for it:
+ *   • THE CHROME STRIP. The task card's is `SingularityBand` — a window bar in
+ *     `-term-chrome` carrying three LEDs and the faction's name. This tile's is
+ *     nine unlit indicator squares and no ground, which is a different drawing
+ *     for a different surface (#2321: a task card and a faction pitch share a
+ *     register, not markup). So the strip takes the register's answer for each
+ *     ROLE it has — `-term-hair` for its rule — and the squares stay a wash of
+ *     `-term-blue`, which is the nearest thing the family has to "an unlit
+ *     chrome dot". Mounting the band here instead is a DESIGN call, not a token
+ *     one, and nobody in this batch has a browser.
+ *   • THE TRAVELLING SWEEP. `-term-sweep` and `.sg-scan` are in the register
+ *     and are deliberately NOT taken: the tile keeps the standing raster
+ *     (`-term-scan`, which it already read) and gains no motion. A 300px pitch
+ *     tile is not a session, and adding an animation is a look change this PR
+ *     has no eyes to check.
+ *   • THE CORNER RADIUS. The task card rounds to 8; the tile is square, as
+ *     every other tile in the directory is. Geometry, not register (§4a).
+ *
+ * The sigil is the shared canonical `SingularitySigil` and is never re-drawn
+ * inline. The box is FLUID at a uniform 360x300 ceiling — `width: 100%` to a
+ * 360 max and `minHeight` rather than a fixed height — so the 375px
+ * single-column mobile directory still works (#732). Nothing here changes the
+ * grid.
  */
-const TERM_VOID = "var(--faction-singularity-card-bg)";
-const TERM_GREEN = "var(--faction-singularity-card-text)";
-const TERM_BLUE = "var(--faction-singularity-border-hard)";
-const TERM_CYAN = "var(--faction-singularity-card-muted)";
-const TERM_CTA_BG = `color-mix(in srgb, ${TERM_BLUE} 14%, transparent)`;
+
+const MONO = "var(--faction-singularity-card-font)"; /* Share Tech Mono */
+
+const CHASSIS = "var(--faction-singularity-term-bg)";
+const BRIGHT = "var(--faction-singularity-term-bright)";
+const DIM = "var(--faction-singularity-term-dim)";
+const BLUE = "var(--faction-singularity-term-blue)";
+/** The CTA's unlit wash, and the chrome dots — the same blue at two densities. */
+const CTA_WASH = `color-mix(in srgb, ${BLUE} 14%, transparent)`;
+const DOT = `color-mix(in srgb, ${BLUE} 50%, transparent)`;
 
 export default function SingularitySelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
   const status = i18n.t(`feed:factionSelect.singularity.status.${state}` as const);
   return (
     <div style={{
       width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
-      background: TERM_VOID, color: TERM_GREEN, fontFamily: "var(--font-faction-terminal)",
-      border: `1px solid ${TERM_BLUE}`, boxShadow: "0 8px 26px var(--color-cast-shadow)", display: "flex", flexDirection: "column",
+      background: CHASSIS, color: BRIGHT, fontFamily: MONO,
+      border: "1px solid var(--faction-singularity-term-border)",
+      boxShadow: "var(--faction-singularity-term-shadow)", display: "flex", flexDirection: "column",
     }}>
       <div style={{ position: "absolute", inset: 0, pointerEvents: "none",
         background: "repeating-linear-gradient(var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)" }} />
-      <div style={{ display: "flex", justifyContent: "space-between", padding: "var(--space-sm) var(--space-md)", borderBottom: `1px solid color-mix(in srgb, ${TERM_CYAN} 40%, transparent)` }}>
-        {Array.from({ length: 9 }).map((_, i) => <i key={i} style={{ width: 6, height: 6, borderRadius: 1, background: `color-mix(in srgb, ${TERM_CYAN} 50%, transparent)` }} />)}
+      <div style={{ display: "flex", justifyContent: "space-between", padding: "var(--space-sm) var(--space-md)", borderBottom: "1px solid var(--faction-singularity-term-hair)" }}>
+        {Array.from({ length: 9 }).map((_, i) => <i key={i} style={{ width: 6, height: 6, borderRadius: 1, background: DOT }} />)}
       </div>
       <div style={{ position: "relative", flex: 1, padding: "var(--space-lg) var(--space-lg) 0" }}>
         {/* The card opened on "singularity protocol" with the blinking cursor
@@ -38,30 +132,34 @@ export default function SingularitySelectCard({ state = "locked", members, onVis
             still reads; the `identity.*` overline was a different, single-faction
             slot on top of it. */}
         <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginTop: "var(--space-md)" }}>
-          <SingularitySigil size={30} color={TERM_GREEN} />
+          <SingularitySigil size={30} color={BRIGHT} />
           {/* eslint-disable-next-line local/no-raw-style-values -- ornament: terminal-printout faction name — display-size mono, the archetype's banner */}
-          <span style={{ fontSize: 30, color: TERM_GREEN, letterSpacing: "0.02em" }}>{i18n.t("feed:factionSelect.singularity.name")}</span>
+          <span style={{ fontSize: 30, color: BRIGHT, letterSpacing: "0.02em" }}>{i18n.t("feed:factionSelect.singularity.name")}</span>
         </div>
-        {/* `#8fe6ac` stood here (#1609) — a fourth green, and BRIGHTER than the
-            phosphor accent above it (13.06:1 against the accent's 11.18:1),
-            which inverts the weighting every other Singularity surface uses.
-            `--faction-singularity-phosphor-dim` is the token minted for exactly
-            this slot: a SOLID dim green so prose can sit below the accent
-            without sitting below AA (7.31:1 on this ground). */}
-        <p className="content-text" style={{ margin: "var(--space-lg) 0 0", lineHeight: 1.65, color: "var(--faction-singularity-phosphor-dim)" }}>
+        {/* `--faction-singularity-phosphor-dim` stood here — a fourth green, and
+            a theme-invariant one, minted in #1609 so prose could sit below the
+            accent without sitting below AA on a frozen ground. The chassis is
+            not frozen; `-term-dim` is the SAME decision made per theme, and it
+            is the ink the task card's own brief is set in. */}
+        <p className="content-text" style={{ margin: "var(--space-lg) 0 0", lineHeight: 1.65, color: DIM }}>
           &gt; {i18n.t("feed:factionSelect.singularity.blurb")}
         </p>
       </div>
       <div style={{ position: "relative", padding: "0 var(--space-lg) var(--space-lg)" }}>
-        <div style={{ fontSize: "var(--text-md)", color: TERM_CYAN, marginBottom: "var(--space-md)" }}>{status}{members != null && <span style={{ float: "right", color: TERM_GREEN }}>{i18n.t("feed:factionSelect.singularity.members", { count: members })}</span>}</div>
+        <div style={{ fontSize: "var(--text-md)", color: BLUE, marginBottom: "var(--space-md)" }}>{status}{members != null && <span style={{ float: "right", color: BRIGHT }}>{i18n.t("feed:factionSelect.singularity.members", { count: members })}</span>}</div>
+        {/* The prompt's `$` carried `opacity: 0.7`, which is a contrast cut no
+            guard can see — an alpha on an ink has no fixed ratio against
+            anything. It is punctuation on the prompt, not an indicator, so it
+            is drawn at full strength: the call the task card's block cursor
+            already makes with `currentColor`. */}
         <button onClick={onVisit} style={{
           display: "flex", alignItems: "center", width: "100%", cursor: "pointer", gap: "var(--space-sm)",
-          border: `1px solid ${TERM_BLUE}`, background: TERM_CTA_BG, color: TERM_GREEN,
-          fontFamily: "var(--font-faction-terminal)", fontSize: "var(--text-xl)", letterSpacing: "0.06em", padding: "var(--space-sm) var(--space-md)",
+          border: `1px solid ${BRIGHT}`, background: CTA_WASH, color: BRIGHT,
+          fontFamily: MONO, fontSize: "var(--text-xl)", letterSpacing: "0.06em", padding: "var(--space-sm) var(--space-md)",
         }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = TERM_GREEN; e.currentTarget.style.color = TERM_VOID; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = TERM_CTA_BG; e.currentTarget.style.color = TERM_GREEN; }}
-        ><span style={{ opacity: 0.7 }}>$</span> {i18n.t("feed:factionSelect.singularity.cta")}</button>
+          onMouseEnter={(e) => { e.currentTarget.style.background = "var(--faction-singularity-term-cta-bg)"; e.currentTarget.style.color = "var(--faction-singularity-term-cta-ink)"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = CTA_WASH; e.currentTarget.style.color = BRIGHT; }}
+        ><span>$</span> {i18n.t("feed:factionSelect.singularity.cta")}</button>
       </div>
     </div>
   );

--- a/frontend/src/components/selectCard/SingularitySelectCard.tsx
+++ b/frontend/src/components/selectCard/SingularitySelectCard.tsx
@@ -1,0 +1,68 @@
+import i18n from "../../i18n";
+import type { FactionSelectCardProps } from "./FactionSelectCard";
+import { SingularitySigil } from "../sigil/SingularitySigil";
+
+/**
+ * The Singularity tile's palette (#1609).
+ *
+ * These are `var()` strings rather than values, so the names below carry no
+ * colour of their own. Every one is theme-INVARIANT in `index.css` — Singularity
+ * is always-dark, and this tile is near-black in both cascades, so an ink that
+ * flipped underneath it would be the #1792 defect (a token that moves on a
+ * ground that does not).
+ */
+const TERM_VOID = "var(--faction-singularity-card-bg)";
+const TERM_GREEN = "var(--faction-singularity-card-text)";
+const TERM_BLUE = "var(--faction-singularity-border-hard)";
+const TERM_CYAN = "var(--faction-singularity-card-muted)";
+const TERM_CTA_BG = `color-mix(in srgb, ${TERM_BLUE} 14%, transparent)`;
+
+export default function SingularitySelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
+  const status = i18n.t(`feed:factionSelect.singularity.status.${state}` as const);
+  return (
+    <div style={{
+      width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
+      background: TERM_VOID, color: TERM_GREEN, fontFamily: "var(--font-faction-terminal)",
+      border: `1px solid ${TERM_BLUE}`, boxShadow: "0 8px 26px var(--color-cast-shadow)", display: "flex", flexDirection: "column",
+    }}>
+      <div style={{ position: "absolute", inset: 0, pointerEvents: "none",
+        background: "repeating-linear-gradient(var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)" }} />
+      <div style={{ display: "flex", justifyContent: "space-between", padding: "var(--space-sm) var(--space-md)", borderBottom: `1px solid color-mix(in srgb, ${TERM_CYAN} 40%, transparent)` }}>
+        {Array.from({ length: 9 }).map((_, i) => <i key={i} style={{ width: 6, height: 6, borderRadius: 1, background: `color-mix(in srgb, ${TERM_CYAN} 50%, transparent)` }} />)}
+      </div>
+      <div style={{ position: "relative", flex: 1, padding: "var(--space-lg) var(--space-lg) 0" }}>
+        {/* The card opened on "singularity protocol" with the blinking cursor
+            after it (`feed:identity.singularity.protocol`). That key is on
+            #1864's CUT list, so #1909 removed it here too — the surface KEPT by
+            the audit is `feed:factionSelect.*`, every one of which this card
+            still reads; the `identity.*` overline was a different, single-faction
+            slot on top of it. */}
+        <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginTop: "var(--space-md)" }}>
+          <SingularitySigil size={30} color={TERM_GREEN} />
+          {/* eslint-disable-next-line local/no-raw-style-values -- ornament: terminal-printout faction name — display-size mono, the archetype's banner */}
+          <span style={{ fontSize: 30, color: TERM_GREEN, letterSpacing: "0.02em" }}>{i18n.t("feed:factionSelect.singularity.name")}</span>
+        </div>
+        {/* `#8fe6ac` stood here (#1609) — a fourth green, and BRIGHTER than the
+            phosphor accent above it (13.06:1 against the accent's 11.18:1),
+            which inverts the weighting every other Singularity surface uses.
+            `--faction-singularity-phosphor-dim` is the token minted for exactly
+            this slot: a SOLID dim green so prose can sit below the accent
+            without sitting below AA (7.31:1 on this ground). */}
+        <p className="content-text" style={{ margin: "var(--space-lg) 0 0", lineHeight: 1.65, color: "var(--faction-singularity-phosphor-dim)" }}>
+          &gt; {i18n.t("feed:factionSelect.singularity.blurb")}
+        </p>
+      </div>
+      <div style={{ position: "relative", padding: "0 var(--space-lg) var(--space-lg)" }}>
+        <div style={{ fontSize: "var(--text-md)", color: TERM_CYAN, marginBottom: "var(--space-md)" }}>{status}{members != null && <span style={{ float: "right", color: TERM_GREEN }}>{i18n.t("feed:factionSelect.singularity.members", { count: members })}</span>}</div>
+        <button onClick={onVisit} style={{
+          display: "flex", alignItems: "center", width: "100%", cursor: "pointer", gap: "var(--space-sm)",
+          border: `1px solid ${TERM_BLUE}`, background: TERM_CTA_BG, color: TERM_GREEN,
+          fontFamily: "var(--font-faction-terminal)", fontSize: "var(--text-xl)", letterSpacing: "0.06em", padding: "var(--space-sm) var(--space-md)",
+        }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = TERM_GREEN; e.currentTarget.style.color = TERM_VOID; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = TERM_CTA_BG; e.currentTarget.style.color = TERM_GREEN; }}
+        ><span style={{ opacity: 0.7 }}>$</span> {i18n.t("feed:factionSelect.singularity.cta")}</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/selectCard/__tests__/singularityWearsTheTerminalRegister.test.ts
+++ b/frontend/src/components/selectCard/__tests__/singularityWearsTheTerminalRegister.test.ts
@@ -1,0 +1,122 @@
+/**
+ * THE SEAM: the tile and its task card must name ONE token family (#2326).
+ *
+ * A SOURCE sweep, not a ratio, and that is the whole point — a ratio is exactly
+ * what cannot see this bug. The Singularity directory tile spent this epic
+ * painted in `--faction-singularity-card-bg` / `-card-text` / `-card-muted` /
+ * `-border-hard` / `-phosphor-dim`, every one theme-INVARIANT, while its own
+ * task card had long been on `--faction-singularity-term-*`, "a real two-theme
+ * contract" whose light half lifts the chassis to #07130c and walks two inks up
+ * to pay for it. BOTH halves are real, declared tokens, so nothing in CI could
+ * see the drift: every lint passed, every census counted them, and
+ * `factionContrast.test.ts` dutifully measured each family against the ground
+ * its own documentation named — and both families PASSED, in both themes. A
+ * forked family is only visible as a pairing, or, cheaply, as this: does the
+ * tile name a family its task card does not?
+ *
+ * The shape is #2322's, which seven sibling tiles copy (#2323-#2329).
+ *
+ * No DOM: `renderToStaticMarkup` is the harness's ceiling and nothing here even
+ * needs that — reading the sources is enough.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect } from "vitest";
+
+import { stripComments } from "../../../utils/__tests__/cssVars";
+
+const read = (relative: string): string =>
+  readFileSync(fileURLToPath(new URL(relative, import.meta.url)), "utf8");
+
+/** Comments are the decision record and cite the retired names on purpose. */
+const code = (relative: string): string => stripComments(read(relative));
+
+const TILE = "../SingularitySelectCard.tsx";
+
+/**
+ * THE REGISTER IS THE TASK CARD AS RENDERED, not the one file — the same call
+ * #2322 had to make. `SingularityTaskCard` mounts its window chrome from
+ * `cardMasthead/factionBands` and its points well and process light from
+ * `factionMarks/`, and several of the register's inks are spelt only in those:
+ * the chrome ground and the hairline rule in the band, and `-term-blue` in
+ * {@link SingularityReadout}, which is where #2042 moved it when the well
+ * became a shared mark. The card's own file still names it — in a COMMENT,
+ * saying it left. Slicing the card alone reports those as inventions.
+ *
+ * `factionBands` holds all nine factions' bands, so only `SingularityBand`'s own
+ * body counts: S.N.I.D.E.'s acid is not Singularity's register.
+ */
+function registerSource(): string {
+  const bands = code("../../cardMasthead/factionBands.tsx");
+  const at = bands.indexOf("function SingularityBand()");
+  expect(at, "no `SingularityBand` in cardMasthead/factionBands.tsx").toBeGreaterThan(-1);
+  return [
+    code("../../taskCard/SingularityTaskCard.tsx"),
+    code("../../factionMarks/SingularityReadout.tsx"),
+    code("../../factionMarks/SingularityProcessLight.tsx"),
+    bands.slice(at, bands.indexOf("\n}", at)),
+  ].join("\n");
+}
+
+/** Every custom property named in a source, in document order, deduplicated. */
+const propsIn = (source: string): string[] => [
+  ...new Set([...source.matchAll(/--[a-z0-9-]+/g)].map((match) => match[0])),
+];
+
+describe("the Singularity tile wears the terminal's register (#2326)", () => {
+  it("names no token family its own task card does not", () => {
+    const register = registerSource();
+    const strays = propsIn(code(TILE))
+      // House tokens — spacing, the type ramp, radii — are not a faction family
+      // and are shared by every tile in the directory.
+      .filter((prop) => prop.startsWith("--faction-") || prop.startsWith("--font-"))
+      .filter((prop) => !register.includes(prop));
+
+    expect(
+      strays,
+      `Each name is a token the DIRECTORY TILE paints with and the TASK CARD
+never names — the shape #2321 calls a forked family. Both halves are real
+tokens, so no lint, census or contrast sweep can see it; only this can.
+Fix it by finding the \`--faction-singularity-term-*\` role that answers the
+same question, not by widening this test.`,
+    ).toEqual([]);
+  });
+
+  it("leaves no theme-INVARIANT Singularity family on the tile", () => {
+    // The named half of the assertion above, spelt out so a failure says WHICH
+    // fork returned. These five are the exact names the tile carried before
+    // #2326; each is declared identically in `:root` and `[data-theme="dark"]`,
+    // which is why a frozen tile could sit on a chassis that lifts by day and
+    // no measurement anywhere would report it.
+    const source = code(TILE);
+    for (const frozen of [
+      "--faction-singularity-card-bg",
+      "--faction-singularity-card-text",
+      "--faction-singularity-card-muted",
+      "--faction-singularity-border-hard",
+      "--faction-singularity-phosphor-dim",
+    ]) {
+      expect(source, `${frozen} does not flip; the chassis under it does`).not.toContain(frozen);
+    }
+  });
+
+  it("spells the face as the faction's ROLE token, not the global family", () => {
+    // The inverse of #2322's call: there, the role token named the face
+    // directly and the unread global alias was retired. Here
+    // `--faction-singularity-card-font` IS an alias to `--font-faction-terminal`,
+    // so the family token keeps a reader and only the tile moves.
+    const source = code(TILE);
+    expect(source, "--font-faction-terminal is the raw family").not.toContain("--font-faction-terminal");
+    expect(source).toContain("--faction-singularity-card-font");
+  });
+
+  it("keeps the fluid 360x300 box the directory grid is built on (#732)", () => {
+    // Not a colour question, and the one geometry the epic promised not to move:
+    // the 375px single-column mobile directory depends on all three.
+    const source = code(TILE);
+    expect(source).toContain('width: "100%"');
+    expect(source).toContain("maxWidth: 360");
+    expect(source).toContain("minHeight: 300");
+    expect(source, "a fixed height would break the phone column").not.toMatch(/\bheight: 300\b/);
+  });
+});

--- a/frontend/src/factions/singularity.ts
+++ b/frontend/src/factions/singularity.ts
@@ -29,7 +29,7 @@ const SingularityPraxisDetail = lazyArchetype(() => import('../pages/praxisDetai
 const SingularityScoreStamp = lazyArchetype(() => import('../components/praxisCard/scoreStamp/SingularityScoreStamp'))
 const SingularitySeal = lazyArchetype(() => import('../components/metataskSeal/skins/SingularitySeal'))
 const SingularitySigilAdapter = lazyArchetype(() => import('../components/sigil/FactionSigil').then((m) => ({ default: m.SingularitySigilAdapter })))
-const SingularitySelectCard = lazyArchetype(() => import('../components/selectCard/FactionSelectCard').then((m) => ({ default: m.SingularitySelectCard })))
+const SingularitySelectCard = lazyArchetype(() => import('../components/selectCard/SingularitySelectCard'))
 
 export const SINGULARITY_MANIFEST: FactionManifest = {
   slug: 'singularity',

--- a/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
+++ b/frontend/src/pages/praxisDetail/__tests__/singularityDetail.test.tsx
@@ -337,8 +337,10 @@ describe("Singularity praxis detail — the terminal dress", () => {
   });
 
   it("paints no raw hex — every colour is a token", () => {
-    // `SingularitySelectCard` carries grandfathered raw hex that the lint rule
-    // cannot see. A net-new file must not copy that pattern.
+    // `SingularitySelectCard` used to carry grandfathered raw hex that the lint
+    // rule could not see, through a module constant. #1609 retired it and #2326
+    // moved the tile onto its task card's register, so the example is gone —
+    // the rule it stood for is not, and a net-new file still owes this.
     const { html } = render(state());
     const hex = html.match(/#[0-9a-fA-F]{3,8}\b/g) ?? [];
     expect(hex, `raw hex in the markup: ${hex.join(", ")}`).toHaveLength(0);

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -1111,6 +1111,16 @@ const ARCHETYPE_PAIRS: Pair[] = [
   { what: "singularity points well, total", surface: "--faction-singularity-term-readout", text: "--faction-singularity-term-blue-bright" },
   { what: "singularity points well, unit", surface: "--faction-singularity-term-readout", text: "--faction-singularity-term-blue" },
   { what: "singularity CTA, prompt", surface: "--faction-singularity-term-cta-bg", text: "--faction-singularity-term-cta-ink" },
+  // THE ONE ROW THE TASK CARD DOES NOT ALREADY MAKE (#2326). The directory tile
+  // draws the same key UNLIT at rest and lights it on hover, so its label sits
+  // on a 14% wash of `-term-blue` over the chassis rather than on the solid
+  // `-term-cta-bg` the row above measures. The wash is only 1.16:1 against the
+  // bare chassis, which is the point of writing it down: what makes the control
+  // findable is its `-term-bright` edge, not its fill, and what makes the label
+  // legible is that the wash barely moves the ground under it. Every other
+  // pairing on that tile IS one of the rows above, ink for ground, so none of
+  // them is restated here — a second `what` for one pair measures nothing new.
+  { what: "singularity tile CTA at rest, label", surface: "--faction-singularity-term-bg", veil: { token: "--faction-singularity-term-blue", alpha: 0.14 }, text: "--faction-singularity-term-bright" },
 
   // S.N.I.D.E. — THE RANSOM CLIPPING (task card v2, #1023). Unlike the faction's
   // older ink-dark families, this one FLIPS, so each row genuinely measures two


### PR DESCRIPTION
The fifth child of #2321, following the shape #2322 set: extract in one commit, prove no pixel moved, repaint in a second.

Closes #2326

## 1. The extraction (`73f610f5`), byte-for-byte

`SingularitySelectCard` leaves `FactionSelectCard.tsx` for its own file, matching `components/taskCard/`. Registration is a plain default-export `lazyArchetype` in `factions/singularity.ts` — the per-faction file, so no sibling child collides there.

**The `TERM_*` hazard, resolved by grep rather than by line range.** #2326 flags that the consts sit ABOVE the function, so a naive cut leaves them in the dispatcher or hands them to the Everymen tile that follows. Each was checked across `frontend/src`:

| const | verdict |
|---|---|
| `TERM_VOID` / `TERM_GREEN` / `TERM_BLUE` / `TERM_CYAN` / `TERM_CTA_BG` | **mine alone** — moved |
| `CAST` | **shared** (the Everymen tile, #2327, reads it) — **left in the dispatcher** |

`CAST` is not exported and not hoisted: exporting it would put a shared line in every sibling's rebase path, and its declaration carries the dispatcher's "the tiles are NOT dark" record, which is a property of the grid rather than of one tile. The single site here inlines the string it already resolved to — `0 8px 26px var(--color-cast-shadow)`, same characters — and commit 2 retires the site anyway. **No import was reordered and nothing in the dispatcher was reformatted.**

**Proof:** `renderToStaticMarkup` of `<FactionSelectCard faction="singularity" />` across all six `state` x `members` combinations is byte-identical before and after — 22,098 bytes, `diff` clean. Throwaway probe; the standing guard is `factionSelectCardDispatch.test.tsx`.

One docstring paragraph is **deleted rather than carried**, as briefed: it described `const green = "#4ade80"` reaching "four style objects and two hover handlers as an Identifier" in the present tense. #1609 retired that constant and this prose was its last trace in the repo. A stale twin in `pages/praxisDetail/__tests__/singularityDetail.test.tsx` (which cited this tile as an example of grandfathered raw hex) is corrected in commit 2 — the rule it stood for survives, the example does not. `FactionSelectCard`'s "the tiles are dark" was already deleted by #2322 and is not restored.

## 2. The register (`d9f12fbd`)

`SingularityTaskCard` paints in `--faction-singularity-term-*`, "a real two-theme contract" whose light chassis lifts to `#07130c` with two inks walked UP to pay for it. The tile was on `-card-bg` / `-card-text` / `-card-muted` / `-border-hard` / `-phosphor-dim` — **all five declared identically in `:root` and `[data-theme="dark"]`.** Both halves real tokens, so no lint, census or ratio could see it.

| role | before | after |
|---|---|---|
| ground | `-card-bg` (#050f08 both) | `-term-bg` (#07130c / #050f08) |
| edge | `-border-hard`, solid blue | `-term-border` |
| lift | `--color-cast-shadow` | `-term-shadow` |
| rule | `color-mix(-card-muted 40%)` | `-term-hair` |
| name + sigil | `-card-text` | `-term-bright` |
| brief | `-phosphor-dim` | `-term-dim` |
| status | `-card-muted` | `-term-blue` (the same blue, walked up per theme) |
| members | `-card-text` | `-term-bright` |
| CTA fill | `color-mix(-border-hard 14%)` | the same wash on `-term-blue` |
| CTA edge | `1px solid -border-hard` | `-term-bright` |
| CTA pressed | a hand-mixed green flood | `-term-cta-bg` / `-term-cta-ink` |
| face | `--font-faction-terminal` | `--faction-singularity-card-font` |

**This fork is not S.N.I.D.E.'s, and the PR says so rather than manufacturing a failure to match its siblings.** #2322's tile had a 2.96:1 status line by day; nothing here was ever illegible — the old invariant tile measured 11.18 / 7.31 / 7.66 in *both* cascades, because its ground never moved. What was wrong is narrower and still worth fixing: a tile frozen at the dark half's chassis while the card it pitches lifts by day, so its inks never take the walk the light chassis was tuned around, and the two drift the next time either moves.

**No token is deleted from `index.css`, unlike #2322.** All five retired names have many other readers (avatar, metatask seal, profile body, faction hero, field desk, praxis card, feed frame, vote shell). This tile was one consumer of a live family, not its whole readership. Likewise the face: `--faction-singularity-card-font` is an *alias to* `--font-faction-terminal` — the inverse of the `--font-faction-anton` case — so the global family keeps its reader.

**Where the task card has no answer** (said, not invented):
- **The chrome strip.** The card's is `SingularityBand`: a window bar in `-term-chrome` with three LEDs and the faction name. The tile's is nine unlit squares and no ground — a different drawing for a different surface. It takes the register's answer for each ROLE it *has* (`-term-hair` for its rule); the squares stay a wash of `-term-blue`. Mounting the band here is a DESIGN call, not a token one.
- **The travelling sweep** (`-term-sweep` + `.sg-scan`) is in the register and deliberately *not* taken. The tile keeps the standing raster (`-term-scan`, which it already read) and gains no motion.
- **The 8px corner radius** is geometry (§4a); every tile in the directory is square.

**One deletion the sweep found:** the prompt's `$` carried `opacity: 0.7` — an alpha on an ink is a contrast cut no guard can see, because it has no fixed ratio against anything. It is punctuation, not an indicator, so it draws at full strength: the call the task card's block cursor makes with `currentColor`.

## Contrast — every pairing, both cascades, on its real ground

| pairing | size | light | dark |
|---|---|---|---|
| name + sigil, `-term-bright` on chassis | 30px | 10.88 | 13.87 |
| brief, `-term-dim` on chassis | 18px `.content-text` | 5.03 | 5.80 |
| status, `-term-blue` on chassis | 11px `--text-md` | 5.05 | 7.66 |
| members, `-term-bright` on chassis | 11px | 10.88 | 13.87 |
| CTA label at rest, on the 14% wash | 14px `--text-xl` | 9.35 | 11.41 |
| CTA pressed, `-term-cta-ink` on `-term-cta-bg` | 14px | 11.00 | 11.00 |
| *mark:* CTA edge vs its own fill (1.4.11, 3:1) | — | 9.35 | 11.41 |

The rest fill is only 1.16 / 1.22 against the chassis, which is worth writing down: what makes that control findable is its **edge**, not its ground.

## Testing — the seams, named

**(a) The directory renders byte-identically after the pure extraction.** Own commit, proven above.

**(b) The tile references no token family its own task card does not** — `selectCard/__tests__/singularityWearsTheTerminalRegister.test.ts`, a **SOURCE sweep, not a ratio**, because a ratio is exactly what cannot see this bug: both families pass AA, in both themes, against the grounds their own documentation names.

*"As rendered" is load-bearing here.* `-term-blue` is spelt only in `SingularityReadout` — #2042 moved the well's unit label there, and the card's own file names it in a **comment saying it left**, which `stripComments` correctly discards. So the register is the card **plus** `SingularityBand`, `SingularityReadout` and `SingularityProcessLight`. The sweep caught this itself on first run.

**Mutation-checked:** pointing `CHASSIS` back at `--faction-singularity-card-bg` fails **2 of the 4** assertions.

New contrast row pinned in **both** themes: `singularity tile CTA at rest, label` (`veil: { token: --faction-singularity-term-blue, alpha: 0.14 }`). Every other pairing on the tile is already one of the task card's rows, ink for ground, so none is restated — a second `what` for one pair measures nothing new.

## Verification

Every job in `.github/workflows/test.yml`'s `frontend` block, locally:

- `npm run lint` — clean (`no-raw-style-values` ratchet untouched; nothing added to `.eslint-legacy-raw-colours.txt`)
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npx vitest run` — **369 files / 6,566 passed, 1 skipped**
- `npm run build` — clean
- `node scripts/bundle-budget.mjs` — **CSS 22,870 B gzip-9, delta 0** (measured against the same tree with the repaint stashed; this PR touches no stylesheet and adds no Tailwind-scannable utility name). Still WARN, exactly as `main` is.

`origin/main` re-fetched at `c263f6b7`; the branch rebases clean.

## Visual QA is OUTSTANDING

There is no browser and no dev stack here. Everything above is `tsc`, `eslint`, `vitest` and arithmetic. **Nothing in this PR has been looked at.**

### What to eyeball

- **LIGHT theme, `/factions`.** The tile's chassis is now `#07130c` rather than `#050f08` and its inks are the walked-up light half — the whole point of the change, and the only place it is visible. Does it still read as the same terminal beside its eight neighbours?
- **DARK theme, `/factions`.** The chassis value is unchanged (`#050f08`), but three inks are not: the name and members figure move `#4ade80` -> `#86efac`, and the brief moves `#7ba98a` -> `#3a9e63`. The brief is the one to look at — it is a *dimmer* green than before, at 5.80:1.
- **The card edge, both themes.** `-border-hard`'s solid `#2563eb` becomes `-term-border`'s rgba (1.53 / 1.69 against the chassis) plus `-term-shadow`'s inset phosphor ring. Softer on purpose — it is what the task card ships. Confirm the tile still has a boundary against `--color-bg-page`.
- **The CTA, rest and hover, both themes.** Rest: `-term-bright` edge, near-invisible blue wash, bright label. Hover: the solid lit green key. Confirm the hover still reads as a press and not as a different button.
- **The nine chrome squares and the rule under them,** both themes — the rule moved from a blue mix to `-term-hair` (green), which is a hue change on that hairline.
- **375px single column.** `width: 100%` / `maxWidth: 360` / `minHeight: 300` are unchanged and pinned by the guard, but confirm the phone column still holds (#732).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
