### PR TITLE
The Albescent tile gets its own file, and the repaint stays parked on #2301 (#2329)

### DIFF
--- a/frontend/src/components/selectCard/AlbescentSelectCard.tsx
+++ b/frontend/src/components/selectCard/AlbescentSelectCard.tsx
@@ -1,0 +1,97 @@
+import i18n from "../../i18n";
+import type { FactionSelectCardProps } from "./FactionSelectCard";
+import FactionSigil from "../sigil/FactionSigil";
+
+/**
+ * Albescent — the one tile that still wears the society's own face (#783).
+ *
+ * Albescent has no theme any more: it renders Default everywhere a player is
+ * seen, so a member is indistinguishable from an unaffiliated one. This card is
+ * the exception for the same reason the invitation letter is — it is a REVEAL
+ * surface. `/factions` omits Albescent server-side until an account has been
+ * revealed to it (ADR-0027, #390, routers/factions.py), so anyone who can see
+ * this tile at all already knows the society exists. It reads
+ * `--albescent-reveal-*`, never `factionCssVar('albescent', …)`, which resolves
+ * to the neutral default.
+ *
+ * Deleting this component is now safe for the hiding, which it was not before
+ * #796: the dispatcher used to fall back to UA's costume, so an Albescent tile
+ * without this card went UA orange rather than quiet. It falls back to
+ * `DefaultSelectCard` instead, and per #783/#794 Albescent resolves to the
+ * default/na path anyway — so an unregistered Albescent would get the na
+ * rainbow, which is exactly "hiding by looking unaffiliated". No branch here
+ * says so; the value test in `resolveCssKey` does.
+ *
+ * ── ONE FILE PER FACTION (#2329, the last child of #2321) ───────────────────
+ *
+ * The eighth and final archetype to leave the 595-line `FactionSelectCard.tsx`,
+ * mirroring how `components/taskCard/` is laid out. That file is now the
+ * dispatcher, the shared types and `LEGACY_SLUG` and nothing else. This move is
+ * a PURE move: not a byte of the markup below changed, and the six
+ * `state` × `members` renders are identical before and after.
+ *
+ * ── THE REPAINT IS PARKED, DELIBERATELY (#2301) ─────────────────────────────
+ *
+ * The other seven children each gathered their tile's register off its own task
+ * card. This one cannot, and the reason is not scheduling — there is no register
+ * to gather. `AlbescentTaskCard` is fifty lines that draw nothing of their own:
+ * it renders `DefaultTaskCard` and washes two motion overlays over it, because
+ * ADR-0048 and that card's own docstring rule that *"a secret society hiding in
+ * plain sight is revealed by a shimmer, never by a colour — a repaint in
+ * Albescent's own hues would put it back in the spectrum and un-hide it."* Its
+ * token families are `--faction-default-*`. Adopting them here would delete this
+ * tile's face outright.
+ *
+ * That tension — a reveal surface painting in `--albescent-reveal-*` while every
+ * ordinary surface must not — is real, and it is NOT settled here. The owner has
+ * ruled the reveal family gets a dark half (#2301, still `needs-design`) and
+ * `index.css` still carries a comment forbidding exactly that. Whatever #2301
+ * lands is what decides this tile's ground, so the colour is left untouched and
+ * the extraction stands on its own. The light half is therefore still UNMEASURED
+ * here, which is the one acceptance line of #2321 this tile does not yet meet.
+ *
+ * The sigil comes from the shared canonical dispatcher — `FactionSigil` resolves
+ * `albescent` to `AlbescentSigil` (the labyrinth, which carries no hue of its
+ * own) through an adapter, so the mark is never re-drawn inline.
+ *
+ * The box is FLUID, not fixed: `width: 100%` up to a 360 max and `minHeight`
+ * rather than a hard height, so the same art survives a 375px phone in the
+ * single-column mobile directory (#732).
+ */
+export default function AlbescentSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
+  const status = i18n.t(`feed:factionSelect.albescent.status.${state}` as const);
+  return (
+    <div style={{
+      width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
+      background: "var(--albescent-reveal-surface)", color: "var(--albescent-reveal-text)", fontFamily: "var(--font-faction-vellum)",
+      border: "1px solid var(--albescent-reveal-border)", boxShadow: "var(--albescent-reveal-shadow)", display: "flex", flexDirection: "column",
+    }}>
+      <div style={{ position: "absolute", inset: 12, border: "1px solid var(--albescent-reveal-border-faint)", pointerEvents: "none" }} />
+      <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-2xl) 0", display: "flex", flexDirection: "column" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+          <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.34em", color: "var(--albescent-reveal-text-muted)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.albescent.eyebrow")}</div>
+          {/* Was the surveyor's cross-hair on the reveal ink; the order has no
+              mark of its own any more (#1891 ruling 6). Same 26px, so the
+              header row's metrics are unchanged. */}
+          <FactionSigil slug="albescent" size={26} />
+        </div>
+        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: vellum-letter name — the archetype's calligraphic display type */}
+        <div style={{ fontFamily: "var(--font-faction-vellum)", fontStyle: "italic", fontWeight: 600, fontSize: 40, lineHeight: 1, letterSpacing: "0.01em", marginTop: "var(--space-lg)" }}>{i18n.t("feed:factionSelect.albescent.name")}</div>
+        <div style={{ width: 44, height: 1, background: "var(--albescent-reveal-text)", opacity: 0.5, margin: "var(--space-md) 0" }} />
+        <p className="content-text" style={{ margin: 0, fontStyle: "italic", lineHeight: 1.45, color: "var(--albescent-reveal-ink)" }}>
+          {i18n.t("feed:factionSelect.albescent.blurb")}
+        </p>
+      </div>
+      <div style={{ position: "relative", padding: "var(--space-lg) var(--space-2xl) var(--space-xl)" }}>
+        <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.06em", color: "var(--albescent-reveal-text-muted)", marginBottom: "var(--space-md)", textTransform: "uppercase" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.albescent.members", { count: members })}`}</div>
+        <button onClick={onVisit} style={{
+          width: "100%", cursor: "pointer", border: "1px solid var(--albescent-reveal-text)", background: "transparent", color: "var(--albescent-reveal-text)",
+          fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.22em", padding: "var(--space-md)", textTransform: "uppercase", transition: "background 140ms, color 140ms",
+        }}
+          onMouseEnter={(e) => { e.currentTarget.style.background = "var(--albescent-reveal-text)"; e.currentTarget.style.color = "var(--albescent-reveal-surface)"; }}
+          onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--albescent-reveal-text)"; }}
+        >{i18n.t("feed:factionSelect.albescent.cta")}</button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/selectCard/FactionSelectCard.tsx
+++ b/frontend/src/components/selectCard/FactionSelectCard.tsx
@@ -1,4 +1,3 @@
-import i18n from "../../i18n";
 // Each select card is drawn in its faction's own display face, all six from the
 // lazily-fetched faction sheet (#2079). `pages/Factions.tsx` imports this
 // component directly rather than through `surfaceMap`, so the directory renders
@@ -7,30 +6,34 @@ import "../../factionFaces";
 import { pickVariant } from "../../utils/factionDispatch";
 import { hasOwnKey } from "../../utils/hasOwnKey";
 import { surfaceMap } from "../../factions";
-import FactionSigil from "../sigil/FactionSigil";
 import DefaultSelectCard from "./DefaultSelectCard";
 
 /**
- * FactionSelectCard — the faction-DIRECTORY tile, one per faction. The compact
- * card a player meets when browsing "Choose your faction": each renders in its
- * faction's full archetype (gilt placard, candlelit spell slip, ransom dispatch,
- * codex leaf, terminal printout, union poster, vellum letter) at a UNIFORM
- * 360×300 ceiling so the desktop grid stays tidy. The box is FLUID, not fixed:
- * `width: 100%` up to a 360 max, `minHeight` rather than a hard height, so the
- * same art survives a 375px phone in the single-column mobile directory (#732).
- * Desktop is unchanged — DesktopFactions' flexWrap grid still hands each 360px.
+ * FactionSelectCard — the DISPATCHER for the faction-directory tile, and since
+ * #2329 that is all it is. The compact card a player meets when browsing
+ * "Choose your faction"; each faction's archetype now lives in its own file
+ * beside this one, mirroring how `components/taskCard/` is laid out (epic
+ * #2321). This file keeps the dispatcher, the shared types and `LEGACY_SLUG`.
  *
- * Ported from the Claude Design select.card. Faction-agnostic payload is just
- * { state, members?, onVisit }; name / archetype / blurb / status copy / CTA
- * are component-owned, derived from the faction slug. Joining is NOT on the
- * tile — the CTA visits the faction's detail page, which owns the Join block.
+ * There is deliberately no inventory of the nine tiles here. The list this
+ * docstring used to carry went stale every time a tile was redressed, and the
+ * "the tiles are dark" premise it asserted alongside it was already false —
+ * Coven's is pink, UA's is cream, Albescent's is white vellum — which is what
+ * let two dark-only registers look correct on a surface that flips (#2321).
+ * Each file states its own register; `surfaceMap("factionSelectCard")` is the
+ * only authoritative list of who has one.
  *
- * Dispatcher + per-faction archetypes. (It used to say it mirrored
- * `factionCard/FactionCard.tsx`; #2024 retired that surface — it had never had
- * a production mount, because #422 gave the directory THIS card on both form
- * factors — so this is the shape rather than a copy of one.) The
- * per-faction sigils are the shared canonical *Sigil components (one dedicated
- * file each), imported here — never re-drawn inline.
+ * The contract every tile honours: a UNIFORM 360×300 ceiling so the desktop grid
+ * stays tidy, on a FLUID box rather than a fixed one — `width: 100%` up to a 360
+ * max, `minHeight` rather than a hard height — so the same art survives a 375px
+ * phone in the single-column mobile directory (#732). Desktop is unchanged;
+ * DesktopFactions' flexWrap grid still hands each 360px.
+ *
+ * Faction-agnostic payload is just { state, members?, onVisit }; name /
+ * archetype / blurb / status copy / CTA are component-owned, derived from the
+ * faction slug. Joining is NOT on the tile — the CTA visits the faction's detail
+ * page, which owns the Join block. Per-faction sigils are the shared canonical
+ * *Sigil components (one dedicated file each) — never re-drawn inline.
  *
  * The neutral tile lives in its own file, `DefaultSelectCard.tsx`, next to the
  * rest of the na kit (`DefaultTaskCard`, `DefaultSigil`): it is the archetype
@@ -50,67 +53,6 @@ export interface FactionSelectCardProps {
   /** Visit-faction handler (the per-faction "visit" CTA). */
   onVisit?: () => void;
 }
-
-// ─── Per-faction archetypes ───────────────────────────────────────────────────
-/**
- * Albescent — the one tile that still wears the society's own face (#783).
- *
- * Albescent has no theme any more: it renders Default everywhere a player is
- * seen, so a member is indistinguishable from an unaffiliated one. This card is
- * the exception for the same reason the invitation letter is — it is a REVEAL
- * surface. `/factions` omits Albescent server-side until an account has been
- * revealed to it (ADR-0027, #390, routers/factions.py), so anyone who can see
- * this tile at all already knows the society exists. It reads
- * `--albescent-reveal-*`, never `factionCssVar('albescent', …)`, which resolves
- * to the neutral default.
- *
- * Deleting this component is now safe for the hiding, which it was not before
- * #796: the dispatcher below used to fall back to UA's costume, so an Albescent
- * tile without this card went UA orange rather than quiet. It falls back to
- * `DefaultSelectCard` instead, and per #783/#794 Albescent resolves to the
- * default/na path anyway — so an unregistered Albescent would get the na
- * rainbow, which is exactly "hiding by looking unaffiliated". No branch here
- * says so; the value test in `resolveCssKey` does.
- */
-export function AlbescentSelectCard({ state = "locked", members, onVisit }: Omit<FactionSelectCardProps, "faction">) {
-  const status = i18n.t(`feed:factionSelect.albescent.status.${state}` as const);
-  return (
-    <div style={{
-      width: "100%", maxWidth: 360, minHeight: 300, boxSizing: "border-box", position: "relative", overflow: "hidden",
-      background: "var(--albescent-reveal-surface)", color: "var(--albescent-reveal-text)", fontFamily: "var(--font-faction-vellum)",
-      border: "1px solid var(--albescent-reveal-border)", boxShadow: "var(--albescent-reveal-shadow)", display: "flex", flexDirection: "column",
-    }}>
-      <div style={{ position: "absolute", inset: 12, border: "1px solid var(--albescent-reveal-border-faint)", pointerEvents: "none" }} />
-      <div style={{ position: "relative", flex: 1, padding: "var(--space-xl) var(--space-2xl) 0", display: "flex", flexDirection: "column" }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
-          <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.34em", color: "var(--albescent-reveal-text-muted)", textTransform: "uppercase" }}>{i18n.t("feed:factionSelect.albescent.eyebrow")}</div>
-          {/* Was the surveyor's cross-hair on the reveal ink; the order has no
-              mark of its own any more (#1891 ruling 6). Same 26px, so the
-              header row's metrics are unchanged. */}
-          <FactionSigil slug="albescent" size={26} />
-        </div>
-        {/* eslint-disable-next-line local/no-raw-style-values -- ornament: vellum-letter name — the archetype's calligraphic display type */}
-        <div style={{ fontFamily: "var(--font-faction-vellum)", fontStyle: "italic", fontWeight: 600, fontSize: 40, lineHeight: 1, letterSpacing: "0.01em", marginTop: "var(--space-lg)" }}>{i18n.t("feed:factionSelect.albescent.name")}</div>
-        <div style={{ width: 44, height: 1, background: "var(--albescent-reveal-text)", opacity: 0.5, margin: "var(--space-md) 0" }} />
-        <p className="content-text" style={{ margin: 0, fontStyle: "italic", lineHeight: 1.45, color: "var(--albescent-reveal-ink)" }}>
-          {i18n.t("feed:factionSelect.albescent.blurb")}
-        </p>
-      </div>
-      <div style={{ position: "relative", padding: "var(--space-lg) var(--space-2xl) var(--space-xl)" }}>
-        <div style={{ fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.06em", color: "var(--albescent-reveal-text-muted)", marginBottom: "var(--space-md)", textTransform: "uppercase" }}>{status}{members != null && ` · ${i18n.t("feed:factionSelect.albescent.members", { count: members })}`}</div>
-        <button onClick={onVisit} style={{
-          width: "100%", cursor: "pointer", border: "1px solid var(--albescent-reveal-text)", background: "transparent", color: "var(--albescent-reveal-text)",
-          fontFamily: "var(--font-body)", fontSize: "var(--text-md)", letterSpacing: "0.22em", padding: "var(--space-md)", textTransform: "uppercase", transition: "background 140ms, color 140ms",
-        }}
-          onMouseEnter={(e) => { e.currentTarget.style.background = "var(--albescent-reveal-text)"; e.currentTarget.style.color = "var(--albescent-reveal-surface)"; }}
-          onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--albescent-reveal-text)"; }}
-        >{i18n.t("feed:factionSelect.albescent.cta")}</button>
-      </div>
-    </div>
-  );
-}
-
-// ─── Dispatcher ──────────────────────────────────────────────────────────────
 
 // Retired/renamed slugs → their live archetype. Raw slug wins first, so a
 // first-class faction always renders its own card rather than a legacy skin.

--- a/frontend/src/factions/albescent.ts
+++ b/frontend/src/factions/albescent.ts
@@ -32,7 +32,7 @@
 import type { FactionManifest } from './manifest'
 import { lazyArchetype } from './lazyArchetype'
 
-const AlbescentSelectCard = lazyArchetype(() => import('../components/selectCard/FactionSelectCard').then((m) => ({ default: m.AlbescentSelectCard })))
+const AlbescentSelectCard = lazyArchetype(() => import('../components/selectCard/AlbescentSelectCard'))
 const AlbescentTaskCard = lazyArchetype(() => import('../components/taskCard/AlbescentTaskCard'))
 const AlbescentVote = lazyArchetype(() => import('../components/vote/AlbescentVote'))
 const AlbescentPraxisCard = lazyArchetype(() => import('../components/praxisCard/desktop/AlbescentPraxisCard'))

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6243,8 +6243,33 @@
 .fielddesk-life:hover { transform: translateY(-6px); }
 .fielddesk-life:disabled { cursor: default; }
 
-/* ── Faction display-font tokens referenced by FactionSelectCard (design
-   select.card). Aliased to families already loaded in index.html. ── */
+/* ── Faction display-font aliases. Each names a family already loaded in
+   index.html; the header used to say "referenced by FactionSelectCard (design
+   select.card)", which was true when the directory's eight archetypes lived
+   inline in that one file and is true of NONE of the three below now that epic
+   #2321 has split them out (#2329, the last child). Re-derived rather than
+   patched — an attribution nothing checks is how a comment outlives its fact:
+
+     --font-faction-codex-script  read ONLY by `--faction-ua-body-font` above.
+                                  No component names it; UA's role token is its
+                                  entire readership.
+     --font-faction-vellum        read by the three ALBESCENT REVEAL surfaces —
+                                  `selectCard/AlbescentSelectCard`,
+                                  `AlbescentInvitation` and
+                                  `pages/AlbescentSecretPlaceholder`. The only
+                                  one of the three a component still spells, and
+                                  the reason it is not a role token is that
+                                  Albescent has no --faction-albescent-* block
+                                  to hold one (see the reveal note below).
+     --font-faction-medieval      read ONLY by `--faction-wow-card-font` above,
+                                  which has ~30 readers of its own.
+
+   NONE of the three has lost its last reader, so nothing is retired here.
+   `fontsLoaded.test.ts` is what would notice if one had: an unread family token
+   is not inert, because index.css is itself in the corpus the family check
+   searches, so the declaration vouches for its own family and holds the face in
+   the shipped kit — which is how `--font-faction-anton` (#2322) and
+   `--font-faction-poster` (#2327) came to go. ── */
 :root {
   /* `--font-faction-anton` stood here. The S.N.I.D.E. directory tile was its
      last reader and #2322 moved it onto `--faction-snide-font-impact`, the
@@ -6266,10 +6291,13 @@
   --font-faction-medieval: "MedievalSharp", cursive;
 }
 
-/* ── Bare faction extension tokens consumed by FactionSelectCard (design
-   select.card). Values from the design system's tokens/colors.css. The repo
-   already carries these hues under the --faction-<slug>-* namespace; the
-   select cards reference the bare names, so alias them here. ── */
+/* ── Bare faction extension tokens (design select.card). Values from the design
+   system's tokens/colors.css. The repo already carries these hues under the
+   --faction-<slug>-* namespace; the bare names are aliased here. The header used
+   to say "consumed by FactionSelectCard": two of the three families it named are
+   now retired outright (see the tombstones below), and the survivor is read by
+   `selectCard/AlbescentSelectCard` and the other reveal surfaces since #2329
+   split the directory's archetypes into one file each. ── */
 :root {
   /* The `--gestalt-*` whimsy.exe alias family stood here (eleven names, both
      cascades). `FactionSelectCard`'s COVEN tile was its entire readership and


### PR DESCRIPTION
Closes #2329

The last child of #2321. **Extract-only, deliberately** — the repaint is parked on #2301, as the issue's own title rules.

## Why this one gathers no register

The other seven children each adopted the token families their own task card wears. This tile cannot, and the reason is not scheduling — **there is nothing to gather.** `AlbescentTaskCard` is fifty lines that draw nothing of their own: it renders `DefaultTaskCard` and washes two motion overlays over it. ADR-0048 and that card's own docstring state the rule — *"a secret society hiding in plain sight is revealed by a shimmer, never by a colour."* Its families are `--faction-default-*`. Adopting them here would delete the tile's face outright, not fix it.

And the tension that creates — a reveal surface painting in `--albescent-reveal-*` while every ordinary Albescent surface must not — is live and contested on **#2301** (*"The Albescent reveal gets a dark half"*, still `needs-design`), with `index.css` still carrying a comment forbidding exactly that. Whatever #2301 lands decides this tile's ground. **So not a colour moves.** The tile's light half is therefore still unmeasured, and that is the one acceptance line of #2321 this tile does not yet meet — it belongs to #2301, not here.

## The seam under test

**The byte-identical render across all six `state` x `members` combinations.** For a pure move that is the entire question, and a register sweep would have been worse than useless: there is no register to sweep against, so asserting one would entrench the parked decision.

Proven two ways, both before/after the move:

1. `renderToStaticMarkup` of the component across all six combinations, dumped to a file on each side and diffed — **identical, same md5** (`21b4239aba70d90e3903c615c9938664`).
2. Through the dispatcher: `<FactionSelectCard faction="albescent" …>` resolves to the new module and is byte-identical to the component rendered directly, on all six, and distinct from `DefaultSelectCard` on all six.

Both probes were scratch files in the worktree and are not committed — there is nothing left for them to compare against once the old copy is gone.

## What moved

- **New** `frontend/src/components/selectCard/AlbescentSelectCard.tsx`, default export. Markup copied verbatim, including the `feed:factionSelect.albescent.*` i18n keys, the `FactionSigil slug="albescent" size={26}` call — which resolves to `AlbescentSigil`'s labyrinth through the adapter in `FactionSigil.tsx`, never re-drawn inline — and the one `no-raw-style-values` disable on the 40px vellum name.
- **`FactionSelectCard.tsx` is now the dispatcher, the shared types and `LEGACY_SLUG` and nothing else** — 146 lines to 88. The unused `i18n` and `FactionSigil` imports went with the tile.
- **`factions/albescent.ts`**: `lazyArchetype(() => import('../components/selectCard/AlbescentSelectCard'))`, dropping the `.then((m) => ({ default: m.AlbescentSelectCard }))` unwrap the way every sibling did.

### The docstring

`FactionSelectCard`'s *"the tiles are dark"* claim was already gone — an earlier sibling removed it, so there was nothing to avoid carrying. What remained was an inventory of the eight archetypes that no longer live in the file. Since this is the last one out, it goes: the replacement says the file is a dispatcher, records **why** there is no inventory (the list went stale on every redress, and the false "dark" premise beside it is what let two dark-only registers look correct on a surface that flips), and points at `surfaceMap("factionSelectCard")` as the only authoritative list. The still-true contract — 360x300 ceiling, fluid box, `{ state, members?, onVisit }`, joining is not on the tile, `DefaultSelectCard` is the fallback — stays.

## The comment tidy-up the last child owes (second commit)

Two block headers in `index.css` named `FactionSelectCard` as the consumer of the tokens below them. True while the eight archetypes lived inline; **this PR makes it true of nothing.** Re-derived rather than patched:

| alias | actual reader now | verdict |
|---|---|---|
| `--font-faction-codex-script` | only `--faction-ua-body-font` (index.css:525) | live |
| `--font-faction-vellum` | the three Albescent reveal surfaces — `AlbescentSelectCard`, `AlbescentInvitation`, `AlbescentSecretPlaceholder` | live |
| `--font-faction-medieval` | only `--faction-wow-card-font` (index.css:532) | live |

**Nothing is retired.** Unlike `--font-faction-anton` (#2322) and `--font-faction-poster` (#2327), none of the three has lost its last reader — the two that no component names are each read by a faction ROLE token with many readers of its own, so removing them is a repoint, not a retirement, and it is not this PR's. `fontsLoaded.test.ts` is the check that would have said otherwise, and it is green.

The second header (the bare `--albescent-reveal-*` block) got the same one-clause correction. **The reveal family's own note is untouched** — that is #2301's.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean
- `npm run typecheck` — clean (app + e2e)
- `npm run typecheck:design-sync` — clean
- `npx vitest run` — **373 files, 6629 passed, 1 skipped**
- `npm run build` — clean
- `npm run budget` — see below

Backend `test` and `api-schema` are untouched: three frontend files, no schema surface.

### Byte budget, measured at gzip level 9 against a clean `origin/main` build

| | `origin/main` | this branch | delta |
|---|---|---|---|
| blocking JS | 130,301 B | 130,295 B | **-6 B** |
| blocking CSS | 22,756 B | 22,756 B | **0 B** |

Both builds emit `assets/index-DHgmzruM.css` — **the same content hash** — because the minifier strips CSS comments, so the second commit is provably zero bytes on the wire. **The CSS `WARN` is pre-existing on `main` and is not moved by this PR** (22.2 KB against a 22.2 KB warn line, both sides).

## Noted, deliberately not fixed

- **The CTA's hover is two inline handlers**, not a CSS `:hover` — `onMouseEnter`/`onMouseLeave` mutating `e.currentTarget.style` to swap fill and ink. #2328's agent flagged it as worth a pass once this tile existed. It is a **behaviour change inside a parked repaint**, so it is not this PR; it wants its own issue, and it should probably wait on #2301 since it repaints the same two tokens.
- **`albescent.ts`'s `factionSelectCard` comment is stale**: it still says *"the dispatcher's fallback is UA's costume, not a neutral card (#796)"*. #796 fixed exactly that — the fallback has been `DefaultSelectCard` since. One line, in a file this PR touches, but unrelated to the extraction; left for whoever files the hover issue.
- **`progression.json` still carries `"Join /Albescent"` and `"Defect a life you carry to /Albescent"`** with the leading slash #2332 removed from `names.albescent`. Reported on #2332 and deliberately out of scope there and here.

## What to eyeball

**Nothing should look different at all. That is the acceptance.** No browser tools or dev stack here, so **visual QA is outstanding** — but this diff moves code and touches no value, and the six-way markup diff is byte-for-byte, so the bar is "spot the difference and there is none":

1. `/factions` as a **revealed** account, light **and** dark — the Albescent tile is white vellum in both (it always was; it does not flip, and #2301 owns whether it should).
2. The tile's **sigil**: the labyrinth, 26px, top-right of the header row.
3. The **CTA hover** still inverts — dark fill, white ink — since the inline handlers moved with the markup.
4. The tile at **375px** in the single-column mobile directory: fluid to a 360 max, `minHeight` not a fixed height (#732).
5. `/factions` as an **unrevealed** account — Albescent is omitted server-side (ADR-0027) and nothing here changes that.
6. The other eight tiles, since the dispatcher changed shape: each still draws its own archetype and `na` still gets `DefaultSelectCard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
