### PR TITLE
The praxis-card byline stops naming the author's faction: the sigil beside the photo already says it (#2366)

### DIFF
--- a/frontend/src/components/__tests__/factionCardSlots.test.tsx
+++ b/frontend/src/components/__tests__/factionCardSlots.test.tsx
@@ -211,34 +211,46 @@ describe("praxis-card content-parity slots (#587)", () => {
   }
 });
 
-// The byline surfaces the author's OWN faction only when it differs from the
-// task faction (the frame already carries the task faction's voice).
-describe("praxis-card byline author faction (#587)", () => {
-  const OFF_FACTION: PraxisCardOut = {
-    ...PRAXIS,
-    task_faction_slug: "ua",
-    created_by_faction_slug: "snide",
-  };
-  const SAME_FACTION: PraxisCardOut = {
-    ...PRAXIS,
-    task_faction_slug: "ua",
-    created_by_faction_slug: "ua",
-  };
+/*
+ * #2366 — THE BYLINE WRITES NO FACTION NAME. It used to print the AUTHOR's own
+ * faction at the far edge whenever that faction differed from the task's; the
+ * owner deleted it (#2245 rule 1: the sigil beside a player's photo carries
+ * membership on its own, no text). `FactionAvatar` sits immediately to the left
+ * of the name and draws that same faction's sigil, so the tag was a second copy
+ * of a fact already on the row.
+ *
+ * THE FIXTURE MUST BE OFF-FACTION OR IT PROVES NOTHING: on a same-faction card
+ * the tag never rendered, so a praxis whose author matches the task would pass
+ * against the old code too. Every fixture here is therefore an author faction
+ * on a `ua` task, and the byline was the only site under `praxisCard/` that
+ * ever called `factionName` — so a hit in the stripped text is this tag and
+ * nothing else, WITH ONE EXCEPTION the author faction is picked to dodge: the
+ * Coven card writes "Cozy Coven" in its own slip-sheet chrome, so on that one
+ * archetype the author is a different faction again.
+ *
+ * Asserted on the TAG-STRIPPED text, not the markup: the faction still reaches
+ * assistive technology through `FactionAvatar`'s own accessible name, which
+ * lives in an attribute and must survive.
+ */
+describe("praxis-card byline prints no faction name (#2366)", () => {
+  for (const [slug, Card] of Object.entries(praxisArchetypes)) {
+    const authorSlug = slug === "coven" ? "wow" : "coven";
+    const offFaction: PraxisCardOut = {
+      ...PRAXIS,
+      task_faction_slug: "ua",
+      created_by_faction_slug: authorSlug,
+    };
 
-  it("shows the author faction when it differs from the task faction", () => {
-    const { text } = markup(
-      <DefaultPraxisCard praxis={OFF_FACTION} adminProps={{ ...PRAXIS_ADMIN, praxis: OFF_FACTION }} />,
-    );
-    expect(text).toContain(factionName("snide"));
-  });
-
-  it("omits the author faction when it matches the task faction", () => {
-    const { text } = markup(
-      <DefaultPraxisCard praxis={SAME_FACTION} adminProps={{ ...PRAXIS_ADMIN, praxis: SAME_FACTION }} />,
-    );
-    // The UA name should not appear as a byline tag (only the task faction voice).
-    expect(text).not.toContain(`· ${factionName("ua")}`);
-  });
+    it(`${slug} omits the author's faction name beside the portrait`, () => {
+      const { text } = markup(
+        <Card praxis={offFaction} adminProps={{ ...PRAXIS_ADMIN, praxis: offFaction }} />,
+      );
+      expect(text, "the author name still reads").toContain("Ada");
+      expect(text, "no faction name in the byline").not.toContain(
+        factionName(authorSlug),
+      );
+    });
+  }
 });
 
 // ─── Task cards ───────────────────────────────────────────────────────────────

--- a/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/cardChrome.test.tsx
@@ -168,14 +168,13 @@ describe('the byline name is not shaved against its portrait (#1633, #2309)', ()
 
 /**
  * #2309 — owner ruling on a screenshot of the Ephemerists card: the portrait
- * goes to the LEFT of the name. The faction tag keeps the far edge, the slot the
- * score vacated in #888.
+ * goes to the LEFT of the name.
  *
  * The seam is `PraxisByline`'s own markup, and it has to be: no DOM and no
  * layout here, so what is observable is source ORDER — which is what decides
  * the painted order inside a plain flex row that sets no `order`.
  */
-describe('the byline reads portrait, then name, then faction tag (#2309)', () => {
+describe('the byline reads portrait, then name (#2309)', () => {
   const bylineAt = (path: string) =>
     renderToStaticMarkup(
       <MemoryRouter initialEntries={[path]}>
@@ -207,10 +206,14 @@ describe('the byline reads portrait, then name, then faction tag (#2309)', () =>
     expect(html.indexOf('<img')).toBeLessThan(nameAt(html))
   })
 
-  it('leaves the faction tag on the far edge', () => {
-    const html = bylineAt('/praxis/1')
-    expect(html).toContain('Cozy Coven')
-    expect(nameAt(html)).toBeLessThan(html.indexOf('Cozy Coven'))
+  // "leaves the faction tag on the far edge" was here. #2366 deleted the tag —
+  // the sigil this fixture's `created_by_faction_slug` already draws inside
+  // `FactionAvatar` is the membership statement, and the name beside it was a
+  // second copy. The fixture is deliberately left OFF-FACTION (coven author,
+  // ua task), which is the only case in which the tag ever rendered, so the
+  // two order cases above now also witness its absence.
+  it('writes no faction name beside the author (#2366)', () => {
+    expect(bylineAt('/praxis/1')).not.toContain('Cozy Coven')
   })
 })
 
@@ -305,7 +308,12 @@ describe('the applied-metatask seal stack (#932)', () => {
 })
 
 describe('the faction font pair (#888)', () => {
-  it('threads the display face to the author name and the body face beside it', () => {
+  // The byline used to carry BOTH faces — the display one on the author name,
+  // the body one on the faction tag beside it. #2366 deleted the tag, so the
+  // byline is a display-face slot now and the body face is asserted where it
+  // still lands: the meta line. The PAIR is what #888 is about, so both halves
+  // stay pinned, just at the two slots that consume them.
+  it('threads the display face to the author name', () => {
     const html = render(
       <PraxisByline
         praxis={praxis({ created_by_faction_slug: 'snide' })}
@@ -313,6 +321,18 @@ describe('the faction font pair (#888)', () => {
       />,
     )
     expect(html).toContain('var(--faction-snide-card-font)')
+    expect(html, 'and no longer prints anything in the body face').not.toContain(
+      'var(--faction-snide-font-type)',
+    )
+  })
+
+  it('threads the body face to the meta line', () => {
+    const html = render(
+      <PraxisStats
+        praxis={praxis({})}
+        fonts={{ display: 'var(--faction-snide-card-font)', body: 'var(--faction-snide-font-type)' }}
+      />,
+    )
     expect(html).toContain('var(--faction-snide-font-type)')
   })
 

--- a/frontend/src/components/praxisCard/shared.tsx
+++ b/frontend/src/components/praxisCard/shared.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Link, useLocation } from "react-router-dom";
 import type { CharacterOut } from "../../api/auth";
 import { UNSCORED_MODERATION_STATUSES, type PraxisCardOut } from "../../api/praxis";
-import { factionCssVar, factionName } from "../../utils/factions";
+import { factionCssVar } from "../../utils/factions";
 import { isDuelPraxis } from "../../utils/praxis";
 import { mediaUrl } from "../../utils/media";
 import FactionAvatar from "../avatar/FactionAvatar";
@@ -280,13 +280,28 @@ function authorAsCharacter(praxis: PraxisCardOut): CharacterOut {
 const BYLINE_PORTRAIT_SIZE = 28;
 
 /**
- * Slot: the author byline (dashed rule on top) — portrait, name, faction tag.
+ * Slot: the author byline (dashed rule on top) — portrait, then name.
  *
- * The praxis TOTAL used to sit at the right of this row. It is gone (#888,
- * closing #663): the score stamp is the card's sole owner of that number, and
- * a card that states its total twice invites the reader to check whether the
- * two agree. The author's faction tag takes the far edge the score vacated,
- * and it keeps it.
+ * THE ROW HAS ONE CHILD (#2366). Two things have been deleted off its far
+ * edge. First the praxis TOTAL (#888, closing #663): the score stamp is the
+ * card's sole owner of that number, and a card that states its total twice
+ * invites the reader to check whether the two agree. Then the author's faction
+ * TAG, which had inherited that vacated edge — the owner deleted it under
+ * #2245 rule 1, "the sigil beside a player's photo carries membership on its
+ * own, no text". `FactionAvatar`, one element to the left, draws exactly that
+ * sigil, so the tag was a second copy of a fact already on the row; it printed
+ * only when the author's faction differed from the task's, which is why a
+ * same-faction card looks unchanged.
+ *
+ * `justify-content: space-between` and the row `gap` are kept and are now
+ * inert BY DESIGN, not by oversight: a lone flex item under space-between sits
+ * at the start, which is precisely where the name group sat with the tag
+ * present. Swapping in `flex-start` would repaint nothing and cost the nine
+ * archetypes their byte-identical markup.
+ *
+ * The faction has NOT left the row for assistive technology — it reaches a
+ * screen reader through `FactionAvatar`'s own accessible name, which is where
+ * it always came from. No `aria-label` was touched.
  *
  * The portrait led the name's right-hand side and now LEADS the row (#2309,
  * owner ruling on the Ephemerists card): a face before a name is how every
@@ -326,11 +341,6 @@ export function PraxisByline({
    */
   divider?: ReactNode;
 }) {
-  // The author's own member faction, shown only when it differs from the task
-  // faction (the frame already carries the task faction's voice). Resolved via
-  // the factions.json catalog (factionName), never a hardcoded map.
-  const authorFaction = praxis.created_by_faction_slug;
-  const showFaction = !!authorFaction && authorFaction !== praxis.task_faction_slug;
   const authorHref = `/characters/${praxis.created_by_id}`;
   const authorName = praxis.created_by_display_name || `#${praxis.created_by_id}`;
   /*
@@ -448,13 +458,6 @@ export function PraxisByline({
             </Link>
           )}
         </span>
-        {showFaction && (
-          <span
-            style={{ fontFamily: fonts?.body, opacity: 0.7, whiteSpace: "nowrap" }}
-          >
-            {factionName(authorFaction)}
-          </span>
-        )}
       </div>
     </>
   );


### PR DESCRIPTION
Closes #2366

The praxis-card byline printed the AUTHOR's own faction name at the far edge of the row, immediately to the right of a `FactionAvatar` already drawing that faction's sigil. Deleted, per the owner's ruling — #2245 rule 1, "the sigil beside a player's photo carries membership on its own, no text".

## The seam I tested at

**The nine mounted praxis-card archetypes plus the default fallback**, in `frontend/src/components/__tests__/factionCardSlots.test.tsx` — not `PraxisByline` in isolation. `PraxisByline` has exactly one mount (`PraxisBody` in `praxisCard/desktop/shared.tsx`), so a guard at the component would prove the span is gone without proving it is gone from any card a player sees; the archetype loop proves both, and it is the loop that catches an archetype that later composes its own byline.

The guard replaces the `#587` block that pinned the OPPOSITE behaviour on `DefaultPraxisCard` alone.

**The fixture is off-faction by construction, because nothing else exercises this.** The tag rendered only when `created_by_faction_slug !== task_faction_slug`; on a same-faction card it never drew, so a same-faction fixture passes against the old code and proves nothing. Every case here is an off-faction author on a `ua` task. It went red on all nine archetypes on the real defect before the deletion, green after.

One wrinkle the red run surfaced: **the Coven card writes "Cozy Coven" in its own slip-sheet chrome**, so a fixed author faction would have collided with that card's own text rather than measured the byline. The author faction is picked to differ from the archetype under test as well as from the task.

## What changed

`frontend/src/components/praxisCard/shared.tsx`
- deleted the `{showFaction && (<span>…{factionName(authorFaction)}</span>)}` tag, plus `showFaction` and `authorFaction`;
- `factionName` leaves the import — the byline was its only caller in this file, and the only site under `praxisCard/` that ever called it;
- `praxis.created_by_faction_slug` STAYS. It still feeds `authorAsCharacter` and therefore the avatar, which is also how the faction still reaches a screen reader. **No `aria-label` was deleted anywhere.**

`justify-content: space-between` and the row `gap` are deliberately kept, now inert. A lone flex item under `space-between` sits at the start — exactly where the name group sat with the tag present — so the left group does not stretch, centre or justify into the vacated space. Swapping in `flex-start` would repaint nothing and would cost the nine archetypes their byte-identical byline markup (`bylineDivider.test.tsx` pins that class list).

Two existing tests pinned the deleted tag and were updated rather than deleted:
- `cardChrome.test.tsx` "leaves the faction tag on the far edge" → "writes no faction name beside the author", on the same off-faction fixture;
- `cardChrome.test.tsx` "the faction font pair (#888)" — the byline carried both faces, display on the name and **body on the faction tag**. With the tag gone the byline consumes only `fonts.display`, so the pair is now pinned across the two slots that consume it: display at the byline, body at the meta line (`PraxisStats`).

## Verification

Ran every step `.github/workflows/test.yml` names for the `frontend` job: `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (373 files, 6637 passed), `npm run build`, `npm run budget`. Zero backend and zero schema changes, so `api-schema` and the backend job are untouched.

`npm run budget` reports a pre-existing CSS **WARN** (22.2 KB against a 22.2 KB warn line, fail at 24.4 KB) — this branch touches zero `.css` files and removes markup rather than adding it, so the warn is main's, not this change's.

**Visual QA is outstanding.** No browser and no dev stack here; everything above is tests, tsc, eslint and the byte budget.

## What to eyeball

- **An off-faction praxis card on the feed** — a proof whose author belongs to a different faction than the task. This is the ONLY state that ever drew the tag; a same-faction card should look pixel-identical to today. Check the name group has not drifted right, centred, or stretched into the space the tag left.
- **All nine skins in that state**: UA, S.N.I.D.E., Cozy Coven, Warriors of Whimsy, The Ephemerists, Everymen, Singularity, Albescent, and the `na`/default card. The Ephemerists plate is the one the owner screenshotted; its byline sets Poiret One and its divider is the rune strip rather than the dashed rule, so it is the likeliest place a spacing change would read.
- **A long display name** on an off-faction card. The name used to wrap against a tag holding the far edge; with the row's only child gone it now wraps against the card edge. Check it still yields and does not paint over the portrait.
- **Both themes**, light and dark — the byline's rule is `currentColor`-derived, and the tag carried an `opacity: 0.7` that is now gone from the row entirely.
- **The author's own character page**, where the name renders as plain text rather than a link (#2125) — the other of the two byline branches.
- **A screen reader on an off-faction card**: the author's faction must still be announced, via `FactionAvatar`'s accessible name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
