### PR TITLE
The Ephemerists entry gets its rung of air, and the seal keeps the cornice (#2360)

### DIFF
--- a/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
+++ b/frontend/src/components/praxisCard/__tests__/ephemeristsPlateSurfaces.test.tsx
@@ -232,6 +232,51 @@ describe('the Ephemerists praxis card wears the Valley plate (#1207)', () => {
     expect(leaf?.[1], 'the journal leaf declares a layer').toBeDefined()
     expect(Number(leaf?.[1])).toBeGreaterThan(Number(cornice?.[1]))
   })
+
+  /**
+   * #2360 — THE ENTRY GETS ITS AIR, THE SEAL KEEPS THE CORNICE.
+   *
+   * This was the only praxis card in the kit opening with zero top padding, so
+   * the title butted the cavetto. The obvious repair — a top pad on the leaf —
+   * is the one that must NOT happen: the crown hangs at `top: -13` off the
+   * SCORE STAMP's box, and the stamp's box sits at the leaf's content top, so
+   * padding the leaf moves the crown down out of the 12px cornice and into the
+   * new padding. It still LOOKS right, because the crown only draws on a
+   * crowned praxis — hence this test renders one.
+   *
+   * The air therefore goes on the TITLE, a flex SIBLING of the stamp's column:
+   * a margin there cannot displace the stamp. What is decidable in an SSR
+   * harness with no layout engine is exactly that split, so all three legs are
+   * asserted together — each alone is satisfiable by the wrong fix.
+   */
+  it('gives the title its space without moving the crown off the cornice (#2360)', () => {
+    const markup = render(
+      <EphemeristsPraxisCard praxis={praxis({ is_top_for_task: true })} adminProps={adminProps} />,
+    )
+    // (1) The crowned path really is the one under test.
+    expect(markup, 'the one praxis mark').toContain('var(--fdl-ring)')
+    expect(markup, "the crown's overhang, unchanged").toContain('top:-13px')
+
+    // (2) The leaf's top edge has not moved: the first rung of its padding
+    // shorthand is still zero, so the -13 measures from the cavetto's underside.
+    const leaf = markup.match(/<div style="position:relative;z-index:\d+;padding:([^ ;"]*)/)
+    expect(leaf?.[1], 'the leaf declares a padding').toBeDefined()
+    expect(leaf?.[1], 'a top pad here would pull the crown out of the cornice').toBe('0')
+
+    // (3) Nor has the heading ROW gained one — it carries the stamp.
+    const row = markup.match(/<div style="display:flex;justify-content:space-between;[^"]*"/)
+    expect(row?.[0], 'the heading row is rendered').toBeDefined()
+    expect(row?.[0], 'a pad on the row moves the stamp with the title').not.toMatch(
+      /(margin|padding)-(top|block-start)/,
+    )
+
+    // (4) And the air is on the title itself, at the kit's rung.
+    const title = markup.match(/<h2 class="content-title[^"]*" style="([^"]*)"/)
+    expect(title?.[1], 'the title is rendered').toBeDefined()
+    expect(title?.[1], "the entry's air, matching its eight fellows").toContain(
+      'margin-top:var(--space-xl)',
+    )
+  })
 })
 
 describe('one card, both form factors (ADR-0067)', () => {

--- a/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/EphemeristsPraxisCard.tsx
@@ -124,7 +124,19 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
           it, and the crown's own `z-index: 3` could not help: an inner number
           never lifts a child out of its parent's stacking context. NOT an
           `overflow` fix — the frame clips at the card's border box and the
-          crown never reaches it. Nothing else in the leaf meets the band. */}
+          crown never reaches it. Nothing else in the leaf meets the band.
+
+          SO THE ZERO IS LOAD-BEARING (#2360). This was the only praxis card in
+          the kit opening with no top pad — every other frame gives its title
+          `--space-xl` or `--space-lg` — and the owner's report is that the
+          entry reads cramped against the cavetto. The repair may NOT be a top
+          rung here: the crown's `-13` is measured off the STAMP's box, the
+          stamp's box sits at this element's content top, and 24px of padding
+          would drop the crown clear of the 12px cornice and into the padding —
+          undoing #2240 and #2122 on a card that still screenshots correctly,
+          because the crown only draws on a crowned praxis. The air goes on the
+          TITLE instead (`titleStyle` below), which is a flex SIBLING of the
+          stamp's column and so cannot displace it. */}
       <div
         style={{
           position: "relative",
@@ -147,7 +159,19 @@ export function EphemeristsPraxisCard({ praxis, adminProps, showCrown }: Archety
           muted={QUIET}
           paper={PLATE}
           showCrown={showCrown}
-          titleStyle={{ fontFamily: DECO, fontWeight: 400, letterSpacing: "0.02em", color: INK }}
+          // THE ENTRY OPENS A RUNG BELOW THE CAVETTO (#2360). `--space-xl` is
+          // the rung five of its eight fellows already give their title, and it
+          // rides on the title rather than on the leaf for the reason the leaf's
+          // comment gives: the seal keeps hanging off the cornice, the entry
+          // starts under it. A praxis with no score renders no stamp at all, so
+          // this is also the whole of the air on an unscored card.
+          titleStyle={{
+            fontFamily: DECO,
+            fontWeight: 400,
+            letterSpacing: "0.02em",
+            color: INK,
+            marginTop: "var(--space-xl)",
+          }}
           // Poiret One for the display line, Spectral for the reading matter.
           fonts={{ display: DECO, body: READING }}
           // #1909 CUT the two strings that used to fill the shared slots here:


### PR DESCRIPTION
The Ephemerists praxis card was the only one of the nine opening with **no top
padding on its body**, so the entry's title butted straight into the cavetto
cornice. It now opens a rung below it — and the score stamp's crown still hangs
into the cornice, because the rung is not where the naive fix would put it.

Closes #2360

## The axis, confirmed from the code

The issue asked for the axis to be confirmed before anything moved. The vertical
figure is the only real difference:

- **Vertical** — `padding: "0 var(--space-xl) var(--space-lg)"` on the leaf. The
  other eight open with `--space-xl` (five of them), `--space-lg` (two) or
  `--space-lg` on a `--space-2xl` gutter (Everymen). Ephemerists opened with `0`,
  and `PraxisTitle` declares only a `margin-bottom`, so there was literally
  nothing above the title.
- **Horizontal** — nothing is out of family. The leaf's side pad is
  `var(--space-xl)`, the same as its fellows'; the heading row's
  `gap: var(--space-md)` lives in the shared `PraxisBody` and is one value for
  all nine; and `EphemeristsScoreStamp` caps at `STAMP_WIDTH = 128` / `ROSE = 84`,
  i.e. narrower than UA (134), Everymen (118 mount) and Default (150). There is
  no per-faction horizontal figure to correct.

**Browser confirmation of the axis is outstanding** — I have no browser, so this
is reasoned from the measured padding table and the shared row, not seen.

## Why the crown still reaches the cornice

The `0` was load-bearing and it stays `0`.

`EphemeristsScoreStamp` hangs the crown at `top: -13` off the **stamp's own
box**, and the stamp's box sits at the *leaf's content top* — which, with a zero
top pad, is the underside of the 12px `Cornice`. So the crown covers the whole
cornice and 1px of the band above it, which is what #2240 fixed (and what #2122
moved the crown out of the panel's `clip-path` to allow).

Padding the leaf by `--space-xl` would move the stamp's box down 24px with
everything else, and the crown would land 11px *below* the cornice, hanging into
the new padding instead. That is the silent regression the issue names.

Because the title and the stamp are the two **flex siblings** of the heading row,
they can be moved independently, and only one of them is pinned. So the air goes
on the title, through the `titleStyle` prop this card already passes:

- the leaf's padding is untouched → the leaf's top edge, and therefore the stamp's
  box and the crown's `-13`, are exactly where #2240 left them;
- the heading row gains no top spacing → the stamp is not displaced;
- `margin-top: var(--space-xl)` on the `<h2>` pushes the *text column* down, and a
  margin inside one flex item cannot move its sibling.

Read as a drawing this reinforces the plate: the seal hangs from the cornice, the
entry begins under it.

**Rung chosen: `var(--space-xl)` (24px)**, per the acceptance criterion — it is
what five of the eight fellows give their title, and the leaf already uses `xl`
on its sides, so the entry's block now sits in one square inset. I did not go
down a rung: the cavetto is only 12px of drawn rule, and `--space-lg` (16px)
would still read tighter than the cards it is being matched to.

**Rejected alternative:** giving `EphemeristsScoreStamp` a bigger negative `top`
to clear a padded leaf. That detaches the crown ~24px from the plate it crowns,
and the stamp is mounted on surfaces beyond this card, so the number would have
to be per-mount. The pinned thing here is the *stamp's box*, not a magic number.

## The seam I tested at, and the trap

**Seam:** the rendered markup of `EphemeristsPraxisCard` on a **crowned** praxis
(`is_top_for_task: true`), in the existing SSR harness.

The trap the issue calls out is real: the crown only draws on a crowned praxis, so
a change that regresses the overhang passes every uncrowned screenshot and every
uncrowned test. The new test therefore renders the crowned path and asserts all
four legs together — each one alone is satisfiable by the wrong fix:

1. the crown is actually on this render (`var(--fdl-ring)`) and still declares
   `top:-13px`;
2. the leaf's padding shorthand still opens with `0` — a top rung here is the
   regression;
3. the heading **row** declares no top margin/padding — a rung there moves the
   stamp with the title;
4. the title carries `margin-top:var(--space-xl)`.

Legs 1–3 pass on `origin/main` (they pin what #2240 established); leg 4 was the
red. There is no layout engine in this harness, so an *overlap* is not decidable
— what is decidable is which box the spacing was declared on, which is the whole
of this defect.

## Verified

`npm run lint` · `npm run typecheck` · `npm run typecheck:design-sync` ·
`npm test` (373 files, 6630 passed) · `npm run build` · `npm run budget`
(exit 0; the CSS line was already at WARN on `main` and this PR changes no CSS at
all — the diff is two `.tsx` files).

Nothing moves on the other eight praxis cards: the change is two lines inside
`EphemeristsPraxisCard.tsx`, and no shared module was touched.

## What to eyeball

**Visual QA is outstanding — I have no browser.** In both cascades
(`data-theme` light *and* dark):

- [ ] A **CROWNED** Ephemerists praxis card (`is_top_for_task`) at desktop: the
      crown must still overhang the leaf's top edge **into the cavetto cornice**,
      above the band, exactly as #2240 left it — not sitting on the papyrus.
- [ ] The same **crowned** card at the **394px** `--praxis-card-basis`, where the
      heading row has the least slack.
- [ ] The same **crowned** card at **375px** (one card per row, ADR-0067): confirm
      the crown does not collide with the title now that the title sits 24px lower,
      and that the stamp still shrinks rather than crowding it (#2114).
- [ ] The title's new air reads as the same order of space its eight fellows give
      theirs, and the card no longer reads cramped.
- [ ] The **stamp deliberately did not move** — it still hangs flush with the
      cornice while the title starts below it. If that split reads wrong rather
      than as a seal hung from the cornice, say so and the fix goes back to the
      drawing board rather than into the leaf's padding.
- [ ] An **uncrowned** and an **unscored** Ephemerists praxis card: with no stamp
      rendered at all, the title's own margin is the whole of the top air.
- [ ] Spot-check one other faction's praxis card (e.g. Coven or S.N.I.D.E.) to
      confirm nothing moved there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
