### PR TITLE
The sign-in panel stops being a phone sheet on a laptop (#2355)

### DIFF
--- a/frontend/src/components/SignInOptions.tsx
+++ b/frontend/src/components/SignInOptions.tsx
@@ -1,6 +1,7 @@
 import { useEffect, type CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import { loginWith, type AuthProvider } from '../api/auth'
+import { useFormFactor } from '../hooks/useFormFactor'
 import { drawAtRoot } from './ui/drawAtRoot'
 
 /**
@@ -77,18 +78,30 @@ export default function SignInOptions({
  * The NavBar's logged-out button opens this.
  *
  * One nav button cannot hold two providers, and this is the repo's existing
- * answer to that: the same bottom-sheet band `CharacterSwitcherSheet` uses —
- * `drawAtRoot` to escape `ShellContent`'s stacking context (#1591), scrim 39 /
- * sheet 40, the same tokens — rather than a second overlay primitive. NavBar is
- * desktop-only (`Layout.tsx` gives the phone `MobileHeader`, which has no
- * logged-out control at all), so unlike the character switcher this one never
- * needs to clear the mobile tab bar.
+ * answer to that: `drawAtRoot` to escape `ShellContent`'s stacking context
+ * (#1591), the sheet band's altitude, the same tokens — rather than a second
+ * overlay primitive.
+ *
+ * TWO FORMS, ONE CHASSIS (#2355). It borrowed `CharacterSwitcherSheet`'s
+ * bottom-sheet half and not the form-factor split, so a laptop got a phone
+ * sheet glued to the bottom edge of the window. The chassis is now
+ * `ConfirmDialog`'s and `MetataskRemoveConfirm`'s, ternary for ternary: one
+ * fixed flex frame, `items-end` on a phone and `items-center` on a laptop, a
+ * bounded and edged card in the second case. No new overlay idiom.
+ *
+ * REACHABILITY, honestly: `Layout.tsx` mounts `NavBar` only on the desktop
+ * branch (the phone gets `MobileHeader`, which has no logged-out control at
+ * all), so today nothing can render the phone half of this. It is kept because
+ * a sheet that only knows one viewport is exactly the bug above, and because
+ * the logged-out phone gap is somebody else's issue to close.
  */
 export function SignInSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
   const { t } = useTranslation('common')
+  const isMobile = useFormFactor() === 'mobile'
 
   // A modal that only the mouse can dismiss is not dismissible. The character
   // switcher predates this and does without; a new overlay does not get to.
+  // Both forms get the same Escape, the same labelled scrim button.
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {
@@ -101,10 +114,16 @@ export function SignInSheet({ open, onClose }: { open: boolean; onClose: () => v
   if (!open) return null
 
   return drawAtRoot(
-    <div role="dialog" aria-modal="true" aria-label={t('signIn.title')}>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('signIn.title')}
+      style={frame(isMobile)}
+    >
       <button type="button" aria-label={t('signIn.close')} onClick={onClose} style={scrim} />
-      <div style={sheet}>
-        <span style={grab} />
+      <div style={sheet(isMobile)}>
+        {/* A drag affordance belongs to the form that can be dragged. */}
+        {isMobile && <span style={grab} />}
         <div style={sheetTitle}>{t('signIn.title')}</div>
         <div style={options}>
           <SignInOptions style={fullWidth} />
@@ -115,22 +134,39 @@ export function SignInSheet({ open, onClose }: { open: boolean; onClose: () => v
 }
 
 // --- token-driven styles ----------------------------------------------------
-// The bottom-sheet band, read in the ROOT stacking context: backdrop 0 <
-// content 5 < chrome 10 < sheets 39/40 < ConfirmDialog 50 < full-screen modals
-// 1000. See `ui/drawAtRoot` for the whole argument.
+// The sheet band, read in the ROOT stacking context: backdrop 0 < content 5 <
+// chrome 10 < sheets 39/40 < ConfirmDialog 50 < full-screen modals 1000. See
+// `ui/drawAtRoot` for the whole argument. The scrim and the panel used to be
+// two fixed siblings at 39 and 40; they are now one frame at 40 with the scrim
+// nested inside it, so the panel paints over the scrim on DOM order alone and
+// the pair can no longer be separated by anything.
 
+const frame = (isMobile: boolean): CSSProperties => ({
+  position: 'fixed', inset: 0, zIndex: 40,
+  display: 'flex', justifyContent: 'center',
+  alignItems: isMobile ? 'flex-end' : 'center',
+  padding: isMobile ? 0 : 'var(--space-lg)',
+})
 const scrim: CSSProperties = {
-  position: 'fixed', inset: 0, zIndex: 39, border: 'none', padding: 0,
+  position: 'absolute', inset: 0, border: 'none', padding: 0,
   background: 'var(--color-overlay-strong)', cursor: 'pointer',
 }
-const sheet: CSSProperties = {
-  position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 40,
-  background: 'var(--color-bg-surface)', borderRadius: '22px 22px 0 0',
-  padding: 'var(--space-md) var(--space-lg) var(--space-xl)',
+const sheet = (isMobile: boolean): CSSProperties => ({
+  position: 'relative',
+  background: 'var(--color-bg-surface)',
+  width: isMobile ? '100%' : 'min(440px, 100%)',
+  borderRadius: isMobile ? '22px 22px 0 0' : 12,
+  // No faction owns a logged-out surface, so the edge that tells a card from a
+  // sheet is the neutral border token rather than ConfirmDialog's task accent.
+  border: isMobile ? 'none' : '2px solid var(--color-border-strong)',
+  padding: isMobile ? 'var(--space-md) var(--space-lg) var(--space-xl)' : 'var(--space-lg)',
   // The colour half is the half that would drift between themes, so it is the
-  // half that comes from a token (CharacterSwitcherSheet, ConfirmDialog).
-  boxShadow: '0 -12px 34px var(--color-cast-shadow)',
-}
+  // half that comes from a token (CharacterSwitcherSheet, ConfirmDialog). A
+  // sheet is lit from above the bottom edge; a centred card casts downward.
+  boxShadow: isMobile
+    ? '0 -12px 34px var(--color-cast-shadow)'
+    : '0 8px 28px var(--color-cast-shadow)',
+})
 const grab: CSSProperties = {
   display: 'block', width: 38, height: 4, borderRadius: 999,
   background: 'var(--color-border-strong)', margin: 'var(--space-xs) auto var(--space-lg)',
@@ -142,6 +178,9 @@ const sheetTitle: CSSProperties = {
 }
 const options: CSSProperties = {
   display: 'flex', flexDirection: 'column', gap: 'var(--space-md)',
+  // Not a second width rule racing the panel's: the panel is full-bleed on a
+  // phone and this caps the button column inside it, while on a laptop the
+  // panel's own 440 less 2×--space-lg of padding is 404, so this never binds.
   maxWidth: 420, margin: '0 auto',
 }
 const fullWidth: CSSProperties = {

--- a/frontend/src/components/__tests__/signInSheetFormFactor.test.tsx
+++ b/frontend/src/components/__tests__/signInSheetFormFactor.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * The seam: `SignInSheet`'s chassis × `useFormFactor()` (#2355).
+ *
+ * The sheet shipped with NO `useFormFactor()` call at all, so the desktop nav's
+ * sign-in panel was a phone bottom sheet glued to the bottom edge of a laptop
+ * window. `ConfirmDialog` (#1082) and `MetataskRemoveConfirm` (#933) already own
+ * the repo's answer — centred card on a laptop, bottom sheet on a phone, out of
+ * one flex chassis — and this pins that `SignInSheet` now reads the same way.
+ *
+ * What is asserted is the chassis, not the copy (that is `signInOptions.test.tsx`):
+ * the alignment ternary, the panel's width, its corners and its edge. The MOBILE
+ * half is pinned just as hard, because the fix's failure mode is dragging the
+ * phone form toward the laptop's.
+ *
+ * `useFormFactor` is mocked because the harness has no DOM: `renderToStaticMarkup`
+ * always takes `useSyncExternalStore`'s server snapshot, which is 'desktop', so
+ * the phone branch is unreachable without it (the shape `duelSealFormFactor`
+ * established).
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import '../../i18n'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+vi.mock('../../api/auth', () => ({ loginWith: () => {} }))
+
+const { SignInSheet } = await import('../SignInOptions')
+
+const draw = (formFactor: 'mobile' | 'desktop') => {
+  mocks.formFactor = formFactor
+  return renderToStaticMarkup(<SignInSheet open onClose={() => {}} />)
+}
+
+describe('SignInSheet chassis', () => {
+  beforeEach(() => {
+    mocks.formFactor = 'desktop'
+  })
+
+  it('is a centred, bounded, edged card on a laptop', () => {
+    const markup = draw('desktop')
+
+    expect(markup).toContain('align-items:center')
+    expect(markup).toContain('width:min(440px, 100%)')
+    expect(markup).toContain('border:2px solid var(--color-border-strong)')
+    expect(markup).toContain('border-radius:12px')
+  })
+
+  it('is still a full-bleed bottom sheet on a phone', () => {
+    const markup = draw('mobile')
+
+    expect(markup).toContain('align-items:flex-end')
+    expect(markup).toContain('width:100%')
+    expect(markup).toContain('border-radius:22px 22px 0 0')
+    expect(markup).not.toContain('border:2px')
+  })
+
+  it('keeps the grab handle to the form that can be dragged', () => {
+    // A drag affordance on a centred dialog is the tell that a sheet was left
+    // where a dialog belongs.
+    expect(draw('mobile')).toContain('width:38px')
+    expect(draw('desktop')).not.toContain('width:38px')
+  })
+
+  it('offers the same ways in and the same ways out in both forms', () => {
+    for (const form of ['mobile', 'desktop'] as const) {
+      const markup = draw(form)
+
+      expect(markup).toContain('role="dialog"')
+      expect(markup).toContain('aria-modal="true"')
+      expect(markup).toContain('data-testid="sign-in-google"')
+      expect(markup).toContain('data-testid="sign-in-discord"')
+      // The scrim is a real, labelled button: dismissal is not mouse-only.
+      expect(markup).toContain('aria-label="Close"')
+    }
+  })
+})


### PR DESCRIPTION
Closes #2355

## The defect

`SignInSheet` (in `components/SignInOptions.tsx`) had **no `useFormFactor()` call at all**. Scrim `position: fixed; inset: 0`, panel `position: fixed; left/right/bottom: 0` — a phone bottom sheet, drawn that way on a laptop too, where the desktop nav is the only thing that opens it.

## The seam I tested at

`SignInSheet`'s rendered chassis × `useFormFactor()` — the seam `duelSealFormFactor.test.tsx` established. New file `components/__tests__/signInSheetFormFactor.test.tsx` mocks the hook (the harness has no DOM, so `useSyncExternalStore` always returns the `desktop` server snapshot and the phone branch is otherwise unreachable) and asserts the panel's alignment, width, corners and edge in **both** forms.

It went red on the real defect first — at desktop the panel came back `bottom:0` with `border-radius:22px 22px 0 0` and no `align-items` anywhere.

## The fix

`ConfirmDialog`'s split, ternary for ternary — no new overlay idiom:

| | phone | laptop |
|---|---|---|
| frame align | `flex-end` | `center` |
| panel width | `100%` | `min(440px, 100%)` |
| border | `none` | `2px solid var(--color-border-strong)` |
| radius | `22px 22px 0 0` (unchanged) | `12` |

Three deliberate departures from a literal copy, all in the same direction:

- **Radius stays 22 on the phone**, not `ConfirmDialog`'s 16. Mobile is unchanged; that was the higher rule.
- **The edge is `--color-border-strong`, not a faction accent.** `ConfirmDialog` wears the task's faction because it interrupts a faction surface. Nothing owns a logged-out surface, so it takes the neutral token — the same one the grab handle already used in this file. **This is the one look decision in the diff and the one `frontend-style` may want to overrule.**
- **The grab handle and the upward shadow are phone-only.** A drag affordance and a shadow cast upward off a bottom edge are the tells that a sheet was left where a dialog belongs. Desktop gets `0 8px 28px`, `ConfirmDialog`'s.

Two smaller things:

- **The two width rules are resolved, not stacked.** `options` keeps `maxWidth: 420` because on a phone the panel is full-bleed and that caps the button column inside it. On a laptop the panel is 440 less 2×`--space-lg` = 404 of content box, so the inner cap can never bind. Comment says so at the site.
- **The scrim moved inside the frame** as an absolutely-positioned child instead of staying a fixed sibling at z-index 39. The frame has to be `position: fixed; inset: 0` to do the flex centring, which would otherwise cover the scrim; nesting means the panel paints over the scrim on DOM order alone, with no `pointer-events` juggling. The pair now occupies one altitude (40) in the band `drawAtRoot` documents, still under `ConfirmDialog`'s 50.

Escape, the labelled scrim button and both provider buttons are identical in both forms; a test asserts that.

## One thing you should know before you merge

**The phone half of this cannot currently render.** `Layout.tsx:68` is `{isMobile ? <MobileHeader /> : <NavBar />}`, and `NavBar` is the sheet's only caller — the phone gets `MobileHeader`, which has no logged-out control at all. So at 375px there is no sign-in panel to look at, from the nav or anywhere else.

I kept the phone form anyway rather than deleting it, because the issue asks for it in as many words and because a sheet that knows one viewport is precisely the bug above. But it is the mirror image of #2354's call (delete the unreachable caller). **If you would rather it go, say so and it is a six-line deletion** — the ternaries collapse and the test's mobile cases go with them. Not doing that unilaterally, since the issue's acceptance says the opposite.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (374 files / 6633 tests), `npm run build`, `npm run budget` — all green locally. The budget's CSS **WARN** is pre-existing and non-blocking (exit 0); this diff touches no CSS and adds no Tailwind class.

**Visual QA is outstanding** — I have no browser and no dev stack.

## What to eyeball

- The sign-in panel from the **desktop nav at desktop width**, **light** — centred, bordered, fully rounded, no grab pill.
- Same, **dark** — the 2px `--color-border-strong` edge should still read against `--color-bg-surface`.
- Same panel at **375px**, **light** and **dark**. Read the note above first: expect to find no sign-in button in the mobile header at all. If you do reach it (a narrow desktop window at ≤767px will not, since `NavBar` unmounts), it should be the unchanged bottom sheet — square-shouldered at the bottom, 22px top corners, grab pill, no border.
- Escape and a click on the dim area both close it, in whichever form you can reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
