### PR TITLE
The Ephemerists hero takes the notation band back into its header (#2367)

### DIFF
--- a/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
+++ b/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
@@ -19,16 +19,22 @@ import {
 
 /**
  * The Ephemerists faction-page hero — the plate's CORNICE MASTHEAD at page width
- * (#1208, swept off the illuminated codex). The night band behind two incised
- * glyph registers and a ghost survey graticule, the emblem struck in a stepped
- * octagon, a letterspaced Poiret One wordmark, the motto on a ruled cartouche, a
+ * (#1208, swept off the illuminated codex). The night band behind a ghost survey
+ * graticule, the emblem struck in a stepped octagon, a letterspaced Poiret One
+ * wordmark closed off by the notation band, the motto on a ruled cartouche, a
  * running gloss, and a brass-ruled stat ledger on the side. The cavetto cornice
  * closes it, exactly as it closes the masthead on the task detail.
  *
- * Every ink is measured on the BAND, which is the only ground here: `band-ink`
- * 12.4:1, `gold` 9.4, `band-quiet` 8.6, `brass-light` 6.1. `nile` and `ochre`
- * are 2.3 and 2.6 on this ground and appear nowhere — the codex's lapis
- * last-word tic went with them (see `EphemeristsCard`).
+ * Every ink is measured on the BAND, which is the only ground here, and the
+ * three tokens that make it — `-plate-band`, `-plate-band-ink`,
+ * `-plate-brass-rule` — are each declared once and do not flip, so the readings
+ * hold in both cascades: `band-ink` 7.6:1, `gold` 13.4, `band-quiet` 8.6
+ * (re-measured against today's #12151f in #2367 — the first two were stale by
+ * two token moves). `brass-light` is not an ink here at all: it draws the
+ * graticule and the survey rays, it is the one thing on this hero that DOES
+ * flip, and a 0.6px hairline is not text. `nile` and `ochre` are 2.3 and 2.6 on
+ * this ground and appear nowhere — the codex's lapis last-word tic went with
+ * them (see `EphemeristsCard`).
  *
  * Takes raw counts and labels them in the faction's own voice — the page stays
  * vocabulary-agnostic (see FactionHeroProps in FactionDetail).

--- a/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
+++ b/frontend/src/components/factionHero/EphemeristsFactionHero.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "react-i18next";
 import i18n from "../../i18n";
+import EphemeristsNotationBand from "../factionMarks/EphemeristsNotationBand";
 import {
   BAND,
   BAND_INK,
@@ -54,12 +55,10 @@ function HeroGrids() {
       </svg>
       {/* TWO INCISED REGISTERS STOOD HERE (#2210), one along the top of the
           band and one along the bottom. They were the OLD glyph vocabulary, and
-          #2143's notation band is the faction's only ornament row now. Nothing
-          replaces them on this hero: the band is the MASTHEAD's last line, and
-          this hero heads itself — it draws its own wordmark and stat ledger and
-          mounts no `EphemeristsMasthead`, so a band here would be ornament
-          filling a gap rather than a lockup closing itself off. What the ground
-          keeps is the graticule and the survey rays above. */}
+          #2143's notation band is the faction's only ornament row now. The row
+          came back in the new vocabulary (#2367) but NOT to the ground: it is
+          the header's own last line, so it is mounted under the wordmark
+          below. What the ground keeps is the graticule and the survey rays. */}
     </div>
   );
 }
@@ -119,6 +118,30 @@ export default function EphemeristsFactionHero({
           >
             {name}
           </h1>
+          {/* THE NOTATION BAND, the header's last line (#2367).
+
+              The placement law is PAGE-VERSUS-CARD, not masthead-versus-no-
+              masthead: a page carries the band in its header, a card carries it
+              at the call to action. This hero is a page and it heads itself, so
+              the band sits where the masthead puts its own — directly under the
+              wordmark, ruled off in brass, closing the lockup against the motto
+              below.
+
+              THE GROUND IS THE SAME GROUND. `side="band"` paints `-plate-band-
+              ink` for a `-plate-band` ground, and `-plate-band` is exactly what
+              this header is: 7.59:1, and every token in the pairing (band,
+              band-ink, brass-rule 3.8:1 as a graphical rule) is declared once
+              and does not flip, so the row measures the same in both cascades.
+              What the hero adds over the masthead's is the graticule and the
+              survey rays, whose `brass-light` DOES flip — by day it is darker
+              than the band and lifts nothing; by night the ink still reads 6.2:1
+              over the ruling and 5.4:1 over a ray, which is the condition the
+              wordmark and the gloss have sat in since #1208.
+
+              Seeded from the surface, and the surface here is the faction page
+              itself — one stable string, so the row is the hero's own and comes
+              back byte-identical on every render. */}
+          <EphemeristsNotationBand seed="faction:ephemerists" side="band" />
           <div
             style={{
               display: "inline-block",

--- a/frontend/src/components/factionHero/__tests__/ephemeristsHeroNotationBand.test.tsx
+++ b/frontend/src/components/factionHero/__tests__/ephemeristsHeroNotationBand.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * The seam: what the Ephemerists faction-page hero renders into its own header
+ * (#2367).
+ *
+ * #2210 cut two incised registers of the OLD glyph vocabulary off this hero and
+ * put nothing back, and the file grew a comment asserting that nothing was the
+ * right answer because the hero "mounts no `EphemeristsMasthead`". That was
+ * never the ruling. The owner's law is PAGE-VERSUS-CARD: a page carries the
+ * notation band in its header, a card carries it at the call to action. The hero
+ * is a page with a header, so the band goes in the header.
+ *
+ * The harness is `renderToStaticMarkup` — no DOM, no layout, no effects — so the
+ * band's own marks CANNOT appear here: `markCount(0)` is 0 by design, and the
+ * arithmetic and the seeding are asserted at the function in
+ * `ephemeristsNotationBand.test`. What this file can hold is the two things a
+ * mount decides and only a mount can get wrong: that the device is worn at all,
+ * and that it is worn on the PAGE side of the law rather than a card's.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it, expect } from "vitest";
+
+// Initialize the catalog so copy keys resolve to English text.
+import "../../../i18n";
+import EphemeristsFactionHero from "../EphemeristsFactionHero";
+
+const html = renderToStaticMarkup(
+  <EphemeristsFactionHero name="The Ephemerists" members={4} tasks={9} praxes={2} />,
+);
+
+describe("the Ephemerists hero wears the notation band (#2367)", () => {
+  it("mounts it once, and only once", () => {
+    expect(html.match(/data-eph-runes=/g)).toHaveLength(1);
+  });
+
+  it("wears the PAGE placement — the band's own slot, not a card's CTA offset", () => {
+    // `side` is the whole of the placement law at a mount: "band" is the
+    // masthead's slot, ruled off in brass on the plate's night band, which is
+    // this hero's ground too. "top" / "bottom" / "divider" bracket a button or a
+    // byline, and this header has neither.
+    expect(html).toContain('data-eph-runes="band"');
+  });
+
+  it("is ornament: hidden from assistive technology", () => {
+    // The marks are a drawing with no reading. A screen reader spelling out
+    // "integral, sum, therefore" under a faction wordmark would be worse than
+    // useless.
+    expect(html).toMatch(/aria-hidden="true"[^>]*data-eph-runes/);
+  });
+});

--- a/frontend/src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx
@@ -330,17 +330,25 @@ describe("it is drawn ONCE — keyed on the drawing, not the name (#2230, #2341)
     expect(found).toEqual([]);
   });
 
-  it("is mounted at the masthead, the three CTA surfaces and the praxis byline", () => {
-    // Five files, six rows: the task card and the task page each bracket their
+  it("is mounted at the two page headers, the three CTA surfaces and the praxis byline", () => {
+    // Six files, seven rows: the task card and the task page each bracket their
     // button with two. `EphemeristsPraxisDetail` gets none — no button to
-    // bracket; the faction page and the field desk do paint the plate CTA (both
-    // wear `.eph-cta`) but neither brackets it, which is #2067's separate ruling
-    // about where the MOTIF lives. A sixth file appearing here is a design
-    // decision that should fail rather than land quietly.
+    // bracket; the field desk paints the plate CTA (it wears `.eph-cta`) but
+    // does not bracket it, which is #2067's separate ruling about where the
+    // MOTIF lives. A seventh file appearing here is a design decision that
+    // should fail rather than land quietly.
+    //
+    // THE LAW THIS LIST OBEYS is page-versus-card (#2367): a PAGE wears the band
+    // in its header — the masthead surfaces, and the faction hero, which heads
+    // itself and mounts no masthead — and a CARD wears it at the call to action.
+    // `EphemeristsFeedFrame` is the one deliberate absence: it wraps a stream of
+    // OTHER players' items, so a faction ornament row there would be the faction
+    // stamping itself on content that is not its own.
     const mounts = files
       .filter(([, source]) => source.includes("<EphemeristsNotationBand"))
       .map(([path]) => path.slice(SRC.length).replace(/\\/g, "/"));
     expect(mounts.sort()).toEqual([
+      "components/factionHero/EphemeristsFactionHero.tsx",
       "components/factionMarks/EphemeristsMasthead.tsx",
       "components/praxisCard/desktop/EphemeristsPraxisCard.tsx",
       "components/taskCard/EphemeristsTaskCard.tsx",


### PR DESCRIPTION
Closes #2367

The Ephemerists faction hero lost its ornament row in #2210 and never got the new vocabulary back. It gets it back, as the header's last line.

## The seam I tested at

Two, and neither is the row's arithmetic — that is `markCount` / `drawNotation`, already pinned in `ephemeristsNotationBand.test`.

1. **The mount census** (`src/components/factionMarks/__tests__/ephemeristsNotationBand.test.tsx`) — the source-tree list of every file that wears `<EphemeristsNotationBand`. It is the only place the *placement law* is expressible: a file appearing or disappearing there is a design decision, and it should fail rather than land quietly. Went red on the missing hero.
2. **The hero's own render** (new: `src/components/factionHero/__tests__/ephemeristsHeroNotationBand.test.tsx`) — `renderToStaticMarkup` of the hero, asserting it wears exactly one `data-eph-runes`, that it is `"band"` (the page slot, not a card's CTA offset), and that the row is `aria-hidden`. The harness has no DOM, so the marks themselves cannot render here by construction — `markCount(0)` is 0 on purpose — and that is precisely why these three facts, which belong to the *mount* rather than to the device, are worth holding.

Red first on all four assertions, then green.

## What changed

`frontend/src/components/factionHero/EphemeristsFactionHero.tsx`

- Mounts `EphemeristsNotationBand seed="faction:ephemerists" side="band"` directly under the `<h1>` wordmark — the same slot, the same brass rules and the same drawing the three masthead surfaces wear. No second transcription (the pool census still resolves to one file), no inline `animation:`, `aria-hidden`, one stable seed so the row is the hero's own and comes back byte-identical every render.
- Deletes the false comment. It asserted the hero "mounts no `EphemeristsMasthead`, so a band here would be ornament filling a gap" — a "probably" in an AI-drafted issue body that the codebase promoted to a stated fact. What is left in its place says only what is true: the registers were the old vocabulary, and the row came back to the *header*, not to the ground.

## The measurement, on the hero's own ground

The hero's ground turns out to be the masthead's ground — literally the same token, `--faction-ephemerists-plate-band` #12151f — so `side="band"` is not a borrowed pairing:

| pairing | reading | flips? |
|---|---|---|
| `-plate-band-ink` #c9a24b on `-plate-band` #12151f | **7.6:1** | no — both declared once |
| `-plate-brass-rule` #8a6d2c on the same (graphical rule, 3:1 floor) | **3.8:1** | no |

What the hero adds over the masthead is the graticule and the survey rays, whose `brass-light` *does* flip. By day it is darker than the band and lifts nothing. By night the mark still reads **6.2:1** over the ruling and **5.4:1** over a ray; only where a 0.6px ray crosses a grid line does it reach ~4.2, and that is the condition the wordmark and the gloss have sat in since #1208, not something this row introduces.

While measuring I found the hero's docblock ledger stale by two token moves and corrected it in its own commit: `band-ink` is 7.6:1 and not 12.4, `gold` is 13.4 and not 9.4, and `brass-light` was listed as an ink when it draws hairlines.

## Out of scope, deliberately

`components/feed/EphemeristsFeedFrame.tsx` is untouched and still has no ornament row. The census test now says why in prose, so the next sweep does not "complete the set": the feed frame wraps a stream of *other players'* items, and a faction ornament row there is the faction stamping itself on content that is not its own.

No card gained a band and no page gained a CTA strip — the census is the guard for both.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (374 files, 6632 passing), `npm run build`, `npm run budget` — all run locally, all clean. The CSS budget prints its pre-existing `WARN`; I measured the same build with this change reverted and the stylesheet is byte-identical (`index-DHgmzruM.css` both ways), so this PR moves zero CSS bytes.

**No visual QA has been done** — I have no browser and no dev stack.

## What to eyeball

- The **Ephemerists faction page hero**, in **both cascades** (light and dark): the notation band sits under the wordmark, ruled hairline-above / double-below, spread corner to corner of the text column, marks fading independently. It should read as the lockup's last line, closing the wordmark against the motto — not as a stripe floating on the ground.
- The same hero at **phone width**, where the text column narrows: the row should thin to its 7-mark floor and stay a band rather than a row of bullets, and it must not twitch from 7 to 13 on load.
- The hero's band beside a **task detail masthead's** band: same drawing, same rules, different row (different seed).
- **Please confirm the feed frame still has no ornament row** — an Ephemerists feed, top and bottom of the frame, should be bare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
