### PR TITLE
The faction disclosure marker goes hairline on all eight: 1px, butt cap, three values in one file (#2372)

### DIFF
--- a/frontend/src/pages/factionDetail/__tests__/sectionDisclosure.test.tsx
+++ b/frontend/src/pages/factionDetail/__tests__/sectionDisclosure.test.tsx
@@ -168,6 +168,66 @@ describe('every faction folds both galleries', () => {
   })
 })
 
+/**
+ * The marker's DRAWING, at the same slug × section seam (#2372). The owner's
+ * ruling, after the per-archetype design was put to her: the hairline goes
+ * "Everywhere" — one stroke beside all eight faces, not eight tuned ones. So
+ * the assertion is a CONSTANT across the sixteen call sites, and this suite is
+ * what goes red the day a per-faction value is re-introduced without saying so.
+ *
+ * The em sizing and `currentColor` are asserted alongside because they are the
+ * two things a stroke change is most likely to be "tidied" into breaking: the
+ * marker must track its heading's size and take its heading's ink, on a page
+ * where both are set eight different ways.
+ */
+describe('the disclosure marker is a hairline on every face', () => {
+  /** The whole control — opening tag through `</button>`, so the assertion is
+   *  scoped to the marker this disclosure actually draws. */
+  function disclosureMarkup(html: string, bodyId: string): string | undefined {
+    const start = html.search(new RegExp(`<button[^>]*aria-controls="${bodyId}"`))
+    if (start < 0) return undefined
+    const end = html.indexOf('</button>', start)
+    return end < 0 ? undefined : html.slice(start, end + '</button>'.length)
+  }
+
+  for (const slug of SLUGS) {
+    for (const section of FACTION_SECTION_IDS) {
+      it(`${slug} · ${section} — 1px, butt cap, miter join`, () => {
+        const markup = disclosureMarkup(page(slug), factionSectionBodyId(section))
+        expect(markup, `${slug}'s ${section} disclosure never closes`).toBeDefined()
+
+        expect(markup).toContain('stroke-width="1"')
+        expect(markup).toContain('stroke-linecap="butt"')
+        expect(markup).toContain('stroke-linejoin="miter"')
+        // The heading's own ink, never a token picked per faction.
+        expect(markup).toContain('stroke="currentColor"')
+        // Sized in `em`, so it tracks the display face it sits beside.
+        expect(markup).toContain('width="0.55em"')
+        expect(markup).toContain('height="0.8em"')
+      })
+    }
+  }
+
+  it('draws no chevron CHARACTER, on any face', () => {
+    // The SVG exists because several of the eight display faces have no U+203A
+    // and would paint a tofu box on a faction's front door. A thinner stroke is
+    // no reason to revisit that — so no chevron glyph may appear inside a
+    // disclosure control, however tempting the one-line version looks.
+    for (const slug of SLUGS) {
+      const html = page(slug)
+      for (const section of FACTION_SECTION_IDS) {
+        const markup = disclosureMarkup(html, factionSectionBodyId(section))
+        expect(markup, `${slug} · ${section}`).toContain('<svg')
+        for (const glyph of ['\u203a', '\u276f', '\u3009', '\u00bb']) {
+          expect(markup, `${slug} · ${section} draws a glyph marker`).not.toContain(
+            glyph,
+          )
+        }
+      }
+    }
+  })
+})
+
 describe('a folded section is still worth reading', () => {
   afterEach(() => {
     Reflect.deleteProperty(globalThis, 'localStorage')

--- a/frontend/src/pages/factionDetail/sectionDisclosure.tsx
+++ b/frontend/src/pages/factionDetail/sectionDisclosure.tsx
@@ -191,6 +191,14 @@ export function useFactionSections(): Readonly<
  * the rail's `›` glyph because these headings are set in eight display faces,
  * several of which have no U+203A — a missing glyph is a tofu box on a faction's
  * front door, and this costs a hundred bytes to be sure it cannot happen.
+ *
+ * The drawing is ONE hairline on all eight faces — 1px, butt cap, miter join
+ * (#2372), the owner's answer to "is this the Ephemerists' value or everyone's"
+ * being "Everywhere". It was put to her that at 1px beside Anton and Archivo
+ * Black the marker may read as an artefact rather than a mark; she reaffirmed
+ * it. So if a per-faction stroke is ever wanted, that is a NEW decision with
+ * screenshots behind it, not a bug in this line — the seam to carry it is three
+ * props with these values as defaults.
  */
 export function SectionToggle({
   section,
@@ -230,9 +238,9 @@ export function SectionToggle({
           d="M1.5 1.5 L6.5 6 L1.5 10.5"
           fill="none"
           stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
+          strokeWidth="1"
+          strokeLinecap="butt"
+          strokeLinejoin="miter"
         />
       </svg>
     </button>


### PR DESCRIPTION
Closes #2372

## What changed

Three attribute values in one file, `frontend/src/pages/factionDetail/sectionDisclosure.tsx`:

| | before | after |
|---|---|---|
| `strokeWidth` | `"2"` | `"1"` |
| `strokeLinecap` | `"round"` | `"butt"` |
| `strokeLinejoin` | `"round"` | `"miter"` |

Plus a paragraph in the component's docblock recording *why* it is one value and not eight, and an extension to the existing test suite.

**No props. No archetype file. No manifest. No CSS.** The built `index-*.css` hashes byte-identically to `origin/main`, so this adds zero bytes to the blocking sheet.

## Why the issue body's design is not what got built

The issue specifies stroke props on `SectionToggle` and eight `*FactionBody.tsx` archetypes each passing their own values. The owner's amendment supersedes that: asked whether `strokeWidth: 1` / `linecap: butt` was the Ephemerists' value or the value for all eight, she answered **"Everywhere"**, and reaffirmed it after the objection was put to her that at 1px beside Anton and Archivo Black the marker may read as a hairline artefact next to a slab.

With one value on all eight there is nothing for the seam to carry, and eight files passing the same three constants is worse than one file holding them. So the plumbing is not built.

The marker is still an **SVG, not a glyph** — several of the eight display faces have no U+203A, and a missing glyph is a tofu box on a faction's front door. It stays sized in `em` (`0.55em` / `0.8em`) so it tracks its heading, stroked in `currentColor`, and the shared 160ms `rotate(90deg)` is untouched.

## The seam I tested at

**Sixteen call sites: eight faction archetypes × the Tasks and Praxis sections, driven through the real `FactionDetail` page dispatch.** This is the seam the existing `sectionDisclosure.test.tsx` already walks — by slug × section key, deliberately, because the eight archetypes share no heading component and a component-name grep reaches only twelve of the sixteen.

The new `describe` block was written first and went **red 16/16 on the real defect** (`expected … to contain 'stroke-width="1"'`, received `stroke-width="2" stroke-linecap="round" stroke-linejoin="round"`) before the component was touched. It asserts the stroke as a **constant** across all sixteen — so the day a per-faction value is re-introduced without a decision behind it, this goes red — plus the `em` sizing, `currentColor`, and that no chevron *character* (U+203A, U+276F, U+3009, U+00BB) appears inside any disclosure control.

The suite was extended, not replaced: 26 existing tests still pass, 42 total.

## Verification

Ran every step in the `frontend` job of `.github/workflows/test.yml`, locally:

- `npm run lint` — clean (incl. the `no-raw-style-values` ratchet)
- `npm run typecheck` — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **377 files, 6739 passed**, 1 skipped
- `npm run build` — clean
- `npm run budget` — CSS **WARN is pre-existing**; verified by building `origin/main` in the same worktree and getting the identical CSS asset hash (`index-DHgmzruM.css`). This PR's CSS delta is 0 bytes.

Backend and schema untouched, so `test` and `api-schema` are not in play.

## Visual QA is OUTSTANDING

**I have no browser and no dev stack, so no screenshot in this PR is possible.** The issue's headline deliverable — all eight headings, collapsed and expanded, in both cascades — is exactly the thing I cannot produce, and it is exactly the thing that decides whether "Everywhere" survives contact with Anton. That is the whole reason this is a draft.

If the hairline vanishes beside a heavy face, per-faction tuning becomes a follow-up **with evidence behind it**, and the seam to carry it is five lines: three props on `SectionToggle` with these values as the defaults. The docblock says so, so the next reader does not mistake this line for a bug.

## What to eyeball

Each page below, **collapsed and expanded**, in **both light and dark**, looking at the two section headings (Tasks and Recent praxis). The question is one question: *does the mark still read as a mark beside this face, or has it become a scratch?*

1. `/factions/ephemerists` — Poiret One. The face the value was chosen for; this one should be right by construction.
2. `/factions/coven` — the braid-row display cut.
3. `/factions/everymen`
4. `/factions/singularity` — phosphor caps.
5. `/factions/snide` — **the one to look hardest at.** Its section headings are set in `--faction-snide-font-impact`, which is Anton; `--faction-snide-font-black` is Archivo Black. This is the heavy face the objection to "Everywhere" was about, and the marker also inherits the skew and the acid plate here.
6. `/factions/ua`
7. `/factions/wow`
8. `/factions/albescent` — falls through to `DefaultFactionBody`, which draws a bare `h2.label-heading` rather than a bespoke heading, so it is the one to check for a *different* reason: no archetype styling is carrying the mark here.

S.N.I.D.E. against the Ephemerists is the comparison that decides it: Anton beside Poiret One is the widest gap in the set, and a 1px butt-capped stroke is likeliest to vanish on the first. That is the outcome the owner asked to *see* rather than be told about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
