### PR TITLE
The ground says whether it is busy: the ornament-alternation predicate (#2195 phase 1)

### DIFF
--- a/frontend/src/components/backdrop/BackdropContext.tsx
+++ b/frontend/src/components/backdrop/BackdropContext.tsx
@@ -1,5 +1,6 @@
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -7,15 +8,25 @@ import {
   type ReactNode,
 } from 'react'
 
+import { backdropIsOrnamented } from './ornamentedGrounds'
+
 /**
  * Page-backdrop context. A page declares its "contextual faction" via
  * useFactionBackdrop(slug); <FactionBackdrop> reads it and swaps the full-page
  * background. Mixed / neutral pages leave it null and get the global watercolor.
  * See docs/spec/SPEC-faction-ui-profile.md §2.
+ *
+ * It also answers, for the cards standing on that ground, "is the ground busy?"
+ * — see {@link useGroundIsBusy}.
  */
 interface BackdropContextValue {
   slug: string | null
-  setSlug: (slug: string | null) => void
+  /**
+   * The declaring page claimed the faction-page exemption: its cards keep their
+   * ornament however busy the ground is. See {@link useFactionBackdrop}.
+   */
+  cardsKeepOrnament: boolean
+  setGround: (slug: string | null, cardsKeepOrnament: boolean) => void
 }
 
 /**
@@ -27,14 +38,28 @@ interface BackdropContextValue {
  */
 export const BackdropContext = createContext<BackdropContextValue>({
   slug: null,
-  setSlug: () => {},
+  cardsKeepOrnament: false,
+  setGround: () => {},
 })
 
 export function BackdropProvider({ children }: { children: ReactNode }) {
-  const [slug, setSlug] = useState<string | null>(null)
-  // Memoize so consumers (e.g. FactionBackdrop) only re-render when slug changes,
-  // not on every Layout render.
-  const value = useMemo(() => ({ slug, setSlug }), [slug])
+  // One piece of state, so a page's slug and its ornament claim can never be
+  // half-applied: `useFactionBackdrop` sets both in one call.
+  const [ground, setGround] = useState<{
+    slug: string | null
+    cardsKeepOrnament: boolean
+  }>({ slug: null, cardsKeepOrnament: false })
+  const set = useCallback(
+    (slug: string | null, cardsKeepOrnament: boolean) =>
+      setGround({ slug, cardsKeepOrnament }),
+    [],
+  )
+  // Memoize so consumers (e.g. FactionBackdrop) only re-render when the ground
+  // changes, not on every Layout render.
+  const value = useMemo(
+    () => ({ ...ground, setGround: set }),
+    [ground, set],
+  )
   return <BackdropContext.Provider value={value}>{children}</BackdropContext.Provider>
 }
 
@@ -44,14 +69,49 @@ export function useBackdropSlug(): string | null {
 }
 
 /**
+ * IS THE GROUND UNDER THIS CARD BUSY? (#2195)
+ *
+ * The law, owner 2026-08-17: a card on an ornamented ground drops its own
+ * background texture; a card on a plain ground wears it. True here means "go
+ * plain". Chrome — frame, masthead, points mark, dividers — never branches on
+ * this.
+ *
+ * There is exactly ONE route where this is true today: a character profile,
+ * which paints the page in the profiled player's faction (`CharacterProfile`).
+ * A faction's own page mounts a backdrop too and is EXEMPT (owner, 2026-08-18:
+ * "we can have a busy faction background page with busy task and praxis cards
+ * on it"), and every other route themes nothing and is plain by default. It is
+ * still a hook rather than a prop the profile threads down: the cards there sit
+ * inside nine `profileBody` archetypes, so a prop would be nine files wide and
+ * would have to be re-threaded by every kit that ever grows a card.
+ *
+ * Computed at READ time from two context values rather than pushed into state,
+ * so the suite can reach every branch — effects never run under
+ * `renderToStaticMarkup` (see the note on {@link BackdropContext}).
+ */
+export function useGroundIsBusy(): boolean {
+  const { slug, cardsKeepOrnament } = useContext(BackdropContext)
+  return !cardsKeepOrnament && backdropIsOrnamented(slug)
+}
+
+/**
  * Theme the page backdrop to a faction for as long as the calling page is
  * mounted. Pass null/undefined (or omit the call) to keep the global watercolor.
  * Auto-clears on unmount so navigating away resets to the fallback.
+ *
+ * `cardsKeepOrnament` claims the faction-page exemption from the ornament
+ * alternation (#2195) — see {@link useGroundIsBusy}. It defaults to false
+ * because the law is the default and the carve-out is the special case: a page
+ * that mounts a patterned backdrop and says nothing gets plain cards, rather
+ * than silently keeping a clash nobody typed out.
  */
-export function useFactionBackdrop(slug: string | null | undefined) {
-  const { setSlug } = useContext(BackdropContext)
+export function useFactionBackdrop(
+  slug: string | null | undefined,
+  { cardsKeepOrnament = false }: { cardsKeepOrnament?: boolean } = {},
+) {
+  const { setGround } = useContext(BackdropContext)
   useEffect(() => {
-    setSlug(slug ?? null)
-    return () => setSlug(null)
-  }, [slug, setSlug])
+    setGround(slug ?? null, cardsKeepOrnament)
+    return () => setGround(null, false)
+  }, [slug, cardsKeepOrnament, setGround])
 }

--- a/frontend/src/components/backdrop/__tests__/factionBackdrop.test.tsx
+++ b/frontend/src/components/backdrop/__tests__/factionBackdrop.test.tsx
@@ -42,7 +42,9 @@ import WowBackdrop from '../WowBackdrop'
 /** Render the dispatcher as if a page had themed the ground to `slug`. */
 function backdropFor(slug: string | null): string {
   return renderToStaticMarkup(
-    <BackdropContext.Provider value={{ slug, setSlug: () => {} }}>
+    <BackdropContext.Provider
+      value={{ slug, cardsKeepOrnament: false, setGround: () => {} }}
+    >
       <FactionBackdrop />
     </BackdropContext.Provider>,
   )

--- a/frontend/src/components/backdrop/__tests__/groundIsBusy.test.tsx
+++ b/frontend/src/components/backdrop/__tests__/groundIsBusy.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * The ornament-alternation predicate (#2195 phase 1).
+ *
+ * THE SEAM: `the ground a page declared` → `what useGroundIsBusy() tells a card`.
+ * Two halves, both pure and both here:
+ *
+ *   1. `backdropIsOrnamented(slug)` — is that page ground a PATTERN or a wash?
+ *      A table, so a new backdrop that forgets to file itself is visible.
+ *   2. `useGroundIsBusy()` — the context read a card family will consume,
+ *      including the faction-page exemption (owner, 2026-08-18).
+ *
+ * NO CARD READS THIS YET, deliberately: phase 1 merges alone so nine kits are
+ * not each shipping a branch on a boolean that does not exist. This file is
+ * therefore the ONLY consumer in the tree, and the only thing standing between
+ * the predicate and a silent inversion later.
+ *
+ * Effects never run here (`renderToStaticMarkup`, no DOM — see
+ * `BackdropContext`'s own note), which is exactly why the predicate is computed
+ * at READ time from context values rather than pushed into state by
+ * `useFactionBackdrop`'s effect: everything below is reachable in this harness.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+
+import { BackdropContext, useGroundIsBusy } from '../BackdropContext'
+import {
+  ORNAMENTED_BACKDROP_SLUGS,
+  backdropIsOrnamented,
+} from '../ornamentedGrounds'
+
+/** A card's-eye view: what the predicate says under a given declared ground. */
+function Probe() {
+  return <>{String(useGroundIsBusy())}</>
+}
+
+function busyUnder(slug: string | null, cardsKeepOrnament = false): boolean {
+  const markup = renderToStaticMarkup(
+    <BackdropContext.Provider
+      value={{ slug, cardsKeepOrnament, setGround: () => {} }}
+    >
+      <Probe />
+    </BackdropContext.Provider>,
+  )
+  return markup === 'true'
+}
+
+describe('backdropIsOrnamented', () => {
+  it('calls the five patterned grounds busy', () => {
+    // Everymen's conic rays + dot grid + double hatch, SNIDE's flyposted wall,
+    // Singularity's circuit grid + scanlines, the Ephemerists' chart net, WOW's
+    // 135° gilt hatch. Each repeats across the whole field.
+    for (const slug of ['everymen', 'snide', 'singularity', 'ephemerists', 'wow']) {
+      expect(backdropIsOrnamented(slug), `${slug} is a pattern`).toBe(true)
+    }
+    expect([...ORNAMENTED_BACKDROP_SLUGS].sort()).toEqual(
+      ['ephemerists', 'everymen', 'singularity', 'snide', 'wow'].sort(),
+    )
+  })
+
+  it('calls a WASH plain — Coven candlelight and UA mesa (owner, #2195)', () => {
+    // Both draw a flat token plus soft figures at 6–9%. The owner ruled these
+    // are not busy: there is no second texture for a card to fight.
+    expect(backdropIsOrnamented('coven')).toBe(false)
+    expect(backdropIsOrnamented('ua')).toBe(false)
+  })
+
+  it('calls every ground that resolves to the watercolour plain', () => {
+    // `null` is every route that themes nothing (/tasks, Home, FieldDesk, both
+    // detail pages) — the case that must stay false, or the alternation would
+    // strip the ornament off cards site-wide. `albescent` ships a manifest with
+    // no `backdrop` and `na` ships no manifest at all, so both land on
+    // `WatercolorBackground` via `FactionBackdrop`'s fallback.
+    for (const slug of [null, 'na', 'albescent', 'default', 'no-such-faction']) {
+      expect(backdropIsOrnamented(slug), `${slug} is plain`).toBe(false)
+    }
+  })
+})
+
+describe('useGroundIsBusy', () => {
+  it('is false on every unthemed route — the site-wide default', () => {
+    expect(busyUnder(null)).toBe(false)
+  })
+
+  it('is true on a patterned ground, whatever faction the card is', () => {
+    // Owner ruled (a): ANY ornamented ground, not just the card's own faction.
+    // A Coven card on the Everymen wall is still two textures fighting.
+    expect(busyUnder('everymen')).toBe(true)
+    expect(busyUnder('singularity')).toBe(true)
+  })
+
+  it('is false on a wash, so a Coven profile keeps its cards ornamented', () => {
+    expect(busyUnder('coven')).toBe(false)
+  })
+
+  it('is false when the page claimed the exemption, however busy the ground', () => {
+    // Owner, 2026-08-18: "for the complex background rule, faction pages are
+    // exempt. We can have a busy faction background page with busy task and
+    // praxis cards on it." `useFactionDetail` is the one caller that claims it.
+    expect(busyUnder('everymen', true)).toBe(false)
+    expect(busyUnder('snide', true)).toBe(false)
+  })
+
+  it('defaults to NOT exempt, so a new busy page gets the law for free', () => {
+    // The safe default is the law; the carve-out is what has to be typed out.
+    // A page that mounts a patterned backdrop and says nothing about ornament
+    // gets plain cards rather than silently keeping the clash.
+    expect(busyUnder('snide')).toBe(true)
+  })
+})

--- a/frontend/src/components/backdrop/ornamentedGrounds.ts
+++ b/frontend/src/components/backdrop/ornamentedGrounds.ts
@@ -1,0 +1,67 @@
+/**
+ * WHICH PAGE GROUNDS ARE BUSY — the data half of the ornament alternation
+ * (#2195). The law, owner 2026-08-17: **each faction has ONE ornament; a card on
+ * an ornamented ground goes plain, a card on a plain ground wears it.**
+ *
+ * "Ornament" there means a card's BACKGROUND texture, never its frame, masthead,
+ * points mark or divider. This file answers only the other half of the sentence:
+ * is the GROUND the card is standing on a pattern, or a wash?
+ *
+ * It lives beside the eight backdrop components on purpose. The backdrop is the
+ * only thing that knows whether it is busy, and the alternative — nine card
+ * families each comparing slugs — spreads one judgement over nine files that
+ * cannot see each other. A table can be read in one screen and a new backdrop
+ * that forgets to file itself shows up as an absent row, which is the safe
+ * answer (plain) rather than a wrong one.
+ *
+ * THE LINE: a PATTERN repeats across the whole field (rays, a grid, scanlines, a
+ * hatch, a chart net). A WASH is flat colour plus soft figures — the owner named
+ * Coven's candlelight and UA's mesa as washes explicitly, and both are exactly
+ * that: one token plus blooms/figures held at 6–9% so an unrelated faction's
+ * card can be read straight through them (ADR-0002).
+ *
+ * The predicate is ANY ornamented ground, not just the card's own faction
+ * (owner ruled (a) over the narrower same-faction reading): a Coven card on the
+ * Everymen wall is still two textures fighting, and "sometimes it alternates" is
+ * a worse rule than "it always does".
+ */
+
+/**
+ * The grounds that repeat a texture across the field. Every other slug — and
+ * every route that themes nothing — is plain.
+ *
+ * | slug | what it draws | verdict |
+ * |---|---|---|
+ * | everymen | `.em-backdrop`: conic rays + 6px dot grid + ±45° hatch | pattern |
+ * | snide | `.snide-backdrop`: 5px dot grid + 28°/-19° crosshatch | pattern |
+ * | singularity | `SingularityBackdrop`: 32px circuit grid + 4px scanlines | pattern |
+ * | ephemerists | `EphemeristsBackdrop`: the `EphemerisNet` chart at 0.17 | pattern |
+ * | wow | `.wow-backdrop`: 135° gilt hatch every 24px, + the checker rail | pattern |
+ * | coven | `.coven-backdrop`: flat ward-page + four drifting blooms | WASH |
+ * | ua | `UaBackdrop`: flat mesa sand + mandala/ensō at 6–7% | WASH |
+ * | albescent, na, anything else | `WatercolorBackground` via the dispatcher's fallback | wash |
+ *
+ * `wow` is the one row the owner did not name either way. It is filed as a
+ * pattern because the gilt hatch is a `repeating-linear-gradient` over the
+ * entire viewport, which is the same kind of thing as Everymen's hatch and not
+ * the same kind of thing as Coven's four blooms. It changes nothing for a WOW
+ * card (WOW wears no ornament, so alternation is a no-op for it) — it decides
+ * only what ANOTHER faction's card does on a WOW player's profile.
+ */
+export const ORNAMENTED_BACKDROP_SLUGS: readonly string[] = [
+  'everymen',
+  'snide',
+  'singularity',
+  'ephemerists',
+  'wow',
+]
+
+/**
+ * Is the page ground for `slug` a pattern? `null` (no page themed the backdrop)
+ * and any unregistered slug are the watercolour, which is a wash — so the
+ * answer off a faction page is `false`, which is what keeps the alternation a
+ * no-op on /tasks, Home, the FieldDesk and both detail pages.
+ */
+export function backdropIsOrnamented(slug: string | null | undefined): boolean {
+  return slug != null && ORNAMENTED_BACKDROP_SLUGS.includes(slug)
+}

--- a/frontend/src/pages/factionDetail/useFactionDetail.ts
+++ b/frontend/src/pages/factionDetail/useFactionDetail.ts
@@ -159,7 +159,15 @@ export function useFactionDetail(
 
   // Theme the page backdrop to this faction (Tier-3 surface #10). Falls back to
   // the global watercolor for factions without a backdrop variant.
-  useFactionBackdrop(slug);
+  //
+  // THE ONE PAGE EXEMPT FROM THE ORNAMENT ALTERNATION (#2195). The law is that a
+  // card on an ornamented ground goes plain; the owner carved this page out of
+  // it on 2026-08-18 — "for the complex background rule, faction pages are
+  // exempt. We can have a busy faction background page with busy task and praxis
+  // cards on it." A faction page IS the kit at full volume, so its roster of
+  // task and praxis cards keeps every ornament however loud the wall behind it.
+  // This leaves `CharacterProfile` as the only route where a card goes plain.
+  useFactionBackdrop(slug, { cardsKeepOrnament: true });
 
   useEffect(() => {
     if (!slug) return;


### PR DESCRIPTION
Part of #2195

Phase 1 only: **the mechanism**. No kit's card is touched, no ornament is added
or removed, and the Everymen 7-to-1 collapse is not here. Nothing in the tree
reads the new predicate except its own test, so this is a no-op for every card
today — which is the point of landing it alone.

## Rung zero: I re-asked the question, and the answer moved

The issue argues for a backdrop-declared boolean **because two routes mount an
ornamented ground**. The owner's 2026-08-18 amendment exempts faction pages, so
that argument is now about one route. I verified both call sites on
`origin/main` before writing anything — `useFactionBackdrop` has exactly two
callers and no more:

- `frontend/src/pages/CharacterProfile.tsx:110` — the one route where a card must go plain
- `frontend/src/pages/factionDetail/useFactionDetail.ts:162` — now exempt

**Verdict: keep it on the backdrop context, but stop short of threading
anything.** Two things decided it, and neither is momentum:

1. **A per-route flag alone is not correct.** Even on the single remaining
   route, "go plain" is false about half the time: a Coven or UA player's
   profile paints a *wash*, and the owner ruled a wash is not busy. So the
   character profile cannot just say "cards plain here" — the predicate has to
   know which grounds are patterns either way. Once that table exists, hanging
   the answer off the context it already keys on costs one field.
2. **The nine card families were never the cost.** The threading the amendment
   warns about would be a *prop*, and the cards on the character profile sit
   inside nine `profileBody` archetypes — a prop is nine files wide today and
   has to be re-threaded by every kit that grows a card later. A hook is one
   import at each site that wants it, and phase 3 kits can be worked in
   parallel without touching a shared file.

What I did **not** build: a boolean pushed through the backdrop components, a
new provider, a new context, a manifest surface, or any per-kit registration.

## The seam I tested at

**`the ground a page declared` → `what useGroundIsBusy() tells a card`**, in
`frontend/src/components/backdrop/__tests__/groundIsBusy.test.tsx` (8 tests).
Both halves are pure and reachable in this harness:

- `backdropIsOrnamented(slug)` — the pattern/wash table, tested directly.
- `useGroundIsBusy()` — rendered through `BackdropContext.Provider`, the same
  way `factionBackdrop.test.tsx` already reaches a chosen slug.

The predicate is computed at **read** time from two context values rather than
pushed into state by `useFactionBackdrop`'s effect, specifically so the suite
can reach every branch: there is no DOM here (`renderToStaticMarkup`, no jsdom),
so effects never run and anything an effect computed would be untestable. The
test went red first (module not found), then green.

## What landed

| File | What |
|---|---|
| `frontend/src/components/backdrop/ornamentedGrounds.ts` **(new)** | `ORNAMENTED_BACKDROP_SLUGS` + `backdropIsOrnamented(slug)` — the pattern/wash table, next to the eight backdrop components |
| `frontend/src/components/backdrop/BackdropContext.tsx` | `useGroundIsBusy()`; state carries `{ slug, cardsKeepOrnament }` in one object; `useFactionBackdrop(slug, { cardsKeepOrnament })` |
| `frontend/src/pages/factionDetail/useFactionDetail.ts` | claims the exemption, with the owner's words quoted at the call site |
| `frontend/src/components/backdrop/__tests__/groundIsBusy.test.tsx` **(new)** | the seam, 8 tests |
| `frontend/src/components/backdrop/__tests__/factionBackdrop.test.tsx` | one provider literal follows the context's new shape |

The exemption **defaults to false**, so the law is what a new page gets for
free and the carve-out is the thing that has to be typed out. A future page that
mounts a patterned backdrop and says nothing gets plain cards rather than
silently keeping a clash.

### The pattern/wash table as filed

| slug | ground | verdict |
|---|---|---|
| everymen | conic rays + 6px dot grid + ±45° hatch | **busy** |
| snide | 5px dot grid + 28°/−19° crosshatch | **busy** |
| singularity | 32px circuit grid + 4px scanlines | **busy** |
| ephemerists | the `EphemerisNet` chart at 0.17 | **busy** |
| wow | 135° gilt hatch every 24px + checker rail | **busy** — see below |
| coven | flat ward-page + four drifting blooms | wash (owner) |
| ua | flat mesa sand + mandala/ensō at 6–7% | wash (owner) |
| albescent, `na`, null, anything else | `WatercolorBackground` | wash |

`albescent` ships a manifest with no `backdrop`, so it falls through to the
watercolour — pinned by the existing dispatch test, and plain here for the same
reason.

## Follow-ups to file from this PR

Phase 2 and 3 in the issue's own order. Each consumes `useGroundIsBusy()` from
`components/backdrop/BackdropContext` and branches **only** the card's
background texture — chrome untouched:

- **Everymen** (phase 2, largest): the 7-geometry collapse to one shared class,
  the three non-burst texture deletions, plus the alternation. Its own issue.
- **Singularity** — two scanline pitches collapse to one, then alternate.
- **S.N.I.D.E.** — the wall already ships on both cards (#2177); what remains is
  the branch.
- **Coven** — the cat watermark, worn on the praxis card too, then alternate.
- **Albescent** — the aurora, added to the praxis card, then alternate. Note its
  ground is the watercolour, so its own profile never triggers the branch; it
  only goes plain on someone else's patterned profile.
- **Ephemerists** — the gravity field, added to both cards, then alternate.

WOW, UA and Default/`na` wear no ornament, so they need no issue: the
alternation is a no-op for their cards regardless of what ground they stand on.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

- `npm run lint` — clean
- `npm run typecheck` (`tsc --noEmit` + the e2e project) — clean
- `npm run typecheck:design-sync` — clean
- `npm test` — **378 files, 6730 passed**, 1 skipped
- `npm run build` — built
- `npm run budget` — exit 0. CSS shows the same pre-existing WARN as `main`;
  this branch touches **zero** CSS bytes and zero backend files (no
  `api-schema` regeneration is owed).

**Visual QA is outstanding** — I have no browser. There is nothing to look at
yet by design (no card reads the predicate), so the eyeball list below is about
the two judgements, not pixels.

## What to eyeball

1. **WOW filed as busy.** The one row the owner did not name either way. The
   gilt hatch is a `repeating-linear-gradient` across the whole viewport, which
   is the same kind of thing as Everymen's hatch and not the same kind of thing
   as Coven's four blooms. It changes nothing for a WOW card; it decides only
   what *another* faction's card does on a WOW player's profile. Flip one array
   entry in `ornamentedGrounds.ts` if you read it the other way.
2. **Ephemerists filed as busy.** Its ground is a flat vellum token plus one
   drawn chart net at 0.17 — louder than a wash, quieter than the poster walls.
   Second-most likely row to want a different verdict.
3. **The exemption reads as the owner's sentence.** `useFactionDetail.ts:162`
   now says `useFactionBackdrop(slug, { cardsKeepOrnament: true })` with the
   2026-08-18 quote above it. That is the whole of the faction-page carve-out.
4. **The default direction.** Not-exempt is the default; check you want the law
   to be what a new busy page gets for free.
5. **The name.** `useGroundIsBusy()` keeps the issue's word. The call-site
   option is `cardsKeepOrnament`, which says what it does where it is typed
   rather than restating "exempt".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
