### PR TITLE
The S.N.I.D.E. hero: a black sticker that keeps its edge, a subhead in the faction's voice, and a gate line that stops saying S.N.I.D.E.. (#2368)

### DIFF
--- a/frontend/src/components/factionHero/SnideFactionHero.tsx
+++ b/frontend/src/components/factionHero/SnideFactionHero.tsx
@@ -31,13 +31,24 @@ import i18n from "../../i18n";
 const WALL = "var(--faction-snide-wall)";
 /** Type on that ground (16.03:1 light / 17.52:1 dark). */
 const NOTE_INK = "var(--faction-snide-note-ink)";
-/** The quiet tier on it (6.75:1 / 12.38:1). */
-const NOTE_MUTED = "var(--faction-snide-note-muted)";
+/* The wall's quiet tier (6.75:1 / 12.38:1) stood here and has no site left on
+   this hero: its one reader was the wordmark's expansion, which #2368 made a
+   subhead in the full ink. The tier itself is untouched — the four panels below
+   the hero still read it. */
 /** The wall's own texture ink — the hue `.snide-backdrop` draws its raster with. */
 const GRAIN = "var(--faction-snide-wall-text)";
 const ACID = "var(--faction-snide-acid)";
 /** The plate acid owes the wall (#2173). Invariant, so the bar dissolves at night. */
 const PLATE = "var(--faction-snide-ink)";
+/**
+ * The CHROME hue, which flips #6fae00 -> #b6ff2e — a different token from `ACID`
+ * and the medallion's only ink (#2368). It is legal on that disc precisely
+ * because the disc is frozen on `PLATE` and BOTH of its ends were measured
+ * there: 6.93:1 by day, 15.55:1 by night.
+ */
+const CHROME = "var(--faction-snide)";
+/** The stock the disc gave up, kept as the raster that reads on it. Invariant. */
+const STOCK = "var(--faction-snide-paper)";
 
 const HERO_GHOSTS = [
   { w: 122, h: 152, top: -24, left: 54, rot: -12 },
@@ -190,6 +201,13 @@ export default function SnideFactionHero({
               slammed line box the glyphs deliberately overflow, and a plate on
               the block would have clipped them top and bottom. Horizontal
               padding is the strike of the redaction and stays here. */}
+          {/* THE WORDMARK AND ITS EXPANSION ARE ONE HEADING (#2368). `<hgroup>`
+              is the platform's own device for a heading plus its subhead — the
+              HTML spec defines it as exactly one h1-h6 with `<p>`s around it —
+              so the relationship is in the markup rather than in a `<div>` that
+              happens to sit underneath. The h1's own top margin collapses
+              through this box, so nothing moves. */}
+          <hgroup style={{ margin: 0 }}>
           <h1
             style={{
               fontFamily: "var(--faction-snide-font-impact)",
@@ -204,21 +222,45 @@ export default function SnideFactionHero({
           >
             <span style={{ color: ACID, background: PLATE, padding: "0 var(--space-md)" }}>{name}</span>
           </h1>
-          <div
+          {/* THE EXPANSION IS A SUBHEAD, NOT A CAPTION (#2368).
+              It was `var(--font-body)` — Courier Prime, the app's generic body
+              face — at `--text-base` in the wall's QUIET tier, which is the
+              recipe for a footnote, on a page where the faction owns five faces
+              of its own. Three things move together, because a subhead is a
+              STEP in a hierarchy and any one of them alone leaves it a caption:
+
+              THE FACE is `-font-cond` (Bebas Neue). Of the five it is the one
+              built for a letterspaced caps line under a wordmark — a condensed
+              grotesque with no lowercase to lose — where `-font-type` (Special
+              Elite) is already the eyebrow's typewriter, `-font-black` is the
+              motto sticker's, `-font-impact` is the wordmark itself, and
+              `-font-marker` is the scrawl. It is also the only one of the five
+              that costs nothing: `--font-accent` is a SHELL face, already in the
+              render-blocking sheet for every visitor, while the other four live
+              in the deferred `fonts.faction.css` (#2079).
+
+              THE TIER is the wall's full ink, the one the h1 register reads.
+              15.95:1 by day, 17.52:1 by night — the same pairing SNIDE_WALL_PAIRS
+              already measures; nothing is minted.
+
+              THE SIZE is `--text-xl`, the top rung of the scale and the step the
+              other uppercase heading register takes; `--text-base` was the
+              eyebrow's rung, and a subhead cannot sit below the line above it. */}
+          <p
             style={{
-              fontFamily: "var(--font-body)",
-              fontSize: "var(--text-base)",
+              fontFamily: "var(--faction-snide-font-cond)",
+              fontSize: "var(--text-xl)",
+              lineHeight: 1.05,
               letterSpacing: "0.16em",
               textTransform: "uppercase",
-              // `-card-muted` is the SLAB's quiet tier and reads 1.24:1 on the
-              // light wall (#2173's other half). The wall's quiet tier flips.
-              color: NOTE_MUTED,
+              color: NOTE_INK,
               margin: "var(--space-md) 0 0",
               transform: "rotate(-0.4deg)",
             }}
           >
             {i18n.t("feed:identity.snide.fullName")}
-          </div>
+          </p>
+          </hgroup>
           {/* motto */}
           <div
             style={{
@@ -262,58 +304,64 @@ export default function SnideFactionHero({
                 width: 94,
                 height: 94,
                 borderRadius: "50%",
-                background: "var(--faction-snide-paper)",
+                // THE DISC IS BLACK IN BOTH CASCADES — THE OWNER'S RULING
+                // (#2368), and it REVERSES the ground #2364 settled on eleven
+                // days of history above. The stock was `--faction-snide-paper`,
+                // and #2364 answered a mark that flipped on a frozen disc by
+                // freezing the mark. The ruling answers it from the other end:
+                // the disc is the press's own ink, invariant, and BOTH ends of
+                // the chrome hue were measured on it — 6.93:1 at #6fae00,
+                // 15.55:1 at #b6ff2e. Both clear AA, so the mark is allowed to
+                // go on flipping and is deliberately NOT frozen here.
+                background: PLATE,
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
-                // THE DISC IS FROZEN, SO ITS RIM AND ITS MARK ARE (#2364). This
-                // rim and the sigil below both painted `--faction-snide` — the
-                // CHROME hue, the one that flips #6fae00 -> #b6ff2e — on a disc
-                // whose stock has exactly one value in both cascades (#2227
-                // pinned it there, and six surfaces spend it as an ink). Acid on
-                // cream measures 2.41:1 by day and **1.07:1** by night: the mark
-                // was simply not there in dark. It is the mirror of #2173 above,
-                // where the ink was frozen and the ground flipped, and #2173's
-                // repair is the wrong tool for it — a plate would take the disc
-                // away, and the disc is paper BY DESIGN, which is what makes the
-                // medallion a slapped sticker rather than another censor bar.
-                // So the mark moves instead, onto the press's own ink, which is
-                // the same answer the three other S.N.I.D.E. surfaces drawing on
-                // this exact stock already shipped (the faction page's inverted
-                // monogram, the praxis-detail avatar tile, the profile laurel):
-                // 16.68:1 in both cascades. Acid is not lost from the hero — it
-                // is the wordmark, the motto sticker, the torn strip and all
-                // three chits — and it cannot be lifted onto cream anyway, since
-                // no acid rung is dark enough for this stock (#2133).
-                border: "2px solid var(--faction-snide-ink)",
-                // The second layer is the medallion's offset register (#1609);
-                // the first is a solid ink rim, not a shadow.
-                boxShadow:
-                  "0 0 0 4px var(--faction-snide-ink), 3px 4px 0 color-mix(in srgb, var(--color-print-offset) 40%, transparent)",
+                // THE RING IS RESOLVED, NOT LEFT BEHIND. The 2px rim and the 4px
+                // ring under it were both `--faction-snide-ink` on a cream disc:
+                // move the disc onto that ink and they are black on black. That
+                // is not merely invisible, it is the medallion's only edge at
+                // night — the disc is #14110b and the DARK wall is #0a0a0b, so
+                // the sticker reads 1.05:1 against the wall it is slapped on. By
+                // day the black disc is 15.95:1 on xerox stock and separates
+                // itself; the rim carries the other cascade, in the chrome hue
+                // its own mark takes (2.30:1 on the light wall by luminance,
+                // where it reads by chroma as the torn strip does, and 16.33:1
+                // on the dark one, where it is the whole edge).
+                //
+                // THE 4px RING IS GONE RATHER THAN RECOLOURED. Six pixels of
+                // solid rim was the drawing of a BLACK ring on a PALE disc; six
+                // pixels of chrome around a black one is a different object. The
+                // 2px that is left is the same rim the stat chits directly below
+                // wear, which is what makes the right-hand column one material.
+                border: `2px solid ${CHROME}`,
+                // What remains is the medallion's offset register (#1609), which
+                // was always the second layer.
+                boxShadow: "3px 4px 0 color-mix(in srgb, var(--color-print-offset) 40%, transparent)",
               }}
             >
-              {/* The medallion's own raster, and the LAST raw colour on this
-                  file (#1853's list, class 2). It does not flip and must not:
-                  the disc under it is `--faction-snide-paper`, which has one
-                  value in both cascades, so photocopier ink at 6% is correct by
-                  day and by night alike. The literal was still a literal,
-                  though, and `color-mix(in srgb, <token> N%, transparent)` IS
-                  that rgba to the byte — so the density stays here, the hue gets
-                  its name, and the file comes off the list. */}
+              {/* The medallion's own raster. It does not flip and must not —
+                  both the disc and this ink have exactly one value in both
+                  cascades — but it INVERTS with the stock it is printed on
+                  (#2368): photocopier ink at 6% on cream is nothing at all on a
+                  black disc, so the raster is now the paper the face gave up, at
+                  the same 6% and the same pitch. The density is the drawing and
+                  stays at this call site; only the hue moved. */}
               <div
                 className="ht-dots"
                 style={{
                   position: "absolute",
                   inset: 0,
-                  color: `color-mix(in srgb, ${PLATE} 6%, transparent)`,
+                  color: `color-mix(in srgb, ${STOCK} 6%, transparent)`,
                   borderRadius: "50%",
                   pointerEvents: "none",
                 }}
               />
-              {/* The mark itself, in the press's ink for the reason the rim
-                  states (#2364). A drawn mark owes 3:1 (WCAG 1.4.11), not the
-                  text floor; this reads 16.68:1 in both cascades. */}
-              <SnideSigil size={54} color="var(--faction-snide-ink)" />
+              {/* The mark, in the chrome hue the rim takes, for the reason the
+                  disc states (#2368). A drawn mark owes 3:1 (WCAG 1.4.11), not
+                  the text floor; this reads 6.93:1 by day and 15.55:1 by night,
+                  which is why it is allowed to keep flipping. */}
+              <SnideSigil size={54} color={CHROME} />
             </div>
           </div>
 

--- a/frontend/src/locales/__tests__/catalog.test.ts
+++ b/frontend/src/locales/__tests__/catalog.test.ts
@@ -1027,3 +1027,54 @@ describe("the owner's copy pass keeps the rows that look like bugs (#2332)", () 
     expect(i18n.t('factions:albescent.letter.wordmark')).toBe('Albescent')
   })
 })
+
+/* ========================================================================== *
+ * #2368 — A SENTENCE MAY NOT END ON AN INTERPOLATED FACTION NAME.
+ *
+ * THE SEAM IS THE RENDERED SENTENCE, not the catalog leaf. `mobile.gateHint`
+ * read "…an invitation to {{faction}}." and every leaf-level check passed it:
+ * one shared key (#1911), it interpolates, it ends in a full stop. The defect
+ * exists only after substitution, and only for ONE of the nine names —
+ * "S.N.I.D.E." is the only faction whose name already ends in a full stop, so
+ * the gate line on its faction page read "…an invitation to S.N.I.D.E..".
+ *
+ * WHY THE FIX IS THE SENTENCE AND NOT THE NAME. Stripping the trailing stop from
+ * `names.snide` would be a change to the faction's NAME — it is an initialism
+ * and the stops are the wordmark, printed that way on the hero, the select card
+ * and the roster. The sentence moves its interpolation off the end instead,
+ * which costs one leaf and leaves all nine names alone.
+ *
+ * THE SWEEP IS EVERY NAME, not the one that was reported: any future faction
+ * whose name ends in a stop lands the same way, and so does any future shared
+ * string that closes on `{{faction}}`.
+ * ========================================================================== */
+describe('no faction sentence renders a double full stop (#2368)', () => {
+  const NAMES = Object.keys(factions.names) as Array<keyof typeof factions.names>
+
+  it('S.N.I.D.E. is the name that makes this a real case', () => {
+    // If this ever goes false the guards below still hold, but the REASON in
+    // this block's header has stopped being true — read it before deleting.
+    const trailing = NAMES.filter((slug) => i18n.t(`factions:names.${slug}`).endsWith('.'))
+    expect(trailing).toEqual(['snide'])
+  })
+
+  it('the gate hint reads cleanly for every faction', () => {
+    for (const slug of NAMES) {
+      const line = i18n.t('factions:mobile.gateHint', { faction: factionName(slug) })
+      expect(line, `factions:mobile.gateHint for ${slug} is "${line}"`).not.toContain('..')
+    }
+  })
+
+  it('no catalog string puts a full stop straight after the name', () => {
+    // THE GENERAL FORM, and it is narrower than "ends on the interpolation".
+    // Five other leaves close on `{{faction}}` and are all correct — "Join
+    // {{faction}}", "Join {{faction}}?", "You left {{faction}}" — because a
+    // label, a question mark and a name that ends in a stop compose fine. It is
+    // specifically the APPENDED FULL STOP that doubles up, wherever it falls.
+    const offenders = catalogLeaves()
+      .filter(([id]) => id.startsWith('factions.json:'))
+      .filter(([, value]) => /\{\{faction\}\}\./.test(value))
+      .map(([id, value]) => `${id} -> "${value}"`)
+    expect(offenders).toEqual([])
+  })
+})

--- a/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
+++ b/frontend/src/locales/__tests__/factionCopyCollapse.test.ts
@@ -102,7 +102,11 @@ const FAMILIES: Array<{ banned: string; shared: string; wording: string }> = [
   { banned: `factions:{F}\\.invitation\\.terms\\.1\\.label`, shared: 'factions:invitation.skillsLabel', wording: 'Required skills' },
   { banned: `factions:{F}\\.invitation\\.terms\\.2\\.label`, shared: 'factions:invitation.outputLabel', wording: 'Expected output' },
   { banned: `factions:{F}\\.${JOIN}\\.confirmButton`, shared: 'factions:mobile.confirm', wording: 'Confirm' },
-  { banned: `factions:{F}\\.${JOIN}\\.gateBody`, shared: 'factions:mobile.gateHint', wording: 'Keep completing tasks to earn an invitation to {{faction}}.' },
+  // The interpolation moved off the end of the sentence (#2368): "…to
+  // {{faction}}." appended a full stop to "S.N.I.D.E.", the one faction name
+  // that already carries one, and rendered "S.N.I.D.E..". The imperative is
+  // still here, it just lands last. `catalog.test.ts` holds the general guard.
+  { banned: `factions:{F}\\.${JOIN}\\.gateBody`, shared: 'factions:mobile.gateHint', wording: 'An invitation to {{faction}} is earned. Keep completing tasks.' },
   { banned: `factions:{F}\\.mobile\\.eyebrow`, shared: 'factions:detail.eyebrow', wording: 'Faction' },
   { banned: `factions:{F}\\.praxis\\.empty`, shared: 'factions:detail.default.recentEmpty', wording: 'No praxis submitted yet.' },
   { banned: `factions:{F}\\.praxis\\.heading`, shared: 'factions:detail.default.recentHeading', wording: 'Recent praxis' },

--- a/frontend/src/locales/en/factions.json
+++ b/frontend/src/locales/en/factions.json
@@ -424,7 +424,7 @@
     "joining": "Joining…",
     "confirm": "Confirm",
     "memberBadge": "You're a member",
-    "gateHint": "Keep completing tasks to earn an invitation to {{faction}}.",
-    "burnedHint": "You left {{faction}}. It can't take you back until the next era begins."
+    "gateHint": "An invitation to {{faction}} is earned. Keep completing tasks.",
+    "burnedHint": "You left {{faction}}, and it can't take you back until the next era begins."
   }
 }

--- a/frontend/src/utils/__tests__/factionContrast.test.ts
+++ b/frontend/src/utils/__tests__/factionContrast.test.ts
@@ -3308,7 +3308,10 @@ describe("the S.N.I.D.E. faction page stands on the wall (#2343)", () => {
     [HERO]: [
       ["WALL", "--faction-snide-wall"],
       ["NOTE_INK", "--faction-snide-note-ink"],
-      ["NOTE_MUTED", "--faction-snide-note-muted"],
+      // NO `NOTE_MUTED` ROW. The hero's one reader of the wall's quiet tier was
+      // the wordmark's expansion, and #2368 made that a SUBHEAD in the full ink;
+      // the alias came off the file with it. The tier is untouched and the four
+      // panels in BODY still read it, which is what the row below still checks.
       ["GRAIN", "--faction-snide-wall-text"],
       ["ACID", "--faction-snide-acid"],
       ["PLATE", "--faction-snide-ink"],
@@ -3536,34 +3539,23 @@ describe("the S.N.I.D.E. faction page stands on the wall (#2343)", () => {
  * S.N.I.D.E. surfaces that draw on this same disc already shipped: the press's
  * own `-ink`, 16.68:1 in both cascades. Their rows are here so the family is
  * pinned rather than only the site that was reported.
+ *
+ * THE HERO IS NO LONGER ONE OF THEM (#2368). The owner ruled its medallion black
+ * in both cascades, so that disc is the press's `-ink` now and its marks are
+ * measured by the block below — on a frozen ground whose BOTH ends were checked,
+ * which is why the sigil is allowed to keep flipping there. Nothing about this
+ * block changed: the cream stock is still frozen, and the three surfaces still
+ * drawing on it still owe it a frozen mark.
  */
 describe("a mark on the invariant xerox disc is frozen too (#2364)", () => {
   const DISC = "--faction-snide-paper";
-  const HERO = "components/factionHero/SnideFactionHero.tsx";
 
-  /** The three surfaces that already draw a mark on this disc, as tokens. */
+  /** The three surfaces that draw a mark on this disc. */
   const DISC_MARKS: ReadonlyArray<readonly [string, string]> = [
     ["the faction page's inverted monogram (SnideFactionBody)", "--faction-snide-ink"],
     ["the praxis detail's avatar tile (SnidePraxisDetail)", "--faction-snide-ink"],
     ["the profile laurel's glyph (SnideProfileBody)", "--faction-snide-ink"],
   ];
-
-  /**
-   * The hero medallion's two marks, read OFF THE SOURCE rather than listed, so
-   * the rows cannot go on measuring a token the component stopped painting.
-   */
-  function heroMedallionMarks(): Array<[string, string]> {
-    const source = stripComments(sourceOf(HERO));
-    expect(source, `the hero medallion no longer grounds on ${DISC}`).toContain(`background: "var(${DISC})"`);
-    const rim = source.match(/border:\s*"2px solid var\((--[a-z-]+)\)"/);
-    const sigil = source.match(/<SnideSigil[^>]*color="var\((--[a-z-]+)\)"/);
-    expect(rim, "no `2px solid` rim on the hero medallion").not.toBeNull();
-    expect(sigil, "the hero draws no `SnideSigil` in a token colour").not.toBeNull();
-    return [
-      ["the hero medallion's rim", rim![1]],
-      ["the hero medallion's sigil", sigil![1]],
-    ];
-  }
 
   it("the disc itself cannot flip — the premise the rest of this block rests on", () => {
     const [light, dark] = BOTH_THEMES.map((theme) => resolveColor(DISC, theme).raw);
@@ -3572,7 +3564,7 @@ describe("a mark on the invariant xerox disc is frozen too (#2364)", () => {
   });
 
   it("every mark drawn on it is frozen too", () => {
-    for (const [role, token] of [...heroMedallionMarks(), ...DISC_MARKS]) {
+    for (const [role, token] of DISC_MARKS) {
       const [light, dark] = BOTH_THEMES.map((theme) => resolveColor(token, theme).raw);
       expect(light, `${token} resolved to nothing in light`).not.toBeNull();
       expect(
@@ -3586,7 +3578,7 @@ describe("a mark on the invariant xerox disc is frozen too (#2364)", () => {
     it(`every mark clears the 3:1 graphical floor (${theme})`, () => {
       const ground = resolveColor(DISC, theme);
       expect(ground.color, `${DISC} (${theme}) resolved to "${ground.raw}"`).not.toBeNull();
-      for (const [role, token] of [...heroMedallionMarks(), ...DISC_MARKS]) {
+      for (const [role, token] of DISC_MARKS) {
         const mark = resolveColor(token, theme);
         expect(mark.color, `${token} (${theme}) resolved to "${mark.raw}"`).not.toBeNull();
         const ratio = contrastRatio(mark.color!, ground.color!);
@@ -3595,6 +3587,201 @@ describe("a mark on the invariant xerox disc is frozen too (#2364)", () => {
           `${role}: ${token} on ${DISC} (${theme}) is ${formatRatio(ratio)}. A drawn mark owes WCAG 1.4.11's 3:1, and the acid a S.N.I.D.E. surface reaches for by reflex reads 2.40:1 on this stock even in light — there is no acid rung dark enough for cream (#2133's arithmetic, one surface over).`,
         ).toBeGreaterThanOrEqual(AA_LARGE);
       }
+    });
+  }
+});
+
+/**
+ * #2368 — THE BLACK STICKER, AND THE EDGE IT HAS ON THE WALL.
+ *
+ * OWNER RULING: the hero medallion's disc is black in BOTH cascades. That
+ * reverses the ground of the block above for this one surface (the other three
+ * still draw on the cream stock), and it re-opens from the other side the
+ * pairing #2364 closed: with the disc frozen on the press's `-ink`, a mark that
+ * flips is legal again, because BOTH ends of the chrome hue were measured on it
+ * — 6.93:1 at the light `#6fae00`, 15.55:1 at the dark `#b6ff2e`. Both clear AA,
+ * so the sigil keeps flipping rather than being frozen to one value.
+ *
+ * WHAT THE RULING BREAKS, WHICH IS WHY THIS BLOCK EXISTS. The medallion's rim
+ * and its 4px ring were `--faction-snide-ink` on a cream disc. Move the disc
+ * onto that same ink and the rim is black on black. It is not ornament: the disc
+ * is `#14110b` and the DARK wall is `#0a0a0b`, so at night the sticker reads
+ * **1.05:1** against the wall it is slapped on and the rim is the only edge it
+ * has. By day the disc is 15.95:1 on xerox stock and separates itself.
+ *
+ * SO THE ASSERTION IS NOT A RATIO ON ONE PAIRING. It is: in EACH cascade, at
+ * least one of {disc, rim} clears the 3:1 graphical floor against the wall.
+ * Neither side can state that alone — a disc-vs-wall row fails in dark by
+ * design, and a rim-vs-wall row fails in light by design (the chrome hue is
+ * 2.30:1 on xerox stock) — and no per-token manifest can see it at all.
+ *
+ * THE SUBHEAD IS HERE TOO because it is the same surface and the same kind of
+ * claim: the wordmark's expansion was `var(--font-body)` at `--text-base` in the
+ * wall's QUIET tier, i.e. a caption, on a page whose faction owns five faces.
+ * The ink it lands on is measured on the hero's real ground, which is the wall.
+ */
+describe("the S.N.I.D.E. hero's black medallion and its subhead (#2368)", () => {
+  const HERO = "components/factionHero/SnideFactionHero.tsx";
+  const WALL = "--faction-snide-wall";
+
+  /**
+   * The aliases the rows below are written against, so a rename fails loudly
+   * instead of matching nothing — the same guard shape the #2343 block uses.
+   */
+  const ALIASES: ReadonlyArray<readonly [string, string]> = [
+    ["WALL", "--faction-snide-wall"],
+    ["NOTE_INK", "--faction-snide-note-ink"],
+    ["PLATE", "--faction-snide-ink"],
+    ["ACID", "--faction-snide-acid"],
+    ["CHROME", "--faction-snide"],
+    ["STOCK", "--faction-snide-paper"],
+  ];
+
+  function heroSource(): string {
+    // `stripComments` only knows `/* … */`; this surface argues for itself in
+    // `//` lines BETWEEN declarations, which is exactly where the rows below
+    // read. Both go, so a paragraph of reasoning cannot hide a declaration.
+    const source = stripComments(sourceOf(HERO)).replace(/^[^\S\n]*\/\/.*$/gm, "");
+    for (const [alias, token] of ALIASES) {
+      expect(
+        source,
+        `${HERO} no longer binds \`${alias}\` to ${token}; retarget this guard at whatever it is called there now.`,
+      ).toMatch(new RegExp(`const ${alias} = ["']var\\(${token}\\)["']`));
+    }
+    return source;
+  }
+
+  /** An alias (bare, `{X}` or `${X}`) or a literal `var(--token)`, as its token. */
+  function tokenOf(expression: string, role: string): string {
+    const trimmed = expression.replace(/[`"'${}]/g, "").replace(/[,;]$/, "").trim();
+    const alias = ALIASES.find(([name]) => name === trimmed);
+    if (alias) return alias[1];
+    const bare = trimmed.match(/^var\((--[a-z-]+)\)$/);
+    expect(bare, `${role} paints \`${trimmed}\`, which is neither an alias this guard knows nor a var()`).not.toBeNull();
+    return bare![1];
+  }
+
+  /** The medallion, read OFF THE SOURCE so no row measures a token it stopped painting. */
+  function medallion(): { disc: string; marks: Array<[string, string]>; raster: string } {
+    const source = heroSource();
+    const disc = source.match(/borderRadius: "50%",\s*background: ([^,\n]+),/);
+    const rim = source.match(/border: [`"]2px solid ([^`"]+)[`"]/);
+    const sigil = source.match(/<SnideSigil[^>]*color=([^\s/>]+)/);
+    // The medallion's own raster — the 6% one; the hero's wall grain is 5.5%
+    // and the five pasted ghosts are 7%/3.5%/2.5%.
+    const raster = source.match(/color-mix\(in srgb, ([^\s]+) 6%, transparent\)/);
+    expect(disc, "no disc in the hero — nothing here is measuring the medallion").not.toBeNull();
+    expect(rim, "no `2px solid` rim on the hero medallion").not.toBeNull();
+    expect(sigil, "the hero draws no `SnideSigil` in a colour this guard can read").not.toBeNull();
+    expect(raster, "the medallion's 6% raster is gone").not.toBeNull();
+    return {
+      disc: tokenOf(disc![1], "the medallion's disc"),
+      marks: [
+        ["the medallion's rim", tokenOf(rim![1], "the medallion's rim")],
+        ["the medallion's sigil", tokenOf(sigil![1], "the medallion's sigil")],
+      ],
+      raster: tokenOf(raster![1], "the medallion's raster"),
+    };
+  }
+
+  it("the disc is black in both cascades — the owner's ruling, as a measurement", () => {
+    const { disc } = medallion();
+    const [light, dark] = BOTH_THEMES.map((theme) => resolveColor(disc, theme));
+    expect(light.raw, `${disc} resolved to nothing in light`).not.toBeNull();
+    expect(dark.raw, `the medallion grounds on ${disc}, which flips ${light.raw} -> ${dark.raw}. The ruling is that this disc is black no matter what the cascade does.`).toBe(light.raw);
+    expect(
+      relativeLuminance(light.color!),
+      `${disc} is ${light.raw}, whose relative luminance is not a black disc's. Freezing the stock is only half the ruling.`,
+    ).toBeLessThan(0.05);
+  });
+
+  for (const theme of BOTH_THEMES) {
+    it(`every mark on the disc clears the 3:1 graphical floor (${theme})`, () => {
+      const { disc, marks, raster } = medallion();
+      const ground = resolveColor(disc, theme);
+      expect(ground.color, `${disc} (${theme}) resolved to "${ground.raw}"`).not.toBeNull();
+      for (const [role, token] of marks) {
+        const mark = resolveColor(token, theme);
+        expect(mark.color, `${token} (${theme}) resolved to "${mark.raw}"`).not.toBeNull();
+        const ratio = contrastRatio(mark.color!, ground.color!);
+        expect(
+          ratio,
+          `${role}: ${token} on ${disc} (${theme}) is ${formatRatio(ratio)}. A drawn mark owes WCAG 1.4.11's 3:1, and the failure this catches is the cheap one — leaving a mark in the ink the disc itself became.`,
+        ).toBeGreaterThanOrEqual(AA_LARGE);
+      }
+      // The raster owes no ratio — it is a texture — but painting it in the
+      // disc's own ink means painting nothing at all.
+      expect(raster, "the medallion's raster is the disc's own colour, so it draws nothing").not.toBe(disc);
+    });
+  }
+
+  for (const theme of BOTH_THEMES) {
+    it(`the sticker has an edge against the wall (${theme})`, () => {
+      const { disc, marks } = medallion();
+      const wall = resolveColor(WALL, theme);
+      expect(wall.color, `${WALL} (${theme}) resolved to "${wall.raw}"`).not.toBeNull();
+      const rim = marks[0][1];
+      const readings = [disc, rim].map((token) => {
+        const value = resolveColor(token, theme);
+        expect(value.color, `${token} (${theme}) resolved to "${value.raw}"`).not.toBeNull();
+        return { token, ratio: contrastRatio(value.color!, wall.color!) };
+      });
+      const best = Math.max(...readings.map((r) => r.ratio));
+      expect(
+        best,
+        `neither the disc nor its rim separates the medallion from the wall in ${theme}: ${readings
+          .map((r) => `${r.token} ${formatRatio(r.ratio)}`)
+          .join(", ")}. One of the two has to carry the edge in each cascade — the black disc does it by day (15.95:1 on xerox stock), and at night it is 1.05:1 on the #0a0a0b wall and only the rim is left.`,
+      ).toBeGreaterThanOrEqual(AA_LARGE);
+    });
+  }
+
+  /** The wordmark's expansion line, as `style={{ … }}` up to the string it renders. */
+  function subhead(): string {
+    const source = heroSource();
+    const at = source.indexOf("identity.snide.fullName");
+    expect(at, `${HERO} no longer renders the faction's full name`).toBeGreaterThan(-1);
+    const open = source.lastIndexOf("style={{", at);
+    expect(open, "the expansion line is rendered by no styled element").toBeGreaterThan(-1);
+    return source.slice(open, at);
+  }
+
+  it("the expansion line speaks in one of the faction's own five faces", () => {
+    const face = subhead().match(/fontFamily: "var\((--[a-z-]+)\)"/);
+    expect(face, "the expansion line sets no fontFamily at all").not.toBeNull();
+    expect(
+      face![1],
+      `the expansion line is set in ${face![1]} on a page whose faction owns five faces of its own (-font-impact, -font-cond, -font-black, -font-type, -font-marker).`,
+    ).toMatch(/^--faction-snide-font-/);
+  });
+
+  it("it is marked up as the wordmark's subhead, not a caption hanging off it", () => {
+    const source = heroSource();
+    const group = source.match(/<hgroup[\s\S]*?<\/hgroup>/);
+    expect(group, "the wordmark and its expansion are not grouped as a heading and its subhead").not.toBeNull();
+    expect(group![0], "the h1 is not in the group").toContain("<h1");
+    expect(group![0], "the expansion is not in the group").toContain("identity.snide.fullName");
+    const ink = subhead().match(/color: ([^,\n]+),/);
+    expect(ink, "the expansion line sets no colour").not.toBeNull();
+    expect(
+      tokenOf(ink![1], "the expansion line"),
+      "a subhead is a step in the hierarchy, not a footnote — the wall's QUIET tier is the caption rung this line came off.",
+    ).not.toBe("--faction-snide-note-muted");
+  });
+
+  for (const theme of BOTH_THEMES) {
+    it(`the subhead's ink clears AA on the hero's real ground (${theme})`, () => {
+      const ink = subhead().match(/color: ([^,\n]+),/);
+      expect(ink, "the expansion line sets no colour").not.toBeNull();
+      const token = tokenOf(ink![1], "the expansion line");
+      const text = resolveColor(token, theme);
+      const ground = resolveColor(WALL, theme);
+      expect(text.color, `${token} (${theme}) resolved to "${text.raw}"`).not.toBeNull();
+      const ratio = contrastRatio(text.color!, ground.color!);
+      expect(
+        ratio,
+        `the wordmark's subhead: ${token} on ${WALL} (${theme}) is ${formatRatio(ratio)}. The hero's ground is the wall, not the slab — the card tiers read 1.05:1 and 1.24:1 on it by day (#2173).`,
+      ).toBeGreaterThanOrEqual(AA_NORMAL);
     });
   }
 });


### PR DESCRIPTION
Closes #2368

Owner review of the S.N.I.D.E. faction page. Three of the four items were live; the fourth had already shipped.

## Item 1 — already done, no work in this PR

`SnideFactionBody.tsx` on `origin/main` paints no dot-wash ground. The page's ground is `.snide-backdrop` through `useFactionBackdrop`, and `index.css:3652` declares that paint **once** for two mounts — `.snide-backdrop` (the page) and `.snd-detail-sheet` (the task/praxis detail sheet). That is exactly the "one shared source" the acceptance asked for, and #2343/#2363 landed it. The `Halftone` component still in the file is a different thing: a per-panel raster (5px pitch, `--faction-snide-wall-text` at 8%) drawn *inside* the flyposted panels, re-inked by #2343 so it reverses polarity with the wall. Nothing here was re-done.

## The seam I tested at

`frontend/src/utils/__tests__/factionContrast.test.ts` — the pairing seam. Both defects below are pairings, which is the shape no per-token manifest can see: the tokens are all declared, all measured, and each side is individually correct. So the rows read the *component source* for what it actually paints and measure that against its real ground, in both cascades.

The loop went red on the real defect first. With the disc black and the rim left as it was, the block reports:

    the medallion's rim: --faction-snide-ink on --faction-snide-ink (light) is 1.00:1
    neither the disc nor its rim separates the medallion from the wall in dark:
      --faction-snide-ink 1.05:1, --faction-snide-ink 1.05:1

## Item 2 — the expansion line is a subhead, in the faction's voice

`SnideFactionHero.tsx`. It was `var(--font-body)` (Courier Prime, the app's generic body face) at `--text-base` in the wall's *quiet* tier — the recipe for a footnote. Three things move, because a subhead is a step in a hierarchy and any one alone leaves it a caption:

- **Face — `--faction-snide-font-cond` (Bebas Neue).** Of the five faces the faction owns it is the one built for a letterspaced caps line under a wordmark, and the other four are already spoken for on this hero (`-font-impact` is the wordmark, `-font-type` the eyebrow, `-font-black` the motto sticker, `-font-marker` the scrawl). It is also the only one of the five that costs **zero bytes**: `--font-accent` is a shell face, already in the render-blocking sheet for every visitor, while the other four live in the deferred `fonts.faction.css` (#2079).
- **Ink — `--faction-snide-note-ink`,** the wall's full ink, measured on the hero's real ground (`--faction-snide-wall`): **15.95:1 light / 17.52:1 dark**. It was `--faction-snide-note-muted` (6.75 / 12.38) — legible, but the caption rung. Nothing minted; `SNIDE_WALL_PAIRS` already measures this pairing.
- **Size + markup — `--text-xl`, inside an `<hgroup>` with the `h1`.** `<hgroup>` is the platform's own device for a heading plus its subhead, so the relationship is in the markup and not in a `<div>` that happens to sit underneath. The h1's own top margin collapses through it, so nothing moves.

## Item 3 — the disc is black, and the ring is resolved

Per the ruling, the medallion grounds on `--faction-snide-ink` in both cascades. The mark is **not** frozen: both ends of `--faction-snide` were measured on that disc — **6.93:1** (`#6fae00`) and **15.55:1** (`#b6ff2e`) — so `SnideSigil` keeps flipping, as instructed.

**What the ring becomes, and why.** The 2px rim and the 4px ring under it were both `--faction-snide-ink`, i.e. black on black. That is not just an invisible shadow, it is load-bearing: the disc is `#14110b` and the **dark wall is `#0a0a0b`**, so at night the sticker reads **1.05:1** against the wall it is slapped on and the rim is the only edge it has (by day the black disc is 15.95:1 on xerox stock and separates itself).

- **The 4px ring is deleted, not recoloured.** Six pixels of solid rim was the drawing of a *black* ring on a *pale* disc; six pixels of chrome around a black one is a different object. It was a spread `box-shadow`, so removing it repaints without reflowing.
- **The 2px rim takes `--faction-snide`,** the same hue as the mark, so the sticker prints in one ink — and it is the same 2px rim the stat chits directly below it already wear, which makes the right-hand column one material. Against the wall: 2.30:1 light (reading by chroma, as the torn acid strip on this same hero already does) and **16.33:1 dark**, where it is the whole edge.
- **The 6% raster inverts with the stock:** photocopier ink at 6% paints nothing on a black disc, so it is now `--faction-snide-paper` at the same 6% and the same pitch. Both tokens are invariant, so the "frozen raster on frozen stock" argument survives intact.

The guard states this as a property rather than a row, because neither single pairing can: *in each cascade, at least one of {disc, rim} clears 3:1 against the wall.* A disc-vs-wall row fails in dark by design; a rim-vs-wall row fails in light by design.

`--faction-snide-note-muted` now has no site on this hero (its one reader was the expansion line), so the alias came off the file and out of the #2343 guard's alias list, with a note. The tier itself is untouched — the four panels below still read it.

## Item 4 — "S.N.I.D.E.." (copy pick flagged)

`mobile.gateHint` ended on `{{faction}}.`, appending a stop to the one name that already carries one. Not solved by touching any faction name — the initialism's stops *are* the wordmark.

    - "Keep completing tasks to earn an invitation to {{faction}}."
    + "An invitation to {{faction}} is earned. Keep completing tasks."

**This is a copy decision I made rather than stalling on, per the brief.** It keeps the imperative (now in final position, where the call to action belongs), adds no claim the original did not make, and moves the interpolation off the end. If the owner prefers different words it is a one-leaf edit; the guard does not care about the wording, only about the shape.

**The general sweep found a second one:** `mobile.burnedHint` was `"You left {{faction}}. It can't take you back…"` — same defect, same shape. It is fixed in place with a comma (`"You left {{faction}}, and it can't…"`). Note it renders **nowhere** today — every body reads `detail.burned.body` instead — so it is effectively dead copy; I fixed it rather than deleting it, since retiring a catalog leaf is a copy-lifecycle call, not a styling one.

## Explicitly not touched

The ABOUT heading. `--faction-snide-acid-deep` on `--faction-snide-ink` is theme-invariant by construction — neither token has a `[data-theme="dark"]` override — and no dark half was minted for either. The sign-off stays true by construction.

## Verification

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (377 files / 6734 tests), `npm run build`, `npm run budget` — all clean.

The byte budget prints `WARN CSS 22.2 KB` — **pre-existing**. I built `origin/main` in the same worktree to check: same 22.2 KB, same warning, and the emitted CSS asset is byte-identical (`index-DHgmzruM.css` before and after), so this PR adds zero CSS. It touches no stylesheet and mints no token.

**Visual QA is outstanding.** I have no browser and no dev stack; every claim above is a computed ratio or a source guard, not a screenshot.

## What to eyeball

On the **S.N.I.D.E. faction page** (`/factions/snide`), in **both cascades**:

1. **Light.** The medallion is a black disc with a green rim and a green mark, sitting on cream — it should read as a slapped sticker, not a hole. Check it against the stat chits below it, which now wear the same 2px rim.
2. **Dark.** The same disc on a near-black wall: the rim is the only thing separating them. Is 2px enough, or does this want the 4px back in chrome?
3. **The wordmark block, both cascades.** "SOCIETY FOR NIHILISTIC INTENT & DISRUPTIVE EFFORTS" in Bebas at `--text-xl` under the 82px Anton wordmark — does it read as a subhead of the mark, and does it wrap acceptably at phone width (the identity column floors at `min(300px, 100%)`)?
4. **The "RE: YOU" card** on an account that is not a member: the gate line should read "An invitation to S.N.I.D.E. is earned. Keep completing tasks." — one stop, and the words should sound right in the owner's ear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
