### PR TITLE
Everymen's giant hands: the slack chain asks for the card's own link by name (#2380)

### DIFF
--- a/frontend/src/components/cardMasthead/CardMasthead.tsx
+++ b/frontend/src/components/cardMasthead/CardMasthead.tsx
@@ -177,14 +177,18 @@ export default function CardMasthead({
         color: "inherit",
         textDecoration: "none",
         /* THE BAND DOES NOT TAKE THE ROW'S SLACK. `.task-card-row` hands a
-           card's spare height down a chain that ends at `a[href]` (index.css,
-           the equal-height row), so the moment this element became an anchor it
-           joined that chain and would have stretched beside the body link,
-           splitting the slack between them. The band is a band: it is as tall
-           as its own content, and the body still absorbs the difference.
+           card's spare height down a chain that ends at the one anchor marked
+           `data-card-link` (index.css, the equal-height row), and this band is
+           not it. That was not always the selector: the chain used to end at
+           `a[href]`, so the moment this element became an anchor (#2167) it
+           joined the chain and stretched beside the body link, splitting the
+           slack between them — this pin was the correction. #2380 moved the
+           chain onto the hook, so the pin now restates the initial value
+           instead. It stays as the belt: a band is as tall as its own content
+           whatever a later rule decides, and only `flex-grow` is pinned, so
+           shrink and basis keep the values the band had as a plain block.
            `frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx` holds
-           this. Only `flex-grow` is pinned, so shrink and basis stay the
-           initial values the band had as a plain block. */
+           the chain to a single anchor. */
         flexGrow: 0,
         ...style,
       }}

--- a/frontend/src/components/cardMasthead/factionBands.tsx
+++ b/frontend/src/components/cardMasthead/factionBands.tsx
@@ -107,10 +107,12 @@ function CovenBand() {
         background: "var(--faction-coven-slip-sigil-ground)",
         borderBottom: "1px solid var(--faction-coven-slip-pk)",
         /* The twinkle box is the one wrapper standing between a card's root and
-           its band, so since #2167 made the band a link it matches
-           `:has(a[href])` on the equal-height row's slack chain (index.css) and
-           would stretch past its 44px. The band inside pins its own growth for
-           the same reason; this pins the box. */
+           its band, so while the equal-height row's slack chain ended at
+           `:has(a[href])` (index.css), #2167's linked band made this box match
+           and stretch past its 44px. #2380 re-keyed that chain onto the
+           `data-card-link` hook, which this box does not contain, so the pin is
+           belt rather than braces now — kept, like the band's own, because a
+           band's height is its content. */
         flexGrow: 0,
       }}
     >

--- a/frontend/src/components/taskCard/CovenTaskCard.tsx
+++ b/frontend/src/components/taskCard/CovenTaskCard.tsx
@@ -182,7 +182,7 @@ export default function CovenTaskCard({
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
-          <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+          <Link to={`/tasks/${task.id}`} data-card-link="" style={{ display: "block", textDecoration: "none", color: "inherit" }}>
             {/* The slip's pencilled ordinal ("Task {id}", hand-lettered under the
                 masthead) is gone with #1124 — the id no longer shows on any card,
                 and it was the whole line. */}

--- a/frontend/src/components/taskCard/DefaultTaskCard.tsx
+++ b/frontend/src/components/taskCard/DefaultTaskCard.tsx
@@ -113,9 +113,16 @@ export default function DefaultTaskCard({
         }}
       >
         {/* Everything but the CTA reads the full call — a card-sized target
-            that stays valid HTML (no <button> nested in an <a>). */}
+            that stays valid HTML (no <button> nested in an <a>).
+
+            `data-card-link` is the hook the equal-height row hands a card's
+            spare height down to (index.css, the `.task-card-row` block). It
+            marks THIS anchor as the card-wide one; a card may draw others —
+            the masthead does, and the CTA slot does for a viewer holding a
+            draft — and none of them are on that chain (#2380). */}
         <Link
           to={`/tasks/${task.id}`}
+          data-card-link=""
           style={{ display: "block", textDecoration: "none", color: "inherit" }}
         >
           {/* Hero — level, a hairline, the marks in their ring, the modifier.

--- a/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
+++ b/frontend/src/components/taskCard/EphemeristsTaskCard.tsx
@@ -235,7 +235,7 @@ export default function EphemeristsTaskCard({
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
-          <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+          <Link to={`/tasks/${task.id}`} data-card-link="" style={{ display: "block", textDecoration: "none", color: "inherit" }}>
             {/* #1020's brass cartouche stood here, ruling off the uniform "Task
                 {id}" ordinal at both ends. #1124 retired the id from every card
                 and the cartouche held nothing else, so both are gone. */}

--- a/frontend/src/components/taskCard/EverymenTaskCard.tsx
+++ b/frontend/src/components/taskCard/EverymenTaskCard.tsx
@@ -307,7 +307,7 @@ export default function EverymenTaskCard({
           <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
             {/* Everything but the CTA reads the full call — a card-sized target
                 that stays valid HTML (no <button> nested in an <a>). */}
-            <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+            <Link to={`/tasks/${task.id}`} data-card-link="" style={{ display: "block", textDecoration: "none", color: "inherit" }}>
               {/* The dateline carried the uniform "Task {id}" ordinal and nothing
                   else, so #1124's retirement of the id takes the whole line. */}
               {/* LEVEL and the seal ride in two EQUAL halves with the cog

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -176,7 +176,7 @@ export default function SingularityTaskCard({
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
-          <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+          <Link to={`/tasks/${task.id}`} data-card-link="" style={{ display: "block", textDecoration: "none", color: "inherit" }}>
             <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-md)", marginBottom: "var(--space-lg)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1 }}>
                 <span style={{ ...LABEL, fontSize: "var(--text-md)", marginBottom: "var(--space-xs)" }}>

--- a/frontend/src/components/taskCard/SnideTaskCard.tsx
+++ b/frontend/src/components/taskCard/SnideTaskCard.tsx
@@ -195,7 +195,7 @@ export default function SnideTaskCard({
         <div style={{ position: "relative", zIndex: 2, padding: size.bodyPad }}>
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
-          <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+          <Link to={`/tasks/${task.id}`} data-card-link="" style={{ display: "block", textDecoration: "none", color: "inherit" }}>
             <div style={{ display: "flex", alignItems: "flex-end", gap: "var(--space-md)", padding: "var(--space-lg) 0 var(--space-md)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
                 <span

--- a/frontend/src/components/taskCard/UaTaskCard.tsx
+++ b/frontend/src/components/taskCard/UaTaskCard.tsx
@@ -194,7 +194,7 @@ export default function UaTaskCard({
         <div style={{ position: "relative", padding: size.pad }}>
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
-          <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+          <Link to={`/tasks/${task.id}`} data-card-link="" style={{ display: "block", textDecoration: "none", color: "inherit" }}>
             <div style={{ display: "flex", alignItems: "center", gap: "var(--space-md)", marginBottom: "var(--space-md)" }}>
               <div style={{ flex: "0 0 auto", display: "flex", flexDirection: "column", alignItems: "flex-start", lineHeight: 1 }}>
                 <span style={{ ...UA_EYEBROW, fontSize: "var(--text-md)", marginBottom: "var(--space-xs)" }}>

--- a/frontend/src/components/taskCard/WowTaskCard.tsx
+++ b/frontend/src/components/taskCard/WowTaskCard.tsx
@@ -208,7 +208,7 @@ export default function WowTaskCard({
         <div style={{ padding: size.pad }}>
           {/* Everything but the CTA reads the full call — a card-sized target
               that stays valid HTML (no <button> nested in an <a>). */}
-          <Link to={`/tasks/${task.id}`} style={{ display: "block", textDecoration: "none", color: "inherit" }}>
+          <Link to={`/tasks/${task.id}`} data-card-link="" style={{ display: "block", textDecoration: "none", color: "inherit" }}>
             {/* The decree-lettered eyebrow held the uniform "Task {id}" ordinal and
               nothing else, so #1124's retirement of the id takes the line with
               it. The masthead and its ribbon are the card's top note now. */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4368,8 +4368,8 @@
      not the thing that gets painted. Every task card mounts as
 
        row > TaskCard's positioned wrapper > skin root ([data-form-factor])
-           > <article>   ← the frame, the ground and the shadow live here
-           > … > <a>     ← the region a player reads
+           > <article>                  ← the frame, the ground and the shadow
+           > … > <a data-card-link>     ← the region a player reads
 
      and a block box does not inherit its parent's height. So the height is
      handed down that chain one level at a time, and it stops at the region
@@ -4387,11 +4387,11 @@
      ride down with the frame, which is where a corner ornament belongs.
 
      A SKIN MAY NOT BREAK THE CHAIN. `[data-form-factor] > article` and the one
-     anchor per card are the contract this file is written against;
-     `pages/tasks/__tests__/equalHeightRow.test.tsx` renders all nine skins and
-     fails if a redraw moves the frame off the skin root or adds a second link.
-     Nothing here can be restated inline in a component: an inline `display`
-     would beat every rule below. */
+     `data-card-link` anchor per card are the contract this file is written
+     against; `pages/tasks/__tests__/equalHeightRow.test.tsx` renders all nine
+     skins and fails if a redraw moves the frame off the skin root or moves the
+     hook. Nothing here can be restated inline in a component: an inline
+     `display` would beat every rule below. */
   .task-card-row {
     display: flex;
     flex-wrap: wrap;
@@ -4402,12 +4402,29 @@
      so the height keeps travelling instead of stopping at the first block.
      `:has(> [data-form-factor])` is Albescent: its tell wraps a second skin root
      one level deeper than the other eight, and it is named by what it contains
-     rather than counted, so nesting may change without this going quiet. */
+     rather than counted, so nesting may change without this going quiet.
+
+     WHY THE HOOK AND NOT `a[href]` (#2380). These two rules used to end in
+     `:has(a[href])` — *any* descendant holding *any* anchor — and agreed with
+     the paragraph above them only because the reading link was, for a while,
+     the only anchor a card drew. It stopped being: #2167 gave the masthead one
+     (which then had to pin `flex-grow: 0` in TWO components to climb back off
+     this chain), and #2359 gave the CTA slot a link branch for a viewer holding
+     a draft. That branch is a SIBLING of the reading link — deliberately, so
+     the markup stays valid — and it flipped its own row to a column, which
+     turned Everymen's two `flex: 0 1 96px` marks from 96px wide into 96px tall
+     with `width: 100%` behind them: hands the full width of the card.
+
+     `data-card-link` is the fix and it is one attribute: the card-wide anchor
+     says which anchor it is, and the selector asks for that one instead of
+     guessing. A skin that draws a second link now costs nothing, and one that
+     forgets the hook fails the suite named above rather than quietly ceasing to
+     stretch. */
   .task-card-row > *,
   .task-card-row > * :has(> [data-form-factor]),
   .task-card-row [data-form-factor],
   .task-card-row [data-form-factor] > article,
-  .task-card-row [data-form-factor] > article :has(a[href]) {
+  .task-card-row [data-form-factor] > article :has(a[data-card-link]) {
     display: flex;
     flex-direction: column;
   }
@@ -4419,7 +4436,7 @@
   .task-card-row > * :has(> [data-form-factor]),
   .task-card-row [data-form-factor],
   .task-card-row [data-form-factor] > article,
-  .task-card-row [data-form-factor] > article :is(a[href], :has(a[href])) {
+  .task-card-row [data-form-factor] > article :is(a[data-card-link], :has(a[data-card-link])) {
     flex: 1 1 auto;
   }
 

--- a/frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx
+++ b/frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx
@@ -19,11 +19,14 @@
  * This repo has no jsdom, so nothing here measures a height: `renderToStaticMarkup`
  * runs no layout. VISUAL QA IS OUTSTANDING and stated as such on the PR.
  */
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router-dom'
 import type { ComponentType, ReactElement } from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import '../../../i18n'
+import { SIGNUP_REASON_ALREADY_ACTIVE_MEMBER } from '../../taskDetail/signupCta'
 import type { CurrentUser } from '../../../api/auth'
 import type { CardProps } from '../../../components/taskCard/TaskCard'
 import type { TasksState } from '../useTasks'
@@ -204,6 +207,99 @@ describe('every skin honours the chain the row hands its height down', () => {
         /display:/,
       )
     }
+  })
+})
+
+/**
+ * #2380 — THE CHAIN MUST KEY ON THE CARD'S OWN LINK, NOT ON "A LINK".
+ *
+ * THE SEAM: the selector in `index.css` that decides which boxes become
+ * columns, read against the markup a card renders for a viewer holding a draft.
+ * Both halves of the chain used to end in `a[href]`, which reads as *any*
+ * descendant holding *any* anchor. That agreed with the comment above it by
+ * accident, for exactly as long as the card-wide reading link was the only
+ * anchor a card drew. #2167 added the masthead — which had to patch itself
+ * twice with `flexGrow: 0` to get back off the chain — and #2359 gave
+ * `CardCtaControl` a link branch for the `already_active_member` draft, a
+ * SIBLING of the reading link. That sibling matched, its row flipped to a
+ * column, and Everymen's two `flex: 0 1 96px` marks read their basis as a
+ * HEIGHT with `width: 100%` behind it: hands the full width of the card.
+ *
+ * So the assertion is not "the row is still a row" — nothing here lays anything
+ * out. It is that the selector and the markup name the SAME single anchor.
+ */
+const CSS = readFileSync(fileURLToPath(new URL('../../../index.css', import.meta.url)), 'utf8')
+
+/**
+ * The anchor attributes the two chain rules key on, read out of the stylesheet
+ * rather than restated here — restating them is how a CSS rule and its guard
+ * drift in the same direction and both stay green.
+ *
+ * ponytail: this reads `a[attr]`-shaped compounds only, ignoring values and
+ * combinators. Ceiling: a chain rule keyed on `a[href^="/tasks/"]` would be
+ * reported as keying on `href`, and this suite would call it broken — which is
+ * the right answer for a value-matched guess anyway, since the CTA's own
+ * `/praxis/…` href is one route rename away from matching it. Upgrade path if
+ * that ever stops being true: a real selector parser (none is installed).
+ */
+function chainAnchorKeys(): string[] {
+  const rules = CSS.split('\n').filter((line) => line.includes('[data-form-factor] > article :'))
+  expect(rules, 'both halves of the chain — the column and the grow — are still here').toHaveLength(
+    2,
+  )
+  return [...new Set([...rules.join('\n').matchAll(/\ba\[([\w-]+)/g)].map((m) => m[1]))]
+}
+
+const anchorTags = (out: string): string[] => [...out.matchAll(/<a\s[^>]*>/g)].map((m) => m[0])
+const carries = (tag: string, attr: string): boolean =>
+  new RegExp(`\\s${attr}(?=[=\\s>/])`).test(tag)
+
+/** A viewer who already holds an open draft on this task — the #2359 branch. */
+const DRAFT_TASK = aTask({
+  description: TASK.description,
+  signup_reason: SIGNUP_REASON_ALREADY_ACTIVE_MEMBER,
+  in_progress_praxis_id: 77,
+  can_sign_up: false,
+})
+const DRAFT_HREF = '/praxis/77/edit'
+
+function draftCard(Card: ComponentType<CardProps>): string {
+  dispatch.formFactor = 'desktop'
+  return markup(
+    <Card
+      task={DRAFT_TASK}
+      basePoints={DRAFT_TASK.point_value}
+      multiplier={1}
+      inProgressCount={2}
+      onSignup={() => {}}
+    />,
+  )
+}
+
+describe('a sibling CTA row holding a link stays off the slack chain (#2380)', () => {
+  it.each(SKINS)('%s: the draft link is not on the chain', (_name, Card) => {
+    const cta = anchorTags(draftCard(Card)).find((tag) => tag.includes(`href="${DRAFT_HREF}"`))
+    expect(cta, 'the draft branch renders a <Link>, so the premise still holds').toBeDefined()
+    expect(
+      chainAnchorKeys().filter((key) => carries(cta as string, key)),
+      'the CTA link matches the chain selector, so its row is flipped to a column',
+    ).toEqual([])
+  })
+
+  it.each(SKINS)('%s: exactly one anchor is on the chain, and it reads the task', (_name, Card) => {
+    // Three anchors are in this card in this state — masthead, reading link,
+    // draft link — and the chain must end at the middle one. The masthead's
+    // `flexGrow: 0` and the CTA row's position outside the frame's column are
+    // both defences; neither is what makes this true. The selector naming one
+    // anchor is.
+    const keys = chainAnchorKeys()
+    const onChain = anchorTags(draftCard(Card)).filter((tag) =>
+      keys.some((key) => carries(tag, key)),
+    )
+    expect(onChain, 'one anchor carries the chain hook').toHaveLength(1)
+    expect(onChain[0], 'and it is the card-wide reading link').toContain(
+      `href="/tasks/${DRAFT_TASK.id}"`,
+    )
   })
 })
 


### PR DESCRIPTION
Closes #2380

## The seam I tested at

**The selector in `index.css` that decides which boxes join the equal-height row's slack chain, read against the markup a task card renders for a viewer holding a draft.** Not "Everymen's hands" and not any per-faction file — the marks were the symptom that shouted loudest, not the defect.

`frontend/src/pages/tasks/__tests__/equalHeightRow.test.tsx` grew a new block that reads the two chain rules out of the stylesheet, extracts the anchor attributes they key on, and matches them against every anchor each of the nine skins renders in the `already_active_member`-with-a-draft state. **It went red first, on `main`'s selector: 18 failures across 9 skins** — three anchors on a chain that must end at one, and the CTA's own link among them. The old suite's 29 assertions still pass unchanged.

## What was wrong

There were **two** rules of this shape, not the one the issue's comment names:

```css
.task-card-row [data-form-factor] > article :has(a[href])                    { display:flex; flex-direction:column }
.task-card-row [data-form-factor] > article :is(a[href], :has(a[href]))      { flex: 1 1 auto }
```

`article :has(a[href])` reads as *any* descendant holding *any* anchor. It agreed with its own comment ("the path from the row down to the card's link") only while the card-wide reading link was the only anchor a card drew.

That stopped being true twice:

- **#2167** gave the masthead an anchor. It joined the chain, and got patched back off it by hand — `flexGrow: 0` in `CardMasthead.tsx` *and* again in `factionBands.tsx`. Two workarounds for this defect were already in the tree.
- **#2359** gave `CardCtaControl` an `<a href>` branch. That link is a deliberate **sibling** of the reading link (nesting it would be invalid HTML), so its row matched, flipped to a column, and Everymen's two `flex: 0 1 96px` marks read their basis as a *height* with `width: 100%` behind them. Hands the width of the card.

## The fix

The card-wide anchor now says which anchor it is. `data-card-link` on the reading link in all nine skins (eight files — Albescent renders the default sheet verbatim), and both rules key on `a[data-card-link]`. One change at the shared seam; **no per-faction override, no per-faction file patched**, and `.task-card-row > *` still never grows, so §6's ragged widths are untouched.

Side effect worth knowing: the masthead's wrapper boxes were also on the chain and were also growing. They are off it now, which is what the chain's comment always said it meant.

The two `flexGrow: 0` pins stay — a band's height is its content whatever a later rule decides — but their comments no longer claim to be the thing keeping the band off the chain, because they aren't.

## Verified

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (382 files / 6858 tests), `npm run build`, `npm run budget` all green. The budget's CSS **WARN is pre-existing on `main`**; this change adds ~27 raw bytes of selector and no rules.

## What to eyeball — VISUAL QA IS OUTSTANDING

I have no browser and this repo has no jsdom, so nothing here measured a single pixel. Every combination below needs a human, and **all of them need a character who holds an open draft on the task shown** — that is the `cta.href` branch, and without it the bug does not reproduce and neither does the fix.

1. **Everymen faction page** (`/factions/everymen`), desktop, viewer holding a draft — the reported defect. The two fists should flank the button at ~96px wide, not stack above and below it card-wide.
2. **The same page, viewer with no draft** — the button branch. It looked correct before; confirm it still does.
3. **Coven, S.N.I.D.E. and the Ephemerists faction pages**, draft-holding viewer — the other three converted-bar archetypes, whose CTA rows lay out horizontally and were flipped by the same selector.
4. **The remaining five** (na/default, Albescent, UA, WoW, Singularity) on their faction pages — they centre a pill, so they should be unchanged; this is the regression check.
5. **`/tasks`**, draft-holding viewer, desktop **and** mobile — the issue's second screenshot looked fine only because those cards took the button branch.
6. **A character profile's task list** (`characterProfile` archetypes) — the third `.task-card-row` mount, easy to forget.
7. **The bottom edge of every wrapping row above** — the thing the chain exists for. Cards in a row should still level their bottom edges, and no row's cards should have become equal-*width*.
8. **The faction masthead band on all seven faction cards**, both themes — it stopped taking row slack in a second way with this change. It should read exactly as tall as its own content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
