### PR TITLE
The Coven cat comes off a busy ground (#2396)

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/covenCatAlternates.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/covenCatAlternates.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * The cat ALTERNATES (#2396, epic #2195).
+ *
+ * The law, owner 2026-08-17: each faction has one ornament; a card on an
+ * ornamented ground goes plain, a card on a plain ground wears it. Coven's
+ * ornament is the cat — `CovenCat` at 0.09 with `.cvn-wheel`'s slow turn — and
+ * it is worn on BOTH cards, so both branch on the same predicate.
+ *
+ * THE SEAM: `the ground a page declared` → `the card's rendered markup`. Phase 1
+ * (#2387) already tests the predicate itself in
+ * `backdrop/__tests__/groundIsBusy.test.tsx`; what is untested until here is
+ * that the two Coven cards consume it, and consume it the same way. So these
+ * assertions are about markup under a provided `BackdropContext`, never about
+ * `useGroundIsBusy` in isolation — a card that reads the boolean and forgets to
+ * branch passes every other check in the tree.
+ *
+ * It lives beside `covenCat.test.tsx` on purpose: that file guards "one drawing,
+ * five mounts", this one guards the two of those five that alternate. The other
+ * three (the profile body, the praxis composer, both detail columns) are page
+ * bodies and columns, not cards, and the law is explicitly about cards.
+ *
+ * WHY EACH GROUND BELOW. `coven` is the interesting one: the candlelight
+ * backdrop is a WASH (flat ward-page plus four drifting blooms), so a Coven card
+ * on a Coven profile KEEPS its cat. A per-route flag — "the character profile
+ * tells its cards to go plain" — would have got that wrong, which is why the
+ * pattern/wash table exists.
+ *
+ * SSR-only harness (`renderToStaticMarkup`, no DOM, effects never run), which is
+ * why the ground is provided through `BackdropContext` directly rather than by
+ * calling `useFactionBackdrop` — its effect would never fire here.
+ */
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+
+// The praxis card's score stamp reaches for `useTheme()`, which throws outside a
+// `ThemeProvider` by design (#701). Mocked, the shape `covenSlipSheet.test.tsx`
+// established: the theme is an input here and nothing below depends on it.
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light', toggle: () => {} }),
+}))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => 'desktop',
+}))
+
+import { BackdropContext } from '../../backdrop/BackdropContext'
+import CovenTaskCard from '../../taskCard/CovenTaskCard'
+import CovenPraxisCard from '../../praxisCard/desktop/CovenPraxisCard'
+import { aTask, aPraxisCard } from '../../../test/fixtures'
+
+const TASK = aTask({ primary_faction_slug: 'coven' })
+const PRAXIS = aPraxisCard({ task_faction_slug: 'coven' })
+
+const adminProps = {
+  praxis: PRAXIS,
+  showAdminControls: false,
+  onHide: () => {},
+  onDelete: () => {},
+} as unknown as Parameters<typeof CovenPraxisCard>[0]['adminProps']
+
+function onGround(slug: string | null, card: ReactNode, cardsKeepOrnament = false): string {
+  return renderToStaticMarkup(
+    <BackdropContext.Provider value={{ slug, cardsKeepOrnament, setGround: () => {} }}>
+      <MemoryRouter>{card}</MemoryRouter>
+    </BackdropContext.Provider>,
+  )
+}
+
+const taskCard = (
+  <CovenTaskCard
+    task={TASK}
+    basePoints={TASK.point_value}
+    multiplier={1}
+    inProgressCount={TASK.in_progress_count}
+    onSignup={() => {}}
+  />
+)
+
+const praxisCard = <CovenPraxisCard praxis={PRAXIS} adminProps={adminProps} />
+
+const CARDS: [string, ReactNode][] = [
+  ['task card', taskCard],
+  ['praxis card', praxisCard],
+]
+
+describe.each(CARDS)('the Coven %s', (_name, card) => {
+  it('wears the cat on every unthemed route — the site-wide default', () => {
+    // `null` is /tasks, Home, the FieldDesk and both detail pages: the vast
+    // majority of the mounts, and the case that must not change.
+    expect(onGround(null, card)).toContain('class="cvn-wheel"')
+  })
+
+  it('drops the cat on a patterned ground, whatever faction painted it', () => {
+    // Owner ruled (a): ANY ornamented ground. A Coven card lands on someone
+    // else's profile whenever a player of another faction files praxis against
+    // a Coven task — `PraxisCard` dispatches on `task_faction_slug`.
+    expect(onGround('everymen', card)).not.toContain('cvn-wheel')
+    expect(onGround('snide', card)).not.toContain('cvn-wheel')
+  })
+
+  it('keeps the cat on a Coven profile, because candlelight is a WASH', () => {
+    expect(onGround('coven', card)).toContain('class="cvn-wheel"')
+  })
+
+  it('keeps the cat when the page claimed the faction-page exemption', () => {
+    // Owner, 2026-08-18: a faction page may show busy cards on a busy ground.
+    // `useFactionDetail` is the one caller that claims it.
+    expect(onGround('everymen', card, true)).toContain('class="cvn-wheel"')
+  })
+
+  it('goes BARE where the cat is not worn — no substitute texture', () => {
+    // "Either burst, or plain" (owner, 2026-08-17). The slip sheet is the
+    // card's PAPER, not an ornament, so it stays on both grounds and is the
+    // only thing that does: the plain card differs from the ornamented one by
+    // the cat and nothing else.
+    const plain = onGround('everymen', card)
+    const worn = onGround(null, card)
+    expect(plain).toContain('--faction-coven-slip-from')
+    expect(worn.replace(/<svg class="cvn-wheel".*?<\/svg>/s, '')).toEqual(plain)
+  })
+})

--- a/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx
@@ -1,4 +1,5 @@
 import { CovenBand } from "../../cardMasthead/factionBands";
+import { useGroundIsBusy } from "../../backdrop/BackdropContext";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 import {
@@ -80,6 +81,12 @@ import {
  * and a name, not a card's whole content.
  */
 export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+  /* THE CAT ALTERNATES (#2396, epic #2195), on the same predicate and at the
+     same reading as `CovenTaskCard`'s: one ornament per faction, worn on both
+     cards, dropped on a patterned ground. A Coven profile keeps it — candlelight
+     is a wash. Nothing else on this card branches; the band, the sheet and the
+     braid are chrome. */
+  const groundIsBusy = useGroundIsBusy();
   return (
     <div
       style={{
@@ -106,8 +113,13 @@ export function CovenPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
           narrower — #2135 pins them rather than picking a second placement, and
           the opacity is the 0.09 every mount holds (the measurements are at
           {@link CovenCat}). `.cvn-wheel` owns the turn and its reduced-motion
-          guard in index.css; the body below sits above it on its own layer. */}
-      <CovenCat size={190} style={{ right: -6, bottom: -4, opacity: 0.09 }} />
+          guard in index.css; the body below sits above it on its own layer.
+
+          #2396 takes it off a busy ground: "either burst, or plain" — the slip
+          is then BARE, and no second texture stands in for the cat. */}
+      {!groundIsBusy && (
+        <CovenCat size={190} style={{ right: -6, bottom: -4, opacity: 0.09 }} />
+      )}
 
       {/* THE SLIP'S BAND (#2185) — the same one `CovenTaskCard` wears, twinkle
           field and all, mounted from the shared module. The field is the band's

--- a/frontend/src/components/taskCard/CovenTaskCard.tsx
+++ b/frontend/src/components/taskCard/CovenTaskCard.tsx
@@ -7,6 +7,7 @@ import { CardCtaControl } from "./CardCtaControl";
 import { taskCardSignupCta } from "./signupAffordance";
 import CovenCauldron from "../factionMarks/CovenCauldron";
 import { CovenCat, SLIP_SHEET } from "../factionMarks/covenSlip";
+import { useGroundIsBusy } from "../backdrop/BackdropContext";
 import i18n from "../../i18n";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
@@ -121,6 +122,12 @@ export default function CovenTaskCard({
 }: CardProps) {
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
+  /* THE CAT ALTERNATES (#2396, epic #2195). True on exactly one route today —
+     a character profile painted in a PATTERNED faction's ground — and false
+     everywhere else, including a Coven profile, whose candlelight is a wash.
+     Only the watermark branches: the sheet, band, braid, cauldron and CTA are
+     chrome and never move. */
+  const groundIsBusy = useGroundIsBusy();
   const cta = taskCardSignupCta(task, onSignup);
   const showMultiplier = !isNeutralMultiplier(multiplier);
 
@@ -162,8 +169,14 @@ export default function CovenTaskCard({
             38px clear of the edge.
 
             Opacity holds at 0.09 rather than taking #2041's 0.15; the reason,
-            with the measurements, is at {@link CovenCat}. */}
-        <CovenCat size={190} style={{ right: -6, bottom: -4, opacity: 0.09 }} />
+            with the measurements, is at {@link CovenCat}.
+
+            AND IT COMES OFF ON A BUSY GROUND (#2396): "either burst, or plain"
+            — where the cat is not worn the slip is BARE, never a substitute
+            texture. Nothing takes its place below. */}
+        {!groundIsBusy && (
+          <CovenCat size={190} style={{ right: -6, bottom: -4, opacity: 0.09 }} />
+        )}
 
         {/* Masthead. THE WORDMARK MOVES (#2029): it floated over the slip
             under a pentagram badge, with a braid tied off beneath it; v3 pins it


### PR DESCRIPTION
Closes #2396

Phase 3 of #2195 for Cozy Coven. The cat comes off the card when the page ground is a pattern, and nothing takes its place.

## The two jobs, and why only one needed code

**Job 1 — "add the cat to the praxis card" — was already done.** `CovenPraxisCard` has mounted `CovenCat size={190}` at `right: -6 / bottom: -4 / opacity 0.09` since **#2135**, which landed after the epic's 2026-08-17 inventory was written; `covenSlipSheet.test.tsx` already pins those numbers. So this PR adds no mount and picks no placement — the rung-zero answer was "it exists". (The five-mounts/four-placements hazard therefore never came up: the mount I needed was there, at the task card's own numbers.)

**Job 2 — consume the predicate.** Both Coven cards now read `useGroundIsBusy()` (#2387) and render the watermark only when it is false:

- `frontend/src/components/taskCard/CovenTaskCard.tsx`
- `frontend/src/components/praxisCard/desktop/CovenPraxisCard.tsx`

That is the whole change: three lines per file plus the comments explaining the branch. **Chrome never branches** — the slip sheet, the `CovenBand` masthead and its twinkle field, the celtic braid, the cauldron points mark and the pink CTA are all untouched in both states. **"Either burst, or plain"**: where the cat is not worn the slip is bare, and a test asserts that the plain markup is the ornamented markup *minus the cat svg and nothing else*.

## The seam I tested at

`the ground a page declared` → `the card's rendered markup`, with the ground supplied through `BackdropContext.Provider` (effects never run under `renderToStaticMarkup`, so the provider is the only way to reach a non-null slug).

New file: `frontend/src/components/factionMarks/__tests__/covenCatAlternates.test.tsx`, five assertions run against **both** cards via `describe.each`:

| ground | expectation | why |
|---|---|---|
| `null` | wears the cat | /tasks, Home, FieldDesk, both detail pages — the vast majority of mounts |
| `everymen`, `snide` | drops it | owner ruled (a): ANY ornamented ground. `PraxisCard` dispatches on `task_faction_slug`, so a Coven card genuinely lands on another faction's profile |
| `coven` | **keeps** it | candlelight is a WASH, per `ornamentedGrounds.ts` — a per-route flag would have stripped the cat off a Coven card on a Coven profile |
| `everymen` + `cardsKeepOrnament` | keeps it | the faction-page exemption (owner, 2026-08-18) |
| `everymen` vs `null` diff | bare, not re-textured | "either burst, or plain" |

It went red first on exactly the two rows that assert the drop (4 of 10 failing), which is the real defect.

Placed beside `covenCat.test.tsx`: that file guards "one drawing, five mounts", this one guards the two of those five that alternate. The other three mounts (profile body, praxis composer, both detail columns) are page bodies and columns, not cards, and the law is about cards.

## Measured byte delta — gzip level 9, `node frontend/scripts/bundle-budget.mjs`

Built this branch and its parent (`origin/main` content) in the same worktree and gzipped at level 9:

| blocking asset | main | this branch | delta |
|---|---|---|---|
| `index-*.css` | **22,993 B** | **22,993 B** | **0 B** |
| `index-*.js` (entry) | 129,769 B | 129,784 B | +15 B |
| second entry chunk | 2,106 B | 2,109 B | +3 B |

**Zero CSS.** No stylesheet was touched — the ornament is a component mount, and the branch is a JSX conditional. CSS stays at WARN exactly where it was (22,993 of a 24,400 fail ceiling), so this PR consumes none of the ~1.4 KB of headroom the batch is sharing. JS moves +18 B total.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally: `npm run lint` clean, `npm run typecheck` clean, `npm run typecheck:design-sync` clean, `npm test` **383 files / 6,850 passed**, `npm run build` clean, `npm run budget` unchanged (CSS WARN as on main). No backend or schema change, so `api-schema` is untouched.

The three named guards stay green unchanged: `praxisCard/__tests__/covenSlipSheet.test.tsx`, `taskCard/__tests__/covenTaskCardV3.test.tsx`, `praxisCard/scoreStamp/__tests__/covenScoreStamp.test.tsx` (all render without a provider, so the default ground is `null` and the cat is worn).

## What to eyeball — **visual QA is outstanding; I have no browser**

Everything below is asserted at the markup level only. The pixels are unverified.

1. **A Coven task card and a Coven praxis card on an EVERYMEN player's profile** (`/characters/<id>` for a player in Everymen who filed praxis against a Coven task) — the cat should be gone from both, the pink slip should look bare rather than re-textured, and the band/braid/cauldron should be exactly as before. Light **and** dark.
2. **The same two cards on a COVEN player's profile** — the cat must still be there. This is the case a per-route flag would have broken.
3. **The Coven faction page** (`/factions/coven`) — cards keep the cat (the exemption). Also worth a look: **another faction's page**, e.g. `/factions/snide`, if any Coven-task praxis shows there — also exempt, so also ornamented.
4. **`/tasks`, Home, the FieldDesk, task detail, praxis detail** — the cat unchanged everywhere. These are the no-op routes and the ones a regression would be loudest on.
5. **A SNIDE or SINGULARITY player's profile** with Coven cards — the two busiest grounds, and the best read on whether "bare" looks intentional rather than unfinished.
6. **`prefers-reduced-motion`** on a profile where the cat *is* worn — `.cvn-wheel`'s turn is index.css's and untouched, but it is worth confirming the branch did not disturb it.

## Not done here, deliberately

`WORLD_ZERO_STYLE.md` gets no edit. The alternation law deserves a §6 paragraph, but six parallel PRs each appending to the same file is how a batch goes red — it wants one authoring pass after the six land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
