### PR TITLE
S.N.I.D.E.'s wall alternates: the four printed layers come off on a patterned ground

### DIFF
--- a/frontend/src/components/factionMarks/__tests__/snideWallAlternates.test.tsx
+++ b/frontend/src/components/factionMarks/__tests__/snideWallAlternates.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * S.N.I.D.E.'s ornament alternates (#2395, epic #2195).
+ *
+ * THE SEAM: `the ground a page declared` → `the background declaration the two
+ * cards render`. Phase 1 (#2387) already tests the predicate itself in
+ * `backdrop/__tests__/groundIsBusy.test.tsx`; nothing here repeats it. What is
+ * only checkable at THIS seam is that the cards consume it, that they drop the
+ * right layers, and that the chrome beside them does not move.
+ *
+ * It lives beside `snideAtoms` rather than in either card's folder because the
+ * drawing is one drawing with two mounts: a branch added to one card and
+ * forgotten on the other is exactly the defect, and a file per card cannot see
+ * it. (`covenCat.test.tsx` sits here for the same reason.)
+ *
+ * SSR-only harness (`renderToStaticMarkup`, no DOM, effects never run) — which
+ * is why the ground is reached by rendering a `BackdropContext.Provider`
+ * directly, the escape `BackdropContext`'s own note describes. Assertions are
+ * about markup given props, never interaction.
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../i18n";
+
+vi.mock("../../../hooks/useFormFactor", () => ({ useFormFactor: () => "desktop" }));
+// `useTheme()` throws outside a `ThemeProvider` by design (#701) and the praxis
+// card's score stamp reaches for it. Which half it gets is irrelevant here: the
+// ground is a token either way, which is the point of a token dress.
+vi.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ theme: "light", toggle: () => {} }),
+}));
+
+// Imported after the mocks are registered.
+import { BackdropContext } from "../../backdrop/BackdropContext";
+import type { PraxisCardOut } from "../../../api/praxis";
+import SnideTaskCard from "../../taskCard/SnideTaskCard";
+import SnidePraxisCard from "../../praxisCard/desktop/SnidePraxisCard";
+import { aTask } from "../../../test/fixtures";
+
+const TASK = aTask({ description: "Fly-post the whole of Corporation Street." });
+
+const PRAXIS = {
+  id: 1,
+  title: "Fly-posted the whole of Corporation Street",
+  task_id: 4,
+  task_title: "Say the thing nobody will put their name to",
+  created_by_id: 7,
+  created_by_display_name: "Vex",
+  created_by_faction_slug: "snide",
+  created_by_avatar_url: "",
+  task_faction_slug: "snide",
+  task_level_required: 2,
+  task_point_value: 12,
+  member_count: 1,
+  score: 13.6,
+  display_multiplier: 1,
+  metatask_points: 0,
+  points_from_votes: 4,
+  voter_count: 3,
+  is_top_for_task: false,
+  media_items: [],
+  applied_metatasks: [],
+} as unknown as PraxisCardOut;
+
+const adminProps = {
+  praxis: PRAXIS,
+  showAdminControls: false,
+  onHide: () => {},
+  onFail: () => {},
+} as unknown as Parameters<typeof SnidePraxisCard>[0]["adminProps"];
+
+/** Render either card standing on a page that declared `slug`. */
+function under(
+  card: "task" | "praxis",
+  slug: string | null,
+  cardsKeepOrnament = false,
+): string {
+  return renderToStaticMarkup(
+    <BackdropContext.Provider value={{ slug, cardsKeepOrnament, setGround: () => {} }}>
+      <MemoryRouter>
+        {card === "task" ? (
+          <SnideTaskCard
+            task={TASK}
+            basePoints={TASK.point_value}
+            multiplier={1}
+            inProgressCount={0}
+            onSignup={() => {}}
+          />
+        ) : (
+          <SnidePraxisCard praxis={PRAXIS} adminProps={adminProps} />
+        )}
+      </MemoryRouter>
+    </BackdropContext.Provider>,
+  );
+}
+
+/** The card element's own opening tag — its ground, and nothing nested in it. */
+function frame(card: "task" | "praxis", slug: string | null, keep = false): string {
+  const markup = under(card, slug, keep);
+  const from = markup.indexOf(card === "task" ? "<article" : '<div class="snd-praxis-frame');
+  expect(from, "a card to look at").toBeGreaterThan(-1);
+  return markup.slice(from, markup.indexOf(">", from));
+}
+
+/** The four PRINTED layers — the ornament. The ramp under them is not one. */
+const PRINTED = [
+  "--faction-snide-note-grain",
+  "--faction-snide-note-scan",
+  "--faction-snide-note-wash-acid",
+  "--faction-snide-note-wash-pink",
+];
+
+describe.each(["task", "praxis"] as const)("the %s card's wall alternates", (card) => {
+  it("wears all four printed layers on an unthemed route", () => {
+    // /tasks, Home, the FieldDesk, both detail pages — the site-wide default,
+    // and the case that must not move: this is where the wall is the look.
+    const outer = frame(card, null);
+    for (const layer of PRINTED) expect(outer, layer).toContain(layer);
+    expect(outer, "the ramp").toContain("--faction-snide-wall-deep");
+  });
+
+  it("drops them on a patterned ground and keeps the bare ramp", () => {
+    // The one live route: a character profile of a player whose faction paints
+    // a pattern. `everymen` rather than `snide` on purpose — the predicate is
+    // ANY ornamented ground, not the card's own faction (owner ruled (a)).
+    const outer = frame(card, "everymen");
+    for (const layer of PRINTED) expect(outer, layer).not.toContain(layer);
+    // "Either burst, or plain": what is left is the card's GROUND COLOUR, not a
+    // substitute texture and not nothing — a transparent slab is not plain.
+    expect(outer, "the ramp survives").toContain("--faction-snide-wall-deep");
+    expect(outer, "no substitute texture").not.toContain("repeating-linear-gradient");
+  });
+
+  it("keeps them on a WASH — a Coven profile is not busy", () => {
+    const outer = frame(card, "coven");
+    for (const layer of PRINTED) expect(outer, layer).toContain(layer);
+  });
+
+  it("keeps them where the page claimed the faction-page exemption", () => {
+    // Owner, 2026-08-18: a faction page may carry busy cards on a busy ground.
+    // S.N.I.D.E.'s own page is the whole wall, on the whole wall.
+    const outer = frame(card, "snide", true);
+    for (const layer of PRINTED) expect(outer, layer).toContain(layer);
+  });
+
+  it("never branches the CHROME", () => {
+    // The law is about the card's BACKGROUND TEXTURE alone. Everything that
+    // separates the clipping from what it is pasted to has to survive the
+    // branch — on a patterned page it is the ONLY thing left doing that job.
+    const [plain, busy] = [frame(card, null), frame(card, "everymen")];
+    for (const chrome of ["border:", "box-shadow:"]) {
+      expect(busy, chrome).toContain(chrome);
+      expect(
+        busy.slice(busy.indexOf(chrome)).split(";")[0],
+        `${chrome} is the same on both grounds`,
+      ).toBe(plain.slice(plain.indexOf(chrome)).split(";")[0]);
+    }
+    // The masthead band is painted, not the wall showing through, so it is the
+    // same strip on either ground.
+    expect(under(card, "everymen"), "the band").toContain("--faction-snide-note-bar");
+  });
+});
+
+describe("the praxis card's container channel still wins", () => {
+  it("keeps the `--snd-praxis-ground` override in front of BOTH grounds", () => {
+    // Task detail's black slab (#2177) arrives through this channel, and that
+    // column themes no backdrop — so the branch must not eat the fallback form.
+    for (const slug of [null, "everymen"]) {
+      expect(frame("praxis", slug), `${slug}`).toContain("var(--snd-praxis-ground,");
+    }
+  });
+});

--- a/frontend/src/components/factionMarks/snideAtoms.tsx
+++ b/frontend/src/components/factionMarks/snideAtoms.tsx
@@ -13,6 +13,25 @@
 import type { CSSProperties } from "react";
 
 /**
+ * THE BARE WALL — the same ramp with nothing printed on it (#2395, epic #2195).
+ *
+ * The law, owner 2026-08-17: **a card on an ornamented ground goes plain, a card
+ * on a plain ground wears its faction's ornament.** S.N.I.D.E.'s ornament is the
+ * four printed layers of {@link WALL} — the xerox raster, the scanline and the
+ * two washed corners. The ramp underneath is not ornament, it is the card's
+ * GROUND COLOUR, and a card still needs one: dropping the whole recipe would
+ * leave a transparent slab on a patterned page rather than a plain one. So
+ * "plain" here is the ramp alone, which is also "either burst, or plain" —
+ * bare stock, never a substitute texture.
+ *
+ * NO NEW PAIRING COMES WITH IT. `factionContrast.test.ts` (SNIDE_WALL_PAIRS)
+ * measures the `-note-*` inks on all four readings of the wall, and the two ramp
+ * stops are two of them; taking the washes off leaves a strict subset.
+ */
+export const WALL_PLAIN =
+  "linear-gradient(180deg, var(--faction-snide-wall) 0%, var(--faction-snide-wall-deep) 100%)";
+
+/**
  * THE FLYPOSTED WALL — S.N.I.D.E.'s one ground (#2177).
  *
  * Five layers bottom-to-top over the `-wall` ramp: the diagonal xerox raster, a
@@ -39,7 +58,7 @@ export const WALL = [
   "repeating-linear-gradient(0deg, var(--faction-snide-note-scan) 0 1px, transparent 1px 4px)",
   "radial-gradient(120% 80% at 8% -10%, var(--faction-snide-note-wash-acid), transparent 60%)",
   "radial-gradient(90% 70% at 100% 110%, var(--faction-snide-note-wash-pink), transparent 62%)",
-  "linear-gradient(180deg, var(--faction-snide-wall) 0%, var(--faction-snide-wall-deep) 100%)",
+  WALL_PLAIN,
 ].join(", ");
 
 /**

--- a/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SnidePraxisCard.tsx
@@ -1,5 +1,6 @@
 import { SnideBand } from "../../cardMasthead/factionBands";
-import { WALL } from "../../factionMarks/snideAtoms";
+import { WALL, WALL_PLAIN } from "../../factionMarks/snideAtoms";
+import { useGroundIsBusy } from "../../backdrop/BackdropContext";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
 
@@ -26,6 +27,13 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  * the wall, and the wall's own alarm/notice/credit for the marks the shared
  * slots paint. All of it is measured on the ramp's two stops AND its two washed
  * corners, in both themes, in `factionContrast.test.ts` (SNIDE_WALL_PAIRS).
+ *
+ * IT ALTERNATES (#2395). On a page that already paints a pattern — one route,
+ * a character profile of a player whose faction is a patterned one — the four
+ * printed layers come off and the card grounds on the bare ramp
+ * ({@link WALL_PLAIN}): "either burst, or plain", bare stock and never a
+ * substitute texture. Faction pages are EXEMPT (owner, 2026-08-18) and claim it
+ * through `useFactionBackdrop`, so S.N.I.D.E.'s own page is unchanged.
  *
  * ON TASK DETAIL IT IS BLACK. That page's column already wears the wall, and a
  * wall inside a wall stops reading as a thing pasted ON something. The switch is
@@ -69,7 +77,13 @@ import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
  * The dashed acid rule above the vote widget is the design's, and is the one
  * divider the slab carries.
  */
-const GROUND = `var(--snd-praxis-ground, ${WALL})`;
+/**
+ * The wall, or the bare ramp when the PAGE is already patterned (#2395, epic
+ * #2195) — the container's `--snd-praxis-ground` still overrides both, because
+ * the task-detail black is a separate ruling and that column themes no backdrop.
+ */
+const ground = (busy: boolean) =>
+  `var(--snd-praxis-ground, ${busy ? WALL_PLAIN : WALL})`;
 const INK = "var(--snd-praxis-ink, var(--faction-snide-note-ink))";
 const MUTED = "var(--snd-praxis-muted, var(--faction-snide-note-muted))";
 /** The pink that is TEXT on the wall; acid is an ink only on a slab (#2066). */
@@ -77,6 +91,10 @@ const ACCENT = "var(--snd-praxis-accent, var(--faction-snide-note-pink-ink))";
 const PAPER = "var(--snd-praxis-paper, var(--faction-snide-note-paper))";
 
 export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+  // #2395: the ornament alternates — see `ground` above. Only the BODY TEXTURE
+  // branches; the band, the acid border, the drop shadow and the dashed rule are
+  // chrome and are untouched.
+  const groundIsBusy = useGroundIsBusy();
   return (
     <div
       className="snd-praxis-frame"
@@ -84,7 +102,7 @@ export function SnidePraxisCard({ praxis, adminProps, showCrown }: ArchetypeProp
         ...frameBase,
         // No borderRadius: the evidence slab has hard corners in the prototype.
         position: "relative",
-        background: GROUND,
+        background: ground(groundIsBusy),
         border: "1.5px solid var(--faction-snide-acid-deep)",
         boxShadow: "6px 8px 0 var(--faction-snide-slab-shadow)",
         /* NO PADDING ON THE FRAME since #2185: the band is full-bleed, and an

--- a/frontend/src/components/taskCard/SnideTaskCard.tsx
+++ b/frontend/src/components/taskCard/SnideTaskCard.tsx
@@ -8,7 +8,8 @@ import { taskCardSignupCta } from "./signupAffordance";
 import i18n from "../../i18n";
 import { isNeutralMultiplier } from "../../utils/points";
 import { useFormFactor } from "../../hooks/useFormFactor";
-import { PenCircle, WALL } from "../factionMarks/snideAtoms";
+import { PenCircle, WALL, WALL_PLAIN } from "../factionMarks/snideAtoms";
+import { useGroundIsBusy } from "../backdrop/BackdropContext";
 
 /**
  * S.N.I.D.E. — THE RANSOM CLIPPING (task card v2, #1023).
@@ -154,6 +155,8 @@ export default function SnideTaskCard({
 }: CardProps) {
   const formFactor = useFormFactor();
   const size = SIZES[formFactor];
+  // #2395: the ornament alternates. See the ground comment below.
+  const groundIsBusy = useGroundIsBusy();
   const cta = taskCardSignupCta(task, onSignup);
   const showMultiplier = !isNeutralMultiplier(multiplier);
 
@@ -168,6 +171,15 @@ export default function SnideTaskCard({
           composer and to the praxis card: this card was its only mount when it
           was written inline here, and it is one of three now.
 
+          IT ALTERNATES (#2395, epic #2195). On a page whose own ground is
+          already a pattern the card drops the four printed layers and grounds on
+          the bare ramp ({@link WALL_PLAIN}) — "either burst, or plain", so what
+          is left is bare stock and never a substitute texture. Exactly one route
+          makes that true today: a character profile of a player whose faction
+          paints a pattern. A faction page is EXEMPT (owner, 2026-08-18) and says
+          so through `useFactionBackdrop`, so S.N.I.D.E.'s own page still shows
+          the full wall on the full wall. The CHROME below never branches on it.
+
           THE EDGE AND THE SHADOW ARE LOAD-BEARING. On the S.N.I.D.E. faction
           page `useFactionBackdrop` paints the page with this same wall, so these
           two are the only thing that still separates the card from what it is
@@ -180,7 +192,7 @@ export default function SnideTaskCard({
           boxSizing: "border-box",
           width: "100%",
           color: INK,
-          background: WALL,
+          background: groundIsBusy ? WALL_PLAIN : WALL,
           border: "1px solid var(--faction-snide-note-wall-edge)",
           boxShadow: "var(--faction-snide-note-wall-shadow)",
           transform: "rotate(-0.4deg)",


### PR DESCRIPTION
Closes #2395

Phase 3 of #2195 for S.N.I.D.E. The collapse and the praxis-card reversal already shipped in #2177, so all that was left is the alternation branch on top of the wall. The diff is three source files and one test, and that is the whole of it.

## What "plain" is for this kit

`WALL` is five layers: four PRINTED ones (the xerox raster, the scanline, the acid corner, the pink corner) over a `-wall` → `-wall-deep` ramp. The four printed layers are the ornament; the ramp is the card's **ground colour**, and a card still needs one — dropping the whole recipe would leave a transparent slab on a patterned page rather than a plain one. So the branch swaps in `WALL_PLAIN`, the ramp alone: bare stock, never a substitute texture ("either burst, or plain").

`WALL_PLAIN` is a new export beside `WALL` in `components/factionMarks/snideAtoms.tsx` and is literally the array's last element, so the two can never drift.

**No new contrast pairing comes with it.** `factionContrast.test.ts` (`SNIDE_WALL_PAIRS`) already measures the `-note-*` inks on all four readings of the wall in both cascades, and the two ramp stops are two of those four — taking the washes off leaves a strict subset of what is already gated.

## The seam I tested at

**`the ground a page declared` → `the background declaration the two cards render`**, via `renderToStaticMarkup` over a `BackdropContext.Provider` at a chosen slug (the escape `BackdropContext`'s own note documents — effects never run in this harness). New file: `frontend/src/components/factionMarks/__tests__/snideWallAlternates.test.tsx`, beside the atom rather than in either card's folder, because the drawing is one drawing with two mounts and "branched one card, forgot the other" is exactly the defect a per-card file cannot see.

It went **red on the real defect first**: with the branch reverted, exactly the two "drops them on a patterned ground and keeps the bare ramp" cases fail and the other nine pass. The nine cover the no-ops that would be the expensive mistakes — the unthemed route (site-wide default, where the wall *is* the look), a WASH ground (`coven`), the faction-page exemption, the praxis card's `--snd-praxis-ground` override still winning in front of both grounds (task detail's black slab, #2177), and that the chrome declarations are byte-identical on both grounds.

`everymen` rather than `snide` is the busy ground in the test on purpose: the predicate is ANY ornamented ground, not the card's own faction (owner ruled (a)).

## Chrome is untouched

The band, the acid border, the 6px/8px drop shadow, the -0.4deg rotation, the dashed acid rule, the pen circle. On a patterned page the border and the shadow are the *only* thing separating the clipping from what it is pasted to, which is why the test asserts they do not move rather than trusting the comment.

## Measured bytes (repo script, gzip **level 9**)

Both builds run in this worktree, `main` at `4cd063e8`:

| blocking asset | main | this branch | delta |
|---|---|---|---|
| `index-*.css` | 22,993 B | 22,993 B | **0 B** |
| `index-*.js` | 129,769 B | 129,786 B | +17 B |

**Zero critical-CSS delta** — the change is entirely in TSX, and no rule was added to `index.css`. CSS stays exactly where `main` left it (WARN, ~1.4 KB under the 24,400 B fail ceiling), so this PR can be sequenced anywhere in the batch without moving the others' headroom.

## Checks run locally

`npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (383 files / 6,851 passed), `npm run build`, `npm run budget` — every step `.github/workflows/test.yml` names for the `frontend` job. No backend file, route, `response_model` or schema is touched, so `api-schema` has nothing to regenerate.

## Not done here, deliberately

`WORLD_ZERO_STYLE.md` does not yet record the alternation law. Six sibling PRs are open on the same epic and each editing that file would be six conflicts on one paragraph, so the doc entry wants to land once — in the epic's closing PR or a follow-up — not here.

## What to eyeball (visual QA is OUTSTANDING — I have no browser)

Exactly one route makes the branch true, so most of this list is checking that nothing moved.

1. **Character profile of an EVERYMEN player, holding S.N.I.D.E. task and praxis cards** — light and dark. The one case that changes: the cards should read as flat cream (light) / flat pitch (dark) slabs against the conic rays, with the acid border and the hard drop shadow still lifting them off the page. Confirm the card is still clearly *on* something and has not gone invisible.
2. **The same profile for a SINGULARITY, EPHEMERISTS or WOW player** — same expectation; these are the other three patterned grounds.
3. **A COVEN or UA player's profile** — a wash, so the cards must still wear the full wall. This is the case a per-route flag would have got wrong.
4. **S.N.I.D.E.'s own faction page** — exempt (owner, 2026-08-18). The wall on the wall, unchanged.
5. **/tasks, Home, the FieldDesk, task detail, praxis detail** — the site-wide default. Every S.N.I.D.E. card must look exactly as it does on `main`; any change here is a regression, not the feature.
6. **Task detail's praxis gallery** — the black slab exception (#2177) must still be black.
7. **Both form factors** on 1 and 5 — `SnideTaskCard` serves phone and desktop from one component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
