### PR TITLE
Singularity's scanline: one pitch, and it alternates with the ground (#2394)

### DIFF
--- a/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/SingularityPraxisCard.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties } from "react";
+import { useGroundIsBusy } from "../../backdrop/BackdropContext";
 import { SingularityBand } from "../../cardMasthead/factionBands";
 import { AdminOverlay } from "../shared";
 import { PraxisBody, frameBase, type ArchetypeProps } from "./shared";
@@ -91,6 +92,9 @@ const scanSweepStyle: CSSProperties = {
 };
 
 export function SingularityPraxisCard({ praxis, adminProps, showCrown }: ArchetypeProps) {
+  // THE ORNAMENT ALTERNATES (#2195): on a patterned page ground the raster
+  // comes off and the slab is BARE — never a quieter substitute texture.
+  const groundIsBusy = useGroundIsBusy();
   return (
     <div
       style={{
@@ -101,9 +105,16 @@ export function SingularityPraxisCard({ praxis, adminProps, showCrown }: Archety
         background: "var(--faction-singularity-card-bg)",
         border: "1px solid var(--faction-singularity-frame)",
         boxShadow: "0 4px 18px var(--color-cast-shadow)",
-        // The standing raster — ornament geometry, raw by §4a.
-        backgroundImage:
-          "repeating-linear-gradient(to bottom, transparent 0 2px, var(--faction-singularity-scanline) 2px 3px)",
+        /* THE STANDING RASTER — ornament geometry, raw by §4a, and the ONE
+           drawing the kit has (#2394). This card used to run its own second
+           pitch (`to bottom, transparent 0 2px`) off a private
+           `--faction-singularity-scanline` at 0.03; that token is retired and
+           this is the line the task card, the feed frame, the comment voice,
+           the select card, the profile body, the edit-praxis panel and both
+           detail pages all already draw. Dropped entirely on a busy ground. */
+        backgroundImage: groundIsBusy
+          ? undefined
+          : "repeating-linear-gradient(0deg, var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)",
         /* NO PADDING ON THE FRAME since #2185: the window chrome is full-bleed,
            and an inset frame would have floated it off three edges. The slab's
            inset moved to the body box below. */

--- a/frontend/src/components/taskCard/SingularityTaskCard.tsx
+++ b/frontend/src/components/taskCard/SingularityTaskCard.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { Link } from "react-router-dom";
 import type { CardProps } from "./TaskCard";
+import { useGroundIsBusy } from "../backdrop/BackdropContext";
 import { SingularityBand } from "../cardMasthead/factionBands";
 import { CARD_CTA } from "./cardCta";
 import { CardCtaControl } from "./CardCtaControl";
@@ -115,6 +116,9 @@ export default function SingularityTaskCard({
   onSignup,
 }: CardProps) {
   const formFactor = useFormFactor();
+  // THE ORNAMENT ALTERNATES (#2195): on a patterned page ground the standing
+  // raster comes off and the chassis is BARE — never a substitute texture.
+  const groundIsBusy = useGroundIsBusy();
   const size = SIZES[formFactor];
   const cta = taskCardSignupCta(task, onSignup);
   const showMultiplier = !isNeutralMultiplier(multiplier);
@@ -138,18 +142,22 @@ export default function SingularityTaskCard({
           fontFamily: MONO,
         }}
       >
-        {/* The standing raster — a fixed scrim, no motion. */}
-        <div
-          aria-hidden="true"
-          style={{
-            position: "absolute",
-            inset: 0,
-            pointerEvents: "none",
-            zIndex: 3,
-            background:
-              "repeating-linear-gradient(0deg, var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)",
-          }}
-        />
+        {/* The standing raster — a fixed scrim, no motion, and the kit's ONE
+            ornament (#2394): the praxis card now draws this same line. Gone,
+            not softened, when the page ground is already a pattern. */}
+        {!groundIsBusy && (
+          <div
+            aria-hidden="true"
+            style={{
+              position: "absolute",
+              inset: 0,
+              pointerEvents: "none",
+              zIndex: 3,
+              background:
+                "repeating-linear-gradient(0deg, var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)",
+            }}
+          />
+        )}
 
         {/* The scan sweep. `.sg-scan` owns both the resting offset and the
             reduced-motion-guarded travel (#842's keyframe, reused). */}

--- a/frontend/src/components/taskCard/__tests__/singularityScanlineAlternation.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/singularityScanlineAlternation.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * Singularity's ornament is the SCANLINE — one drawing, and it alternates
+ * (#2394, phase 3 of #2195).
+ *
+ * ## The seam
+ *
+ * `the ground a page declared` → `the standing raster in each card's markup`.
+ * Both Singularity card families are rendered under a real
+ * `BackdropContext.Provider` and their markup read back
+ * (`renderToStaticMarkup`, the SSR-only harness the rest of the card suites
+ * use — no DOM, no layout, no computed styles). Three claims live here and no
+ * other file can see any of them:
+ *
+ *  1. **ONE PITCH.** The task card drew `0 1px / 1px 3px` off
+ *     `--faction-singularity-term-scan`; the praxis card drew a second raster,
+ *     `0 2px / 2px 3px`, off a private `--faction-singularity-scanline` at a
+ *     third of the alpha. Owner-ruled one drawing per faction, so the praxis
+ *     card takes the task card's — the one the other six Singularity surfaces
+ *     already draw — and the private token is retired. The test asserts the
+ *     retirement in `index.css` too, or the token would sit there dead and the
+ *     next surface would pick the wrong one back up.
+ *  2. **IT ALTERNATES.** `useGroundIsBusy()` true ⇒ the raster is GONE, not
+ *     swapped for something quieter ("either burst, or plain", owner
+ *     2026-08-17). False ⇒ it is worn.
+ *  3. **CHROME NEVER BRANCHES.** The terminal frame, the window band and the
+ *     `.sg-scan` sweep are identical on both grounds. The alternation governs
+ *     the card's BACKGROUND texture and nothing else.
+ *
+ * Only ONE route makes the predicate true today — a character profile of a
+ * player whose faction paints a pattern. A faction's own page is exempt (owner,
+ * 2026-08-18) and claims it through `useFactionBackdrop`, and every other route
+ * themes nothing. That is why the ground is injected through the context
+ * provider here rather than through a page: the provider IS the seam, and
+ * `useFactionBackdrop` sets the slug from an effect, which never runs in this
+ * harness.
+ *
+ * WHAT IS NOT HERE: whether it looks right at either card size. That is visual
+ * QA and is stated as outstanding on the PR.
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { renderToStaticMarkup } from "react-dom/server";
+import { MemoryRouter } from "react-router-dom";
+import { describe, it, expect, vi } from "vitest";
+import "../../../i18n";
+
+// The praxis card's score stamp reaches for `useTheme()`, which throws outside a
+// `ThemeProvider` by design (#701). Mocked rather than wrapped, the shape
+// `snideOneGround.test.tsx` established: nothing asserted below depends on which
+// half it gets — Singularity's terminal tokens are theme-invariant (§6).
+vi.mock("../../../hooks/useTheme", () => ({
+  useTheme: () => ({ theme: "dark", toggle: () => {} }),
+}));
+
+import SingularityTaskCard from "../SingularityTaskCard";
+import { SingularityPraxisCard } from "../../praxisCard/desktop/SingularityPraxisCard";
+import { BackdropContext } from "../../backdrop/BackdropContext";
+import { aTask, aPraxisCard } from "../../../test/fixtures";
+
+const CSS = readFileSync(
+  fileURLToPath(new URL("../../../index.css", import.meta.url)),
+  "utf8",
+);
+
+/**
+ * THE one Singularity raster, byte for byte as six other surfaces in the kit
+ * already write it (the comment voice, the feed frame, the select card, the
+ * profile body, the edit-praxis panel and both detail pages).
+ */
+const RASTER =
+  "repeating-linear-gradient(0deg, var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)";
+
+/** The retired second pitch, in the two spellings it could come back as. */
+const OLD_PITCH = "transparent 0 2px";
+const OLD_TOKEN = "--faction-singularity-scanline";
+
+const TASK = aTask({ primary_faction_slug: "singularity" });
+const PRAXIS = aPraxisCard({
+  task_faction_slug: "singularity",
+  created_by_faction_slug: "singularity",
+});
+
+const adminProps = {
+  praxis: PRAXIS,
+  showAdminControls: false,
+  onHide: () => {},
+  onFail: () => {},
+} as unknown as Parameters<typeof SingularityPraxisCard>[0]["adminProps"];
+
+/** Render both card families on a page ground of `slug`. */
+function onGround(
+  slug: string | null,
+  cardsKeepOrnament = false,
+): { task: string; praxis: string } {
+  const under = (node: React.ReactNode) =>
+    renderToStaticMarkup(
+      <BackdropContext.Provider
+        value={{ slug, cardsKeepOrnament, setGround: () => {} }}
+      >
+        <MemoryRouter>{node}</MemoryRouter>
+      </BackdropContext.Provider>,
+    );
+  return {
+    task: under(
+      <SingularityTaskCard
+        task={TASK}
+        basePoints={TASK.point_value}
+        multiplier={1}
+        inProgressCount={0}
+        onSignup={() => {}}
+      />,
+    ),
+    praxis: under(
+      <SingularityPraxisCard praxis={PRAXIS} adminProps={adminProps} />,
+    ),
+  };
+}
+
+describe("one scanline pitch, not two (#2394)", () => {
+  it("draws the SAME raster on both card families", () => {
+    const { task, praxis } = onGround(null);
+    expect(task, "task card").toContain(RASTER);
+    expect(praxis, "praxis card").toContain(RASTER);
+  });
+
+  it("retires the praxis card's second pitch and its private token", () => {
+    const { praxis } = onGround(null);
+    expect(praxis, "the 0 2px phase").not.toContain(OLD_PITCH);
+    expect(praxis, "the private token").not.toContain(OLD_TOKEN);
+    // ...and it is gone from the sheet, not merely unused: a dead declaration
+    // is the next surface's wrong answer.
+    expect(CSS, "the retired declaration").not.toContain(`${OLD_TOKEN}:`);
+  });
+});
+
+describe("the scanline alternates with the ground (#2195)", () => {
+  it("is worn on every unthemed route — the site-wide default", () => {
+    const { task, praxis } = onGround(null);
+    expect(task).toContain(RASTER);
+    expect(praxis).toContain(RASTER);
+  });
+
+  it("is worn on a WASH, so a Coven or UA profile keeps it", () => {
+    for (const slug of ["coven", "ua"]) {
+      const { task, praxis } = onGround(slug);
+      expect(task, `${slug} task`).toContain(RASTER);
+      expect(praxis, `${slug} praxis`).toContain(RASTER);
+    }
+  });
+
+  it("DROPS on a patterned ground — any faction's, not just its own", () => {
+    // Owner ruled (a): the predicate is any ornamented ground. A Singularity
+    // card on the Everymen wall is still two textures fighting.
+    for (const slug of ["singularity", "everymen", "snide", "ephemerists", "wow"]) {
+      const { task, praxis } = onGround(slug);
+      expect(task, `${slug} task`).not.toContain(RASTER);
+      expect(praxis, `${slug} praxis`).not.toContain(RASTER);
+    }
+  });
+
+  it("leaves the ground BARE — no substitute texture", () => {
+    // "Either burst, or plain" (owner, 2026-08-17). The only thing that may
+    // replace the raster is nothing.
+    const { task, praxis } = onGround("everymen");
+    for (const [name, html] of [
+      ["task", task],
+      ["praxis", praxis],
+    ] as const) {
+      expect(html, `${name}: no second raster`).not.toContain(
+        "repeating-linear-gradient",
+      );
+    }
+  });
+
+  it("is worn on a faction page, which is exempt (owner, 2026-08-18)", () => {
+    const { task, praxis } = onGround("singularity", true);
+    expect(task, "task card on its own faction page").toContain(RASTER);
+    expect(praxis, "praxis card on its own faction page").toContain(RASTER);
+  });
+});
+
+describe("chrome never branches on the ground", () => {
+  it("keeps the frame, the window band and the sweep on a busy ground", () => {
+    const plain = onGround(null);
+    const busy = onGround("everymen");
+    for (const key of ["task", "praxis"] as const) {
+      // The scan SWEEP is motion chrome, not the ornament: `.sg-scan` owns the
+      // resting offset and the reduced-motion-guarded travel, and it survives.
+      expect(busy[key], `${key}: the sweep`).toContain("sg-scan");
+      expect(plain[key], `${key}: the sweep`).toContain("sg-scan");
+      // The terminal frame token is in both dresses.
+      expect(busy[key], `${key}: a frame`).toContain("--faction-singularity-");
+    }
+    // The window band (#2185) is the same bar on both cards and both grounds.
+    const band = (html: string) => html.includes("SINGULARITY") || html.includes("singularity");
+    expect(band(busy.task) && band(busy.praxis), "the window band").toBe(true);
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1393,7 +1393,9 @@
   --faction-singularity-rule: rgba(74, 222, 128, 0.2);
   --faction-singularity-bracket: #60a5fa; /* cyan corner brackets */
   --faction-singularity-scan: rgba(96, 165, 250, 0.16); /* scanline sweep peak */
-  --faction-singularity-scanline: rgba(74, 222, 128, 0.03); /* the standing raster */
+  /* The standing raster is NOT here. One drawing per faction (#2394): the whole
+     kit — both cards included — draws it off --faction-singularity-term-scan,
+     and the 0.03 twin this line used to hold was the praxis card's alone. */
   --faction-singularity-stamp-bg: #030b06;
   --faction-singularity-stamp-border: rgba(96, 165, 250, 0.5);
   --faction-singularity-stamp-rule: rgba(74, 222, 128, 0.25);


### PR DESCRIPTION
Closes #2394

Phase 3 of #2195, the Singularity slice: **one scanline pitch, and it alternates with the ground.**

## The seam I tested at

`the ground a page declared` → `the standing raster in each Singularity card's markup`.

Both card families are rendered under a real `BackdropContext.Provider` at a chosen slug and the markup read back (`renderToStaticMarkup`, the SSR-only harness the card suites already use). The provider *is* the seam: `useFactionBackdrop` sets the slug from an effect, and effects never run in this harness — which is exactly why phase 1 computes the predicate at read time. New file: `frontend/src/components/taskCard/__tests__/singularityScanlineAlternation.test.tsx`. It went red on all three claims first (7 of 8 failing), then green.

## 1. The collapse — I picked the TASK card's pitch

| | before | after |
|---|---|---|
| task card | `repeating-linear-gradient(0deg, var(--faction-singularity-term-scan) 0 1px, transparent 1px 3px)` | unchanged |
| praxis card | `repeating-linear-gradient(to bottom, transparent 0 2px, var(--faction-singularity-scanline) 2px 3px)` | **takes the task card's line** |

Why that one, and not the praxis card's:

- **It is already the kit's canonical drawing.** Six other Singularity surfaces write it byte for byte — the comment voice, the feed frame, the select card, the profile body, the edit-praxis panel, and both detail pages. The praxis card was the sole outlier, so "one drawing per faction" was one file's edit, not seven.
- **The two were not only a different phase, they were a different TOKEN.** The praxis card ran a private `--faction-singularity-scanline` at `rgba(74,222,128,0.03)` against the rest of the kit's `--faction-singularity-term-scan` at `0.05` (`0.045` dark). At a third of the alpha on a `#050f08` slab that raster was below the visible floor — the praxis card was nominally scanlined and effectively bare, while the task card beside it in the same feed was not.
- **It reads at both sizes because the duty cycle does not change with the box.** Both spellings are a 3px period with a 1px line; the pitch is fixed in device pixels and phase-anchored at `0deg`, so the same 1-in-3 raster lands on a 384px task card and a 394px praxis card identically. Nothing here scales with card height, which is what would have made a choice between them size-dependent.
- The two grounds are near-identical anyway (`--faction-singularity-card-bg` `#050f08` vs `--faction-singularity-term-bg` `#07130c`/`#050f08`), so the single alpha is correct on both.

`--faction-singularity-scanline` had exactly one consumer and is **retired from `index.css`**, with a comment in its place saying where the raster actually lives — a dead token is the next surface's wrong answer.

## 2. The alternation

Both cards now read `useGroundIsBusy()` (#2387). True ⇒ the raster is **dropped**, not softened — "either burst, or plain". The task card's scrim `<div>` is not rendered; the praxis card's `backgroundImage` goes `undefined`.

Chrome is untouched and asserted so: the terminal frame, the window band (#2185), the four cyan brackets, the dashed rules, the readout and the `.sg-scan` sweep are byte-identical on a busy ground. The sweep in particular is motion chrome, not the ornament — the epic's inventory names only the standing raster.

## Byte budget

Measured with the repo's own `node frontend/scripts/bundle-budget.mjs` after a full `npm run build`, **gzip level 9**, blocking `index-*.css`:

| | gzip-9 | raw |
|---|---|---|
| `origin/main` (4cd063e8) | **22,993 B** | 118,625 B |
| this branch | **22,984 B** | 118,569 B |
| delta | **−9 B** | −56 B |

**Net negative** — one retired custom property, and CSS comments do not ship. Still `WARN CSS` (fail > 24,400 B), one rung further from the ceiling than main. JS is unchanged at 126.7 KB per the budget report; the diff adds two hook calls and no new module to the entry chunk.

## Verification run locally

Every step in `.github/workflows/test.yml`'s `frontend` job: `npm run lint` ✓ · `npm run typecheck` ✓ · `npm run typecheck:design-sync` ✓ · `npm test` ✓ (383 files, 6,848 passed / 1 skipped) · `npm run build` ✓ · `npm run budget` ✓. No backend, route, `response_model` or Pydantic schema touched, so `api-schema` has nothing to regenerate.

## What to eyeball — visual QA is OUTSTANDING

I have no browser and did not run the dev server; nothing below has been looked at.

1. **`/characters/<id>` of a SINGULARITY player** — the one route that makes the branch true for this kit. The profile paints the circuit grid + 4px scanlines; every task and praxis card on it should now be a bare terminal slab. Check the cards still read as cards without the raster — the frame, brackets and band are all that separate them from the ground.
2. **`/characters/<id>` of an EVERYMEN, S.N.I.D.E., EPHEMERISTS or WOW player, with a Singularity task/praxis card in the grid** — the same drop, on someone else's pattern (owner ruling (a)). WOW is the judgement-call row in `ornamentedGrounds.ts`; this is where flipping it would show.
3. **`/characters/<id>` of a COVEN or UA player** — a wash, so the Singularity cards must KEEP the raster here. This is the case a per-route flag would have got wrong.
4. **`/factions/singularity`** — exempt (owner, 2026-08-18). Busy ground *and* rastered cards, deliberately.
5. **`/tasks`, Home, the FieldDesk, `/tasks/<id>`, `/praxis/<id>`** — no backdrop, so no change at all. Worth one glance to confirm the branch really is a no-op there.
6. **The praxis card at the new alpha, beside a task card.** This is the change most likely to be a taste call: the praxis card's raster went from 0.03 to 0.05 and the pair should now look like one kit. Both themes — Singularity's terminal tokens are tuned per theme (`-term-scan` is 0.05 light / 0.045 dark), so look at both.
7. **A known, deliberate asymmetry I did NOT touch:** the task card paints its raster as a `z-index: 3` overlay *above* the content, the praxis card as a `backgroundImage` *under* it. The issue asked for one drawing, not one layer, and moving the praxis card's would be structural work on chrome. If the pair still reads unmatched in the flesh, that is the remaining lever.
8. `prefers-reduced-motion` on both cards: the sweep must still be gated exactly as before on both grounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
