### PR TITLE
The list count names its window: "Showing first 50" while more remain (#2384)

### DIFF
--- a/frontend/src/locales/en/praxis.json
+++ b/frontend/src/locales/en/praxis.json
@@ -11,6 +11,7 @@
     "emptyCaughtUp": "All caught up",
     "emptyCaughtUpHint": "Nothing is waiting on your vote.",
     "count": "{{count}} shown",
+    "countWindowed": "Showing first {{count}}",
     "loadMore": "Load more",
     "taskFilter": {
       "notice": "Proof of action, narrowed to a single task.",

--- a/frontend/src/locales/en/tasks.json
+++ b/frontend/src/locales/en/tasks.json
@@ -1,6 +1,7 @@
 {
   "listPage": {
     "count": "{{count}} shown",
+    "countWindowed": "Showing first {{count}}",
     "loading": "Loading tasks...",
     "empty": "No tasks match your filters.",
     "emptyFiltered": "Nothing open under those terms. Clear the search or pick a different faction.",

--- a/frontend/src/pages/__tests__/listCountNamesTheWindow.test.tsx
+++ b/frontend/src/pages/__tests__/listCountNamesTheWindow.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * #2384 — the count beside the filters must name the WINDOW, not read as a
+ * page-size setting.
+ *
+ * Seam: `<TaskFilterBar>` / `<PraxisFilterBar>` → `FilterBar`'s
+ * `filter-bar__summary` slot. Tested here rather than through `<Tasks>` /
+ * `<Praxes>` because `renderToStaticMarkup` runs no effects, so a page render
+ * never settles a fetch — `hasMore` is permanently false and the branch this
+ * issue is about would never be exercised. Handing the bar a state object is
+ * the only place both sides of it are reachable without a DOM.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, it, expect } from 'vitest'
+import '../../i18n'
+import i18n from '../../i18n'
+import TaskFilterBar from '../tasks/TaskFilterBar'
+import PraxisFilterBar from '../praxes/PraxisFilterBar'
+import { LANDING_FILTERS } from '../praxes/feedFilterParams'
+import { TASK_SORT_DEFAULT, TASK_STATUS_DEFAULT, TASK_TYPE_DEFAULT, type TasksState } from '../tasks/useTasks'
+import type { PraxesFeedState } from '../praxes/usePraxes'
+
+const COUNT = 50
+
+// The bars read `.length` and nothing else off the rows, so the rows are
+// stand-ins — a real `TaskOut`/`PraxisCardOut` ×50 would assert nothing extra.
+const rows = <T,>(): T[] => Array.from({ length: COUNT }, () => ({}) as T)
+
+const noop = () => {}
+
+function taskState(hasMore: boolean): TasksState {
+  return {
+    user: null,
+    tasks: rows(),
+    loading: false,
+    error: null,
+    factions: [],
+    factionConfigs: [],
+    statusFilters: [TASK_STATUS_DEFAULT, 'active'],
+    taskType: TASK_TYPE_DEFAULT,
+    setTaskType: noop,
+    sort: TASK_SORT_DEFAULT,
+    setSort: noop,
+    status: TASK_STATUS_DEFAULT,
+    setStatus: noop,
+    selectedFactions: [],
+    setSelectedFactions: noop,
+    canSignUp: false,
+    setCanSignUp: noop,
+    query: '',
+    setQuery: noop,
+    clearFilters: noop,
+    hasMore,
+    loadMore: noop,
+    signupMsg: null,
+    handleSignup: async () => {},
+    displayPointsFor: () => 0,
+    displayMultiplierFor: () => 1,
+  }
+}
+
+function praxisState(hasMore: boolean): PraxesFeedState {
+  return {
+    items: rows(),
+    loading: false,
+    error: null,
+    isEmpty: false,
+    emptyState: 'register',
+    factions: [],
+    filters: LANDING_FILTERS,
+    setFilters: noop,
+    clearAllFilters: noop,
+    canFilterByVote: false,
+    query: '',
+    setQuery: noop,
+    taskId: null,
+    clearTaskFilter: noop,
+    hasMore,
+    loadMore: noop,
+  }
+}
+
+const summary = (bar: React.ReactElement): string =>
+  renderToStaticMarkup(bar).match(
+    /class="filter-bar__summary">([^<]*)</,
+  )?.[1] ?? ''
+
+const surfaces = [
+  {
+    page: 'tasks',
+    bar: (hasMore: boolean) => <TaskFilterBar state={taskState(hasMore)} />,
+    windowed: i18n.t('tasks:listPage.countWindowed', { count: COUNT }),
+    whole: i18n.t('tasks:listPage.count', { count: COUNT }),
+  },
+  {
+    page: 'praxis',
+    bar: (hasMore: boolean) => <PraxisFilterBar state={praxisState(hasMore)} />,
+    windowed: i18n.t('praxis:listPage.countWindowed', { count: COUNT }),
+    whole: i18n.t('praxis:listPage.count', { count: COUNT }),
+  },
+]
+
+describe.each(surfaces)('the $page count (#2384)', ({ bar, windowed, whole }) => {
+  it('names the window while more rows remain', () => {
+    // The point of the issue: a bare "50" beside a dropdown reads as a page
+    // size. "Showing first 50" cannot.
+    expect(windowed).toMatch(/first/i)
+    expect(summary(bar(true))).toBe(windowed)
+  })
+
+  it('says plainly that is everything once nothing remains', () => {
+    expect(summary(bar(false))).toBe(whole)
+  })
+
+  it('does not print the same sentence in both states', () => {
+    expect(windowed).not.toBe(whole)
+  })
+})

--- a/frontend/src/pages/praxes/PraxisFilterBar.tsx
+++ b/frontend/src/pages/praxes/PraxisFilterBar.tsx
@@ -21,11 +21,16 @@ import type { PraxesFeedState, SortOrder, VotedFilter, EraScope } from './usePra
  * to state it as well — and the answer is to state it once, here, beside the
  * controls that change it. Neither header prints it now; this is the only copy,
  * and it is the bar's because the bar is what moves it.
+ *
+ * It names the WINDOW rather than stating a bare number (#2384) — see
+ * `TaskFilterBar` for why, and for why the branch is `hasMore` rather than a
+ * length comparison. Same wording on both lists, on purpose.
  */
 export default function PraxisFilterBar({ state }: { state: PraxesFeedState }) {
   const { t } = useTranslation('praxis')
   const { t: tc } = useTranslation('common')
-  const { items, filters, setFilters, clearAllFilters, canFilterByVote, factions } = state
+  const { items, filters, setFilters, clearAllFilters, canFilterByVote, factions, hasMore } =
+    state
 
   const rails: FilterRail[] = [
     {
@@ -88,7 +93,9 @@ export default function PraxisFilterBar({ state }: { state: PraxesFeedState }) {
         ),
       ]}
       onClearAll={clearAllFilters}
-      summary={t('listPage.count', { count: items.length })}
+      summary={t(hasMore ? 'listPage.countWindowed' : 'listPage.count', {
+        count: items.length,
+      })}
       search={{
         value: state.query,
         onChange: state.setQuery,

--- a/frontend/src/pages/tasks/TaskFilterBar.tsx
+++ b/frontend/src/pages/tasks/TaskFilterBar.tsx
@@ -60,6 +60,12 @@ const ELIGIBILITY_ON = 'canSignUp'
  * one component printing it is what keeps the desktop eyebrow and the mobile
  * caption from drifting apart — they both used to print it, in two spellings,
  * one of them hardcoded English.
+ *
+ * It names the WINDOW rather than stating a bare number (#2384): beside a
+ * dropdown and a search box, "50 shown" reads as a page-size setting a player
+ * could change, and the "Load more" that explains it is a page-scroll below. So
+ * the copy branches on `hasMore` — the same flag that raises that button, never
+ * `tasks.length === PAGE_LIMIT`, which is wrong once the window has grown.
  */
 export default function TaskFilterBar({ state }: { state: TasksState }) {
   const { t } = useTranslation('tasks')
@@ -67,6 +73,7 @@ export default function TaskFilterBar({ state }: { state: TasksState }) {
   const {
     user,
     tasks,
+    hasMore,
     factions,
     statusFilters,
     taskType,
@@ -179,7 +186,9 @@ export default function TaskFilterBar({ state }: { state: TasksState }) {
       rails={rails}
       facets={[factionFacet(factions, selectedFactions, setSelectedFactions)]}
       onClearAll={clearFilters}
-      summary={t('listPage.count', { count: tasks.length })}
+      summary={t(hasMore ? 'listPage.countWindowed' : 'listPage.count', {
+        count: tasks.length,
+      })}
       search={{
         value: query,
         onChange: setQuery,


### PR DESCRIPTION
Closes #2384

"50 shown" sits beside a filter dropdown and a search box, where a bare number reads as a page-size setting a player could change. It is not one: both lists are windowed at `PAGE_LIMIT = 50`, and the "Load more" that explains the number is a full page-scroll below it.

## What changed

Both filter bars branch their `summary` on `hasMore`:

- more remain → **"Showing first 50"**
- that is everything → **"50 shown"** (unchanged)

Four files, ~20 lines of substance:

- `frontend/src/locales/en/tasks.json` and `frontend/src/locales/en/praxis.json` — one new key each, `listPage.countWindowed`. `en` is the only locale directory in the repo, so there is no second catalog tree to keep in step. ADR-0032 satisfied: both strings are keyed and reach the component through `t()`, nothing inline (`npm run lint` green).
- `frontend/src/pages/tasks/TaskFilterBar.tsx` and `frontend/src/pages/praxes/PraxisFilterBar.tsx` — read `hasMore` and pick the key.

**`hasMore` needed no threading.** The brief expected it to live only beside `loadMore` in the page component; it is in fact already a field on `TasksState` and `PraxesFeedState`, and both bars already take the whole state object. So the diff is a destructure, not a new prop on two pages plus two mobile surfaces. Deliberately *not* re-derived from `items.length === 50` — that is `pageHasMore(data?.length, limit)`'s job, and a length-vs-`PAGE_LIMIT` comparison goes wrong the moment one "Load more" grows `limit` to 100.

One component per page serves both form factors here (`Tasks.tsx`, `mobileArchetypes/DefaultTasks.tsx`, `Praxes.tsx`, `MobilePraxisFeed.tsx` all mount the same bar), so mobile picks the new copy up for free.

## The seam I tested at

`<TaskFilterBar state={…}>` / `<PraxisFilterBar state={…}>` → `FilterBar`'s `filter-bar__summary` slot, with a hand-built state object. New file: `frontend/src/pages/__tests__/listCountNamesTheWindow.test.tsx` (6 tests, `describe.each` over the two surfaces).

**Not** through `<Tasks>` / `<Praxes>`, and that is the point: the suite renders with `renderToStaticMarkup`, so no effect runs, no fetch settles, `data` stays `null` and `hasMore` is permanently `false`. A page-level test would have exercised exactly one side of the new branch and passed against the old code. The existing #2262 page test still asserts the `hasMore: false` wording, so the "nothing remains" side is covered at both levels.

It went red on the real defect first (`missing copy key "tasks:listPage.countWindowed"`) before the catalog entries existed.

## Verification

Every step in the `frontend` job of `.github/workflows/test.yml`, run locally:

| Step | Result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` (`tsc --noEmit` + e2e project) | clean |
| `npm run typecheck:design-sync` | clean |
| `npm test` | 387 files, 6910 passed, 1 skipped |
| `npm run build` | built |
| `npm run budget` | JS ok 126.8 KB; CSS WARN 22.3 KB |

The CSS WARN is pre-existing on `main` — this diff touches no CSS, no `index.css`, no `factions.ts`. `api-schema` has nothing to regenerate: no route, `response_model` or Pydantic schema was touched, and there is no backend change at all.

**Visual QA is outstanding.** I have no browser and no dev stack; everything above is tests, types, lint and bytes.

## Not built, on purpose

**A real total ("50 of 214")** — the better feature, and explicitly not this issue. `GET /tasks` and `GET /praxes` return no count, so it needs two route changes plus a `COUNT` per filtered load, on the page the architecture audit already flagged for query volume. **Worth filing separately** if you want it; say the word and it can be an issue. Also untouched: the count's placement, the bar's styling, and the "Load more" control.

One honest wrinkle to note rather than fix: `hasMore` is true whenever a page comes back exactly full, so a result set of exactly 50 says "Showing first 50" when 50 *is* everything. That is the existing growing-window contract — the "Load more" button has the same false positive today, and the two now agree with each other. Fixing it needs the real total above.

## What to eyeball

Both pages, both states, both form factors:

- **`/tasks`, desktop, a filter returning fewer than 50** (e.g. a narrow search, or the `pending` status) — reads "N shown", no "Load more" at the foot.
- **`/tasks`, desktop, a filter returning more than 50** (bare `/tasks`) — reads "Showing first 50", "Load more" present; click it and it should become "Showing first 100", then flip to "N shown" on the page that comes back short.
- **`/praxis`, desktop, the same two cases** — `?q=` something rare for the short one, bare `/praxis` for the long one.
- **All four again at mobile width**, where the bar folds itself down — checking that the longer sentence does not wrap badly or collide with the search box in the collapsed layout. This is the one place the new copy is meaningfully longer than the old, and the one thing I could not check.
- Both themes, in case the summary's line length interacts with anything.

If the collapsed mobile bar needs layout work to hold the longer string, that is a `frontend-style` job, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
