### PR TITLE
At the top of the ladder the profile stops printing its own coercion (#2383)

### DIFF
--- a/frontend/src/locales/en/common.json
+++ b/frontend/src/locales/en/common.json
@@ -297,7 +297,7 @@
       "points_one": "point",
       "points_other": "points",
       "toNextLevel": "{{points}} to Level {{level}}",
-      "topLevel": "Top of the era's ladder",
+      "topLevel": "Nowhere to go from here but the top",
       "allTime": "{{points}} all-time",
       "trackLabel": "{{score}} of {{target}} points toward Level {{level}}",
       "noCharacter": "No character yet"

--- a/frontend/src/pages/CharacterProfile.tsx
+++ b/frontend/src/pages/CharacterProfile.tsx
@@ -255,12 +255,15 @@ export default function CharacterProfile() {
     : null;
   const progression: ProfileProgression | null = track
     ? {
-        // At the top of the curve `levelTrack` reports no next rung; the panel
-        // keeps the degenerate shape it has always had — the current level
-        // named as "next", the band collapsed to a point, the bar full.
-        nextLevel: track.nextLevel ?? character.level,
+        // At the top of the curve `levelTrack` reports no next rung, and it is
+        // passed through untouched (#2383). Two coercions used to stand here —
+        // the current level named as "next", the band's far edge faked as the
+        // near one — and they are what printed "next · lvl 8" beside "0 / 0
+        // pts this level" on a level-8 profile. The skins branch on the `null`
+        // the way the field desk always has. Do not reintroduce a `??` here.
+        nextLevel: track.nextLevel,
         currentThreshold: track.currentThreshold,
-        nextThreshold: track.nextThreshold || track.currentThreshold,
+        nextThreshold: track.nextThreshold,
         pointsIntoLevel: track.pointsIntoLevel,
         levelSpan: track.levelSpan,
         progressPercent: track.fillPercent,

--- a/frontend/src/pages/characterProfile/FactionProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/FactionProfileBody.tsx
@@ -37,11 +37,17 @@ import DefaultProfileBody from './archetypes/DefaultProfileBody'
  * places did the same arithmetic the two bars disagreed.
  */
 export interface ProfileProgression {
-  /** The level the current score is climbing toward (capped at max level). */
-  nextLevel: number
+  /**
+   * The level the current score is climbing toward — `null` at the top of the
+   * era's curve, exactly as `levelTrack` reports it (#2383). This used to be
+   * `number`, which forced `CharacterProfile` to coerce the `null` into the
+   * current level: a level-8 character was told the next level was 8, beside a
+   * band of "0 / 0 pts". A skin MUST branch on this rather than re-coerce.
+   */
+  nextLevel: number | null
   /** Absolute score where the current level began. */
   currentThreshold: number
-  /** Absolute score where nextLevel begins. */
+  /** Absolute score where nextLevel begins; `0` at the top of the curve. */
   nextThreshold: number
   /** The bar's numerator: points banked inside the current level. */
   pointsIntoLevel: number

--- a/frontend/src/pages/characterProfile/__tests__/profileTopOfLadder.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileTopOfLadder.test.tsx
@@ -36,6 +36,17 @@ import FactionProfileBody, { type ProfileBodyProps } from '../FactionProfileBody
 const SLUGS = ['na', 'ua', 'snide', 'wow', 'coven', 'ephemerists', 'everymen', 'singularity']
 const FORM_FACTORS = ['desktop', 'mobile'] as const
 
+/**
+ * Where a level track is actually mounted. Every kit draws one on a laptop; on
+ * a phone WOW alone does not — its mobile skin trades the track for a tally of
+ * deeds. The exclusion is pinned by its own test at the bottom of this file so
+ * it cannot quietly become a hole.
+ */
+const TRACK_MOUNTS: Record<(typeof FORM_FACTORS)[number], readonly string[]> = {
+  desktop: SLUGS,
+  mobile: SLUGS.filter((slug) => slug !== 'wow'),
+}
+
 /** Level 8 is the last rung of era 1's curve; `levelTrack` reports this shape. */
 const AT_THE_TOP: ProfileBodyProps['progression'] = {
   nextLevel: null,
@@ -113,7 +124,7 @@ describe('at the top of the era ladder, no profile prints a degenerate climb (#2
   })
 
   for (const formFactor of FORM_FACTORS) {
-    for (const slug of SLUGS) {
+    for (const slug of TRACK_MOUNTS[formFactor]) {
       it(`${slug}/${formFactor} says the top of the ladder and nothing about 0 / 0`, () => {
         mocks.formFactor = formFactor
         const text = renderText(slug, AT_THE_TOP, 8)
@@ -127,7 +138,7 @@ describe('at the top of the era ladder, no profile prints a degenerate climb (#2
   // The other half: mid-climb is untouched. A fix that simply deleted the two
   // figures would pass every assertion above.
   for (const formFactor of FORM_FACTORS) {
-    for (const slug of SLUGS) {
+    for (const slug of TRACK_MOUNTS[formFactor]) {
       it(`${slug}/${formFactor} still draws the band and the next rung mid-climb`, () => {
         mocks.formFactor = formFactor
         const text = renderText(slug, MID_CLIMB, 7)
@@ -139,4 +150,20 @@ describe('at the top of the era ladder, no profile prints a degenerate climb (#2
       })
     }
   }
+
+  // The one exclusion above, asserted rather than assumed: WOW's phone skin
+  // trades the whole track for a tally of deeds, so it has no climb readout to
+  // get wrong. If it ever grows one, this fails and the skin joins the loops.
+  it('wow/mobile draws no level track at all, in either state', () => {
+    mocks.formFactor = 'mobile'
+    for (const [track, level] of [
+      [AT_THE_TOP, 8],
+      [MID_CLIMB, 7],
+    ] as const) {
+      const text = renderText('wow', track, level)
+      expect(text).not.toContain('pts this level')
+      expect(text).not.toContain('next · ')
+      expect(text).not.toContain(TOP_OF_LADDER)
+    }
+  })
 })

--- a/frontend/src/pages/characterProfile/__tests__/profileTopOfLadder.test.tsx
+++ b/frontend/src/pages/characterProfile/__tests__/profileTopOfLadder.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * The seam: `FactionProfileBody` → every archetype → the words drawn for a
+ * character at the TOP of the era's curve (#2383).
+ *
+ * `levelTrack` has always got the top right — `nextLevel: null`, a full bar,
+ * and a band of width zero because there is no next threshold to subtract.
+ * `ProfileProgression.nextLevel` was typed `number`, so `CharacterProfile` had
+ * to coerce that `null` away (`track.nextLevel ?? character.level`), and the
+ * profile printed the coercion: "0 / 0 pts this level" beside "next · lvl 8"
+ * on a level-8 character. The field desk never had the bug — it honours the
+ * `null` — so this file asks the profile the question the field desk already
+ * answers.
+ *
+ * All eight kits, both form factors, because the readout has THREE mounts
+ * (`DefaultProfileBody`'s two branches and the shared `profileSkin`) and a
+ * fix to one of them typechecks perfectly while the other two keep printing
+ * 0/0.
+ */
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+
+import '../../../i18n'
+import i18n from '../../../i18n'
+import type { CharacterOut } from '../../../api/auth'
+
+const mocks = vi.hoisted(() => ({ formFactor: 'desktop' as 'mobile' | 'desktop' }))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => mocks.formFactor,
+}))
+
+import FactionProfileBody, { type ProfileBodyProps } from '../FactionProfileBody'
+
+/** The eight kits `FactionProfileBody` dispatches to. */
+const SLUGS = ['na', 'ua', 'snide', 'wow', 'coven', 'ephemerists', 'everymen', 'singularity']
+const FORM_FACTORS = ['desktop', 'mobile'] as const
+
+/** Level 8 is the last rung of era 1's curve; `levelTrack` reports this shape. */
+const AT_THE_TOP: ProfileBodyProps['progression'] = {
+  nextLevel: null,
+  currentThreshold: 2000,
+  nextThreshold: 0,
+  pointsIntoLevel: 0,
+  levelSpan: 0,
+  progressPercent: 100,
+}
+
+const MID_CLIMB: ProfileBodyProps['progression'] = {
+  nextLevel: 8,
+  currentThreshold: 1500,
+  nextThreshold: 2000,
+  pointsIntoLevel: 380,
+  levelSpan: 500,
+  progressPercent: 76,
+}
+
+function renderText(
+  factionSlug: string,
+  progression: ProfileBodyProps['progression'],
+  level: number,
+): string {
+  const character: CharacterOut = {
+    id: 7,
+    username: 'reza',
+    display_name: 'Reza',
+    bio: '',
+    tagline: '',
+    avatar_url: '',
+    location: '',
+    level,
+    score: 2400,
+    all_time_score: 2400,
+    faction_slug: factionSlug,
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    badges: [],
+    invitations: [],
+  }
+  const html = renderToStaticMarkup(
+    <MemoryRouter>
+      <FactionProfileBody
+        character={character}
+        submissions={[]}
+        proposedTasks={[]}
+        progression={progression}
+        identityActions={null}
+      />
+    </MemoryRouter>,
+  )
+  return html
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&#x27;|&#39;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&')
+}
+
+/** Resolved from the catalog so a copy edit moves this suite, not breaks it. */
+const TOP_OF_LADDER = i18n.t('common:sidebar.characterCard.topLevel')
+const ZERO_BAND = i18n.t('common:profile.ptsThisLevel', { current: 0, span: 0 })
+const NEXT_IS_SELF = i18n.t('common:profile.nextLevel', { level: 8 })
+
+describe('at the top of the era ladder, no profile prints a degenerate climb (#2383)', () => {
+  it('has words to look for, so the loops below cannot pass by asserting nothing', () => {
+    for (const word of [TOP_OF_LADDER, ZERO_BAND, NEXT_IS_SELF]) {
+      expect(word.length).toBeGreaterThan(0)
+    }
+    // The exact strings the bug report showed.
+    expect(ZERO_BAND).toContain('0 / 0')
+    expect(NEXT_IS_SELF).toContain('8')
+  })
+
+  for (const formFactor of FORM_FACTORS) {
+    for (const slug of SLUGS) {
+      it(`${slug}/${formFactor} says the top of the ladder and nothing about 0 / 0`, () => {
+        mocks.formFactor = formFactor
+        const text = renderText(slug, AT_THE_TOP, 8)
+        expect(text, `${slug}/${formFactor}: top-of-ladder line`).toContain(TOP_OF_LADDER)
+        expect(text, `${slug}/${formFactor}: 0 / 0 band`).not.toContain(ZERO_BAND)
+        expect(text, `${slug}/${formFactor}: next is itself`).not.toContain(NEXT_IS_SELF)
+      })
+    }
+  }
+
+  // The other half: mid-climb is untouched. A fix that simply deleted the two
+  // figures would pass every assertion above.
+  for (const formFactor of FORM_FACTORS) {
+    for (const slug of SLUGS) {
+      it(`${slug}/${formFactor} still draws the band and the next rung mid-climb`, () => {
+        mocks.formFactor = formFactor
+        const text = renderText(slug, MID_CLIMB, 7)
+        expect(text, `${slug}/${formFactor}: band`).toContain(
+          i18n.t('common:profile.ptsThisLevel', { current: 380, span: 500 }),
+        )
+        expect(text, `${slug}/${formFactor}: next rung`).toContain(NEXT_IS_SELF)
+        expect(text, `${slug}/${formFactor}: no top-of-ladder line`).not.toContain(TOP_OF_LADDER)
+      })
+    }
+  }
+})

--- a/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/DefaultProfileBody.tsx
@@ -459,15 +459,36 @@ function DesktopProfile({
                       marginBottom: 'var(--space-sm)',
                     }}
                   >
-                    <span
-                      className="font-body"
-                      style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}
-                    >
-                      {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
-                    </span>
-                    <span style={{ ...EYEBROW, fontSize: 'var(--text-md)', letterSpacing: '0.08em' }}>
-                      {t('profile.nextLevel', { level: progression.nextLevel })}
-                    </span>
+                    {/* THE TOP OF THE CURVE IS ITS OWN LINE (#2383). There is
+                        no rung above the last one, so the band collapses to
+                        zero width and there is no level to name: both figures
+                        would print as noise ("0 / 0 pts this level", "next ·
+                        lvl 8"). The field desk has always drawn one sentence
+                        here instead, and this is the same string in the same
+                        body voice — the eyebrow's caps are for a two-word
+                        label, not for a sentence. The slot is the whole row,
+                        which is the point: the line is four times the length
+                        of the eyebrow it replaces. */}
+                    {progression.nextLevel === null ? (
+                      <span
+                        className="font-body"
+                        style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}
+                      >
+                        {t('sidebar.characterCard.topLevel')}
+                      </span>
+                    ) : (
+                      <>
+                        <span
+                          className="font-body"
+                          style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}
+                        >
+                          {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
+                        </span>
+                        <span style={{ ...EYEBROW, fontSize: 'var(--text-md)', letterSpacing: '0.08em' }}>
+                          {t('profile.nextLevel', { level: progression.nextLevel })}
+                        </span>
+                      </>
+                    )}
                   </div>
                   <div
                     style={{
@@ -494,10 +515,15 @@ function DesktopProfile({
                       one the bar tracked. The bar reads the band; this line
                       annotates it, in the voice the home page's "185 all-time"
                       caption uses. `.label-caption` is the minted tier
-                      (#1307), so no new style is invented for it. */}
-                  <div className="label-caption" style={{ marginTop: 'var(--space-xs)' }}>
-                    {t('profile.ptsToNext', { score: character.score, threshold: progression.nextThreshold })}
-                  </div>
+                      (#1307), so no new style is invented for it. At the top
+                      of the curve there is no threshold for it to annotate and
+                      the line goes (#2383) — the era-points figure it carried
+                      is still on the credential beside this panel. */}
+                  {progression.nextLevel !== null && (
+                    <div className="label-caption" style={{ marginTop: 'var(--space-xs)' }}>
+                      {t('profile.ptsToNext', { score: character.score, threshold: progression.nextThreshold })}
+                    </div>
+                  )}
                 </div>
               </div>
             )}
@@ -716,12 +742,24 @@ function MobileProfile({
                       marginBottom: 'var(--space-sm)',
                     }}
                   >
-                    <span className="font-body" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}>
-                      {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
-                    </span>
-                    <span style={{ ...EYEBROW, fontSize: 'var(--text-md)', letterSpacing: '0.08em' }}>
-                      {t('profile.nextLevel', { level: progression.nextLevel })}
-                    </span>
+                    {/* The phone's half of the top-of-the-curve line (#2383) —
+                        see the laptop branch above. Narrower still here, which
+                        is exactly why the sentence gets the whole row rather
+                        than the right-hand eyebrow slot. */}
+                    {progression.nextLevel === null ? (
+                      <span className="font-body" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}>
+                        {t('sidebar.characterCard.topLevel')}
+                      </span>
+                    ) : (
+                      <>
+                        <span className="font-body" style={{ fontSize: 'var(--text-content)', color: 'var(--color-text-secondary)' }}>
+                          {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
+                        </span>
+                        <span style={{ ...EYEBROW, fontSize: 'var(--text-md)', letterSpacing: '0.08em' }}>
+                          {t('profile.nextLevel', { level: progression.nextLevel })}
+                        </span>
+                      </>
+                    )}
                   </div>
                   <div style={{ height: 10, borderRadius: 20, background: 'var(--color-border)', overflow: 'hidden' }}>
                     <div
@@ -741,10 +779,15 @@ function MobileProfile({
                       one the bar tracked. The bar reads the band; this line
                       annotates it, in the voice the home page's "185 all-time"
                       caption uses. `.label-caption` is the minted tier
-                      (#1307), so no new style is invented for it. */}
-                  <div className="label-caption" style={{ marginTop: 'var(--space-xs)' }}>
-                    {t('profile.ptsToNext', { score: character.score, threshold: progression.nextThreshold })}
-                  </div>
+                      (#1307), so no new style is invented for it. At the top
+                      of the curve there is no threshold for it to annotate and
+                      the line goes (#2383) — the era-points figure it carried
+                      is still on the credential beside this panel. */}
+                  {progression.nextLevel !== null && (
+                    <div className="label-caption" style={{ marginTop: 'var(--space-xs)' }}>
+                      {t('profile.ptsToNext', { score: character.score, threshold: progression.nextThreshold })}
+                    </div>
+                  )}
                 </div>
               </div>
             )}

--- a/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
+++ b/frontend/src/pages/characterProfile/archetypes/profileSkin.tsx
@@ -651,27 +651,51 @@ export function ProfileSkin({
                         marginBottom: 'var(--space-sm)',
                       }}
                     >
-                      <span
-                        style={{
-                          fontFamily: kit.bodyFont ?? kit.eyebrowFont,
-                          // points into level: a number the player cares about
-                          fontSize: 'var(--text-content)',
-                          color: headerMuted,
-                        }}
-                      >
-                        {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
-                      </span>
-                      <span
-                        style={{
-                          fontFamily: kit.eyebrowFont,
-                          fontSize: 'var(--text-md)',
-                          letterSpacing: '0.1em',
-                          textTransform: 'uppercase',
-                          color: headerMuted,
-                        }}
-                      >
-                        {t('profile.nextLevel', { level: progression.nextLevel })}
-                      </span>
+                      {/* THE TOP OF THE CURVE IS ITS OWN LINE (#2383), for all
+                          seven kits at once — this row is the only one they
+                          have. Above the last rung the band has zero width and
+                          there is no level to name, so the two figures would
+                          read "0 / 0 pts this level" and "next · lvl 8" on a
+                          level-8 character. The field desk's sentence replaces
+                          both, in each kit's body voice: the eyebrow slot is
+                          uppercased and letter-spaced for a two-word label,
+                          and a sentence shouted through it would be the second
+                          bug. The slot is the whole row. */}
+                      {progression.nextLevel === null ? (
+                        <span
+                          style={{
+                            fontFamily: kit.bodyFont ?? kit.eyebrowFont,
+                            fontSize: 'var(--text-content)',
+                            color: headerMuted,
+                          }}
+                        >
+                          {t('sidebar.characterCard.topLevel')}
+                        </span>
+                      ) : (
+                        <>
+                          <span
+                            style={{
+                              fontFamily: kit.bodyFont ?? kit.eyebrowFont,
+                              // points into level: a number the player cares about
+                              fontSize: 'var(--text-content)',
+                              color: headerMuted,
+                            }}
+                          >
+                            {t('profile.ptsThisLevel', { current: pointsIntoLevel, span: levelSpan })}
+                          </span>
+                          <span
+                            style={{
+                              fontFamily: kit.eyebrowFont,
+                              fontSize: 'var(--text-md)',
+                              letterSpacing: '0.1em',
+                              textTransform: 'uppercase',
+                              color: headerMuted,
+                            }}
+                          >
+                            {t('profile.nextLevel', { level: progression.nextLevel })}
+                          </span>
+                        </>
+                      )}
                     </div>
                     <div
                       style={{


### PR DESCRIPTION
Closes #2383

A level-8 character's profile read `0 / 0 pts this level` beside `next · lvl 8`. Both figures are a coercion, not arithmetic.

## The defect

`frontend/src/utils/levelTrack.ts` already gets the top of the curve right: `nextLevel: null`, `fillPercent: 100`, and a band of width zero because there is no next threshold to subtract. Level 8 is the last rung of era 1's curve.

`ProfileProgression.nextLevel` was typed `number`. That forced `CharacterProfile.tsx` to throw the `null` away —

```ts
nextLevel: track.nextLevel ?? character.level,
nextThreshold: track.nextThreshold || track.currentThreshold,
```

— and the profile then printed the coercion. Its own comment called it *"the degenerate shape it has always had"*. The field desk never had the bug, because it honours the `null`.

So: widen the type, delete both coercions, and let the three render sites branch on the `null` the way the field desk always has.

## The seam I tested at

`FactionProfileBody` → archetype → the words rendered, at the top of the curve and mid-climb, for **all eight kits × both form factors** — `frontend/src/pages/characterProfile/__tests__/profileTopOfLadder.test.tsx`.

That seam, not the util and not the page, because the readout has **three mounts**: `DefaultProfileBody`'s two form-factor branches and the shared `profileSkin` that dresses the seven faction kits. Fixing one of them typechecks perfectly while the other two keep printing `0 / 0`.

The test went red first, and red at the real defect: it did not compile against the old type —

```
src/pages/characterProfile/__tests__/profileTopOfLadder.test.tsx(41,3):
  error TS2322: Type 'null' is not assignable to type 'number'.
```

It also pins the other half — mid-climb still draws the band and the next rung — so a fix that merely deleted the two figures would fail.

One exclusion, asserted rather than assumed: **WOW's phone skin has no level track at all** (it trades the whole track for a tally of deeds), so it has no climb readout to get wrong. Its own test fails if it ever grows one.

## What changed

- `FactionProfileBody.tsx` — `nextLevel: number | null`, documented, with a "do not re-coerce" note on it.
- `CharacterProfile.tsx` — both coercions gone; `track` is passed through.
- `DefaultProfileBody.tsx` (desktop + mobile branches) and `profileSkin.tsx` (the seven kits) — at the top of the curve the row draws one line, `sidebar.characterCard.topLevel`, in each kit's **body** voice.
- `common.json` — `sidebar.characterCard.topLevel` takes its new value, *"Nowhere to go from here but the top"*. One string, both surfaces: the field desk, the sidebar and the profile all speak it. No second string was minted.

Two judgement calls worth your eye, both flagged rather than buried:

1. **The line gets the whole row, starting at the left.** The ruling says the slot widens to hold it; the right-hand slot it replaces is an uppercased, letter-spaced eyebrow sized for a two-word label, and a 34-character sentence shouted through it would have been the second bug. So the sentence takes the row in the body voice the field desk uses. If you want it right-aligned instead, that is a one-line change.
2. **`profile.ptsToNext` (`2400 / 0 pts`, `DefaultProfileBody` only) is hidden at the top of the curve**, because it annotates a next threshold that does not exist. The era-points figure it carried is still on the CredentialCard beside the panel, on every kit. If you want an explicit all-time figure in that slot instead of nothing, say so — `sidebar.characterCard.allTime` already exists and it is another one-liner.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally on the rebased branch:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean |
| `npm run typecheck:design-sync` | clean (`previews/_state.tsx` builds a `ProfileProgression`; a `number` is assignable to `number \| null`, so no fixture change was needed and none was faked) |
| `npm test` | 388 files, 6950 passed, 1 skipped |
| `npm run build` | clean |
| `npm run budget` | JS ok; **CSS WARN is pre-existing** — I built `origin/main` in the same worktree and got the *identical* asset hash (`index-eJXNcVY_.css`, 22.2 KB). This PR touches no CSS. |

`api-schema` and the backend job are untouched — no route, schema or Python change.

## What to eyeball — visual QA is outstanding

**I have no browser and no dev stack.** Everything above is tsc, eslint, vitest and the byte budget. Nobody has looked at this. The new line is roughly four times the length of the `next · lvl 9` eyebrow it displaces, and that is exactly the risk the issue flagged, so the layout needs human eyes:

**At max level (level 8) — the new state:**
- `na` / default profile, **desktop** and **mobile** — the two branches are separate code, so check both.
- The seven faction kits through `profileSkin`, **desktop** and **mobile**: `ua`, `snide`, `coven`, `ephemerists`, `everymen`, `singularity`, and `wow` on **desktop**. Each kit sets its own `bodyFont`, so the sentence sets differently in seven faces — Ephemerists and Singularity are the two most likely to run long or wrap.
- `wow` on **mobile** should be unchanged: it has no track.
- The bar should read **full**, and no `0 / 0` or `next · lvl 8` anywhere.

**Mid-climb (say level 7) — the regression check:**
- Same eight kits, both form factors. The band figure, the next-rung eyebrow and the caption should all be exactly as before.

**Both themes**, since the line lands in `--color-text-secondary` / each kit's `headerMuted` — no new token, but the sentence occupies more of the row than the figure it replaced.

**The other surfaces the copy change touches** (value-only, no layout change): the desktop sidebar character card and all nine mobile field desks now say *"Nowhere to go from here but the top"* instead of *"Top of the era's ladder"*. Worth a glance at the field desk's narrow left slot, since that string got 6 characters longer.
