### PR TITLE
Albescent: the aurora comes to the praxis card, and alternates on a busy ground

### DIFF
--- a/frontend/src/components/praxisCard/desktop/AlbescentPraxisCard.tsx
+++ b/frontend/src/components/praxisCard/desktop/AlbescentPraxisCard.tsx
@@ -1,5 +1,6 @@
 import DefaultPraxisCard from "./DefaultPraxisCard";
 import { AlbescentSparks } from "../shared";
+import { useGroundIsBusy } from "../../backdrop/BackdropContext";
 import { frameBase, type ArchetypeProps } from "./shared";
 
 /**
@@ -33,8 +34,36 @@ import { frameBase, type ArchetypeProps } from "./shared";
  * number, and now the one place it is written: `--faction-default-card-radius`
  * is the Default/Albescent rung, and the ring reads it back with
  * `border-radius: inherit`.
+ *
+ * #2397 (epic #2195) gives this card the kit's ORNAMENT and alternates it. The
+ * law, owner 2026-08-17: one ornament per faction, worn on both cards, dropped
+ * on a patterned page ground. Albescent's is the AURORA, which until now was
+ * worn on the task card and not here — so the two cards showed a different
+ * texture, which is the exact complaint the epic opened on.
+ *
+ * ONE DRAWING, TWO MOUNTS. `.alb-task-aurora` is reused rather than copied under
+ * a praxis-shaped name: the epic's own supporting ruling is "one drawing per
+ * faction, not one per surface", and a second class name would state a second
+ * drawing. The `-task-` in it is historical — where it was first drawn, not what
+ * it belongs to. It carries its own geometry (inset 22%, blurred past
+ * recognition), so it needs nothing from this sheet but a positioned, clipping
+ * parent, which this wrapper already is.
+ *
+ * THE DRIFT GOES WITH IT. `.alb-rainbow` is this card's other background
+ * texture, so leaving it standing while the aurora comes off would be the
+ * "substitute texture" the ruling forbids ("either burst, or plain"): the card
+ * would still be two textures fighting the ground, just quieter ones.
+ *
+ * WHAT DOES NOT BRANCH, because it is chrome: the drifting `.spectrum-frame`
+ * ring (shared with five other mounts since #2407), the masthead, the score box
+ * — and the three `AlbescentSparks`. The sparks are three ✦ glyphs, not a
+ * ground texture, and they are the half of the tell (#842) that keeps an
+ * Albescent card on someone else's patterned profile from reading as a plain
+ * unaffiliated card. ADR-0048 reveals the society by motion; the alternation
+ * takes the texture, never the tell.
  */
 export function AlbescentPraxisCard(props: ArchetypeProps) {
+  const groundIsBusy = useGroundIsBusy();
   return (
     <div
       className="alb-praxis-card spectrum-frame"
@@ -42,7 +71,12 @@ export function AlbescentPraxisCard(props: ArchetypeProps) {
       style={{ ...frameBase, borderRadius: "var(--faction-default-card-radius)", /* inherits the Default sheet */ position: "relative", overflow: "hidden" }}
     >
       <DefaultPraxisCard {...props} />
-      <span aria-hidden className="alb-rainbow" />
+      {!groundIsBusy && (
+        <>
+          <span aria-hidden className="alb-rainbow" />
+          <span aria-hidden className="alb-task-aurora" />
+        </>
+      )}
       <AlbescentSparks />
     </div>
   );

--- a/frontend/src/components/taskCard/AlbescentTaskCard.tsx
+++ b/frontend/src/components/taskCard/AlbescentTaskCard.tsx
@@ -1,5 +1,6 @@
 import type { CardProps } from "./TaskCard";
 import DefaultTaskCard from "./DefaultTaskCard";
+import { useGroundIsBusy } from "../backdrop/BackdropContext";
 
 /**
  * Albescent — the task card's tell (#1023, ADR-0048). The SECOND Albescent
@@ -28,8 +29,17 @@ import DefaultTaskCard from "./DefaultTaskCard";
  * {@link CardProps} and forwards it whole, so a change to the contract or to the
  * na card reaches Albescent with no edit here. That is the property a
  * hand-copied skin could never keep.
+ *
+ * #2397 (epic #2195) makes the AURORA the kit's one ornament and alternates it:
+ * on a patterned page ground the bloom comes off and the sheet is BARE. The edge
+ * is CHROME and never branches — it is `.spectrum-frame`'s shared ring since
+ * #2407, worn by six mounts, five of which are not this card's to decide. So an
+ * Albescent card on the Everymen wall is still revealed by motion (the drifting
+ * frame), which is what ADR-0048 requires; only the texture under the vellum
+ * yields.
  */
 export default function AlbescentTaskCard(props: CardProps) {
+  const groundIsBusy = useGroundIsBusy();
   return (
     <div
       /* The wrapper's one job besides holding the overlays: it repoints
@@ -43,7 +53,9 @@ export default function AlbescentTaskCard(props: CardProps) {
       style={{ position: "relative", width: "fit-content", maxWidth: "100%" }}
     >
       <DefaultTaskCard {...props} />
-      <span aria-hidden="true" className="alb-task-aurora" />
+      {/* The ornament. "Either burst, or plain" (owner, 2026-08-17): where it is
+          not worn the vellum is bare, and no quieter texture stands in. */}
+      {!groundIsBusy && <span aria-hidden="true" className="alb-task-aurora" />}
       <span aria-hidden="true" className="alb-task-edge" />
     </div>
   );

--- a/frontend/src/components/taskCard/__tests__/albescentAuroraAlternates.test.tsx
+++ b/frontend/src/components/taskCard/__tests__/albescentAuroraAlternates.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * The aurora ALTERNATES, and the praxis card finally has one (#2397, epic #2195).
+ *
+ * The law, owner 2026-08-17: each faction has one ornament; a card on an
+ * ornamented ground goes plain, a card on a plain ground wears it. Albescent's
+ * is the AURORA — seven blooms blurred past recognition under the vellum — and
+ * until #2397 it was worn on the task card only, while the praxis card showed
+ * `.alb-rainbow`'s drift instead. Two surfaces, two textures, which is the exact
+ * complaint the epic opened on. Both cards now wear the same drawing and both
+ * drop it on the same predicate.
+ *
+ * THE SEAM: `the ground a page declared` → `the card's rendered markup`. Phase 1
+ * (#2387) already tests the predicate itself in
+ * `backdrop/__tests__/groundIsBusy.test.tsx`; what is untested until here is
+ * that the two Albescent cards consume it, and consume it the same way. So every
+ * assertion below is about markup under a provided `BackdropContext`, never
+ * about `useGroundIsBusy` in isolation — a card that reads the boolean and
+ * forgets to branch passes every other check in the tree.
+ *
+ * WHY THE `albescent` GROUND IS THE INTERESTING ROW. Albescent's own backdrop is
+ * the watercolour, a WASH, so an Albescent card on an Albescent player's profile
+ * KEEPS its aurora and this kit's alternation is visible on someone ELSE's
+ * patterned profile only. A per-route flag — "the character profile tells its
+ * cards to go plain" — would have got that wrong.
+ *
+ * WHAT MUST SURVIVE A BUSY GROUND. The alternation takes the card's background
+ * TEXTURE and nothing else, and for this kit that line is load-bearing twice
+ * over. `.alb-task-edge` is the shared `.spectrum-frame` ring since #2407, worn
+ * by six mounts; branching it here would reach five surfaces this issue does not
+ * own. And ADR-0048 reveals the society by MOTION, never by a colour — so a
+ * plain Albescent card still has to be tellable from an unaffiliated one, which
+ * the drifting edge and the three sparks are what do.
+ *
+ * SSR-only harness (`renderToStaticMarkup`, no DOM, effects never run), which is
+ * why the ground is provided through `BackdropContext` directly rather than by
+ * calling `useFactionBackdrop` — its effect would never fire here.
+ */
+import type { ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi } from 'vitest'
+import '../../../i18n'
+
+// The praxis card's score stamp reaches for `useTheme()`, which throws outside a
+// `ThemeProvider` by design (#701). Mocked, the shape the sibling alternation
+// suites established: the theme is an input here and nothing below depends on it.
+vi.mock('../../../hooks/useTheme', () => ({
+  useTheme: () => ({ theme: 'light', toggle: () => {} }),
+}))
+
+vi.mock('../../../hooks/useFormFactor', () => ({
+  useFormFactor: () => 'desktop',
+}))
+
+import { BackdropContext } from '../../backdrop/BackdropContext'
+import AlbescentTaskCard from '../AlbescentTaskCard'
+import AlbescentPraxisCard from '../../praxisCard/desktop/AlbescentPraxisCard'
+import { aTask, aPraxisCard } from '../../../test/fixtures'
+
+const TASK = aTask({ primary_faction_slug: 'albescent' })
+const PRAXIS = aPraxisCard({ task_faction_slug: 'albescent' })
+
+const adminProps = {
+  praxis: PRAXIS,
+  showAdminControls: false,
+  onHide: () => {},
+  onDelete: () => {},
+} as unknown as Parameters<typeof AlbescentPraxisCard>[0]['adminProps']
+
+function onGround(slug: string | null, card: ReactNode, cardsKeepOrnament = false): string {
+  return renderToStaticMarkup(
+    <BackdropContext.Provider value={{ slug, cardsKeepOrnament, setGround: () => {} }}>
+      <MemoryRouter>{card}</MemoryRouter>
+    </BackdropContext.Provider>,
+  )
+}
+
+const taskCard = (
+  <AlbescentTaskCard
+    task={TASK}
+    basePoints={TASK.point_value}
+    multiplier={1}
+    inProgressCount={TASK.in_progress_count}
+    onSignup={() => {}}
+  />
+)
+
+const praxisCard = <AlbescentPraxisCard praxis={PRAXIS} adminProps={adminProps} />
+
+const CARDS: [string, ReactNode][] = [
+  ['task card', taskCard],
+  ['praxis card', praxisCard],
+]
+
+describe.each(CARDS)('the Albescent %s', (_name, card) => {
+  it('wears the aurora on every unthemed route — the site-wide default', () => {
+    // `null` is /tasks, Home, the FieldDesk and both detail pages: the vast
+    // majority of the mounts. For the praxis card this is also the new half of
+    // #2397 — the aurora was not on this surface at all before.
+    expect(onGround(null, card)).toContain('alb-task-aurora')
+  })
+
+  it('drops the aurora on a patterned ground, whatever faction painted it', () => {
+    // Owner ruled (a): ANY ornamented ground. An Albescent card lands on someone
+    // else's profile whenever a player of another faction files praxis against
+    // an Albescent task — `PraxisCard` dispatches on `task_faction_slug`.
+    expect(onGround('everymen', card)).not.toContain('alb-task-aurora')
+    expect(onGround('snide', card)).not.toContain('alb-task-aurora')
+  })
+
+  it('keeps the aurora on an Albescent profile, because the watercolour is a WASH', () => {
+    expect(onGround('albescent', card)).toContain('alb-task-aurora')
+  })
+
+  it('keeps the aurora when the page claimed the faction-page exemption', () => {
+    // Owner, 2026-08-18: a faction page may show busy cards on a busy ground.
+    // `useFactionDetail` is the one caller that claims it.
+    expect(onGround('everymen', card, true)).toContain('alb-task-aurora')
+  })
+
+  it('keeps the drifting spectrum edge on a busy ground — the edge is CHROME', () => {
+    // Both cards wear a masked spectrum ring, and neither may lose it: it is one
+    // shared rule across six mounts (#2407), and it is the motion that keeps
+    // ADR-0048's tell alive on a card that has gone plain.
+    const plain = onGround('everymen', card)
+    expect(plain).toMatch(/alb-task-edge|spectrum-frame/)
+  })
+
+  it('goes BARE where the aurora is not worn — no substitute texture', () => {
+    // "Either burst, or plain" (owner, 2026-08-17). Strip the ornament spans
+    // from the worn card and what is left is the plain card, byte for byte: the
+    // two differ by the texture and by nothing else. On the praxis card that
+    // means `.alb-rainbow` travels WITH the aurora — a drift left standing alone
+    // is exactly the substitute texture the ruling forbids.
+    const worn = onGround(null, card)
+    const plain = onGround('everymen', card)
+    const ornament = /<span aria-hidden="true" class="alb-(?:task-aurora|rainbow)"><\/span>/g
+    expect(worn).toMatch(ornament)
+    expect(worn.replace(ornament, '')).toEqual(plain)
+  })
+})
+
+it('leaves the three sparks on a busy ground — a glyph is not a ground texture', () => {
+  // #842's half of the tell. Three ✦ at 9–15px are the praxis card's, and they
+  // are why a plain Albescent card still does not read as an unaffiliated one.
+  expect(onGround('everymen', praxisCard)).toContain('alb-spark')
+})

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5904,6 +5904,12 @@
    stops differ in alpha interpolates differently once you flatten it, and
    moving that into `opacity` would be a repaint.
 
+   IT COMES OFF WITH THE AURORA (#2397, epic #2195). This is the praxis card's
+   other background texture and its only mount, so a busy page ground takes both
+   — leaving the drift standing alone would be the "substitute texture" the
+   alternation forbids. `AlbescentPraxisCard` owns that branch; the sparks and
+   the drifting frame stay, so the card is still revealed by motion (ADR-0048).
+
    What did change, deliberately, is the hue SET: orange and teal rejoin the
    wash, dark's red and yellow land back on their stops, and eight stops share
    the same 220px tile where six did — a fuller spectrum in finer stripes. The
@@ -6009,7 +6015,26 @@
    • The aurora BLENDS rather than sits behind. `mix-blend-mode: multiply` on the
      light sheet and `screen` on the dark one is what keeps ink legible through
      an overlay — the design put the bloom UNDER the copy at `normal`, which is
-     not a position an overlay can take. Same call `.alb-rainbow` already makes. */
+     not a position an overlay can take. Same call `.alb-rainbow` already makes.
+
+   THE AURORA IS THE KIT'S ONE ORNAMENT, AND IT ALTERNATES (#2397, epic #2195).
+   Since #2397 `.alb-task-aurora` has TWO mounts, not one: the task card and the
+   PRAXIS card, which wore `.alb-rainbow`'s drift and no aurora. One drawing per
+   faction, not one per surface — the `-task-` in the name records where it was
+   first drawn, not what it belongs to, and a praxis-shaped copy of the same
+   seven blooms would have stated a second drawing. It travels well because it
+   carries its own geometry: everything visible is on the `::before` at
+   `inset: 22%`, blurred past recognition, so the only thing it asks of a host is
+   a positioned parent that clips.
+
+   Both mounts are CONDITIONAL in their components: a card standing on a
+   patterned page ground drops the bloom and the vellum is BARE ("either burst,
+   or plain", owner 2026-08-17). On the praxis card `.alb-rainbow` comes off with
+   it, being that card's other background texture. Nothing here branches — the
+   predicate is `useGroundIsBusy()` and the components mount or omit the span, so
+   a plain card costs no rules and this sheet stays a drawing rather than a
+   decision. THE EDGE NEVER BRANCHES: it is chrome, and since #2407 it is the
+   shared `.spectrum-frame` ring five other mounts wear. */
 @keyframes alb-task-drift {
   0%, 100% { transform: translate3d(-6%, -4%, 0) scale(1.12) rotate(0deg); }
   50% { transform: translate3d(6%, 5%, 0) scale(1.24) rotate(8deg); }


### PR DESCRIPTION
Phase 3 of #2195, the Albescent kit. **The aurora is the ornament; it now lives on both cards and it alternates.**

Closes #2397

## What changed

Albescent's one ornament is the aurora — seven blooms blurred past recognition under the vellum. It was worn on the task card and **not** on the praxis card, which showed `.alb-rainbow`'s drift instead: two surfaces, two textures, which is the complaint the epic opened on.

- **`AlbescentPraxisCard.tsx`** gains the aurora, and it is the *same drawing*: `.alb-task-aurora` is reused, not copied under a praxis-shaped name. The epic's own supporting ruling is "one drawing per faction, not one per surface", and a second class name would state a second drawing. The `-task-` in it is now historical — where it was first drawn, not what it belongs to; the CSS docblock says so. It travels because everything visible is on its `::before` at `inset: 22%`, so all it asks of a host is a positioned parent that clips, which this wrapper already is.
- **Both cards** drop the ornament when `useGroundIsBusy()` is true. The branch is a conditional mount in the component, not a rule in the sheet — a plain card costs zero CSS.
- **`.alb-rainbow` travels with the aurora** on the praxis card. It is that card's other background texture and its only mount, so leaving it standing while the aurora came off would be exactly the substitute texture "either burst, or plain" forbids — the card would still be two textures fighting the ground, just quieter ones.
- **`index.css`**: comments only. Two docblocks record the second mount and the alternation. Zero rules added, changed or deleted — see the byte measurement below.

## What deliberately does NOT branch

- **The edge.** It is chrome, and since #2407 it is the shared `.spectrum-frame` ring across six mounts; branching it here would reach five surfaces this issue does not own. It is also what keeps ADR-0048 true on a card that has gone plain: **Albescent is revealed by motion, never by a colour**, and a card stripped of every flourish would read as a plain unaffiliated card on someone else's wall.
- **The three `AlbescentSparks`.** Three ✦ glyphs at 9–15px are not a ground texture. They are #842's half of the tell and they stay. Flagging this as the one judgement call in the diff — if the owner reads the sparks as ornament rather than as a mark, it is a one-line change in the same file.
- Masthead, score box, CTA rule opacity, the media lift (#1646): untouched.

## The seam I tested at

`the ground a page declared` → `the card's rendered markup`, under a provided `BackdropContext` — never `useGroundIsBusy()` in isolation, because a card that reads the boolean and forgets to branch passes every other check in the tree. New file: `frontend/src/components/taskCard/__tests__/albescentAuroraAlternates.test.tsx`, 13 cases across both cards.

**It went red first**, on `origin/main`'s two components, in exactly the six places this PR changes (task card drops / task card bare / praxis card wears it on three grounds / praxis card bare). The rows that matter:

- `null` ground (i.e. /tasks, Home, the FieldDesk, both detail pages) — worn. The overwhelming majority of mounts, unchanged.
- `everymen`, `snide` — plain.
- **`albescent` — worn.** Albescent's own backdrop is the watercolour, a **wash**, so an Albescent card on an Albescent profile keeps its aurora. This kit alternates on someone *else's* patterned profile only.
- `cardsKeepOrnament: true` — worn (faction-page exemption, owner 2026-08-18).
- **Bare, not substituted**: strip the ornament spans from the worn render and it equals the plain render byte for byte. That is the assertion that would catch a "go plain" which starts taking chrome with it.

## Measured byte delta

Built both sides in this worktree, gzip **level 9**, `frontend/scripts/bundle-budget.mjs`'s own ledger (blocking entry assets from `dist/index.html`):

| | before (`origin/main` @ af53523) | after | delta |
|---|---|---|---|
| critical CSS | 115,978 raw / **22,758** gzip9 | 115,978 raw / **22,758** gzip9 | **0 B** |
| entry JS | 129,766 gzip9 | 129,773 gzip9 | **+7 B** |

The emitted CSS is **byte-identical** — same content hash, and a chunk-level diff of the two minified sheets reports 0 added and 0 removed rules. Comments are stripped by the build, the branch is a mount rather than a rule, and Tailwind picked nothing new out of the new prose. `npm run budget` reports the same WARN CSS state `main` is already in (22.2 KB, warn>22.2, fail>24.4); this PR does not move it.

Rebased onto `af53523` mid-build — #2393/#2418 (Everymen) landed under me and briefly faked a large Everymen diff in my baseline. The numbers above are all post-rebase.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, locally, after the rebase: `npm run lint`, `npm run typecheck`, `npm run typecheck:design-sync`, `npm test` (**388 files, 6931 passed, 1 skipped**), `npm run build`, `npm run budget`. No backend or schema surface is touched, so `test` and `api-schema` have nothing to say here.

`WORLD_ZERO_STYLE.md` is **not** touched: #2393's PR already landed the §6 entry ("One ornament per faction, ONE drawing of it, and it alternates"), it covers this kit, and the sibling PRs in this batch stayed off the file to avoid a six-way conflict.

## What to eyeball

**I have no browser and did not run the dev server — visual QA is outstanding.** Everything above is tests, tsc and byte counts. The things worth a human eye, in order:

1. **The aurora on the praxis card, light and dark.** It is a drawing sized for the task card being reused on a taller sheet: seven blooms at `inset: 22%` with a 52px blur, so on a long praxis write-up expect a tall vertical bloom rather than the task card's squarer one. That is "one drawing, not one per surface" behaving as ruled, but it is the thing most likely to want a number changed.
2. **The aurora *under* `.alb-rainbow`'s drift, on the same sheet.** Two blended light layers at 0.34 / 0.15 (light) and 0.30 / 0.2475 (dark). Every other Albescent surface layers 2–4 light layers, so this is the kit's idiom — but this pairing has never been on screen together.
3. **Ink legibility on the praxis card** at both themes, especially the score box and the byline, with both layers on.
4. **A character profile of an Everymen / S.N.I.D.E. / Singularity / Ephemerists / WOW player** who has filed praxis against an Albescent task, or an Albescent task card on that page: the sheet should be *bare*, with the spectrum frame still drifting and the three sparks still catching.
5. **An Albescent player's profile** — the opposite case. The watercolour is a wash, so both cards should keep the aurora there.
6. The proof photo still paints last (#1646's lift clears the new layer at `z-index: 3` > the aurora's 1 — asserted only indirectly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
