### PR TITLE
The skills stop warning about a OneDrive that is gone

### DIFF
--- a/.claude/skills/builder-bot/SKILL.md
+++ b/.claude/skills/builder-bot/SKILL.md
@@ -330,9 +330,9 @@ auto-starting another batch.
 ## Hazards block — paste into EVERY subagent prompt, verbatim
 
 ```
-1. Commit + push INCREMENTALLY. OneDrive silently reverts long-uncommitted edits; the Edit
-   tool can silently drop writes — `grep` each file on disk after editing to confirm. Never
-   batch into one final commit. Prefer a worktree OUTSIDE OneDrive (C:\Users\pixie\AppData\Local\Temp\).
+1. Commit + push INCREMENTALLY. A concurrent `/git-reaper` sweep has twice emptied a live
+   worktree — uncommitted work in one is not safe. `grep` each file on disk after editing to
+   confirm the write landed. Never batch into one final commit.
 2. node_modules: the worktree lacks it. `mklink` is a **cmd.exe builtin and is NOT on
    PATH** in Bash or PowerShell — it needs the call through `cmd`, or use `npm ci`:
    Bash: `cmd //c mklink /J "$(pwd)/frontend/node_modules" "<ABSOLUTE Windows path to main>\frontend\node_modules"`

--- a/.claude/skills/git-reaper/SKILL.md
+++ b/.claude/skills/git-reaper/SKILL.md
@@ -125,8 +125,8 @@ cmd //c rmdir "<worktree>\frontend\node_modules"
 
 Then `git worktree remove --force <path>`.
 
-**When that fails with `Permission denied` on `.git/worktrees/<name>`** — it will, on the
-OneDrive checkout, because of the `fsmonitor--daemon/cookies` directory — Git Bash `rm -rf`
+**When that fails with `Permission denied` on `.git/worktrees/<name>`** — the
+`fsmonitor--daemon/cookies` directory is the usual cause — Git Bash `rm -rf`
 succeeds where both git's own unlink and Python's `shutil.rmtree` fail. Remove the working
 directory, remove the metadata directory, then `git worktree prune`.
 


### PR DESCRIPTION
Post-migration cleanup: the working copy moved off OneDrive to
`C:\Users\pixie\Documents\WorldZero`, and three lines of skill guidance were
still describing the old checkout.

**builder-bot + wz-next-batch hazard block** — every subagent was being told
"OneDrive silently reverts long-uncommitted edits" and "prefer a worktree
OUTSIDE OneDrive (`C:\Users\pixie\AppData\Local\Temp\`)". Both are dead advice
now, and the temp-worktree preference actively costs a `node_modules` junction
for no reason. The **commit-incrementally rule stays** — a concurrent
`/git-reaper` sweep has twice emptied a live worktree, so uncommitted work in
one is still unsafe. The rule now names that as its reason instead.

**git-reaper** — asserted the `Permission denied` on `.git/worktrees/<name>`
"will" happen "on the OneDrive checkout". The `fsmonitor--daemon/cookies`
directory is the real cause and is not OneDrive-specific; the paragraph now
says so, and the `rm -rf` remedy below it is unchanged.

Docs only — no code, no CI surface.

Verified after editing (per the skill-file corruption trap): no `OneDrive` or
`AppData\Local\Temp` string survives anywhere under `.claude/skills/`, and all
three files' YAML frontmatter still parses with its `description` intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014toYoAdmDetJy3rxWSCWNQ
