### PR TITLE
A refused metatask attach prints inside the picker, not behind it

### DIFF
--- a/frontend/src/components/metataskSeal/MetataskPicker.tsx
+++ b/frontend/src/components/metataskSeal/MetataskPicker.tsx
@@ -31,6 +31,7 @@ import MetataskSeal from "./MetataskSeal";
 import { drawAtRoot } from "../ui/drawAtRoot";
 import { useFormFactor } from "../../hooks/useFormFactor";
 import { factionCssVar, factionName } from "../../utils/factions";
+import { ErrorBanner } from "../../pages/editPraxis/archetypes/shared";
 import type { EditPraxisState } from "../../pages/editPraxis/useEditPraxis";
 
 const ALL_FILTER = "all" as const;
@@ -259,6 +260,18 @@ export default function MetataskPicker({ state }: { state: EditPraxisState }) {
             );
           })}
         </div>
+
+        {/*
+         * A refused attach belongs to the sheet, not the page under it (#2382).
+         * `addMetatask` reports one through the composer's shared `error`, and
+         * the only thing that renders that is the archetype's own ErrorBanner,
+         * at the foot of a long sheet BEHIND this overlay — so sealing a
+         * metatask past the cap read as an Attach button that did nothing at
+         * all. Same banner, drawn where the click was. It sits above the footer
+         * rather than inside it so the buttons never reflow under a long
+         * message.
+         */}
+        <ErrorBanner message={state.error} />
 
         {/* Footer — confirms the pending choice */}
         <div

--- a/frontend/src/components/metataskSeal/metataskCompose.test.tsx
+++ b/frontend/src/components/metataskSeal/metataskCompose.test.tsx
@@ -145,6 +145,32 @@ describe("MetataskPicker", () => {
     );
     expect(html).toContain(i18n.t("editPraxis.attach.alreadyAttached", { ns: "forms" }));
   });
+
+  // #2382: a refused attach — stacking past the metatask cap — used to land in
+  // the archetype's banner at the foot of the sheet BEHIND this overlay, so
+  // Attach looked inert. The refusal has to print inside the picker itself.
+  it("prints a refused attach inside the sheet", () => {
+    const html = renderToStaticMarkup(
+      <MetataskPicker
+        state={mkState({
+          metatasks: rows,
+          metataskPickerOpen: true,
+          error: "You can only apply 3 metatasks.",
+        })}
+      />,
+    );
+    expect(html).toContain("You can only apply 3 metatasks.");
+    expect(html).toContain('role="alert"');
+  });
+
+  it("draws no banner when nothing has been refused", () => {
+    const html = renderToStaticMarkup(
+      <MetataskPicker
+        state={mkState({ metatasks: rows, metataskPickerOpen: true })}
+      />,
+    );
+    expect(html).not.toContain('role="alert"');
+  });
 });
 
 describe("MetataskRemoveConfirm", () => {

--- a/frontend/src/pages/editPraxis/useMetataskApply.ts
+++ b/frontend/src/pages/editPraxis/useMetataskApply.ts
@@ -145,10 +145,13 @@ export function useMetataskApply(
     }
   }, [praxis, metataskRemovalTarget, setError]);
 
-  const openMetataskPicker = useCallback(
-    () => setMetataskPickerOpen(true),
-    [],
-  );
+  // Clear first: the picker now prints `error` itself (#2382), and the composer
+  // shares one error slot, so a failure from publish or a duel would otherwise
+  // greet the author the moment the sheet opens.
+  const openMetataskPicker = useCallback(() => {
+    setError("");
+    setMetataskPickerOpen(true);
+  }, [setError]);
   const closeMetataskPicker = useCallback(
     () => setMetataskPickerOpen(false),
     [],


### PR DESCRIPTION
Closes #2382.

## What was happening

Applying a fourth metatask when three is the cap looked like an Attach button
that did nothing at all.

It was never inert. `addMetatask` (`useMetataskApply.ts`) catches the refusal
and reports it through the composer's shared `setError` — and the only thing
that renders that error is the archetype's own `<ErrorBanner>`, at the foot of
a long composer sheet. `MetataskPicker` has drawn at the document root since
#2244 as an `inset: 0` overlay, so it sits squarely on top of the one surface
the message lands on. The author's only way to read their own refusal was to
give up, close the sheet, and scroll — exactly what the report says.

## The change

Three files, no new component and no new copy.

- **`MetataskPicker.tsx`** renders the existing `<ErrorBanner>` above its
  footer. It goes *above* the footer row rather than inside it so a long
  message never reflows Cancel/Attach. The banner already carries
  `role="alert"` and its own `--color-danger-veil` ground, so it reads on the
  picker's neutral `--faction-default-card-bg` without a skin override — this
  surface deliberately wears no faction.
- **`useMetataskApply.ts`** — `openMetataskPicker` clears the error first. The
  composer has **one** error slot, shared with publish, leave, drop, mode
  changes and the duel flow. Now that the picker prints it, a stale failure
  from any of those would have greeted the author the instant the sheet opened.
- **`metataskCompose.test.tsx`** — two tests: the refusal renders inside the
  sheet, and no banner is drawn when nothing was refused.

## Verification

Every step in `.github/workflows/test.yml`'s `frontend` job, run locally:

| step | result |
|---|---|
| `npm run lint` | clean |
| `npm run typecheck` | clean (`tsc` 5.9.3 confirmed actually executing) |
| `npm run typecheck:design-sync` | clean |
| `npm test` | **391 files, 6975 passed**, 1 skipped |
| `npm run build` | built in 4.75s |
| `npm run budget` | JS 126.8 KB ok; CSS 22.2 KB WARN |

The CSS warning is inherited from `main`, not from this branch — the diff adds
no class name and no stylesheet, so the CSS asset is byte-identical.

The two new tests were confirmed **red** against the unfixed component
(`prints a refused attach inside the sheet` fails, 8 others pass) and green
with it, so they assert the behaviour rather than the markup.

## How to see it

Open a praxis composer on a character that has already sealed the maximum
metatasks, hit **+ Add a metatask**, pick one, and press **Attach**. The
refusal now prints in the sheet above the buttons instead of vanishing behind
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014toYoAdmDetJy3rxWSCWNQ
