### PR TITLE
The migrations are checked against the models they claim to build (#2426)

### DIFF
--- a/backend/tests/integration/test_migrations_match_models.py
+++ b/backend/tests/integration/test_migrations_match_models.py
@@ -1,0 +1,222 @@
+"""The migration chain must produce the schema ``models/`` describes (#2426).
+
+CI runs ``alembic upgrade head`` and then throws that schema away: every other
+integration test builds its own via ``Base.metadata.create_all`` (see
+``conftest.py``). So the migrations were only ever proved to *execute*. A column
+a revision forgot, a type that diverged, an enum value added to a Python enum but
+not to ``0002_squashed``'s ``ENUMS`` list — all of it passed CI green and would
+first be seen on deploy, and ``main`` auto-deploys.
+
+**Seam under test:** the migrated database vs. ``Base.metadata``, on a database
+reached only through the chain. This deliberately does *not* change how the rest
+of the suite gets its schema; it adds an independent check that the two agree.
+
+⚠️ **What ``alembic check`` can and cannot see here, and why the enum check
+exists.** ``0002_squashed.upgrade()`` builds every table with
+``Base.metadata.create_all``. So on a *fresh* database the tables are the ORM's
+by construction, and autogenerate can only ever report drift introduced by a
+revision *after* the root — a revision that renames, retypes or drops something
+the models still describe. It is structurally incapable of noticing the opposite
+direction (a model column with no migration behind it), because the root absorbs
+it silently. Verified, not assumed: a nullable column added to ``Task`` with no
+revision leaves ``alembic check`` green (#2426).
+
+Enum *values* are the exception, and the one the issue named as the known trap.
+``create_type=False`` (forced for every enum in ``alembic/env.py``) means
+``create_all`` emits no ``CREATE TYPE`` at all — migrations own every one of them
+explicitly, in ``0002_squashed.ENUMS``. That makes the values in the migrated
+database genuinely independent of the models, so comparing them is not circular:
+a value added to a Python enum without being added to a migration shows up here,
+and *only* here. It is invisible to ``alembic check`` (autogenerate does not
+diff enum members) and invisible to the rest of the suite, whose ``create_all``
+schema does emit ``CREATE TYPE`` and so always has the new value.
+
+Closing the wider hole — model→migration drift for tables — needs a baseline
+that is not derived from the live models (a checked-in schema snapshot, or a
+root revision with static DDL). That is a schema-policy decision, not something
+this test can assert its way around.
+
+Runs on its own throwaway database, created and dropped here. It cannot use
+``worldzero_test``: that one is shared (by CI's own ``upgrade head`` step, and by
+parallel agents whose session-scoped ``drop_all`` teardown would pull tables out
+from under a migration mid-run).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import asyncpg
+import pytest_asyncio
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.engine import make_url
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+from config import settings
+import models  # noqa: F401 — registers every mapped class on Base.metadata
+from models.base import Base
+
+BACKEND_DIR = Path(__file__).resolve().parents[2]
+
+# Named for the issue that introduced it, so a stray copy on a shared Postgres
+# is traceable. Nothing else may point here.
+MIGRATION_TEST_DB = "wz2426_test"
+
+# ``alembic_version.version_num`` is VARCHAR(32). Overflow fails *mid*-upgrade,
+# after the DDL has run, leaving a half-applied migration.
+VERSION_NUM_MAX_LEN = 32
+
+_BASE_URL = make_url(os.environ.get("TEST_DATABASE_URL") or settings.DATABASE_URL)
+
+
+def _dsn(database: str) -> str:
+    """A plain libpq DSN for ``database`` on the configured server."""
+    return _BASE_URL.set(drivername="postgresql", database=database).render_as_string(
+        hide_password=False
+    )
+
+
+def _alembic(*args: str) -> "subprocess.CompletedProcess[str]":
+    """Run the alembic CLI the way ``start.sh`` and CI do, against the throwaway DB."""
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=BACKEND_DIR,
+        env={**os.environ, "DATABASE_URL": _dsn(MIGRATION_TEST_DB)},
+        capture_output=True,
+        text=True,
+    )
+
+
+def _report(label: str, result: "subprocess.CompletedProcess[str]") -> str:
+    return (
+        f"`alembic {label}` exited {result.returncode}\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+
+
+async def _enum_values_in_db(database: str) -> dict[str, set[str]]:
+    """Every public enum type in ``database``, mapped to its values."""
+    conn = await asyncpg.connect(_dsn(database))
+    try:
+        rows = await conn.fetch(
+            "SELECT t.typname, e.enumlabel FROM pg_type t"
+            " JOIN pg_enum e ON e.enumtypid = t.oid"
+            " JOIN pg_namespace n ON n.oid = t.typnamespace"
+            " WHERE n.nspname = 'public'"
+        )
+    finally:
+        await conn.close()
+
+    found: dict[str, set[str]] = {}
+    for row in rows:
+        found.setdefault(row["typname"], set()).add(row["enumlabel"])
+    return found
+
+
+def _enum_values_in_models() -> dict[str, set[str]]:
+    """Every native Postgres enum the ORM declares, mapped to its values."""
+    declared: dict[str, set[str]] = {}
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            type_ = column.type
+            if isinstance(type_, SAEnum) and type_.name and type_.native_enum:
+                declared.setdefault(type_.name, set()).update(type_.enums)
+    return declared
+
+
+@pytest_asyncio.fixture
+async def migration_db() -> str:
+    """An empty database of our own, dropped again however the test ends."""
+    admin = await asyncpg.connect(_dsn("postgres"))
+    try:
+        await admin.execute(f'DROP DATABASE IF EXISTS "{MIGRATION_TEST_DB}" WITH (FORCE)')
+        await admin.execute(f'CREATE DATABASE "{MIGRATION_TEST_DB}"')
+    finally:
+        await admin.close()
+
+    yield MIGRATION_TEST_DB
+
+    admin = await asyncpg.connect(_dsn("postgres"))
+    try:
+        await admin.execute(f'DROP DATABASE IF EXISTS "{MIGRATION_TEST_DB}" WITH (FORCE)')
+    finally:
+        await admin.close()
+
+
+async def test_migrations_match_models(migration_db: str) -> None:
+    """Upgrade to head, prove no drift, then prove the newest revision reverses.
+
+    The three steps are one sequence on one database on purpose: ``check`` only
+    means anything against a database the chain itself built, and the second
+    ``check`` is what makes the down/up round trip an assertion rather than a
+    smoke test — a downgrade that drops the wrong thing shows up there.
+    """
+    upgrade = _alembic("upgrade", "head")
+    assert upgrade.returncode == 0, _report("upgrade head", upgrade)
+
+    check = _alembic("check")
+    assert check.returncode == 0, (
+        "The migration chain and models/ disagree. Autogenerate wants to emit "
+        "operations that no revision performs, which means a deployed database "
+        "would end up with a schema the ORM does not expect.\n\n"
+        "Fix the migration (do NOT relax this check): add a revision carrying the "
+        "change forward — see docs/agents/db-migrations.md.\n\n"
+        + _report("check", check)
+    )
+
+    in_db = await _enum_values_in_db(migration_db)
+    in_models = _enum_values_in_models()
+    missing = {
+        name: sorted(values - in_db.get(name, set()))
+        for name, values in in_models.items()
+        if values - in_db.get(name, set())
+    }
+    assert not missing, (
+        "Enum values the models can produce that the migrated database has no "
+        f"type member for: {missing}\n\n"
+        "The rest of the suite cannot see this: its create_all schema emits its "
+        "own CREATE TYPE. A deployed database will reject the value at INSERT. "
+        "Add it to a migration (0002_squashed's ENUMS builds fresh databases; a "
+        "deployed one needs ALTER TYPE ... ADD VALUE in a new revision)."
+    )
+    unreachable = {
+        name: sorted(values - in_models.get(name, set()))
+        for name, values in in_db.items()
+        if values - in_models.get(name, set())
+    }
+    assert not unreachable, (
+        "Enum values the migrations create that no model declares — states the "
+        f"database accepts and the application cannot produce: {unreachable}\n\n"
+        "Drop them from the migration, or add them to the Python enum."
+    )
+
+    down = _alembic("downgrade", "-1")
+    assert down.returncode == 0, (
+        "The head revision has no working downgrade().\n\n" + _report("downgrade -1", down)
+    )
+
+    reupgrade = _alembic("upgrade", "head")
+    assert reupgrade.returncode == 0, _report("upgrade head (after downgrade)", reupgrade)
+
+    recheck = _alembic("check")
+    assert recheck.returncode == 0, (
+        "downgrade -1 followed by upgrade head did not restore the schema.\n\n"
+        + _report("check (after round trip)", recheck)
+    )
+
+
+def test_revision_ids_fit_the_version_table() -> None:
+    """``alembic_version.version_num`` is VARCHAR(32); a longer id fails mid-upgrade."""
+    script = ScriptDirectory.from_config(Config(str(BACKEND_DIR / "alembic.ini")))
+    too_long = {
+        rev.revision: len(rev.revision)
+        for rev in script.walk_revisions()
+        if len(rev.revision) > VERSION_NUM_MAX_LEN
+    }
+    assert not too_long, (
+        f"Revision ids longer than {VERSION_NUM_MAX_LEN} chars overflow "
+        f"alembic_version.version_num and fail after the DDL has already run: {too_long}"
+    )

--- a/backend/tests/integration/test_migrations_match_models.py
+++ b/backend/tests/integration/test_migrations_match_models.py
@@ -130,6 +130,12 @@ def _enum_values_in_models() -> dict[str, set[str]]:
 @pytest_asyncio.fixture
 async def migration_db() -> str:
     """An empty database of our own, dropped again however the test ends."""
+    assert _BASE_URL.database != MIGRATION_TEST_DB, (
+        f"{MIGRATION_TEST_DB!r} is this test's scratch database and gets DROPped "
+        "below — the rest of the suite must not be pointed at it. Set "
+        "TEST_DATABASE_URL to a different database name."
+    )
+
     admin = await asyncpg.connect(_dsn("postgres"))
     try:
         await admin.execute(f'DROP DATABASE IF EXISTS "{MIGRATION_TEST_DB}" WITH (FORCE)')

--- a/backend/tests/integration/test_migrations_match_models.py
+++ b/backend/tests/integration/test_migrations_match_models.py
@@ -50,13 +50,13 @@ from pathlib import Path
 
 import asyncpg
 import pytest_asyncio
+from alembic.config import Config
+from alembic.script import ScriptDirectory
 from sqlalchemy import Enum as SAEnum
 from sqlalchemy.engine import make_url
 
-from alembic.config import Config
-from alembic.script import ScriptDirectory
-from config import settings
 import models  # noqa: F401 — registers every mapped class on Base.metadata
+from config import settings
 from models.base import Base
 
 BACKEND_DIR = Path(__file__).resolve().parents[2]
@@ -138,7 +138,9 @@ async def migration_db() -> str:
 
     admin = await asyncpg.connect(_dsn("postgres"))
     try:
-        await admin.execute(f'DROP DATABASE IF EXISTS "{MIGRATION_TEST_DB}" WITH (FORCE)')
+        await admin.execute(
+            f'DROP DATABASE IF EXISTS "{MIGRATION_TEST_DB}" WITH (FORCE)'
+        )
         await admin.execute(f'CREATE DATABASE "{MIGRATION_TEST_DB}"')
     finally:
         await admin.close()
@@ -147,7 +149,9 @@ async def migration_db() -> str:
 
     admin = await asyncpg.connect(_dsn("postgres"))
     try:
-        await admin.execute(f'DROP DATABASE IF EXISTS "{MIGRATION_TEST_DB}" WITH (FORCE)')
+        await admin.execute(
+            f'DROP DATABASE IF EXISTS "{MIGRATION_TEST_DB}" WITH (FORCE)'
+        )
     finally:
         await admin.close()
 
@@ -201,11 +205,14 @@ async def test_migrations_match_models(migration_db: str) -> None:
 
     down = _alembic("downgrade", "-1")
     assert down.returncode == 0, (
-        "The head revision has no working downgrade().\n\n" + _report("downgrade -1", down)
+        "The head revision has no working downgrade().\n\n"
+        + _report("downgrade -1", down)
     )
 
     reupgrade = _alembic("upgrade", "head")
-    assert reupgrade.returncode == 0, _report("upgrade head (after downgrade)", reupgrade)
+    assert reupgrade.returncode == 0, _report(
+        "upgrade head (after downgrade)", reupgrade
+    )
 
     recheck = _alembic("check")
     assert recheck.returncode == 0, (
@@ -224,5 +231,6 @@ def test_revision_ids_fit_the_version_table() -> None:
     }
     assert not too_long, (
         f"Revision ids longer than {VERSION_NUM_MAX_LEN} chars overflow "
-        f"alembic_version.version_num and fail after the DDL has already run: {too_long}"
+        f"alembic_version.version_num and fail after the DDL has already "
+        f"run: {too_long}"
     )


### PR DESCRIPTION
Closes #2426

CI ran `alembic upgrade head` and then threw the migrated schema away — every integration test builds its own via `Base.metadata.create_all`. This adds one pytest test that keeps the migrated schema and compares it to the models, on a throwaway database it creates and drops itself. No workflow edit: the `test` job already runs the whole suite, and this repo already lints via pytest (`test_uncoded_error_ratchet.py`, `test_model_conventions.py`).

**Seam under test:** the database reached *only* through the migration chain, vs. `Base.metadata` — i.e. what `alembic check` compares, plus the enum values `alembic check` is blind to.

`backend/tests/integration/test_migrations_match_models.py`, on `wz2426_test` (created and dropped by the test; the shared `worldzero_test` gets its tables dropped mid-run by parallel agents, and CI's own `upgrade head` step already owns it):

1. `alembic upgrade head`
2. `alembic check` reports no new upgrade operations
3. every enum value the models can produce exists in the migrated database, and vice versa
4. `downgrade -1`, then `upgrade head`, then `check` again — so the round trip asserts something rather than just not crashing
5. every revision id is <= 32 chars (`alembic_version.version_num` is VARCHAR(32); overflow fails *after* the DDL has run)

`create_all` stays. The integration suite is untouched; this is an independent check that the two agree.

## ⚠️ Finding: step 2 alone cannot catch model→migration drift here

The issue asked for the red proof to be "add a nullable column to a model without a migration". **I did that, and the test stayed green** — `alembic check` passed. That is not a flaw in the assertion; it is a property of this chain:

> `0002_squashed.upgrade()` builds every table with `Base.metadata.create_all`.

So on a fresh database the tables *are* the ORM's, by construction. Autogenerate can only ever report drift a revision *after* the root introduces (a rename, a retype, a drop the models still describe). The opposite direction — a model column with no migration behind it — is absorbed silently by the root, on every fresh database, forever. The databases that can actually drift are ones stamped before the model changed, i.e. production.

That is why step 3 is in here and is the load-bearing half. `alembic/env.py` forces `create_type=False` on every enum, so `create_all` emits **no** `CREATE TYPE` — migrations own all of them explicitly in `0002_squashed.ENUMS`. The enum values in a migrated database are therefore genuinely independent of the models, and comparing them is not circular. This is also the exact trap the issue named: a value added to a Python enum but not to a migration is invisible to `alembic check` (autogenerate does not diff enum members) *and* invisible to the rest of the suite (whose `create_all` schema does emit `CREATE TYPE`, so it always has the new value) — and a deployed database rejects it at INSERT.

Closing the wider hole needs a baseline not derived from the live models — a checked-in schema snapshot, or a root revision with static DDL. That is a schema-policy decision, not something a test can assert its way around, and I did not make it. Worth its own issue.

## Red first — all four assertions, with output

Nothing here is a green assertion that never had a red state.

**a) Enum value in the model, not in any migration** (`TaskStatus.drift_probe_2426`) — the finding above, and the one the check exists for. `alembic check` stayed green; step 3 failed:

```
AssertionError: Enum values the models can produce that the migrated database has no
type member for: {'taskstatus': ['drift_probe_2426']}
```

**b) A migration that diverges from the models** (temp revision adding `task.drift_probe_2426`, no model column) — step 2 failed:

```
FAILED: New upgrade operations detected: [('remove_column', None, 'task',
Column('drift_probe_2426', TEXT(), table=<task>))]
```

**c) Head revision with a broken `downgrade()`** — step 4 failed:

```
AssertionError: The head revision has no working downgrade().
asyncpg.exceptions.UndefinedColumnError: column "no_such_column" of relation "task" does not exist
```

**d) A 48-char revision id** — step 5 failed:

```
AssertionError: Revision ids longer than 32 chars overflow alembic_version.version_num
and fail after the DDL has already run: {'9999_drift_probe_...overlong_id': 48}
```

All four probes were reverted; the temp revision file is deleted (`git status` clean, `alembic/versions/` ends at `0013_praxis_member_is_done`).

Note: the issue's text refers to `0001_squashed` and a 30-char `0003_backfill_praxis_seal_time`. Neither exists on `main` — the chain is `0002_squashed` → `0013_praxis_member_is_done`, and the longest id is `0005_praxis_member_habit_bonus` at 30 chars (so the headline "peaks at 30" still holds, just on a different revision). The check is written against the cap, not against that number.

## Tests

```
pytest --cov=. --cov-report=term-missing --cov-fail-under=80
```
from `backend/`, with `TEST_DATABASE_URL` on a private database: **1501 passed**, coverage **94.23%** (was 1499 / 94.22%). New file alone: `pytest tests/integration/test_migrations_match_models.py` — 2 passed in 4.5s, so it adds ~5s to the job and sits well inside the 60s `pytest-timeout`.

No migration added. No route, `response_model` or Pydantic schema touched, so `openapi.json` and the generated frontend types are unaffected (`api-schema` has nothing to regenerate). No frontend files touched.

## Safety

The test `DROP`s its own database, so the fixture refuses to run if `TEST_DATABASE_URL` is pointed at `wz2426_test` — a misconfiguration there would otherwise delete the suite's schema mid-run.

## What to eyeball

- **The finding above is the thing to read first.** If you disagree that the enum comparison is the right stand-in for the red proof the issue asked for, say so — I did not want to ship an assertion I could not make fail.
- The database name `wz2426_test` is baked into the test permanently. The issue suggested `wz_migrations_test`; I was directed to `wz2426_test`. Say the word and I will rename it.
- Whether the strict "no unreachable values" half of step 3 is wanted. It is green today (the squash deliberately dropped three such values), but it means retiring a Python enum member now requires a migration to drop it from the type.
- Whether the follow-up (frozen schema baseline, so model→migration drift is catchable at all) should be filed.

**Visual QA is outstanding** — I have no browser tools and no dev stack. Nothing here renders, but the claim is only that tests/tsc pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
