### PR TITLE
The backend gets a linter, as a ratchet: ruff at E,F,I with 777 findings grandfathered (#2427)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,35 @@
+# Ruff — the backend's only linter (#2427).
+#
+# This file exists for `[tool.ruff]` and nothing else. There is no `[project]`
+# or `[build-system]` table because nothing ever installs `backend/` as a
+# package; adding one would change how pip and the Docker image behave for no
+# gain. `pytest.ini` sits alongside this file and keeps precedence for pytest's
+# rootdir, so pytest is unaffected by this file's existence.
+#
+# The gate is `tests/unit/test_ruff_clean.py`, not a CI workflow step:
+# `.github/workflows/**` is owner-only, and the `test` job already runs pytest.
+# Same precedent as the uncoded-error ratchet and the model-convention test.
+#
+# Out of scope by owner ruling: `ruff format` / black, and mypy. Each is its
+# own issue. Do not add `[tool.ruff.format]` here to sneak the first one in.
+
+[tool.ruff]
+target-version = "py312"
+
+# The ruff default, taken deliberately rather than tuned. Raising it to 100
+# would drop E501 from 585 findings to 66 — which is exactly why it is not
+# raised here: the number to move is the allowlist, not the threshold.
+line-length = 88
+
+[tool.ruff.lint]
+# Deliberately narrow (#2427): pycodestyle errors, pyflakes, import sorting.
+# A broad ruleset on a mature codebase produces thousands of findings and gets
+# switched off. Widening this list later is one line — but every rule added
+# here has to be either clean or grandfathered in `tests/unit/ruff_allowlist.py`
+# in the same commit, because the ratchet compares in both directions.
+select = ["E", "F", "I"]
+
+# There is deliberately no `ignore` list. Grandfathering happens per file *and
+# per rule code* in tests/unit/ruff_allowlist.py, which only shrinks; an
+# `ignore` entry would switch a rule off everywhere and forever, including in
+# code nobody has written yet.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,8 @@ pytest
 pytest-asyncio
 pytest-cov
 pytest-timeout
+
+# The linter (#2427). Pinned exactly: the shrink-only allowlist in
+# tests/unit/ruff_allowlist.py is a count of what THIS version reports, so an
+# unpinned upgrade would move the number without anyone touching the code.
+ruff==0.16.4

--- a/backend/tests/unit/ruff_allowlist.py
+++ b/backend/tests/unit/ruff_allowlist.py
@@ -1,0 +1,318 @@
+"""The shrink-only allowlist of ruff findings the backend shipped with (#2427).
+
+Ruff landed on a codebase that had never had a linter, so it landed on **777
+existing findings across 172 files**. The owner's ruling was a ratchet, not a
+repo-wide ``--fix``: a tree-wide autofix would rewrite 256 files, bury every
+real diff behind it, and conflict with every open branch. So the seed below is
+complete — that is the point. Without a complete seed, "the debt went down" is
+a sentence someone has to agree with; with one, it is arithmetic.
+
+WHAT THE 777 ARE
+----------------
+====== ======== ======= ========================================
+ code   found    files   what it is
+====== ======== ======= ========================================
+ E501      585     133   line-too-long
+ I001       97      80   unsorted-imports
+ F401       69      23   unused-import
+ E402       22       2   module-import-not-at-top-of-file
+ F541        2       1   f-string-missing-placeholders
+ F811        2       1   redefined-while-unused
+====== ======== ======= ========================================
+
+E501 is three-quarters of it, and 61% of the whole inventory sits under
+``tests/``. Neither is a reason to exclude anything: tests are backend code,
+and an excluded directory is a rule that is off, not a rule that is satisfied.
+
+THE RULE
+--------
+**This mapping may only shrink.** Two directions, two meanings:
+
+* A number that goes **up**, or a key that appears, means a new finding landed.
+  Fix the code instead of editing this file — ``E``/``F``/``I`` findings in new
+  code are cheap to fix at the moment you write them, which is the entire
+  argument for having a linter. ``tests/unit/test_ruff_clean.py`` fails either
+  way.
+* A number that goes **down**, or a key that disappears, is a cleanup. Lower or
+  delete the entry in the same commit — the test requires the allowlist to
+  match reality exactly, so it cannot quietly stop describing the code.
+
+There is deliberately no escape hatch for "this one is fine". If a *finding* is
+genuinely wrong, ``# noqa: CODE`` on the line is the escape hatch ruff already
+ships, and it costs one entry here going down by one. If a *rule* is wrong, it
+comes out of ``select`` in ``backend/pyproject.toml`` and out of this file, in
+the same commit, where a reviewer can see it.
+
+KEYED ON FILE **AND** CODE
+--------------------------
+``services/praxis.py::F401``, not ``services/praxis.py``. Per-file
+grandfathering would mean a file with one over-long line is also exempt from
+unused imports forever; per file and code, with a count, is the tightest thing
+that still lets the tree be green on day one. Line numbers are deliberately not
+in the key — they churn on every edit above the finding, which would make this
+a merge-conflict generator rather than a ratchet.
+
+BURNING IT DOWN
+---------------
+``ruff check --fix`` fixes 170 of the 777 mechanically (F401, F541, F811,
+I001). Do that **per directory, in its own PR**, and lower the entries here in
+the same commit. Do not do it tree-wide — that is the thing this ratchet exists
+to avoid having to review.
+
+To regenerate this mapping after a cleanup, from ``backend/``::
+
+    python -m ruff check --no-cache --output-format concise . |
+        awk -F: '{print $1"::"}'   # ...or just read the test's failure message,
+                                   # which prints the exact lines to edit.
+"""
+
+from __future__ import annotations
+
+#: The headline number. Asserted against the sum of the entries below, so it
+#: cannot drift into being a separate claim about the code.
+RUFF_FINDING_TOTAL = 777
+
+#: ``<path relative to backend/>::<rule code>`` -> how many that file is still
+#: allowed. Sorted by path; keep it sorted so diffs stay readable.
+RUFF_ALLOWLIST: dict[str, int] = {
+    "alembic/env.py::E501": 1,
+    "alembic/env.py::I001": 1,
+    "alembic/versions/0002_squashed.py::I001": 1,
+    "alembic/versions/0003_character_tagline.py::E501": 1,
+    "alembic/versions/0004_onboarding_cross_faction.py::I001": 1,
+    "alembic/versions/0005_praxis_member_habit_bonus.py::E501": 1,
+    "config.py::E501": 2,
+    "db.py::I001": 1,
+    "elevate_admin.py::E501": 7,
+    "eras/_template.py::E501": 2,
+    "eras/_template.py::F401": 3,
+    "eras/_template.py::I001": 1,
+    "eras/era_1.py::I001": 1,
+    "eras/era_2.py::I001": 1,
+    "game_config.py::E501": 12,
+    "import_tasks_csv.py::E501": 3,
+    "main.py::E501": 9,
+    "main.py::I001": 1,
+    "models/__init__.py::I001": 1,
+    "models/account.py::E501": 2,
+    "models/character.py::E501": 2,
+    "models/character_block.py::E501": 1,
+    "models/character_block.py::I001": 1,
+    "models/character_stats.py::E501": 3,
+    "models/contact.py::E501": 1,
+    "models/duel.py::F401": 1,
+    "models/era.py::E501": 1,
+    "models/faction.py::E501": 1,
+    "models/praxis.py::E501": 3,
+    "models/task.py::E501": 1,
+    "models/task.py::I001": 1,
+    "models/vote.py::E501": 1,
+    "routers/admin.py::E501": 3,
+    "routers/admin.py::I001": 1,
+    "routers/auth.py::E501": 1,
+    "routers/auth.py::I001": 1,
+    "routers/characters.py::E402": 12,
+    "routers/characters.py::E501": 1,
+    "routers/duel.py::E501": 2,
+    "routers/duel.py::F401": 2,
+    "routers/factions.py::E501": 1,
+    "routers/praxes.py::E402": 10,
+    "routers/praxes.py::E501": 3,
+    "routers/praxes.py::F401": 1,
+    "routers/praxes.py::I001": 1,
+    "routers/relationships.py::I001": 1,
+    "routers/tasks.py::I001": 1,
+    "schemas/activity_feed.py::E501": 2,
+    "schemas/activity_feed.py::I001": 1,
+    "schemas/admin.py::I001": 1,
+    "schemas/auth.py::E501": 2,
+    "schemas/auth.py::I001": 1,
+    "schemas/character.py::E501": 1,
+    "schemas/character.py::I001": 1,
+    "schemas/comment.py::I001": 1,
+    "schemas/contact.py::I001": 1,
+    "schemas/duel.py::I001": 1,
+    "schemas/faction.py::I001": 1,
+    "schemas/praxis.py::E501": 10,
+    "schemas/praxis.py::I001": 1,
+    "schemas/relationship.py::I001": 1,
+    "schemas/sidebar.py::I001": 1,
+    "schemas/task.py::I001": 1,
+    "schemas/vote.py::F401": 1,
+    "schemas/vote.py::I001": 1,
+    "script_utils.py::E501": 1,
+    "script_utils.py::I001": 1,
+    "scripts/backfill_character_stats.py::E501": 3,
+    "scripts/backfill_vote_budget.py::E501": 3,
+    "scripts/check_db_stamp.py::E501": 2,
+    "scripts/era_reset.py::E501": 8,
+    "scripts/reset_e2e_db.py::E501": 3,
+    "scripts/reset_render_db.py::E501": 5,
+    "scripts/seed_demo_praxes.py::E501": 11,
+    "scripts/seed_demo_praxes.py::I001": 1,
+    "scripts/sweep_orphan_media.py::E501": 11,
+    "seed.py::E501": 4,
+    "seed.py::F541": 2,
+    "seed.py::I001": 1,
+    "services/activity_feed.py::E501": 8,
+    "services/activity_feed.py::I001": 1,
+    "services/admin_service.py::E501": 6,
+    "services/admin_service.py::I001": 1,
+    "services/auth.py::E501": 5,
+    "services/character.py::E501": 5,
+    "services/character.py::I001": 1,
+    "services/character_stats.py::E501": 4,
+    "services/character_stats.py::I001": 1,
+    "services/collab_consensus.py::E501": 3,
+    "services/duel.py::E501": 5,
+    "services/duel.py::I001": 1,
+    "services/era.py::E501": 2,
+    "services/era.py::I001": 1,
+    "services/faction_service.py::F401": 2,
+    "services/media.py::E501": 4,
+    "services/media.py::I001": 1,
+    "services/media_sweep.py::E501": 5,
+    "services/media_sweep.py::I001": 1,
+    "services/praxis.py::E501": 21,
+    "services/praxis.py::I001": 1,
+    "services/praxis_metatask.py::E501": 1,
+    "services/praxis_out.py::E501": 8,
+    "services/praxis_out.py::I001": 1,
+    "services/praxis_room.py::E501": 1,
+    "services/praxis_scoring.py::E501": 3,
+    "services/relationship_service.py::E501": 1,
+    "services/relationship_service.py::I001": 1,
+    "services/scoring.py::E501": 3,
+    "services/task.py::E501": 6,
+    "services/task.py::I001": 1,
+    "services/vote.py::E501": 3,
+    "tests/integration/conftest.py::E501": 9,
+    "tests/integration/conftest.py::F401": 1,
+    "tests/integration/conftest.py::I001": 3,
+    "tests/integration/factories.py::E501": 4,
+    "tests/integration/factories.py::I001": 1,
+    "tests/integration/test_account_linking.py::I001": 1,
+    "tests/integration/test_activity_feed.py::E501": 2,
+    "tests/integration/test_activity_feed.py::I001": 1,
+    "tests/integration/test_activity_feed_archive.py::E501": 1,
+    "tests/integration/test_activity_feed_global_task_backlog.py::E501": 2,
+    "tests/integration/test_activity_feed_query_count.py::E501": 1,
+    "tests/integration/test_activity_feed_vote_points.py::E501": 3,
+    "tests/integration/test_admin.py::E501": 4,
+    "tests/integration/test_admin.py::F401": 3,
+    "tests/integration/test_admin.py::I001": 4,
+    "tests/integration/test_admin_task_import.py::F401": 2,
+    "tests/integration/test_albescent_unlock.py::E501": 3,
+    "tests/integration/test_auth.py::E501": 3,
+    "tests/integration/test_auth.py::I001": 1,
+    "tests/integration/test_badges.py::E501": 1,
+    "tests/integration/test_ban_and_departure.py::E501": 9,
+    "tests/integration/test_blocks.py::E501": 1,
+    "tests/integration/test_character_stats.py::E501": 4,
+    "tests/integration/test_characters.py::E501": 17,
+    "tests/integration/test_characters.py::F401": 2,
+    "tests/integration/test_characters.py::I001": 1,
+    "tests/integration/test_collab_solo_conversion.py::I001": 1,
+    "tests/integration/test_collab_vote_recalc.py::E501": 3,
+    "tests/integration/test_dev_login.py::E501": 4,
+    "tests/integration/test_duel_era_resolution.py::F401": 9,
+    "tests/integration/test_duel_era_resolution.py::I001": 2,
+    "tests/integration/test_duel_opponent_lookup.py::E501": 2,
+    "tests/integration/test_duel_opponent_lookup.py::F401": 1,
+    "tests/integration/test_duel_self_duel.py::E501": 7,
+    "tests/integration/test_duel_self_duel.py::I001": 1,
+    "tests/integration/test_duel_service.py::I001": 1,
+    "tests/integration/test_duel_victor_badge.py::E501": 5,
+    "tests/integration/test_duel_victor_badge.py::F401": 12,
+    "tests/integration/test_duelist_badge.py::E501": 3,
+    "tests/integration/test_duelist_badge.py::F401": 15,
+    "tests/integration/test_era_reset_retires_board.py::E501": 1,
+    "tests/integration/test_era_reset_script.py::F401": 2,
+    "tests/integration/test_era_reset_script.py::I001": 1,
+    "tests/integration/test_era_scoped_recalc.py::E501": 1,
+    "tests/integration/test_faction_filter_folds_albescent.py::E501": 1,
+    "tests/integration/test_factions.py::E501": 3,
+    "tests/integration/test_factions.py::I001": 2,
+    "tests/integration/test_failed_praxis.py::E501": 1,
+    "tests/integration/test_failed_praxis.py::F401": 2,
+    "tests/integration/test_failed_praxis.py::I001": 1,
+    "tests/integration/test_flag_account_scope.py::E501": 5,
+    "tests/integration/test_game_config.py::E501": 1,
+    "tests/integration/test_hidden_praxis_media_quarantine.py::E501": 10,
+    "tests/integration/test_hidden_praxis_media_quarantine.py::I001": 1,
+    "tests/integration/test_invitation_delivery.py::E501": 15,
+    "tests/integration/test_leaderboard.py::I001": 1,
+    "tests/integration/test_level_jump_signup.py::F401": 1,
+    "tests/integration/test_me.py::E501": 6,
+    "tests/integration/test_media_sweep_db.py::E501": 1,
+    "tests/integration/test_multi_character.py::E501": 9,
+    "tests/integration/test_nudge.py::I001": 1,
+    "tests/integration/test_nudge_bulk.py::E501": 1,
+    "tests/integration/test_player_facing_error_codes.py::I001": 1,
+    "tests/integration/test_praxes.py::E501": 47,
+    "tests/integration/test_praxes.py::F401": 2,
+    "tests/integration/test_praxes.py::F811": 2,
+    "tests/integration/test_praxes.py::I001": 4,
+    "tests/integration/test_praxis_card_breakdown.py::E501": 1,
+    "tests/integration/test_praxis_card_breakdown.py::I001": 1,
+    "tests/integration/test_praxis_delete_and_signup_race.py::E501": 3,
+    "tests/integration/test_praxis_era_stamp.py::E501": 2,
+    "tests/integration/test_praxis_feed_scope.py::E501": 3,
+    "tests/integration/test_praxis_list_query_count.py::E501": 2,
+    "tests/integration/test_praxis_media_batch.py::E501": 9,
+    "tests/integration/test_praxis_room.py::E501": 17,
+    "tests/integration/test_praxis_roster_avatars.py::E501": 1,
+    "tests/integration/test_praxis_scoring.py::F401": 1,
+    "tests/integration/test_praxis_scoring.py::I001": 1,
+    "tests/integration/test_praxis_visibility.py::E501": 18,
+    "tests/integration/test_praxis_voted_filter.py::E501": 2,
+    "tests/integration/test_praxis_voted_filter.py::I001": 1,
+    "tests/integration/test_relationships.py::I001": 1,
+    "tests/integration/test_seed_score_fixtures.py::E501": 1,
+    "tests/integration/test_seed_task_sync.py::E501": 1,
+    "tests/integration/test_signup_eligibility.py::E501": 4,
+    "tests/integration/test_task_can_sign_up_filter.py::E501": 2,
+    "tests/integration/test_task_crown.py::E501": 1,
+    "tests/integration/test_task_list_query_count.py::E501": 2,
+    "tests/integration/test_task_signup_reason.py::F401": 2,
+    "tests/integration/test_task_start_here.py::I001": 1,
+    "tests/integration/test_task_visibility_gates.py::E501": 3,
+    "tests/integration/test_task_visibility_gates.py::F401": 2,
+    "tests/integration/test_tasks.py::E501": 10,
+    "tests/integration/test_tasks.py::I001": 6,
+    "tests/integration/test_taunts.py::I001": 1,
+    "tests/integration/test_vote_dedupe_repair.py::E501": 11,
+    "tests/integration/test_votes.py::E501": 14,
+    "tests/integration/test_votes.py::F401": 1,
+    "tests/integration/test_votes.py::I001": 2,
+    "tests/test_adr_numbers_are_unique.py::E501": 1,
+    "tests/test_deleted_routes_stay_deleted.py::E501": 1,
+    "tests/test_issue_comment_guard.py::E501": 1,
+    "tests/test_issue_comment_guard.py::I001": 1,
+    "tests/test_migration_revision_ids.py::E501": 1,
+    "tests/test_openapi_response_required.py::E501": 3,
+    "tests/unit/test_character_capabilities.py::E501": 5,
+    "tests/unit/test_character_capabilities.py::I001": 1,
+    "tests/unit/test_era_config.py::E501": 12,
+    "tests/unit/test_era_config.py::I001": 1,
+    "tests/unit/test_era_reset.py::E501": 1,
+    "tests/unit/test_era_reset.py::F401": 1,
+    "tests/unit/test_errors.py::E501": 3,
+    "tests/unit/test_errors.py::I001": 1,
+    "tests/unit/test_faction_config.py::E501": 1,
+    "tests/unit/test_i18n_catalog_coverage.py::E501": 1,
+    "tests/unit/test_level_jump.py::I001": 1,
+    "tests/unit/test_level_profiles.py::E501": 1,
+    "tests/unit/test_media_service.py::E501": 3,
+    "tests/unit/test_media_sweep.py::E501": 2,
+    "tests/unit/test_metatask_cap.py::E501": 2,
+    "tests/unit/test_model_conventions.py::E501": 1,
+    "tests/unit/test_model_conventions.py::I001": 1,
+    "tests/unit/test_praxis_mode_gates.py::I001": 1,
+    "tests/unit/test_scoring.py::E501": 20,
+    "tests/unit/test_scoring.py::I001": 2,
+    "tests/unit/test_uncoded_error_ratchet.py::I001": 1,
+    "tests/unit/test_vote_tally.py::E501": 1,
+    "tests/unit/uncoded_error_allowlist.py::E501": 1,
+    "tests/unit/uncoded_error_scan.py::E501": 2,
+}

--- a/backend/tests/unit/ruff_scan.py
+++ b/backend/tests/unit/ruff_scan.py
@@ -1,0 +1,125 @@
+"""Runs ruff over the shipped backend and tallies what it finds (#2427).
+
+This is the measuring instrument behind the shrink-only allowlist in
+``ruff_allowlist.py``. It is deliberately thin: ruff is the scanner, this module
+only decides *how it is invoked* and *what a finding is keyed on*.
+
+HOW IT IS INVOKED
+-----------------
+``sys.executable -m ruff`` rather than a bare ``ruff`` on ``PATH``. The two are
+not the same thing on a machine with several environments, and the version that
+matters is the one pinned in ``requirements.txt`` and installed next to pytest —
+a different ruff on ``PATH`` would report a different number and the ratchet
+would swing for reasons that have nothing to do with the code.
+
+``--no-cache`` so the run leaves no ``.ruff_cache/`` behind for a ``.gitignore``
+to have to know about, and ``cwd=BACKEND_ROOT`` so ruff finds
+``backend/pyproject.toml`` no matter where pytest was invoked from.
+
+WHAT A FINDING IS KEYED ON
+--------------------------
+``<path relative to backend/>::<rule code>``, e.g. ``services/praxis.py::F401``.
+
+Two deliberate choices there, both copied from the uncoded-error ratchet:
+
+* **Line numbers are not part of the key.** They churn on every edit above the
+  finding, which would make the allowlist a merge-conflict generator rather
+  than a ratchet.
+* **The rule code is.** Grandfathering a whole *file* would mean a file with one
+  long line is also exempt from unused imports and unsorted imports forever.
+  Per file *and* per code, with a count, is the tightest thing that still lets
+  the tree be green on day one.
+
+A NOTE ON FAILING LOUDLY
+------------------------
+``python -m ruff`` on an environment without ruff exits 1 with an empty stdout,
+which is indistinguishable from "ruff ran and found nothing" if you only look
+at the exit code. That would turn a missing linter into a green test forever.
+So the module checks ruff is importable *first*, and then insists stdout parses
+as a JSON list.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+#: ``backend/``. Resolved from this file, not the cwd.
+BACKEND_ROOT = Path(__file__).resolve().parents[2]
+
+#: What ruff reports for a file it could not parse. ``code`` is ``null`` in the
+#: JSON for those, and a syntax error is not something to grandfather — giving
+#: it a key at least makes the failure say what happened.
+SYNTAX_ERROR_CODE = "syntax-error"
+
+
+def ruff_is_installed() -> bool:
+    return importlib.util.find_spec("ruff") is not None
+
+
+def run_ruff() -> list[dict]:
+    """Return ruff's raw JSON findings for ``backend/``.
+
+    Raises ``RuntimeError`` if ruff could not be run or did not produce JSON,
+    because both of those look like "clean" to an exit-code check.
+    """
+    if not ruff_is_installed():
+        raise RuntimeError(
+            "ruff is not installed in this environment, so the lint ratchet"
+            " cannot run. It is pinned in backend/requirements.txt:"
+            " `pip install -r requirements.txt`."
+        )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "ruff",
+            "check",
+            "--no-cache",
+            "--output-format",
+            "json",
+            ".",
+        ],
+        cwd=BACKEND_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    # 0 = clean, 1 = findings. Anything else is ruff itself complaining.
+    if completed.returncode not in (0, 1):
+        raise RuntimeError(
+            f"ruff exited {completed.returncode}:\n{completed.stderr.strip()}"
+        )
+
+    try:
+        findings = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "ruff produced no parseable JSON — treating that as 'clean' is how"
+            f" a broken linter stays green.\nstdout: {completed.stdout[:400]!r}"
+            f"\nstderr: {completed.stderr[:400]!r}"
+        ) from exc
+
+    if not isinstance(findings, list):
+        raise RuntimeError(f"ruff JSON was not a list: {type(findings).__name__}")
+
+    return findings
+
+
+def key_for(finding: dict) -> str:
+    """``services/praxis.py::F401`` — the allowlist's unit."""
+    path = Path(finding["filename"]).resolve().relative_to(BACKEND_ROOT).as_posix()
+    return f"{path}::{finding.get('code') or SYNTAX_ERROR_CODE}"
+
+
+def tally(findings: list[dict]) -> Counter[str]:
+    return Counter(key_for(finding) for finding in findings)
+
+
+def scan_backend() -> Counter[str]:
+    return tally(run_ruff())

--- a/backend/tests/unit/test_ruff_clean.py
+++ b/backend/tests/unit/test_ruff_clean.py
@@ -1,0 +1,185 @@
+"""The ratchet: ruff findings in the backend may only shrink (#2427).
+
+The seam under test is **the linter's verdict on the shipped tree**, not any
+one file's style. There is no CI workflow step — ``.github/workflows/**`` is
+owner-only and the ``test`` job already runs pytest — so this test *is* the
+gate, on the same precedent as ``test_uncoded_error_ratchet.py`` and
+``test_model_conventions.py``.
+
+:func:`test_ruff_findings_match_the_allowlist` is the ratchet proper. It runs
+ruff over ``backend/`` and compares the inventory to ``ruff_allowlist`` in
+**both directions**, because a one-directional check is not a ratchet:
+
+* the code grew a finding the allowlist does not know about — a regression;
+* the allowlist claims findings the code no longer has — the pawl slipped, and
+  "we burned down N" stops being a fact about the code.
+
+The rest of the file tests the *instrument*, because every cheap way to make
+this test pass without fixing anything runs through the instrument rather than
+through the allowlist: uninstall ruff, add an ``ignore``, add a
+``per-file-ignores``, exclude a directory, or scatter bare ``# noqa``. Each of
+those makes the number go down while the code stays exactly as it was.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from tests.unit.ruff_allowlist import RUFF_ALLOWLIST, RUFF_FINDING_TOTAL
+from tests.unit.ruff_scan import BACKEND_ROOT, run_ruff, scan_backend, tally
+
+PYPROJECT = BACKEND_ROOT / "pyproject.toml"
+
+#: The narrow set ruff landed with (#2427). Widening it is a one-line change to
+#: pyproject.toml *and* to this constant, in the same commit — which is the
+#: point: it makes widening a reviewable decision rather than a quiet one.
+EXPECTED_SELECT = ["E", "F", "I"]
+
+
+@pytest.fixture(scope="module")
+def actual() -> dict[str, int]:
+    """One ruff run for the whole module — it is a subprocess, not a function."""
+    return dict(scan_backend())
+
+
+# ---------------------------------------------------------------------------
+# The ratchet
+# ---------------------------------------------------------------------------
+
+
+def test_allowlist_total_matches_its_entries() -> None:
+    """The headline number is the sum of the entries, not a separate claim."""
+    assert RUFF_FINDING_TOTAL == sum(RUFF_ALLOWLIST.values())
+
+
+def test_ruff_findings_match_the_allowlist(actual: dict[str, int]) -> None:
+    appeared = sorted(
+        f"{key}: {count}"
+        for key, count in actual.items()
+        if key not in RUFF_ALLOWLIST
+    )
+    assert not appeared, (
+        "New ruff findings in files the allowlist does not cover:\n  "
+        + "\n  ".join(appeared)
+        + "\n\nFix them — `ruff check --fix` handles F401/F541/F811/I001"
+        " automatically — instead of adding them to tests/unit/ruff_allowlist.py."
+        " The allowlist only shrinks."
+    )
+
+    grew = sorted(
+        f'    "{key}": {count},  # was {RUFF_ALLOWLIST[key]}'
+        for key, count in actual.items()
+        if count > RUFF_ALLOWLIST[key]
+    )
+    assert not grew, (
+        "Ruff findings increased in files that already had some:\n"
+        + "\n".join(grew)
+        + "\n\nFix the new ones. The allowlist only shrinks."
+    )
+
+    shrank = sorted(
+        (
+            f'    "{key}": {actual.get(key, 0)},  # was {allowed}'
+            if actual.get(key, 0)
+            else f"    (delete) {key}  # was {allowed}"
+        )
+        for key, allowed in RUFF_ALLOWLIST.items()
+        if actual.get(key, 0) < allowed
+    )
+    assert not shrank, (
+        "The allowlist is stale — these findings are fixed (or the file is"
+        " gone) now:\n"
+        + "\n".join(shrank)
+        + "\n\nApply those edits to tests/unit/ruff_allowlist.py and lower"
+        " RUFF_FINDING_TOTAL to match. Shrinking it is the point; leaving it"
+        " oversized is what makes 'we burned down N' stop meaning anything."
+    )
+
+
+# ---------------------------------------------------------------------------
+# The instrument: every cheap way to make the number go down without fixing
+# ---------------------------------------------------------------------------
+
+
+def _ruff_config() -> dict:
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))["tool"]["ruff"]
+
+
+def test_the_selected_rules_are_the_ones_that_landed() -> None:
+    """Narrowing ``select`` would shrink the inventory without fixing anything."""
+    assert _ruff_config()["lint"]["select"] == EXPECTED_SELECT
+
+
+def test_no_rule_is_switched_off_wholesale() -> None:
+    """`ignore` / `per-file-ignores` are per-*rule* suppression, not a ratchet.
+
+    Grandfathering belongs in ``ruff_allowlist.py``, where it is per file, per
+    code, counted, and can only go down. An entry here would exempt code nobody
+    has written yet.
+    """
+    lint = _ruff_config()["lint"]
+    assert "ignore" not in lint
+    assert "extend-ignore" not in lint
+    assert "per-file-ignores" not in lint
+
+
+def test_no_directory_is_excluded_from_the_scan(actual: dict[str, int]) -> None:
+    """An excluded directory is a rule that is off, not a rule that is satisfied.
+
+    Ruff's built-in default excludes cover ``.venv``/``__pycache__`` and friends
+    via ``.gitignore``; anything *added* would silently drop findings. The
+    reach assertion is the second half: ``tests/`` is 61% of the seeded
+    inventory and the most tempting thing to exclude.
+    """
+    config = _ruff_config()
+    assert "exclude" not in config
+    assert "extend-exclude" not in config
+
+    scanned = {key.split("/", 1)[0] for key in actual}
+    assert {"routers", "services", "tests", "models", "schemas"} <= scanned
+
+
+def test_a_missing_ruff_fails_loudly_rather_than_reading_as_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`python -m ruff` with no ruff exits 1 with empty stdout — i.e. "clean"."""
+    monkeypatch.setattr("tests.unit.ruff_scan.ruff_is_installed", lambda: False)
+    with pytest.raises(RuntimeError, match="not installed"):
+        run_ruff()
+
+
+def test_bare_noqa_would_launder_a_finding_and_is_not_used() -> None:
+    """`# noqa` with no code suppresses *everything* on the line, invisibly.
+
+    Every ``noqa`` in the backend today names its rule, so the ratchet can see
+    what was silenced. A bare one is the one suppression that leaves no trace
+    in this file or in pyproject.toml.
+
+    This file is skipped: it is the only one in the backend that *writes about*
+    the token rather than using it, and there is nothing lint-suppressible in a
+    file made of assertions.
+    """
+    this_file = Path(__file__).resolve()
+    offenders = [
+        f"{path.relative_to(BACKEND_ROOT).as_posix()}:{number}"
+        for path in BACKEND_ROOT.rglob("*.py")
+        if ".venv" not in path.parts
+        and "__pycache__" not in path.parts
+        and path.resolve() != this_file
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+        if "# noqa" in line and "# noqa:" not in line
+    ]
+    assert not offenders, (
+        "Bare `# noqa` suppresses every rule on the line:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nName the code: `# noqa: F401 - why`."
+    )
+
+
+def test_the_scan_and_the_tally_agree_on_the_run(actual: dict[str, int]) -> None:
+    """A sanity check that the key derivation did not swallow findings."""
+    assert sum(actual.values()) == len(run_ruff())
+    assert tally([]) == {}


### PR DESCRIPTION
Closes #2427

The backend had no linter, formatter or type checker at all. This lands `ruff` — narrow, gated by pytest, and as a **shrink-only ratchet** rather than a repo-wide autofix.

## The seam

**The linter's verdict on the shipped tree**, compared in both directions against a per-file/per-rule allowlist. Not any one file's style, and not a CI workflow step: `.github/workflows/**` is owner-only, and the `test` job already runs pytest. Same precedent as `test_uncoded_error_ratchet.py` and `test_model_conventions.py`.

The failing test came first and went red on the real defect: appending one unused import to `services/scoring.py` produced *"New ruff findings in files the allowlist does not cover"*, and reverting it went green. The other direction was proven the same way — bumping one allowlist entry by 1 produced *"The allowlist is stale — these findings are fixed (or the file is gone) now"* with the exact line to edit.

## The debt this ratchet will burn down

`ruff check --select E,F,I` on a tree that has never been linted: **777 findings across 172 files.**

| code | found | files | what it is |
|---|---:|---:|---|
| E501 | 585 | 133 | line-too-long |
| I001 | 97 | 80 | unsorted-imports |
| F401 | 69 | 23 | unused-import |
| E402 | 22 | 2 | module-import-not-at-top-of-file |
| F541 | 2 | 1 | f-string-missing-placeholders |
| F811 | 2 | 1 | redefined-while-unused |

**After grandfathering: 0 unallowed.** All 777 are seeded, so `pytest` is green on this branch and any *new* E/F/I finding fails CI.

61% of the inventory sits under `tests/`. Nothing is excluded — an excluded directory is a rule that is off, not a rule that is satisfied.

`ruff check --fix` would clear 170 of the 777 mechanically (F401/F541/F811/I001). That is deliberately **not** done here per the owner ruling; the allowlist docstring says to do it per directory, in its own PR, lowering entries in the same commit.

## What is in the diff

- `backend/requirements.txt` — `ruff==0.16.4`, pinned exactly. The allowlist is a count of what *this* version reports, so an unpinned upgrade would move the number without anyone touching the code.
- `backend/pyproject.toml` — `[tool.ruff]` with `select = ["E", "F", "I"]`, `target-version = "py312"`, and **no `ignore` list**. No `[project]` / `[build-system]` table, so pip and the Docker image are unaffected; `pytest.ini` keeps precedence for pytest's rootdir.
- `backend/tests/unit/ruff_scan.py` — invokes `sys.executable -m ruff ... --output-format json --no-cache` and keys findings on `<path>::<CODE>`.
- `backend/tests/unit/ruff_allowlist.py` — the seeded shrink-only mapping (240 entries) + `RUFF_FINDING_TOTAL`.
- `backend/tests/unit/test_ruff_clean.py` — the ratchet, plus five instrument tests.

## Two decisions worth a second's attention

**Keyed on file *and* rule code, not file alone.** `services/praxis.py::F401`, not `services/praxis.py`. Plain per-file grandfathering would mean a file with one over-long line is also exempt from unused imports forever. Line numbers are deliberately out of the key — they churn on every edit above the finding, which would make the allowlist a merge-conflict generator.

**`line-length = 88` is the ruff default, taken deliberately rather than tuned.** Raising it to 100 would drop E501 from 585 to 66 — which is exactly why it is not raised. The number to move is the allowlist, not the threshold. If you want it at 100 it is a one-line change plus a mass allowlist shrink, and it should be its own PR.

## The instrument is tested, because that is where the cheap cheats are

Every way to make this test pass without fixing anything runs through the instrument, not the allowlist. Each is pinned:

- **Uninstall ruff.** `python -m ruff` with no ruff exits 1 with empty stdout — indistinguishable from "clean" to an exit-code check. `run_ruff()` checks importability first and insists stdout parses as a JSON list.
- **Narrow `select`.** Pinned against `["E", "F", "I"]`, so widening or narrowing is a reviewable two-file change.
- **Add `ignore` / `per-file-ignores`.** Asserted absent — those are per-*rule* suppression that would exempt code nobody has written yet.
- **Add `exclude` / `extend-exclude`.** Asserted absent, plus a reach assertion that `routers`/`services`/`tests`/`models`/`schemas` all appear in the scan.
- **Bare `# noqa`.** Suppresses every rule on the line and leaves no trace in either config file. Every `noqa` in the backend today names its code; the test keeps it that way.

## Tests

```
pytest --cov=. --cov-report=term-missing --cov-fail-under=80   # from backend/
1507 passed, 1 warning in 174.46s
Required test coverage of 80% reached. Total coverage: 94.22%
```

Baseline was 1499 passed / 94.22%; the +8 are this file. The one warning is the pre-existing `AuthlibDeprecationWarning` in `services/auth.py`. Run against a dedicated `wz2427_test` database.

`api-schema` and `frontend` are untouched — no route, `response_model`, Pydantic schema or frontend file is in this diff.

## Coordination note

#2426 is concurrently adding `backend/tests/integration/test_migrations_match_models.py`, which this branch's allowlist does not know about. **Whichever of the two merges second needs its new file to be ruff-clean** (or the second PR adds its entries). That is the ratchet doing its job, but it is a real ordering interaction, not a surprise.

## What to eyeball

- [ ] **The `line-length = 88` call.** It is 75% of the seeded debt. If you would rather have 100, say so and it is one line plus a shrink — but I did not make that call unilaterally.
- [ ] **`select = ["E", "F", "I"]` and nothing else** in `backend/pyproject.toml`, and no `ignore` key anywhere.
- [ ] **The allowlist is complete, not curated.** Spot-check a few entries in `backend/tests/unit/ruff_allowlist.py` against `python -m ruff check --no-cache --output-format concise .` from `backend/`.
- [ ] **`ruff==0.16.4` pinned exactly** in `backend/requirements.txt` — it is below the `pytest` family, in the dev/CI file, so it never reaches the prod image (`requirements-prod.txt` is what the Dockerfile installs).
- [ ] The burn-down instructions in the `ruff_allowlist.py` docstring say what you want them to say to the next agent that touches it.

**Visual QA is outstanding.** I have no browser tools and no dev stack; this change has no UI surface at all, but nothing here was checked in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
